### PR TITLE
groups: Fix overflow issue in New Group modal in safari 

### DIFF
--- a/ui/src/groups/NewGroup/NewGroup.tsx
+++ b/ui/src/groups/NewGroup/NewGroup.tsx
@@ -151,7 +151,7 @@ export default function NewGroup() {
     <Dialog defaultOpen modal={true} onOpenChange={onOpenChange}>
       <DialogContent
         onInteractOutside={(e) => e.preventDefault()}
-        className="sm:inset-y-24"
+        className="w-[500px] sm:inset-y-24"
         containerClass="w-full h-full sm:max-w-lg"
       >
         <FormProvider {...form}>


### PR DESCRIPTION
by setting a definite width on the dialog.

Fixes #1236 