### PR TITLE
desk: fix kick resubscribe loop due to public/rolling mismatch

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -141,7 +141,7 @@
     =+  !<(req=create:c vase)
     (create req)
   ::
-      %chat-action-0
+      ?(%chat-action-0 %chat-action)
     =+  !<(=action:c vase)
     =.  p.q.action  now.bowl
     =/  chat-core  (ca-abed:ca-core p.action)
@@ -835,8 +835,8 @@
         %fact
       =*  cage  cage.sign 
       ?+  p.cage  ca-core
-        %chat-logs-0    (ca-apply-logs !<(logs:c q.cage))
-        %chat-update-0  (ca-update !<(update:c q.cage))
+        ?(%chat-logs %chat-logs-0)      (ca-apply-logs !<(logs:c q.cage))
+        ?(%chat-update %chat-update-0)  (ca-update !<(update:c q.cage))
       ==
     ==
   ++  ca-proxy
@@ -844,7 +844,7 @@
     ^+  ca-core
     ?>  ca-can-write
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  chat-action-0+!>([flag update])
+    =/  =cage  chat-action+!>([flag update])
     =.  cor
       (emit %pass ca-area %agent dock %poke cage)
     ca-core
@@ -877,7 +877,7 @@
       ?~  path  log.chat
       =/  =time  (slav %da i.path)
       (lot:log-on:c log.chat `time ~)
-    =/  =cage  chat-logs-0+!>(logs)
+    =/  =cage  chat-logs+!>(logs)
     =.  cor  (give %fact ~ cage)
     ca-core
   ::
@@ -933,10 +933,10 @@
       %-  ~(gas in *(set path))
       (turn ~(tap in ca-subscriptions) tail)
     =.  paths  (~(put in paths) (snoc ca-area %ui))
-    =/  cag=cage  chat-update-0+!>([time d])
+    =/  cag=cage  chat-update+!>([time d])
     =.  cor
       (give %fact ~(tap in paths) cag)
-    =.  cor  (give %fact ~[/ui] chat-action-0+!>([flag [time d]]))
+    =.  cor  (give %fact ~[/ui] chat-action+!>([flag [time d]]))
     =?  cor  ?=(%writs -.d)
       =/  =cage  writ-diff+!>(p.d)
       (give %fact ~[(welp ca-area /ui/writs)] writ-diff+!>(p.d))

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -107,7 +107,7 @@
     =+  !<(req=create:d vase)
     (create req)
   ::
-      %diary-action-0
+      ?(%diary-action-0 %diary-action)
     =+  !<(=action:d vase)
     =.  p.q.action  now.bowl
     =/  diary-core  (di-abed:di-core p.action)
@@ -393,8 +393,8 @@
         %fact
       =*  cage  cage.sign 
       ?+  p.cage  di-core
-        %diary-logs-0    (di-apply-logs !<(log:d q.cage))
-        %diary-update-0  (di-update !<(update:d q.cage))
+        ?(%diary-logs %diary-logs-0)      (di-apply-logs !<(log:d q.cage))
+        ?(%diary-update %diary-update-0)  (di-update !<(update:d q.cage))
       ==
     ==
   ++  di-proxy
@@ -402,7 +402,7 @@
     ^+  di-core
     ?>  di-can-write
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  diary-action-0+!>([flag update])
+    =/  =cage  diary-action+!>([flag update])
     =.  cor
       (emit %pass di-area %agent dock %poke cage)
     di-core
@@ -435,7 +435,7 @@
       ?~  path  log.diary
       =/  =time  (slav %da i.path)
       (lot:log-on:d log.diary `time ~)
-    =/  =cage  diary-logs-0+!>(log)
+    =/  =cage  diary-logs+!>(log)
     =.  cor  (give %fact ~ cage)
     di-core
   ::
@@ -492,8 +492,8 @@
       (turn ~(tap in di-subscriptions) tail)
     =.  paths  (~(put in paths) (snoc di-area %ui))
     ~&  [flag [time d]]
-    =.  cor  (give %fact ~[/ui] diary-action-0+!>([flag [time d]]))
-    =/  cag=cage  diary-update-0+!>([time d])
+    =.  cor  (give %fact ~[/ui] diary-action+!>([flag [time d]]))
+    =/  cag=cage  diary-update+!>([time d])
     =.  cor
       (give %fact ~(tap in paths) cag)
     di-core

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -110,7 +110,7 @@
     =.  cor  (give-invites flag ~(key by members.create))
     go-abet:go-init:(go-abed:group-core flag)
   ::
