### PR TITLE
migration: changing import flag tracking for better logic

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -34,6 +34,7 @@
         bad=(set ship)
         inv=(set ship)
         voc=(map [flag:c id:c] (unit said:c))
+        ::  true represents imported, false pending import
         imp=(map flag:c ?)
     ==
   --

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -34,7 +34,7 @@
         bad=(set ship)
         inv=(set ship)
         voc=(map [flag:c id:c] (unit said:c))
-        imp=(set flag:g)
+        imp=(map flag:c ?)
     ==
   --
 =|  current-state
@@ -161,7 +161,14 @@
   |^  ^+  cor 
   ?+    mark  ~|(bad-poke/mark !!)
   ::
-      %import-flags   cor(imp !<((set flag:c) vase))
+      %import-flags
+    =+  !<(flags=(set flag:c) vase)
+    =.  imp  %-  ~(gas by *(map flag:c ?))
+      ^-  (list [flag:c ?])
+      %+  turn
+        ~(tap in flags)
+      |=(=flag:c [flag |])
+    cor
       %graph-imports  (import !<(imports:c vase))
   ::
       %dm-imports     (import-dms !<(graph:gra:c vase))
@@ -426,9 +433,9 @@
         perm
         pact
     ==
-  =.  imp    (~(del in imp) flag)
+  =.  imp    (~(put by imp) flag &)
   =.  cor
-    (give %fact ~[/imp] flags+!>(imp))
+    (give %fact ~[/imp] migrate-map+!>(imp))
   =.  chats  (~(put by chats) flag chat)
   =.  cor
     ca-abet:(ca-import:(ca-abed:ca-core flag) writers association)
@@ -561,7 +568,7 @@
   |=  =path
   ^-  (unit (unit cage))
   ?+  path  [~ ~]
-    [%x %imp ~]   ``flags+!>(imp)
+    [%x %imp ~]   ``migrate-map+!>(imp)
   ::
     [%x %chat ~]  ``flags+!>(~(key by chats))
   ::

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -17,7 +17,7 @@
     $:  %0
         =shelf:d
         voc=(map [flag:d time] (unit said:d))
-        imp=(set flag:d)
+        imp=(map flag:d ?)
     ==
   --
 =|  current-state
@@ -160,7 +160,14 @@
   ?+    mark  ~|(bad-poke/mark !!)
   ::
       %graph-imports  (import !<(imports:d vase))
-      %import-flags   cor(imp !<((set flag:d) vase))
+      %import-flags
+    =+  !<(flags=(set flag:d) vase)
+    =.  imp  %-  ~(gas by *(map flag:d ?))
+      ^-  (list [flag:d ?])
+      %+  turn 
+        ~(tap in flags) 
+      |=(=flag:d [flag |])
+    cor
   ::
       ?(%flag %channel-join)
     =+  !<(=flag:d vase)
@@ -253,8 +260,9 @@
         remark
     ==
   =.  shelf  (~(put by shelf) flag diary)
-  =.  imp    (~(del in imp) flag)
-  =.  cor    (give %fact ~[/imp] flags+!>(imp))
+  =.  imp    (~(put by imp) flag &)
+  =.  cor
+    (give %fact ~[/imp] migrate-map+!>(imp))
   =.  cor    di-abet:(di-import:(di-abed:di-core flag) writers association)
   loop(imports t.imports)
   ::
@@ -487,7 +495,7 @@
   ^-  (unit (unit cage))
   ?+  path  [~ ~]
   ::
-    [%x %imp ~]    ``flags+!>(imp)
+    [%x %imp ~]    ``migrate-map+!>(imp)
   ::
     [%x %shelf ~]  ``shelf+!>(shelf)
   ::

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -17,6 +17,7 @@
     $:  %0
         =shelf:d
         voc=(map [flag:d time] (unit said:d))
+        ::  true represents imported, false pending import
         imp=(map flag:d ?)
     ==
   --

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -14,6 +14,7 @@
     $:  %0
         =stash:h
         voc=(map [flag:h time] (unit said:h))
+        ::  true represents imported, false pending import
         imp=(map flag:h ?)
     ==
   ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -14,7 +14,7 @@
     $:  %0
         =stash:h
         voc=(map [flag:h time] (unit said:h))
-        imp=(set flag:h)
+        imp=(map flag:h ?)
     ==
   ::
   --
@@ -99,7 +99,14 @@
   ?+    mark  ~|(bad-poke/mark !!)
   ::
       %graph-imports  (import-graphs !<(imports:h vase))
