### PR TITLE
sidebar: recent sorting

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1112,8 +1112,6 @@
       (put:log-on:c log.chat time d)
     =.  ca-core
       (ca-give-updates time d)
-    =.  cor
-      (give-brief flag/flag ca-brief)
     ?-    -.d
         %add-sects
       =*  p  perm.chat
@@ -1131,6 +1129,7 @@
     ::
         %writs
       =.  pact.chat  (reduce:ca-pact time p.d)
+      =.  cor  (give-brief flag/flag ca-brief)
       ?-  -.q.p.d  
           ?(%del %add-feel %del-feel)  ca-core
           %add

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -600,6 +600,7 @@
     ?-    -.dif
         %notes
       =.  notes.diary  (reduce:di-notes time p.dif)
+      =.  cor  (give-brief flag di-brief)
       =/  cons=(list (list content:ha))
         (hark:di-notes our.bowl p.dif)
       =.  cor

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -540,6 +540,7 @@
     ?-    -.d
         %curios
       =.  curios.heap  (reduce:he-curios time q.p.d)
+      =.  cor  (give-brief flag he-brief)
       ?-  -.q.p.d
           ?(%edit %del %add-feel %del-feel)  he-core
           %add

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback } from 'react';
 import { format, isToday } from 'date-fns';
 import { useLocation, useNavigate } from 'react-router';
+import { daToUnix, udToDec } from '@urbit/api';
+import bigInt from 'big-integer';
 import XIcon from '@/components/icons/XIcon';
-import { pluralize } from '../logic/utils';
-import { useChatState, useGetFirstUnreadID } from '../state/chat';
+import { pluralize } from '@/logic/utils';
+import { useChatState, useGetFirstUnreadID } from '@/state/chat';
 import { useChatInfo } from './useChatStore';
 
 interface ChatUnreadAlertsProps {
@@ -32,7 +34,11 @@ export default function ChatUnreadAlerts({ whom }: ChatUnreadAlertsProps) {
   }
 
   const { brief } = chatInfo.unread;
-  const date = brief ? new Date(brief.last) : new Date();
+  const readId = brief['read-id'];
+  const udTime = readId
+    ? daToUnix(bigInt(udToDec(readId.split('/')[1])))
+    : null;
+  const date = udTime ? new Date(udTime) : new Date();
   const since = isToday(date)
     ? `${format(date, 'HH:mm')} today`
     : format(date, 'LLLL d');

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -69,8 +69,6 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
   const isMobile = useIsMobile();
   const { isChannelUnread } = useIsChannelUnread();
 
-  usePrefetchChannels(flag);
-
   if (!group) {
     return null;
   }

--- a/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`ChannelList > renders as expected 1`] = `
           <span
             class="mr-2 pl-1"
           >
-            Sort: A → Z
+            Sort: Arranged
           </span>
         </span>
         <svg
@@ -54,7 +54,11 @@ exports[`ChannelList > renders as expected 1`] = `
     </div>
     <ul
       class="space-y-1"
