### PR TITLE
subs: reduce ref fetching (again)

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -38,7 +38,7 @@ async function setupAPI() {
   if (!client) {
     const api = new Urbit('', '', window.desk);
     api.ship = window.ship;
-    api.verbose = true;
+    api.verbose = import.meta.env.DEV;
     client = api;
   }
 

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -79,6 +79,7 @@ import MobileGroupsNavHome from './nav/MobileRoot';
 import MobileGroupsActions from './groups/MobileGroupsActions';
 import MobileGroupRoot from './nav/MobileGroupRoot';
 import MobileGroupActions from './groups/MobileGroupActions';
+import { useStorage } from './state/storage';
 
 const DiaryAddNote = React.lazy(() => import('./diary/DiaryAddNote'));
 const SuspendedDiaryAddNote = (
@@ -447,6 +448,7 @@ function App() {
       fetchAll();
 
       useContactState.getState().initialize(api);
+      useStorage.getState().initialize(api);
     })();
   }, [handleError]);
 

--- a/ui/src/components/DisconnectNotice.tsx
+++ b/ui/src/components/DisconnectNotice.tsx
@@ -13,6 +13,7 @@ import {
   useLocalState,
   useSubscriptionStatus,
 } from '@/state/local';
+import { useStorage } from '@/state/storage';
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 
 export default function DisconnectNotice() {
@@ -35,6 +36,7 @@ export default function DisconnectNotice() {
       fetchAll();
 
       useContactState.getState().initialize(api);
+      useStorage.getState().initialize(api);
     } else {
       window.location.reload();
     }

--- a/ui/src/logic/subscriptionTracking.ts
+++ b/ui/src/logic/subscriptionTracking.ts
@@ -1,0 +1,37 @@
+export interface PreviewCheck {
+  inProgress: boolean;
+  attempted: number;
+}
+
+const DEFAULT_WAIT = 10 * 60 * 1000;
+
+export function getPreviewTracker(wait = DEFAULT_WAIT) {
+  const tracked: Record<string, PreviewCheck> = {};
+
+  const getPreviewTracking = (k: string) =>
+    tracked[k] || {
+      inProgress: false,
+      attempted: 0,
+    };
+
+  const isPastWaiting = (attempted: number) => Date.now() - attempted >= wait;
+
+  return {
+    tracked,
+    shouldLoad: (k: string) => {
+      const { attempted, inProgress } = getPreviewTracking(k);
+      console.log(k);
+      return isPastWaiting(attempted) && !inProgress;
+    },
+    newAttempt: (k: string) => {
+      console.log(k);
+      tracked[k] = {
+        inProgress: true,
+        attempted: Date.now(),
+      };
+    },
+    finished: (k: string) => {
+      tracked[k].inProgress = false;
+    },
+  };
+}

--- a/ui/src/logic/subscriptionTracking.ts
+++ b/ui/src/logic/subscriptionTracking.ts
@@ -20,7 +20,6 @@ export function getPreviewTracker(wait = DEFAULT_WAIT) {
     tracked,
     shouldLoad: (k: string) => {
       const { attempted, inProgress } = getPreviewTracking(k);
-      console.log(k);
       return isPastWaiting(attempted) && !inProgress;
     },
     newAttempt: (k: string) => {

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -22,10 +22,6 @@ function useFileUpload() {
   const [hasCredentials, setHasCredentials] = useState(false);
 
   useEffect(() => {
-    useStorage.getState().initialize(api);
-  }, []);
-
-  useEffect(() => {
     const hasCreds =
       credentials?.accessKeyId &&
       credentials?.endpoint &&


### PR DESCRIPTION
This makes sure that we aren't attempting to initiate multiple requests for the same content at once. That state lives outside of the react state lifecycle so that it is immediately updated. This currently puts all retries at 10 mins. Fixes #1406 and #1354