### PR TITLE
ux: profile supports color hexes starting with 0

### DIFF
--- a/ui/src/logic/utils.test.ts
+++ b/ui/src/logic/utils.test.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
-import { whomIsFlag } from './utils';
+import { normalizeUrbitColor, whomIsFlag } from './utils';
 
 describe('whomIsFlag', () => {
   it('passes valid flags', () => {
@@ -44,5 +44,45 @@ describe('whomIsFlag', () => {
     ];
 
     flags.forEach((f) => expect(whomIsFlag(f)).toEqual(false));
+  });
+});
+
+describe('normalizeUrbitColor', () => {
+  describe('the user submits a color hex value with one or more leading zeroes', () => {
+    it('normalizes @ux values of color hexes for all zeroes', () => {
+      expect(normalizeUrbitColor('0x0')).toEqual('#000000');
+    });
+
+    it('normalizes @ux values of color hexes with 5 leading zeros', () => {
+      expect(normalizeUrbitColor('0xf')).toEqual('#00000F');
+    });
+
+    it('normalizes @ux values of color hexes with 4 leading zeros', () => {
+      expect(normalizeUrbitColor('0xff')).toEqual('#0000FF');
+    });
+
+    it('normalizes @ux values of color hexes with 3 leading zeros', () => {
+      expect(normalizeUrbitColor('0xfff')).toEqual('#000FFF');
+    });
+
+    it('normalizes @ux values of color hexes with 2 leading zeros', () => {
+      expect(normalizeUrbitColor('0xffff')).toEqual('#00FFFF');
+    });
+
+    it('normalizes @ux values of color hexes with 1 leading zero', () => {
+      expect(normalizeUrbitColor('0xf.ffff')).toEqual('#0FFFFF');
+    });
+  });
+
+  it('normalizes colors with a leading alpha char', () => {
+    expect(normalizeUrbitColor('0xff.ffff')).toEqual('#FFFFFF');
+  });
+
+  it('normalizes colors with a leading 0', () => {
+    expect(normalizeUrbitColor('0x00.0000')).toEqual('#000000');
+  });
+
+  it('passes through color hexes', () => {
+    expect(normalizeUrbitColor('#ffffff')).toEqual('#ffffff');
   });
 });

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -144,7 +144,7 @@ export function normalizeUrbitColor(color: string): string {
   }
 
   const colorString = color.slice(2).replace('.', '').toUpperCase();
-  const lengthAdjustedColor = _.padEnd(colorString, 6, _.last(colorString));
+  const lengthAdjustedColor = _.padStart(colorString, 6, '0');
   return `#${lengthAdjustedColor}`;
 }
 

--- a/ui/src/profiles/EditProfile/ProfileFields.tsx
+++ b/ui/src/profiles/EditProfile/ProfileFields.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { ContactEditField } from '@urbit/api';
+import { debounce } from 'lodash';
 import ColorPicker from '@/components/ColorPicker';
 import CheckIcon from '@/components/icons/CheckIcon';
 import { normalizeUrbitColor } from '@/logic/utils';
@@ -29,6 +30,8 @@ export default function ProfileFields() {
     });
   };
 
+  const debouncedSetColor = debounce(setColor, 100);
+
   return (
     <>
       <div className="flex">
@@ -38,7 +41,7 @@ export default function ProfileFields() {
             <div className="relative flex w-full items-baseline">
               <ColorPicker
                 color={normalizeUrbitColor(watchSigilColor || '0x0')}
-                setColor={setColor}
+                setColor={debouncedSetColor}
                 className="z-50"
               />
             </div>


### PR DESCRIPTION
This resolves #1390 by changing how `@ux` values are normalized in the frontend. When a color hex such as `#00FFFF` is persisted in the backend, it is converted to a `@ux` (unsigned hexadecimal). The extraneous 0 values are not saved, which then requires them to be restored when loaded in the frontend. See the comments in #1390 for more detail.

Also:
- debounce the color picker's state updating (previously it was firing rapidly as the user dragged the picker cursor)
- add test coverage for `normalizeUrbitColor`


https://user-images.githubusercontent.com/16504501/216297458-a18e8886-b75e-4404-b54f-6b209e18dd2c.mov

