### PR TITLE
chat: get and store dimensions of uploaded images

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "landscape-apps",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "landscape-apps",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.190.0",
@@ -80,6 +80,7 @@
         "react-error-boundary": "^3.1.4",
         "react-helmet": "^6.1.0",
         "react-hook-form": "^7.30.0",
+        "react-image-size": "^2.0.0",
         "react-intersection-observer": "^9.4.0",
         "react-oembed-container": "^1.0.1",
         "react-router": "^6.3.0",
@@ -22868,6 +22869,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-image-size": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-image-size/-/react-image-size-2.0.0.tgz",
+      "integrity": "sha512-6wjalqkkRKnU8VslTOUPooP954lvD9G7zSo2zu9S3vvboN4WRDfFmnfm291Pl5wcXroobYrcVpywP8ijshMmeg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-inspector": {
@@ -45974,6 +45984,12 @@
       "version": "7.34.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.34.2.tgz",
       "integrity": "sha512-1lYWbEqr0GW7HHUjMScXMidGvV0BE2RJV3ap2BL7G0EJirkqpccTaawbsvBO8GZaB3JjCeFBEbnEWI1P8ZoLRQ==",
+      "requires": {}
+    },
+    "react-image-size": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-image-size/-/react-image-size-2.0.0.tgz",
+      "integrity": "sha512-6wjalqkkRKnU8VslTOUPooP954lvD9G7zSo2zu9S3vvboN4WRDfFmnfm291Pl5wcXroobYrcVpywP8ijshMmeg==",
       "requires": {}
     },
     "react-inspector": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -110,6 +110,7 @@
     "react-error-boundary": "^3.1.4",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.30.0",
+    "react-image-size": "^2.0.0",
     "react-intersection-observer": "^9.4.0",
     "react-oembed-container": "^1.0.1",
     "react-router": "^6.3.0",

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames';
 import { Editor, EditorContent, JSONContent, useEditor } from '@tiptap/react';
 import React, { useCallback, useEffect, useMemo } from 'react';
+import _ from 'lodash';
 import Document from '@tiptap/extension-document';
 import Blockquote from '@tiptap/extension-blockquote';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -23,7 +24,6 @@ import Mention from '@tiptap/extension-mention';
 import { PASTEABLE_IMAGE_TYPES } from '@/constants';
 import useFileUpload from '@/logic/useFileUpload';
 import { useFileStore } from '@/state/storage';
-import { EditorProps } from 'prosemirror-view';
 import MentionPopup from './Mention/MentionPopup';
 
 interface HandlerParams {
@@ -107,17 +107,22 @@ export function useMessageEditor({
     [uploadFiles, whom]
   );
 
-  // update the Attached Items view when files are uploaded
+  // update the Attached Items view when files finish uploading and have a size
   useEffect(() => {
-    if (whom && files && Object.values(files).length) {
+    if (
+      whom &&
+      files &&
+      Object.values(files).length &&
+      !_.some(Object.values(files), (f) => f.size === undefined)
+    ) {
       // TODO: handle existing blocks (other refs)
       setBlocks(
         whom,
         Object.values(files).map((f) => ({
           image: {
             src: f.url, // TODO: what to put when still loading?
-            height: 200, // TODO
-            width: 200,
+            width: f.size[0],
+            height: f.size[1],
             alt: f.file.name,
           },
         }))

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -5,6 +5,12 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { dateToDa, deSig } from '@urbit/api';
 import { useFileStore, useStorage } from '@/state/storage';
 import { Upload } from '@/types/storage';
+import { getImageSize } from 'react-image-size';
+
+function imageSize(url: string) {
+  const size = getImageSize(url).then(({ width, height }) => [width, height]);
+  return size;
+}
 
 function useFileUpload() {
   const { s3, ...storage } = useStorage();
@@ -17,6 +23,7 @@ function useFileUpload() {
     setFileStatus,
     setErrorMessage,
     setFileURL,
+    setFileSize,
   } = useFileStore();
   const [hasCredentials, setHasCredentials] = useState(false);
 
@@ -68,6 +75,7 @@ function useFileUpload() {
         .then(() => {
           setFileStatus([key, 'success']);
           setFileURL([key, url.split('?')[0]]);
+          imageSize(url.split('?')[0]).then((s) => setFileSize([key, s]));
         })
         .catch((error: any) => {
           setFileStatus([key, 'error']);
@@ -78,7 +86,7 @@ function useFileUpload() {
           console.log({ error });
         });
     },
-    [client, setFileStatus, s3, setFileURL, setErrorMessage]
+    [client, setFileStatus, s3, setFileURL, setErrorMessage, setFileSize]
   );
 
   const uploadFiles = useCallback(

--- a/ui/src/state/storage/upload.tsx
+++ b/ui/src/state/storage/upload.tsx
@@ -60,6 +60,13 @@ export const useFileStore = create<FileStore>((set) => ({
         draft.files[key].url = url;
       })
     ),
+  setFileSize: (file) =>
+    set(
+      produce((draft) => {
+        const [key, size] = file;
+        draft.files[key].size = size;
+      })
+    ),
   clearFiles: () =>
     set(
       produce((draft) => {

--- a/ui/src/types/storage.ts
+++ b/ui/src/types/storage.ts
@@ -44,6 +44,7 @@ export interface FileStoreFile {
   url: string;
   for: string;
   key: string;
+  size: [number, number];
 }
 
 export interface FileStore {
@@ -56,6 +57,7 @@ export interface FileStore {
   setFiles: (file: Upload) => void;
   setFileStatus: (file: Array<number | string>) => void;
   setFileURL: (file: Array<number | string>) => void;
+  setFileSize: (file: Array<number | string>) => void;
   clearFiles: () => void;
   removeFileByURL: (i: ChatImage) => void;
 }


### PR DESCRIPTION
1. Adds a getImageSize promise to the useFileUpload hook and stores the dimensions of the uploaded image in the FileStore
2. Only updates the attachment blocks in MessageEditor when these sizes are resolved
3. Passes the correct width and height of the story to the back-end when the images are posted

As an end result, images are properly sized in the chat view, which fixes #1557.