### PR TITLE
heap: store links as link content type

### DIFF
--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
-import { HeapCurio } from '@/types/heap';
+import { HeapCurio, isLink } from '@/types/heap';
 import cn from 'classnames';
 import { isValidUrl, validOembedCheck } from '@/logic/utils';
 import { useCalm } from '@/state/settings';
@@ -157,7 +157,8 @@ interface BottomBarProps {
 function BottomBar({ curio, provider, title, asRef }: BottomBarProps) {
   const { content, sent } = curio.heart;
   const replyCount = curio.seal.replied.length;
-  const url = content.length > 0 ? content[0].toString() : '';
+  const url =
+    content.length > 0 && isLink(content[0]) ? content[0].link.href : '';
   const prettySent = formatDistanceToNow(sent);
 
   if (asRef) {
@@ -200,7 +201,8 @@ export default function HeapBlock({
 }: HeapBlockProps) {
   const [embed, setEmbed] = useState<any>();
   const { content } = curio.heart;
-  const url = content.length > 0 ? content[0].toString() : '';
+  const url =
+    content.length > 0 && isLink(content[0]) ? content[0].link.href : '';
   const calm = useCalm();
   const { isImage, isAudio, isText } = useHeapContentType(url);
   const textFallbackTitle = content
@@ -265,7 +267,7 @@ export default function HeapBlock({
         <BottomBar
           {...botBar}
           provider="Image"
-          title={curio.heart.title || undefined}
+          title={curio.heart.title || url}
         />
       </div>
     );
@@ -281,7 +283,7 @@ export default function HeapBlock({
         <BottomBar
           {...botBar}
           provider="Audio"
-          title={curio.heart.title || undefined}
+          title={curio.heart.title || url}
         />
       </div>
     );
@@ -301,11 +303,7 @@ export default function HeapBlock({
           }}
         >
           <TopBar canEdit={canEdit} {...topBar} />
-          <BottomBar
-            {...botBar}
-            provider={provider}
-            title={curio.heart.title || title}
-          />
+          <BottomBar {...botBar} provider={provider} title={title || url} />
         </div>
       );
     }
@@ -328,7 +326,7 @@ export default function HeapBlock({
           <BottomBar
             {...botBar}
             provider={provider}
-            title={curio.heart.title || undefined}
+            title={twitterHandle || url}
           />
         </div>
       );
@@ -342,7 +340,7 @@ export default function HeapBlock({
         <BottomBar
           {...botBar}
           provider={provider ? provider : 'Link'}
-          title={curio.heart.title || undefined}
+          title={title || url}
         />
       </div>
     );
@@ -354,11 +352,7 @@ export default function HeapBlock({
       <div className="flex grow flex-col items-center justify-center">
         <LinkIcon className="h-16 w-16 text-gray-300" />
       </div>
-      <BottomBar
-        {...botBar}
-        provider="Link"
-        title={curio.heart.title || undefined}
-      />
+      <BottomBar {...botBar} provider="Link" title={url || undefined} />
     </div>
   );
 }

--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import useHeapContentType from '@/logic/useHeapContentType';
 import useEmbedState from '@/state/embed';
 import { validOembedCheck } from '@/logic/utils';
-import { HeapCurio } from '@/types/heap';
+import { HeapCurio, isLink } from '@/types/heap';
 import HeapContent from '@/heap/HeapContent';
 import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
 import HeapDetailEmbed from '@/heap/HeapDetail/HeapDetailEmbed';
@@ -12,7 +12,8 @@ import HeapAudioPlayer from '@/heap/HeapAudioPlayer';
 export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
   const [embed, setEmbed] = useState<any>();
   const { content } = curio.heart;
-  const url = content[0].toString();
+  const url =
+    content.length > 0 && isLink(content[0]) ? content[0].link.href : '';
   const isMobile = useIsMobile();
 
   const { isText, isImage, isAudio, isVideo } = useHeapContentType(url);

--- a/ui/src/heap/NewCurioForm.tsx
+++ b/ui/src/heap/NewCurioForm.tsx
@@ -78,7 +78,7 @@ export default function NewCurioForm() {
     async ({ content }: NewCurioFormSchema) => {
       await useHeapState.getState().addCurio(chFlag, {
         title: null,
-        content: [content],
+        content: [{ link: { href: content, content } }],
         author: window.our,
         sent: Date.now(),
         replying: null,


### PR DESCRIPTION
For #1182 

Also, rather than returning `undefined` for titles we should just show the URL.