### PR TITLE
chat: prevent user from sending messages while disconnected

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -29,6 +29,7 @@ import { useFileStore } from '@/state/storage';
 import { isImageUrl } from '@/logic/utils';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import * as Popover from '@radix-ui/react-popover';
+import { useSubscriptionStatus } from '@/state/local';
 
 interface ChatInputProps {
   whom: string;
@@ -83,6 +84,7 @@ export default function ChatInput({
   sendMessage,
 }: ChatInputProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const subscription = useSubscriptionStatus();
   const pact = usePact(whom);
   const chatInfo = useChatInfo(whom);
   const reply = replying || chatInfo?.replying || null;
@@ -309,6 +311,8 @@ export default function ChatInput({
           className="button"
           disabled={
             sendDisabled ||
+            subscription === 'reconnecting' ||
+            subscription === 'disconnected' ||
             (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
           }
           onClick={onClick}

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -192,10 +192,13 @@ export default function ChatInput({
     allowMentions: true,
     onEnter: useCallback(
       ({ editor }) => {
-        onSubmit(editor);
-        return true;
+        if (subscription === 'connected') {
+          onSubmit(editor);
+          return true;
+        }
+        return false;
       },
-      [onSubmit]
+      [onSubmit, subscription]
     ),
   });
 

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -206,6 +206,12 @@ export default function ChatInput({
   }, [whom, messageEditor]);
 
   useEffect(() => {
+    if (subscription === 'disconnected' || subscription === 'reconnecting') {
+      messageEditor?.setEditable(false);
+    }
+  }, [subscription, messageEditor]);
+
+  useEffect(() => {
     if (
       (autoFocus || reply) &&
       !isMobile &&

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -206,12 +206,6 @@ export default function ChatInput({
   }, [whom, messageEditor]);
 
   useEffect(() => {
-    if (subscription === 'disconnected' || subscription === 'reconnecting') {
-      messageEditor?.setEditable(false);
-    }
-  }, [subscription, messageEditor]);
-
-  useEffect(() => {
     if (
       (autoFocus || reply) &&
       !isMobile &&


### PR DESCRIPTION
For #1398 

Disables post the send button and the editor while a the frontend is disconnected.