### PR TITLE
nav: use the fallback colors if CORS is broken for the group header image

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { FastAverageColor } from 'fast-average-color';
 import { mix, transparentize } from 'color2k';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
@@ -20,12 +20,17 @@ function GroupHeader() {
   const group = useGroup(flag);
   const navPrimary = useNavStore((state) => state.navigatePrimary);
   const [groupCoverHover, setGroupCoverHover] = useState(false);
+  const [noCors, setNoCors] = useState(false);
   const [coverImgColor, setCoverImgColor] = useState('');
   const cover = useRef(null);
   const fac = new FastAverageColor();
   const dark = useMedia('(prefers-color-scheme: dark)');
   const hoverFallbackForeground = dark ? 'white' : 'black';
   const hoverFallbackBackground = dark ? '#333333' : '#CCCCCC';
+
+  const onError = useCallback(() => {
+    setNoCors(true);
+  }, []);
 
   const getCoverImageColor = () => {
     fac
@@ -85,9 +90,10 @@ function GroupHeader() {
     <li className="relative mb-2 w-full rounded-lg" style={coverStyles()}>
       {group && !isColor(group?.meta.cover) && (
         <img
+          {...(noCors ? {} : { crossOrigin: 'anonymous' })}
           src={group?.meta.cover}
           ref={cover}
-          crossOrigin="anonymous"
+          onError={onError}
           onLoad={() => getCoverImageColor()}
           className="absolute h-full w-full flex-none rounded-lg object-cover"
         />


### PR DESCRIPTION
I was running into an issue where certain images would break if we ran getColor on them. upon @liam-fitzgerald's suggestion, I copied the fallback behavior from groups 1's remote image embeds – now the header image will load in and the header color extraction will fall back to the same colors used if there's a broken image.