### PR TITLE
chat: fix new dms

### DIFF
--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -395,7 +395,7 @@ export default function ShipSelector({
 
         if (parts.every((s) => isValidNewOption(preSig(s)))) {
           const options: ShipOption[] = parts.map((p) => ({
-            value: p,
+            value: preSig(p),
             label: contacts[p]?.nickname || p,
           }));
           const newShips = _.uniqBy([...ships, ...options], 'value');
@@ -422,9 +422,9 @@ export default function ShipSelector({
         actionMeta.action
       )
     ) {
-      const validPatps = newValue.filter((o) =>
-        isValidNewOption(preSig(o.value))
-      );
+      const validPatps = newValue
+        .map((v) => ({ ...v, value: preSig(v.value) }))
+        .filter((o) => isValidNewOption(o.value));
       setShips(validPatps);
     }
   };
@@ -439,9 +439,10 @@ export default function ShipSelector({
       ) &&
       newValue !== null
     ) {
-      const validPatp = isValidNewOption(preSig(newValue.value));
+      const normValue = { ...newValue, value: preSig(newValue.value) };
+      const validPatp = isValidNewOption(normValue.value);
       if (validPatp) {
-        setShips([newValue]);
+        setShips([normValue]);
       }
     }
   };

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -7,7 +7,8 @@ import { ShipOption } from '@/components/ShipSelector';
 import { useChatState, useMultiDms } from '@/state/chat';
 import createClub from '@/state/chat/createClub';
 import { ChatMemo } from '@/types/chat';
-import { createStorageKey, newUv, preSig } from './utils';
+import { BigIntOrderedMap } from '@urbit/api';
+import { createStorageKey, newUv, preSig, whomIsDm } from './utils';
 
 export default function useMessageSelector() {
   const navigate = useNavigate();

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -7,8 +7,7 @@ import { ShipOption } from '@/components/ShipSelector';
 import { useChatState, useMultiDms } from '@/state/chat';
 import createClub from '@/state/chat/createClub';
 import { ChatMemo } from '@/types/chat';
-import { BigIntOrderedMap } from '@urbit/api';
-import { createStorageKey, newUv, preSig, whomIsDm } from './utils';
+import { createStorageKey, newUv, preSig } from './utils';
 
 export default function useMessageSelector() {
   const navigate = useNavigate();

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -7,7 +7,7 @@ import { ShipOption } from '@/components/ShipSelector';
 import { useChatState, useMultiDms } from '@/state/chat';
 import createClub from '@/state/chat/createClub';
 import { ChatMemo } from '@/types/chat';
-import { createStorageKey, newUv, preSig } from './utils';
+import { createStorageKey, newUv } from './utils';
 
 export default function useMessageSelector() {
   const navigate = useNavigate();
@@ -17,7 +17,7 @@ export default function useMessageSelector() {
     []
   );
   const isMultiDm = ships.length > 1;
-  const shipValues = useMemo(() => ships.map((o) => preSig(o.value)), [ships]);
+  const shipValues = useMemo(() => ships.map((o) => o.value), [ships]);
   const multiDms = useMultiDms();
 
   const existingDm = useMemo(() => {
@@ -28,7 +28,7 @@ export default function useMessageSelector() {
     const { briefs: chatBriefs } = useChatState.getState();
     return (
       Object.entries(chatBriefs).find(([flag, _brief]) => {
-        const theShip = preSig(ships[0].value);
+        const theShip = ships[0].value;
         const sameDM = theShip === flag;
         return sameDM;
       })?.[0] ?? null
@@ -63,17 +63,15 @@ export default function useMessageSelector() {
       if (existingMultiDm) {
         navigate(`/dm/${existingMultiDm}`);
       } else if (existingDm) {
-        navigate(`/dm/${preSig(existingDm)}`);
+        navigate(`/dm/${existingDm}`);
       } else if (isMultiDm) {
         await createClub(
           newClubId,
-          invites
-            .filter((i) => preSig(i.value) !== window.our)
-            .map((s) => preSig(s.value))
+          invites.filter((i) => i.value !== window.our).map((s) => s.value)
         );
         navigate(`/dm/${newClubId}`);
       } else {
-        navigate(`/dm/${preSig(invites[0].value)}`);
+        navigate(`/dm/${invites[0].value}`);
       }
 
       setShips([]);
@@ -89,7 +87,7 @@ export default function useMessageSelector() {
 
       await useChatState.getState().sendMessage(whom, memo);
       setShips([]);
-      navigate(`/dm/${isMultiDm ? whom : preSig(whom)}`);
+      navigate(`/dm/${isMultiDm ? whom : whom}`);
     },
     [isMultiDm, shipValues, existingMultiDm, setShips, navigate]
   );
@@ -116,7 +114,7 @@ export default function useMessageSelector() {
 
   useEffect(() => {
     if (existingDm) {
-      navigate(`/dm/${preSig(existingDm)}`);
+      navigate(`/dm/${existingDm}`);
     } else if (existingMultiDm) {
       navigate(`/dm/${existingMultiDm}`);
     } else if (shipValues.length > 0) {

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -487,9 +487,10 @@ export const useChatState = createState<ChatState>(
       };
       const diff = { add: memo };
 
+      const { pacts } = get();
+      const isNew = !(whom in pacts);
       if (isDM) {
-        const { pacts } = get();
-        if (!(whom in pacts)) {
+        if (isNew) {
           set((draft) => ({
             ...draft,
             pacts: {
@@ -501,7 +502,13 @@ export const useChatState = createState<ChatState>(
 
         pokeOptimisticallyN(useChatState, dmAction(whom, { add: memo }, id), [
           writsReducer(whom),
-        ]).then(() => set((draft) => draft.postedMessages.push(id)));
+        ]).then(() =>
+          set((draft) => {
+            if (!isNew) {
+              draft.postedMessages.push(id);
+            }
+          })
+        );
       } else if (isMultiDm) {
         pokeOptimisticallyN(
           useChatState,
@@ -518,7 +525,15 @@ export const useChatState = createState<ChatState>(
           writsReducer(whom),
         ]).then(() => set((draft) => draft.postedMessages.push(id)));
       }
-      set((draft) => draft.sentMessages.push(id));
+
+      set((draft) => {
+        // dms first message won't be heard through a fact
+        if (isDM && isNew) {
+          return;
+        }
+
+        draft.sentMessages.push(id);
+      });
     },
     delMessage: async (whom, id) => {
       const isDM = whomIsDm(whom);

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -488,6 +488,17 @@ export const useChatState = createState<ChatState>(
       const diff = { add: memo };
 
       if (isDM) {
+        const { pacts } = get();
+        if (!(whom in pacts)) {
+          set((draft) => ({
+            ...draft,
+            pacts: {
+              ...draft.pacts,
+              [whom]: { index: {}, writs: new BigIntOrderedMap() },
+            },
+          }));
+        }
+
         pokeOptimisticallyN(useChatState, dmAction(whom, { add: memo }, id), [
           writsReducer(whom),
         ]).then(() => set((draft) => draft.postedMessages.push(id)));


### PR DESCRIPTION
There were two bugs here. Fixes #1927 and also ensures that ship selector always outputs valid @p's, because if you were typing a patp without one and selecting it when it was an exact match (not in contact store) this would pass a bad `whom` along.