### PR TITLE
groups: only show 'mark as read' if unreads exist

### DIFF
--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -6,7 +6,6 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { ViewProps } from '@/types/groups';
@@ -75,13 +74,10 @@ export default function Notifications({
   const [hasUnreads, setHasUnreads] = useState(false);
 
   useEffect(() => {
-    const allNotifs: object[] = [];
-    notifications.map((day) => day.bins.map((bin) => allNotifs.push(bin)));
-    if (_.some(allNotifs, { unread: true })) {
-      setHasUnreads(true);
-    } else {
-      setHasUnreads(false);
-    }
+    const hasUnreadNotifs = notifications.some((day) =>
+      day.bins.some((bin) => bin.unread === true)
+    );
+    setHasUnreads(hasUnreadNotifs);
   }, [notifications]);
 
   const markAllRead = useCallback(() => {

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -70,15 +70,8 @@ export default function Notifications({
 }: NotificationsProps) {
   const flag = useRouteGroup();
   const group = useGroup(flag);
-  const { notifications } = useNotifications(flag);
-  const [hasUnreads, setHasUnreads] = useState(false);
-
-  useEffect(() => {
-    const hasUnreadNotifs = notifications.some((day) =>
-      day.bins.some((bin) => bin.unread === true)
-    );
-    setHasUnreads(hasUnreadNotifs);
-  }, [notifications]);
+  const { notifications, count } = useNotifications(flag);
+  const hasUnreads = count > 0;
 
   const markAllRead = useCallback(() => {
     useHarkState.getState().sawSeam({ desk: 'groups' });

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -1,5 +1,12 @@
 import { useRouteGroup, useGroup } from '@/state/groups';
-import React, { ComponentType, PropsWithChildren, useCallback } from 'react';
+import React, {
+  ComponentType,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { ViewProps } from '@/types/groups';
@@ -65,6 +72,17 @@ export default function Notifications({
   const flag = useRouteGroup();
   const group = useGroup(flag);
   const { notifications } = useNotifications(flag);
+  const [hasUnreads, setHasUnreads] = useState(false);
+
+  useEffect(() => {
+    const allNotifs: object[] = [];
+    notifications.map((day) => day.bins.map((bin) => allNotifs.push(bin)));
+    if (_.some(allNotifs, { unread: true })) {
+      setHasUnreads(true);
+    } else {
+      setHasUnreads(false);
+    }
+  }, [notifications]);
 
   const markAllRead = useCallback(() => {
     useHarkState.getState().sawSeam({ desk: 'groups' });
@@ -80,9 +98,11 @@ export default function Notifications({
         </title>
       </Helmet>
       <div className="flex w-full items-center justify-end">
-        <button className="small-button bg-blue" onClick={markAllRead}>
-          Mark All as Read
-        </button>
+        {hasUnreads && (
+          <button className="small-button bg-blue" onClick={markAllRead}>
+            Mark All as Read
+          </button>
+        )}
       </div>
       {notifications.map((grouping) => (
         <div key={grouping.date}>


### PR DESCRIPTION
On the tin. Only shows the "Mark All as Read" button in groups/notifications if there are any actual unread notifications.

![image](https://user-images.githubusercontent.com/748181/211119153-38aedf8a-dd5f-45c8-86c9-20f6c213ad27.png)

After clicking: 

![image](https://user-images.githubusercontent.com/748181/211119167-05bd1df7-8c7e-4a99-89fd-0e215a6ce32c.png)
