### PR TITLE
groups: prevent avatar squishing

### DIFF
--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -165,7 +165,7 @@ export default function Avatar({
   ) {
     return (
       <img
-        className={classNames(className, classes)}
+        className={classNames(className, classes, 'object-cover')}
         src={previewAvatar}
         alt=""
         style={style}
@@ -176,7 +176,7 @@ export default function Avatar({
   if (avatar && !calm.disableRemoteContent && !calm.disableAvatars) {
     return (
       <img
-        className={classNames(className, classes)}
+        className={classNames(className, classes, 'object-cover')}
         src={avatar}
         alt=""
         style={style}


### PR DESCRIPTION
Accounts for non-square source images.

Before: 
![image](https://user-images.githubusercontent.com/748181/201944258-59e927a3-f253-443a-8efb-3aebd0973b46.png)


After:
![image](https://user-images.githubusercontent.com/748181/201944108-7e36828b-9304-43f8-b77b-8c26a67ea46f.png)
