### PR TITLE
chat: handle gboard pastes on android

### DIFF
--- a/ui/src/logic/tiptap.ts
+++ b/ui/src/logic/tiptap.ts
@@ -711,7 +711,7 @@ export function normalizeInline(inline: Inline[]): Inline[] {
   );
 }
 
-export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
+const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 
 export function refPasteRule(onReference: (r: Cite) => void) {
   return new PasteRule({

--- a/ui/src/logic/tiptap.ts
+++ b/ui/src/logic/tiptap.ts
@@ -711,7 +711,7 @@ export function normalizeInline(inline: Inline[]): Inline[] {
   );
 }
 
-const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
+export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 
 export function refPasteRule(onReference: (r: Cite) => void) {
   return new PasteRule({


### PR DESCRIPTION
for #1679 
Fixes both pasting of refs and regular links from gboard in Android.

Google's gboard supports "pastes" while composing within an input. These pastes don't register because the user is actually in composition mode, it's as if the user just typed the content in, so a paste event never fires and therefore never gets caught by our existing paste rules.