### PR TITLE
groups: add admin channel actions to channel header

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -1,29 +1,32 @@
-import cn from 'classnames';
-import React, { PropsWithChildren, useCallback } from 'react';
+import React, { PropsWithChildren, useCallback, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
-import EllipsisIcon from '@/components/icons/EllipsisIcon';
-import GridIcon from '@/components/icons/GridIcon';
-import SortIcon from '@/components/icons/SortIcon';
+import cn from 'classnames';
+import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import * as Popover from '@radix-ui/react-popover';
+import { GroupChannel } from '@/types/groups';
 import { useIsMobile } from '@/logic/useMedia';
+import useIsChannelHost from '@/logic/useIsChannelHost';
+import { nestToFlag, getFlagParts } from '@/logic/utils';
+import useIsChat from '@/logic/useIsChat';
 import {
   useGroup,
   useChannel,
   useAmAdmin,
   useRouteGroup,
+  useGroupState,
 } from '@/state/groups';
-import ListIcon from '@/components/icons/ListIcon';
-import ChannelIcon from '@/channels/ChannelIcon';
-import * as Popover from '@radix-ui/react-popover';
-import Divider from '@/components/Divider';
-import LeaveIcon from '@/components/icons/LeaveIcon';
-import SlidersIcon from '@/components/icons/SlidersIcon';
-import useIsChannelHost from '@/logic/useIsChannelHost';
-import { nestToFlag, getFlagParts } from '@/logic/utils';
 import { useChatState } from '@/state/chat';
 import { useDiaryState } from '@/state/diary';
 import { useHeapState } from '@/state/heap/heap';
-import useIsChat from '@/logic/useIsChat';
+import EditChannelModal from '@/groups/GroupAdmin/AdminChannels/EditChannelModal';
+import DeleteChannelModal from '@/groups/GroupAdmin/AdminChannels/DeleteChannelModal';
+import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
+import ChannelIcon from '@/channels/ChannelIcon';
+import Divider from '@/components/Divider';
+import EllipsisIcon from '@/components/icons/EllipsisIcon';
+import GridIcon from '@/components/icons/GridIcon';
+import ListIcon from '@/components/icons/ListIcon';
+import SortIcon from '@/components/icons/SortIcon';
 
 export type ChannelHeaderProps = PropsWithChildren<{
   flag: string;
@@ -84,14 +87,24 @@ function ChannelHeaderMenuButton({
   );
 }
 
-function ChannelActions({ nest }: { nest: string }) {
-  const [_app, flag] = nestToFlag(nest);
-  const isAdmin = useAmAdmin(flag);
-  const isChannelHost = useIsChannelHost(flag);
+function ChannelActions({
+  nest,
+  channel,
+  isAdmin,
+}: {
+  nest: string;
+  channel: GroupChannel | undefined;
+  isAdmin: boolean | undefined;
+}) {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const [_app, flag] = nestToFlag(nest);
   const groupFlag = useRouteGroup();
   const { ship, name } = getFlagParts(groupFlag);
-  const isMobile = useIsMobile();
+  const [dropdownIsOpen, setDropdownIsOpen] = useState(false);
+  const [editIsOpen, setEditIsOpen] = useState(false);
+  const [deleteChannelIsOpen, setDeleteChannelIsOpen] = useState(false);
+  const isChannelHost = useIsChannelHost(flag);
 
   const leave = useCallback(
     (chFlag: string) => {
@@ -122,41 +135,72 @@ function ChannelActions({ nest }: { nest: string }) {
     }
   }, [flag, ship, name, navigate, leave, isMobile]);
 
+  const onDeleteChannelConfirm = useCallback(async () => {
+    try {
+      setDeleteChannelIsOpen(!deleteChannelIsOpen);
+      useGroupState.getState().deleteChannel(groupFlag, nest);
+      navigate(
+        isMobile
+          ? `/groups/${ship}/${name}`
+          : `/groups/${ship}/${name}/channels`
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  }, [deleteChannelIsOpen, groupFlag, isMobile, name, navigate, nest, ship]);
+
   return (
-    <Popover.Root>
-      <Popover.Trigger asChild>
-        <button className="icon-button h-8 w-8 bg-transparent">
-          <EllipsisIcon className="h-6 w-6" />
-        </button>
-      </Popover.Trigger>
-      <Popover.Content>
-        <div className="flex flex-col rounded-lg bg-white leading-5 drop-shadow-lg">
-          {!isChannelHost ? (
-            <ChannelHeaderMenuButton
-              className="hover:bg-red-soft"
+    <>
+      <Dropdown.Root open={dropdownIsOpen} onOpenChange={setDropdownIsOpen}>
+        <Dropdown.Trigger asChild>
+          <button className="icon-button h-8 w-8 bg-transparent">
+            <EllipsisIcon className="h-6 w-6" />
+          </button>
+        </Dropdown.Trigger>
+        <Dropdown.Content className="dropdown">
+          {isAdmin && (
+            <>
+              <Dropdown.Item
+                className="dropdown-item"
+                onClick={() => setEditIsOpen(!editIsOpen)}
+              >
+                Edit Channel
+              </Dropdown.Item>
+              <Dropdown.Item
+                className="dropdown-item text-red"
+                onClick={() => setDeleteChannelIsOpen(!deleteChannelIsOpen)}
+              >
+                Delete Channel
+              </Dropdown.Item>
+            </>
+          )}
+          {!isChannelHost && (
+            <Dropdown.Item
+              className="dropdown-item text-red"
               onClick={leaveChannel}
             >
-              <LeaveIcon className="h-6 w-6 text-red-400" />
-              <span className="font-semibold text-red">Leave Channel</span>
-            </ChannelHeaderMenuButton>
-          ) : null}
-          {isAdmin ? (
-            <>
-              <Divider>Admin</Divider>
-              <Link
-                to={`/groups/${flag}/info/channels`}
-                className="block no-underline"
-              >
-                <ChannelHeaderMenuButton>
-                  <SlidersIcon className="h-6 w-6 text-gray-400" />
-                  <span className="font-semibold">Edit Channels</span>
-                </ChannelHeaderMenuButton>
-              </Link>
-            </>
-          ) : null}
-        </div>
-      </Popover.Content>
-    </Popover.Root>
+              Leave Channel
+            </Dropdown.Item>
+          )}
+        </Dropdown.Content>
+      </Dropdown.Root>
+      {channel && (
+        <>
+          <EditChannelModal
+            editIsOpen={editIsOpen}
+            setEditIsOpen={setEditIsOpen}
+            nest={nest}
+            channel={channel}
+          />
+          <DeleteChannelModal
+            deleteChannelIsOpen={deleteChannelIsOpen}
+            onDeleteChannelConfirm={onDeleteChannelConfirm}
+            setDeleteChannelIsOpen={setDeleteChannelIsOpen}
+            channel={channel}
+          />
+        </>
+      )}
+    </>
   );
 }
 
@@ -244,6 +288,7 @@ export default function ChannelHeader({
   const groupName = group?.meta.title;
   const isChat = useIsChat();
   const BackButton = isMobile ? Link : 'div';
+  const isAdmin = useAmAdmin(flag);
 
   return (
     <div
@@ -308,10 +353,10 @@ export default function ChannelHeader({
             <HeapSortControls setSortMode={setSortMode} />
           )}
 
-          <ChannelActions {...{ nest }} />
+          <ChannelActions {...{ nest, channel, isAdmin }} />
         </div>
       ) : (
-        <ChannelActions {...{ nest }} />
+        <ChannelActions {...{ nest, channel, isAdmin }} />
       )}
     </div>
   );

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -106,6 +106,19 @@ function ChannelActions({
   const [deleteChannelIsOpen, setDeleteChannelIsOpen] = useState(false);
   const isChannelHost = useIsChannelHost(flag);
 
+  function prettyAppName() {
+    switch (_app) {
+      case 'diary':
+        return 'Notebook';
+      case 'chat':
+        return 'Chat';
+      case 'heap':
+        return 'Gallery';
+      default:
+        return 'Channel';
+    }
+  }
+
   const leave = useCallback(
     (chFlag: string) => {
       const leaver =
@@ -164,13 +177,13 @@ function ChannelActions({
                 className="dropdown-item"
                 onClick={() => setEditIsOpen(!editIsOpen)}
               >
-                Edit Channel
+                Edit {prettyAppName()}
               </Dropdown.Item>
               <Dropdown.Item
                 className="dropdown-item text-red"
                 onClick={() => setDeleteChannelIsOpen(!deleteChannelIsOpen)}
               >
-                Delete Channel
+                Delete {prettyAppName()}
               </Dropdown.Item>
             </>
           )}
@@ -179,7 +192,7 @@ function ChannelActions({
               className="dropdown-item text-red"
               onClick={leaveChannel}
             >
-              Leave Channel
+              Leave {prettyAppName()}
             </Dropdown.Item>
           )}
         </Dropdown.Content>


### PR DESCRIPTION
Adds admin-specific actions to the context menu in the channel header. You may now edit and remove channels from within the channel itself.

Administrator (channel host) view:

https://user-images.githubusercontent.com/748181/201430842-fe9d70ce-0046-4532-a675-4a9a42f38ca3.mov

Administrator (non-host) view:

![image](https://user-images.githubusercontent.com/748181/201431013-a0d98fba-6e22-4c62-b899-d98658e15aee.png)

Member (non-host) view:

https://user-images.githubusercontent.com/748181/201430870-c5b5804e-a31e-4fc6-933a-d4a0e6102a4a.mov



Fixes #1127 