### PR TITLE
devex: add scripts and config for use with bouncer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+ops
+bin

--- a/bin/bounce
+++ b/bin/bounce
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/hodl/ops/bounce.yml
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/bounce.yml

--- a/bin/bounce
+++ b/bin/bounce
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/hodl/ops/bounce.yml

--- a/bin/bounce
+++ b/bin/bounce
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/bounce.yml
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/ops/bounce.yml

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+cd ui
+npm run dev

--- a/bin/sync
+++ b/bin/sync
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/hodl/ops/sync.yml

--- a/bin/sync
+++ b/bin/sync
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/hodl/ops/sync.yml
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/ops/sync.yml

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,17 @@
+# ops
+
+These are optional config files for use with [bouncer](https://github.com/tloncorp/bouncer).
+
+Note that the paths in the yml files and bin scripts will need to be updated for your system. TODO: make configurable :)
+
+## Usage
+
+### Sync the desk to a new fake ship
+
+1. Create a fake ~zod
+2. `bin/bounce`
+
+### Sync the desk after making changes
+
+1. Start the fake ~zod
+2. `bin/sync`

--- a/ops/bounce.yml
+++ b/ops/bounce.yml
@@ -1,0 +1,29 @@
+env:
+  desk: 'groups'
+  urbit_path: '~/dev/urbit/urbit'
+  repo_path: '~/dev/urbit/landscape-apps'
+  ship_path: '~/dev/urbit/ships'
+script:
+  - merge:
+    - cmd: 'merge %garden our %base'
+      type: 'urbit:app'
+    - cmd: 'merge %groups our %base'
+      type: 'urbit:app'
+  - mount:
+    - cmd: 'mount %garden'
+      type: 'urbit:app'
+    - cmd: 'mount %groups'
+      type: 'urbit:app'
+  - sync:
+    - cmd: './apps/landscape/sync.sh'
+      type: 'system'
+  - commit:
+    - cmd: 'commit %garden'
+      type: 'urbit:app'
+    - cmd: 'commit %groups'
+      type: 'urbit:app'
+  - install:
+    - cmd: 'install our %garden'
+      type: 'urbit:app'
+    - cmd: 'install our %groups'
+      type: 'urbit:app'

--- a/ops/bounce.yml
+++ b/ops/bounce.yml
@@ -15,7 +15,7 @@ script:
     - cmd: 'mount %groups'
       type: 'urbit:app'
   - sync:
-    - cmd: './apps/landscape/sync.sh'
+    - cmd: '~/dev/urbit/landscape-apps/ops/sync.sh'
       type: 'system'
   - commit:
     - cmd: 'commit %garden'

--- a/ops/sync.sh
+++ b/ops/sync.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+rsync -avqL --delete $URBIT_PATH/pkg/base-dev/* $SHIP_PATH/$SHIP/garden/ && \
+rsync -avqL $URBIT_PATH/pkg/garden/* $SHIP_PATH/$SHIP/garden/ && \
+rsync -avqL --delete $URBIT_PATH/pkg/base-dev/* $SHIP_PATH/$SHIP/$DESK/ && \
+rsync -avqL $URBIT_PATH/pkg/garden-dev/* $SHIP_PATH/$SHIP/$DESK/ && \
+rsync -avqL $REPO_PATH/desk/* $SHIP_PATH/$SHIP/$DESK/ && \
+rsync -avqL $REPO_PATH/landscape-dev/* $SHIP_PATH/$SHIP/$DESK/

--- a/ops/sync.yml
+++ b/ops/sync.yml
@@ -5,7 +5,7 @@ env:
   ship_path: '~/dev/urbit/ships'
 script:
   - sync:
-    - cmd: '~/dev/groups/ops/sync.sh'
+    - cmd: '~/dev/urbit/landscape-apps/ops/sync.sh'
       type: 'system'
   - commit:
     - cmd: 'commit %groups'

--- a/ops/sync.yml
+++ b/ops/sync.yml
@@ -1,0 +1,15 @@
+env:
+  desk: 'groups'
+  urbit_path: '~/dev/urbit/urbit'
+  repo_path: '~/dev/urbit/landscape-apps'
+  ship_path: '~/dev/urbit/ships'
+script:
+  - sync:
+    - cmd: '~/dev/groups/ops/sync.sh'
+      type: 'system'
+  - commit:
+    - cmd: 'commit %groups'
+      type: 'urbit:app'
+  - install:
+    - cmd: 'install our %groups'
+      type: 'urbit:app'


### PR DESCRIPTION
These are optional config files for use with [bouncer](https://github.com/tloncorp/bouncer).

Note that the paths in the yml files and bin scripts will need to be updated for your system.

The change includes an update to the gitignore for these directories. This way, others can tweak the bouncer config without introducing a git diff in their local repo. Eventually we can use ENV vars or similar to customize config for each individual system