### PR TITLE
chat-input: better use of debounce + hooks

### DIFF
--- a/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
+++ b/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
@@ -1,0 +1,68 @@
+// Vitest Snapshot v1
+
+exports[`ChatInput > renders as expected 1`] = `
+<DocumentFragment>
+  <div
+    class="flex w-full items-end space-x-2"
+  >
+    <div
+      class="flex-1"
+    >
+      <div
+        class="flex items-center justify-end"
+      >
+        <div
+          class="input block p-0 w-full"
+        >
+          <div
+            class="w-full"
+          >
+            <div
+              aria-label="Message editor with formatting menu"
+              class="ProseMirror input-inner"
+              contenteditable="true"
+              tabindex="0"
+              translate="no"
+            >
+              <p
+                class="is-empty is-editor-empty"
+                data-placeholder="Message"
+              >
+                <br
+                  class="ProseMirror-trailingBreak"
+                />
+              </p>
+            </div>
+          </div>
+          <div
+            class="pointer-events-none fixed"
+          />
+        </div>
+        <button
+          aria-label="Add attachment"
+          class="absolute mr-2 text-gray-600 hover:text-gray-800"
+        >
+          <svg
+            class="h-6 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              class="stroke-current"
+              d="M4 12h16m-8-8v16"
+              stroke-linecap="round"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <button
+      class="button"
+    >
+      Send
+    </button>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
My poor construction meant that we'd accidentally get stale closures and drafts end up saving for other ships. This fixes that #411.