### PR TITLE
Only show unread date divider if there is actually an unread message

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -70,7 +70,7 @@ const ChatMessage = React.memo<
 
       return (
         <div ref={ref} className="flex flex-col">
-          {unread ? (
+          {unread && unread.count > 0 ? (
             <DateDivider date={unix} unreadCount={unread.count} />
           ) : null}
           {newDay && !unread ? <DateDivider date={unix} /> : null}


### PR DESCRIPTION
Fixes #757 

Apparently we can sometimes have an unread object with an unread count of zero so we can't just check for the existence of the object itself.