### PR TITLE
heap/ux: smaller button targets

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -82,29 +82,33 @@ export default function HeapDetail() {
       <div className="flex flex-wrap lg:h-full lg:flex-nowrap">
         <div className="group relative flex-1">
           {hasNext ? (
-            <Link
-              to={curioHref(nextCurio?.[0])}
-              className={
-                'absolute top-0 left-0 z-50 flex h-full w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
-              }
-            >
-              <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
-                <CaretLeftIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
-              </div>
-            </Link>
+            <div className="absolute top-0 left-0 flex h-full w-16 flex-col justify-center">
+              <Link
+                to={curioHref(nextCurio?.[0])}
+                className={
+                  'z-50 flex h-16 w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
+                }
+              >
+                <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
+                  <CaretLeftIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
+                </div>
+              </Link>
+            </div>
           ) : null}
           <HeapDetailBody curio={curio} />
           {hasPrev ? (
-            <Link
-              to={curioHref(prevCurio?.[0])}
-              className={
-                'absolute top-0 right-0 z-50 flex h-full w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
-              }
-            >
-              <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
-                <CaretRightIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
-              </div>
-            </Link>
+            <div className="absolute top-0 right-0 flex h-full w-16 flex-col justify-center">
+              <Link
+                to={curioHref(prevCurio?.[0])}
+                className={
+                  'z-50 flex h-16 w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
+                }
+              >
+                <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
+                  <CaretRightIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
+                </div>
+              </Link>
+            </div>
           ) : null}
         </div>
         <div className="mt-5 flex h-full w-full flex-col border-gray-50 bg-white lg:mt-0 lg:w-72 lg:border-l-2 xl:w-96">


### PR DESCRIPTION
This resolves #910 by shrinking the size of next / prev button targets to prevent occluding Youtube / Vimeo player controls.

# Preview

![image](https://user-images.githubusercontent.com/16504501/191164542-389c1bc9-892f-47d6-a173-d4438b73cd7f.png)
