### PR TITLE
chat: stop inserting linebreaks before/after styled text

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -35,11 +35,7 @@ export function GroupsAppMenu() {
       icon={
         <DropdownMenu.Root onOpenChange={() => setMenuOpen(!menuOpen)}>
           <DropdownMenu.Trigger asChild className="appearance-none">
-            <div
-              className={cn(
-                'h-6 w-6 rounded group-hover:bg-gray-100'
-              )}
-            >
+            <div className={cn('h-6 w-6 rounded group-hover:bg-gray-100')}>
               <AppGroupsIcon
                 className={cn(
                   'h-6 w-6',

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Sidebar > renders as expected 1`] = `
         >
           <div
             aria-haspopup="menu"
-            class="appearance-none h-6 w-6 rounded mix-blend-multiply group-hover:bg-gray-100"
+            class="appearance-none h-6 w-6 rounded group-hover:bg-gray-100"
             data-state="closed"
             id="radix-0"
             type="button"

--- a/ui/src/logic/tiptap.test.ts
+++ b/ui/src/logic/tiptap.test.ts
@@ -408,10 +408,10 @@ describe('JSONToInlines', () => {
   it('styled paragraph', () => {
     const input: JSONContent = {
       type: 'paragraph',
-      content: [{ type: 'text', text: 'foobar', marks: [{ type: 'bold' }] }],
+      content: [{ type: 'text', text: 'the following should be bold:' }, { type: 'text', text: 'foobar', marks: [{ type: 'bold' }] }],
     };
     const output = JSONToInlines(input);
-    const expected: Inline[] = [{ bold: ['foobar'] }, { break: null }];
+    const expected: Inline[] = ['the following should be bold:', { bold: ['foobar'] }, { break: null }];
     expect(output).toEqual(expected);
   });
 

--- a/ui/src/logic/tiptap.test.ts
+++ b/ui/src/logic/tiptap.test.ts
@@ -408,10 +408,17 @@ describe('JSONToInlines', () => {
   it('styled paragraph', () => {
     const input: JSONContent = {
       type: 'paragraph',
-      content: [{ type: 'text', text: 'the following should be bold:' }, { type: 'text', text: 'foobar', marks: [{ type: 'bold' }] }],
+      content: [
+        { type: 'text', text: 'the following should be bold:' },
+        { type: 'text', text: 'foobar', marks: [{ type: 'bold' }] },
+      ],
     };
     const output = JSONToInlines(input);
-    const expected: Inline[] = ['the following should be bold:', { bold: ['foobar'] }, { break: null }];
+    const expected: Inline[] = [
+      'the following should be bold:',
+      { bold: ['foobar'] },
+      { break: null },
+    ];
     expect(output).toEqual(expected);
   });
 

--- a/ui/src/logic/tiptap.ts
+++ b/ui/src/logic/tiptap.ts
@@ -165,11 +165,19 @@ export function JSONToInlines(
         return [{ break: null }];
       }
 
-      const inlines = json.content.reduce(
-        (memo, c) =>
-          memo.concat(JSONToInlines(c, limitNewlines), [{ break: null }]),
-        [] as (Inline | DiaryBlock)[]
-      );
+      const inlines = json.content.reduce((memo, c, idx) => {
+        // this check is here again, for typescript "null" detection
+        if (!json.content) {
+          return [{ break: null }];
+        }
+        const isContentFinal = idx === json.content.length - 1;
+        if (isContentFinal) {
+          return memo.concat(JSONToInlines(c, limitNewlines), [
+            { break: null },
+          ]);
+        }
+        return memo.concat(JSONToInlines(c, limitNewlines));
+      }, [] as (Inline | DiaryBlock)[]);
       return limitNewlines ? limitBreaks(inlines) : inlines;
     }
     case 'doc': {


### PR DESCRIPTION
see: #987 

the tests weren't catching this because our previous test for a "styled paragraph" consisted of a single word that was styled, in which case inserting the single linebreak after the word perfectly aligned with expected behavior.