### PR TITLE
devex: forward ref for ChannelHeaderButton

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -24,21 +24,21 @@ export interface ChannelHeaderProps {
   isHeap?: boolean;
 }
 
-function ChannelHeaderButton({
-  children,
-  onClick,
-  className,
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-  className?: string;
-}) {
+const ChannelHeaderButton = React.forwardRef<
+  HTMLButtonElement,
+  React.HTMLProps<HTMLButtonElement>
+>((props, ref) => {
+  const { children, className, onClick } = props;
   return (
-    <button onClick={onClick} className={cn('secondary-button', className)}>
+    <button
+      ref={ref}
+      onClick={onClick}
+      className={cn('secondary-button', className)}
+    >
       {children}
     </button>
   );
-}
+});
 
 function ChannelHeaderMenuButton({
   children,


### PR DESCRIPTION
The parent radix-ui component expects its child to forward the ref. This resolves an error message in the JS console.

# Before

![image](https://user-images.githubusercontent.com/16504501/187563522-93702543-0f79-4a00-82e7-585554cd4348.png)


# After

gone :)