### PR TITLE
chat: don't mark self unread

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -897,12 +897,14 @@
     ::
         %writ
       =.  pact.club  (reduce:cu-pact now.bowl diff.delta)
-      =.  cu-core  (cu-give-writs-diff diff.delta)
-      =.  cor  (give-brief club/id cu-brief)
+      =.  cu-core  (cu-give-writs-diff diff.delta)      
       ?-  -.q.diff.delta  
           ?(%del %add-feel %del-feel)  cu-core
           %add
         =/  memo=memo:c  p.q.diff.delta
+        =?  remark.club  =(author.memo our.bowl)  
+          remark.club(last-read `@da`(add now.bowl (div ~s1 100)))
+        =.  cor  (give-brief club/id cu-brief)
         ?:  =(our.bowl author.memo)  cu-core
         ?-  -.content.memo
             %notice  cu-core
@@ -1547,17 +1549,19 @@
     =.  cor  (emit %give %fact ~[path] writ-diff+!>(diff))
     =/  old-brief  di-brief
     =.  pact.dm  (reduce:di-pact now.bowl diff)
-    =?  cor  &(!=(old-brief di-brief) !=(net.dm %invited))
-      (give-brief ship/ship di-brief)
     =?  cor  &(=(net.dm %invited) !=(ship our.bowl))
       (give-invites ship)
     =.  di-core
       (di-notify diff)
-    ?:  from-self  di-core
     ?-  -.q.diff
         ?(%del %add-feel %del-feel)  di-core
         %add
       =/  memo=memo:c  p.q.diff
+      =?  remark.dm  =(author.memo our.bowl)  
+        remark.dm(last-read `@da`(add now.bowl (div ~s1 100)))
+      =?  cor  &(!=(old-brief di-brief) !=(net.dm %invited))
+        (give-brief ship/ship di-brief)
+      ?:  from-self  di-core
       ?-  -.content.memo
           %notice  di-core
           %story

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1397,11 +1397,13 @@
     ::
         %writs
       =.  pact.chat  (reduce:ca-pact time p.d)
-      =.  cor  (give-brief flag/flag ca-brief)
       ?-  -.q.p.d
           ?(%del %add-feel %del-feel)  ca-core
           %add
         =/  memo=memo:c  p.q.p.d
+        =?  remark.chat  =(author.memo our.bowl)  
+          remark.chat(last-read `@da`(add now.bowl (div ~s1 100)))
+        =.  cor  (give-brief flag/flag ca-brief)
         ?-  -.content.memo
             %notice  ca-core
             %story


### PR DESCRIPTION
Fixes #1693 by moving read marker to after my message if I post in a chat.