### PR TITLE
quips: refactor

### DIFF
--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -258,24 +258,6 @@
   ^-  yarn:ha
   =/  id  (end [7 1] (shax eny.bowl))
   [id rope now.bowl con wer but]
-++  flatten
-  |=  content=(list inline:d)
-  ^-  cord
-  %-  crip
-  %-  zing
-  %+  turn
-    content
-  |=  c=inline:d
-  ^-  tape
-  ?@  c  (trip c)
-  ?-  -.c
-      %break  ""
-      %tag    (trip p.c)
-      %link   (trip q.c)
-      %block   (trip q.c)
-      ?(%code %inline-code)  ""
-      ?(%italics %bold %strike %blockquote)  (trip (flatten p.c))
-  ==
 ++  from-self  =(our src):bowl
 ++  di-core
   |_  [=flag:d =diary:d gone=_|]
@@ -359,9 +341,6 @@
     ?+  pole  [~ ~]
         [%notes rest=*]  (peek:di-notes rest.pole)
         [%perm ~]        ``diary-perm+!>(perm.diary)
-        [%quips time=@ rest=*]  
-      =/  =time  (slav %ud time.pole)
-      (~(peek qup (~(gut by banter.diary) time *quips:d)) rest.pole)
     ==
   ::
   ++  di-revoke
@@ -525,38 +504,15 @@
       (di-give-updates time dif)
     ?-    -.dif
         %notes
-      di-core(notes.diary (reduce:di-notes time p.dif))
-    ::
-        %quips
-      =/  =quips:d      (~(gut by banter.diary) p.dif *quips:d)
-      =.  quips         (~(reduce qup quips) time q.dif)
-      =.  banter.diary  (~(put by banter.diary) p.dif quips)
-      ?-  -.q.q.dif
-          ?(%del %add-feel %del-feel)  di-core
-          %add
-        =/  =memo:d  p.q.q.dif
-        =/  [ti=^time =note:d]  (~(got not notes.diary) p.dif)        
-        =/  in-replies
-          %+  lien
-            (tap:on:quips:d quips)
-          |=  [=^time =quip:d]
-          =(author.quip our.bowl)
-        ?:  |(=(author.memo our.bowl) !in-replies)  di-core
-        =/  yarn
-          %^  di-spin
-            /note/(rsh 4 (scot %ui replying.memo))
-            :~  [%ship author.memo]
-                ' commented on '
-                [%emph title.note]
-                ': '
-                [%ship author.memo]
-                ': '
-                (flatten content.memo)
-            ==
-          ~  
-        =.  cor  (emit (pass-hark & & yarn))
-        di-core
-      ==
+      =.  notes.diary  (reduce:di-notes time p.dif)
+      =/  cons=(list (list content:ha))
+        (hark:di-notes our.bowl p.dif)
+      =.  cor
+        %-  emil
+        %+  turn  cons
+        |=  cs=(list content:ha)
+        (pass-hark & & (di-spin /note/(rsh 4 (scot %ui time)) cs ~))
+      di-core
     ::
         %add-sects
       =*  p  perm.diary

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -8,12 +8,12 @@
 =>
   |%
   +$  card  card:agent:gall
-  +$  state-0
-    $:  %0
+  +$  current-state
+    $:  %1
         =shelf:d
     ==
   --
-=|  state-0
+=|  current-state
 =*  state  -
 =< 
   %+  verb  &
@@ -31,18 +31,90 @@
   ++  on-save  !>(state)
   ++  on-load
     |=  =vase
-    ^-  (quip card _this)
-    =/  old=(unit state-0)
-      (mole |.(!<(state-0 vase)))  
-    ?^  old  `this(state u.old)
-    ~&  >>>  "Incompatible load, nuking"
-    =^  cards  this  on-init
-    :_  this
-    =-  (welp - cards)
-    %+  turn  ~(tap in ~(key by wex.bowl))
-    |=  [=wire =ship =term] 
-    ^-  card
-    [%pass wire %agent [ship term] %leave ~]
+    =|  cards=(list card)
+    |^  ^-  (quip card _this)
+    =+  !<(old=versioned-state vase)
+    |-
+    ?-  -.old
+      %1  [cards this(state old)]
+    ::
+        %0
+      %=  $
+        old  (state-0-to-1 old)
+      ==
+    ==
+    ::
+    +$  versioned-state
+      $%  state-0
+          state-1
+      ==
+    +$  state-0  [%0 =shelf:zero]
+    ++  zero     zero:old:d
+    +$  state-1  current-state
+    ++  one      d
+    ++  state-0-to-1
+      |=  sta=state-0
+      ^-  state-1
+      :-  %1
+      %-  ~(run by shelf.sta)
+      |=  =diary:zero
+      ^-  diary:one
+      %*  .  *diary:one
+        net    net.diary
+        log    (log-0-to-1 log.diary)
+        perm   perm.diary
+        view   view.diary
+        sort   sort.diary
+        notes  (notes-0-to-1 notes.diary banter.diary)
+        remark  remark.diary
+      ==
+    ::
+    ++  log-0-to-1
+      |=  =log:zero
+      ^-  log:one
+      %+  gas:log-on:one  *log:one
+      %+  turn  (tap:log-on:zero log)
+      |=  [=time =diff:zero]
+      ^-  [_time diff:one]
+      :-  time
+      ^-  diff:one
+      ?.  ?=(%quips -.diff)  diff
+      ^-  diff:one
+      [%notes p.diff %quips (quips-diff-0-to-1 q.diff)]
+    ::
+    ++  quips-diff-0-to-1
+      |=  =diff:quips:zero
+      ^-  diff:quips:one
+      :-  p.diff
+      ?.  ?=(%add -.q.diff)  q.diff
+      add/(memo-0-to-1 p.q.diff)
+    ::
+    ++  notes-0-to-1
+      |=  [=notes:zero banter=(map time quips:zero)] 
+      ^-  notes:one
+      %+  gas:on:notes:one  *notes:one
+      %+  turn  (tap:on:notes:zero notes)
+      |=  [=time =note:zero]
+      ^-  [_time note:one]
+      :-  time
+      :_  +.note
+      ^-  seal:one
+      [time (quips-0-to-1 (~(gut by banter) time *quips:zero)) feels.note]
+    ::
+    ++  quips-0-to-1
+      |=  =quips:zero
+      ^-  quips:one
+      %+  gas:on:quips:one  *quips:one
+      ^-  (list [time quip:one])
+      %+  turn  (tap:on:quips:zero quips)
+      |=  [=time =quip:zero]
+      [time -.quip (memo-0-to-1 +.quip)]
+    ::
+    ++  memo-0-to-1
+      |=  =memo:zero
+      ^-  memo:one
+      [`content author sent]:memo
+    --
   ::
   ++  on-poke
     |=  [=mark =vase]

