### PR TITLE
ux: Leap sorts by pinned, unreads, and pals

### DIFF
--- a/ui/src/components/Leap/MenuOptions.tsx
+++ b/ui/src/components/Leap/MenuOptions.tsx
@@ -29,18 +29,11 @@ export interface IMenuOption {
 
 export const groupsMenuOptions: IMenuOption[] = [
   {
-    title: 'Profile',
-    subtitle: '',
-    to: '/profile/edit',
-    icon: CommandBadge,
-  },
-  {
     title: 'Notifications',
     subtitle: '',
     to: '/',
     icon: CommandBadge,
   },
-
   {
     title: 'Find Groups',
     subtitle: '',
@@ -52,6 +45,12 @@ export const groupsMenuOptions: IMenuOption[] = [
     subtitle: '',
     to: '/groups/new',
     icon: PlusBadge,
+  },
+  {
+    title: 'Profile',
+    subtitle: '',
+    to: '/profile/edit',
+    icon: CommandBadge,
   },
   {
     title: 'Talk',

--- a/ui/src/components/Leap/useLeap.ts
+++ b/ui/src/components/Leap/useLeap.ts
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { cite, Contact, deSig, preSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import { getFlagParts, nestToFlag } from '@/logic/utils';
-import { useGroups } from '@/state/groups';
+import { useGroupFlag, useGroups } from '@/state/groups';
 import { Group, GroupChannel } from '@/types/groups';
 import {
   LEAP_DESCRIPTION_TRUNCATE_LENGTH,
@@ -32,6 +32,7 @@ export default function useLeap() {
   const navigate = useNavigate();
   const modalNavigate = useModalNavigate();
   const groups = useGroups();
+  const currentGroupFlag = useGroupFlag();
   const { isGroupUnread } = useIsGroupUnread();
   const isChannelUnread = useCheckChannelUnread();
   const pinnedGroups = usePinnedGroups();
@@ -227,7 +228,7 @@ export default function useLeap() {
       // pinned channels are strong signals
       const isPinned = pinnedChats.includes(nest);
       if (isPinned) {
-        newScore += 10;
+        newScore += 8;
       }
 
       // so are unread channels
@@ -236,7 +237,13 @@ export default function useLeap() {
         newScore += 7;
       }
 
-      // so are pinned groups, but less so
+      // so is if the channel we're looking for is within the current group that we're in
+      const isCurrentGroup = groupFlag === currentGroupFlag;
+      if (isCurrentGroup) {
+        newScore += 6;
+      }
+
+      // so are channels within pinned groups, but less so
       const isGroupPinned = groupFlag in pinnedGroups;
       if (isGroupPinned) {
         newScore += 4;
@@ -306,6 +313,7 @@ export default function useLeap() {
       }),
     ];
   }, [
+    currentGroupFlag,
     groups,
     inputValue,
     isChannelUnread,

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -7,6 +7,7 @@ export const MAX_DISPLAYED_OPTIONS = 40;
 export const NOTE_REF_DISPLAY_LIMIT = 600;
 export const LEAP_DESCRIPTION_TRUNCATE_LENGTH = 48;
 export const LEAP_RESULT_TRUNCATE_SIZE = 5;
+export const LEAP_RESULT_SCORE_THRESHOLD = 10;
 
 export const PASTEABLE_IMAGE_TYPES = [
   'image/gif',

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -8,6 +8,7 @@ import { useGroupState } from './groups';
 import useHarkState from './hark';
 import { useHeapState } from './heap/heap';
 import useKilnState from './kiln';
+import usePalsState from './pals';
 import { useSettingsState } from './settings';
 import { useStorage } from './storage';
 
@@ -41,4 +42,6 @@ export default async function bootstrap(reset = false) {
   useKilnState.getState().initializeKiln();
   const { fetchCharges } = useDocketState.getState();
   fetchCharges();
+
+  usePalsState.getState().initializePals();
 }

--- a/ui/src/state/pals.ts
+++ b/ui/src/state/pals.ts
@@ -1,0 +1,153 @@
+// Special thanks @willbach of @uqbar-dao
+import create, { SetState } from 'zustand';
+import api from '@/api';
+
+interface Outgoing {
+  lists: string[];
+  ack: boolean | null;
+}
+
+export interface PalsRequests {
+  incoming: { [key: string]: boolean };
+  outgoing: { [key: string]: Outgoing | null };
+}
+
+export interface MutualPals {
+  [key: string]: { lists: string[] } | null;
+}
+
+interface PalsState {
+  loading: boolean;
+  installed: boolean;
+  pals: PalsRequests;
+  mutuals: MutualPals;
+  pending: string[];
+  fetchPals: () => Promise<void>;
+  addPal: (ship: string, tags?: string[]) => Promise<void>;
+  removePal: (ship: string) => Promise<void>;
+  initializePals: () => Promise<void>;
+  set: SetState<PalsState>;
+}
+
+const usePalsState = create<PalsState>((set, get) => ({
+  loading: true,
+  installed: false,
+  pals: { incoming: {}, outgoing: {} },
+  mutuals: {},
+  pending: [],
+  fetchPals: async () => {
+    try {
+      const data: any = await api.scry({ app: 'pals', path: '/json' });
+      if (!data.incoming) {
+        data.incoming = {};
+      }
+      if (!data.outgoing) {
+        data.outgoing = {};
+      }
+      const mutuals = Object.keys(data.outgoing).reduce((acc, cur) => {
+        if (data?.incoming?.[cur]) {
+          // eslint-disable-next-line no-param-reassign
+          acc[cur] = data?.outgoing?.[cur]?.lists;
+        }
+        return acc;
+      }, {} as { [key: string]: any });
+      set({
+        pals: data,
+        mutuals,
+        installed: true,
+        loading: false,
+      });
+    } catch (err) {
+      console.warn('PALS SCRY ERROR:', err);
+      set({ loading: false });
+    }
+  },
+  addPal: async (ship: string, tags = []) => {
+    await api.poke({
+      app: 'pals',
+      mark: 'pals-command',
+      json: {
+        meet: { ship, in: tags },
+      },
+    });
+
+    set({
+      pals: {
+        ...get().pals,
+        outgoing: {
+          ...get().pals.outgoing,
+          [ship]: { ack: true, lists: tags },
+        },
+      },
+    });
+  },
+  removePal: async (ship: string) => {
+    await api.poke({
+      app: 'pals',
+      mark: 'pals-command',
+      json: {
+        part: { ship, in: [] },
+      },
+    });
+  },
+  initializePals: async () => {
+    await get().fetchPals();
+
+    api.subscribe({
+      app: 'pals',
+      path: '/leeches',
+      event: (data: any) => {
+        usePalsState.getState().set((draft) => {
+          const { near } = data;
+
+          if (!draft.mutuals[near]) {
+            draft.pals.incoming[near] = true;
+
+            if (draft.pals.outgoing[near]) {
+              draft.mutuals[near] = { lists: [] };
+            } else {
+              draft.pending = draft.pending
+                .filter((s) => s !== near)
+                .concat([near]);
+            }
+          }
+        });
+      },
+    });
+
+    api.subscribe({
+      app: 'pals',
+      path: '/targets',
+      event: (data: any) => {
+        usePalsState.getState().set((draft) => {
+          const { meet, part } = data;
+          if (meet) {
+            if (!draft.mutuals[meet]) {
+              draft.pals.outgoing[meet] = { ack: true, lists: [] };
+
+              if (draft.pals.incoming[meet]) {
+                draft.mutuals[meet] = { lists: [] };
+              }
+            }
+          } else if (part) {
+            draft.mutuals[part] = null;
+            draft.pals.outgoing[part] = null;
+          }
+        });
+      },
+    });
+  },
+  set,
+}));
+
+const selPals = (state: PalsState) => state.pals;
+export function usePals() {
+  return usePalsState(selPals);
+}
+
+const selMutuals = (state: PalsState) => state.mutuals;
+export function useMutuals() {
+  return usePalsState(selMutuals);
+}
+
+export default usePalsState;


### PR DESCRIPTION
# Context

After using preview Leap, noticed I was using it to primarily jump between my unreads and pins. So, this PR bakes in some of this behavior.

# Changes

- [x] score Group results by membership in `pinnedGroups`, then by `isGroupUnread`, then A-->Z
- [x] score Channel results by membership in `pinned`, then if it's a member of a group in `pinnedGroups`, then by if the channel is within the currently viewed group, then by `isChannelUnread`, then by A-->Z
- [x] score Ships results by prioritizing mutuals in %pals graph, the mention heuristics (e.g., downrank comets), then by unread status
- [x] fuzzy string compare when filtering
