### PR TITLE
channels: use heap icon in sidebar and admin list

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,7 @@
   },
   "lint-staged": {
     "**/*.ts?(x)": [
-      "tsc-files --noEmit src/window.ts src/env.d.ts"
+      "tsc-files --noEmit src/window.ts src/env.d.ts src/global.d.ts"
     ],
     "*.{js,jsx,ts,tsx}": [
       "npm run lint:fix",

--- a/ui/src/groups/GroupAdmin/AdminChannels/AdminChannelListItem.tsx
+++ b/ui/src/groups/GroupAdmin/AdminChannels/AdminChannelListItem.tsx
@@ -3,14 +3,14 @@ import cn from 'classnames';
 import { DraggableProvided, DraggableStateSnapshot } from 'react-beautiful-dnd';
 import { GroupChannel } from '@/types/groups';
 import EditChannelModal from '@/groups/GroupAdmin/AdminChannels/EditChannelModal';
-import { useChat, useChatState } from '@/state/chat';
+import { useChatState } from '@/state/chat';
 import { useHeapState } from '@/state/heap/heap';
 import { useGroupState, useRouteGroup } from '@/state/groups';
 import SixDotIcon from '@/components/icons/SixDotIcon';
-import BubbleIcon from '@/components/icons/BubbleIcon';
 import { getPrivacyFromChannel, nestToFlag } from '@/logic/utils';
 import { Chat } from '@/types/chat';
 import { Heap } from '@/types/heap';
+import ChannelIcon from '@/channels/ChannelIcon';
 import AdminChannelListDropdown from './AdminChannelListDropdown';
 import DeleteChannelModal from './DeleteChannelModal';
 import { PRIVACY_TYPE } from './ChannelPermsSelector';
@@ -70,7 +70,7 @@ export default function AdminChannelListItem({
               <SixDotIcon className="mr-3 h-5 w-5 fill-gray-600" />
             </div>
             <div className="mr-3 flex h-8 w-8 items-center justify-center rounded bg-gray-50">
-              <BubbleIcon className="h-5 w-5 text-gray-400" />
+              <ChannelIcon nest={nest} className="h-5 w-5 text-gray-400" />
             </div>
             <div>
               <div className="flex items-center space-x-2">

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -5,7 +5,6 @@ import useAllBriefs from '@/logic/useAllBriefs';
 import { channelHref, nestToFlag } from '@/logic/utils';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroup } from '@/state/groups';
-import BubbleIcon from '@/components/icons/BubbleIcon';
 import useNavStore from '@/components/Nav/useNavStore';
 import CaretDownIcon from '@/components/icons/CaretDownIcon';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
@@ -14,6 +13,7 @@ import { DEFAULT } from '@/logic/useSidebarSort';
 import useChannelSections from '@/logic/useChannelSections';
 import { GroupChannel } from '@/types/groups';
 import Divider from '@/components/Divider';
+import ChannelIcon from '@/channels/ChannelIcon';
 import ChannelSortOptions from './ChannelSortOptions';
 
 const UNZONED = 'default';
@@ -37,36 +37,38 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
     }
   }, [navPrimary, isMobile]);
 
-  const icon = (active: boolean) =>
-    isMobile ? (
-      <span
-        className={cn(
-          'flex h-12 w-12 items-center justify-center rounded-md',
-          !active && 'bg-gray-50',
-          active && 'bg-white'
-        )}
-      >
-        <BubbleIcon className="h-6 w-6" />
-      </span>
-    ) : (
-      <BubbleIcon className="h-6 w-6" />
-    );
-
   if (!group) {
     return null;
   }
 
   const renderChannels = (channels: [string, GroupChannel][]) =>
-    channels.map(([nest, channel]) => (
-      <SidebarItem
-        key={nest}
-        icon={icon}
-        to={channelHref(flag, nest)}
-        onClick={hide}
-      >
-        {channel.meta.title || nest}
-      </SidebarItem>
-    ));
+    channels.map(([nest, channel]) => {
+      const icon = (active: boolean) =>
+        isMobile ? (
+          <span
+            className={cn(
+              'flex h-12 w-12 items-center justify-center rounded-md',
+              !active && 'bg-gray-50',
+              active && 'bg-white'
+            )}
+          >
+            <ChannelIcon nest={nest} className="h-6 w-6" />
+          </span>
+        ) : (
+          <ChannelIcon nest={nest} className="h-6 w-6" />
+        );
+
+      return (
+        <SidebarItem
+          key={nest}
+          icon={icon}
+          to={channelHref(flag, nest)}
+          onClick={hide}
+        >
+          {channel.meta.title || nest}
+        </SidebarItem>
+      );
+    });
 
   const unsectionedChannels = sortChannels(group.channels).filter(([n]) => {
     const [_app, f] = nestToFlag(n);

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -9,8 +9,7 @@ EditorView.prototype.updateState = function updateState(state) {
   }
   // (this as any).updateStateInner(state, this.state.plugins != state.plugins); //eslint-disable-line
   oldUpdateState.call(this, state);
-}
-
+};
 
 import React from 'react';
 import { render } from 'react-dom';
@@ -35,8 +34,6 @@ if (IS_MOCK) {
 }
 
 window.our = `~${window.ship}`;
-
-
 
 const root = document.getElementById('app') as HTMLElement;
 render(


### PR DESCRIPTION
# Changes

This change updates the ChannelList and AdminChannelListItem components to use the correct icon depending on the Channel's channel type. It also fixes an issue with the pre-commit script failing on `tsc`, and addresses a lint formatting issue.

# Preview

## Channel Sidebar
![image](https://user-images.githubusercontent.com/16504501/185044578-405ad6be-ca3d-4b4e-9814-70dca50a6cd2.png)

## Admin Channel List
![image](https://user-images.githubusercontent.com/16504501/185044608-f97292c6-6163-45c0-9ecc-9a1cc4ab8334.png)
