### PR TITLE
groups: suppress superfluous notifications

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,6 +77,11 @@ This project uses husky to run git pre-commit hooks. You may disable Husky by ad
 
 ## Glossary
 
+_bloc_
+: superuser sects
+
+sects in the bloc set are allowed to make modifications to the group, and its various metadata and permissions
+
 _brief_
 : a representation of the last thing we've seen, and how many new items since
 

--- a/bin/bounce
+++ b/bin/bounce
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/ops/bounce.yml
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/ops/bounce.yml "$@"

--- a/bin/sync
+++ b/bin/sync
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/ops/sync.yml
+ruby ~/dev/urbit/bouncer/bouncer.rb -c ~/dev/urbit/landscape-apps/ops/sync.yml "$@"

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -437,6 +437,8 @@
   ++  go-link
     |=  link=path 
     (welp /groups/(scot %p p.flag)/[q.flag] link)
+  ++  go-is-our-bloc
+    (~(has in go-bloc-who) our.bowl)
   ++  go-is-bloc
     |(=(src.bowl p.flag) (~(has in go-bloc-who) src.bowl))
   ++  go-bloc-who
@@ -838,7 +840,7 @@
                   [%emph title.meta.group]
               ==
           ==
-        =?  cor  go-is-bloc  
+        =?  cor  go-is-our-bloc
           (emit (pass-hark & & yarn))
         go-core
       ::
@@ -912,7 +914,7 @@
                 [%emph title.meta.group]
             ==
         ==
-      =?  cor  go-is-bloc  
+      =?  cor  go-is-our-bloc
         (emit (pass-hark & & yarn))
       ?-  -.cordon.group
           ?(%open %afar)  go-core
@@ -946,7 +948,7 @@
                 [%emph title.meta.group]
             ==
         ==
-      =?  cor  go-is-bloc  
+      =?  cor  go-is-our-bloc
         (emit (pass-hark & & yarn))
       ?:  (~(has in ships) our.bowl)
         go-core(gone &)
@@ -986,7 +988,7 @@
                 [%emph role-list]
             ==
         ==
-      =?  cor  go-is-bloc  
+      =?  cor  go-is-our-bloc
         (emit (pass-hark & & yarn))
       go-core
     ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -821,7 +821,6 @@
         ?>  |(go-is-bloc =(~(tap in q.diff) ~[src.bowl]))
         =.  ask.cordon.group  (~(uni in ask.cordon) q.diff)
         =/  ships  q.diff
-        ~&  [src.bowl our.bowl]
         ?:  from-self  go-core
         =/  link  (go-link /info/members/pending)
         =/  yarn
@@ -839,7 +838,8 @@
                   [%emph title.meta.group]
               ==
           ==
-        =.  cor  (emit (pass-hark & & yarn))
+        =?  cor  go-is-bloc  
+          (emit (pass-hark & & yarn))
         go-core
       ::
           [%del-ships %ask]
@@ -912,7 +912,8 @@
                 [%emph title.meta.group]
             ==
         ==
-      =.  cor  (emit (pass-hark & & yarn))
+      =?  cor  go-is-bloc  
+        (emit (pass-hark & & yarn))
       ?-  -.cordon.group
           ?(%open %afar)  go-core
           %shut  
@@ -945,7 +946,8 @@
                 [%emph title.meta.group]
             ==
         ==
-      =.  cor  (emit (pass-hark & & yarn))
+      =?  cor  go-is-bloc  
+        (emit (pass-hark & & yarn))
       ?:  (~(has in ships) our.bowl)
         go-core(gone &)
       go-core
@@ -984,7 +986,8 @@
                 [%emph role-list]
             ==
         ==
-      =.  cor  (emit (pass-hark & & yarn))
+      =?  cor  go-is-bloc  
+        (emit (pass-hark & & yarn))
       go-core
     ::
         %del-sects


### PR DESCRIPTION
# Context

This closes #754 by filtering certain notifications to only be sent to Admin users.

# Changes

Suppress the following notifications for non-Admin users (ie, those not in the bloc):

- joined channel
- requested to join
- left channel
- member role change (user is now an ...)

# Preview

*On Admin ship*
![image](https://user-images.githubusercontent.com/16504501/198574592-da86cad3-01ca-468d-8abb-d17fa6988f3a.png)

*On Member ship*
![image](https://user-images.githubusercontent.com/16504501/198574699-69882c5d-8ffd-45fd-9a41-5c2de11c127e.png)
