### PR TITLE
heap: comment-specific text input layout

### DIFF
--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
@@ -14,7 +14,7 @@ export default function HeapDetailCommentField() {
   const replyToTime = idCurio ? decToUd(idCurio) : undefined;
 
   return (
-    <div className="flex-end flex h-32 w-full flex-col sm:h-24 sm:flex-row">
+    <div className="flex-end">
       <HeapTextInput
         flag={chFlag}
         draft={draftText}
@@ -22,6 +22,7 @@ export default function HeapDetailCommentField() {
         replyTo={replyToTime}
         className="flex-1"
         placeholder="Comment"
+        comment={true}
       />
     </div>
   );

--- a/ui/src/heap/HeapTextInput.tsx
+++ b/ui/src/heap/HeapTextInput.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames';
 import { Editor, JSONContent } from '@tiptap/react';
 import React, { useCallback, useEffect } from 'react';
 import { HeapInline, CurioHeart, HeapInlineKey, LIST } from '@/types/heap';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MessageEditor, { useMessageEditor } from '@/components/MessageEditor';
 import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
 import { useIsMobile } from '@/logic/useMedia';
@@ -15,6 +16,7 @@ import {
   useChatStore,
 } from '@/chat/useChatStore';
 import X16Icon from '@/components/icons/X16Icon';
+import ArrowNIcon16 from '@/components/icons/ArrowNIcon16';
 
 interface HeapTextInputProps {
   flag: string;
@@ -25,6 +27,7 @@ interface HeapTextInputProps {
   replyTo?: string | null;
   className?: string;
   inputClass?: string;
+  comment?: boolean;
 }
 
 const MERGEABLE_KEYS = ['italics', 'bold', 'strike', 'blockquote'] as const;
@@ -58,6 +61,13 @@ function normalizeHeapInline(inline: HeapInline[]): HeapInline[] {
   );
 }
 
+function SubmitLabel({ comment }: { comment?: boolean }) {
+  if (comment) {
+    return <ArrowNIcon16 className="h-4 w-4" />;
+  }
+  return <span>Post</span>;
+}
+
 export default function HeapTextInput({
   flag,
   draft,
@@ -67,6 +77,7 @@ export default function HeapTextInput({
   placeholder,
   className,
   inputClass,
+  comment = false,
 }: HeapTextInputProps) {
   const isMobile = useIsMobile();
   const { isPending, setPending, setReady } = useRequestState();
@@ -164,11 +175,11 @@ export default function HeapTextInput({
   return (
     <>
       <div
-        className={cn('relative', className)}
+        className={cn('items-end', className)}
         onClick={() => messageEditor.commands.focus()}
       >
         {chatInfo.blocks.length > 0 ? (
-          <div className="my-2 flex items-center justify-start font-semibold">
+          <div className="my-2 flex w-full items-center justify-start font-semibold">
             <span className="mr-2 text-gray-600">Attached: </span>
             {chatInfo.blocks.length} reference
             {chatInfo.blocks.length === 1 ? '' : 's'}
@@ -180,27 +191,41 @@ export default function HeapTextInput({
             </button>
           </div>
         ) : null}
-        <MessageEditor
-          editor={messageEditor}
-          className={cn('h-full w-full rounded-lg', inputClass)}
-          inputClassName={cn(
-            // Since TipTap simulates an input using a <p> tag, only style
-            // the fake placeholder when the field is empty
-            messageEditor.getText() === '' ? 'font-semibold text-gray-400' : ''
+        <div
+          className={cn(
+            'w-full',
+            comment ? 'flex flex-row items-end' : 'relative flex h-full'
           )}
-        />
-        {!sendDisabled ? (
-          <button
-            className="button absolute bottom-3 right-3 rounded-md px-2 py-1"
-            disabled={
-              isPending ||
-              (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
-            }
-            onClick={onClick}
-          >
-            {isPending ? 'Posting...' : 'Post'}
-          </button>
-        ) : null}
+        >
+          <MessageEditor
+            editor={messageEditor}
+            className={cn('w-full rounded-lg', inputClass)}
+            inputClassName={cn(
+              // Since TipTap simulates an input using a <p> tag, only style
+              // the fake placeholder when the field is empty
+              messageEditor.getText() === '' ? 'text-gray-400' : ''
+            )}
+          />
+          {!sendDisabled ? (
+            <button
+              className={cn(
+                'button',
+                comment ? 'ml-2 shrink-0' : 'absolute bottom-2 right-2'
+              )}
+              disabled={
+                isPending ||
+                (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
+              }
+              onClick={onClick}
+            >
+              {isPending ? (
+                <LoadingSpinner secondary="black" />
+              ) : (
+                <SubmitLabel comment={comment} />
+              )}
+            </button>
+          ) : null}
+        </div>
       </div>
       {isMobile && messageEditor.isFocused ? (
         <ChatInputMenu editor={messageEditor} />

--- a/ui/src/heap/NewCurioForm.tsx
+++ b/ui/src/heap/NewCurioForm.tsx
@@ -214,8 +214,8 @@ export default function NewCurioForm() {
             )}
             inputClass={cn(
               isListMode
-                ? 'border-gray-100 bg-white focus-within:border-gray-300 mb-4 focus:outline-none rounded-tl-none min-h-[60px]'
-                : 'border-gray-50 overflow-y-auto focus-within:border-gray-50 bg-gray-50 focus-within:bg-gray-50 focus:outline-none'
+                ? 'border-gray-100 bg-white focus-within:border-gray-300 mb-12 focus:outline-none rounded-tl-none min-h-[60px]'
+                : 'overflow-y-auto focus-within:border-white focus:outline-none bg-transparent mb-12'
             )}
           />
         )}


### PR DESCRIPTION
- Allows the comment input box to expand vertically forever
- Moves the "Post" button out of the text area to prevent overlapping
- Adds a spinner during posting
- Changes "Post" to an up arrow to conserve some space in comments

![Screenshot 2023-03-02 at 9 46 48 AM](https://user-images.githubusercontent.com/748181/222466827-c08b1a6e-b57a-431e-9d60-71128e3ba153.png)

![Screenshot 2023-03-02 at 9 47 27 AM](https://user-images.githubusercontent.com/748181/222466970-649653a5-2323-49ee-ad40-191a140b0c32.png)

fixes #2006, partially fixes #2045