### PR TITLE
Chat: fix bug where group channels aren't rendering

### DIFF
--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -37,7 +37,7 @@ function ChannelSidebarItem({ whom, brief }: MessagesSidebarItemProps) {
 
   return (
     <SidebarItem
-      to={`/groups/${groupFlag}/channels/chat/${whom}`}
+      to={`/groups/${groupFlag}/channels/${whom}`}
       icon={<GroupAvatar size="h-12 w-12 sm:h-6 sm:w-6" {...group?.meta} />}
       actions={
         (brief?.count ?? 0) > 0 ? (


### PR DESCRIPTION
Chat channels weren't rendering because of a lingering bug from the switchover to `nest`