### PR TITLE
(wip) migration: ux and warnings

### DIFF
--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -1,12 +1,14 @@
 import cn from 'classnames';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import * as Popover from '@radix-ui/react-popover';
 import useAllBriefs from '@/logic/useAllBriefs';
 import {
   channelHref,
-  nestToFlag,
   isChannelJoined,
   canReadChannel,
+  nestToFlag,
+  getFlagParts,
 } from '@/logic/utils';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroup, useVessel } from '@/state/groups';
@@ -19,11 +21,11 @@ import useChannelSections from '@/logic/useChannelSections';
 import { GroupChannel } from '@/types/groups';
 import Divider from '@/components/Divider';
 import ChannelIcon from '@/channels/ChannelIcon';
-import useIsChannelUnread, {
-  useCheckChannelUnread,
-} from '@/logic/useIsChannelUnread';
+import { useCheckChannelUnread } from '@/logic/useIsChannelUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
-import usePrefetchChannels from '@/logic/usePrefetchChannels';
+import ShipName from '@/components/ShipName';
+import usePendingImports from '@/logic/usePendingImports';
+import Bullet16Icon from '@/components/icons/Bullet16Icon';
 import ChannelSortOptions from './ChannelSortOptions';
 
 const UNZONED = 'default';
@@ -67,9 +69,67 @@ export function ChannelSorter({ isMobile }: ChannelSorterProps) {
   );
 }
 
+interface UnmigratedChannelProps {
+  icon: ReactNode;
+  title: string;
+  host: string;
+  isMobile: boolean;
+}
+
+function UnmigratedChannel({
+  icon,
+  host,
+  title,
+  isMobile,
+}: UnmigratedChannelProps) {
+  return (
+    <Popover.Root>
+      <Popover.Anchor>
+        <Popover.Trigger asChild>
+          <SidebarItem
+            icon={icon}
+            actions={
+              <Bullet16Icon className="m-2 h-4 w-4 text-orange opacity-60" />
+            }
+          >
+            <span className="opacity-60">{title}</span>
+          </SidebarItem>
+        </Popover.Trigger>
+      </Popover.Anchor>
+      <Popover.Content
+        side={isMobile ? 'top' : 'right'}
+        sideOffset={isMobile ? 0 : 16}
+        className="z-10"
+      >
+        <div className="flex w-[200px] flex-col space-y-4 rounded-lg bg-white p-4 leading-5 drop-shadow-lg">
+          <span>
+            This channel will become available once{' '}
+            <ShipName name={host} className="font-semibold" /> has migrated.
+          </span>
+        </div>
+        <Popover.Arrow asChild>
+          <svg
+            width="17"
+            height="8"
+            viewBox="0 0 17 8"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16.5 0L0.5 0L7.08579 6.58579C7.86684 7.36684 9.13316 7.36684 9.91421 6.58579L16.5 0Z"
+              className="fill-white"
+            />
+          </svg>
+        </Popover.Arrow>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}
+
 export default function ChannelList({ flag, className }: ChannelListProps) {
   const group = useGroup(flag);
   const briefs = useAllBriefs();
+  const pendingImports = usePendingImports();
   const { sortFn, sortChannels } = useChannelSort();
   const isDefaultSort = sortFn === DEFAULT;
   const { sectionedChannels, sections } = useChannelSections(flag);
@@ -85,14 +145,19 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
     channels
       .filter(
         ([nest, chan]) =>
-          isChannelJoined(nest, briefs) && canReadChannel(chan, vessel)
+          (isChannelJoined(nest, briefs) && canReadChannel(chan, vessel)) ||
+          pendingImports.includes(nest)
       )
       .map(([nest, channel]) => {
+        const [, chFlag] = nestToFlag(nest);
+        const { ship } = getFlagParts(chFlag);
+        const pending = pendingImports.includes(nest);
         const icon = (active: boolean) =>
           isMobile ? (
             <span
               className={cn(
                 'flex h-12 w-12 items-center justify-center rounded-md',
+                pending && 'opacity-60',
                 !active && 'bg-gray-50',
                 active && 'bg-white'
               )}
@@ -100,8 +165,22 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
               <ChannelIcon nest={nest} className="h-6 w-6" />
             </span>
           ) : (
-            <ChannelIcon nest={nest} className="h-6 w-6" />
+            <ChannelIcon
+              nest={nest}
+              className={cn('h-6 w-6', pending && 'opacity-60')}
+            />
           );
+
+        if (pending) {
+          return (
+            <UnmigratedChannel
+              icon={icon}
+              title={channel.meta.title || nest}
+              host={ship}
+              isMobile={isMobile}
+            />
+          );
+        }
 
         return (
           <SidebarItem

--- a/ui/src/logic/usePendingImports.ts
+++ b/ui/src/logic/usePendingImports.ts
@@ -1,0 +1,26 @@
+import { useChatState } from '@/state/chat';
+import { useDiaryState } from '@/state/diary';
+import { useHeapState } from '@/state/heap/heap';
+import { useMemo } from 'react';
+
+interface ChannelAgent {
+  pendingImports: string[];
+}
+
+const selPendImports = (s: ChannelAgent) => s.pendingImports;
+
+export default function usePendingImports() {
+  const chats = useChatState(selPendImports);
+  const heaps = useHeapState(selPendImports);
+  const diaries = useDiaryState(selPendImports);
+
+  return useMemo(
+    () =>
+      ([] as string[]).concat(
+        chats.map((c) => `chat/${c}`),
+        heaps.map((h) => `heap/${h}`),
+        diaries.map((d) => `diary/${d}`)
+      ),
+    [chats, heaps, diaries]
+  );
+}

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -127,6 +127,7 @@ export const useChatState = createState<ChatState>(
     dmSubs: [],
     multiDmSubs: [],
     pendingDms: [],
+    pendingImports: [],
     pins: [],
     sentMessages: [],
     postedMessages: [],
@@ -299,6 +300,25 @@ export const useChatState = createState<ChatState>(
             } else if ('add-sects' in diff) {
               chat.perms.writers = chat.perms.writers.concat(diff['add-sects']);
             }
+          });
+        },
+      });
+
+      const pendingImports = await api.scry<string[]>({
+        app: 'chat',
+        path: '/imp',
+      });
+
+      get().batchSet((draft) => {
+        draft.pendingImports = pendingImports;
+      });
+
+      api.subscribe({
+        app: 'chat',
+        path: '/imp',
+        event: (imports: string[]) => {
+          get().batchSet((draft) => {
+            draft.pendingImports = imports;
           });
         },
       });

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -28,6 +28,7 @@ export interface ChatState {
   drafts: {
     [whom: string]: ChatStory;
   };
+  pendingImports: string[];
   chatSubs: string[];
   dmSubs: string[];
   sentMessages: string[];

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -81,6 +81,7 @@ export const useDiaryState = create<DiaryState>(
       banter: {},
       diarySubs: [],
       briefs: {},
+      pendingImports: [],
       markRead: async (flag) => {
         await api.poke({
           app: 'diary',
@@ -179,6 +180,25 @@ export const useDiaryState = create<DiaryState>(
                   diff['add-sects']
                 );
               }
+            });
+          },
+        });
+
+        const pendingImports = await api.scry<string[]>({
+          app: 'diary',
+          path: '/imp',
+        });
+
+        get().batchSet((draft) => {
+          draft.pendingImports = pendingImports;
+        });
+
+        api.subscribe({
+          app: 'diary',
+          path: '/imp',
+          event: (imports: string[]) => {
+            get().batchSet((draft) => {
+              draft.pendingImports = imports;
             });
           },
         });

