### PR TITLE
chat: better handling of thread unreads

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/state/chat';
 import Avatar from '@/components/Avatar';
 import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
+import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { useChatInfo, useChatStore } from '../useChatStore';
 
 export interface ChatMessageProps {
@@ -64,6 +65,7 @@ const ChatMessage = React.memo<
       const { seal, memo } = writ;
       const chatInfo = useChatInfo(whom);
       const unread = chatInfo?.unread;
+      const unreadId = unread?.brief['read-id'];
       const { ref: viewRef } = useInView({
         threshold: 1,
         onChange: useCallback(
@@ -118,6 +120,9 @@ const ChatMessage = React.memo<
       const pact = usePact(whom);
 
       const numReplies = seal.replied.length;
+      const repliesContainsUnreadId = unreadId
+        ? seal.replied.includes(unreadId)
+        : false;
       const replyAuthors = _.flow(
         f.map((k: string) => {
           const t = pact.index[k];
@@ -189,6 +194,12 @@ const ChatMessage = React.memo<
                     }
                   >
                     <div className="flex items-center space-x-2">
+                      {repliesContainsUnreadId ? (
+                        <UnreadIndicator
+                          className="h-6 w-6 text-blue transition-opacity"
+                          aria-label="Unread replies in this thread"
+                        />
+                      ) : null}
                       {replyAuthors.map((ship) => (
                         <Avatar key={ship} ship={ship} size="xs" />
                       ))}

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -1,11 +1,16 @@
 import React, { useCallback } from 'react';
 import { format, isToday } from 'date-fns';
 import { daToUnix, udToDec } from '@urbit/api';
-import bigInt from 'big-integer';
+import bigInt, { BigInteger } from 'big-integer';
 import { VirtuosoHandle } from 'react-virtuoso';
 import XIcon from '@/components/icons/XIcon';
 import { pluralize } from '@/logic/utils';
-import { useChatKeys, useChatState, useGetFirstUnreadID } from '@/state/chat';
+import {
+  useChatKeys,
+  useChatState,
+  useGetFirstUnreadID,
+  useWrit,
+} from '@/state/chat';
 import { useChatInfo } from './useChatStore';
 
 interface ChatUnreadAlertsProps {
@@ -18,6 +23,16 @@ export default function ChatUnreadAlerts({
   whom,
 }: ChatUnreadAlertsProps) {
   const chatInfo = useChatInfo(whom);
+  const maybeWrit = useWrit(whom, chatInfo?.unread?.brief['read-id'] || '');
+  let replyToId: BigInteger = bigInt(0);
+  if (maybeWrit) {
+    const [_, writ] = maybeWrit;
+    const replyTo = writ.memo.replying || '';
+    replyToId =
+      replyTo !== ''
+        ? bigInt(replyTo.split('/')[1].replaceAll('.', ''))
+        : bigInt(0);
+  }
   const markRead = useCallback(() => {
     useChatState.getState().markRead(whom);
   }, [whom]);
@@ -26,7 +41,24 @@ export default function ChatUnreadAlerts({
   const firstUnreadID = useGetFirstUnreadID(whom);
   const keys = useChatKeys({ whom, replying: false });
   const goToFirstUnread = useCallback(() => {
-    if (!firstUnreadID || !scrollerRef.current) {
+    if (!scrollerRef.current) {
+      return;
+    }
+
+    if (replyToId !== bigInt(0)) {
+      const idx = keys.findIndex((k) => k.greaterOrEquals(replyToId));
+      if (idx === -1) {
+        return;
+      }
+
+      scrollerRef.current.scrollToIndex({
+        index: idx,
+        align: 'start',
+        behavior: 'auto',
+      });
+    }
+
+    if (!firstUnreadID) {
       return;
     }
 
@@ -40,7 +72,7 @@ export default function ChatUnreadAlerts({
       align: 'start',
       behavior: 'auto',
     });
-  }, [firstUnreadID, keys, scrollerRef]);
+  }, [firstUnreadID, keys, scrollerRef, replyToId]);
 
   if (!chatInfo.unread || chatInfo.unread.seen) {
     return null;

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -11,7 +11,7 @@ import {
   useGetFirstUnreadID,
   useWrit,
 } from '@/state/chat';
-import { useChatInfo } from './useChatStore';
+import { useChatInfo, useChatStore } from './useChatStore';
 
 interface ChatUnreadAlertsProps {
   scrollerRef: React.RefObject<VirtuosoHandle>;
@@ -35,6 +35,7 @@ export default function ChatUnreadAlerts({
   }
   const markRead = useCallback(() => {
     useChatState.getState().markRead(whom);
+    useChatStore.getState().read(whom);
   }, [whom]);
 
   // TODO: how to handle replies?


### PR DESCRIPTION
Fixes #1453 

Shows a blue "unread" dot next to a thread if it contains the last unread message.

Also allows for a user to click "Click to view" button in the unread banner and get taken to the parent (replied-to message) in the chat scroller if the last unread message is in a thread under that message.

tl;dr: makes unread threads less annoying.