### PR TITLE
support improvement omnibus

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -48,7 +48,7 @@
         "@tlon/sigil-js": "^1.4.5",
         "@tloncorp/mock-http-api": "^1.2.0",
         "@types/prosemirror-view": "^1.23.3",
-        "@urbit/api": "^2.1.1",
+        "@urbit/api": "^2.2.0",
         "@urbit/aura": "^0.4.0",
         "@urbit/http-api": "^2.2.0",
         "any-ascii": "^0.3.1",
@@ -9260,9 +9260,9 @@
       }
     },
     "node_modules/@urbit/api": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@urbit/api/-/api-2.1.1.tgz",
-      "integrity": "sha512-QRlqhtJ73q+pgMdSwuOO62HlxA7/2c5ylCcOUT01LXkJ2LTVCl5u+QnejdDvUmqjOuN2PyZk7df30xJVg6rC2A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@urbit/api/-/api-2.2.0.tgz",
+      "integrity": "sha512-W8kP9OT6yOK62n+4yCPO3i9QqU5xriLvZQ9WYW4SAV7ktbSrGuf2kmYbnoqfA/NybIs9Q/MbFkPewrz4XJ96Ag==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "big-integer": "^1.6.48",
@@ -36117,9 +36117,9 @@
       }
     },
     "@urbit/api": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@urbit/api/-/api-2.1.1.tgz",
-      "integrity": "sha512-QRlqhtJ73q+pgMdSwuOO62HlxA7/2c5ylCcOUT01LXkJ2LTVCl5u+QnejdDvUmqjOuN2PyZk7df30xJVg6rC2A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@urbit/api/-/api-2.2.0.tgz",
+      "integrity": "sha512-W8kP9OT6yOK62n+4yCPO3i9QqU5xriLvZQ9WYW4SAV7ktbSrGuf2kmYbnoqfA/NybIs9Q/MbFkPewrz4XJ96Ag==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "big-integer": "^1.6.48",

--- a/ui/package.json
+++ b/ui/package.json
@@ -78,7 +78,7 @@
     "@tlon/sigil-js": "^1.4.5",
     "@tloncorp/mock-http-api": "^1.2.0",
     "@types/prosemirror-view": "^1.23.3",
-    "@urbit/api": "^2.1.1",
+    "@urbit/api": "^2.2.0",
     "@urbit/aura": "^0.4.0",
     "@urbit/http-api": "^2.2.0",
     "any-ascii": "^0.3.1",

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -82,6 +82,7 @@ import MobileGroupActions from './groups/MobileGroupActions';
 import { useStorage } from './state/storage';
 import { isTalk } from './logic/utils';
 import bootstrap from './state/bootstrap';
