### PR TITLE
hark: await mark read call

### DIFF
--- a/ui/src/state/hark.ts
+++ b/ui/src/state/hark.ts
@@ -140,7 +140,7 @@ const useHarkState = create<HarkState>((set, get) => ({
     );
   },
   sawSeam: async (seam) => {
-    api.poke(
+    await api.poke(
       harkAction({
         'saw-seam': seam,
       })


### PR DESCRIPTION
This is a followup to #1798 to ensure the spinner is rendered when marking all notifications as read.