### PR TITLE
chat: fix chat input focus loss

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -194,8 +194,6 @@ export default function ChatInput({
     ),
   });
 
-  const text = messageEditor?.getText();
-
   useEffect(() => {
     if (whom && messageEditor && !messageEditor.isDestroyed) {
       messageEditor?.commands.setContent('');
@@ -212,13 +210,6 @@ export default function ChatInput({
       messageEditor.commands.focus();
     }
   }, [autoFocus, reply, isMobile, messageEditor]);
-
-  useEffect(() => {
-    if (messageEditor && !messageEditor.isDestroyed) {
-      // if the draft is empty, clear the editor
-      messageEditor.commands.setContent(null, true);
-    }
-  }, [messageEditor]);
 
   const onClick = useCallback(
     () => messageEditor && onSubmit(messageEditor),

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -93,13 +93,6 @@ export function useMessageEditor({
       if (!whom) {
         return false;
       }
-      const text = event.clipboardData?.getData('text/plain');
-
-      if (text && isRef(text)) {
-        onReference(pathToCite(text));
-
-        return true;
-      }
 
       if (
         uploader &&
@@ -115,8 +108,6 @@ export function useMessageEditor({
 
       return false;
     },
-    // no need to update onReference
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [uploader, whom]
   );
 

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -115,7 +115,9 @@ export function useMessageEditor({
 
       return false;
     },
-    [uploader, whom, onReference]
+    // no need to update onReference
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [uploader, whom]
   );
 
   // update the Attached Items view when files finish uploading and have a size


### PR DESCRIPTION
Fixes #1729 

It turns out this was caused by including `onReference` in the dependency array of the useCallback in handlePaste.

I also removed the useEffect we originally had in ChatInput for clearing text if no draft exists (didn't cause the issue we were seeing, but it was useless anyway and could cause other issues, I imagine).