### PR TITLE
talk: correct width for multi-DM info modal

### DIFF
--- a/ui/src/components/ColorPicker.tsx
+++ b/ui/src/components/ColorPicker.tsx
@@ -28,7 +28,7 @@ export default function ColorPicker({
       <Popover.Root>
         <Popover.Trigger
           style={{ backgroundColor: color }}
-          className="h-6 w-6 rounded"
+          className="h-6 w-6 shrink-0 rounded"
         />
         <Popover.Content>
           <HexColorPicker color={color} onChange={setColor} />
@@ -37,7 +37,7 @@ export default function ColorPicker({
       </Popover.Root>
       <HexColorInput
         prefixed
-        className="input-inner grow py-0"
+        className="input-inner w-full"
         type="text"
         color={color}
         onChange={setColor}

--- a/ui/src/components/ImageOrColorField.tsx
+++ b/ui/src/components/ImageOrColorField.tsx
@@ -77,9 +77,9 @@ export default function ImageOrColorField<FormType extends FieldValues>({
         ) : null}
         {status === 'color' ? (
           <div className="input flex h-8 w-full items-center rounded-lg">
-            <ColorPickerField fieldName={fieldName} className="grow" />
+            <ColorPickerField fieldName={fieldName} />
             <button
-              className="small-button line-break-none w-max"
+              className="small-button h-6 whitespace-nowrap"
               onClick={handleImageIconType}
             >
               Add Image

--- a/ui/src/components/ImageURLUploadField.tsx
+++ b/ui/src/components/ImageURLUploadField.tsx
@@ -52,7 +52,7 @@ export default function ImageURLUploadField({
   return (
     <div className="input relative flex h-8 w-full items-center justify-end">
       <input
-        className={cn('input-inner grow p-0')}
+        className={cn('input-inner w-full py-0 pl-0 pr-2')}
         onFocus={() => setIsFocused(true)}
         {...formRegister(formValue, {
           onBlur: () => setIsFocused(false),
@@ -69,7 +69,7 @@ export default function ImageURLUploadField({
       {loaded && hasCredentials ? (
         <button
           title={'Upload an image'}
-          className="small-button whitespace-nowrap"
+          className="small-button h-6 whitespace-nowrap"
           aria-label="Add attachment"
           onClick={(e) => {
             e.preventDefault();

--- a/ui/src/dms/MultiDMEditModal.tsx
+++ b/ui/src/dms/MultiDMEditModal.tsx
@@ -30,7 +30,7 @@ export default function MultiDMEditModal() {
     <Dialog defaultOpen onOpenChange={(open) => !open && dismiss()}>
       {editing ? (
         <DialogContent showClose containerClass="w-max-lg">
-          <div className="sm:w-96">
+          <div className="w-80">
             <header className="flex items-center ">
               <h2 className="text-xl font-bold">Edit Chat Info</h2>
             </header>
@@ -42,7 +42,7 @@ export default function MultiDMEditModal() {
         </DialogContent>
       ) : (
         <DialogContent showClose containerClass="max-w-lg">
-          <div className="sm:w-96">
+          <div className="w-80">
             <header className="flex items-center ">
               <h2 className="text-xl font-bold">Chat Info</h2>
             </header>

--- a/ui/src/dms/MultiDMInfoForm.tsx
+++ b/ui/src/dms/MultiDMInfoForm.tsx
@@ -75,16 +75,20 @@ export default function MultiDMInfoForm({
           <div className="flex items-center space-x-3 py-4">
             {iconType === 'color' ? (
               <ColorBoxIcon
-                className="ml-2 h-14 w-14 text-xl"
+                className="h-14 w-14 shrink-0 text-xl"
                 color={watchImage ? watchImage : '#000000'}
                 letter={letter ? letter : 'T'}
               />
             ) : null}
             {iconType === 'image' && isValidUrl(watchImage) ? (
-              <GroupAvatar size="ml-2 h-14 w-14" image={watchImage} />
+              <GroupAvatar
+                size="h-14 w-14"
+                className="shrink-0"
+                image={watchImage}
+              />
             ) : null}
             {showEmpty ? (
-              <EmptyIconBox className="ml-2 h-14 w-14 text-gray-300" />
+              <EmptyIconBox className="h-14 w-14 shrink-0 text-gray-300" />
             ) : null}
             <div className="flex-1 space-y-1.5">
               <label htmlFor="title" className="w-full font-bold">


### PR DESCRIPTION
Un-squishes the MultiDmInfoForm and adds adaptive sizing to the ImageOrColorField input elements such that they don't shrink or over-expand unexpectedly.

![Screen Shot 2022-12-23 at 14 29 12 PM](https://user-images.githubusercontent.com/748181/209399333-01a8b91b-4345-4163-847f-6b5721a9eb1e.png)

Also sizes the image URL field such that the value and the button don't occlude.

![input-overflow](https://user-images.githubusercontent.com/748181/209399482-b4a81a28-251a-45c8-a1d7-7504001d8af1.gif)

fixes #1503
fixes #1239