### PR TITLE
nav: improving mobile

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -72,6 +72,7 @@ import MobileMessagesSidebar from './dms/MobileMessagesSidebar';
 import MobileSidebar from './components/Sidebar/MobileSidebar';
 import MobileGroupsNavHome from './nav/MobileRoot';
 import MobileGroupRoot from './nav/MobileGroupRoot';
+import MobileGroupActions from './groups/MobileGroupActions';
 
 const DiaryAddNote = React.lazy(() => import('./diary/DiaryAddNote'));
 const SuspendedDiaryAddNote = (
@@ -269,6 +270,7 @@ function GroupsRoutes({ state, location, isMobile }: RoutesProps) {
                 path="channels"
                 element={<ChannelIndex title={` • ${appHead('').title}`} />}
               />
+              <Route path="actions" element={<MobileGroupActions />} />
             </Route>
             <Route
               path="channels/join/:app/:chShip/:chName"

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -64,7 +64,7 @@ const ChatMessage = React.memo<
       const isMessagePosted = useIsMessagePosted(seal.id);
 
       useEffect(() => {
-        if (inView === true && unread) {
+        if (inView && unread) {
           markRead(whom);
         }
       }, [unread, inView, markRead, whom]);

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -64,10 +64,10 @@ const ChatMessage = React.memo<
       const isMessagePosted = useIsMessagePosted(seal.id);
 
       useEffect(() => {
-        if (inView === true) {
+        if (inView === true && unread) {
           markRead(whom);
         }
-      }, [inView, markRead, whom]);
+      }, [unread, inView, markRead, whom]);
 
       const unix = new Date(daToUnix(time));
 

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -26,7 +26,7 @@ export default function ChatWindow({
   return (
     <div className="relative h-full">
       <ChatUnreadAlerts brief={brief} whom={whom} />
-      <div className="flex h-full w-full flex-col overflow-hidden px-2">
+      <div className="flex h-full w-full flex-col overflow-hidden">
         <ChatScroller
           messages={messages}
           whom={whom}

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -1,13 +1,19 @@
+import cn from 'classnames';
 import React from 'react';
-import { Outlet } from 'react-router';
+import { Outlet, useLocation, useMatch } from 'react-router';
 import { useNotifications } from '@/notifications/useNotifications';
 import NavTab from '../NavTab';
 import GroupIcon from '../icons/GroupIcon';
 import ActivityIndicator from './ActivityIndicator';
 import AsteriskIcon from '../icons/Asterisk16Icon';
+import Avatar from '../Avatar';
+import AddIcon16 from '../icons/Add16Icon';
+import MagnifyingGlassIcon from '../icons/MagnifyingGlassIcon';
 
 export default function MobileSidebar() {
   const { count } = useNotifications();
+  const location = useLocation();
+  const isProfile = useMatch('/profile/*');
 
   return (
     <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-r-2 border-gray-50 bg-white">
@@ -15,22 +21,35 @@ export default function MobileSidebar() {
       <footer className="flex-none border-t-2 border-gray-50">
         <nav>
           <ul className="flex justify-items-stretch">
-            <NavTab to="/">
+            <NavTab to="/" aria-label="Groups">
               <GroupIcon className="mb-0.5 h-6 w-6" />
-              Groups
             </NavTab>
-            <NavTab to="/notifications">
+            <NavTab to="/notifications" aria-label="Notifications">
               <ActivityIndicator count={count} className="mb-0.5" />
-              Notifications
+            </NavTab>
+            <NavTab to="/groups/new" state={{ backgroundLocation: location }}>
+              <div className="icon-button bg-blue text-white dark:bg-blue-900 dark:text-blue">
+                <AddIcon16 className="h-4 w-4" />
+              </div>
+            </NavTab>
+            <NavTab to="/find">
+              <MagnifyingGlassIcon className="mb-0.5 h-6 w-6" />
             </NavTab>
             <NavTab
               linkClass="no-underline"
               href="https://github.com/tloncorp/homestead/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=groups:"
               target="_blank"
               rel="noreferrer"
+              aria-label="Submit Issue"
             >
               <AsteriskIcon className="mb-0.5 h-6 w-6" />
-              Submit Issue
+            </NavTab>
+            <NavTab to="/profile/edit" aria-label="Profile">
+              <Avatar
+                size="xs"
+                ship={window.our}
+                className={cn('mb-0.5', !isProfile && 'opacity-70 grayscale')}
+              />
             </NavTab>
           </ul>
         </nav>

--- a/ui/src/components/Sidebar/SidebarSorter.tsx
+++ b/ui/src/components/Sidebar/SidebarSorter.tsx
@@ -3,7 +3,6 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 import SortIcon from '@/components/icons/SortIcon';
 import useSidebarSort from '@/logic/useSidebarSort';
-import CaretDownIcon from '@/components/icons/CaretDownIcon';
 
 type SidebarSorterProps = Omit<
   ReturnType<typeof useSidebarSort>,
@@ -25,8 +24,8 @@ export default function SidebarSorter({
           className="default-focus flex items-center rounded-lg p-2 text-base font-semibold"
           aria-label="Groups Sort Options"
         >
-          <h1 className="mr-4 text-xl font-medium">All Groups</h1>
-          <CaretDownIcon className="h-6 w-6 text-gray-400" />
+          <h1 className="mr-4 text-base font-semibold">All Groups</h1>
+          <CaretDown16Icon className="h-4 w-4 text-gray-400" />
         </DropdownMenu.Trigger>
       ) : (
         <DropdownMenu.Trigger

--- a/ui/src/components/icons/CaretRight16Icon.tsx
+++ b/ui/src/components/icons/CaretRight16Icon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function CaretRight16Icon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <path
+        className="stroke-current"
+        d="m7 4 4 4-4 4"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -22,6 +22,8 @@ import { useDiaryState } from '@/state/diary';
 import useIsChannelHost from '@/logic/useIsChannelHost';
 import useIsChannelJoined from '@/logic/useIsChannelJoined';
 import useAllBriefs from '@/logic/useAllBriefs';
+import { useIsMobile } from '@/logic/useMedia';
+import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 
 const UNZONED = 'default';
 
@@ -264,16 +266,30 @@ export default function ChannelIndex({ title }: ViewProps) {
   const navigate = useNavigate();
   const isAdmin = useAmAdmin(flag);
   const group = useGroup(flag);
+  const isMobile = useIsMobile();
+  const BackButton = isMobile ? Link : 'div';
 
   return (
-    <section className="w-full overflow-y-scroll p-4">
+    <section className="w-full sm:overflow-y-scroll">
       <Helmet>
         <title>
           {group ? `All Channels in ${group?.meta?.title} ${title}` : title}
         </title>
       </Helmet>
-      <div className="mb-4 flex flex-row justify-between">
-        <h1 className="text-lg font-bold">All Channels</h1>
+      <div className="flex flex-row items-center justify-between py-1 px-2 sm:p-4">
+        <BackButton
+          to="../"
+          className={cn(
+            'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
+            isMobile && 'flex items-center rounded-lg hover:bg-gray-50'
+          )}
+          aria-label="Back to Channels Menu"
+        >
+          {isMobile ? (
+            <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-400" />
+          ) : null}
+          <h1 className="text-base font-semibold sm:text-lg">All Channels</h1>
+        </BackButton>
         {isAdmin ? (
           <button
             onClick={() => navigate(`/groups/${flag}/info/channels`)}
@@ -283,21 +299,23 @@ export default function ChannelIndex({ title }: ViewProps) {
           </button>
         ) : null}
       </div>
-      {sections.map((section) =>
-        sectionedChannels[section] ? (
-          <div
-            key={section}
-            className="mb-2 w-full rounded-xl bg-white py-1 pl-4 pr-2"
-          >
-            <ChannelSection
-              channels={
-                section in sectionedChannels ? sectionedChannels[section] : []
-              }
-              zone={section}
-            />
-          </div>
-        ) : null
-      )}
+      <div className="p-4">
+        {sections.map((section) =>
+          sectionedChannels[section] ? (
+            <div
+              key={section}
+              className="mb-2 w-full rounded-xl bg-white py-1 pl-4 pr-2"
+            >
+              <ChannelSection
+                channels={
+                  section in sectionedChannels ? sectionedChannels[section] : []
+                }
+                zone={section}
+              />
+            </div>
+          ) : null
+        )}
+      </div>
     </section>
   );
 }

--- a/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
+++ b/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
@@ -3,16 +3,22 @@
 exports[`ChannelIndex > renders as expected 1`] = `
 <DocumentFragment>
   <section
-    class="w-full overflow-y-scroll p-4"
+    class="w-full sm:overflow-y-scroll"
   >
     <div
-      class="mb-4 flex flex-row justify-between"
+      class="flex flex-row items-center justify-between py-1 px-2 sm:p-4"
     >
-      <h1
-        class="text-lg font-bold"
+      <div
+        aria-label="Back to Channels Menu"
+        class="cursor-pointer select-none p-2 sm:cursor-text sm:select-text"
+        to="../"
       >
-        All Channels
-      </h1>
+        <h1
+          class="text-base font-semibold sm:text-lg"
+        >
+          All Channels
+        </h1>
+      </div>
       <button
         class="rounded-md bg-gray-800 py-1 px-2 text-[12px] font-semibold leading-4 text-white"
       >
@@ -20,9 +26,13 @@ exports[`ChannelIndex > renders as expected 1`] = `
       </button>
     </div>
     <div
-      class="mb-2 w-full rounded-xl bg-white py-1 pl-4 pr-2"
+      class="p-4"
     >
-      <ul />
+      <div
+        class="mb-2 w-full rounded-xl bg-white py-1 pl-4 pr-2"
+      >
+        <ul />
+      </div>
     </div>
   </section>
 </DocumentFragment>

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -175,12 +175,12 @@ export default function FindGroups({ title }: ViewProps) {
     val ? ob.isValidPatp(preSig(val)) || whomIsFlag(val) : false;
 
   return (
-    <div className="flex grow bg-gray-50">
+    <div className="flex grow overflow-y-auto bg-gray-50">
       <Helmet>
         <title>{title ? title : document.title}</title>
       </Helmet>
       <div className="w-full p-4">
-        <section className="card mb-4 space-y-8 p-8">
+        <section className="card mb-4 space-y-8 sm:p-8">
           <h1 className="text-lg font-bold">Find Groups</h1>
           <div>
             <label htmlFor="flag" className="mb-1.5 block font-semibold">
@@ -211,7 +211,7 @@ export default function FindGroups({ title }: ViewProps) {
           ) : null}
         </section>
         {hasKeys(pendingGangs) ? (
-          <section className="card mb-4 space-y-8 p-8">
+          <section className="card mb-4 space-y-8 sm:p-8">
             <h1 className="text-lg font-bold">Pending Invites</h1>
             <GroupJoinList gangs={pendingGangs} />
           </section>

--- a/ui/src/groups/GroupAdmin/GroupAdmin.tsx
+++ b/ui/src/groups/GroupAdmin/GroupAdmin.tsx
@@ -1,9 +1,9 @@
 import cn from 'classnames';
 import React from 'react';
 import { Link, NavLink, Outlet } from 'react-router-dom';
-import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
 import { useIsMobile } from '@/logic/useMedia';
 import { useAmAdmin, useRouteGroup } from '@/state/groups/groups';
+import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 
 export default function GroupAdmin() {
   const flag = useRouteGroup();
@@ -16,9 +16,9 @@ export default function GroupAdmin() {
         <div className="px-2 py-1">
           <Link
             to="../"
-            className="default-focus inline-flex items-center rounded-lg p-2 text-xl font-medium text-gray-800 hover:bg-gray-50"
+            className="default-focus inline-flex items-center rounded-lg p-2 text-base font-semibold text-gray-800 hover:bg-gray-50"
           >
-            <CaretLeftIcon className="mr-4 h-6 w-6 text-gray-600" />
+            <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-600" />
             Group Info
           </Link>
         </div>

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -6,6 +6,7 @@ import HashIcon from '@/components/icons/HashIcon';
 import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import NavTab from '@/components/NavTab';
 import ActivityIndicator from '@/components/Sidebar/ActivityIndicator';
+import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import GroupAvatar from '../GroupAvatar';
 
 export default function MobileGroupSidebar() {
@@ -21,30 +22,30 @@ export default function MobileGroupSidebar() {
       <footer className="mt-auto flex-none border-t-2 border-gray-50">
         <nav>
           <ul className="flex items-center">
-            <NavTab to="." end>
+            <NavTab to="." end aria-label="Channels">
               <HashIcon className="mb-0.5 h-6 w-6" />
-              Channels
             </NavTab>
-            <NavTab to="./info">
+            <NavTab to="./info" aria-label="Group Info">
               <GroupAvatar
                 {...group?.meta}
                 size="h-6 w-6"
                 className={cn('mb-0.5', !match && 'opacity-50')}
               />
-              Group
             </NavTab>
-            <NavTab to="./activity">
+            <NavTab to="./activity" aria-label="Activity">
               <ActivityIndicator count={activityCount} className="mb-0.5" />
-              Activity
             </NavTab>
             <NavTab
               linkClass="flex-1 no-underline"
               href="https://github.com/tloncorp/homestead/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=groups:"
               target="_blank"
               rel="noreferrer"
+              aria-label="Submit Issue"
             >
               <AsteriskIcon className="mb-0.5 h-6 w-6" />
-              Submit Issue
+            </NavTab>
+            <NavTab to="./actions" aria-label="Group Actions">
+              <ElipsisIcon className="mb-0.5 h-6 w-6" />
             </NavTab>
           </ul>
         </nav>

--- a/ui/src/groups/MobileGroupActions.tsx
+++ b/ui/src/groups/MobileGroupActions.tsx
@@ -7,19 +7,17 @@ import SlidersIcon from '@/components/icons/SlidersIcon';
 import { useGroupActions } from '@/groups/GroupActions';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import LeaveIcon from '@/components/icons/LeaveIcon';
-
-interface MobileGroupActionsProps {
-  flag: string;
-}
+import { useGroupFlag } from '@/state/groups';
 
 const { ship } = window;
 
-export default function MobileGroupActions({ flag }: MobileGroupActionsProps) {
+export default function MobileGroupActions() {
+  const flag = useGroupFlag();
   const location = useLocation();
   const { onCopy, copyItemText } = useGroupActions(flag);
 
   return (
-    <nav>
+    <nav className="p-2">
       <ul className="space-y-3">
         <SidebarItem
           to={`/groups/${flag}/invite`}

--- a/ui/src/nav/MobileGroupRoot.tsx
+++ b/ui/src/nav/MobileGroupRoot.tsx
@@ -1,4 +1,5 @@
-import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
+import CaretRight16Icon from '@/components/icons/CaretRight16Icon';
 import ChannelList from '@/groups/GroupSidebar/ChannelList';
 import { useGroupFlag } from '@/state/groups';
 import React from 'react';
@@ -9,13 +10,17 @@ export default function MobileGroupRoot() {
 
   return (
     <>
-      <header className="flex-none px-2 py-1">
+      <header className="flex flex-none items-center   justify-between px-2 py-1">
         <Link
           to="/"
-          className="default-focus inline-flex items-center rounded-lg p-2 text-xl font-medium text-gray-800 hover:bg-gray-50"
+          className="default-focus inline-flex items-center rounded-lg p-2 text-base font-semibold text-gray-800 hover:bg-gray-50"
         >
-          <CaretLeftIcon className="mr-4 h-6 w-6 text-gray-400" />
+          <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-400" />
           Channels
+        </Link>
+        <Link to="./channels" className="small-secondary-button pr-1">
+          <span>All</span>
+          <CaretRight16Icon className="ml-1 h-4 w-4 text-gray-400" />
         </Link>
       </header>
       <div className="h-full w-full flex-1 overflow-y-scroll p-2 pr-0">

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -3,7 +3,7 @@ import React, { ComponentType, PropsWithChildren } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { ViewProps } from '@/types/groups';
-import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import { Bin, useNotifications } from './useNotifications';
 
 export interface NotificationsProps {
@@ -23,7 +23,7 @@ export function MainWrapper({
   return (
     <>
       <header className="flex-none px-2 py-1">
-        <h1 className="p-2 text-xl font-medium">Notifications</h1>
+        <h1 className="p-2 text-base font-semibold">Notifications</h1>
       </header>
       <nav className="h-full flex-1 overflow-y-auto">{children}</nav>
     </>
@@ -43,10 +43,10 @@ export function GroupWrapper({
     <>
       <header className="flex-none px-2 py-1">
         <Link
-          to="/"
-          className="default-focus inline-flex items-center rounded-lg p-2 text-xl font-medium text-gray-800 hover:bg-gray-50"
+          to="../"
+          className="default-focus inline-flex items-center rounded-lg p-2 text-base font-semibold text-gray-800 hover:bg-gray-50"
         >
-          <CaretLeftIcon className="mr-4 h-6 w-6 text-gray-400" />
+          <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-400" />
           Activity
         </Link>
       </header>

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -135,6 +135,7 @@ export const useChatState = createState<ChatState>(
     pins: [],
     sentMessages: [],
     postedMessages: [],
+    loadedWrits: {},
     briefs: {},
     togglePin: async (whom, pin) => {
       const { pins } = get();
@@ -860,6 +861,19 @@ export function useWritByFlagAndWritId(chFlag: string, idWrit: string) {
     };
   }, [chFlag, idWrit]);
   return res;
+}
+
+export function useLoadedWrits(whom: string) {
+  return useChatState(
+    useCallback(
+      (s) =>
+        s.loadedWrits[whom] || {
+          oldest: unixToDa(Date.now()),
+          newest: unixToDa(0),
+        },
+      [whom]
+    )
+  );
 }
 
 (window as any).chat = useChatState.getState;

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -1,3 +1,4 @@
+import bigInt from 'big-integer';
 import {
   Chat,
   ChatWhom,
@@ -38,6 +39,12 @@ export interface ChatState {
   fetchMultiDm: (id: string, force?: boolean) => Promise<Club>;
   pacts: {
     [whom: ChatWhom]: Pact;
+  };
+  loadedWrits: {
+    [whom: ChatWhom]: {
+      oldest: bigInt.BigInteger;
+      newest: bigInt.BigInteger;
+    };
   };
   pendingDms: string[];
   briefs: ChatBriefs;

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -162,7 +162,8 @@ export default function makeWritsStore(
         return false;
       }
 
-      const fetchStart = decToUd(pact.writs.peekLargest()[0].toString());
+      const newest = pact.writs.peekLargest()[0];
+      const fetchStart = decToUd(newest.toString());
 
       const writs = await api.scry<ChatWrits>({
         app: 'chat',
@@ -177,6 +178,11 @@ export default function makeWritsStore(
           pact.index[writ.seal.id] = tim;
         });
         draft.pacts[whom] = { ...pact };
+        const loaded = draft.loadedWrits[whom] || {
+          oldest: unixToDa(Date.now()),
+          newest: unixToDa(0),
+        };
+        draft.loadedWrits[whom] = { ...loaded, newest };
       });
 
       const newMessageSize = get().pacts[whom].writs.size;
@@ -202,7 +208,8 @@ export default function makeWritsStore(
         return false;
       }
 
-      const fetchStart = decToUd(pact.writs.peekSmallest()[0].toString());
+      const oldest = pact.writs.peekSmallest()[0];
+      const fetchStart = decToUd(oldest.toString());
 
       const writs = await api.scry<ChatWrits>({
         app: 'chat',
@@ -217,6 +224,11 @@ export default function makeWritsStore(
           pact.index[writ.seal.id] = tim;
         });
         draft.pacts[whom] = { ...pact };
+        const loaded = draft.loadedWrits[whom] || {
+          oldest: unixToDa(Date.now()),
+          newest: unixToDa(0),
+        };
+        draft.loadedWrits[whom] = { ...loaded, oldest };
       });
 
       const newMessageSize = get().pacts[whom].writs.size;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -78,7 +78,7 @@
 }
 
 .card {
-  @apply w-full rounded-xl bg-white p-6;
+  @apply w-full rounded-lg bg-white p-4 sm:rounded-xl sm:p-6;
 }
 
 .switch {


### PR DESCRIPTION
This addresses #1005 by adding more routes to the bottom nav. I decided it would be difficult to represent the difference between all channels and joined channels so I added that one to the top right header only on the channels page.

This also throws in some mobile styling tweaks to headers that @urcades was working on, and some improvements to how the virtual scroller manages keys/data and loading.