### PR TITLE
utils: correct image url regex

### DIFF
--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -335,7 +335,7 @@ export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
-  /(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|webm|svg)/i;
+  /^(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|webm|svg)$/i;
 export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 
 export function isImageUrl(url: string) {


### PR DESCRIPTION
Fixes #1677. This should only ever match a string that is entirely an image URL not a partial of a string.