### PR TITLE
ux: clearer Find Groups copy when Not Found

### DIFF
--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -192,14 +192,10 @@ export default function FindGroups({ title }: ViewProps) {
       }
 
       return (
-        <div>
-          The search timed out. This happens when:
-          <ul className="list-inside list-disc">
-            <li>The ship doesn&apos;t host any groups</li>
-            <li>The ship is under heavy load</li>
-            <li>The ship is offline</li>
-          </ul>
-        </div>
+        <span>
+          Your search timed out, which may happen when a ship hosts no groups,
+          is under heavy load, or is offline.
+        </span>
       );
     }
 

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -191,7 +191,16 @@ export default function FindGroups({ title }: ViewProps) {
         );
       }
 
-      return <span>This ship doesn&apos;t host any groups</span>;
+      return (
+        <div>
+          The search timed out. This happens when:
+          <ul className="list-inside list-disc">
+            <li>The ship doesn&apos;t host any groups</li>
+            <li>The ship is under heavy load</li>
+            <li>The ship is offline</li>
+          </ul>
+        </div>
+      );
     }
 
     return null;


### PR DESCRIPTION
When the search times out, it could be due to multiple root causes.

This clarifies the message as it has caused confusion in UC Help a few times now:

![image](https://user-images.githubusercontent.com/16504501/214762105-391529d1-019b-4d56-97ca-bedeb806f1f1.png)

Resolves #1666.

# Preview

## Before
![image](https://user-images.githubusercontent.com/16504501/214761920-967cf82b-d803-473f-858f-1102a5ca93d1.png)

## After
![image](https://user-images.githubusercontent.com/16504501/214781033-4e87f1c4-a3d1-46ab-bcaf-ded0598a6d4b.png)

