### PR TITLE
groups/channels: rank level bans

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -291,7 +291,6 @@
     |=  =flag:c
     ^+  cor
     ?<  (~(has by chats) flag)
-    =.  chats  (~(put by chats) flag *chat:c)
     ca-abet:(ca-join:ca-core flag)
   ::
   ++  create
@@ -1261,17 +1260,14 @@
   ::
   ++  ca-can-write
     ?:  =(p.flag src.bowl)  &
-    =/  bloc=path
-      %+  welp  ca-groups-scry
-      /fleet/(scot %p src.bowl)/is-bloc/loob
-    =+  .^(is-bloc=? %gx bloc)
-    ?:  is-bloc  &
     =/  =path
       %+  welp  ca-groups-scry
-      /fleet/(scot %p src.bowl)/vessel/noun
-    =+  .^(=vessel:fleet:g %gx path)
-    ?:  =(~ writers.perm.chat)  &
-    !=(~ (~(int in writers.perm.chat) sects.vessel))
+      /channel/[dap.bowl]/(scot %p p.flag)/[q.flag]/can-write/(scot %p src.bowl)/noun
+    =+  .^(write=(unit [bloc=? sects=(set sect:g)]) %gx path)
+    ?~  write  |
+    =/  perms  (need write) 
+    ?:  |(bloc.perms =(~ writers.perm.chat))  &
+    !=(~ (~(int in writers.perm.chat) sects.perms))
   ::
   ++  ca-can-read
     |=  her=ship

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -205,7 +205,6 @@
     |=  =flag:d
     ^+  cor
     ?<  (~(has by shelf) flag)
-    =.  shelf  (~(put by shelf) flag *diary:d)
     di-abet:(di-join:di-core flag)
   ::
   ++  create
@@ -795,17 +794,14 @@
   ::
   ++  di-can-write
     ?:  =(p.flag src.bowl)  &
-    =/  bloc=path
+    =/  =path 
       %+  welp  di-groups-scry
-      /fleet/(scot %p src.bowl)/is-bloc/loob
-    =+  .^(is-bloc=? %gx bloc)
-    ?:  is-bloc  &
-    =/  =path
-      %+  welp  di-groups-scry
-      /fleet/(scot %p src.bowl)/vessel/noun
-    =+  .^(=vessel:fleet:g %gx path)
-    ?:  =(~ writers.perm.diary)  &
-    !=(~ (~(int in writers.perm.diary) sects.vessel))
+      /channel/[dap.bowl]/(scot %p p.flag)/[q.flag]/can-write/(scot %p src.bowl)/noun
+    =+  .^(write=(unit [bloc=? sects=(set sect:g)]) %gx path)
+    ?~  write  |
+    =/  perms  (need write) 
+    ?:  |(bloc.perms =(~ writers.perm.diary))  &
+    !=(~ (~(int in writers.perm.diary) sects.perms))
   ::
   ++  di-can-read
     |=  her=ship

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -721,6 +721,18 @@
       out
     (~(put in out) who)
   ::
+  ++  go-is-banned
+    |=  =ship
+    =*  cordon  cordon.group
+    ?&  =(-.cordon %open)
+        ?-  -.cordon
+            ?(%shut %afar)  |
+            %open
+          ?|  (~(has in ranks.ban.cordon) (clan:title ship))
+              (~(has in ships.ban.cordon) ship)
+          ==
+        ==
+    ==
   ++  go-pass
     |%
     ++  leave
@@ -870,6 +882,10 @@
         [%fleet ship=@ %is-bloc ~]
       =/  src  (slav %p ship.pole)
       `loob+!>((~(has in go-bloc-who) src))
+      ::
+        [%fleet ship=@ %is-ban ~]
+      =/  src  (slav %p ship.pole)
+      `loob+!>((go-is-banned src))
       ::
         [%channel app=@ ship=@ name=@ rest=*]
       =/  nes=nest:g  [app.pole (slav %p ship.pole) name.pole]
@@ -1264,17 +1280,19 @@
     ^+  go-core
     =/  user-join  &((~(has in ships) src.bowl) =(1 ~(wyt in ships)))
     =/  am-host  =(p.flag our.bowl)
+    =*  cordon  cordon.group
     ?-    -.diff
         %add
       ?>  ?|  am-host
               =(p.flag src.bowl) :: subscription
               user-join
           ==
-      ?<  ?&  =(-.cordon.group %shut) 
-              ?-  -.cordon.group
+      ?<  (go-is-banned src.bowl)
+      ?<  ?&  =(-.cordon %shut) 
+              ?-  -.cordon
                   ?(%open %afar)  |
                   %shut
