### PR TITLE
groups: change collection to gallery

### DIFF
--- a/ui/src/channels/ChannelTypeSelector.tsx
+++ b/ui/src/channels/ChannelTypeSelector.tsx
@@ -22,7 +22,7 @@ const CHANNEL_TYPE: Record<ChannelType, ChannelTypeMetadata> = {
   },
   heap: {
     icon: <ShapesIcon className="h-6 w-6 text-gray-600" />,
-    title: 'Collection',
+    title: 'Gallery',
     description: 'Gather, connect, and arrange rich media',
     color: 'bg-green-soft',
   },

--- a/ui/src/channels/NewChannel/__snapshots__/NewChannel.test.tsx.snap
+++ b/ui/src/channels/NewChannel/__snapshots__/NewChannel.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`NewChannelModal > renders as expected 1`] = `
                     <span
                       class="font-semibold"
                     >
-                      Collection
+                      Gallery
                     </span>
                     <span
                       class="text-sm font-medium text-gray-600"

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -122,7 +122,7 @@ function DiaryChannel() {
         <div className="relative flex flex-col items-center">
           <Toast.Root duration={3000} defaultOpen={false} open={showToast}>
             <Toast.Description asChild>
-              <div className="absolute z-10 flex w-[415px] -translate-x-2/4 items-center justify-between space-x-2 rounded-lg bg-white font-semibold text-white drop-shadow-lg dark:bg-gray-200 dark:text-black">
+              <div className="absolute z-10 flex w-[415px] -translate-x-2/4 items-center justify-between space-x-2 rounded-lg bg-white font-semibold text-black drop-shadow-lg dark:bg-gray-200">
                 <span className="py-2 px-4">Note successfully published</span>
                 <button
                   onClick={onCopy}

--- a/ui/src/mocks/groups.ts
+++ b/ui/src/mocks/groups.ts
@@ -270,8 +270,8 @@ const mockGroupTwo: Group = {
     },
     'heap/~zod/testHeap': {
       meta: {
-        title: 'Martini Collection',
-        description: 'Martini Maker Collection',
+        title: 'Martini Gallery',
+        description: 'Martini Maker Gallery',
         image: '',
         cover: '',
       },


### PR DESCRIPTION
fixes tloncorp/homestead#894

Also fixes a light-mode color regression in the "Note successfully published" toast notification (that I introduced).