### PR TITLE
Po/fix hidden member role in member management view

### DIFF
--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -24,7 +24,7 @@ import ElipsisCircleIcon from '../../components/icons/EllipsisCircleIcon';
 import LeaveIcon from '../../components/icons/LeaveIcon';
 import CheckIcon from '../../components/icons/CheckIcon';
 import CaretDown16Icon from '../../components/icons/CaretDown16Icon';
-import { getSectTitle } from '../../logic/utils';
+import { getSectTitle, toTitleCase } from '../../logic/utils';
 import { Vessel } from '../../types/groups';
 
 export default function GroupMemberManager() {
@@ -149,12 +149,7 @@ export default function GroupMemberManager() {
                 <Dropdown.Root>
                   <Dropdown.Trigger className="default-focus mr-2 flex items-center rounded px-2 py-1.5 text-gray-400">
                     {vessel.sects
-                      .map((s) => {
-                        const sectTitle = getSectTitle(group.cabals, s);
-                        return (
-                          sectTitle.charAt(0).toUpperCase() + sectTitle.slice(1)
-                        );
-                      })
+                      .map((s) => toTitleCase(getSectTitle(group.cabals, s)))
                       .join(', ')}
                     <CaretDown16Icon className="ml-2 h-4 w-4" />
                   </Dropdown.Trigger>


### PR DESCRIPTION
Fixes #460 

Per discussion with Liam in the kickoff today, every member is always a "Member", so the backend does not return that role. We're just going to show "Member" in the dropdown on the frontend for every user to reduce confusion.