### PR TITLE
chat: prevent a fact update from host crashing

### DIFF
--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -65,9 +65,9 @@
     (jab replying |=(writ:c +<(replied (~(put in replied) ^id))))
   ::
       %del
-    =/  =time     (~(get by dex.pac) id)
-    ?~  time  pac
-    =.  time  (need time)
+    =/  tim=(unit time)  (~(get by dex.pac) id)
+    ?~  tim  pac
+    =/  =time  (need tim)
     =^  wit=(unit writ:c)  wit.pac
       (del:on:writs:c wit.pac time)
     =.  dex.pac  (~(del by dex.pac) id)

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -65,7 +65,9 @@
     (jab replying |=(writ:c +<(replied (~(put in replied) ^id))))
   ::
       %del
-    =/  =time     (~(got by dex.pac) id)
+    =/  =time     (~(get by dex.pac) id)
+    ?~  time  pac
+    =.  time  (need time)
     =^  wit=(unit writ:c)  wit.pac
       (del:on:writs:c wit.pac time)
     =.  dex.pac  (~(del by dex.pac) id)


### PR DESCRIPTION
This fixes #1606 at least the immediate issue. There may be more crashes lurking. We need to do an audit for anything surrounding taking facts and remove any crashes.