### PR TITLE
chat: fix seal crash errors

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { differenceInDays } from 'date-fns';
-import { daToUnix } from '@urbit/api';
+import { BigIntOrderedMap, daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import ChatWritScroller from './ChatWritScroller';
 import { IChatScroller } from './IChatScroller';
@@ -10,6 +10,7 @@ import ChatNotice from '../ChatNotice';
 import { ChatState } from '../../state/chat/type';
 import { useChatState } from '../../state/chat/chat';
 import { MESSAGE_FETCH_PAGE_SIZE } from '../../constants';
+import { ChatWrit } from '../../types/chat';
 
 export default function ChatScroller(props: IChatScroller) {
   const { whom, messages, replying } = props;
@@ -25,6 +26,10 @@ export default function ChatScroller(props: IChatScroller) {
       }
       return messages.get(k)?.memo.replying === null;
     });
+  const mess = keys.reduce(
+    (acc, val) => acc.set(val, messages.get(val)),
+    new BigIntOrderedMap<ChatWrit>()
+  );
 
   interface RendererProps {
     index: bigInt.BigInteger;
@@ -43,7 +48,8 @@ export default function ChatScroller(props: IChatScroller) {
       const lastWritKey = keyIdx > 0 ? keys[keyIdx - 1] : undefined;
       const lastWrit = lastWritKey ? messages.get(lastWritKey) : undefined;
       const newAuthor = lastWrit
-        ? writ.memo.author !== lastWrit.memo.author
+        ? writ.memo.author !== lastWrit.memo.author ||
+          'notice' in lastWrit.memo.content
         : true;
       const writDay = new Date(daToUnix(index));
       const lastWritDay = lastWritKey
@@ -92,8 +98,8 @@ export default function ChatScroller(props: IChatScroller) {
           key={whom}
           origin="bottom"
           style={{ height: '100%' }}
-          data={messages}
-          size={messages.size}
+          data={mess}
+          size={mess.size}
           pendingSize={0} // TODO
           averageHeight={48}
           renderer={renderer}

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -40,7 +40,7 @@ export default function ChatThread(
         label={`${replies.size} ${replies.size === 1 ? 'Reply' : 'Replies'}`}
       />
       <div className="flex flex-col">
-        <ChatMessages messages={replies} whom={whom} replying={true} />
+        <ChatMessages messages={replies} whom={whom} replying />
       </div>
       <div className="sticky bottom-0 z-10 bg-white py-4">
         <ChatInput whom={whom} replying={id} />


### PR DESCRIPTION
Prevents the chatscroller from being updated in-place when switching
from DM another DM. This will ensure that the invariants of the
VirtualScroller are preserved as the component requires that it be torn
down and recreated.

Also fixes a regression introduced by the addition of the
virtualscroller. Threaded messages are no longer shown in the main view.

Fixes #190 