### PR TITLE
gallery: virtualize list, fetch new items at bottom

### DIFF
--- a/ui/src/heap/NewCurioForm.tsx
+++ b/ui/src/heap/NewCurioForm.tsx
@@ -36,7 +36,7 @@ export default function NewCurioForm() {
   const isListMode = displayMode === LIST;
   const isLinkMode = inputMode === LINK;
   const isTextMode = inputMode === TEXT;
-  const perms = useHeapPerms(nest);
+  const perms = useHeapPerms(chFlag);
   const vessel = useVessel(flag, window.our);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
 
@@ -147,7 +147,9 @@ export default function NewCurioForm() {
   );
 
   return (
-    <div className={cn(isGridMode && 'aspect-h-1 aspect-w-1')}>
+    <div
+      className={cn(isGridMode && 'virtuoso-grid-item aspect-h-1 aspect-w-1')}
+    >
       {isListMode ? modeToggle() : null}
       <div
         className={cn(


### PR DESCRIPTION
Fixes #1928 

Add VirtuosoGrid, fetch 50 new items when we reach the bottom of the current list. Had to create a fake curio and prepend it to the sortedCurio array (and then replace it) in order to get the NewCurioForm to render in the list.

https://user-images.githubusercontent.com/1221094/218874834-cf4f1e41-cb4b-4a86-b5e9-d335f5946c4e.mov