--- a/desk/lib/diary-json.hoon
+++ b/desk/lib/diary-json.hoon
@@ -5,6 +5,26 @@
 ++  enjs
   =,  enjs:format
   |%
+  ++  outline
+    |=  o=outline:d
+    %-  pairs
+    :~  title/s/title.o
+        image/s/image.o
+        content/a/(turn content.o verse)
+        author+(ship author.o)
+        sent+(time sent.o)
+        'quipCount'^(numb quips.o)
+        quippers/a/(turn ~(tap in quippers.o) ship)
+    ==
+  ::
+  ++  outlines
+    |=  os=outlines:d
+    %-  pairs
+    %+  turn  (tap:on:outlines:d os)
+    |=  [t=@da o=outline:d]
+    ^-  [cord json]
+    [(scot %ud t) (outline o)]
+  ::
   ++  quips-diff
     |=  d=diff:quips:d
     %-  pairs
@@ -248,8 +268,9 @@
     ::
         :-  %quips
         %-  pairs
-        :~  foo/s/'foo'
-        ==
+        %+  turn  (tap:on:quips:d quips.seal)
+        |=  [t=@da q=quip:d]
+        [(scot %ud t) (quip q)]
     ::
         :-  %feels
         %-  pairs

--- a/desk/lib/diary-json.hoon
+++ b/desk/lib/diary-json.hoon
@@ -204,13 +204,19 @@
     :~  cork+(cork -.q)
         memo+(memo +.q)
     ==
+  ++  story
+    |=  s=story:d
+    ^-  json
+    %-  pairs
+    :~  block/a/(turn p.s block)
+        inline/a/(turn q.s inline)
+    ==
   ::
   ++  memo
     |=  m=memo:d
     ^-  json
     %-  pairs
-    :~  replying/s/(scot %ud replying.m)
-        content/a/(turn content.m inline)
+    :~  content/(story content.m)
         author/(ship author.m)
         sent/(time sent.m)
     ==
@@ -320,10 +326,15 @@
         add-feel/add-feel
     ==
   ::
+  ++  story
+    %-  ot
+    :~  block/(ar block)
+        inline/(ar inline)
+    ==
+  ::
   ++  memo
     %-  ot
-    :~  replying/(se %ud)
-        content/(ar inline)
+    :~  content/story
         author/(se %p)
         sent/di
     ==

--- a/desk/lib/diary-json.hoon
+++ b/desk/lib/diary-json.hoon
@@ -90,7 +90,6 @@
       %view       s/p.diff
       %sort       s/p.diff
       %notes     (notes-diff p.diff)
-      %quips     (pairs id/s/(scot %ud p.diff) diff/(quips-diff q.diff) ~)
       %add-sects  a/(turn ~(tap in p.diff) (lead %s))
       %del-sects  a/(turn ~(tap in p.diff) (lead %s))
     ==
@@ -109,6 +108,7 @@
       %add       (essay p.delta)
       %edit      (essay p.delta)
       %del       ~
+      %quips     (quips-diff p.delta)
       %add-feel  (add-feel +.delta)
     ==
   ::
@@ -201,7 +201,7 @@
     |=  q=quip:d
     ^-  json
     %-  pairs
-    :~  seal+(seal -.q)
+    :~  cork+(cork -.q)
         memo+(memo +.q)
     ==
   ::
@@ -222,10 +222,28 @@
         essay+(essay +.note)
     ==
   ::
+  ++  cork
+    |=  =cork:d
+    %-  pairs
+    :~  time+(time time.cork)
+    ::
+        :-  %feels
+        %-  pairs
+        %+  turn  ~(tap by feels.cork)
+        |=  [her=@p =feel:d]
+        [(scot %p her) s+feel]
+    ==
+
+  ::
   ++  seal
     |=  =seal:d
     %-  pairs
     :~  time+(time time.seal)
+    ::
+        :-  %quips
+        %-  pairs
+        :~  foo/s/'foo'
+        ==
     ::
         :-  %feels
         %-  pairs
@@ -285,7 +303,6 @@
     :~  notes/notes-diff
         view/(su (perk %grid %list ~))
         sort/(su (perk %time %alpha ~))
-        quips/(ot id/(se %ud) diff/quips-diff ~)
         add-sects/add-sects
         del-sects/del-sects
     ==
@@ -323,6 +340,7 @@
     :~  add/essay
         edit/essay
         del/ul
