### PR TITLE
channel: prevent brief marking from triggering infinite loop

### DIFF
--- a/ui/src/dms/DMOptions.tsx
+++ b/ui/src/dms/DMOptions.tsx
@@ -33,8 +33,8 @@ export default function DmOptions({
   const location = useLocation();
   const navigate = useNavigate();
   const pinned = usePinned();
-  const { isChannelUnread } = useIsChannelUnread();
-  const hasActivity = isChannelUnread(`chat/${whom}`) || pending;
+  const isUnread = useIsChannelUnread(`chat/${whom}`);
+  const hasActivity = isUnread || pending;
   const [isOpen, setIsOpen] = useState(false);
   const [inviteIsOpen, setInviteIsOpen] = useState(false);
   const onArchive = () => {

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -19,7 +19,9 @@ import useChannelSections from '@/logic/useChannelSections';
 import { GroupChannel } from '@/types/groups';
 import Divider from '@/components/Divider';
 import ChannelIcon from '@/channels/ChannelIcon';
-import useIsChannelUnread from '@/logic/useIsChannelUnread';
+import useIsChannelUnread, {
+  useCheckChannelUnread,
+} from '@/logic/useIsChannelUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import usePrefetchChannels from '@/logic/usePrefetchChannels';
 import ChannelSortOptions from './ChannelSortOptions';
@@ -72,7 +74,7 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
   const isDefaultSort = sortFn === DEFAULT;
   const { sectionedChannels, sections } = useChannelSections(flag);
   const isMobile = useIsMobile();
-  const { isChannelUnread } = useIsChannelUnread();
+  const isChannelUnread = useCheckChannelUnread();
   const vessel = useVessel(flag, window.our);
 
   if (!group) {

--- a/ui/src/logic/useDismissChannelNotifications.ts
+++ b/ui/src/logic/useDismissChannelNotifications.ts
@@ -17,7 +17,7 @@ export default function useDismissChannelNotifications({
 }: UseDismissChannelProps) {
   const flag = useRouteGroup();
   const [, chFlag] = nestToFlag(nest);
-  const { isChannelUnread } = useIsChannelUnread();
+  const unread = useIsChannelUnread(nest);
   const { notifications } = useNotifications(flag);
 
   /**
@@ -29,7 +29,7 @@ export default function useDismissChannelNotifications({
    */
   // dismiss unread notifications while viewing channel
   useEffect(() => {
-    if (nest && isChannelUnread(nest)) {
+    if (nest && unread) {
       // dismiss brief
       markRead(chFlag);
       // iterate bins, saw each rope
@@ -45,5 +45,5 @@ export default function useDismissChannelNotifications({
         });
       });
     }
-  }, [nest, chFlag, markRead, isChannelUnread, notifications]);
+  }, [nest, chFlag, markRead, unread, notifications]);
 }

--- a/ui/src/logic/useIsChannelUnread.ts
+++ b/ui/src/logic/useIsChannelUnread.ts
@@ -5,28 +5,34 @@ import { nestToFlag } from './utils';
 
 const selChats = (s: ChatStore) => s.chats;
 
-export default function useIsChannelUnread() {
+function channelUnread(
+  nest: string,
+  briefs: ReturnType<typeof useAllBriefs>,
+  chats: ChatStore['chats']
+) {
+  const [app, chFlag] = nestToFlag(nest);
+  const unread = chats[chFlag]?.unread;
+
+  if (app === 'chat') {
+    return unread && !unread.seen;
+  }
+
+  return (briefs[nest]?.count ?? 0) > 0;
+}
+
+export function useCheckChannelUnread() {
   const briefs = useAllBriefs();
   const chats = useChatStore(selChats);
 
-  /**
-   * A Channel is unread if it's brief has new unseen items
-   */
-  const isChannelUnread = useCallback(
-    (nest: string) => {
-      const [app, chFlag] = nestToFlag(nest);
-      const unread = chats[chFlag]?.unread;
-
-      if (app === 'chat') {
-        return unread && !unread.seen;
-      }
-
-      return (briefs[nest]?.count ?? 0) > 0;
-    },
+  return useCallback(
+    (nest: string) => channelUnread(nest, briefs, chats),
     [briefs, chats]
   );
+}
 
-  return {
-    isChannelUnread,
-  };
+export default function useIsChannelUnread(nest: string) {
+  const briefs = useAllBriefs();
+  const chats = useChatStore(selChats);
+
+  return channelUnread(nest, briefs, chats);
 }


### PR DESCRIPTION
OTT, basically each time dismiss channel marked read it updated the brief, which updated the deps in its useEffect which in turn did it again.