### PR TITLE
channels: recent sort applies to all channel types

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar/Sidebar.test.tsx
@@ -13,7 +13,9 @@ vi.mock('@/state/chat', () => ({
   useBriefs: () => ({}),
   usePinnedGroups: () => ({}),
   usePinned: () => [],
-  useGetLatestMessage: () => () => 0,
+  useGetLatestChat: () => () => 0,
+  useGetLatestCurio: () => () => 0,
+  useGetLatestNote: () => () => 0,
 }));
 
 vi.mock('@/state/groups', () => ({

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -16,7 +16,7 @@ import Divider from '@/components/Divider';
 import ChannelIcon from '@/channels/ChannelIcon';
 import useIsChannelUnread from '@/logic/useIsChannelUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
-import usePrefetchGroupMessages from '@/logic/usePrefetchGroupMessages';
+import usePrefetchChannels from '@/logic/usePrefetchChannels';
 import ChannelSortOptions from './ChannelSortOptions';
 
 const UNZONED = 'default';
@@ -63,13 +63,13 @@ export function ChannelSorter({ isMobile }: ChannelSorterProps) {
 export default function ChannelList({ flag, className }: ChannelListProps) {
   const group = useGroup(flag);
   const briefs = useAllBriefs();
-  const { sortFn, sortOptions, setSortFn, sortChannels } = useChannelSort();
+  const { sortFn, sortChannels } = useChannelSort();
   const isDefaultSort = sortFn === DEFAULT;
   const { sectionedChannels, sections } = useChannelSections(flag);
   const isMobile = useIsMobile();
   const { isChannelUnread } = useIsChannelUnread(flag);
 
-  usePrefetchGroupMessages(flag);
+  usePrefetchChannels(flag);
 
   if (!group) {
     return null;

--- a/ui/src/logic/usePrefetchChannels.ts
+++ b/ui/src/logic/usePrefetchChannels.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect } from 'react';
 import { useGroup } from '@/state/groups';
 import { useChatState } from '@/state/chat';
 import { asyncForEach } from '@/lib';
+import { useHeapState } from '@/state/heap/heap';
+import { useDiaryState } from '@/state/diary';
 import { nestToFlag } from './utils';
 
 /**
@@ -10,16 +12,30 @@ import { nestToFlag } from './utils';
  *
  * @param flag The group's flag
  */
-export default function usePrefetchGroupMessages(flag: string) {
+export default function usePrefetchChannels(flag: string) {
   const group = useGroup(flag);
-  const { initialize } = useChatState.getState();
+  const { initialize: initializeChat } = useChatState.getState();
+  const { initialize: initializeDiary } = useDiaryState.getState();
+  const { initialize: initializeHeap } = useHeapState.getState();
 
   const fetchChannel = useCallback(
     async (channel) => {
-      const [, chFlag] = nestToFlag(channel);
-      initialize(chFlag);
+      const [chType, chFlag] = nestToFlag(channel);
+      switch (chType) {
+        case 'chat':
+          initializeChat(chFlag);
+          break;
+        case 'diary':
+          initializeDiary(chFlag);
+          break;
+        case 'heap':
+          initializeHeap(chFlag);
+          break;
+        default:
+          break;
+      }
     },
-    [initialize]
+    [initializeChat, initializeDiary, initializeHeap]
   );
 
   const fetchAll = useCallback(async () => {

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -877,7 +877,7 @@ export function useLatestMessage(chFlag: string) {
   return messages.size > 0 ? messages.peekLargest() : [bigInt(), null];
 }
 
-export function useGetLatestMessage() {
+export function useGetLatestChat() {
   const def = useMemo(() => new BigIntOrderedMap<ChatWrit>(), []);
   const empty = [bigInt(), null];
   const pacts = usePacts();

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -30,6 +30,7 @@ import {
   createStorageKey,
   clearStorageMigration,
   storageVersion,
+  nestToFlag,
 } from '@/logic/utils';
 import { DiaryState } from './type';
 import makeNotesStore from './notes';
@@ -319,6 +320,10 @@ export function useNotes(flag: DiaryFlag) {
   return useDiaryState(useCallback((s) => s.notes[flag], [flag]));
 }
 
+export function useAllNotes() {
+  return useDiaryState(useCallback((s: DiaryState) => s.notes, []));
+}
+
 export function useCurrentNotesSize(flag: DiaryFlag) {
   return useDiaryState(useCallback((s) => s.notes[flag]?.size ?? 0, [flag]));
 }
@@ -404,6 +409,18 @@ export function useBrief(flag: string) {
 //   const getQuip = useQuips;
 //   const quipNotes = Array.from(notes).map(([time, note]) => [time, getQuip(flag, time.toString())]);
 // }
+
+export function useGetLatestNote() {
+  const def = useMemo(() => new BigIntOrderedMap<DiaryLetter>(), []);
+  const empty = [bigInt(), null];
+  const allNotes = useAllNotes();
+
+  return (chFlag: string) => {
+    const noteFlag = chFlag.startsWith('~') ? chFlag : nestToFlag(chFlag)[1];
+    const notes = allNotes[noteFlag] ?? def;
+    return notes.size > 0 ? notes.peekLargest() : empty;
+  };
+}
 
 (window as any).diary = useDiaryState.getState;
 

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -24,6 +24,7 @@ import {
   createStorageKey,
   clearStorageMigration,
   storageVersion,
+  nestToFlag,
 } from '@/logic/utils';
 import useNest from '@/logic/useNest';
 import { intersection } from 'lodash';
@@ -276,6 +277,10 @@ export function useCurios(flag: HeapFlag) {
   return useHeapState(useCallback((s) => s.curios[flag], [flag]));
 }
 
+export function useAllCurios() {
+  return useHeapState(useCallback((s) => s.curios, []));
+}
+
 export function useCurrentCuriosSize(flag: HeapFlag) {
   return useHeapState(useCallback((s) => s.curios[flag]?.size ?? 0, [flag]));
 }
@@ -350,6 +355,18 @@ export function useOrderedCurios(
     nextCurio,
     prevCurio,
     sortedCurios,
+  };
+}
+
+export function useGetLatestCurio() {
+  const def = useMemo(() => new BigIntOrderedMap<HeapCurio>(), []);
+  const empty = [bigInt(), null];
+  const allCurios = useAllCurios();
+
+  return (chFlag: string) => {
+    const curioFlag = chFlag.startsWith('~') ? chFlag : nestToFlag(chFlag)[1];
+    const curios = allCurios[curioFlag] ?? def;
+    return curios.size > 0 ? curios.peekLargest() : empty;
   };
 }
 


### PR DESCRIPTION
# Context

The previous PR (#1114) only supported chat channels; this adds support diary and heap channels too.

# Preview

https://user-images.githubusercontent.com/16504501/201310743-70d962c5-6be4-4727-abdf-218f25d55a35.mp4


