### PR TITLE
groups: Prevent refs from loading while scrolling

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -20,7 +20,7 @@ import { Link } from 'react-router-dom';
 
 interface ChatContentProps {
   story: ChatStory;
-  isScrolling: boolean;
+  isScrolling?: boolean;
 }
 
 interface InlineContentProps {
@@ -151,7 +151,10 @@ export function BlockContent({ story, isScrolling }: BlockContentProps) {
   throw new Error(`Unhandled message type: ${JSON.stringify(story)}`);
 }
 
-export default function ChatContent({ story, isScrolling }: ChatContentProps) {
+export default function ChatContent({
+  story,
+  isScrolling = false,
+}: ChatContentProps) {
   const inlineLength = story.inline.length;
   const blockLength = story.block.length;
 

--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 
 interface ChatContentProps {
   story: ChatStory;
+  isScrolling: boolean;
 }
 
 interface InlineContentProps {
@@ -28,6 +29,7 @@ interface InlineContentProps {
 
 interface BlockContentProps {
   story: ChatBlock;
+  isScrolling: boolean;
 }
 
 interface ShipMentionProps {
@@ -131,7 +133,7 @@ export function InlineContent({ story }: InlineContentProps) {
   throw new Error(`Unhandled message type: ${JSON.stringify(story)}`);
 }
 
-export function BlockContent({ story }: BlockContentProps) {
+export function BlockContent({ story, isScrolling }: BlockContentProps) {
   if (isChatImage(story)) {
     return (
       <ChatContentImage
@@ -143,13 +145,13 @@ export function BlockContent({ story }: BlockContentProps) {
     );
   }
   if ('cite' in story) {
-    return <ContentReference cite={story.cite} />;
+    return <ContentReference cite={story.cite} isScrolling={isScrolling} />;
   }
 
   throw new Error(`Unhandled message type: ${JSON.stringify(story)}`);
 }
 
-export default function ChatContent({ story }: ChatContentProps) {
+export default function ChatContent({ story, isScrolling }: ChatContentProps) {
   const inlineLength = story.inline.length;
   const blockLength = story.block.length;
 
@@ -164,7 +166,7 @@ export default function ChatContent({ story }: ChatContentProps) {
                 key={`${storyItem.toString()}-${index}`}
                 className="flex flex-col"
               >
-                <BlockContent story={storyItem} />
+                <BlockContent story={storyItem} isScrolling={isScrolling} />
               </div>
             ))}
         </>

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -35,6 +35,7 @@ export interface ChatMessageProps {
   hideOptions?: boolean;
   isLast?: boolean;
   isLinked?: boolean;
+  isScrolling?: boolean;
 }
 
 function briefMatches(brief: ChatBrief, id: string): boolean {
@@ -56,6 +57,7 @@ const ChatMessage = React.memo<
         hideOptions = false,
         isLast = false,
         isLinked = false,
+        isScrolling = false,
       }: ChatMessageProps,
       ref
     ) => {
@@ -89,7 +91,7 @@ const ChatMessage = React.memo<
                as seen and start a timer to mark it read so it goes away.
                we ensure that the brief matches and hasn't changed before
                doing so. we don't want to accidentally clear unreads when
-               the state has changed 
+               the state has changed
             */
             if (inView && briefMatches(brief, writ.seal.id) && !seen) {
               markSeen(whom);
@@ -168,7 +170,10 @@ const ChatMessage = React.memo<
                 )}
               >
                 {'story' in memo.content ? (
-                  <ChatContent story={memo.content.story} />
+                  <ChatContent
+                    story={memo.content.story}
+                    isScrolling={isScrolling}
+                  />
                 ) : null}
                 {Object.keys(seal.feels).length > 0 && (
                   <ChatReactions seal={seal} whom={whom} />

--- a/ui/src/components/References/AppReference.tsx
+++ b/ui/src/components/References/AppReference.tsx
@@ -6,19 +6,23 @@ import { useCalm } from '@/state/settings';
 
 interface AppReferenceProps {
   desk: string;
+  isScrolling?: boolean;
 }
 
-export default function AppReference({ desk }: AppReferenceProps) {
+export default function AppReference({
+  desk,
+  isScrolling = false,
+}: AppReferenceProps) {
   const [ship, deskId] = desk.split('/');
   const treaty = useTreaty(ship, deskId);
   const calm = useCalm();
   const href = `/apps/grid/leap/search/${ship}/apps/${ship}/${deskId}`;
 
   useEffect(() => {
-    if (!treaty) {
+    if (!treaty && !isScrolling) {
       useDocketState.getState().requestTreaty(ship, desk);
     }
-  }, [treaty, ship, desk]);
+  }, [treaty, ship, desk, isScrolling]);
 
   function openLink() {
     window.open(`${window.location.origin}${href}`);

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -17,21 +17,13 @@ function ContentReference({
   cite: Cite;
   isScrolling?: boolean;
 }) {
-  if (isScrolling) {
-    // Without this console log we don't see the loading state.
-    // TODO: Figure out why.
-    // eslint-disable-next-line no-console
-    console.log('scrolling, not rendering');
-    return <HeapLoadingBlock reference />;
-  }
-
   if ('group' in cite) {
-    return <GroupReference flag={cite.group} />;
+    return <GroupReference flag={cite.group} isScrolling={isScrolling} />;
   }
 
   if ('desk' in cite) {
     const { desk } = cite.desk;
-    return <AppReference desk={desk} />;
+    return <AppReference desk={desk} isScrolling={isScrolling} />;
   }
 
   if ('chan' in cite) {
@@ -41,15 +33,36 @@ function ContentReference({
 
     if (app === 'heap') {
       const idCurio = udToDec(segments[2]);
-      return <CurioReference chFlag={chFlag} nest={nest} idCurio={idCurio} />;
+      return (
+        <CurioReference
+          chFlag={chFlag}
+          nest={nest}
+          idCurio={idCurio}
+          isScrolling={isScrolling}
+        />
+      );
     }
     if (app === 'chat') {
       const idWrit = `${segments[2]}/${segments[3]}`;
-      return <WritReference chFlag={chFlag} nest={nest} idWrit={idWrit} />;
+      return (
+        <WritReference
+          isScrolling={isScrolling}
+          chFlag={chFlag}
+          nest={nest}
+          idWrit={idWrit}
+        />
+      );
     }
     if (app === 'diary') {
       const idNote = udToDec(segments[2]);
-      return <NoteReference chFlag={chFlag} nest={nest} id={idNote} />;
+      return (
+        <NoteReference
+          chFlag={chFlag}
+          nest={nest}
+          id={idNote}
+          isScrolling={isScrolling}
+        />
+      );
     }
   }
 

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { nestToFlag } from '@/logic/utils';
 import { Cite } from '@/types/chat';
 import { udToDec } from '@urbit/api';
+import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import CurioReference from './CurioReference';
 // eslint-disable-next-line import/no-cycle
 import WritReference from './WritReference';
@@ -9,7 +10,21 @@ import GroupReference from './GroupReference';
 import NoteReference from './NoteReference';
 import AppReference from './AppReference';
 
-function ContentReference({ cite }: { cite: Cite }) {
+function ContentReference({
+  cite,
+  isScrolling,
+}: {
+  cite: Cite;
+  isScrolling: boolean;
+}) {
+  if (isScrolling) {
+    // Without this console log we don't see the loading state.
+    // TODO: Figure out why.
+    // eslint-disable-next-line no-console
+    console.log('scrolling, not rendering');
+    return <HeapLoadingBlock reference />;
+  }
+
   if ('group' in cite) {
     return <GroupReference flag={cite.group} />;
   }

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -12,10 +12,10 @@ import AppReference from './AppReference';
 
 function ContentReference({
   cite,
-  isScrolling,
+  isScrolling = false,
 }: {
   cite: Cite;
-  isScrolling: boolean;
+  isScrolling?: boolean;
 }) {
   if (isScrolling) {
     // Without this console log we don't see the loading state.

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -12,10 +12,12 @@ export default function CurioReference({
   chFlag,
   nest,
   idCurio,
+  isScrolling = false,
 }: {
   chFlag: string;
   nest: string;
   idCurio: string;
+  isScrolling?: boolean;
 }) {
   const curioObject = useCurio(chFlag, idCurio);
   const preview = useChannelPreview(nest);
@@ -25,13 +27,15 @@ export default function CurioReference({
     : undefined;
 
   useEffect(() => {
-    useHeapState
-      .getState()
-      .initialize(chFlag)
-      .catch((reason) => {
-        setScryError(reason);
-      });
-  }, [chFlag]);
+    if (!isScrolling) {
+      useHeapState
+        .getState()
+        .initialize(chFlag)
+        .catch((reason) => {
+          setScryError(reason);
+        });
+    }
+  }, [chFlag, isScrolling]);
 
   if (scryError !== undefined) {
     // TODO handle requests for single curios like we do for single writs.

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -9,9 +9,13 @@ import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 
 interface GroupReferenceProps {
   flag: string;
+  isScrolling?: boolean;
 }
 
-export default function GroupReference({ flag }: GroupReferenceProps) {
+export default function GroupReference({
+  flag,
+  isScrolling = false,
+}: GroupReferenceProps) {
   const gang = useGang(flag);
   const { group, privacy, open, reject, button, status } = useGroupJoin(
     flag,
@@ -22,10 +26,10 @@ export default function GroupReference({ flag }: GroupReferenceProps) {
   const meta = group?.meta || gang?.preview?.meta;
 
   useEffect(() => {
-    if (!gang?.preview && !group) {
+    if (!gang?.preview && !group && !isScrolling) {
       useGroupState.getState().search(flag);
     }
-  }, [gang, group, flag]);
+  }, [gang, group, flag, isScrolling]);
 
   if (privacy === 'secret') {
     return (

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -15,10 +15,12 @@ export default function NoteReference({
   chFlag,
   nest,
   id,
+  isScrolling = false,
 }: {
   chFlag: string;
   nest: string;
   id: string;
+  isScrolling?: boolean;
 }) {
   const preview = useChannelPreview(nest);
   const [scryError, setScryError] = useState<string>();
@@ -31,13 +33,15 @@ export default function NoteReference({
   const totalComments = Array.from(quips).length;
 
   useEffect(() => {
-    useDiaryState
-      .getState()
-      .initialize(chFlag)
-      .catch((reason) => {
-        setScryError(reason);
-      });
-  }, [chFlag]);
+    if (!isScrolling) {
+      useDiaryState
+        .getState()
+        .initialize(chFlag)
+        .catch((reason) => {
+          setScryError(reason);
+        });
+    }
+  }, [chFlag, isScrolling]);
 
   if (scryError !== undefined) {
     // TODO handle requests for single notes like we do for single writs.

--- a/ui/src/components/References/WritReference.tsx
+++ b/ui/src/components/References/WritReference.tsx
@@ -6,7 +6,7 @@ import { useChannelPreview } from '@/state/groups';
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import ReferenceBar from './ReferenceBar';
 
 export default function WritReference({
@@ -18,15 +18,15 @@ export default function WritReference({
   nest: string;
   idWrit: string;
 }) {
-  const unSubbedWrit = useWritByFlagAndWritId(chFlag, idWrit);
+  const writObject = useWritByFlagAndWritId(chFlag, idWrit);
   const preview = useChannelPreview(nest);
 
   // TODO: handle failure for useWritByFlagAndWritId call.
-  if (!unSubbedWrit) {
-    return <LoadingSpinner />;
+  if (!writObject) {
+    return <HeapLoadingBlock reference />;
   }
 
-  const { writ } = unSubbedWrit;
+  const { writ } = writObject;
   const time = bigInt(udToDec(writ.seal.id.split('/')[1]));
 
   if (!('story' in writ.memo.content)) {
@@ -43,7 +43,7 @@ export default function WritReference({
         }
         className="cursor-pointer p-2 group-hover:bg-gray-50"
       >
-        <ChatContent story={writ.memo.content.story} />
+        <ChatContent story={writ.memo.content.story} isScrolling={false} />
       </Link>
       <ReferenceBar
         nest={nest}

--- a/ui/src/components/References/WritReference.tsx
+++ b/ui/src/components/References/WritReference.tsx
@@ -13,12 +13,14 @@ export default function WritReference({
   chFlag,
   nest,
   idWrit,
+  isScrolling,
 }: {
   chFlag: string;
   nest: string;
   idWrit: string;
+  isScrolling: boolean;
 }) {
-  const writObject = useWritByFlagAndWritId(chFlag, idWrit);
+  const writObject = useWritByFlagAndWritId(chFlag, idWrit, isScrolling);
   const preview = useChannelPreview(nest);
 
   // TODO: handle failure for useWritByFlagAndWritId call.

--- a/ui/src/heap/HeapLoadingBlock.tsx
+++ b/ui/src/heap/HeapLoadingBlock.tsx
@@ -10,7 +10,7 @@ export default function HeapLoadingBlock({
     <div
       className={
         reference
-          ? 'heap-inline-block items-center justify-center bg-gray-100'
+          ? 'heap-inline-block h-[126px] items-center justify-center bg-gray-100'
           : 'heap-block items-center justify-center bg-gray-100'
       }
     >

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -960,16 +960,19 @@ type UnsubbedWrit = {
   writ: ChatWrit;
 };
 
-export function useWritByFlagAndWritId(chFlag: string, idWrit: string) {
+export function useWritByFlagAndWritId(
+  chFlag: string,
+  idWrit: string,
+  isScrolling: boolean
+) {
   const [res, setRes] = useState(null as UnsubbedWrit | null);
   useEffect(() => {
-    subscribeOnce<UnsubbedWrit>('chat', `/said/${chFlag}/msg/${idWrit}`).then(
-      setRes
-    );
-    return () => {
-      setRes(null);
-    };
-  }, [chFlag, idWrit]);
+    if (!isScrolling) {
+      subscribeOnce<UnsubbedWrit>('chat', `/said/${chFlag}/msg/${idWrit}`).then(
+        setRes
+      );
+    }
+  }, [chFlag, idWrit, isScrolling]);
   return res;
 }
 


### PR DESCRIPTION
For #1216 

Notice that this does introduce some visual noise (switching from loading state to refs).

I tried to extract the scrolling state out into a hook, but the other components didn't seem to pick up on the changes in scrolling state from the hook so I ended up prop-drilling.

Might still be some jank in here. Please pull it down and play with it and feel free to make suggestions.

Also note that virtuoso has a built-in affordance for this type of behavior but it's meant to apply to all items in the list: https://virtuoso.dev/scroll-seek-placeholders/