### PR TITLE
clubs: only send to part of list so we actually are gossiping

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -828,10 +828,25 @@
       =/  =cage  club-action+!>(`action:club:c`[id diff])
       [%pass wire %agent dock %poke cage]
     ::
+    ++  ship-list
+      ^-  (list ship)
+      =/  roster  ~(tap in cu-out)
+      ?:  (lte ~(wyt in cu-out) 3)
+        roster
+      =/  rng  ~(. og eny.bowl)
+      =|  ships=(set ship)
+      |-
+      ?:  =(~(wyt in ships) (div (lent roster) 2))
+        ~(tap in ships)
+      =^  rand  rng  (rads:rng (sub (lent roster) 1))
+      =/  candidate  (snag rand roster)
+      $(ships (~(put in ships) candidate))
+    ::
     ++  gossip
       |=  =diff:club:c
-      ^-  (list card)
-      %+  turn  ~(tap in cu-out)
+      ^-  (list card)    
+      %+  turn 
+        ship-list 
       |=  =ship
       (act ship diff)
     --


### PR DESCRIPTION
This should help with the explosion of networking activity in large group dms, but will not fix all the issues we're currently seeing with them. Definitely up to any better ways of doing this until we can fix the overarching issues. This is just to stop the bleeding.

Need to test this with a good amount of ships, maybe we can get some test ones in hosting plus some personal moons? @jamesacklin 