### PR TITLE
chat: fix issue with chat scroller not loading older messages

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -272,6 +272,10 @@ export default function ChatScroller({
     [isScrolling, atBottom]
   );
 
+  if (keys.length === 0) {
+    return null;
+  }
+
   return (
     <div className="relative h-full flex-1">
       <Virtuoso


### PR DESCRIPTION
We're sometimes rendering Virtuoso without setting a firstItemIndex because the keys haven't loaded yet. We need to make sure we have keys before rendering Virtuoso.

Fixes #1437 