### PR TITLE
Only show pinned if we have talk pins, filter out left/deleted group channels from briefs

### DIFF
--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -89,6 +89,10 @@ export default function MessagesList({
           return false;
         }
 
+        if (isGroupBrief(b) && !group) {
+          return false;
+        }
+
         return true; // is all
       }),
     [allPending, briefs, chats, filter, groups, pinned, sortMessages]


### PR DESCRIPTION
Applying the same fix applied to the mobile messages list (only show the "Pinned" section if we have pinned channels/DMs, not pinned groups, which won't render anyway), and fix a separate issue where a blank row could appear in the list if a user has left a group/channel or that group/channel was deleted (not sure how we missed this before).