### PR TITLE
groups: mobile nav redesign

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -72,6 +72,7 @@ import TalkNav from './nav/TalkNav';
 import MobileMessagesSidebar from './dms/MobileMessagesSidebar';
 import MobileSidebar from './components/Sidebar/MobileSidebar';
 import MobileGroupsNavHome from './nav/MobileRoot';
+import MobileGroupsActions from './groups/MobileGroupsActions';
 import MobileGroupRoot from './nav/MobileGroupRoot';
 import MobileGroupActions from './groups/MobileGroupActions';
 
@@ -247,6 +248,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 <EditProfile title={`Edit Profile • ${appHead('').title}`} />
               }
             />
+            <Route path="/actions" element={<MobileGroupsActions />} />
           </Route>
           <Route path="/groups/:ship/:name" element={<Groups />}>
             <Route element={isMobile ? <MobileGroupSidebar /> : undefined}>

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -16,7 +16,6 @@ import ListIcon from '@/components/icons/ListIcon';
 import ChannelIcon from '@/channels/ChannelIcon';
 import * as Popover from '@radix-ui/react-popover';
 import Divider from '@/components/Divider';
-import BulletIcon from '@/components/icons/BulletIcon';
 import LeaveIcon from '@/components/icons/LeaveIcon';
 import SlidersIcon from '@/components/icons/SlidersIcon';
 import useIsChannelHost from '@/logic/useIsChannelHost';
