### PR TITLE
groups: adding better handling for errored group joins

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -145,6 +145,10 @@
     =+  !<(=flag:g vase)
     ga-abet:ga-rescind:(ga-abed:gang-core flag)
   ::
+      %group-cancel
+    =+  !<(=flag:g vase)
+    ga-abet:ga-cancel:(ga-abed:gang-core flag)
+  ::
       %invite-decline
     =+  !<(=flag:g vase)
     ga-abet:ga-invite-reject:(ga-abed:gang-core flag)
@@ -1162,6 +1166,12 @@
   ++  ga-start-join
     ^+  ga-core
     =.  cor  (emit add-self:ga-pass)
+    ga-core
+  ::
+  ++  ga-cancel
+    ^+  ga-core
+    =.  cam.gang  ~
+    =.  cor  ga-give-update
     ga-core
   ::
   ++  ga-knock

--- a/desk/mar/group/cancel.hoon
+++ b/desk/mar/group/cancel.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/flag
+mark

--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -137,16 +137,17 @@ function GangItem(props: { flag: string }) {
   const { preview, claim } = useGang(flag);
   const isMobile = useIsMobile();
 
-  if (!claim || claim.progress === 'error') {
+  if (!claim) {
     return null;
   }
 
   const requested = claim.progress === 'knocking';
+  const errored = claim.progress === 'error';
   const handleCancel = async () => {
     if (requested) {
       await useGroupState.getState().rescind(flag);
     } else {
-      await useGroupState.getState().reject(flag);
+      await useGroupState.getState().cancel(flag);
     }
   };
 
@@ -182,6 +183,14 @@ function GangItem(props: { flag: string }) {
                 receive an invitation to join.
               </span>
             </>
+          ) : errored ? (
+            <>
+              <span>You were unable to join the group.</span>
+              <span>
+                The group may not exist or they may be running an incompatible
+                version.
+              </span>
+            </>
           ) : (
             <>
               <span>You are currently joining this group.</span>
@@ -191,16 +200,18 @@ function GangItem(props: { flag: string }) {
               </span>
             </>
           )}
-          <div className="flex">
-            <Popover.Close>
-              <button
-                className="small-button bg-gray-50 text-gray-800"
-                onClick={handleCancel}
-              >
-                {requested ? 'Cancel Request' : 'Cancel Join'}
-              </button>
-            </Popover.Close>
-          </div>
+          {(errored || requested) && (
+            <div className="flex">
+              <Popover.Close>
+                <button
+                  className="small-button bg-gray-50 text-gray-800"
+                  onClick={handleCancel}
+                >
+                  {requested ? 'Cancel Request' : 'Cancel Join'}
+                </button>
+              </Popover.Close>
+            </div>
+          )}
         </div>
       </Popover.Content>
     </Popover.Root>

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -246,6 +246,17 @@ export const useGroupState = create<GroupState>(
           draft.gangs[flag].invite = null;
         });
       },
+      cancel: async (flag) => {
+        await api.poke({
+          app: 'groups',
+          mark: 'group-cancel',
+          json: flag,
+        });
+
+        get().batchSet((draft) => {
+          draft.gangs[flag].claim = null;
+        });
+      },
       leave: async (flag: string) => {
         await api.poke({
           app: 'groups',
@@ -627,7 +638,12 @@ export function usePendingGangsWithoutClaim() {
 
   Object.entries(gangs)
     .filter(([flag, g]) => g.invite !== null && !(flag in groups))
-    .filter(([_, gang]) => !gang.claim || gang.claim.progress === 'knocking')
+    .filter(
+      ([_, gang]) =>
+        !gang.claim ||
+        gang.claim.progress === 'error' ||
+        gang.claim.progress === 'knocking'
+    )
     .forEach(([flag, gang]) => {
       pendingGangs[flag] = gang;
     });

--- a/ui/src/state/groups/type.ts
+++ b/ui/src/state/groups/type.ts
@@ -61,6 +61,7 @@ export interface GroupState {
     kind: 'ask' | 'pending'
   ) => Promise<void>;
   reject: (flag: string) => Promise<void>;
+  cancel: (flag: string) => Promise<void>;
   createZone: (flag: string, zone: string, meta: GroupMeta) => Promise<void>;
   editZone: (flag: string, zone: string, meta: GroupMeta) => Promise<void>;
   moveZone: (flag: string, zone: string, index: number) => Promise<void>;


### PR DESCRIPTION
This addresses the immediate issues with #1067 by adding an ability remove "errored" joins and also lets new invites show up even if a join was errored. Also adds a new cancel flow for "errored" joins so they can be removed from the sidebar.

This also removes the "Cancel Join" button from the join in progress popover because it's currently not possible to remove a join in progress (only maybe hide it and it would still have the potential to go through). We may be able to come up with something later that gives us the ability to completely cancel, but we need quite a bit to do it.