--- a/ui/src/state/diary/type.ts
+++ b/ui/src/state/diary/type.ts
@@ -21,6 +21,7 @@ export interface DiaryState {
     [flag: DiaryFlag]: DiaryNoteMap;
   };
   briefs: DiaryBriefs;
+  pendingImports: string[];
   create: (req: DiaryCreate) => Promise<void>;
   start: () => Promise<void>;
   fetchNote: (flag: DiaryFlag, noteId: string) => Promise<void>;

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -77,6 +77,7 @@ export const useHeapState = create<HeapState>(
       curios: {},
       heapSubs: [],
       briefs: {},
+      pendingImports: [],
       markRead: async (flag) => {
         await api.poke({
           app: 'heap',
@@ -151,6 +152,25 @@ export const useHeapState = create<HeapState>(
                   diff['add-sects']
                 );
               }
+            });
+          },
+        });
+
+        const pendingImports = await api.scry<string[]>({
+          app: 'heap',
+          path: '/imp',
+        });
+
+        get().batchSet((draft) => {
+          draft.pendingImports = pendingImports;
+        });
+
+        api.subscribe({
+          app: 'heap',
+          path: '/imp',
+          event: (imports: string[]) => {
+            get().batchSet((draft) => {
+              draft.pendingImports = imports;
             });
           },
         });

--- a/ui/src/state/heap/type.ts
+++ b/ui/src/state/heap/type.ts
@@ -19,6 +19,7 @@ export interface HeapState {
     [flag: HeapFlag]: HeapCurioMap;
   };
   briefs: HeapBriefs;
+  pendingImports: string[];
   create: (req: HeapCreate) => Promise<void>;
   start: () => Promise<void>;
   initialize: (flag: HeapFlag) => Promise<void>;


### PR DESCRIPTION
@urcades @jamesacklin here's the start of my attempt at signalling what's happening during migration. I ended up putting the same popover/tooltip over the pending migration button as in the sidebar. This is all inside the group, working on how we display that the group itself isn't migrated.

<img width="1598" alt="Screen Shot 2022-11-28 at 7 37 12 PM" src="https://user-images.githubusercontent.com/5466421/204440877-d7f3a7bf-a252-44aa-b9b5-de7cb226c88f.png">
<img width="506" alt="Screen Shot 2022-11-28 at 8 38 08 PM" src="https://user-images.githubusercontent.com/5466421/204440943-bcd2445a-3171-4e98-9a37-48c3c905fa4a.png">
