### PR TITLE
clearing notifications upon leaving chat even if timer hasn't finished

### DIFF
--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -7,7 +7,7 @@ import { VirtuosoHandle } from 'react-virtuoso';
 import ChatUnreadAlerts from '@/chat/ChatUnreadAlerts';
 import { ChatWrit } from '@/types/chat';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
-import { useChatStore } from './useChatStore';
+import { useChatInfo, useChatStore } from './useChatStore';
 
 interface ChatWindowProps {
   whom: string;
@@ -23,10 +23,20 @@ export default function ChatWindow({
   const location = useLocation();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const scrollTo = new URLSearchParams(location.search).get('msg');
+  const readTimeout = useChatInfo(whom).unread?.readTimeout;
 
   useEffect(() => {
     useChatStore.getState().setCurrent(whom);
   }, [whom]);
+
+  useEffect(
+    () => () => {
+      if (readTimeout !== undefined && readTimeout !== 0) {
+        useChatStore.getState().read(whom);
+      }
+    },
+    [readTimeout, whom]
+  );
 
   return (
     <div className="relative h-full">


### PR DESCRIPTION
see: #1426 
when the chat channel unmounts, if there's an "unread clear timer", we just mark the whole thing read.