### PR TITLE
groups: fix for jumping/mis-ordered admin channel list

### DIFF
--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -420,7 +420,7 @@ export const useGroupState = create<GroupState>(
           },
         };
         await api.poke(groupAction(flag, diff));
-        await useGroupState.getState().start();
+        await useGroupState.getState().updateGroups();
       },
       setChannelPerm: async (flag, nest, sects) => {
         const currentReaders = get().groups[flag].channels[nest]?.readers || [];
@@ -453,6 +453,13 @@ export const useGroupState = create<GroupState>(
           },
         };
         await api.poke(groupAction(flag, diff));
+      },
+      updateGroups: async () => {
+        const groups = await api.scry<Groups>({
+          app: 'groups',
+          path: '/groups',
+        });
+        set(() => ({ groups }));
       },
       start: async () => {
         const [groups, gangs] = await Promise.all([

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -420,6 +420,7 @@ export const useGroupState = create<GroupState>(
           },
         };
         await api.poke(groupAction(flag, diff));
+        await useGroupState.getState().start();
       },
       setChannelPerm: async (flag, nest, sects) => {
         const currentReaders = get().groups[flag].channels[nest]?.readers || [];

--- a/ui/src/state/groups/type.ts
+++ b/ui/src/state/groups/type.ts
@@ -47,6 +47,7 @@ export interface GroupState {
   leave: (flag: string) => Promise<void>;
   edit: (flag: string, metadata: GroupMeta) => Promise<void>;
   delete: (flag: string) => Promise<void>;
+  updateGroups: () => Promise<void>;
   start: () => Promise<void>;
   channelPreview: (nest: string) => Promise<void>;
   search: (flag: string) => Promise<void>;


### PR DESCRIPTION
Fixes #1035 by reloading group state (await useGroupState.getState().start()) when moving a channel. Incorrect list will flash briefly (a few milliseconds) before correct one is shown.