### PR TITLE
virtual-scroller: fix not loading messages initially

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -264,7 +264,6 @@ export default function ChatInput({
   const pact = usePact(whom);
   const chatInfo = useChatInfo(whom);
   const reply = replying || chatInfo?.replying || null;
-  console.log(reply);
   const replyingWrit = reply && pact.writs.get(pact.index[reply]);
   const ship = replyingWrit && replyingWrit.memo.author;
   const isMobile = useIsMobile();

--- a/ui/src/components/VirtualScroller/VirtualScroller.tsx
+++ b/ui/src/components/VirtualScroller/VirtualScroller.tsx
@@ -435,7 +435,7 @@ export default class VirtualScroller<K, V> extends Component<
 
   get lastOffset() {
     const { size } = this.props;
-    return Math.min(size - this.pageSize, size);
+    return Math.min(Math.max(size - this.pageSize, 0), size);
   }
 
   setScrollRef = (el: HTMLDivElement | null) => {


### PR DESCRIPTION
This calculation was sometimes coming back negative so we'd slice the array incorrectly, also cleaned up the errant console log.