### PR TITLE
groups: updated GroupAvatar to handle emoji + other unicode

### DIFF
--- a/ui/src/groups/GroupAvatar.tsx
+++ b/ui/src/groups/GroupAvatar.tsx
@@ -41,6 +41,7 @@ export default function GroupAvatar({
   const dark = useIsDark();
   const calm = useCalm();
   let background;
+  const symbols = [...(title || '')];
 
   if (!calm.disableRemoteContent) {
     background = image || (dark ? '#333333' : '#E5E5E5');
@@ -54,7 +55,7 @@ export default function GroupAvatar({
     <ColorBoxIcon
       className={cn('rounded', size, textSize(size), className)}
       color={background}
-      letter={title ? title.charAt(0) : ''}
+      letter={title ? symbols[0] : ''}
     />
   );
 }

--- a/ui/src/groups/GroupInfoFields.tsx
+++ b/ui/src/groups/GroupInfoFields.tsx
@@ -10,7 +10,6 @@ import { GroupMeta } from '@/types/groups';
 
 export default function GroupInfoFields() {
   const { register, watch } = useFormContext<GroupMeta>();
-  const [iconLetter, setIconLetter] = useState<string>();
   const [iconType, setIconType] = useState<ImageOrColorFieldState>('color');
   const [coverType, setCoverType] = useState<ImageOrColorFieldState>('color');
   const watchImage = watch('image');
@@ -19,12 +18,6 @@ export default function GroupInfoFields() {
   const showEmpty = iconType === 'image' && !isValidUrl(watchImage);
   const showCoverEmpty = coverType === 'image' && !isValidUrl(watchCover);
   const calm = useCalm();
-
-  useEffect(() => {
-    if (iconType === 'color' && watchTitle !== '') {
-      setIconLetter((watchTitle as string).slice(0, 1));
-    }
-  }, [iconType, watchTitle]);
 
   return (
     <>
@@ -49,7 +42,6 @@ export default function GroupInfoFields() {
             watchImage={watchImage}
             watchTitle={watchTitle}
             watchCover={watchCover}
-            iconLetter={iconLetter}
             coverType={coverType}
             showCoverEmpty={showCoverEmpty}
           />

--- a/ui/src/groups/NewGroup/GroupInfoPreview.tsx
+++ b/ui/src/groups/NewGroup/GroupInfoPreview.tsx
@@ -12,7 +12,6 @@ interface GroupInfoPreviewProps {
   watchImage: string;
   watchCover: string;
   watchTitle: string;
-  iconLetter: string | undefined;
   coverType: ImageOrColorFieldState;
   showCoverEmpty: boolean;
 }
@@ -24,7 +23,6 @@ export default function GroupInfoPreview({
   watchCover,
   watchTitle,
   watchImage,
-  iconLetter,
   showCoverEmpty,
 }: GroupInfoPreviewProps) {
   return (
@@ -49,15 +47,12 @@ export default function GroupInfoPreview({
       <div className="relative flex w-full flex-col justify-between p-2 text-lg sm:text-base">
         <div className="flex items-center space-x-2">
           <div className="flex items-center">
-            {iconType === 'color' ? (
-              <ColorBoxIcon
-                className="h-6 w-6 text-lg"
-                color={watchImage ? watchImage : '#999999'}
-                letter={iconLetter ? iconLetter : 'T'}
+            {iconType === 'color' || isValidUrl(watchImage) ? (
+              <GroupAvatar
+                title={watchTitle}
+                size=" h-6 w-6"
+                image={watchImage}
               />
-            ) : null}
-            {iconType === 'image' && isValidUrl(watchImage) ? (
-              <GroupAvatar size=" h-6 w-6" image={watchImage} />
             ) : null}
             {showEmpty ? (
               <EmptyIconBox className=" h-6 w-6 text-gray-300" />


### PR DESCRIPTION
see: #1423.

This may still break if people use the multi-emoji sequences that display as one emoji (like the families where they all have different user-selectable skin tones) but it'll fall back relatively gracefully