### PR TITLE
chat: add image upload (and pasting of image URLs) to chat input

### DIFF
--- a/talk/desk.docket-0
+++ b/talk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Send encrypted direct messages to one or many friends. Talk is a simple chat tool for catching up, getting work done, and everything in between.'
     color+0x10.5ec7
     image+'https://bootstrap.urbit.org/icon-talk.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v1.jqipp.fgkp5.18cee.r2n34.lu0m3.glob' 0v1.jqipp.fgkp5.18cee.r2n34.lu0m3]
+    glob-http+['https://bootstrap.urbit.org/glob-0v5.cpbbv.e7l7l.bp8np.enk0k.1q1bd.glob' 0v5.cpbbv.e7l7l.bp8np.enk0k.1q1bd]
     base+'talk'
     version+[0 2 0]
     website+'https://tlon.io'

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -27,7 +27,6 @@ import useFileUpload from '@/logic/useFileUpload';
 import { useFileStore } from '@/state/storage';
 import { isImageUrl } from '@/logic/utils';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import * as Popover from '@radix-ui/react-popover';
 
 interface ChatInputProps {
@@ -48,26 +47,25 @@ function UploadErrorPopover({
   setUploadError: (error: string | null) => void;
 }) {
   return (
-    <Popover.Root>
+    <Popover.Root open>
       <Popover.Anchor>
-        <Popover.Trigger asChild>
-          <button
-            onClick={() => {
-              setTimeout(() => {
-                setUploadError(null);
-              }, 2000);
-            }}
-            title={'Error uploading image'}
-            aria-label="Show error"
-          >
-            <ExclamationPoint className="h-4 w-4" />
-          </button>
-        </Popover.Trigger>
+        <AddIcon className="h-6 w-4 text-gray-600" />
       </Popover.Anchor>
-      <Popover.Content sideOffset={5}>
-        <div className="flex h-48 w-48 flex-col items-center justify-center rounded-lg bg-gray-100">
-          <ExclamationPoint className="h-8 w-8 text-red-500" />
-          <div className="mt-2 text-center text-red-500">{errorMessage}</div>
+      <Popover.Content
+        sideOffset={5}
+        onEscapeKeyDown={() => setUploadError(null)}
+        onPointerDownOutside={() => setUploadError(null)}
+      >
+        <div className="flex w-[200px] flex-col items-center justify-center rounded-lg bg-white p-4 leading-5 drop-shadow-lg">
+          <span className="mb-2 font-semibold text-gray-800">
+            This file can't be posted.
+          </span>
+          <div className="flex flex-col justify-start">
+            <span className="mt-2 text-gray-800">{errorMessage}</span>
+            {/*
+              <button className="small-button mt-4 w-[84px]">Learn more</button>
+            */}
+          </div>
         </div>
       </Popover.Content>
     </Popover.Root>

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -318,7 +318,10 @@ export default function ChatInput({
           <div className="flex items-center justify-end">
             <Avatar size="xs" ship={window.our} className="mr-2" />
             <MessageEditor editor={messageEditor} className="w-full" />
-            {loaded && hasCredentials && !uploadError ? (
+            {loaded &&
+            hasCredentials &&
+            !uploadError &&
+            mostRecentFile?.status !== 'loading' ? (
               <button
                 title={'Upload an image'}
                 className="absolute mr-2 text-gray-600 hover:text-gray-800"

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -73,8 +73,11 @@ function useFileUpload() {
         })
         .catch((error: any) => {
           setFileStatus([key, 'error']);
-          setErrorMessage([key, `${error.toString()}`]);
-          console.error(error);
+          setErrorMessage([
+            key,
+            `S3 upload error: ${error.message}, check your S3 configuration.`,
+          ]);
+          console.log({ error });
         });
 
       return uploadData;

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -82,9 +82,7 @@ function useFileUpload() {
       const newFiles = _.keyBy(
         [...e.target.files].map((file) => ({
           file,
-          key: `${window.ship}/${deSig(
-            dateToDa(new Date())
-          )}-${encodeURIComponent(file.name)}`,
+          key: `${window.ship}/${deSig(dateToDa(new Date()))}-${file.name}`,
           for: e.target.id,
           status: 'initial',
           url: '',

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -15,6 +15,7 @@ function useFileUpload() {
     createClient,
     setStatus,
     setFileStatus,
+    setErrorMessage,
     setFileURL,
     ...fs
   } = useFileStore();
@@ -62,8 +63,9 @@ function useFileUpload() {
             setFileStatus([key, 'success']);
             setFileURL([key, url.split('?')[0]]);
           })
-          .catch((error: unknown) => {
+          .catch((error: any) => {
             setFileStatus([key, 'error']);
+            setErrorMessage([key, `${error.toString()}`]);
             console.error(error);
           });
         return uploadData;
@@ -71,7 +73,7 @@ function useFileUpload() {
       setStatus('error');
       return false;
     },
-    [fs, s3, setStatus, setFileStatus, setFileURL]
+    [fs, s3, setStatus, setFileStatus, setFileURL, setErrorMessage]
   );
 
   const onFiles = useCallback(

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -4,7 +4,7 @@ import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { dateToDa, deSig } from '@urbit/api';
 import { useFileStore, useStorage } from '@/state/storage';
-import { Upload, UploadInputProps } from '@/types/storage';
+import { Upload } from '@/types/storage';
 import api from '../api';
 
 function useFileUpload() {

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -1,0 +1,121 @@
+import { useCallback, ChangeEvent, useEffect, useState } from 'react';
+import _ from 'lodash';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { dateToDa, deSig } from '@urbit/api';
+import { useFileStore, useStorage } from '@/state/storage';
+import { Upload, UploadInputProps } from '@/types/storage';
+import api from '../api';
+
+function useFileUpload() {
+  const { s3, ...storage } = useStorage();
+  const { credentials } = s3;
+  const {
+    setFiles,
+    createClient,
+    setStatus,
+    setFileStatus,
+    setFileURL,
+    ...fs
+  } = useFileStore();
+  const [hasCredentials, setHasCredentials] = useState(false);
+
+  useEffect(() => {
+    useStorage.getState().initialize(api);
+  }, []);
+
+  useEffect(() => {
+    const hasCreds =
+      credentials?.accessKeyId &&
+      credentials?.endpoint &&
+      credentials?.secretAccessKey;
+    if (hasCreds) {
+      setHasCredentials(true);
+      const connect = async () => {
+        createClient(credentials);
+      };
+      connect()
+        .then(() => setStatus('success'))
+        .catch((error: unknown) => {
+          console.error(error);
+        });
+    }
+  }, [createClient, setStatus, credentials]);
+
+  const uploadFile = useCallback(
+    async (upload) => {
+      const { file, key } = upload;
+      if (fs.client) {
+        setFileStatus([key, 'loading']);
+        const command = new PutObjectCommand({
+          Bucket: s3.configuration.currentBucket,
+          Key: key,
+          Body: file,
+          ContentType: file.type,
+          ContentLength: file.size,
+          ACL: 'public-read',
+        });
+        const url = await getSignedUrl(fs.client, command);
+        const uploadData = fs.client
+          .send(command)
+          .then(() => {
+            setFileStatus([key, 'success']);
+            setFileURL([key, url.split('?')[0]]);
+          })
+          .catch((error: unknown) => {
+            setFileStatus([key, 'error']);
+            console.error(error);
+          });
+        return uploadData;
+      }
+      setStatus('error');
+      return false;
+    },
+    [fs, s3, setStatus, setFileStatus, setFileURL]
+  );
+
+  const onFiles = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (!e.target.files) return;
+      const newFiles = _.keyBy(
+        [...e.target.files].map((file) => ({
+          file,
+          key: `${window.ship}/${deSig(
+            dateToDa(new Date())
+          )}-${encodeURIComponent(file.name)}`,
+          for: e.target.id,
+          status: 'initial',
+          url: '',
+        })),
+        'key'
+      );
+      _.map(newFiles, (file: Upload) => setFiles(file));
+      _.map(newFiles, (file) => uploadFile(file));
+    },
+    [setFiles, uploadFile]
+  );
+
+  const promptUpload = useCallback(
+    (fileId: string) => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.multiple = true;
+      input.id = fileId;
+      input.accept = 'image/*,video/*,audio/*';
+      input.addEventListener('change', (e) => {
+        onFiles(e as any);
+      });
+      input.click();
+    },
+    [onFiles]
+  );
+
+  return {
+    storage,
+    hasCredentials,
+    loaded: storage.loaded,
+    promptUpload,
+  };
+}
+
+export default useFileUpload;

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -262,6 +262,12 @@ export const AUDIO_REGEX = /(\.mp3|\.wav|\.ogg|\.m4a)$/i;
 export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
+export const IMAGE_URL_REGEX =
+  /(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|gif|png|webp)/i;
+
+export function isImageUrl(url: string) {
+  return IMAGE_URL_REGEX.test(url);
+}
 
 export function isValidUrl(str?: string): boolean {
   return str ? !!URL_REGEX.test(str) : false;

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -263,7 +263,7 @@ export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
-  /(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|gif|png|webp)/i;
+  /(http(s?):)([/|.|\w|\s|-]|%20)*\.(?:jpg|gif|png|webp)/i;
 
 export function isImageUrl(url: string) {
   return IMAGE_URL_REGEX.test(url);

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -11,7 +11,7 @@ export function prefixEndpoint(endpoint: string) {
 export const useFileStore = create<FileStore>((set) => ({
   client: null,
   status: 'initial',
-  files: {},
+  files: null,
   createClient: (credentials: S3Credentials) => {
     const endpoint = new URL(prefixEndpoint(credentials.endpoint));
     const client = new S3Client({
@@ -20,7 +20,9 @@ export const useFileStore = create<FileStore>((set) => ({
         hostname: endpoint.host,
         path: endpoint.pathname || '/',
       },
-      region: 'global',
+      // this is necessary for compatibility with other S3 providers
+      region: 'us-east-1',
+      apiVersion: '2006-03-01',
       credentials,
       forcePathStyle: true,
     });

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -20,9 +20,8 @@ export const useFileStore = create<FileStore>((set) => ({
         hostname: endpoint.host,
         path: endpoint.pathname || '/',
       },
-      // this is necessary for compatibility with other S3 providers
+      // this region is necessary for compatibility with other S3 providers (i.e., filebase)
       region: 'us-east-1',
-      apiVersion: '2006-03-01',
       credentials,
       forcePathStyle: true,
     });
@@ -45,6 +44,13 @@ export const useFileStore = create<FileStore>((set) => ({
       produce((draft) => {
         const [key, status] = file;
         draft.files[key].status = status;
+      })
+    ),
+  setErrorMessage: (file) =>
+    set(
+      produce((draft) => {
+        const [key, errorMessage] = file;
+        draft.files[key].errorMessage = errorMessage;
       })
     ),
   setFileURL: (file) =>

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -2,7 +2,7 @@ import { S3Credentials } from '@urbit/api';
 import { S3Client } from '@aws-sdk/client-s3';
 import create from 'zustand';
 import produce from 'immer';
-import { FileStore, FileStoreFile } from '@/types/storage';
+import { FileStore } from '@/types/storage';
 
 export function prefixEndpoint(endpoint: string) {
   return endpoint.match(/https?:\/\//) ? endpoint : `https://${endpoint}`;
@@ -11,7 +11,7 @@ export function prefixEndpoint(endpoint: string) {
 export const useFileStore = create<FileStore>((set) => ({
   client: null,
   status: 'initial',
-  files: {} as FileStoreFile[],
+  files: {},
   createClient: (credentials: S3Credentials) => {
     const endpoint = new URL(prefixEndpoint(credentials.endpoint));
     const client = new S3Client({

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -2,7 +2,7 @@ import { S3Credentials } from '@urbit/api';
 import { S3Client } from '@aws-sdk/client-s3';
 import create from 'zustand';
 import produce from 'immer';
-import { FileStore } from '@/types/storage';
+import { FileStore, FileStoreFile } from '@/types/storage';
 
 export function prefixEndpoint(endpoint: string) {
   return endpoint.match(/https?:\/\//) ? endpoint : `https://${endpoint}`;
@@ -11,7 +11,7 @@ export function prefixEndpoint(endpoint: string) {
 export const useFileStore = create<FileStore>((set) => ({
   client: null,
   status: 'initial',
-  files: null,
+  files: {} as FileStoreFile[],
   createClient: (credentials: S3Credentials) => {
     const endpoint = new URL(prefixEndpoint(credentials.endpoint));
     const client = new S3Client({

--- a/ui/src/types/storage.ts
+++ b/ui/src/types/storage.ts
@@ -36,10 +36,18 @@ export interface Upload {
   };
 }
 
+export interface FileStoreFile {
+  file: File;
+  status: 'initial' | 'loading' | 'success' | 'error';
+  url: string;
+  for: string;
+  key: string;
+}
+
 export interface FileStore {
   client: S3Client | null;
   status: 'initial' | 'loading' | 'success' | 'error';
-  files: object;
+  files: FileStoreFile[] | null;
   createClient: (s3: S3Credentials) => void;
   setStatus: (status: string) => void;
   setFiles: (file: Upload) => void;

--- a/ui/src/types/storage.ts
+++ b/ui/src/types/storage.ts
@@ -48,7 +48,7 @@ export interface FileStoreFile {
 export interface FileStore {
   client: S3Client | null;
   status: 'initial' | 'loading' | 'success' | 'error';
-  files: FileStoreFile[] | null;
+  files: Record<string, FileStoreFile>;
   createClient: (s3: S3Credentials) => void;
   setStatus: (status: string) => void;
   setErrorMessage: (file: Array<number | string>) => void;

--- a/ui/src/types/storage.ts
+++ b/ui/src/types/storage.ts
@@ -39,6 +39,7 @@ export interface Upload {
 export interface FileStoreFile {
   file: File;
   status: 'initial' | 'loading' | 'success' | 'error';
+  errorMessage?: string;
   url: string;
   for: string;
   key: string;
@@ -50,6 +51,7 @@ export interface FileStore {
   files: FileStoreFile[] | null;
   createClient: (s3: S3Credentials) => void;
   setStatus: (status: string) => void;
+  setErrorMessage: (file: Array<number | string>) => void;
   setFiles: (file: Upload) => void;
   setFileStatus: (file: Array<number | string>) => void;
   setFileURL: (file: Array<number | string>) => void;


### PR DESCRIPTION
[mostly] closes #160 

Added a new hook called useFileUpload that can be used anywhere we want to dynamically insert a hidden upload input.
Added the ability to upload images to chat.
Added the ability to paste an image URL into the chat input and have it get sent as an Image block type.
Added some loading/error states around chat input.

Note:
Does not include pasting of images directly into chat from the clipboard.
Does not show the image as a preview, just adds the image URL to the chat input.


https://user-images.githubusercontent.com/1221094/198136649-fba0f2f4-4878-461b-a71e-50c1cb008ed5.mov



https://user-images.githubusercontent.com/1221094/198136787-29971834-778b-420e-b35e-284d8949f8cb.mov