+import AboutDialog from './components/AboutDialog';
 
 const DiaryAddNote = React.lazy(() => import('./diary/DiaryAddNote'));
 const SuspendedDiaryAddNote = (
@@ -355,6 +356,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
       </Routes>
       {state?.backgroundLocation ? (
         <Routes>
+          <Route path="/about" element={<AboutDialog />} />
           <Route path="/groups/new" element={<NewGroup />} />
           <Route path="/groups/:ship/:name">
             <Route path="invite" element={<GroupInviteDialog />} />

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -198,6 +198,7 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
       </Routes>
       {state?.backgroundLocation ? (
         <Routes>
+          <Route path="/about" element={<AboutDialog />} />
           <Route path="/dm/:id/edit-info" element={<MultiDMEditModal />} />
           <Route path="/profile/:ship" element={<ProfileModal />} />
           <Route path="/gangs/:ship/:name" element={<JoinGroupModal />} />

--- a/ui/src/components/AboutDialog.tsx
+++ b/ui/src/components/AboutDialog.tsx
@@ -43,8 +43,10 @@ export default function AboutDialog() {
           </span>
           <span className="text-sm text-gray-500">{appDescription}</span>
           <div className="flex flex-row items-center text-sm">
-            <span className="font-bold text-gray-500">Hash:</span>
-            <code className="ml-2 break-all">{pike?.hash}</code>
+            <div className="flex flex-row items-end">
+              <span className="font-bold text-gray-500">Hash:</span>
+              <code className="ml-2 break-all">{pike?.hash}</code>
+            </div>
             <IconButton
               label="Copy Hash"
               icon={

--- a/ui/src/components/AboutDialog.tsx
+++ b/ui/src/components/AboutDialog.tsx
@@ -1,5 +1,6 @@
 import { useDismissNavigate } from '@/logic/routing';
 import { isTalk, useCopy } from '@/logic/utils';
+import { useCharge } from '@/state/docket';
 import { usePike } from '@/state/kiln';
 import Dialog, { DialogContent } from './Dialog';
 import IconButton from './IconButton';
@@ -9,11 +10,15 @@ import CopyIcon from './icons/CopyIcon';
 export default function AboutDialog() {
   const dismiss = useDismissNavigate();
   const pike = usePike(isTalk ? 'talk' : 'groups');
+  const charge = useCharge(isTalk ? 'talk' : 'groups');
   const { didCopy: didCopyHash, doCopy: doCopyHash } = useCopy(
     pike?.hash || ''
   );
   const { didCopy: didCopyShip, doCopy: doCopyShip } = useCopy(
     pike?.sync?.ship || ''
+  );
+  const { didCopy: didCopyVersion, doCopy: doCopyVersion } = useCopy(
+    charge?.version || ''
   );
 
   const onOpenChange = (open: boolean) => {
@@ -21,15 +26,6 @@ export default function AboutDialog() {
       dismiss();
     }
   };
-
-  const appDescription = isTalk
-    ? `Send encrypted direct messages to one or many friends.
-    Talk is a simple chat tool for catching up, getting work done,
-    and everything in between.`
-    : `Start, host, and cultivate communities. Own your communications,
-            organize your resources, and share documents. Groups is a
-            decentralized platform that integrates with Talk, Notebook, and
-            Gallery for a full, communal suite of tools.`;
 
   return (
     <Dialog defaultOpen modal onOpenChange={onOpenChange}>
@@ -41,7 +37,22 @@ export default function AboutDialog() {
           <span className="text-lg font-bold">
             About {isTalk ? 'Talk' : 'Groups'}
           </span>
-          <span className="text-sm text-gray-500">{appDescription}</span>
+          <span className="text-sm text-gray-500">{charge?.info}</span>
+          <div className="flex flex-row items-center text-sm">
+            <span className="font-bold text-gray-500">Version:</span>
+            <code className="ml-1">{charge?.version}</code>
+            <IconButton
+              label="Copy Version"
+              icon={
+                didCopyVersion ? (
+                  <CheckIcon className="h-6 w-6 text-gray-400" />
+                ) : (
+                  <CopyIcon className="h-6 w-6 text-gray-400" />
+                )
+              }
+              action={doCopyVersion}
+            />
+          </div>
           <div className="flex flex-row items-center text-sm">
             <div className="flex flex-row items-end">
               <span className="font-bold text-gray-500">Hash:</span>
@@ -63,7 +74,7 @@ export default function AboutDialog() {
             <span className="font-bold text-gray-500">Source:</span>
             <code className="ml-2 break-all">{pike?.sync?.ship}</code>
             <IconButton
-              label="Copy Hash"
+              label="Copy Source"
               icon={
                 didCopyShip ? (
                   <CheckIcon className="h-6 w-6 text-gray-400" />

--- a/ui/src/components/AboutDialog.tsx
+++ b/ui/src/components/AboutDialog.tsx
@@ -1,0 +1,71 @@
+import { isTalk, useCopy } from '@/logic/utils';
+import { usePike } from '@/state/kiln';
+import Dialog, { DialogContent } from './Dialog';
+import IconButton from './IconButton';
+import CheckIcon from './icons/CheckIcon';
+import CopyIcon from './icons/CopyIcon';
+
+export default function AboutDialog() {
+  const pike = usePike(isTalk ? 'talk' : 'groups');
+  const { didCopy: didCopyHash, doCopy: doCopyHash } = useCopy(
+    pike?.hash || ''
+  );
+  const { didCopy: didCopyShip, doCopy: doCopyShip } = useCopy(
+    pike?.sync?.ship || ''
+  );
+
+  const appDescription = isTalk
+    ? `Send encrypted direct messages to one or many friends.
+    Talk is a simple chat tool for catching up, getting work done,
+    and everything in between.`
+    : `Start, host, and cultivate communities. Own your communications,
+            organize your resources, and share documents. Groups is a
+            decentralized platform that integrates with Talk, Notebook, and
+            Gallery for a full, communal suite of tools.`;
+
+  return (
+    <Dialog defaultOpen modal>
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        className="w-[500px] sm:inset-y-24"
+      >
+        <div className="flex flex-col space-y-2">
+          <span className="text-lg font-bold">
+            About {isTalk ? 'Talk' : 'Groups'}
+          </span>
+          <span className="text-sm text-gray-500">{appDescription}</span>
+          <div className="flex flex-row items-center text-sm">
+            <span className="font-bold text-gray-500">Hash:</span>
+            <code className="ml-2 break-all">{pike?.hash}</code>
+            <IconButton
+              label="Copy Hash"
+              icon={
+                didCopyHash ? (
+                  <CheckIcon className="h-6 w-6 text-gray-400" />
+                ) : (
+                  <CopyIcon className="h-6 w-6 text-gray-400" />
+                )
+              }
+              action={doCopyHash}
+            />
+          </div>
+          <div className="flex flex-row items-center text-sm">
+            <span className="font-bold text-gray-500">Source:</span>
+            <code className="ml-2 break-all">{pike?.sync?.ship}</code>
+            <IconButton
+              label="Copy Hash"
+              icon={
+                didCopyShip ? (
+                  <CheckIcon className="h-6 w-6 text-gray-400" />
+                ) : (
+                  <CopyIcon className="h-6 w-6 text-gray-400" />
+                )
+              }
+              action={doCopyShip}
+            />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/AboutDialog.tsx
+++ b/ui/src/components/AboutDialog.tsx
@@ -1,3 +1,4 @@
+import { useDismissNavigate } from '@/logic/routing';
 import { isTalk, useCopy } from '@/logic/utils';
 import { usePike } from '@/state/kiln';
 import Dialog, { DialogContent } from './Dialog';
@@ -6,6 +7,7 @@ import CheckIcon from './icons/CheckIcon';
 import CopyIcon from './icons/CopyIcon';
 
 export default function AboutDialog() {
+  const dismiss = useDismissNavigate();
   const pike = usePike(isTalk ? 'talk' : 'groups');
   const { didCopy: didCopyHash, doCopy: doCopyHash } = useCopy(
     pike?.hash || ''
@@ -13,6 +15,12 @@ export default function AboutDialog() {
   const { didCopy: didCopyShip, doCopy: doCopyShip } = useCopy(
     pike?.sync?.ship || ''
   );
+
+  const onOpenChange = (open: boolean) => {
+    if (!open) {
+      dismiss();
+    }
+  };
 
   const appDescription = isTalk
     ? `Send encrypted direct messages to one or many friends.
@@ -24,7 +32,7 @@ export default function AboutDialog() {
             Gallery for a full, communal suite of tools.`;
 
   return (
-    <Dialog defaultOpen modal>
+    <Dialog defaultOpen modal onOpenChange={onOpenChange}>
       <DialogContent
         onInteractOutside={(e) => e.preventDefault()}
         className="w-[500px] sm:inset-y-24"

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import { useNotifications } from '@/notifications/useNotifications';
 import { debounce } from 'lodash';
 import ArrowNWIcon from '../icons/ArrowNWIcon';
 import MenuIcon from '../icons/MenuIcon';
+import AsteriskIcon from '../icons/Asterisk16Icon';
 
 export function GroupsAppMenu() {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -57,20 +58,26 @@ export function GroupsAppMenu() {
 
           <DropdownMenu.Content className="dropdown mt-2 -ml-2 w-60">
             <a
-              className="no-underline"
+              className="dropdown-item flex flex-row items-center p-2 no-underline"
               href="https://airtable.com/shrflFkf5UyDFKhmW"
               target="_blank"
               rel="noreferrer"
             >
+              <div className="flex h-12 w-12 items-center justify-center rounded-md">
+                <AsteriskIcon className="h-6 w-6" />
+              </div>
               <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
                 Submit Feedback
               </DropdownMenu.Item>
             </a>
             <Link
               to="/about"
-              className="no-underline"
+              className="dropdown-item flex flex-row items-center p-2 no-underline"
               state={{ backgroundLocation: location }}
             >
+              <div className="flex h-12 w-12 items-center justify-center rounded-md">
+                <AppGroupsIcon className="h-6 w-6" />
+              </div>
               <DropdownMenu.Item className="dropdown-item pl-3 text-gray-600">
                 About Groups
               </DropdownMenu.Item>

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useMemo, useCallback } from 'react';
 import cn from 'classnames';
+import { Link } from 'react-router-dom';
 import { useLocation } from 'react-router';
 import ActivityIndicator from '@/components/Sidebar/ActivityIndicator';
 import MobileSidebar from '@/components/Sidebar/MobileSidebar';
@@ -24,6 +25,7 @@ import MenuIcon from '../icons/MenuIcon';
 
 export function GroupsAppMenu() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
   return (
     <SidebarItem
       div
@@ -64,6 +66,15 @@ export function GroupsAppMenu() {
                 Submit Feedback
               </DropdownMenu.Item>
             </a>
+            <Link
+              to="/about"
+              className="no-underline"
+              state={{ backgroundLocation: location }}
+            >
+              <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
+                About Groups
+              </DropdownMenu.Item>
+            </Link>
           </DropdownMenu.Content>
         </DropdownMenu.Root>
       }

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -71,7 +71,7 @@ export function GroupsAppMenu() {
               className="no-underline"
               state={{ backgroundLocation: location }}
             >
-              <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
+              <DropdownMenu.Item className="dropdown-item pl-3 text-gray-600">
                 About Groups
               </DropdownMenu.Item>
             </Link>

--- a/ui/src/components/UpdateNotice.tsx
+++ b/ui/src/components/UpdateNotice.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import AsteriskIcon from '@/components/icons/Asterisk16Icon';
+import { isTalk } from '@/logic/utils';
+
+export default function UpdateNotice() {
+  const appName = isTalk ? 'Talk' : 'Groups';
+  function onClick() {
+    window.location.reload();
+  }
+
+  return (
+    <div className="z-50 flex items-center justify-between bg-yellow py-1 px-2 text-sm font-medium text-black dark:text-white">
+      <div className="flex items-center">
+        <AsteriskIcon className="mr-3 h-4 w-4" />
+        <span className="mr-1">
+          {appName} has updated in the background. Please reload.
+        </span>
+      </div>
+      <button className="py-1 px-2" onClick={onClick}>
+        Reload
+      </button>
+    </div>
+  );
+}

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -75,7 +75,7 @@ export function TalkAppMenu() {
               className="no-underline"
               state={{ backgroundLocation: location }}
             >
-              <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
+              <DropdownMenu.Item className="dropdown-item pl-3 text-gray-600">
                 About Talk
               </DropdownMenu.Item>
             </Link>

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/state/settings';
 import { debounce } from 'lodash';
 import { Link, useLocation } from 'react-router-dom';
+import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
 import { MessagesScrollingContext } from './MessagesScrollingContext';
@@ -61,20 +62,26 @@ export function TalkAppMenu() {
 
           <DropdownMenu.Content className="dropdown mt-2 -ml-2 w-60">
             <a
-              className="no-underline"
+              className="dropdown-item flex flex-row items-center p-2 no-underline"
               href="https://airtable.com/shrflFkf5UyDFKhmW"
               target="_blank"
               rel="noreferrer"
             >
+              <div className="flex h-12 w-12 items-center justify-center rounded-md">
+                <AsteriskIcon className="h-6 w-6" />
+              </div>
               <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
                 Submit Feedback
               </DropdownMenu.Item>
             </a>
             <Link
               to="/about"
-              className="no-underline"
+              className="dropdown-item flex flex-row items-center p-2 no-underline"
               state={{ backgroundLocation: location }}
             >
+              <div className="flex h-12 w-12 items-center justify-center rounded-md">
+                <TalkIcon className="h-6 w-6" />
+              </div>
               <DropdownMenu.Item className="dropdown-item pl-3 text-gray-600">
                 About Talk
               </DropdownMenu.Item>

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -18,6 +18,7 @@ import {
   SettingsState,
 } from '@/state/settings';
 import { debounce } from 'lodash';
+import { Link, useLocation } from 'react-router-dom';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
 import { MessagesScrollingContext } from './MessagesScrollingContext';
@@ -28,6 +29,7 @@ const selMessagesFilter = (s: SettingsState) => ({
 
 export function TalkAppMenu() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
   return (
     <SidebarItem
       div
@@ -68,6 +70,15 @@ export function TalkAppMenu() {
                 Submit Feedback
               </DropdownMenu.Item>
             </a>
+            <Link
+              to="/about"
+              className="no-underline"
+              state={{ backgroundLocation: location }}
+            >
+              <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
+                About Talk
+              </DropdownMenu.Item>
+            </Link>
           </DropdownMenu.Content>
         </DropdownMenu.Root>
       }

--- a/ui/src/groups/MobileGroupsActions.tsx
+++ b/ui/src/groups/MobileGroupsActions.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import AsteriskIcon from '@/components/icons/Asterisk16Icon';
+import { Link, useLocation } from 'react-router-dom';
+import AppGroupsIcon from '@/components/icons/AppGroupsIcon';
 
 export default function MobileGroupsActions() {
+  const location = useLocation();
   return (
     <nav className="h-full flex-1 overflow-y-auto p-2">
       <ul className="space-y-3">
@@ -22,6 +25,21 @@ export default function MobileGroupsActions() {
           >
             Submit Feedback
           </a>
+        </SidebarItem>
+        <SidebarItem
+          icon={
+            <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+              <AppGroupsIcon className="h-6 w-6" />
+            </div>
+          }
+        >
+          <Link
+            to="/about"
+            className="no-underline"
+            state={{ backgroundLocation: location }}
+          >
+            About Groups
+          </Link>
         </SidebarItem>
       </ul>
     </nav>

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -3,6 +3,7 @@ import { isTalk } from '@/logic/utils';
 import { useChatState } from './chat';
 import useContactState from './contact';
 import { useDiaryState } from './diary';
+import useDocketState from './docket';
 import { useGroupState } from './groups';
 import useHarkState from './hark';
 import { useHeapState } from './heap/heap';
@@ -30,4 +31,6 @@ export default async function bootstrap() {
 
   useStorage.getState().initialize(api);
   useKilnState.getState().initializeKiln();
+  const { fetchCharges } = useDocketState.getState();
+  fetchCharges();
 }

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -14,8 +14,6 @@ export default async function bootstrap() {
   useGroupState.getState().start();
   useChatState.getState().start();
 
-  useKilnState.getState().initializeKiln();
-
   if (isTalk) {
     useChatState.getState().fetchDms();
   } else {
@@ -31,4 +29,5 @@ export default async function bootstrap() {
   fetchAll();
 
   useStorage.getState().initialize(api);
+  useKilnState.getState().initializeKiln();
 }

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -6,12 +6,15 @@ import { useDiaryState } from './diary';
 import { useGroupState } from './groups';
 import useHarkState from './hark';
 import { useHeapState } from './heap/heap';
+import useKilnState from './kiln';
 import { useSettingsState } from './settings';
 import { useStorage } from './storage';
 
-export default function bootstrap() {
+export default async function bootstrap() {
   useGroupState.getState().start();
   useChatState.getState().start();
+
+  useKilnState.getState().initializeKiln();
 
   if (isTalk) {
     useChatState.getState().fetchDms();

--- a/ui/src/state/kiln.ts
+++ b/ui/src/state/kiln.ts
@@ -1,0 +1,54 @@
+import { scryLag, getPikes, Pikes, Pike } from '@urbit/api';
+import create from 'zustand';
+import produce from 'immer';
+import { useCallback } from 'react';
+import api from '@/api';
+
+interface KilnState {
+  pikes: Pikes;
+  loaded: boolean;
+  lag: boolean;
+  fetchLag: () => Promise<void>;
+  fetchPikes: () => Promise<void>;
+  set: (s: KilnState) => void;
+  initializeKiln: () => Promise<void>;
+}
+const useKilnState = create<KilnState>((set, get) => ({
+  pikes: {},
+  lag: false,
+  loaded: false,
+  fetchPikes: async () => {
+    const pikes = await api.scry<Pikes>(getPikes);
+    set({ pikes, loaded: true });
+  },
+  fetchLag: async () => {
+    const lag = await api.scry<boolean>(scryLag);
+    set({ lag });
+  },
+  set: produce(set),
+  initializeKiln: async () => {
+    await get().fetchLag();
+    await get().fetchPikes();
+  },
+}));
+
+const selPikes = (s: KilnState) => s.pikes;
+export function usePikes(): Pikes {
+  return useKilnState(selPikes);
+}
+
+export function usePike(desk: string): Pike | undefined {
+  return useKilnState(useCallback((s) => s.pikes[desk], [desk]));
+}
+
+const selLag = (s: KilnState) => s.lag;
+export function useLag() {
+  return useKilnState(selLag);
+}
+
+const selLoaded = (s: KilnState) => s.loaded;
+export function useKilnLoaded() {
+  return useKilnState(selLoaded);
+}
+
+export default useKilnState;


### PR DESCRIPTION
This is for #1733, but also includes some other nice features.

I added a kiln state (required updated @urbit/api) that we can use to get info about desks the user has installed (same as in %garden/landscape). For now, we can use this to surface the base hash of the app that the user is currently looking at, but we could use it in the future to check for the existence of other apps that we could interoperate with.

This PR adds:

1) A way to poll the backend to find out if we have an update:


https://user-images.githubusercontent.com/1221094/215599321-af9a025d-1d23-4e54-b3d1-b8709d872487.mov

2) An "About Groups" (or Talk) modal that shows basic information:


https://user-images.githubusercontent.com/1221094/215598995-472cd514-4f69-4776-b730-ce0c26ba60ec.mov


