### PR TITLE
chat: fix emoji picker disappearing on subsequent messages

### DIFF
--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -40,7 +40,7 @@ export default function EmojiPicker({
         <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-12' : ''} />
       )}
       <Popover.Portal>
-        <Popover.Content side="bottom" sideOffset={40} collisionPadding={15}>
+        <Popover.Content side="bottom" sideOffset={30} collisionPadding={15}>
           <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (
               <Picker


### PR DESCRIPTION
Fixes #1950 

Was caused by the new way we handle hover state in chat messages. As soon as we leave the div for the message we'll lose its children that depend on hover. There was enough space between the message options and the emoji picker for the onOut to fire. Had to sacrifice some space between the picker and the chat message options.