### PR TITLE
chat: use scrollTo to scroll to messages, fix thread exits

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -192,7 +192,7 @@ export default function ChatScroller({
     // switching chats. Diff remains zero when it shouldn't.
     // This is a hack to force it to scroll to the bottom.
 
-    if (indexData.firstItemIndex === FIRST_INDEX && diff === 0) {
+    if (indexData.firstItemIndex === FIRST_INDEX && diff === 0 && !scrollTo) {
       // We need to wait to make sure the virtuoso component has been updated.
       setTimeout(() => {
         virtuoso?.current?.scrollToIndex({
@@ -200,7 +200,18 @@ export default function ChatScroller({
         });
       }, 50);
     }
-  }, [whom, oldWhom, keys, mess, indexData]);
+
+    if (scrollTo) {
+      const idx = keys.findIndex((k) => k.eq(scrollTo));
+      if (idx !== -1) {
+        setTimeout(() => {
+          virtuoso?.current?.scrollToIndex({
+            index: idx,
+          });
+        }, 50);
+      }
+    }
+  }, [whom, oldWhom, keys, mess, indexData, scrollTo]);
 
   const Message = useMemo(
     () =>

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -31,19 +31,18 @@ export default function ChatThread({ whom, children }: ChatThreadProps) {
   const id = `${idShip!}/${idTime!}`;
   const maybeWrit = useWrit(whom, id);
   const replies = useReplies(whom, id);
-  const returnURL = () => {
-    if (location.pathname.includes('groups')) {
-      return `/groups/${ship}/${name}/channels/chat/${chShip}/${chName}?msg=${udToDec(
-        idTime!
-      )}`;
-    }
-    return `/dm/${ship}?msg=${udToDec(idTime!)}`;
-  };
 
   if (!maybeWrit) {
     return null;
   }
   const [time, writ] = maybeWrit;
+
+  const returnURL = () => {
+    if (location.pathname.includes('groups')) {
+      return `/groups/${ship}/${name}/channels/chat/${chShip}/${chName}?msg=${time.toString()}`;
+    }
+    return `/dm/${ship}?msg=${time.toString()}`;
+  };
 
   return (
     <div className="flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l">

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -1,6 +1,8 @@
 import React, { PropsWithChildren } from 'react';
-import { useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
+import useIsChat from '@/logic/useIsChat';
+import { udToDec } from '@urbit/api';
 import { useChannelFlag } from '../../hooks';
 import { useChatState, useReplies, useWrit } from '../../state/chat';
 import { useChannel, useRouteGroup } from '../../state/groups/groups';
@@ -15,12 +17,28 @@ type ChatThreadProps = PropsWithChildren<{
 }>;
 
 export default function ChatThread({ whom, children }: ChatThreadProps) {
-  const { idTime, idShip } = useParams<{ idShip: string; idTime: string }>();
+  const { ship, name, chShip, chName, idTime, idShip } = useParams<{
+    ship: string;
+    name: string;
+    chShip: string;
+    chName: string;
+    idShip: string;
+    idTime: string;
+  }>();
   const { sendMessage } = useChatState.getState();
+  const location = useLocation();
 
   const id = `${idShip!}/${idTime!}`;
   const maybeWrit = useWrit(whom, id);
   const replies = useReplies(whom, id);
+  const returnURL = () => {
+    if (location.pathname.includes('groups')) {
+      return `/groups/${ship}/${name}/channels/chat/${chShip}/${chName}?msg=${udToDec(
+        idTime!
+      )}`;
+    }
+    return `/dm/${ship}?msg=${udToDec(idTime!)}`;
+  };
 
   if (!maybeWrit) {
     return null;
@@ -32,7 +50,7 @@ export default function ChatThread({ whom, children }: ChatThreadProps) {
       <div className="space-y-2 p-4">
         <div className="sticky top-0 z-10 flex justify-between rounded border bg-white p-3 ">
           {children}
-          <Link to="..">
+          <Link to={returnURL()}>
             <X16Icon className="h-4 w-4 text-gray-400" />
           </Link>
         </div>


### PR DESCRIPTION
Fixes #1105 

We can now scroll to a message using the URL param `msg` (such as when clicking a chat reference).

Also, when closing a thread we'll return to the message attached to that thread in the scroller (important for mobile).