### PR TITLE
groups: only let host send invites

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -429,6 +429,7 @@
 ::
 ++  give-invites
   |=  [=flag:g ships=(set ship)]
+  ?.  =(p.flag our.bowl)  cor
   %-  emil
     %+  turn
       ~(tap in ships)
@@ -1168,9 +1169,10 @@
     |=  [ships=(set ship) =diff:fleet:g]
     ^+  go-core
     =/  user-join  &((~(has in ships) src.bowl) =(1 ~(wyt in ships)))
+    =/  am-host  =(p.flag our.bowl)
     ?-    -.diff
         %add
-      ?>  ?|  =(p.flag our.bowl) :: self
+      ?>  ?|  am-host
               =(p.flag src.bowl) :: subscription
               user-join
           ==
@@ -1183,7 +1185,7 @@
                 !=(~(wyt in ships) ~(wyt in cross))
               ==
           ==      
-      =?  cor  !user-join  (give-invites flag ships)
+      =?  cor  &(!user-join am-host)  (give-invites flag ships)
       =.  fleet.group
         %-  ~(uni by fleet.group)
           %-  malt
@@ -1546,6 +1548,7 @@
           ga-core
           ::
             %kick
+          ~&  [(~(has by xeno) flag) (~(has by groups) flag) pev.gang]
           ?.  (~(has by xeno) flag)  ga-core
           ?^  pev.gang  ga-core
           ga-core(cor (emit get-preview:ga-pass))


### PR DESCRIPTION
we were accidentally sending group invites from every member that heard the person getting added to the group... Fixes #1464 