### PR TITLE
chat: Note reference fixes

### DIFF
--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -57,7 +57,7 @@ export default function NoteReference({
     }
 
     let charCount = 0;
-    const truncated = outline.content.slice(0, 1).map((verse, index) => {
+    return outline.content.slice(0, 1).map((verse, index) => {
       if ('inline' in verse) {
         return (
           <div key={index}>
@@ -78,8 +78,6 @@ export default function NoteReference({
       // TODO: handle blocks.
       return '';
     });
-
-    return truncated;
   }, [outline]);
 
   if (scryError !== undefined) {
@@ -96,7 +94,10 @@ export default function NoteReference({
 
   return (
     <div className="note-inline-block not-prose group">
-      <div className="flex flex-col space-y-2 p-2 group-hover:bg-gray-50">
+      <div
+        onClick={handleOpenReferenceClick}
+        className="flex cursor-pointer flex-col space-y-2 p-2 group-hover:bg-gray-50"
+      >
         {outline.image ? (
           <div
             className="relative h-36 w-full rounded-lg bg-gray-100 bg-cover bg-center px-4"

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -4,6 +4,7 @@ export const STANDARD_MESSAGE_FETCH_PAGE_SIZE = 100;
 export const LARGE_MESSAGE_FETCH_PAGE_SIZE = 200;
 export const FETCH_BATCH_SIZE = 3;
 export const MAX_DISPLAYED_OPTIONS = 40;
+export const NOTE_REF_DISPLAY_LIMIT = 600;
 
 export const PASTEABLE_IMAGE_TYPES = [
   'image/gif',


### PR DESCRIPTION
# Context

This PR resolves a couple known issues with Note references in chat.

- [x] fix note ref links to source (#1664)
- [x] truncate long notes in Note ref previews (#1778)

# Preview

## Note Ref Click to View

https://user-images.githubusercontent.com/16504501/214521730-a0220dbb-7f16-45db-87cc-0570b4943321.mp4

## Long Note Truncation

### Before
![Screenshot from 2023-01-24 21-16-06](https://user-images.githubusercontent.com/16504501/214486152-01ce6377-f06f-40cf-9703-f0df81790982.png)

### After
![Screenshot from 2023-01-24 21-16-19](https://user-images.githubusercontent.com/16504501/214486154-0ee0a8ae-9f77-4724-8ed1-7c21e9ffd6a1.png)