### PR TITLE
groups: adding new harness for tracking poke results

### DIFF
--- a/ui/src/groups/NewGroup/NewGroup.tsx
+++ b/ui/src/groups/NewGroup/NewGroup.tsx
@@ -11,6 +11,7 @@ import NavigationDots from '@/components/NavigationDots';
 import { useDismissNavigate } from '@/logic/routing';
 import { Cordon, GroupFormSchema } from '@/types/groups';
 import { useStep } from 'usehooks-ts';
+import { Status } from '@/logic/status';
 
 type Role = 'Member' | 'Moderator' | 'Admin';
 
@@ -25,6 +26,7 @@ export default function NewGroup() {
   const navigate = useNavigate();
   const dismiss = useDismissNavigate();
   const [shipsToInvite, setShipsToInvite] = useState<ShipWithRoles[]>([]);
+  const [status, setStatus] = useState<Status>('initial');
   // const [templateType, setTemplateType] = useState<TemplateTypes>('none');
 
   const onOpenChange = (isOpen: boolean) => {
@@ -75,9 +77,19 @@ export default function NewGroup() {
             },
           };
 
-    await useGroupState.getState().create({ ...values, name, members, cordon });
-    const flag = `${window.our}/${name}`;
-    navigate(`/groups/${flag}`);
+    setStatus('loading');
+
+    try {
+      await useGroupState
+        .getState()
+        .create({ ...values, name, members, cordon });
+
+      setStatus('success');
+      const flag = `${window.our}/${name}`;
+      navigate(`/groups/${flag}`);
+    } catch (error) {
+      setStatus('error');
+    }
   }, [shipsToInvite, navigate, form]);
 
   // const nextWithTemplate = (template?: string) => {
@@ -113,6 +125,7 @@ export default function NewGroup() {
     case 3:
       currentStepComponent = (
         <NewGroupInvite
+          status={status}
           groupName={form.getValues('title')}
           groupPrivacy={form.getValues('privacy')}
           goToPrevStep={goToPrevStep}

--- a/ui/src/groups/NewGroup/NewGroupInvite.tsx
+++ b/ui/src/groups/NewGroup/NewGroupInvite.tsx
@@ -9,6 +9,9 @@ import CaretDownIcon from '@/components/icons/CaretDownIcon';
 import IconButton from '@/components/IconButton';
 import XIcon from '@/components/icons/XIcon';
 import { PrivacyType } from '@/types/groups';
+import { Status } from '@/logic/status';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import X16Icon from '@/components/icons/X16Icon';
 
 interface NewGroupInviteProps {
   groupName: string;
@@ -17,6 +20,7 @@ interface NewGroupInviteProps {
   goToNextStep: () => void;
   shipsToInvite: ShipWithRoles[];
   setShipsToInvite: React.Dispatch<React.SetStateAction<ShipWithRoles[]>>;
+  status: Status;
 }
 
 type Role = 'Member' | 'Moderator' | 'Admin';
@@ -136,9 +140,13 @@ export default function NewGroupInvite({
   groupPrivacy,
   shipsToInvite,
   setShipsToInvite,
+  status,
 }: NewGroupInviteProps) {
   const [shipSelectorShips, setShipSelectorShips] = useState<ShipOption[]>([]);
   const [selectedRole, setSelectedRole] = useState<Role>('Member');
+  const submitText =
+    shipsToInvite.length > 0 ? 'Invite People & Create Group' : 'Create Group';
+  const ready = status === 'initial';
 
   const handleEnter = (ships: ShipOption[]) => {
     setShipsToInvite((prevState) => [
@@ -187,10 +195,20 @@ export default function NewGroupInvite({
         <button className="secondary-button" onClick={goToPrevStep}>
           Back
         </button>
-        <button className="button" onClick={goToNextStep}>
-          {shipsToInvite.length > 0
-            ? 'Invite People & Create Group'
-            : 'Create Group'}
+        <button className="button" onClick={goToNextStep} disabled={!ready}>
+          {ready ? (
+            submitText
+          ) : status === 'loading' ? (
+            <>
+              <LoadingSpinner className="mr-2 h-4 w-4" />
+              <span>Creating</span>
+            </>
+          ) : status === 'error' ? (
+            <>
+              <X16Icon className="mr-2 h-4 w-4" />
+              <span>Errored</span>
+            </>
+          ) : null}
         </button>
       </div>
     </div>

--- a/ui/src/logic/status.ts
+++ b/ui/src/logic/status.ts
@@ -1,0 +1,1 @@
+export type Status = 'initial' | 'loading' | 'success' | 'error';

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -24,6 +24,7 @@ import {
 } from '@/logic/utils';
 import groupsReducer from './groupsReducer';
 import { GroupState } from './type';
+import useSubscriptionState from '../subscription';
 
 export const GROUP_ADMIN = 'admin';
 
@@ -159,13 +160,32 @@ export const useGroupState = create<GroupState>(
       edit: async (flag, metadata) => {
         await api.poke(groupAction(flag, { meta: metadata }));
       },
-      create: async (req) => {
-        await api.poke({
-          app: 'groups',
-          mark: 'group-create',
-          json: req,
-        });
-      },
+      create: async (req) =>
+        new Promise((resolve, reject) => {
+          api.poke({
+            app: 'groups',
+            mark: 'group-create',
+            json: req,
+            onError: () => reject(),
+            onSuccess: async () => {
+              await useSubscriptionState
+                .getState()
+                .track('groups/groups/ui', (event) => {
+                  if ('update' in event) {
+                    const { update } = event as GroupAction;
+                    return (
+                      'create' in update.diff &&
+                      req.title === update.diff.create.meta.title
+                    );
+                  }
+
+                  return false;
+                });
+
+              resolve();
+            },
+          });
+        }),
       delete: async (flag) => {
         await api.poke(groupAction(flag, { del: null }));
       },

--- a/ui/src/state/subscription.ts
+++ b/ui/src/state/subscription.ts
@@ -1,0 +1,46 @@
+import _ from 'lodash';
+import create from 'zustand';
+
+type Hook = (event: any, mark: string) => boolean;
+
+interface Watcher {
+  id: string;
+  hook: Hook;
+  resolve: (value: void | PromiseLike<void>) => void;
+  reject: (reason?: any) => void;
+}
+
+interface SubscriptionState {
+  watchers: {
+    [path: string]: Watcher[];
+  };
+  track: (path: string, hook: Hook) => Promise<void>;
+  remove: (path: string, id: string) => void;
+}
+
+const useSubscriptionState = create<SubscriptionState>((set, get) => ({
+  watchers: {},
+  track: (path, hook) =>
+    new Promise((resolve, reject) => {
+      set((draft) => {
+        draft.watchers[path] = [
+          ...(draft.watchers[path] || []),
+          {
+            id: _.uniqueId(),
+            hook,
+            resolve,
+            reject,
+          },
+        ];
+      });
+    }),
+  remove: (path, id) => {
+    set((draft) => {
+      draft.watchers[path] = (draft.watchers[path] || []).filter(
+        (w) => w.id === id
+      );
+    });
+  },
+}));
+
+export default useSubscriptionState;


### PR DESCRIPTION
This adds a pathway for tracking poke responses that come down subscriptions so that we can start culling the missing loading states in #566 (and not just track the poke's request itself which is only half of the loading). 

This adds a loading state to group creation as an example. Essentially, when doing a poke that will eventually produce a fact down a subscription, you call and await `useSubscriptionState.getState.track(...)`. The function you pass must be able to read the facts on a subscription and determine the correct fact has come down. When this promise is finished you can assume that the function you passed returned true and it's safe to show success/proceed.