### PR TITLE
groups: simplify grouplist, fix scroll pinned groups issue, remove dnd

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -12,14 +12,11 @@ import AppGroupsIcon from '@/components/icons/AppGroupsIcon';
 import MagnifyingGlass from '@/components/icons/MagnifyingGlass16Icon';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import AddIcon16 from '@/components/icons/Add16Icon';
-import SidebarSorter from '@/components/Sidebar/SidebarSorter';
 import { usePinnedGroups } from '@/state/chat';
-import { hasKeys } from '@/logic/utils';
 import ShipName from '@/components/ShipName';
 import Avatar, { useProfileColor } from '@/components/Avatar';
 import useGroupSort from '@/logic/useGroupSort';
 import { useNotifications } from '@/notifications/useNotifications';
-import { debounce } from 'lodash';
 import ArrowNWIcon from '../icons/ArrowNWIcon';
 import MenuIcon from '../icons/MenuIcon';
 import AsteriskIcon from '../icons/Asterisk16Icon';
@@ -110,44 +107,15 @@ export default function Sidebar() {
   const isMobile = useIsMobile();
   const location = useLocation();
   const pendingInvites = usePendingInvites();
-  const [scrolledFromTop, setScrolledFromTop] = useState(false);
 
   const pendingInvitesCount = pendingInvites.length;
   const { count } = useNotifications();
 
-  const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
+  const { sortGroups } = useGroupSort();
   const groups = useGroups();
   const pinnedGroups = usePinnedGroups();
   const sortedGroups = sortGroups(groups);
-  const sortedPinnedGroups = sortGroups(pinnedGroups);
   const shipColor = useProfileColor(window.our);
-
-  const ref = useRef<HTMLUListElement>(null);
-
-  const classes = useMemo(
-    () =>
-      cn(
-        'flex w-full flex-col space-y-1 px-2 pt-2',
-        scrolledFromTop && 'bottom-shadow'
-      ),
-    [scrolledFromTop]
-  );
-
-  // to prevent re-render, only set state when necessary
-  const scrollHandler = useCallback(() => {
-    debounce(() => {
-      if (ref.current?.scrollTop === 0) {
-        if (!scrolledFromTop) {
-          setScrolledFromTop(true);
-        }
-      } else {
-        // eslint-disable-next-line no-lonely-if
-        if (scrolledFromTop) {
-          setScrolledFromTop(false);
-        }
-      }
-    }, 100);
-  }, [scrolledFromTop]);
 
   if (isMobile) {
     return <MobileSidebar />;
@@ -155,7 +123,7 @@ export default function Sidebar() {
 
   return (
     <nav className="flex h-full w-64 flex-col bg-white">
-      <ul className={classes}>
+      <ul>
         {/* TODO: FETCH WINDOW.OUR WITHOUT IT RETURNING UNDEFINED */}
         <GroupsAppMenu />
         <div className="h-5" />
@@ -194,38 +162,11 @@ export default function Sidebar() {
           Create Group
         </SidebarItem>
       </ul>
-      <ul
-        ref={ref}
-        onScroll={scrollHandler}
-        className="flex-initial overflow-y-auto overflow-x-hidden px-2"
-      >
-        {hasKeys(pinnedGroups) ? (
-          <GroupList
-            className="p-2"
-            pinned
-            groups={sortedGroups}
-            pinnedGroups={sortedPinnedGroups}
-          />
-        ) : null}
-        <li className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
-          <span className="ml-4 text-sm font-semibold text-gray-400">
-            All Groups
-          </span>
-        </li>
-        <li className="relative p-2">
-          <SidebarSorter
-            sortFn={sortFn}
-            setSortFn={setSortFn}
-            sortOptions={sortOptions}
-            isMobile={isMobile}
-          />
-        </li>
-      </ul>
       <div className="flex-auto">
         <GroupList
           className="p-2"
           groups={sortedGroups}
-          pinnedGroups={sortedPinnedGroups}
+          pinnedGroups={Object.entries(pinnedGroups)}
         />
       </div>
     </nav>

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -5,9 +5,7 @@ exports[`Sidebar > renders as expected 1`] = `
   <nav
     class="flex h-full w-64 flex-col bg-white"
   >
-    <ul
-      class="flex w-full flex-col space-y-1 px-2 pt-2"
-    >
+    <ul>
       <div
         class="group relative flex w-full items-center justify-between rounded-lg text-lg font-semibold sm:text-base text-gray-600 hover:bg-gray-50"
       >
@@ -292,69 +290,6 @@ exports[`Sidebar > renders as expected 1`] = `
             Create Group
           </div>
         </a>
-      </li>
-    </ul>
-    <ul
-      class="flex-initial overflow-y-auto overflow-x-hidden px-2"
-    >
-      <li
-        class="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2"
-      >
-        <span
-          class="ml-4 text-sm font-semibold text-gray-400"
-        >
-          All Groups
-        </span>
-      </li>
-      <li
-        class="relative p-2"
-      >
-        <button
-          aria-expanded="false"
-          aria-haspopup="menu"
-          aria-label="Groups Sort Options"
-          class="default-focus flex w-full items-center justify-between rounded-lg bg-gray-50 py-1 px-2 text-sm font-semibold"
-          data-state="closed"
-          id="radix-1"
-          type="button"
-        >
-          <span
-            class="flex items-center"
-          >
-            <svg
-              class="h-4 w-4 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                class="fill-current"
-                clip-rule="evenodd"
-                d="M17.207 4.793a1 1 0 0 0-1.414 0l-3 3a1 1 0 0 0 1.414 1.414L15.5 7.914V17.5a1 1 0 1 0 2 0V7.914l1.293 1.293a1 1 0 1 0 1.414-1.414l-3-3ZM8.5 5.5a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414l3 3a1 1 0 0 0 1.414 0l3-3a1 1 0 0 0-1.414-1.414L8.5 15.086V5.5Z"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <span
-              class="mr-2 pl-1"
-            >
-              Sort: A → Z
-            </span>
-          </span>
-          <svg
-            class="h-4 w-4 text-gray-400"
-            fill="none"
-            viewBox="0 0 16 16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="stroke-current"
-              d="m4 6 4 4 4-4"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </button>
       </li>
     </ul>
     <div

--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -16,6 +16,8 @@ import {
   SidebarFilter,
   useSettingsState,
 } from '@/state/settings';
+import { useGroupState } from '@/state/groups';
+import { whomIsDm, whomIsMultiDm } from '@/logic/utils';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
 import { MessagesScrollingContext } from './MessagesScrollingContext';
@@ -28,6 +30,15 @@ export default function MobileMessagesSidebar() {
   const [isScrolling, setIsScrolling] = useState(false);
   const { messagesFilter } = useSettingsState(selMessagesFilter);
   const pinned = usePinned();
+  const filteredPins = pinned.filter((p) => {
+    const nest = `chat/${p}`;
+    const { groups } = useGroupState.getState();
+    const groupFlag = Object.entries(groups).find(
+      ([k, v]) => nest in v.channels
+    )?.[0];
+    const channel = groups[groupFlag || '']?.channels[nest];
+    return !!channel || whomIsDm(p) || whomIsMultiDm(p);
+  });
 
   const setFilterMode = (mode: SidebarFilter) => {
     useSettingsState.getState().putEntry('talk', 'messagesFilter', mode);
@@ -45,7 +56,7 @@ export default function MobileMessagesSidebar() {
     >
       <MessagesScrollingContext.Provider value={isScrolling}>
         <MessagesList filter={messagesFilter} isScrolling={scroll.current}>
-          {pinned && pinned.length > 0 ? (
+          {filteredPins && filteredPins.length > 0 ? (
             <div className="-mb-2 md:mb-0">
               <div className="-mb-2 flex items-center p-2 md:m-0">
                 <Divider>Pinned</Divider>

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
 import useGroupSort from '@/logic/useGroupSort';
-import { hasKeys } from '@/logic/utils';
 import { usePinnedGroups } from '@/state/chat';
 import { useGroups } from '@/state/groups';
 import GroupList from '@/components/Sidebar/GroupList';
@@ -15,7 +14,6 @@ export default function MobileRoot() {
   const groups = useGroups();
   const pinnedGroups = usePinnedGroups();
   const sortedGroups = sortGroups(groups);
-  const sortedPinnedGroups = sortGroups(pinnedGroups);
 
   return (
     <>
@@ -38,24 +36,11 @@ export default function MobileRoot() {
         </div>
       </header>
       <nav className="flex h-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
-        {hasKeys(pinnedGroups) ? (
-          <ul className="mb-3 space-y-2 px-2 sm:mb-2 sm:space-y-0 md:mb-0">
-            <GroupList
-              pinned
-              groups={sortedGroups}
-              pinnedGroups={sortedPinnedGroups}
-            />
-          </ul>
-        ) : null}
-        <ul className="mb-3 space-y-2 px-2 sm:mb-2 sm:space-y-0 md:mb-0">
-          <li className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
-            <span className="ml-4 text-sm font-semibold text-gray-400">
-              All Groups
-            </span>
-          </li>
-        </ul>
         <div className="flex-1">
-          <GroupList groups={sortedGroups} pinnedGroups={sortedPinnedGroups} />
+          <GroupList
+            groups={sortedGroups}
+            pinnedGroups={Object.entries(pinnedGroups)}
+          />
         </div>
       </nav>
     </>


### PR DESCRIPTION
Fixes #1824 

Didn't create the context for scrolling since we don't have nearly as many items in this list as we do in Talk.

We do have a separate scrollable section here for non-pinned groups since we're using Virtuoso to render them separately. Should we?

https://user-images.githubusercontent.com/1221094/218182443-156d07a8-f7fa-421c-9ba6-b6b0b74f818d.mov

Also fixes #1835 

