### PR TITLE
notify: use %uv consistently

### DIFF
--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -402,7 +402,7 @@
   =/  params=(list [@t @t])
     :~  identity+(rsh [3 1] (scot %p who))
         action+`@t`action.update
-        uid+(scot %ux uid.update)
+        uid+(scot %uv uid.update)
     ==
   %:  post-form
       /send-notification/(scot %uv (sham eny.bowl))


### PR DESCRIPTION
This has already been monkey patched in the only place that it matters (the provider ship), but should be fixed upstream.

Uses %uv to encode the ID of the yarn being notified about, given that hark supports fetching by %uv encoding only.
