### PR TITLE
Catch disconnects caused by subscription errors, use errorCount

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -5,8 +5,8 @@ import Urbit, {
   SubscriptionRequestInterface,
   Thread,
 } from '@urbit/http-api';
-import { useLocalState } from './state/local';
-import useSubscriptionState from './state/subscription';
+import { useLocalState } from '@/state/local';
+import useSubscriptionState from '@/state/subscription';
 
 export const IS_MOCK =
   import.meta.env.MODE === 'mock' || import.meta.env.MODE === 'staging';
@@ -57,12 +57,18 @@ const api = {
         await setupAPI();
       }
 
+      client.onError = () => {
+        (async () => {
+          useLocalState.setState({ errorCount: errorCount + 1 });
+        })();
+      };
+
       const clientPoke = await client.poke<T>(params);
       useLocalState.setState({ subscription: 'connected' });
       useLocalState.setState({ errorCount: 0 });
+
       return clientPoke;
     } catch (e) {
-      useLocalState.setState({ subscription: 'disconnected' });
       useLocalState.setState({ errorCount: errorCount + 1 });
       throw e;
     }
@@ -102,7 +108,6 @@ const api = {
       useLocalState.setState({ errorCount: 0 });
       return clientSubscribe;
     } catch (e) {
-      useLocalState.setState({ subscription: 'disconnected' });
       useLocalState.setState({ errorCount: errorCount + 1 });
       throw e;
     }
@@ -113,12 +118,17 @@ const api = {
         await setupAPI();
       }
 
+      client.onError = () => {
+        (async () => {
+          useLocalState.setState({ errorCount: errorCount + 1 });
+        })();
+      };
+
       const clientThread = await client.thread<Return, T>(params);
       useLocalState.setState({ subscription: 'connected' });
       useLocalState.setState({ errorCount: 0 });
       return clientThread;
     } catch (e) {
-      useLocalState.setState({ subscription: 'disconnected' });
       useLocalState.setState({ errorCount: errorCount + 1 });
       throw e;
     }