-      %group-action  
+      ?(%group-action %group-action-0)
     =+  !<(=action:g vase)
     =.  p.q.action  now.bowl
     =/  group-core  (go-abed:group-core p.action)
@@ -423,7 +423,7 @@
       (~(put by groups) flag net group)
     ?.  gone  cor
     =/  =action:g  [flag now.bowl %del ~]
-    (give %fact ~[/groups/ui] group-action-0+!>(action))
+    (give %fact ~[/groups/ui] group-action+!>(action))
   ++  go-abed
     |=  f=flag:g
     ^+  go-core
@@ -459,7 +459,7 @@
       =/  =wire  (snoc go-area %proxy)
       =/  =dock  [p.flag dap.bowl]
       =/  =cage
-        :-  %group-action-0
+        :-  %group-action
         !>  ^-  action:g
         [flag now.bowl %fleet (silt our.bowl ~) %del ~]
       [%pass wire %agent dock %poke cage]
@@ -602,9 +602,9 @@
       =*  cage  cage.sign 
       ::  XX: does init need to be handled specially?
       ?+  p.cage  go-core
-        %group-log-0     (go-apply-log !<(log:g q.cage))
-        %group-update-0  (go-update !<(update:g q.cage))
-        %group-init-0    (go-fact-init !<(init:g q.cage))
+        ?(%group-log-0 %group-log)        (go-apply-log !<(log:g q.cage))
+        ?(%group-update-0 %group-update)  (go-update !<(update:g q.cage))
+        ?(%group-init-0 %group-init)      (go-fact-init !<(init:g q.cage))
       ==
     ==
   ::
@@ -622,7 +622,7 @@
     =/  =time  (slav %da i.path)
     =/  =log:g
       (lot:log-on:g p.net `time ~)
-    group-log-0+!>(log)
+    group-log+!>(log)
   ::
   ++  go-apply-log
     |=  =log:g
@@ -638,7 +638,7 @@
     =.  net  [%sub time] 
     =/  create=diff:g  [%create group]
     =.  cor  
-      (give %fact ~[/groups /groups/ui] group-action-0+!>(`action:g`[flag now.bowl create]))
+      (give %fact ~[/groups /groups/ui] group-action+!>(`action:g`[flag now.bowl create]))
     =.  cor
       (give %fact ~[/groups /groups/ui] gang-gone+!>(flag))
     =.  cor
@@ -656,9 +656,9 @@
       (~(put in out) path)
     =.  paths  (~(put in paths) (snoc go-area %ui))
     =.  cor
-      (give %fact ~(tap in paths) group-update-0+!>(`update:g`[time diff]))
+      (give %fact ~(tap in paths) group-update+!>(`update:g`[time diff]))
     =.  cor
-      (give %fact ~[/groups /groups/ui] group-action-0+!>(`action:g`[flag time diff]))
+      (give %fact ~[/groups /groups/ui] group-action+!>(`action:g`[flag time diff]))
     go-core
   ::
   ++  go-tell-update
@@ -1145,16 +1145,16 @@
     ++  add-self
       =/  =vessel:fleet:g  [~ now.bowl]
       =/  =action:g  [flag now.bowl %fleet (silt ~[our.bowl]) %add ~]
-      (poke-host /join/add group-action-0+!>(action))
+      (poke-host /join/add group-action+!>(action))
     ::
     ++  knock
       =/  ships=(set ship)  (~(put in *(set ship)) our.bowl)
       =/  =action:g  [flag now.bowl %cordon %shut %add-ships %ask ships]
-      (poke-host /knock group-action-0+!>(action))
+      (poke-host /knock group-action+!>(action))
     ++  rescind
       =/  ships=(set ship)  (~(put in *(set ship)) our.bowl)
       =/  =action:g  [flag now.bowl %cordon %shut %del-ships %ask ships]
-      (poke-host /rescind group-action-0+!>(action))
+      (poke-host /rescind group-action+!>(action))
     ++  get-preview
       =/  =task:agent:gall  [%watch /groups/(scot %p p.flag)/[q.flag]/preview]
       (pass-host /preview task)

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -106,7 +106,7 @@
     =+  !<(req=create:h vase)
     (create req)
   ::
-      %heap-action-0
+      ?(%heap-action-0 %heap-action)
     =+  !<(=action:h vase)
     =.  p.q.action  now.bowl
     =/  heap-core  (he-abed:he-core p.action)
@@ -388,8 +388,8 @@
         %fact
       =*  cage  cage.sign 
       ?+  p.cage  he-core
-        %heap-logs-0    (he-apply-logs !<(log:h q.cage))
-        %heap-update-0  (he-update !<(update:h q.cage))
+        ?(%heap-logs-0 %heap-logs)      (he-apply-logs !<(log:h q.cage))
+        ?(%heap-update-0 %heap-update)  (he-update !<(update:h q.cage))
       ==
     ==
   ++  he-proxy
@@ -397,7 +397,7 @@
     ^+  he-core
     ?>  he-can-write
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  heap-action-0+!>([flag update])
+    =/  =cage  heap-action+!>([flag update])
     =.  cor
       (emit %pass he-area %agent dock %poke cage)
     he-core
@@ -430,7 +430,7 @@
       ?~  path  log.heap
       =/  =time  (slav %da i.path)
       (lot:log-on:h log.heap `time ~)
