### PR TITLE
groups: use landscape settings

### DIFF
--- a/ui/src/chat/ChatContent/ChatContentImage.tsx
+++ b/ui/src/chat/ChatContent/ChatContentImage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useCalm } from '@/state/settings';
 
 interface ChatContentImage {
   src: string;
@@ -13,19 +14,25 @@ export default function ChatContentImage({
   width,
   altText,
 }: ChatContentImage) {
+  const calm = useCalm();
+
   return (
     <div
       className="group relative w-full py-2"
       style={{ maxWidth: width ? (width > 600 ? 600 : width) : 600 }}
     >
       <a href={src} target="_blank" rel="noreferrer">
-        <img
-          src={src}
-          className="max-w-full rounded"
-          height={height}
-          width={width}
-          alt={altText ? altText : 'A chat image'}
-        />
+        {calm?.disableRemoteContent ? (
+          <span>{src}</span>
+        ) : (
+          <img
+            src={src}
+            className="max-w-full rounded"
+            height={height}
+            width={width}
+            alt={altText ? altText : 'A chat image'}
+          />
+        )}
       </a>
       {/*
         TODO: put these icons back in after they've been finalized by design.

--- a/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
+++ b/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`ChatInput > renders as expected 1`] = `
               aria-label="Message editor with formatting menu"
               class="ProseMirror input-inner"
               contenteditable="true"
+              spellcheck="true"
               tabindex="0"
               translate="no"
             >

--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -5,6 +5,7 @@ import { sigil as sigilRaw, reactRenderer } from '@tlon/sigil-js';
 import { deSig, Contact, cite } from '@urbit/api';
 import _ from 'lodash';
 import { darken, lighten, parseToHsla } from 'color2k';
+import { useCalm } from '@/state/settings';
 import { useCurrentTheme } from '../state/local';
 import { normalizeUrbitColor, isValidUrl } from '../logic/utils';
 import { useContact } from '../state/contact';
@@ -138,6 +139,7 @@ export default function Avatar({
 }: AvatarProps) {
   const currentTheme = useCurrentTheme();
   const contact = useContact(ship);
+  const calm = useCalm();
   const { previewColor, previewAvatar } = previewData ?? {};
   const previewAvatarIsValid =
     previewAvatar && previewAvatar !== null && isValidUrl(previewAvatar);
@@ -156,7 +158,11 @@ export default function Avatar({
     foregroundColor
   );
 
-  if (previewAvatarIsValid) {
+  if (
+    previewAvatarIsValid &&
+    !calm.disableRemoteContent &&
+    !calm.disableAvatars
+  ) {
     return (
       <img
         className={classNames(className, classes)}
@@ -167,7 +173,7 @@ export default function Avatar({
     );
   }
 
-  if (avatar) {
+  if (avatar && !calm.disableRemoteContent && !calm.disableAvatars) {
     return (
       <img
         className={classNames(className, classes)}

--- a/ui/src/components/ButterBar.tsx
+++ b/ui/src/components/ButterBar.tsx
@@ -20,7 +20,9 @@ function ButterBar({ dismissKey, message }: ButterBarProps) {
         <AsteriskIcon className="mr-3 h-4 w-4" />
         {message}
       </div>
-      <button className="py-1 px-2" onClick={onClick}>Dismiss</button>
+      <button className="py-1 px-2" onClick={onClick}>
+        Dismiss
+      </button>
     </div>
   );
 }

--- a/ui/src/components/CoverImageInput.tsx
+++ b/ui/src/components/CoverImageInput.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 import { useFormContext } from 'react-hook-form';
 import { NoteEssay } from '@/types/diary';
+import { useCalm } from '@/state/settings';
 
 interface CoverImageInputProps {
   className?: string;
@@ -15,6 +16,7 @@ export default function CoverImageInput({
   const { register, watch } =
     useFormContext<Pick<NoteEssay, 'title' | 'image'>>();
   const image = watch('image');
+  const calm = useCalm();
 
   return (
     <div
@@ -22,7 +24,11 @@ export default function CoverImageInput({
         'relative h-36 w-full rounded-lg bg-gray-100 bg-cover bg-center px-4',
         className
       )}
-      style={image ? { backgroundImage: `url(${image})` } : {}}
+      style={
+        image && !calm.disableRemoteContent
+          ? { backgroundImage: `url(${image})` }
+          : {}
+      }
     >
       <div className="absolute bottom-0 left-0 w-full p-4">
         {!image && (

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -24,6 +24,7 @@ import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
 import { refPasteRule, Shortcuts } from '@/logic/tiptap';
 import { ChatBlock, Cite } from '@/types/chat';
 import { useChatStore } from '@/chat/useChatStore';
+import { useCalm } from '@/state/settings';
 
 interface HandlerParams {
   editor: Editor;
@@ -46,6 +47,8 @@ export function useMessageEditor({
   onEnter,
   onUpdate,
 }: useMessageEditorParams) {
+  const calm = useCalm();
+
   const onReference = useCallback(
     (r) => {
       if (!whom) {
@@ -101,6 +104,7 @@ export function useMessageEditor({
         attributes: {
           class: cn('input-inner', editorClass),
           'aria-label': 'Message editor with formatting menu',
+          spellcheck: `${!calm.disableSpellcheck}`,
         },
       },
       onUpdate: ({ editor }) => {

--- a/ui/src/components/ShipName.tsx
+++ b/ui/src/components/ShipName.tsx
@@ -1,5 +1,6 @@
 import { cite } from '@urbit/api';
 import React, { HTMLAttributes } from 'react';
+import { useCalm } from '@/state/settings';
 import { useContact } from '../state/contact';
 
 type ShipNameProps = {
@@ -15,6 +16,7 @@ export default function ShipName({
   const contact = useContact(name);
   const separator = /([_^-])/;
   const citedName = cite(name);
+  const calm = useCalm();
 
   if (!citedName) {
     return null;
@@ -25,7 +27,7 @@ export default function ShipName({
 
   return (
     <span {...props}>
-      {contact?.nickname && showAlias ? (
+      {contact?.nickname && !calm.disableNicknames && showAlias ? (
         <span title={citedName}>{contact.nickname}</span>
       ) : (
         <>

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -16,3 +16,5 @@ export const AUTHORS = [
   '~rovnys-ricfer',
   '~mister-dister-dozzod-dozzod',
 ];
+
+export const lsDesk = 'garden';

--- a/ui/src/diary/DiaryContent/DiaryContentImage.tsx
+++ b/ui/src/diary/DiaryContent/DiaryContentImage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useCalm } from '@/state/settings';
 
 interface DiaryContentImage {
   src: string;
@@ -13,19 +14,25 @@ export default function DiaryContentImage({
   width,
   altText,
 }: DiaryContentImage) {
+  const calm = useCalm();
+
   return (
     <div
       className="group relative w-full py-2"
       style={{ maxWidth: width ? (width > 600 ? 600 : width) : 600 }}
     >
       <a href={src} target="_blank" rel="noreferrer">
-        <img
-          src={src}
-          className="max-w-full rounded"
-          height={height}
-          width={width}
-          alt={altText ? altText : 'A Diary image'}
-        />
+        {calm?.disableRemoteContent ? (
+          <span>{src}</span>
+        ) : (
+          <img
+            src={src}
+            className="max-w-full rounded"
+            height={height}
+            width={width}
+            alt={altText ? altText : 'A Diary image'}
+          />
+        )}
       </a>
       {/*
         TODO: put these icons back in after they've been finalized by design.

--- a/ui/src/diary/DiaryImageNode.tsx
+++ b/ui/src/diary/DiaryImageNode.tsx
@@ -1,3 +1,4 @@
+import { useCalm } from '@/state/settings';
 import LinkIcon from '@/components/icons/LinkIcon';
 import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import { Node, NodeViewProps } from '@tiptap/core';
@@ -13,6 +14,7 @@ function DiaryImageComponent(props: NodeViewProps) {
   const [error, setError] = useState(false);
   const [src, setSrc] = useState(null as string | null);
   const image = useRef<HTMLImageElement>(null);
+  const calm = useCalm();
   const onError = () => {
     setError(true);
   };
@@ -72,7 +74,7 @@ function DiaryImageComponent(props: NodeViewProps) {
             </div>
           ) : null}
         </div>
-        {src && !error ? (
+        {src && !error && !calm?.disableRemoteContent ? (
           <img
             ref={image}
             className="rounded-xl"

--- a/ui/src/diary/DiaryInlineEditor.tsx
+++ b/ui/src/diary/DiaryInlineEditor.tsx
@@ -34,6 +34,7 @@ import cn from 'classnames';
 import History from '@tiptap/extension-history';
 import Paragraph from '@tiptap/extension-paragraph';
 import HardBreak from '@tiptap/extension-hard-break';
+import { useCalm } from '@/state/settings';
 import { useIsMobile } from '@/logic/useMedia';
 import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
 import { Shortcuts } from '@/logic/tiptap';
@@ -272,6 +273,8 @@ export function useDiaryInlineEditor({
   onEnter,
   onUpdate,
 }: useDiaryInlineEditorParams) {
+  const calm = useCalm();
+
   const ed = useEditor(
     {
       extensions: [
@@ -309,6 +312,7 @@ export function useDiaryInlineEditor({
         attributes: {
           class: 'input-transparent',
           'aria-label': 'Note editor with formatting menu',
+          spellcheck: `${!calm.disableSpellcheck}`,
         },
       },
       onUpdate: onUpdate || (() => false),

--- a/ui/src/diary/DiaryList/DiaryGridItem.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridItem.tsx
@@ -13,6 +13,7 @@ import DiaryCommenters from '@/diary/DiaryCommenters';
 import { useChannelFlag } from '@/hooks';
 import { useQuips } from '@/state/diary';
 import CheckIcon from '@/components/icons/CheckIcon';
+import { useCalm } from '@/state/settings';
 import DiaryNoteOptionsDropdown from '../DiaryNoteOptionsDropdown';
 import useDiaryActions from '../useDiaryActions';
 
@@ -36,6 +37,7 @@ export default function DiaryGridItem({ note, time }: DiaryGridItemProps) {
   const flag = useRouteGroup();
   const isAdmin = useAmAdmin(flag);
   const canEdit = isAdmin || window.our === note.essay.author;
+  const calm = useCalm();
 
   const commenters = _.flow(
     f.compact,
@@ -51,7 +53,7 @@ export default function DiaryGridItem({ note, time }: DiaryGridItemProps) {
         'flex w-full cursor-pointer flex-col space-y-8 rounded-xl bg-white bg-cover bg-center p-8'
       }
       style={
-        hasImage
+        hasImage && !calm?.disableRemoteContent
           ? {
               backgroundImage: `linear-gradient(0deg, rgba(0, 0, 0, 0.33), rgba(0, 0, 0, 0.33)), url(${note.essay.image})`,
               color: '#ffffff',

--- a/ui/src/diary/DiaryNoteHeadline.tsx
+++ b/ui/src/diary/DiaryNoteHeadline.tsx
@@ -12,6 +12,7 @@ import CopyIcon from '@/components/icons/CopyIcon';
 import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import DiaryNoteOptionsDropdown from '@/diary/DiaryNoteOptionsDropdown';
 import { useRouteGroup, useAmAdmin } from '@/state/groups/groups';
+import { useCalm } from '@/state/settings';
 import { useGroupFlag } from '@/state/groups';
 import { useCopyToClipboard } from 'usehooks-ts';
 import { useNavigate } from 'react-router-dom';
@@ -38,6 +39,8 @@ export default function DiaryNoteHeadline({
     time: time.toString(),
   });
 
+  const calm = useCalm();
+
   const commenters = _.flow(
     f.compact,
     f.uniq,
@@ -48,13 +51,13 @@ export default function DiaryNoteHeadline({
 
   return (
     <>
-      {note.essay.image && (
+      {note.essay.image && !calm.disableRemoteContent ? (
         <img
           src={note.essay.image}
           alt=""
           className="h-auto w-full rounded-xl"
         />
-      )}
+      ) : null}
       <header className="mt-8 space-y-8">
         <h1 className="text-3xl font-semibold leading-10">
           {note.essay.title}

--- a/ui/src/groups/GroupAvatar.tsx
+++ b/ui/src/groups/GroupAvatar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { isColor } from '@/logic/utils';
 import useMedia from '@/logic/useMedia';
+import { useCalm } from '@/state/settings';
 
 interface GroupAvatarProps {
   image?: string;
@@ -38,9 +39,16 @@ export default function GroupAvatar({
   title,
 }: GroupAvatarProps) {
   const dark = useMedia('(prefers-color-scheme: dark)');
-  const background = image || (dark ? '#333333' : '#E5E5E5');
+  const calm = useCalm();
+  let background;
 
-  return image && !isColor(image) ? (
+  if (!calm.disableRemoteContent) {
+    background = image || (dark ? '#333333' : '#E5E5E5');
+  } else {
+    background = dark ? '#333333' : '#E5E5E5';
+  }
+
+  return image && !calm.disableRemoteContent && !isColor(image) ? (
     <img className={cn('rounded', size, className)} src={image} />
   ) : (
     <ColorBoxIcon

--- a/ui/src/groups/GroupInfoFields.tsx
+++ b/ui/src/groups/GroupInfoFields.tsx
@@ -5,6 +5,7 @@ import EmptyIconBox from '@/components/icons/EmptyIconBox';
 import ImageOrColorField, {
   ImageOrColorFieldState,
 } from '@/components/ImageOrColorField';
+import { useCalm } from '@/state/settings';
 import { isValidUrl } from '@/logic/utils';
 import { GroupMeta } from '@/types/groups';
 import GroupAvatar from './GroupAvatar';
@@ -17,6 +18,7 @@ export default function GroupInfoFields() {
   const watchTitle = watch('title');
   const showEmpty =
     iconType === 'initial' || (iconType === 'image' && !isValidUrl(watchImage));
+  const calm = useCalm();
 
   useEffect(() => {
     if (iconType === 'color' && watchTitle !== '') {
@@ -73,6 +75,7 @@ export default function GroupInfoFields() {
           // TODO: set sane maxLength
           {...register('description', { maxLength: 300 })}
           className="input"
+          spellCheck={`${!calm.disableSpellcheck}`}
         />
       </div>
     </>

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -9,6 +9,7 @@ import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import HashIcon16 from '@/components/icons/HashIcon16';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import useHarkState from '@/state/hark';
+import { useCalm } from '@/state/settings';
 import { isColor } from '@/logic/utils';
 import { foregroundFromBackground } from '@/components/Avatar';
 import Sidebar from '@/components/Sidebar/Sidebar';
@@ -30,6 +31,7 @@ function GroupHeader() {
   const dark = useMedia('(prefers-color-scheme: dark)');
   const hoverFallbackForeground = dark ? 'white' : 'black';
   const hoverFallbackBackground = dark ? '#333333' : '#CCCCCC';
+  const calm = useCalm();
 
   const onError = useCallback(() => {
     setNoCors(true);
@@ -92,7 +94,7 @@ function GroupHeader() {
 
   return (
     <li className="relative mb-2 w-full rounded-lg" style={coverStyles()}>
-      {group && !isColor(group?.meta.cover) && (
+      {group && !calm?.disableRemoteContent && !isColor(group?.meta.cover) && (
         <img
           {...(noCors ? {} : { crossOrigin: 'anonymous' })}
           src={group?.meta.cover}
@@ -101,6 +103,9 @@ function GroupHeader() {
           onLoad={() => getCoverImageColor()}
           className="absolute h-full w-full flex-none rounded-lg object-cover"
         />
+      )}
+      {group && calm.disableRemoteContent && !isColor(group?.meta.cover) && (
+        <div className="absolute h-full w-full flex-none rounded-lg bg-gray-400" />
       )}
       <div
         style={group && !isColor(group?.meta.cover) ? { height: '240px' } : {}}

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { HeapCurio } from '@/types/heap';
 import cn from 'classnames';
 import { isValidUrl, validOembedCheck } from '@/logic/utils';
+import { useCalm } from '@/state/settings';
 import useEmbedState from '@/state/embed';
 import { useRouteGroup, useAmAdmin } from '@/state/groups/groups';
 import HeapContent from '@/heap/HeapContent';
@@ -198,7 +199,7 @@ export default function HeapBlock({
   const [embed, setEmbed] = useState<any>();
   const { content } = curio.heart;
   const url = content.length > 0 ? content[0].toString() : '';
-
+  const calm = useCalm();
   const { isImage, isAudio, isText } = useHeapContentType(url);
 
   const flag = useRouteGroup();
@@ -245,7 +246,7 @@ export default function HeapBlock({
     );
   }
 
-  if (isImage) {
+  if (isImage && !calm?.disableRemoteContent) {
     return (
       <div
         className={cnm(
@@ -265,11 +266,11 @@ export default function HeapBlock({
     );
   }
 
-  if (isAudio) {
+  if (isAudio && !calm?.disableRemoteContent) {
     return (
       <div className={cnm()}>
         <TopBar hasIcon canEdit {...topBar} />
-        <div className="flex flex-col items-center justify-center">
+        <div className="flex grow flex-col items-center justify-center">
           <MusicLargeIcon className="h-16 w-16 text-gray-300" />
         </div>
         <BottomBar
@@ -283,7 +284,7 @@ export default function HeapBlock({
 
   const isOembed = validOembedCheck(embed, url);
 
-  if (isOembed) {
+  if (isOembed && !calm?.disableRemoteContent) {
     const { title, thumbnail_url: thumbnail, provider_name: provider } = embed;
 
     if (thumbnail) {
@@ -310,7 +311,7 @@ export default function HeapBlock({
       return (
         <div className={cnm()}>
           <TopBar isTwitter canEdit={canEdit} {...topBar} />
-          <div className="flex flex-col items-center justify-center">
+          <div className="flex grow flex-col items-center justify-center space-y-2">
             <img
               className="h-[46px] w-[46px] rounded-full"
               src={twitterProfilePic}

--- a/ui/src/heap/HeapRow.tsx
+++ b/ui/src/heap/HeapRow.tsx
@@ -3,6 +3,7 @@ import cn from 'classnames';
 import CopyIcon from '@/components/icons/CopyIcon';
 import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import { HeapCurio } from '@/types/heap';
+import { useCalm } from '@/state/settings';
 import { isValidUrl, validOembedCheck } from '@/logic/utils';
 import useHeapContentType from '@/logic/useHeapContentType';
 import useEmbedState from '@/state/embed';
@@ -32,6 +33,7 @@ export default function HeapRow({
   const [embed, setEmbed] = useState<any>();
   const { content, sent, title } = curio.heart;
   const { replied } = curio.seal;
+  const calm = useCalm();
   // TODO: improve this
   const contentString = content.length > 0 ? content[0].toString() : '';
   const flag = useRouteGroup();
@@ -98,7 +100,7 @@ export default function HeapRow({
     <div className="flex w-full items-center justify-between space-x-2 rounded-lg bg-white">
       <div className="flex space-x-2">
         <div>
-          {isImage ? (
+          {isImage && !calm?.disableRemoteContent ? (
             <div
               className="relative inline-block h-14 w-14 cursor-pointer overflow-hidden rounded-l-lg bg-cover bg-no-repeat"
               style={{ backgroundImage: `url(${contentString})` }}

--- a/ui/src/profiles/EditProfile/ProfileFields.tsx
+++ b/ui/src/profiles/EditProfile/ProfileFields.tsx
@@ -6,6 +6,7 @@ import ColorPicker from '@/components/ColorPicker';
 import CheckIcon from '@/components/icons/CheckIcon';
 import { isValidUrl, normalizeUrbitColor } from '@/logic/utils';
 import LinkIcon from '@/components/icons/LinkIcon';
+import { useCalm } from '@/state/settings';
 
 interface ProfileFormSchema extends ContactEditField {
   isContactPublic: boolean;
@@ -23,6 +24,7 @@ export default function ProfileFields() {
   const coverHasLength = watchCover?.length;
   const watchSigilColor = watch('color');
   const isPublicSelected = watch('isContactPublic') === true;
+  const calm = useCalm();
 
   const setColor = (newColor: string) => {
     setValue('color', normalizeUrbitColor(newColor), {
@@ -71,7 +73,16 @@ export default function ProfileFields() {
           ) : null}
         </div>
         <div className="mt-1 text-sm font-semibold text-gray-600">
-          Overlay avatars may be hidden by other users
+          {calm.disableAvatars || calm.disableRemoteContent ? (
+            <span>
+              You are hiding {calm.disableAvatars && 'avatars'}
+              {calm.disableAvatars && calm.disableRemoteContent ? ' and ' : ''}
+              {calm.disableRemoteContent && 'remote content'} in your Landscape
+              settings, but your avatar may be visible to others.
+            </span>
+          ) : (
+            <span>Overlay avatars may be hidden by other users.</span>
+          )}
         </div>
       </div>
       <div className="flex flex-col">
@@ -95,6 +106,14 @@ export default function ProfileFields() {
             </div>
           ) : null}
         </div>
+        <div className="mt-1 text-sm font-semibold text-gray-600">
+          {calm.disableRemoteContent ? (
+            <span>
+              You are hiding remote content in your Landscape settings, but your
+              header image may be visible to others.
+            </span>
+          ) : null}
+        </div>
       </div>
       <div className="flex flex-col">
         <label htmlFor="nickname" className="pb-2 font-bold">
@@ -107,6 +126,13 @@ export default function ProfileFields() {
           type="text"
           placeholder="Name"
         />
+
+        {calm.disableNicknames ? (
+          <div className="mt-1 text-sm font-semibold text-gray-600">
+            You are hiding display names in your Landscape settings, but your
+            display name may be visible to others.
+          </div>
+        ) : null}
       </div>
       <div className="flex flex-col">
         <label htmlFor="bio" className="pb-2 font-bold">
@@ -117,6 +143,7 @@ export default function ProfileFields() {
           {...register('bio', { maxLength: 1000 })}
           className="input"
           placeholder="Add a bio"
+          spellCheck={`${!calm.disableSpellcheck}`}
         />
       </div>
       <label

--- a/ui/src/profiles/ProfileCoverImage.tsx
+++ b/ui/src/profiles/ProfileCoverImage.tsx
@@ -27,7 +27,7 @@ export default function ProfileCoverImage({
 }: CoverProps) {
   const contact = useContact(ship);
   const { disableRemoteContent } = useCalm();
-  const cover = contact || emptyContact;
+  const { cover } = contact || emptyContact;
 
   return (
     <div

--- a/ui/src/profiles/ProfileCoverImage.tsx
+++ b/ui/src/profiles/ProfileCoverImage.tsx
@@ -26,8 +26,8 @@ export default function ProfileCoverImage({
   children,
 }: CoverProps) {
   const contact = useContact(ship);
-  const calm = useCalm();
-  const cover = !calm.disableRemoteContent || contact || emptyContact;
+  const { disableRemoteContent } = useCalm();
+  const cover = contact || emptyContact;
 
   return (
     <div
@@ -35,7 +35,11 @@ export default function ProfileCoverImage({
         'relative h-36 w-full rounded-t-lg bg-gray-100 bg-cover bg-center px-4',
         className
       )}
-      style={cover ? { backgroundImage: `url(${cover})` } : {}}
+      style={
+        cover && !disableRemoteContent
+          ? { backgroundImage: `url(${cover})` }
+          : {}
+      }
     >
       {children}
     </div>

--- a/ui/src/profiles/ProfileCoverImage.tsx
+++ b/ui/src/profiles/ProfileCoverImage.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
 import React, { PropsWithChildren } from 'react';
 import { Contact } from '@urbit/api';
-import { useContact } from '../state/contact';
+import { useContact } from '@/state/contact';
+import { useCalm } from '@/state/settings';
 
 type CoverProps = PropsWithChildren<{
   ship: string;
@@ -25,7 +26,8 @@ export default function ProfileCoverImage({
   children,
 }: CoverProps) {
   const contact = useContact(ship);
-  const { cover } = contact || emptyContact;
+  const calm = useCalm();
+  const cover = !calm.disableRemoteContent || contact || emptyContact;
 
   return (
     <div


### PR DESCRIPTION
Dependent on urbit/garden#10.

Implements controls from Landscape to disable:
- avatars
- nicknames
- remote image fetching
- spellcheck

Manifests in the following product locations:
- Chat images
- Ship avatars
- Ship names
- Profile headers
- Notebook headers
- Notebook images
- Gallery items
- Notebook, gallery, profile bio, and chat text inputs
- Group icons
- Group headers

Also introduces a constant for the Landscape desk, since we're using `%garden` now and will eventually use `%landscape`.

fixes tloncorp/landscape-apps#936