### PR TITLE
refs: improve reference perf

### DIFF
--- a/ui/src/components/References/AppReference.tsx
+++ b/ui/src/components/References/AppReference.tsx
@@ -11,7 +11,7 @@ interface AppReferenceProps {
   isScrolling: boolean;
 }
 
-export default function AppReference({ flag, isScrolling }: AppReferenceProps) {
+function AppReference({ flag, isScrolling }: AppReferenceProps) {
   const { ship, name: deskId } = getFlagParts(flag);
   const treaty = useTreaty(ship, deskId);
   const calm = useCalm();
@@ -94,3 +94,5 @@ export default function AppReference({ flag, isScrolling }: AppReferenceProps) {
     </div>
   );
 }
+
+export default React.memo(AppReference);

--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -13,7 +13,7 @@ import NoteReference from './NoteReference';
 // eslint-disable-next-line import/no-cycle
 import WritBaitReference from './WritBaitReference';
 
-export default function BaitReference({
+function BaitReference({
   bait,
   isScrolling,
 }: {
@@ -75,3 +75,5 @@ export default function BaitReference({
 
   return <HeapLoadingBlock reference />;
 }
+
+export default React.memo(BaitReference);

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -13,7 +13,7 @@ import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
 import UnavailableReference from './UnavailableReference';
 
-export default function CurioReference({
+function CurioReference({
   chFlag,
   nest,
   idCurio,
@@ -108,3 +108,5 @@ export default function CurioReference({
     </div>
   );
 }
+
+export default React.memo(CurioReference);

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -5,13 +5,11 @@ import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 // eslint-disable-next-line import/no-cycle
 import HeapBlock from '@/heap/HeapBlock';
 import { useChannelPreview, useGang } from '@/state/groups';
-import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { useLocation, useNavigate } from 'react-router';
 import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
-import UnavailableReference from './UnavailableReference';
 
 function CurioReference({
   chFlag,
@@ -39,7 +37,6 @@ function CurioReference({
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
-  const [scryError, setScryError] = useState<string>();
   const refToken = preview?.group
     ? `${preview.group.flag}/channels/${nest}/curio/${idCurio}`
     : undefined;
@@ -53,23 +50,6 @@ function CurioReference({
     }
     navigateByApp(`/groups/${groupFlag}/channels/${nest}/curio/${idCurio}`);
   };
-
-  useEffect(() => {
-    if (!isScrolling) {
-      useHeapState
-        .getState()
-        .initialize(chFlag)
-        .catch((reason) => {
-          console.log(reason);
-        });
-    }
-  }, [chFlag, isScrolling]);
-
-  if (scryError !== undefined) {
-    // TODO handle requests for single curios like we do for single writs.
-    const time = bigInt(udToDec(idCurio));
-    return <UnavailableReference time={time} nest={nest} preview={preview} />;
-  }
 
   if (!curio) {
     return <HeapLoadingBlock reference />;

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -21,7 +21,7 @@ interface GroupReferenceProps {
   description?: string;
 }
 
-export default function GroupReference({
+function GroupReference({
   flag,
   isScrolling = false,
   plain = false,
@@ -172,3 +172,5 @@ export default function GroupReference({
     </div>
   );
 }
+
+export default React.memo(GroupReference);

--- a/ui/src/components/References/NoteCommentReference.tsx
+++ b/ui/src/components/References/NoteCommentReference.tsx
@@ -14,7 +14,7 @@ import { useChannelFlag } from '@/hooks';
 import ReferenceBar from './ReferenceBar';
 import UnavailableReference from './UnavailableReference';
 
-export default function NoteCommentReference({
+function NoteCommentReference({
   chFlag,
   nest,
   noteId,
@@ -106,3 +106,5 @@ export default function NoteCommentReference({
     </div>
   );
 }
+
+export default React.memo(NoteCommentReference);

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -13,7 +13,7 @@ import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
 import UnavailableReference from './UnavailableReference';
 
-export default function NoteReference({
+function NoteReference({
   chFlag,
   nest,
   id,
@@ -160,3 +160,5 @@ export default function NoteReference({
     </div>
   );
 }
+
+export default React.memo(NoteReference);

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -1,17 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
-import { useDiaryState, useRemoteOutline } from '@/state/diary';
+import { useRemoteOutline } from '@/state/diary';
 import { useChannelPreview, useGang } from '@/state/groups';
 import { makePrettyDate, pluralize } from '@/logic/utils';
-import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import Avatar from '@/components/Avatar';
 import { NOTE_REF_DISPLAY_LIMIT } from '@/constants';
 import useGroupJoin from '@/groups/useGroupJoin';
 import useNavigateByApp from '@/logic/useNavigateByApp';
 import ReferenceBar from './ReferenceBar';
-import UnavailableReference from './UnavailableReference';
 
 function NoteReference({
   chFlag,
@@ -25,7 +23,6 @@ function NoteReference({
   isScrolling?: boolean;
 }) {
   const preview = useChannelPreview(nest, isScrolling);
-  const [scryError, setScryError] = useState<string>();
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
@@ -33,20 +30,6 @@ function NoteReference({
   const navigateByApp = useNavigateByApp();
   const navigate = useNavigate();
   const location = useLocation();
-
-  const initialize = useCallback(async () => {
-    try {
-      await useDiaryState.getState().initialize(chFlag);
-    } catch (e) {
-      console.log("Couldn't initialize diary state", e);
-    }
-  }, [chFlag]);
-
-  useEffect(() => {
-    if (!isScrolling) {
-      initialize();
-    }
-  }, [chFlag, isScrolling, initialize]);
 
   const handleOpenReferenceClick = () => {
     if (!group) {
@@ -87,12 +70,6 @@ function NoteReference({
       return '';
     });
   }, [outline]);
-
-  if (scryError !== undefined) {
-    // TODO handle requests for single notes like we do for single writs.
-    const time = bigInt(udToDec(id));
-    return <UnavailableReference time={time} nest={nest} preview={preview} />;
-  }
 
   if (!outline) {
     return <HeapLoadingBlock reference />;

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useChannelPreview, useGang } from '@/state/groups';
 // eslint-disable-next-line import/no-cycle
 import ChatContent from '@/chat/ChatContent/ChatContent';
-import bigInt from 'big-integer';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { ChatWrit } from '@/types/chat';
 import useGroupJoin from '@/groups/useGroupJoin';
@@ -20,7 +19,7 @@ interface WritBaseReferenceProps {
   isScrolling: boolean;
 }
 
-export default function WritBaseReference({
+function WritBaseReference({
   nest,
   writ,
   chFlag,
@@ -89,3 +88,5 @@ export default function WritBaseReference({
     </div>
   );
 }
+
+export default React.memo(WritBaseReference);

--- a/ui/src/components/References/WritChanReference.tsx
+++ b/ui/src/components/References/WritChanReference.tsx
@@ -3,7 +3,7 @@ import { useWritByFlagAndWritId } from '@/state/chat';
 // eslint-disable-next-line import/no-cycle
 import WritBaseReference from './WritBaseReference';
 
-export default function WritChanReference(props: {
+function WritChanReference(props: {
   chFlag: string;
   nest: string;
   idWrit: string;
@@ -13,3 +13,5 @@ export default function WritChanReference(props: {
   const writ = useWritByFlagAndWritId(chFlag, idWrit, isScrolling);
   return <WritBaseReference writ={writ} {...props} />;
 }
+
+export default React.memo(WritChanReference);


### PR DESCRIPTION
Fixes #1970 

We don't need to initialize the relevant channel, we were still doing that for curios/notes.

I also memoized all of the reference components.