### PR TITLE
talk: ignore channel unreads that I can no longer read

### DIFF
--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -163,8 +163,9 @@
   ++  diff
     |=  =diff:c
     %+  frond  -.diff
-    ?+  -.diff  ~
-      %writs     (writs-diff p.diff)
+    ?-  -.diff
+      %create     (pairs ~[perms/(perm p.diff)])
+      %writs      (writs-diff p.diff)
       %add-sects  a/(turn ~(tap in p.diff) (lead %s))
       %del-sects  a/(turn ~(tap in p.diff) (lead %s))
     ==

--- a/ui/src/groups/ChannelIndex/ChannelIndex.tsx
+++ b/ui/src/groups/ChannelIndex/ChannelIndex.tsx
@@ -30,7 +30,6 @@ import useIsChannelHost from '@/logic/useIsChannelHost';
 import useAllBriefs from '@/logic/useAllBriefs';
 import { useIsMobile } from '@/logic/useMedia';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
-import usePendingImports from '@/logic/usePendingImports';
 import MigrationTooltip from '@/components/MigrationTooltip';
 import { useStartedMigration } from '@/logic/useMigrationInfo';
 import useFilteredSections from '@/logic/useFilteredSections';
@@ -317,8 +316,6 @@ export default function ChannelIndex({ title }: ViewProps) {
   const group = useGroup(flag);
   const isMobile = useIsMobile();
   const BackButton = isMobile ? Link : 'div';
-
-  console.log(filteredSections, sectionedChannels);
 
   return (
     <section className="w-full sm:overflow-y-scroll">

--- a/ui/src/logic/useIsChannelUnread.ts
+++ b/ui/src/logic/useIsChannelUnread.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { ChatStore, useChatStore } from '@/chat/useChatStore';
 import useAllBriefs from '@/logic/useAllBriefs';
+import { useBriefs, useChats } from '@/state/chat';
 import { useCallback } from 'react';
 import { nestToFlag } from './utils';
 
@@ -26,10 +27,9 @@ interface ChannelUnreadCount {
 }
 
 export function useChannelUnreadCounts(args: ChannelUnreadCount) {
-  const briefs = useAllBriefs();
-  const chatKeys = Object.keys(useChatStore(selChats)).map(
-    (key) => `chat/${key}`
-  );
+  const briefs = useBriefs();
+  const chats = useChats();
+  const chatKeys = Object.keys(chats);
 
   switch (args.scope) {
     case 'All Messages':

--- a/ui/src/logic/useIsChannelUnread.ts
+++ b/ui/src/logic/useIsChannelUnread.ts
@@ -2,8 +2,9 @@ import _ from 'lodash';
 import { ChatStore, useChatStore } from '@/chat/useChatStore';
 import useAllBriefs from '@/logic/useAllBriefs';
 import { useBriefs, useChats } from '@/state/chat';
+import { useGroups } from '@/state/groups';
 import { useCallback } from 'react';
-import { nestToFlag } from './utils';
+import { canReadChannel, nestToFlag } from './utils';
 
 const selChats = (s: ChatStore) => s.chats;
 
@@ -29,17 +30,32 @@ interface ChannelUnreadCount {
 export function useChannelUnreadCounts(args: ChannelUnreadCount) {
   const briefs = useBriefs();
   const chats = useChats();
+  const groups = useGroups();
   const chatKeys = Object.keys(chats);
+
+  const filteredBriefs = _.fromPairs(
+    Object.entries(briefs).filter(([k, v]) => {
+      const chat = chats[k];
+      if (chat) {
+        const group = groups[chat.perms.group];
+        const channel = group.channels[`chat/${k}`];
+        const vessel = group.fleet[window.our];
+        return channel && vessel && canReadChannel(channel, vessel, group.bloc);
+      }
+
+      return true;
+    })
+  );
 
   switch (args.scope) {
     case 'All Messages':
-      return _.sumBy(Object.values(briefs), 'count');
+      return _.sumBy(Object.values(filteredBriefs), 'count');
     case 'Group Channels':
-      return _.sumBy(Object.values(_.pick(briefs, chatKeys)), 'count');
+      return _.sumBy(Object.values(_.pick(filteredBriefs, chatKeys)), 'count');
     case 'Direct Messages':
       return _.sumBy(Object.values(_.omit(briefs, chatKeys)), 'count');
     default:
-      return _.sumBy(Object.values(briefs), 'count');
+      return _.sumBy(Object.values(filteredBriefs), 'count');
   }
 }
 

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -304,6 +304,8 @@ export const useChatState = createState<ChatState>(
                   draft.pacts[flag].index[id] = newTime;
                 }
               }
+            } else if ('create' in diff) {
+              draft.chats[flag] = diff.create;
             } else if ('del-sects' in diff) {
               chat.perms.writers = chat.perms.writers.filter(
                 (w) => !diff['del-sects'].includes(w)

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -149,8 +149,13 @@ export interface WritDiff {
   delta: WritDelta;
 }
 
+export interface ChatDiffCreate {
+  create: Chat;
+}
+
 export type ChatDiff =
   | { writs: WritDiff }
+  | ChatDiffCreate
   | ChatDiffAddSects
   | ChatDiffDelSects;
 


### PR DESCRIPTION
This fixes the scenario where a channel has gone admin only but still has unreads. It also fixes a small issue where trying to update a channel after just creating it was failing because the chat had not been added to state yet.

There's a larger issue here with how ships receive facts about changing permissions that I started to explore but dropped. Essentially sometimes as it stands right now the existing permissions can interfere with hearing about updates to permissions themselves causing the host and subscriber to get out of sync. This was mostly unrelated to what I was trying to fix so deferred for later, but should make into an issue.