### PR TITLE
groups/create: properly set default color

### DIFF
--- a/ui/src/groups/GroupInfoFields.tsx
+++ b/ui/src/groups/GroupInfoFields.tsx
@@ -60,6 +60,13 @@ export default function GroupInfoFields() {
     register('color');
   }, []); // eslint-disable-line
 
+  const handleColorIconType = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    setIconType('color');
+    setIconColor(defaultColor as string);
+    setValue('color', defaultColor);
+  };
+
   const handleCancelColorIcon = (e: React.SyntheticEvent) => {
     e.preventDefault();
     setIconType(undefined);
@@ -101,7 +108,7 @@ export default function GroupInfoFields() {
                     </span>
                     <span
                       className="pointer-events-auto text-blue"
-                      onClick={() => setIconType('color')}
+                      onClick={handleColorIconType}
                     >
                       {' '}
                       or choose fill color


### PR DESCRIPTION
Accepting the default group color (#000 if you're in light mode; #FFF if you're in dark mode) would not carry over through to the group creation step unless you modified the color field. This fixes that.

---

Before:
![image](https://user-images.githubusercontent.com/748181/183100053-81f4de56-423f-40fb-9ecc-1423e818305c.png)

... resulted in:

![image](https://user-images.githubusercontent.com/748181/183100175-6537e1bc-74eb-4995-b548-f4af234e2e4a.png)

---

After, accepting the same default:
![image](https://user-images.githubusercontent.com/748181/183100241-14ff8596-c701-44e5-8304-57ba93310c01.png)
