### PR TITLE
(wip) chat: ensuring briefs are correctly updated

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1081,7 +1081,7 @@
         %unwatch  remark.chat(watching |)
         %read-at  !! ::  ca-core(last-read.remark.chat p.diff)
       ::
-          %read   remark.chat(last-read now.bowl)
+          %read   remark.chat(last-read (add [act now]:bowl))
   ::    =/  [=time =writ:c]  (need (ram:on:writs:c writs.chat))
   ::    =.  last-read.remark.chat  time
   ::    ca-core


### PR DESCRIPTION
Trying to fix #1042 I have no idea how this is possible, shooting in the dark with @liam-fitzgerald 's suggestion. This only seems to happen on the Tlon group in the alpha.

For context:
> ok referring to the above, we have an ordered map of chats keyed by time, when I see all of the unread chats we send a marker saying hey go clear unreads. this sets last-read to now.bowl. we use that with lot:on to get the list of unreads, which shove in a brief which we send to the frontend to say when was this last read, how many are unread, what's the id of the message to place the marker at. well what I'm seeing is a stream of messages come in, we mark read during the stream, and then somehow this sends an update back without fully clearing and we get stuck trying to clear over and over. this makes it seem like the time in now.bowl is off or maybe we're making assumptions that we shouldn't be.
> 
> we send a brief in the same event as clearing so there shouldn't be other state modifications right?
> it's not like I'm seeing us receive a brief with 0 unreads and then get another fact that we actually have 4