### PR TITLE
channels: restore lost subscriptions

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1228,7 +1228,7 @@
     ca-core
   ::
   ++  ca-safe-sub
-    ?:  ca-has-sub
+    ?:  |(ca-has-sub =(our.bowl p.flag))
       ca-core
     ca-sub
   ::

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -124,6 +124,7 @@
     =-  %+  fall  -  ~&  >  %bad-load  [state &]
     (mole |.([!<(versioned-state vase) |]))
   =.  state  old
+  =.  cor  restore-missing-subs
   ?:  =(okay cool)  cor
   :: =?  cor  bad  (emit (keep !>(old)))
   %-  (note:wood %ver leaf/"New Epic" ~)
@@ -135,6 +136,12 @@
   =.  cor
     ca-abet:ca-upgrade:(ca-abed:ca-core i.chats)
   $(chats t.chats)
+  ::
+  ++  restore-missing-subs
+    %+  roll
+      ~(tap by chats)
+    |=  [[=flag:c *] core=_cor]
+    ca-abet:ca-safe-sub:(ca-abed:ca-core flag)
   ::
   ++  keep
     |=  bad=^vase
@@ -1219,6 +1226,11 @@
     =/  =cage  chat-logs+!>(logs)
     =.  cor  (give %fact ~ cage)
     ca-core
+  ::
+  ++  ca-safe-sub
+    ?:  ca-has-sub
+      ca-core
+    ca-sub
   ::
   ++  ca-has-sub
     ^-  ?

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -102,6 +102,7 @@
     =-  %+  fall  -  ~&  >  %bad-load  [state &]
     (mole |.([!<(versioned-state vase) |]))
   =.  state  old
+  =.  cor  restore-missing-subs
   =.  cor
     (emil (drop load:epos))
   =/  diaries  ~(tap in ~(key by shelf))
@@ -113,6 +114,11 @@
   $(diaries t.diaries)
   ::
   +$  versioned-state  $%(current-state)
+  ++  restore-missing-subs
+    %+  roll
+      ~(tap by shelf)
+    |=  [[=flag:d *] core=_cor]
+    di-abet:di-safe-sub:(di-abed:di-core flag)
   --
 ::
 ++  watch-epic

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -619,8 +619,12 @@
     =.  saga.net.diary  chi/~
     di-safe-sub
   ::
+  ++  di-has-sub
+    ^-  ?
+    (~(has by wex.bowl) [(snoc di-area %updates) p.flag dap.bowl])
+  ::
   ++  di-safe-sub
-    ?:  (~(has by wex.bowl) [(snoc di-area %updates) p.flag dap.bowl])
+    ?:  |(di-has-sub =(our.bowl p.flag))
       di-core
     di-sub
   ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -813,9 +813,13 @@
     =.  cor  (give %fact ~ cage)
     he-core
   ::
+  ++  he-has-sub
+    ^-  ?
+    (~(has by wex.bowl) [(snoc he-area %updates) p.flag dap.bowl])
+  ::
   ++  he-safe-sub
     ^+  he-core
-    ?:  (~(has by wex.bowl) [(snoc he-area %updates) p.flag dap.bowl])
+    ?:  |(he-has-sub =(our.bowl p.flag))
       he-core
     he-sub
   ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -179,6 +179,7 @@
     =-  %+  fall  -  ~&  >  %bad-load  [state &]
     (mole |.([!<(versioned-state vase) |]))
   =.  state  old
+  =.  cor  restore-missing-subs
   ?:  =(okay cool)  cor
   ::  speak the good news
   =.  cor  (emil (drop load:epos))
@@ -191,6 +192,12 @@
   $(heaps t.heaps)
   ::
   +$  versioned-state  $%(current-state)
+  ++  restore-missing-subs
+    %+  roll
+      ~(tap by stash)
+    |=  [[=flag:h *] core=_cor]
+    he-abet:he-safe-sub:(he-abed:he-core flag)
+  ::
   --
 ::
 ++  watch


### PR DESCRIPTION
Somewhere in the process of migration we lost subscriptions to the updates for certain channels. This should safely restore them if missing. Fixes #1478