### PR TITLE
ux: ShipSelector prefers nicknames for display, and considers them for search

### DIFF
--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -171,8 +171,14 @@ export default function ShipSelector({
       return contactOptions;
     }
 
+    // fuzzy search both nicknames and patps; fuzzy#filter only supports
+    // string comparision, so concat nickname + patp
+    const searchSpace = Object.entries(contacts).map(
+      (entry) => `${entry[1].nickname}${entry[0]}`
+    );
+
     const fuzzyNames = fuzzy
-      .filter(inputValue, contactNames)
+      .filter(inputValue, searchSpace)
       .sort((a, b) => {
         const filter = deSig(inputValue) || '';
         const left = deSig(a.string)?.startsWith(filter)


### PR DESCRIPTION
# Context

When available, prefer the contact's nickname for both dropdown options and multi-select chiclets. Also, consider it when searching for a contact (in addition to `@p`).

This closes #370.

# Changes

- [x] Enable the ShipSelector to search ContactStore for nicknames as well. Searching for james should James M. and I; searching for ~rilfun-lidlen should show me.
- [x] Flip the order of dropdown menu items; nickname should take primacy (e.g. [James ~rilfun-lidlen])
- [x] When selecting a ship, show the ship's nickname in the token (e.g. [James x])
- [x] If no nickname is given, surface only the @p (existing behavior, e.g. [~datder-sonnet] and [~datder-sonnet x] respectively)

# Preview

![image](https://user-images.githubusercontent.com/16504501/178012712-d490bace-64df-45ff-9cf5-58b6b5636540.png)
