### PR TITLE
groups: accepting invite navigates sidebar

### DIFF
--- a/ui/src/groups/useGroupJoin.ts
+++ b/ui/src/groups/useGroupJoin.ts
@@ -1,3 +1,4 @@
+import useNavStore from '@/components/Nav/useNavStore';
 import { useModalNavigate, useDismissNavigate } from '@/logic/routing';
 import { getGroupPrivacy } from '@/logic/utils';
 import { useGroup, useGroupState } from '@/state/groups';
@@ -38,25 +39,28 @@ export default function useGroupJoin(
     : 'public';
   const requested = gang?.claim?.progress === 'knocking';
   const invited = gang?.invite;
+  const navPrimary = useNavStore((state) => state.navigatePrimary);
 
   const open = useCallback(() => {
     if (group) {
+      navPrimary('group', flag);
       return navigate(`/groups/${flag}`);
     }
 
     return navigate(`/gangs/${flag}`, {
       state: { backgroundLocation: location },
     });
-  }, [flag, group, location, navigate]);
+  }, [flag, group, location, navPrimary, navigate]);
 
   const join = useCallback(async () => {
     if (privacy === 'public' || (privacy === 'private' && invited)) {
       await useGroupState.getState().join(flag, true);
+      navPrimary('group', flag);
       navigate(`/groups/${flag}`);
     } else {
       await useGroupState.getState().knock(flag);
     }
-  }, [flag, privacy, invited, navigate]);
+  }, [privacy, invited, flag, navPrimary, navigate]);
 
   const reject = useCallback(async () => {
     /**


### PR DESCRIPTION
Before this change, clicking Join from a Group Invite would navigate the user to the Group > Activity view (expected), but would not update the Sidebar to the Group Sidebar view.

This resolves #790 by navigating the sidebar when joining or opening a group.


https://user-images.githubusercontent.com/16504501/189276146-f8fb8a9c-2e80-4732-bc2b-cfaf71f39484.mp4