@@ -134,7 +144,6 @@ const api = {
       useLocalState.setState({ errorCount: 0 });
       return clientUnsubscribe;
     } catch (e) {
-      useLocalState.setState({ subscription: 'disconnected' });
       useLocalState.setState({ errorCount: errorCount + 1 });
       throw e;
     }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -15,7 +15,7 @@ const URL = (import.meta.env.VITE_MOCK_URL ||
 
 let client = undefined as unknown as Urbit | UrbitMock;
 
-const { errorCount } = useLocalState.getState();
+const { errorCount, airLockErrorCount } = useLocalState.getState();
 
 async function setupAPI() {
   if (IS_MOCK) {
@@ -44,7 +44,8 @@ async function setupAPI() {
 
   client.onError = () => {
     (async () => {
-      useLocalState.setState({ errorCount: errorCount + 1 });
+      useLocalState.setState({ airLockErrorCount: airLockErrorCount + 1 });
+      useLocalState.setState({ subscription: 'reconnecting' });
     })();
   };
 }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -41,6 +41,12 @@ async function setupAPI() {
     api.verbose = true;
     client = api;
   }
+
+  client.onError = () => {
+    (async () => {
+      useLocalState.setState({ errorCount: errorCount + 1 });
+    })();
+  };
 }
 
 const api = {
@@ -56,12 +62,6 @@ const api = {
       if (!client) {
         await setupAPI();
       }
-
-      client.onError = () => {
-        (async () => {
-          useLocalState.setState({ errorCount: errorCount + 1 });
-        })();
-      };
 
       const clientPoke = await client.poke<T>(params);
       useLocalState.setState({ subscription: 'connected' });
@@ -117,12 +117,6 @@ const api = {
       if (!client) {
         await setupAPI();
       }
-
-      client.onError = () => {
-        (async () => {
-          useLocalState.setState({ errorCount: errorCount + 1 });
-        })();
-      };
 
       const clientThread = await client.thread<Return, T>(params);
       useLocalState.setState({ subscription: 'connected' });

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -24,6 +24,7 @@ import useIsChat from '@/logic/useIsChat';
 import useErrorHandler from '@/logic/useErrorHandler';
 import { useSettingsState, useTheme } from '@/state/settings';
 import {
+  useAirLockErrorCount,
   useErrorCount,
   useLocalState,
   useSubscriptionStatus,
@@ -411,6 +412,7 @@ function App() {
   const isSmall = useMedia('(max-width: 1023px)');
   const subscription = useSubscriptionStatus();
   const errorCount = useErrorCount();
+  const airLockErrorCount = useAirLockErrorCount();
 
   useEffect(() => {
     handleError(() => {
@@ -441,10 +443,13 @@ function App() {
   const state = location.state as { backgroundLocation?: Location } | null;
 
   useEffect(() => {
-    if (errorCount > 2 && subscription === 'connected') {
+    if (
+      (errorCount > 4 || airLockErrorCount > 1) &&
+      subscription === 'connected'
+    ) {
       useLocalState.setState({ subscription: 'disconnected' });
     }
-  }, [errorCount, subscription]);
+  }, [errorCount, subscription, airLockErrorCount]);
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -23,7 +23,11 @@ import useMedia, { useIsMobile } from '@/logic/useMedia';
 import useIsChat from '@/logic/useIsChat';
 import useErrorHandler from '@/logic/useErrorHandler';
 import { useSettingsState, useTheme } from '@/state/settings';
-import { useLocalState, useSubscriptionStatus } from '@/state/local';
+import {
+  useErrorCount,
+  useLocalState,
+  useSubscriptionStatus,
+} from '@/state/local';
 import useContactState from '@/state/contact';
 import ErrorAlert from '@/components/ErrorAlert';
 import DMHome from '@/dms/DMHome';
@@ -406,6 +410,7 @@ function App() {
   const isMobile = useIsMobile();
   const isSmall = useMedia('(max-width: 1023px)');
   const subscription = useSubscriptionStatus();
+  const errorCount = useErrorCount();
 
   useEffect(() => {
     handleError(() => {
@@ -434,6 +439,12 @@ function App() {
   }, [handleError]);
 
   const state = location.state as { backgroundLocation?: Location } | null;
+
+  useEffect(() => {
+    if (errorCount > 2 && subscription === 'connected') {
+      useLocalState.setState({ subscription: 'disconnected' });
+    }
+  }, [errorCount, subscription]);
 
   return (
     <div className="flex h-full w-full flex-col">

--- a/ui/src/components/DisconnectNotice.tsx
+++ b/ui/src/components/DisconnectNotice.tsx
@@ -13,6 +13,7 @@ import {
   useLocalState,
   useSubscriptionStatus,
 } from '@/state/local';
+import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 
 export default function DisconnectNotice() {
   const errorCount = useErrorCount();
@@ -42,7 +43,11 @@ export default function DisconnectNotice() {
   return (
     <div className="z-50 flex items-center justify-between bg-yellow py-1 px-2 text-sm font-medium text-black dark:text-white">
       <div className="flex items-center">
-        <AsteriskIcon className="mr-3 h-4 w-4" />
+        {subscription === 'reconnecting' ? (
+          <LoadingSpinner className="mr-3 h-4 w-4" />
+        ) : (
+          <AsteriskIcon className="mr-3 h-4 w-4" />
+        )}
         {subscription === 'reconnecting' ? (
           <span>Reconnecting...</span>
         ) : (

--- a/ui/src/components/DisconnectNotice.tsx
+++ b/ui/src/components/DisconnectNotice.tsx
@@ -15,7 +15,6 @@ import {
 } from '@/state/local';
 
 export default function DisconnectNotice() {
-  // const reconnect = useReconnect();
   const errorCount = useErrorCount();
   const subscription = useSubscriptionStatus();
 

--- a/ui/src/state/local.ts
+++ b/ui/src/state/local.ts
@@ -14,6 +14,7 @@ interface LocalState {
   currentTheme: 'light' | 'dark';
   subscription: SubscriptionStatus;
   errorCount: number;
+  airLockErrorCount: number;
   set: (f: (s: LocalState) => void) => void;
 }
 
@@ -25,6 +26,7 @@ export const useLocalState = create<LocalState>(
       browserId: '',
       subscription: 'connected',
       errorCount: 0,
+      airLockErrorCount: 0,
     }),
     {
       name: createStorageKey('local'),
@@ -55,4 +57,9 @@ export function useSubscriptionStatus() {
 const selErrorCount = (s: LocalState) => s.errorCount;
 export function useErrorCount() {
   return useLocalState(selErrorCount);
+}
+
+const selAirLockErrorCount = (s: LocalState) => s.airLockErrorCount;
+export function useAirLockErrorCount() {
+  return useLocalState(selAirLockErrorCount);
 }


### PR DESCRIPTION
Closes #1086 

It seems we were already showing the disconnect bar on ship shutdown, but we weren't catching errors with subscriptions themselves. This *should* solve that.