### PR TITLE
quips: prevent double submit of Diary comments

### DIFF
--- a/ui/src/diary/DiaryCommentField.tsx
+++ b/ui/src/diary/DiaryCommentField.tsx
@@ -43,8 +43,8 @@ export default function DiaryCommentField({
         JSONToInlines(editor?.getJSON()) as DiaryInline[]
       );
 
-      await useDiaryState.getState().addQuip(flag, replyTo, content);
       editor?.commands.setContent('');
+      await useDiaryState.getState().addQuip(flag, replyTo, content);
       setReady();
     },
     [sendDisabled, setPending, replyTo, flag, setReady]


### PR DESCRIPTION
Was unable to repro this locally or via SHIP_URL. This resolves #1439 by changing the order in the Diary quip submit handler to match the submit handler in ChatInput