### PR TITLE
groups: adds ellipsis to name-hover in group sidebar

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -14,6 +14,7 @@ import { foregroundFromBackground } from '@/components/Avatar';
 import ChannelList from '@/groups/GroupSidebar/ChannelList';
 import GroupAvatar from '@/groups/GroupAvatar';
 import GroupActions from '@/groups/GroupActions';
+import ElipsisIcon from '@/components/icons/EllipsisIcon';
 
 function GroupHeader() {
   const flag = useGroupFlag();
@@ -128,7 +129,7 @@ function GroupHeader() {
           {groupCoverHover && <span>Back to Groups</span>}
         </SidebarItem>
         <GroupActions flag={flag} className="">
-          <button className="default-focus flex w-full items-center space-x-3 rounded-lg p-2 pr-4 font-semibold">
+          <button className="group flex w-full items-center space-x-3 rounded-lg p-2 font-semibold focus:outline-none">
             <GroupAvatar {...group?.meta} />
             <div
               title={group?.meta.title}
@@ -141,6 +142,10 @@ function GroupHeader() {
             >
               {group?.meta.title}
             </div>
+            <ElipsisIcon
+              aria-label="Open Menu"
+              className={cn('h-6 w-6 opacity-0 group-hover:opacity-100')}
+            />
           </button>
         </GroupActions>
       </div>


### PR DESCRIPTION
Brings consistency with group items in the All Groups view; indicates that the group name is navigable.

![image](https://user-images.githubusercontent.com/748181/201117276-1c2da638-a321-4852-9aa9-171f44672fb4.png)
