### PR TITLE
ux: ShipSelector perf enhancement

### DIFF
--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export const MESSAGE_FETCH_PAGE_SIZE = 100;
+export const MAX_DISPLAYED_OPTIONS = 40;


### PR DESCRIPTION
# Context

There is a known issue with react-select's performance for large lists of options:
https://github.com/JedWatson/react-select/issues/4516
https://github.com/JedWatson/react-select/issues/3128

# Changes

Use fuzzy-filtering + capping the number of contacts to enhance ShipSelector performance when a user has many contacts. This resolves the remaining open action item in #310.