### PR TITLE
final pieces before migration

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -989,7 +989,7 @@
     ?>  (ca-can-read src.bowl)
     ?>  ?=([@ ~] wer)
     =/  time=@   (slav %ud i.wer)
-    =.  cor  (give-kick ~ %chat-said !>((got:on:writs:c wit.pact.chat time)))
+    =.  cor  (give-kick ~ %chat-said !>([flag (got:on:writs:c wit.pact.chat time)]))
     ca-core
   ::
   ++  ca-said

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -510,6 +510,7 @@
 ++  take-said
   |=  [=flag:c =id:c =sign:agent:gall]
   ^+  cor
+  =/  wire  (said-wire flag id)
   ?+    -.sign  !!
       %watch-ack
     %.  cor
@@ -519,11 +520,15 @@
       %kick
     ?:  (~(has by voc) [flag id])
       cor  :: subscription ended politely
-    (proxy-said flag id)
+    ::  XX: only versioned subscriptions should rewatch on kick
+    (give %kick ~[wire] ~)
+    :: (proxy-said flag id)  
   ::
       %fact
     =.  cor
-      (give %fact ~[(said-wire flag id)] cage.sign)
+      (give %fact ~[wire] cage.sign)
+    =.  cor
+      (give %kick ~[wire] ~)
     ?+    p.cage.sign  ~|(funny-mark/p.cage.sign !!)
         %chat-said
       =+  !<(=said:c q.cage.sign)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -34,6 +34,7 @@
         bad=(set ship)
         inv=(set ship)
         voc=(map [flag:c id:c] (unit said:c))
+        fish=(map [flag:c @] id:c)
         ::  true represents imported, false pending import
         imp=(map flag:c ?)
     ==
@@ -283,17 +284,20 @@
       [%briefs ~]  ?>(from-self cor)
       [%ui ~]  ?>(from-self cor)
       [%dm %invited ~]  ?>(from-self cor)
-    ::
+  ::
       [%epic ~]
     (give %fact ~ epic+!>(okay))
-    ::
+  ::
       [%said host=@ name=@ %msg sender=@ time=@ ~]
     =/  host=ship  (slav %p host.pole)
     =/  =flag:c     [host name.pole]
     =/  sender=ship  (slav %p sender.pole)
     =/  =id:c       [sender (slav %ud time.pole)]
     (watch-said flag id)
