### PR TITLE
talk: minimal viable chat-cli for groups 2

### DIFF
--- a/talk/app/talk-cli.hoon
+++ b/talk/app/talk-cli.hoon
@@ -1,0 +1,1282 @@
+::  chat-cli: cli chat client using chat-store and friends
+::
+::    pulls all known messages into a single stream.
+::    type ;help for usage instructions.
+::
+::    note that while the chat-store only cares about paths,
+::    we mostly deal with [ship path] (aka target) here.
+::    when sending messages (through the chat hook),
+::    we concat the ship onto the head of the path,
+::    and trust it to take care of the rest.
+::
+/-  chat
+/+  shoe, default-agent, verb, dbug
+::
+|%
++$  card  card:shoe
+::
++$  versioned-state
+  $%  state-4
+      state-3
+      state-2
+      state-1
+      state-0
+  ==
+::
++$  state-4
+  $:  %4
+      sessions=(map sole-id session)                ::  sole sessions
+      bound=(map resource glyph)                    ::  bound resource glyphs
+      binds=(jug glyph resource)                    ::  resource glyph lookup
+      settings=(set term)                           ::  frontend flags
+      width=@ud                                     ::  display width
+      timez=(pair ? @ud)                            ::  timezone adjustment
+  ==
+::
++$  state-3
+  $:  %3
+      sessions=(map @ta session)
+      bound=(map resource glyph)
+      binds=(jug glyph resource)
+      settings=(set term)
+      width=@ud
+      timez=(pair ? @ud)
+  ==
+::
++$  sole-id  sole-id:shoe
++$  session
+  $:  viewing=(set resource)                        ::  connected graphs
+      history=(list uid:post)                       ::  scrollback pointers
+      count=@ud                                     ::  (lent history)
+      audience=target                               ::  active target
+  ==
+::
+::TODO  remove for breach
++$  target-2  [in-group=? =ship =path]
++$  mail  [source=target-2 envelope:store]
++$  state-2
+  $:  %2
+      grams=(list mail)                             ::  all messages
+      known=(set [target-2 serial:store])           ::  known message lookup
+      count=@ud                                     ::  (lent grams)
+      bound=(map target-2 glyph)                    ::  bound circle glyphs
+      binds=(jug glyph target-2)                    ::  circle glyph lookup
+      audience=(set target-2)                       ::  active targets
+      settings=(set term)                           ::  frontend flags
+      width=@ud                                     ::  display width
+      timez=(pair ? @ud)                            ::  timezone adjustment
+  ==
+::
++$  state-1
+  $:  %1
+      grams=(list mail)                             ::  all messages
+      known=(set [target-2 serial:store])           ::  known message lookup
+      count=@ud                                     ::  (lent grams)
+      bound=(map target-2 glyph)                    ::  bound circle glyphs
+      binds=(jug glyph target-2)                    ::  circle glyph lookup
+      audience=(set target-2)                       ::  active targets
+      settings=(set term)                           ::  frontend flags
+      width=@ud                                     ::  display width
+      timez=(pair ? @ud)                            ::  timezone adjustment
+      cli=state=sole-share:shoe                     ::  console state
+      eny=@uvJ                                      ::  entropy
+  ==
+::
++$  state-0
+  $:  grams=(list [[=ship =path] envelope:store])   ::  all messages
+      known=(set [[=ship =path] serial:store])      ::  known message lookup
+      count=@ud                                     ::  (lent grams)
+      bound=(map [=ship =path] glyph)               ::  bound circle glyphs
+      binds=(jug glyph [=ship =path])               ::  circle glyph lookup
+      audience=(set [=ship =path])                  ::  active targets
+      settings=(set term)                           ::  frontend flags
+      width=@ud                                     ::  display width
+      timez=(pair ? @ud)                            ::  timezone adjustment
+      cli=state=sole-share:shoe                     ::  console state
+      eny=@uvJ                                      ::  entropy
+  ==
+::
++$  target  resource
+::
++$  glyph  char
+++  glyphs  "!@#$%^&()-=_+[]\{}'\\:\",.<>?"
+::
++$  command
+  $%  [%target target]                              ::  set messaging target
+      [%say content:post]                           ::  send message
+      [%eval cord hoon]                             ::  send #-message
+    ::                                              ::
+      [%view $?(~ target)]                          ::  notice chat
+      [%flee target]                                ::  ignore chat
+    ::                                              ::
+      [%bind glyph target]                          ::  bind glyph
+      [%unbind glyph (unit target)]                 ::  unbind glyph
+      [%what (unit $@(char target))]                ::  glyph lookup
+    ::                                              ::
+      [%settings ~]                                 ::  show active settings
+      [%set term]                                   ::  set settings flag
+      [%unset term]                                 ::  unset settings flag
+      [%width @ud]                                  ::  adjust display width
+      [%timezone ? @ud]                             ::  adjust time printing
+    ::                                              ::
+      [%select $@(rel=@ud [zeros=@u abs=@ud])]      ::  rel/abs msg selection
+      [%chats ~]                                    ::  list available chats
+      [%help ~]                                     ::  print usage info
+  ==                                                ::
+::
+--
+=|  state-4
+=*  state  -
+::
+%-  agent:dbug
+%+  verb  |
+%-  (agent:shoe command)
+^-  (shoe:shoe command)
+=<
+  |_  =bowl:gall
+  +*  this       .
+      talk-core  +>
+      tc         ~(. talk-core bowl)
+      def        ~(. (default-agent this %|) bowl)
+      des        ~(. (default:shoe this command) bowl)
+  ::
+  ++  on-init
+    ^-  (quip card _this)
+    =^  cards  state  (prep:tc ~)
+    [cards this]
+  ::
+  ++  on-save  !>(state)
+  ::
+  ++  on-load
+    |=  old-state=vase
+    ^-  (quip card _this)
+    =/  old  !<(versioned-state old-state)
+    =^  cards  state  (prep:tc `old)
+    [cards this]
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    =^  cards  state
+      ?+  mark        (on-poke:def mark vase)
+        %noun         (poke-noun:tc !<(* vase))
+      ==
+    [cards this]
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    =^  cards  state
+      ?-    -.sign
+        %poke-ack   [- state]:(on-agent:def wire sign)
+        %watch-ack  [- state]:(on-agent:def wire sign)
+      ::
+          %kick
+        :_  state
+        ?+  wire  ~
+          [%graph-store ~]  ~[connect:tc]
+        ==
+      ::
+          %fact
+        ?+  p.cage.sign  ~|([dap.bowl %bad-sub-mark wire p.cage.sign] !!)
+            %graph-update-3
+          %-  on-graph-update:tc
+          !<(update:graph q.cage.sign)
+        ==
+      ==
+    [cards this]
+  ::
+  ++  on-watch  on-watch:def
+  ++  on-leave  on-leave:def
+  ++  on-peek   on-peek:def
+  ++  on-arvo   on-arvo:def
+  ++  on-fail   on-fail:def
+  ::
+  ++  command-parser
+    |=  =sole-id
+    parser:(make:sh:tc sole-id)
+  ::
+  ++  tab-list
+    |=  =sole-id
+    tab-list:sh:tc
+  ::
+  ++  on-command
+    |=  [=sole-id =command]
+    =^  cards  state
+      (work:(make:sh:tc sole-id) command)
+    [cards this]
+  ::
+  ++  on-connect
+    |=  =sole-id
+    ^-  (quip card _this)
+    [[prompt:(make:sh-out:tc sole-id)]~ this]
+  ::
+  ++  can-connect     can-connect:des
+  ++  on-disconnect   on-disconnect:des
+  --
+::
+|_  =bowl:gall
++*  libgraph  ~(. ^libgraph bowl)
+::  +prep: setup & state adapter
+::
+++  prep
+  |=  old=(unit versioned-state)
+  ^-  (quip card _state)
+  ?~  old
+    [~[connect] state(width 80)]
+  ::
+  =?  u.old  ?=(?(~ ^) -.u.old)
+    ^-  state-1
+    :-  %1
+    %=  u.old
+      grams  ~  ::NOTE  this only impacts historic message lookup in chat-cli
+    ::
+        known
+      ^-  (set [target-2 serial:store])
+      %-  ~(run in known.u.old)
+      |=  [t=[ship path] s=serial:store]
+      [`target-2`[| t] s]
+    ::
+        bound
+      ^-  (map target-2 glyph)
+      %-  ~(gas by *(map target-2 glyph))
+      %+  turn  ~(tap by bound.u.old)
+      |=  [t=[ship path] g=glyph]
+      [`target-2`[| t] g]
+    ::
+        binds
+      ^-  (jug glyph target-2)
+      %-  ~(run by binds.u.old)
+      |=  s=(set [ship path])
+      %-  ~(run in s)
+      |=  t=[ship path]
+      `target-2`[| t]
+    ::
+        audience
+      ^-  (set target-2)
+      %-  ~(run in audience.u.old)
+      |=  t=[ship path]
+      `target-2`[| t]
+    ==
+  ::
+  =?  u.old  ?=(%1 -.u.old)
+    ^-  state-2
+    =,  u.old
+    :*  %2
+      grams  known  count
+      bound  binds  audience
+      settings  width  timez
+    ==
+  ::
+  =^  cards-1  u.old
+    ?.  ?=(%2 -.u.old)  [~ u.old]
+    :-  :~  [%pass /chat-store %agent [our-self %chat-store] %leave ~]
+            [%pass /invites %agent [our.bowl %invite-store] %leave ~]
+        ==
+    ^-  state-3
+    :-  %3
+    :*  %+  ~(put in *(map @ta session))
+          (cat 3 'drum_' (scot %p our.bowl))
+        :*  ~  ~  0
+          ::
+            ?~  audience.u.old  *target
+            [ship ?~(path %$ i.path)]:n.audience.u.old
+        ==
+      ::
+        %-  ~(gas by *(map resource glyph))
+        %+  turn  ~(tap in bound.u.old)
+        |=  [t=target-2 g=glyph]
+        [[ship.t ?~(path.t %$ i.path.t)] g]
+      ::
+        ^-  (jug glyph resource)
+        %-  ~(run by binds.u.old)
+        |=  s=(set target-2)
+        %-  ~(run in s)
+        |=  t=target-2
+        [ship.t ?~(path.t %$ i.path.t)]
+      ::
+        settings.u.old
+        width.u.old
+        timez.u.old
+    ==
+  ::
+  =^  cards-2  u.old
+    ?.  ?=(%3 -.u.old)  [~ u.old]
+    :-  %+  turn  ~(tap in ~(key by sessions.u.old))
+        |=  id=@ta
+        ^-  card:agent:gall
+        [%give %kick ~[/sole/[id]] ~]
+    =-  u.old(- %4, sessions -)
+    %-  ~(gas by *(map sole-id session))
+    %+  murn  ~(tap by sessions.u.old)
+    |=  [id=@ta s=session]
+    (bind (upgrade-id:sole:shoe id) (late s))
+  ::
+  ?>  ?=(%4 -.u.old)
+  :_  u.old
+  ;:  welp
+    cards-1
+    cards-2
+  ::
+    ?:  %-  ~(has by wex.bowl)
+        [/graph-store our-self %graph-store]
+      ~
+    ~[connect]
+  ==
+::  +connect: connect to the graph-store
+::
+++  connect
+  ^-  card
+  [%pass /graph-store %agent [our-self %graph-store] %watch /updates]
+::
+::TODO  better moon support. (name:title our.bowl)
+++  our-self  our.bowl
+::
+++  get-session
+  |=  =sole-id
+  ^-  session
+  (~(gut by sessions) sole-id %*(. *session audience [our-self %$]))
+::  +tor: term ordering for targets
+::
+++  tor
+  |=  [[* a=term] [* b=term]]
+  (aor a b)
+::  +ior: index ordering for nodes
+::
+++  ior
+  |=  [[a=index:post *] [b=index:post *]]
+  (aor a b)
+::  +safe-get-graph: virtualized +get-graph
+::
+++  safe-get-graph
+  |=  =resource
+  ^-  (unit update:graph)
+  =/  res=(each update:graph tang)
+    ::TODO  doesn't actually contain the crash?
+    %-  mule  |.
+    (get-graph:libgraph resource)
+  ?-  -.res
+    %&  `p.res
+    %|  ~
+  ==
+::  +is-chat-graph: check whether graph contains chat-style data
+::
+++  is-chat-graph
+  |=  =resource
+  ^-  ?
+  =/  update=(unit update:graph)
+    (safe-get-graph resource)
+  ?~  update  |
+  ?>  ?=(%add-graph -.q.u.update)
+  =(`%graph-validator-chat mark.q.u.update)
+::  +poke-noun: debug helpers
+::
+++  poke-noun
+  |=  a=*
+  ^-  (quip card _state)
+  ?:  ?=(%connect a)
+    [[connect ~] state]
+  [~ state]
+::  +handle-graph-update: get new mailboxes & messages
+::
+++  on-graph-update
+  |=  upd=update:graph
+  ^-  (quip card _state)
+  ?.  ?=(?(%remove-graph %add-nodes) -.q.upd)
+    [~ state]
+  =/  sez=(list [=sole-id =session])
+    ~(tap by sessions)
+  =|  cards=(list card)
+  |-
+  ?~  sez  [cards state]
+  =^  caz  session.i.sez
+    ?-  -.q.upd
+      %remove-graph  (~(notice-remove se i.sez) +.q.upd)
+    ::
+        %add-nodes
+      ?.  (~(has in viewing.session.i.sez) resource.q.upd)
+        [~ session.i.sez]
+      %+  ~(read-posts se i.sez)
+        resource.q.upd
+      (sort ~(tap by nodes.q.upd) ior)
+    ==
+  =.  sessions  (~(put by sessions) i.sez)
+  $(sez t.sez, cards (weld cards caz))
+::  +se: session event handling
+::
+++  se
+  |_  [=sole-id =session]
+  +*  sh-out  ~(. ^sh-out sole-id session)
+  ::
+  ++  read-posts
+    |=  [=target nodes=(list [=index:post =node:graph])]
+    ^-  (quip card _session)
+    =^  cards  nodes
+      ^-  (quip card _nodes)
+      =+  count=(lent nodes)
+      ?.  (gth count 10)  [~ nodes]
+      :_  (swag [(sub count 10) 10] nodes)
+      [(print:sh-out "skipping {(scow %ud (sub count 10))} messages...")]~
+    |-
+    ?~  nodes  [cards session]
+    =^  caz  session
+      (read-post target [index post.node]:i.nodes)
+    $(cards (weld cards caz), nodes t.nodes)
+  ::
+  ::  +read-post: add envelope to state and show it to user
+  ::
+  ++  read-post
+    |=  [=target =index:post =maybe-post:graph]
+    ^-  (quip card _session)
+    ?-    -.maybe-post
+        %|  [~ session]
+        %&
+      :-  (show-post:sh-out target p.maybe-post)
+      %_  session
+        history  [[target index] history.session]
+        count    +(count.session)
+      ==
+    ==
+  ::
+  ++  notice-remove
+    |=  =target
+    ^-  (quip card _session)
+    ?.  (~(has in viewing.session) target)
+      [~ session]
+    :-  [(show-delete:sh-out target) ~]
+    session(viewing (~(del in viewing.session) target))
+  --
+::
+::  +bind-default-glyph: bind to default, or random available
+::
+++  bind-default-glyph
+  |=  =target
+  ^-  (quip card _state)
+  =;  =glyph  (bind-glyph glyph target)
+  |^  =/  g=glyph  (choose glyphs)
+      ?.  (~(has by binds) g)  g
+      =/  available=(list glyph)
+        %~  tap  in
+        (~(dif in `(set glyph)`(sy glyphs)) ~(key by binds))
+      ?~  available  g
+      (choose available)
+  ++  choose
+    |=  =(list glyph)
+    =;  i=@ud  (snag i list)
+    (mod (mug target) (lent list))
+  --
+::  +bind-glyph: add binding for glyph
+::
+++  bind-glyph
+  |=  [=glyph =target]
+  ^-  (quip card _state)
+  ::TODO  should send these to settings store eventually
+  ::  if the target was already bound to another glyph, un-bind that
+  ::
+  =?  binds  (~(has by bound) target)
+    (~(del ju binds) (~(got by bound) target) target)
+  =.  bound  (~(put by bound) target glyph)
+  =.  binds  (~(put ju binds) glyph target)
+  [(show-glyph:sh-out glyph `target) state]
+::  +unbind-glyph: remove all binding for glyph
+::
+++  unbind-glyph
+  |=  [=glyph targ=(unit target)]
+  ^-  (quip card _state)
+  ?^  targ
+    =.  binds  (~(del ju binds) glyph u.targ)
+    =.  bound  (~(del by bound) u.targ)
+    [(show-glyph:sh-out glyph ~) state]
+  =/  ole=(set target)
+    (~(get ju binds) glyph)
+  =.  binds  (~(del by binds) glyph)
+  =.  bound
+    |-
+    ?~  ole  bound
+    =.  bound  $(ole l.ole)
+    =.  bound  $(ole r.ole)
+    (~(del by bound) n.ole)
+  [(show-glyph:sh-out glyph ~) state]
+::  +decode-glyph: find the target that matches a glyph, if any
+::
+++  decode-glyph
+  |=  [=session =glyph]
+  ^-  (unit target)
+  =+  lax=(~(get ju binds) glyph)
+  ::  no target
+  ?:  =(~ lax)  ~
+  %-  some
+  ::  single target
+  ?:  ?=([* ~ ~] lax)  n.lax
+  ::  in case of multiple matches, pick one we're viewing
+  =.  lax  (~(uni in lax) viewing.session)
+  ?:  ?=([* ~ ~] lax)  n.lax
+  ::  in case of multiple audiences, pick the most recently active one
+  |-  ^-  target
+  ?~  history.session  -:~(tap in lax)
+  =*  resource  resource.i.history.session
+  ?:  (~(has in lax) resource)
+    resource
+  $(history.session t.history.session)
+::
+::  +sh: shoe handling
+::
+++  sh
+  |_  [=sole-id session]
+  +*  session  +<+
+      sh-out   ~(. ^sh-out sole-id session)
+      put-ses  state(sessions (~(put by sessions) sole-id session))
+  ::
+  ++  make
+    |=  =^sole-id
+    %_  ..make
+      sole-id  sole-id
+      +<+      (get-session sole-id)
+    ==
+  ::  +read: command parser
+  ::
+  ::    parses the command line buffer.
+  ::    produces commands which can be executed by +work.
+  ::
+  ++  parser
+    |^
+      %+  stag  |
+      %+  knee  *command  |.  ~+
+      =-  ;~(pose ;~(pfix mic -) message)
+      ;~  pose
+        (stag %target targ)
+      ::
+        ;~((glue ace) (tag %view) targ)
+        ;~((glue ace) (tag %flee) targ)
+        ;~(plug (tag %view) (easy ~))
+      ::
+        ;~((glue ace) (tag %bind) glyph targ)
+        ;~((glue ace) (tag %unbind) ;~(plug glyph (punt ;~(pfix ace targ))))
+        ;~(plug (perk %what ~) (punt ;~(pfix ace ;~(pose glyph targ))))
+      ::
+        ;~(plug (tag %settings) (easy ~))
+        ;~((glue ace) (tag %set) flag)
+        ;~((glue ace) (tag %unset) flag)
+        ;~(plug (cold %width (jest 'set width ')) dem:ag)
+      ::
+        ;~  plug
+          (cold %timezone (jest 'set timezone '))
+          ;~  pose
+            (cold %| (just '-'))
+            (cold %& (just '+'))
+          ==
+          %+  sear
+            |=  a=@ud
+            ^-  (unit @ud)
+            ?:(&((gte a 0) (lte a 14)) `a ~)
+          dem:ag
+        ==
+      ::
+        ;~(plug (tag %chats) (easy ~))
+        ;~(plug (tag %help) (easy ~))
+      ::
+        (stag %select nump)
+      ==
+    ::
+    ::TODO
+    :: ++  cmd
+    ::   |*  [cmd=term req=(list rule) opt=(list rule)]
+    ::   |^  ;~  plug
+    ::         (tag cmd)
+    ::       ::
+    ::         ::TODO  this feels slightly too dumb
+    ::         ?~  req
+    ::           ?~  opt  (easy ~)
+    ::           (opt-rules opt)
+    ::         ?~  opt  (req-rules req)
+    ::         ;~(plug (req-rules req) (opt-rules opt))  ::TODO  rest-loop
+    ::       ==
+    ::   ++  req-rules
+    ::     |*  req=(lest rule)
+    ::     =-  ;~(pfix ace -)
+    ::     ?~  t.req  i.req
+    ::     ;~(plug i.req $(req t.req))
+    ::   ++  opt-rules
+    ::     |*  opt=(lest rule)
+    ::     =-  (punt ;~(pfix ace -))
+    ::     ?~  t.opt  ;~(pfix ace i.opt)
+    ::     ;~(pfix ace ;~(plug i.opt $(opt t.opt)))
+    ::   --
+    ::
+    ++  group  ;~((glue fas) ship sym)
+    ++  tag   |*(a=@tas (cold a (jest a)))  ::TODO  into stdlib
+    ++  ship  ;~(pfix sig fed:ag)
+    ++  name  ;~(pfix fas urs:ab)
+    ::  +tarl: local target, as /path
+    ::
+    ++  tarl  (stag our-self name)
+    ::  +targ: any target, as tarl, tarp, ~ship/path or glyph
+    ::
+    ++  targ
+      ;~  pose
+        tarl
+        ;~(plug ship name)
+        (sear (cury decode-glyph session) glyph)
+      ==
+    ::  +tars: set of comma-separated targs
+    ::
+    ++  tars
+      %+  cook  ~(gas in *(set target))
+      (most ;~(plug com (star ace)) targ)
+    ::  +ships: set of comma-separated ships
+    ::
+    ++  ships
+      %+  cook  ~(gas in *(set ^ship))
+      (most ;~(plug com (star ace)) ship)
+    ::  +glyph: shorthand character
+    ::
+    ++  glyph  (mask glyphs)
+    ::  +flag: valid flag
+    ::
+    ++  flag
+      %-  perk  :~
+        %notify
+        %showtime
+      ==
+    ::  +nump: message number reference
+    ::
+    ++  nump
+      ;~  pose
+        ;~(pfix hep dem:ag)
+        ;~  plug
+          (cook lent (plus (just '0')))
+          ;~(pose dem:ag (easy 0))
+        ==
+        (stag 0 dem:ag)
+        (cook lent (star mic))
+      ==
+    ::  +message: all messages
+    ::
+    ++  message
+      ;~  pose
+        ;~(plug (cold %eval hax) expr)
+        (stag %say content)
+      ==
+    ::  +content: simple messages
+    ::TODO  mentions
+    ::
+    ++  content
+      ;~  pose
+        (stag %url turl)
+        (stag %text ;~(less mic hax text))
+      ==
+    ::  +turl: url parser
+    ::
+    ++  turl
+      =-  (sear - text)
+      |=  t=cord
+      ^-  (unit cord)
+      ?~((rush t aurf:de-purl:html) ~ `t)
+    ::  +text: text message body
+    ::
+    ++  text
+      %+  cook  crip
+      (plus next)
+    ::  +expr: parse expression into [cord hoon]
+    ::
+    ++  expr
+      |=  tub=nail
+      %.  tub
+      %+  stag  (crip q.tub)
+      wide:(vang & [&1:% &2:% (scot %da now.bowl) |3:%])
+    --
+  ::  +tab-list: command descriptions
+  ::
+  ++  tab-list
+    ^-  (list [@t tank])
+    :~
+      [';view' leaf+";view ~ship/chat-name (glyph)"]
+      [';flee' leaf+";flee ~ship/chat-name"]
+    ::
+      [';bind' leaf+";bind [glyph] ~ship/chat-name"]
+      [';unbind' leaf+";unbind [glyph]"]
+      [';what' leaf+";what (~ship/chat-name) (glyph)"]
+    ::
+      [';settings' leaf+";settings"]
+      [';set' leaf+";set key (value)"]
+      [';unset' leaf+";unset key"]
+    ::
+      [';chats' leaf+";chats"]
+      [';help' leaf+";help"]
+    ==
+  ::  +work: run user command
+  ::
+  ++  work
+    |=  job=command
+    ^-  (quip card _state)
+    |^  ?-  -.job
+          %target    (set-target +.job)
+          %say       (say +.job)
+          %eval      (eval +.job)
+        ::
+          %view      (view +.job)
+          %flee      (flee +.job)
+        ::
+          %bind      (bind-glyph +.job)
+          %unbind    (unbind-glyph +.job)
+          %what      (lookup-glyph +.job)
+        ::
+          %settings  show-settings
+          %set       (set-setting +.job)
+          %unset     (unset-setting +.job)
+          %width     (set-width +.job)
+          %timezone  (set-timezone +.job)
+        ::
+          %select    (select +.job)
+          %chats     chats
+          %help      help
+        ==
+    ::  +act: build action card
+    ::
+    ++  act
+      |=  [what=term app=term =cage]
+      ^-  card
+      :*  %pass
+          /cli-command/[what]
+          %agent
+          [our-self app]
+          %poke
+          cage
+      ==
+    ::  +set-target: set audience, update prompt
+    ::
+    ++  set-target
+      |=  =target
+      ^-  (quip card _state)
+      =.  audience  target
+      [[prompt:sh-out ~] put-ses]
+    ::  +view: start printing messages from a resource
+    ::
+    ++  view
+      |=  target=$?(~ target)
+      ^-  (quip card _state)
+      ::  without argument, print all we're viewing
+      ::
+      ?~  target
+        [[(show-chats:sh-out ~(tap in viewing))]~ state]
+      ::  only view existing chat-type graphs
+      ::
+      ?.  (is-chat-graph target)
+        [[(note:sh-out "no such chat")]~ put-ses]
+      =.  audience  target
+      =.  viewing   (~(put in viewing) target)
+      =^  cards  state
+        ?:  (~(has by bound) target)
+          [~ state]
+        (bind-default-glyph target)
+      [[prompt:sh-out cards] put-ses]
+    ::  +flee: stop printing messages from a resource
+    ::
+    ++  flee
+      |=  =target
+      ^-  (quip card _state)
+      =.  viewing  (~(del in viewing) target)
+      [~ put-ses]
+    ::  +say: send messages
+    ::
+    ++  say
+      |=  msg=content:post
+      ^-  (quip card _state)
+      =/  =serial:store  (shaf %msg-uid eny.bowl)
+      :_  state
+      :_  ~
+      ::TODO  move creation into lib?
+      %^  act  %out-message
+        %graph-push-hook
+      :-  %graph-update-3
+      !>  ^-  update:graph
+      :-  now.bowl
+      :+  %add-nodes  audience
+      %-  ~(put by *(map index:post node:graph))
+      :-  ~[now.bowl]
+      :_  *internal-graph:graph
+      ^-  maybe-post:graph
+      [%& `post:post`[our-self ~[now.bowl] now.bowl [msg]~ ~ ~]]
+    ::  +eval: run hoon, send code and result as message
+    ::
+    ::    this double-virtualizes and clams to disable .^ for security reasons
+    ::
+    ++  eval
+      |=  [txt=cord exe=hoon]
+      ~&  %eval-tmp-disabled
+      [~ state]
+      ::TODO  why -find.eval??
+      :: (say %code txt (eval:store bowl exe))
+    ::  +lookup-glyph: print glyph info for all, glyph or target
+    ::
+    ++  lookup-glyph
+      |=  qur=(unit $@(glyph target))
+      ^-  (quip card _state)
+      =-  [[- ~] state]
+      ?^  qur
+        ?^  u.qur
+          =+  gyf=(~(get by bound) u.qur)
+          (print:sh-out ?~(gyf "none" [u.gyf]~))
+        =+  pan=~(tap in (~(get ju binds) `@t`u.qur))
+        ?:  =(~ pan)  (print:sh-out "~")
+        =<  (effect:sh-out %mor (turn pan .))
+        |=(t=target [%txt ~(phat tr t)])
+      %-  print-more:sh-out
+      %-  ~(rep by binds)
+      |=  $:  [=glyph tars=(set target)]
+              lis=(list tape)
+          ==
+      %+  weld  lis
+      ^-  (list tape)
+      %-  ~(rep in tars)
+      |=  [t=target l=(list tape)]
+      %+  weld  l
+      ^-  (list tape)
+      [glyph ' ' ~(phat tr t)]~
+    ::  +show-settings: print enabled flags, timezone and width settings
+    ::
+    ++  show-settings
+      ^-  (quip card _state)
+      :_  state
+      :~  %-  print:sh-out
+          %-  zing
+          ^-  (list tape)
+          :-  "flags: "
+          %+  join  ", "
+          (turn `(list @t)`~(tap in settings) trip)
+        ::
+          %-  print:sh-out
+          %+  weld  "timezone: "
+          ^-  tape
+          :-  ?:(p.timez '+' '-')
+          (scow %ud q.timez)
+        ::
+          (print:sh-out "width: {(scow %ud width)}")
+      ==
+    ::  +set-setting: enable settings flag
+    ::
+    ++  set-setting
+      |=  =term
+      ^-  (quip card _state)
+      [~ state(settings (~(put in settings) term))]
+    ::  +unset-setting: disable settings flag
+    ::
+    ++  unset-setting
+      |=  =term
+      ^-  (quip card _state)
+      [~ state(settings (~(del in settings) term))]
+    ::  +set-width: configure cli printing width
+    ::
+    ++  set-width
+      |=  w=@ud
+      [~ state(width (max 40 w))]
+    ::  +set-timezone: configure timestamp printing adjustment
+    ::
+    ++  set-timezone
+      |=  tz=[? @ud]
+      [~ state(timez tz)]
+    ::  +select: expand message from number reference
+    ::
+    ++  select
+      ::NOTE  rel is the nth most recent message,
+      ::      abs is the last message whose numbers ends in n
+      ::      (with leading zeros used for precision)
+      ::
+      |=  num=$@(rel=@ud [zeros=@u abs=@ud])
+      ^-  (quip card _state)
+      |^  ?@  num
+            =+  tum=(scow %s (new:si | +(num)))
+            ?:  (gte rel.num count)
+              %-  just-print
+              "{tum}: no such telegram"
+            (activate tum rel.num)
+          ?.  (gte abs.num count)
+            ?:  =(count 0)
+              (just-print "0: no messages")
+            =+  msg=(index (dec count) num)
+            (activate (scow %ud msg) (sub count +(msg)))
+          %-  just-print
+          "…{(reap zeros.num '0')}{(scow %ud abs.num)}: no such telegram"
+      ::  +just-print: full [cards state] output with a single print card
+      ::
+      ++  just-print
+        |=  txt=tape
+        [[(print:sh-out txt) ~] state]
+      ::  +index: get message index from absolute reference
+      ::
+      ++  index
+        |=  [max=@ud nul=@u fin=@ud]
+        ^-  @ud
+        =+  dog=|-(?:(=(0 fin) 1 (mul 10 $(fin (div fin 10)))))
+        =.  dog  (mul dog (pow 10 nul))
+        =-  ?:((lte - max) - (sub - dog))
+        (add fin (sub max (mod max dog)))
+      ::  +activate: echo message selector and print details
+      ::
+      ++  activate
+        |=  [number=tape index=@ud]
+        ^-  (quip card _state)
+        ::NOTE  graph store allows node deletion, so can this crash?
+        =/  =uid:post    (snag index history)
+        =/  =node:graph  (got-node:libgraph uid)
+        =.  audience     resource.uid
+        ?:  ?=(%| -.post.node)
+          [~ state]
+        :_  put-ses
+        ^-  (list card)
+        :~  (print:sh-out ['?' ' ' number])
+            (effect:sh-out ~(render-activate mr resource.uid p.post.node))
+            prompt:sh-out
+        ==
+      --
+    ::  +chats: display list of joined chats
+    ::
+    ++  chats
+      ^-  (quip card _state)
+      :_  state
+      :_  ~
+      %-  show-chats:sh-out
+      (skim ~(tap in get-keys:libgraph) is-chat-graph)
+    ::  +help: print (link to) usage instructions
+    ::
+    ++  help
+      ^-  (quip card _state)
+      :_  state
+      =-  (turn - print:sh-out)
+      :~  ";view ~host/chat to print messages for a chat you've already joined."
+          ";flee ~host/chat to stop printing messages for a chat."
+          "For more details:"
+          "https://urbit.org/using/operations/using-your-ship/#messaging"
+      ==
+    --
+  --
+::
+::  +sh-out: ouput to session
+::
+++  sh-out
+  |_  [=sole-id session]
+  ++  make
+    |=  =^sole-id
+    %_  ..make
+      sole-id  sole-id
+      +<+      (get-session sole-id)
+    ==
+  ::  +effex: emit shoe effect card
+  ::
+  ++  effex
+    |=  effect=shoe-effect:shoe
+    ^-  card
+    [%shoe ~[sole-id] effect]
+  ::  +effect: emit console effect card
+  ::
+  ++  effect
+    |=  effect=sole-effect:shoe
+    ^-  card
+    (effex %sole effect)
+  ::  +print: puts some text into the cli as-is
+  ::
+  ++  print
+    |=  txt=tape
+    ^-  card
+    (effect %txt txt)
+  ::  +print-more: puts lines of text into the cli
+  ::
+  ++  print-more
+    |=  txs=(list tape)
+    ^-  card
+    %+  effect  %mor
+    (turn txs |=(t=tape [%txt t]))
+  ::  +note: prints left-padded ---| txt
+  ::
+  ++  note
+    |=  txt=tape
+    ^-  card
+    =+  lis=(simple-wrap txt (sub width 16))
+    %-  print-more
+    =+  ?:((gth (lent lis) 0) (snag 0 lis) "")
+    :-  (runt [14 '-'] '|' ' ' -)
+    %+  turn  (slag 1 lis)
+    |=(a=tape (runt [14 ' '] '|' ' ' a))
+  ::  +prompt: update prompt to display current audience
+  ::
+  ++  prompt
+    ^-  card
+    %+  effect  %pro
+    :+  &  %talk-line
+    =+  ~(show tr audience)
+    ?:(=(1 (lent -)) "{-} " "[{-}] ")
+  ::  +show-post: print incoming message
+  ::
+  ::    every five messages, prints the message number also.
+  ::    if the message mentions the user's (shortened) ship name,
+  ::    and the %notify flag is set, emit a bell.
+  ::
+  ++  show-post
+    |=  [=target =post:post]
+    ^-  (list card)
+    %+  weld
+      ^-  (list card)
+      ?.  =(0 (mod count 5))  ~
+      :_  ~
+      =+  num=(scow %ud count)
+      %-  print
+      (runt [(sub 13 (lent num)) '-'] "[{num}]")
+    ^-  (list card)
+    :-  (effex ~(render-inline mr target post))
+    =;  mentioned=?
+      ?.  mentioned  ~
+      [(effect %bel ~)]~
+    %+  lien  contents.post
+    (cury test %mention our.bowl)
+  ::  +show-create: print mailbox creation notification
+  ::
+  ++  show-create
+    |=  =target
+    ^-  card
+    (note "new: {~(phat tr target)}")
+  ::  +show-delete: print mailbox deletion notification
+  ::
+  ++  show-delete
+    |=  =target
+    ^-  card
+    (note "del: {~(phat tr target)}")
+  ::  +show-glyph: print glyph un/bind notification
+  ::
+  ++  show-glyph
+    |=  [=glyph target=(unit target)]
+    ^-  (list card)
+    :_  [prompt ~]
+    %-  note
+    %+  weld  "set: {[glyph ~]} "
+    ?~  target  "unbound"
+    ~(phat tr u.target)
+  ::  +show-chats: print list of targets
+  ::
+  ++  show-chats
+    |=  chats=(list target)
+    ^-  card
+    %-  print-more
+    %+  turn  (sort chats tor)
+    |=  resource
+    "{(nome:mr entity)}/{(trip name)}"
+  --
+::
+::  +tr: render targets (resource identifiers)
+::
+++  tr
+  |_  tr=target
+  ::  +full: render target fully, always (as ~ship/path)
+  ::
+  ++  full
+    ^-  tape
+    "{(scow %p entity.tr)}/{(trip name.tr)}"
+  ::  +phat: render target with local shorthand
+  ::
+  ::    renders as ~ship/path.
+  ::    for local mailboxes, renders just /path.
+  ::
+  ++  phat
+    ^-  tape
+    %+  weld
+      ?:  =(our-self entity.tr)  ~
+      (scow %p entity.tr)
+    "/{(trip name.tr)}"
+  ::  +show: render as tape, as glyph if we can
+  ::
+  ++  show
+    ^-  tape
+    =+  cha=(~(get by bound) tr)
+    ?~(cha phat [u.cha ~])
+  ::  +glyph: tape for glyph of target, defaulting to *
+  ::
+  ++  glyph
+    ^-  tape
+    [(~(gut by bound) tr '*') ~]
+  --
+::
+::  +mr: render messages
+::
+++  mr
+  |_  $:  source=target
+          post:post
+      ==
+  +*  showtime  (~(has in settings) %showtime)
+      notify    (~(has in settings) %notify)
+  ::
+  ++  content-width
+    ::  termwidth, minus author, timestamp, and padding
+    %+  sub  width
+    %+  add  15
+    ?:(showtime 11 0)
+  ::
+  ++  render-inline
+    ^-  shoe-effect:shoe
+    :+  %row
+      :-  15
+      ?.  showtime
+        ~[(sub width 16)]
+      ~[(sub width 26) 9]
+    :+  t+(crip (weld (nome author) ~(glyph tr source)))
+      t+(crip line)
+    ?.  showtime  ~
+    :_  ~
+    :-  %t
+    =.  time-sent
+      %-  ?:(p.timez add sub)
+      [time-sent (mul q.timez ~h1)]
+    =+  dat=(yore time-sent)
+    =*  t   (d-co:co 2)
+    =,  t.dat
+    %-  crip
+    :(weld "~" (t h) "." (t m) "." (t s))
+  ::
+  ++  line
+    ^-  tape
+    %-  zing
+    %+  join  "\0a"
+    %-  turn
+    :_  |=(ls=(list tape) `tape`(zing (join " " ls)))
+    %+  roll  contents
+    |=  [=content:post out=(list (list tape))]
+    ?-  -.content
+      %text       (append-inline out (trip text.content))
+      %mention    (append-inline out (scow %p ship.content))
+      %reference  (append-inline out "^")
+    ::
+        %code
+      %+  snoc  out
+      ^-  (list tape)
+      :-  (trip expression.content)
+      ?:  =(~ output.content)  ~
+      :-  "\0a"
+      ~(ram re (snag 0 output.content))^~
+    ::
+        %url
+      %+  append-inline  out
+      =+  wyd=content-width
+      =+  ful=(trip url.content)
+      ::  if the full url fits, just render it.
+      ?:  (gte wyd (lent ful))  ful
+      ::  if it doesn't, prefix with _ and truncate domain with ellipses
+      =.  wyd  (sub wyd 2)
+      :-  '_'
+      =-  (weld - "_")
+      =+  prl=(rust ful aurf:de-purl:html)
+      ?~  prl  (scag wyd ful)
+      =+  hok=r.p.p.u.prl
+      =;  domain=tape
+        %+  swag
+          [(sub (max wyd (lent domain)) wyd) wyd]
+        domain
+      ?.  ?=(%& -.hok)
+        +:(scow %if p.hok)
+      %+  reel  p.hok
+      |=  [a=knot b=tape]
+      ?~  b  (trip a)
+      (welp b '.' (trip a))
+    ==
+  ::
+  ++  append-newline
+    |=  [content=(list (list tape)) newline=tape]
+    ^-  (list (list tape))
+    (snoc content ~[newline])
+  ::
+  ++  append-inline
+    |=  [content=(list (list tape)) inline=tape]
+    ^-  (list (list tape))
+    ?:  =(~ content)
+      ~[~[inline]]
+    =/  last
+      (dec (lent content))
+    =/  old=(list tape)
+      (snag last content)
+    =/  new=(list tape)
+      (snoc old inline)
+    (snap content last new)
+
+  ::  +activate: produce sole-effect for printing message details
+  ::
+  ++  render-activate
+    ^-  sole-effect:shoe
+    ~[%mor [%tan meta] body]
+  ::  +meta: render message metadata (serial, timestamp, author, target)
+  ::
+  ++  meta
+    ^-  tang
+    =+  hed=leaf+"{(scow %uv (fall hash 0))} at {(scow %da time-sent)}"
+    =/  src=tape  ~(phat tr source)
+    [%rose [" " ~ ~] [hed >author< [%rose [", " "to " ~] [leaf+src]~] ~]]~
+  ::  +body: long-form render of message contents
+  ::
+  ++  body
+    |-  ^-  sole-effect:shoe
+    :-  %mor
+    %+  turn  contents
+    |=  =content:post
+    ^-  sole-effect:shoe
+    ?-  -.content
+      %text       txt+(trip text.content)
+      %url        url+url.content
+    ::
+        %reference
+      ?-  -.reference.content
+          %graph
+        txt+"[reference to msg in {~(phat tr resource.uid.reference.content)}]"
+      ::
+          %group
+        txt+"[reference to msg in {~(phat tr group.reference.content)}]"
+      ::
+          %app
+        =,  reference.content
+        txt+"[reference to app: {(scow %p ship)}/{(trip desk)}{(spud path)}]"
+      ==
+    ::
+        %mention
+      ?.  =(ship.content our-self)  txt+(scow %p ship.content)
+      :-  %mor
+      :-  klr+[[`%br ~ ~]^(scow %p ship.content)]~  ::TODO  inline
+      ?.(notify ~ [%bel ~]~)
+    ::
+        %code
+      :-  %txt
+      %+  weld  (trip expression.content)
+      ?:  =(~ output.content)  ~
+      :-  '\0a'
+      ~(ram re (snag 0 output.content))
+    ==
+  ::  +nome: prints a ship name in 14 characters, left-padding with spaces
+  ::
+  ++  nome
+    |=  =ship
+    ^-  tape
+    =+  raw=(cite:title ship)
+    (runt [(sub 14 (lent raw)) ' '] raw)
+  --
+::
+++  simple-wrap
+  |=  [txt=tape wid=@ud]
+  ^-  (list tape)
+  ?~  txt  ~
+  =/  [end=@ud nex=?]
+    =+  ret=(find "\0a" (scag +(wid) `tape`txt))
+    ?^  ret  [u.ret &]
+    ?:  (lte (lent txt) wid)  [(lent txt) &]
+    =+  ace=(find " " (flop (scag +(wid) `tape`txt)))
+    ?~  ace  [wid |]
+    [(sub wid u.ace) &]
+  :-  (tufa (scag end `(list @)`txt))
+  $(txt (slag ?:(nex +(end) end) `tape`txt))
+::
+::NOTE  anything that uses this breaks moons support, because moons don't sync
+::      full app state rn
+++  scry-for
+  |*  [=mold app=term =path]
+  .^  mold
+    %gx
+    (scot %p our.bowl)
+    app
+    (scot %da now.bowl)
+    (snoc `^path`path %noun)
+  ==
+--
+

--- a/talk/lib/graph-store.hoon
+++ b/talk/lib/graph-store.hoon
@@ -1,0 +1,994 @@
+/-  sur=graph-store, pos=post, pull-hook, hark=hark-store
+/+  res=resource, migrate
+=<  [sur .]
+=<  [pos .]
+=,  sur
+=,  pos
+|%
+++  hark-content
+  |=  =content
+  ^-  content:hark
+  ?-  -.content
+    %text       content
+    %mention    ship+ship.content
+    %url        text+url.content
+    %code       text+'A code excerpt'
+    %reference  text+'A reference'       
+  ==
+::
+++  hark-contents
+  |=  cs=(list content) 
+  (turn cs hark-content)
+::  NOTE: move these functions to zuse
+++  nu                                              ::  parse number as hex
+  |=  jon=json
+  ?>  ?=([%s *] jon)
+  (rash p.jon hex)
+::
+++  re                                                ::  recursive reparsers
+  |*  [gar=* sef=_|.(fist:dejs-soft:format)]
+  |=  jon=json
+  ^-  (unit _gar)
+  =-  ~!  gar  ~!  (need -)  -
+  ((sef) jon)
+::
+++  dank                                              ::  tank
+  ^-  $-(json (unit tank))
+  =,  ^?  dejs-soft:format
+  %+  re  *tank  |.  ~+
+  %-  of  :~
+    leaf+sa
+    palm+(ot style+(ot mid+sa cap+sa open+sa close+sa ~) lines+(ar dank) ~)
+    rose+(ot style+(ot mid+sa open+sa close+sa ~) lines+(ar dank) ~)
+  ==
+::
+++  orm      ((on atom node) gth)
+++  orm-log  ((on time logged-update) gth)
+::
+++  enjs
+  =,  enjs:format
+  |%
+  ::
+  ++  signatures
+    |=  s=^signatures
+    ^-  json
+    [%a (turn ~(tap in s) signature)]
+  ::
+  ++  signature
+    |=  s=^signature
+    ^-  json
+    %-  pairs
+    :~  [%signature s+(scot %ux p.s)]
+        [%ship (ship q.s)]
+        [%life (numb r.s)]
+    ==
+  ::
+  ++  index
+    |=  ind=^index
+    ^-  json
+    :-  %s
+    ?:  =(~ ind)
+      '/'
+    %+  roll  ind
+    |=  [cur=@ acc=@t]
+    ^-  @t
+    =/  num  (numb cur)
+    ?>  ?=(%n -.num)
+    (rap 3 acc '/' p.num ~) 
+  ::
+  ++  uid
+    |=  u=^uid
+    ^-  json
+    %-  pairs
+    :~  [%resource (enjs:res resource.u)]
+        [%index (index index.u)]
+    ==
+  ::
+  ++  content
+    |=  c=^content
+    ^-  json
+    ?-  -.c
+        %mention    (frond %mention (ship ship.c))
+        %text       (frond %text s+text.c)
+        %url        (frond %url s+url.c)
+        %reference  (frond %reference (reference +.c))
+        %code
+      %+  frond  %code
+      %-  pairs
+      :-  [%expression s+expression.c]
+      :_  ~
+      :-  %output
+      ::  virtualize output rendering, +tank:enjs:format might crash
+      ::
+      =/  result=(each (list json) tang)
+        (mule |.((turn output.c tank)))
+      ?-  -.result
+        %&  a+p.result
+        %|  a+[a+[%s '[[output rendering error]]']~]~
+      ==
+    ==
+  ::
+  ++  reference
+    |=  ref=^reference
+    |^
+    %+  frond  -.ref
+    ?-  -.ref
+      %graph  (graph +.ref)
+      %group  (group +.ref)
+      %app    (app +.ref)
+    ==
+    ::
+    ++  graph
+      |=  [grp=res gra=res idx=^index]
+      %-  pairs
+      :~  graph+s+(enjs-path:res gra)
+          group+s+(enjs-path:res grp)
+          index+(index idx)
+      ==
+    ::
+    ++  group
+      |=  grp=res
+      s+(enjs-path:res grp)
+    ::
+    ++  app
+      |=  [=^ship =desk p=^path]
+      %-  pairs
+      :~  ship+s+(scot %p ship)
+          desk+s+desk
+          path+(path p)
+      ==
+    --
+  ::
+  ++  maybe-post
+    |=  mp=^maybe-post
+    ^-  json
+    ?-  -.mp
+      %|  s+(scot %ux p.mp)
+      %&  (post p.mp)
+    ==
+  ::
+  ++  post
+    |=  p=^post
+    ^-  json
+    %-  pairs
+    :~  [%author (ship author.p)]
+        [%index (index index.p)]
+        [%time-sent (time time-sent.p)]
+        [%contents [%a (turn contents.p content)]]
+        [%hash ?~(hash.p ~ s+(scot %ux u.hash.p))]
+        [%signatures (signatures signatures.p)]
+    ==
+  ::
+  ++  update
+    |=  upd=^update
+    ^-  json
+    |^  (frond %graph-update (pairs ~[(encode q.upd)]))
+    ::
+    ++  encode
+      |=  upd=action
+      ^-  [cord json]
+      ?-  -.upd
+          %add-graph
+        :-  %add-graph
+        %-  pairs
+        :~  [%resource (enjs:res resource.upd)]
+            [%graph (graph graph.upd)]
+            [%mark ?~(mark.upd ~ s+u.mark.upd)]
+            [%overwrite b+overwrite.upd]
+        ==
+      ::
+          %remove-graph
+        [%remove-graph (enjs:res resource.upd)]
+      ::
+          %add-nodes
+        :-  %add-nodes
+        %-  pairs
+        :~  [%resource (enjs:res resource.upd)]
+            [%nodes (nodes nodes.upd)]
+        ==
+      ::
+          %remove-posts
+        :-  %remove-posts
+        %-  pairs
+        :~  [%resource (enjs:res resource.upd)]
+            [%indices (indices indices.upd)]
+        ==
+      ::
+          %add-signatures
+        :-  %add-signatures
+        %-  pairs
+        :~  [%uid (uid uid.upd)]
+            [%signatures (signatures signatures.upd)]
+        ==
+      ::
+          %remove-signatures
+        :-  %remove-signatures
+        %-  pairs
+        :~  [%uid (uid uid.upd)]
+            [%signatures (signatures signatures.upd)]
+        ==
+      ::
+          %add-tag
+        :-  %add-tag
+        %-  pairs
+        :~  [%term s+term.upd]
+            [%uid (uid uid.upd)]
+        ==
+      ::
+          %remove-tag
+        :-  %remove-tag
+        %-  pairs
+        :~  [%term s+term.upd]
+            [%uid (uid uid.upd)]
+        ==
+      ::
+          %archive-graph
+        [%archive-graph (enjs:res resource.upd)]
+      ::
+          %unarchive-graph
+        [%unarchive-graph (enjs:res resource.upd)]
+      ::
+          %keys
+        [%keys [%a (turn ~(tap in resources.upd) enjs:res)]]
+      ::
+          %tags
+        [%tags [%a (turn ~(tap in tags.upd) |=(=term s+term))]]
+      ::
+          %run-updates
+        [%run-updates ~]
+      ::
+          %tag-queries
+        :-  %tag-queries
+        %-  pairs
+        %+  turn  ~(tap by tag-queries.upd)
+        |=  [=term uids=(set ^uid)]
+        ^-  [cord json]
+        [term [%a (turn ~(tap in uids) uid)]]
+      ==
+    ::
+    ++  graph
+      |=  g=^graph
+      ^-  json
+      %-  pairs
+      %+  turn
+        (tap:orm g)
+      |=  [a=atom n=^node]
+      ^-  [@t json]
+      :_  (node n)
+      =/  idx  (numb a)
+      ?>  ?=(%n -.idx)
+      p.idx
+    ::
+    ++  node
+      |=  n=^node
+      ^-  json
+      %-  pairs
+      :~  [%post (maybe-post post.n)]
+          :-  %children
+          ?-  -.children.n
+              %empty  ~
+              %graph  (graph +.children.n)
+          ==
+      ==
+    ::
+    ++  nodes
+      |=  m=(map ^index ^node)
+      ^-  json
+      %-  pairs
+      %+  turn  ~(tap by m)
+      |=  [n=^index o=^node]
+      ^-  [@t json]
+      :_  (node o)
+      =/  idx  (index n)
+      ?>  ?=(%s -.idx)
+      p.idx
+    ::
+    ++  indices
+      |=  i=(set ^index)
+      ^-  json
+      [%a (turn ~(tap in i) index)]
+    ::
+    --
+  --
+::
+++  dejs
+  =,  dejs:format
+  |%
+  ++  update
+    |=  jon=json
+    ^-  ^update
+    :-  *time
+    ^-  action
+    =<  (decode jon)
+    |%
+    ++  decode
+      %-  of
+      :~  [%add-nodes add-nodes]
+          [%remove-posts remove-posts]
+          [%add-signatures add-signatures]
+          [%remove-signatures remove-signatures]
+        ::
+          [%add-graph add-graph]
+          [%remove-graph remove-graph]
+        ::
+          [%add-tag add-tag]
+          [%remove-tag remove-tag]
+        ::
+          [%archive-graph archive-graph]
+          [%unarchive-graph unarchive-graph]
+          [%run-updates run-updates]
+        ::
+          [%keys keys]
+          [%tags tags]
+          [%tag-queries tag-queries]
+      ==
+    ::
+    ++  add-graph
+      %-  ot
+      :~  [%resource dejs:res]
+          [%graph graph]
+          [%mark (mu so)]
+          [%overwrite bo]
+      ==
+    ::
+    ++  graph
+      |=  a=json
+      ^-  ^graph
+      =/  or-mp  ((on atom ^node) gth)
+      %+  gas:or-mp  ~
+      %+  turn  ~(tap by ((om node) a))
+      |*  [b=cord c=*]
+      ^-  [atom ^node]
+      =>  .(+< [b c]=+<)
+      [(rash b dem) c]
+    ::
+    ++  remove-graph  (ot [%resource dejs:res]~)
+    ++  archive-graph  (ot [%resource dejs:res]~)
+    ++  unarchive-graph  (ot [%resource dejs:res]~)
+    ::
+    ++  add-nodes
+      %-  ot
+      :~  [%resource dejs:res]
+          [%nodes nodes]
+      ==
+    ::
+    ++  nodes  (op ;~(pfix fas (more fas dem)) node)
+    ::
+    ++  node
+      %-  ot
+      :~  [%post maybe-post]
+          [%children internal-graph]
+      ==
+    ::
+    ++  internal-graph
+      |=  jon=json
+      ^-  ^internal-graph
+      ?~  jon
+        [%empty ~]
+      [%graph (graph jon)]
+    ::
+    ++  maybe-post
+      |=  jon=json
+      ^-  ^maybe-post
+      ?~  jon    !!
+      ?+  -.jon  !!
+        %s  [%| (nu jon)]
+        %o  [%& (post jon)]
+      ==
+    ::
+    ++  post
+      %-  ot
+      :~  [%author (su ;~(pfix sig fed:ag))]
+          [%index index]
+          [%time-sent di]
+          [%contents (ar content)]
+          [%hash (mu nu)]
+          [%signatures (as signature)]
+      ==
+    ::
+    ++  content
+      %-  of
+      :~  [%mention (su ;~(pfix sig fed:ag))]
+          [%text so]
+          [%url so]
+          [%reference reference]
+          [%code eval]
+      ==
+    ::
+    ++  reference
+      |^
+      %-  of
+      :~  graph+graph
+          group+dejs-path:res
+          app+app
+      ==
+      ::
+      ++  graph
+        %-  ot
+        :~  group+dejs-path:res
+            graph+dejs-path:res
+            index+index
+        ==
+      ::
+      ++  app
+        %-  ot
+        :~  ship+(su ;~(pfix sig fed:ag))
+            desk+so
+            path+pa
+        ==
+      --
+    ::
+    ++  tang 
+      |=  jon=^json
+      ^-  ^tang
+      ?>  ?=(%a -.jon)
+      %-  zing
+      %+  turn
+        p.jon
+      |=  jo=^json
+      ^-  (list tank)
+      ?>  ?=(%a -.jo)
+      %+  turn
+        p.jo
+      |=  j=^json
+      ?>  ?=(%s -.j)
+      ^-  tank
+      leaf+(trip p.j)
+    ::
+    ++  eval
+      %-  ot
+      :~  expression+so
+          output+tang
+      ==
+    ::
+    ++  remove-posts
+      %-  ot
+      :~  [%resource dejs:res]
+          [%indices (as index)]
+      ==
+    ::
+    ++  add-signatures
+      %-  ot
+      :~  [%uid uid]
+          [%signatures (as signature)]
+      ==
+    ::
+    ++  remove-signatures
+      %-  ot
+      :~  [%uid uid]
+          [%signatures (as signature)]
+      ==
+    ::
+    ++  signature
+      %-  ot
+      :~  [%hash nu]
+          [%ship (su ;~(pfix sig fed:ag))]
+          [%life ni]
+      ==
+    ::
+    ++  uid
+      %-  ot
+      :~  [%resource dejs:res]
+          [%index index]
+      ==
+    ::
+    ++  index  (su ;~(pfix fas (more fas dem)))
+    ::
+    ++  add-tag
+      %-  ot
+      :~  [%term so]
+          [%uid uid]
+      ==
+    ::
+    ++  remove-tag
+      %-  ot
+      :~  [%term so]
+          [%uid uid]
+      ==
+    ::
+    ++  keys
+      |=  =json
+      *resources
+    ::
+    ++  tags
+      |=  =json
+      *(set term)
+    ::
+    ++  tag-queries
+      |=  =json
+      *^tag-queries
+    ::
+    ++  run-updates
+      |=  a=json
+      ^-  [resource update-log]
+      [*resource *update-log]
+    --
+  ++  pa
+    |=  j=json
+    ^-  path
+    ?>  ?=(%s -.j)
+    ?:  =('/' p.j)  /
+    (stab p.j)
+  ::
+  --
+::
+++  create
+  |_  [our=ship now=time]
+  ++  post
+    |=  [=index contents=(list content)]
+    ^-  ^post
+    :*  our
+        index
+        now
+        contents
+        ~
+        *signatures
+    ==
+  --
+::
+++  upgrade
+  |%
+  ++  is-old-dm  |=(r=resource =('dm--' (end [3 4] name.r)))
+  ++  backup
+    |=  =bowl:gall
+    |=  [r=resource m=marked-graph]
+    ^-  card:agent:gall
+    =/  pax  /(rap 3 'archive-' (scot %p entity.r) '-' name.r ~)/noun
+    =/  =cage  drum-put+!>([pax (jam r m)])
+    [%pass /archive %agent [our.bowl %hood] %poke cage]
+  ++  strip-sigs-graph
+    |=  g=graph
+    ^+  g
+    =*  loop  $
+    %+  gas:orm  *graph
+    %+  turn  (tap:orm g)
+    |=  [key=@ val=node]  :: optional: also strip out deleted messages?
+    =?  children.val  ?=(%graph -.children.val)
+      [%graph loop(g p.children.val)]
+    :-  key
+    ?.  ?=(%& -.post.val)
+      val
+    val(signatures.p.post ~)
+  ++  strip-sigs-log
+    |=  u=update-log
+    %+  gas:orm-log  *update-log
+    %+  turn  (tap:orm-log u)
+    |=  [key=@ upd=logged-update]
+    :-  key
+    :-  p.upd
+    ?+    -.q.upd  q.upd
+        %add-graph
+      q.upd(graph (strip-sigs-graph graph.q.upd))
+    ::
+        %add-signatures
+      q.upd(signatures ~)
+    ::
+        %remove-signatures
+      q.upd(signatures ~)
+    ::
+        %add-nodes
+      %=    q.upd
+          nodes
+        %-  ~(run by nodes.q.upd)
+        |=  =node
+        ^+  node
+        %=    node
+            children
+          ?.  ?=(%graph -.children.node)
+            children.node
+          [%graph (strip-sigs-graph p.children.node)]
+        ::
+            post
+          ?.  ?=(%& -.post.node)
+            post.node
+          =.  signatures.p.post.node  ~
+          post.node
+        ==
+      ==
+    ==
+  ::
+  ++  nuke-groups
+    |=  =bowl:gall
+    |^  ^-  (list card:agent:gall)
+    ?.  .^(? (gall-scry %u %groups))
+      ~
+    =+  .^(=desk (gall-scry %d %groups))
+    :~  [%pass /nuke %agent [our.bowl %hood] %poke kiln-nuke+!>([desk &])]
+        [%pass /nuke %agent [our.bowl %docket] %poke docket-uninstall+!>(desk)]
+        [%pass /nuke %agent [our.bowl %docket] %poke docket-uninstall+!>(%talk)]
+    ==
+    ::
+    ++  gall-scry
+      |=  [=care:clay dap=dude:gall]
+      ^-  path
+      /(cat 3 %g care)/(scot %p our.bowl)/[dap]/(scot %da now.bowl)
+    --
+  ::
+  ::  +two
+  ::
+  ++  marked-graph-to-two
+    |=  [=graph:one m=(unit mark)]
+    [(graph-to-two graph) m]
+  ::
+  ++  graph-to-two
+    |=  =graph:one
+    (graph:(upgrade ,post:one ,maybe-post:two) graph post-to-two)
+  ::
+  ++  post-to-two
+    |=  p=post:one
+    ^-  maybe-post:two
+    [%& p]
+  ::
+  ::
+  ::  +one
+  ::
+  ++  update-log-to-one
+    |=  =update-log:zero
+    ^-  update-log:one
+    %+  gas:orm-log:one  *update-log:one
+    %+  turn  (tap:orm-log:zero update-log)
+    |=  [=time =logged-update:zero]
+    ^-  [^time logged-update:one]
+    :-  time
+    :-  p.logged-update  
+    (logged-update-to-one q.logged-update)
+  ::
+  ++  logged-update-to-one
+    |=  upd=logged-update-0:zero
+    ^-  logged-action:one
+    ?+  -.upd  upd
+      %add-graph  upd(graph (graph-to-one graph.upd))
+      %add-nodes  upd(nodes (~(run by nodes.upd) node-to-one))
+    ==
+  ::
+  ++  node-to-one
+    |=  =node:zero
+    (node:(upgrade ,post:zero ,post:one) node post-to-one)
+  ::
+  ++  graph-to-one
+    |=  =graph:zero
+    (graph:(upgrade ,post:zero ,post:one) graph post-to-one)
+  ::
+  ++  marked-graph-to-one
+    |=  [=graph:zero m=(unit mark)]
+    [(graph-to-one graph) m]
+  ::
+  ++  post-to-one
+    |=  p=post:zero
+    ^-  post:one
+    p(contents (contents-to-one contents.p))
+  ::
+  ++  contents-to-one
+    |=  cs=(list content:zero)
+    ^-  (list content:one)
+    %+  murn  cs
+    |=  =content:zero
+    ^-  (unit content:one)
+    ?:  ?=(%reference -.content)  ~
+    `content
+  ::
+  ++  upgrade
+    |*  [in-pst=mold out-pst=mold]
+    =>
+      |%
+      ++  in-orm
+        ((on atom in-node) gth)
+      +$  in-node
+        [post=in-pst children=in-internal-graph]
+      +$  in-graph
+        ((mop atom in-node) gth)
+      +$  in-internal-graph
+        $~  [%empty ~]
+        $%  [%graph p=in-graph]
+            [%empty ~]
+        ==
+      ::
+      ++  out-orm
+        ((on atom out-node) gth)
+      +$  out-node
+        [post=out-pst children=out-internal-graph]
+      +$  out-graph
+        ((mop atom out-node) gth)
+      +$  out-internal-graph
+        $~  [%empty ~]
+        $%  [%graph p=out-graph]
+            [%empty ~]
+        ==
+      --
+    |%
+    ::
+    ++  graph
+      |=  $:  gra=in-graph
+              fn=$-(in-pst out-pst)
+          ==
+      ^-  out-graph
+      %+  gas:out-orm  *out-graph
+      ^-  (list [atom out-node])
+      %+  turn  (tap:in-orm gra)
+      |=  [a=atom n=in-node]
+      ^-  [atom out-node]
+      [a (node n fn)]
+    ::
+    ++  node
+      |=  [nod=in-node fn=$-(in-pst out-pst)]
+      ^-  out-node
+      :-  (fn post.nod)
+      ^-  out-internal-graph
+      ?:  ?=(%empty -.children.nod)
+        [%empty ~]
+      [%graph (graph p.children.nod fn)]
+    --
+  ::
+  ++  zero-load
+    :: =* infinitely recurses
+    =,  store=zero
+    =,  orm=orm:zero
+    =,  orm-log=orm-log:zero
+    |%
+    ++  change-revision-graph
+      |=  [=graph:store q=(unit mark)]
+      ^-  [graph:store (unit mark)]
+      |^
+      :_  q
+      ?+    q  graph
+        [~ %graph-validator-link]     convert-links
+        [~ %graph-validator-publish]  convert-publish
+      ==
+      ::
+      ++  convert-links
+        %+  gas:orm  *graph:store
+        %+  turn  (tap:orm graph)
+        |=  [=atom =node:store]
+        ^-  [^atom node:store]
+        ::  top-level
+        ::
+        :+  atom  post.node
+        ?:  ?=(%empty -.children.node)
+          [%empty ~]
+        :-  %graph
+        %+  gas:orm  *graph:store
+        %+  turn  (tap:orm p.children.node)
+        |=  [=^atom =node:store]
+        ^-  [^^atom node:store]
+        ::  existing comments get turned into containers for revisions
+        ::
+        :^    atom
+            post.node(contents ~, hash ~)
+          %graph
+        %+  gas:orm  *graph:store
+        :_  ~  :-  %0
+        :_  [%empty ~]
+        post.node(index (snoc index.post.node atom), hash ~)
+      ::
+      ++  convert-publish
+        %+  gas:orm  *graph:store
+        %+  turn  (tap:orm graph)
+        |=  [=atom =node:store]
+        ^-  [^atom node:store]
+        ::  top-level
+        ::
+        :+  atom  post.node
+        ?:  ?=(%empty -.children.node)
+          [%empty ~]
+        :-  %graph
+        %+  gas:orm  *graph:store
+        %+  turn  (tap:orm p.children.node)
+        |=  [=^atom =node:store]
+        ^-  [^^atom node:store]
+        ::  existing container for publish note revisions
+        ::
+        ?+    atom  !!
+            %1  [atom node]
+            %2
+          :+  atom  post.node
+          ?:  ?=(%empty -.children.node)
+            [%empty ~]
+          :-  %graph
+          %+  gas:orm  *graph:store
+          %+  turn  (tap:orm p.children.node)
+          |=  [=^^atom =node:store]
+          ^-  [^^^atom node:store]
+          :+  atom  post.node(contents ~, hash ~)
+          :-  %graph
+          %+  gas:orm  *graph:store
+          :_  ~  :-  %1
+          :_  [%empty ~]
+          post.node(index (snoc index.post.node atom), hash ~)
+        ==
+      --
+    ::  
+    ++  maybe-unix-to-da
+      |=  =atom
+      ^-  @
+      ::  (bex 127) is roughly 226AD
+      ?.  (lte atom (bex 127))
+        atom
+      (add ~1970.1.1 (div (mul ~s1 atom) 1.000))
+    ::
+    ++  convert-unix-timestamped-node
+      |=  =node:store
+      ^-  node:store
+      =.  index.post.node
+        (convert-unix-timestamped-index index.post.node)
+      ?.  ?=(%graph -.children.node)
+        node
+      :+  post.node
+        %graph
+      (convert-unix-timestamped-graph p.children.node)
+    ::
+    ++  convert-unix-timestamped-index
+      |=  =index:store
+      (turn index maybe-unix-to-da)
+    ::
+    ++  convert-unix-timestamped-graph
+      |=  =graph:store
+      %+  gas:orm  *graph:store
+      %+  turn
+        (tap:orm graph)
+      |=  [=atom =node:store]
+      ^-  [^atom node:store]
+      :-  (maybe-unix-to-da atom)
+      (convert-unix-timestamped-node node)
+    --
+  --
+++  import
+  |=  [arc=* our=ship]
+  ^-  (quip card:agent:gall [%7 network])
+  |^
+  =/  sty  [%7 (remake-network ;;(tree-network +.arc))]
+  :_  sty
+  %+  turn  ~(tap by graphs.sty)
+  |=  [rid=resource =marked-graph]
+  ^-  card:agent:gall
+  ?:  =(our entity.rid)
+    =/  =cage  [%push-hook-action !>([%add rid])]
+    [%pass / %agent [our %graph-push-hook] %poke cage]
+  (try-rejoin rid 0)
+  ::
+  +$  tree-network
+    $:  graphs=tree-graphs
+        tag-queries=(tree [term (tree uid)])
+        update-logs=tree-update-logs
+        archive=tree-graphs
+        ~
+    ==
+  +$  tree-graphs          (tree [resource tree-marked-graph])
+  +$  tree-marked-graph    [p=tree-graph q=(unit ^mark)]
+  +$  tree-graph           (tree [atom tree-node])
+  +$  tree-node            [post=tree-maybe-post children=tree-internal-graph]
+  +$  tree-internal-graph
+    $~  [%empty ~]
+    $%  [%graph p=tree-graph]
+        [%empty ~]
+    ==
+  +$  tree-update-logs     (tree [resource tree-update-log])
+  +$  tree-update-log      (tree [time tree-logged-update])
+  +$  tree-logged-update
+    $:  p=time
+        $=  q
+        $%  [%add-graph =resource =tree-graph mark=(unit ^mark) ow=?]
+            [%add-nodes =resource nodes=(tree [index tree-node])]
+            [%remove-posts =resource indices=(tree index)]
+            [%add-signatures =uid signatures=tree-signatures]
+            [%remove-signatures =uid signatures=tree-signatures]
+        ==
+    ==
+  +$  tree-signatures      (tree signature)
+  +$  tree-maybe-post      (each tree-post hash)
+  +$  tree-post
+    $:  author=ship
+        =index
+        time-sent=time
+        contents=(list content)
+        hash=(unit hash)
+        signatures=tree-signatures
+    ==
+  ::
+  ++  remake-network
+    |=  t=tree-network
+    ^-  network
+    :*  (remake-graphs graphs.t)
+        (remake-jug:migrate tag-queries.t)
+        (remake-update-logs update-logs.t)
+        (remake-graphs archive.t)
+        ~
+    ==
+  ::
+  ++  remake-graphs
+    |=  t=tree-graphs
+    ^-  graphs
+    %-  remake-map:migrate
+    (~(run by t) remake-marked-graph)
+  ::
+  ++  remake-marked-graph
+    |=  t=tree-marked-graph
+    ^-  marked-graph
+    [(remake-graph p.t) q.t]
+  ::
+  ++  remake-graph
+    |=  t=tree-graph
+    ^-  graph
+    %+  gas:orm  *graph
+    %+  turn  ~(tap by t)
+    |=  [a=atom tn=tree-node]
+    ^-  [atom node]
+    [a (remake-node tn)]
+  ::
+  ++  remake-internal-graph
+    |=  t=tree-internal-graph
+    ^-  internal-graph
+    ?:  ?=(%empty -.t)
+      [%empty ~]
+    [%graph (remake-graph p.t)]
+  ::
+  ++  remake-node
+    |=  t=tree-node
+    ^-  node
+    :-  (remake-post post.t)
+    (remake-internal-graph children.t)
+  ::
+  ++  remake-update-logs
+    |=  t=tree-update-logs
+    ^-  update-logs
+    %-  remake-map:migrate
+    (~(run by t) remake-update-log)
+  ::
+  ++  remake-update-log
+    |=  t=tree-update-log
+    ^-  update-log
+    =/  ulm  ((on time logged-update) gth)
+    %+  gas:ulm  *update-log
+    %+  turn  ~(tap by t)
+    |=  [=time tlu=tree-logged-update]
+    ^-  [^time logged-update]
+    [time (remake-logged-update tlu)]
+  ::
+  ++  remake-logged-update
+    |=  t=tree-logged-update
+    ^-  logged-update
+    :-  p.t
+    ?-  -.q.t
+        %add-graph
+      :*  %add-graph
+          resource.q.t
+          (remake-graph tree-graph.q.t)
+          mark.q.t
+          ow.q.t
+      ==
+    ::
+        %add-nodes
+      :-  %add-nodes
+      :-  resource.q.t
+      %-  remake-map:migrate
+      (~(run by nodes.q.t) remake-node)
+    ::
+        %remove-posts
+      [%remove-posts resource.q.t (remake-set:migrate indices.q.t)]
+    ::
+        %add-signatures
+      [%add-signatures uid.q.t (remake-set:migrate signatures.q.t)]
+    ::
+        %remove-signatures
+      [%remove-signatures uid.q.t (remake-set:migrate signatures.q.t)]
+    ==
+  ::
+  ++  remake-post
+    |=  t=tree-maybe-post
+    ^-  maybe-post
+    ?-  -.t
+      %|  t
+      %&  t(signatures.p (remake-set:migrate signatures.p.t))
+    ==
+  ::
+  ++  try-rejoin
+    |=  [rid=resource nack-count=@]
+    ^-  card:agent:gall
+    =/  res-path  (en-path:res rid)
+    =/  wire  [%try-rejoin (scot %ud nack-count) res-path]
+    =/  =cage  
+      :-  %pull-hook-action 
+      !>  ^-  action:pull-hook
+      [%add [entity .]:rid]
+    [%pass wire %agent [our %graph-pull-hook] %poke cage]
+  --
+--

--- a/talk/lib/migrate.hoon
+++ b/talk/lib/migrate.hoon
@@ -1,0 +1,1 @@
+../../desk/lib/migrate.hoon

--- a/talk/lib/resource.hoon
+++ b/talk/lib/resource.hoon
@@ -1,0 +1,1 @@
+../../desk/lib/resource.hoon

--- a/talk/lib/shoe.hoon
+++ b/talk/lib/shoe.hoon
@@ -1,0 +1,557 @@
+::  shoe: console application library
+::
+::    /lib/sole: draw some characters
+::    /lib/shoe: draw the rest of the fscking app
+::
+::    call +agent with a type, then call the resulting function with a core
+::    of the shape described in +shoe.
+::    you may produce classic gall cards and "shoe-effects", shorthands for
+::    sending cli events to connected clients.
+::    default implementations for the shoe-specific arms are in +default.
+::    for a simple usage example, see /app/shoe.
+::
+/-  *sole
+/+  sole, auto=language-server-complete
+|%
++$  state-1
+  $:  %1
+      soles=(map sole-id sole-share)
+  ==
+::  $card: standard gall cards plus shoe effects
+::
++$  card
+  $%  card:agent:gall
+      [%shoe sole-ids=(list sole-id) effect=shoe-effect]  ::  ~ sends to all
+  ==
+::  $shoe-effect: easier sole-effects
+::
++$  shoe-effect
+  $%  ::  %sole: raw sole-effect
+      ::
+      [%sole effect=sole-effect]
+      ::  %table: sortable, filterable data, with suggested column char widths
+      ::
+      [%table head=(list dime) wide=(list @ud) rows=(list (list dime))]
+      ::  %row: line sections with suggested char widths
+      ::
+      [%row wide=(list @ud) cols=(list dime)]
+  ==
+::  +shoe: gall agent core with extra arms
+::
+++  shoe
+  |*  command-type=mold
+  $_  ^|
+  |_  bowl:gall
+  ::  +command-parser: input parser for a specific session
+  ::
+  ::    if the head of the result is true, instantly run the command
+  ::
+  ++  command-parser
+    |~  =sole-id
+    |~(nail *(like [? command-type]))
+  ::  +tab-list: autocomplete options for the session (to match +command-parser)
+  ::
+  ++  tab-list
+    |~  =sole-id
+    ::  (list [@t tank])
+    *(list (option:auto tank))
+  ::  +on-command: called when a valid command is run
+  ::
+  ++  on-command
+    |~  [=sole-id command=command-type]
+    *(quip card _^|(..on-init))
+  ::
+  ++  can-connect
+    |~  =sole-id
+    *?
+  ::
+  ++  on-connect
+    |~  =sole-id
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-disconnect
+    |~  =sole-id
+    *(quip card _^|(..on-init))
+  ::
+  ::NOTE  standard gall agent arms below, though they may produce %shoe cards
+  ::
+  ++  on-init
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-save
+    *vase
+  ::
+  ++  on-load
+    |~  vase
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-poke
+    |~  [mark vase]
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-watch
+    |~  path
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-leave
+    |~  path
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-peek
+    |~  path
+    *(unit (unit cage))
+  ::
+  ++  on-agent
+    |~  [wire sign:agent:gall]
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-arvo
+    |~  [wire sign-arvo]
+    *(quip card _^|(..on-init))
+  ::
+  ++  on-fail
+    |~  [term tang]
+    *(quip card _^|(..on-init))
+  --
+::  +default: bare-minimum implementations of shoe arms
+::
+++  default
+  |*  [shoe=* command-type=mold]
+  |_  =bowl:gall
+  ++  command-parser
+    |=  =sole-id
+    (easy *[? command-type])
+  ::
+  ++  tab-list
+    |=  =sole-id
+    ~
+  ::
+  ++  on-command
+    |=  [=sole-id command=command-type]
+    [~ shoe]
+  ::
+  ++  can-connect
+    |=  =sole-id
+    (team:title [our src]:bowl)
+  ::
+  ++  on-connect
+    |=  =sole-id
+    [~ shoe]
+  ::
+  ++  on-disconnect
+    |=  =sole-id
+    [~ shoe]
+  --
+::  +agent: creates wrapper core that handles sole events and calls shoe arms
+::
+++  agent
+  |*  command-type=mold
+  |=  =(shoe command-type)
+  =|  state-1
+  =*  state  -
+  ^-  agent:gall
+  =>
+    |%
+    ++  deal
+      |=  cards=(list card)
+      %+  turn  cards
+      |=  =card
+      ^-  card:agent:gall
+      ?.  ?=(%shoe -.card)  card
+      ?-  -.effect.card
+          %sole
+        =-  [%give %fact - %sole-effect !>(effect.effect.card)]
+        %+  turn
+          ?^  sole-ids.card  sole-ids.card
+          ~(tap in ~(key by soles))
+        id-to-path:sole
+      ::
+          %table
+        =;  fez=(list sole-effect)
+          $(effect.card [%sole %mor fez])
+        =,  +.effect.card
+        :-  (row:draw & wide head)
+        %+  turn  rows
+        (cury (cury row:draw |) wide)
+      ::
+          %row
+        $(effect.card [%sole (row:draw | +.effect.card)])
+      ==
+    --
+  ::
+  |_  =bowl:gall
+  +*  this  .
+      og    ~(. shoe bowl)
+  ::
+  ++  on-init
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  on-init:og
+    [(deal cards) this]
+  ::
+  ++  on-save   !>([%shoe-app on-save:og state])
+  ::
+  ++  on-load
+    |=  old-state=vase
+    ^-  (quip card:agent:gall agent:gall)
+    ::  we could be upgrading from a shoe-less app, in which case the vase
+    ::  contains inner application state instead of our +on-save.
+    ::  to distinguish between the two, we check for the presence of our own
+    ::  +on-save tag in the vase.
+    ::
+    ?.  ?=([%shoe-app ^] q.old-state)
+      =^  cards  shoe  (on-load:og old-state)
+      [(deal cards) this]
+    |^  =|  old-outer=state-any
+        =^  old-inner  old-outer
+          +:!<([%shoe-app vase state-any] old-state)
+          :: ~!  q.old-state
+          :: ?+  +>.q.old-state  !!
+          ::   [%0 *]  +:!<([%shoe-app vase state-0] old-state)
+          ::   [%1 *]  +:!<([%shoe-app vase state-1] old-state)
+          :: ==
+        =^  caz  shoe  (on-load:og old-inner)
+        =^  cuz  old-outer
+          ?.  ?=(%0 -.old-outer)  [~ old-outer]
+          (state-0-to-1 old-outer)
+        ?>  ?=(%1 -.old-outer)
+        [(weld cuz (deal caz)) this(state old-outer)]
+    ::
+    +$  state-any  $%(state-1 state-0)
+    +$  state-0    [%0 soles=(map @ta sole-share)]
+    ++  state-0-to-1
+      |=  old=state-0
+      ^-  (quip card:agent:gall state-1)
+      :-  %+  turn  ~(tap in ~(key by soles.old))
+          |=  id=@ta
+          ^-  card:agent:gall
+          [%give %kick ~[/sole/[id]] ~]
+      :-  %1
+      %-  ~(gas by *(map sole-id sole-share))
+      %+  murn  ~(tap by soles.old)
+      |=  [id=@ta s=sole-share]
+      (bind (upgrade-id:sole id) (late s))
+    --
+  ::
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card:agent:gall agent:gall)
+    ?.  ?=(%sole-action mark)
+      =^  cards  shoe  (on-poke:og mark vase)
+      [(deal cards) this]
+    ::
+    =/  act  !<(sole-action vase)
+    =*  sole-id  id.act
+    =/  cli-state=sole-share
+      (~(gut by soles) sole-id *sole-share)
+    |^  =^  [cards=(list card) =_cli-state]  shoe
+          ?-  -.dat.act
+            %det  (apply-edit +.dat.act)
+            %clr  [[~ cli-state] shoe]
+            %ret  try-command
+            %tab  [(tab +.dat.act) shoe]
+          ==
+        :-  (deal cards)
+        this(soles (~(put by soles) sole-id cli-state))
+    ::
+    ++  effect
+      |=  =sole-effect
+      ^-  card
+      [%shoe [sole-id]~ %sole sole-effect]
+    ::
+    ++  apply-edit
+      |=  =sole-change
+      ^+  [[*(list card) cli-state] shoe]
+      =^  inverse  cli-state
+        (~(transceive sole cli-state) sole-change)
+      ::  res: & for fully parsed, | for parsing failure at location
+      ::
+      =/  res=(each (unit [run=? cmd=command-type]) @ud)
+        %+  rose  (tufa buf.cli-state)
+        (command-parser:og sole-id)
+      ?:  ?=(%& -.res)
+        ::  only auto-run eligible commands if they were typed out
+        ::  (that is, not retrieved from command history)
+        ::
+        ?.  &(?=(^ p.res) run.u.p.res !?=(%set -.ted.sole-change))
+          [[~ cli-state] shoe]
+        (run-command cmd.u.p.res)
+      :_  shoe
+      ::  parsing failed
+      ::
+      ?.  &(?=(%del -.inverse) =(+(p.inverse) (lent buf.cli-state)))
+        ::  if edit was somewhere in the middle, let it happen anyway
+        ::
+        [~ cli-state]
+      ::  if edit was insertion at buffer tail, revert it
+      ::
+      =^  undo  cli-state
+        (~(transmit sole cli-state) inverse)
+      :_  cli-state
+      :_  ~
+      %+  effect  %mor
+      :~  [%det undo]   ::  undo edit
+          [%err p.res]  ::  cursor to error location
+      ==
+    ::
+    ++  try-command
+      ^+  [[*(list card) cli-state] shoe]
+      =/  res=(unit [? cmd=command-type])
+        %+  rust  (tufa buf.cli-state)
+        (command-parser:og sole-id)
+      ?^  res  (run-command cmd.u.res)
+      [[[(effect %bel ~)]~ cli-state] shoe]
+    ::
+    ++  run-command
+      |=  cmd=command-type
+      ^+  [[*(list card) cli-state] shoe]
+      =^  cards  shoe  (on-command:og sole-id cmd)
+      ::  clear buffer
+      ::
+      =^  clear  cli-state  (~(transmit sole cli-state) [%set ~])
+      =-  [[[- cards] cli-state] shoe]
+      %+  effect  %mor
+      :~  [%nex ~]
+          [%det clear]
+      ==
+    ::
+    ++  tab
+      |=  pos=@ud
+      ^-  (quip card _cli-state)
+      =+  (get-id-cord:auto pos (tufa buf.cli-state))
+      =/  needle=term
+        (fall id %$)
+      ::  autocomplete empty command iff user at start of command
+      ::
+      =/  options=(list (option:auto tank))
+        (search-prefix:auto needle (tab-list:og sole-id))
+      =/  advance=term
+        (longest-match:auto options)
+      =/  to-send=tape
+        %-  trip
+        (rsh [3 (met 3 needle)] advance)
+      =/  send-pos=@ud
+        %+  add  pos
+        (met 3 (fall forward ''))
+      =|  cards=(list card)
+      ::  only render the option list if we couldn't complete anything
+      ::
+      =?  cards  &(?=(~ to-send) ?=(^ options))
+        [(effect %tab options) cards]
+      |-  ^-  (quip card _cli-state)
+      ?~  to-send
+        [(flop cards) cli-state]
+      =^  char  cli-state
+        (~(transmit sole cli-state) [%ins send-pos `@c`i.to-send])
+      %_  $
+        cards     [(effect %det char) cards]
+        send-pos  +(send-pos)
+        to-send   t.to-send
+      ==
+    --
+  ::
+  ++  on-watch
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    ?~  sole-id=(path-to-id:sole path)
+      =^  cards  shoe
+        (on-watch:og path)
+      [(deal cards) this]
+    ?>  (can-connect:og u.sole-id)
+    =.  soles  (~(put by soles) u.sole-id *sole-share)
+    =^  cards  shoe
+      (on-connect:og u.sole-id)
+    :_  this
+    %-  deal
+    :_  cards
+    [%shoe [u.sole-id]~ %sole %pro & dap.bowl "> "]
+  ::
+  ++  on-leave
+    |=  =path
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-leave:og path)
+    [(deal cards) this]
+  ::
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?.  =(/x/dbug/state path)  (on-peek:og path)
+    ``noun+(slop on-save:og !>(shoe=state))
+  ::
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-agent:og wire sign)
+    [(deal cards) this]
+  ::
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-arvo:og wire sign-arvo)
+    [(deal cards) this]
+  ::
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card:agent:gall agent:gall)
+    =^  cards  shoe  (on-fail:og term tang)
+    [(deal cards) this]
+  --
+::
+++  draw
+  |%
+  ++  row
+    |=  [bold=? wide=(list @ud) cols=(list dime)]
+    ^-  sole-effect
+    :-  %mor
+    ^-  (list sole-effect)
+    =/  cows=(list [wid=@ud col=dime])
+      %-  head
+      %^  spin  cols  wide
+      |=  [col=dime wiz=(list @ud)]
+      ~|  [%too-few-wide col]
+      ?>  ?=(^ wiz)
+      [[i.wiz col] t.wiz]
+    =/  cobs=(list [wid=@ud (list tape)])
+      (turn cows col-as-lines)
+    =+  [lin=0 any=|]
+    =|  fez=(list sole-effect)
+    |-  ^+  fez
+    =;  out=tape
+      ::  done when we're past the end of all columns
+      ::
+      ?:  (levy out (cury test ' '))
+        (flop fez)
+      =;  fec=sole-effect
+        $(lin +(lin), fez [fec fez])
+      ?.  bold  txt+out
+      klr+[[`%br ~ ~]^[(crip out)]~]~
+    %+  roll  cobs
+    |=  [[wid=@ud lines=(list tape)] out=tape]
+    %+  weld  out
+    %+  weld  ?~(out "" " ")
+    =+  l=(swag [lin 1] lines)
+    ?^(l i.l (reap wid ' '))
+  ::
+  ++  col-as-lines
+    |=  [wid=@ud col=dime]
+    ^-  [@ud (list tape)]
+    :-  wid
+    %+  turn
+      (break wid (col-as-text col) (break-sets -.col))
+    (cury (cury pad wid) (alignment -.col))
+  ::
+  ++  col-as-text
+    |=  col=dime
+    ^-  tape
+    ?+  p.col  (scow col)
+      %t       (trip q.col)
+      %tas     ['%' (scow col)]
+    ==
+  ::
+  ++  alignment
+    |=  wut=@ta
+    ^-  ?(%left %right)
+    ?:  ?=(?(%t %ta %tas %da) wut)
+      %left
+    %right
+  ::
+  ++  break-sets
+    |=  wut=@ta
+    ::  for: may break directly before these characters
+    ::  aft: may break directly after these characters
+    ::  new: always break on these characters, consuming them
+    ::
+    ^-  [for=(set @t) aft=(set @t) new=(set @t)]
+    ?+  wut  [(sy " ") (sy ".:-/") (sy "\0a")]
+      ?(%p %q)  [(sy "-") (sy "-") ~]
+      %ux       [(sy ".") ~ ~]
+    ==
+  ::
+  ++  break
+    |=  [wid=@ud cot=tape brs=_*break-sets]
+    ^-  (list tape)
+    ~|  [wid cot]
+    ?:  =("" cot)  ~
+    =;  [lin=tape rem=tape]
+      [lin $(cot rem)]
+    ::  take snip of max width+1, search for breakpoint on that.
+    ::  we grab one char extra, to look-ahead for for.brs.
+    ::  later on, we always transfer _at least_ the extra char.
+    ::
+    =^  lin=tape  cot
+      [(scag +(wid) cot) (slag +(wid) cot)]
+    =+  len=(lent lin)
+    ::  find the first newline character
+    ::
+    =/  new=(unit @ud)
+      =+  new=~(tap in new.brs)
+      =|  las=(unit @ud)
+      |-
+      ?~  new  las
+      $(new t.new, las (hunt lth las (find [i.new]~ lin)))
+    ::  if we found a newline, break on it
+    ::
+    ?^  new
+      :-  (scag u.new lin)
+      (weld (slag +(u.new) lin) cot)
+    ::  if it fits, we're done
+    ::
+    ?:  (lte len wid)
+      [lin cot]
+    =+  nil=(flop lin)
+    ::  search for latest aft match
+    ::
+    =/  aft=(unit @ud)
+      ::  exclude the look-ahead character from search
+      ::
+      =.  len  (dec len)
+      =.  nil  (slag 1 nil)
+      =-  ?~(- ~ `+(u.-))
+      ^-  (unit @ud)
+      =+  aft=~(tap in aft.brs)
+      =|  las=(unit @ud)
+      |-
+      ?~  aft  (bind las (cury sub (dec len)))
+      $(aft t.aft, las (hunt lth las (find [i.aft]~ nil)))
+    ::  search for latest for match
+    ::
+    =/  for=(unit @ud)
+      =+  for=~(tap in for.brs)
+      =|  las=(unit @ud)
+      |-
+      ?~  for  (bind las (cury sub (dec len)))
+      =-  $(for t.for, las (hunt lth las -))
+      =+  (find [i.for]~ nil)
+      ::  don't break before the first character
+      ::
+      ?:(=(`(dec len) -) ~ -)
+    ::  if any result, break as late as possible
+    ::
+    =+  brk=(hunt gth aft for)
+    ?~  brk
+      ::  lin can't break, produce it in its entirety
+      ::  (after moving the look-ahead character back)
+      ::
+      :-  (scag wid lin)
+      (weld (slag wid lin) cot)
+    :-  (scag u.brk lin)
+    =.  cot  (weld (slag u.brk lin) cot)
+    ::  eat any leading whitespace the next line might have, "clean break"
+    ::
+    |-  ^+  cot
+    ?~  cot  ~
+    ?.  ?=(?(%' ' %'\09') i.cot)
+      cot
+    $(cot t.cot)
+  ::
+  ++  pad
+    |=  [wid=@ud lyn=?(%left %right) lin=tape]
+    ^+  lin
+    =+  l=(lent lin)
+    ?:  (gte l wid)  lin
+    =+  p=(reap (sub wid l) ' ')
+    ?-  lyn
+      %left   (weld lin p)
+      %right  (weld p lin)
+    ==
+  --
+--

--- a/talk/sur/chat-0.hoon
+++ b/talk/sur/chat-0.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/chat-0.hoon

--- a/talk/sur/chat.hoon
+++ b/talk/sur/chat.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/chat.hoon

--- a/talk/sur/cite.hoon
+++ b/talk/sur/cite.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/cite.hoon

--- a/talk/sur/epic.hoon
+++ b/talk/sur/epic.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/epic.hoon

--- a/talk/sur/graph-store.hoon
+++ b/talk/sur/graph-store.hoon
@@ -1,0 +1,272 @@
+/-  *post
+|%
++$  graph         ((mop atom node) gth)
++$  marked-graph  [p=graph q=(unit mark)]
+::
++$  maybe-post    (each post hash)
++$  node          [post=maybe-post children=internal-graph]
++$  graphs        (map resource marked-graph)
+::
++$  tag-queries   (jug term uid)
+::
++$  update-log    ((mop time logged-update) gth)
++$  update-logs   (map resource update-log)
+::
++$  internal-graph
+  $~  [%empty ~]
+  $%  [%graph p=graph]
+      [%empty ~]
+  ==
+::
++$  network
+  $:  =graphs
+      =tag-queries
+      =update-logs
+      archive=graphs
+      ~
+  ==
+::
++$  update  [p=time q=action]
+::
++$  logged-update  [p=time q=logged-action]
+  
+::
++$  logged-action
+  $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+      [%add-nodes =resource nodes=(map index node)]
+      [%remove-posts =resource indices=(set index)]
+      [%add-signatures =uid =signatures]
+      [%remove-signatures =uid =signatures]
+  ==
+::
++$  action
+  $%  logged-action
+      [%remove-graph =resource]
+    ::
+      [%add-tag =term =uid]
+      [%remove-tag =term =uid]
+    ::
+      [%archive-graph =resource]
+      [%unarchive-graph =resource]
+      [%run-updates =resource =update-log]
+    ::
+    ::  NOTE: cannot be sent as pokes
+    ::
+      [%keys =resources]
+      [%tags tags=(set term)]
+      [%tag-queries =tag-queries]
+  ==
+::
++$  permissions  
+  [admin=permission-level writer=permission-level reader=permission-level]
+::
+::  $permission-level:  levels of permissions in increasing order
+::  
+::    %no: May not add/remove node
+::    %self: May only nodes beneath nodes that were added by
+::      the same pilot, may remove nodes that the pilot 'owns'
+::    %yes: May add a node or remove node
++$  permission-level
+  ?(%no %self %yes)
+::
+::  %graph-store types version 2
+::
+++  two
+  =<  [. post-one]
+  =,  post-one
+  |%
+  +$  maybe-post    (each post hash)
+  ++  orm      ((on atom node) gth)
+  ++  orm-log  ((on time logged-update) gth)
+  ::
+  +$  graph         ((mop atom node) gth)
+  +$  marked-graph  [p=graph q=(unit mark)]
+  ::
+  +$  node          [post=maybe-post children=internal-graph]
+  +$  graphs        (map resource marked-graph)
+  ::
+  +$  tag-queries   (jug term resource)
+  ::
+  +$  update-log    ((mop time logged-update) gth)
+  +$  update-logs   (map resource update-log)
+  ::
+  +$  internal-graph
+    $~  [%empty ~]
+    $%  [%graph p=graph]
+        [%empty ~]
+    ==
+  ::
+  +$  network
+    $:  =graphs
+        =tag-queries
+        =update-logs
+        archive=graphs
+        validators=(set mark)
+    ==
+  ::
+  +$  update  [p=time q=action]
+  ::
+  +$  logged-update  [p=time q=logged-action]
+  ::
+  +$  logged-action
+    $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+        [%add-nodes =resource nodes=(map index node)]
+        [%remove-nodes =resource indices=(set index)]
+        [%add-signatures =uid =signatures]
+        [%remove-signatures =uid =signatures]
+    ==
+  ::
+  +$  action
+    $%  logged-action
+        [%remove-graph =resource]
+      ::
+        [%add-tag =term =resource]
+        [%remove-tag =term =resource]
+      ::
+        [%archive-graph =resource]
+        [%unarchive-graph =resource]
+        [%run-updates =resource =update-log]
+      ::
+      ::  NOTE: cannot be sent as pokes
+      ::
+        [%keys =resources]
+        [%tags tags=(set term)]
+        [%tag-queries =tag-queries]
+    ==
+  --
+::
+::  %graph-store types version 1
+::
+++  one 
+  =<  [. post-one]
+  =,  post-one
+  |%
+  ++  orm      ((on atom node) gth)
+  ++  orm-log  ((on time logged-update) gth)
+  ::
+  +$  graph         ((mop atom node) gth)
+  +$  marked-graph  [p=graph q=(unit mark)]
+  ::
+  +$  node          [=post children=internal-graph]
+  +$  graphs        (map resource marked-graph)
+  ::
+  +$  tag-queries   (jug term resource)
+  ::
+  +$  update-log    ((mop time logged-update) gth)
+  +$  update-logs   (map resource update-log)
+  ::
+  +$  internal-graph
+    $~  [%empty ~]
+    $%  [%graph p=graph]
+        [%empty ~]
+    ==
+  ::
+  +$  network
+    $:  =graphs
+        =tag-queries
+        =update-logs
+        archive=graphs
+        validators=(set mark)
+    ==
+  ::
+  +$  update  [p=time q=action]
+  ::
+  +$  logged-update  [p=time q=logged-action]
+  ::
+  +$  logged-action
+    $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+        [%add-nodes =resource nodes=(map index node)]
+        [%remove-nodes =resource indices=(set index)]
+        [%add-signatures =uid =signatures]
+        [%remove-signatures =uid =signatures]
+    ==
+  ::
+  +$  action
+    $%  logged-action
+        [%remove-graph =resource]
+      ::
+        [%add-tag =term =resource]
+        [%remove-tag =term =resource]
+      ::
+        [%archive-graph =resource]
+        [%unarchive-graph =resource]
+        [%run-updates =resource =update-log]
+      ::
+      ::  NOTE: cannot be sent as pokes
+      ::
+        [%keys =resources]
+        [%tags tags=(set term)]
+        [%tag-queries =tag-queries]
+    ==
+  --
+::
+::  %graph-store types version 0
+::
+++  zero
+  =<  [. post-zero]
+  =,  post-zero
+  |%
+  ++  orm      ((ordered-map atom node) gth)
+  ++  orm-log  ((ordered-map time logged-update) gth)
+  ::
+  +$  graph         ((mop atom node) gth)
+  +$  marked-graph  [p=graph q=(unit mark)]
+  ::
+  +$  node          [=post children=internal-graph]
+  +$  graphs        (map resource marked-graph)
+  ::
+  +$  tag-queries   (jug term resource)
+  ::
+  +$  update-log    ((mop time logged-update) gth)
+  +$  update-logs   (map resource update-log)
+  ::
+  ::
+  +$  internal-graph
+    $~  [%empty ~]
+    $%  [%graph p=graph]
+        [%empty ~]
+    ==
+  ::
+  +$  network
+    $:  =graphs
+        =tag-queries
+        =update-logs
+        archive=graphs
+        validators=(set mark)
+    ==
+  ::
+  +$  update
+    $%  [%0 p=time q=update-0]
+    ==
+  ::
+  +$  logged-update
+    $%  [%0 p=time q=logged-update-0]
+    ==
+  ::
+  +$  logged-update-0
+    $%  [%add-graph =resource =graph mark=(unit mark) overwrite=?]
+        [%add-nodes =resource nodes=(map index node)]
+        [%remove-nodes =resource indices=(set index)]
+        [%add-signatures =uid =signatures]
+        [%remove-signatures =uid =signatures]
+    ==
+  ::
+  +$  update-0
+    $%  logged-update-0
+        [%remove-graph =resource]
+      ::
+        [%add-tag =term =resource]
+        [%remove-tag =term =resource]
+      ::
+        [%archive-graph =resource]
+        [%unarchive-graph =resource]
+        [%run-updates =resource =update-log]
+      ::
+      ::  NOTE: cannot be sent as pokes
+      ::
+        [%keys =resources]
+        [%tags tags=(set term)]
+        [%tag-queries =tag-queries]
+    ==
+  --
+--

--- a/talk/sur/group-store.hoon
+++ b/talk/sur/group-store.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/group-store.hoon

--- a/talk/sur/group.hoon
+++ b/talk/sur/group.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/group.hoon

--- a/talk/sur/groups.hoon
+++ b/talk/sur/groups.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/groups.hoon

--- a/talk/sur/meta.hoon
+++ b/talk/sur/meta.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/meta.hoon

--- a/talk/sur/metadata-store.hoon
+++ b/talk/sur/metadata-store.hoon
@@ -1,0 +1,138 @@
+/-  *resource
+^?
+|%
+::
++$  app-name      term
++$  md-resource   [=app-name =resource]
++$  association   [group=resource =metadatum]
++$  associations  (map md-resource association)
++$  group-preview
+  $:  group=resource
+      channels=associations
+      members=@ud
+      channel-count=@ud
+      =metadatum
+  ==
+::
++$  color  @ux
++$  url    @t
+::
+::  $vip-metadata: variation in permissions
+::
+::    This will be passed to the graph-permissions mark
+::    conversion to allow for custom permissions.
+::
+::    %reader-comments: Allow readers to comment, regardless
+::      of whether they can write. (notebook, collections)
+::    %member-metadata: Allow members to add channels (groups)
+::    %host-feed: Only host can post to group feed
+::    %admin-feed: Only admins and host can post to group feed
+::    %$: No variation
+::
++$  vip-metadata  
+  $?  %reader-comments
+      %member-metadata 
+      %host-feed
+      %admin-feed
+      %$
+  ==
+::
++$  md-config
+  $~  [%empty ~]
+  $%  [%group feed=(unit (unit md-resource))]
+      [%graph module=term] 
+      [%empty ~]
+  ==
+::
++$  edit-field
+  $%  [%title title=cord]
+      [%description description=cord]
+      [%color color=@ux]
+      [%picture =url]
+      [%preview preview=?]
+      [%hidden hidden=?]
+      [%vip vip=vip-metadata]
+  ==
+::
++$  metadatum
+  $:  title=cord
+      description=cord
+      =color
+      date-created=time
+      creator=ship
+      config=md-config
+      picture=url
+      preview=?
+      hidden=?
+      vip=vip-metadata
+  ==
+::
++$  action
+  $%  [%add group=resource resource=md-resource =metadatum]
+      [%remove group=resource resource=md-resource]
+      [%edit group=resource resource=md-resource =edit-field]
+      [%initial-group group=resource =associations]
+  ==
+::
++$  hook-update
+   $%  [%req-preview group=resource]
+       [%preview group-preview]
+   ==
+::
++$  update
+  $%  action
+      [%associations =associations]
+      $:  %updated-metadata 
+          group=resource
+          resource=md-resource 
+          before=metadatum
+          =metadatum
+      ==
+  ==
+::  historical
+++  one
+  |%
+  ::
+  +$  action
+    $~  [%remove *resource *md-resource]
+    $<  %edit  ^action
+  ::
+  +$  update
+    $~  [%remove *resource *md-resource]
+    $<  %edit  ^update
+  ::
+  --
+++  zero
+  |%
+  ::
+  +$  association   [group=resource =metadatum]
+  ::
+  +$  associations  (map md-resource association)
+  ::
+  +$  metadatum
+    $:  title=cord
+        description=cord
+        =color
+        date-created=time
+        creator=ship
+        module=term
+        picture=url
+        preview=?
+        vip=vip-metadata
+    ==
+  ::
+  +$  update
+    $%  [%add group=resource resource=md-resource =metadatum]
+        [%remove group=resource resource=md-resource]
+        [%initial-group group=resource =associations]
+        [%associations =associations]
+        $:  %updated-metadata 
+            group=resource
+            resource=md-resource 
+            before=metadatum
+            =metadatum
+        ==
+    ==
+  ::
+  --
+--

--- a/talk/sur/post.hoon
+++ b/talk/sur/post.hoon
@@ -1,0 +1,91 @@
+/-  *resource
+|%
++$  index       (list atom)
++$  uid         [=resource =index]
+::
+::  +sham (half sha-256) hash of +validated-portion
++$  hash  @ux
+::
++$  signature   [p=@ux q=ship r=life]
++$  signatures  (set signature)
++$  post
+  $:  author=ship
+      =index
+      time-sent=time
+      contents=(list content)
+      hash=(unit hash)
+      =signatures
+  ==
+::
++$  indexed-post  [a=atom p=post]
+::
++$  validated-portion
+  $:  parent-hash=(unit hash)
+      author=ship
+      time-sent=time
+      contents=(list content)
+  ==
+::
++$  reference
+  $%  [%graph group=resource =uid]
+      [%group group=resource]
+      [%app =ship =desk =path]
+  ==
+::
++$  content
+  $%  [%text text=cord]
+      [%mention =ship]
+      [%url url=cord]
+      [%code expression=cord output=(list tank)]
+      [%reference =reference]
+  ==
+::
+++  post-one
+  |%
+  ::
+  +$  indexed-post  [a=atom p=post]
+  ::
+  +$  post
+    $:  author=ship
+        =index
+        time-sent=time
+        contents=(list content)
+        hash=(unit hash)
+        =signatures
+    ==
+  ::
+  +$  content
+    $%  [%text text=cord]
+        [%mention =ship]
+        [%url url=cord]
+        [%code expression=cord output=(list tank)]
+        [%reference =reference]
+  ==
+  ::
+  +$  reference
+    $%  [%graph group=resource =uid]
+        [%group group=resource]
+    ==
+  --
+::
+++  post-zero
+  |%
+  ::
+  +$  content
+    $%  [%text text=cord]
+        [%mention =ship]
+        [%url url=cord]
+        [%code expression=cord output=(list tank)]
+        [%reference =uid]
+    ==
+  ::
+  +$  post
+    $:  author=ship
+        =index
+        time-sent=time
+        contents=(list content)
+        hash=(unit hash)
+        =signatures
+    ==
+  --
+--

--- a/talk/sur/pull-hook.hoon
+++ b/talk/sur/pull-hook.hoon
@@ -1,0 +1,11 @@
+/-  *resource
+|%
++$  action
+  $%  [%add =ship =resource]
+      [%remove =resource]
+  ==
+::
++$  update
+  $%  [%tracking tracking=(map resource ship)]
+  ==
+--

--- a/talk/sur/resource.hoon
+++ b/talk/sur/resource.hoon
@@ -1,0 +1,1 @@
+../../desk/sur/resource.hoon


### PR DESCRIPTION
What with the incoming release of session support for the (web)terminal, it'd be a shame if we didn't have an app for which that feature made some sort of sense. So here it is, chat-cli updated to work with groups 2's chat.

The good:
- Supports most of the features chat-cli supported.
- Includes session support.
- Pays respects to times long past: `/app/talk`.
- Tries its best to gracefully render gui-oriented contents such as `%img` and `%cite`.

The bad:
- No DMs or group DMs support.
- Does not even attempt to resolve message references, except for user-prompted history lookup with `;123` commands. We can scry for messages, but cannot scry for an _existence check_ of messages, so the content scry may crash if we don't know the message the reference points to.
- Took a somewhat shoehorn approach to message rendering. Most messages should display fine, and we do chat-cli usual best-effort at inline url rendering. But expanded messages no longer auto-open the url they contain, we do not make use of output styling capabilities where possible, and are overall just a lower-fidelity experience.
- No reacts support. 😮

The ugly:
- Passes smoke tests. Renders a handful of strange messages I threw at it. But haven't done Deep Testing™.
- What to do about dependencies? Do I just hard-copy /lib/shoe into this repo?
- Should we auto-start this? Users will want to `|link %talk` manually anyway, but should we require them to `|start %groups %talk` once?
- Does not import or clean up old chat-cli state at all.

Probably best to just review 32cd9ea standalone for now. 68f41c6 just imports the old chat-cli that had been updated for nu-term compatibility. Obviously requires zuse 416 (terminal release).