### PR TITLE
vscroll: load newer messages onScroll in ascending direction

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -100,7 +100,9 @@ export default function ChatScroller({
   const fetchMessages = useCallback(
     async (newer: boolean) => {
       if (newer) {
-        return true;
+        return useChatState
+          .getState()
+          .fetchNewer(whom, MESSAGE_FETCH_PAGE_SIZE.toString());
       }
 
       return useChatState

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -44,19 +44,31 @@ const sortByUd = (aString: string, bString: string) => {
   return a.compare(b);
 };
 
+const emptyChatWritsSet = {};
+
 const chatWritsSet1 = makeFakeChatWrits(0);
-const startIndexSet1 = Object.keys(chatWritsSet1).sort(sortByUd)[0];
-const set1Da = startIndexSet1;
+const chatWritsSet1Keys = Object.keys(chatWritsSet1).sort(sortByUd);
+const startIndexSet1 = chatWritsSet1Keys[0];
+const set1StartDa = startIndexSet1;
+const set1EndDa = chatWritsSet1Keys[chatWritsSet1Keys.length - 1];
 
 const chatWritsSet2 = makeFakeChatWrits(1);
-const startIndexSet2 = Object.keys(chatWritsSet2).sort(sortByUd)[0];
-const set2Da = startIndexSet2;
+const chatWritsSet2Keys = Object.keys(chatWritsSet2).sort(sortByUd);
+const startIndexSet2 = chatWritsSet2Keys[0];
+const set2StartDa = startIndexSet2;
+const set2EndDa = chatWritsSet2Keys[chatWritsSet2Keys.length - 1];
 
 const chatWritsSet3 = makeFakeChatWrits(2);
-const startIndexSet3 = Object.keys(chatWritsSet3).sort(sortByUd)[0];
-const set3Da = startIndexSet3;
+const chatWritsSet3Keys = Object.keys(chatWritsSet3).sort(sortByUd);
+const startIndexSet3 = chatWritsSet3Keys[0];
+const set3StartDa = startIndexSet3;
+const set3EndDa = chatWritsSet3Keys[chatWritsSet3Keys.length - 1];
 
 const chatWritsSet4 = makeFakeChatWrits(3);
+const chatWritsSet4Keys = Object.keys(chatWritsSet4).sort(sortByUd);
+const startIndexSet4 = chatWritsSet4Keys[0];
+const set4StartDa = startIndexSet4;
+const set4EndDa = chatWritsSet4Keys[chatWritsSet4Keys.length - 1];
 
 const fakeDefaultSub = {
   action: 'subscribe',
@@ -279,24 +291,57 @@ const chat: Handler[] = [
   },
 ];
 
-const olderChats: Handler[] = [
+const newerChats: ScryHandler[] = [
   {
     action: 'scry' as const,
-    path: `/chat/:ship/:name/writs/older/${set1Da}/100`,
+    path: `/chat/:ship/:name/writs/newer/${set1EndDa}/100`,
+    app: 'chat',
+    func: () => emptyChatWritsSet,
+  },
+  {
+    action: 'scry' as const,
+    path: `/chat/:ship/:name/writs/newer/${set2EndDa}/100`,
+    app: 'chat',
+    func: () => chatWritsSet1,
+  },
+  {
+    action: 'scry' as const,
+    path: `/chat/:ship/:name/writs/newer/${set3EndDa}/100`,
     app: 'chat',
     func: () => chatWritsSet2,
   },
   {
     action: 'scry' as const,
-    path: `/chat/:ship/:name/writs/older/${set2Da}/100`,
+    path: `/chat/:ship/:name/writs/newer/${set4EndDa}/100`,
+    app: 'chat',
+    func: () => chatWritsSet3,
+  },
+];
+
+const olderChats: ScryHandler[] = [
+  {
+    action: 'scry' as const,
+    path: `/chat/:ship/:name/writs/older/${set1StartDa}/100`,
+    app: 'chat',
+    func: () => chatWritsSet2,
+  },
+  {
+    action: 'scry' as const,
+    path: `/chat/:ship/:name/writs/older/${set2StartDa}/100`,
     app: 'chat',
     func: () => chatWritsSet3,
   },
   {
     action: 'scry' as const,
-    path: `/chat/:ship/:name/writs/older/${set3Da}/100`,
+    path: `/chat/:ship/:name/writs/older/${set3StartDa}/100`,
     app: 'chat',
     func: () => chatWritsSet4,
+  },
+  {
+    action: 'scry' as const,
+    path: `/chat/:ship/:name/writs/older/${set4StartDa}/100`,
+    app: 'chat',
+    func: () => emptyChatWritsSet,
   },
 ];
 
@@ -314,23 +359,55 @@ const dms: Handler[] = [
     app: 'chat',
     func: () => chatWritsSet1,
   },
+  // newer
   {
     action: 'scry' as const,
-    path: `/dm/:ship/writs/older/${set1Da}/100`,
+    path: `/dm/:ship/writs/newer/${set1EndDa}/100`,
+    app: 'chat',
+    func: () => emptyChatWritsSet,
+  },
+  {
+    action: 'scry' as const,
+    path: `/dm/:ship/writs/newer/${set2EndDa}/100`,
+    app: 'chat',
+    func: () => chatWritsSet1,
+  },
+  {
+    action: 'scry' as const,
+    path: `/dm/:ship/writs/newer/${set3EndDa}/100`,
     app: 'chat',
     func: () => chatWritsSet2,
   },
   {
     action: 'scry' as const,
-    path: `/dm/:ship/writs/older/${set2Da}/100`,
+    path: `/dm/:ship/writs/newer/${set4EndDa}/100`,
+    app: 'chat',
+    func: () => chatWritsSet3,
+  },
+  // older
+  {
+    action: 'scry' as const,
+    path: `/dm/:ship/writs/older/${set1StartDa}/100`,
+    app: 'chat',
+    func: () => chatWritsSet2,
+  },
+  {
+    action: 'scry' as const,
+    path: `/dm/:ship/writs/older/${set2StartDa}/100`,
     app: 'chat',
     func: () => chatWritsSet3,
   },
   {
     action: 'scry' as const,
-    path: `/dm/:ship/writs/older/${set3Da}/100`,
+    path: `/dm/:ship/writs/older/${set3StartDa}/100`,
     app: 'chat',
     func: () => chatWritsSet4,
+  },
+  {
+    action: 'scry' as const,
+    path: `/dm/:ship/writs/older/${set4StartDa}/100`,
+    app: 'chat',
+    func: () => emptyChatWritsSet,
   },
   {
     action: 'scry',
@@ -545,6 +622,6 @@ const mockHandlers: Handler[] = (
       }),
     },
   ] as Handler[]
-).concat(groups, chat, dms, olderChats, clubHandlers);
+).concat(groups, chat, dms, newerChats, olderChats, clubHandlers);
 
 export default mockHandlers;

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -125,7 +125,6 @@ export const useChatState = create<ChatState>(
             draft.pinnedDms = draft.pinnedDms.filter((s) => s !== ship);
           }
         });
