### PR TITLE
nav/groups: adds active highlight to special actions

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -38,14 +38,16 @@ export default function Sidebar() {
           Search My Groups
         </SidebarItem>
         <SidebarItem
-          color="text-blue"
+          color="text-blue hover:bg-blue-soft hover:dark:bg-blue-900"
+          highlight="bg-blue-soft dark:bg-blue-900"
           icon={<AsteriskIcon className="m-1 h-4 w-4" />}
           to="/groups/join"
         >
           Join Group
         </SidebarItem>
         <SidebarItem
-          color="text-green"
+          color="text-green hover:bg-green-soft hover:dark:bg-green-900"
+          highlight="bg-green-soft dark:bg-green-900"
           icon={<AddIcon16 className="m-1 h-4 w-4" />}
           to="/groups/new"
         >

--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -7,6 +7,7 @@ type SidebarProps = PropsWithChildren<{
   to?: string;
   actions?: React.ReactNode;
   color?: string;
+  highlight?: string;
 }> &
   ButtonHTMLAttributes<HTMLButtonElement> &
   Omit<LinkProps, 'to'>;
@@ -31,6 +32,7 @@ export default function SidebarItem({
   icon,
   to,
   color = 'text-gray-600',
+  highlight = 'bg-gray-50',
   actions,
   className,
   children,
@@ -44,7 +46,7 @@ export default function SidebarItem({
       className={cn(
         'group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold hover:bg-gray-50 sm:text-base',
         color,
-        active && 'bg-gray-50'
+        active && highlight
       )}
     >
       <Action

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Sidebar > renders as expected 1`] = `
         </a>
       </li>
       <li
-        class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold hover:bg-gray-50 sm:text-base text-blue"
+        class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold hover:bg-gray-50 sm:text-base text-blue hover:bg-blue-soft hover:dark:bg-blue-900"
       >
         <a
           class="default-focus flex w-full flex-1 items-center space-x-3 rounded-lg p-2 font-semibold"
@@ -99,7 +99,7 @@ exports[`Sidebar > renders as expected 1`] = `
         </a>
       </li>
       <li
-        class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold hover:bg-gray-50 sm:text-base text-green"
+        class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold hover:bg-gray-50 sm:text-base text-green hover:bg-green-soft hover:dark:bg-green-900"
       >
         <a
           class="default-focus flex w-full flex-1 items-center space-x-3 rounded-lg p-2 font-semibold"


### PR DESCRIPTION
Adds soft blue and green active states for "Join Group" and "Create Group" actions in the Groups sidebar.

Active states, light mode:
![image](https://user-images.githubusercontent.com/748181/175127612-5f5d5277-7454-4164-b94f-7a240e73c288.png)
![image](https://user-images.githubusercontent.com/748181/175127713-c3edb70a-7517-493b-9dc2-a2343e98f969.png)

Active states, dark mode:
![image](https://user-images.githubusercontent.com/748181/175127755-886c2cda-e3ba-4181-a6e7-ec09063259d4.png)
![image](https://user-images.githubusercontent.com/748181/175127823-0eb33213-b3f7-45d7-93f9-a8cd113728c1.png)

Hover colors are identical.