### PR TITLE
chat: fix paste issues on mobile chrome

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -21,7 +21,7 @@ import AddIcon from '@/components/icons/AddIcon';
 import ArrowNWIcon16 from '@/components/icons/ArrowNIcon16';
 import useFileUpload from '@/logic/useFileUpload';
 import { useFileStore } from '@/state/storage';
-import { IMAGE_REGEX, isImageUrl } from '@/logic/utils';
+import { IMAGE_REGEX, isImageUrl, isValidUrl } from '@/logic/utils';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import * as Popover from '@radix-ui/react-popover';
 import { useSubscriptionStatus } from '@/state/local';
@@ -200,6 +200,8 @@ export default function ChatInput({
     ),
   });
 
+  const text = messageEditor?.getText();
+
   useEffect(() => {
     if (whom && messageEditor && !messageEditor.isDestroyed) {
       messageEditor?.commands.setContent('');
@@ -223,6 +225,19 @@ export default function ChatInput({
       messageEditor.commands.setContent(null, true);
     }
   }, [messageEditor]);
+
+  useEffect(() => {
+    if (messageEditor && !messageEditor.isDestroyed) {
+      // if text is just a valid URL, make it a link.
+      // this is necessary because the editor doesn't
+      // keep focus on mobile in some cases (chrome/android).
+      if (text && isValidUrl(text)) {
+        messageEditor.commands.selectAll();
+        messageEditor.commands.setLink({ href: text });
+        messageEditor.commands.selectTextblockEnd();
+      }
+    }
+  }, [messageEditor, text]);
 
   const onClick = useCallback(
     () => messageEditor && onSubmit(messageEditor),

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -24,6 +24,7 @@ import Mention from '@tiptap/extension-mention';
 import { PASTEABLE_IMAGE_TYPES } from '@/constants';
 import useFileUpload from '@/logic/useFileUpload';
 import { useFileStore } from '@/state/storage';
+import { isRef, isValidUrl, pathToCite } from '@/logic/utils';
 import MentionPopup from './Mention/MentionPopup';
 
 interface HandlerParams {
@@ -91,6 +92,14 @@ export function useMessageEditor({
       if (!whom) {
         return false;
       }
+      const text = event.clipboardData?.getData('text/plain');
+
+      if (text && isRef(text)) {
+        onReference(pathToCite(text));
+
+        return true;
+      }
+
       if (
         event.clipboardData &&
         Array.from(event.clipboardData.files).some((f) =>
@@ -104,7 +113,7 @@ export function useMessageEditor({
 
       return false;
     },
-    [uploadFiles, whom]
+    [uploadFiles, whom, onReference]
   );
 
   // update the Attached Items view when files finish uploading and have a size

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -24,7 +24,7 @@ import Mention from '@tiptap/extension-mention';
 import { PASTEABLE_IMAGE_TYPES } from '@/constants';
 import useFileUpload from '@/logic/useFileUpload';
 import { useFileStore } from '@/state/storage';
-import { isRef, isValidUrl, pathToCite } from '@/logic/utils';
+import { isRef, pathToCite } from '@/logic/utils';
 import MentionPopup from './Mention/MentionPopup';
 
 interface HandlerParams {

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -336,9 +336,14 @@ export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
   /(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|webm|svg)/i;
+export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 
 export function isImageUrl(url: string) {
   return IMAGE_URL_REGEX.test(url);
+}
+
+export function isRef(text: string) {
+  return REF_REGEX.test(text);
 }
 
 export function isValidUrl(str?: string): boolean {


### PR DESCRIPTION
For #1679 

I *think* this is caused by both a peculiarity in the way focus works on Android when pasting and the newish onPaste handler we used for chatblock images.

Using the tiptap commands was the much more straightforward way of handling the href issue (not clear how to correctly update or replace a node without a specific selection in ProseMirror).