### PR TITLE
groups: remove extraneous migration checks

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -42,7 +42,7 @@
 =|  current-state
 =*  state  -
 =<
-  %+  verb-lib  &
+  %+  verb-lib  |
   %-  agent:dbug
   |_  =bowl:gall
   +*  this  .

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -24,7 +24,7 @@
 =|  current-state
 =*  state  -
 =< 
-  %+  verb  &
+  %+  verb  |
   %-  agent:dbug
   |_  =bowl:gall
   +*  this  .

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -26,7 +26,7 @@
 =|  current-state
 =*  state  -
 =< 
-  %+  verb  &
+  %+  verb  |
   %-  agent:dbug
   |_  =bowl:gall
   +*  this  .

--- a/desk/app/hark.hoon
+++ b/desk/app/hark.hoon
@@ -32,7 +32,7 @@
   ==
 --
 %-  agent:dbug
-%+  verb  &
+%+  verb  |
 =|  state-0
 =*  state  -
 =<

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -22,7 +22,7 @@
 =|  current-state
 =*  state  -
 =< 
-  %+  verb  &
+  %+  verb  |
   %-  agent:dbug
   |_  =bowl:gall
   +*  this  .


### PR DESCRIPTION
This removes the manual checking we were doing for unjoined channels now that the migration has stabilized. It also changes the verb flag to be off so that we aren't filling people's dojos with spam. Should help with urbit/urbit#6176