### PR TITLE
safari dark-mode only text selection override

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -64,3 +64,8 @@ a:not([class]) {
 ::selection {
   @apply bg-gray-100;
 }
+
+/* Ensures text selection is visible on dark mode desktop safari */
+_::-webkit-full-page-media, _:future, :root .safari_only, body.dark ::selection {
+  @apply bg-gray-800;
+}

--- a/ui/src/styles/utilities.css
+++ b/ui/src/styles/utilities.css
@@ -24,7 +24,3 @@ a[aria-disabled='true'] {
     display: none; /* Safari and Chrome */
   }
 }
-
-_::-webkit-full-page-media, _:future, :root .safari_only, body.dark ::selection {
-  @apply bg-gray-800;
-}


### PR DESCRIPTION
Fixes #203. 

It turned out to be a dark-mode only issue, something about safari or tailwind makes the text `::selection` continue using the light mode theme even in dark mode, which led to text selections showing up as the same `#333333` that the dark mode background uses

I'm forcing safari only to use the light mode's `bg-grey-800` for text selection, which seems to create a visible selector, although safari seems to have issues parsing the opacity as well so the selection is a slightly different color than chrome's.