### PR TITLE
changed emoji picker popover to come out of left side of trigger

### DIFF
--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -28,7 +28,7 @@ export default function EmojiPicker({
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-12' : ''} />
-      <Popover.Content sideOffset={8}>
+      <Popover.Content side={isMobile ? 'bottom' : 'left'} sideOffset={40}>
         {data ? (
           <Picker
             data={data}


### PR DESCRIPTION
see: #1253.

I had a lot of trouble recreating this locally, though I could get it to show up sometimes after checking out a pre-version bump commit – I think the version bump may have solved it?