-    =/  =cage  heap-logs-0+!>(log)
+    =/  =cage  heap-logs+!>(log)
     =.  cor  (give %fact ~ cage)
     he-core
   ::
@@ -486,10 +486,10 @@
       %-  ~(gas in *(set path))
       (turn ~(tap in he-subscriptions) tail)
     =.  paths  (~(put in paths) (snoc he-area %ui))
-    =/  cag=cage  heap-update-0+!>([time d])
+    =/  cag=cage  heap-update+!>([time d])
     =.  cor
       (give %fact ~(tap in paths) cag)
-    =.  cor  (give %fact ~[/ui] heap-action-0+!>([flag [time d]]))
+    =.  cor  (give %fact ~[/ui] heap-action+!>([flag [time d]]))
     =?  cor  ?=(%curios -.d)
       =/  =cage  curios-diff+!>(p.d)
       (give %fact ~[(welp he-area /ui/curios)] cage)

--- a/desk/mar/chat/action.hoon
+++ b/desk/mar/chat/action.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/chat/action-0
+mark

--- a/desk/mar/chat/logs.hoon
+++ b/desk/mar/chat/logs.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/chat/logs-0
+mark

--- a/desk/mar/chat/update.hoon
+++ b/desk/mar/chat/update.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/chat/update-0
+mark

--- a/desk/mar/diary/action.hoon
+++ b/desk/mar/diary/action.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/diary/action-0
+mark

--- a/desk/mar/diary/logs.hoon
+++ b/desk/mar/diary/logs.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/diary/logs-0
+mark

--- a/desk/mar/diary/update.hoon
+++ b/desk/mar/diary/update.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/diary/update-0
+mark

--- a/desk/mar/group/action.hoon
+++ b/desk/mar/group/action.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/group/action-0
+mark

--- a/desk/mar/group/init.hoon
+++ b/desk/mar/group/init.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/group/init-0
+mark

--- a/desk/mar/group/log.hoon
+++ b/desk/mar/group/log.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/group/log-0
+mark

--- a/desk/mar/group/update.hoon
+++ b/desk/mar/group/update.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/group/update-0
+mark

--- a/desk/mar/heap/action.hoon
+++ b/desk/mar/heap/action.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/heap/action-0
+mark

--- a/desk/mar/heap/logs.hoon
+++ b/desk/mar/heap/logs.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/heap/logs-0
+mark

--- a/desk/mar/heap/update.hoon
+++ b/desk/mar/heap/update.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/heap/update-0
+mark


### PR DESCRIPTION
The internal rolling release build is using numbered marks, whilst the public alpha is using unnumbered marks. As the public alpha lacks the mark files for the numbered marks and the rolling release lacks mark files for the unnumbered marks, this causes a kick-resubscribe loop whenever two ships on different builds attempt to communicate over a subscription. Rectifies this issue by returning to sending unnumbered marks over a subscription and adding the ability to receive numbered or unnumbered marks as pokes and %facts. Once this commit has been deployed to public alpha, we can return to giving numbered marks over subscriptions.