### PR TITLE
chat: sent/delivered status for messages

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -15,7 +15,12 @@ import ChatContent from '@/chat/ChatContent/ChatContent';
 import ChatReactions from '@/chat/ChatReactions/ChatReactions';
 import DateDivider from '@/chat/ChatMessage/DateDivider';
 import ChatMessageOptions from '@/chat/ChatMessage/ChatMessageOptions';
-import { usePact, useChatState, useIsMessageDelivered } from '@/state/chat';
+import {
+  usePact,
+  useChatState,
+  useIsMessageDelivered,
+  useIsMessagePosted,
+} from '@/state/chat';
 import Avatar from '@/components/Avatar';
 import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 
@@ -56,6 +61,7 @@ const ChatMessage = React.memo<
         triggerOnce: true,
       });
       const isMessageDelivered = useIsMessageDelivered(seal.id);
+      const isMessagePosted = useIsMessagePosted(seal.id);
 
       useEffect(() => {
         if (inView === true) {
@@ -105,7 +111,7 @@ const ChatMessage = React.memo<
                 className={cn(
                   'flex w-full grow flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50',
                   isReplyOp && 'bg-gray-50',
-                  !isMessageDelivered && 'text-gray-400'
+                  !isMessageDelivered && !isMessagePosted && 'text-gray-400'
                 )}
               >
                 {'story' in memo.content ? (
@@ -146,7 +152,7 @@ const ChatMessage = React.memo<
                 {!isMessageDelivered && (
                   <DoubleCaretRightIcon
                     className="h-5 w-5"
-                    primary="text-gray-200"
+                    primary={isMessagePosted ? 'text-black' : 'text-gray-200'}
                     secondary="text-gray-200"
                   />
                 )}

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -15,8 +15,9 @@ import ChatContent from '@/chat/ChatContent/ChatContent';
 import ChatReactions from '@/chat/ChatReactions/ChatReactions';
 import DateDivider from '@/chat/ChatMessage/DateDivider';
 import ChatMessageOptions from '@/chat/ChatMessage/ChatMessageOptions';
-import { usePact, useChatState } from '@/state/chat';
+import { usePact, useChatState, useIsMessageDelivered } from '@/state/chat';
 import Avatar from '@/components/Avatar';
+import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 
 export interface ChatMessageProps {
   whom: string;
@@ -54,6 +55,7 @@ const ChatMessage = React.memo<
         threshold: 1,
         triggerOnce: true,
       });
+      const isMessageDelivered = useIsMessageDelivered(seal.id);
 
       useEffect(() => {
         if (inView === true) {
@@ -102,6 +104,7 @@ const ChatMessage = React.memo<
               className={cn(
                 'flex w-full flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50',
                 isReplyOp && 'bg-gray-50'
+                // sendStatus === 'sent' && 'text-gray-400'
               )}
             >
               {'story' in memo.content ? (
@@ -138,6 +141,9 @@ const ChatMessage = React.memo<
                 </NavLink>
               ) : null}
             </div>
+          </div>
+          <div>
+            {/* <DoubleCaretRightIcon className='h-6 w-6 text-gray-400' primary='text-gray-400' secondary='text-gray-400' /> */}
           </div>
         </div>
       );

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -100,50 +100,58 @@ const ChatMessage = React.memo<
             <div className="-ml-1 mr-1 py-2 text-xs font-semibold text-gray-400 opacity-0 group-one-hover:opacity-100">
               {format(unix, 'HH:mm')}
             </div>
-            <div
-              className={cn(
-                'flex w-full flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50',
-                isReplyOp && 'bg-gray-50'
-                // sendStatus === 'sent' && 'text-gray-400'
-              )}
-            >
-              {'story' in memo.content ? (
-                <ChatContent story={memo.content.story} />
-              ) : null}
-              {Object.keys(seal.feels).length > 0 && (
-                <ChatReactions seal={seal} whom={whom} />
-              )}
-              {numReplies > 0 && !hideReplies ? (
-                <NavLink
-                  to={`message/${seal.id}`}
-                  className={({ isActive }) =>
-                    cn(
-                      'rounded p-2 text-sm font-semibold text-blue',
-                      isActive ? 'bg-gray-50' : ''
-                    )
-                  }
-                >
-                  <div className="flex items-center space-x-2">
-                    {replyAuthors.map((ship) => (
-                      <Avatar key={ship} ship={ship} size="xs" />
-                    ))}
+            <div className="flex w-full">
+              <div
+                className={cn(
+                  'flex w-full grow flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50',
+                  isReplyOp && 'bg-gray-50',
+                  !isMessageDelivered && 'text-gray-400'
+                )}
+              >
+                {'story' in memo.content ? (
+                  <ChatContent story={memo.content.story} />
+                ) : null}
+                {Object.keys(seal.feels).length > 0 && (
+                  <ChatReactions seal={seal} whom={whom} />
+                )}
+                {numReplies > 0 && !hideReplies ? (
+                  <NavLink
+                    to={`message/${seal.id}`}
+                    className={({ isActive }) =>
+                      cn(
+                        'rounded p-2 text-sm font-semibold text-blue',
+                        isActive ? 'bg-gray-50' : ''
+                      )
+                    }
+                  >
+                    <div className="flex items-center space-x-2">
+                      {replyAuthors.map((ship) => (
+                        <Avatar key={ship} ship={ship} size="xs" />
+                      ))}
 
-                    <span>
-                      {numReplies} {numReplies > 1 ? 'replies' : 'reply'}{' '}
-                    </span>
-                    <span className="text-gray-400">
-                      Last reply{' '}
-                      {isToday(unix)
-                        ? `${formatDistanceToNow(unix)} ago`
-                        : formatRelative(unix, new Date())}
-                    </span>
-                  </div>
-                </NavLink>
-              ) : null}
+                      <span>
+                        {numReplies} {numReplies > 1 ? 'replies' : 'reply'}{' '}
+                      </span>
+                      <span className="text-gray-400">
+                        Last reply{' '}
+                        {isToday(unix)
+                          ? `${formatDistanceToNow(unix)} ago`
+                          : formatRelative(unix, new Date())}
+                      </span>
+                    </div>
+                  </NavLink>
+                ) : null}
+              </div>
+              <div className="flex items-end rounded-r group-one-hover:bg-gray-50">
+                {!isMessageDelivered && (
+                  <DoubleCaretRightIcon
+                    className="h-5 w-5"
+                    primary="text-gray-200"
+                    secondary="text-gray-200"
+                  />
+                )}
+              </div>
             </div>
-          </div>
-          <div>
-            {/* <DoubleCaretRightIcon className='h-6 w-6 text-gray-400' primary='text-gray-400' secondary='text-gray-400' /> */}
           </div>
         </div>
       );

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -251,23 +251,29 @@ exports[`ChatMessage > renders as expected 1`] = `
         13:00
       </div>
       <div
-        class="flex w-full flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50"
+        class="flex w-full"
       >
         <div
-          class="leading-6"
+          class="flex w-full grow flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50"
         >
-          <strong>
+          <div
+            class="leading-6"
+          >
+            <strong>
+              <span>
+                A bold test message
+              </span>
+            </strong>
             <span>
-              A bold test message
+              with some more text
             </span>
-          </strong>
-          <span>
-            with some more text
-          </span>
+          </div>
         </div>
+        <div
+          class="flex items-end rounded-r group-one-hover:bg-gray-50"
+        />
       </div>
     </div>
-    <div />
   </div>
 </DocumentFragment>
 `;

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -267,6 +267,7 @@ exports[`ChatMessage > renders as expected 1`] = `
         </div>
       </div>
     </div>
+    <div />
   </div>
 </DocumentFragment>
 `;

--- a/ui/src/state/base.ts
+++ b/ui/src/state/base.ts
@@ -138,7 +138,7 @@ export const createState = <T extends Record<string, unknown>>(
   properties:
     | T
     | ((set: SetState<T & BaseState<T>>, get: GetState<T & BaseState<T>>) => T),
-  blacklist: (keyof BaseState<T> | keyof T)[] = [],
+  whitelist: (keyof BaseState<T> | keyof T)[] = [],
   subscriptions: ((
     set: SetState<T & BaseState<T>>,
     get: GetState<T & BaseState<T>>
@@ -175,7 +175,7 @@ export const createState = <T extends Record<string, unknown>>(
           : properties),
       }),
       {
-        blacklist,
+        whitelist,
         name: stateStorageKey(name),
         version: storageVersion,
         migrate: clearStorageMigration,

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -629,15 +629,6 @@ export const useChatState = createState<ChatState>(
       ).initialize();
     },
   }),
-  // {
-  //   name: createStorageKey('chat'),
-  //   version: storageVersion,
-  //   migrate: clearStorageMigration,
-  //   partialize: (state) => ({
-  //     multiDms: state.multiDms,
-  //     pins: state.pins,
-  //   }),
-  // },
   ['multiDms', 'pins'],
   []
 );
@@ -645,12 +636,7 @@ export const useChatState = createState<ChatState>(
 export function useMessagesForChat(whom: string) {
   const def = useMemo(() => new BigIntOrderedMap<ChatWrit>(), []);
   return useChatState(
-    useCallback(
-      (s) =>
-        // debugger;
-        s.pacts[whom]?.writs || def,
-      [whom, def]
-    )
+    useCallback((s) => s.pacts[whom]?.writs || def, [whom, def])
   );
 }
 

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -134,6 +134,7 @@ export const useChatState = createState<ChatState>(
     pendingDms: [],
     pins: [],
     sentMessages: [],
+    postedMessages: [],
     briefs: {},
     togglePin: async (whom, pin) => {
       const { pins } = get();
@@ -422,7 +423,7 @@ export const useChatState = createState<ChatState>(
       if (isDM) {
         pokeOptimisticallyN(useChatState, dmAction(whom, { add: memo }, id), [
           writsReducer(whom),
-        ]);
+        ]).then(() => set((draft) => draft.postedMessages.push(id)));
       } else if (isMultiDm) {
         pokeOptimisticallyN(
           useChatState,
@@ -433,11 +434,11 @@ export const useChatState = createState<ChatState>(
             },
           }),
           [writsReducer(whom)]
-        );
+        ).then(() => set((draft) => draft.postedMessages.push(id)));
       } else {
         pokeOptimisticallyN(useChatState, chatWritDiff(whom, id, diff), [
           writsReducer(whom),
-        ]);
+        ]).then(() => set((draft) => draft.postedMessages.push(id)));
       }
       set((draft) => draft.sentMessages.push(id));
     },
