### PR TITLE
groups: various first-run fixes

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -223,10 +223,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 isMobile ? (
                   <MobileGroupsNavHome />
                 ) : (
-                  <Notifications
-                    child={GroupNotification}
-                    title={`All Notifications • ${appHead('').title}`}
-                  />
+                  <FindGroups title={`Find Groups • ${appHead('').title}`} />
                 )
               }
             />

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -72,15 +72,15 @@ export default function GroupReference({
       >
         <div className="flex items-center space-x-3 font-semibold">
           <GroupAvatar {...meta} size="h-12 w-12" />
-          <div className="space-y-2">
-            <div className="flex items-center space-x-3">
-              <h3>{meta?.title || flag}</h3>
+          <div className="leading-5">
+            <h3>
+              {meta?.title || flag}{' '}
               {!plain && (
                 <span className="font-semibold text-gray-400">
-                  by <ShipName name={ship} />
+                  by <ShipName className="whitespace-nowrap" name={ship} />
                 </span>
               )}
-            </div>
+            </h3>
             {!plain && (
               <span className="capitalize text-gray-400">
                 Group • {privacy}
@@ -92,13 +92,13 @@ export default function GroupReference({
           </div>
         </div>
       </button>
-      <div className="absolute right-5 flex flex-row">
+      <div className="mr-2 flex flex-row">
         {banned ? (
-          <span className="inline-block px-2 font-semibold text-gray-600">
+          <div className="rounded-lg bg-gray-100 p-2 text-center text-xs font-semibold leading-3 text-gray-600">
             {banned === 'ship'
-              ? "You've been banned from this group"
+              ? 'You are banned'
               : `${toTitleCase(pluralRank(banned))} are banned`}
-          </span>
+          </div>
         ) : (
           <>
             {gang.invite && !group && status !== 'loading' ? (

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -65,7 +65,7 @@ export function GroupsAppMenu() {
               target="_blank"
               rel="noreferrer"
             >
-              <div className="flex h-12 w-12 items-center justify-center rounded-md">
+              <div className="flex h-12 w-12 items-center justify-center rounded-md text-blue">
                 <AsteriskIcon className="h-6 w-6" />
               </div>
               <DropdownMenu.Item className="dropdown-item pl-3 text-blue">
@@ -218,6 +218,12 @@ export default function Sidebar() {
                   sortOptions={sortOptions}
                   isMobile={isMobile}
                 />
+                {!sortedGroups.length && (
+                  <div className="mt-4 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
+                    Check out <strong>Find Groups</strong> above to find new
+                    groups in your network or view group invites.
+                  </div>
+                )}
               </li>
             </ul>
             {gangs.map((flag) => (

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -69,7 +69,7 @@ export function TalkAppMenu() {
               target="_blank"
               rel="noreferrer"
             >
-              <div className="flex h-12 w-12 items-center justify-center rounded-md">
+              <div className="flex h-12 w-12 items-center justify-center rounded-md text-blue">
                 <AsteriskIcon className="h-6 w-6" />
               </div>
               <DropdownMenu.Item className="dropdown-item pl-3 text-blue">

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -15,6 +15,7 @@ import { hasKeys, preSig, whomIsFlag } from '@/logic/utils';
 import { useNavigate, useParams, useLocation } from 'react-router';
 import asyncCallWithTimeout from '@/logic/asyncWithTimeout';
 import { useModalNavigate } from '@/logic/routing';
+import GroupReference from '@/components/References/GroupReference';
 import GroupJoinList from './GroupJoinList';
 import GroupJoinListPlaceholder from './GroupJoinListPlaceholder';
 
@@ -275,6 +276,35 @@ export default function FindGroups({ title }: ViewProps) {
               <GroupJoinList gangs={pendingGangs} />
             </section>
           ) : null}
+
+          {!hasKeys(pendingGangs) && !selectedShip && (
+            <section
+              className={cn('mb-8 space-y-8', !isMobile && 'card mb-4 sm:p-8')}
+            >
+              <h1 className="text-lg font-bold">Suggested Groups</h1>
+              <p className="leading-6">
+                Here are some groups we recommend joining to learn more about
+                Groups and how to use it in interesting ways:
+              </p>
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+                <GroupReference
+                  flag="~halbex-palheb/uf-public"
+                  plain
+                  description="Learn about the Urbit Project"
+                />
+                <GroupReference
+                  flag="~natnex-ronret/door-link"
+                  description="A cult of music lovers"
+                  plain
+                />
+                <GroupReference
+                  flag="~nibset-napwyn/tlon"
+                  description="A place to ask for help"
+                  plain
+                />
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </>

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -5,7 +5,7 @@ import { mix, transparentize } from 'color2k';
 import { useIsDark } from '@/logic/useMedia';
 import { useGroup, useGroupFlag } from '@/state/groups/groups';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
-import HashIcon16 from '@/components/icons/HashIcon16';
+import BellIcon from '@/components/icons/BellIcon';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import useHarkState from '@/state/hark';
 import { useCalm } from '@/state/settings';
@@ -15,7 +15,6 @@ import ChannelList from '@/groups/GroupSidebar/ChannelList';
 import GroupAvatar from '@/groups/GroupAvatar';
 import GroupActions from '@/groups/GroupActions';
 import ElipsisIcon from '@/components/icons/EllipsisIcon';
-import HomeIcon from '@/components/icons/HomeIcon';
 import HashIcon from '@/components/icons/HashIcon';
 
 function GroupHeader() {
@@ -202,7 +201,7 @@ export default function GroupSidebar() {
           <GroupHeader />
           <SidebarItem
             icon={
-              <HomeIcon
+              <BellIcon
                 className={cn('m-1 h-6 w-6 rounded bg-gray-50', {
                   'mix-blend-multiply': !isDark,
                 })}
@@ -210,7 +209,7 @@ export default function GroupSidebar() {
             }
             to={`/groups/${flag}/activity`}
           >
-            Home
+            Activity
           </SidebarItem>
           <SidebarItem
             icon={

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -5,7 +5,7 @@ import { useGroup, useGroupFlag } from '@/state/groups/groups';
 import NavTab from '@/components/NavTab';
 import HashIcon from '@/components/icons/HashIcon';
 import ElipsisIcon from '@/components/icons/EllipsisIcon';
-import HomeIcon from '@/components/icons/HomeIcon';
+import BellIcon from '@/components/icons/BellIcon';
 import GroupAvatar from '../GroupAvatar';
 
 export default function MobileGroupSidebar() {
@@ -20,8 +20,8 @@ export default function MobileGroupSidebar() {
         <nav>
           <ul className="flex items-center">
             <NavTab to={`.`} end>
-              <HomeIcon className="mb-0.5 h-6 w-6" />
-              Home
+              <BellIcon className="mb-0.5 h-6 w-6" />
+              Activity
             </NavTab>
             <NavTab to={`/groups/${flag}/channellist`} end>
               <HashIcon className="mb-0.5 h-6 w-6" />

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -15,7 +15,6 @@ import useRequestState from '@/logic/useRequestState';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useIsMobile } from '@/logic/useMedia';
 import { randomElement, randomIntInRange } from '@/logic/utils';
-import GroupSummary from '@/groups/GroupSummary';
 import { Bin, useNotifications } from './useNotifications';
 
 export interface NotificationsProps {
@@ -154,15 +153,6 @@ export default function Notifications({
             : title}
         </title>
       </Helmet>
-      {!isMobile && group && (
-        <div className="mb-7 flex-col space-y-7 rounded-xl bg-white p-7">
-          <h1 className="text-lg font-bold">Group Info</h1>
-          <GroupSummary flag={flag} preview={{ ...group, flag }} />
-          {group.meta.description && (
-            <p className="leading-6">{group.meta.description}</p>
-          )}
-        </div>
-      )}
       <div className="flex w-full items-center justify-between">
         <div
           className={cn('flex flex-row', {
@@ -199,9 +189,9 @@ export default function Notifications({
       </div>
       {loaded ? (
         notifications.length === 0 ? (
-          <div className="flex w-full items-center justify-center">
-            <span className="text-xl font-semibold">
-              No notifications for {group ? 'this' : 'any'} group.
+          <div className="mt-3 flex w-full items-center justify-center">
+            <span className="text-base font-semibold text-gray-400">
+              No notifications from {group ? 'this' : 'any'} group.
             </span>
           </div>
         ) : (


### PR DESCRIPTION
- Removes GroupSummary from the group home
- Renames group home to "Activity" and uses bell icon:
![image](https://user-images.githubusercontent.com/748181/220724018-f501421e-6af6-4a34-bfab-54af76771406.png)
- Cleans up overlapping GroupReference layout
- Sets the default app route to Find Groups
- De-emphasizes the empty activity notices
- Adds suggested groups in Find Groups:
![image](https://user-images.githubusercontent.com/748181/220723825-248e8d32-fabd-44c1-ab78-b7ac61e0f470.png)
