### PR TITLE
chat: drafts reborn

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -113,7 +113,13 @@ function ChatChannel({ title }: ViewProps) {
             )}
           >
             {canWrite ? (
-              <ChatInput whom={chFlag} sendMessage={sendMessage} showReply />
+              <ChatInput
+                key={chFlag}
+                whom={chFlag}
+                sendMessage={sendMessage}
+                showReply
+                autoFocus
+              />
             ) : null}
           </div>
         }

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -26,7 +26,14 @@ import ChatScrollerPlaceholder from '@/chat/ChatScoller/ChatScrollerPlaceholder'
 
 function ChatChannel({ title }: ViewProps) {
   const navigate = useNavigate();
-  const { chShip, chName } = useParams();
+  const { chShip, chName, idTime, idShip } = useParams<{
+    name: string;
+    chShip: string;
+    ship: string;
+    chName: string;
+    idShip: string;
+    idTime: string;
+  }>();
   const chFlag = `${chShip}/${chName}`;
   const nest = `chat/${chFlag}`;
   const groupFlag = useRouteGroup();
@@ -42,6 +49,7 @@ function ChatChannel({ title }: ViewProps) {
   const canRead = channel
     ? canReadChannel(channel, vessel, group?.bloc)
     : false;
+  const inThread = idShip && idTime;
   const { sendMessage } = useChatState.getState();
   const briefs = useAllBriefs();
   const joined = Object.keys(briefs).some((k) => k.includes('chat/'))
@@ -118,7 +126,7 @@ function ChatChannel({ title }: ViewProps) {
                 whom={chFlag}
                 sendMessage={sendMessage}
                 showReply
-                autoFocus
+                autoFocus={!inThread}
               />
             ) : null}
           </div>

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -165,6 +165,20 @@ export default function ChatInput({
     }
   }, [files, id]);
 
+  const onUpdate = useRef(
+    debounce(({ editor }: HandlerParams) => {
+      setDraft(editor.getJSON());
+    }, 300)
+  );
+
+  // ensure we store any drafts before dismounting
+  useEffect(
+    () => () => {
+      onUpdate.current.flush();
+    },
+    []
+  );
+
   const onSubmit = useCallback(
     async (editor: Editor) => {
       if (sendDisabled) return;
@@ -227,6 +241,8 @@ export default function ChatInput({
         sendMessage(whom, memo);
       }
       editor?.commands.setContent('');
+      onUpdate.current.flush();
+      setDraft(inlinesToJSON(['']));
       setTimeout(() => {
         useChatStore.getState().read(whom);
         closeReply();
@@ -236,6 +252,7 @@ export default function ChatInput({
     [
       whom,
       id,
+      setDraft,
       clearAttachments,
       sendMessage,
       closeReply,
@@ -244,20 +261,6 @@ export default function ChatInput({
       replying,
       chatInfo,
     ]
-  );
-
-  const onUpdate = useRef(
-    debounce(({ editor }: HandlerParams) => {
-      setDraft(editor.getJSON());
-    }, 300)
-  );
-
-  // ensure we store any drafts before dismounting
-  useEffect(
-    () => () => {
-      onUpdate.current.flush();
-    },
-    []
   );
 
   /**

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -131,6 +131,7 @@ export default function ChatThread() {
             replying={id}
             sendMessage={sendMessage}
             inThread
+            autoFocus
           />
         )}
       </div>

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -25,7 +25,7 @@ import { PASTEABLE_IMAGE_TYPES } from '@/constants';
 import { useFileStore } from '@/state/storage';
 import MentionPopup from './Mention/MentionPopup';
 
-interface HandlerParams {
+export interface HandlerParams {
   editor: Editor;
 }
 

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -107,6 +107,7 @@ export default function Dm() {
           isAccepted ? (
             <div className="border-t-2 border-gray-50 p-4">
               <ChatInput
+                key={ship}
                 whom={ship}
                 sendMessage={
                   isSelectingMessage ? sendDmFromMessageSelector : sendMessage

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -103,6 +103,7 @@ export default function MultiDm() {
           isAccepted ? (
             <div className="border-t-2 border-gray-50 p-4">
               <ChatInput
+                key={clubId}
                 whom={clubId}
                 sendMessage={
                   isSelectingMessage ? sendDmFromMessageSelector : sendMessage


### PR DESCRIPTION
This changes how we handle the `ChatInput` around the app. Since we really want distinct breaks between one chat or another I added keys to force remount between chats, similar to the scroller. This makes the initialization of the input much cleaner since we know that we won't have states lingering between. To combat any kind of wiping this now stores typed messages in local storage. Fixes #1953, fixes #1925 