### PR TITLE
chat: reduced treatment on mobile, alignment issues

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from '@/logic/useMedia';
 import { normalizeInline, JSONToInlines } from '@/logic/tiptap';
 import { Inline } from '@/types/content';
 import AddIcon from '@/components/icons/AddIcon';
+import ArrowNWIcon16 from '@/components/icons/ArrowNIcon16';
 import useFileUpload from '@/logic/useFileUpload';
 import { useFileStore } from '@/state/storage';
 import { IMAGE_REGEX, isImageUrl } from '@/logic/utils';
@@ -294,6 +295,7 @@ export default function ChatInput({
               ))}
             </div>
           ) : null}
+
           {chatInfo.blocks.length > 0 ? (
             <div className="mb-4 flex items-center justify-start font-semibold">
               <span className="mr-2 text-gray-600">Attached: </span>
@@ -321,11 +323,21 @@ export default function ChatInput({
               </button>
             </div>
           ) : null}
-          <div className="flex items-center justify-end">
-            <Avatar size="xs" ship={window.our} className="mr-2" />
+          <div className="relative flex items-end justify-end">
+            {!isMobile && (
+              <Avatar size="xs" ship={window.our} className="mr-2" />
+            )}
             <MessageEditor
               editor={messageEditor}
-              className="w-full break-words"
+              className={cn(
+                'w-full break-words',
+                loaded &&
+                  hasCredentials &&
+                  !uploadError &&
+                  mostRecentFile?.status !== 'loading'
+                  ? 'pr-8'
+                  : ''
+              )}
             />
             {loaded &&
             hasCredentials &&
@@ -333,18 +345,18 @@ export default function ChatInput({
             mostRecentFile?.status !== 'loading' ? (
               <button
                 title={'Upload an image'}
-                className="absolute mr-2 text-gray-600 hover:text-gray-800"
+                className="absolute bottom-2 mr-2 text-gray-600 hover:text-gray-800"
                 aria-label="Add attachment"
                 onClick={() => promptUpload(fileId.current)}
               >
-                <AddIcon className="h-6 w-4" />
+                <AddIcon className="h-4 w-4" />
               </button>
             ) : null}
             {mostRecentFile && mostRecentFile.status === 'loading' ? (
-              <LoadingSpinner className="absolute mr-2 h-4 w-4" />
+              <LoadingSpinner className="absolute bottom-2 mr-2 h-4 w-4" />
             ) : null}
             {uploadError ? (
-              <div className="absolute mr-2">
+              <div className="absolute bottom-2 mr-2">
                 <UploadErrorPopover
                   errorMessage={uploadError}
                   setUploadError={setUploadError}
@@ -354,7 +366,7 @@ export default function ChatInput({
           </div>
         </div>
         <button
-          className="button"
+          className={cn('button', isMobile && 'px-2')}
           disabled={
             sendDisabled ||
             subscription === 'reconnecting' ||
@@ -363,7 +375,7 @@ export default function ChatInput({
           }
           onClick={onClick}
         >
-          Send
+          {isMobile ? <ArrowNWIcon16 className="h-4 w-4" /> : 'Send'}
         </button>
       </div>
       {isMobile ? <ChatInputMenu editor={messageEditor} /> : null}

--- a/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
+++ b/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ChatInput > renders as expected 1`] = `
       class="flex-1"
     >
       <div
-        class="flex items-center justify-end"
+        class="relative flex items-end justify-end"
       >
         <div
           class="relative flex flex-none items-center justify-center rounded bg-black w-6 h-6 rounded p-1.5 mr-2"

--- a/ui/src/components/icons/ArrowNIcon16.tsx
+++ b/ui/src/components/icons/ArrowNIcon16.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function ArrowNWIcon16({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        className="stroke-current"
+        d="M8 3L4 7M8 3L12 7M8 3V13"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Reduces the mobile chat input as per #1269, makes room for the attachment button such that the message input doesn't collide with the icon, and bottom-aligns the sigil and input on desktop.

Desktop:
![Screenshot 2023-01-02 at 10 26 58 AM](https://user-images.githubusercontent.com/748181/210251815-7a210d49-96f7-4ee5-99b8-59bb8e94bce2.png)

Mobile:
![Screenshot 2023-01-02 at 10 15 22 AM](https://user-images.githubusercontent.com/748181/210251839-4bb21cd3-f8eb-4947-bf40-31ecaed36ed9.png)

fixes tloncorp/landscape-apps#1269