### PR TITLE
docket: fix requestTreaty

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -113,6 +113,13 @@ const api = {
       throw e;
     }
   },
+  async subscribeOnce<T>(app: string, path: string, timeout?: number) {
+    if (!client) {
+      await setupAPI();
+    }
+
+    return client.subscribeOnce<T>(app, path, timeout);
+  },
   async thread<Return, T>(params: Thread<T>) {
     try {
       if (!client) {

--- a/ui/src/state/docket.ts
+++ b/ui/src/state/docket.ts
@@ -89,16 +89,16 @@ const useDocketState = create<DocketState>((set, get) => ({
     set((s) => ({ treaties: { ...s.treaties, ...treaties } }));
     return treaties;
   },
-  requestTreaty: async (ship: string, desk: string) => {
-    const { treaties } = get();
+  requestTreaty: async (ship: string, flag: string) => {
+    const { treaties }: { treaties: Treaties } = get();
 
-    const key = `${ship}/${desk}`;
+    const key = flag;
     if (key in treaties) {
       return treaties[key];
     }
 
     const result = await api.subscribeOnce('treaty', `/treaty/${key}`, 20000);
-    const treaty = { ...normalizeDocket(result, desk), ship };
+    const treaty = { ...normalizeDocket(result, flag), ship };
     set((state) => ({
       treaties: { ...state.treaties, [key]: treaty },
     }));
@@ -244,11 +244,6 @@ export function useCharges() {
 
 export function useCharge(desk: string) {
   return useDocketState(useCallback((state) => state.charges[desk], [desk]));
-}
-
-const selRequest = (s: DocketState) => s.requestTreaty;
-export function useRequestDocket() {
-  return useDocketState(selRequest);
 }
 
 const selAllies = (s: DocketState) => s.allies;


### PR DESCRIPTION
This fixes app refs by exposing the `@urbit/api#subscribeOnce` to the `useDocketState` hook. 

![image](https://user-images.githubusercontent.com/16504501/206368846-c7ff869a-3686-4826-8538-d035a2978f5b.png)
