### PR TITLE
channels: protect from accidental rejoins

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -242,6 +242,7 @@
   ++  join
     |=  =flag:c
     ^+  cor
+    ?<  (~(has by chats) flag)
     =.  chats  (~(put by chats) flag *chat:c)
     ca-abet:(ca-join:ca-core flag)
   ::

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -198,6 +198,7 @@
   ++  join
     |=  =flag:d
     ^+  cor
+    ?<  (~(has by shelf) flag)
     =.  shelf  (~(put by shelf) flag *diary:d)
     di-abet:(di-join:di-core flag)
   ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -137,6 +137,7 @@
   ++  join
     |=  =flag:h
     ^+  cor
+    ?<  (~(has by stash) flag)
     =.  stash  (~(put by stash) flag *heap:h)
     he-abet:(he-join:he-core flag)
   ::


### PR DESCRIPTION
We weren't protecting from rejoins. If you already have the channel, it would get bunted and then try to sub, but since it's a duplicate sub you're just left with an empty channel. This prevents part of #1452 still not sure how ted got in this state in the first place though.