### PR TITLE
channel: add create channel modal

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -11,7 +11,6 @@ import { ErrorBoundary } from 'react-error-boundary';
 import Groups from '@/groups/Groups';
 import Channel from '@/pages/Channel';
 import { useGroupState } from '@/state/groups';
-import NewChannel from '@/pages/NewChannel';
 import Members from '@/pages/Members';
 import Roles from '@/pages/Roles';
 import { useChatState } from '@/state/chat';
@@ -40,6 +39,7 @@ import GroupMemberManager from '@/groups/GroupAdmin/GroupMemberManager';
 import GroupInfo from '@/groups/GroupAdmin/GroupInfo';
 import NewGroup from '@/groups/NewGroup/NewGroup';
 import MultiDMEditModal from './dms/MultiDMEditModal';
+import NewChannel from './channels/NewChannel/NewChannel';
 
 interface RoutesProps {
   state: { backgroundLocation?: Location } | null;
@@ -108,7 +108,6 @@ function GroupsRoutes({ state, location }: RoutesProps) {
             path="channels/:app/:chShip/:chName/settings"
             element={<ChannelSettings />}
           />
-          <Route path="channels/new" element={<NewChannel />} />
         </Route>
       </Routes>
       {state?.backgroundLocation ? (
@@ -119,6 +118,10 @@ function GroupsRoutes({ state, location }: RoutesProps) {
             <Route path="invite" element={<GroupInviteDialog />} />
           </Route>
           <Route path="/gangs/:ship/:name" element={<GangModal />} />
+          <Route
+            path="/groups/:ship/:name/channels/new"
+            element={<NewChannel />}
+          />
         </Routes>
       ) : null}
     </>

--- a/ui/src/channels/NewChannel/NewChannel.test.tsx
+++ b/ui/src/channels/NewChannel/NewChannel.test.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from '../../../test/utils';
+import NewChannel from './NewChannel';
+
+describe('NewChannel', () => {
+  it('renders as expected', () => {
+    const { asFragment } = render(<NewChannel />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/ui/src/channels/NewChannel/NewChannel.tsx
+++ b/ui/src/channels/NewChannel/NewChannel.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Dialog, { DialogContent } from '@/components/Dialog';
+import { useDismissNavigate } from '@/logic/routing';
+import NewChannelForm from './NewChannelForm';
+
+export default function NewChannel() {
+  const dismiss = useDismissNavigate();
+
+  const onOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      dismiss();
+    }
+  };
+
+  return (
+    <Dialog defaultOpen onOpenChange={onOpenChange}>
+      <DialogContent containerClass="w-full sm:max-w-lg">
+        <NewChannelForm />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
-import { useChatState } from '../state/chat';
-import { useRouteGroup } from '../state/groups/groups';
-import { strToSym } from '../logic/utils';
+import { useChatState } from '../../state/chat';
+import { useRouteGroup } from '../../state/groups/groups';
+import { channelHref, strToSym } from '../../logic/utils';
 
 interface FormSchema {
   title: string;
   description: string;
 }
 
-export default function NewChannel() {
+export default function NewChannelForm() {
   const group = useRouteGroup();
   const navigate = useNavigate();
+  const flag = useRouteGroup();
   const defaultValues: FormSchema = {
     title: '',
     description: '',
@@ -23,7 +24,7 @@ export default function NewChannel() {
     await useChatState
       .getState()
       .create({ ...values, name, group, readers: [] });
-    navigate(`../channels/chat/${window.our}/${name}`);
+    navigate(channelHref(flag, name));
   };
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">

--- a/ui/src/channels/NewChannel/__snapshots__/NewChannel.test.tsx.snap
+++ b/ui/src/channels/NewChannel/__snapshots__/NewChannel.test.tsx.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1
+
+exports[`NewChannel > renders as expected 1`] = `
+<DocumentFragment>
+  <div
+    aria-hidden="true"
+    class="fixed inset-0 z-30 transform-gpu bg-black opacity-30"
+    data-aria-hidden="true"
+    data-state="open"
+    style="pointer-events: auto;"
+  />
+  <section
+    aria-describedby="radix-2"
+    aria-labelledby="radix-1"
+    class="dialog-container w-full sm:max-w-lg"
+    data-state="open"
+    id="radix-0"
+    role="dialog"
+    style="pointer-events: auto;"
+    tabindex="-1"
+  >
+    <div
+      class="dialog"
+    >
+      <form
+        class="flex flex-col"
+      >
+        <div
+          class="p-2"
+        >
+          <label
+            for="title"
+          >
+            Title
+          </label>
+          <input
+            class="rounded border"
+            name="title"
+            type="text"
+          />
+        </div>
+        <div
+          class="p-2"
+        >
+          <label
+            for="description"
+          >
+            Description
+          </label>
+          <input
+            class="rounded border"
+            name="description"
+            type="text"
+          />
+        </div>
+        <button
+          type="submit"
+        >
+          Submit
+        </button>
+      </form>
+      <button
+        class="icon-button absolute top-6 right-6"
+        type="button"
+      >
+        <svg
+          class="h-4 w-4"
+          fill="none"
+          viewBox="0 0 16 16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class="stroke-current"
+            d="m8 8 4-4M8 8 4 4m4 4-4 4m4-4 4 4"
+            stroke-linecap="round"
+            stroke-width="2"
+          />
+        </svg>
+      </button>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { useIsMobile } from '../../logic/useMedia';
-import { useGroup } from '../../state/groups/groups';
-import useNavStore from '../../components/Nav/useNavStore';
-import CaretLeft16Icon from '../../components/icons/CaretLeft16Icon';
-// import MagnifyingGlass from '../../components/icons/MagnifyingGlass16Icon';
-import AsteriskIcon from '../../components/icons/Asterisk16Icon';
-import HashIcon16 from '../../components/icons/HashIcon16';
+import { useLocation } from 'react-router';
+import { useIsMobile } from '@/logic/useMedia';
+import { useGroup } from '@/state/groups/groups';
+import useNavStore from '@/components/Nav/useNavStore';
+import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
+import AsteriskIcon from '@/components/icons/Asterisk16Icon';
+import HashIcon16 from '@/components/icons/HashIcon16';
+import ActivityIndicator from '@/components/Sidebar/ActivityIndicator';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import AddIcon16 from '@/components/icons/Add16Icon';
 import MobileGroupSidebar from './MobileGroupSidebar';
 import ChannelList from './ChannelList';
-import ActivityIndicator from '../../components/Sidebar/ActivityIndicator';
-import SidebarItem from '../../components/Sidebar/SidebarItem';
 import GroupAvatar from '../GroupAvatar';
 import GroupActions from '../GroupActions';
 import './GroupSidebar.css';
@@ -17,6 +18,7 @@ import './GroupSidebar.css';
 export default function GroupSidebar() {
   const flag = useNavStore((state) => state.flag);
   const group = useGroup(flag);
+  const location = useLocation();
   const isMobile = useIsMobile();
   const navPrimary = useNavStore((state) => state.navigatePrimary);
   // TODO: get activity count from hark store
@@ -69,6 +71,15 @@ export default function GroupSidebar() {
             to={`/groups/${flag}/all`}
           >
             All Channels
+          </SidebarItem>
+          <SidebarItem
+            color="text-green"
+            highlight="bg-green-soft dark:bg-green-900 hover:bg-green-soft hover:dark:bg-green-900"
+            icon={<AddIcon16 className="m-1 h-4 w-4" />}
+            to={`/groups/${flag}/channels/new`}
+            state={{ backgroundLocation: location }}
+          >
+            Create Channel
           </SidebarItem>
           <a
             className="no-underline"

--- a/ui/src/groups/GroupSidebar/__snapshots__/GroupSidebar.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/GroupSidebar.test.tsx.snap
@@ -119,6 +119,34 @@ exports[`GroupSidebar > renders as expected 1`] = `
             </div>
           </a>
         </li>
+        <li
+          class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold sm:text-base text-green hover:bg-green-soft hover:dark:bg-green-900"
+        >
+          <a
+            class="default-focus flex w-full flex-1 items-center space-x-3 rounded-lg p-2 font-semibold"
+            href="/groups//channels/new"
+          >
+            <svg
+              class="m-1 h-4 w-4"
+              fill="none"
+              viewBox="0 0 16 16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="stroke-current"
+                d="M3 8h10M8 3v10"
+                stroke-linecap="round"
+                stroke-width="2"
+              />
+            </svg>
+            <div
+              class="max-w-full flex-1 truncate text-left"
+              title="Create Channel"
+            >
+              Create Channel
+            </div>
+          </a>
+        </li>
         <a
           class="no-underline"
           href="https://github.com/tloncorp/homestead/issues/new?assignees=&labels=bug&template=bug_report.md&title=groups:"


### PR DESCRIPTION
# Context

Adds a debug-quality modal for creating a new channel. This is a pre-req for #229 (Channel Index).

# Changes

- add NewChannelForm, NewChannel modal
- test coverage

# Preview

**Create Channel button in sidebar**
![image](https://user-images.githubusercontent.com/16504501/178802155-f469d406-f00d-4ccd-a30f-26faf37bfbf6.png)

**Create Channel modal (it's beautiful!)**
![image](https://user-images.githubusercontent.com/16504501/178802598-8f39671c-0344-4911-b601-7edf69397400.png)

# TODO

- [ ] navigate to newly created channel
- [ ] trigger resubscribe after creation? sometimes a refresh is needed to update the sidebar listing of channels
- [ ] mock handler