### PR TITLE
groups: fix for note and curio detail not loading on refresh

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { useHeapState, useOrderedCurios } from '@/state/heap/heap';
 import useNest from '@/logic/useNest';
@@ -36,9 +36,13 @@ export default function HeapDetail() {
     return `/groups/${groupFlag}/channels/heap/${chFlag}/curio/${id}`;
   };
 
-  useEffect(() => {
-    useHeapState.getState().initialize(chFlag);
+  const load = useCallback(async () => {
+    await useHeapState.getState().initialize(chFlag);
   }, [chFlag]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
 
   useEventListener('keydown', (e) => {
     switch (e.key) {

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -458,7 +458,7 @@ export function useNote(
       (s) => {
         const notes = s.notes[flag];
         const fallback = [bigInt(0), emptyNote] as const;
-        if (!notes) {
+        if (!notes || !notes.get) {
           return fallback;
         }
 

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -368,7 +368,7 @@ export function useCurio(flag: HeapFlag, time: string) {
     useCallback(
       (s) => {
         const curios = s.curios[flag];
-        if (!curios) {
+        if (!curios || !curios.get) {
           return undefined;
         }
 


### PR DESCRIPTION
For #1811 

It looks like switching out createState for create probably caused notes/curios to sometimes not return as a proper BigIntOrderedMap. I'm not totally sure why yet, but checking for the existence of the `.get` method stops the bleeding for now.