### PR TITLE
Get deploy action/workflow purring

### DIFF
--- a/.github/actions/deploy/entrypoint.sh
+++ b/.github/actions/deploy/entrypoint.sh
@@ -9,7 +9,6 @@ chmod 600 /id_ssh
 chmod 600 /id_ssh.pub
 
 janeway \
-    --verbose \
     --ci \
     --credentials /service-account \
     --ssh-key /id_ssh \
@@ -18,7 +17,6 @@ janeway \
   | bash
 
 janeway \
-    --verbose \
     --ci \
     --credentials /service-account \
     --ssh-key /id_ssh \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'jt/action'
+      - 'master'
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just a few tweaks, which should be all that's required to get this working:

* supplies the janeway service account creds and janeway-bot ssh key using absolute paths (I think this is the only change strictly required)
* supply the --ssh-key argument to the OTA command (avoids generating a ssh key on the container)
* prunes explicitly working from the $GITHUB_WORKSPACE dir and setting the safe directory (don't need 'em)
* supplies the janeway command-line flags and args in a more robust order (easier to swap in --verbose, --no-upload, etc.)