### PR TITLE
chat: don't show placeholder for empty chat channels

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router';
 import { Helmet } from 'react-helmet';
 import cn from 'classnames';
@@ -24,9 +24,15 @@ function ChatChannel({ title }: ViewProps) {
   const nest = `chat/${chFlag}`;
   const groupFlag = useRouteGroup();
   const { setRecentChannel } = useRecentChannel(groupFlag);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    useChatState.getState().initialize(chFlag);
+    const initializeChannel = async () => {
+      setLoading(true);
+      await useChatState.getState().initialize(chFlag);
+      setLoading(false);
+    };
+    initializeChannel();
     setRecentChannel(nest);
   }, [chFlag, nest, setRecentChannel]);
 
@@ -65,7 +71,7 @@ function ChatChannel({ title }: ViewProps) {
               : title}
           </title>
         </Helmet>
-        <ChatWindow whom={chFlag} messages={messages} />
+        <ChatWindow whom={chFlag} messages={messages} loading={loading} />
       </Layout>
       <Outlet />
     </>

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -139,6 +139,7 @@ export default function ChatScroller({
   prefixedElement,
   scrollTo = undefined,
   scrollerRef,
+  loading,
 }: IChatScroller) {
   const brief = useChatState((s: ChatState) => s.briefs[whom]);
   const firstUnreadID = useGetFirstUnreadID(whom);
@@ -283,7 +284,7 @@ export default function ChatScroller({
     [BottomLoader, TopLoader]
   );
 
-  if (keys.length === 0) {
+  if (loading) {
     return (
       <div className="h-full">
         <ChatScrollerPlaceholder count={30} />

--- a/ui/src/chat/ChatScroller/IChatScroller.ts
+++ b/ui/src/chat/ChatScroller/IChatScroller.ts
@@ -11,4 +11,5 @@ export interface IChatScroller {
   prefixedElement?: ReactNode;
   scrollTo?: BigInteger;
   scrollerRef: React.RefObject<VirtuosoHandle>;
+  loading?: boolean;
 }

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -13,11 +13,13 @@ interface ChatWindowProps {
   whom: string;
   messages: BigIntOrderedMap<ChatWrit>;
   prefixedElement?: ReactNode;
+  loading?: boolean;
 }
 
 export default function ChatWindow({
   whom,
   messages,
+  loading,
   prefixedElement,
 }: ChatWindowProps) {
   const location = useLocation();
@@ -52,6 +54,7 @@ export default function ChatWindow({
            * the channel would be scrolled to the top.
            */
           key={whom}
+          loading={loading}
           messages={messages}
           whom={whom}
           prefixedElement={prefixedElement}

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -691,7 +691,7 @@ export const useChatState = createState<ChatState>(
         draft.chatSubs.push(whom);
       });
 
-      makeWritsStore(
+      await makeWritsStore(
         whom,
         get,
         `/chat/${whom}/writs`,


### PR DESCRIPTION
For #1763 

We need to check to see if we actually initialized chat state for the channel, empty channels always have zero keys.