### PR TITLE
admin: fixes invite button/search field alignment, various improvements

### DIFF
--- a/ui/src/groups/ChannelsList/ChannelsListSearch.tsx
+++ b/ui/src/groups/ChannelsList/ChannelsListSearch.tsx
@@ -19,7 +19,7 @@ export default function ChannelsListSearch() {
         <MagnifyingGlass16Icon className="h-4 w-4" />
       </span>
       <input
-        className="input h-10 w-[260px] bg-gray-50 pl-7 text-sm mix-blend-multiply placeholder:font-normal md:text-base"
+        className="input h-10 w-[260px] bg-gray-50 pl-7 text-sm mix-blend-multiply placeholder:font-normal dark:bg-white dark:mix-blend-normal md:text-base"
         placeholder="Filter Channel Titles and Sections"
         value={searchInput}
         onChange={handleChange}

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -13,6 +13,7 @@ import LeaveIcon from '@/components/icons/LeaveIcon';
 import useIsGroupUnread from '@/logic/useIsGroupUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { citeToPath, useCopy } from '@/logic/utils';
+import { useAmAdmin } from '@/state/groups';
 
 const { ship } = window;
 
@@ -22,6 +23,7 @@ export function useGroupActions(flag: string) {
   const [copyItemText, setCopyItemText] = useState('Copy Group Link');
   const pinned = usePinnedGroups();
   const isPinned = Object.keys(pinned).includes(flag);
+  const isAdmin = useAmAdmin(flag);
 
   const onCopy = useCallback(() => {
     doCopy();
@@ -61,6 +63,7 @@ const GroupActions = React.memo(
     const { isGroupUnread } = useIsGroupUnread();
     const location = useLocation();
     const hasActivity = isGroupUnread(flag);
+    const isAdmin = useAmAdmin(flag);
 
     const { isOpen, setIsOpen, isPinned, copyItemText, onCopy, onPinClick } =
       useGroupActions(flag);
@@ -99,19 +102,21 @@ const GroupActions = React.memo(
             )}
           </DropdownMenu.Trigger>
           <DropdownMenu.Content className="dropdown min-w-52 text-gray-800">
-            <DropdownMenu.Item
-              asChild
-              className="dropdown-item text-blue hover:bg-blue-soft hover:dark:bg-blue-900"
-            >
-              <Link
-                to={`/groups/${flag}/invite`}
-                state={{ backgroundLocation: location }}
-                className="flex items-center space-x-2"
+            {isAdmin && (
+              <DropdownMenu.Item
+                asChild
+                className="dropdown-item text-blue hover:bg-blue-soft hover:dark:bg-blue-900"
               >
-                <InviteIcon16 className="h-6 w-6 opacity-60" />
-                <span className="pr-2">Invite People</span>
-              </Link>
-            </DropdownMenu.Item>
+                <Link
+                  to={`/groups/${flag}/invite`}
+                  state={{ backgroundLocation: location }}
+                  className="flex items-center space-x-2"
+                >
+                  <InviteIcon16 className="h-6 w-6 opacity-60" />
+                  <span className="pr-2">Invite People</span>
+                </Link>
+              </DropdownMenu.Item>
+            )}
             <DropdownMenu.Item
               className={
                 'dropdown-item flex items-center space-x-2 text-blue hover:bg-blue-soft hover:dark:bg-blue-900'

--- a/ui/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/ui/src/groups/GroupAdmin/GroupInfo.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
-import { capitalize } from 'lodash';
 import { Helmet } from 'react-helmet';
 import { ViewProps } from '@/types/groups';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { useRouteGroup, useGroup, useAmAdmin } from '../../state/groups/groups';
-import GroupAvatar from '../GroupAvatar';
 import GroupInfoEditor from './GroupInfoEditor';
 import GroupMemberManager from './GroupMemberManager';
+import GroupSummary from '../GroupSummary';
 
 export default function GroupInfo({ title }: ViewProps) {
   const flag = useRouteGroup();
   const group = useGroup(flag);
-  const { privacy } = useGroupPrivacy(flag);
 
   const isAdmin = useAmAdmin(flag);
   if (isAdmin) {
@@ -30,15 +28,9 @@ export default function GroupInfo({ title }: ViewProps) {
           {group?.meta ? `Info for ${group.meta.title} ${title}` : title}
         </title>
       </Helmet>
-      <div className="card mb-4 flex flex-col items-center">
-        <GroupAvatar {...meta} size="h-20 w-20" />
-        <div className="my-4 text-center">
-          <h2 className="center mb-2 font-semibold">{meta.title}</h2>
-          <h3 className="text-base text-gray-600">
-            {capitalize(privacy)} Group
-          </h3>
-        </div>
-        <p className="w-full leading-5">{meta.description}</p>
+      <div className="card mb-4 flex flex-col">
+        <GroupSummary flag={flag} preview={{ ...group, flag }} />
+        <p className="mt-4 w-full leading-5">{meta.description}</p>
       </div>
       <GroupMemberManager />
     </>

--- a/ui/src/groups/GroupAdmin/GroupMemberItem.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberItem.tsx
@@ -105,9 +105,9 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
   return (
     <>
       <div className="cursor-pointer" onClick={() => onViewProfile(member)}>
-        <Avatar ship={member} size="small" className="mr-2" />
+        <Avatar ship={member} size="small" icon={false} className="mr-2" />
       </div>
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col space-y-0.5">
         <h2>
           {contact?.nickname ? contact.nickname : <ShipName name={member} />}
         </h2>
@@ -115,12 +115,20 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
           <p className="text-sm text-gray-400">{member}</p>
         ) : null}
       </div>
+      {isHost && (
+        <div className="mr-2 rounded border border-green-500 px-2 py-0.5 text-xs font-medium uppercase text-green-500">
+          Host
+        </div>
+      )}
       {isAdmin && vessel ? (
         <Dropdown.Root>
-          <Dropdown.Trigger className="default-focus mr-2 flex items-center rounded px-2 py-1.5 text-gray-400">
-            {vessel.sects
-              .map((s) => toTitleCase(getSectTitle(group.cabals, s)))
-              .join(', ')}
+          <Dropdown.Trigger className="small-secondary-button default-focus mr-2 flex max-w-xs items-center whitespace-nowrap">
+            {vessel.sects.length > 3
+              ? `${vessel.sects.length} Roles`
+              : vessel.sects
+                  .map((s) => toTitleCase(getSectTitle(group.cabals, s)))
+                  .concat('Member')
+                  .join(', ')}
             <CaretDown16Icon className="ml-2 h-4 w-4" />
           </Dropdown.Trigger>
           <Dropdown.Content className="dropdown min-w-52 text-gray-800">
@@ -129,25 +137,27 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
                 key={s}
                 className={cn(
                   'dropdown-item flex items-center',
-                  !vessel.sects.includes(s) && 'text-gray-400'
+                  !vessel.sects.includes(s) && 'text-gray-800'
                 )}
                 onSelect={toggleSect(member, s, vessel)}
               >
-                {getSectTitle(group.cabals, s)}
                 {sectStatus === 'loading' ? (
-                  <LoadingSpinner className="ml-auto h-4 w-4" />
+                  <div className="mr-2 flex h-6 w-6 items-center justify-center">
+                    <LoadingSpinner className="h-4 w-4" />
+                  </div>
                 ) : vessel.sects.includes(s) ? (
-                  <CheckIcon className="ml-auto h-6 w-6 text-green" />
+                  <CheckIcon className="mr-2 h-6 w-6 text-green" />
                 ) : (
-                  <div className="ml-auto h-6 w-6" />
+                  <div className="mr-2 h-6 w-6" />
                 )}
+                {getSectTitle(group.cabals, s)}
               </Dropdown.Item>
             ))}
             <Dropdown.Item
-              className={cn('dropdown-item flex items-center', 'text-gray-400')}
+              className={cn('dropdown-item flex items-center', 'text-gray-800')}
             >
+              <CheckIcon className="mr-2 h-6 w-6 text-green" />
               Member
-              <CheckIcon className="ml-auto h-6 w-6 text-green" />
             </Dropdown.Item>
           </Dropdown.Content>
         </Dropdown.Root>
@@ -155,13 +165,12 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
       {isAdmin && !isHost ? (
         <Dropdown.Root>
           {member !== window.our ? (
-            <Dropdown.Trigger className="default-focus ml-auto rounded text-gray-400">
-              <ElipsisCircleIcon className="h-6 w-6" />
+            <Dropdown.Trigger className="default-focus ml-auto text-gray-800">
+              <ElipsisIcon className="h-6 w-6" />
             </Dropdown.Trigger>
           ) : (
             <div className="h-6 w-6" />
           )}
-
           <Dropdown.Content className="dropdown min-w-52 text-gray-800">
             <Dropdown.Item
               className="dropdown-item flex items-center text-red"
@@ -181,7 +190,7 @@ function GroupMemberItem({ member }: GroupMemberItemProps) {
         </Dropdown.Root>
       ) : (
         <Dropdown.Root>
-          <Dropdown.Trigger className="default-focus ml-auto rounded text-gray-400">
+          <Dropdown.Trigger className="default-focus ml-auto rounded text-gray-800">
             <ElipsisIcon className="h-6 w-6" />
           </Dropdown.Trigger>
           <Dropdown.Content className="dropdown min-w-52 text-gray-800">

--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -5,11 +5,14 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import cn from 'classnames';
 import { debounce } from 'lodash';
 import { deSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import { Link, useLocation } from 'react-router-dom';
 import { useGroup, useRouteGroup } from '@/state/groups/groups';
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
+import { useAmAdmin } from '@/state/groups';
 import MemberScroller from './MemberScroller';
 
 export default function GroupMemberManager() {
@@ -18,6 +21,7 @@ export default function GroupMemberManager() {
   const group = useGroup(flag);
   const [rawInput, setRawInput] = useState('');
   const [search, setSearch] = useState('');
+  const amAdmin = useAmAdmin(flag);
   const members = useMemo(() => {
     if (!group) {
       return [];
@@ -69,25 +73,35 @@ export default function GroupMemberManager() {
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <p className="mb-4 text-sm font-semibold text-gray-400">
-        {members.length} total
-      </p>
-      <div className="mb-4 flex items-center">
-        <input
-          value={rawInput}
-          onChange={onChange}
-          className="input flex-1 font-semibold"
-          placeholder="Search Members"
-          aria-label="Search Members"
-        />
-        <Link
-          to={`/groups/${flag}/invite`}
-          state={{ backgroundLocation: location }}
-          className="button ml-2 bg-blue dark:text-black"
-        >
-          Invite
-        </Link>
+    <div className={cn(!amAdmin && 'card', 'flex h-full grow flex-col')}>
+      <div
+        className={cn(
+          amAdmin && 'mt-2',
+          'mb-4 flex w-full items-center justify-between'
+        )}
+      >
+        {amAdmin && (
+          <Link
+            to={`/groups/${flag}/invite`}
+            state={{ backgroundLocation: location }}
+            className="button bg-blue dark:text-black"
+          >
+            Invite
+          </Link>
+        )}
+
+        <label className="relative ml-auto flex items-center">
+          <span className="sr-only">Search Prefences</span>
+          <span className="absolute inset-y-[5px] left-0 flex h-8 w-8 items-center pl-2 text-gray-400">
+            <MagnifyingGlass16Icon className="h-4 w-4" />
+          </span>
+          <input
+            className="input h-10 w-[260px] bg-gray-50 pl-7 text-sm mix-blend-multiply placeholder:font-normal md:text-base"
+            placeholder={`Filter Members (${members.length} total)`}
+            value={rawInput}
+            onChange={onChange}
+          />
+        </label>
       </div>
       <div className="grow">
         <MemberScroller members={results} />

--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -96,7 +96,7 @@ export default function GroupMemberManager() {
             <MagnifyingGlass16Icon className="h-4 w-4" />
           </span>
           <input
-            className="input h-10 w-[260px] bg-gray-50 pl-7 text-sm mix-blend-multiply placeholder:font-normal md:text-base"
+            className="input h-10 w-[260px] bg-gray-50 pl-7 text-sm mix-blend-multiply placeholder:font-normal dark:mix-blend-normal md:text-base"
             placeholder={`Filter Members (${members.length} total)`}
             value={rawInput}
             onChange={onChange}

--- a/ui/src/groups/GroupAdmin/MemberScroller.tsx
+++ b/ui/src/groups/GroupAdmin/MemberScroller.tsx
@@ -9,13 +9,17 @@ interface MemberScrollerProps {
 
 const Components: VirtuosoComponents<string> = {
   List: forwardRef((props, listRef) => (
-    <div className="h-full w-full space-y-6 py-2" {...props} ref={listRef}>
+    <div className="h-full w-full" {...props} ref={listRef}>
       {props.children}
     </div>
   )),
   Item: forwardRef((props, itemRef) => (
-    // @ts-expect-error tsc complains about the ref prop, but it's fine
-    <div className="flex items-center font-semibold" {...props} ref={itemRef}>
+    <div
+      className="flex items-center border-t border-gray-100 py-3 font-semibold hover:bg-gray-50"
+      {...props}
+      // @ts-expect-error tsc complains about the ref prop, but it's fine
+      ref={itemRef}
+    >
       {props.children}
     </div>
   )),


### PR DESCRIPTION
Adjusts the layout of the invite/member search field in the admin/member manager to follow the button/filter pattern in #1995. 

Also removes the ability for non-admins to invite members to a group.

Also makes some UX fixes to the member manager itself that have been bothering me for a while:

- Adds row striping and mouseover backgrounds to each member row for more accurate editing
- Moves the member count to inside the filter field to eliminate a disconnected layout element
- Adds a very obvious "HOST" badge for channel and group hosts
- Makes the role change dropdown a button, moves the check-marks to the left
- Lists everyone as a member
- Gracefully overflows 3+ roles
- Unifies ancillary action styles for each row
- Wraps the members list in a card for non-admins
- Fixes the filter inputs to display in dark mode
- Standardizes the non-admin group info display to use GroupSummary

![image](https://user-images.githubusercontent.com/748181/221302226-13f6b240-c14a-47b0-a202-72d3f37535d7.png)

![image](https://user-images.githubusercontent.com/748181/221302305-05f2d797-8950-4d5b-a812-71557f6315f9.png)

fixes #1365