### PR TITLE
everywhere: disabled CSS hover on touchscreens

### DIFF
--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -100,6 +100,10 @@ const dark = {
 module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class', // or 'media' or 'class'
+  // This disables CSS hovers on mobile, avoiding double-tap scenarios
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
   theme: {
     fontFamily: {
       sans: [


### PR DESCRIPTION
see #1076.

simple as.

tradeoff: some tooltips may no longer be visible on mobile without long-pressing. the only one I can think of that isn't purely instructional is the emoji react hover action that shows who reacted – we likely want to implement an alternative method to see this anyway (to account for cases where more than 5 or so people have reacted to a message with the same emoji, which happens pretty often in group-based chat apps like this)