### PR TITLE
s3: key FileStore on input ID

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.190.0",
+        "@aws-sdk/s3-request-presigner": "^3.190.0",
         "@emoji-mart/data": "^1.0.6",
         "@emoji-mart/react": "^1.0.1",
         "@faker-js/faker": "^6.3.1",
@@ -773,6 +774,24 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.190.0.tgz",
+      "integrity": "sha512-jpsfQ1MuXVOBXtlMAkM/Dy5Qrv70K1V0FkRPYI6zftqfhDSf2sWb5Uc887m904bWwwQE4hIlkQJIPByZVkT0+g==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.190.0.tgz",
@@ -1049,6 +1068,25 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.190.0.tgz",
+      "integrity": "sha512-Ae1xElBPBtMoJK69wVM/6rSiD3os6McT3vtoFS8anyBJOrmdimZfbMYtWp8ywLH6gb3alJrqKLklPo52KXhq3w==",
+      "dependencies": {
+        "@aws-sdk/middleware-endpoint": "3.190.0",
+        "@aws-sdk/middleware-sdk-s3": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4-multi-region": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-create-request": "3.190.0",
+        "@aws-sdk/util-format-url": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/service-error-classification": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
@@ -1212,6 +1250,20 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-create-request": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.190.0.tgz",
+      "integrity": "sha512-GOLwJ01uF45bUPAthISC0NlOZE0qMV5MKXbA1r+qh3o7KGx53QVq4qLzZYcFRgPpNVtRml0LpWGhQJgfZ2t53w==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
@@ -1240,6 +1292,19 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.190.0.tgz",
+      "integrity": "sha512-YZhE13LnzskDPyZh8hnqD/KyPxfqVgea1jzKmMcLSTB2doIo7BAS+EN96C+Gl7hZMayUbSYiqLDiwmgPevfRxw==",
+      "dependencies": {
+        "@aws-sdk/querystring-builder": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
@@ -29418,6 +29483,21 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.190.0.tgz",
+      "integrity": "sha512-jpsfQ1MuXVOBXtlMAkM/Dy5Qrv70K1V0FkRPYI6zftqfhDSf2sWb5Uc887m904bWwwQE4hIlkQJIPByZVkT0+g==",
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/url-parser": "3.190.0",
+        "@aws-sdk/util-config-provider": "3.188.0",
+        "@aws-sdk/util-middleware": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/middleware-expect-continue": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.190.0.tgz",
@@ -29633,6 +29713,22 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.190.0.tgz",
+      "integrity": "sha512-Ae1xElBPBtMoJK69wVM/6rSiD3os6McT3vtoFS8anyBJOrmdimZfbMYtWp8ywLH6gb3alJrqKLklPo52KXhq3w==",
+      "requires": {
+        "@aws-sdk/middleware-endpoint": "3.190.0",
+        "@aws-sdk/middleware-sdk-s3": "3.190.0",
+        "@aws-sdk/protocol-http": "3.190.0",
+        "@aws-sdk/signature-v4-multi-region": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "@aws-sdk/util-create-request": "3.190.0",
+        "@aws-sdk/util-format-url": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/service-error-classification": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.190.0.tgz",
@@ -29755,6 +29851,17 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-create-request": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.190.0.tgz",
+      "integrity": "sha512-GOLwJ01uF45bUPAthISC0NlOZE0qMV5MKXbA1r+qh3o7KGx53QVq4qLzZYcFRgPpNVtRml0LpWGhQJgfZ2t53w==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.190.0",
+        "@aws-sdk/smithy-client": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/util-defaults-mode-browser": {
       "version": "3.190.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.190.0.tgz",
@@ -29775,6 +29882,16 @@
         "@aws-sdk/credential-provider-imds": "3.190.0",
         "@aws-sdk/node-config-provider": "3.190.0",
         "@aws-sdk/property-provider": "3.190.0",
+        "@aws-sdk/types": "3.190.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.190.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.190.0.tgz",
+      "integrity": "sha512-YZhE13LnzskDPyZh8hnqD/KyPxfqVgea1jzKmMcLSTB2doIo7BAS+EN96C+Gl7hZMayUbSYiqLDiwmgPevfRxw==",
+      "requires": {
+        "@aws-sdk/querystring-builder": "3.190.0",
         "@aws-sdk/types": "3.190.0",
         "tslib": "^2.3.1"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.190.0",
+    "@aws-sdk/s3-request-presigner": "^3.190.0",
     "@emoji-mart/data": "^1.0.6",
     "@emoji-mart/react": "^1.0.1",
     "@faker-js/faker": "^6.3.1",

--- a/ui/src/components/_ExampleFileUpload.tsx
+++ b/ui/src/components/_ExampleFileUpload.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import _ from 'lodash';
+import UploadInput from '@/components/FileUpload';
+import { useFileStore } from '@/state/storage';
+
+// Example interface to enforce types
+interface Uploader {
+  id: string;
+  multiple?: boolean;
+}
+
+function Uploader({ id, multiple }: Uploader) {
+  // Selector based on id
+  let files = useFileStore((state) => _.filter(state.files, ['for', id]));
+  // Only get the latest file for the input if !multiple
+  if (!multiple) {
+    files = !multiple && _.takeRight(files);
+  }
+
+  return (
+    <div>
+      {files.length
+        ? _.map(files, (file) => {
+            const { url, key } = file;
+            return <img key={key} src={url} />;
+          })
+        : null}
+      <UploadInput multiple={multiple} id={id} />
+    </div>
+  );
+}
+
+export default function Example() {
+  // Input is required, since that's what we use for the selector.
+  return <Uploader id="required-input-id" />;
+}

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -48,7 +48,6 @@ export const filters: Record<string, SidebarFilter> = {
   groups: 'Group Channels',
 };
 
-
 interface BaseSettingsState {
   display: {
     theme: 'light' | 'dark' | 'auto';

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -45,4 +45,11 @@ export const useFileStore = create<FileStore>((set) => ({
         draft.files[idx].status = status;
       })
     ),
+  setFileURL: (file) =>
+    set(
+      produce((draft) => {
+        const [idx, url] = file;
+        draft.files[idx].url = url;
+      })
+    ),
 }));

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -11,7 +11,7 @@ export function prefixEndpoint(endpoint: string) {
 export const useFileStore = create<FileStore>((set) => ({
   client: null,
   status: 'initial',
-  files: [],
+  files: {},
   createClient: (credentials: S3Credentials) => {
     const endpoint = new URL(prefixEndpoint(credentials.endpoint));
     const client = new S3Client({
@@ -32,24 +32,24 @@ export const useFileStore = create<FileStore>((set) => ({
         draft.status = status;
       })
     ),
-  setFiles: (files) =>
+  setFiles: (file) =>
     set(
       produce((draft) => {
-        draft.files = files;
+        draft.files[file.key] = file;
       })
     ),
   setFileStatus: (file) =>
     set(
       produce((draft) => {
-        const [idx, status] = file;
-        draft.files[idx].status = status;
+        const [key, status] = file;
+        draft.files[key].status = status;
       })
     ),
   setFileURL: (file) =>
     set(
       produce((draft) => {
-        const [idx, url] = file;
-        draft.files[idx].url = url;
+        const [key, url] = file;
+        draft.files[key].url = url;
       })
     ),
 }));

--- a/ui/src/types/storage.ts
+++ b/ui/src/types/storage.ts
@@ -28,6 +28,7 @@ export interface BaseStorageState {
 export interface Upload {
   file: File;
   status: 'initial' | 'loading' | 'success' | 'error';
+  url: string;
 }
 
 export interface FileStore {
@@ -38,6 +39,7 @@ export interface FileStore {
   setStatus: (status: string) => void;
   setFiles: (files: object) => void;
   setFileStatus: (file: Array<number | string>) => void;
+  setFileURL: (file: Array<number | string>) => void;
 }
 
 export interface UploadInputProps {

--- a/ui/src/types/storage.ts
+++ b/ui/src/types/storage.ts
@@ -26,22 +26,28 @@ export interface BaseStorageState {
 }
 
 export interface Upload {
-  file: File;
-  status: 'initial' | 'loading' | 'success' | 'error';
-  url: string;
+  key: string;
+  (key: string): {
+    file: File;
+    status: 'initial' | 'loading' | 'success' | 'error';
+    url: string;
+    for: string;
+    key: string;
+  };
 }
 
 export interface FileStore {
   client: S3Client | null;
   status: 'initial' | 'loading' | 'success' | 'error';
-  files: Array<Upload>;
+  files: object;
   createClient: (s3: S3Credentials) => void;
   setStatus: (status: string) => void;
-  setFiles: (files: object) => void;
+  setFiles: (file: Upload) => void;
   setFileStatus: (file: Array<number | string>) => void;
   setFileURL: (file: Array<number | string>) => void;
 }
 
 export interface UploadInputProps {
   multiple?: boolean;
+  id: string;
 }


### PR DESCRIPTION
Embellishes the FileStore a bit by:
- Adding a pre-signed URL for all uploads
- Keying the FileStore, rather than referring to uploads by index
- Adds a 'for' field and a required ID on all image inputs
- Adds an example implementation to show how to produce a (or a list of) URL(s) from a file input

As a result, the component supports multiple inputs on the same page.