### PR TITLE
chat/mobile: navigate to / on back from DM

### DIFF
--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -8,7 +8,7 @@ import ChatSmallIcon from '@/components/icons/ChatSmallIcon';
 import PersonSmallIcon from '@/components/icons/Person16Icon';
 import CmdSmallIcon from '@/components/icons/CmdSmallIcon';
 import useNavStore from '@/components/Nav/useNavStore';
-import AddIcon from '@/components/icons/AddIcon';
+import NewMessageIcon from '@/components/icons/NewMessageIcon';
 import {
   useBriefs,
   usePinned,
@@ -96,8 +96,9 @@ export default function MobileMessagesSidebar() {
           to="/dm/new"
           onClick={() => navPrimary('hidden')}
           aria-label="New Direct Message"
+          className="mr-2"
         >
-          <AddIcon className="h-6 w-6 text-gray-600" />
+          <NewMessageIcon className="h-6 w-6 text-blue" />
         </Link>
       </header>
       <MessagesList filter={filter} />

--- a/ui/src/pages/Dm.tsx
+++ b/ui/src/pages/Dm.tsx
@@ -1,19 +1,36 @@
 import React, { useCallback, useEffect } from 'react';
 import cn from 'classnames';
 import { Outlet, useParams } from 'react-router';
-import ChatInput from '../chat/ChatInput/ChatInput';
-import Layout from '../components/Layout/Layout';
-import { useChatState, useDmIsPending, useDmMessages } from '../state/chat';
-import ChatWindow from '../chat/ChatWindow';
-import { useChatInfo } from '../chat/useChatStore';
-import DmInvite from '../dms/DmInvite';
-import Avatar from '../components/Avatar';
-import DmOptions from '../dms/DMOptions';
-import { useContact } from '../state/contact';
-import CaretLeftIcon from '../components/icons/CaretLeftIcon';
-import { useIsMobile } from '../logic/useMedia';
-import DMHero from '../dms/DMHero';
-import useNavStore from '../components/Nav/useNavStore';
+import { Link } from 'react-router-dom';
+import ChatInput from '@/chat/ChatInput/ChatInput';
+import Layout from '@/components/Layout/Layout';
+import { useChatState, useDmIsPending, useDmMessages } from '@/state/chat';
+import ChatWindow from '@/chat/ChatWindow';
+import { useChatInfo } from '@/chat/useChatStore';
+import DmInvite from '@/dms/DmInvite';
+import Avatar from '@/components/Avatar';
+import DmOptions from '@/dms/DMOptions';
+import { useContact } from '@/state/contact';
+import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import { useIsMobile } from '@/logic/useMedia';
+import DMHero from '@/dms/DMHero';
+import useNavStore from '@/components/Nav/useNavStore';
+
+function BackLink({
+  children,
+  mobile,
+}: {
+  children: React.ReactNode;
+  mobile: boolean;
+}) {
+  return mobile ? (
+    <Link className="no-underline" to="/">
+      {children}
+    </Link>
+  ) : (
+    <div>{children}</div>
+  );
+}
 
 export default function Dm() {
   const ship = useParams<{ ship: string }>().ship!;
@@ -44,31 +61,34 @@ export default function Dm() {
       className="h-full grow"
       header={
         <div className="flex h-full items-center justify-between border-b-2 border-gray-50 p-2">
-          <button
-            className={cn(
-              'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
-              isMobile && '-ml-2 flex items-center rounded-lg hover:bg-gray-50'
-            )}
-            onClick={() => isMobile && navPrimary('dm')}
-            aria-label="Open Messages Menu"
-          >
-            {isMobile ? (
-              <CaretLeftIcon className="mr-1 h-5 w-5 text-gray-500" />
-            ) : null}
-            <div className="flex items-center space-x-3">
-              <Avatar size="small" ship={ship} />
-              <div className="flex flex-col items-start">
-                {contact?.nickname ? (
-                  <>
-                    <span className="font-semibold">{contact.nickname}</span>
-                    <span className="text-gray-600">{ship}</span>
-                  </>
-                ) : (
-                  <span className="font-semibold">{ship}</span>
-                )}
+          <BackLink mobile={isMobile}>
+            <button
+              className={cn(
+                'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
+                isMobile &&
+                  '-ml-2 flex items-center rounded-lg hover:bg-gray-50'
+              )}
+              onClick={() => isMobile && navPrimary('dm')}
+              aria-label="Open Messages Menu"
+            >
+              {isMobile ? (
+                <CaretLeftIcon className="mr-1 h-5 w-5 text-gray-500" />
+              ) : null}
+              <div className="flex items-center space-x-3">
+                <Avatar size="small" ship={ship} />
+                <div className="flex flex-col items-start">
+                  {contact?.nickname ? (
+                    <>
+                      <span className="font-semibold">{contact.nickname}</span>
+                      <span className="text-gray-600">{ship}</span>
+                    </>
+                  ) : (
+                    <span className="font-semibold">{ship}</span>
+                  )}
+                </div>
               </div>
-            </div>
-          </button>
+            </button>
+          </BackLink>
           {canStart ? (
             <DmOptions whom={ship} pending={!isAccepted} alwaysShowEllipsis />
           ) : null}


### PR DESCRIPTION
Navigates the user back to / when they tap the ship name + caret in the header of a DM.

Also swaps the black + on mobile to our blue NewMessageIcon.