### PR TITLE
channels: fix recent sort in sidebar

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -7,7 +7,12 @@ import ChatInput from '@/chat/ChatInput/ChatInput';
 import ChatWindow from '@/chat/ChatWindow';
 import Layout from '@/components/Layout/Layout';
 import { ViewProps } from '@/types/groups';
-import { useChatPerms, useChatState, useMessagesForChat } from '@/state/chat';
+import {
+  useChatPerms,
+  useChatState,
+  useLatestMessage,
+  useMessagesForChat,
+} from '@/state/chat';
 import {
   useRouteGroup,
   useVessel,

--- a/ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar/Sidebar.test.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
+import { describe, expect, it } from 'vitest';
 import { createMockGroup } from '@/mocks/groups';
 import { Group } from '@/types/groups';
-import { describe, expect, it } from 'vitest';
 import { render } from '../../../test/utils';
 import Sidebar from './Sidebar';
 
@@ -13,6 +13,7 @@ vi.mock('@/state/chat', () => ({
   useBriefs: () => ({}),
   usePinnedGroups: () => ({}),
   usePinned: () => [],
+  useGetLatestMessage: () => () => 0,
 }));
 
 vi.mock('@/state/groups', () => ({

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { useCallback } from 'react';
+import React from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import useAllBriefs from '@/logic/useAllBriefs';
 import { channelHref, nestToFlag, filterJoinedChannels } from '@/logic/utils';
@@ -16,6 +16,7 @@ import Divider from '@/components/Divider';
 import ChannelIcon from '@/channels/ChannelIcon';
 import useIsChannelUnread from '@/logic/useIsChannelUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
+import usePrefetchGroupMessages from '@/logic/usePrefetchGroupMessages';
 import ChannelSortOptions from './ChannelSortOptions';
 
 const UNZONED = 'default';
@@ -32,6 +33,8 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
   const { sectionedChannels, sections } = useChannelSections(flag);
   const isMobile = useIsMobile();
   const { isChannelUnread } = useIsChannelUnread(flag);
+
+  usePrefetchGroupMessages(flag);
 
   if (!group) {
     return null;

--- a/ui/src/lib.ts
+++ b/ui/src/lib.ts
@@ -8,3 +8,10 @@ export function randInt(min: number, max: number) {
   const rand = Math.random() * range;
   return Math.floor(Math.random() * range) + min;
 }
+
+export async function asyncForEach<T>(
+  array: Array<T>,
+  callback: (element: T, idx?: number, ary?: Array<T>) => Promise<void>
+) {
+  await Promise.all(array.map((e, i) => callback(e, i, array)));
+}

--- a/ui/src/logic/useChannelSort.ts
+++ b/ui/src/logic/useChannelSort.ts
@@ -1,21 +1,48 @@
+import { get } from 'lodash';
+import { useCallback } from 'react';
 import { useGroup, useRouteGroup } from '@/state/groups';
 import { GroupChannel, Channels, Zone } from '@/types/groups';
-import { get } from 'lodash';
+import { useGetLatestMessage } from '@/state/chat';
+import { ChatWhom } from '@/types/chat';
 import useSidebarSort, {
   ALPHABETICAL,
   DEFAULT,
   RECENT,
   sortAlphabetical,
   Sorter,
-  useRecentSort,
 } from './useSidebarSort';
 
 const UNZONED = 'default';
 
+function useRecentChannelSort() {
+  const getLatest = useGetLatestMessage();
+
+  const sortRecent = useCallback(
+    (a: ChatWhom, b: ChatWhom) => {
+      // TODO: why is bigInt comparison not working? strings do work :)
+      // const aLast = getLatest(a)[0] ?? bigInt(Number.NEGATIVE_INFINITY);
+      // const bLast = getLatest(b)[0] ?? bigInt(Number.NEGATIVE_INFINITY);
+      const aLast = (getLatest(a)[0] ?? Number.NEGATIVE_INFINITY).toString();
+      const bLast = (getLatest(b)[0] ?? Number.NEGATIVE_INFINITY).toString();
+
+      if (aLast < bLast) {
+        return -1;
+      }
+      if (aLast > bLast) {
+        return 1;
+      }
+      return 0;
+    },
+    [getLatest]
+  );
+
+  return sortRecent;
+}
+
 export default function useChannelSort() {
   const groupFlag = useRouteGroup();
   const group = useGroup(groupFlag);
-  const sortRecent = useRecentSort();
+  const sortRecent = useRecentChannelSort();
 
   const sortDefault = (a: Zone, b: Zone) => {
     if (!group) {
@@ -47,7 +74,7 @@ export default function useChannelSort() {
     const accessors: Record<string, (k: string, v: GroupChannel) => string> = {
       [ALPHABETICAL]: (_flag: string, channel: GroupChannel) =>
         get(channel, 'meta.title'),
-      [DEFAULT]: (flag: string, channel: GroupChannel) =>
+      [DEFAULT]: (_flag: string, channel: GroupChannel) =>
         channel.zone || UNZONED,
       [RECENT]: (flag: string, _channel: GroupChannel) => flag,
     };

--- a/ui/src/logic/usePrefetchGroupMessages.ts
+++ b/ui/src/logic/usePrefetchGroupMessages.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect } from 'react';
+import { useGroup } from '@/state/groups';
+import { useChatState } from '@/state/chat';
+import { asyncForEach } from '@/lib';
+import { nestToFlag } from './utils';
+
+/**
+ * On load, prefetches the messages for the group that the user is currently in.
+ * The sidebar's recent sort depends on the messages being present in the store.
+ *
+ * @param flag The group's flag
+ */
+export default function usePrefetchGroupMessages(flag: string) {
+  const group = useGroup(flag);
+  const { initialize } = useChatState.getState();
+
+  const fetchChannel = useCallback(
+    async (channel) => {
+      const [, chFlag] = nestToFlag(channel);
+      initialize(chFlag);
+    },
+    [initialize]
+  );
+
+  const fetchAll = useCallback(async () => {
+    await asyncForEach(Object.keys(group?.channels ?? {}), fetchChannel);
+  }, [fetchChannel, group]);
+
+  useEffect(() => {
+    if (!group) {
+      return;
+    }
+
+    fetchAll();
+  }, [fetchAll, group]);
+}

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -7,9 +7,8 @@ import {
   Pact,
   WritDiff,
   ChatAction,
-  WritDelta,
 } from '../../types/chat';
-import { ChatState, BasedChatState } from './type';
+import { BasedChatState } from './type';
 
 interface WritsStore {
   initialize: () => Promise<void>;


### PR DESCRIPTION
# Context

This resolves #1073 by refactoring the channel list sort behavior and adding an effect hook to prefetch messages. When selecting a group, the messages for each channel will be fetched, then the last message timestamp will be compared to determine the sort order.

For now this is done somewhat ineffciently. In discussion with @arthyn, we came up with a more scalable approach that can be implemented after the initial release. In short, implement a new backend endpoint that publishes the latest message for each channel.

# Preview

https://user-images.githubusercontent.com/16504501/201065746-db26cb48-d881-495b-9d9e-e955f96bc767.mp4
