### PR TITLE
heap: use the correct type for reduce

### DIFF
--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -524,7 +524,7 @@
       (he-give-updates time d)
     ?-    -.d
         %curios
-      =.  curios.heap  (reduce:he-curios time p.d)
+      =.  curios.heap  (reduce:he-curios time q.p.d)
       ?-  -.q.p.d
           ?(%edit %del %add-feel %del-feel)  he-core
           %add


### PR DESCRIPTION
Some leftovers from the timestamp pairing, previously this used the whole curio diff but now we only need the delta. 

plz compile before committing uwu