### PR TITLE
Fix missing chat channels in chatstead

### DIFF
--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -118,6 +118,8 @@ export default function MessagesSidebarItem({
   brief,
   pending,
 }: MessagesSidebarItemProps) {
+  const channelWhom = `chat/${whom}`;
+
   if (whomIsDm(whom)) {
     return <DMSidebarItem pending={pending} whom={whom} brief={brief} />;
   }
@@ -126,5 +128,5 @@ export default function MessagesSidebarItem({
     return <MultiDMSidebarItem whom={whom} brief={brief} pending={pending} />;
   }
 
-  return <ChannelSidebarItem whom={whom} brief={brief} />;
+  return <ChannelSidebarItem whom={channelWhom} brief={brief} />;
 }


### PR DESCRIPTION
Fixes #548 

After the flag -> nest changes we lost the list of chat channels in chatstead since those channels were appened with `chat/`, this fixes that.