### PR TITLE
groups: remove Create Channel sidebar action

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -8,7 +8,6 @@ import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import HashIcon16 from '@/components/icons/HashIcon16';
 import ActivityIndicator from '@/components/Sidebar/ActivityIndicator';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
-import AddIcon16 from '@/components/icons/Add16Icon';
 import MobileGroupSidebar from './MobileGroupSidebar';
 import ChannelList from './ChannelList';
 import GroupAvatar from '../GroupAvatar';
@@ -18,7 +17,6 @@ import './GroupSidebar.css';
 export default function GroupSidebar() {
   const flag = useNavStore((state) => state.flag);
   const group = useGroup(flag);
-  const location = useLocation();
   const isMobile = useIsMobile();
   const navPrimary = useNavStore((state) => state.navigatePrimary);
   // TODO: get activity count from hark store
@@ -71,15 +69,6 @@ export default function GroupSidebar() {
             to={`/groups/${flag}/channels`}
           >
             All Channels
-          </SidebarItem>
-          <SidebarItem
-            color="text-green"
-            highlight="bg-green-soft dark:bg-green-900 hover:bg-green-soft hover:dark:bg-green-900"
-            icon={<AddIcon16 className="m-1 h-4 w-4" />}
-            to={`/groups/${flag}/channels/new`}
-            state={{ backgroundLocation: location }}
-          >
-            Create Channel
           </SidebarItem>
           <a
             className="no-underline"

--- a/ui/src/groups/GroupSidebar/__snapshots__/GroupSidebar.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/GroupSidebar.test.tsx.snap
@@ -119,34 +119,6 @@ exports[`GroupSidebar > renders as expected 1`] = `
             </div>
           </a>
         </li>
-        <li
-          class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold sm:text-base text-green hover:bg-green-soft hover:dark:bg-green-900"
-        >
-          <a
-            class="default-focus flex w-full flex-1 items-center space-x-3 rounded-lg p-2 font-semibold"
-            href="/groups//channels/new"
-          >
-            <svg
-              class="m-1 h-4 w-4"
-              fill="none"
-              viewBox="0 0 16 16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                class="stroke-current"
-                d="M3 8h10M8 3v10"
-                stroke-linecap="round"
-                stroke-width="2"
-              />
-            </svg>
-            <div
-              class="max-w-full flex-1 truncate text-left"
-              title="Create Channel"
-            >
-              Create Channel
-            </div>
-          </a>
-        </li>
         <a
           class="no-underline"
           href="https://github.com/tloncorp/homestead/issues/new?assignees=&labels=bug&template=bug_report.md&title=groups:"


### PR DESCRIPTION
# Context

In light of #416, this button is now longer needed since it now lives in the Group Info > Channels menu.

# Preview

![image](https://user-images.githubusercontent.com/16504501/180070988-93aa48d6-baee-4e9f-85b2-a446f82737eb.png)
