### PR TITLE
chat: Handle code block input/display

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cn from 'classnames';
 import { ChatBlock, isChatImage, ChatStory } from '@/types/chat';
 import {
   isBlockquote,
@@ -125,7 +126,7 @@ export function InlineContent({ story }: InlineContentProps) {
 
   if (isBlockCode(story)) {
     return (
-      <pre className="rounded bg-gray-50 px-1.5">
+      <pre className="bg-gray-50 px-4">
         <code>{story.code}</code>
       </pre>
     );
@@ -166,6 +167,10 @@ export default function ChatContent({
 }: ChatContentProps) {
   const inlineLength = story.inline.length;
   const blockLength = story.block.length;
+  const firstBlockCode = story.inline.findIndex(isBlockCode);
+  // @ts-expect-error - this is a bug in typescript
+  // https://github.com/microsoft/TypeScript/issues/48829
+  const lastBlockCode = story.inline.findLastIndex(isBlockCode);
 
   return (
     <div className="leading-6">
@@ -185,12 +190,35 @@ export default function ChatContent({
       ) : null}
       {inlineLength > 0 ? (
         <>
-          {story.inline.map((storyItem, index) => (
-            <InlineContent
-              key={`${storyItem.toString()}-${index}`}
-              story={storyItem}
-            />
-          ))}
+          {story.inline.map((storyItem, index) => {
+            // we need to add top and bottom padding to first/last lines of code blocks.
+            if (index === firstBlockCode) {
+              return (
+                <div className="rounded bg-gray-50 pt-2">
+                  <InlineContent
+                    key={`${storyItem.toString()}-${index}`}
+                    story={storyItem}
+                  />
+                </div>
+              );
+            }
+            if (index === lastBlockCode) {
+              return (
+                <div className="rounded bg-gray-50 pb-2">
+                  <InlineContent
+                    key={`${storyItem.toString()}-${index}`}
+                    story={storyItem}
+                  />
+                </div>
+              );
+            }
+            return (
+              <InlineContent
+                key={`${storyItem.toString()}-${index}`}
+                story={storyItem}
+              />
+            );
+          })}
         </>
       ) : null}
     </div>

--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import { findLastIndex } from 'lodash';
 import { ChatBlock, isChatImage, ChatStory } from '@/types/chat';
 import {
   isBlockquote,
@@ -168,9 +168,7 @@ export default function ChatContent({
   const inlineLength = story.inline.length;
   const blockLength = story.block.length;
   const firstBlockCode = story.inline.findIndex(isBlockCode);
-  // @ts-expect-error - this is a bug in typescript
-  // https://github.com/microsoft/TypeScript/issues/48829
-  const lastBlockCode = story.inline.findLastIndex(isBlockCode);
+  const lastBlockCode = findLastIndex(story.inline, isBlockCode);
 
   return (
     <div className="leading-6">

--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -10,6 +10,7 @@ import {
   isStrikethrough,
   Inline,
   isShip,
+  isBlockCode,
 } from '@/types/content';
 import ChatContentImage from '@/chat/ChatContent/ChatContentImage';
 // eslint-disable-next-line import/no-cycle
@@ -119,6 +120,14 @@ export function InlineContent({ story }: InlineContentProps) {
           story['inline-code']
         )}
       </code>
+    );
+  }
+
+  if (isBlockCode(story)) {
+    return (
+      <pre className="rounded bg-gray-50 px-1.5">
+        <code>{story.code}</code>
+      </pre>
     );
   }
 

--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -170,8 +170,6 @@ export default function ChatContent({
   const firstBlockCode = story.inline.findIndex(isBlockCode);
   const lastBlockCode = findLastIndex(story.inline, isBlockCode);
 
-  console.log({ firstBlockCode, lastBlockCode, story });
-
   return (
     <div className="leading-6">
       {blockLength > 0 ? (

--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -170,6 +170,8 @@ export default function ChatContent({
   const firstBlockCode = story.inline.findIndex(isBlockCode);
   const lastBlockCode = findLastIndex(story.inline, isBlockCode);
 
+  console.log({ firstBlockCode, lastBlockCode, story });
+
   return (
     <div className="leading-6">
       {blockLength > 0 ? (
@@ -190,6 +192,18 @@ export default function ChatContent({
         <>
           {story.inline.map((storyItem, index) => {
             // we need to add top and bottom padding to first/last lines of code blocks.
+
+            if (firstBlockCode === 0 && firstBlockCode === lastBlockCode) {
+              return (
+                <div className="rounded bg-gray-50 py-2">
+                  <InlineContent
+                    key={`${storyItem.toString()}-${index}`}
+                    story={storyItem}
+                  />
+                </div>
+              );
+            }
+
             if (index === firstBlockCode) {
               return (
                 <div className="rounded bg-gray-50 pt-2">

--- a/ui/src/chat/ChatInputMenu/ChatInputMenuToolbar.tsx
+++ b/ui/src/chat/ChatInputMenu/ChatInputMenuToolbar.tsx
@@ -12,6 +12,7 @@ import LinkIcon from '@/components/icons/LinkIcon';
 import StrikeIcon from '@/components/icons/StrikeIcon';
 import X16Icon from '@/components/icons/X16Icon';
 import ChatInputMenuButton from '@/chat/ChatInputMenu/ChatInputMenuButton';
+import CodeBlockIcon from '@/components/icons/CodeBlockIcon';
 
 export type MenuState = 'closed' | 'open' | 'editing-link' | 'link-hover';
 
@@ -153,7 +154,7 @@ export default function ChatInputMenuToolbar({
             unpressedLabel="Apply Code"
             pressedLabel="Remove Code"
           >
-            <CaretRightIcon className="h-6 w-6" />
+            <CodeIcon className="h-6 w-6" />
           </ChatInputMenuButton>
           <ChatInputMenuButton
             isActive={editor.isActive('codeBlock')}
@@ -162,7 +163,7 @@ export default function ChatInputMenuToolbar({
             unpressedLabel="Apply Code Block"
             pressedLabel="Remove Code Block"
           >
-            <CodeIcon className="h-6 w-6" />
+            <CodeBlockIcon className="h-6 w-6" />
           </ChatInputMenuButton>
           <ChatInputMenuButton
             textButton

--- a/ui/src/chat/ChatInputMenu/ChatInputMenuToolbar.tsx
+++ b/ui/src/chat/ChatInputMenu/ChatInputMenuToolbar.tsx
@@ -2,15 +2,16 @@ import React, { KeyboardEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import isURL from 'validator/es/lib/isURL';
 import { Editor as CoreEditor } from '@tiptap/core';
-import { useIsMobile } from '../../logic/useMedia';
-import BlockquoteIcon from '../../components/icons/BlockquoteIcon';
-import BoldIcon from '../../components/icons/BoldIcon';
-import CodeIcon from '../../components/icons/CodeIcon';
-import ItalicIcon from '../../components/icons/ItalicIcon';
-import LinkIcon from '../../components/icons/LinkIcon';
-import StrikeIcon from '../../components/icons/StrikeIcon';
-import X16Icon from '../../components/icons/X16Icon';
-import ChatInputMenuButton from './ChatInputMenuButton';
+import CaretRightIcon from '@/components/icons/CaretRightIcon';
+import { useIsMobile } from '@/logic/useMedia';
+import BlockquoteIcon from '@/components/icons/BlockquoteIcon';
+import BoldIcon from '@/components/icons/BoldIcon';
+import CodeIcon from '@/components/icons/CodeIcon';
+import ItalicIcon from '@/components/icons/ItalicIcon';
+import LinkIcon from '@/components/icons/LinkIcon';
+import StrikeIcon from '@/components/icons/StrikeIcon';
+import X16Icon from '@/components/icons/X16Icon';
+import ChatInputMenuButton from '@/chat/ChatInputMenu/ChatInputMenuButton';
 
 export type MenuState = 'closed' | 'open' | 'editing-link' | 'link-hover';
 
@@ -151,6 +152,15 @@ export default function ChatInputMenuToolbar({
             onClick={() => editor.chain().focus().toggleCode().run()}
             unpressedLabel="Apply Code"
             pressedLabel="Remove Code"
+          >
+            <CaretRightIcon className="h-6 w-6" />
+          </ChatInputMenuButton>
+          <ChatInputMenuButton
+            isActive={editor.isActive('codeBlock')}
+            isSelected={isSelected('codeBlock')}
+            onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+            unpressedLabel="Apply Code Block"
+            pressedLabel="Remove Code Block"
           >
             <CodeIcon className="h-6 w-6" />
           </ChatInputMenuButton>

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -12,6 +12,7 @@ import Blockquote from '@tiptap/extension-blockquote';
 import Placeholder from '@tiptap/extension-placeholder';
 import Bold from '@tiptap/extension-bold';
 import Code from '@tiptap/extension-code';
+import CodeBlock from '@tiptap/extension-code-block';
 import Italic from '@tiptap/extension-italic';
 import Strike from '@tiptap/extension-strike';
 import Link from '@tiptap/extension-link';
@@ -84,6 +85,7 @@ export function useMessageEditor({
     Blockquote,
     Bold,
     Code.extend({ excludes: undefined }),
+    CodeBlock,
     Document,
     HardBreak,
     History.configure({ newGroupDelay: 100 }),

--- a/ui/src/components/icons/CodeBlockIcon.tsx
+++ b/ui/src/components/icons/CodeBlockIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function CodeBlockIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 7L9.07813 11.2318C9.55789 11.6316 9.55789 12.3684 9.07813 12.7682L4 17"
+        className="stroke-current"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10 19H17C18.1046 19 19 18.1046 19 17V7C19 5.89543 18.1046 5 17 5H10"
+        className="stroke-current"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
For #1283 

We need a way to differentiate inline code formatting vs code block formatting in the toolbar, @urcades . For now I used a right caret to indicate inline.

Video demo:

https://user-images.githubusercontent.com/1221094/204890576-d2c25220-e3ce-47bd-8eb7-0210f9e7170f.mov

