### PR TITLE
chat: using tiptap editor in a 'controlled' way is bad

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -287,7 +287,7 @@ export default function ChatInput({
    */
   const messageEditor = useMessageEditor({
     whom: id,
-    content: draft,
+    content: '',
     uploadKey,
     placeholder: 'Message',
     allowMentions: true,
@@ -312,9 +312,16 @@ export default function ChatInput({
       !messageEditor.isDestroyed
     ) {
       // end brings the cursor to the end of the content
-      messageEditor.commands.focus('end');
+      messageEditor?.commands.focus('end');
     }
   }, [autoFocus, replyCite, isMobile, messageEditor]);
+
+  useEffect(() => {
+    if (messageEditor && !messageEditor.isDestroyed) {
+      messageEditor?.commands.setContent(draft);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageEditor]);
 
   useEffect(() => {
     if (

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -201,7 +201,7 @@ export function useMessageEditor({
         }
       },
     },
-    [keyMapExt, placeholder, handlePaste]
+    [keyMapExt, placeholder]
   );
 }
 

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -89,7 +89,8 @@ export default function useMessageSelector() {
       setShips([]);
       navigate(`/dm/${isMultiDm ? whom : whom}`);
     },
-    [isMultiDm, shipValues, existingMultiDm, setShips, navigate]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isMultiDm, JSON.stringify(shipValues), existingMultiDm, setShips, navigate]
   );
 
   const whom = useMemo(


### PR DESCRIPTION
Fixes #1982, my previous change for drafts in #1954 basically made the tiptap editor act in a controlled manner which was mostly fine except that since it was constantly recreating the editor it was pulling focus off and reapplying it in places where we have `autoFocus` on. However, in the new DM situation we don't want the input to pull focus over the ship selector so we saw this bug. This switches things around so that we only set the draft on first mount. We need to put this through it's paces though I'm worried about some kind of async bug where the draft gets applied repeatedly or after submitting, etc.