### PR TITLE
chat: add placeholder for chat scroller

### DIFF
--- a/ui/src/chat/ChatScoller/ChatScrollerPlaceholder.tsx
+++ b/ui/src/chat/ChatScoller/ChatScrollerPlaceholder.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import cn from 'classnames';
+import { randomElement, randomIntInRange } from '@/logic/utils';
+import { useIsMobile } from '@/logic/useMedia';
+
+function ChatItemPlaceholder() {
+  const background = `bg-gray-${randomElement([100, 200, 400])}`;
+  const isMobile = useIsMobile();
+
+  return (
+    <div className="flex w-full flex-col rounded-lg">
+      <div className="flex w-full flex-1 space-x-3 rounded-lg p-2">
+        <div className="flex h-6 w-6 justify-center rounded-md bg-gray-100 text-sm" />
+        <div className="flex h-6 w-24 justify-center rounded-md bg-gray-100 text-sm" />
+      </div>
+      <div className="flex w-full flex-1 space-x-3 rounded-lg p-2">
+        <div
+          className={cn(background, 'h-12 w-full rounded-md')}
+          style={{ width: `${randomIntInRange(300, isMobile ? 300 : 900)}px` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface ChatScrollerPlaceholderProps {
+  count: number;
+}
+
+function ChatScrollerPlaceholder({ count }: ChatScrollerPlaceholderProps) {
+  return (
+    <div className="flex h-full animate-pulse flex-col justify-end space-y-3 p-2 sm:space-y-0">
+      {new Array(count).fill(true).map((_, i) => (
+        <ChatItemPlaceholder key={i} />
+      ))}
+    </div>
+  );
+}
+
+export default React.memo(ChatScrollerPlaceholder);

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -28,6 +28,7 @@ import { IChatScroller } from './IChatScroller';
 import ChatMessage from '../ChatMessage/ChatMessage';
 import { ChatInfo, useChatStore } from '../useChatStore';
 import ChatNotice from '../ChatNotice';
+import ChatScrollerPlaceholder from '../ChatScoller/ChatScrollerPlaceholder';
 
 interface CreateRendererParams {
   messages: BigIntOrderedMap<ChatWrit>;
@@ -274,7 +275,11 @@ export default function ChatScroller({
   );
 
   if (keys.length === 0) {
-    return null;
+    return (
+      <div className="h-full">
+        <ChatScrollerPlaceholder count={30} />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
For #1728 

Improves experience for #1665 but doesn't address the issue with using `bap` on line 99 of lib/dm.hoon, or change the load order on the frontend.

Screenshots:

https://user-images.githubusercontent.com/1221094/213242478-01102c14-b0ea-4198-a2b5-9eb4e2d76cdd.mov


https://user-images.githubusercontent.com/1221094/213242497-3257589c-61e2-4640-ad0e-cdb4d1a6615d.mov

