### PR TITLE
clubs: fix compilation err

### DIFF
--- a/desk/mar/clubs.hoon
+++ b/desk/mar/clubs.hoon
@@ -9,6 +9,6 @@
   --
 ++  grab
   |%
-  ++  noun  (map id:club:c crew:c)
+  ++  noun  (map id:club:c crew:club:c)
   --
 --


### PR DESCRIPTION
This fixes a compilation error when bouncing a fresh fakezod from `master`.