### PR TITLE
diary: update ChannelIcon to support Notebooks

### DIFF
--- a/ui/src/channels/ChannelIcon.tsx
+++ b/ui/src/channels/ChannelIcon.tsx
@@ -16,7 +16,7 @@ export default function ChannelIcon({ nest, ...rest }: ChannelIconProps) {
       return <BubbleIcon {...rest} />;
     case 'heap':
       return <ShapesIcon {...rest} />;
-    case 'note': // TODO: update to whatever app name is used for Notebooks
+    case 'diary':
       return <NotebookIcon {...rest} />;
     default:
       return <UnknownAvatarIcon {...rest} />;


### PR DESCRIPTION
# Changes

Renames the app name in ChannelIcon from `note` --> `diary`. This fixes the icon display in All Channels, Channel Sidebar, and Channel Admin views.

# Preview

## Sidebar
![image](https://user-images.githubusercontent.com/16504501/185283759-6a890013-bf65-4ba5-9273-4ca4a8c86fe1.png)

## All Channels
![image](https://user-images.githubusercontent.com/16504501/185283795-93396389-8ef5-4329-8860-b8a783593e84.png)

## Channels Admin
![image](https://user-images.githubusercontent.com/16504501/185283857-e90f0604-d24b-428c-864b-a3a9e98c0ec1.png)
