### PR TITLE
scroller: refactor scrollTo behavior

### DIFF
--- a/ui/src/chat/ChatScroller/IChatScroller.ts
+++ b/ui/src/chat/ChatScroller/IChatScroller.ts
@@ -1,6 +1,7 @@
 import { BigIntOrderedMap } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import { ReactNode } from 'react';
+import { VirtuosoHandle } from 'react-virtuoso';
 import { ChatWrit } from '../../types/chat';
 
 export interface IChatScroller {
@@ -9,4 +10,5 @@ export interface IChatScroller {
   replying?: boolean;
   prefixedElement?: ReactNode;
   scrollTo?: BigInteger;
+  scrollerRef: React.RefObject<VirtuosoHandle>;
 }

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -1,7 +1,8 @@
 import cn from 'classnames';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useLocation, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
+import { VirtuosoHandle } from 'react-virtuoso';
 import { useChannelFlag } from '@/hooks';
 import { useChatState, useReplies, useWrit } from '@/state/chat';
 import { useChannel, useRouteGroup } from '@/state/groups/groups';
@@ -9,7 +10,6 @@ import ChatInput from '@/chat/ChatInput/ChatInput';
 import BranchIcon from '@/components/icons/BranchIcon';
 import X16Icon from '@/components/icons/X16Icon';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
-import useIsChat from '@/logic/useIsChat';
 import { whomIsFlag } from '@/logic/utils';
 
 export default function ChatThread() {
@@ -21,14 +21,13 @@ export default function ChatThread() {
     idShip: string;
     idTime: string;
   }>();
+  const scrollerRef = useRef<VirtuosoHandle>(null);
   const flag = useChannelFlag()!;
   const whom = flag || ship || '';
   const groupFlag = useRouteGroup();
   const { sendMessage } = useChatState.getState();
-  const isChat = useIsChat();
   const location = useLocation();
   const channel = useChannel(groupFlag, `chat/${flag}`)!;
-
   const id = `${idShip!}/${idTime!}`;
   const maybeWrit = useWrit(whom, id);
   const replies = useReplies(whom, id);
@@ -68,7 +67,12 @@ export default function ChatThread() {
         </div>
       </header>
       <div className="flex flex-1 flex-col px-2 py-0">
-        <ChatScroller messages={thread} whom={whom} replying />
+        <ChatScroller
+          messages={thread}
+          whom={whom}
+          scrollerRef={scrollerRef}
+          replying
+        />
       </div>
       <div className="sticky bottom-0 z-10 border-t-2 border-gray-50 bg-white p-4">
         <ChatInput whom={whom} replying={id} sendMessage={sendMessage} />

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -1,8 +1,9 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import _ from 'lodash';
 import { BigIntOrderedMap } from '@urbit/api';
 import bigInt from 'big-integer';
 import { useLocation } from 'react-router';
+import { VirtuosoHandle } from 'react-virtuoso';
 import ChatUnreadAlerts from '@/chat/ChatUnreadAlerts';
 import { ChatWrit } from '@/types/chat';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
@@ -20,6 +21,7 @@ export default function ChatWindow({
   prefixedElement,
 }: ChatWindowProps) {
   const location = useLocation();
+  const scrollerRef = useRef<VirtuosoHandle>(null);
   const scrollTo = new URLSearchParams(location.search).get('msg');
 
   useEffect(() => {
@@ -28,7 +30,7 @@ export default function ChatWindow({
 
   return (
     <div className="relative h-full">
-      <ChatUnreadAlerts whom={whom} />
+      <ChatUnreadAlerts whom={whom} scrollerRef={scrollerRef} />
       <div className="flex h-full w-full flex-col overflow-hidden">
         <ChatScroller
           /**
@@ -44,6 +46,7 @@ export default function ChatWindow({
           whom={whom}
           prefixedElement={prefixedElement}
           scrollTo={scrollTo ? bigInt(scrollTo) : undefined}
+          scrollerRef={scrollerRef}
         />
       </div>
     </div>


### PR DESCRIPTION
This refactors the scroller to use a provided ref, which subsequently allows other components (such as the Unread banner) to control the scroll index. This is then used to scrollback the index to the first unread message when clicking on the banner. Further, a useEffect hook is no longer used; instead, virtuoso's `initialTopMostIndex` is used on load if there is a `msg` param in the URL.

This resolves #1200