-      %import-flags   cor(imp !<((set flag:h) vase))
+      %import-flags
+    =+  !<(flags=(set flag:h) vase)
+    =.  imp  %-  ~(gas by *(map flag:h ?))
+      ^-  (list [flag:h ?])
+      %+  turn
+        ~(tap in flags) 
+      |=(=flag:h [flag |])
+    cor
   ::
       ?(%flag %channel-join)
     =+  !<(=flag:h vase)
@@ -368,7 +375,7 @@
   ?+  path  [~ ~]
   ::
     [%x %stash ~]  ``stash+!>(stash)
-    [%x %imp ~]    ``flags+!>(imp)
+    [%x %imp ~]    ``migrate-map+!>(imp)
   ::
       [%x %heap @ @ *]
     =/  =ship  (slav %p i.t.t.path)
@@ -407,8 +414,9 @@
       curios
       [now.bowl | ~]
     ==
-  =.  imp  (~(del in imp) flag)
-  =.  cor  (give %fact ~[/imp] flags+!>(imp))
+  =.  imp    (~(put by imp) flag &)
+  =.  cor
+    (give %fact ~[/imp] migrate-map+!>(imp))
   =.  cor
     he-abet:(he-import:(he-abed:he-core flag) writers association)
   loop(imports t.imports)

