### PR TITLE
app: move grid redirect to prevent resubscribing on navigate change

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -86,48 +86,49 @@ interface RoutesProps {
 function ChatRoutes({ state, location }: RoutesProps) {
   return (
     <>
-      <Nav />
       <Routes location={state?.backgroundLocation || location}>
-        <Route
-          path="/notifications"
-          element={
-            <Notifications
-              child={DMNotification}
-              title={`${appHead('chat').title} • All Notifications`}
-            />
-          }
-        />
-        <Route path="/dm/" element={<Dms />}>
-          <Route index element={<DMHome />} />
-          <Route path="new" element={<NewDM />} />
-          <Route path=":ship" element={<Message />}>
-            <Route path="search" element={<Search />} />
-            <Route path="message/:idShip/:idTime" element={<DmThread />} />
-          </Route>
-        </Route>
-
-        <Route path="/groups/:ship/:name/*" element={<Groups />}>
+        <Route element={<Nav />}>
           <Route
-            path="channels/join/:app/:chShip/:chName"
-            element={<Channel />}
+            path="/notifications"
+            element={
+              <Notifications
+                child={DMNotification}
+                title={`${appHead('chat').title} • All Notifications`}
+              />
+            }
           />
-          <Route
-            path="channels/chat/:chShip/:chName"
-            element={<ChatChannel title={`${appHead('chat').title} • `} />}
-          >
-            <Route
-              path="message/:idShip/:idTime"
-              element={<GroupChatThread />}
-            />
+          <Route path="/dm/" element={<Dms />}>
+            <Route index element={<DMHome />} />
+            <Route path="new" element={<NewDM />} />
+            <Route path=":ship" element={<Message />}>
+              <Route path="search" element={<Search />} />
+              <Route path="message/:idShip/:idTime" element={<DmThread />} />
+            </Route>
           </Route>
-        </Route>
 
-        <Route
-          path="/profile/edit"
-          element={
-            <EditProfile title={`${appHead('chat').title} • Edit Profile`} />
-          }
-        />
+          <Route path="/groups/:ship/:name/*" element={<Groups />}>
+            <Route
+              path="channels/join/:app/:chShip/:chName"
+              element={<Channel />}
+            />
+            <Route
+              path="channels/chat/:chShip/:chName"
+              element={<ChatChannel title={`${appHead('chat').title} • `} />}
+            >
+              <Route
+                path="message/:idShip/:idTime"
+                element={<GroupChatThread />}
+              />
+            </Route>
+          </Route>
+
+          <Route
+            path="/profile/edit"
+            element={
+              <EditProfile title={`${appHead('chat').title} • Edit Profile`} />
+            }
+          />
+        </Route>
       </Routes>
       {state?.backgroundLocation ? (
         <Routes>


### PR DESCRIPTION
We were recreating subscriptions every time `navigate` changed 😬 oops