### PR TITLE
Edit to DateDivider vertical padding

### DIFF
--- a/ui/src/components/ChatMessage/DateDivider.tsx
+++ b/ui/src/components/ChatMessage/DateDivider.tsx
@@ -9,7 +9,7 @@ export default function DateDivider({ date }: DateDividerProps) {
   const prettyDay = makePrettyDay(date);
 
   return (
-    <div className="flex w-full items-center pb-1 pt-3">
+    <div className="flex w-full items-center py-4">
       <div className="h-[2px] w-6 rounded-sm bg-gray-200">&nbsp;</div>
       <span className="whitespace-nowrap px-3 font-semibold text-gray-500">
         {prettyDay}


### PR DESCRIPTION
While inspecting the latest preview of the chat interface, I realized I miscommunicated some spacing/padding intent to @patosullivan and decided to jump in and amend the component myself.

All I'm doing is changing the padding scheme of this component from `pb-1 pt-3` to `py-4`. This change better reflects some of the spacing intent of the date divider in our designs.