### PR TITLE
heaps: keyboard navigation for carousel

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { useCurio, useHeapState, useOrderedCurios } from '@/state/heap/heap';
 import useNest from '@/logic/useNest';
 import Layout from '@/components/Layout/Layout';
@@ -9,12 +9,14 @@ import { Link } from 'react-router-dom';
 import bigInt from 'big-integer';
 import CaretRightIcon from '@/components/icons/CaretRightIcon';
 import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import { useEventListener } from 'usehooks-ts';
 import HeapDetailSidebarInfo from './HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo';
 import HeapDetailComments from './HeapDetail/HeapDetailSidebar/HeapDetailComments';
 import HeapDetailHeader from './HeapDetail/HeapDetailHeader';
 import HeapDetailBody from './HeapDetail/HeapDetailBody';
 
 export default function HeapDetail() {
+  const navigate = useNavigate();
   const groupFlag = useRouteGroup();
   const nest = useNest();
   const { idCurio } = useParams();
@@ -39,6 +41,14 @@ export default function HeapDetail() {
   useEffect(() => {
     useHeapState.getState().initialize(chFlag);
   }, [chFlag]);
+
+  useEventListener('keydown', (e) => {
+    if (hasPrev && e.key === 'ArrowRight') {
+      navigate(curioHref(prevCurio?.[0]));
+    } else if (hasNext && e.key === 'ArrowLeft') {
+      navigate(curioHref(nextCurio?.[0]));
+    }
+  });
 
   if (!curio || !time) {
     return null;


### PR DESCRIPTION
Use the left and right arrow keys to navigate through Curios in a Heap.

Leverages [`useEventListener` hook](https://usehooks-ts.com/react-hook/use-event-listener), which automatically removes the `keydown` event listener on unmount.