### PR TITLE
channels: avoid ungodly unread backlog

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -942,6 +942,7 @@
         (cu-post-notice ship '' ' declined the invite')
       =.  cor  (give-brief club/id cu-brief)
       =.  team.club  (~(put in team.club) ship)
+      =?  last-read.remark.club  =(ship our.bowl)  now.bowl  
       (cu-post-notice ship '' ' joined the chat')
     ::
         %hive
@@ -1315,6 +1316,7 @@
     ^+  ca-core
     =.  chats  (~(put by chats) chan.j *chat:c)
     =.  ca-core  (ca-abed chan.j)
+    =.  last-read.remark.chat  now.bowl
     =.  group.perm.chat  group.j
     =.  cor  (give-brief flag/flag ca-brief)
     ca-sub

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -840,6 +840,7 @@
     =.  shelf  (~(put by shelf) chan.j *diary:d)
     =.  di-core  (di-abed chan.j)
     =.  group.perm.diary  group.j
+    =.  last-read.remark.diary  now.bowl
     =.  cor  (give-brief flag di-brief)
     di-sub
   ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -841,6 +841,7 @@
     =.  stash  (~(put by stash) chan.j *heap:h)
     =.  he-core  (he-abed chan.j)
     =.  group.perm.heap  group.j
+    =.  last-read.remark.heap  now.bowl
     =.  cor  (give-brief flag he-brief)
     he-sub
   ::


### PR DESCRIPTION
OTT I don't think we have this issue recorded, but joining any channel with a large backlog gives an ungodly amount of unreads. This sanely sets the last read time to the join time.