### PR TITLE
nav: fixes pinned heights in groups; unify chat

### DIFF
--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -123,7 +123,7 @@ function GroupItemContainer({
     <li
       ref={drop}
       className={cn(
-        'relative flex h-10 w-full ring-4',
+        'relative flex h-16 w-full ring-4 sm:h-10',
         isOver && 'ring-blue-500',
         !isOver && 'ring-transparent'
       )}
@@ -209,7 +209,7 @@ export default function GroupList({
           : undefined
       }
     >
-      <li className="flex items-center space-x-2 px-2 py-3">
+      <li className="-mb-2 flex items-center sm:m-0 md:pr-2">
         <Divider>Pinned</Divider>
         <div className="grow border-b-2 border-gray-100" />
       </li>

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -21,7 +21,7 @@ export default function MobileSidebar() {
     <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-r-2 border-gray-50 bg-white">
       <header className="flex-none px-2 py-1">
         {pinned ? (
-          <ul>
+          <ul className="mb-3 space-y-2 sm:mb-2 sm:space-y-0 md:mb-0">
             <GroupList pinned />
           </ul>
         ) : null}

--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -63,7 +63,7 @@ function DMSidebarItem({ whom, brief, pending }: MessagesSidebarItemProps) {
       to={`/dm/${whom}`}
       icon={
         pending ? (
-          <UnknownAvatarIcon className="h-12 w-12 rounded-md text-blue sm:h-6 sm:w-6" />
+          <UnknownAvatarIcon className="h-12 w-12 rounded-md text-blue md:h-6 md:w-6" />
         ) : (
           <Avatar size={isMobile ? 'default' : 'xs'} ship={whom} />
         )
@@ -100,7 +100,7 @@ export function MultiDMSidebarItem({
       to={`/dm/${whom}`}
       icon={
         pending ? (
-          <UnknownAvatarIcon className="h-12 w-12 rounded-md text-blue sm:h-6 sm:w-6" />
+          <UnknownAvatarIcon className="h-12 w-12 rounded-md text-blue md:h-6 md:w-6" />
         ) : (
           <MultiDmAvatar {...club?.meta} size={isMobile ? 'default' : 'xs'} />
         )

--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -2,21 +2,22 @@ import React, { useMemo } from 'react';
 import cn from 'classnames';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Link } from 'react-router-dom';
-import CaretDown16Icon from '../components/icons/CaretDown16Icon';
-import ChatSmallIcon from '../components/icons/ChatSmallIcon';
-import PersonSmallIcon from '../components/icons/Person16Icon';
-import CmdSmallIcon from '../components/icons/CmdSmallIcon';
-import MessagesList from './MessagesList';
-import useNavStore from '../components/Nav/useNavStore';
-import AddIcon from '../components/icons/AddIcon';
-import useMessagesFilter, { filters } from './useMessagesFilter';
-import MessagesSidebarItem from './MessagesSidebarItem';
+import Divider from '@/components/Divider';
+import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
+import ChatSmallIcon from '@/components/icons/ChatSmallIcon';
+import PersonSmallIcon from '@/components/icons/Person16Icon';
+import CmdSmallIcon from '@/components/icons/CmdSmallIcon';
+import useNavStore from '@/components/Nav/useNavStore';
+import AddIcon from '@/components/icons/AddIcon';
 import {
   useBriefs,
   usePinned,
   usePinnedChats,
   usePinnedClubs,
-} from '../state/chat';
+} from '@/state/chat';
+import MessagesList from './MessagesList';
+import useMessagesFilter, { filters } from './useMessagesFilter';
+import MessagesSidebarItem from './MessagesSidebarItem';
 
 export default function MobileMessagesSidebar() {
   const { filter, setFilter } = useMessagesFilter();
@@ -30,6 +31,23 @@ export default function MobileMessagesSidebar() {
         'fixed top-0 left-0 z-40 flex h-full w-full flex-col border-r-2 border-gray-50 bg-white'
       )}
     >
+      {pinned && pinned.length > 0 ? (
+        <div className="-mb-2 md:mb-0">
+          <div className="-mb-2 flex items-center p-2 md:m-0">
+            <Divider>Pinned</Divider>
+            <div className="grow border-b-2 border-gray-100" />
+          </div>
+          <div className="flex flex-col space-y-2 px-2 pb-2">
+            {pinned.map((ship: string) => (
+              <MessagesSidebarItem
+                key={ship}
+                whom={ship}
+                brief={briefs[ship]}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
       <header className="flex flex-none items-center justify-between px-2 py-1">
         <DropdownMenu.Root>
           <DropdownMenu.Trigger
@@ -82,27 +100,6 @@ export default function MobileMessagesSidebar() {
           <AddIcon className="h-6 w-6 text-gray-600" />
         </Link>
       </header>
-      {pinned && pinned.length > 0 ? (
-        <>
-          <div className="mb-1 flex items-center space-x-2 px-4 pt-2">
-            <span className="text-sm font-semibold text-gray-400">Pinned</span>
-            <div className="grow border-b-2 border-gray-100" />
-          </div>
-          <div className="flex flex-col space-y-2 px-2 pb-2">
-            {pinned.map((ship: string) => (
-              <MessagesSidebarItem
-                key={ship}
-                whom={ship}
-                brief={briefs[ship]}
-              />
-            ))}
-          </div>
-          <div
-            className="border-b-2 border-gray-100 px-2"
-            style={{ width: 'calc(100% - 2rem)', margin: '0 auto 0.5rem' }}
-          />
-        </>
-      ) : null}
       <MessagesList filter={filter} />
     </nav>
   );


### PR DESCRIPTION
Evenly spaces pinned Groups in the mobile nav. Situates pinned items above the main navigation in Chat, mirroring the Groups pattern. Prevents spacing regressions in desktop-sized viewports.

![localhost_3000_(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/748181/178765435-433a16c2-f249-4b65-9e18-ce60aeabd575.png)
![localhost_3000_(iPhone 12 Pro)](https://user-images.githubusercontent.com/748181/178765439-4bbd1ae1-e55b-4751-a1ae-c6caf3461d1f.png)

