### PR TITLE
heap: fix occlusion of long tweets

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -84,7 +84,7 @@ export default function HeapDetail() {
       }
     >
       <div className="flex h-full w-full flex-col overflow-y-auto lg:flex-row">
-        <div className="group relative flex-1">
+        <div className="group relative flex flex-1">
           {hasNext ? (
             <div className="absolute top-0 left-0 flex h-full w-16 flex-col justify-center">
               <Link

--- a/ui/src/heap/HeapDetail/HeapDetailEmbed.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailEmbed.tsx
@@ -15,8 +15,8 @@ export default function HeapDetailEmbed({ oembed, url }: HeapDetailEmbedProps) {
   }
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <EmbedContainer markup={html}>
+    <div className="flex h-full w-full items-center justify-center overflow-y-scroll">
+      <EmbedContainer className="max-h-full" markup={html}>
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </EmbedContainer>
     </div>


### PR DESCRIPTION
This resolves #1543 by tweaking the layout to prevent long embeds from being occluded by the heap detail header

# Preview

## Before

![image](https://user-images.githubusercontent.com/16504501/208040308-4ba92a23-c8f4-43ee-ab1d-470e9957a97f.png)
## After

<img width="621" alt="image" src="https://user-images.githubusercontent.com/16504501/215795434-dde3b02f-f8f5-408f-a0e5-7c11bb9476ed.png">
