### PR TITLE
chat: fix persistent loading spinner in multiDMs

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -203,15 +203,20 @@ export default function ChatScroller({
         return;
       }
 
-      setFetching(newer ? 'bottom' : 'top');
+      try {
+        setFetching(newer ? 'bottom' : 'top');
 
-      if (newer) {
-        await useChatState.getState().fetchNewer(whom, pageSize.toString());
-      } else {
-        await useChatState.getState().fetchOlder(whom, pageSize.toString());
+        if (newer) {
+          await useChatState.getState().fetchNewer(whom, pageSize.toString());
+        } else {
+          await useChatState.getState().fetchOlder(whom, pageSize.toString());
+        }
+
+        setFetching('initial');
+      } catch (e) {
+        console.log(e);
+        setFetching('initial');
       }
-
-      setFetching('initial');
     },
     [whom, messages, loaded]
   );


### PR DESCRIPTION
fixes #1291 

404s are expected to happen when fetching newer/older messages in clubs, it seems, and we were not setting `fetching` to `'initial'` again after those failed calls in ChatScroller.