### PR TITLE
app: fix media query deduplication

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -19,7 +19,7 @@ import api, { IS_MOCK } from '@/api';
 import Dms from '@/dms/Dms';
 import NewDM from '@/dms/NewDm';
 import { DmThread, GroupChatThread } from '@/chat/ChatThread/ChatThread';
-import useMedia, { useIsMobile } from '@/logic/useMedia';
+import useMedia, { useIsDark, useIsMobile } from '@/logic/useMedia';
 import useIsChat from '@/logic/useIsChat';
 import useErrorHandler from '@/logic/useErrorHandler';
 import { useSettingsState, useTheme } from '@/state/settings';
@@ -495,7 +495,7 @@ function RoutedApp() {
   };
 
   const theme = useTheme();
-  const isDarkMode = useMedia('(prefers-color-scheme: dark)');
+  const isDarkMode = useIsDark();
 
   useEffect(() => {
     if ((isDarkMode && theme === 'auto') || theme === 'dark') {

--- a/ui/src/groups/GroupAvatar.tsx
+++ b/ui/src/groups/GroupAvatar.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import React from 'react';
 import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { isColor } from '@/logic/utils';
-import useMedia from '@/logic/useMedia';
+import { useIsDark } from '@/logic/useMedia';
 import { useCalm } from '@/state/settings';
 
 interface GroupAvatarProps {
@@ -38,7 +38,7 @@ export default function GroupAvatar({
   className,
   title,
 }: GroupAvatarProps) {
-  const dark = useMedia('(prefers-color-scheme: dark)');
+  const dark = useIsDark();
   const calm = useCalm();
   let background;
 

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { FastAverageColor } from 'fast-average-color';
 import { mix, transparentize } from 'color2k';
-import useMedia from '@/logic/useMedia';
+import { useIsDark } from '@/logic/useMedia';
 import { useGroup, useGroupFlag } from '@/state/groups/groups';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import HashIcon16 from '@/components/icons/HashIcon16';
@@ -25,7 +25,7 @@ function GroupHeader() {
   const cover = useRef(null);
   const fac = new FastAverageColor();
   const averageSucceeded = isColor(coverImgColor);
-  const dark = useMedia('(prefers-color-scheme: dark)');
+  const dark = useIsDark();
   const hoverFallbackForeground = dark ? 'white' : 'black';
   const hoverFallbackBackground = dark ? '#333333' : '#CCCCCC';
   const calm = useCalm();


### PR DESCRIPTION
This showed up as an issue because I noticed our media query not picking up theme changes. Essentially on first render before the setQuery call can update the initialized flag, each invocation was creating a query listener. I moved the tracking outside of react state so that it's updated immediately.