### PR TITLE
migration: %bait placeholder

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1,4 +1,4 @@
-/-  c=chat, g=groups
+/-  c=chat, g=groups, n=nark
 /-  meta
 /-  ha=hark
 /-  e=epic
@@ -10,6 +10,7 @@
 /+  epos-lib=saga
 /+  wood-lib=wood
 /+  mig=chat-graph
+/+  nar=nark
 /*  desk-bill  %bill  /desk/bill
 ^-  agent:gall
 =>
@@ -362,7 +363,7 @@
   =/  =id:club:c  (shax (jam flag))  :: TODO: determinstic, but collisions ig?
   =/  meta=data:meta
     [title description '' '']:metadatum.association
-  =.  clubs  (~(put by clubs) id (graph-to-pact graph) ships ~ meta %done |)
+  =.  clubs  (~(put by clubs) id (graph-to-pact graph flag) ships ~ meta %done |)
   $(cus t.cus)
 ::
 ++  import-dms
@@ -377,22 +378,22 @@
   ?.  ?=(%graph -.children.node)
     loop(old-dms t.old-dms)
   =.  dms  
-    (~(put by dms) ship (graph-to-pact p.children.node) remark %done |)
+    (~(put by dms) ship (graph-to-pact p.children.node [ship (scot %p ship)]) remark %done |)
   loop(old-dms t.old-dms)
 ++  graph-to-pact
-  |=  =graph:gra:c
+  |=    [=graph:gra:c =flag:c]
   ^-  pact:c
   %-  ~(gas pac *pact:c)
   %+  murn  (tap:orm-gra:c graph)
   |=  [=time =node:gra:c]
   ^-  (unit [_time writ:c])
-  ?~  wit=(node-to-writ time node)
+  ?~  wit=(node-to-writ time node flag)
     ~
   `[time u.wit]
 ::  TODO: review crashing semantics
 ::        check graph ordering (backwards iirc)
 ++  node-to-writ
-  |=  [=time =node:gra:c]
+  |=  [=time =node:gra:c =flag:c]
   ^-  (unit writ:c)
   ?.  ?=(%& -.post.node)
     ~
@@ -404,7 +405,7 @@
   :: XX: probably change?
   :-  ~
   :-  [[author.pos time] ~ ~]
-  [~ author.pos time-sent.pos (con:mig contents.pos)]
+  [~ author.pos time-sent.pos (~(con nert:mig flag) contents.pos)]
 ::
 ++  import
   |=  =imports:c
@@ -418,7 +419,7 @@
   =/  =perm:c
     :_  group.association
     ?:(=(~ writers) ~ (silt (rap 3 %chat '-' (scot %p p.flag) '-' q.flag ~) ~))
-  =/  =pact:c  (graph-to-pact graph)
+  =/  =pact:c  (graph-to-pact graph flag)
   =/  =chat:c
     :*  net=?:(=(our.bowl p.flag) pub/~ sub/[p.flag | chi/~])
         *remark:c

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1,4 +1,4 @@
-/-  c=chat, g=groups, n=nark
+/-  c=chat, g=groups
 /-  meta
 /-  ha=hark
 /-  e=epic
@@ -10,7 +10,6 @@
 /+  epos-lib=saga
 /+  wood-lib=wood
 /+  mig=chat-graph
-/+  nar=nark
 /*  desk-bill  %bill  /desk/bill
 ^-  agent:gall
 =>
@@ -405,7 +404,7 @@
   :: XX: probably change?
   :-  ~
   :-  [[author.pos time] ~ ~]
-  [~ author.pos time-sent.pos (~(con nert:mig flag) contents.pos)]
+  [~ author.pos time-sent.pos story/(~(con nert:mig flag %chat) contents.pos)]
 ::
 ++  import
   |=  =imports:c

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -333,7 +333,7 @@
     ;<  [@ latest=node:gra:d]  _biff  (pry:orm graph)
     ;<  =post:gra:d            _biff  (node-to-post latest)
     =/  =cork:d  [time ~]
-    =/  =memo:d  =,(post [[~ (inline:nert:chat-migrate contents)] author time-sent])
+    =/  =memo:d  =,(post [(con:nert:chat-migrate contents) author time-sent])
     `[cork memo]
   --
 ::

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -333,7 +333,7 @@
     ;<  [@ latest=node:gra:d]  _biff  (pry:orm graph)
     ;<  =post:gra:d            _biff  (node-to-post latest)
     =/  =cork:d  [time ~]
-    =/  =memo:d  =,(post [[~ (inline:chat-migrate contents)] author time-sent])
+    =/  =memo:d  =,(post [[~ (inline:nert:chat-migrate contents)] author time-sent])
     `[cork memo]
   --
 ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -113,7 +113,7 @@
       [sects *time]
     =/  =group:g
       :*  fleet
-          ~  ~  ~  ~  ~
+          ~  ~  ~  ~  ~  ~
           cordon.create
           secret.create
           title.create
@@ -456,6 +456,7 @@
         zone-ord
         bloc
         channels
+        ~(key by channels)
         cordon
         =(%invite -.policy.group)
         meta

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -113,7 +113,7 @@
       [sects *time]
     =/  =group:g
       :*  fleet
-          ~  ~  ~  ~  ~  ~
+          ~  ~  ~  ~  ~
           cordon.create
           secret.create
           title.create
@@ -456,7 +456,6 @@
         zone-ord
         bloc
         channels
-        ~(key by channels)
         cordon
         =(%invite -.policy.group)
         meta

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -242,6 +242,10 @@
       [%x %groups ship=@ name=@ rest=*]
     =/  ship  (slav %p ship.pole)
     (go-peek:(go-abed:group-core ship name.pole) rest.pole)
+  ::
+      [%x %exists ship=@ name=@ rest=*]
+      =/  src  (slav %p ship.pole)
+      ``noun+!>((~(has by groups) [src name.pole]))
   ==
 ::
 ++  agent

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -471,7 +471,7 @@
     ;<  [@ latest=node:gra:h]  _biff  (pry:orm graph)
     ;<  =post:gra:h            _biff  (node-to-post latest)
     =/  =seal:h  [time ~ ~]
-    =/  con=(list inline:h)  (inline:nert:chat-migrate contents.post)
+    =/  con=(list inline:h)  +:(con:nert:chat-migrate contents.post)
     =/  =heart:h  
       =,(post [~ con author time-sent `reply])
     `[seal heart]

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -471,7 +471,7 @@
     ;<  [@ latest=node:gra:h]  _biff  (pry:orm graph)
     ;<  =post:gra:h            _biff  (node-to-post latest)
     =/  =seal:h  [time ~ ~]
-    =/  con=(list inline:h)  (inline:chat-migrate contents.post)
+    =/  con=(list inline:h)  (inline:nert:chat-migrate contents.post)
     =/  =heart:h  
       =,(post [~ con author time-sent `reply])
     `[seal heart]

--- a/desk/lib/chat-graph.hoon
+++ b/desk/lib/chat-graph.hoon
@@ -4,7 +4,7 @@
 /+  pac=dm
 |%
 ++  nert
-  |_  =flag:g
+  |_  [=flag:g =dude:gall]
 ++  node-to-memo
   |=  =node:gra
   ^-  (unit memo:c)
@@ -15,77 +15,42 @@
   :*  replying=~
       author=author.p
       sent=time-sent.p
-      contents=(con contents.p)
+      contents=story/(con contents.p)
   ==
-++  inline
+++  con
   |=  cs=(list content:gra)
-  ^-  (list inline:c)
-  %-  zing
-  %+  turn  cs
-  |=  con=content:gra
-  ^-  (list inline:c)
+  ^-  story:c
+  %+  roll  cs
+  |=  [con=content:gra p=(list block:c) q=(list inline:c)]
+  ^-  story:c
   ?-  -.con
-    %text       (fall (rush text.con apex:parse) ~[text.con])
-    %mention    ~[`@t`(scot %p ship.con)]
-    %url        [%link [. .]:url.con]~
-    %code       [%inline-code expression.con]~
-    %reference  ~  :: shouldn't hit this
+    %text       [p (welp q (fall (rush text.con apex:parse) ~[text.con]))]
+    %mention    [p (snoc q ship/ship.con)]
+    %url        [p (snoc q [%link [. .]:url.con])] :: XX: maybe try pull images?
+    %code       [p (snoc q [%inline-code expression.con])]
+    %reference  :_(q (snoc p (ref reference.con)))
   ==
-  ++  con
-    |=  cs=(list content:gra)
-    ^-  content:c
-    =/  fer=(unit id:c)  (ref cs)
-    ?~  fer  story/[~ (inline cs)]
-    =/  wer=path  /msg/(scot %p p.u.fer)/(scot %ud q.u.fer)
-    story/[(turn (cit cs) (lead %cite)) (inline cs)]
   ::
   ++  ref
-    |=  cs=(list content:gra)
-    ^-  (unit id:c)
-    %+  roll  cs
-    |=  [con=content:gra fer=(unit id:c)]
-    ?+     -.con  fer
-        %reference
-      ?.  ?=(%graph -.reference.con)  fer
-      =/  [res=resource:gra author=ship =index:gra]
-      :*  resource.uid.reference.con
-          entity.resource.uid.reference.con
-          index.uid.reference.con
-      ==
-      ::  XX unsure about this bunt
-      =-  `[author -]
-      ?~(index *@da `@da`(head index))
-    ==
-  ::
-  ++  cit
-    |=  cs=(list content:gra)
-    ^-  (list cite:cite)
-    =;  refs
-      %+  turn  refs
-      |=  =reference:gra
-      ?-    -.reference
-          %graph
-        =/  grp=resource:gra  group:reference
-        =/  [res=resource:gra idx=index:gra]  uid:reference
-        =/  =time  ?~(idx *time (head idx))
-        =/  wer=path
-          /msg/(scot %p entity.res)/(scot %ud time)
-        ?.  =(grp flag)  [%bait grp flag wer]
-        =/  =nest:g  [%chat res]
-          [%chan nest wer]
-        ::
-          %group  *cite:cite :: XX TODO: shia lebouf says just do it
-        ::
-          %app  *cite:cite :: XX TODO: do it
-      ==
+    |=  ref=reference:gra
+    ^-  block:c
+    =;  =cite
+      [%cite cite]
+    ?-    -.ref
+        %group  [%group group.ref]
+        %app    [%desk [ship desk] path]:ref
     ::
-    %+  roll  cs
-    |=  [con=content:gra fer=(list reference:gra)]
-    ?+     -.con  fer
-        %reference
-      (snoc fer reference.con)
+        %graph
+      ?.  ?&  =(resource.uid.ref flag)
+              ?=(?(~ [@ ~]) index.uid.ref)
+              =(%chat dude)
+          ==
+        [%bait group.ref uid.ref]
+      =/  wer=path
+         ?~  index.uid.ref   /
+         [%msg index.uid.ref]
+      [%chan [dude flag] wer]
     ==
-    ::
   --
   ::
 ::

--- a/desk/lib/chat-graph.hoon
+++ b/desk/lib/chat-graph.hoon
@@ -1,23 +1,10 @@
-/-  c=chat
+/-  c=chat, g=groups
+/-  cite
 /+  gra=graph-store
 /+  pac=dm
 |%
-++  convert
-  |=  =graph:gra
-  ^-  pact:c
-  =|  =pact:c
-  =/  nodes=(list (pair atom node:gra))
-    (tap:orm:gra graph)
-  |- 
-  ?~  nodes
-    ~&  'nothing to do :('
-    pact
-  =/  node  i.nodes
-  ?~  mem=(node-to-memo q.node)
-    $(nodes t.nodes)
-  =/  =id:c
-    [author.u.mem p.node] :: technically wrong, but defends against poor clients
-  $(nodes t.nodes, pact (~(reduce pac pact) p.node id %add u.mem))
+++  nert
+  |_  =flag:g
 ++  node-to-memo
   |=  =node:gra
   ^-  (unit memo:c)
@@ -30,12 +17,6 @@
       sent=time-sent.p
       contents=(con contents.p)
   ==
-
-++  con
-  |=  cs=(list content:gra)
-  ^-  content:c
-  story/[~ (inline cs)]
-::
 ++  inline
   |=  cs=(list content:gra)
   ^-  (list inline:c)
@@ -48,8 +29,65 @@
     %mention    ~[`@t`(scot %p ship.con)]
     %url        [%link [. .]:url.con]~
     %code       [%inline-code expression.con]~
-    %reference  ~['elided reference'] :: TODO fix?
+    %reference  ~  :: shouldn't hit this
   ==
+  ++  con
+    |=  cs=(list content:gra)
+    ^-  content:c
+    =/  fer=(unit id:c)  (ref cs)
+    ?~  fer  story/[~ (inline cs)]
+    =/  wer=path  /msg/(scot %p p.u.fer)/(scot %ud q.u.fer)
+    story/[(turn (cit cs) (lead %cite)) (inline cs)]
+  ::
+  ++  ref
+    |=  cs=(list content:gra)
+    ^-  (unit id:c)
+    %+  roll  cs
+    |=  [con=content:gra fer=(unit id:c)]
+    ?+     -.con  fer
+        %reference
+      ?.  ?=(%graph -.reference.con)  fer
+      =/  [res=resource:gra author=ship =index:gra]
+      :*  resource.uid.reference.con
+          entity.resource.uid.reference.con
+          index.uid.reference.con
+      ==
+      ::  XX unsure about this bunt
+      =-  `[author -]
+      ?~(index *@da `@da`(head index))
+    ==
+  ::
+  ++  cit
+    |=  cs=(list content:gra)
+    ^-  (list cite:cite)
+    =;  refs
+      %+  turn  refs
+      |=  =reference:gra
+      ?-    -.reference
+          %graph
+        =/  grp=resource:gra  group:reference
+        =/  [res=resource:gra idx=index:gra]  uid:reference
+        =/  =time  ?~(idx *time (head idx))
+        =/  wer=path
+          /msg/(scot %p entity.res)/(scot %ud time)
+        ?.  =(grp flag)  [%bait grp flag wer]
+        =/  =nest:g  [%chat res]
+          [%chan nest wer]
+        ::
+          %group  *cite:cite :: XX TODO: shia lebouf says just do it
+        ::
+          %app  *cite:cite :: XX TODO: do it
+      ==
+    ::
+    %+  roll  cs
+    |=  [con=content:gra fer=(list reference:gra)]
+    ?+     -.con  fer
+        %reference
+      (snoc fer reference.con)
+    ==
+    ::
+  --
+  ::
 ::
 ++  parse
   |%

--- a/desk/lib/cite-json.hoon
+++ b/desk/lib/cite-json.hoon
@@ -48,8 +48,8 @@
       ::
       :-  %bait
       %-  ot
-      :~  old/flag:dejs:j
-          flag/flag:dejs:j
+      :~  group/flag:dejs:j
+          graph/flag:dejs:j
           where/pa
       ==
   ==

--- a/desk/lib/cite-json.hoon
+++ b/desk/lib/cite-json.hoon
@@ -22,8 +22,8 @@
   ::
       %bait
     %-  pairs
-    :~  old/s/(flag:enjs:j old.cite)
-        flag/s/(flag:enjs:j flag.cite)
+    :~  group/s/(flag:enjs:j grp.cite)
+        graph/s/(flag:enjs:j gra.cite)
         where/s/(spat wer.cite)
     ==
   ==

--- a/desk/lib/cite-json.hoon
+++ b/desk/lib/cite-json.hoon
@@ -19,6 +19,13 @@
     :~  nest/s/(nest:enjs:j nest.cite)
         where/s/(spat wer.cite)
     ==
+  ::
+      %bait
+    %-  pairs
+    :~  old/s/(flag:enjs:j old.cite)
+        flag/s/(flag:enjs:j flag.cite)
+        where/s/(spat wer.cite)
+    ==
   ==
 ::
 ++  dejs
@@ -36,6 +43,13 @@
       :-  %chan
       %-  ot
       :~  nest/nest:dejs:j
+          where/pa
+      ==
+      ::
+      :-  %bait
+      %-  ot
+      :~  old/flag:dejs:j
+          flag/flag:dejs:j
           where/pa
       ==
   ==

--- a/desk/sur/cite.hoon
+++ b/desk/sur/cite.hoon
@@ -35,7 +35,7 @@
     %chan   chan/(welp (nest nest.c) wer.c)
     %desk   desk/(welp (flag flag.c) wer.c)
     %group  group/(flag flag.c)
-    %bait   bait/(flag flag.c)
+    %bait   bait/:(welp (flag grp.c) (flag gra.c) wer.c)
   ==
   ++  flag
     |=  f=flag:g
@@ -49,7 +49,7 @@
   $%  [%chan =nest:g wer=path]
       [%group =flag:g]
       [%desk =flag:g wer=path]
-      [%bait old=flag:g =flag:g wer=path]
+      [%bait grp=flag:g gra=flag:g wer=path]
       :: scry into groups when you receive a bait for a chat that doesn't exist yet
       :: work out what app
   ==

--- a/desk/sur/cite.hoon
+++ b/desk/sur/cite.hoon
@@ -35,6 +35,7 @@
     %chan   chan/(welp (nest nest.c) wer.c)
     %desk   desk/(welp (flag flag.c) wer.c)
     %group  group/(flag flag.c)
+    %bait   bait/(flag flag.c)
   ==
   ++  flag
     |=  f=flag:g
@@ -48,6 +49,9 @@
   $%  [%chan =nest:g wer=path]
       [%group =flag:g]
       [%desk =flag:g wer=path]
+      [%bait old=flag:g =flag:g wer=path]
+      :: scry into groups when you receive a bait for a chat that doesn't exist yet
+      :: work out what app
   ==
 --
 

--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -1,42 +1,39 @@
-import { useBait } from '@/state/chat';
-// eslint-disable-next-line import/no-cycle
-import WritReference from './WritReference';
-
-interface BaitReferenceProps {
-  old: string;
-  flag: string;
-  where: string;
-  isScrolling: boolean;
-}
+import { useGroup } from '@/state/groups';
+import { BaitCite } from '@/types/chat';
+import cn from 'classnames';
+import React from 'react';
+import ExclamationPoint from '../icons/ExclamationPoint';
 
 export default function BaitReference({
-  old,
-  flag,
+  group,
+  graph,
   where,
-  isScrolling,
-}: BaitReferenceProps) {
-  const bait = useBait(old, flag, where);
-  if (!bait) {
-    return (
-      <div className="writ-inline-block group">
-        {`exists: ${bait}`} {old} {flag} {where}
-      </div>
-    );
-  }
+}: BaitCite['bait']) {
+  const theGroup = useGroup(group);
+  const groupTitle = theGroup?.meta.title;
 
-  if (bait.exists) {
-    return (
-      <WritReference
-        chFlag={''}
-        nest={''}
-        idWrit={''}
-        isScrolling={isScrolling}
-      />
-    );
-  }
   return (
-    <div className="writ-inline-block group">
-      {`exists: ${bait}`} {old} {flag} {where}
+    <div className="heap-inline-block group">
+      <div className="h-full w-full p-2">
+        <div className="flex h-full w-full flex-col items-center justify-center rounded-lg bg-gray-50 font-semibold text-gray-600">
+          <ExclamationPoint className="mb-3 h-12 w-12" />
+          <span>This content is still being migrated.</span>
+          <span className="font-mono">{where}</span>
+        </div>
+      </div>
+      <div className="flex items-center justify-between border-t-2 border-gray-50 p-2 group-hover:bg-gray-50">
+        <div className="flex cursor-pointer items-center space-x-2 text-gray-400 group-hover:text-gray-600">
+          <span className="font-semibold">{graph}</span>
+          {groupTitle ? (
+            <>
+              <span className="font-bold">•</span>
+              <span className="font-semibold">{groupTitle}</span>
+            </>
+          ) : (
+            group
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -1,0 +1,42 @@
+import { useBait } from '@/state/chat';
+// eslint-disable-next-line import/no-cycle
+import WritReference from './WritReference';
+
+interface BaitReferenceProps {
+  old: string;
+  flag: string;
+  where: string;
+  isScrolling: boolean;
+}
+
+export default function BaitReference({
+  old,
+  flag,
+  where,
+  isScrolling,
+}: BaitReferenceProps) {
+  const bait = useBait(old, flag, where);
+  if (!bait) {
+    return (
+      <div className="writ-inline-block group">
+        {`exists: ${bait}`} {old} {flag} {where}
+      </div>
+    );
+  }
+
+  if (bait.exists) {
+    return (
+      <WritReference
+        chFlag={''}
+        nest={''}
+        idWrit={''}
+        isScrolling={isScrolling}
+      />
+    );
+  }
+  return (
+    <div className="writ-inline-block group">
+      {`exists: ${bait}`} {old} {flag} {where}
+    </div>
+  );
+}

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { nestToFlag } from '@/logic/utils';
 import { Cite } from '@/types/chat';
 import { udToDec } from '@urbit/api';
-import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import CurioReference from './CurioReference';
 // eslint-disable-next-line import/no-cycle
 import WritReference from './WritReference';
 import GroupReference from './GroupReference';
 import NoteReference from './NoteReference';
 import AppReference from './AppReference';
+// eslint-disable-next-line import/no-cycle
+import BaitReference from './BaitReference';
 
 function ContentReference({
   cite,
@@ -26,6 +27,10 @@ function ContentReference({
     return <AppReference desk={desk} isScrolling={isScrolling} />;
   }
 
+  if ('bait' in cite) {
+    const { old, flag, where } = cite.bait;
+    return <BaitReference old={old} flag={flag} where={where} />;
+  }
   if ('chan' in cite) {
     const { nest, where } = cite.chan;
     const [app, chFlag] = nestToFlag(cite.chan.nest);

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -8,7 +8,6 @@ import WritReference from './WritReference';
 import GroupReference from './GroupReference';
 import NoteReference from './NoteReference';
 import AppReference from './AppReference';
-// eslint-disable-next-line import/no-cycle
 import BaitReference from './BaitReference';
 
 function ContentReference({
@@ -28,8 +27,7 @@ function ContentReference({
   }
 
   if ('bait' in cite) {
-    const { old, flag, where } = cite.bait;
-    return <BaitReference old={old} flag={flag} where={where} />;
+    return <BaitReference {...cite.bait} />;
   }
   if ('chan' in cite) {
     const { nest, where } = cite.chan;

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -371,7 +371,11 @@ export function citeToPath(cite: Cite) {
   if ('chan' in cite) {
     return `/1/chan/${cite.chan.nest}${cite.chan.where}`;
   }
-  return `/1/group/${cite.group}`;
+  if ('group' in cite) {
+    return `/1/group/${cite.group}`;
+  }
+
+  return `/1/bait/${cite.bait.group}/${cite.bait.graph}/${cite.bait.where}`;
 }
 
 export function pathToCite(path: string): Cite | undefined {

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -985,23 +985,6 @@ type UnsubbedWrit = {
   writ: ChatWrit;
 };
 
-type UnsubbedBait = {
-  exists: boolean;
-};
-
-export function useBait(old: string, flag: string, where: string) {
-  const [res, setRes] = useState(null as UnsubbedBait | null);
-  useEffect(() => {
-    subscribeOnce<UnsubbedBait>('nark', `/bait/${old}/${flag}/${where}`).then(
-      setRes
-    );
-
-    return () => {
-      setRes(null);
-    };
-  }, [old, flag, where]);
-  return res;
-}
 const selLoadedRefs = (s: ChatState) => s.loadedRefs;
 export function useWritByFlagAndWritId(
   chFlag: string,

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -985,6 +985,23 @@ type UnsubbedWrit = {
   writ: ChatWrit;
 };
 
+type UnsubbedBait = {
+  exists: boolean;
+};
+
+export function useBait(old: string, flag: string, where: string) {
+  const [res, setRes] = useState(null as UnsubbedBait | null);
+  useEffect(() => {
+    subscribeOnce<UnsubbedBait>('nark', `/bait/${old}/${flag}/${where}`).then(
+      setRes
+    );
+
+    return () => {
+      setRes(null);
+    };
+  }, [old, flag, where]);
+  return res;
+}
 const selLoadedRefs = (s: ChatState) => s.loadedRefs;
 export function useWritByFlagAndWritId(
   chFlag: string,

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -31,8 +31,8 @@ export interface GroupCite {
 
 export interface BaitCite {
   bait: {
-    old: string;
-    flag: string;
+    group: string;
+    graph: string;
     where: string;
   };
 }

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -29,6 +29,14 @@ export interface GroupCite {
   group: string;
 }
 
+export interface BaitCite {
+  bait: {
+    old: string;
+    flag: string;
+    where: string;
+  };
+}
+
 export interface DeskCite {
   desk: {
     desk: string;
@@ -36,7 +44,7 @@ export interface DeskCite {
   };
 }
 
-export type Cite = ChanCite | GroupCite | DeskCite;
+export type Cite = ChanCite | GroupCite | DeskCite | BaitCite;
 
 export type ChatBlock = ChatImage | { cite: Cite };
 

--- a/ui/src/types/diary.ts
+++ b/ui/src/types/diary.ts
@@ -70,8 +70,8 @@ export interface DeskCite {
 
 export interface BaitCite {
   bait: {
-    old: string;
-    flag: string;
+    group: string;
+    graph: string;
     where: string;
   };
 }

--- a/ui/src/types/diary.ts
+++ b/ui/src/types/diary.ts
@@ -68,7 +68,15 @@ export interface DeskCite {
   };
 }
 
-export type Cite = ChanCite | GroupCite | DeskCite;
+export interface BaitCite {
+  bait: {
+    old: string;
+    flag: string;
+    where: string;
+  };
+}
+
+export type Cite = ChanCite | GroupCite | DeskCite | BaitCite;
 
 export interface DiaryCite {
   cite: Cite;


### PR DESCRIPTION
Adds a `%bait` field to `%cite` representing an imported reference.

a `%bait` will only appear through the migrate flow and only when the
group being imported is not the same as the group holding the referenced
source. This disctinction must be made because `%cite` may not contain
enough information to reconstruct the imported reference, since the host
of the given reference may not have migrated yet.

Thus, `%bait` is primarily a placeholder for a potentially unresolvable
reference that will be handled at a later date by the `%nark` app. This
will allow us to begin the migration without losing the necessary data
needed to reconstruct refs.

(This will be available to anyone who migrates, so an enterprising
developer could theoretically create custom reference types for
imported instances.)