### PR TITLE
chat: fix several issues with drafts

### DIFF
--- a/ui/src/logic/tiptap.test.ts
+++ b/ui/src/logic/tiptap.test.ts
@@ -299,7 +299,6 @@ describe('inlinesToJSON', () => {
         { type: 'paragraph' },
         { type: 'paragraph' },
         { type: 'paragraph', content: [{ type: 'text', text: 'foo' }] },
-        { type: 'paragraph' },
       ],
     };
     expect(output).toEqual(expected);
@@ -373,7 +372,6 @@ describe('inlinesToJSON', () => {
             { type: 'text', text: 'style', marks: [{ type: 'bold' }] },
           ],
         },
-        { type: 'paragraph' },
       ],
     };
     expect(output).toEqual(expected);


### PR DESCRIPTION
Fixes the following issues with drafts:
- Adding a new line when returning to a draft (fixes #978)
- Not showing most recent draft if more than one draft has been created
- Unnecessarily updating drafts (when new draft is the same as the old draft)

There may be an issue with the backend code causing these empty paragraphs/breaks to get added to messages. If that's the case, it'll obviate most of the code here.