+        quips/quips-diff
         add-feel/add-feel
     ==
   ::

--- a/desk/lib/notes.hoon
+++ b/desk/lib/notes.hoon
@@ -111,7 +111,7 @@
       ': '
       [%ship author.memo]
       ': '
-      (flatten content.memo)
+      (flatten q.content.memo)
   ==
 ::
 ++  peek

--- a/desk/lib/notes.hoon
+++ b/desk/lib/notes.hoon
@@ -1,4 +1,6 @@
 /-  d=diary
+/-  ha=hark
+/+  qip=quips
 |_  not=notes:d
 ++  brief
   |=  [our=ship last-read=time]
@@ -38,7 +40,7 @@
   ^+  not
   ?-  -.del
       %add
-    =/  =seal:d  [time ~]
+    =/  =seal:d  [time ~ ~]
     ?:  (~(has by not) time)
       not
     (put:on:notes:d not time [seal p.del])
@@ -53,6 +55,11 @@
       (del:on:notes:d not time)
     not
   ::
+      %quips
+    %+  jab  time
+    |=  =note:d
+    note(quips (~(reduce qip quips.note) now p.p.del q.p.del))
+  ::
       %add-feel
     %+  jab  time
     |=  =note:d
@@ -62,6 +69,49 @@
     %+  jab  time
     |=  =note:d
     note(feels (~(del by feels.note) p.del))
+  ==
+++  flatten
+  |=  content=(list inline:d)
+  ^-  cord
+  %-  crip
+  %-  zing
+  %+  turn
+    content
+  |=  c=inline:d
+  ^-  tape
+  ?@  c  (trip c)
+  ?-  -.c
+      %break  ""
+      %tag    (trip p.c)
+      %link   (trip q.c)
+      %block   (trip q.c)
+      ?(%code %inline-code)  ""
+      ?(%italics %bold %strike %blockquote)  (trip (flatten p.c))
+  ==
+::
+++  hark
+  |=  [our=ship =time =delta:notes:d]
+  ^-  (list (list content:ha))
+  ?.  ?=(%quips -.delta)
+    ~
+  =/  [@ =note:d]  (got time)
+  ~!  q.p.delta
+  ?.  ?=(%add -.q.p.delta)
+    ~
+  =/  =memo:d  p.q.p.delta
+  =/  in-replies
+    %+  lien  (tap:on:quips:d quips.note)
+    |=  [=^time =quip:d]
+    =(author.quip our)
+  ?:  |(=(author.memo our) !in-replies)  ~
+  =-  ~[-]
+  :~  [%ship author.memo]
+      ' commented on '
+      [%emph title.note]
+      ': '
+      [%ship author.memo]
+      ': '
+      (flatten content.memo)
   ==
 ::
 ++  peek
@@ -96,5 +146,9 @@
       [%note %id time=@ ~]
     =/  time  (slav %ud time.pole)
     ``note+!>((got `@da`time))
+  ::
+      [%note %id time=@ %quips rest=*]
+    =/  time  (slav %ud time.pole)
+    (~(peek qip quips:note:(got `@da`time)) rest.pole)
   ==
 --

--- a/desk/lib/notes.hoon
+++ b/desk/lib/notes.hoon
@@ -113,6 +113,20 @@
       ': '
       (flatten q.content.memo)
   ==
+::  +trace: turn note into outline
+::
+::    XX: should trim actual note contents, probably
+::
+++  trace
+  |=  =note:d
+  ^-  outline:d
+  =;  quippers=(set ship)
+    [~(wyt by quips.note) quippers +.note]
+  =-  (~(gas in *(set ship)) (scag 3 ~(tap in -)))
+  %-  ~(gas in *(set ship))
+  %+  turn  (tap:on:quips:d quips.note)
+  |=  [@ =quip:d]
+  author.quip
 ::
 ++  peek
   |=  =(pole knot)
@@ -122,10 +136,14 @@
   ?+    pole  [~ ~]
   ::
   ::  TODO: less iterations?
-      [%newest count=@ ~]
+      [%newest count=@ mode=?(%outline %note) ~]
     =/  count  (slav %ud count.pole)
     =/  ls    (scag count (bap:on not))
-    ``diary-notes+!>((gas:on *notes:d ls))
+    ?:  =(mode.pole %note)
+      ``diary-notes+!>((gas:on *notes:d ls))
+    =-  ``diary-outlines+!>(-)
+    %+  gas:on:outlines:d  *outlines:d
+    (turn ls |=([=time =note:d] [time (trace note)]))
   ::
       [%older start=@ count=@ ~]
     =/  count  (slav %ud count.pole)
