### PR TITLE
groups: prevent channel host removal

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -715,6 +715,14 @@
       out
     (~(put in out) who)
   ::
+  ++  go-channel-hosts
+    ^-  (set ship)
+    %-  ~(gas in *(set ship))
+    %+  turn  
+      ~(tap by channels.group)
+    |=  [=nest:g *]
+    p.q.nest
+  ::
   ++  go-is-banned
     |=  =ship
     =*  cordon  cordon.group
@@ -865,6 +873,9 @@
     ^-  (unit (unit cage))
     :-  ~
     ?+    pole  ~
+        [%hosts ~]
+      `ships+!>(go-channel-hosts)
+      ::
         [%fleet %ships ~]
       `ships+!>(~(key by fleet.group))
       ::
@@ -1339,7 +1350,13 @@
       ==
     ::
         %del
-      ?<  &((~(has in ships) our.bowl) =(p.flag our.bowl))
+      =/  intersect  (~(int in ships) go-channel-hosts)
+      ~&  intersect  
+      ?<  ?|  &((~(has in ships) our.bowl) =(p.flag our.bowl))              
+              %+  lth  0
+              %~  wyt  in
+              (~(int in ships) go-channel-hosts)
+          ==
       ?>  ?|  go-is-bloc
               =(p.flag src.bowl)
               (~(has in ships) src.bowl)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1187,7 +1187,11 @@
       ?-  -.diff
       ::
           %add-ships
-        ?<  &((~(has in p.diff) our.bowl) =(p.flag our.bowl))
+        ?<  ?|  &((~(has in p.diff) our.bowl) =(p.flag our.bowl))              
+                %+  lth  0
+                %~  wyt  in
+                (~(int in p.diff) go-channel-hosts)
+            ==
         =.  fleet.group
         %-  malt
           %+  skip
@@ -1350,8 +1354,6 @@
       ==
     ::
         %del
-      =/  intersect  (~(int in ships) go-channel-hosts)
-      ~&  intersect  
       ?<  ?|  &((~(has in ships) our.bowl) =(p.flag our.bowl))              
               %+  lth  0
               %~  wyt  in

--- a/ui/src/groups/GroupAdmin/GroupMemberItem.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberItem.tsx
@@ -9,7 +9,7 @@ import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import LeaveIcon from '@/components/icons/LeaveIcon';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ShipName from '@/components/ShipName';
-import { toTitleCase, getSectTitle } from '@/logic/utils';
+import { toTitleCase, getSectTitle, getChannelHosts } from '@/logic/utils';
 import {
   useAmAdmin,
   useGroup,
@@ -100,6 +100,8 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
     return null;
   }
 
+  const isHost = getChannelHosts(group).includes(member);
+
   return (
     <>
       <div className="cursor-pointer" onClick={() => onViewProfile(member)}>
@@ -150,7 +152,7 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
           </Dropdown.Content>
         </Dropdown.Root>
       ) : null}
-      {isAdmin ? (
+      {isAdmin && !isHost ? (
         <Dropdown.Root>
           {member !== window.our ? (
             <Dropdown.Trigger className="default-focus ml-auto rounded text-gray-400">

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -390,6 +390,14 @@ export function isChannelJoined(
   return isChannelHost || (nest && nest in briefs);
 }
 
+export function getChannelHosts(group: Group): string[] {
+  return Object.keys(group.channels).map((c) => {
+    const [, chFlag] = nestToFlag(c);
+    const { ship } = getFlagParts(chFlag);
+    return ship;
+  });
+}
+
 export function canReadChannel(
   channel: GroupChannel,
   vessel: Vessel,

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -637,7 +637,7 @@ export const useChatState = createState<ChatState>(
               const { update, flag } = event;
               if (
                 'create' in update.diff &&
-                flag === `${req.group.split('/')[0]}/${req.name}`
+                flag === `${window.our}/${req.name}`
               ) {
                 return true;
               }

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -310,7 +310,7 @@ export const useDiaryState = createState<DiaryState>(
               const { update, flag } = event;
               if (
                 'create' in update.diff &&
-                flag === `${req.group.split('/')[0]}/${req.name}`
+                flag === `${window.our}/${req.name}`
               ) {
                 return true;
               }

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -244,7 +244,7 @@ export const useHeapState = createState<HeapState>(
               const { update, flag } = event;
               if (
                 'create' in update.diff &&
-                flag === `${req.group.split('/')[0]}/${req.name}`
+                flag === `${window.our}/${req.name}`
               ) {
                 return true;
               }


### PR DESCRIPTION
Although there are no real technical issues with removing channel hosts there are some UX concerns. Given that this removes the UI for kicking/banning channel hosts and also guards against it on the backend. Fixes #1807