### PR TITLE
talk: perf part 1 and local storage cleanup

### DIFF
--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -6,9 +6,10 @@ import { deSig, Contact, cite } from '@urbit/api';
 import _ from 'lodash';
 import { darken, lighten, parseToHsla } from 'color2k';
 import { useCalm } from '@/state/settings';
-import { useCurrentTheme } from '../state/local';
-import { normalizeUrbitColor, isValidUrl } from '../logic/utils';
-import { useContact } from '../state/contact';
+import { useCurrentTheme } from '@/state/local';
+import { normalizeUrbitColor, isValidUrl } from '@/logic/utils';
+import { useContact } from '@/state/contact';
+import { useAvatar } from '@/state/avatar';
 
 export type AvatarSizes = 'xs' | 'small' | 'default' | 'huge';
 
@@ -139,8 +140,6 @@ export default function Avatar({
   loadImage = true,
   previewData,
 }: AvatarProps) {
-  const [loaded, setLoaded] = useState(false);
-  const showImage = loadImage || loaded;
   const currentTheme = useCurrentTheme();
   const contact = useContact(ship);
   const calm = useCalm();
@@ -148,6 +147,10 @@ export default function Avatar({
   const previewAvatarIsValid =
     previewAvatar && previewAvatar !== null && isValidUrl(previewAvatar);
   const { color, avatar } = contact || emptyContact;
+  const { hasLoaded, load } = useAvatar(
+    (previewAvatarIsValid ? previewAvatar : avatar) || ''
+  );
+  const showImage = loadImage || hasLoaded;
   const { classes, size: sigilSize } = sizeMap[size];
   const adjustedColor = themeAdjustColor(
     normalizeUrbitColor(previewColor || color),
@@ -174,7 +177,7 @@ export default function Avatar({
         src={previewAvatar}
         alt=""
         style={style}
-        onLoad={() => setLoaded(true)}
+        onLoad={load}
       />
     );
   }
@@ -191,7 +194,7 @@ export default function Avatar({
         src={avatar}
         alt=""
         style={style}
-        onLoad={() => setLoaded(true)}
+        onLoad={load}
       />
     );
   }

--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -1,6 +1,6 @@
 import { isValidPatp } from 'urbit-ob';
 import classNames from 'classnames';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, useState } from 'react';
 import { sigil as sigilRaw, reactRenderer } from '@tlon/sigil-js';
 import { deSig, Contact, cite } from '@urbit/api';
 import _ from 'lodash';
@@ -22,6 +22,7 @@ interface AvatarProps {
     previewColor?: string;
     previewAvatar?: string;
   };
+  loadImage?: boolean;
 }
 
 interface AvatarMeta {
@@ -135,8 +136,11 @@ export default function Avatar({
   className,
   style,
   icon = true,
+  loadImage = true,
   previewData,
 }: AvatarProps) {
+  const [loaded, setLoaded] = useState(false);
+  const showImage = loadImage || loaded;
   const currentTheme = useCurrentTheme();
   const contact = useContact(ship);
   const calm = useCalm();
@@ -159,6 +163,7 @@ export default function Avatar({
   );
 
   if (
+    showImage &&
     previewAvatarIsValid &&
     !calm.disableRemoteContent &&
     !calm.disableAvatars
@@ -169,17 +174,24 @@ export default function Avatar({
         src={previewAvatar}
         alt=""
         style={style}
+        onLoad={() => setLoaded(true)}
       />
     );
   }
 
-  if (avatar && !calm.disableRemoteContent && !calm.disableAvatars) {
+  if (
+    avatar &&
+    showImage &&
+    !calm.disableRemoteContent &&
+    !calm.disableAvatars
+  ) {
     return (
       <img
         className={classNames(className, classes, 'object-cover')}
         src={avatar}
         alt=""
         style={style}
+        onLoad={() => setLoaded(true)}
       />
     );
   }

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useRef } from 'react';
-import cn from 'classnames';
+import React, { PropsWithChildren, useMemo } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 import useMessageSort from '@/logic/useMessageSort';
-import { useGroups, useVessel } from '@/state/groups';
+import { useGroups } from '@/state/groups';
 import { filters, SidebarFilter } from '@/state/settings';
-import { RECENT } from '../logic/useSidebarSort';
-import { canReadChannel, whomIsDm, whomIsMultiDm } from '../logic/utils';
+import { useIsMobile } from '@/logic/useMedia';
+import { canReadChannel, whomIsDm, whomIsMultiDm } from '@/logic/utils';
 import {
   usePendingDms,
   useBriefs,
@@ -15,73 +15,103 @@ import {
 } from '../state/chat';
 import MessagesSidebarItem from './MessagesSidebarItem';
 
-interface MessagesListProps {
+type MessagesListProps = PropsWithChildren<{
   filter: SidebarFilter;
-}
+  atTopChange?: (atTop: boolean) => void;
+  isScrolling?: (scrolling: boolean) => void;
+}>;
 
-export default function MessagesList({ filter }: MessagesListProps) {
+export default function MessagesList({
+  filter,
+  atTopChange,
+  isScrolling,
+  children,
+}: MessagesListProps) {
   const pending = usePendingDms();
   const pendingMultis = usePendingMultiDms();
   const pinned = usePinned();
-  const { sortOptions } = useMessageSort();
+  const { sortMessages } = useMessageSort();
   const briefs = useBriefs();
   const chats = useChats();
   const groups = useGroups();
-
   const allPending = pending.concat(pendingMultis);
+  const isMobile = useIsMobile();
+  const thresholds = {
+    atBottomThreshold: 125,
+    atTopThreshold: 125,
+    overscan: isMobile
+      ? { main: 200, reverse: 200 }
+      : { main: 400, reverse: 400 },
+  };
 
-  const organizedBriefs = Object.keys(briefs)
-    .filter((b) => {
-      const chat = chats[b];
-      const groupFlag = chat?.perms.group;
-      const group = groups[groupFlag || ''];
-      const vessel = group?.fleet[window.our];
-      const channel = group?.channels[`chat/${b}`];
+  const organizedBriefs = sortMessages(briefs).filter(([b]) => {
+    const chat = chats[b];
+    const groupFlag = chat?.perms.group;
+    const group = groups[groupFlag || ''];
+    const vessel = group?.fleet[window.our];
+    const channel = group?.channels[`chat/${b}`];
 
-      if (channel && vessel && !canReadChannel(channel, vessel)) {
-        return false;
-      }
+    if (channel && vessel && !canReadChannel(channel, vessel)) {
+      return false;
+    }
 
-      if (pinned.includes(b)) {
-        return false;
-      }
+    if (pinned.includes(b)) {
+      return false;
+    }
 
-      if (allPending.includes(b)) {
-        return false;
-      }
+    if (allPending.includes(b)) {
+      return false;
+    }
 
-      if (filter === filters.groups && (whomIsDm(b) || whomIsMultiDm(b))) {
-        return false;
-      }
+    if (filter === filters.groups && (whomIsDm(b) || whomIsMultiDm(b))) {
+      return false;
+    }
 
-      if (filter === filters.dms && isGroupBrief(b)) {
-        return false;
-      }
+    if (filter === filters.dms && isGroupBrief(b)) {
+      return false;
+    }
 
-      return true; // is all
-    })
-    .sort((a, b) => sortOptions[RECENT](`chat/${a}`, `chat/${b}`))
-    .reverse();
+    return true; // is all
+  });
+
+  const head = useMemo(
+    () => (
+      <>
+        {children}
+        {allPending &&
+          filter !== filters.groups &&
+          allPending.map((whom) => (
+            <MessagesSidebarItem
+              pending
+              key={whom}
+              whom={whom}
+              brief={briefs[whom]}
+            />
+          ))}
+      </>
+    ),
+    [children, allPending, briefs, filter]
+  );
 
   return (
-    <ul
-      className={cn(
-        'flex w-full flex-col space-y-3 overflow-x-hidden pr-0 sm:space-y-1'
+    <Virtuoso
+      {...thresholds}
+      data={organizedBriefs}
+      computeItemKey={(i, [whom]) => whom}
+      itemContent={(i, [whom, brief]) => (
+        <div className="pl-2 pb-3 sm:pb-1">
+          <MessagesSidebarItem key={whom} whom={whom} brief={brief} />
+        </div>
       )}
-    >
-      {allPending &&
-        filter !== filters.groups &&
-        allPending.map((whom) => (
-          <MessagesSidebarItem
-            pending
-            key={whom}
-            whom={whom}
-            brief={briefs[whom]}
-          />
-        ))}
-      {organizedBriefs.map((ship) => (
-        <MessagesSidebarItem key={ship} whom={ship} brief={briefs[ship]} />
-      ))}
-    </ul>
+      components={{
+        Header: () => head,
+      }}
+      atTopStateChange={atTopChange}
+      isScrolling={isScrolling}
+      className="w-full overflow-x-hidden"
+      style={{
+        overflowY: 'scroll',
+      }}
+    />
   );
 }

--- a/ui/src/dms/MessagesScrollingContext.ts
+++ b/ui/src/dms/MessagesScrollingContext.ts
@@ -1,0 +1,7 @@
+import React, { useContext } from 'react';
+
+export const MessagesScrollingContext = React.createContext(false);
+
+export function useMessagesScrolling() {
+  return useContext(MessagesScrollingContext);
+}

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback, useMemo } from 'react';
 import cn from 'classnames';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import AddIcon from '@/components/icons/AddIcon';
@@ -17,8 +17,10 @@ import {
   SidebarFilter,
   SettingsState,
 } from '@/state/settings';
+import { debounce } from 'lodash';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
+import { MessagesScrollingContext } from './MessagesScrollingContext';
 
 const selMessagesFilter = (s: SettingsState) => ({
   messagesFilter: s.talk.messagesFilter,
@@ -91,27 +93,28 @@ export function TalkAppMenu() {
 }
 
 export default function MessagesSidebar() {
-  const [scrollTop, setScrollTop] = useState(0);
+  const [atTop, setAtTop] = useState(true);
+  const [isScrolling, setIsScrolling] = useState(false);
   const { messagesFilter } = useSettingsState(selMessagesFilter);
   const briefs = useBriefs();
   const pinned = usePinned();
 
-  const ref = useRef<HTMLDivElement>(null);
-
-  const scrollHandler = () => {
-    setScrollTop(ref.current?.scrollTop || 0);
-  };
-
   const setFilterMode = (mode: SidebarFilter) => {
     useSettingsState.getState().putEntry('talk', 'messagesFilter', mode);
   };
+
+  const atTopChange = useCallback((top: boolean) => setAtTop(top), []);
+
+  const scroll = useRef(
+    debounce((scrolling: boolean) => setIsScrolling(scrolling), 200)
+  );
 
   return (
     <nav className="flex h-full w-64 flex-none flex-col border-r-2 border-gray-50 bg-white">
       <ul
         className={cn(
           'flex w-full flex-col space-y-1 px-2 pt-2',
-          scrollTop > 0 && 'bottom-shadow'
+          !atTop && 'bottom-shadow'
         )}
       >
         <TalkAppMenu />
@@ -126,86 +129,85 @@ export default function MessagesSidebar() {
           New Message
         </SidebarItem>
       </ul>
-      <div
-        ref={ref}
-        onScroll={scrollHandler}
-        className="w-full overflow-y-auto overflow-x-hidden"
-      >
-        <ul
-          className={
-            'flex w-full flex-col space-y-3 overflow-x-hidden px-2 sm:space-y-1'
-          }
+      <MessagesScrollingContext.Provider value={isScrolling}>
+        <MessagesList
+          filter={messagesFilter}
+          atTopChange={atTopChange}
+          isScrolling={scroll.current}
         >
-          {pinned && pinned.length > 0 ? (
-            <>
-              <li className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
-                <span className="ml-4 text-sm font-semibold text-gray-400">
-                  Pinned Messages
-                </span>
-              </li>
-              {pinned.map((ship: string) => (
-                <MessagesSidebarItem
-                  key={ship}
-                  whom={ship}
-                  brief={briefs[ship]}
-                />
-              ))}
-            </>
-          ) : null}
-          <li className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
-            <span className="ml-4 text-sm font-semibold text-gray-400">
-              Messages
-            </span>
-          </li>
-          <li className="p-2">
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger
-                className={
-                  'default-focus flex w-full items-center justify-between space-x-2 rounded-lg bg-gray-50 px-2 py-1 text-sm font-semibold'
-                }
-                aria-label="Groups Filter Options"
-              >
-                <span className="flex items-center">
-                  <Filter16Icon className="w-4 text-gray-400" />
-                  <span className="pl-1">Filter: {messagesFilter}</span>
-                </span>
-                <CaretDown16Icon className="w-4 text-gray-400" />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content className="dropdown w-56 text-gray-600">
-                <DropdownMenu.Item
-                  className={cn(
-                    'dropdown-item flex items-center space-x-2 rounded-none',
-                    messagesFilter === filters.all && 'bg-gray-50 text-gray-800'
-                  )}
-                  onClick={() => setFilterMode(filters.all)}
+          <div className="flex w-full flex-col space-y-3 overflow-x-hidden px-2 sm:space-y-1">
+            {pinned && pinned.length > 0 ? (
+              <>
+                <div className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
+                  <span className="ml-4 text-sm font-semibold text-gray-400">
+                    Pinned Messages
+                  </span>
+                </div>
+                {pinned.map((ship: string) => (
+                  <MessagesSidebarItem
+                    key={ship}
+                    whom={ship}
+                    brief={briefs[ship]}
+                  />
+                ))}
+              </>
+            ) : null}
+            <div className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
+              <span className="ml-4 text-sm font-semibold text-gray-400">
+                Messages
+              </span>
+            </div>
+            <div className="p-2">
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger
+                  className={
+                    'default-focus flex w-full items-center justify-between space-x-2 rounded-lg bg-gray-50 px-2 py-1 text-sm font-semibold'
+                  }
+                  aria-label="Groups Filter Options"
                 >
-                  All Messages
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className={cn(
-                    'dropdown-item flex items-center space-x-2 rounded-none',
-                    messagesFilter === filters.dms && 'bg-gray-50 text-gray-800'
-                  )}
-                  onClick={() => setFilterMode(filters.dms)}
-                >
-                  Direct Messages
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className={cn(
-                    'dropdown-item flex items-center space-x-2 rounded-none',
-                    messagesFilter === filters.groups &&
-                      'bg-gray-50 text-gray-800'
-                  )}
-                  onClick={() => setFilterMode(filters.groups)}
-                >
-                  Group Channels
-                </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
-          </li>
-          <MessagesList filter={messagesFilter} />
-        </ul>
-      </div>
+                  <span className="flex items-center">
+                    <Filter16Icon className="w-4 text-gray-400" />
+                    <span className="pl-1">Filter: {messagesFilter}</span>
+                  </span>
+                  <CaretDown16Icon className="w-4 text-gray-400" />
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content className="dropdown w-56 text-gray-600">
+                  <DropdownMenu.Item
+                    className={cn(
+                      'dropdown-item flex items-center space-x-2 rounded-none',
+                      messagesFilter === filters.all &&
+                        'bg-gray-50 text-gray-800'
+                    )}
+                    onClick={() => setFilterMode(filters.all)}
+                  >
+                    All Messages
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={cn(
+                      'dropdown-item flex items-center space-x-2 rounded-none',
+                      messagesFilter === filters.dms &&
+                        'bg-gray-50 text-gray-800'
+                    )}
+                    onClick={() => setFilterMode(filters.dms)}
+                  >
+                    Direct Messages
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className={cn(
+                      'dropdown-item flex items-center space-x-2 rounded-none',
+                      messagesFilter === filters.groups &&
+                        'bg-gray-50 text-gray-800'
+                    )}
+                    onClick={() => setFilterMode(filters.groups)}
+                  >
+                    Group Channels
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Root>
+            </div>
+          </div>
+        </MessagesList>
+      </MessagesScrollingContext.Provider>
     </nav>
   );
 }

--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -12,6 +12,7 @@ import GroupAvatar from '../groups/GroupAvatar';
 import SidebarItem from '../components/Sidebar/SidebarItem';
 import MultiDmAvatar from './MultiDmAvatar';
 import { whomIsDm, whomIsMultiDm } from '../logic/utils';
+import { useMessagesScrolling } from './MessagesScrollingContext';
 
 interface MessagesSidebarItemProps {
   whom: string;
@@ -31,6 +32,7 @@ function ChannelSidebarItem({
   )?.[0];
   const channel = useChannel(groupFlag || '', nest);
   const group = useGroup(groupFlag || '');
+  const isScrolling = useMessagesScrolling();
 
   if (!channel) {
     return null;
@@ -39,7 +41,13 @@ function ChannelSidebarItem({
   return (
     <SidebarItem
       to={`/groups/${groupFlag}/channels/${nest}`}
-      icon={<GroupAvatar size="h-12 w-12 sm:h-6 sm:w-6" {...group?.meta} />}
+      icon={
+        <GroupAvatar
+          size="h-12 w-12 sm:h-6 sm:w-6"
+          {...group?.meta}
+          loadImage={!isScrolling}
+        />
+      }
       actions={<DmOptions whom={whom} pending={!!pending} />}
     >
       {channel.meta.title}
@@ -49,11 +57,18 @@ function ChannelSidebarItem({
 
 function DMSidebarItem({ whom, brief, pending }: MessagesSidebarItemProps) {
   const isMobile = useIsMobile();
+  const isScrolling = useMessagesScrolling();
 
   return (
     <SidebarItem
       to={`/dm/${whom}`}
-      icon={<Avatar size={isMobile ? 'default' : 'xs'} ship={whom} />}
+      icon={
+        <Avatar
+          size={isMobile ? 'default' : 'xs'}
+          ship={whom}
+          loadImage={!isScrolling}
+        />
+      }
       actions={<DmOptions whom={whom} pending={!!pending} />}
     >
       <ShipName
@@ -74,6 +89,7 @@ export function MultiDMSidebarItem({
   const club = useMultiDm(whom);
   const allMembers = club?.team.concat(club.hive);
   const groupName = club?.meta.title || allMembers?.join(', ') || whom;
+  const isScrolling = useMessagesScrolling();
 
   if (club && !allMembers?.includes(window.our)) {
     return null;
@@ -90,6 +106,7 @@ export function MultiDMSidebarItem({
             {...club?.meta}
             title={groupName}
             size={isMobile ? 'default' : 'xs'}
+            loadImage={!isScrolling}
           />
         )
       }

--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import cn from 'classnames';
+import { debounce } from 'lodash';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Link } from 'react-router-dom';
 import Divider from '@/components/Divider';
@@ -17,12 +18,14 @@ import {
 } from '@/state/settings';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
+import { MessagesScrollingContext } from './MessagesScrollingContext';
 
 const selMessagesFilter = (s: SettingsState) => ({
   messagesFilter: s.talk.messagesFilter,
 });
 
 export default function MobileMessagesSidebar() {
+  const [isScrolling, setIsScrolling] = useState(false);
   const { messagesFilter } = useSettingsState(selMessagesFilter);
   const briefs = useBriefs();
   const pinned = usePinned();
@@ -31,83 +34,86 @@ export default function MobileMessagesSidebar() {
     useSettingsState.getState().putEntry('talk', 'messagesFilter', mode);
   };
 
+  const scroll = useRef(
+    debounce((scrolling: boolean) => setIsScrolling(scrolling), 200)
+  );
+
   return (
     <nav
       className={cn(
         'flex h-full w-full flex-col border-r-2 border-gray-50 bg-white'
       )}
     >
-      <div className="overflow-y-auto">
-        {pinned && pinned.length > 0 ? (
-          <div className="-mb-2 md:mb-0">
-            <div className="-mb-2 flex items-center p-2 md:m-0">
-              <Divider>Pinned</Divider>
-              <div className="grow border-b-2 border-gray-100" />
+      <MessagesScrollingContext.Provider value={isScrolling}>
+        <MessagesList filter={messagesFilter} isScrolling={scroll.current}>
+          {pinned && pinned.length > 0 ? (
+            <div className="-mb-2 md:mb-0">
+              <div className="-mb-2 flex items-center p-2 md:m-0">
+                <Divider>Pinned</Divider>
+                <div className="grow border-b-2 border-gray-100" />
+              </div>
+              <div className="flex flex-col space-y-2 px-2 pb-2">
+                {pinned.map((ship: string) => (
+                  <MessagesSidebarItem
+                    key={ship}
+                    whom={ship}
+                    brief={briefs[ship]}
+                  />
+                ))}
+              </div>
             </div>
-            <div className="flex flex-col space-y-2 px-2 pb-2">
-              {pinned.map((ship: string) => (
-                <MessagesSidebarItem
-                  key={ship}
-                  whom={ship}
-                  brief={briefs[ship]}
-                />
-              ))}
-            </div>
-          </div>
-        ) : null}
-        <header className="flex flex-none items-center justify-between px-2 py-1">
-          <DropdownMenu.Root>
-            <DropdownMenu.Trigger
-              className={
-                'default-focus flex items-center rounded-lg p-2 text-base font-semibold hover:bg-gray-50'
-              }
-              aria-label="Groups Filter Options"
-            >
-              <h1 className="mr-4 text-xl font-medium">{messagesFilter}</h1>
-              <CaretDown16Icon className="h-4 w-4 text-gray-400" />
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content className="dropdown text-gray-600">
-              <DropdownMenu.Item
-                className={cn(
-                  'dropdown-item flex items-center space-x-2 rounded-none',
-                  messagesFilter === filters.all && 'bg-gray-50 text-gray-800'
-                )}
-                onClick={() => setFilterMode(filters.all)}
+          ) : null}
+          <header className="flex flex-none items-center justify-between px-2 py-1">
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger
+                className={
+                  'default-focus flex items-center rounded-lg p-2 text-base font-semibold hover:bg-gray-50'
+                }
+                aria-label="Groups Filter Options"
               >
-                <ChatSmallIcon className="mr-2 h-4 w-4" />
-                All Messages
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                className={cn(
-                  'dropdown-item flex items-center space-x-2 rounded-none',
-                  messagesFilter === filters.dms && 'bg-gray-50 text-gray-800'
-                )}
-                onClick={() => setFilterMode(filters.dms)}
-              >
-                <PersonSmallIcon className="mr-2 h-4 w-4" />
-                Direct Messages
-              </DropdownMenu.Item>
-              <DropdownMenu.Item
-                className={cn(
-                  'dropdown-item flex items-center space-x-2 rounded-none',
-                  messagesFilter === filters.groups &&
-                    'bg-gray-50 text-gray-800'
-                )}
-                onClick={() => setFilterMode(filters.groups)}
-              >
-                <CmdSmallIcon className="mr-2 h-4 w-4" />
-                Group Talk Channels
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
-          <Link to="/dm/new" aria-label="New Direct Message" className="mr-2">
-            <NewMessageIcon className="h-6 w-6 text-blue" />
-          </Link>
-        </header>
-        <div className="px-2">
-          <MessagesList filter={messagesFilter} />
-        </div>
-      </div>
+                <h1 className="mr-4 text-xl font-medium">{messagesFilter}</h1>
+                <CaretDown16Icon className="h-4 w-4 text-gray-400" />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content className="dropdown text-gray-600">
+                <DropdownMenu.Item
+                  className={cn(
+                    'dropdown-item flex items-center space-x-2 rounded-none',
+                    messagesFilter === filters.all && 'bg-gray-50 text-gray-800'
+                  )}
+                  onClick={() => setFilterMode(filters.all)}
+                >
+                  <ChatSmallIcon className="mr-2 h-4 w-4" />
+                  All Messages
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className={cn(
+                    'dropdown-item flex items-center space-x-2 rounded-none',
+                    messagesFilter === filters.dms && 'bg-gray-50 text-gray-800'
+                  )}
+                  onClick={() => setFilterMode(filters.dms)}
+                >
+                  <PersonSmallIcon className="mr-2 h-4 w-4" />
+                  Direct Messages
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className={cn(
+                    'dropdown-item flex items-center space-x-2 rounded-none',
+                    messagesFilter === filters.groups &&
+                      'bg-gray-50 text-gray-800'
+                  )}
+                  onClick={() => setFilterMode(filters.groups)}
+                >
+                  <CmdSmallIcon className="mr-2 h-4 w-4" />
+                  Group Talk Channels
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+            <Link to="/dm/new" aria-label="New Direct Message" className="mr-2">
+              <NewMessageIcon className="h-6 w-6 text-blue" />
+            </Link>
+          </header>
+        </MessagesList>
+      </MessagesScrollingContext.Provider>
     </nav>
   );
 }

--- a/ui/src/dms/MultiDmAvatar.tsx
+++ b/ui/src/dms/MultiDmAvatar.tsx
@@ -1,6 +1,6 @@
 import GroupAvatar from '@/groups/GroupAvatar';
 import cn from 'classnames';
-import React from 'react';
+import React, { useState } from 'react';
 import { isColor } from '@/logic/utils';
 import PeopleIcon from '../components/icons/PeopleIcon';
 
@@ -12,6 +12,7 @@ interface MultiDmAvatarProps {
   size?: MultiDmAvatarSize;
   className?: string;
   title?: string;
+  loadImage?: boolean;
 }
 
 const sizeMap = {
@@ -39,15 +40,30 @@ export default function MultiDmAvatar({
   size = 'default',
   className,
   title,
+  loadImage = true,
 }: MultiDmAvatarProps) {
+  const [loaded, setLoaded] = useState(false);
+  const showImage = loaded || loadImage;
+
   if (image && isColor(image)) {
     return (
-      <GroupAvatar size={sizeMap[size].size} image={image} title={title} />
+      <GroupAvatar
+        size={sizeMap[size].size}
+        image={image}
+        title={title}
+        loadImage={loadImage}
+      />
     );
   }
 
-  if (image) {
-    return <img className={cn(sizeMap[size].size, className)} src={image} />;
+  if (image && showImage) {
+    return (
+      <img
+        className={cn(sizeMap[size].size, className)}
+        src={image}
+        onLoad={() => setLoaded(true)}
+      />
+    );
   }
 
   return (

--- a/ui/src/dms/MultiDmAvatar.tsx
+++ b/ui/src/dms/MultiDmAvatar.tsx
@@ -2,6 +2,7 @@ import GroupAvatar from '@/groups/GroupAvatar';
 import cn from 'classnames';
 import React, { useState } from 'react';
 import { isColor } from '@/logic/utils';
+import { useAvatar } from '@/state/avatar';
 import PeopleIcon from '../components/icons/PeopleIcon';
 
 type MultiDmAvatarSize = 'xs' | 'small' | 'default' | 'huge';
@@ -42,8 +43,8 @@ export default function MultiDmAvatar({
   title,
   loadImage = true,
 }: MultiDmAvatarProps) {
-  const [loaded, setLoaded] = useState(false);
-  const showImage = loaded || loadImage;
+  const { hasLoaded, load } = useAvatar(image || '');
+  const showImage = hasLoaded || loadImage;
 
   if (image && isColor(image)) {
     return (
@@ -61,7 +62,7 @@ export default function MultiDmAvatar({
       <img
         className={cn(sizeMap[size].size, className)}
         src={image}
-        onLoad={() => setLoaded(true)}
+        onLoad={load}
       />
     );
   }

--- a/ui/src/groups/GroupAvatar.tsx
+++ b/ui/src/groups/GroupAvatar.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React from 'react';
+import React, { useState } from 'react';
 import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { isColor } from '@/logic/utils';
 import { useIsDark } from '@/logic/useMedia';
@@ -10,6 +10,7 @@ interface GroupAvatarProps {
   size?: string;
   className?: string;
   title?: string;
+  loadImage?: boolean;
 }
 
 const textSize = (size: string) => {
@@ -37,24 +38,31 @@ export default function GroupAvatar({
   size = 'h-6 w-6',
   className,
   title,
+  loadImage = true,
 }: GroupAvatarProps) {
+  const [loaded, setLoaded] = useState(false);
+  const showImage = loaded || loadImage;
   const dark = useIsDark();
   const calm = useCalm();
   let background;
 
-  if (!calm.disableRemoteContent) {
+  if (showImage && !calm.disableRemoteContent) {
     background = image || (dark ? '#333333' : '#E5E5E5');
   } else {
     background = dark ? '#333333' : '#E5E5E5';
   }
 
-  return image && !calm.disableRemoteContent && !isColor(image) ? (
-    <img className={cn('rounded', size, className)} src={image} />
+  return image && showImage && !calm.disableRemoteContent && !isColor(image) ? (
+    <img
+      className={cn('rounded', size, className)}
+      src={image}
+      onLoad={() => setLoaded(true)}
+    />
   ) : (
     <ColorBoxIcon
       className={cn('rounded', size, textSize(size), className)}
       color={background}
-      letter={title ? title.charAt(0) : ''}
+      letter={title ? Array.from(title)[0] : ''}
     />
   );
 }

--- a/ui/src/groups/GroupAvatar.tsx
+++ b/ui/src/groups/GroupAvatar.tsx
@@ -4,6 +4,7 @@ import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { isColor } from '@/logic/utils';
 import { useIsDark } from '@/logic/useMedia';
 import { useCalm } from '@/state/settings';
+import { useAvatar } from '@/state/avatar';
 
 interface GroupAvatarProps {
   image?: string;
@@ -40,8 +41,8 @@ export default function GroupAvatar({
   title,
   loadImage = true,
 }: GroupAvatarProps) {
-  const [loaded, setLoaded] = useState(false);
-  const showImage = loaded || loadImage;
+  const { hasLoaded, load } = useAvatar(image || '');
+  const showImage = hasLoaded || loadImage;
   const dark = useIsDark();
   const calm = useCalm();
   let background;
@@ -53,11 +54,7 @@ export default function GroupAvatar({
   }
 
   return image && showImage && !calm.disableRemoteContent && !isColor(image) ? (
-    <img
-      className={cn('rounded', size, className)}
-      src={image}
-      onLoad={() => setLoaded(true)}
-    />
+    <img className={cn('rounded', size, className)} src={image} onLoad={load} />
   ) : (
     <ColorBoxIcon
       className={cn('rounded', size, textSize(size), className)}

--- a/ui/src/logic/useMessageSort.ts
+++ b/ui/src/logic/useMessageSort.ts
@@ -10,14 +10,17 @@ export default function useMessageSort() {
   const sortOptions: Record<string, Sorter> = {
     [RECENT]: sortRecent,
   };
-  const { sortFn, setSortFn, sortRecordsBy } = useSidebarSort({ sortOptions });
+  const { sortFn, setSortFn, sortRecordsBy } = useSidebarSort({
+    defaultSort: RECENT,
+    sortOptions,
+  });
 
   function sortMessages(briefs: ChatBriefs) {
     const accessors: Record<string, (k: string, v: ChatBrief) => string> = {
-      [RECENT]: (flag: string, _brief: ChatBrief) => flag,
+      [RECENT]: (flag: string, _brief: ChatBrief) => `chat/${flag}`,
     };
 
-    return sortRecordsBy(briefs, accessors[sortFn], sortFn === RECENT);
+    return sortRecordsBy(briefs, accessors[sortFn], true);
   }
 
   return {

--- a/ui/src/logic/useSidebarSort.ts
+++ b/ui/src/logic/useSidebarSort.ts
@@ -54,12 +54,13 @@ export function useRecentSort() {
  * @returns an object with sorting functions to be consumed in view components
  */
 export default function useSidebarSort({
+  defaultSort,
   sortOptions,
   flag = '~',
 }: UseSidebarSort) {
   const { sideBarSort } = useSettingsState(selSideBarSort);
   const groupSideBarSort = useGroupSideBarSort();
-  const sortFn = groupSideBarSort[flag] || sideBarSort;
+  const sortFn = defaultSort || groupSideBarSort[flag] || sideBarSort;
 
   const setSideBarSort = (mode: string) => {
     useSettingsState.getState().putEntry('groups', 'sideBarSort', mode);

--- a/ui/src/state/avatar.ts
+++ b/ui/src/state/avatar.ts
@@ -1,0 +1,33 @@
+import produce from 'immer';
+import { useCallback } from 'react';
+import create from 'zustand';
+
+interface AvatarStore {
+  status: Record<string, boolean>;
+  loaded: (src: string) => void;
+}
+
+const useAvatarStore = create<AvatarStore>((set, get) => ({
+  status: {},
+  loaded: (src) => {
+    set(
+      produce((draft) => {
+        draft.status[src] = true;
+      })
+    );
+  },
+}));
+
+export function useAvatar(src: string) {
+  return useAvatarStore(
+    useCallback(
+      (store: AvatarStore) => ({
+        hasLoaded: store.status[src] || false,
+        load: () => store.loaded(src),
+      }),
+      [src]
+    )
+  );
+}
+
+export default useAvatarStore;

--- a/ui/src/state/contact.ts
+++ b/ui/src/state/contact.ts
@@ -128,7 +128,7 @@ const useContactState = createState<BaseContactState>(
       await api.poke(pokeSetPublic(isPublic));
     },
   },
-  ['nackedContacts'],
+  ['contacts'],
   [
     (set, get) =>
       createSubscription('contact-pull-hook', '/nacks', (e) => {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -785,9 +785,16 @@ export const useGroupState = create<GroupState>(
       name: createStorageKey('groups'),
       version: storageVersion,
       migrate: clearStorageMigration,
-      partialize: (state) => ({
-        groups: state.groups,
-      }),
+      merge: (persisted, current) => _.merge(current, persisted),
+      partialize: (state) => {
+        const groups = _.mapValues(state.groups, ({ fleet, ...group }) => ({
+          ...group,
+          fleet: {},
+        }));
+        return {
+          groups,
+        };
+      },
     }
   )
 );

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -165,7 +165,7 @@ export const useSettingsState = createState<BaseSettingsState>(
       set(newState);
     },
   }),
-  ['heaps', 'diary', 'groups', 'talk'],
+  ['display', 'heaps', 'diary', 'groups', 'talk'],
   [
     (set, get) =>
       createSubscription('settings-store', `/desk/${window.desk}`, (e) => {

--- a/ui/src/state/storage/storage.tsx
+++ b/ui/src/state/storage/storage.tsx
@@ -17,7 +17,7 @@ let numLoads = 0;
 export type StorageState = BaseStorageState & BaseState<BaseStorageState>;
 
 export const useStorage = createState<BaseStorageState>(
-  'Settings',
+  'Storage',
   (set, get) => ({
     loaded: false,
     hasCredentials: false,
@@ -51,7 +51,7 @@ export const useStorage = createState<BaseStorageState>(
       credentials: null,
     },
   }),
-  ['loaded', 's3', 'gcp'],
+  [],
   [
     (set, get) =>
       createSubscription('s3-store', '/all', (e) => {


### PR DESCRIPTION
Changes talk sidebar to be virtualized. Also introduces the ability for us to control when avatars load their images, like when scrolling. This should make going from channel back to all messages much faster.

Also threw in a fix for #1397 by removing fleet from persisted groups and fixed a few things with localStorage, like bad keys being saved or the fact that storage was named setting which was overriding persisted settings. 