--- a/desk/mar/migrate-map.hoon
+++ b/desk/mar/migrate-map.hoon
@@ -1,0 +1,20 @@
+/-  g=groups
+/+  j=groups-json
+|_  flags=(map flag:g ?)
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  flags
+  ++  json
+    |=  fs=(map flag:g ?)
+    =,  enjs:format
+    %-  pairs
+    %+  turn  ~(tap by fs)
+    |=  [f=flag:g mig=?]
+    [(rap 3 (scot %p p.f) '/' q.f ~) b+mig]
+  --
+++  grab
+  |%
+  ++  noun  (map flag:g ?)
+  --
+--

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -120,7 +120,7 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
       .filter(
         ([nest, chan]) =>
           (isChannelJoined(nest, briefs) && canReadChannel(chan, vessel)) ||
-          pendingImports.includes(nest)
+          nest in pendingImports
       )
       .map(([nest, channel]) => {
         const [, chFlag] = nestToFlag(nest);

--- a/ui/src/logic/useMigrationInfo.ts
+++ b/ui/src/logic/useMigrationInfo.ts
@@ -17,6 +17,8 @@ export function useStartedMigration() {
   const chats = useChats();
   const stash = useHeapState(selStash);
   const shelf = useDiaryState(selShelf);
+  const pendingImports = usePendingImports();
+  const pendingShips = Object.keys(pendingImports).map(getNestShip);
   const ships = useMemo(
     () => [
       ...Object.keys(chats).map(getShip),
@@ -26,7 +28,13 @@ export function useStartedMigration() {
     [chats, stash, shelf]
   );
 
-  return useCallback((ship: string) => ships.includes(ship), [ships]);
+  return useCallback(
+    (ship: string) => {
+      const inPending = pendingShips.includes(ship);
+      return !inPending || (inPending && ships.includes(ship));
+    },
+    [ships, pendingShips]
+  );
 }
 
 export function useHasMigratedChannels(flag: string) {

--- a/ui/src/logic/usePendingImports.ts
+++ b/ui/src/logic/usePendingImports.ts
@@ -1,10 +1,11 @@
+import _ from 'lodash';
 import { useChatState } from '@/state/chat';
 import { useDiaryState } from '@/state/diary';
 import { useHeapState } from '@/state/heap/heap';
 import { useMemo } from 'react';
 
 interface ChannelAgent {
-  pendingImports: string[];
+  pendingImports: Record<string, boolean>;
 }
 
 const selPendImports = (s: ChannelAgent) => s.pendingImports;
@@ -15,12 +16,11 @@ export default function usePendingImports() {
   const diaries = useDiaryState(selPendImports);
 
   return useMemo(
-    () =>
-      ([] as string[]).concat(
-        chats.map((c) => `chat/${c}`),
-        heaps.map((h) => `heap/${h}`),
-        diaries.map((d) => `diary/${d}`)
-      ),
+    () => ({
+      ..._.mapKeys(chats, (v, c) => `chat/${c}`),
+      ..._.mapKeys(heaps, (v, h) => `heap/${h}`),
+      ..._.mapKeys(diaries, (v, d) => `diary/${d}`),
+    }),
     [chats, heaps, diaries]
   );
 }

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -465,6 +465,12 @@ export function getNestShip(nest: string) {
   return ship;
 }
 
-export function isChannelImported(nest: string, pending: string[]) {
-  return !pending.includes(nest) || window.our === getNestShip(nest);
+export function isChannelImported(
+  nest: string,
+  pending: Record<string, boolean>
+) {
+  const isImport = nest in pending;
+  return (
+    !isImport || (isImport && pending[nest]) || window.our === getNestShip(nest)
+  );
 }

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -127,7 +127,7 @@ export const useChatState = createState<ChatState>(
     dmSubs: [],
     multiDmSubs: [],
     pendingDms: [],
-    pendingImports: [],
+    pendingImports: {},
     pins: [],
     sentMessages: [],
     postedMessages: [],
@@ -305,7 +305,7 @@ export const useChatState = createState<ChatState>(
         },
       });
 
-      const pendingImports = await api.scry<string[]>({
+      const pendingImports = await api.scry<Record<string, boolean>>({
         app: 'chat',
         path: '/imp',
       });
@@ -317,7 +317,7 @@ export const useChatState = createState<ChatState>(
       api.subscribe({
         app: 'chat',
         path: '/imp',
-        event: (imports: string[]) => {
+        event: (imports: Record<string, boolean>) => {
           get().batchSet((draft) => {
             draft.pendingImports = imports;
           });

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -29,7 +29,7 @@ export interface ChatState {
   drafts: {
     [whom: string]: ChatStory;
   };
-  pendingImports: string[];
+  pendingImports: Record<string, boolean>;
   chatSubs: string[];
   dmSubs: string[];
   sentMessages: string[];

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -94,7 +94,7 @@ export const useDiaryState = create<DiaryState>(
       diarySubs: [],
       loadedNotes: {},
       briefs: {},
-      pendingImports: [],
+      pendingImports: {},
       markRead: async (flag) => {
         await api.poke({
           app: 'diary',
@@ -197,7 +197,7 @@ export const useDiaryState = create<DiaryState>(
           },
         });
 
-        const pendingImports = await api.scry<string[]>({
+        const pendingImports = await api.scry<Record<string, boolean>>({
           app: 'diary',
           path: '/imp',
         });
@@ -209,7 +209,7 @@ export const useDiaryState = create<DiaryState>(
         api.subscribe({
           app: 'diary',
           path: '/imp',
-          event: (imports: string[]) => {
+          event: (imports: Record<string, boolean>) => {
             get().batchSet((draft) => {
               draft.pendingImports = imports;
             });

--- a/ui/src/state/diary/type.ts
+++ b/ui/src/state/diary/type.ts
@@ -24,7 +24,7 @@ export interface DiaryState {
     [flag: DiaryFlag]: DiaryNoteMap;
   };
   briefs: DiaryBriefs;
-  pendingImports: string[];
+  pendingImports: Record<string, boolean>;
   create: (req: DiaryCreate) => Promise<void>;
   start: () => Promise<void>;
   fetchNote: (flag: DiaryFlag, noteId: string) => Promise<void>;

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -89,7 +89,7 @@ export const useHeapState = create<HeapState>(
       heapSubs: [],
       loadedRefs: {},
       briefs: {},
-      pendingImports: [],
+      pendingImports: {},
       markRead: async (flag) => {
         await api.poke({
           app: 'heap',
@@ -168,7 +168,7 @@ export const useHeapState = create<HeapState>(
           },
         });
 
-        const pendingImports = await api.scry<string[]>({
+        const pendingImports = await api.scry<Record<string, boolean>>({
           app: 'heap',
           path: '/imp',
         });
@@ -180,7 +180,7 @@ export const useHeapState = create<HeapState>(
         api.subscribe({
           app: 'heap',
           path: '/imp',
-          event: (imports: string[]) => {
+          event: (imports: Record<string, boolean>) => {
             get().batchSet((draft) => {
               draft.pendingImports = imports;
             });

--- a/ui/src/state/heap/type.ts
+++ b/ui/src/state/heap/type.ts
@@ -23,7 +23,7 @@ export interface HeapState {
     [flag: HeapFlag]: HeapCurioMap;
   };
   briefs: HeapBriefs;
-  pendingImports: string[];
+  pendingImports: Record<string, boolean>;
   create: (req: HeapCreate) => Promise<void>;
   start: () => Promise<void>;
   initialize: (flag: HeapFlag) => Promise<void>;


### PR DESCRIPTION
Deleting the flags was removing a key piece of information so instead I changed it to work as a map and we just mark a boolean flag once import is complete. This way we know when to ignore migration guards for groups/channels. 

As it stands before this pr, if you were to make a completely new group/channel they would show as pending migration.