### PR TITLE
chat: tooltip durability

### DIFF
--- a/ui/src/components/IconButton.tsx
+++ b/ui/src/components/IconButton.tsx
@@ -21,7 +21,7 @@ export default function IconButton({
 }: IconButtonProps) {
   return (
     <div className={cn('group-two cursor-pointer', className)}>
-      <Tooltip.Root delayDuration={0}>
+      <Tooltip.Root delayDuration={800} disableHoverableContent>
         {showTooltip ? (
           <Tooltip.Portal>
             <Tooltip.Content asChild sideOffset={5} hideWhenDetached>


### PR DESCRIPTION
addresses concern bought up by ~poldec-tonteg and expanded on by @urcades 

added a delay before showing the tooltip, and disabled the ability to hover over it (the double-nested hover states allowed you to enter a state where only the tooltip was open)