### PR TITLE
groups: update image regex

### DIFF
--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -263,7 +263,7 @@ export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
-  /(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|gif|png|webp)/i;
+  /(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|webm|svg)/i;
 
 export function isImageUrl(url: string) {
   return IMAGE_URL_REGEX.test(url);


### PR DESCRIPTION
Handles the same file extensions in the `IMAGE_URL_REGEX` function as in the `IMAGE_REGEX` function.

Practically speaking, handles jpegs from iOS in the S3 file uploader in chat.