### PR TITLE
hark: suppress extraneous invite notification

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1642,7 +1642,8 @@
                     [%emph title.meta.u.pev.gang]
                 ==
             ==
-          =.  cor  (emit (pass-hark & & yarn))
+          =?  cor  !(~(has by groups) flag)
+            (emit (pass-hark & & yarn))
           ga-core
           ::
             %kick


### PR DESCRIPTION
This is a bandaid that resolves #1599 by addressing the symptomatic behavior. With this change, the "sampel-palnet sent you an invite" notification will not be sent if one is already a member of the group.

I have yet to be able to reliably repro this issue, but I did see it once on mainnet. Tested this by monkey-patching my mainnet ship and have not experienced it since. 

As part of the troubleshooting for this task, I reviewed the invite flow in the backend (as well as my novice hoon proficiency allows for). Given the observed behavior I experienced while attempting to repro with local fakezods and comets, it appears there is an upstream issue somewhere in the flow. It appears that somehow the group host is occasionally generating a `vit.gang` for the joining user. This then triggers the downstream behavior in #1599. 

Here is a screenshot showing this unexpected state (note the `vit`, but this ship was never invited):

```hoon
:groups +dbug [%state %xeno]
```

![image](https://user-images.githubusercontent.com/16504501/210484539-0d7617d6-4700-4fd3-a390-ead805849175.png)