### PR TITLE
chat: fix backscroll loading

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -88,15 +88,13 @@ export function InlineContent({ story }: InlineContentProps) {
 
   if (isInlineCode(story)) {
     return (
-      <div className="w-full overflow-x-scroll">
-        <code>
-          {typeof story['inline-code'] === 'object' ? (
-            <InlineContent story={story['inline-code']} />
-          ) : (
-            story['inline-code']
-          )}
-        </code>
-      </div>
+      <code className="break-all rounded bg-gray-50 px-1">
+        {typeof story['inline-code'] === 'object' ? (
+          <InlineContent story={story['inline-code']} />
+        ) : (
+          story['inline-code']
+        )}
+      </code>
     );
   }
 

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -323,7 +323,10 @@ export default function ChatInput({
           ) : null}
           <div className="flex items-center justify-end">
             <Avatar size="xs" ship={window.our} className="mr-2" />
-            <MessageEditor editor={messageEditor} className="w-full" />
+            <MessageEditor
+              editor={messageEditor}
+              className="w-full break-all"
+            />
             {loaded &&
             hasCredentials &&
             !uploadError &&

--- a/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
+++ b/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ChatInput > renders as expected 1`] = `
           </svg>
         </div>
         <div
-          class="input block p-0 w-full"
+          class="input block p-0 w-full break-all"
         >
           <div
             class="w-full"

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -237,10 +237,10 @@ export default function ChatScroller({
 
   const fetchMessages = useCallback(
     async (newer: boolean) => {
-      const newest = mess.peekLargest();
-      const seenNewest = newer && newest && loaded.newest.leq(newest[0]);
-      const oldest = mess.peekSmallest();
-      const seenOldest = !newer && oldest && loaded.oldest.geq(oldest[0]);
+      const newest = messages.peekLargest();
+      const seenNewest = newer && newest && loaded.newest.geq(newest[0]);
+      const oldest = messages.peekSmallest();
+      const seenOldest = !newer && oldest && loaded.oldest.leq(oldest[0]);
 
       if (seenNewest || seenOldest) {
         return;
@@ -260,7 +260,7 @@ export default function ChatScroller({
 
       setFetching('initial');
     },
-    [whom, mess, loaded]
+    [whom, messages, loaded]
   );
 
   return (
@@ -276,10 +276,18 @@ export default function ChatScroller({
         style={{
           overflowY: 'scroll',
         }}
-        atBottomThreshold={250}
-        atTopThreshold={250}
-        atTopStateChange={(top) => top && fetchMessages(false)}
-        atBottomStateChange={(bot) => bot && fetchMessages(true)}
+        atBottomThreshold={2500}
+        atTopThreshold={2500}
+        atTopStateChange={(top) => {
+          if (top) {
+            fetchMessages(false);
+          }
+        }}
+        atBottomStateChange={(bot) => {
+          if (bot) {
+            fetchMessages(true);
+          }
+        }}
         itemContent={(i, realIndex) => <Message index={realIndex} />}
         computeItemKey={computeItemKey}
         components={{

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -276,7 +276,7 @@ export default function ChatScroller({
         style={{
           overflowY: 'scroll',
         }}
-        atBottomThreshold={2500}
+        atBottomThreshold={250}
         atTopThreshold={2500}
         atTopStateChange={(top) => {
           if (top) {


### PR DESCRIPTION
This fixes #1143 and throws in some extra word breaking for inline code and chat input.

Side note, we don't handle block code right now. We should add handling for that with the potential for overflow scrolling.

Btw when doing this I couldn't find our old message row/type spec in figma @urcades so that I could match what inline code was supposed to be.