-    ::
+  ::
+      [%hook host=@ name=@ rest=*]
+    =,(pole (watch-hook [(slav %p host) name] rest))
+  ::
       [%chat ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
     ?>  (ca-can-read:(ca-abed:ca-core [ship name.pole]) src.bowl)
@@ -316,6 +320,9 @@
   ::
       [%epic ~]
     (take-epic sign)
+  ::
+      [%hook host=@ name=@ rest=*]
+    =,(pole (take-hook [(slav %p host) name] rest sign))
   ::
       [%said host=@ name=@ %msg sender=@ time=@ ~]
     =/  host=ship    (slav %p host.pole)
@@ -357,6 +364,43 @@
       ?.  =(%group-action-0 p.cage.sign)  cor
       (take-groups !<(=action:g q.cage.sign))
     ==
+  ==
+++  give-kick
+  |=  [pas=(list path) =cage]
+  =.  cor  (give %fact pas cage)
+  (give %kick ~ ~)
+::
+++  watch-hook
+  |=  [=flag:g wer=path]
+  ^+  cor
+  ?:  (~(has by chats) flag)
+    ca-abet:(ca-hook:(ca-abed:ca-core flag) wer)
+  ?<  =(our.bowl flag)
+  ?>  ?=([@ ~] wer)
+  =/  time=@  (slav %ud i.wer)
+  ?^  fis=(~(get by fish) [flag time])
+    (give-kick ~ chat-said+!>((~(got by voc) flag u.fis)))
+  =/  =path  (welp /hook/(scot %p p.flag)/[q.flag] wer)
+  (emit %pass path %agent [p.flag dap.bowl] %watch path)
+::
+++  take-hook
+  |=  [=flag:g wer=path =sign:agent:gall]
+  ^+  cor
+  ?>  ?=([@ ~] wer)
+  =/  =path  (welp /hook/(scot %p p.flag)/[q.flag] wer)
+  ?+    -.sign  cor
+      %kick  (give %kick ~[path] ~)
+      %watch-ack
+    ?~  p.sign  cor
+    (give %kick ~[path] ~)
+  ::
+      %fact
+    ?.  =(%chat-said p.cage.sign)
+      cor
+    =+  !<(=said:c q.cage.sign)
+    =/  time=@  (slav %ud i.wer)
+    =.  fish    (~(put by fish) [flag time] id.q.said)
+    (give-kick ~[path] cage.sign)
   ==
 ::
 ++  import-clubs
@@ -940,21 +984,23 @@
     ::
     ==
   ::
+  ++  ca-hook
+    |=  wer=path
+    ?>  (ca-can-read src.bowl)
+    ?>  ?=([@ ~] wer)
+    =/  time=@   (slav %ud i.wer)
+    =.  cor  (give-kick ~ %chat-said !>((got:on:writs:c wit.pact.chat time)))
+    ca-core
+  ::
   ++  ca-said
     |=  =id:c
-    |^  ^+  ca-core
+    ^+  ca-core
     ?.  (ca-can-read src.bowl)
-      (give-kick chat-denied+!>(~))
-    =/  [=time =writ:c]  (got:ca-pact id)
-    %+  give-kick  %chat-said
-    !>  ^-  said:c
-    [flag writ]
-    ++  give-kick
-      |=  =cage
-      =.  cor  (give %fact ~ cage)
-      =.  cor  (give %kick ~ ~)
+      =.  cor  (give-kick ~ chat-denied+!>(~))
       ca-core
-    --
+    =/  [=time =writ:c]  (got:ca-pact id)
+    =.  cor  (give-kick ~ %chat-said !>([flag writ]))
+    ca-core
   ::
   ++  ca-upgrade
     ^+  ca-core

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -378,6 +378,7 @@
 ::
 ++  take-said
   |=  [=flag:d =time =sign:agent:gall]
+  =/  =wire  (said-wire flag time)
   ^+  cor
   ?+    -.sign  !!
       %watch-ack
@@ -388,11 +389,13 @@
       %kick
     ?:  (~(has by voc) [flag time])
       cor  :: subscription ended politely
-    (proxy-said flag time)
+    ::  XX: only versioned subscriptions should rewatch on kick
+    (give %kick ~[wire] ~)
+    :: (proxy-said flag time)  
   ::
       %fact
-    =.  cor
-      (give %fact ~[(said-wire flag time)] cage.sign)
+    =.  cor  (give %fact ~[wire] cage.sign)
+    =.  cor  (give %kick ~[wire] ~)
     ?+    p.cage.sign  ~|(funny-mark/p.cage.sign !!)
         %diary-said
       =+  !<(=said:d q.cage.sign)

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -16,7 +16,7 @@
   +$  current-state
     $:  %0
         =shelf:d
-        voc=(map [flag:d time] (unit said:d))
+        voc=(map [flag:d plan:d] (unit said:d))
         ::  true represents imported, false pending import
         imp=(map flag:d ?)
     ==
@@ -359,26 +359,28 @@
     =/  =ship  (slav %p ship.pole)
     di-abet:(di-watch:(di-abed:di-core ship name.pole) rest.pole)
     ::
-      [%said host=@ name=@ %note time=@ ~]
+      [%said host=@ name=@ %note time=@ quip=?(~ [@ ~])]
     =/  host=ship   (slav %p host.pole)
     =/  =flag:d     [host name.pole]
-    =/  =time       (slav %ud time.pole)
-    (watch-said flag time)
+    =/  =plan:d     =,(pole [(slav %ud time) ?~(quip ~ `(slav %ud -.quip))])
+    (watch-said flag plan)
   ==
 ::
 ++  watch-said
-  |=  [=flag:d =time]
+  |=  [=flag:d =plan:d]
   ?.  (~(has by shelf) flag)
-    (proxy-said flag time)
-  di-abet:(di-said:(di-abed:di-core flag) time)
+    (proxy-said flag plan)
+  di-abet:(di-said:(di-abed:di-core flag) plan)
 ++  said-wire
-  |=  [=flag:d =time]
+  |=  [=flag:d =plan:d]
   ^-  wire
-  /said/(scot %p p.flag)/[q.flag]/note/(scot %ud time)
+  %+  welp
+    /said/(scot %p p.flag)/[q.flag]/note/(scot %ud p.plan)
+  ?~(q.plan / /(scot %ud u.q.plan))
 ::
 ++  take-said
-  |=  [=flag:d =time =sign:agent:gall]
-  =/  =wire  (said-wire flag time)
+  |=  [=flag:d =plan:d =sign:agent:gall]
+  =/  =wire  (said-wire flag plan)
   ^+  cor
   ?+    -.sign  !!
       %watch-ack
@@ -387,7 +389,7 @@
     (slog leaf/"Preview failed" u.p.sign)
   ::
       %kick
-    ?:  (~(has by voc) [flag time])
+    ?:  (~(has by voc) [flag plan])
       cor  :: subscription ended politely
     ::  XX: only versioned subscriptions should rewatch on kick
     (give %kick ~[wire] ~)
@@ -399,19 +401,19 @@
     ?+    p.cage.sign  ~|(funny-mark/p.cage.sign !!)
         %diary-said
       =+  !<(=said:d q.cage.sign)
-      =.  voc  (~(put by voc) [flag time] `said)
+      =.  voc  (~(put by voc) [flag plan] `said)
       cor
     ::
         %diary-denied
-      =.  voc  (~(put by voc) [flag time] ~)
+      =.  voc  (~(put by voc) [flag plan] ~)
       cor
     ==
   ==
 ::
 ++  proxy-said
-  |=  [=flag:d =time]
+  |=  [=flag:d =plan:d]
   =/  =dock  [p.flag dap.bowl]
-  =/  wire  (said-wire flag time)
+  =/  wire  (said-wire flag plan)
   =/  =card  [%pass wire %agent dock %watch wire]
   (emit card)
 ::
@@ -433,11 +435,11 @@
     =/  =ship  (slav %p ship.pole)
     di-abet:(di-agent:(di-abed:di-core ship name.pole) rest.pole sign)
   ::
-      [%said host=@ name=@ %note time=@ ~]
+      [%said host=@ name=@ %note time=@ quip=?(~ [@ ~])]
     =/  host=ship   (slav %p host.pole)
     =/  =flag:d     [host name.pole]
-    =/  id=time     (slav %ud time.pole)
-    (take-said flag id sign)
+    =/  =plan:d     =,(pole [(slav %ud time) ?~(quip ~ `(slav %ud -.quip))])
+    (take-said flag plan sign)
   ::
       [%groups ~]
     ?+    -.sign  !!
@@ -567,11 +569,11 @@
     di-core
   ::
   ++  di-said
-    |=  =time
+    |=  =plan:d
     |^  ^+  di-core
     ?.  (di-can-read src.bowl)
       (give-kick diary-denied+!>(~))
-    =/  [* =note:d]  (got:di-notes time)
+    =/  [* =note:d]  (got:di-notes p.plan)
     =/  =outline:d  (trace:di-notes note)
     %+  give-kick  %diary-said
     !>  ^-  said:d

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -18,6 +18,8 @@
     $:  %0
         groups=net-groups:g
         xeno=gangs:g
+        shoal=(map flag:g dude:gall)
+
     ==
   ::
   --
@@ -208,6 +210,9 @@
   ::
     [%epic ~]  (give %fact ~ epic+!>(okay))
   ::
+      [%bait s=@ n=@ gs=@ gn=@ ~]
+    =,(pole (cast [(slav %p gs) gn] [(slav %p s) n]))
+  ::
       [%groups ship=@ name=@ rest=*]
     =/  ship=@p  (slav %p ship.pole)
     go-abet:(go-watch:(go-abed:group-core ship name.pole) rest.pole)
@@ -249,7 +254,6 @@
   ==
 ::
 ++  agent
-
   |=  [=(pole knot) =sign:agent:gall]
   ^+  cor
   ?+    pole  ~|(bad-agent-take/pole !!)
@@ -257,6 +261,7 @@
       [%epic ~]  (take-epic sign)
       [%hark ~]  cor
       [%helm *]  cor
+      [%cast ship=@ name=@ ~]  (take-cast [(slav %p ship.pole) name.pole] sign)
   ::
       [%groups ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
@@ -273,6 +278,7 @@
     =/  =ship  (slav %p ship.pole)
     =/  =nest:g  [app.pole ship name.pole]
     (take-chan nest sign)
+    
 
   ==
 ::
@@ -280,6 +286,49 @@
   |=  [=wire sign=sign-arvo]
   ^+  cor
   !!
+::
+++  cast
+  |=  [grp=flag:g gra=flag:g]
+  ^+  cor
+  ?^  dud=(~(get by shoal) gra)
+    =.  cor   (give %fact ~ dude+!>(u.dud))
+    (give %kick ~ ~)
+  =/  grp-path=path   /(scot %p p.grp)/[q.grp]
+  =/  gra-path=path   /(scot %p p.gra)/[q.gra]
+  =/  =wire          [%cast gra-path]
+  =/  =path          :(welp /groups grp-path /bait gra-path)
+  ?:  (~(has by wex.bowl) wire p.grp dap.bowl)
+    cor
+  (emit %pass wire %agent [p.grp dap.bowl] %watch path)
+::
+++  take-cast
+  |=  [gra=flag:g =sign:agent:gall]
+  ^+  cor
+  =/  matching=(list path)
+    =-  ~(tap in -)
+    %-  ~(gas in *(set path))
+    %+  murn  ~(val by sup.bowl)
+    |=  [=ship =path]
+    ^-  (unit ^path)
+    ?.  =((scag 3 path) [%bait (scot %p p.gra) q.gra ~])
+      ~
+    `path
+  ?+    -.sign  cor
+      %kick  (give %kick matching ~)
+  ::
+      %watch-ack
+    ?~  p.sign  cor
+    (give %kick matching ~)
+  ::
+      %fact
+    ?.  =(p.cage.sign %dude)
+      ~&  trash-fish/p.cage.sign
+      cor
+    =+  !<(=dude:gall q.cage.sign)
+    =.  shoal  (~(put by shoal) gra dude)
+    =.  cor  (give %fact matching cage.sign)
+    (give %kick matching ~)
+  ==
 ::
 ++  watch-epic
   |=  her=ship
@@ -665,10 +714,25 @@
   ++  go-watch
     |=  =(pole knot)
     ^+  go-core
-    ?+  pole  !!
-      [%updates rest=*]  (go-pub rest.pole)
-      [%ui ~]            go-core
-      [%preview ~]       go-preview
+    ?+    pole  !!
+        [%updates rest=*]  (go-pub rest.pole)
+        [%ui ~]            go-core
+        [%preview ~]       go-preview
+    ::
+        [%bait host=@ name=@ ~]
+      ?>  ?=(%open -.cordon.group)
+      =/  =flag:g  [(slav %p host.pole) name.pole]
+      =;  =nest:g
+        =.  cor  (give %fact ~ dude+!>(p.nest))
+        =.  cor  (give %kick ~ ~)
+        go-core
+      %-  need
+      %+  roll  ~(tap in imported.group)
+      |=  [=nest:g out=(unit nest:g)]
+      ^-  (unit nest:g)
+      ?.  =(~ out)  out
+      ?.  =(q.nest flag)  ~
+      `nest
     ==
   ::
   ++  go-preview

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -113,7 +113,7 @@
       [sects *time]
     =/  =group:g
       :*  fleet
-          ~  ~  ~  ~  ~
+          ~  ~  ~  ~  ~  ~
           cordon.create
           secret.create
           title.create
@@ -456,6 +456,7 @@
         zone-ord
         bloc
         channels
+        ~(key by channels)
         cordon
         =(%invite -.policy.group)
         meta

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -19,7 +19,6 @@
         groups=net-groups:g
         xeno=gangs:g
         shoal=(map flag:g dude:gall)
-
     ==
   ::
   --
@@ -515,6 +514,10 @@
       pub/(put:log-on:g *log:g import-epoch create/group)
     [%sub (sub import-epoch ~d1) | chi/~]
   =.  groups  (~(put by groups) flag [net group])
+  =.  shoal
+    %-  ~(gas by shoal)
+    %+  turn  ~(tap in imported.group)
+    |=(=nest:g [q p]:nest)
   go-abet:(go-init:(go-abed:group-core flag) &) :: setup defaults
   ::
   ++  sect-for-flag

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -225,6 +225,7 @@
 ::
 ++  take-said
   |=  [=flag:h =time =sign:agent:gall]
+  =/  =wire  (said-wire flag time)
   ^+  cor
   ?+    -.sign  !!
       %watch-ack
@@ -235,11 +236,13 @@
       %kick
     ?:  (~(has by voc) [flag time])
       cor  :: subscription ended politely
-    (proxy-said flag time)
+    ::  XX: only versioned subscriptions should rewatch on kick
+    (give %kick ~[wire] ~)
+    ::  (proxy-said flag time)
   ::
       %fact
-    =.  cor
-      (give %fact ~[(said-wire flag time)] cage.sign)
+    =.  cor  (give %fact ~[wire] cage.sign)
+    =.  cor  (give %kick ~[wire] ~)
     ?+    p.cage.sign  ~|(funny-mark/p.cage.sign !!)
         %heap-said
       =+  !<(=said:h q.cage.sign)

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -456,10 +456,12 @@
     ?.  ?=([[%text @] $%([%url @] [%reference *]) ~] con)
       :: invariant
       *curios:h
-    =-  (put:on:curios:h curios time [seal `text.i.con - author.u.pos time-sent.u.pos ~])
+    =;  =content:h
+      %^  put:on:curios:h  curios  time
+      [seal `text.i.con content author.u.pos time-sent.u.pos ~]
     ?-  -.i.t.con
-      %reference  ~
-      %url        [%link url.i.t.con '']~
+      %reference  :_(~ (ref:nert:chat-migrate reference.i.t.con)^~)
+      %url        [~ [%link url.i.t.con '']~]
     ==
   ::
   ++  node-to-quips
@@ -483,9 +485,9 @@
     ;<  [@ latest=node:gra:h]  _biff  (pry:orm graph)
     ;<  =post:gra:h            _biff  (node-to-post latest)
     =/  =seal:h  [time ~ ~]
-    =/  con=(list inline:h)  +:(con:nert:chat-migrate contents.post)
+    =/  =content:h  (con:nert:chat-migrate contents.post)
     =/  =heart:h  
-      =,(post [~ con author time-sent `reply])
+      =,(post [~ content author time-sent `reply])
     `[seal heart]
   ::
   ++  node-to-children
@@ -916,7 +918,7 @@
             ?~  curio  %.n
             =(author.curio.u.curio our.bowl)
         ?:  |(=(author.heart our.bowl) !in-replies)  he-core
-        =/  content  (trip (flatten content.curio))
+        =/  content  (trip (flatten q.content.curio))
         =/  title
           ?:  !=(title.heart ~)  (need title.heart)
           ?:  (lte (lent content) 80)  (crip content)
@@ -930,7 +932,7 @@
                 ': '
                 [%ship author.heart]
                 ': '
-                (flatten content.heart)
+                (flatten q.content.heart)
             ==
           ~  
         =.  cor  (emit (pass-hark & & yarn))

--- a/desk/lib/chat-graph.hoon
+++ b/desk/lib/chat-graph.hoon
@@ -39,8 +39,10 @@
     ?-  -.ref
       %group  [%group group.ref]
       %app    [%desk [ship desk] path]:ref
-      %graph  [%bait group.ref uid.ref]
+      %graph  [%bait group.ref resource.uid.ref (idx-to-path index.uid.ref)]
     ==
+  ++  idx-to-path  |=(=index:gra (turn index (cury scot %ud)))
+    
   --
   ::
 ::

--- a/desk/lib/chat-graph.hoon
+++ b/desk/lib/chat-graph.hoon
@@ -36,20 +36,10 @@
     ^-  block:c
     =;  =cite
       [%cite cite]
-    ?-    -.ref
-        %group  [%group group.ref]
-        %app    [%desk [ship desk] path]:ref
-    ::
-        %graph
-      ?.  ?&  =(resource.uid.ref flag)
-              ?=(?(~ [@ ~]) index.uid.ref)
-              =(%chat dude)
-          ==
-        [%bait group.ref uid.ref]
-      =/  wer=path
-         ?~  index.uid.ref   /
-         [%msg index.uid.ref]
-      [%chan [dude flag] wer]
+    ?-  -.ref
+      %group  [%group group.ref]
+      %app    [%desk [ship desk] path]:ref
+      %graph  [%bait group.ref uid.ref]
     ==
   --
   ::

--- a/desk/lib/curios.hoon
+++ b/desk/lib/curios.hoon
@@ -41,6 +41,12 @@
     =/  =seal:h  [new ~ ~]
     ?:  (~(has by cur) new)
       cur
+    ~|  curio-failed-validation/p.del
+    ?>  ?|  ?=(^ replying.p.del)
+            ?&  ?=(^ title.p.del) 
+                |(?=([~ ^] content.p.del) ?=([[* ~] ~] content.p.del))
+            ==
+        ==
     =.  cur
       (put:on:curios:h cur new [seal p.del])
     ?~  replying.p.del  cur

--- a/desk/lib/diary-graph.hoon
+++ b/desk/lib/diary-graph.hoon
@@ -1,5 +1,6 @@
 /-  d=diary
 /-  graph=graph-store
+/+  chat-graph
 =<  migrate
 =|  [=flag:d time=@ud]
 |%
@@ -258,7 +259,7 @@
       %text       (welp out (ring (trip text.con) prev-break))
       %mention    (snoc out [%inline ~[ship/ship.con]])  :: TODO: i swear I PR'd ships
       %code       (snoc out [%inline ~[code/expression.con]])
-      %reference  (snoc out [%inline ~[code/(crip <reference.con>) break/~]])
+      %reference  (snoc out [%block (ref:nert:chat-graph reference.con)])
   ::
       %url        
     =/  def=verse:d

--- a/desk/lib/heap-json.hoon
+++ b/desk/lib/heap-json.hoon
@@ -1,5 +1,6 @@
 /-  h=heap
 /-  meta
+/+  cite=cite-json
 |%
 ++  enjs
   =,  enjs:format
@@ -104,10 +105,32 @@
     |=  =heart:h
     %-  pairs
     :~  title+?~(title.heart ~ s+u.title.heart)
-        content/a/(turn content.heart inline)
+        content+(content content.heart)
         author+(ship author.heart)
         sent+(time sent.heart)
         replying+?~(replying.heart ~ s/(scot %ud u.replying.heart))
+    ==
+  ::
+  ++  content
+    |=  =content:h
+    %-  pairs
+    :~  block+a+(turn p.content block)
+        inline+a+(turn q.content inline)
+    ==
+  ::
+  ++  block
+    |=  b=block:h
+    ^-  json
+    %+  frond  -.b
+    ?-  -.b
+        %cite  (enjs:cite cite.b)
+        %image
+      %-  pairs
+      :~  src+s+src.b
+          height+(numb height.b)
+          width+(numb width.b)
+          alt+s+alt.b
+      ==
     ==
   ::
   ++  inline
@@ -252,10 +275,30 @@
     ^-  $-(json heart:h)
     %-  ot
     :~  title/(mu so)
-        content/(ar inline)
+        content/content
         author/ship
         sent/di
         replying/(mu (se %ud))
+    ==
+  ::
+  ++  content
+    %-  ot
+    :~  block/(ar block)
+       inline/(ar inline)
+    ==
+  ::
+  ++  block
+    ^-  $-(json block:h)
+    %-  of
+    :~  cite/dejs:cite
+    ::
+      :-  %image
+      %-  ot
+      :~  src/so
+          height/ni
+          width/ni
+          alt/so
+      ==
     ==
   ::
   ++  inline

--- a/desk/mar/dude.hoon
+++ b/desk/mar/dude.hoon
@@ -1,0 +1,12 @@
+|_  =dude:gall
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  dude
+  ++  json  s/dude
+  --
+++  grab
+  |%
+  ++  noun  dude:gall
+  --
+--

--- a/desk/sur/diary.hoon
+++ b/desk/sur/diary.hoon
@@ -14,6 +14,12 @@
 +$  shelf  (map flag diary)
 ::  $said: used for references
 +$  said  (pair flag outline)
+::  $plan: index into diary state
+::    p: Note being referred to
+::    q: Quip being referred to, if any
+::    
++$  plan
+  (pair time (unit time))
 ::
 ::  $diary: written longform communication
 ::

--- a/desk/sur/groups.hoon
+++ b/desk/sur/groups.hoon
@@ -131,6 +131,7 @@
       zone-ord=(list zone)
       =bloc
       =channels:channel
+      imported=(set nest)
       =cordon
       secret=?
       meta=data:meta

--- a/desk/sur/heap.hoon
+++ b/desk/sur/heap.hoon
@@ -1,4 +1,5 @@
 /-  graph-store
+/-  cite
 /-  g=groups, e=epic
 /-  metadata-store
 /+  lib-graph=graph-store
@@ -75,10 +76,19 @@
 ::
 +$  heart
   $:  title=(unit @t)
-      content=(list inline)
+      =content
       author=ship
       sent=time
       replying=(unit time)
+  ==
+::  $content: curio content
+::
++$  content
+  (pair (list block) (list inline))
+::  $block: block-level curio content
++$  block
+  $%  [%image src=cord height=@ud width=@ud alt=cord]
+      [%cite =cite]
   ==
 ::  $inline: curio content that flows within a paragraph
 ::

--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -1,39 +1,63 @@
-import { useGroup } from '@/state/groups';
+import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
+import { useGroup, useShoal } from '@/state/groups';
 import { BaitCite } from '@/types/chat';
+import { udToDec } from '@urbit/api';
 import cn from 'classnames';
 import React from 'react';
 import ExclamationPoint from '../icons/ExclamationPoint';
+import CurioReference from './CurioReference';
+import NoteReference from './NoteReference';
+
+// eslint-disable-next-line import/no-cycle
+import WritBaitReference from './WritBaitReference';
 
 export default function BaitReference({
-  group,
-  graph,
-  where,
-}: BaitCite['bait']) {
+  bait,
+  isScrolling,
+}: {
+  isScrolling: boolean;
+  bait: BaitCite['bait'];
+}) {
+  const { group, graph, where } = bait;
   const theGroup = useGroup(group);
   const groupTitle = theGroup?.meta.title;
+  const agent = useShoal(bait);
+  const [, ...segments] = where.split('/');
+  const nest = agent ? `${agent}/${graph}` : null;
+  const id = udToDec(segments[0]);
 
-  return (
-    <div className="heap-inline-block group">
-      <div className="h-full w-full p-2">
-        <div className="flex h-full w-full flex-col items-center justify-center rounded-lg bg-gray-50 font-semibold text-gray-600">
-          <ExclamationPoint className="mb-3 h-12 w-12" />
-          <span>This content is still being migrated.</span>
-          <span className="font-mono">{where}</span>
-        </div>
-      </div>
-      <div className="flex items-center justify-between border-t-2 border-gray-50 p-2 group-hover:bg-gray-50">
-        <div className="flex cursor-pointer items-center space-x-2 text-gray-400 group-hover:text-gray-600">
-          <span className="font-semibold">{graph}</span>
-          {groupTitle ? (
-            <>
-              <span className="font-bold">•</span>
-              <span className="font-semibold">{groupTitle}</span>
-            </>
-          ) : (
-            group
-          )}
-        </div>
-      </div>
-    </div>
-  );
+  if (agent === 'heap') {
+    return (
+      <CurioReference
+        idCurio={id}
+        chFlag={graph}
+        nest={`heap/${graph}`}
+        isScrolling={isScrolling}
+      />
+    );
+  }
+
+  if (nest && agent === 'chat') {
+    return (
+      <WritBaitReference
+        chFlag={graph}
+        nest={nest}
+        index={where}
+        isScrolling={isScrolling}
+      />
+    );
+  }
+
+  if (nest && agent === 'diary') {
+    return (
+      <NoteReference
+        chFlag={graph}
+        nest={nest}
+        id={id}
+        isScrolling={isScrolling}
+      />
+    );
+  }
+
+  return <HeapLoadingBlock reference />;
 }

--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -5,6 +5,7 @@ import { udToDec } from '@urbit/api';
 import cn from 'classnames';
 import React from 'react';
 import ExclamationPoint from '../icons/ExclamationPoint';
+// eslint-disable-next-line import/no-cycle
 import CurioReference from './CurioReference';
 import NoteReference from './NoteReference';
 

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -4,10 +4,11 @@ import { Cite } from '@/types/chat';
 import { udToDec } from '@urbit/api';
 import CurioReference from './CurioReference';
 // eslint-disable-next-line import/no-cycle
-import WritReference from './WritReference';
+import WritChanReference from './WritChanReference';
 import GroupReference from './GroupReference';
 import NoteReference from './NoteReference';
 import AppReference from './AppReference';
+// eslint-disable-next-line import/no-cycle
 import BaitReference from './BaitReference';
 
 function ContentReference({
@@ -27,7 +28,7 @@ function ContentReference({
   }
 
   if ('bait' in cite) {
-    return <BaitReference {...cite.bait} />;
+    return <BaitReference bait={cite.bait} isScrolling={isScrolling} />;
   }
   if ('chan' in cite) {
     const { nest, where } = cite.chan;
@@ -48,7 +49,7 @@ function ContentReference({
     if (app === 'chat') {
       const idWrit = `${segments[2]}/${segments[3]}`;
       return (
-        <WritReference
+        <WritChanReference
           isScrolling={isScrolling}
           chFlag={chFlag}
           nest={nest}

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { nestToFlag } from '@/logic/utils';
 import { Cite } from '@/types/chat';
 import { udToDec } from '@urbit/api';
+// eslint-disable-next-line import/no-cycle
 import CurioReference from './CurioReference';
 // eslint-disable-next-line import/no-cycle
 import WritChanReference from './WritChanReference';

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useCurio, useHeapState, useRemoteCurio } from '@/state/heap/heap';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
+// eslint-disable-next-line import/no-cycle
 import HeapBlock from '@/heap/HeapBlock';
 import { useChannelPreview } from '@/state/groups';
 import { udToDec } from '@urbit/api';

--- a/ui/src/components/References/WritBaitReference.tsx
+++ b/ui/src/components/References/WritBaitReference.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  useWritByFlagAndGraphIndex,
+  useWritByFlagAndWritId,
+} from '@/state/chat';
+import { useChannelPreview } from '@/state/groups';
+// eslint-disable-next-line import/no-cycle
+import WritBaseReference from './WritBaseReference';
+
+export default function WritBaitReference(props: {
+  chFlag: string;
+  nest: string;
+  index: string;
+  isScrolling: boolean;
+}) {
+  const { chFlag, nest, index, isScrolling } = props;
+  const writ = useWritByFlagAndGraphIndex(chFlag, index, isScrolling);
+  return <WritBaseReference writ={writ || undefined} {...props} />;
+}

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -7,20 +7,21 @@ import ChatContent from '@/chat/ChatContent/ChatContent';
 import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
+import { ChatWrit } from '@/types/chat';
 import ReferenceBar from './ReferenceBar';
 
-export default function WritReference({
+export default function WritBaseReference({
   chFlag,
   nest,
-  idWrit,
+  writ,
   isScrolling,
 }: {
   chFlag: string;
   nest: string;
-  idWrit: string;
+  writ?: ChatWrit;
   isScrolling: boolean;
 }) {
-  const writ = useWritByFlagAndWritId(chFlag, idWrit, isScrolling);
+  console.log(writ);
   const preview = useChannelPreview(nest);
 
   // TODO: handle failure for useWritByFlagAndWritId call.

--- a/ui/src/components/References/WritChanReference.tsx
+++ b/ui/src/components/References/WritChanReference.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useWritByFlagAndWritId } from '@/state/chat';
+import { useChannelPreview } from '@/state/groups';
+// eslint-disable-next-line import/no-cycle
+import WritBaseReference from './WritBaseReference';
+
+export default function WritChanReference(props: {
+  chFlag: string;
+  nest: string;
+  idWrit: string;
+  isScrolling: boolean;
+}) {
+  const { chFlag, nest, idWrit, isScrolling } = props;
+  const writ = useWritByFlagAndWritId(chFlag, idWrit, isScrolling);
+  return <WritBaseReference writ={writ} {...props} />;
+}

--- a/ui/src/heap/EditCurioForm.tsx
+++ b/ui/src/heap/EditCurioForm.tsx
@@ -9,6 +9,8 @@ import { isLinkCurio, isValidUrl } from '@/logic/utils';
 import useRequestState from '@/logic/useRequestState';
 import { JSONContent } from '@tiptap/core';
 import { inlinesToJSON, JSONToInlines } from '@/logic/tiptap';
+import { ChatBlock } from '@/types/chat';
+import { Inline } from '@/types/content';
 import useCurioFromParams from './useCurioFromParams';
 import HeapTextInput from './HeapTextInput';
 
@@ -57,7 +59,12 @@ export default function EditCurioForm() {
       }
       const editedContent = isLinkMode
         ? [content]
-        : (JSONToInlines(draftText || {}) as HeapInline[]);
+        : (JSONToInlines(draftText || {}) as Inline[]);
+
+      const con = {
+        block: [] as ChatBlock[],
+        inline: editedContent,
+      };
 
       try {
         setPending();
@@ -65,7 +72,7 @@ export default function EditCurioForm() {
           .getState()
           .editCurio(chFlag, time?.toString() || '', {
             ...curio.heart,
-            ...{ title, content: editedContent },
+            ...{ title, content: con },
           });
         setReady();
         dismiss();
@@ -105,7 +112,7 @@ export default function EditCurioForm() {
   // on load, set the text draft to the persisted state
   useEffect(() => {
     if (curio && !isLinkMode) {
-      const parsed = inlinesToJSON(curio.heart.content);
+      const parsed = inlinesToJSON(curio.heart.content.inline);
       setDraftText(parsed);
     }
   }, [curio, isLinkMode]);

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -6,6 +6,7 @@ import { isValidUrl, validOembedCheck } from '@/logic/utils';
 import { useCalm } from '@/state/settings';
 import useEmbedState from '@/state/embed';
 import { useRouteGroup, useAmAdmin } from '@/state/groups/groups';
+// eslint-disable-next-line import/no-cycle
 import HeapContent from '@/heap/HeapContent';
 import TwitterIcon from '@/components/icons/TwitterIcon';
 import { formatDistanceToNow } from 'date-fns';
@@ -236,6 +237,22 @@ export default function HeapBlock({
     asRef ? refClass || '' : 'heap-block group';
   const topBar = { time, refToken };
   const botBar = { curio, asRef };
+
+  if (content.block.length > 0 && 'cite' in content.block[0]) {
+    return (
+      <div className={cnm()}>
+        <TopBar hasIcon canEdit={canEdit} {...topBar} />
+        <div className="flex grow flex-col items-center justify-center">
+          <LinkIcon className="h-16 w-16 text-gray-300" />
+        </div>
+        <BottomBar
+          {...botBar}
+          provider="Urbit Reference"
+          title={curio.heart.title || 'Urbit Reference'}
+        />
+      </div>
+    );
+  }
 
   if (isText) {
     return (

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -158,7 +158,9 @@ function BottomBar({ curio, provider, title, asRef }: BottomBarProps) {
   const { content, sent } = curio.heart;
   const replyCount = curio.seal.replied.length;
   const url =
-    content.length > 0 && isLink(content[0]) ? content[0].link.href : '';
+    content.inline.length > 0 && isLink(content.inline[0])
+      ? content.inline[0].link.href
+      : '';
   const prettySent = formatDistanceToNow(sent);
 
   if (asRef) {
@@ -202,10 +204,12 @@ export default function HeapBlock({
   const [embed, setEmbed] = useState<any>();
   const { content } = curio.heart;
   const url =
-    content.length > 0 && isLink(content[0]) ? content[0].link.href : '';
+    content.inline.length > 0 && isLink(content.inline[0])
+      ? content.inline[0].link.href
+      : '';
   const calm = useCalm();
   const { isImage, isAudio, isText } = useHeapContentType(url);
-  const textFallbackTitle = content
+  const textFallbackTitle = content.inline
     .map((inline) => inlineToString(inline))
     .join(' ')
     .toString();

--- a/ui/src/heap/HeapContent.tsx
+++ b/ui/src/heap/HeapContent.tsx
@@ -11,6 +11,9 @@ import {
   CurioContent,
 } from '@/types/heap';
 
+// eslint-disable-next-line import/no-cycle
+import ContentReference from '@/components/References/ContentReference';
+
 interface HeapContentProps {
   content: CurioContent;
   className?: string;
@@ -101,9 +104,16 @@ export function InlineContent({ inline }: InlineContentProps) {
 
 export default function HeapContent({ content, className }: HeapContentProps) {
   const inlineLength = content.inline.length;
+  const block = content.block.map(Object.keys).join(', ');
 
   return (
     <div className={className}>
+      {content.block.map((b, idx) => {
+        if ('cite' in b) {
+          return <ContentReference cite={b.cite} />;
+        }
+        return '??';
+      })}
       {inlineLength > 0 ? (
         <>
           {content.inline.map((inlineItem, index) => (

--- a/ui/src/heap/HeapContent.tsx
+++ b/ui/src/heap/HeapContent.tsx
@@ -100,13 +100,13 @@ export function InlineContent({ inline }: InlineContentProps) {
 }
 
 export default function HeapContent({ content, className }: HeapContentProps) {
-  const inlineLength = content.length;
+  const inlineLength = content.inline.length;
 
   return (
     <div className={className}>
       {inlineLength > 0 ? (
         <>
-          {content.map((inlineItem, index) => (
+          {content.inline.map((inlineItem, index) => (
             <InlineContent
               key={`${inlineItem.toString()}-${index}`}
               inline={inlineItem}

--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -8,6 +8,7 @@ import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
 import HeapDetailEmbed from '@/heap/HeapDetail/HeapDetailEmbed';
 import { useIsMobile } from '@/logic/useMedia';
 import HeapAudioPlayer from '@/heap/HeapAudioPlayer';
+import ContentReference from '@/components/References/ContentReference';
 
 export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
   const [embed, setEmbed] = useState<any>();
@@ -27,6 +28,16 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
     };
     getOembed();
   }, [url, isMobile]);
+
+  if (content.block.length > 0 && 'cite' in content.block[0]) {
+    return (
+      <div className="mx-auto flex h-full w-full items-center justify-center p-8 text-[18px] leading-[26px]">
+        <div className="max-h-[100%] min-w-32 max-w-prose overflow-y-auto">
+          <ContentReference cite={content.block[0].cite} />
+        </div>
+      </div>
+    );
+  }
 
   if (isText) {
     return (

--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -13,7 +13,9 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
   const [embed, setEmbed] = useState<any>();
   const { content } = curio.heart;
   const url =
-    content.length > 0 && isLink(content[0]) ? content[0].link.href : '';
+    content.inline.length > 0 && isLink(content.inline[0])
+      ? content.inline[0].link.href
+      : '';
   const isMobile = useIsMobile();
 
   const { isText, isImage, isAudio, isVideo } = useHeapContentType(url);

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -13,6 +13,7 @@ import CheckIcon from '@/components/icons/CheckIcon';
 import HeapDetailHeaderDescription from '@/heap/HeapDetail/HeapDetailHeaderDescription';
 import { isImageUrl, makePrettyDayAndTime } from '@/logic/utils';
 import { isLink } from '@/types/heap';
+import useHeapContentType from '@/logic/useHeapContentType';
 import useCurioActions from '../useCurioActions';
 
 export interface ChannelHeaderProps {
@@ -30,10 +31,12 @@ export default function HeapDetailHeader({
   const group = useGroup(flag);
   const isMobile = useIsMobile();
   const curio = curioObject ? curioObject[1] : null;
+  const content = curio ? curio.heart.content : { block: [], inline: [] };
   const curioContent =
     (isLink(curio?.heart.content.inline[0])
       ? curio?.heart.content.inline[0].link.href
-      : curio?.heart.content.inline[0].toString()) || '';
+      : (curio?.heart.content.inline[0] || '').toString()) || '';
+  const { description } = useHeapContentType(curioContent);
   // TODO: a better title fallback
   const prettyDayAndTime = makePrettyDayAndTime(
     new Date(curio?.heart.sent || Date.now())
@@ -45,6 +48,7 @@ export default function HeapDetailHeader({
     time: idCurio,
   });
 
+  const isCite = content.block.length > 0 && 'cite' in content.block[0];
   const BackButton = isMobile ? Link : 'div';
 
   return (
@@ -84,7 +88,9 @@ export default function HeapDetailHeader({
                 {isImageLink && !curioTitle ? curioContent : null}
                 {!isImageLink && !curioTitle ? prettyDayAndTime : null}
               </span>
-              <HeapDetailHeaderDescription url={curioContent} />
+              <div className="text-md font-semibold text-gray-600">
+                {isCite ? 'Reference' : description()}
+              </div>
             </div>
           </div>
         </BackButton>

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -31,9 +31,9 @@ export default function HeapDetailHeader({
   const isMobile = useIsMobile();
   const curio = curioObject ? curioObject[1] : null;
   const curioContent =
-    (isLink(curio?.heart.content[0])
-      ? curio?.heart.content[0].link.href
-      : curio?.heart.content[0].toString()) || '';
+    (isLink(curio?.heart.content.inline[0])
+      ? curio?.heart.content.inline[0].link.href
+      : curio?.heart.content.inline[0].toString()) || '';
   // TODO: a better title fallback
   const prettyDayAndTime = makePrettyDayAndTime(
     new Date(curio?.heart.sent || Date.now())

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
@@ -14,7 +14,7 @@ export default function HeapDetailSidebarInfo({
 }: HeapDetailSidebarProps) {
   const { content, author, sent, title } = curio.heart;
   const unixDate = new Date(sent);
-  const stringContent = content.inline[0].toString();
+  const stringContent = (content.inline?.[0] || '').toString();
   const textPreview = content.inline
     .map((inline) => inlineToString(inline))
     .join(' ')

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
@@ -14,8 +14,8 @@ export default function HeapDetailSidebarInfo({
 }: HeapDetailSidebarProps) {
   const { content, author, sent, title } = curio.heart;
   const unixDate = new Date(sent);
-  const stringContent = content[0].toString();
-  const textPreview = content
+  const stringContent = content.inline[0].toString();
+  const textPreview = content.inline
     .map((inline) => inlineToString(inline))
     .join(' ')
     .toString();

--- a/ui/src/heap/HeapRow.tsx
+++ b/ui/src/heap/HeapRow.tsx
@@ -38,11 +38,12 @@ export default function HeapRow({
   const { replied } = curio.seal;
   const calm = useCalm();
   // TODO: improve this
-  const contentString = content.length > 0 ? content[0].toString() : '';
+  const contentString =
+    content.inline.length > 0 ? content.inline[0].toString() : '';
   const flag = useRouteGroup();
   const isAdmin = useAmAdmin(flag);
   const canEdit = isAdmin || window.our === curio.heart.author;
-  const textFallbackTitle = content
+  const textFallbackTitle = content.inline
     .map((inline) => inlineToString(inline))
     .join(' ')
     .toString();

--- a/ui/src/heap/HeapTextInput.tsx
+++ b/ui/src/heap/HeapTextInput.tsx
@@ -79,9 +79,12 @@ export default function HeapTextInput({
 
       setPending();
 
-      const content = normalizeHeapInline(
-        JSONToInlines(editor?.getJSON()) as HeapInline[]
-      );
+      const content = {
+        block: [],
+        inline: normalizeHeapInline(
+          JSONToInlines(editor?.getJSON()) as HeapInline[]
+        ),
+      };
 
       const heart: CurioHeart = {
         title: null,

--- a/ui/src/heap/NewCurioForm.tsx
+++ b/ui/src/heap/NewCurioForm.tsx
@@ -78,7 +78,7 @@ export default function NewCurioForm() {
     async ({ content }: NewCurioFormSchema) => {
       await useHeapState.getState().addCurio(chFlag, {
         title: null,
-        content: [{ link: { href: content, content } }],
+        content: { block: [], inline: [{ link: { href: content, content } }] },
         author: window.our,
         sent: Date.now(),
         replying: null,

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -348,17 +348,17 @@ export function canReadChannel(channel: GroupChannel, vessel: Vessel) {
  * @param content CurioContent
  * @returns boolean
  */
-export function isLinkCurio(content: CurioContent) {
+export function isLinkCurio({ inline }: CurioContent) {
   return (
-    content.length === 1 &&
-    typeof content[0] === 'string' &&
-    isValidUrl(content[0])
+    inline.length === 1 &&
+    typeof inline[0] === 'string' &&
+    isValidUrl(inline[0])
   );
 }
 
 export function linkFromCurioContent(content: CurioContent) {
   if (isLinkCurio(content)) {
-    return content[0] as string;
+    return content.inline[0] as string;
   }
 
   return '';

--- a/ui/src/mocks/heaps.ts
+++ b/ui/src/mocks/heaps.ts
@@ -26,9 +26,12 @@ const mockCurios: HeapCurios = {
     },
     heart: {
       title: 'House rendering',
-      content: [
-        'https://finned-palmer.s3.filebase.com/finned-palmer/2022.3.31..15.13.50-rendering1.png',
-      ],
+      content: {
+        block: [],
+        inline: [
+          'https://finned-palmer.s3.filebase.com/finned-palmer/2022.3.31..15.13.50-rendering1.png',
+        ],
+      },
       author: '~finned-palmer',
       sent: unixTime,
       replying: null,
@@ -42,9 +45,12 @@ const mockCurios: HeapCurios = {
     },
     heart: {
       title: 'Description of a Martini',
-      content: [
-        'The martini is a cocktail made with gin and vermouth, and garnished with an olive or a lemon twist.',
-      ],
+      content: {
+        block: [],
+        inline: [
+          'The martini is a cocktail made with gin and vermouth, and garnished with an olive or a lemon twist.',
+        ],
+      },
       author: '~finned-palmer',
       sent: unixTime,
       replying: null,
@@ -58,9 +64,12 @@ const mockCurios: HeapCurios = {
     },
     heart: {
       title: 'House rendering',
-      content: [
-        'https://finned-palmer.s3.filebase.com/finned-palmer/2022.3.31..15.13.50-rendering1.png',
-      ],
+      content: {
+        block: [],
+        inline: [
+          'https://finned-palmer.s3.filebase.com/finned-palmer/2022.3.31..15.13.50-rendering1.png',
+        ],
+      },
       author: '~finned-palmer',
       sent: unixTime,
       replying: null,
@@ -74,9 +83,12 @@ const mockCurios: HeapCurios = {
     },
     heart: {
       title: '',
-      content: [
-        'https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/15-09-26-RalfR-WLC-0084.jpg/1920px-15-09-26-RalfR-WLC-0084.jpg',
-      ],
+      content: {
+        block: [],
+        inline: [
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/15-09-26-RalfR-WLC-0084.jpg/1920px-15-09-26-RalfR-WLC-0084.jpg',
+        ],
+      },
       author: '~finned-palmer',
       sent: unixTime,
       replying: null,
@@ -90,9 +102,12 @@ const mockCurios: HeapCurios = {
     },
     heart: {
       title: 'One Thing About Me',
-      content: [
-        'https://twitter.com/noagencynewyork/status/1540353656326946817?s=20&t=OSmaPCFVGbJmjvs1VtJtkg',
-      ],
+      content: {
+        block: [],
+        inline: [
+          'https://twitter.com/noagencynewyork/status/1540353656326946817?s=20&t=OSmaPCFVGbJmjvs1VtJtkg',
+        ],
+      },
       author: '~finned-palmer',
       sent: unixTime,
       replying: null,

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -134,6 +134,7 @@ export const useChatState = createState<ChatState>(
     loadedWrits: {},
     loadedRefs: {},
     briefs: {},
+    loadedGraphRefs: {},
     togglePin: async (whom, pin) => {
       const { pins } = get();
       let newPins = [];
@@ -1006,6 +1007,39 @@ export function useWritByFlagAndWritId(
   }, [path, isScrolling]);
 
   return cached;
+}
+
+export function useWritByFlagAndGraphIndex(
+  chFlag: string,
+  index: string,
+  isScrolling: boolean
+) {
+  const res = useChatState(
+    useCallback((s) => s.loadedGraphRefs[chFlag + index], [chFlag, index])
+  );
+
+  useEffect(() => {
+    if (!res && !isScrolling) {
+      (async () => {
+        let w: ChatWrit | null;
+        try {
+          const { writ } = await subscribeOnce(
+            'chat',
+            `/hook/${chFlag}${index}`
+          );
+          w = writ;
+        } catch (e) {
+          console.warn(e);
+        }
+
+        useChatState.getState().batchSet((draft) => {
+          draft.loadedGraphRefs[chFlag + index] = w;
+        });
+      })();
+    }
+  }, [isScrolling, chFlag, index, res]);
+
+  return res;
 }
 
 export function useLoadedWrits(whom: string) {

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -51,6 +51,9 @@ export interface ChatState {
   loadedRefs: {
     [path: string]: ChatWrit;
   };
+  loadedGraphRefs: {
+    [path: string]: ChatWrit | null;
+  };
   pendingDms: string[];
   briefs: ChatBriefs;
   togglePin: (whom: string, pin: boolean) => Promise<void>;

--- a/ui/src/state/groups/type.ts
+++ b/ui/src/state/groups/type.ts
@@ -1,3 +1,4 @@
+import { BaitCite } from '@/types/chat';
 import {
   Gangs,
   Group,
@@ -19,6 +20,10 @@ export interface GroupState {
   groups: {
     [flag: string]: Group;
   };
+  shoal: {
+    [flag: string]: string | null;
+  };
+  fetchShoal: (b: BaitCite['bait']) => Promise<string | null>;
   gangs: Gangs;
   initialize: (flag: string) => Promise<number>;
   delRole: (flag: string, sect: string) => Promise<void>;

--- a/ui/src/types/heap.ts
+++ b/ui/src/types/heap.ts
@@ -1,4 +1,5 @@
 import { BigIntOrderedMap } from '@urbit/api';
+import { ChatBlock } from './chat';
 import {
   Italics,
   Strikethrough,
@@ -9,6 +10,7 @@ import {
   Blockquote,
   Link,
   Tag,
+  Inline,
 } from './content';
 
 export type Patda = string;
@@ -82,7 +84,10 @@ export interface CurioSeal {
   replied: string[];
 }
 
-export type CurioContent = HeapInline[];
+export interface CurioContent {
+  block: ChatBlock[];
+  inline: Inline[];
+}
 
 export interface CurioHeart {
   title: string | null;


### PR DESCRIPTION
- Adds endpoints for agent discovery, allowing graph references to be resolved to an `nest`
- Implements UI for the above
- Adds endpoints for resolving chats from old-style IDs
- Adds a reference type to heap
- Adds reference rendering support to heap (no input though)
- Prevents kick-resub loop in previews
- Validates the structure of heap items (cc: @arthyn make sure you double check this, hopefully not too overeager)