### PR TITLE
groups/channel-edit: stay on page when creating channel

### DIFF
--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -74,7 +74,7 @@ export default function NewChannelForm() {
           .addChannelToZone(section, groupFlag, newChannelNest);
       }
 
-      navigate(channelHref(groupFlag, newChannelNest));
+      navigate(`/groups/${groupFlag}/info/channels`);
     },
     [section, groupFlag, navigate]
   );


### PR DESCRIPTION
Fixes tloncorp/homestead#753

Avoids an annoying redirect when creating a new channel.