### PR TITLE
ui: fix focus state, sidebar sorter occlusion

### DIFF
--- a/ui/src/components/GroupSidebar.tsx
+++ b/ui/src/components/GroupSidebar.tsx
@@ -119,7 +119,7 @@ export default function GroupSidebar() {
             All Channels
           </SidebarLink>
 
-          <li>
+          <li className="my-1">
             <DropdownMenu.Root>
               <DropdownMenu.Trigger
                 className={'default-focus rounded-lg p-0.5 text-gray-600'}

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -93,7 +93,7 @@ export default function Sidebar() {
             Create Group
           </SidebarLink>
 
-          <li>
+          <li className="my-1">
             <DropdownMenu.Root>
               <DropdownMenu.Trigger
                 className={'default-focus rounded-lg p-0.5 text-gray-600'}

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -105,7 +105,9 @@ exports[`Sidebar > renders as expected 1`] = `
             </h3>
           </a>
         </li>
-        <li>
+        <li
+          class="my-1"
+        >
           <button
             aria-haspopup="menu"
             aria-label="Groups Sort Options"

--- a/ui/src/components/__snapshots__/GroupSidebar.test.tsx.snap
+++ b/ui/src/components/__snapshots__/GroupSidebar.test.tsx.snap
@@ -108,7 +108,9 @@ exports[`GroupSidebar > renders as expected 1`] = `
             </h3>
           </a>
         </li>
-        <li>
+        <li
+          class="my-1"
+        >
           <button
             aria-haspopup="menu"
             aria-label="Channels Sort Options"

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -11,7 +11,7 @@ import NewMessageIcon from '../components/icons/NewMessageIcon';
 import { useIsMobile } from '../logic/useMedia';
 import SidebarLink from '../components/Sidebar/SidebarLink';
 import MagnifyingGlass from '../components/icons/MagnifyingGlass';
-import useSidebarSort, { RECENT } from '../components/Sidebar/useSidebarSort';
+import useSidebarSort, { RECENT } from '../logic/useSidebarSort';
 import CaretDownIcon from '../components/icons/CaretDownIcon';
 import ChatSmallIcon from '../components/icons/ChatSmallIcon';
 import PersonSmallIcon from '../components/icons/PersonSmallIcon';

--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -49,10 +49,6 @@ function ChannelSidebarItem({ whom, brief }: MessagesSidebarItemProps) {
           />
         ) : null}
       </NavLink>
-      {/* <DmOptions
-        ship={whom}
-        className="group-two absolute right-0 opacity-0 transition-opacity hover:opacity-100 focus:opacity-100 group-hover:opacity-100"
-      /> */}
     </li>
   );
 }
@@ -79,7 +75,7 @@ function DMSidebarItem({ whom, brief, pending }: MessagesSidebarItemProps) {
       </NavLink>
       <DmOptions
         ship={whom}
-        className="group-two absolute right-0 opacity-0 transition-opacity hover:opacity-100 focus:opacity-100 group-hover:opacity-100"
+        className="group-two absolute right-0 opacity-0 transition-opacity hover:opacity-100 focus-visible:opacity-100 group-hover:opacity-100"
       />
     </li>
   );

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1,13 +1,13 @@
 .button {
-  @apply inline-flex items-center justify-center rounded-lg bg-gray-800 py-2 px-4 text-lg font-semibold leading-4 text-white ring-gray-200 ring-offset-2 ring-offset-white focus:outline-none focus:ring-2 disabled:bg-gray-200 disabled:text-gray-400 sm:text-base;
+  @apply inline-flex items-center justify-center rounded-lg bg-gray-800 py-2 px-4 text-lg font-semibold leading-4 text-white ring-gray-200 ring-offset-2 ring-offset-white focus:outline-none focus-visible:ring-2 disabled:bg-gray-200 disabled:text-gray-400 sm:text-base;
 }
 
 .icon-button {
-  @apply inline-flex h-6 w-6 items-center justify-center rounded-lg bg-gray-100 p-0 text-sm font-bold leading-4 text-gray-600 ring-gray-200 ring-offset-2 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 disabled:text-gray-300 sm:text-base;
+  @apply inline-flex h-6 w-6 items-center justify-center rounded-lg bg-gray-100 p-0 text-sm font-bold leading-4 text-gray-600 ring-gray-200 ring-offset-2 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 disabled:text-gray-300 sm:text-base;
 }
 
 .icon-toggle {
-  @apply inline-flex h-6 w-6 items-center justify-center rounded-lg bg-white p-0 text-sm font-bold leading-4 text-gray-400 ring-gray-200 ring-offset-2 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 disabled:text-gray-200 sm:text-base;
+  @apply inline-flex h-6 w-6 items-center justify-center rounded-lg bg-white p-0 text-sm font-bold leading-4 text-gray-400 ring-gray-200 ring-offset-2 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 disabled:text-gray-200 sm:text-base;
 }
 
 .icon-toggle-active {
@@ -16,7 +16,7 @@
 
 .input {
   @apply flex rounded-lg border-2 border-transparent bg-gray-50 py-1 px-2 text-lg leading-5 transition-colors focus-within:border-gray-100 focus-within:bg-white
-  focus:border-gray-100 focus:bg-white focus:outline-none sm:text-base sm:leading-5;
+  focus-visible:border-gray-100 focus-visible:bg-white focus:outline-none sm:text-base sm:leading-5;
 }
 
 .input-inner {
@@ -46,5 +46,5 @@
 }
 
 .dropdown-item {
-  @apply cursor-pointer rounded-lg px-2 py-3 ring-gray-200 focus:outline-none focus:ring-2;
+  @apply cursor-pointer rounded-lg px-2 py-3 ring-gray-200 focus:outline-none focus-visible:ring-2;
 }

--- a/ui/src/styles/utilities.css
+++ b/ui/src/styles/utilities.css
@@ -1,5 +1,5 @@
 .default-focus {
-  @apply ring-gray-200 ring-offset-2 ring-offset-white focus:outline-none focus:ring-2;
+  @apply ring-gray-200 ring-offset-2 ring-offset-white focus:outline-none focus-visible:ring-2;
 }
 
 /* Useful for showing selections programmatically */


### PR DESCRIPTION
This resolves #238 by fixing UI focus states and the sidebar sorter dropdown visual occlusion. It also fixes a broken import.

![image](https://user-images.githubusercontent.com/16504501/173424715-608ecee5-cedd-416f-aaba-7db66d4465fe.png)
