### PR TITLE
ops: fix ref deploys

### DIFF
--- a/.github/actions/deploy/entrypoint.sh
+++ b/.github/actions/deploy/entrypoint.sh
@@ -23,5 +23,5 @@ janeway \
     --ssh-key /id_ssh \
     release ota \
     "$1" "$2" \
-    ${6:+"--ref $6"} \
+    ${6:+"--ref"} ${6:+"$6"} \
   | bash


### PR DESCRIPTION
The bash output needed the space in between to work