### PR TITLE
groups: set channel as default upon creation

### DIFF
--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -75,6 +75,12 @@ export default function NewChannelForm() {
           .addChannelToZone(section, groupFlag, newChannelNest);
       }
 
+      if (values.join === true) {
+        await useGroupState
+          .getState()
+          .setChannelJoin(groupFlag, newChannelNest, true);
+      }
+
       navigate(`/groups/${groupFlag}/info/channels`);
     },
     [section, groupFlag, navigate]


### PR DESCRIPTION
see: #1034 

had to add in a call to set the channel as default as apparently "CreateChannel" doesn't take a "join" argument