### PR TITLE
keep input text on blur in ship selector

### DIFF
--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import ob from 'urbit-ob';
 import fuzzy from 'fuzzy';
 import {
@@ -381,9 +381,16 @@ export default function ShipSelector({
     }
   };
 
-  const onInputChange = (newValue: string, _actionMeta: InputActionMeta) => {
-    setInputValue(newValue);
-  };
+  const onInputChange = useCallback(
+    (newValue: string, { action }: InputActionMeta) => {
+      if (['input-blur', 'menu-close'].indexOf(action) === -1) {
+        setInputValue(newValue);
+        return newValue;
+      }
+      return inputValue;
+    },
+    [inputValue]
+  );
 
   const onChange = (
     newValue: MultiValue<ShipOption>,
@@ -485,6 +492,7 @@ export default function ShipSelector({
             : isValidNewOption(val)
         }
         onKeyDown={onKeyDown}
+        inputValue={inputValue}
         placeholder={isMobile ? mobilePlaceholder : placeholder}
         hideSelectedOptions
         // TODO: create custom filter for sorting potential DM participants.
@@ -580,6 +588,7 @@ export default function ShipSelector({
           : isValidNewOption(val)
       }
       onKeyDown={onKeyDown}
+      inputValue={inputValue}
       placeholder={isMobile ? mobilePlaceholder : placeholder}
       hideSelectedOptions
       // TODO: create custom filter for sorting potential DM participants.


### PR DESCRIPTION
for #1157 

Had a lot of trouble getting onInputChange to do what we wanted here before I realized that we could pass inputValue as a prop to the CreatableSelect component itself (and thus have onInputChange fire at appropriate times). Passing this prop doesn't seem to change any other functionality, but please test and let me know if you find something.