### PR TITLE
chat/threads: added key to chatscroller in thread

### DIFF
--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -68,6 +68,7 @@ export default function ChatThread() {
       </header>
       <div className="flex flex-1 flex-col px-2 py-0">
         <ChatScroller
+          key={idTime}
           messages={thread}
           whom={whom}
           scrollerRef={scrollerRef}


### PR DESCRIPTION
see: #1396.

the object being passed down to ChatScroller when the thread was changed was always correct, even when the issue was triggered (often when switching between threads quickly), so this was likely an issue with react being unable to tell that the thread being referred to by the thread component was actually different.

i've been clicking around for a while trying to trigger this and don't seem to be able to, but i highly recommend pulling this branch and testing yourself as part of the review.