### PR TITLE
clubs: only accept once

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -321,7 +321,7 @@
   ^+  cor
   ?+    pole  ~|(bad-watch-path/path !!)
       [%imp ~]        ?>(from-self cor)
-      [%club %new ~]  ?>(from-self cor)
+      [%clubs %ui ~]  ?>(from-self cor)
       [%briefs ~]  ?>(from-self cor)
       [%ui ~]  ?>(from-self cor)
       [%dm %invited ~]  ?>(from-self cor)
@@ -862,11 +862,11 @@
     =.  pact.club  (reduce:cu-pact now.bowl w-d)
     (cu-give-writs-diff w-d)
   ::
-  ++  cu-give-delta
-    |=  =delta:club:c
+  ++  cu-give-action
+    |=  =action:club:c
+    =/  =cage  club-action+!>(action)
     =.  cor
-      =/  =cage  club-delta+!>(delta)
-      (emit %give %fact ~[(snoc cu-area %ui)] cage)
+      (emit %give %fact ~[/clubs/ui] cage)
     cu-core
   ::
   ++  cu-give-writs-diff
@@ -881,6 +881,7 @@
     ::  ?>  (~(has in cu-circle) src.bowl)  :: TODO: signatures?? probably overkill
     =?  cor  (lth echo club-eq)
       (emil (gossip:cu-pass +(echo) delta))
+    =/  =action:club:c  [id [echo delta]]
     ?-    -.delta
     ::
         %init
@@ -888,14 +889,11 @@
           team.club  team.delta
           met.club   met.delta
       ==
-      =/  cage  club-invite+!>([id (tail delta)])
-      =.  cor  (emit %give %fact ~[`wire`/club/new] cage)
-      cu-core
+      (cu-give-action action)
     ::
         %meta
       =.  met.club  meta.delta
-      =.  cu-core  (cu-give-delta delta)
-      cu-core
+      (cu-give-action action)
     ::
         %writ
       =.  pact.club  (reduce:cu-pact now.bowl diff.delta)
@@ -923,7 +921,7 @@
     ::
         %team
       =*  ship  ship.delta
-      =.  cu-core  (cu-give-delta delta)
+      =.  cu-core  (cu-give-action action)
       =/  loyal  (~(has in team.club) ship)
       ?:  &(!ok.delta loyal)
         ?.  =(our src):bowl
@@ -940,7 +938,7 @@
       (cu-post-notice ship '' ' joined the chat')
     ::
         %hive
-      =.  cu-core  (cu-give-delta delta)
+      =.  cu-core  (cu-give-action action)
       ?:  add.delta
         ?:  (~(has in hive.club) for.delta)
           cu-core

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -18,6 +18,21 @@
         writ/(writ q.s)
     ==
   ::
+  ++  club-action
+    |=  a=action:club:c
+    ^-  json
+    %-  pairs
+    :~  id/s/(scot %uv p.a)
+        diff/(club-diff q.a)
+    ==
+  ::
+  ++  club-diff
+    |=  d=diff:club:c
+    ^-  json
+    %-  pairs
+    :~  echo/(numb p.d)
+        delta/(club-delta q.d)
+    ==
   ++  club-delta
     |=  d=delta:club:c
     %+  frond  -.d

--- a/desk/mar/club/action.hoon
+++ b/desk/mar/club/action.hoon
@@ -5,6 +5,7 @@
 ++  grow
   |%
   ++  noun  action
