### PR TITLE
groups: hard-code suggested groups

### DIFF
--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -17,6 +17,7 @@ interface GroupReferenceProps {
   flag: string;
   isScrolling?: boolean;
   plain?: boolean;
+  onlyButton?: boolean;
   description?: string;
 }
 
@@ -24,6 +25,7 @@ export default function GroupReference({
   flag,
   isScrolling = false,
   plain = false,
+  onlyButton = false,
   description,
 }: GroupReferenceProps) {
   const gang = useGang(flag);
@@ -53,6 +55,45 @@ export default function GroupReference({
       <div className="relative flex h-16 items-center space-x-3 rounded-lg border-2 border-gray-50 bg-gray-50 p-2 text-base font-semibold text-gray-600">
         <ExclamationPoint className="h-8 w-8 text-gray-400" />
         <span>This content is unavailable to you</span>
+      </div>
+    );
+  }
+
+  if (onlyButton) {
+    return (
+      <div>
+        {banned ? (
+          <div className="rounded-lg bg-gray-100 p-2 text-center text-xs font-semibold leading-3 text-gray-600">
+            {banned === 'ship'
+              ? 'You are banned'
+              : `${toTitleCase(pluralRank(banned))} are banned`}
+          </div>
+        ) : (
+          <>
+            {gang.invite && !group && status !== 'loading' ? (
+              <button
+                className="small-button bg-red text-white dark:text-black"
+                onClick={reject}
+              >
+                Reject
+              </button>
+            ) : null}
+            {status === 'loading' ? (
+              <div className="flex items-center space-x-2">
+                <span className="text-gray-400">Joining...</span>
+                <LoadingSpinner />
+              </div>
+            ) : (
+              <button
+                className="small-button ml-3 whitespace-nowrap bg-blue text-white dark:text-black"
+                onClick={button.action}
+                disabled={button.disabled || status === 'error'}
+              >
+                {status === 'error' ? 'Errored' : button.text}
+              </button>
+            )}
+          </>
+        )}
       </div>
     );
   }

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -18,6 +18,7 @@ import { useModalNavigate } from '@/logic/routing';
 import GroupReference from '@/components/References/GroupReference';
 import GroupJoinList from './GroupJoinList';
 import GroupJoinListPlaceholder from './GroupJoinListPlaceholder';
+import GroupAvatar from './GroupAvatar';
 
 export default function FindGroups({ title }: ViewProps) {
   const { ship, name } = useParams<{ ship: string; name: string }>();
@@ -286,22 +287,42 @@ export default function FindGroups({ title }: ViewProps) {
                 Here are some groups we recommend joining to learn more about
                 Groups and how to use it in interesting ways:
               </p>
-              <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-                <GroupReference
-                  flag="~halbex-palheb/uf-public"
-                  plain
-                  description="Learn about the Urbit Project"
-                />
-                <GroupReference
-                  flag="~natnex-ronret/door-link"
-                  description="A cult of music lovers"
-                  plain
-                />
-                <GroupReference
-                  flag="~nibset-napwyn/tlon"
-                  description="A place to ask for help"
-                  plain
-                />
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                <div className="flex items-center justify-between">
+                  <GroupAvatar
+                    image="https://interstellar.nyc3.digitaloceanspaces.com/battus-datsun/2022.11.07..19.39.22-Sig.png"
+                    size="h-12 w-12 shrink-0"
+                  />
+                  <div className="mx-2 grow">
+                    <h2 className="text-base font-semibold">
+                      Urbit Foundation
+                    </h2>
+                    <p className="text-xs">Learn about the Urbit project</p>
+                  </div>
+                  <GroupReference flag="~halbex-palheb/uf-public" onlyButton />
+                </div>
+                <div className="flex items-center justify-between">
+                  <GroupAvatar
+                    image="https://www.door.link/logowhite.svg"
+                    size="h-12 w-12 shrink-0"
+                  />
+                  <div className="mx-2 grow">
+                    <h2 className="text-base font-semibold">door.link</h2>
+                    <p className="text-xs">A cult of music lovers</p>
+                  </div>
+                  <GroupReference flag="~natnex-ronret/door-link" onlyButton />
+                </div>
+                <div className="flex items-center justify-between">
+                  <GroupAvatar
+                    image="https://sfo3.digitaloceanspaces.com/zurbit-images/dovsem-bornyl/2022.6.16..19.11.20-flooring.jpeg"
+                    size="h-12 w-12 shrink-0"
+                  />
+                  <div className="mx-2 grow">
+                    <h2 className="text-base font-semibold">Tlon Public</h2>
+                    <p className="text-xs">A place to ask for help</p>
+                  </div>
+                  <GroupReference flag="~nibset-napwyn/tlon" onlyButton />
+                </div>
               </div>
             </section>
           )}


### PR DESCRIPTION
Adds a button-only mode to GroupReference, hard-codes our suggested groups.

![image](https://user-images.githubusercontent.com/748181/222535508-9004569b-4022-4ac9-85bb-0ba4a9ef2214.png)

Fixes #2027 