### PR TITLE
chat: mark group notifications read on viewing group channels

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -1,4 +1,9 @@
-import React, { PropsWithChildren, useCallback, useState } from 'react';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useState,
+  useEffect,
+} from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import cn from 'classnames';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
@@ -26,6 +31,9 @@ import GridIcon from '@/components/icons/GridIcon';
 import ListIcon from '@/components/icons/ListIcon';
 import SortIcon from '@/components/icons/SortIcon';
 import { Status } from '@/logic/status';
+import useIsGroupUnread from '@/logic/useIsGroupUnread';
+import { useNotifications } from '@/notifications/useNotifications';
+import useHarkState from '@/state/hark';
 
 export type ChannelHeaderProps = PropsWithChildren<{
   flag: string;
@@ -301,6 +309,21 @@ export default function ChannelHeader({
   const groupName = group?.meta.title;
   const BackButton = isMobile ? Link : 'div';
   const isAdmin = useAmAdmin(flag);
+  const { isGroupUnread } = useIsGroupUnread();
+  const hasActivity = isGroupUnread(flag);
+  const { notifications } = useNotifications(flag);
+
+  useEffect(() => {
+    if (hasActivity) {
+      const unreadBins = notifications.filter((n) =>
+        n.bins.filter((b) => b.unread === true)
+      )[0].bins;
+
+      unreadBins.forEach((n) => {
+        useHarkState.getState().sawRope(n.topYarn.rope);
+      });
+    }
+  }, [hasActivity, notifications]);
 
   return (
     <div

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -315,15 +315,19 @@ export default function ChannelHeader({
 
   useEffect(() => {
     if (hasActivity) {
-      const unreadBins = notifications.filter((n) =>
-        n.bins.filter((b) => b.unread === true)
-      )[0].bins;
+      const unreadBins = notifications
+        .filter((n) => n.bins.some((b) => b.unread === true))[0]
+        ?.bins.filter((b) => b.unread === true);
 
-      unreadBins.forEach((n) => {
-        useHarkState.getState().sawRope(n.topYarn.rope);
-      });
+      if (unreadBins) {
+        unreadBins
+          .filter((b) => b.topYarn.wer.includes(nest))
+          .forEach((n) => {
+            useHarkState.getState().sawRope(n.topYarn.rope);
+          });
+      }
     }
-  }, [hasActivity, notifications]);
+  }, [hasActivity, notifications, nest]);
 
   return (
     <div

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React, { useEffect } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router';
 import { Helmet } from 'react-helmet';
@@ -13,8 +12,6 @@ import {
   useVessel,
   useGroup,
   useChannel,
-  useAmAdmin,
-  GROUP_ADMIN,
 } from '@/state/groups/groups';
 import ChannelHeader from '@/channels/ChannelHeader';
 import useRecentChannel from '@/logic/useRecentChannel';


### PR DESCRIPTION
Currently we show a blue "unread indicator" dot for groups for which a user has an unread non-new-message/meta notification (~sampel-palnet mentioned you, ~sampel-palnet joined, new channel added, etc). This PR allows us to mark those notifications as read upon viewing the associated channel in that group (or the group itself) so that the user doesn't have to individually mark-as-read or click on each notification on the notifications view.

Note that we don't show blue notification dots next to the channels themselves for this sort of thing. Should we?

Alternatively, we could *only* show the blue notification dot on groups for unread messages (and not these other types of notifications).

Fixes #1475 #1427 and maybe a few others.