### PR TITLE
groups: mark all notifications as read

### DIFF
--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -1,9 +1,10 @@
 import { useRouteGroup, useGroup } from '@/state/groups';
-import React, { ComponentType, PropsWithChildren } from 'react';
+import React, { ComponentType, PropsWithChildren, useCallback } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { ViewProps } from '@/types/groups';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
+import useHarkState from '@/state/hark';
 import { Bin, useNotifications } from './useNotifications';
 
 export interface NotificationsProps {
@@ -65,6 +66,10 @@ export default function Notifications({
   const group = useGroup(flag);
   const { notifications } = useNotifications(flag);
 
+  const markAllRead = useCallback(() => {
+    useHarkState.getState().sawSeam({ desk: 'groups' });
+  }, []);
+
   return (
     <section className="h-full w-full overflow-y-auto bg-white p-6">
       <Helmet>
@@ -74,6 +79,11 @@ export default function Notifications({
             : title}
         </title>
       </Helmet>
+      <div className="flex w-full items-center justify-end">
+        <button className="small-button bg-blue" onClick={markAllRead}>
+          Mark All as Read
+        </button>
+      </div>
       {notifications.map((grouping) => (
         <div key={grouping.date}>
           <h2 className="mt-8 mb-4 text-lg font-bold text-gray-400">


### PR DESCRIPTION
see: #1265. (only partially resolved, the garden portion will be in a separate PR in the garden repo)

targeting the groups desk here, as writing this feature resulted in the discovery of #1637.