### PR TITLE
groups: allow group joins from references

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -26,7 +26,6 @@ import ChatScrollerPlaceholder from '@/chat/ChatScoller/ChatScrollerPlaceholder'
 
 function ChatChannel({ title }: ViewProps) {
   const navigate = useNavigate();
-  const joinRef = new URLSearchParams(window.location.search).get('joinref');
   const { chShip, chName } = useParams();
   const chFlag = `${chShip}/${chName}`;
   const nest = `chat/${chFlag}`;
@@ -51,26 +50,18 @@ function ChatChannel({ title }: ViewProps) {
 
   const joinChannel = useCallback(async () => {
     setJoining(true);
-    if (joinRef) {
-      setTimeout(async () => {
-        await useChatState.getState().joinChat(chFlag);
-      }, 300);
-    } else {
+    try {
       await useChatState.getState().joinChat(chFlag);
+    } catch (e) {
+      console.log("Couldn't join chat (maybe already joined)", e);
     }
     setJoining(false);
-  }, [chFlag, joinRef]);
+  }, [chFlag]);
 
   const initializeChannel = useCallback(async () => {
-    if (joinRef) {
-      setTimeout(async () => {
-        await useChatState.getState().initialize(chFlag);
-      }, 300);
-    } else {
-      await useChatState.getState().initialize(chFlag);
-    }
+    await useChatState.getState().initialize(chFlag);
     setLoading(false);
-  }, [chFlag, joinRef]);
+  }, [chFlag]);
 
   useEffect(() => {
     if (!joined) {
@@ -80,7 +71,7 @@ function ChatChannel({ title }: ViewProps) {
 
   useEffect(() => {
     setLoading(true);
-    if (joined && channel && canRead && !joining) {
+    if (joined && canRead && !joining) {
       initializeChannel();
       setRecentChannel(nest);
     }

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -26,6 +26,7 @@ import ChatScrollerPlaceholder from '@/chat/ChatScoller/ChatScrollerPlaceholder'
 
 function ChatChannel({ title }: ViewProps) {
   const navigate = useNavigate();
+  const joinRef = new URLSearchParams(window.location.search).get('joinref');
   const { chShip, chName } = useParams();
   const chFlag = `${chShip}/${chName}`;
   const nest = `chat/${chFlag}`;
@@ -50,14 +51,26 @@ function ChatChannel({ title }: ViewProps) {
 
   const joinChannel = useCallback(async () => {
     setJoining(true);
-    await useChatState.getState().joinChat(chFlag);
+    if (joinRef) {
+      setTimeout(async () => {
+        await useChatState.getState().joinChat(chFlag);
+      }, 300);
+    } else {
+      await useChatState.getState().joinChat(chFlag);
+    }
     setJoining(false);
-  }, [chFlag]);
+  }, [chFlag, joinRef]);
 
   const initializeChannel = useCallback(async () => {
-    await useChatState.getState().initialize(chFlag);
+    if (joinRef) {
+      setTimeout(async () => {
+        await useChatState.getState().initialize(chFlag);
+      }, 300);
+    } else {
+      await useChatState.getState().initialize(chFlag);
+    }
     setLoading(false);
-  }, [chFlag]);
+  }, [chFlag, joinRef]);
 
   useEffect(() => {
     if (!joined) {

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { useCurio, useHeapState, useRemoteCurio } from '@/state/heap/heap';
+import { useHeapState, useRemoteCurio } from '@/state/heap/heap';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 // eslint-disable-next-line import/no-cycle
 import HeapBlock from '@/heap/HeapBlock';
-import { useChannelPreview } from '@/state/groups';
+import { useChannelPreview, useGang } from '@/state/groups';
 import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
+import useGroupJoin from '@/groups/useGroupJoin';
+import { useLocation, useNavigate } from 'react-router';
+import useAppName from '@/logic/useAppName';
 import ReferenceBar from './ReferenceBar';
 import UnavailableReference from './UnavailableReference';
 
@@ -22,10 +25,31 @@ export default function CurioReference({
 }) {
   const curio = useRemoteCurio(chFlag, idCurio, isScrolling);
   const preview = useChannelPreview(nest);
+  const location = useLocation();
+  const navigate = useNavigate();
+  const app = useAppName();
+  const groupFlag = preview?.group?.flag || '~zod/test';
+  const gang = useGang(groupFlag);
+  const { group } = useGroupJoin(groupFlag, gang);
   const [scryError, setScryError] = useState<string>();
   const refToken = preview?.group
     ? `${preview.group.flag}/channels/${nest}/curio/${idCurio}`
     : undefined;
+
+  const handleOpenReferenceClick = () => {
+    if (!group) {
+      navigate(`/gangs/${groupFlag}?type=curio&nest=${nest}&id=${idCurio}`, {
+        state: { backgroundLocation: location },
+      });
+      return;
+    }
+    if (app === 'Talk') {
+      const href = `/apps/groups/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`;
+      window.open(`${window.location.origin}${href}`, '_blank');
+      return;
+    }
+    navigate(`/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`);
+  };
 
   useEffect(() => {
     if (!isScrolling) {
@@ -49,7 +73,12 @@ export default function CurioReference({
   }
   return (
     <div className="heap-inline-block not-prose group">
-      <HeapBlock curio={curio} time={idCurio} refToken={refToken} asRef />
+      <div
+        onClick={handleOpenReferenceClick}
+        className="flex h-full cursor-pointer flex-col justify-between p-2"
+      >
+        <HeapBlock curio={curio} time={idCurio} refToken={refToken} asRef />
+      </div>
       <ReferenceBar
         nest={nest}
         time={bigInt(idCurio)}

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -8,7 +8,7 @@ import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { useLocation, useNavigate } from 'react-router';
-import useAppName from '@/logic/useAppName';
+import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
 import UnavailableReference from './UnavailableReference';
 
@@ -27,7 +27,7 @@ export default function CurioReference({
   const preview = useChannelPreview(nest);
   const location = useLocation();
   const navigate = useNavigate();
-  const app = useAppName();
+  const navigateByApp = useNavigateByApp();
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
@@ -43,12 +43,7 @@ export default function CurioReference({
       });
       return;
     }
-    if (app === 'Talk') {
-      const href = `/apps/groups/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`;
-      window.open(`${window.location.origin}${href}`, '_blank');
-      return;
-    }
-    navigate(`/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`);
+    navigateByApp(`/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`);
   };
 
   useEffect(() => {

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -7,9 +7,9 @@ import { makePrettyDate, pluralize } from '@/logic/utils';
 import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import Avatar from '@/components/Avatar';
-import useAppName from '@/logic/useAppName';
 import { NOTE_REF_DISPLAY_LIMIT } from '@/constants';
 import useGroupJoin from '@/groups/useGroupJoin';
+import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
 import UnavailableReference from './UnavailableReference';
 
@@ -30,9 +30,9 @@ export default function NoteReference({
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
   const outline = useRemoteOutline(chFlag, id, isScrolling);
+  const navigateByApp = useNavigateByApp();
   const navigate = useNavigate();
   const location = useLocation();
-  const app = useAppName();
 
   const initialize = useCallback(async () => {
     try {
@@ -55,12 +55,8 @@ export default function NoteReference({
       });
       return;
     }
-    if (app === 'Talk') {
-      const href = `/apps/groups/groups/${groupFlag}/channels/${nest}/note/${id}`;
-      window.open(`${window.location.origin}${href}`, '_blank');
-      return;
-    }
-    navigate(`/groups/${groupFlag}/channels/${nest}/note/${id}`);
+
+    navigateByApp(`/groups/${groupFlag}/channels/${nest}/note/${id}`);
   };
 
   const contentPreview = useMemo(() => {

--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback } from 'react';
 import cn from 'classnames';
 import Author from '@/chat/ChatMessage/Author';
-import { useNavigate } from 'react-router';
 import { daToUnix } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import ChannelIcon from '@/channels/ChannelIcon';
-import { nestToFlag } from '@/logic/utils';
-import useAppName from '@/logic/useAppName';
+import useNavigateByApp from '@/logic/useNavigateByApp';
 
 export default function ReferenceBar({
   nest,
@@ -28,23 +26,17 @@ export default function ReferenceBar({
   unSubbed?: boolean;
 }) {
   const groupFlagOrZod = groupFlag || '~zod/test';
-  const [nestApp] = nestToFlag(nest);
-  const app = useAppName();
-
-  const navigate = useNavigate();
+  const navigateByApp = useNavigateByApp();
   const unix = new Date(daToUnix(time));
 
   const navigateToChannel = useCallback(() => {
     if (unSubbed) {
       // TODO: hook this up to the Join Channel Modal
       console.log('join channel modal');
-    } else if (app === 'Talk' && (nestApp === 'diary' || nestApp === 'heap')) {
-      const href = `/apps/groups/groups/${groupFlagOrZod}/channels/${nest}`;
-      window.open(`${window.location.origin}${href}`, '_blank');
     } else {
-      navigate(`/groups/${groupFlagOrZod}/channels/${nest}`);
+      navigateByApp(`/groups/${groupFlagOrZod}/channels/${nest}`);
     }
-  }, [navigate, nest, groupFlagOrZod, unSubbed, app, nestApp]);
+  }, [nest, groupFlagOrZod, unSubbed, navigateByApp]);
 
   return (
     <div

--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -14,7 +14,6 @@ export default function ReferenceBar({
   channelTitle,
   author,
   top = false,
-  unSubbed = false,
 }: {
   nest: string;
   time: BigInteger;
@@ -23,20 +22,14 @@ export default function ReferenceBar({
   channelTitle?: string;
   author?: string;
   top?: boolean;
-  unSubbed?: boolean;
 }) {
   const groupFlagOrZod = groupFlag || '~zod/test';
   const navigateByApp = useNavigateByApp();
   const unix = new Date(daToUnix(time));
 
   const navigateToChannel = useCallback(() => {
-    if (unSubbed) {
-      // TODO: hook this up to the Join Channel Modal
-      console.log('join channel modal');
-    } else {
-      navigateByApp(`/groups/${groupFlagOrZod}/channels/${nest}`);
-    }
-  }, [nest, groupFlagOrZod, unSubbed, navigateByApp]);
+    navigateByApp(`/groups/${groupFlagOrZod}/channels/${nest}`);
+  }, [nest, groupFlagOrZod, navigateByApp]);
 
   return (
     <div

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -57,7 +57,6 @@ export default function WritBaseReference({
         nest={nest}
         time={time}
         author={writ.memo.author}
-        unSubbed
         groupFlag={preview?.group.flag}
         groupTitle={preview?.group.meta.title}
         channelTitle={preview?.meta?.title}

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -7,8 +7,8 @@ import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { ChatWrit } from '@/types/chat';
-import useAppName from '@/logic/useAppName';
 import useGroupJoin from '@/groups/useGroupJoin';
+import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
 
 export default function WritBaseReference({
@@ -21,7 +21,7 @@ export default function WritBaseReference({
   const preview = useChannelPreview(nest);
   const location = useLocation();
   const navigate = useNavigate();
-  const app = useAppName();
+  const navigateByApp = useNavigateByApp();
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
@@ -44,12 +44,7 @@ export default function WritBaseReference({
       });
       return;
     }
-    if (app === 'Talk') {
-      const href = `/apps/groups/groups/${groupFlag}/channels/${nest}?msg=${time}`;
-      window.open(`${window.location.origin}${href}`, '_blank');
-      return;
-    }
-    navigate(`/groups/${groupFlag}/channels/${nest}?msg=${time}`);
+    navigateByApp(`/groups/${groupFlag}/channels/${nest}?msg=${time}`);
   };
 
   return (

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -8,7 +8,6 @@ import bigInt from 'big-integer';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { ChatWrit } from '@/types/chat';
 import useGroupJoin from '@/groups/useGroupJoin';
-import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
 
 export default function WritBaseReference({
@@ -21,7 +20,6 @@ export default function WritBaseReference({
   const preview = useChannelPreview(nest);
   const location = useLocation();
   const navigate = useNavigate();
-  const navigateByApp = useNavigateByApp();
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
@@ -44,7 +42,7 @@ export default function WritBaseReference({
       });
       return;
     }
-    navigateByApp(`/groups/${groupFlag}/channels/${nest}?msg=${time}`);
+    navigate(`/groups/${groupFlag}/channels/${nest}?msg=${time}`);
   };
 
   return (

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -85,7 +85,6 @@ function setNewDays(quips: [string, DiaryCommentProps[]][]) {
 export default function DiaryNote() {
   const [loading, setLoading] = useState(false);
   const { chShip, chName, noteId = '' } = useParams();
-  const joinRef = new URLSearchParams(window.location.search).get('joinref');
   const chFlag = `${chShip}/${chName}`;
   const flag = useRouteGroup();
   const group = useGroup(flag);
@@ -112,16 +111,13 @@ export default function DiaryNote() {
 
   const load = useCallback(async () => {
     await useDiaryState.getState().initialize(chFlag);
-    if (joinRef) {
-      setTimeout(async () => {
-        // TODO: figure out why this is setTimeout necessary
-        await useDiaryState.getState().fetchNote(chFlag, noteId);
-      }, 300);
-    } else {
+    try {
       await useDiaryState.getState().fetchNote(chFlag, noteId);
+    } catch (e) {
+      console.log("Couldn't load note", e);
     }
     setLoading(false);
-  }, [chFlag, noteId, joinRef]);
+  }, [chFlag, noteId]);
 
   const setSort = useCallback(
     (setting: 'asc' | 'dsc') => {

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Divider from '@/components/Divider';
 import Layout from '@/components/Layout/Layout';
 import { canWriteChannel, pluralize, sampleQuippers } from '@/logic/utils';
@@ -86,6 +85,7 @@ function setNewDays(quips: [string, DiaryCommentProps[]][]) {
 export default function DiaryNote() {
   const [loading, setLoading] = useState(false);
   const { chShip, chName, noteId = '' } = useParams();
+  const joinRef = new URLSearchParams(window.location.search).get('joinref');
   const chFlag = `${chShip}/${chName}`;
   const flag = useRouteGroup();
   const group = useGroup(flag);
@@ -112,9 +112,16 @@ export default function DiaryNote() {
 
   const load = useCallback(async () => {
     await useDiaryState.getState().initialize(chFlag);
-    await useDiaryState.getState().fetchNote(chFlag, noteId);
+    if (joinRef) {
+      setTimeout(async () => {
+        // TODO: figure out why this is setTimeout necessary
+        await useDiaryState.getState().fetchNote(chFlag, noteId);
+      }, 300);
+    } else {
+      await useDiaryState.getState().fetchNote(chFlag, noteId);
+    }
     setLoading(false);
-  }, [chFlag, noteId]);
+  }, [chFlag, noteId, joinRef]);
 
   const setSort = useCallback(
     (setting: 'asc' | 'dsc') => {

--- a/ui/src/groups/Join/JoinGroupModal.tsx
+++ b/ui/src/groups/Join/JoinGroupModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import Dialog, { DialogContent } from '@/components/Dialog';
-import { useGang, useRouteGroup } from '@/state/groups';
+import { useGang, useGroupState, useRouteGroup } from '@/state/groups';
 import GroupSummary from '@/groups/GroupSummary';
 import useGroupJoin from '@/groups/useGroupJoin';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
@@ -10,10 +10,24 @@ import { matchesBans, pluralRank, toTitleCase } from '@/logic/utils';
 export default function JoinGroupModal() {
   const navigate = useNavigate();
   const flag = useRouteGroup();
+  const nest = new URLSearchParams(window.location.search).get('nest');
+  const id = new URLSearchParams(window.location.search).get('id');
+  const type = new URLSearchParams(window.location.search).get('type');
   const gang = useGang(flag);
-  const { group, dismiss, reject, button, status } = useGroupJoin(flag, gang);
+  const { group, dismiss, reject, button, status } = useGroupJoin(
+    flag,
+    gang,
+    true,
+    nest && id && type ? { nest, id, type } : undefined
+  );
   const cordon = gang.preview?.cordon || group?.cordon;
   const banned = cordon ? matchesBans(cordon, window.our) : null;
+
+  useEffect(() => {
+    if (!gang.preview && !group) {
+      useGroupState.getState().search(flag);
+    }
+  }, [flag, gang.preview, group]);
 
   useEffect(() => {
     if (group) {
@@ -25,7 +39,7 @@ export default function JoinGroupModal() {
     <Dialog defaultOpen onOpenChange={() => dismiss()}>
       <DialogContent containerClass="w-full max-w-md">
         <div className="space-y-6">
-          <h2 className="text-lg font-bold">Join a Group</h2>
+          <h2 className="text-lg font-bold">Join This Group</h2>
           <GroupSummary flag={flag} preview={gang.preview} />
           <p>{gang.preview?.meta.description}</p>
           <div className="flex items-center justify-end space-x-2">

--- a/ui/src/groups/useGroupJoin.ts
+++ b/ui/src/groups/useGroupJoin.ts
@@ -29,7 +29,10 @@ function getButtonText(
 export default function useGroupJoin(
   flag: string,
   gang: Gang,
-  inModal = false
+  inModal = false,
+  redirectItem:
+    | { nest: string; id: string; type: string }
+    | undefined = undefined
 ) {
   const [status, setStatus] = useState<Status>('initial');
   const location = useLocation();
@@ -79,7 +82,25 @@ export default function useGroupJoin(
       try {
         await useGroupState.getState().join(flag, true);
         setStatus('success');
-        if (isTalk) {
+        if (redirectItem) {
+          if (redirectItem.type === 'chat') {
+            if (isTalk) {
+              const href = `/apps/groups/groups/${flag}/channels/${redirectItem.nest}?msg=${redirectItem.id}&joinref=true`;
+              window.open(`${window.location.origin}${href}`, '_blank');
+            } else {
+              navigate(
+                `/groups/${flag}/channels/${redirectItem.nest}?msg=${redirectItem.id}&joinref=true`
+              );
+            }
+          } else if (isTalk) {
+            const href = `/apps/groups/groups/${flag}/channels/${redirectItem.nest}/${redirectItem.type}/${redirectItem.id}&joinref=true`;
+            window.open(`${window.location.origin}${href}`, '_blank');
+          } else {
+            navigate(
+              `/groups/${flag}/channels/${redirectItem.nest}/${redirectItem.type}/${redirectItem.id}?joinref=true`
+            );
+          }
+        } else if (isTalk) {
           const href = `/apps/groups/groups/${flag}/`;
           window.open(`${window.location.origin}${href}`, '_blank');
         } else {
@@ -100,7 +121,7 @@ export default function useGroupJoin(
         }
       }
     }
-  }, [privacy, invited, flag, navigate, requested]);
+  }, [privacy, invited, flag, navigate, requested, redirectItem]);
 
   const reject = useCallback(async () => {
     /**

--- a/ui/src/groups/useGroupJoin.ts
+++ b/ui/src/groups/useGroupJoin.ts
@@ -79,11 +79,11 @@ export default function useGroupJoin(
         if (redirectItem) {
           if (redirectItem.type === 'chat') {
             return navigateByApp(
-              `/groups/${flag}/channels/${redirectItem.nest}?msg=${redirectItem.id}&joinref=true`
+              `/groups/${flag}/channels/${redirectItem.nest}?msg=${redirectItem.id}`
             );
           }
           return navigateByApp(
-            `/groups/${flag}/channels/${redirectItem.nest}/${redirectItem.type}/${redirectItem.id}?joinref=true`
+            `/groups/${flag}/channels/${redirectItem.nest}/${redirectItem.type}/${redirectItem.id}`
           );
         }
         return navigateByApp(`/groups/${flag}`);

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useHeapState, useOrderedCurios } from '@/state/heap/heap';
 import useNest from '@/logic/useNest';
@@ -22,6 +22,7 @@ export default function HeapDetail() {
   const nest = useNest();
   const [, chFlag] = nestToFlag(nest);
   const { time, curio } = useCurioFromParams();
+  const [loading, setLoading] = useState(false);
 
   const { hasNext, hasPrev, nextCurio, prevCurio } = useOrderedCurios(
     chFlag,
@@ -38,9 +39,11 @@ export default function HeapDetail() {
 
   const load = useCallback(async () => {
     await useHeapState.getState().initialize(chFlag);
+    setLoading(false);
   }, [chFlag]);
 
   useEffect(() => {
+    setLoading(true);
     load();
   }, [load]);
 
@@ -68,10 +71,6 @@ export default function HeapDetail() {
     }
   });
 
-  if (!curio || !time) {
-    return null;
-  }
-
   return (
     <Layout
       className="flex-1 bg-gray-50"
@@ -79,7 +78,7 @@ export default function HeapDetail() {
         <HeapDetailHeader
           flag={groupFlag}
           chFlag={chFlag}
-          idCurio={time.toString() || ''}
+          idCurio={time?.toString() || ''}
         />
       }
     >
@@ -99,7 +98,7 @@ export default function HeapDetail() {
               </Link>
             </div>
           ) : null}
-          <HeapDetailBody curio={curio} />
+          {curio ? <HeapDetailBody curio={curio} /> : null}
           {hasPrev ? (
             <div className="absolute top-0 right-0 flex h-full w-16 flex-col justify-center">
               <Link
@@ -116,8 +115,12 @@ export default function HeapDetail() {
           ) : null}
         </div>
         <div className="flex w-full flex-col border-gray-50 bg-white sm:mt-5 lg:mt-0 lg:h-full lg:w-72 lg:border-l-2 xl:w-96">
-          <HeapDetailSidebarInfo curio={curio} />
-          <HeapDetailComments time={time} />
+          {curio && time ? (
+            <>
+              <HeapDetailSidebarInfo curio={curio} />
+              <HeapDetailComments time={time} />
+            </>
+          ) : null}
         </div>
       </div>
     </Layout>

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -39,7 +39,11 @@ export default function HeapDetail() {
   };
 
   const load = useCallback(async () => {
-    await useHeapState.getState().initialize(chFlag);
+    try {
+      await useHeapState.getState().initialize(chFlag);
+    } catch (e) {
+      console.log("Couldn't load heap", e);
+    }
     setLoading(false);
   }, [chFlag]);
 

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -10,6 +10,7 @@ import bigInt from 'big-integer';
 import CaretRightIcon from '@/components/icons/CaretRightIcon';
 import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
 import { useEventListener } from 'usehooks-ts';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import HeapDetailSidebarInfo from './HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo';
 import HeapDetailComments from './HeapDetail/HeapDetailSidebar/HeapDetailComments';
 import HeapDetailHeader from './HeapDetail/HeapDetailHeader';
@@ -83,45 +84,51 @@ export default function HeapDetail() {
       }
     >
       <div className="flex h-full w-full flex-col overflow-y-auto lg:flex-row">
-        <div className="group relative flex flex-1">
-          {hasNext ? (
-            <div className="absolute top-0 left-0 flex h-full w-16 flex-col justify-center">
-              <Link
-                to={curioHref(nextCurio?.[0])}
-                className={
-                  'z-40 flex h-16 w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
-                }
-              >
-                <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
-                  <CaretLeftIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
+        {loading ? (
+          <LoadingSpinner />
+        ) : (
+          <>
+            <div className="group relative flex flex-1">
+              {hasNext ? (
+                <div className="absolute top-0 left-0 flex h-full w-16 flex-col justify-center">
+                  <Link
+                    to={curioHref(nextCurio?.[0])}
+                    className={
+                      'z-40 flex h-16 w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
+                    }
+                  >
+                    <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
+                      <CaretLeftIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
+                    </div>
+                  </Link>
                 </div>
-              </Link>
-            </div>
-          ) : null}
-          {curio ? <HeapDetailBody curio={curio} /> : null}
-          {hasPrev ? (
-            <div className="absolute top-0 right-0 flex h-full w-16 flex-col justify-center">
-              <Link
-                to={curioHref(prevCurio?.[0])}
-                className={
-                  'z-40 flex h-16 w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
-                }
-              >
-                <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
-                  <CaretRightIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
+              ) : null}
+              {curio ? <HeapDetailBody curio={curio} /> : null}
+              {hasPrev ? (
+                <div className="absolute top-0 right-0 flex h-full w-16 flex-col justify-center">
+                  <Link
+                    to={curioHref(prevCurio?.[0])}
+                    className={
+                      'z-40 flex h-16 w-16 flex-col items-center justify-center bg-transparent opacity-0 transition-opacity group-hover:opacity-100'
+                    }
+                  >
+                    <div className="h-8 w-8 rounded border-gray-300 bg-white p-[3px]">
+                      <CaretRightIcon className="my-0 mx-auto block h-6 w-6 text-gray-300" />
+                    </div>
+                  </Link>
                 </div>
-              </Link>
+              ) : null}
             </div>
-          ) : null}
-        </div>
-        <div className="flex w-full flex-col border-gray-50 bg-white sm:mt-5 lg:mt-0 lg:h-full lg:w-72 lg:border-l-2 xl:w-96">
-          {curio && time ? (
-            <>
-              <HeapDetailSidebarInfo curio={curio} />
-              <HeapDetailComments time={time} />
-            </>
-          ) : null}
-        </div>
+            <div className="flex w-full flex-col border-gray-50 bg-white sm:mt-5 lg:mt-0 lg:h-full lg:w-72 lg:border-l-2 xl:w-96">
+              {curio && time ? (
+                <>
+                  <HeapDetailSidebarInfo curio={curio} />
+                  <HeapDetailComments time={time} />
+                </>
+              ) : null}
+            </div>
+          </>
+        )}
       </div>
     </Layout>
   );

--- a/ui/src/logic/useNavigateByApp.ts
+++ b/ui/src/logic/useNavigateByApp.ts
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router';
+import useAppName from './useAppName';
+
+export default function useNavigateByApp() {
+  const { origin } = window.location;
+  const navigate = useNavigate();
+  const app = useAppName();
+
+  const navFn = (path: string) => {
+    const isGroupsPath =
+      path.startsWith('/groups') ||
+      path.startsWith('/find') ||
+      path.startsWith('/gangs');
+    const isTalkPath = path.startsWith('/dm');
+
+    if (app === 'Talk') {
+      if (isGroupsPath) {
+        const href = `${origin}/apps/groups${path}`;
+        return window.open(href, '_blank');
+      }
+      return navigate(path);
+    }
+
+    if (app === 'Groups') {
+      if (isTalkPath) {
+        const href = `${origin}/apps/talk${path}`;
+        return window.open(href, '_blank');
+      }
+      return navigate(path);
+    }
+
+    return navigate(path);
+  };
+
+  return navFn;
+}

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import React, { useCallback } from 'react';
+import { useParams } from 'react-router';
 import { useDismissNavigate } from '@/logic/routing';
 import { useCopy } from '@/logic/utils';
 import { useContact } from '@/state/contact';
 import Avatar from '@/components/Avatar';
 import Dialog, { DialogContent } from '@/components/Dialog';
 import ShipName from '@/components/ShipName';
-import useAppName from '@/logic/useAppName';
+import useNavigateByApp from '@/logic/useNavigateByApp';
 import ProfileCoverImage from './ProfileCoverImage';
 import FavoriteGroupGrid from './FavoriteGroupGrid';
 import ProfileBio from './ProfileBio';
@@ -14,11 +14,10 @@ import ProfileBio from './ProfileBio';
 export default function ProfileModal() {
   const { ship } = useParams();
   const { doCopy, didCopy } = useCopy(ship || '');
-  const navigate = useNavigate();
-  const app = useAppName();
   const contact = useContact(ship ? ship : '');
   const cover = contact?.cover || '';
   const dismiss = useDismissNavigate();
+  const navigateByApp = useNavigateByApp();
 
   const onCopy = useCallback(() => {
     doCopy();
@@ -35,12 +34,7 @@ export default function ProfileModal() {
   };
 
   const handleMessageClick = () => {
-    if (app === 'Groups') {
-      const href = `/apps/talk/dm/${ship}`;
-      window.open(`${window.location.origin}${href}`, '_blank');
-    } else {
-      navigate(`/dm/${ship}`);
-    }
+    navigateByApp(`/dm/${ship}`);
   };
 
   const handleCopyClick = () => {


### PR DESCRIPTION
Fixes #1841 

Using the group join modal and some URL parameters to give users the option to join a (public, otherwise they wouldn't be able to see the ref anyway) group from a ref and then automatically navigating the user to the content from the ref after the join completes.

Demo video (excuse the confusion after I click through the first ref, I used the browser back button instead of the app nav):

https://user-images.githubusercontent.com/1221094/216381861-8ca124cc-ae9d-4a18-865c-ba9ea03304f9.mov

