### PR TITLE
groups: click to copy ID

### DIFF
--- a/ui/src/chat/ChatMessage/Author.tsx
+++ b/ui/src/chat/ChatMessage/Author.tsx
@@ -3,6 +3,7 @@ import {
   makePrettyDayAndDateAndTime,
   makePrettyDayAndTime,
   makePrettyTime,
+  useCopy,
 } from '@/logic/utils';
 import { useLocation } from 'react-router';
 import { useModalNavigate } from '@/logic/routing';
@@ -22,6 +23,7 @@ export default function Author({
   hideTime,
 }: AuthorProps) {
   const location = useLocation();
+  const { didCopy, doCopy } = useCopy(ship);
   const modalNavigate = useModalNavigate();
   const prettyTime = date ? makePrettyTime(date) : undefined;
   const prettyDayAndTime = date ? makePrettyDayAndTime(date) : undefined;
@@ -41,7 +43,13 @@ export default function Author({
         <div onClick={handleProfileClick}>
           <Avatar ship={ship} size="xs" className="cursor-pointer" />
         </div>
-        <ShipName name={ship} showAlias className="text-md font-semibold" />
+        <div onClick={doCopy} className="text-md cursor-pointer font-semibold">
+          {didCopy ? (
+            'Copied!'
+          ) : (
+            <ShipName name={ship} showAlias className="text-md font-semibold" />
+          )}
+        </div>
       </div>
     );
   }
@@ -51,7 +59,14 @@ export default function Author({
       <div onClick={handleProfileClick}>
         <Avatar ship={ship} size="xs" className="cursor-pointer" />
       </div>
-      <ShipName name={ship} showAlias className="text-md font-semibold" />
+      <div onClick={doCopy} className="text-md cursor-pointer font-semibold">
+        {didCopy ? (
+          'Copied!'
+        ) : (
+          <ShipName name={ship} showAlias className="text-md font-semibold" />
+        )}
+      </div>
+
       {hideTime ? (
         <span className="hidden text-sm font-semibold text-gray-500 group-hover:block">
           {prettyDayAndTime}

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -112,28 +112,32 @@ exports[`ChatMessage > renders as expected 1`] = `
           </svg>
         </div>
       </div>
-      <span
-        class="text-md font-semibold"
+      <div
+        class="text-md cursor-pointer font-semibold"
       >
         <span
-          aria-hidden="true"
+          class="text-md font-semibold"
         >
-          ~
+          <span
+            aria-hidden="true"
+          >
+            ~
+          </span>
+          <span>
+            finned
+          </span>
+          <span
+            aria-hidden="true"
+          >
+            -
+          </span>
+          <span
+            aria-hidden="false"
+          >
+            palmer
+          </span>
         </span>
-        <span>
-          finned
-        </span>
-        <span
-          aria-hidden="true"
-        >
-          -
-        </span>
-        <span
-          aria-hidden="false"
-        >
-          palmer
-        </span>
-      </span>
+      </div>
       <span
         class="hidden text-sm font-semibold text-gray-500 group-hover:block"
       >


### PR DESCRIPTION
see: #1037.

There's an `Author` component that consists of an avatar and a shipname that we're using in contexts where authorship is connoted that I'm pretty sure covers all cases where a ShipName is used and there isn't additional interactivity, let me know if i'm missing any instances with this.