### PR TITLE
groups: hide group joins with "error" states

### DIFF
--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -142,7 +142,7 @@ function GangItem(props: { flag: string }) {
   const { preview, claim } = useGang(flag);
   const isMobile = useIsMobile();
 
-  if (!claim) {
+  if (!claim || claim.progress === 'error') {
     return null;
   }
 

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Sidebar > renders as expected 1`] = `
         >
           <div
             aria-haspopup="menu"
-            class="appearance-none h-6 w-6 rounded mix-blend-multiply group-hover:bg-gray-100"
+            class="appearance-none h-6 w-6 rounded group-hover:bg-gray-100"
             data-state="closed"
             id="radix-0"
             type="button"


### PR DESCRIPTION
see: #782.

group joins that have an "error" state (due to nonexistent target group etc) were still appearing, this PR prevents them from appearing. tradeoff: the errored joins still technically persist in the backend, and could potentially build up and affect performance after long periods of use

the ideal fix for this requires backend changes (a separate "possible error/nonexistent group" visual state/tooltip text arrangement, with a cancel button).

unfortunately the only function to cancel a group join currently doesn't seem to work if the join process itself has errored – if we desire this functionality soon, we should create a separate issue for it.