### PR TITLE
New channel manager fixes

### DIFF
--- a/ui/src/channels/EditChannelForm.tsx
+++ b/ui/src/channels/EditChannelForm.tsx
@@ -93,9 +93,9 @@ export default function EditChannelForm({
           : useDiaryState.getState();
 
       if (privacy !== 'public') {
-        chState.addSects(channelFlag, ['admin']);
+        await chState.addSects(channelFlag, ['admin']);
       } else {
-        chState.delSects(channelFlag, ['admin']);
+        await chState.delSects(channelFlag, ['admin']);
       }
 
       if (retainRoute === true && setEditIsOpen) {

--- a/ui/src/groups/ChannelsList/SectionNameEditInput.tsx
+++ b/ui/src/groups/ChannelsList/SectionNameEditInput.tsx
@@ -50,31 +50,34 @@ export default function SectionNameEditInput({
     defaultValues,
   });
 
-  const addChannelsToZone = async (
-    zone: string,
-    groupFlag: string,
-    channelFlag: string
-  ) => {
-    await useGroupState
-      .getState()
-      .addChannelToZone(zone, groupFlag, channelFlag);
-  };
-
   const onSubmit = async (values: GroupMeta) => {
     setSaveStatus('loading');
     const zoneFlag = strToSym(sectionKey);
+    const titleExists = values.title.trim() !== '';
     handleEditingChange();
     try {
       if (isNew === true) {
-        await useGroupState.getState().createZone(group, zoneFlag, values);
+        await useGroupState
+          .getState()
+          .createZone(
+            group,
+            zoneFlag,
+            titleExists ? values : untitledSectionValues
+          );
         await useGroupState.getState().moveZone(group, zoneFlag, 1);
       } else {
-        await useGroupState.getState().editZone(group, zoneFlag, values);
+        await useGroupState
+          .getState()
+          .editZone(
+            group,
+            zoneFlag,
+            titleExists ? values : untitledSectionValues
+          );
       }
-      channels.forEach((channel) => {
-        addChannelsToZone(zoneFlag, group, channel.key);
-      });
-      onSectionEditNameSubmit(zoneFlag, values.title);
+      onSectionEditNameSubmit(
+        zoneFlag,
+        titleExists ? values.title : untitledSectionValues.title
+      );
       setSaveStatus('success');
     } catch (e) {
       setSaveStatus('error');
@@ -83,31 +86,8 @@ export default function SectionNameEditInput({
   };
 
   const onLoseFocus = async () => {
-    setSaveStatus('loading');
-    const zoneFlag = strToSym(sectionKey);
     const values = getValues();
-    handleEditingChange();
-    try {
-      await useGroupState
-        .getState()
-        .createZone(
-          group,
-          zoneFlag,
-          values.title.length > 0 ? values : untitledSectionValues
-        );
-      await useGroupState.getState().moveZone(group, zoneFlag, 1);
-      onSectionEditNameSubmit(
-        zoneFlag,
-        values.title.length > 0 ? values.title : untitledSectionValues.title
-      );
-      channels.forEach((channel) => {
-        addChannelsToZone(zoneFlag, group, channel.key);
-      });
-      setSaveStatus('success');
-    } catch (e) {
-      setSaveStatus('error');
-      console.log(e);
-    }
+    onSubmit(values);
   };
 
   return (


### PR DESCRIPTION
Fixes #2000 

We had some weird logic in the SectionNameEditInput component that was causing the first issue. 

We were also re-adding channels to a section each time we updated the title, which appears to be unnecessary (maybe a previous hack to deal with the state not updating?), which was causing the channels to reorder when renaming a section.

The channel permissions state not updating was due to the relevant calls not being awaited.