### PR TITLE
ops: fix version bump action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,9 +16,10 @@ jobs:
           token: ${{ secrets.REPO_TOKEN }}
       - name: Bump
         run: |
-          sed -i "s/version\+\[.*]/version+[${{ github.event.inputs.tag }}]/" desk/desk.docket-0
-          sed -i "s/version\+\[.*]/version+[${{ github.event.inputs.tag }}]/" talk/desk.docket-0
+          sed -i "s/version+\[.*]/version+[${{ github.event.inputs.tag }}]/" desk/desk.docket-0
+          sed -i "s/version+\[.*]/version+[${{ github.event.inputs.tag }}]/" talk/desk.docket-0
       - name: Commit
         uses: EndBug/add-and-commit@v9
         with:
           add: '-A'
+          message: 'version bump: ${{ github.event.inputs.tag }} [skip actions]'


### PR DESCRIPTION
fixes sed syntax and and adds a commit message so it doesn't trigger the deploy action