### PR TITLE
Always open chat at bottom

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -89,7 +89,12 @@ const ChatMessage = React.memo<
       )(seal.replied);
 
       return (
-        <div ref={ref} className="flex flex-col">
+        <div
+          ref={ref}
+          className={cn('flex flex-col', {
+            'pt-2': newAuthor,
+          })}
+        >
           {unread && unread.count > 0 ? (
             <DateDivider date={unix} unreadCount={unread.count} ref={viewRef} />
           ) : null}

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -34,6 +34,7 @@ export interface ChatMessageProps {
   unread?: ChatBrief;
   hideReplies?: boolean;
   hideOptions?: boolean;
+  isLast?: boolean;
 }
 
 const ChatMessage = React.memo<
@@ -51,6 +52,7 @@ const ChatMessage = React.memo<
         newDay = false,
         hideReplies = false,
         hideOptions = false,
+        isLast = false,
       }: ChatMessageProps,
       ref
     ) => {
@@ -93,6 +95,7 @@ const ChatMessage = React.memo<
           ref={ref}
           className={cn('flex flex-col', {
             'pt-2': newAuthor,
+            'pb-2': isLast,
           })}
         >
           {unread && unread.count > 0 ? (

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ChatMessage > renders as expected 1`] = `
 <DocumentFragment>
   <div
-    class="flex flex-col"
+    class="flex flex-col pt-2"
   >
     <div
       class="flex w-full items-center py-4"

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -94,6 +94,7 @@ function createRenderer({
           newDay={newDay}
           ref={ref}
           unread={unreadBrief}
+          isLast={keyIdx === keys.length - 1}
         />
       );
     }

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -5,12 +5,13 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { isSameDay } from 'date-fns';
-import { BigIntOrderedMap, daToUnix, unixToDa } from '@urbit/api';
+import { BigIntOrderedMap, daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
-import { Virtuoso } from 'react-virtuoso';
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { ChatState } from '@/state/chat/type';
 import { useChatState, useLoadedWrits } from '@/state/chat/chat';
@@ -133,6 +134,7 @@ export default function ChatScroller({
   const loaded = useLoadedWrits(whom);
   const [oldWhom, setOldWhom] = useState(whom);
   const [fetching, setFetching] = useState<FetchingState>('initial');
+  const virtuoso = useRef<VirtuosoHandle>(null);
 
   const keys = useMemo(
     () =>
@@ -183,6 +185,19 @@ export default function ChatScroller({
         firstItemIndex: indexData.firstItemIndex - diff,
         data: keys,
       });
+    }
+
+    // Sometimes the virtuoso component doesn't scroll to the bottom when
+    // switching chats. Diff remains zero when it shouldn't.
+    // This is a hack to force it to scroll to the bottom.
+
+    if (indexData.firstItemIndex === FIRST_INDEX && diff === 0) {
+      // We need to wait to make sure the virtuoso component has been updated.
+      setTimeout(() => {
+        virtuoso?.current?.scrollToIndex({
+          index: indexData.data.length - 1,
+        });
+      }, 50);
     }
   }, [whom, oldWhom, keys, mess, indexData]);
 
@@ -240,6 +255,7 @@ export default function ChatScroller({
     <div className="relative h-full flex-1">
       <Virtuoso
         {...indexData}
+        ref={virtuoso}
         followOutput
         alignToBottom
         className="h-full overflow-x-hidden p-4"


### PR DESCRIPTION
Fixes #1096 and #1102 

Note that this doesn't account for scrolling directly to a message, as it appears that for now we don't actually use the `scrollTo` prop. Should it?