### PR TITLE
diary: breaking up paragraphs correctly

### DIFF
--- a/ui/src/diary/DiaryContent/DiaryContent.test.tsx
+++ b/ui/src/diary/DiaryContent/DiaryContent.test.tsx
@@ -1,0 +1,46 @@
+import { DiaryInline } from '@/types/diary';
+import { describe, expect, it } from 'vitest';
+import { groupByParagraph } from './DiaryContent';
+
+const br = { break: null };
+
+describe('groupByParagraphs', () => {
+  it('does nothing when empty', () => {
+    const input: DiaryInline[] = [];
+    const output = groupByParagraph(input);
+    const expected: DiaryInline[][] = [];
+    expect(output).toEqual(expected);
+  });
+
+  it('gives single break as paragraph', () => {
+    const input: DiaryInline[] = [br];
+    const output = groupByParagraph(input);
+    const expected: DiaryInline[][] = [[br]];
+    expect(output).toEqual(expected);
+  });
+
+  it('handles multiple breaks as separate paragraphs', () => {
+    const input: DiaryInline[] = ['hi', br, br, 'hello'];
+    const output = groupByParagraph(input);
+    const expected: DiaryInline[][] = [['hi'], [br], ['hello']];
+    expect(output).toEqual(expected);
+  });
+
+  it('handles styling and an ending break', () => {
+    const input: DiaryInline[] = [
+      'test text',
+      br,
+      br,
+      'with ',
+      { bold: ['style'] },
+      br,
+    ];
+    const output = groupByParagraph(input);
+    const expected: DiaryInline[][] = [
+      ['test text'],
+      [br],
+      ['with ', { bold: ['style'] }],
+    ];
+    expect(output).toEqual(expected);
+  });
+});

--- a/ui/src/diary/DiaryContent/DiaryContent.tsx
+++ b/ui/src/diary/DiaryContent/DiaryContent.tsx
@@ -14,6 +14,7 @@ import {
 import ContentReference from '@/components/References/ContentReference';
 import {
   DiaryBlock,
+  DiaryInline,
   DiaryListing,
   isDiaryImage,
   NoteContent,
@@ -38,6 +39,26 @@ interface InlineContentProps {
 
 interface BlockContentProps {
   story: DiaryBlock;
+}
+
+export function groupByParagraph(inlines: DiaryInline[]): DiaryInline[][] {
+  let index = 0;
+  const final = [];
+
+  while (index < inlines.length) {
+    const remaining = _.slice(inlines, index);
+    const nextParagraph = _.takeWhile(remaining, (i) => !isBreak(i));
+    const head = _.head(remaining);
+    if (nextParagraph.length === 0 && head) {
+      final.push([head]);
+      index += 1;
+    } else {
+      final.push(nextParagraph);
+      index += nextParagraph.length + 1;
+    }
+  }
+
+  return final;
 }
 
 export function InlineContent({ story }: InlineContentProps) {
@@ -231,6 +252,7 @@ export const BlockContent = React.memo(({ story }: BlockContentProps) => {
 });
 
 export default function DiaryContent({ content }: DiaryContentProps) {
+  console.log(content);
   return (
     <article className="prose-lg prose break-words dark:prose-invert">
       {content.map((c, index) => {
@@ -239,11 +261,21 @@ export default function DiaryContent({ content }: DiaryContentProps) {
         }
 
         return (
-          <p key={index}>
-            {c.inline.map((con, i) => (
-              <InlineContent key={i} story={con} />
-            ))}
-          </p>
+          <React.Fragment key={index}>
+            {groupByParagraph(c.inline).map((con, i) => {
+              if (con.length === 1 && isBreak(con[0])) {
+                return <br key={i} />;
+              }
+
+              return (
+                <p key={i}>
+                  {con.map((s, j) => (
+                    <InlineContent key={j} story={s} />
+                  ))}
+                </p>
+              );
+            })}
+          </React.Fragment>
         );
       })}
     </article>


### PR DESCRIPTION
This parses our breaks so that they form paragraphs fixing #1959. We could probably refine this further with code blocks and blockquotes (these should probably not be part of the inline type anyway).

Fixes #1959 