-                =/  cross  (~(int in pend.cordon.group) ships)
+                =/  cross  (~(int in pend.cordon) ships)
                 ~&  [cross ~(wyt in ships) ~(wyt in cross)]
                 !=(~(wyt in ships) ~(wyt in cross))
               ==
@@ -1310,10 +1328,10 @@
         ==
       =?  cor  go-is-our-bloc
         (emit (pass-hark & & yarn))
-      ?-  -.cordon.group
+      ?-  -.cordon
           ?(%open %afar)  go-core
           %shut  
-        =.  pend.cordon.group  (~(dif in pend.cordon.group) ships)
+        =.  pend.cordon  (~(dif in pend.cordon) ships)
         go-core
       ==
     ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -894,6 +894,14 @@
           [%can-read src=@ ~]
         =/  src  (slav %p src.rest.pole)
         `loob+!>((go-can-read src channel))
+        ::
+          [%can-write src=@ ~]
+        =/  src  (slav %p src.rest.pole)
+        =-  `noun+!>(-)
+        ?:  |((go-is-banned src) !(~(has by fleet.group) src))  ~
+        %-  some
+        :-  bloc=(~(has in go-bloc-who) src.bowl)
+        sects=sects:(~(got by fleet.group) src)
       ==
     ==
   ::
@@ -902,6 +910,7 @@
     =/  open  =(-.cordon.group %open)
     =/  ves  (~(get by fleet.group) src)
     =/  visible  =(~ readers.channel)
+    ?:  (go-is-banned src)  |
     ?:  ?|  (~(has in go-bloc-who) src)
             &(open visible)
             &(!=(~ ves) visible)

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -138,7 +138,6 @@
     |=  =flag:h
     ^+  cor
     ?<  (~(has by stash) flag)
-    =.  stash  (~(put by stash) flag *heap:h)
     he-abet:(he-join:he-core flag)
   ::
   ++  create
@@ -787,17 +786,14 @@
   ::
   ++  he-can-write
     ?:  =(p.flag src.bowl)  &
-    =/  bloc=path
+    =/  =path 
       %+  welp  he-groups-scry
-      /fleet/(scot %p src.bowl)/is-bloc/loob
-    =+  .^(is-bloc=? %gx bloc)
-    ?:  is-bloc  &
-    =/  =path
-      %+  welp  he-groups-scry
-      /fleet/(scot %p src.bowl)/vessel/noun
-    =+  .^(=vessel:fleet:g %gx path)
-    ?:  =(~ writers.perm.heap)  &
-    !=(~ (~(int in writers.perm.heap) sects.vessel))
+      /channel/[dap.bowl]/(scot %p p.flag)/[q.flag]/can-write/(scot %p src.bowl)/noun
+    =+  .^(write=(unit [bloc=? sects=(set sect:g)]) %gx path)
+    ?~  write  |
+    =/  perms  (need write) 
+    ?:  |(bloc.perms =(~ writers.perm.heap))  &
+    !=(~ (~(int in writers.perm.heap) sects.perms))
   ::
   ++  he-can-read
     |=  her=ship

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -2,7 +2,12 @@ import React, { useEffect } from 'react';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { useGang, useGroupState } from '@/state/groups';
 import GroupAvatar from '@/groups/GroupAvatar';
-import { getFlagParts } from '@/logic/utils';
+import {
+  getFlagParts,
+  matchesBans,
+  pluralRank,
+  toTitleCase,
+} from '@/logic/utils';
 import ShipName from '@/components/ShipName';
 import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