-    />
+    >
+      <div
+        class="space-y-1"
+      />
+    </ul>
   </div>
 </DocumentFragment>
 `;

--- a/ui/src/logic/useChannelSort.ts
+++ b/ui/src/logic/useChannelSort.ts
@@ -1,11 +1,6 @@
 import { get } from 'lodash';
-import { useCallback } from 'react';
 import { useGroup, useRouteGroup } from '@/state/groups';
 import { GroupChannel, Channels, Zone } from '@/types/groups';
-import { useGetLatestChat } from '@/state/chat';
-import { ChatWhom } from '@/types/chat';
-import { useGetLatestNote } from '@/state/diary';
-import { useGetLatestCurio } from '@/state/heap/heap';
 import useSidebarSort, {
   ALPHABETICAL,
   DEFAULT,
@@ -14,55 +9,8 @@ import useSidebarSort, {
   Sorter,
   useRecentSort,
 } from './useSidebarSort';
-import { nestToFlag } from './utils';
 
 const UNZONED = 'default';
-
-function useGetLatestPost() {
-  const getLatestChat = useGetLatestChat();
-  const getLatestCurio = useGetLatestCurio();
-  const getLatestNote = useGetLatestNote();
-
-  return (flag: string) => {
-    const [chType, _chFlag] = nestToFlag(flag);
-
-    switch (chType) {
-      case 'chat':
-        return (getLatestChat(flag)[0] ?? Number.NEGATIVE_INFINITY).toString();
-
-      case 'diary':
-        return (getLatestNote(flag)[0] ?? Number.NEGATIVE_INFINITY).toString();
-
-      case 'heap':
-        return (getLatestCurio(flag)[0] ?? Number.NEGATIVE_INFINITY).toString();
-
-      default:
-        return Number.NEGATIVE_INFINITY.toString();
-    }
-  };
-}
-
-function useRecentChannelSort() {
-  const getLatestPost = useGetLatestPost();
-
-  const sortRecent = useCallback(
-    (a: ChatWhom, b: ChatWhom) => {
-      const aLast = getLatestPost(a);
-      const bLast = getLatestPost(b);
-
-      if (aLast < bLast) {
-        return -1;
-      }
-      if (aLast > bLast) {
-        return 1;
-      }
-      return 0;
-    },
-    [getLatestPost]
-  );
-
-  return sortRecent;
-}
 
 export default function useChannelSort() {
   const groupFlag = useRouteGroup();

--- a/ui/src/logic/useChannelSort.ts
+++ b/ui/src/logic/useChannelSort.ts
@@ -12,6 +12,7 @@ import useSidebarSort, {
   RECENT,
   sortAlphabetical,
   Sorter,
+  useRecentSort,
 } from './useSidebarSort';
 import { nestToFlag } from './utils';
 
@@ -66,7 +67,7 @@ function useRecentChannelSort() {
 export default function useChannelSort() {
   const groupFlag = useRouteGroup();
   const group = useGroup(groupFlag);
-  const sortRecent = useRecentChannelSort();
+  const sortRecent = useRecentSort();
 
   const sortDefault = (a: Zone, b: Zone) => {
     if (!group) {

--- a/ui/src/logic/useGroupSort.ts
+++ b/ui/src/logic/useGroupSort.ts
@@ -32,7 +32,11 @@ export default function useGroupSort() {
       },
     };
 
-    return sortRecordsBy(groups, accessors[sortFn], sortFn === RECENT);
+    return sortRecordsBy(
+      groups,
+      accessors[sortFn] || accessors[ALPHABETICAL],
+      sortFn === RECENT
+    );
   }
 
   return {

--- a/ui/src/logic/useSidebarSort.ts
+++ b/ui/src/logic/useSidebarSort.ts
@@ -1,11 +1,10 @@
 import { useCallback } from 'react';
-import { useBriefs } from '@/state/chat';
-import { ChatWhom } from '@/types/chat';
 import {
   SettingsState,
   useSettingsState,
   useGroupSideBarSort,
 } from '@/state/settings';
+import useAllBriefs from './useAllBriefs';
 
 export const ALPHABETICAL = 'A → Z';
 export const DEFAULT = 'Arranged';
@@ -21,19 +20,19 @@ interface UseSidebarSort {
   flag?: string;
 }
 
-export const sortAlphabetical = (a: ChatWhom, b: ChatWhom) =>
-  a.localeCompare(b);
+export const sortAlphabetical = (aNest: string, bNest: string) =>
+  aNest.localeCompare(bNest);
 
 const selSideBarSort = (s: SettingsState) => ({
   sideBarSort: s.groups.sideBarSort,
 });
 
 export function useRecentSort() {
-  const briefs = useBriefs();
+  const briefs = useAllBriefs();
   const sortRecent = useCallback(
-    (a: ChatWhom, b: ChatWhom) => {
-      const aLast = briefs[a]?.last ?? Number.NEGATIVE_INFINITY;
-      const bLast = briefs[b]?.last ?? Number.NEGATIVE_INFINITY;
+    (aNest: string, bNest: string) => {
+      const aLast = briefs[aNest]?.last ?? Number.NEGATIVE_INFINITY;
+      const bLast = briefs[bNest]?.last ?? Number.NEGATIVE_INFINITY;
       if (aLast < bLast) {
         return -1;
       }
@@ -89,7 +88,8 @@ export default function useSidebarSort({
       const aVal = accessor(aKey, aObj);
       const bVal = accessor(bKey, bObj);
 
-      return sortOptions[sortFn ?? 'A → Z'](aVal, bVal);
+      const sorter = sortOptions[sortFn] ?? sortOptions[ALPHABETICAL];
+      return sorter(aVal, bVal);
     });
 
     return reverse ? entries.reverse() : entries;

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -141,7 +141,7 @@ export const useSettingsState = createState<BaseSettingsState>(
     },
     groups: {
       orderedGroupPins: [],
-      sideBarSort: ALPHABETICAL,
+      sideBarSort: DEFAULT,
       groupSideBarSort: '{"~": "A → Z"}' as Stringified<GroupSideBarSort>,
     },
     talk: {
@@ -243,7 +243,7 @@ export function useHeapSortMode(flag: string): HeapSortMode {
 export function useHeapDisplayMode(flag: string): HeapDisplayMode {
   const settings = useHeapSettings();
   const heapSetting = getSetting(settings, flag);
-  return heapSetting?.displayMode ?? 'list';
+  return heapSetting?.displayMode ?? 'grid';
 }
 
 const selDiarySettings = (s: SettingsState) => s.diary.settings;


### PR DESCRIPTION
Unfortunately I think I sent @tomholford down the wrong path for #1114 my apologies! The `brief.last` is the correct thing to use for the last message we just had a few issues. We weren't using nests, looking at all channel types, updating briefs for posts in all channel types, and our chat brief was going off out of order so it was always one behind. This corrects all of that and also changes the default sort for channels to arranged and default heap view to grid.

This does rip out the channel prefetching which I think we need to revisit after launch. The prefetching was incurring too many requests + subscriptions holding up loading anything else for like 10s+ which I think is not a decent enough trade off yet. Also we don't really want to be subscribed to all channel updates because that was why we split them out in the first place.