### PR TITLE
migration: fix cover values and bad mark

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -499,7 +499,8 @@
   ++  old-to-new-meta
     |=  =metadatum:m-one
     ^-  data:meta
-    =,(metadatum [title description picture (scot %ux color)])
+    =/  hex  (crip (welp ~['#'] (trip (en:base16:mimes:html 3 color))))
+    =,(metadatum [title description picture hex])
   ::
   ++  policy-to-cordon
     |=  =policy:g-one

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -496,11 +496,13 @@
    |=  =association:m-one
    (old-to-new-meta metadatum.association)
   ::
+  ++  get-hex
+    |=  =color:m-one
+    (crip (welp ~['#'] (trip (en:base16:mimes:html 3 color))))
   ++  old-to-new-meta
     |=  =metadatum:m-one
     ^-  data:meta
-    =/  hex  (crip (welp ~['#'] (trip (en:base16:mimes:html 3 color))))
-    =,(metadatum [title description picture hex])
+    =,(metadatum [title description picture (get-hex color)])
   ::
   ++  policy-to-cordon
     |=  =policy:g-one

--- a/desk/mar/migrate-map.hoon
+++ b/desk/mar/migrate-map.hoon
@@ -11,7 +11,7 @@
     %-  pairs
     %+  turn  ~(tap by fs)
     |=  [f=flag:g mig=?]
-    [(rap 3 (scot %p p.f) '/' q.f ~) b+mig]
+    [s+(rap 3 (scot %p p.f) '/' q.f ~) b+mig]
   --
 ++  grab
   |%


### PR DESCRIPTION
This fixes the issue with cover values other than `0x0` and also fix the mark conversion.