### PR TITLE
talk: set ShipSelector padding to avoid size jumping

### DIFF
--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -240,7 +240,7 @@ function ShipDropDownMenuList({
 
 function Input({ children, ...props }: InputProps<ShipOption, true>) {
   return (
-    <components.Input className="text-gray-800" {...props}>
+    <components.Input className="py-0.5 text-gray-800" {...props}>
       {children}
     </components.Input>
   );

--- a/ui/src/pages/NewDm.tsx
+++ b/ui/src/pages/NewDm.tsx
@@ -83,7 +83,7 @@ export default function NewDM() {
             isMulti={true}
           />
         </div>
-        <Link className="secondary-button" to="/">
+        <Link className="secondary-button py-2.5" to="/">
           Cancel
         </Link>
       </div>


### PR DESCRIPTION
this one's about #785, it just needed a little bump in padding value to keep it from "filling up", and a corresponding mod to the button.

@urcades this is the simplest fix but it does make the input a tiny bit taller (as tall as it was after it "jumps" in the current version)