@@ -143,9 +161,9 @@
     (scag count (tap:on (lot:on not `start ~)))
 
   ::
-      [%note %id time=@ ~]
+      [%note time=@ ~]
     =/  time  (slav %ud time.pole)
-    ``note+!>((got `@da`time))
+    ``diary-note+!>(+:(got `@da`time))
   ::
       [%note %id time=@ %quips rest=*]
     =/  time  (slav %ud time.pole)

--- a/desk/lib/quips.hoon
+++ b/desk/lib/quips.hoon
@@ -27,10 +27,10 @@
   ^+  qup
   ?-  -.del
       %add
-    =/  =seal:d  [time ~]
+    =/  =cork:d  [time ~]
     ?:  (~(has by qup) time)
       qup
-    (put:on:quips:d qup now [seal p.del])
+    (put:on:quips:d qup now [cork p.del])
   ::
       %del
     =^  no=(unit quip:d)  qup

--- a/desk/mar/diary/note.hoon
+++ b/desk/mar/diary/note.hoon
@@ -1,0 +1,14 @@
+/-  d=diary
+/+  j=diary-json
+|_  =note:d
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  note
+  ++  json  (note:enjs:j note)
+  --
+++  grab
+  |%
+  ++  noun  note:d
+  --
+--

--- a/desk/mar/diary/outline.hoon
+++ b/desk/mar/diary/outline.hoon
@@ -1,0 +1,14 @@
+/-  d=diary
+/+  j=diary-json
+|_  =outline:d
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  outline
+  ++  json  (outline:enjs:j outline)
+  --
+++  grab
+  |%
+  ++  noun  outline:d
+  --
+--

--- a/desk/mar/diary/outlines.hoon
+++ b/desk/mar/diary/outlines.hoon
@@ -1,0 +1,14 @@
+/-  d=diary
+/+  j=diary-json
+|_  =outlines:d
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  outlines
+  ++  json  (outlines:enjs:j outlines)
+  --
+++  grab
+  |%
+  ++  noun  outlines:d
+  --
+--

--- a/desk/sur/diary-0.hoon
+++ b/desk/sur/diary-0.hoon
@@ -1,12 +1,8 @@
-/-  g=groups, c=cite, zer=diary-0
+/-  g=groups, c=cite
 |%
-++  old
-  |%
-  ++  zero  zer
-  --
 ::  $flag: identifier for a diary channel
 +$  flag  (pair ship term)
-::  $feel: either an emoji identifier like :diff or a URL for custom
+::  $feel: either an emoji identifier like :wave or a URL for custom
 +$  feel  @ta
 ::  $view: the persisted display format for a diary
 +$  view  ?(%grid %list)
@@ -34,14 +30,15 @@
       =sort
       =notes
       =remark
+      banter=(map time quips)
   ==
 ::
 ::  $notes: a set of time ordered diary posts
 ::
 ++  notes
-  =<  rock
+  =<  notes
   |%
-  +$  rock
+  +$  notes
     ((mop time note) lte)
   ++  on
     ((^on time note) lte)
@@ -51,7 +48,6 @@
     $%  [%add p=essay]
         [%edit p=essay]
         [%del ~]
-        [%quips p=diff:quips]
         [%add-feel p=ship q=feel]
         [%del-feel p=ship]
     ==
@@ -60,9 +56,9 @@
 ::  $quips: a set of time ordered note comments
 ::
 ++  quips
-  =<  rock
+  =<  quips
   |%
-  +$  rock
+  +$  quips
     ((mop time quip) lte)
   ++  on
     ((^on time quip) lte)
@@ -75,38 +71,15 @@
         [%del-feel p=ship]
     ==
   --
-::
-::  $outline: abridged $note
-::    .quips: number of comments
-::
-+$  outline
-  [quips=@ud quippers=(set ship) essay]
-::
-++  outlines
-  =<  outlines
-  |%
-  +$  outlines  ((mop time outline) lte)
-  ++  on        ((^on time outline) lte)
-  --
-::
 ::  $note: a diary post
 ::
 +$  note  [seal essay]
 ::  $quip: a post comment
 ::
-+$  quip  [cork memo]
-::
-::  $seal: host-side data for a note
++$  quip  [seal memo]
+::  $seal: the id and reactions to a post
 ::
 +$  seal
-  $:  =time
-      =quips
-      feels=(map ship feel)
-  ==
-::
-::  $cork: host-side data for a quip
-::
-+$  cork
   $:  =time
       feels=(map ship feel)
   ==
@@ -125,15 +98,16 @@
       author=ship
       sent=time      
   ==
-+$  story  (pair (list block) (list inline))
 ::  $memo: the comment data itself
 ::
+::    replying: which post we're replying to
 ::    content: the body of the comment
 ::    author: the ship that wrote the comment
 ::    sent: the client-side time the comment was made
 ::
 +$  memo
-  $:  content=story
+  $:  replying=time
+      content=(list inline)
       author=ship
       sent=time
   ==
@@ -203,6 +177,7 @@
 ::
 +$  diff
   $%  [%notes p=diff:notes]
+      [%quips p=time q=diff:quips]
     ::
       [%add-sects p=(set sect:g)]
       [%del-sects p=(set sect:g)]

--- a/desk/sur/diary.hoon
+++ b/desk/sur/diary.hoon
@@ -2,7 +2,7 @@
 |%
 ::  $flag: identifier for a diary channel
 +$  flag  (pair ship term)
-::  $feel: either an emoji identifier like :wave or a URL for custom
+::  $feel: either an emoji identifier like :diff or a URL for custom
 +$  feel  @ta
 ::  $view: the persisted display format for a diary
 +$  view  ?(%grid %list)
@@ -35,9 +35,9 @@
 ::  $notes: a set of time ordered diary posts
 ::
 ++  notes
-  =<  notes
+  =<  rock
   |%
-  +$  notes
+  +$  rock
     ((mop time note) lte)
   ++  on
     ((^on time note) lte)
@@ -56,9 +56,9 @@
 ::  $quips: a set of time ordered note comments
 ::
 ++  quips
-  =<  quips
+  =<  rock
   |%
-  +$  quips
+  +$  rock
     ((mop time quip) lte)
   ++  on
     ((^on time quip) lte)
@@ -71,6 +71,20 @@
         [%del-feel p=ship]
     ==
   --
+::
+::  $outline: abridged $note
+::    .quips: number of comments
+::
++$  outline
+  [quips=@ud quippers=(set ship) essay]
+::
+++  outlines
+  =<  outlines
+  |%
+  +$  outlines  ((mop time outline) lte)
+  ++  on        ((^on time outline) lte)
+  --
+::
 ::  $note: a diary post
 ::
 +$  note  [seal essay]

--- a/desk/sur/diary.hoon
+++ b/desk/sur/diary.hoon
@@ -30,7 +30,6 @@
       =sort
       =notes
       =remark
-      banter=(map time quips)
   ==
 ::
 ::  $notes: a set of time ordered diary posts
@@ -48,6 +47,7 @@
     $%  [%add p=essay]
         [%edit p=essay]
         [%del ~]
+        [%quips p=diff:quips]
         [%add-feel p=ship q=feel]
         [%del-feel p=ship]
     ==
@@ -76,10 +76,19 @@
 +$  note  [seal essay]
 ::  $quip: a post comment
 ::
-+$  quip  [seal memo]
-::  $seal: the id and reactions to a post
++$  quip  [cork memo]
+::
+::  $seal: host-side data for a note
 ::
 +$  seal
+  $:  =time
+      =quips
+      feels=(map ship feel)
+  ==
+::
+::  $cork: host-side data for a quip
+::
++$  cork
   $:  =time
       feels=(map ship feel)
   ==
@@ -177,7 +186,6 @@
 ::
 +$  diff
   $%  [%notes p=diff:notes]
-      [%quips p=time q=diff:quips]
     ::
       [%add-sects p=(set sect:g)]
       [%del-sects p=(set sect:g)]

--- a/desk/sur/diary.hoon
+++ b/desk/sur/diary.hoon
@@ -107,16 +107,15 @@
       author=ship
       sent=time      
   ==
++$  story  (pair (list block) (list inline))
 ::  $memo: the comment data itself
 ::
-::    replying: which post we're replying to
 ::    content: the body of the comment
 ::    author: the ship that wrote the comment
 ::    sent: the client-side time the comment was made
 ::
 +$  memo
-  $:  replying=time
-      content=(list inline)
+  $:  content=story
       author=ship
       sent=time
   ==

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Link } from 'react-router-dom';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
-import { useDiaryState, useNote, useQuips } from '@/state/diary';
+import { useDiaryState, useNote } from '@/state/diary';
 import { useChannelPreview } from '@/state/groups';
 import { makePrettyDate } from '@/logic/utils';
 import { udToDec } from '@urbit/api';
@@ -24,7 +24,7 @@ export default function NoteReference({
   const [scryError, setScryError] = useState<string>();
   const groupFlag = preview?.group?.flag || '~zod/test';
   const noteObject = useNote(chFlag, id);
-  const quips = useQuips(chFlag, id);
+  const { quips } = noteObject[1].seal;
   const commentAuthors = _.uniq(
     Array.from(quips).map(([, quip]) => quip.memo.author)
   );

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -33,7 +33,7 @@ function DiaryChannel() {
   const nest = `diary/${chFlag}`;
   const flag = useRouteGroup();
   const vessel = useVessel(flag, window.our);
-  const notes = useNotesForDiary(chFlag);
+  const letters = useNotesForDiary(chFlag);
   const location = useLocation();
   const navigate = useNavigate();
   const [, setRecent] = useLocalStorage(
@@ -101,7 +101,7 @@ function DiaryChannel() {
     markRead: useDiaryState.getState().markRead,
   });
 
-  const sortedNotes = Array.from(notes).sort(([a], [b]) => {
+  const sortedNotes = Array.from(letters).sort(([a], [b]) => {
     if (sortMode === 'time-dsc') {
       return b.compare(a);
     }
@@ -169,8 +169,12 @@ function DiaryChannel() {
         ) : (
           <div className="h-full p-6">
             <div className="mx-auto flex h-full max-w-[600px] flex-col space-y-4">
-              {sortedNotes.map(([time, note]) => (
-                <DiaryListItem key={time.toString()} time={time} note={note} />
+              {sortedNotes.map(([time, letter]) => (
+                <DiaryListItem
+                  key={time.toString()}
+                  time={time}
+                  letter={letter}
+                />
               ))}
             </div>
           </div>

--- a/ui/src/diary/DiaryComment.tsx
+++ b/ui/src/diary/DiaryComment.tsx
@@ -25,7 +25,7 @@ const DiaryComment = React.memo<
       { time, quip, unreadCount, newAuthor, newDay }: DiaryCommentProps,
       ref
     ) => {
-      const { seal, memo } = quip;
+      const { cork, memo } = quip;
       const unix = new Date(daToUnix(time));
 
       return (
@@ -43,9 +43,9 @@ const DiaryComment = React.memo<
               {format(unix, 'HH:mm')}
             </div>
             <div className="flex w-full flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50">
-              <ChatContent story={{ block: [], inline: memo.content }} />
-              {/* {Object.keys(seal.feels).length > 0 && (
-                <ChatReactions seal={seal} />
+              <ChatContent story={memo.content} />
+              {/* {Object.keys(cork.feels).length > 0 && (
+                <ChatReactions cork={cork} />
               )} */}
             </div>
           </div>

--- a/ui/src/diary/DiaryList/DiaryGridItem.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridItem.tsx
@@ -11,7 +11,6 @@ import { makePrettyDate } from '@/logic/utils';
 import { daToUnix } from '@urbit/api';
 import DiaryCommenters from '@/diary/DiaryCommenters';
 import { useChannelFlag } from '@/hooks';
-import { useQuips } from '@/state/diary';
 import CheckIcon from '@/components/icons/CheckIcon';
 import DiaryNoteOptionsDropdown from '../DiaryNoteOptionsDropdown';
 import useDiaryActions from '../useDiaryActions';
@@ -24,7 +23,6 @@ interface DiaryGridItemProps {
 export default function DiaryGridItem({ letter, time }: DiaryGridItemProps) {
   const chFlag = useChannelFlag();
   const essay: NoteEssay = letter.type === 'outline' ? letter : letter.essay;
-  const quips = useQuips(chFlag || '', time.toString());
   const unix = new Date(daToUnix(time));
   const date = makePrettyDate(unix);
   const navigate = useNavigate();
@@ -49,7 +47,7 @@ export default function DiaryGridItem({ letter, time }: DiaryGridItemProps) {
           f.compact,
           f.uniq,
           f.take(3)
-        )([...quips].map(([, v]) => v.memo.author));
+        )([...letter.seal.quips].map(([, v]) => v.memo.author));
   const quipCount =
     letter.type === 'outline' ? letter.quipCount : letter.seal.quips.size;
 
@@ -81,7 +79,7 @@ export default function DiaryGridItem({ letter, time }: DiaryGridItemProps) {
         <div role="button" onClick={() => navigate(`note/${time.toString()}`)}>
           <DiaryCommenters
             commenters={commenters}
-            quipCount={quips.size}
+            quipCount={quipCount}
             fullSize={false}
             gridItemHasImage={hasImage}
           />

--- a/ui/src/diary/DiaryList/DiaryGridView.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridView.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { Masonry, RenderComponentProps } from 'masonic';
 import DiaryGridItem from '@/diary/DiaryList/DiaryGridItem';
-import { DiaryNote } from '@/types/diary';
+import { DiaryLetter, DiaryNote } from '@/types/diary';
 
 interface DiaryGridProps {
-  notes: [bigInt.BigInteger, DiaryNote][];
+  notes: [bigInt.BigInteger, DiaryLetter][];
 }
 
 const masonryItem = ({
   data,
-}: RenderComponentProps<[bigInt.BigInteger, DiaryNote]>) => (
-  <DiaryGridItem time={data[0]} note={data[1]} />
+}: RenderComponentProps<[bigInt.BigInteger, DiaryLetter]>) => (
+  <DiaryGridItem time={data[0]} letter={data[1]} />
 );
 
 export default function DiaryGridView({ notes }: DiaryGridProps) {

--- a/ui/src/diary/DiaryList/DiaryListItem.tsx
+++ b/ui/src/diary/DiaryList/DiaryListItem.tsx
@@ -1,15 +1,25 @@
 import React from 'react';
-import { DiaryNote } from '@/types/diary';
+import _ from 'lodash';
+import f from 'lodash/fp';
+import { DiaryLetter, DiaryNote } from '@/types/diary';
 import DiaryNoteHeadline from '@/diary/DiaryNoteHeadline';
 import { useNavigate } from 'react-router';
+import { sampleQuippers } from '@/logic/utils';
 
 interface DiaryListItemProps {
-  note: DiaryNote;
+  letter: DiaryLetter;
   time: bigInt.BigInteger;
 }
 
-export default function DiaryListItem({ note, time }: DiaryListItemProps) {
+export default function DiaryListItem({ letter, time }: DiaryListItemProps) {
   const navigate = useNavigate();
+  const essay = letter.type === 'outline' ? letter : letter.essay;
+  const quippers =
+    letter.type === 'outline'
+      ? letter.quippers
+      : sampleQuippers(letter.seal.quips);
+  const quipCount =
+    letter.type === 'outline' ? letter.quipCount : letter.seal.quips.size;
 
   return (
     <div
@@ -18,7 +28,13 @@ export default function DiaryListItem({ note, time }: DiaryListItemProps) {
       tabIndex={0}
       onClick={() => navigate(`note/${time.toString()}`)}
     >
-      <DiaryNoteHeadline note={note} time={time} isInList />
+      <DiaryNoteHeadline
+        quippers={quippers}
+        quipCount={quipCount}
+        essay={essay}
+        time={time}
+        isInList
+      />
     </div>
   );
 }

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -2,13 +2,7 @@ import _ from 'lodash';
 import Divider from '@/components/Divider';
 import Layout from '@/components/Layout/Layout';
 import { pluralize, sampleQuippers } from '@/logic/utils';
-import {
-  useBrief,
-  useDiaryState,
-  useNote,
-  useQuips,
-  useDiaryPerms,
-} from '@/state/diary';
+import { useBrief, useDiaryState, useNote, useDiaryPerms } from '@/state/diary';
 import { useRouteGroup, useVessel, useAmAdmin } from '@/state/groups/groups';
 import { DiaryBrief, DiaryQuip } from '@/types/diary';
 import { daToUnix } from '@urbit/api';

--- a/ui/src/diary/DiaryNoteHeadline.tsx
+++ b/ui/src/diary/DiaryNoteHeadline.tsx
@@ -1,10 +1,9 @@
 import _ from 'lodash';
 import React, { useCallback, useState } from 'react';
 import f from 'lodash/fp';
-import { DiaryNote, NoteEssay } from '@/types/diary';
+import { DiaryLetter, DiaryNote, NoteEssay } from '@/types/diary';
 import { format } from 'date-fns';
 import { useChannelFlag } from '@/hooks';
-import { useQuips } from '@/state/diary';
 import DiaryCommenters from '@/diary/DiaryCommenters';
 import IconButton from '@/components/IconButton';
 import CheckIcon from '@/components/icons/CheckIcon';
@@ -16,6 +15,7 @@ import { useGroupFlag } from '@/state/groups';
 import { useCopyToClipboard } from 'usehooks-ts';
 import { useNavigate } from 'react-router-dom';
 import Author from '@/chat/ChatMessage/Author';
+import { sampleQuippers } from '@/logic/utils';
 import useDiaryActions from './useDiaryActions';
 
 interface DiaryListItemProps {
@@ -36,17 +36,12 @@ export default function DiaryNoteHeadline({
   const chFlag = useChannelFlag();
   const flag = useRouteGroup();
   const navigate = useNavigate();
-  const quips = useQuips(chFlag || '', time.toString());
   const { justCopied, onCopy } = useDiaryActions({
     flag: chFlag || '',
     time: time.toString(),
   });
 
-  const commenters = _.flow(
-    f.compact,
-    f.uniq,
-    f.take(3)
-  )([...quips].map(([, v]) => v.memo.author));
+  const commenters = quippers;
 
   const isAdmin = useAmAdmin(flag);
 
@@ -80,7 +75,7 @@ export default function DiaryNoteHeadline({
                 >
                   <DiaryCommenters
                     commenters={commenters}
-                    quipCount={quips.size}
+                    quipCount={quipCount}
                     fullSize={!isInList}
                   />
                 </span>
@@ -112,7 +107,7 @@ export default function DiaryNoteHeadline({
               <a href="#comments" className="no-underline">
                 <DiaryCommenters
                   commenters={commenters}
-                  quipCount={quips.size}
+                  quipCount={quipCount}
                   fullSize={!isInList}
                 />
               </a>

--- a/ui/src/diary/DiaryNoteHeadline.tsx
+++ b/ui/src/diary/DiaryNoteHeadline.tsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, { useCallback, useState } from 'react';
 import f from 'lodash/fp';
-import { DiaryNote } from '@/types/diary';
+import { DiaryNote, NoteEssay } from '@/types/diary';
 import { format } from 'date-fns';
 import { useChannelFlag } from '@/hooks';
 import { useQuips } from '@/state/diary';
@@ -19,13 +19,17 @@ import Author from '@/chat/ChatMessage/Author';
 import useDiaryActions from './useDiaryActions';
 
 interface DiaryListItemProps {
-  note: DiaryNote;
+  essay: NoteEssay;
+  quipCount: number;
+  quippers: string[];
   time: bigInt.BigInteger;
   isInList?: boolean;
 }
 
 export default function DiaryNoteHeadline({
-  note,
+  essay,
+  quipCount,
+  quippers,
   time,
   isInList,
 }: DiaryListItemProps) {
@@ -48,26 +52,20 @@ export default function DiaryNoteHeadline({
 
   return (
     <>
-      {note.essay.image && (
-        <img
-          src={note.essay.image}
-          alt=""
-          className="h-auto w-full rounded-xl"
-        />
+      {essay.image && (
+        <img src={essay.image} alt="" className="h-auto w-full rounded-xl" />
       )}
       <header className="mt-8 space-y-8">
-        <h1 className="text-3xl font-semibold leading-10">
-          {note.essay.title}
-        </h1>
+        <h1 className="text-3xl font-semibold leading-10">{essay.title}</h1>
         <p className="font-semibold text-gray-400">
-          {format(note.essay.sent, 'LLLL do, yyyy')}
+          {format(essay.sent, 'LLLL do, yyyy')}
         </p>
         <div className="flex items-center">
           <div
             className="flex items-center space-x-2 font-semibold"
             onClick={(e) => e.stopPropagation()}
           >
-            <Author ship={note.essay.author} hideTime />
+            <Author ship={essay.author} hideTime />
           </div>
 
           <div
@@ -101,7 +99,7 @@ export default function DiaryNoteHeadline({
                 <DiaryNoteOptionsDropdown
                   time={time.toString()}
                   flag={chFlag || ''}
-                  canEdit={isAdmin || window.our === note.essay.author}
+                  canEdit={isAdmin || window.our === essay.author}
                 >
                   <IconButton
                     className="h-8 w-8"

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -1,9 +1,11 @@
 import ob from 'urbit-ob';
+import { BigInteger } from 'big-integer';
 import { unixToDa } from '@urbit/api';
 import { formatUv } from '@urbit/aura';
 import anyAscii from 'any-ascii';
 import { format, differenceInDays, endOfToday } from 'date-fns';
 import _ from 'lodash';
+import f from 'lodash/fp';
 import { Chat, ChatWhom, ChatBrief, Cite } from '@/types/chat';
 import {
   Cabals,
@@ -14,13 +16,22 @@ import {
   Rank,
 } from '@/types/groups';
 import { CurioContent, Heap, HeapBrief } from '@/types/heap';
-import { DiaryBrief } from '@/types/diary';
+import { DiaryBrief, DiaryQuip, DiaryQuipMap, DiaryQuips } from '@/types/diary';
 import { parseToRgba } from 'color2k';
 
 export function nestToFlag(nest: string): [string, string] {
   const [app, ...rest] = nest.split('/');
 
   return [app, rest.join('/')];
+}
+
+export function sampleQuippers(quips: DiaryQuipMap) {
+  return _.flow(
+    f.map(([, q]: [BigInteger, DiaryQuip]) => q.memo.author),
+    f.compact,
+    f.uniq,
+    f.take(3)
+  )([...quips]);
 }
 
 export function renderRank(rank: Rank, plural = false) {

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -181,29 +181,6 @@ export const useDiaryState = create<DiaryState>(
           },
         });
       },
-      fetchQuips: async (flag, noteId) => {
-        const id = decToUd(noteId);
-        const res = await api.scry<DiaryQuips>({
-          app: 'diary',
-          path: `/diary/${flag}/quips/${id}/all`,
-        });
-
-        get().batchSet((draft) => {
-          const map = new BigIntOrderedMap<DiaryQuip>().gas(
-            _.map(res, (val, key) => {
-              const k = bigInt(udToDec(key));
-              return [k, val];
-            })
-          );
-
-          if (!(flag in draft.banter)) {
-            draft.banter[flag] = {};
-          }
-
-          draft.banter[flag][noteId] = map;
-        });
-      },
-
       fetchNote: async (flag, noteId) => {
         const note = await api.scry<DiaryNote>({
           app: 'diary',
@@ -420,18 +397,6 @@ export function useBrief(flag: string) {
   return useDiaryState(useCallback((s: DiaryState) => s.briefs[flag], [flag]));
 }
 
-export function useQuips(flag: string, noteId: string): DiaryQuipMap {
-  useEffect(() => {
-    useDiaryState.getState().fetchQuips(flag, noteId);
-  }, [flag, noteId]);
-
-  return useDiaryState(
-    useCallback(
-      (s) => s.banter[flag]?.[noteId] || new BigIntOrderedMap(),
-      [flag, noteId]
-    )
-  );
-}
 // TODO: this is a WIP part of implementing sorting by most recent comment
 // export function useDiaryQuips(flag: string): [bigInt.BigInteger, DiaryQuipMap][] {
 //   const def = useMemo(() => new BigIntOrderedMap<DiaryQuipMap>(), []);

--- a/ui/src/state/diary/type.ts
+++ b/ui/src/state/diary/type.ts
@@ -20,15 +20,9 @@ export interface DiaryState {
   notes: {
     [flag: DiaryFlag]: DiaryNoteMap;
   };
-  banter: {
-    [flag: DiaryFlag]: {
-      [noteId: string]: DiaryQuipMap;
-    };
-  };
   briefs: DiaryBriefs;
   create: (req: DiaryCreate) => Promise<void>;
   start: () => Promise<void>;
-  fetchQuips: (flag: DiaryFlag, noteId: string) => Promise<void>;
   fetchNote: (flag: DiaryFlag, noteId: string) => Promise<void>;
   initialize: (flag: DiaryFlag) => Promise<void>;
   joinDiary: (flag: DiaryFlag) => Promise<void>;

--- a/ui/src/state/diary/type.ts
+++ b/ui/src/state/diary/type.ts
@@ -29,6 +29,7 @@ export interface DiaryState {
   create: (req: DiaryCreate) => Promise<void>;
   start: () => Promise<void>;
   fetchQuips: (flag: DiaryFlag, noteId: string) => Promise<void>;
+  fetchNote: (flag: DiaryFlag, noteId: string) => Promise<void>;
   initialize: (flag: DiaryFlag) => Promise<void>;
   joinDiary: (flag: DiaryFlag) => Promise<void>;
   leaveDiary: (flag: DiaryFlag) => Promise<void>;

--- a/ui/src/types/diary.ts
+++ b/ui/src/types/diary.ts
@@ -32,6 +32,14 @@ export type DiaryInline =
 
 export interface NoteSeal {
   time: string;
+  quips: DiaryQuipMap;
+  feels: {
+    [ship: Ship]: string;
+  };
+}
+
+export interface NoteCork {
+  time: string;
   feels: {
     [ship: Ship]: string;
   };
@@ -97,24 +105,43 @@ export interface NoteEssay {
 }
 
 export interface DiaryNote {
+  type: 'note';
   seal: NoteSeal;
   essay: NoteEssay;
 }
 
-export interface DiaryNotes {
-  [time: string]: DiaryNote;
+export interface DiaryOutline extends NoteEssay {
+  type: 'outline';
+  quipCount: number;
+  quippers: Ship[];
 }
 
-export type DiaryNoteMap = BigIntOrderedMap<DiaryNote>;
+export interface DiaryOutlines {
+  [time: string]: DiaryOutline;
+}
+
+export type DiaryOutlinesMap = BigIntOrderedMap<DiaryOutline>;
+
+export type DiaryLetter = DiaryOutline | DiaryNote;
+
+export interface DiaryNotes {
+  [time: string]: DiaryLetter;
+}
+
+export type DiaryNoteMap = BigIntOrderedMap<DiaryLetter>;
 
 export interface DiaryQuip {
-  seal: NoteSeal;
+  cork: NoteCork;
   memo: DiaryMemo;
 }
 
+export interface DiaryStory {
+  block: DiaryBlock[];
+  inline: Inline[];
+}
+
 export interface DiaryMemo {
-  replying: string;
-  content: Inline[];
+  content: DiaryStory;
   author: string;
   sent: number;
 }
@@ -153,18 +180,16 @@ interface DiaryDiffDelSects {
   'del-sects': string[];
 }
 
-interface DiaryDiffQuips {
-  quips: {
-    id: string;
-    diff: QuipDiff;
-  };
+interface NoteDeltaQuips {
+  quips: QuipDiff;
 }
 
 export type NoteDelta =
   | NoteDeltaAdd
   | NoteDeltaEdit
   | NoteDeltaDel
-  | NoteDeltaAddFeel;
+  | NoteDeltaAddFeel
+  | NoteDeltaQuips;
 
 export interface NoteDiff {
   time: string;
@@ -179,8 +204,7 @@ export type DiaryDiff =
   | { notes: NoteDiff }
   | DiaryDiffView
   | DiaryDiffAddSects
-  | DiaryDiffDelSects
-  | DiaryDiffQuips;
+  | DiaryDiffDelSects;
 
 export interface DiaryUpdate {
   time: string;


### PR DESCRIPTION
- Moves quips inside the $seal data structure of a note, instead of existing separately to the noteId -> note mapping
- Changes the datatype of publish quips to be at parity with chat messages
- Reworks the fetching of notes so that we don't have to front load so much data
