### PR TITLE
groups: set heap display mode in settings store

### DIFF
--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/state/groups/groups';
 import {
   useCuriosForHeap,
-  useHeapDisplayMode,
   useHeapState,
   useHeapPerms,
 } from '@/state/heap/heap';
@@ -24,13 +23,14 @@ import {
   setSetting,
   useHeapSettings,
   useHeapSortMode,
+  useHeapDisplayMode,
   useSettingsState,
 } from '@/state/settings';
 import HeapBlock from '@/heap/HeapBlock';
 import HeapRow from '@/heap/HeapRow';
 import useDismissChannelNotifications from '@/logic/useDismissChannelNotifications';
 import { createStorageKey } from '@/logic/utils';
-import { GRID, HeapCurio, HeapDisplayMode } from '@/types/heap';
+import { GRID, HeapCurio, HeapDisplayMode, HeapSortMode } from '@/types/heap';
 import bigInt from 'big-integer';
 import NewCurioForm from './NewCurioForm';
 
@@ -60,10 +60,17 @@ function HeapChannel({ title }: ViewProps) {
     _.intersection(perms.writers, vessel.sects).length !== 0;
 
   const setDisplayMode = (setting: HeapDisplayMode) => {
-    useHeapState.getState().viewHeap(chFlag, setting);
+    const newSettings = setSetting<HeapSetting>(
+      settings,
+      { displayMode: setting },
+      chFlag
+    );
+    useSettingsState
+      .getState()
+      .putEntry('heaps', 'heapSettings', JSON.stringify(newSettings));
   };
 
-  const setSortMode = (setting: 'time' | 'alpha') => {
+  const setSortMode = (setting: HeapSortMode) => {
     const newSettings = setSetting<HeapSetting>(
       settings,
       { sortMode: setting },

--- a/ui/src/heap/NewCurioForm.tsx
+++ b/ui/src/heap/NewCurioForm.tsx
@@ -3,11 +3,7 @@ import cn from 'classnames';
 import { intersection } from 'lodash';
 import { useForm } from 'react-hook-form';
 import LinkIcon from '@/components/icons/LinkIcon';
-import {
-  useHeapDisplayMode,
-  useHeapPerms,
-  useHeapState,
-} from '@/state/heap/heap';
+import { useHeapPerms, useHeapState } from '@/state/heap/heap';
 import useNest from '@/logic/useNest';
 import { isValidUrl, nestToFlag } from '@/logic/utils';
 import { useRouteGroup, useVessel } from '@/state/groups';
@@ -22,6 +18,7 @@ import {
   NewCurioFormSchema,
   TEXT,
 } from '@/types/heap';
+import { useHeapDisplayMode } from '@/state/settings';
 import HeapTextInput from './HeapTextInput';
 
 export default function NewCurioForm() {

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -327,11 +327,6 @@ export function useBriefs() {
   return useHeapState(useCallback((s: HeapState) => s.briefs, []));
 }
 
-export function useHeapDisplayMode(flag: string): HeapDisplayMode {
-  const heap = useHeap(flag);
-  return heap?.view ?? GRID;
-}
-
 export function useOrderedCurios(
   flag: HeapFlag,
   currentId: bigInt.BigInteger | string

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -7,6 +7,7 @@ import {
 } from '@urbit/api';
 import _ from 'lodash';
 import { lsDesk } from '@/constants';
+import { HeapDisplayMode, HeapSortMode } from '@/types/heap';
 import {
   BaseState,
   createState,
@@ -21,7 +22,8 @@ interface ChannelSetting {
 }
 
 export interface HeapSetting extends ChannelSetting {
-  sortMode: 'time' | 'alpha';
+  sortMode: HeapSortMode;
+  displayMode: HeapDisplayMode;
 }
 
 export interface DiarySetting extends ChannelSetting {
@@ -47,7 +49,6 @@ export const filters: Record<string, SidebarFilter> = {
   all: 'All Messages',
   groups: 'Group Channels',
 };
-
 
 interface BaseSettingsState {
   display: {
@@ -233,10 +234,16 @@ export function useHeapSettings(): HeapSetting[] {
   return parseSettings(settings ?? '');
 }
 
-export function useHeapSortMode(flag: string): 'time' | 'alpha' {
+export function useHeapSortMode(flag: string): HeapSortMode {
   const settings = useHeapSettings();
   const heapSetting = getSetting(settings, flag);
   return heapSetting?.sortMode ?? 'time';
+}
+
+export function useHeapDisplayMode(flag: string): HeapDisplayMode {
+  const settings = useHeapSettings();
+  const heapSetting = getSetting(settings, flag);
+  return heapSetting?.displayMode ?? 'list';
 }
 
 const selDiarySettings = (s: SettingsState) => s.diary.settings;

--- a/ui/src/types/heap.ts
+++ b/ui/src/types/heap.ts
@@ -16,7 +16,10 @@ export type Ship = string;
 
 export const GRID = 'grid';
 export const LIST = 'list';
+export const TIME = 'time';
+export const ALPHA = 'alpha';
 export type HeapDisplayMode = typeof GRID | typeof LIST;
+export type HeapSortMode = typeof TIME | typeof ALPHA;
 
 export type HeapInline =
   | string


### PR DESCRIPTION
Fixes #926 

We should allow the user to set which mode they'd prefer to view a gallery with on a per-user basis. Previously it was set on a per-gallery basis.