### PR TITLE
meta: change app tile colors

### DIFF
--- a/chatdesk/desk.docket-0
+++ b/chatdesk/desk.docket-0
@@ -1,6 +1,6 @@
 :~  title+'chatstead'
     info+'An Urbit app that does great things'
-    color+0x12.5b50
+    color+0xd5.6f4f
     glob-http+['https://bootstrap.urbit.org/glob-0v4.obev7.81jjs.i99r4.fo184.o4uvr.glob' 0v4.obev7.81jjs.i99r4.fo184.o4uvr]
     base+'chatstead'
     version+[0 0 1]

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -1,6 +1,6 @@
 :~  title+'homestead'
     info+'An Urbit app that does great things'
-    color+0x12.5b50
+    color+0x60.94d2
     glob-http+['https://bootstrap.urbit.org/glob-0v6.bsoia.u40ii.qhujv.usma1.2o867.glob' 0v6.bsoia.u40ii.qhujv.usma1.2o867]
     base+'homestead'
     version+[0 0 1]


### PR DESCRIPTION
Changes the app tile colors to those [designed](https://www.figma.com/file/CZnMVcDGH4Ix0WWDMVfD3J/2022-Q2-Groups?node-id=3932%3A129927) but does not include the icons.

Light mode:
![image](https://user-images.githubusercontent.com/748181/175119628-63b4f5ff-d7a7-4667-9bf0-e1b49b6a01a6.png)

Dark mode:
![image](https://user-images.githubusercontent.com/748181/175119774-7d43ca11-7d32-4760-87ba-5fa527165d9a.png)
