### PR TITLE
chat: use normal sendMessage in MultiDm

### DIFF
--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -14,7 +14,6 @@ import ChatWindow from '@/chat/ChatWindow';
 import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
 import { useIsMobile } from '@/logic/useMedia';
 import { pluralize } from '@/logic/utils';
-import useSendMultiDm from '@/state/chat/useSendMultiDm';
 import MultiDmInvite from './MultiDmInvite';
 import MultiDmAvatar from './MultiDmAvatar';
 import MultiDmHero from './MultiDmHero';
@@ -32,7 +31,7 @@ export default function MultiDm() {
     }
   }, [clubId, club]);
 
-  const sendMessage = useSendMultiDm();
+  const { sendMessage } = useChatState.getState();
   const messages = useMultiDmMessages(clubId);
 
   if (!club) {


### PR DESCRIPTION
Fixes #1696 

The useSendMultiDm hook was causing a re-render. We don't need to use a special sendMessages function for multiDMs after we've already created the multiDM, so I pulled it out.