### PR TITLE
Fix navigation on lack of read perms on channels

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -19,6 +19,7 @@ import {
   canReadChannel,
   canWriteChannel,
   isChannelJoined,
+  isTalk,
 } from '@/logic/utils';
 import useAllBriefs from '@/logic/useAllBriefs';
 import ChatScrollerPlaceholder from '@/chat/ChatScoller/ChatScrollerPlaceholder';
@@ -80,7 +81,11 @@ function ChatChannel({ title }: ViewProps) {
 
   useEffect(() => {
     if (channel && !canRead) {
-      navigate(`/groups/${groupFlag}/activity`);
+      if (isTalk) {
+        navigate('/');
+      } else {
+        navigate(`/groups/${groupFlag}`);
+      }
       setRecentChannel('');
     }
   }, [groupFlag, group, channel, vessel, navigate, setRecentChannel, canRead]);

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -68,7 +68,7 @@ function DiaryChannel() {
 
   useEffect(() => {
     if (channel && !canReadChannel(channel, vessel, group?.bloc)) {
-      navigate(`/groups/${flag}/activity`);
+      navigate(`/groups/${flag}`);
       setRecentChannel('');
     }
   }, [flag, group, channel, vessel, navigate, setRecentChannel]);

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -126,7 +126,7 @@ function HeapChannel({ title }: ViewProps) {
 
   useEffect(() => {
     if (channel && !canRead) {
-      navigate(`/groups/${flag}/activity`);
+      navigate(`/groups/${flag}`);
       setRecentChannel('');
     }
   }, [flag, group, channel, vessel, navigate, setRecentChannel, canRead]);


### PR DESCRIPTION
I don't know if we have an issue for this, but users were being redirected to /groupflag/actvity (regardless of app) if they didn't have read permissions on a channel.

I had thought we already fixed this, but apparently we didn't.