### PR TITLE
groups/search: replaced globe icon with open lock icon

### DIFF
--- a/ui/src/components/icons/LockOpen16Icon.tsx
+++ b/ui/src/components/icons/LockOpen16Icon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function LockOpen16Icon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <path
+        className="fill-current"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6 5.33333C6 3.94296 6.99193 3 8 3C8.56731 3 9.1054 3.27968 9.48923 3.77895C9.80141 4.18501 10 4.72606 10 5.33333H12C12 4.28888 11.658 3.3185 11.0748 2.55996C10.3582 1.62779 9.25985 1 8 1C5.69436 1 4 3.04181 4 5.33333V7C2.89543 7 2 7.89543 2 9V13C2 14.1046 2.89543 15 4 15H12C13.1046 15 14 14.1046 14 13V9C14 7.89543 13.1046 7 12 7H6V5.33333ZM4 13L4 9H12V13H4Z"
+      />
+    </svg>
+  );
+}

--- a/ui/src/groups/GroupSummary.tsx
+++ b/ui/src/groups/GroupSummary.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
+import ShipName from '@/components/ShipName';
 import Lock16Icon from '@/components/icons/Lock16Icon';
-import Globe16Icon from '@/components/icons/Globe16Icon';
 import Private16Icon from '@/components/icons/Private16Icon';
 import { getFlagParts, getGroupPrivacy } from '@/logic/utils';
 import { GroupPreview } from '@/types/groups';
-import { useGroup } from '@/state/groups';
-import Person16Icon from '@/components/icons/Person16Icon';
-import ShipName from '@/components/ShipName';
-import GroupAvatar from './GroupAvatar';
+import LockOpen16Icon from '@/components/icons/LockOpen16Icon';
+import GroupAvatar from '@/groups/GroupAvatar';
 
 export type GroupSummarySize = 'default' | 'small';
 
@@ -42,7 +40,7 @@ export default function GroupSummary({
           {privacy ? (
             <span className="inline-flex items-center space-x-1 capitalize">
               {privacy === 'public' ? (
-                <Globe16Icon className="h-4 w-4" />
+                <LockOpen16Icon className="h-4 w-4" />
               ) : privacy === 'private' ? (
                 <Lock16Icon className="h-4 w-4" />
               ) : (


### PR DESCRIPTION
turns out, we weren't even using the right icon

https://www.figma.com/file/sCFYLlAGjehlYXUkT2rarg/Product-Handoffs-(Locked)?node-id=1593%3A70558&t=Et5CNuy7uGmrCNXY-0