### PR TITLE
groups: default vessel

### DIFF
--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -844,7 +844,14 @@ export function useGroupList(): string[] {
 
 export function useVessel(flag: string, ship: string) {
   return useGroupState(
-    useCallback((s) => s.groups[flag]?.fleet[ship], [ship, flag])
+    useCallback(
+      (s) =>
+        s.groups[flag]?.fleet[ship] || {
+          sects: [],
+          joined: 0,
+        },
+      [ship, flag]
+    )
   );
 }
 

--- a/ui/src/state/groups/groupsReducer.ts
+++ b/ui/src/state/groups/groupsReducer.ts
@@ -65,12 +65,12 @@ function reduceFleet(draft: Group, diff: FleetDiff) {
     });
   } else if ('add-sects' in d) {
     ships.forEach((ship) => {
-      const vessel = draft.fleet[ship];
+      const vessel = draft.fleet[ship] || { sects: [], joined: 0 };
       vessel.sects = [...vessel.sects, ...d['add-sects']];
     });
   } else if ('del-sects' in d) {
     ships.forEach((ship) => {
-      const vessel = draft.fleet[ship];
+      const vessel = draft.fleet[ship] || { sects: [], joined: 0 };
       vessel.sects = vessel.sects.filter((s) => !d['del-sects'].includes(s));
     });
   }


### PR DESCRIPTION
We weren't defaulting the vessel if it's not found, but it should be there. Should fix #1513 #1502, but maybe not the root cause of why it isn't there in the first place.