@@ -91,6 +90,7 @@ function ChannelActions({ nest }: { nest: string }) {
   const navigate = useNavigate();
   const groupFlag = useRouteGroup();
   const { ship, name } = getFlagParts(groupFlag);
+  const isMobile = useIsMobile();
 
   const leave = useCallback(
     (chFlag: string) => {
@@ -109,13 +109,17 @@ function ChannelActions({ nest }: { nest: string }) {
   const leaveChannel = useCallback(async () => {
     try {
       leave(flag);
-      navigate(`/groups/${ship}/${name}/channels`);
+      navigate(
+        isMobile
+          ? `/groups/${ship}/${name}`
+          : `/groups/${ship}/${name}/channels`
+      );
     } catch (error) {
       if (error) {
         console.error(`[ChannelIndex:LeaveError] ${error}`);
       }
     }
-  }, [flag, ship, name, navigate, leave]);
+  }, [flag, ship, name, navigate, leave, isMobile]);
 
   return (
     <Popover.Root>
@@ -126,30 +130,6 @@ function ChannelActions({ nest }: { nest: string }) {
       </Popover.Trigger>
       <Popover.Content>
         <div className="flex flex-col rounded-lg bg-white leading-5 drop-shadow-lg">
-          {/* TODO: Will need channel functionality for all these items
-              <ChannelHeaderMenuButton>
-                <BulletIcon className="h-5 w-5 text-blue-300" />
-                <span className="font-semibold text-blue">Invite to Channel</span>
-              </ChannelHeaderMenuButton>
-              <ChannelHeaderMenuButton>
-                <BulletIcon className="h-5 w-5 text-blue-300" />
-                <span className="font-semibold text-blue">Copy Channel Link</span>
-              </ChannelHeaderMenuButton>
-              <ChannelHeaderMenuButton>
-                <BulletIcon className="h-5 w-5 text-gray-400" />
-                <span className="font-semibold">Subscribed Members...</span>
-              </ChannelHeaderMenuButton>
-            */}
-          {/* TODO: Un-disable this once we have mute controls */}
-          <ChannelHeaderMenuButton className="hover:bg-transparent">
-            <BulletIcon className="h-6 w-6 text-gray-400" />
-            <span className="font-semibold text-gray-400">Mute Channel</span>
-          </ChannelHeaderMenuButton>
-          {/* TODO: Un-disable this once we have mentions and mutes */}
-          <ChannelHeaderMenuButton className="hover:bg-transparent">
-            <BulletIcon className="h-6 w-6 text-gray-400" />
-            <span className="font-semibold text-gray-400">Mute Mentions</span>
-          </ChannelHeaderMenuButton>
           {!isChannelHost ? (
             <ChannelHeaderMenuButton
               className="hover:bg-red-soft"
@@ -270,7 +250,7 @@ export default function ChannelHeader({
       )}
     >
       <BackButton
-        to="../../"
+        to="../.."
         className={cn(
           'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
           isMobile && '-ml-2 flex items-center rounded-lg hover:bg-gray-50'
@@ -296,9 +276,6 @@ export default function ChannelHeader({
       {showControls && displayMode && setDisplayMode && setSortMode ? (
         <div className="flex items-center space-x-3">
           {children}
-          <ChannelHeaderButton onClick={() => console.log('share')}>
-            <span className="font-semibold">Share</span>
-          </ChannelHeaderButton>
           {/* TODO: Switch the popovers to dropdowns */}
           <Popover.Root>
             <Popover.Trigger asChild>

--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -10,11 +10,13 @@ import ChannelPermsSelector from '@/groups/GroupAdmin/AdminChannels/ChannelPerms
 import ChannelJoinSelector from '@/groups/GroupAdmin/AdminChannels/ChannelJoinSelector';
 import { useHeapState } from '@/state/heap/heap';
 import { useDiaryState } from '@/state/diary';
+import { useIsMobile } from '@/logic/useMedia';
 import ChannelTypeSelector from '../ChannelTypeSelector';
 
 export default function NewChannelForm() {
   const { section } = useParams<{ section: string }>();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const groupFlag = useRouteGroup();
   const defaultValues: NewChannelFormSchema = {
     type: 'chat',
@@ -111,10 +113,11 @@ export default function NewChannelForm() {
           .getState()
           .setChannelJoin(groupFlag, newChannelNest, true);
       }
-
-      navigate(`/groups/${groupFlag}/info/channels`);
+      navigate(
+        isMobile ? `/groups/${groupFlag}` : `/groups/${groupFlag}/info/channels`
+      );
     },
-    [section, groupFlag, navigate]
+    [section, groupFlag, navigate, isMobile]
   );
 
   return (

--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -30,6 +30,7 @@ import { useMemoizedContacts } from '@/state/contact';
 import { MAX_DISPLAYED_OPTIONS } from '@/constants';
 import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import { useIsMobile } from '@/logic/useMedia';
 import ShipName from './ShipName';
 import UnknownAvatarIcon from './icons/UnknownAvatarIcon';
 
@@ -276,6 +277,7 @@ export default function ShipSelector({
     true,
     GroupBase<ShipOption>
   > | null>(null);
+  const isMobile = useIsMobile();
   const contacts = useMemoizedContacts();
   const contactNames = Object.keys(contacts);
   const contactOptions = contactNames.map((contact) => ({
@@ -285,6 +287,7 @@ export default function ShipSelector({
   const validShips = ships
     ? ships.every((ship) => isValidNewOption(preSig(ship.value)))
     : false;
+  const mobilePlaceholder = 'Search by @p or nickname';
 
   const handleEnter = () => {
     const isInputting = !!(
@@ -479,7 +482,7 @@ export default function ShipSelector({
             : isValidNewOption(val)
         }
         onKeyDown={onKeyDown}
-        placeholder={placeholder}
+        placeholder={isMobile ? mobilePlaceholder : placeholder}
         hideSelectedOptions
         // TODO: create custom filter for sorting potential DM participants.
         filterOption={() => true} // disable the default filter
@@ -567,7 +570,7 @@ export default function ShipSelector({
       onInputChange={onInputChange}
       isValidNewOption={isValidNewOption}
       onKeyDown={onKeyDown}
-      placeholder={placeholder}
+      placeholder={isMobile ? mobilePlaceholder : placeholder}
       hideSelectedOptions
       // TODO: create custom filter for sorting potential DM participants.
       filterOption={() => true} // disable the default filter

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -21,15 +21,15 @@ export default function MobileSidebar() {
       <footer className="flex-none border-t-2 border-gray-50">
         <nav>
           <ul className="flex justify-items-stretch">
-            <NavTab to="/" aria-label="Groups">
+            <NavTab to="/">
               <AppGroupsIcon className="mb-0.5 h-6 w-6" />
               Groups
             </NavTab>
-            <NavTab to="/notifications" aria-label="Activity">
+            <NavTab to="/notifications">
               <BellIcon className="mb-0.5 h-6 w-6" />
               Activity
             </NavTab>
-            <NavTab to="/find" aria-label="Find">
+            <NavTab to="/find">
               <MagnifyingGlassIcon className="mb-0.5 h-6 w-6" />
               Find Groups
             </NavTab>
@@ -44,7 +44,7 @@ export default function MobileSidebar() {
               />
               Profile
             </NavTab>
-            <NavTab to="/actions" aria-label="Options">
+            <NavTab to="/actions">
               <ElipsisIcon className="mb-0.5 h-6 w-6" />
               Options
             </NavTab>

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -1,19 +1,19 @@
-import cn from 'classnames';
 import React from 'react';
-import { Outlet, useLocation, useMatch } from 'react-router';
+import cn from 'classnames';
+import { Outlet, useMatch } from 'react-router';
 import { useNotifications } from '@/notifications/useNotifications';
 import NavTab from '../NavTab';
-import GroupIcon from '../icons/GroupIcon';
-import ActivityIndicator from './ActivityIndicator';
-import AsteriskIcon from '../icons/Asterisk16Icon';
+import AppGroupsIcon from '../icons/AppGroupsIcon';
+import ElipsisIcon from '../icons/EllipsisIcon';
+import BellIcon from '../icons/BellIcon';
 import Avatar from '../Avatar';
-import AddIcon16 from '../icons/Add16Icon';
-import MagnifyingGlassIcon from '../icons/MagnifyingGlassIcon';
+
+import MagnifyingGlassIcon from '../icons/MagnifyingGlass16Icon';
 
 export default function MobileSidebar() {
+  const ship = window.our;
+  const profileMatch = useMatch('/profile/edit');
   const { count } = useNotifications();
-  const location = useLocation();
-  const isProfile = useMatch('/profile/*');
 
   return (
     <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-r-2 border-gray-50 bg-white">
@@ -22,34 +22,31 @@ export default function MobileSidebar() {
         <nav>
           <ul className="flex justify-items-stretch">
             <NavTab to="/" aria-label="Groups">
-              <GroupIcon className="mb-0.5 h-6 w-6" />
+              <AppGroupsIcon className="mb-0.5 h-6 w-6" />
+              Groups
             </NavTab>
-            <NavTab to="/notifications" aria-label="Notifications">
-              <ActivityIndicator count={count} className="mb-0.5" />
+            <NavTab to="/notifications" aria-label="Activity">
+              <BellIcon className="mb-0.5 h-6 w-6" />
+              Activity
             </NavTab>
-            <NavTab to="/groups/new" state={{ backgroundLocation: location }}>
-              <div className="icon-button bg-blue text-white dark:bg-blue-900 dark:text-blue">
-                <AddIcon16 className="h-4 w-4" />
-              </div>
-            </NavTab>
-            <NavTab to="/find">
+            <NavTab to="/find" aria-label="Find">
               <MagnifyingGlassIcon className="mb-0.5 h-6 w-6" />
+              Find Groups
             </NavTab>
-            <NavTab
-              linkClass="no-underline"
-              href="https://github.com/tloncorp/homestead/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=groups:"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Submit Issue"
-            >
-              <AsteriskIcon className="mb-0.5 h-6 w-6" />
-            </NavTab>
-            <NavTab to="/profile/edit" aria-label="Profile">
+            <NavTab to="/profile/edit">
               <Avatar
                 size="xs"
-                ship={window.our}
-                className={cn('mb-0.5', !isProfile && 'opacity-70 grayscale')}
+                ship={ship}
+                className={cn(
+                  'mb-1 h-6 w-6',
+                  !profileMatch && 'opacity-50 grayscale'
+                )}
               />
+              Profile
+            </NavTab>
+            <NavTab to="/actions" aria-label="Options">
+              <ElipsisIcon className="mb-0.5 h-6 w-6" />
+              Options
             </NavTab>
           </ul>
         </nav>

--- a/ui/src/components/Sidebar/SidebarSorter.tsx
+++ b/ui/src/components/Sidebar/SidebarSorter.tsx
@@ -21,11 +21,10 @@ export default function SidebarSorter({
     <DropdownMenu.Root>
       {isMobile ? (
         <DropdownMenu.Trigger
-          className="default-focus flex items-center rounded-lg p-2 text-base font-semibold"
+          className="default-focus flex items-center rounded-lg p-0 text-base font-semibold"
           aria-label="Groups Sort Options"
         >
-          <h1 className="mr-4 text-base font-semibold">All Groups</h1>
-          <CaretDown16Icon className="h-4 w-4 text-gray-400" />
+          <SortIcon className="h-6 w-6 text-gray-400" />
         </DropdownMenu.Trigger>
       ) : (
         <DropdownMenu.Trigger

--- a/ui/src/components/icons/BellIcon.tsx
+++ b/ui/src/components/icons/BellIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function BellIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 11a6.002 6.002 0 0 1 5-5.917V3h2v2.083c2.838.476 5 2.944 5 5.917v2.382l.764.382a2.236 2.236 0 0 1-1 4.236H15a3 3 0 1 1-6 0H6.236a2.236 2.236 0 0 1-1-4.236L6 13.382V11Zm5 7a1 1 0 1 0 2 0h-2Zm-3-7a4 4 0 1 1 8 0v2.902c0 .439.248.84.64 1.036l1.23.615a.236.236 0 0 1-.106.447H6.236a.236.236 0 0 1-.106-.447l1.23-.615c.392-.196.64-.597.64-1.036V11Z"
+        className="fill-current"
+      />
+    </svg>
+  );
+}

--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -278,12 +278,12 @@ export default function ChannelIndex({ title }: ViewProps) {
       </Helmet>
       <div className="flex flex-row items-center justify-between py-1 px-2 sm:p-4">
         <BackButton
-          to="../"
+          to="../actions"
           className={cn(
             'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
             isMobile && 'flex items-center rounded-lg hover:bg-gray-50'
           )}
-          aria-label="Back to Channels Menu"
+          aria-label="Back to Group Menu"
         >
           {isMobile ? (
             <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-400" />

--- a/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
+++ b/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
@@ -9,9 +9,9 @@ exports[`ChannelIndex > renders as expected 1`] = `
       class="flex flex-row items-center justify-between py-1 px-2 sm:p-4"
     >
       <div
-        aria-label="Back to Channels Menu"
+        aria-label="Back to Group Menu"
         class="cursor-pointer select-none p-2 sm:cursor-text sm:select-text"
-        to="../"
+        to="../actions"
       >
         <h1
           class="text-base font-semibold sm:text-lg"

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
+import cn from 'classnames';
 import ob from 'urbit-ob';
 import {
   useGangs,
   useGroupState,
   usePendingGangsWithoutClaim,
 } from '@/state/groups';
+import { useIsMobile } from '@/logic/useMedia';
 import ShipSelector, { ShipOption } from '@/components/ShipSelector';
 import { Gangs, GroupIndex, ViewProps } from '@/types/groups';
 import useRequestState from '@/logic/useRequestState';
@@ -21,6 +23,7 @@ export default function FindGroups({ title }: ViewProps) {
   const [groupIndex, setGroupIndex] = useState<GroupIndex | null>(null);
   const existingGangs = useGangs();
   const pendingGangs = usePendingGangsWithoutClaim();
+  const isMobile = useIsMobile();
 
   /**
    *  Search results for render:
@@ -184,48 +187,68 @@ export default function FindGroups({ title }: ViewProps) {
     val ? ob.isValidPatp(preSig(val)) || whomIsFlag(val) : false;
 
   return (
-    <div className="flex grow overflow-y-auto bg-gray-50">
-      <Helmet>
-        <title>{title ? title : document.title}</title>
-      </Helmet>
-      <div className="w-full p-4">
-        <section className="card mb-4 space-y-8 sm:p-8">
-          <h1 className="text-lg font-bold">Find Groups</h1>
-          <div>
-            <label htmlFor="flag" className="mb-1.5 block font-semibold">
-              Join Groups via Nickname or Urbit ID
-            </label>
-            <div className="flex flex-col space-y-2">
-              <ShipSelector
-                ships={shipSelectorShips}
-                setShips={setShipSelectorShips}
-                isMulti={false}
-                isClearable={true}
-                isLoading={isPending}
-                hasPrompt={false}
-                placeholder={''}
-                isValidNewOption={isValidNewOption}
-              />
+    <>
+      {isMobile && (
+        <header className="flex h-14 items-center justify-between px-5 py-4">
+          <h1 className="text-base font-bold">Find Groups</h1>
+        </header>
+      )}
+      <div
+        className={cn('flex grow overflow-y-auto', !isMobile && 'bg-gray-50')}
+      >
+        <Helmet>
+          <title>{title ? title : document.title}</title>
+        </Helmet>
+        <div className="w-full p-4">
+          <section
+            className={cn('mb-8 space-y-8', !isMobile && 'card mb-4 sm:p-8')}
+          >
+            {!isMobile && <h1 className="text-lg font-bold">Find Groups</h1>}
+            <div>
+              <label htmlFor="flag" className="mb-1.5 block font-semibold">
+                Join Groups via Nickname or Urbit ID
+              </label>
+              <div className="flex flex-col space-y-2">
+                <ShipSelector
+                  ships={shipSelectorShips}
+                  setShips={setShipSelectorShips}
+                  isMulti={false}
+                  isClearable={true}
+                  isLoading={isPending}
+                  hasPrompt={false}
+                  placeholder={''}
+                  isValidNewOption={isValidNewOption}
+                />
+              </div>
             </div>
-          </div>
-          {selectedShip || (ship && name) ? (
-            <section className="space-y-3">
-              <p className="font-semibold text-gray-400">{resultsTitle()}</p>
-              {isPending ? (
-                <GroupJoinListPlaceholder />
-              ) : indexedGangs && hasKeys(indexedGangs) ? (
-                <GroupJoinList gangs={indexedGangs} />
-              ) : null}
+            {selectedShip || (ship && name) ? (
+              <section className="space-y-3">
+                <p className="font-semibold text-gray-400">{resultsTitle()}</p>
+                {isPending ? (
+                  <GroupJoinListPlaceholder />
+                ) : indexedGangs && hasKeys(indexedGangs) ? (
+                  <GroupJoinList gangs={indexedGangs} />
+                ) : null}
+              </section>
+            ) : null}
+          </section>
+          {hasKeys(pendingGangs) ? (
+            <section
+              className={cn(
+                'mb-4 space-y-4',
+                !isMobile && 'card space-y-8 sm:p-8'
+              )}
+            >
+              <h1
+                className={cn('font-bold', isMobile ? 'text-base' : 'text-lg')}
+              >
+                Pending Invites
+              </h1>
+              <GroupJoinList gangs={pendingGangs} />
             </section>
           ) : null}
-        </section>
-        {hasKeys(pendingGangs) ? (
-          <section className="card mb-4 space-y-8 sm:p-8">
-            <h1 className="text-lg font-bold">Pending Invites</h1>
-            <GroupJoinList gangs={pendingGangs} />
-          </section>
-        ) : null}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/ui/src/groups/GroupAdmin/GroupAdmin.tsx
+++ b/ui/src/groups/GroupAdmin/GroupAdmin.tsx
@@ -1,28 +1,14 @@
-import cn from 'classnames';
 import React from 'react';
-import { Link, NavLink, Outlet } from 'react-router-dom';
-import { useIsMobile } from '@/logic/useMedia';
+import cn from 'classnames';
+import { NavLink, Outlet } from 'react-router-dom';
 import { useAmAdmin, useRouteGroup } from '@/state/groups/groups';
-import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 
 export default function GroupAdmin() {
   const flag = useRouteGroup();
   const isAdmin = useAmAdmin(flag);
-  const isMobile = useIsMobile();
 
   return (
     <section className="w-full overflow-y-scroll">
-      {isMobile ? (
-        <div className="px-2 py-1">
-          <Link
-            to="../"
-            className="default-focus inline-flex items-center rounded-lg p-2 text-base font-semibold text-gray-800 hover:bg-gray-50"
-          >
-            <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-600" />
-            Group Info
-          </Link>
-        </div>
-      ) : null}
       <div className="m-4 sm:my-5 sm:mx-8">
         {isAdmin ? (
           <header className="card mb-4 p-2">

--- a/ui/src/groups/GroupJoinList.tsx
+++ b/ui/src/groups/GroupJoinList.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useCallback } from 'react';
+import cn from 'classnames';
+import { useIsMobile } from '@/logic/useMedia';
 import { Gang, Gangs } from '@/types/groups';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import GroupSummary from './GroupSummary';
@@ -12,6 +14,7 @@ interface GroupJoinItemProps {
 function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
   const [hasBeenClicked, setHasBeenClicked] = useState(false);
   const { open, reject, button, privacy, requested } = useGroupJoin(flag, gang);
+  const isMobile = useIsMobile();
 
   const onClick = useCallback((buttonAction: () => void) => {
     setHasBeenClicked(true);
@@ -21,7 +24,10 @@ function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
   return (
     <li className="relative flex items-center">
       <button
-        className="flex w-full items-center justify-start rounded-xl p-2 text-left hover:bg-gray-50"
+        className={cn(
+          'flex w-full items-center justify-start rounded-xl p-2 text-left hover:bg-gray-50',
+          isMobile && 'bg-gray-50'
+        )}
         onClick={open}
       >
         <GroupSummary flag={flag} {...gang.preview} size={'small'} />

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -19,9 +19,44 @@ import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import ChannelSortOptions from './ChannelSortOptions';
 
 const UNZONED = 'default';
+
+type ChannelSorterProps = {
+  isMobile?: boolean;
+};
+
 interface ChannelListProps {
   flag: string;
   className?: string;
+}
+
+export function ChannelSorter({ isMobile }: ChannelSorterProps) {
+  const { sortFn, sortOptions, setSortFn } = useChannelSort();
+  return (
+    <DropdownMenu.Root>
+      {isMobile ? (
+        <DropdownMenu.Trigger
+          className="default-focus flex items-center rounded-lg p-0 text-base font-semibold"
+          aria-label="Groups Sort Options"
+        >
+          <SortIcon className="h-6 w-6 text-gray-400" />
+        </DropdownMenu.Trigger>
+      ) : (
+        <div className="p-2">
+          <DropdownMenu.Trigger
+            className="default-focus flex w-full items-center justify-between rounded-lg bg-gray-50 py-1 px-2 text-sm font-semibold"
+            aria-label="Channels Sort Options"
+          >
+            <span className="flex items-center">
+              <SortIcon className="h-4 w-4 text-gray-400" />
+              <span className="mr-2 pl-1">{`Sort: ${sortFn}`}</span>
+            </span>
+            <CaretDown16Icon className="h-4 w-4 text-gray-400" />
+          </DropdownMenu.Trigger>
+        </div>
+      )}
+      <ChannelSortOptions sortOptions={sortOptions} setSortFn={setSortFn} />
+    </DropdownMenu.Root>
+  );
 }
 
 export default function ChannelList({ flag, className }: ChannelListProps) {
@@ -75,21 +110,8 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
 
   return (
     <div className={className}>
-      <DropdownMenu.Root>
-        <div className="p-2">
-          <DropdownMenu.Trigger
-            className="default-focus flex w-full items-center justify-between rounded-lg bg-gray-50 py-1 px-2 text-sm font-semibold"
-            aria-label="Channels Sort Options"
-          >
-            <span className="flex items-center">
-              <SortIcon className="h-4 w-4 text-gray-400" />
-              <span className="mr-2 pl-1">{`Sort: ${sortFn}`}</span>
-            </span>
-            <CaretDown16Icon className="h-4 w-4 text-gray-400" />
-          </DropdownMenu.Trigger>
-        </div>
-        <ChannelSortOptions sortOptions={sortOptions} setSortFn={setSortFn} />
-      </DropdownMenu.Root>
+      {!isMobile && <ChannelSorter isMobile={false} />}
+
       <ul className={cn('space-y-1', isMobile && 'flex-none space-y-3')}>
         {isDefaultSort
           ? sections.map((s) => (

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
 import cn from 'classnames';
 import { Outlet, useMatch } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import { useGroup, useGroupFlag } from '@/state/groups/groups';
-import HashIcon from '@/components/icons/HashIcon';
-import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import NavTab from '@/components/NavTab';
-import ActivityIndicator from '@/components/Sidebar/ActivityIndicator';
-import ElipsisIcon from '@/components/icons/EllipsisIcon';
+import HashIcon from '@/components/icons/HashIcon';
+import InviteIcon16 from '@/components/icons/InviteIcon16';
 import GroupAvatar from '../GroupAvatar';
 
 export default function MobileGroupSidebar() {
   const flag = useGroupFlag();
   const group = useGroup(flag);
+  const location = useLocation();
   const match = useMatch('/groups/:ship/:name/info');
-  // TODO: get activity count from hark store
-  const activityCount = 0;
 
   return (
     <section className="flex h-full w-full flex-col overflow-x-hidden border-r-2 border-gray-50 bg-white">
@@ -24,28 +22,22 @@ export default function MobileGroupSidebar() {
           <ul className="flex items-center">
             <NavTab to="." end aria-label="Channels">
               <HashIcon className="mb-0.5 h-6 w-6" />
+              Channels
             </NavTab>
-            <NavTab to="./info" aria-label="Group Info">
+            <NavTab to={`/groups/${flag}/info`}>
               <GroupAvatar
                 {...group?.meta}
                 size="h-6 w-6"
-                className={cn('mb-0.5', !match && 'opacity-50')}
+                className={cn('mb-0.5', !match && 'opacity-50 grayscale')}
               />
-            </NavTab>
-            <NavTab to="./activity" aria-label="Activity">
-              <ActivityIndicator count={activityCount} className="mb-0.5" />
+              Group Info
             </NavTab>
             <NavTab
-              linkClass="flex-1 no-underline"
-              href="https://github.com/tloncorp/homestead/issues/new?assignees=&amp;labels=bug&amp;template=bug_report.md&amp;title=groups:"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Submit Issue"
+              to={`/groups/${flag}/invite`}
+              state={{ backgroundLocation: location }}
             >
-              <AsteriskIcon className="mb-0.5 h-6 w-6" />
-            </NavTab>
-            <NavTab to="./actions" aria-label="Group Actions">
-              <ElipsisIcon className="mb-0.5 h-6 w-6" />
+              <InviteIcon16 className="mb-0.5 h-6 w-6" />
+              Invite
             </NavTab>
           </ul>
         </nav>

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -20,7 +20,7 @@ export default function MobileGroupSidebar() {
       <footer className="mt-auto flex-none border-t-2 border-gray-50">
         <nav>
           <ul className="flex items-center">
-            <NavTab to="." end aria-label="Channels">
+            <NavTab to="." end>
               <HashIcon className="mb-0.5 h-6 w-6" />
               Channels
             </NavTab>

--- a/ui/src/groups/MobileGroupActions.tsx
+++ b/ui/src/groups/MobileGroupActions.tsx
@@ -1,9 +1,11 @@
+/** Deprecated, but leaving around for reference */
+
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import InviteIcon from '@/components/icons/InviteIcon';
 import LinkIcon from '@/components/icons/LinkIcon';
 import PersonIcon from '@/components/icons/PersonIcon';
-import SlidersIcon from '@/components/icons/SlidersIcon';
+import HashIcon16 from '@/components/icons/HashIcon16';
 import { useGroupActions } from '@/groups/GroupActions';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import LeaveIcon from '@/components/icons/LeaveIcon';
@@ -20,11 +22,20 @@ export default function MobileGroupActions() {
     <nav className="p-2">
       <ul className="space-y-3">
         <SidebarItem
+          icon={
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+              <HashIcon16 className="m-1 h-4 w-4" />
+            </div>
+          }
+          to={`/groups/${flag}/channels`}
+        >
+          All Channels
+        </SidebarItem>
+        <SidebarItem
           to={`/groups/${flag}/invite`}
           state={{ backgroundLocation: location }}
-          color="text-blue"
           icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-blue-soft dark:bg-blue-800">
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
               <InviteIcon className="h-6 w-6" />
             </div>
           }
@@ -32,9 +43,8 @@ export default function MobileGroupActions() {
           Invite People
         </SidebarItem>
         <SidebarItem
-          color="text-blue"
           icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-blue-soft dark:bg-blue-800">
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
               <LinkIcon className="h-6 w-6" />
             </div>
           }
@@ -51,15 +61,6 @@ export default function MobileGroupActions() {
           }
         >
           Members &amp; Group Info
-        </SidebarItem>
-        <SidebarItem
-          icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
-              <SlidersIcon className="h-6 w-6" />
-            </div>
-          }
-        >
-          Group Preferences
         </SidebarItem>
         {flag.includes(ship) ? null : (
           <SidebarItem

--- a/ui/src/groups/MobileGroupsActions.tsx
+++ b/ui/src/groups/MobileGroupsActions.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import AsteriskIcon from '@/components/icons/Asterisk16Icon';
+
+export default function MobileGroupsActions() {
+  return (
+    <nav className="h-full flex-1 overflow-y-auto p-2">
+      <ul className="space-y-3">
+        <SidebarItem
+          icon={
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+              <AsteriskIcon className="h-6 w-6" />
+            </div>
+          }
+        >
+          <a
+            className="no-underline"
+            href="https://airtable.com/shrflFkf5UyDFKhmW"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Submit Feedback"
+          >
+            Submit Feedback
+          </a>
+        </SidebarItem>
+      </ul>
+    </nav>
+  );
+}

--- a/ui/src/nav/MobileGroupRoot.tsx
+++ b/ui/src/nav/MobileGroupRoot.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useGroupFlag, useGroup, useAmAdmin } from '@/state/groups';
 import ChannelList, { ChannelSorter } from '@/groups/GroupSidebar/ChannelList';
 import GroupAvatar from '@/groups/GroupAvatar';
-import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
+import CaretLeftIcon from '@/components/icons/CaretLeft16Icon';
 import AddIcon from '@/components/icons/AddIcon';
 
 export default function MobileGroupRoot() {
@@ -20,7 +20,7 @@ export default function MobileGroupRoot() {
             to="/"
             className="default-focus inline-flex items-center text-base font-semibold text-gray-800 hover:bg-gray-50"
           >
-            <CaretLeft16Icon className="mr-2 h-6 w-6 text-gray-400" />
+            <CaretLeftIcon className="mr-2 h-6 w-6 text-gray-400" />
             <GroupAvatar {...group?.meta} size="h-8 w-8" className="mr-3" />
             <h1 className="truncate text-base font-bold">
               {group?.meta.title}

--- a/ui/src/nav/MobileGroupRoot.tsx
+++ b/ui/src/nav/MobileGroupRoot.tsx
@@ -1,27 +1,46 @@
-import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
-import CaretRight16Icon from '@/components/icons/CaretRight16Icon';
-import ChannelList from '@/groups/GroupSidebar/ChannelList';
-import { useGroupFlag } from '@/state/groups';
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+import { useGroupFlag, useGroup, useAmAdmin } from '@/state/groups';
+import ChannelList, { ChannelSorter } from '@/groups/GroupSidebar/ChannelList';
+import GroupAvatar from '@/groups/GroupAvatar';
+import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
+import AddIcon from '@/components/icons/AddIcon';
 
 export default function MobileGroupRoot() {
   const flag = useGroupFlag();
+  const group = useGroup(flag);
+  const isAdmin = useAmAdmin(flag);
+  const location = useLocation();
 
   return (
     <>
-      <header className="flex flex-none items-center   justify-between px-2 py-1">
-        <Link
-          to="/"
-          className="default-focus inline-flex items-center rounded-lg p-2 text-base font-semibold text-gray-800 hover:bg-gray-50"
-        >
-          <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-400" />
-          Channels
-        </Link>
-        <Link to="./channels" className="small-secondary-button pr-1">
-          <span>All</span>
-          <CaretRight16Icon className="ml-1 h-4 w-4 text-gray-400" />
-        </Link>
+      <header className="flex items-center justify-between p-4 pt-3 pr-5">
+        <div>
+          <Link
+            to="/"
+            className="default-focus inline-flex items-center text-base font-semibold text-gray-800 hover:bg-gray-50"
+          >
+            <CaretLeft16Icon className="mr-2 h-6 w-6 text-gray-400" />
+            <GroupAvatar {...group?.meta} size="h-8 w-8" className="mr-3" />
+            <h1 className="truncate text-base font-bold">
+              {group?.meta.title}
+            </h1>
+          </Link>
+        </div>
+        <div>
+          <div className="flex items-center space-x-5">
+            <ChannelSorter isMobile={true} />
+            {isAdmin && (
+              <Link
+                className="default-focus flex items-center rounded bg-blue p-1 text-base font-semibold"
+                to={`/groups/${flag}/channels/new`}
+                state={{ backgroundLocation: location }}
+              >
+                <AddIcon className="h-4 w-4 text-white" />
+              </Link>
+            )}
+          </div>
+        </div>
       </header>
       <div className="h-full w-full flex-1 overflow-y-scroll p-2 pr-0">
         <ChannelList flag={flag} />

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -1,12 +1,16 @@
-import GroupList from '@/components/Sidebar/GroupList';
-import SidebarSorter from '@/components/Sidebar/SidebarSorter';
+import React from 'react';
+import { useLocation } from 'react-router';
+import { Link } from 'react-router-dom';
 import useGroupSort from '@/logic/useGroupSort';
 import { hasKeys } from '@/logic/utils';
 import { usePinnedGroups } from '@/state/chat';
 import { useGroups } from '@/state/groups';
-import React from 'react';
+import GroupList from '@/components/Sidebar/GroupList';
+import SidebarSorter from '@/components/Sidebar/SidebarSorter';
+import AddIcon from '@/components/icons/AddIcon';
 
 export default function MobileRoot() {
+  const location = useLocation();
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
   const groups = useGroups();
   const pinnedGroups = usePinnedGroups();
@@ -15,6 +19,25 @@ export default function MobileRoot() {
 
   return (
     <>
+      <header className="flex items-center justify-between px-5 py-4">
+        <h1 className="text-base font-bold">My Groups</h1>
+        <div className="flex items-center space-x-5">
+          <SidebarSorter
+            sortFn={sortFn}
+            setSortFn={setSortFn}
+            sortOptions={sortOptions}
+            isMobile={true}
+          />
+          <Link
+            className="default-focus flex items-center rounded bg-blue p-1 text-base font-semibold"
+            to="/groups/new"
+            state={{ backgroundLocation: location }}
+          >
+            <AddIcon className="h-4 w-4 text-white" />
+          </Link>
+        </div>
+      </header>
+
       <header className="flex-none px-2 py-1">
         {hasKeys(pinnedGroups) ? (
           <ul className="mb-3 space-y-2 sm:mb-2 sm:space-y-0 md:mb-0">
@@ -25,12 +48,6 @@ export default function MobileRoot() {
             />
           </ul>
         ) : null}
-        <SidebarSorter
-          sortFn={sortFn}
-          setSortFn={setSortFn}
-          sortOptions={sortOptions}
-          isMobile={true}
-        />
       </header>
       <nav className="h-full flex-1 overflow-y-auto">
         <GroupList groups={sortedGroups} pinnedGroups={sortedPinnedGroups} />

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -22,8 +22,8 @@ export function MainWrapper({
 
   return (
     <>
-      <header className="flex-none px-2 py-1">
-        <h1 className="p-2 text-base font-semibold">Notifications</h1>
+      <header className="flex h-14 items-center justify-between px-5 py-4">
+        <h1 className="text-base font-bold">Notifications</h1>
       </header>
       <nav className="h-full flex-1 overflow-y-auto">{children}</nav>
     </>

--- a/ui/src/profiles/EditProfile/EditProfile.tsx
+++ b/ui/src/profiles/EditProfile/EditProfile.tsx
@@ -1,12 +1,9 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import cn from 'classnames';
-import { Link } from 'react-router-dom';
 import _ from 'lodash';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Contact, ContactEditField, uxToHex } from '@urbit/api';
 import { ViewProps } from '@/types/groups';
-import { useIsMobile } from '@/logic/useMedia';
 import useContactState, {
   useOurContact,
   isOurContactPublic,
@@ -257,8 +254,6 @@ function EditProfileContent() {
 }
 
 export default function EditProfile({ title }: ViewProps) {
-  const isMobile = useIsMobile();
-
   return (
     <div className="flex grow overflow-y-scroll bg-gray-50">
       <Helmet>

--- a/ui/src/profiles/EditProfile/EditProfile.tsx
+++ b/ui/src/profiles/EditProfile/EditProfile.tsx
@@ -1,9 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
+import cn from 'classnames';
+import { Link } from 'react-router-dom';
 import _ from 'lodash';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Contact, ContactEditField, uxToHex } from '@urbit/api';
 import { ViewProps } from '@/types/groups';
+import { useIsMobile } from '@/logic/useMedia';
 import useContactState, {
   useOurContact,
   isOurContactPublic,
@@ -185,6 +188,7 @@ function EditProfileContent() {
             <Avatar
               ship={ship}
               previewData={avatarPreviewData}
+              icon={false}
               size="huge"
               className="translate-y-9"
             />
@@ -253,6 +257,8 @@ function EditProfileContent() {
 }
 
 export default function EditProfile({ title }: ViewProps) {
+  const isMobile = useIsMobile();
+
   return (
     <div className="flex grow overflow-y-scroll bg-gray-50">
       <Helmet>

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -47,7 +47,12 @@ export default function ProfileModal() {
           containerClass="w-full sm:max-w-lg"
         >
           <ProfileCoverImage className="flex items-end" ship={ship}>
-            <Avatar ship={ship} size="huge" className="translate-y-9" />
+            <Avatar
+              ship={ship}
+              icon={false}
+              size="huge"
+              className="translate-y-9"
+            />
           </ProfileCoverImage>
           <div className="p-5 pt-14">
             <div className="text-lg font-bold">
@@ -77,7 +82,12 @@ export default function ProfileModal() {
         containerClass="w-full sm:max-w-lg"
       >
         <ProfileCoverImage className="flex items-end" ship={ship}>
-          <Avatar ship={ship} size="huge" className="translate-y-9" />
+          <Avatar
+            icon={false}
+            ship={ship}
+            size="huge"
+            className="translate-y-9"
+          />
         </ProfileCoverImage>
         <div className="p-5 pt-14">
           <div className="text-lg font-bold">


### PR DESCRIPTION
A wholesale redesign of the mobile navigation. Unless otherwise noted, these changes only affect the mobile view and should have no effect on the desktop view.

**Groups app home**
- Add labels to all icons
- Replaces Groups icon
- Switches notification counter to activity bell
- Places Find Groups in the nav
- Adds grayscale/opacity effects to the ship avatar in the inactive Profile tab
- Adds an overflow menu containing the Submit Feedback link
- Adds a Add Group button in the header of the screen
- Relocates the group sorting control to the header

**Find Groups, Notifications**
- Unifies page headers with Groups app home
- Removes gray background and card section treatments

**Group home**
- Adds labels to all icons
- Relocates the Group Info item
- Adds grayscale/opacity effects to the group avatar in the inactive Group Info tab
- Drops the Activity tab
- Adds an Invite tab, which pops the Invite modal
- Adds a back button (goes back to Groups app home) to the header with the group avatar + name
- Relocates the channel sorting dropdown to the header
- For administrators, adds a New Channel button in the header

**New Channel modal**
- Redirects the user back to the group home on success, rather than the channel editor

**Invite modal**
- Switches to shorter placeholder text on mobile to prevent ugly wrapping

**Profile edit and Profile modal (including desktop)**
- Restores details to sigils


https://user-images.githubusercontent.com/748181/200985314-0ee220ca-f789-4e5b-94af-5347a910fba4.mov

**Does not address**
Horizontal overflow issues with group creation or editing; our new group metadata editor is a bit too wide. Logging in a separate issue.