### PR TITLE
chat: make %inline-code not recursive

### DIFF
--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -225,10 +225,10 @@
         %break
       ~
     ::
-        ?(%italics %bold %strike %inline-code)
+        ?(%italics %bold %strike)
       (inline p.i)
     ::
-        ?(%code %tag)
+        ?(%code %tag %inline-code)
       s+p.i
     ::
         %blockquote
@@ -499,7 +499,7 @@
     :~  italics/inline
         bold/inline
         strike/inline
-        inline-code/inline
+        inline-code/so
         code/so
         blockquote/(ar inline)
         tag/so

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -158,7 +158,7 @@
   $%  [%italics p=inline]
       [%bold p=inline]
       [%strike p=inline]
-      [%inline-code p=inline]
+      [%inline-code p=cord]
       [%blockquote p=(list inline)]
       [%block p=@ud q=cord]
       [%code p=cord]

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -34,7 +34,7 @@ export interface Break {
 }
 
 export interface InlineCode {
-  'inline-code': ChatInline;
+  'inline-code': string;
 }
 
 export interface BlockCode {


### PR DESCRIPTION
pointed out by the excellent @Fang- 
am I missing any reason why %inline-code should be recursive?