### PR TITLE
heap: prevent double comments on Curios

### DIFF
--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
@@ -32,8 +32,8 @@ export default function HeapDetailComments({ time }: HeapDetailCommentsProps) {
       >
         {Array.from(comments)
           .sort(([a], [b]) => a.compare(b))
-          .map(([, curio]) => (
-            <HeapComment curio={curio} />
+          .map(([id, curio]) => (
+            <HeapComment key={id.toString()} curio={curio} />
           ))}
       </div>
       {canWrite ? <HeapDetailCommentField /> : null}

--- a/ui/src/heap/HeapTextInput.tsx
+++ b/ui/src/heap/HeapTextInput.tsx
@@ -105,10 +105,11 @@ export default function HeapTextInput({
         content,
       };
 
-      await useHeapState.getState().addCurio(flag, heart);
       setDraft(undefined);
       editor?.commands.setContent('');
       useChatStore.getState().setBlocks(flag, []);
+
+      await useHeapState.getState().addCurio(flag, heart);
       setReady();
     },
     [sendDisabled, setPending, replyTo, flag, setDraft, setReady]
@@ -192,7 +193,6 @@ export default function HeapTextInput({
           <button
             className="button absolute bottom-3 right-3 rounded-md px-2 py-1"
             disabled={
-              sendDisabled ||
               isPending ||
               (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
             }


### PR DESCRIPTION
This resolves #1576 by clearing the editor input before poking the curio. Previously, it would be cleared after submission, which would allowed a brief window to double post by spamming Enter (before the component could process the state update). I tried other approaches (e.g., do not send if isPending), but they were causing weird side effects or extraneous renders.

Also, add keys to mapped comments in HeapDetail view to suppress console error.

https://user-images.githubusercontent.com/16504501/216317586-6e287363-b332-4b58-94cb-1838c818c58a.mov
