### PR TITLE
groups: show default sidebar when GroupSidebar can't render in some situations

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -10,10 +10,11 @@ import SidebarItem from '@/components/Sidebar/SidebarItem';
 import useHarkState from '@/state/hark';
 import { isColor } from '@/logic/utils';
 import { foregroundFromBackground } from '@/components/Avatar';
-import MobileGroupSidebar from './MobileGroupSidebar';
-import ChannelList from './ChannelList';
-import GroupAvatar from '../GroupAvatar';
-import GroupActions from '../GroupActions';
+import Sidebar from '@/components/Sidebar/Sidebar';
+import MobileGroupSidebar from '@/groups/GroupSidebar/MobileGroupSidebar';
+import ChannelList from '@/groups/GroupSidebar/ChannelList';
+import GroupAvatar from '@/groups/GroupAvatar';
+import GroupActions from '@/groups/GroupActions';
 
 function GroupHeader() {
   const flag = useNavStore((state) => state.flag);
@@ -174,5 +175,5 @@ export default function GroupSidebar() {
     );
   }
 
-  return null;
+  return <Sidebar />;
 }


### PR DESCRIPTION
Fixes #844 

There are some situations where the useGroup() hook may not have loaded yet and thus GroupSidebar was returning null or undefined (connectivity issue or bad group state). Rather than return null in the GroupSidebar component we can just show the default Sidebar so the user can get out of the situation.

In the longer term we need to figure out how these bad states could happen (or display some kind of skeleton in the case of connectivity issues?).