### PR TITLE
groups: fix sidebar sort persistence issues

### DIFF
--- a/ui/src/logic/useSidebarSort.ts
+++ b/ui/src/logic/useSidebarSort.ts
@@ -67,16 +67,16 @@ export default function useSidebarSort({
   };
 
   const setGroupSideBarSort = useCallback(
-    () => (mode: string) => {
+    (mode: string) => {
       useSettingsState
         .getState()
         .putEntry(
           'groups',
           'groupSideBarSort',
-          JSON.stringify({ [flag]: mode })
+          JSON.stringify({ ...groupSideBarSort, [flag]: mode })
         );
     },
-    [flag]
+    [flag, groupSideBarSort]
   );
 
   /**
@@ -104,7 +104,8 @@ export default function useSidebarSort({
   }
 
   const setSortFn = useMemo(
-    () => (flag !== '~' ? setGroupSideBarSort : setSideBarSort),
+    () => (mode: string) =>
+      flag !== '~' ? setGroupSideBarSort(mode) : setSideBarSort(mode),
     [flag, setGroupSideBarSort]
   );
 


### PR DESCRIPTION
For #1812 

Both channel list sorting and group sorting settings were not persisting, it looks like we just weren't passing the mode into the sort function.

I also discovered that we were wiping the groupSideBarSort key each time we saved individual group channel sort options, so you could only have one group's sidebar sort settings saved at a time. This also fixes that.