### PR TITLE
nav: find groups triggers wrong nav

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1210,7 +1210,7 @@
           ?:  from-self  ga-core
           ?~  pev.gang   ga-core
           ?~  vit.gang   ga-core
-          =/  link  /groups/find
+          =/  link  /find
           =/  yarn
             %-  spin
             :*  [`flag ~ q.byk.bowl /(scot %p p.flag)/[q.flag]/invite]

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -206,20 +206,20 @@ function GroupsRoutes({ state, location, isMobile }: RoutesProps) {
             />
             {/* Find by Invite URL */}
             <Route
-              path="/groups/find/:ship/:name"
+              path="/find/:ship/:name"
               element={
                 <FindGroups title={`Find Groups • ${appHead('').title}`} />
               }
             />
             {/* Find by Nickname or @p */}
             <Route
-              path="/groups/find/:ship"
+              path="/find/:ship"
               element={
                 <FindGroups title={`Find Groups • ${appHead('').title}`} />
               }
             />
             <Route
-              path="/groups/find"
+              path="/find"
               element={
                 <FindGroups title={`Find Groups • ${appHead('').title}`} />
               }

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -128,7 +128,7 @@ export default function Sidebar() {
         </SidebarItem>
         <SidebarItem
           icon={<MagnifyingGlass className="m-1 h-4 w-4" />}
-          to="/groups/find"
+          to="/find"
         >
           <div className="flex items-center">
             Find Groups

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`Sidebar > renders as expected 1`] = `
       >
         <a
           class="default-focus flex w-full flex-1 items-center space-x-3 rounded-lg p-2 font-semibold"
-          href="/groups/find"
+          href="/find"
         >
           <svg
             class="m-1 h-4 w-4"

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -133,12 +133,12 @@ export default function FindGroups({ title }: ViewProps) {
   // once a ship is selected, redirect to find/[selected query]
   useEffect(() => {
     if (selectedShip) {
-      navigate(`/groups/find/${selectedShip.value}`);
+      navigate(`/find/${selectedShip.value}`);
       return;
     }
 
     // user has cleared selection, redirect back to find root
-    navigate('/groups/find');
+    navigate('/find');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedShip]);
 

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -77,7 +77,7 @@ export default function Notification({
             </span>
             <CaretDown16Icon className="h-4 w-4 text-gray-400" />
           </Dropdown.Trigger>
-          <Dropdown.Content className="dropdown">
+          <Dropdown.Content className="dropdown" portalled={false}>
             {bin.unread ? (
               <Dropdown.Item className="dropdown-item" onSelect={onClick}>
                 Mark Read

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -66,7 +66,7 @@ export default function Notifications({
   const { notifications } = useNotifications(flag);
 
   return (
-    <section className="w-full bg-white p-6">
+    <section className="h-full w-full overflow-y-auto bg-white p-6">
       <Helmet>
         <title>
           {group


### PR DESCRIPTION
This fixes an issue where doing a search in find groups triggers the wrong nav. Also changes notifications so that the scrollbar doesn't jump when opening the dropdown menu.