### PR TITLE
channels: refactor Index to reflect Zone schema

### DIFF
--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -5,7 +5,7 @@ import cn from 'classnames';
 import { useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { useRouteGroup, useGroup, useAmAdmin } from '@/state/groups';
-import { Channel } from '@/types/groups';
+import { Channel, Zone } from '@/types/groups';
 import BubbleIcon from '@/components/icons/BubbleIcon';
 import { channelHref, nestToFlag } from '@/logic/utils';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
@@ -194,8 +194,14 @@ function ChannelSection({
   zone,
 }: {
   channels: [string, Channel][];
-  zone: string | null;
+  zone: Zone | null;
 }) {
+  const flag = useRouteGroup();
+  const group = useGroup(flag);
+  const sectionTitle =
+    zone && group?.zones && zone in group.zones
+      ? group.zones[zone].meta.title
+      : '';
   const sortedChannels = channels.slice();
   sortedChannels.sort(([, a], [, b]) =>
     a.meta.title.localeCompare(b.meta.title)
@@ -203,8 +209,8 @@ function ChannelSection({
 
   return (
     <>
-      {zone !== UNZONED ? (
-        <div className="py-4 font-semibold text-gray-400">{zone}</div>
+      {sectionTitle !== UNZONED ? (
+        <div className="py-4 font-semibold text-gray-400">{sectionTitle}</div>
       ) : null}
       <ul>
         {sortedChannels.map(([nest, channel]) => (


### PR DESCRIPTION
# Context

Since initial implementation, the backend `zone` schema was refactored. This change updates the UI to use the new schema and resolves #484.

# Changes

- ChannelIndex view uses new `zone.meta.title` schema

# Preview

## Before
![image](https://user-images.githubusercontent.com/16504501/181388214-de9e9b3d-a243-4349-87e3-c66445c704b9.png)

## After
![image](https://user-images.githubusercontent.com/16504501/182924281-897f8887-cc82-42ea-a63d-d45c1f6aa222.png)
