### PR TITLE
chat: prevent users from copying refs in dm

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -23,6 +23,7 @@ export default function ChatMessageOptions(props: {
 }) {
   const { whom, writ, hideReply } = props;
   const groupFlag = useRouteGroup();
+  console.log({ groupFlag });
   const { didCopy, doCopy } = useCopy(
     `/1/chan/chat/${whom}/msg/${writ.seal.id}`
   );
@@ -84,18 +85,20 @@ export default function ChatMessageOptions(props: {
           />
         </>
       ) : null}
-      <IconButton
-        icon={
-          didCopy ? (
-            <CheckIcon className="h-6 w-6 text-gray-400" />
-          ) : (
-            <CopyIcon className="h-6 w-6 text-gray-400" />
-          )
-        }
-        label="Copy"
-        showTooltip
-        action={onCopy}
-      />
+      {groupFlag ? (
+        <IconButton
+          icon={
+            didCopy ? (
+              <CheckIcon className="h-6 w-6 text-gray-400" />
+            ) : (
+              <CopyIcon className="h-6 w-6 text-gray-400" />
+            )
+          }
+          label="Copy"
+          showTooltip
+          action={onCopy}
+        />
+      ) : null}
       {/* <IconButton
         icon={<ShareIcon className="h-6 w-6 text-gray-400" />}
         label="Send to..."

--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -23,7 +23,6 @@ export default function ChatMessageOptions(props: {
 }) {
   const { whom, writ, hideReply } = props;
   const groupFlag = useRouteGroup();
-  console.log({ groupFlag });
   const { didCopy, doCopy } = useCopy(
     `/1/chan/chat/${whom}/msg/${writ.seal.id}`
   );

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -208,29 +208,6 @@ exports[`ChatMessage > renders as expected 1`] = `
           class="group-two cursor-pointer"
         >
           <button
-            aria-label="Copy"
-            class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
-            data-state="closed"
-          >
-            <svg
-              class="h-6 w-6 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                class="fill-current"
-                clip-rule="evenodd"
-                d="M5.6 3C4.16406 3 3 4.16406 3 5.6V14.4C3 15.8359 4.16406 17 5.6 17H7V18.4C7 19.8359 8.16406 21 9.6 21H18.4C19.8359 21 21 19.8359 21 18.4V9.6C21 8.16406 19.8359 7 18.4 7H17V5.6C17 4.16406 15.8359 3 14.4 3H5.6ZM15 7V5.6C15 5.26863 14.7314 5 14.4 5H5.6C5.26863 5 5 5.26863 5 5.6V14.4C5 14.7314 5.26863 15 5.6 15H7V9.6C7 8.16406 8.16406 7 9.6 7H15ZM9.6 19C9.26863 19 9 18.7314 9 18.4V16V15V9.6C9 9.26863 9.26863 9 9.6 9H15H16H18.4C18.7314 9 19 9.26863 19 9.6V18.4C19 18.7314 18.7314 19 18.4 19H9.6Z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </button>
-        </div>
-        <div
-          class="group-two cursor-pointer"
-        >
-          <button
             aria-label="Delete"
             class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
             data-state="closed"


### PR DESCRIPTION
Fixes #1259 

Users should not be able to copy chat refs from DMs, this is not intended functionality. We happen to be using chat refs for "replies" in groups right now, so I can see why Zach attempted to use it in DMs, but refs were never intended to be used in DMs.

We *will* have replies in DMs, but that will come when we add proper replies for both groups and talk.