### PR TITLE
s3: fix promptUpload to work with chatBlocks

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -218,26 +218,11 @@ export default function ChatInput({
   }, [autoFocus, reply, isMobile, messageEditor]);
 
   useEffect(() => {
-    if (mostRecentFile && messageEditor && !messageEditor.isDestroyed) {
-      const { url } = mostRecentFile;
-      messageEditor.commands.setContent(null);
-      messageEditor.commands.setContent(url);
-    }
-  }, [mostRecentFile, messageEditor]);
-
-  useEffect(() => {
     if (messageEditor && !messageEditor.isDestroyed) {
-      if (mostRecentFile) {
-        // if there is a most recent file, we want to set the content to the url
-        const { url } = mostRecentFile;
-
-        messageEditor.commands.setContent(url);
-      } else {
-        // if the draft is empty, clear the editor
-        messageEditor.commands.setContent(null, true);
-      }
+      // if the draft is empty, clear the editor
+      messageEditor.commands.setContent(null, true);
     }
-  }, [messageEditor, mostRecentFile]);
+  }, [messageEditor]);
 
   const onClick = useCallback(
     () => messageEditor && onSubmit(messageEditor),
@@ -372,6 +357,8 @@ export default function ChatInput({
             sendDisabled ||
             subscription === 'reconnecting' ||
             subscription === 'disconnected' ||
+            mostRecentFile?.status === 'loading' ||
+            mostRecentFile?.status === 'error' ||
             (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
           }
           onClick={onClick}

--- a/ui/src/logic/useFileUpload.ts
+++ b/ui/src/logic/useFileUpload.ts
@@ -82,13 +82,13 @@ function useFileUpload() {
   );
 
   const uploadFiles = useCallback(
-    async (files: FileList | null) => {
+    async (files: FileList | null, fileId?: string) => {
       if (!files) return;
       const newFiles = _.keyBy(
         [...files].map((file) => ({
           file,
           key: `${window.ship}/${deSig(dateToDa(new Date()))}-${file.name}`,
-          for: window.ship, // TODO: this is unused, should it be kept?
+          for: fileId ?? window.ship,
           status: 'initial',
           url: '',
         })),
@@ -101,7 +101,8 @@ function useFileUpload() {
   );
 
   const onFiles = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => uploadFiles(e.target.files),
+    (e: ChangeEvent<HTMLInputElement>, fileId?: string) =>
+      uploadFiles(e.target.files, fileId),
     [uploadFiles]
   );
 
@@ -113,7 +114,7 @@ function useFileUpload() {
       input.id = fileId;
       input.accept = 'image/*,video/*,audio/*';
       input.addEventListener('change', (e) => {
-        onFiles(e as any);
+        onFiles(e as any, fileId);
       });
       input.click();
     },


### PR DESCRIPTION
fixes #1673 

also sizes images uploaded via the upload dialog appropriately.

We also need to size images posted to the chat via URLs appropriately (covered by #1672 afaik).