### PR TITLE
sidebar: copying link shows confirmation

### DIFF
--- a/ui/src/components/Sidebar/GroupActions.tsx
+++ b/ui/src/components/Sidebar/GroupActions.tsx
@@ -74,7 +74,7 @@ export default function GroupActions({ flag }: { flag: string }) {
           open={isOpen}
         >
           <DropdownMenu.Trigger
-            className={'default-focus rounded-lg p-0.5 text-gray-600'}
+            className={'default-focus rounded-lg p-0.5'}
             aria-label="Open Message Options"
           >
             <EllipsisIcon className="h-5 w-5" />

--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames';
 import React from 'react';
 import useSidebarSort from '../../logic/useSidebarSort';
+import { useBriefs } from '../../state/chat';
 import { useGangList, useGroup, useGroupList } from '../../state/groups';
 import Divider from '../Divider';
 import GangName from '../GangName/GangName';
@@ -11,6 +12,7 @@ import SidebarItem from './SidebarItem';
 
 function GroupItem({ flag }: { flag: string }) {
   const group = useGroup(flag);
+  const briefs = useBriefs();
   const setNavGroups = useNavStore((state) => state.setLocationGroups);
   return (
     <SidebarItem
@@ -19,6 +21,7 @@ function GroupItem({ flag }: { flag: string }) {
       }
       actions={<GroupActions flag={flag} />}
       onClick={() => setNavGroups(flag)}
+      hasActivity={(briefs[flag]?.count ?? 0) > 0}
     >
       {group?.meta.title}
     </SidebarItem>
@@ -34,6 +37,7 @@ function GangItem(props: { flag: string }) {
       icon={<GroupAvatar size="h-12 w-12 sm:h-6 sm:w-6" />}
       to={`/gangs/${flag}`}
       onClick={hideNav}
+      hasActivity
     >
       <GangName flag={flag} className="inline-block w-full truncate" />
     </SidebarItem>

--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -74,7 +74,12 @@ export default function SidebarItem({
         ) : null}
       </Action>
       {actions ? (
-        <div className="group absolute right-0 transition-opacity focus-visible:opacity-100">
+        <div
+          className={cn(
+            'group absolute right-0 transition-opacity focus-visible:opacity-100',
+            hasActivity && 'text-blue'
+          )}
+        >
           {actions}
         </div>
       ) : null}

--- a/ui/src/dms/DMOptions.tsx
+++ b/ui/src/dms/DMOptions.tsx
@@ -16,6 +16,7 @@ interface DMOptionsProps {
 export default function DmOptions({ ship, className }: DMOptionsProps) {
   const navigate = useNavigate();
   const pinned = usePinnedChats();
+  const [isOpen, setIsOpen] = useState(false);
 
   const onArchive = () => {
     navigate(-1);
@@ -48,13 +49,15 @@ export default function DmOptions({ ship, className }: DMOptionsProps) {
   };
 
   return (
-    <>
-      <DropdownMenu.Root>
+    <div
+      className={cn(
+        'group-hover:opacity-100',
+        isOpen ? 'opacity:100' : 'opacity-0'
+      )}
+    >
+      <DropdownMenu.Root onOpenChange={(open) => setIsOpen(open)} open={isOpen}>
         <DropdownMenu.Trigger
-          className={cn(
-            'default-focus rounded-lg p-0.5 text-gray-600',
-            className
-          )}
+          className={cn('default-focus rounded-lg p-0.5', className)}
           aria-label="Open Message Options"
         >
           <EllipsisIcon className="h-6 w-6" />
@@ -105,6 +108,6 @@ export default function DmOptions({ ship, className }: DMOptionsProps) {
           </div>
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   );
 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -66,6 +66,9 @@ a:not([class]) {
 }
 
 /* Ensures text selection is visible on dark mode desktop safari */
-_::-webkit-full-page-media, _:future, :root .safari_only, body.dark ::selection {
+_::-webkit-full-page-media,
+_:future,
+:root .safari_only,
+body.dark ::selection {
   @apply bg-gray-800;
 }


### PR DESCRIPTION
# Context

This resolves #220 by implementing the final step: showing confirmation to the user that the link has been copied. 

# Changes

- implements UX described in #220:
>On click, the label text of the Copy Link item should change to "Copied!" and then flash back.
- fix hover opacity CSS

# Preview

https://user-images.githubusercontent.com/16504501/173961237-a471d447-0b1a-440b-9a7e-7d5c3c1c5b7a.mp4