+  ++  json  (club-action:enjs:j action)
   --
 ++  grab
   |%

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -43,7 +43,9 @@ function ChatChannel({ title }: ViewProps) {
     : false;
   const { sendMessage } = useChatState.getState();
   const briefs = useAllBriefs();
-  const joined = isChannelJoined(nest, briefs);
+  const joined = Object.keys(briefs).some((k) => k.includes('chat/'))
+    ? isChannelJoined(nest, briefs)
+    : true;
 
   const joinChannel = useCallback(async () => {
     setJoining(true);

--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -65,6 +65,7 @@ export default function ChatMessageOptions(props: {
           open={pickerOpen}
           setOpen={setPickerOpen}
           onEmojiSelect={onEmoji}
+          withTrigger={false}
         >
           <IconButton
             icon={<FaceIcon className="h-6 w-6 text-gray-400" />}

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -157,111 +157,107 @@ exports[`ChatMessage > renders as expected 1`] = `
       <div
         class="absolute right-2 -top-5 z-10 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle opacity-0 group-one-hover:opacity-100"
       >
-        <button
-          aria-controls="radix-0"
-          aria-expanded="false"
-          aria-haspopup="dialog"
-          data-state="closed"
-          type="button"
-        >
-          <div
-            class="group-two cursor-pointer"
-          />
-        </button>
-        <button
-          aria-label="React"
-          class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
-          data-state="closed"
-        >
-          <svg
-            class="h-6 w-6 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fill-current"
-              clip-rule="evenodd"
-              d="M7 4h10c1.6569 0 3 1.34315 3 3v10c0 1.6569-1.3431 3-3 3H7c-1.65685 0-3-1.3431-3-3V7c0-1.65685 1.34315-3 3-3Zm10-2H7C4.23858 2 2 4.23858 2 7v10c0 2.7614 2.23858 5 5 5h10c2.7614 0 5-2.2386 5-5V7c0-2.76142-2.2386-5-5-5ZM8.5 8C7.67157 8 7 8.67157 7 9.5v1c0 .8284.67157 1.5 1.5 1.5s1.5-.6716 1.5-1.5v-1C10 8.67157 9.32843 8 8.5 8ZM14 9.5c0-.82843.6716-1.5 1.5-1.5s1.5.67157 1.5 1.5v1c0 .8284-.6716 1.5-1.5 1.5s-1.5-.6716-1.5-1.5v-1ZM13 15c0 .5523-.4477 1-1 1s-1-.4477-1-1 .4477-1 1-1 1 .4477 1 1Zm2 0c0 1.6569-1.3431 3-3 3s-3-1.3431-3-3 1.3431-3 3-3 3 1.3431 3 3Z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="group-two cursor-pointer"
-      >
-        <button
-          aria-label="Start Thread"
-          class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
-          data-state="closed"
-        >
-          <svg
-            class="h-6 w-6 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fill-current"
-              clip-rule="evenodd"
-              d="M10.124 3.00771c.5481.0685.9368.56829.8683 1.11631l-.4845 3.87596h3.9844l.5155-4.12403c.0685-.54802.5683-.93675 1.1163-.86824.5481.0685.9368.56829.8683 1.11631l-.4845 3.87596H19c.5523 0 1 .44772 1 1 0 .55229-.4477 1-1 1h-2.7422L15.7578 14H19c.5523 0 1 .4477 1 1s-.4477 1-1 1h-3.4922l-.5155 4.124c-.0685.548-.5683.9368-1.1163.8683-.5481-.0685-.9368-.5683-.8683-1.1164L13.4922 16H9.50778l-.5155 4.124c-.0685.548-.56829.9368-1.11631.8683s-.93675-.5683-.86825-1.1164L7.49222 16H5c-.55228 0-1-.4477-1-1s.44772-1 1-1h2.74222l.5-4.00002H5c-.55228 0-1-.44771-1-1 0-.55228.44772-1 1-1h3.49222l.5155-4.12403c.0685-.54802.56829-.93675 1.11628-.86824ZM13.7422 14l.5-4.00002h-3.9844L9.75778 14h3.98442Z"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-      <div
-        class="group-two cursor-pointer"
-      >
-        <button
-          aria-label="Delete"
-          class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
-          data-state="closed"
-        >
-          <svg
-            class="h-6 w-6 text-red"
-            fill="none"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="stroke-current"
-              d="m12 12 6-6m-6 6L6 6m6 6-6 6m6-6 6 6"
-              stroke-linecap="round"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-    <div
-      class="-ml-1 mr-1 py-2 text-xs font-semibold text-gray-400 opacity-0 group-one-hover:opacity-100"
-    >
-      13:00
-    </div>
-    <div
-      class="wrap-anywhere flex w-full"
-    >
-      <div
-        class="flex w-full grow flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50"
-      >
         <div
-          class="leading-6"
+          class="group-two cursor-pointer"
         >
-          <strong>
-            <span>
-              A bold test message
-            </span>
-          </strong>
-          <span>
-            with some more text
-          </span>
+          <button
+            aria-label="React"
+            class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
+            data-state="closed"
+          >
+            <svg
+              class="h-6 w-6 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fill-current"
+                clip-rule="evenodd"
+                d="M7 4h10c1.6569 0 3 1.34315 3 3v10c0 1.6569-1.3431 3-3 3H7c-1.65685 0-3-1.3431-3-3V7c0-1.65685 1.34315-3 3-3Zm10-2H7C4.23858 2 2 4.23858 2 7v10c0 2.7614 2.23858 5 5 5h10c2.7614 0 5-2.2386 5-5V7c0-2.76142-2.2386-5-5-5ZM8.5 8C7.67157 8 7 8.67157 7 9.5v1c0 .8284.67157 1.5 1.5 1.5s1.5-.6716 1.5-1.5v-1C10 8.67157 9.32843 8 8.5 8ZM14 9.5c0-.82843.6716-1.5 1.5-1.5s1.5.67157 1.5 1.5v1c0 .8284-.6716 1.5-1.5 1.5s-1.5-.6716-1.5-1.5v-1ZM13 15c0 .5523-.4477 1-1 1s-1-.4477-1-1 .4477-1 1-1 1 .4477 1 1Zm2 0c0 1.6569-1.3431 3-3 3s-3-1.3431-3-3 1.3431-3 3-3 3 1.3431 3 3Z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class=""
+        />
+        <div
+          class="group-two cursor-pointer"
+        >
+          <button
+            aria-label="Start Thread"
+            class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
+            data-state="closed"
+          >
+            <svg
+              class="h-6 w-6 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fill-current"
+                clip-rule="evenodd"
+                d="M10.124 3.00771c.5481.0685.9368.56829.8683 1.11631l-.4845 3.87596h3.9844l.5155-4.12403c.0685-.54802.5683-.93675 1.1163-.86824.5481.0685.9368.56829.8683 1.11631l-.4845 3.87596H19c.5523 0 1 .44772 1 1 0 .55229-.4477 1-1 1h-2.7422L15.7578 14H19c.5523 0 1 .4477 1 1s-.4477 1-1 1h-3.4922l-.5155 4.124c-.0685.548-.5683.9368-1.1163.8683-.5481-.0685-.9368-.5683-.8683-1.1164L13.4922 16H9.50778l-.5155 4.124c-.0685.548-.56829.9368-1.11631.8683s-.93675-.5683-.86825-1.1164L7.49222 16H5c-.55228 0-1-.4477-1-1s.44772-1 1-1h2.74222l.5-4.00002H5c-.55228 0-1-.44771-1-1 0-.55228.44772-1 1-1h3.49222l.5155-4.12403c.0685-.54802.56829-.93675 1.11628-.86824ZM13.7422 14l.5-4.00002h-3.9844L9.75778 14h3.98442Z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="group-two cursor-pointer"
+        >
+          <button
+            aria-label="Delete"
+            class="flex h-8 w-8 items-center justify-center rounded group-two-hover:bg-gray-50 h-8 w-8"
+            data-state="closed"
+          >
+            <svg
+              class="h-6 w-6 text-red"
+              fill="none"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="stroke-current"
+                d="m12 12 6-6m-6 6L6 6m6 6-6 6m6-6 6 6"
+                stroke-linecap="round"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
         </div>
       </div>
       <div
-        class="flex items-end rounded-r group-one-hover:bg-gray-50"
-      />
+        class="-ml-1 mr-1 py-2 text-xs font-semibold text-gray-400 opacity-0 group-one-hover:opacity-100"
+      >
+        13:00
+      </div>
+      <div
+        class="wrap-anywhere flex w-full"
+      >
+        <div
+          class="flex w-full grow flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50"
+        >
+          <div
+            class="leading-6"
+          >
+            <strong>
+              <span>
+                A bold test message
+              </span>
+            </strong>
+            <span>
+              with some more text
+            </span>
+          </div>
+        </div>
+        <div
+          class="flex items-end rounded-r group-one-hover:bg-gray-50"
+        />
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/ui/src/chat/ChatReactions/ChatReaction.tsx
+++ b/ui/src/chat/ChatReactions/ChatReaction.tsx
@@ -43,7 +43,7 @@ export default function ChatReaction({
       {count > 0 && (
         <Tooltip.Provider>
           <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger>
+            <Tooltip.Trigger asChild>
               <button
                 onClick={editFeel}
                 className={cn(

--- a/ui/src/chat/ChatReactions/ChatReactions.tsx
+++ b/ui/src/chat/ChatReactions/ChatReactions.tsx
@@ -46,7 +46,7 @@ export default function ChatReactions({ whom, seal }: ChatReactionsProps) {
           onClick={openPicker}
           aria-label="Add Reaction"
         >
-          <AddReactIcon className="h-6 w-6 text-gray-600" />
+          <AddReactIcon className="h-6 w-6 text-gray-400" />
         </button>
       </EmojiPicker>
     </div>

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -10,12 +10,14 @@ interface EmojiPickerProps extends Record<string, any> {
   open: boolean;
   setOpen: (open: boolean) => void;
   children: React.ReactChild;
+  withTrigger?: boolean;
 }
 
 export default function EmojiPicker({
   open,
   setOpen,
   children,
+  withTrigger = true,
   ...props
 }: EmojiPickerProps) {
   const { data, load } = useEmoji();
@@ -29,8 +31,12 @@ export default function EmojiPicker({
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger>{children}</Popover.Trigger>
-      {isMobile && (
+      {withTrigger ? (
+        <Popover.Trigger asChild>{children}</Popover.Trigger>
+      ) : (
+        children
+      )}
+      {(isMobile || !withTrigger) && (
         <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-12' : ''} />
       )}
       <Popover.Portal>

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -52,7 +52,9 @@ function DiaryChannel() {
   const group = useGroup(flag);
   const channel = useChannel(flag, nest);
   const briefs = useAllBriefs();
-  const joined = isChannelJoined(nest, briefs);
+  const joined = Object.keys(briefs).some((k) => k.includes('diary/'))
+    ? isChannelJoined(nest, briefs)
+    : true;
 
   const joinChannel = useCallback(async () => {
     setJoining(true);
@@ -61,9 +63,7 @@ function DiaryChannel() {
   }, [chFlag]);
 
   const initializeChannel = useCallback(async () => {
-    setTimeout(async () => {
-      await useDiaryState.getState().initialize(chFlag);
-    }, 1000);
+    await useDiaryState.getState().initialize(chFlag);
   }, [chFlag]);
 
   useEffect(() => {

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -101,7 +101,9 @@ export default function MessagesList({
         {allPending &&
           filter !== filters.groups &&
           allPending.map((whom) => (
-            <MessagesSidebarItem pending key={whom} whom={whom} />
+            <div className="pl-2 pb-3 sm:pb-1">
+              <MessagesSidebarItem pending key={whom} whom={whom} />
+            </div>
           ))}
       </>
     ),

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -61,7 +61,9 @@ function HeapChannel({ title }: ViewProps) {
     ? canReadChannel(channel, vessel, group?.bloc)
     : false;
   const briefs = useAllBriefs();
-  const joined = isChannelJoined(nest, briefs);
+  const joined = Object.keys(briefs).some((k) => k.includes('heap/'))
+    ? isChannelJoined(nest, briefs)
+    : true;
 
   const joinChannel = useCallback(async () => {
     setJoining(true);

--- a/ui/src/logic/useMedia.ts
+++ b/ui/src/logic/useMedia.ts
@@ -46,10 +46,6 @@ export default function useMedia(mediaQuery: string) {
 
     query.addEventListener('change', update);
     update({ matches: query.matches } as MediaQueryListEvent);
-    /* eslint-disable-next-line consistent-return */
-    return () => {
-      query.removeEventListener('change', update);
-    };
   }, [update, mediaQuery]);
 
   return value;

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -15,6 +15,7 @@ export default function bootstrap() {
 
   if (isTalk) {
     useChatState.getState().fetchDms();
+    useChatState.getState().fetchMultiDms();
   } else {
     useHeapState.getState().start();
     useDiaryState.getState().start();

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -266,15 +266,9 @@ export const useChatState = createState<ChatState>(
       });
       api.subscribe({
         app: 'chat',
-        path: '/club/new',
-        event: (event: ClubInvite) => {
-          get().batchSet((draft) => {
-            const { id, ...crew } = event;
-            const club = draft.multiDms[id];
-            if (!club) {
-              draft.multiDms[id] = crew;
-            }
-          });
+        path: '/clubs/ui',
+        event: (event: ClubAction) => {
+          get().batchSet(clubReducer(event));
         },
       });
 
@@ -613,14 +607,6 @@ export const useChatState = createState<ChatState>(
         `/club/${id}/writs`,
         `/club/${id}/ui/writs`
       ).initialize();
-
-      api.subscribe({
-        app: 'chat',
-        path: `/club/${id}/ui`,
-        event: (event: ClubDelta) => {
-          get().batchSet(clubReducer(id, event));
-        },
-      });
     },
     createMultiDm: async (id, hive) => {
       get().batchSet((draft) => {

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -252,6 +252,14 @@ export interface Hive {
   add: boolean;
 }
 
+interface ClubDeltaInit {
+  init: {
+    team: string[];
+    hive: string[];
+    meta: GroupMeta;
+  };
+}
+
 interface ClubDeltaEditMetadata {
   meta: GroupMeta;
 }
@@ -276,6 +284,7 @@ interface ClubDeltaWrit {
 }
 
 export type ClubDelta =
+  | ClubDeltaInit
   | ClubDeltaEditMetadata
   | ClubDeltaAddHive
   | ClubDeltaRemoveHive


### PR DESCRIPTION
This fixes #1565 by ensuring that we hear facts about club's membership and meta even if we haven't visited said club and also by loading all clubs initially so that we can reconcile with whatever is stored in local storage.

This does change our subscriptions so this needs to be communicated with external parties.

Also threw in a fix for the issue of channels on refresh not loading, some console errors about nested buttons with chat reactions, and the issue with media query listeners disappearing #1529.