### PR TITLE
sort DMs by most recent

### DIFF
--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -46,7 +46,8 @@ export default function MessagesList({ filter }: MessagesListProps) {
 
       return true; // is all
     })
-    .sort(sortOptions[RECENT]);
+    .sort(sortOptions[RECENT])
+    .reverse();
 
   return (
     <ul


### PR DESCRIPTION
see: 988

apparently the "RECENT" flag in sortOptions was changed to sort by date, but in the wrong direction at some point. I'm reversing the sorted array, which is brute-forcey but works great.