### PR TITLE
groups: pending members show up where they should

### DIFF
--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -38,10 +38,20 @@ export default function GroupMemberManager() {
   const modalNavigate = useModalNavigate();
   const [rawInput, setRawInput] = useState('');
   const [search, setSearch] = useState('');
-  const members = useMemo(
-    () => (group && Object.keys(group.fleet)) || [],
-    [group]
-  );
+  const members = useMemo(() => {
+    if (!group) {
+      return [];
+    }
+    return Object.keys(group.fleet).filter((k) => {
+      if ('shut' in group.cordon) {
+        return (
+          !group.cordon.shut.ask.includes(k) &&
+          !group.cordon.shut.pending.includes(k)
+        );
+      }
+      return true;
+    });
+  }, [group]);
 
   const results = useMemo(
     () =>

--- a/ui/src/groups/GroupAdmin/GroupPendingManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupPendingManager.tsx
@@ -56,10 +56,7 @@ export default function GroupPendingManager() {
     );
 
     if ('shut' in group.cordon) {
-      members = members.concat(
-        group.cordon.shut.ask,
-        group.cordon.shut.pending
-      );
+      members = group.cordon.shut.ask.concat(group.cordon.shut.pending);
     }
 
     return members;


### PR DESCRIPTION
ref: #974 

the "concat" logic was off in the pending list leading to the list getting duplicated, and the members list needed a filter added to it, plus some restructuring so typescript wouldn't go off about the `Cordon` type.