### PR TITLE
notebooks: virtualize list of notes

### DIFF
--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -139,17 +139,19 @@ function DiaryChannel() {
     await useDiaryState.getState().getOlderNotes(chFlag, 30);
   };
 
-  // const keys = sortedNotes.map((sN) => sN[0]);
-
-  // const itemContent = (i: number, realIndex: bigInt.BigInteger) => {
-  //   console.log('getting itemcontent');
-  //   return <DiaryListItem letter={letters.get(realIndex)} time={realIndex} />;
-  // };
+  const itemContent = (
+    i: number,
+    [time, letter]: [bigInt.BigInteger, DiaryLetter]
+  ) => (
+    <div className="my-4 mx-auto max-w-[600px]">
+      <DiaryListItem letter={letter} time={time} />
+    </div>
+  );
 
   return (
     <Layout
       stickyHeader
-      className="flex-1 overflow-y-scroll bg-gray-50"
+      className="flex-1 bg-gray-50"
       aside={<Outlet />}
       header={
         <ChannelHeader
@@ -191,29 +193,23 @@ function DiaryChannel() {
           <Toast.Viewport label="Note successfully published" />
         </div>
       </Toast.Provider>
-      <div className="p-4">
+      <div className="h-full">
         {displayMode === 'grid' ? (
           <DiaryGridView notes={sortedNotes} />
         ) : (
-          <div className="h-full p-6">
-            <div className="mx-auto flex h-full max-w-[600px] flex-col space-y-4">
-              {/* <Virtuoso
-                style={{ height: '100%', width: '100%' }}
-                data={keys}
+          <div className="h-full">
+            <div className="mx-auto flex h-full w-full flex-col">
+              <Virtuoso
+                style={{ height: '100%', width: '100%', paddingTop: '1rem' }}
+                data={sortedNotes}
                 itemContent={itemContent}
-              /> */}
-              {sortedNotes.map(([time, letter]) => (
-                <DiaryListItem
-                  key={time.toString()}
-                  time={time}
-                  letter={letter}
-                />
-              ))}
-              <div className="flex w-full items-center justify-center">
-                <button className="button" onClick={loadOlderNotes}>
-                  Load More
-                </button>
-              </div>
+                overscan={200}
+                atBottomStateChange={loadOlderNotes}
+                components={{
+                  Header: () => <div className="h-8 w-full" />,
+                  Footer: () => <div className="h-4 w-full" />,
+                }}
+              />
             </div>
           </div>
         )}

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
 import bigInt from 'big-integer';
@@ -135,6 +135,10 @@ function DiaryChannel() {
     return b.compare(a);
   });
 
+  // const loadOlderNotes = useCallback(async () => {
+  //   await useDiaryState.getState().getOlderNotes(chFlag, 30);
+  // }, [chFlag]);
+
   const loadOlderNotes = async () => {
     await useDiaryState.getState().getOlderNotes(chFlag, 30);
   };
@@ -195,7 +199,7 @@ function DiaryChannel() {
       </Toast.Provider>
       <div className="h-full">
         {displayMode === 'grid' ? (
-          <DiaryGridView notes={sortedNotes} />
+          <DiaryGridView notes={sortedNotes} loadOlderNotes={loadOlderNotes} />
         ) : (
           <div className="h-full">
             <div className="mx-auto flex h-full w-full flex-col">

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -35,7 +35,6 @@ import { canReadChannel, createStorageKey } from '@/logic/utils';
 import DiaryListItem from './DiaryList/DiaryListItem';
 import useDiaryActions from './useDiaryActions';
 
-
 function DiaryChannel() {
   const { chShip, chName } = useParams();
   const chFlag = `${chShip}/${chName}`;
@@ -134,10 +133,9 @@ function DiaryChannel() {
     return b.compare(a);
   });
 
-
-  const loadOlderNotes = async () => {
+  const loadOlderNotes = useCallback(async () => {
     await useDiaryState.getState().getOlderNotes(chFlag, 30);
-  };
+  }, [chFlag]);
 
   const itemContent = (
     i: number,

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
+import bigInt from 'big-integer';
+import { Virtuoso } from 'react-virtuoso';
 import Layout from '@/components/Layout/Layout';
 import {
   GROUP_ADMIN,
@@ -24,7 +26,7 @@ import {
 } from '@/state/settings';
 import ChannelHeader from '@/channels/ChannelHeader';
 import useDismissChannelNotifications from '@/logic/useDismissChannelNotifications';
-import { DiaryDisplayMode } from '@/types/diary';
+import { DiaryDisplayMode, DiaryLetter } from '@/types/diary';
 import DiaryGridView from '@/diary/DiaryList/DiaryGridView';
 import { Link } from 'react-router-dom';
 import * as Toast from '@radix-ui/react-toast';
@@ -32,6 +34,8 @@ import useRecentChannel from '@/logic/useRecentChannel';
 import { canReadChannel, createStorageKey } from '@/logic/utils';
 import DiaryListItem from './DiaryList/DiaryListItem';
 import useDiaryActions from './useDiaryActions';
+
+// const ListViewItem = React.memo((letter: DiaryLetter, time: bigInt.BigInteger) => <DiaryListItem letter={letter} time={time} key={time.toString()} />);
 
 function DiaryChannel() {
   const { chShip, chName } = useParams();
@@ -131,6 +135,13 @@ function DiaryChannel() {
     return b.compare(a);
   });
 
+  const keys = sortedNotes.map((sN) => sN[0]);
+
+  const itemContent = (i: number, realIndex: bigInt.BigInteger) => {
+    console.log('getting itemcontent');
+    return <DiaryListItem letter={letters.get(realIndex)} time={realIndex} />;
+  };
+
   return (
     <Layout
       stickyHeader
@@ -182,13 +193,18 @@ function DiaryChannel() {
         ) : (
           <div className="h-full p-6">
             <div className="mx-auto flex h-full max-w-[600px] flex-col space-y-4">
-              {sortedNotes.map(([time, letter]) => (
+              <Virtuoso
+                style={{ height: '100%', width: '100%' }}
+                data={keys}
+                itemContent={itemContent}
+              />
+              {/* {sortedNotes.map(([time, letter]) => (
                 <DiaryListItem
                   key={time.toString()}
                   time={time}
                   letter={letter}
                 />
-              ))}
+              ))} */}
             </div>
           </div>
         )}

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -35,7 +35,6 @@ import { canReadChannel, createStorageKey } from '@/logic/utils';
 import DiaryListItem from './DiaryList/DiaryListItem';
 import useDiaryActions from './useDiaryActions';
 
-// const ListViewItem = React.memo((letter: DiaryLetter, time: bigInt.BigInteger) => <DiaryListItem letter={letter} time={time} key={time.toString()} />);
 
 function DiaryChannel() {
   const { chShip, chName } = useParams();
@@ -135,9 +134,6 @@ function DiaryChannel() {
     return b.compare(a);
   });
 
-  // const loadOlderNotes = useCallback(async () => {
-  //   await useDiaryState.getState().getOlderNotes(chFlag, 30);
-  // }, [chFlag]);
 
   const loadOlderNotes = async () => {
     await useDiaryState.getState().getOlderNotes(chFlag, 30);

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -135,12 +135,16 @@ function DiaryChannel() {
     return b.compare(a);
   });
 
-  const keys = sortedNotes.map((sN) => sN[0]);
-
-  const itemContent = (i: number, realIndex: bigInt.BigInteger) => {
-    console.log('getting itemcontent');
-    return <DiaryListItem letter={letters.get(realIndex)} time={realIndex} />;
+  const loadOlderNotes = async () => {
+    await useDiaryState.getState().getOlderNotes(chFlag, 30);
   };
+
+  // const keys = sortedNotes.map((sN) => sN[0]);
+
+  // const itemContent = (i: number, realIndex: bigInt.BigInteger) => {
+  //   console.log('getting itemcontent');
+  //   return <DiaryListItem letter={letters.get(realIndex)} time={realIndex} />;
+  // };
 
   return (
     <Layout
@@ -193,18 +197,23 @@ function DiaryChannel() {
         ) : (
           <div className="h-full p-6">
             <div className="mx-auto flex h-full max-w-[600px] flex-col space-y-4">
-              <Virtuoso
+              {/* <Virtuoso
                 style={{ height: '100%', width: '100%' }}
                 data={keys}
                 itemContent={itemContent}
-              />
-              {/* {sortedNotes.map(([time, letter]) => (
+              /> */}
+              {sortedNotes.map(([time, letter]) => (
                 <DiaryListItem
                   key={time.toString()}
                   time={time}
                   letter={letter}
                 />
-              ))} */}
+              ))}
+              <div className="flex w-full items-center justify-center">
+                <button className="button" onClick={loadOlderNotes}>
+                  Load More
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/ui/src/diary/DiaryList/DiaryGridItem.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridItem.tsx
@@ -7,7 +7,7 @@ import { useRouteGroup, useAmAdmin } from '@/state/groups/groups';
 import IconButton from '@/components/IconButton';
 import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import CopyIcon from '@/components/icons/CopyIcon';
-import { makePrettyDate } from '@/logic/utils';
+import { makePrettyDate, sampleQuippers } from '@/logic/utils';
 import { daToUnix } from '@urbit/api';
 import DiaryCommenters from '@/diary/DiaryCommenters';
 import { useChannelFlag } from '@/hooks';
@@ -28,7 +28,7 @@ export default function DiaryGridItem({ letter, time }: DiaryGridItemProps) {
   const date = makePrettyDate(unix);
   const navigate = useNavigate();
   const hasImage =
-    (letter.type === 'note' ? letter.essay.image : letter.image).length !== 0;
+    (letter.type === 'note' ? letter.essay.image : letter.image)?.length !== 0;
   const { didCopy, onCopy } = useDiaryActions({
     flag: chFlag || '',
     time: time.toString(),
@@ -45,11 +45,7 @@ export default function DiaryGridItem({ letter, time }: DiaryGridItemProps) {
   const commenters =
     letter.type === 'outline'
       ? letter.quippers
-      : _.flow(
-          f.compact,
-          f.uniq,
-          f.take(3)
-        )([...letter.seal.quips].map(([, v]) => v.memo.author));
+      : sampleQuippers(letter.seal.quips);
   const quipCount =
     letter.type === 'outline' ? letter.quipCount : letter.seal.quips.size;
 

--- a/ui/src/diary/DiaryList/DiaryGridView.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridView.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
-import { Masonry, RenderComponentProps } from 'masonic';
+import React, {useState, useRef, useCallback, useEffect} from 'react';
+import { Masonry, MasonryScroller, RenderComponentProps, useContainerPosition, useInfiniteLoader, useMasonry, usePositioner, useResizeObserver, useScroller } from 'masonic';
+import { useElementSize, useWindowSize } from 'usehooks-ts';
 import DiaryGridItem from '@/diary/DiaryList/DiaryGridItem';
 import { DiaryLetter, DiaryNote } from '@/types/diary';
+import { debounce } from 'lodash';
 
 interface DiaryGridProps {
   notes: [bigInt.BigInteger, DiaryLetter][];
+  loadOlderNotes: () => Promise<void>
 }
 
 const masonryItem = ({
@@ -13,17 +16,58 @@ const masonryItem = ({
   <DiaryGridItem time={data[0]} letter={data[1]} />
 );
 
-export default function DiaryGridView({ notes }: DiaryGridProps) {
+export default function DiaryGridView({ notes, loadOlderNotes }: DiaryGridProps) {
+  // const [containerRef, {width, height}] = useElementSize();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const {width: windowWidth, height: windowHeight} = useWindowSize();
+  const {offset, width} = useContainerPosition(containerRef, [windowWidth, windowHeight]);
+  const {scrollTop, isScrolling} = useScroller(offset);
+  // debugger;
+  // console.log(width, height);
+  const positioner = usePositioner({
+    width: containerRef.current?.offsetWidth,
+    columnCount: 2,
+    columnGutter: 16
+  });
+  const resizeObserver = useResizeObserver(positioner);
+  console.log({width, offset});
+  const maybeLoadMore = useInfiniteLoader((startIndex, stopIndex, currentItems) => {
+    console.log(scrollTop);
+    if(startIndex > currentItems.length){
+      loadOlderNotes();
+    }
+  }, {isItemLoaded: (index, items) => !!items[index], threshold: 3});
+  // const masonryGrid = useMasonry(
+  //   {
+  //     positioner,
+  //     resizeObserver,
+  //     items: notes,
+  //     windowHeight,
+  //     scrollTop,
+  //     isScrolling,
+  //     overscanBy: 10,
+  //     render: masonryItem,
+  //     onRender: maybeLoadMore
+  //   }
+  // );
+
+
   if (notes?.length !== 0) {
     return (
-      <div className="h-full p-6">
-        <div className="mx-auto h-full max-w-[600px]">
-          <Masonry
-            columnCount={2}
-            columnGutter={16}
-            items={notes}
+      <div className='h-full w-full overflow-y-auto' ref={containerRef}>
+        <div className='mx-auto box-border h-full w-full max-w-[600px]'>
+          {/* {masonryGrid} */}
+          <MasonryScroller
+            positioner={positioner}
+            // offset={containerRef.current?.offsetTop}
+            height={containerRef?.current?.offsetHeight || 0}
+            containerRef={containerRef}
+            overscanBy={3}
+            resizeObserver={resizeObserver}
             render={masonryItem}
-          />
+            items={notes}
+            onRender={maybeLoadMore}
+           />
         </div>
       </div>
     );

--- a/ui/src/diary/DiaryList/DiaryGridView.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridView.tsx
@@ -1,13 +1,17 @@
-import React, {useState, useRef, useCallback, useEffect} from 'react';
-import { Masonry, MasonryScroller, RenderComponentProps, useContainerPosition, useInfiniteLoader, useMasonry, usePositioner, useResizeObserver, useScroller } from 'masonic';
-import { useElementSize, useWindowSize } from 'usehooks-ts';
+import React, { useRef } from 'react';
+import {
+  RenderComponentProps,
+  useInfiniteLoader,
+  useMasonry,
+  usePositioner,
+  useResizeObserver,
+} from 'masonic';
 import DiaryGridItem from '@/diary/DiaryList/DiaryGridItem';
-import { DiaryLetter, DiaryNote } from '@/types/diary';
-import { debounce } from 'lodash';
+import { DiaryLetter } from '@/types/diary';
 
 interface DiaryGridProps {
   notes: [bigInt.BigInteger, DiaryLetter][];
-  loadOlderNotes: () => Promise<void>
+  loadOlderNotes: () => Promise<void>;
 }
 
 const masonryItem = ({
@@ -16,58 +20,55 @@ const masonryItem = ({
   <DiaryGridItem time={data[0]} letter={data[1]} />
 );
 
-export default function DiaryGridView({ notes, loadOlderNotes }: DiaryGridProps) {
-  // const [containerRef, {width, height}] = useElementSize();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const {width: windowWidth, height: windowHeight} = useWindowSize();
-  const {offset, width} = useContainerPosition(containerRef, [windowWidth, windowHeight]);
-  const {scrollTop, isScrolling} = useScroller(offset);
-  // debugger;
-  // console.log(width, height);
-  const positioner = usePositioner({
-    width: containerRef.current?.offsetWidth,
-    columnCount: 2,
-    columnGutter: 16
-  });
-  const resizeObserver = useResizeObserver(positioner);
-  console.log({width, offset});
-  const maybeLoadMore = useInfiniteLoader((startIndex, stopIndex, currentItems) => {
-    console.log(scrollTop);
-    if(startIndex > currentItems.length){
+export default function DiaryGridView({
+  notes,
+  loadOlderNotes,
+}: DiaryGridProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const gridContainerRef = useRef<HTMLDivElement>(null);
+  const maybeLoadMore = useInfiniteLoader(
+    () => {
       loadOlderNotes();
-    }
-  }, {isItemLoaded: (index, items) => !!items[index], threshold: 3});
-  // const masonryGrid = useMasonry(
-  //   {
-  //     positioner,
-  //     resizeObserver,
-  //     items: notes,
-  //     windowHeight,
-  //     scrollTop,
-  //     isScrolling,
-  //     overscanBy: 10,
-  //     render: masonryItem,
-  //     onRender: maybeLoadMore
-  //   }
-  // );
+    },
+    { isItemLoaded: (index, items) => !!items[index], threshold: 3 }
+  );
 
+  const positioner = usePositioner(
+    {
+      columnCount: 2,
+      width: gridContainerRef.current?.offsetWidth || 600,
+      columnGutter: 16,
+    },
+    [notes.length]
+  );
+  const height = scrollContainerRef.current?.offsetHeight || window.innerHeight;
+  const resizeObserver = useResizeObserver(positioner);
+  const scrollTop = scrollContainerRef.current?.scrollTop || 0;
+
+  const masonryGrid = useMasonry({
+    positioner,
+    resizeObserver,
+    containerRef: scrollContainerRef,
+    overscanBy: 10,
+    render: masonryItem,
+    items: notes,
+    onRender: maybeLoadMore,
+    height,
+    itemHeightEstimate: 220,
+    scrollTop,
+  });
 
   if (notes?.length !== 0) {
     return (
-      <div className='h-full w-full overflow-y-auto' ref={containerRef}>
-        <div className='mx-auto box-border h-full w-full max-w-[600px]'>
-          {/* {masonryGrid} */}
-          <MasonryScroller
-            positioner={positioner}
-            // offset={containerRef.current?.offsetTop}
-            height={containerRef?.current?.offsetHeight || 0}
-            containerRef={containerRef}
-            overscanBy={3}
-            resizeObserver={resizeObserver}
-            render={masonryItem}
-            items={notes}
-            onRender={maybeLoadMore}
-           />
+      <div
+        className="h-full w-full overflow-y-auto py-8"
+        ref={scrollContainerRef}
+      >
+        <div
+          className="mx-auto box-border w-full max-w-[600px]"
+          ref={gridContainerRef}
+        >
+          {masonryGrid}
         </div>
       </div>
     );

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -37,7 +37,7 @@ export function sampleQuippers(quips: DiaryQuipMap) {
     f.compact,
     f.uniq,
     f.take(3)
-  )([...quips]);
+  )(quips.size ? [...quips] : []);
 }
 
 export function renderRank(rank: Rank, plural = false) {

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -334,6 +334,22 @@ export const useDiaryState = create<DiaryState>(
           draft.shelf[flag].perms = perms;
         });
       },
+      getOlderNotes: async (flag: string, count: number) => {
+        await makeNotesStore(
+          flag,
+          get,
+          `/diary/${flag}/notes`,
+          `/diary/${flag}/ui`
+        ).getOlder(count.toString());
+      },
+      getNewerNotes: async (flag: string, count: number) => {
+        await makeNotesStore(
+          flag,
+          get,
+          `/diary/${flag}/notes`,
+          `/diary/${flag}/ui`
+        ).getNewer(count.toString());
+      },
       initialize: async (flag) => {
         if (get().diarySubs.includes(flag)) {
           return;

--- a/ui/src/state/diary/type.ts
+++ b/ui/src/state/diary/type.ts
@@ -36,6 +36,8 @@ export interface DiaryState {
   addNote: (flag: DiaryFlag, essay: NoteEssay) => Promise<string>;
   editNote: (flag: DiaryFlag, time: string, essay: NoteEssay) => Promise<void>;
   delNote: (flag: DiaryFlag, time: string) => Promise<void>;
+  getOlderNotes: (flag: string, count: number) => Promise<void>;
+  getNewerNotes: (flag: string, count: number) => Promise<void>;
   addSects: (flag: DiaryFlag, writers: string[]) => Promise<void>;
   delSects: (flag: DiaryFlag, writers: string[]) => Promise<void>;
   addQuip: (


### PR DESCRIPTION
see: #1458.

also fixes an issue with the `sampleQuippers` hook

note that the autoloading in the grid view is still somewhat janky, but it does work