### PR TITLE
migration: detect unjoined migrations

### DIFF
--- a/ui/src/groups/ChannelIndex/ChannelIndex.test.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/state/groups', () => ({
   useRouteGroup: () => null,
   useAmAdmin: () => true,
   useVessel: () => fakeVessel,
+  useGroupState: () => ({}),
 }));
 
 describe('ChannelIndex', () => {

--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -39,17 +39,18 @@ const UNZONED = 'default';
 function GroupChannel({
   channel,
   nest,
+  migration,
 }: {
   nest: string;
   channel: GroupChannel;
+  migration: ReturnType<typeof useStartedMigration>;
 }) {
   const [_app, flag] = nestToFlag(nest);
   const { ship } = getFlagParts(flag);
   const groupFlag = useRouteGroup();
   const group = useGroup(groupFlag);
   const briefs = useAllBriefs();
-  const pendingImports = usePendingImports();
-  const hasStarted = useStartedMigration();
+  const { hasStarted, pendingImports } = migration;
   const imported = isChannelImported(nest, pendingImports) && hasStarted(ship);
   const joined = isChannelJoined(nest, briefs);
   const isChannelHost = useIsChannelHost(flag);
@@ -254,9 +255,11 @@ function GroupChannel({
 function ChannelSection({
   channels,
   zone,
+  migration,
 }: {
   channels: [string, GroupChannel][];
   zone: Zone | null;
+  migration: ReturnType<typeof useStartedMigration>;
 }) {
   const flag = useRouteGroup();
   const group = useGroup(flag);
@@ -272,7 +275,12 @@ function ChannelSection({
       ) : null}
       <ul>
         {channels.map(([nest, channel]) => (
-          <GroupChannel nest={nest} channel={channel} key={channel.added} />
+          <GroupChannel
+            nest={nest}
+            channel={channel}
+            key={channel.added}
+            migration={migration}
+          />
         ))}
       </ul>
     </>
@@ -283,6 +291,7 @@ export default function ChannelIndex({ title }: ViewProps) {
   const flag = useRouteGroup();
   const { sectionedChannels } = useChannelSections(flag);
   const filteredSections = useFilteredSections(flag);
+  const migration = useStartedMigration(flag);
   const navigate = useNavigate();
   const isAdmin = useAmAdmin(flag);
   const group = useGroup(flag);
@@ -331,6 +340,7 @@ export default function ChannelIndex({ title }: ViewProps) {
                   section in sectionedChannels ? sectionedChannels[section] : []
                 }
                 zone={section}
+                migration={migration}
               />
             </div>
           ) : null

--- a/ui/src/groups/GroupSidebar/ChannelList.test.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/state/groups', () => ({
   useGroup: () => fakeGroup,
   useRouteGroup: () => fakeFlag,
   useVessel: () => fakeVessel,
+  useGroupState: () => ({}),
 }));
 
 describe('ChannelList', () => {

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -102,7 +102,7 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
   const group = useGroup(flag);
   const briefs = useAllBriefs();
   const pendingImports = usePendingImports();
-  const hasStarted = useStartedMigration();
+  const { hasStarted } = useStartedMigration(flag);
   const { sortFn, sortChannels } = useChannelSort();
   const isDefaultSort = sortFn === DEFAULT;
   const { sectionedChannels } = useChannelSections(flag);

--- a/ui/src/state/local.ts
+++ b/ui/src/state/local.ts
@@ -32,6 +32,10 @@ export const useLocalState = create<LocalState>(
       name: createStorageKey('local'),
       version: storageVersion,
       migrate: clearStorageMigration,
+      partialize: ({ currentTheme, browserId }) => ({
+        currentTheme,
+        browserId,
+      }),
     }
   )
 );


### PR DESCRIPTION
This gives us a capability of detecting if previously unjoined channels before the migration have effectively migrated over by reusing our channel preview mechanism. This is somewhat intensive depending on the channel size so it only happens inside the group itself not in the group list. Addresses #1333 as best we can. 

Please don't approve without running locally and looking at either the testnet or livenet.