### PR TITLE
perms: secret group fixes

### DIFF
--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -38,7 +38,10 @@ export default function GroupReference({
     }
   }, [gang, group, flag, isScrolling]);
 
-  if (privacy === 'secret') {
+  const referenceUnavailable =
+    privacy === 'secret' && !(window.our in (group?.fleet ?? {}));
+
+  if (referenceUnavailable) {
     return (
       <div className="relative flex h-16 items-center space-x-3 rounded-lg border-2 border-gray-50 bg-gray-50 p-2 text-base font-semibold text-gray-600">
         <ExclamationPoint className="h-8 w-8 text-gray-400" />


### PR DESCRIPTION
This PR addresses a couple secret groups issues and resolves #1469 


- [x] show secret group reference when a member of the group (before, it would be hidden even if already a member)
- [ ] receiving an invite to a secret group causes a render loop for the reference (#1469)