### PR TITLE
chat: do not allow send on submit if send is disabled on chatinput

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -140,6 +140,7 @@ export default function ChatInput({
 
   const onSubmit = useCallback(
     async (editor: Editor) => {
+      if (sendDisabled) return;
       const blocks = fetchChatBlocks(id);
       if (!editor.getText() && !blocks.length) {
         return;
@@ -205,7 +206,7 @@ export default function ChatInput({
         clearAttachments();
       }, 0);
     },
-    [whom, id, reply, clearAttachments, sendMessage, closeReply]
+    [whom, id, reply, clearAttachments, sendMessage, closeReply, sendDisabled]
   );
 
   /**


### PR DESCRIPTION
This was a cause for the "broken images" appearing in chat. Users could just hit enter on the input and it would send the non-uploaded image url.