### PR TITLE
groups:  in-group options, all channels on mobile

### DIFF
--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -49,6 +49,7 @@ function GroupChannel({
   const [_app, flag] = nestToFlag(nest);
   const { ship } = getFlagParts(flag);
   const groupFlag = useRouteGroup();
+  const isMobile = useIsMobile();
   const group = useGroup(groupFlag);
   const briefs = useAllBriefs();
   const { hasStarted, pendingImports } = migration;
@@ -142,7 +143,10 @@ function GroupChannel({
   return (
     <li className="my-2 flex flex-row items-center justify-between rounded-lg pl-0 pr-2 hover:bg-gray-50">
       <button
-        className="flex w-full items-center justify-start rounded-xl p-2 text-left hover:bg-gray-50"
+        className={cn(
+          'flex w-full items-center justify-start rounded-xl text-left hover:bg-gray-50',
+          !isMobile ? 'p-2' : ''
+        )}
         onClick={open}
         disabled={!joined || !imported}
       >
@@ -177,7 +181,12 @@ function GroupChannel({
           <>
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild className="appearance-none">
-                <button className="button bg-green-soft text-green mix-blend-multiply dark:bg-green-900 dark:mix-blend-screen hover:dark:bg-green-800">
+                <button
+                  className={cn(
+                    'button bg-green-soft text-green mix-blend-multiply dark:bg-green-900 dark:mix-blend-screen hover:dark:bg-green-800',
+                    isMobile && 'text-sm'
+                  )}
+                >
                   <span className="mr-1">Joined</span>{' '}
                   <CaretDown16Icon className="h-4 w-4" />
                 </button>
@@ -238,7 +247,8 @@ function GroupChannel({
                 'text-gray-800': isReady,
                 'text-gray-400': isPending,
                 'text-red': isFailed,
-              }
+              },
+              isMobile ? 'text-sm' : ''
             )}
           >
             {isPending ? (
@@ -313,12 +323,12 @@ export default function ChannelIndex({ title }: ViewProps) {
       </Helmet>
       <div className="flex flex-row items-center justify-between py-1 px-2 sm:p-4">
         <BackButton
-          to="../actions"
+          to={`/groups/${flag}`}
           className={cn(
             'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
             isMobile && 'flex items-center rounded-lg hover:bg-gray-50'
           )}
-          aria-label="Back to Group Menu"
+          aria-label="Back to Group"
         >
           {isMobile ? (
             <CaretLeft16Icon className="mr-1 h-4 w-4 text-gray-400" />
@@ -339,7 +349,10 @@ export default function ChannelIndex({ title }: ViewProps) {
           sectionedChannels[section] ? (
             <div
               key={section}
-              className="mb-2 w-full rounded-xl bg-white py-1 pl-4 pr-2"
+              className={cn(
+                'mb-2 w-full rounded-xl bg-white py-1',
+                !isMobile ? 'pl-4 pr-2' : ''
+              )}
             >
               <ChannelSection
                 channels={

--- a/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
+++ b/ui/src/groups/ChannelIndex/__snapshots__/ChannelIndex.test.tsx.snap
@@ -9,9 +9,9 @@ exports[`ChannelIndex > renders as expected 1`] = `
       class="flex flex-row items-center justify-between py-1 px-2 sm:p-4"
     >
       <div
-        aria-label="Back to Group Menu"
+        aria-label="Back to Group"
         class="cursor-pointer select-none p-2 sm:cursor-text sm:select-text"
-        to="../actions"
+        to="/groups/null"
       >
         <h1
           class="text-base font-semibold sm:text-lg"

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -25,6 +25,7 @@ import { useCheckChannelUnread } from '@/logic/useIsChannelUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import usePendingImports from '@/logic/usePendingImports';
 import Bullet16Icon from '@/components/icons/Bullet16Icon';
+import HashIcon16 from '@/components/icons/HashIcon16';
 import MigrationTooltip from '@/components/MigrationTooltip';
 import { useStartedMigration } from '@/logic/useMigrationInfo';
 import useFilteredSections from '@/logic/useFilteredSections';
@@ -176,6 +177,19 @@ export default function ChannelList({ flag, className }: ChannelListProps) {
 
   return (
     <div className={className}>
+      {isMobile && (
+        <SidebarItem
+          icon={
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+              <HashIcon16 className="m-1 h-4 w-4" />
+            </div>
+          }
+          to={`/groups/${flag}/channels`}
+          className="mb-3"
+        >
+          All Channels
+        </SidebarItem>
+      )}
       {!isMobile && <ChannelSorter isMobile={false} />}
       <ul className={cn('space-y-1', isMobile && 'flex-none space-y-3')}>
         {isDefaultSort

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import cn from 'classnames';
 import { Outlet, useMatch } from 'react-router';
-import { useLocation } from 'react-router-dom';
 import { useGroup, useGroupFlag } from '@/state/groups/groups';
 import NavTab from '@/components/NavTab';
 import HashIcon from '@/components/icons/HashIcon';
-import InviteIcon16 from '@/components/icons/InviteIcon16';
+import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import GroupAvatar from '../GroupAvatar';
 
 export default function MobileGroupSidebar() {
   const flag = useGroupFlag();
   const group = useGroup(flag);
-  const location = useLocation();
   const match = useMatch('/groups/:ship/:name/info');
 
   return (
@@ -32,12 +30,9 @@ export default function MobileGroupSidebar() {
               />
               Group Info
             </NavTab>
-            <NavTab
-              to={`/groups/${flag}/invite`}
-              state={{ backgroundLocation: location }}
-            >
-              <InviteIcon16 className="mb-0.5 h-6 w-6" />
-              Invite
+            <NavTab to={`/groups/${flag}/actions`}>
+              <ElipsisIcon className="mb-0.5 h-6 w-6" />
+              Options
             </NavTab>
           </ul>
         </nav>

--- a/ui/src/groups/MobileGroupActions.tsx
+++ b/ui/src/groups/MobileGroupActions.tsx
@@ -1,11 +1,8 @@
-/** Deprecated, but leaving around for reference */
-
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import InviteIcon from '@/components/icons/InviteIcon';
 import LinkIcon from '@/components/icons/LinkIcon';
 import PersonIcon from '@/components/icons/PersonIcon';
-import HashIcon16 from '@/components/icons/HashIcon16';
 import { useGroupActions } from '@/groups/GroupActions';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import LeaveIcon from '@/components/icons/LeaveIcon';
@@ -21,16 +18,6 @@ export default function MobileGroupActions() {
   return (
     <nav className="p-2">
       <ul className="space-y-3">
-        <SidebarItem
-          icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
-              <HashIcon16 className="m-1 h-4 w-4" />
-            </div>
-          }
-          to={`/groups/${flag}/channels`}
-        >
-          All Channels
-        </SidebarItem>
         <SidebarItem
           to={`/groups/${flag}/invite`}
           state={{ backgroundLocation: location }}


### PR DESCRIPTION
Restores the in-group options menu on mobile and adds a link in the mobile channel selection for All Channels.

fixes #1266