### PR TITLE
groups: hide reject button on group refs for joined groups

### DIFF
--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -101,7 +101,7 @@ export default function GroupReference({
           </span>
         ) : (
           <>
-            {gang.invite && button.text !== 'Go' && status !== 'loading' ? (
+            {gang.invite && !group && status !== 'loading' ? (
               <button
                 className="small-button bg-red text-white dark:text-black"
                 onClick={reject}

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -101,7 +101,7 @@ export default function GroupReference({
           </span>
         ) : (
           <>
-            {gang.invite && status !== 'loading' ? (
+            {gang.invite && button.text !== 'Go' && status !== 'loading' ? (
               <button
                 className="small-button bg-red text-white dark:text-black"
                 onClick={reject}


### PR DESCRIPTION
Fixes #1910 

Still not clear on why these are showing up as gang invites, but for now we can hide the button if we know that you're in the group.