### PR TITLE
chat: show group img/color in Channels sidebar

### DIFF
--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -6,7 +6,7 @@ import DmOptions from './DMOptions';
 import UnknownAvatarIcon from '../components/icons/UnknownAvatarIcon';
 import { ChatBrief } from '../types/chat';
 import { useMultiDm } from '../state/chat';
-import { useChannel, useGroupState } from '../state/groups/groups';
+import { useChannel, useGroup, useGroupState } from '../state/groups/groups';
 import { useIsMobile } from '../logic/useMedia';
 import useNavStore from '../components/Nav/useNavStore';
 import GroupAvatar from '../groups/GroupAvatar';
@@ -29,16 +29,16 @@ function ChannelSidebarItem({ whom, brief }: MessagesSidebarItemProps) {
     ([k, v]) => whom in v.channels
   )?.[0];
   const channel = useChannel(groupFlag || '', whom);
+  const group = useGroup(groupFlag || '');
 
   if (!channel) {
     return null;
   }
 
-  const img = channel.meta.image;
   return (
     <SidebarItem
       to={`/groups/${groupFlag}/channels/chat/${whom}`}
-      icon={<GroupAvatar size="h-12 w-12 sm:h-6 sm:w-6" {...channel.meta} />}
+      icon={<GroupAvatar size="h-12 w-12 sm:h-6 sm:w-6" {...group?.meta} />}
       actions={
         (brief?.count ?? 0) > 0 ? (
           <BulletIcon


### PR DESCRIPTION
OTT. Replaces the gray GroupAvatars for group chat channels in Chat.

![image](https://user-images.githubusercontent.com/748181/180786209-7cc1cdbe-1282-4556-9f7c-994aa9c9c9cf.png)
