### PR TITLE
heap/ux: esc key to nav from detail to index

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -41,10 +41,26 @@ export default function HeapDetail() {
   }, [chFlag]);
 
   useEventListener('keydown', (e) => {
-    if (hasPrev && e.key === 'ArrowRight') {
-      navigate(curioHref(prevCurio?.[0]));
-    } else if (hasNext && e.key === 'ArrowLeft') {
-      navigate(curioHref(nextCurio?.[0]));
+    switch (e.key) {
+      case 'Escape': {
+        navigate('..');
+        break;
+      }
+      case 'ArrowRight': {
+        if (hasPrev) {
+          navigate(curioHref(prevCurio?.[0]));
+        }
+        break;
+      }
+      case 'ArrowLeft': {
+        if (hasNext) {
+          navigate(curioHref(nextCurio?.[0]));
+        }
+        break;
+      }
+      default: {
+        break;
+      }
     }
   });
 


### PR DESCRIPTION
This change was motivated by using the Heap detail view and instinctively reaching for the ESC key to navigate back.