### PR TITLE
ops: Add vercel.json w/rewrites rule, forces use of react-router for all routes

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
Fixes an issue where refreshing causes a 404 on vercel deployments.