### PR TITLE
dm-hero: fixing collapsing hero on moons/comets

### DIFF
--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -158,7 +158,9 @@ export default function Avatar({
       )}
       style={{ backgroundColor: adjustedColor }}
     >
-      {sigilElement}
+      {sigilElement || (
+        <div style={{ width: `${sigilSize}px`, height: `${sigilSize}px` }} />
+      )}
     </div>
   );
 }

--- a/ui/src/mocks/chat.ts
+++ b/ui/src/mocks/chat.ts
@@ -22,6 +22,7 @@ const AUTHORS = [
   '~riprud-tidmel',
   '~wicdev-wisryt',
   '~rovnys-ricfer',
+  '~mister-dister-dozzod-dozzod',
 ];
 
 export const makeFakeChatWrit = (
@@ -149,6 +150,11 @@ export const dmList: ChatBriefs = {
     'read-id': null,
   },
   '~hastuc-dibtux': {
+    last: 0,
+    count: 0,
+    'read-id': null,
+  },
+  '~mister-dister-dozzod-dozzod': {
     last: 0,
     count: 0,
     'read-id': null,


### PR DESCRIPTION
This addresses #210 by inserting an empty element of the appropriate dimensions.