@@ -655,6 +656,10 @@ export function useMessagesForChat(whom: string) {
 
 export function useIsMessageDelivered(id: string) {
   return useChatState(useCallback((s) => !s.sentMessages.includes(id), [id]));
+}
+
+export function useIsMessagePosted(id: string) {
+  return useChatState(useCallback((s) => s.postedMessages.includes(id), [id]));
 }
 
 const defaultPerms = {

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -9,11 +9,12 @@ import {
   Hive,
   ChatCreate,
 } from '../../types/chat';
+import { BaseState } from '../base';
 import { GroupMeta } from '../../types/groups';
 
 export interface ChatState {
-  set: (fn: (sta: ChatState) => void) => void;
-  batchSet: (fn: (sta: ChatState) => void) => void;
+  set: (fn: (sta: BasedChatState) => void) => void;
+  batchSet: (fn: (sta: BasedChatState) => void) => void;
   chats: {
     [flag: string]: Chat;
   };
@@ -28,6 +29,7 @@ export interface ChatState {
   };
   chatSubs: string[];
   dmSubs: string[];
+  sentMessages: string[];
   multiDmSubs: string[];
   pins: ChatWhom[];
   dmArchive: string[];
@@ -81,4 +83,7 @@ export interface ChatState {
   initialize: (flag: string) => Promise<void>;
   initializeDm: (ship: string) => Promise<void>;
   initializeMultiDm: (id: string) => Promise<void>; // id is `@uw`, the Club ID
+  [key: string]: unknown;
 }
+
+export type BasedChatState = ChatState & BaseState<ChatState>;

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -30,6 +30,7 @@ export interface ChatState {
   chatSubs: string[];
   dmSubs: string[];
   sentMessages: string[];
+  postedMessages: string[];
   multiDmSubs: string[];
   pins: ChatWhom[];
   dmArchive: string[];

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -1,8 +1,15 @@
 import { BigIntOrderedMap, decToUd, udToDec, unixToDa } from '@urbit/api';
 import bigInt from 'big-integer';
 import api from '../../api';
-import { ChatWrit, ChatWrits, Pact, WritDiff } from '../../types/chat';
-import { ChatState } from './type';
+import {
+  ChatWrit,
+  ChatWrits,
+  Pact,
+  WritDiff,
+  ChatAction,
+  WritDelta,
+} from '../../types/chat';
+import { ChatState, BasedChatState } from './type';
 
 interface WritsStore {
   initialize: () => Promise<void>;
@@ -10,9 +17,92 @@ interface WritsStore {
   getOlder: (count: string) => Promise<boolean>;
 }
 
+export function writsReducer(whom: string) {
+  return (
+    json: ChatAction | WritDiff,
+    draft: BasedChatState
+  ): BasedChatState => {
+    let id;
+    let delta;
+    if ('update' in json) {
+      if ('writs' in json.update.diff) {
+        id = json.update.diff.writs.id;
+        delta = json.update.diff.writs.delta;
+      }
+    } else {
+      id = json.id;
+      delta = json.delta;
+    }
+    if (!delta || !id) {
+      return draft;
+    }
+
+    const pact = draft.pacts[whom];
+
+    if ('add' in delta && !pact.index[id]) {
+      const time = bigInt(unixToDa(Date.now()));
+      pact.index[id] = time;
+      const seal = { id, feels: {}, replied: [] };
+      const writ = { seal, memo: delta.add };
+      pact.writs = pact.writs.set(time, writ);
+      if (delta.add.replying) {
+        const replyTime = pact.index[delta.add.replying];
+        if (replyTime) {
+          const ancestor = pact.writs.get(replyTime);
+          ancestor.seal.replied = [...ancestor.seal.replied, id];
+          pact.writs.set(replyTime, ancestor);
+        }
+      }
+    } else if ('del' in delta && pact.index[id]) {
+      const time = pact.index[id];
+      const old = pact.writs.get(time);
+      pact.writs = pact.writs.delete(time);
+      delete pact.index[id];
+      if (old.memo.replying) {
+        const replyTime = pact.index[old.memo.replying];
+        if (replyTime) {
+          const ancestor = pact.writs.get(replyTime);
+          ancestor.seal.replied = ancestor.seal.replied.filter(
+            (r) => r !== old.memo.replying
+          );
+          pact.writs.set(replyTime, ancestor);
+        }
+      }
+    } else if ('add-feel' in delta && pact.index[id]) {
+      const time = pact.index[id];
+      const msg = pact.writs.get(time);
+      const { ship, feel } = delta['add-feel'];
+
+      pact.writs = pact.writs.set(time, {
+        ...msg,
+        seal: {
+          ...msg.seal,
+          feels: {
+            ...msg.seal.feels,
+            [ship]: feel,
+          },
+        },
+      });
+    } else if ('del-feel' in delta && pact.index[id]) {
+      const time = pact.index[id];
+      const msg = pact.writs.get(time);
+      const ship = delta['del-feel'];
+      delete msg.seal.feels[ship];
+
+      pact.writs = pact.writs.set(time, {
+        ...msg,
+        seal: msg.seal,
+      });
+    }
+    draft.pacts[whom] = pact;
+
+    return draft;
+  };
+}
+
 export default function makeWritsStore(
   whom: string,
-  get: () => ChatState,
+  get: () => BasedChatState,
   scryPath: string,
   subPath: string
 ): WritsStore {
@@ -42,69 +132,12 @@ export default function makeWritsStore(
       api.subscribe({
         app: 'chat',
         path: subPath,
-        event: (data: unknown) => {
-          const { id, delta } = data as WritDiff;
-          const s = get();
-          s.batchSet((draft) => {
-            const pact = draft.pacts[whom];
-            if ('add' in delta && !pact.index[id]) {
-              const time = bigInt(unixToDa(Date.now()));
-              pact.index[id] = time;
-              const seal = { id, feels: {}, replied: [] };
-              const writ = { seal, memo: delta.add };
-              pact.writs = pact.writs.set(time, writ);
-              if (delta.add.replying) {
-                const replyTime = pact.index[delta.add.replying];
-                if (replyTime) {
-                  const ancestor = pact.writs.get(replyTime);
-                  ancestor.seal.replied = [...ancestor.seal.replied, id];
-                  pact.writs.set(replyTime, ancestor);
-                }
-              }
-            } else if ('del' in delta && pact.index[id]) {
-              const time = pact.index[id];
-              const old = pact.writs.get(time);
-              pact.writs = pact.writs.delete(time);
-              delete pact.index[id];
-              if (old.memo.replying) {
-                const replyTime = pact.index[old.memo.replying];
-                if (replyTime) {
-                  const ancestor = pact.writs.get(replyTime);
-                  ancestor.seal.replied = ancestor.seal.replied.filter(
-                    (r) => r !== old.memo.replying
-                  );
-                  pact.writs.set(replyTime, ancestor);
-                }
-              }
-              // const time = bigInt(udToDec(delta.del));
-              // draft.dms[ship].writs = draft.dms[ship].writs.delete(time);
-            } else if ('add-feel' in delta && pact.index[id]) {
-              const time = pact.index[id];
-              const msg = pact.writs.get(time);
-              const { ship, feel } = delta['add-feel'];
-
-              pact.writs = pact.writs.set(time, {
-                ...msg,
-                seal: {
-                  ...msg.seal,
-                  feels: {
-                    ...msg.seal.feels,
-                    [ship]: feel,
-                  },
-                },
-              });
-            } else if ('del-feel' in delta && pact.index[id]) {
-              const time = pact.index[id];
-              const msg = pact.writs.get(time);
-              const ship = delta['del-feel'];
-              delete msg.seal.feels[ship];
-
-              pact.writs = pact.writs.set(time, {
-                ...msg,
-                seal: msg.seal,
-              });
-            }
-            draft.pacts[whom] = pact;
+        event: (data: WritDiff) => {
+          get().batchSet((draft) => {
+            writsReducer(whom)(data, draft);
+            draft.sentMessages = draft.sentMessages.filter(
+              (id) => id !== data.id
+            );
           });
         },
       });


### PR DESCRIPTION
partially covers #711 

**Functionality that is covered:**
- Optimistic posting of sent messages from input field to ChatScroller
- "Sent from Browser, not delivered to host ship" and "Delivered to host shop" now have distinct visual states.

The effect on UX is that messages now feel like they post instantly now instead of having a percieved lag as the message makes its roundtrip from the host ship back to your urbit. (this is still so much faster than g1, it sometimes feels instant! but often it still doesn't!)

**Functionality that needs to be covered:**
- The distinct intermediary state of "sent from browser to user's ship, not yet reached host ship" detailed in issue #711
- design: https://www.figma.com/file/sCFYLlAGjehlYXUkT2rarg/Product-Handoffs-(Locked)?node-id=1292%3A69107

 @arthyn and i have determined that some sort of backend update is necessary for this to be achievable in any reasonable + reliable fashion, so we'd prefer to break open a second issue to get this feature finished up.

I feel pretty strongly that this visually minor feature should be put in before general release – it's actually incredibly informative on *why* a message didn't deliver instantly (no more going to the terminal to `|hi` a group's host when messages don't seem to deliver! And people who wouldn't think to do this can get the same information at a glance!)

