### PR TITLE
heap, diary: use correct time for marking read

### DIFF
--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -630,7 +630,9 @@
         %unwatch  remark.diary(watching |)
         %read-at  !!
       ::
-          %read   remark.diary(last-read now.bowl)
+          %read
+      =/  [=time =note:d]  (need (ram:on:notes:d notes.diary))
+      remark.diary(last-read `@da`(add time 1))  ::  greater than last
       ==
     =.  cor
       (give-brief flag di-brief)

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -640,7 +640,9 @@
         %unwatch  remark.heap(watching |)
         %read-at  !!
       ::
-          %read   remark.heap(last-read now.bowl)
+          %read
+      =/  [=time =curio:h]  (need (ram:on:curios:h curios.heap))
+      remark.heap(last-read `@da`(add time 1))  ::  greater than last
       ==
     =.  cor
       (give-brief flag he-brief)


### PR DESCRIPTION
Similar to fix for chat, always use the last post's time + 1. Fixes #1042