-
         await api.poke({
           app: 'chat',
           mark: 'dm-pin',
@@ -221,6 +220,23 @@ export const useChatState = create<ChatState>(
             });
           },
         });
+      },
+      fetchNewer: async (whom: string, count: string) => {
+        const isDM = whomIsDm(whom);
+        if (isDM) {
+          return makeWritsStore(
+            whom,
+            get,
+            `/dm/${whom}/writs`,
+            `/dm/${whom}/ui`
+          ).getNewer(count);
+        }
+        return makeWritsStore(
+          whom,
+          get,
+          `/chat/${whom}/writs`,
+          `/chat/${whom}/ui/writs`
+        ).getNewer(count);
       },
       fetchOlder: async (whom: string, count: string) => {
         const isDM = whomIsDm(whom);

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -42,6 +42,7 @@ export interface ChatState {
   start: () => Promise<void>;
   dmRsvp: (ship: string, ok: boolean) => Promise<void>;
   getDraft: (whom: string) => void;
+  fetchNewer: (ship: string, count: string) => Promise<boolean>;
   fetchOlder: (ship: string, count: string) => Promise<boolean>;
   draft: (whom: string, story: ChatStory) => Promise<void>;
   joinChat: (flag: string) => Promise<void>;

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -6,6 +6,7 @@ import { ChatState } from './type';
 
 interface WritsStore {
   initialize: () => Promise<void>;
+  getNewer: (count: string) => Promise<boolean>;
   getOlder: (count: string) => Promise<boolean>;
 }
 
@@ -91,6 +92,42 @@ export default function makeWritsStore(
           });
         },
       });
+    },
+    getNewer: async (count: string) => {
+      // TODO: fix for group chats
+      const { pacts } = get();
+      const pact = pacts[whom];
+
+      const oldMessagesSize = pact.writs.size ?? 0;
+      if (oldMessagesSize === 0) {
+        // already loading the graph
+        return false;
+      }
+
+      const index = pact.writs.peekLargest()?.[0];
+      if (!index) {
+        return false;
+      }
+
+      const fetchStart = decToUd(pact.writs.peekLargest()[0].toString());
+
+      const writs = await api.scry<ChatWrits>({
+        app: 'chat',
+        path: `${scryPath}/newer/${fetchStart}/${count}`,
+      });
+
+      get().batchSet((draft) => {
+        Object.keys(writs).forEach((key) => {
+          const writ = writs[key];
+          const tim = bigInt(udToDec(key));
+          pact.writs = pact.writs.set(tim, writ);
+          pact.index[writ.seal.id] = tim;
+        });
+        draft.pacts[whom] = pact;
+      });
+
+      const newMessageSize = get().pacts[whom].writs.size;
+      return newMessageSize !== oldMessagesSize;
     },
     getOlder: async (count: string) => {
       // TODO: fix for group chats


### PR DESCRIPTION
This change uses the `/newer` endpoint added in #385. It resolves #380.