### PR TITLE
groups: hide empty sections from sidebar

### DIFF
--- a/ui/src/groups/ChannelIndex/ChannelIndex.test.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.test.tsx
@@ -8,11 +8,13 @@ import ChannelIndex from './ChannelIndex';
 
 const fakeGroup: Group = createMockGroup('Fake Group');
 fakeGroup.channels[`chat/~zod/tlon`] = createChannel('Fake Channel');
+const fakeVessel = fakeGroup.fleet['~hastuc-dibtux'];
 
 vi.mock('@/state/groups', () => ({
   useGroup: () => fakeGroup,
   useRouteGroup: () => null,
   useAmAdmin: () => true,
+  useVessel: () => fakeVessel,
 }));
 
 describe('ChannelIndex', () => {

--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -23,6 +23,7 @@ import useIsChannelHost from '@/logic/useIsChannelHost';
 import useAllBriefs from '@/logic/useAllBriefs';
 import { useIsMobile } from '@/logic/useMedia';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
+import useFilteredSections from '@/logic/useFilteredSections';
 
 const UNZONED = 'default';
 
@@ -260,7 +261,8 @@ function ChannelSection({
 
 export default function ChannelIndex({ title }: ViewProps) {
   const flag = useRouteGroup();
-  const { sectionedChannels, sections } = useChannelSections(flag);
+  const { sectionedChannels } = useChannelSections(flag);
+  const filteredSections = useFilteredSections(flag);
   const navigate = useNavigate();
   const isAdmin = useAmAdmin(flag);
   const group = useGroup(flag);
@@ -298,7 +300,7 @@ export default function ChannelIndex({ title }: ViewProps) {
         ) : null}
       </div>
       <div className="p-4">
-        {sections.map((section) =>
+        {filteredSections.map((section) =>
           sectionedChannels[section] ? (
             <div
               key={section}

--- a/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
+++ b/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
@@ -27,13 +27,7 @@ exports[`ChannelIndex > renders as expected 1`] = `
     </div>
     <div
       class="p-4"
-    >
-      <div
-        class="mb-2 w-full rounded-xl bg-white py-1 pl-4 pr-2"
-      >
-        <ul />
-      </div>
-    </div>
+    />
   </section>
 </DocumentFragment>
 `;

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -2,12 +2,7 @@ import cn from 'classnames';
 import React from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import useAllBriefs from '@/logic/useAllBriefs';
-import {
-  channelHref,
-  nestToFlag,
-  isChannelJoined,
-  canReadChannel,
-} from '@/logic/utils';
+import { channelHref, isChannelJoined, canReadChannel } from '@/logic/utils';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroup, useVessel } from '@/state/groups';
 import CaretDown16Icon from '@/components/icons/CaretDownIcon';
@@ -23,7 +18,7 @@ import useIsChannelUnread, {
   useCheckChannelUnread,
 } from '@/logic/useIsChannelUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
-import usePrefetchChannels from '@/logic/usePrefetchChannels';
+import useFilteredSections from '@/logic/useFilteredSections';
 import ChannelSortOptions from './ChannelSortOptions';
 
 const UNZONED = 'default';
@@ -72,10 +67,11 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
   const briefs = useAllBriefs();
   const { sortFn, sortChannels } = useChannelSort();
   const isDefaultSort = sortFn === DEFAULT;
-  const { sectionedChannels, sections } = useChannelSections(flag);
+  const { sectionedChannels } = useChannelSections(flag);
+  const filteredSections = useFilteredSections(flag, true);
   const isMobile = useIsMobile();
-  const isChannelUnread = useCheckChannelUnread();
   const vessel = useVessel(flag, window.our);
+  const isChannelUnread = useCheckChannelUnread();
 
   if (!group) {
     return null;
@@ -123,19 +119,16 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
   return (
     <div className={className}>
       {!isMobile && <ChannelSorter isMobile={false} />}
-
       <ul className={cn('space-y-1', isMobile && 'flex-none space-y-3')}>
         {isDefaultSort
-          ? sections.map((s) => (
+          ? filteredSections.map((s) => (
               <div className="space-y-1" key={s}>
                 {s !== UNZONED ? (
                   <Divider>
                     {s in group.zones ? group.zones[s].meta.title : ''}
                   </Divider>
                 ) : null}
-                {s in sectionedChannels
-                  ? renderChannels(sectionedChannels[s])
-                  : null}
+                {renderChannels(sectionedChannels[s])}
               </div>
             ))
           : renderChannels(unsectionedChannels)}

--- a/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
@@ -55,11 +55,7 @@ exports[`ChannelList > renders as expected 1`] = `
     </div>
     <ul
       class="space-y-1"
-    >
-      <div
-        class="space-y-1"
-      />
-    </ul>
+    />
   </div>
 </DocumentFragment>
 `;

--- a/ui/src/logic/useFilteredSections.ts
+++ b/ui/src/logic/useFilteredSections.ts
@@ -1,0 +1,28 @@
+import { useVessel } from '@/state/groups';
+import useAllBriefs from './useAllBriefs';
+import useChannelSections from './useChannelSections';
+import { canReadChannel, isChannelJoined } from './utils';
+
+const useFilteredSections = (flag: string, filterJoined?: boolean) => {
+  const briefs = useAllBriefs();
+  const { sections, sectionedChannels } = useChannelSections(flag);
+  const vessel = useVessel(flag, window.our);
+
+  const filteredSections = sections.filter(
+    (s) =>
+      sectionedChannels[s] &&
+      sectionedChannels[s].some((sectionedChan) => {
+        if (filterJoined) {
+          return (
+            sectionedChan[1] &&
+            canReadChannel(sectionedChan[1], vessel) &&
+            isChannelJoined(sectionedChan[0], briefs)
+          );
+        }
+        return sectionedChan[1] && canReadChannel(sectionedChan[1], vessel);
+      })
+  );
+  return filteredSections;
+};
+
+export default useFilteredSections;


### PR DESCRIPTION
This also updates channelIndex to hide sections full of admin-only channels from users, and handles the "section full of unjoined channels" issue