### PR TITLE
chat: prevent stuck at top and add scroll to message

### DIFF
--- a/ui/src/chat/ChatReactions/ChatReaction.tsx
+++ b/ui/src/chat/ChatReactions/ChatReaction.tsx
@@ -72,10 +72,10 @@ export default function ChatReaction({
                   <div className="z-[100] w-fit cursor-none rounded bg-gray-400 px-4 py-2">
                     <label className="whitespace-nowrap font-semibold text-white">
                       {ships.map((ship, i) => (
-                        <>
-                          <ShipName key={ship} name={ship} showAlias />
+                        <span key={`${ship}-${i}`}>
+                          <ShipName name={ship} showAlias />
                           {i + 1 === ships.length ? '' : ', '}
-                        </>
+                        </span>
                       ))}
                     </label>
                   </div>

--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -6,6 +6,17 @@ import { BigInteger } from 'big-integer';
 import ChannelIcon from '@/channels/ChannelIcon';
 import useNavigateByApp from '@/logic/useNavigateByApp';
 
+interface ReferenceBarProps {
+  nest: string;
+  time: BigInteger;
+  groupFlag?: string;
+  groupTitle?: string;
+  channelTitle?: string;
+  author?: string;
+  top?: boolean;
+  reply?: boolean;
+}
+
 export default function ReferenceBar({
   nest,
   time,
@@ -15,16 +26,7 @@ export default function ReferenceBar({
   author,
   top = false,
   reply = false,
-}: {
-  nest: string;
-  time: BigInteger;
-  groupFlag?: string;
-  groupTitle?: string;
-  channelTitle?: string;
-  author?: string;
-  top?: boolean;
-  reply?: boolean;
-}) {
+}: ReferenceBarProps) {
   const groupFlagOrZod = groupFlag || '~zod/test';
   const navigateByApp = useNavigateByApp();
   const unix = new Date(daToUnix(time));

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import cn from 'classnames';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useChannelPreview, useGang } from '@/state/groups';
 // eslint-disable-next-line import/no-cycle
 import ChatContent from '@/chat/ChatContent/ChatContent';
-import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { ChatWrit } from '@/types/chat';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { useChannelFlag } from '@/hooks';
+import { useChatState } from '@/state/chat';
+import { unixToDa } from '@urbit/api';
 import ReferenceBar from './ReferenceBar';
 
 interface WritBaseReferenceProps {
@@ -32,13 +33,18 @@ export default function WritBaseReference({
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
+  const time = useMemo(
+    () =>
+      writ
+        ? useChatState.getState().getTime(chFlag, writ.seal.id)
+        : unixToDa(Date.now()),
+    [chFlag, writ]
+  );
 
   // TODO: handle failure for useWritByFlagAndWritId call.
   if (!writ) {
     return <HeapLoadingBlock reference />;
   }
-
-  const time = bigInt(udToDec(writ.seal.id.split('/')[1]));
 
   if (!('story' in writ.memo.content)) {
     return null;

--- a/ui/src/logic/subscriptionTracking.ts
+++ b/ui/src/logic/subscriptionTracking.ts
@@ -23,7 +23,6 @@ export function getPreviewTracker(wait = DEFAULT_WAIT) {
       return isPastWaiting(attempted) && !inProgress;
     },
     newAttempt: (k: string) => {
-      console.log(k);
       tracked[k] = {
         inProgress: true,
         attempted: Date.now(),

--- a/ui/src/logic/useConnectionChecker.ts
+++ b/ui/src/logic/useConnectionChecker.ts
@@ -10,8 +10,6 @@ const retryTime = 30 * 1000;
 let checking = false;
 
 async function checkConnection() {
-  checking = true;
-
   try {
     await asyncCallWithTimeout(
       new Promise<void>((resolve, reject) => {
@@ -63,9 +61,10 @@ async function checkConnection() {
 
 export default function useConnectionChecker() {
   useEffect(() => {
-    // only ever check once
+    // only ever check once, wait a minute before starting
     if (!checking) {
-      checkConnection();
+      checking = true;
+      setTimeout(() => checkConnection(), 60 * 1000);
     }
   }, []);
 }

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -138,6 +138,18 @@ export const useChatState = createState<ChatState>(
     loadedRefs: {},
     briefs: {},
     loadedGraphRefs: {},
+    getTime: (whom, id) => {
+      const { pacts } = get();
+      const pact = pacts[whom];
+
+      if (!pact || !pact.index[id]) {
+        // not accurate, won't be in pact, using until chat ref fetching
+        // returns time alongside writ
+        return bigInt(udToDec(id.split('/')[1]));
+      }
+
+      return pact.index[id];
+    },
     togglePin: async (whom, pin) => {
       const { pins } = get();
       let newPins = [];

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -55,6 +55,7 @@ export interface ChatState {
   };
   pendingDms: string[];
   briefs: ChatBriefs;
+  getTime: (whom: string, id: string) => bigInt.BigInteger;
   togglePin: (whom: string, pin: boolean) => Promise<void>;
   fetchPins: () => Promise<void>;
   markRead: (whom: string) => Promise<void>;

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -118,9 +118,9 @@ export default function makeWritsStore(
       const writs = await scry<ChatWrits>(
         `/newest/${INITIAL_MESSAGE_FETCH_PAGE_SIZE}`
       );
-      const sta = get();
-      sta.batchSet((draft) => {
-        const pact: Pact = {
+
+      get().batchSet((draft) => {
+        const pact: Pact = draft.pacts[whom] || {
           writs: new BigIntOrderedMap<ChatWrit>(),
           index: {},
         };


### PR DESCRIPTION
**scroll to:**
I thought we had this, but the scroller has been through so many changes not sure what happened to it. This adds back in the ability to detect `scrollTo` changes and scroll appropriately. All the dependencies in the `useEffect`'s are very carefully set here. Also found that we weren't always using the correct time for scrolling back so I added that as well.

**stuck at top**
I think recent changes I made made this more likely to happen or maybe it was always this way. Either way, this alters the atTop threshold so that we can escape the "top" on small screens if there's not enough messages to trigger a state change and also ensures that if we initially load at the top because of a `scrollTo` that we manually start loading older messages since `atTopChange` won't fire.

**misc**
- removed errant console log
- connection checker fires too early on slow loads