### PR TITLE
talk: fix sort and persist filter

### DIFF
--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -60,7 +60,7 @@ export default function MessagesList({ filter }: MessagesListProps) {
 
       return true; // is all
     })
-    .sort(sortOptions[RECENT])
+    .sort((a, b) => sortOptions[RECENT](`chat/${a}`, `chat/${b}`))
     .reverse();
 
   return (

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -165,7 +165,7 @@ export const useSettingsState = createState<BaseSettingsState>(
       set(newState);
     },
   }),
-  [],
+  ['heaps', 'diary', 'groups', 'talk'],
   [
     (set, get) =>
       createSubscription('settings-store', `/desk/${window.desk}`, (e) => {


### PR DESCRIPTION
With recent change to `useAllBriefs` using nests, message sort need to be adjusted as well. Also threw in persisted talk filter because it's really annoying to watch it change lol.