### PR TITLE
DM: New DMs are now pinned to the bottom of the screen

### DIFF
--- a/ui/src/components/VirtualScroller/VirtualScroller.tsx
+++ b/ui/src/components/VirtualScroller/VirtualScroller.tsx
@@ -733,6 +733,10 @@ export default class VirtualScroller<K, V> extends Component<
       visibleItems?.[visibleItems.length - 1] || keyBunt
     );
 
+    const scrollBoxMargin = isTop ? 
+    { width: 'calc(100% - 4px)', marginBottom: 'auto' } : 
+    { width: 'calc(100% - 4px)', marginTop: 'auto' };
+
     return (
       <>
         <Scrollbar
@@ -753,7 +757,7 @@ export default class VirtualScroller<K, V> extends Component<
             overflowY: 'scroll',
           }}
         >
-          <div style={{ width: 'calc(100% - 4px)', marginTop: 'auto' }}>
+          <div style={scrollBoxMargin}>
             {(isTop ? !atEnd : !atStart) && (
               <Center>
                 <LoadingSpinner />


### PR DESCRIPTION
fixes #269 – specifically the `Vscroller is pinned to the top; messages should flow in from the bottom even at the beginning of the chat history` item.

This doesn't seem to introduce any side effects w/r/t spinners that I haven't already encountered – though @liam-fitzgerald please let me know if this would break top-to-bottom scrolling, we could introduce a check on the scroll-direction that decides whether we apply the flex classes.