### PR TITLE
nav: channel link highlighting fix

### DIFF
--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -6,6 +6,10 @@ type SidebarProps = PropsWithChildren<{
   icon: React.ReactNode | ((active: boolean) => React.ReactNode);
   to?: string;
   actions?: React.ReactNode;
+  // This is used for links we want to keep in an
+  // "active" state even if the route is deeper than
+  // the link's 'to' attribute
+  inexact?: boolean;
   color?: string;
   div?: boolean;
   highlight?: string;
@@ -37,10 +41,12 @@ export default function SidebarItem({
   actions,
   className,
   children,
+  inexact = false,
   div = false,
   ...rest
 }: SidebarProps) {
-  const matches = useMatch(to || 'DONT_MATCH');
+  const matchString = to && inexact ? `${to}/*` : to;
+  const matches = useMatch(matchString || 'DONT_MATCH');
   const active = !!matches;
   const Wrapper = div ? 'div' : 'li';
 

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -64,6 +64,7 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
 
       return (
         <SidebarItem
+          inexact
           key={nest}
           icon={icon}
           to={channelHref(flag, nest)}

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -1,4 +1,3 @@
-
 import React, { Suspense, useCallback, useEffect } from 'react';
 import { Outlet, useParams, useNavigate } from 'react-router';
 import Layout from '@/components/Layout/Layout';
@@ -54,7 +53,6 @@ function HeapChannel() {
     useHeapState.getState().initialize(chFlag);
   }, [chFlag]);
 
-
   const navigateToDetail = useCallback(
     (time: bigInt.BigInteger) => {
       navigate(`curio/${time}`);
@@ -65,7 +63,6 @@ function HeapChannel() {
   useDismissChannelNotifications({
     markRead: useHeapState.getState().markRead,
   });
-
 
   return (
     <Layout


### PR DESCRIPTION
fixes #672. introduces the "inexact" flag for SidebarItem which can be used to maintain an active state on nested routes