@@ -22,6 +27,8 @@ export default function GroupReference({
     gang
   );
   const { ship } = getFlagParts(flag);
+  const cordon = gang.preview?.cordon || group?.cordon;
+  const banned = cordon ? matchesBans(cordon, window.our) : null;
 
   const meta = group?.meta || gang?.preview?.meta;
 
@@ -60,27 +67,37 @@ export default function GroupReference({
         </div>
       </button>
       <div className="absolute right-5 flex flex-row">
-        {gang.invite && status !== 'loading' ? (
-          <button
-            className="small-button bg-red text-white dark:text-black"
-            onClick={reject}
-          >
-            Reject
-          </button>
-        ) : null}
-        {status === 'loading' ? (
-          <div className="flex items-center space-x-2">
-            <span className="text-gray-400">Joining...</span>
-            <LoadingSpinner />
-          </div>
+        {banned ? (
+          <span className="inline-block px-2 font-semibold text-gray-600">
+            {banned === 'ship'
+              ? "You've been banned from this group"
+              : `${toTitleCase(pluralRank(banned))} are banned`}
+          </span>
         ) : (
-          <button
-            className="small-button ml-2 bg-blue text-white dark:text-black"
-            onClick={button.action}
-            disabled={button.disabled || status === 'error'}
-          >
-            {status === 'error' ? 'Errored' : button.text}
-          </button>
+          <>
+            {gang.invite && status !== 'loading' ? (
+              <button
+                className="small-button bg-red text-white dark:text-black"
+                onClick={reject}
+              >
+                Reject
+              </button>
+            ) : null}
+            {status === 'loading' ? (
+              <div className="flex items-center space-x-2">
+                <span className="text-gray-400">Joining...</span>
+                <LoadingSpinner />
+              </div>
+            ) : (
+              <button
+                className="small-button ml-2 bg-blue text-white dark:text-black"
+                onClick={button.action}
+                disabled={button.disabled || status === 'error'}
+              >
+                {status === 'error' ? 'Errored' : button.text}
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/ui/src/env.d.ts
+++ b/ui/src/env.d.ts
@@ -8,7 +8,3 @@ interface ImportMetaEnv
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
-
-declare module 'urbit-ob' {
-  function isValidPatp(ship: string): boolean;
-}

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -15,3 +15,8 @@ namespace JSX {
     >;
   }
 }
+
+declare module 'urbit-ob' {
+  function isValidPatp(ship: string): boolean;
+  function clan(ship: string): 'galaxy' | 'star' | 'planet' | 'moon' | 'comet';
+}

--- a/ui/src/groups/GroupJoinList.tsx
+++ b/ui/src/groups/GroupJoinList.tsx
@@ -3,6 +3,7 @@ import cn from 'classnames';
 import { useIsMobile } from '@/logic/useMedia';
 import { Gang, Gangs } from '@/types/groups';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import { matchesBans, pluralRank, toTitleCase } from '@/logic/utils';
 import GroupSummary from './GroupSummary';
 import useGroupJoin from './useGroupJoin';
 
@@ -12,8 +13,10 @@ interface GroupJoinItemProps {
 }
 
 function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
-  const { open, reject, button, status } = useGroupJoin(flag, gang);
+  const { open, reject, button, status, group } = useGroupJoin(flag, gang);
   const isMobile = useIsMobile();
+  const cordon = gang.preview?.cordon || group?.cordon;
+  const banned = cordon ? matchesBans(cordon, window.our) : null;
 
   return (
     <li className="relative flex items-center">
@@ -27,27 +30,37 @@ function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
         <GroupSummary flag={flag} preview={gang.preview} size={'small'} />
       </button>
       <div className="absolute right-2 flex flex-row">
-        {gang.invite && status !== 'loading' ? (
-          <button
-            className="button bg-red-soft text-red mix-blend-multiply dark:bg-red-900 dark:mix-blend-screen"
-            onClick={reject}
-          >
-            Reject
-          </button>
-        ) : null}
-        {status === 'loading' ? (
-          <div className="flex items-center justify-center space-x-2">
-            <span className="text-gray-400"> Joining... </span>
-            <LoadingSpinner className="h-4 w-4" />
-          </div>
+        {banned ? (
+          <span className="inline-block px-2 font-semibold text-gray-600">
+            {banned === 'ship'
+              ? "You've been banned from this group"
+              : `${toTitleCase(pluralRank(banned))} are banned`}
+          </span>
         ) : (
-          <button
-            className="button ml-2 bg-blue-soft text-blue mix-blend-multiply disabled:bg-gray-100 dark:bg-blue-900 dark:mix-blend-screen dark:disabled:bg-gray-100"
-            onClick={button.action}
-            disabled={button.disabled || status === 'error'}
-          >
-            {status === 'error' ? 'Errored' : button.text}
-          </button>
+          <>
+            {gang.invite && status !== 'loading' ? (
+              <button
+                className="button bg-red-soft text-red mix-blend-multiply dark:bg-red-900 dark:mix-blend-screen"
+                onClick={reject}
+              >
+                Reject
+              </button>
+            ) : null}
+            {status === 'loading' ? (
+              <div className="flex items-center justify-center space-x-2">
+                <span className="text-gray-400"> Joining... </span>
+                <LoadingSpinner className="h-4 w-4" />
+              </div>
+            ) : (
+              <button
+                className="button ml-2 bg-blue-soft text-blue mix-blend-multiply disabled:bg-gray-100 dark:bg-blue-900 dark:mix-blend-screen dark:disabled:bg-gray-100"
+                onClick={button.action}
+                disabled={button.disabled || status === 'error'}
+              >
+                {status === 'error' ? 'Errored' : button.text}
+              </button>
+            )}
+          </>
         )}
       </div>
     </li>

--- a/ui/src/groups/Join/JoinGroupModal.tsx
+++ b/ui/src/groups/Join/JoinGroupModal.tsx
@@ -5,12 +5,15 @@ import { useGang, useRouteGroup } from '@/state/groups';
 import GroupSummary from '@/groups/GroupSummary';
 import useGroupJoin from '@/groups/useGroupJoin';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import { matchesBans, pluralRank, toTitleCase } from '@/logic/utils';
 
 export default function JoinGroupModal() {
   const navigate = useNavigate();
   const flag = useRouteGroup();
   const gang = useGang(flag);
   const { group, dismiss, reject, button, status } = useGroupJoin(flag, gang);
+  const cordon = gang.preview?.cordon || group?.cordon;
+  const banned = cordon ? matchesBans(cordon, window.our) : null;
 
   useEffect(() => {
     if (group) {
@@ -32,29 +35,39 @@ export default function JoinGroupModal() {
             >
               Back
             </button>
-            {gang.invite && status !== 'loading' ? (
-              <button
-                className="button bg-red text-white dark:text-black"
-                onClick={reject}
-              >
-                Reject Invite
-              </button>
-            ) : null}
-            {status === 'loading' ? (
-              <div className="flex items-center space-x-2">
-                <span className="text-gray-400">Joining...</span>
-                <LoadingSpinner className="h-5 w-4" />
-              </div>
-            ) : status === 'error' ? (
-              <span className="text-red-500">Error</span>
+            {banned ? (
+              <span className="inline-block px-2 font-semibold text-gray-600">
+                {banned === 'ship'
+                  ? "You've been banned from this group"
+                  : `${toTitleCase(pluralRank(banned))} are banned`}
+              </span>
             ) : (
-              <button
-                className="button ml-2 bg-blue text-white dark:text-black"
-                onClick={button.action}
-                disabled={button.disabled}
-              >
-                {button.text}
-              </button>
+              <>
+                {gang.invite && status !== 'loading' ? (
+                  <button
+                    className="button bg-red text-white dark:text-black"
+                    onClick={reject}
+                  >
+                    Reject Invite
+                  </button>
+                ) : null}
+                {status === 'loading' ? (
+                  <div className="flex items-center space-x-2">
+                    <span className="text-gray-400">Joining...</span>
+                    <LoadingSpinner className="h-5 w-4" />
+                  </div>
+                ) : status === 'error' ? (
+                  <span className="text-red-500">Error</span>
+                ) : (
+                  <button
+                    className="button ml-2 bg-blue text-white dark:text-black"
+                    onClick={button.action}
+                    disabled={button.disabled}
+                  >
+                    {button.text}
+                  </button>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -257,6 +257,55 @@ export function getPrivacyFromChannel(
   return 'public';
 }
 
+export function pluralRank(
+  rank: 'galaxy' | 'star' | 'planet' | 'moon' | 'comet'
+) {
+  switch (rank) {
+    case 'galaxy':
+      return 'galaxies';
+    default:
+      return `${rank}s`;
+  }
+}
+
+export function rankToClan(
+  rank: 'czar' | 'king' | 'duke' | 'earl' | 'pawn' | string
+) {
+  switch (rank) {
+    case 'czar':
+      return 'galaxy';
+    case 'king':
+      return 'star';
+    case 'duke':
+      return 'planet';
+    case 'earl':
+      return 'moon';
+    default:
+      return 'comet';
+  }
+}
+
+export function matchesBans(
+  cordon: Cordon,
+  ship: string
+): ReturnType<typeof ob.clan> | 'ship' | null {
+  const siggedShip = preSig(ship);
+  if (!('open' in cordon)) {
+    return null;
+  }
+
+  if (cordon.open.ships.includes(siggedShip)) {
+    return 'ship';
+  }
+
+  const clan = ob.clan(siggedShip);
+  if (cordon.open.ranks.map(rankToClan).includes(clan)) {
+    return clan;
+  }
+
+  return null;
+}
+
 export function toTitleCase(s: string): string {
   if (!s) {
     return '';


### PR DESCRIPTION
This fixes #1593 on the backend and also displays messages on the frontend explaining that you can't join a group if they have banned you or your rank.

This should cover the joining from the frontend, but also anyone trying to be sneaky from the terminal whether they are trying to join a group or a channel since this also updates the can-read/can-write checks to include a check for banned status.

![Screen Shot 2023-01-10 at 4 11 03 PM](https://user-images.githubusercontent.com/5466421/211686026-3bd66306-e323-4912-8fbe-62fe6f214327.png)
