### PR TITLE
groups: auto join channels in same group after clicking a reference

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -31,6 +31,7 @@ function ChatChannel({ title }: ViewProps) {
   const groupFlag = useRouteGroup();
   const { setRecentChannel } = useRecentChannel(groupFlag);
   const [loading, setLoading] = useState(true);
+  const [joining, setJoining] = useState(false);
   const messages = useMessagesForChat(chFlag);
   const perms = useChatPerms(chFlag);
   const vessel = useVessel(groupFlag, window.our);
@@ -45,8 +46,9 @@ function ChatChannel({ title }: ViewProps) {
   const joined = isChannelJoined(nest, briefs);
 
   const joinChannel = useCallback(async () => {
+    setJoining(true);
     await useChatState.getState().joinChat(chFlag);
-    window.location.reload();
+    setJoining(false);
   }, [chFlag]);
 
   const initializeChannel = useCallback(async () => {
@@ -62,11 +64,19 @@ function ChatChannel({ title }: ViewProps) {
 
   useEffect(() => {
     setLoading(true);
-    if (joined && channel && canRead) {
+    if (joined && channel && canRead && !joining) {
       initializeChannel();
       setRecentChannel(nest);
     }
-  }, [nest, setRecentChannel, initializeChannel, joined, canRead, channel]);
+  }, [
+    nest,
+    setRecentChannel,
+    initializeChannel,
+    joined,
+    canRead,
+    channel,
+    joining,
+  ]);
 
   useEffect(() => {
     if (channel && !canRead) {

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -28,7 +28,6 @@ import { IChatScroller } from './IChatScroller';
 import ChatMessage from '../ChatMessage/ChatMessage';
 import { ChatInfo, useChatStore } from '../useChatStore';
 import ChatNotice from '../ChatNotice';
-import ChatScrollerPlaceholder from '../ChatScoller/ChatScrollerPlaceholder';
 
 interface CreateRendererParams {
   messages: BigIntOrderedMap<ChatWrit>;
@@ -139,7 +138,6 @@ export default function ChatScroller({
   prefixedElement,
   scrollTo = undefined,
   scrollerRef,
-  loading,
 }: IChatScroller) {
   const brief = useChatState((s: ChatState) => s.briefs[whom]);
   const firstUnreadID = useGetFirstUnreadID(whom);
@@ -283,14 +281,6 @@ export default function ChatScroller({
     }),
     [BottomLoader, TopLoader]
   );
-
-  if (loading) {
-    return (
-      <div className="h-full">
-        <ChatScrollerPlaceholder count={30} />
-      </div>
-    );
-  }
 
   // perf: define these outside of render
   const atTopStateChange = (top: boolean) => top && fetchMessages(false);

--- a/ui/src/chat/ChatScroller/IChatScroller.ts
+++ b/ui/src/chat/ChatScroller/IChatScroller.ts
@@ -11,5 +11,4 @@ export interface IChatScroller {
   prefixedElement?: ReactNode;
   scrollTo?: BigInteger;
   scrollerRef: React.RefObject<VirtuosoHandle>;
-  loading?: boolean;
 }

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -13,13 +13,11 @@ interface ChatWindowProps {
   whom: string;
   messages: BigIntOrderedMap<ChatWrit>;
   prefixedElement?: ReactNode;
-  loading?: boolean;
 }
 
 export default function ChatWindow({
   whom,
   messages,
-  loading,
   prefixedElement,
 }: ChatWindowProps) {
   const location = useLocation();
@@ -54,7 +52,6 @@ export default function ChatWindow({
            * the channel would be scrolled to the top.
            */
           key={whom}
-          loading={loading}
           messages={messages}
           whom={whom}
           prefixedElement={prefixedElement}

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -129,7 +129,7 @@ function HeapChannel({ title }: ViewProps) {
       navigate('../../activity');
       setRecentChannel('');
     }
-  }, [group, channel, vessel, navigate, setRecentChannel]);
+  }, [group, channel, vessel, navigate, setRecentChannel, canRead]);
   useDismissChannelNotifications({
     nest,
     markRead: useHeapState.getState().markRead,

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -125,7 +125,7 @@ function HeapChannel({ title }: ViewProps) {
   ]);
 
   useEffect(() => {
-    if (channel && !canReadChannel(channel, vessel, group?.bloc)) {
+    if (channel && !canRead) {
       navigate('../../activity');
       setRecentChannel('');
     }

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -37,7 +37,6 @@ export default function HeapDetail() {
   };
 
   useEffect(() => {
-    console.log('initialize heap detail');
     useHeapState.getState().initialize(chFlag);
   }, [chFlag]);
 

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -37,6 +37,7 @@ export default function HeapDetail() {
   };
 
   useEffect(() => {
+    console.log('initialize heap detail');
     useHeapState.getState().initialize(chFlag);
   }, [chFlag]);
 

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -3,7 +3,7 @@ import produce, { setAutoFreeze } from 'immer';
 import { BigIntOrderedMap, decToUd, udToDec, unixToDa } from '@urbit/api';
 import { Poke } from '@urbit/http-api';
 import bigInt, { BigInteger } from 'big-integer';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { Groups } from '@/types/groups';
 import {
   Chat,
@@ -445,10 +445,28 @@ export const useChatState = createState<ChatState>(
       });
     },
     joinChat: async (flag) => {
-      await api.poke({
-        app: 'chat',
-        mark: 'flag',
-        json: flag,
+      await new Promise<void>((resolve, reject) => {
+        api.poke({
+          app: 'chat',
+          mark: 'flag',
+          json: flag,
+          onError: () => reject(),
+          onSuccess: async () => {
+            await useSubscriptionState
+              .getState()
+              .track(`chat/ui`, (event: ChatAction) => {
+                const {
+                  update: { diff },
+                  flag: f,
+                } = event;
+                if (f === flag && 'create' in diff) {
+                  return true;
+                }
+                return false;
+              });
+            resolve();
+          },
+        });
       });
     },
     leaveChat: async (flag) => {
@@ -685,6 +703,7 @@ export const useChatState = createState<ChatState>(
         app: 'chat',
         path: `/chat/${whom}/perm`,
       });
+
       get().batchSet((draft) => {
         const chat = { perms };
         draft.chats[whom] = chat;

--- a/ui/src/state/diary/type.ts
+++ b/ui/src/state/diary/type.ts
@@ -45,4 +45,5 @@ export interface DiaryState {
     noteId: string,
     content: Inline[]
   ) => Promise<void>;
+  [key: string]: unknown;
 }

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -1,7 +1,5 @@
 import bigInt, { BigInteger } from 'big-integer';
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom';
-import create from 'zustand';
-import { persist } from 'zustand/middleware';
 import produce, { setAutoFreeze } from 'immer';
 import { BigIntOrderedMap, decToUd, udToDec, unixToDa } from '@urbit/api';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -15,26 +13,19 @@ import {
   HeapDiff,
   HeapFlag,
   HeapPerm,
-  HeapDisplayMode,
   Stash,
-  GRID,
   HeapSaid,
+  HeapDisplayMode,
 } from '@/types/heap';
 import api from '@/api';
-import {
-  createStorageKey,
-  clearStorageMigration,
-  storageVersion,
-  nestToFlag,
-  canWriteChannel,
-} from '@/logic/utils';
+import { nestToFlag, canWriteChannel } from '@/logic/utils';
 import useNest from '@/logic/useNest';
-import { intersection } from 'lodash';
 import { getPreviewTracker } from '@/logic/subscriptionTracking';
 import { HeapState } from './type';
 import makeCuriosStore from './curios';
 import { useGroup, useVessel } from '../groups';
 import useSubscriptionState from '../subscription';
+import { createState } from '../base';
 
 setAutoFreeze(false);
 
@@ -75,223 +66,237 @@ function getTime() {
   return decToUd(unixToDa(Date.now()).toString());
 }
 
-export const useHeapState = create<HeapState>(
-  persist<HeapState>(
-    (set, get) => ({
-      set: (fn) => {
-        set(produce(get(), fn));
-      },
-      batchSet: (fn) => {
-        batchUpdates(() => {
-          get().set(fn);
-        });
-      },
-      stash: {},
-      curios: {},
-      heapSubs: [],
-      loadedRefs: {},
-      briefs: {},
-      pendingImports: {},
-      markRead: async (flag) => {
-        await api.poke({
-          app: 'heap',
-          mark: 'heap-remark-action',
-          json: {
-            flag,
-            diff: { read: null },
-          },
-        });
-      },
-      start: async () => {
-        // TODO: parallelise
-        api
-          .scry<HeapBriefs>({
-            app: 'heap',
-            path: '/briefs',
-          })
-          .then((briefs) => {
-            get().batchSet((draft) => {
-              draft.briefs = briefs;
-            });
-          });
-
-        api
-          .scry<Stash>({
-            app: 'heap',
-            path: '/stash',
-          })
-          .then((stash) => {
-            get().batchSet((draft) => {
-              draft.stash = stash;
-            });
-          });
-
-        api.subscribe({
+export const useHeapState = createState<HeapState>(
+  'heap',
+  (set, get) => ({
+    set: (fn) => {
+      set(produce(get(), fn));
+    },
+    batchSet: (fn) => {
+      batchUpdates(() => {
+        get().set(fn);
+      });
+    },
+    stash: {},
+    curios: {},
+    heapSubs: [],
+    loadedRefs: {},
+    briefs: {},
+    pendingImports: {},
+    markRead: async (flag) => {
+      await api.poke({
+        app: 'heap',
+        mark: 'heap-remark-action',
+        json: {
+          flag,
+          diff: { read: null },
+        },
+      });
+    },
+    start: async () => {
+      // TODO: parallelise
+      api
+        .scry<HeapBriefs>({
           app: 'heap',
           path: '/briefs',
-          event: (event: unknown, mark: string) => {
-            if (mark === 'heap-leave') {
-              get().batchSet((draft) => {
-                delete draft.briefs[event as string];
-              });
-              return;
+        })
+        .then((briefs) => {
+          get().batchSet((draft) => {
+            draft.briefs = briefs;
+          });
+        });
+
+      api
+        .scry<Stash>({
+          app: 'heap',
+          path: '/stash',
+        })
+        .then((stash) => {
+          get().batchSet((draft) => {
+            draft.stash = stash;
+          });
+        });
+
+      api.subscribe({
+        app: 'heap',
+        path: '/briefs',
+        event: (event: unknown, mark: string) => {
+          if (mark === 'heap-leave') {
+            get().batchSet((draft) => {
+              delete draft.briefs[event as string];
+            });
+            return;
+          }
+
+          const { flag, brief } = event as HeapBriefUpdate;
+          get().batchSet((draft) => {
+            draft.briefs[flag] = brief;
+          });
+        },
+      });
+
+      api.subscribe({
+        app: 'heap',
+        path: '/ui',
+        event: (event: HeapAction) => {
+          get().batchSet((draft) => {
+            const {
+              flag,
+              update: { diff },
+            } = event;
+            const heap = draft.stash[flag];
+
+            if ('view' in diff) {
+              heap.view = diff.view;
+            } else if ('del-sects' in diff) {
+              heap.perms.writers = heap.perms.writers.filter(
+                (w) => !diff['del-sects'].includes(w)
+              );
+            } else if ('add-sects' in diff) {
+              heap.perms.writers = heap.perms.writers.concat(diff['add-sects']);
             }
+          });
+        },
+      });
 
-            const { flag, brief } = event as HeapBriefUpdate;
-            get().batchSet((draft) => {
-              draft.briefs[flag] = brief;
-            });
-          },
-        });
+      const pendingImports = await api.scry<Record<string, boolean>>({
+        app: 'heap',
+        path: '/imp',
+      });
 
-        api.subscribe({
-          app: 'heap',
-          path: '/ui',
-          event: (event: HeapAction) => {
-            get().batchSet((draft) => {
-              const {
-                flag,
-                update: { diff },
-              } = event;
-              const heap = draft.stash[flag];
+      get().batchSet((draft) => {
+        draft.pendingImports = pendingImports;
+      });
 
-              if ('view' in diff) {
-                heap.view = diff.view;
-              } else if ('del-sects' in diff) {
-                heap.perms.writers = heap.perms.writers.filter(
-                  (w) => !diff['del-sects'].includes(w)
-                );
-              } else if ('add-sects' in diff) {
-                heap.perms.writers = heap.perms.writers.concat(
-                  diff['add-sects']
-                );
-              }
-            });
-          },
-        });
-
-        const pendingImports = await api.scry<Record<string, boolean>>({
-          app: 'heap',
-          path: '/imp',
-        });
-
-        get().batchSet((draft) => {
-          draft.pendingImports = pendingImports;
-        });
-
-        api.subscribe({
-          app: 'heap',
-          path: '/imp',
-          event: (imports: Record<string, boolean>) => {
-            get().batchSet((draft) => {
-              draft.pendingImports = imports;
-            });
-          },
-        });
-      },
-      joinHeap: async (flag) => {
-        await api.poke({
+      api.subscribe({
+        app: 'heap',
+        path: '/imp',
+        event: (imports: Record<string, boolean>) => {
+          get().batchSet((draft) => {
+            draft.pendingImports = imports;
+          });
+        },
+      });
+    },
+    joinHeap: async (flag) => {
+      await new Promise<void>((resolve, reject) => {
+        api.poke({
           app: 'heap',
           mark: 'flag',
           json: flag,
+          onError: () => reject(),
+          onSuccess: async () => {
+            await useSubscriptionState
+              .getState()
+              .track(`heap/ui`, (event: HeapAction) => {
+                const {
+                  update: { diff },
+                  flag: f,
+                } = event;
+                if (f === flag && 'create' in diff) {
+                  return true;
+                }
+                return false;
+              });
+            resolve();
+          },
         });
-      },
-      leaveHeap: async (flag) => {
-        await api.poke({
+      });
+    },
+    leaveHeap: async (flag) => {
+      await api.poke({
+        app: 'heap',
+        mark: 'heap-leave',
+        json: flag,
+      });
+    },
+    viewHeap: async (flag, view) => {
+      await api.poke(
+        heapAction(flag, {
+          view,
+        })
+      );
+    },
+    addCurio: async (flag, heart) => {
+      await api.poke(heapCurioDiff(flag, getTime(), { add: heart }));
+    },
+    delCurio: async (flag, time) => {
+      const ud = decToUd(time);
+      await api.poke(heapCurioDiff(flag, ud, { del: null }));
+    },
+    editCurio: async (flag, time, heart) => {
+      const ud = decToUd(time);
+      await api.poke(heapCurioDiff(flag, ud, { edit: heart }));
+    },
+    create: async (req) => {
+      await new Promise<void>((resolve, reject) => {
+        api.poke({
           app: 'heap',
-          mark: 'heap-leave',
-          json: flag,
+          mark: 'heap-create',
+          json: req,
+          onError: () => reject(),
+          onSuccess: async () => {
+            await useSubscriptionState.getState().track('heap/ui', (event) => {
+              const { update, flag } = event;
+              if (
+                'create' in update.diff &&
+                flag === `${req.group.split('/')[0]}/${req.name}`
+              ) {
+                return true;
+              }
+              return false;
+            });
+            resolve();
+          },
         });
-      },
-      viewHeap: async (flag, view) => {
-        await api.poke(
-          heapAction(flag, {
-            view,
-          })
-        );
-      },
-      addCurio: async (flag, heart) => {
-        await api.poke(heapCurioDiff(flag, getTime(), { add: heart }));
-      },
-      delCurio: async (flag, time) => {
-        const ud = decToUd(time);
-        await api.poke(heapCurioDiff(flag, ud, { del: null }));
-      },
-      editCurio: async (flag, time, heart) => {
-        const ud = decToUd(time);
-        await api.poke(heapCurioDiff(flag, ud, { edit: heart }));
-      },
-      create: async (req) => {
-        await new Promise<void>((resolve, reject) => {
-          api.poke({
-            app: 'heap',
-            mark: 'heap-create',
-            json: req,
-            onError: () => reject(),
-            onSuccess: async () => {
-              await useSubscriptionState
-                .getState()
-                .track('heap/ui', (event) => {
-                  const { update, flag } = event;
-                  if (
-                    'create' in update.diff &&
-                    flag === `${req.group.split('/')[0]}/${req.name}`
-                  ) {
-                    return true;
-                  }
-                  return false;
-                });
-              resolve();
-            },
-          });
-        });
-      },
-      addSects: async (flag, sects) => {
-        await api.poke(heapAction(flag, { 'add-sects': sects }));
-        const perms = await api.scry<HeapPerm>({
-          app: 'heap',
-          path: `/heap/${flag}/perm`,
-        });
-        get().batchSet((draft) => {
-          draft.stash[flag].perms = perms;
-        });
-      },
-      delSects: async (flag, sects) => {
-        await api.poke(heapAction(flag, { 'del-sects': sects }));
-        const perms = await api.scry<HeapPerm>({
-          app: 'heap',
-          path: `/heap/${flag}/perm`,
-        });
-        get().batchSet((draft) => {
-          draft.stash[flag].perms = perms;
-        });
-      },
-      initialize: async (flag) => {
-        if (get().heapSubs.includes(flag)) {
-          return;
-        }
+      });
+    },
+    addSects: async (flag, sects) => {
+      await api.poke(heapAction(flag, { 'add-sects': sects }));
+      const perms = await api.scry<HeapPerm>({
+        app: 'heap',
+        path: `/heap/${flag}/perm`,
+      });
+      get().batchSet((draft) => {
+        draft.stash[flag].perms = perms;
+      });
+    },
+    delSects: async (flag, sects) => {
+      await api.poke(heapAction(flag, { 'del-sects': sects }));
+      const perms = await api.scry<HeapPerm>({
+        app: 'heap',
+        path: `/heap/${flag}/perm`,
+      });
+      get().batchSet((draft) => {
+        draft.stash[flag].perms = perms;
+      });
+    },
+    initialize: async (flag) => {
+      if (get().heapSubs.includes(flag)) {
+        console.log('already subscribed to', flag);
+        return;
+      }
 
-        get().batchSet((draft) => {
-          draft.heapSubs.push(flag);
-        });
+      const perms = await api.scry<HeapPerm>({
+        app: 'heap',
+        path: `/heap/${flag}/perm`,
+      });
+      get().batchSet((draft) => {
+        const heap = { perms, view: 'list' as HeapDisplayMode };
+        draft.stash[flag] = heap;
+        draft.heapSubs.push(flag);
+      });
 
-        await makeCuriosStore(
-          flag,
-          get,
-          `/heap/${flag}/curios`,
-          `/heap/${flag}/ui`
-        ).initialize();
-      },
-    }),
-    {
-      name: createStorageKey('heap'),
-      version: storageVersion,
-      migrate: clearStorageMigration,
-      partialize: ({ stash }) => ({
-        stash,
-      }),
-    }
-  )
+      await makeCuriosStore(
+        flag,
+        get,
+        `/heap/${flag}/curios`,
+        `/heap/${flag}/ui`
+      ).initialize();
+    },
+  }),
+  ['briefs', 'stash', 'curios'],
+  []
 );
 
 export function useCuriosForHeap(flag: HeapFlag) {

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -281,7 +281,7 @@ export const useHeapState = createState<HeapState>(
         path: `/heap/${flag}/perm`,
       });
       get().batchSet((draft) => {
-        const heap = { perms, view: 'list' as HeapDisplayMode };
+        const heap = { perms, view: 'grid' as HeapDisplayMode };
         draft.stash[flag] = heap;
         draft.heapSubs.push(flag);
       });

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -273,7 +273,6 @@ export const useHeapState = createState<HeapState>(
     },
     initialize: async (flag) => {
       if (get().heapSubs.includes(flag)) {
-        console.log('already subscribed to', flag);
         return;
       }
 

--- a/ui/src/state/heap/type.ts
+++ b/ui/src/state/heap/type.ts
@@ -36,4 +36,5 @@ export interface HeapState {
   editCurio: (flag: HeapFlag, time: string, heart: CurioHeart) => Promise<void>;
   addSects: (flag: HeapFlag, writers: string[]) => Promise<void>;
   delSects: (flag: HeapFlag, writers: string[]) => Promise<void>;
+  [key: string]: unknown;
 }


### PR DESCRIPTION
For #1655 

Also 
- Eliminated the prop-drilling for the chat loading state (which I did, idk why) and cleaned up the ChatChannel component.
- We were using zustand's create/persist for heap and diary state and for some reason it wasn't actually persisting, this fixes that.
- We weren't actually scrying for perms when initializing heap, also fixed that.

~~I can't seem to figure out a way to actually load just-joined the channel content into the store without doing a page refresh. Any idea what I'm missing here? Try it out by commenting out the `window.location.reload()` in one of the useEffects.~~