### PR TITLE
chat: fix issue with scroll position on channel switch

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -306,7 +306,7 @@ export default function ChatScroller({
           }
         }}
         totalListHeightChanged={(newHeight) => {
-          if (height !== newHeight && atBottom) {
+          if (height < newHeight && atBottom) {
             scrollerRef.current?.scrollBy({ left: 0, top: newHeight - height });
             setHeight(newHeight);
           }


### PR DESCRIPTION
Should fix the issue we were seeing with scroll between chats. Please test it out and let me know if you still see it in some particular situation.

Only issue I see is if you add an emoji, remove it, and add it back the emoji will be hidden below the chat input.