### PR TITLE
chat: move ChatEmbedContent container to inside component

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -93,11 +93,9 @@ export function InlineContent({ story }: InlineContentProps) {
   if (isLink(story)) {
     const containsProtocol = story.link.href.match(/https?:\/\//);
     return (
-      <div className="flex flex-col @container">
-        <ChatEmbedContent
-          url={containsProtocol ? story.link.href : `http://${story.link.href}`}
-        />
-      </div>
+      <ChatEmbedContent
+        url={containsProtocol ? story.link.href : `http://${story.link.href}`}
+      />
     );
   }
 

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -41,28 +41,36 @@ function ChatEmbedContent({ url }: { url: string }) {
 
     if (provider === 'YouTube') {
       return (
-        <YouTubeEmbed
-          url={embedUrl}
-          title={title}
-          thumbnail={thumbnail}
-          author={author}
-          authorUrl={authorUrl}
-        />
+        <div className="flex flex-col @container">
+          <YouTubeEmbed
+            url={embedUrl}
+            title={title}
+            thumbnail={thumbnail}
+            author={author}
+            authorUrl={authorUrl}
+          />
+        </div>
       );
     }
 
     if (provider === 'Twitter') {
       return (
-        <TwitterEmbed
-          authorUrl={authorUrl}
-          author={author}
-          embedHtml={embedHtml}
-        />
+        <div className="flex flex-col @container">
+          <TwitterEmbed
+            authorUrl={authorUrl}
+            author={author}
+            embedHtml={embedHtml}
+          />
+        </div>
       );
     }
 
     if (provider === 'Spotify') {
-      return <SpotifyEmbed url={url} title={title} thumbnailUrl={thumbnail} />;
+      return (
+        <div className="flex flex-col @container">
+          <SpotifyEmbed url={url} title={title} thumbnailUrl={thumbnail} />
+        </div>
+      );
     }
 
     return (


### PR DESCRIPTION
fixes #2052

Keeps non-oEmbed URLs as inline:
![image](https://user-images.githubusercontent.com/748181/222525038-1c4f14ab-6aaf-4875-8556-f10a0387b236.png)

Respects embeds:
![image](https://user-images.githubusercontent.com/748181/222524803-7d965929-e0a4-4481-91c0-cf70531b169a.png)
