### PR TITLE
chat: fix keyboard and input focus issues on android

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -190,7 +190,7 @@ export default function ChatInput({
 
         sendMessage(whom, memo);
       }
-      editor?.chain().setContent('').focus().run();
+      editor?.commands.setContent('');
       setTimeout(() => {
         useChatStore.getState().read(whom);
         closeReply();
@@ -375,7 +375,10 @@ export default function ChatInput({
             mostRecentFile?.status === 'error' ||
             (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
           }
-          onClick={onClick}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onClick();
+          }}
         >
           {isMobile ? <ArrowNWIcon16 className="h-4 w-4" /> : 'Send'}
         </button>


### PR DESCRIPTION
For #1749 

Switching from onClick to onMouseDown and throwing in an e.preventDefault() prevents the button from stealing focus from the input.

This also makes the explicit messageEditor focus() command unnecessary.

to test: log out messageEditor.isFocused in the main body of the ChatInput component, note that it stays focused when you click the button.