### PR TITLE
ui: mobile styling for New Groups modal

### DIFF
--- a/ui/src/channels/NewChannel/__snapshots__/NewChannel.test.tsx.snap
+++ b/ui/src/channels/NewChannel/__snapshots__/NewChannel.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`NewChannelModal > renders as expected 1`] = `
 <DocumentFragment>
   <div
     aria-hidden="true"
-    class="fixed inset-0 z-30 transform-gpu bg-black opacity-30"
+    class="fixed inset-0 z-40 transform-gpu bg-black opacity-30"
     data-aria-hidden="true"
     data-state="open"
     style="pointer-events: auto;"

--- a/ui/src/components/Dialog.tsx
+++ b/ui/src/components/Dialog.tsx
@@ -9,7 +9,7 @@ export default function Dialog({
 }: DialogPrimitive.DialogProps) {
   return (
     <DialogPrimitive.Root {...props}>
-      <DialogPrimitive.Overlay className="fixed inset-0 z-30 transform-gpu bg-black opacity-30" />
+      <DialogPrimitive.Overlay className="fixed inset-0 z-40 transform-gpu bg-black opacity-30" />
       {children}
     </DialogPrimitive.Root>
   );

--- a/ui/src/groups/GroupInfoFields.tsx
+++ b/ui/src/groups/GroupInfoFields.tsx
@@ -40,8 +40,9 @@ export default function GroupInfoFields() {
           placeholder="e.g. Urbit Fan Club"
         />
       </div>
-      <div className="flex space-x-2">
-        <div>
+      <div className="flex flex-col space-x-0 sm:flex-row sm:space-x-2">
+        <div className="pb-2 font-bold sm:hidden">Preview</div>
+        <div className="flex flex-row justify-center pb-2">
           <GroupInfoPreview
             iconType={iconType}
             showEmpty={showEmpty}

--- a/ui/src/groups/NewGroup/NewGroup.tsx
+++ b/ui/src/groups/NewGroup/NewGroup.tsx
@@ -131,7 +131,7 @@ export default function NewGroup() {
     <Dialog defaultOpen modal={true} onOpenChange={onOpenChange}>
       <DialogContent
         onInteractOutside={(e) => e.preventDefault()}
-        className="inset-y-24"
+        className="sm:inset-y-24"
         containerClass="w-full h-full sm:max-w-lg"
       >
         <FormProvider {...form}>

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -7,7 +7,7 @@
 }
 
 .small-button {
-  @apply inline-flex h-6 items-center justify-center rounded-md bg-gray-800 py-1 px-2 text-sm font-semibold leading-4 text-white ring-gray-200 ring-offset-2 ring-offset-white focus:outline-none focus-visible:ring-2 disabled:bg-gray-200 disabled:text-gray-400;
+  @apply inline-flex items-center justify-center rounded-md bg-gray-800 py-1 px-2 text-sm font-semibold text-white ring-gray-200 ring-offset-2 ring-offset-white focus:outline-none focus-visible:ring-2 disabled:bg-gray-200 disabled:text-gray-400 sm:h-6 sm:leading-4;
 }
 
 .small-secondary-button {


### PR DESCRIPTION
# Context

This resolves #1112 by tweaking some of the mobile-specific styling for the Create Group dialog. With this change, the color inputs do not overflow, and the preview image is now centered in the dialog.

# Preview

## Create Group: Mobile

![localhost_3000_apps_groups_groups_new(iPhone SE) (1)](https://user-images.githubusercontent.com/16504501/201032978-aabe43b3-b87d-48fc-979f-b8bfcb7bd909.png)

## Create Group: Desktop

![image](https://user-images.githubusercontent.com/16504501/201033319-b994871c-255c-4328-a9ef-67341e25a885.png)

## Modal Backdrop Tweak

### Dark
![localhost_3000_apps_groups_groups_new(iPhone SE) (3)](https://user-images.githubusercontent.com/16504501/201103836-0d0d8dd4-0dcf-4285-a012-544e81339307.png)

### Light
![localhost_3000_apps_groups_groups_new(iPhone SE) (2)](https://user-images.githubusercontent.com/16504501/201103850-0d6893c6-a50c-4482-a559-27fbf9c9cc6c.png)
