### PR TITLE
chat: fix leaving DMs

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -840,7 +840,7 @@
     ?.  ok  
       ~&  gone/ship
       ?:  =(src.bowl ship)
-        (di-post-notice '' ' left the chat')
+        di-core
       di-core(gone &)
     =.  net.dm  %done
     (di-post-notice '' ' joined the chat')


### PR DESCRIPTION
If the leave poke does not originate from our ship, then it's the
counterparty informing us that they left. Instead of incorrectly
removing the chat, we now just post a message informing the user that
their counterparty left the chat.