### PR TITLE
ux: MessageSelector styling and clean up

### DIFF
--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -51,6 +51,7 @@ interface ShipSelectorProps {
   placeholder?: string;
   isValidNewOption?: (value: string) => boolean;
   autoFocus?: boolean;
+  containerClassName?: string;
 }
 
 function Control({ children, ...props }: ControlProps<ShipOption, true>) {
@@ -273,6 +274,7 @@ export default function ShipSelector({
   placeholder = 'Search for Urbit ID (e.g. ~sampel-palnet) or display name',
   isValidNewOption = (val) => (val ? ob.isValidPatp(preSig(val)) : false),
   autoFocus = true,
+  containerClassName,
 }: ShipSelectorProps) {
   const selectRef = useRef<Select<
     ShipOption,
@@ -436,6 +438,7 @@ export default function ShipSelector({
         ref={selectRef}
         formatCreateLabel={AddNewOption}
         autoFocus={autoFocus}
+        className={containerClassName}
         styles={{
           control: (base) => ({}),
           menu: ({ width, borderRadius, ...base }) => ({
@@ -525,6 +528,7 @@ export default function ShipSelector({
       formatCreateLabel={AddNewOption}
       autoFocus
       isMulti
+      className={containerClassName}
       styles={{
         control: (base) => ({}),
         menuList: ({ padding, paddingTop, paddingBottom, ...base }) => ({

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -42,7 +42,7 @@ export default function Dm() {
     useCallback((s) => ship && Object.keys(s.briefs).includes(ship), [ship])
   );
 
-  const { existingDm, isSelectingMessage } = useMessageSelector();
+  const { isSelectingMessage } = useMessageSelector();
 
   useEffect(() => {
     if (ship && canStart) {
@@ -58,7 +58,9 @@ export default function Dm() {
       <Layout
         className="h-full grow"
         header={
-          isSelectingMessage ? null : (
+          isSelectingMessage ? (
+            <MessageSelector />
+          ) : (
             <div className="flex h-full items-center justify-between border-b-2 border-gray-50 p-2">
               <BackLink mobile={isMobile}>
                 <BackButton
@@ -114,7 +116,6 @@ export default function Dm() {
           ) : null
         }
       >
-        {existingDm ? <MessageSelector /> : null}
         {isAccepted ? (
           <ChatWindow
             whom={ship}

--- a/ui/src/dms/MessageSelector.tsx
+++ b/ui/src/dms/MessageSelector.tsx
@@ -27,7 +27,7 @@ export default function MessageSelector() {
       <div className="my-2.5 flex w-full flex-row justify-evenly sm:w-auto">
         {isMobile ? (
           <button
-            className="secondary-button mr-2.5 w-1/2 py-2.5 sm:w-auto"
+            className="secondary-button mr-1 w-1/2 py-2.5 sm:mr-auto sm:w-auto"
             disabled={!validShips}
             onClick={() => onEnter(ships)}
           >
@@ -35,7 +35,7 @@ export default function MessageSelector() {
           </button>
         ) : null}
         <button
-          className="secondary-button ml-2.5 w-1/2 py-2.5 sm:w-auto"
+          className="secondary-button ml-1 w-1/2 py-2.5 sm:ml-auto sm:w-auto"
           onClick={onCancel}
         >
           Cancel

--- a/ui/src/dms/MessageSelector.tsx
+++ b/ui/src/dms/MessageSelector.tsx
@@ -16,42 +16,31 @@ export default function MessageSelector() {
   }, [navigate, setShips]);
 
   return (
-    <>
-      <div className="relative z-50 flex w-full items-center space-x-2 py-3 px-4">
-        <div className="w-full">
-          <ShipSelector
-            ships={ships}
-            setShips={setShips}
-            onEnter={onEnter}
-            isMulti={true}
-          />
-        </div>
-        <button className="secondary-button py-2.5" onClick={onCancel}>
+    <div className="relative z-50 flex w-full flex-col items-center py-3 px-4 sm:flex-row sm:space-x-2">
+      <ShipSelector
+        ships={ships}
+        setShips={setShips}
+        onEnter={onEnter}
+        isMulti={true}
+        containerClassName="w-full grow"
+      />
+      <div className="my-2.5 flex w-full flex-row justify-evenly sm:w-auto">
+        {isMobile ? (
+          <button
+            className="secondary-button mr-2.5 w-1/2 py-2.5 sm:w-auto"
+            disabled={!validShips}
+            onClick={() => onEnter(ships)}
+          >
+            {action}
+          </button>
+        ) : null}
+        <button
+          className="secondary-button ml-2.5 w-1/2 py-2.5 sm:w-auto"
+          onClick={onCancel}
+        >
           Cancel
         </button>
       </div>
-      {validShips ? (
-        <div className="absolute inset-0 z-40 flex h-full flex-1 flex-col items-center justify-center bg-gray-100/50">
-          <div className="flex w-fit flex-col items-center justify-center rounded-md border border-dashed border-gray-200 bg-gray-100/90 p-8">
-            {isMobile ? (
-              <div className="flex flex-col items-center space-y-2">
-                <button
-                  className="small-button m-2"
-                  onClick={() => onEnter(ships)}
-                >
-                  {action}
-                </button>
-              </div>
-            ) : (
-              <div className="text-lg text-gray-500">
-                Press Enter to {action}
-              </div>
-            )}
-            <div className="text-lg text-gray-300">or</div>
-            <div className="text-lg text-gray-500">Add More Ships</div>
-          </div>
-        </div>
-      ) : null}
-    </>
+    </div>
   );
 }

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -27,7 +27,7 @@ export default function MultiDm() {
   const isAccepted = !useMultiDmIsPending(clubId);
   const club = useMultiDm(clubId);
 
-  const { existingMultiDm, isSelectingMessage } = useMessageSelector();
+  const { isSelectingMessage } = useMessageSelector();
 
   useEffect(() => {
     if (clubId && club) {
@@ -53,7 +53,9 @@ export default function MultiDm() {
       <Layout
         className="h-full grow"
         header={
-          isSelectingMessage ? null : (
+          isSelectingMessage ? (
+            <MessageSelector />
+          ) : (
             <div className="flex h-full w-full items-center justify-between border-b-2 border-gray-50 p-2">
               <BackButton
                 to="/"
@@ -110,7 +112,6 @@ export default function MultiDm() {
           ) : null
         }
       >
-        {existingMultiDm ? <MessageSelector /> : null}
         {isAccepted ? (
           <ChatWindow
             whom={clubId}


### PR DESCRIPTION
# Changes

- improved mobile styles
- remove popover guidance

# Preview

## Mobile: Empty State

![image](https://user-images.githubusercontent.com/16504501/215390300-eebe2b1c-f597-4bf7-a57a-e3de87dc2a51.png)

## Mobile: Results State

![image](https://user-images.githubusercontent.com/16504501/215409770-32dbcab8-422f-4375-bbe3-379f9808b775.png)


## Desktop: Empty State

![image](https://user-images.githubusercontent.com/16504501/215409278-47e553f9-3e24-455f-9a9c-093503ea0916.png)

## Desktop: Results State

![image](https://user-images.githubusercontent.com/16504501/215409226-e0e17981-a68c-4cf6-b419-e697af3305ff.png)


