### PR TITLE
v2.7.0 cosmetics

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -329,6 +329,16 @@ export default function ChannelHeader({
     }
   }, [hasActivity, notifications, nest]);
 
+  function backTo() {
+    if (isMobile && isTalk) {
+      return '/';
+    }
+    if (isMobile && !isTalk) {
+      return `/groups/${flag}/channellist`;
+    }
+    return `/groups/${flag}`;
+  }
+
   return (
     <div
       className={cn(
@@ -336,7 +346,7 @@ export default function ChannelHeader({
       )}
     >
       <BackButton
-        to={isMobile && isTalk ? '/' : `/groups/${flag}`}
+        to={backTo()}
         className={cn(
           'cursor-pointer select-none p-2 sm:cursor-text sm:select-text',
           isMobile && '-ml-2 flex items-center rounded-lg pr-0 hover:bg-gray-50'

--- a/ui/src/components/DisconnectNotice.tsx
+++ b/ui/src/components/DisconnectNotice.tsx
@@ -30,7 +30,7 @@ export default function DisconnectNotice() {
           <AsteriskIcon className="mr-3 h-4 w-4" />
         )}
         {subscription === 'reconnecting' ? (
-          <span>Reconnecting...</span>
+          <span className="py-1">Reconnecting...</span>
         ) : (
           <span className="mr-1">You are currently offline.</span>
         )}

--- a/ui/src/components/LandscapeWayfinding.tsx
+++ b/ui/src/components/LandscapeWayfinding.tsx
@@ -8,6 +8,8 @@ import { useGang } from '@/state/groups';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { setCalmSetting } from '@/state/settings';
 import { useIsMobile } from '@/logic/useMedia';
+import { useLocation } from 'react-router-dom';
+import { isTalk } from '@/logic/utils';
 import Dialog, { DialogContent } from './Dialog';
 
 function GroupsDescription() {
@@ -18,12 +20,12 @@ function GroupsDescription() {
     <div className="flex flex-col leading-5">
       <h1 className="my-8 text-2xl font-bold">Where am I?</h1>
       <p>
-        Tlon Corporation's "Groups" app, a multi-channel communications
-        platform.
+        Tlon Corporation&rsquo;s &ldquo;Groups&rdquo; app, a multi-channel
+        communications platform.
       </p>
       {groupFlagInLocation && (
         <p className="mt-4">
-          You're currently within a group, which might have a variety of
+          You&rsquo;re currently within a group, which might have a variety of
           channels.
         </p>
       )}
@@ -63,14 +65,14 @@ function TalkDescription() {
     <div className="flex flex-col leading-5">
       <h1 className="my-8 text-2xl font-bold">Where am I?</h1>
       <p>
-        Tlon Corporation’s “Talk” app, a simple, powerful, and secure instant
-        messaging software for individuals or small groups of people.
+        Tlon Corporation&rsquo;s “Talk” app, a simple, powerful, and secure
+        instant messaging software for individuals or small groups of people.
       </p>
       <h1 className="my-8 text-2xl font-bold">What can I do here?</h1>
       <p>
-        Talk is simple: It works like any other messaging app you’ve ever used.
-        What makes it special is its directly person-to-person nature, no one
-        person or company can ever snoop the messages you send on Talk.
+        Talk is simple: It works like any other messaging app you&rsquo;ve ever
+        used. What makes it special is its directly person-to-person nature, no
+        one person or company can ever snoop the messages you send on Talk.
       </p>
       <p className="mt-4 mb-8">
         In addition to the experience you expect, Talk can also aggregate group
@@ -86,17 +88,26 @@ export default function LandscapeWayfinding() {
   const app = useAppName();
   const gang = useGang('~nibset-napwyn/tlon');
   const { open } = useGroupJoin('~nibset-napwyn/tlon', gang);
+  const location = useLocation();
 
   const handleHide = () => {
     setCalmSetting('disableWayfinding', true);
   };
 
+  // Don't show the wayfinding button in DMs or Channels pages on mobile
+  if (
+    (isMobile && location.pathname.includes('dm')) ||
+    location.pathname.includes('channels/')
+  ) {
+    return null;
+  }
+
   return (
     <Dropdown.Root>
       <div
-        className={cn('absolute left-5 z-50', {
-          'bottom-10': !isMobile,
-          'bottom-20': isMobile,
+        className={cn('fixed left-5 z-50', {
+          'bottom-10': !isMobile || (isTalk && isMobile),
+          'bottom-20': isMobile && !isTalk,
         })}
       >
         <Dropdown.Trigger className="relative" asChild>

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
+import { debounce } from 'lodash';
 import useGroupSort from '@/logic/useGroupSort';
 import { usePinnedGroups } from '@/state/chat';
 import { useGangList, useGroups } from '@/state/groups';
@@ -9,7 +10,6 @@ import SidebarSorter from '@/components/Sidebar/SidebarSorter';
 import AddIcon from '@/components/icons/AddIcon';
 import GroupsSidebarItem from '@/components/Sidebar/GroupsSidebarItem';
 import GangItem from '@/components/Sidebar/GangItem';
-import { debounce } from 'lodash';
 import { GroupsScrollingContext } from '@/components/Sidebar/GroupsScrollingContext';
 
 export default function MobileRoot() {
@@ -51,7 +51,7 @@ export default function MobileRoot() {
           </Link>
         </div>
       </header>
-      <nav className="flex h-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
+      <nav className="flex h-full flex-1 flex-col overflow-y-auto overflow-x-hidden px-2">
         <div className="flex-1">
           <GroupsScrollingContext.Provider value={isScrolling}>
             <GroupList
@@ -61,21 +61,21 @@ export default function MobileRoot() {
             >
               {Object.entries(pinnedGroups).length > 0 && (
                 <>
-                  <li className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
-                    <span className="-ml-1 text-sm font-semibold text-gray-400">
+                  <div className="-ml-2 grow border-t-2 border-gray-50 pt-3 pb-2">
+                    <span className="ml-4 text-sm font-semibold text-gray-400">
                       Pinned Groups
                     </span>
-                  </li>
+                  </div>
                   {pinnedGroupsOptions}
                 </>
               )}
-              <ul className="mb-3 space-y-2 px-2 sm:mb-2 sm:space-y-0 md:mb-0">
-                <li className="-mx-2 mt-5 grow border-t-2 border-gray-50 pt-3 pb-2">
-                  <span className="ml-3 text-sm font-semibold text-gray-400">
-                    All Groups
-                  </span>
-                </li>
-              </ul>
+
+              <div className="-ml-2 mt-2 grow border-t-2 border-gray-50 pt-3 pb-2">
+                <span className="ml-4 text-sm font-semibold text-gray-400">
+                  All Groups
+                </span>
+              </div>
+
               {gangs.map((flag) => (
                 <GangItem key={flag} flag={flag} />
               ))}

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -41,12 +41,12 @@ function NotificationContent({
             ob.isValidPatp(s.replaceAll(PUNCTUATION_REGEX, '')) ? (
               <span
                 key={`${s}-${index}`}
-                className="mr-1 inline-block rounded bg-blue-soft px-1.5 py-0 text-blue mix-blend-multiply"
+                className="mr-1 inline-block rounded bg-blue-soft px-1.5 py-0 text-blue mix-blend-multiply dark:mix-blend-normal"
               >
                 <ShipName name={s.replaceAll(PUNCTUATION_REGEX, '')} />
               </span>
             ) : (
-              <span className="break-all" key={`${s}-${index}`}>
+              <span className="break-word text-ellipsis" key={`${s}-${index}`}>
                 {s}{' '}
               </span>
             )

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -1,4 +1,3 @@
-import { useRouteGroup, useGroup } from '@/state/groups';
 import cn from 'classnames';
 import React, {
   ComponentType,
@@ -8,6 +7,7 @@ import React, {
 } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
+import { useRouteGroup, useGroup } from '@/state/groups';
 import { ViewProps } from '@/types/groups';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import useHarkState from '@/state/hark';
@@ -122,10 +122,8 @@ export default function Notifications({
             onClick={() => setShowMentionsOnly(false)}
             className={cn('small-button rounded-r-none', {
               'bg-gray-800 text-white': !showMentionsOnly,
-              'bg-gray-50 text-gray-800 ': showMentionsOnly,
-              'mix-blend-multiply': !isDarkMode && showMentionsOnly,
-              'mix-blend-difference': isDarkMode,
-              'whitespace-nowrap': isMobile,
+              'bg-white text-gray-800 ': showMentionsOnly,
+              'grow whitespace-nowrap': isMobile,
             })}
           >
             All Notifications{hasUnreads ? ` • ${count} New` : null}
@@ -134,10 +132,8 @@ export default function Notifications({
             onClick={() => setShowMentionsOnly(true)}
             className={cn('small-button rounded-l-none', {
               'bg-gray-800 text-white': showMentionsOnly,
-              'bg-gray-50 text-gray-800': !showMentionsOnly,
-              'mix-blend-multiply': !showMentionsOnly && !isDarkMode,
-              'mix-blend-difference': isDarkMode,
-              'whitespace-nowrap': isMobile,
+              'bg-white text-gray-800': !showMentionsOnly,
+              'grow whitespace-nowrap': isMobile,
             })}
           >
             Mentions Only
@@ -153,8 +149,11 @@ export default function Notifications({
             })}
             onClick={markAllRead}
           >
-            Mark All as Read
-            {isPending ? <LoadingSpinner className="ml-2 h-4 w-4" /> : null}
+            {isPending ? (
+              <LoadingSpinner className="ml-2 h-4 w-4" />
+            ) : (
+              'Mark All as Read'
+            )}
           </button>
         )}
         {!isMobile && showMentionsOnly && unreadMentions.length > 0 && (
@@ -165,8 +164,11 @@ export default function Notifications({
             })}
             onClick={markAllRead}
           >
-            Mark Mentions as Read
-            {isPending ? <LoadingSpinner className="ml-2 h-4 w-4" /> : null}
+            {isPending ? (
+              <LoadingSpinner className="ml-2 h-4 w-4" />
+            ) : (
+              'Mark Mentions as Read'
+            )}
           </button>
         )}
       </div>
@@ -180,8 +182,11 @@ export default function Notifications({
             })}
             onClick={markAllRead}
           >
-            Mark All as Read
-            {isPending ? <LoadingSpinner className="ml-2 h-4 w-4" /> : null}
+            {isPending ? (
+              <LoadingSpinner className="ml-2 h-4 w-4" />
+            ) : (
+              'Mark All as Read'
+            )}
           </button>
         )}
         {isMobile && showMentionsOnly && (
@@ -194,8 +199,11 @@ export default function Notifications({
             })}
             onClick={markAllRead}
           >
-            Mark Mentions as Read
-            {isPending ? <LoadingSpinner className="ml-2 h-4 w-4" /> : null}
+            {isPending ? (
+              <LoadingSpinner className="ml-2 h-4 w-4" />
+            ) : (
+              'Mark Mentions as Read'
+            )}
           </button>
         )}
       </div>
@@ -206,7 +214,7 @@ export default function Notifications({
             )
             .map((n) => (
               <div key={n.date}>
-                <h2 className="mt-8 mb-4 text-lg font-bold text-gray-400">
+                <h2 className="my-4 text-lg font-bold text-gray-400">
                   {n.date}
                 </h2>
                 <ul className="space-y-2">
@@ -222,7 +230,7 @@ export default function Notifications({
             ))
         : notifications.map((grouping) => (
             <div key={grouping.date}>
-              <h2 className="mt-8 mb-4 text-lg font-bold text-gray-400">
+              <h2 className="my-4 text-lg font-bold text-gray-400">
                 {grouping.date}
               </h2>
               <ul className="space-y-2">


### PR DESCRIPTION
- Adjusts the group home header (fixes #1930, sorry about the confusion there)
- No multiply for @mention tags in notifications, fixes #1929
- Back button in channel header on mobile sends you back to the channel list, fixes #1930 
- Finally re-aligns the Groups menu on mobile (no issue)
- Hides the Wayfinding bug in channels and DMs on mobile, fixes #1924 
- Stops the disconnect/reconnect banner from jumping in height between states (no issue)