### PR TITLE
groups: add necessary fields to create

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -84,9 +84,14 @@
       %group-create
     =+  !<(=create:g vase)
     =/  =flag:g  [our.bowl name.create]
-    =|  =cordon:g
+    ~!  members.create
+    =/  =fleet:g
+      %-  ~(run by members.create)
+      |=  sects=(set sect:g)
+      ^-  vessel:fleet:g
+      [sects now.bowl]
     =/  =group:g
-      [~ ~ ~ ~ ~ cordon title.create description.create image.create color.create] 
+      [fleet ~ ~ ~ ~ cordon.create title.create description.create image.create color.create] 
     =.  groups  (~(put by groups) flag *net:g group)
     go-abet:(go-init:(go-abed:group-core flag) create)
   ::

--- a/desk/lib/groups-json.hoon
+++ b/desk/lib/groups-json.hoon
@@ -265,6 +265,8 @@
         description+so
         image+so
         color+so
+        cordon+cordon
+        members+(op ;~(pfix sig fed:ag) (as sym))
     ==
   ::
   ++  join

--- a/desk/sur/groups.hoon
+++ b/desk/sur/groups.hoon
@@ -143,6 +143,8 @@
       description=cord
       image=cord  
       color=cord
+      =cordon
+      members=(jug ship sect)
   ==
 ::
 +$  init  [=time =group]


### PR DESCRIPTION
@patosullivan 
adds two fields to group-create poke
```
...
cordon: {
  open: {
    ships: [],
    ranks: []
  }
},
members: {
  "~zod": ["admin"]
}
```
alternatively, cordon can be instead of `open:`
```
shut: []
```
needs further work to actually invite ships