### PR TITLE
chat: fix notification links for mentions

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1360,7 +1360,7 @@
           ?:  (mentioned q.p.content.memo our.bowl)
             =/  yarn
               %^  ca-spin
-                /message/(scot %p p.p.p.d)/(scot %ud q.p.p.d)/navigate
+                /message/(scot %p p.p.p.d)/(scot %ud q.p.p.d)
                 :~  [%ship author.memo]
                     ' mentioned you :'
                     (flatten q.p.content.memo)


### PR DESCRIPTION
Fixes #1528, which was also an issue for *any* link to a mention.