### PR TITLE
heap: persist input drafts

### DIFF
--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -46,7 +46,7 @@ export function useMessageEditor({
         priority: 999999,
         addKeyboardShortcuts() {
           return {
-            Enter: ({ editor }) => onEnter({ editor } as any),
+            Enter: ({ editor }) => onEnter({ editor } as HandlerParams),
             'Shift-Enter': ({ editor }) =>
               editor.commands.first(({ commands }) => [
                 () => commands.newlineInCode(),


### PR DESCRIPTION
# Context

This resolves #636 by persisting the input for new Heap items.

# Changes

- additional state hooks to persist draft Links and Text data

# Preview

https://user-images.githubusercontent.com/16504501/185683205-71bb369d-6fda-4d49-aeb5-fa2dded94261.mp4


