### PR TITLE
uselocalstorage: gracefully fail if localstorage errors

### DIFF
--- a/ui/patches/usehooks-ts+2.6.0.patch
+++ b/ui/patches/usehooks-ts+2.6.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/usehooks-ts/src/useLocalStorage/useLocalStorage.ts b/node_modules/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+index 7b23076..29ba2fa 100644
+--- a/node_modules/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
++++ b/node_modules/usehooks-ts/src/useLocalStorage/useLocalStorage.ts
+@@ -64,6 +64,11 @@ function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
+       window.dispatchEvent(new Event('local-storage'))
+     } catch (error) {
+       console.warn(`Error setting localStorage key “${key}”:`, error)
++      
++      // Allow value to be a function so we have the same API as useState
++      const newValue = value instanceof Function ? value(storedValue) : value
++      // Save state
++      setStoredValue(newValue)
+     }
+   })
+ 


### PR DESCRIPTION
Have a feeling Safari is blocking writing to local storage so should fix #1893, but need more info. This is a bug in our dep: juliencrn/usehooks-ts#124