### PR TITLE
Prevent unnecessary calls to noembed on chat embed

### DIFF
--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -7,20 +7,43 @@ import TwitterEmbed from './TwitterEmbed';
 import SpotifyEmbed from './SpotifyEmbed';
 import AudioPlayer from './AudioPlayer';
 
+const trustedProviders = [
+  {
+    name: 'YouTube',
+    regex: /youtube\.com\/watch\?v=|youtu\.be\//,
+  },
+  {
+    name: 'Twitter',
+    regex: /twitter\.com\/\w+\/status\//,
+  },
+  {
+    name: 'Spotify',
+    regex: /open\.spotify\.com\/track\//,
+  },
+];
+
 function ChatEmbedContent({ url, writId }: { url: string; writId: string }) {
   const [embed, setEmbed] = useState<any>();
   const calm = useCalm();
   const isAudio = AUDIO_REGEX.test(url);
+  const isTrusted = trustedProviders.some((provider) =>
+    provider.regex.test(url)
+  );
 
   useEffect(() => {
     const getOembed = async () => {
-      if (isValidUrl(url)) {
+      if (
+        isValidUrl(url) &&
+        isTrusted &&
+        !calm?.disableRemoteContent &&
+        !isAudio
+      ) {
         const oembed = await useEmbedState.getState().getEmbed(url);
         setEmbed(oembed);
       }
     };
     getOembed();
-  }, [url]);
+  }, [url, calm, isTrusted, isAudio]);
 
   if (isAudio) {
     return <AudioPlayer url={url} embed writId={writId} />;

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -238,7 +238,7 @@ export default function HeapBlock({
 
   useEffect(() => {
     const getOembed = async () => {
-      if (isValidUrl(url) && !notEmbed) {
+      if (isValidUrl(url) && !notEmbed && !calm.disableRemoteContent) {
         try {
           const oembed = await useEmbedState.getState().getEmbed(url);
           setEmbed(oembed);
@@ -249,7 +249,7 @@ export default function HeapBlock({
       }
     };
     getOembed();
-  }, [url, notEmbed]);
+  }, [url, notEmbed, calm]);
 
   if (isValidUrl(url) && embed === undefined && !notEmbed) {
     return <HeapLoadingBlock />;

--- a/ui/src/heap/HeapRow.tsx
+++ b/ui/src/heap/HeapRow.tsx
@@ -55,7 +55,11 @@ export default function HeapRow({
 
   useEffect(() => {
     const getOembed = async () => {
-      if (isValidUrl(contentString) && !notEmbed) {
+      if (
+        isValidUrl(contentString) &&
+        !notEmbed &&
+        !calm?.disableRemoteContent
+      ) {
         try {
           const oembed = await useEmbedState.getState().getEmbed(contentString);
           setEmbed(oembed);
@@ -66,7 +70,7 @@ export default function HeapRow({
       }
     };
     getOembed();
-  }, [contentString, notEmbed]);
+  }, [contentString, notEmbed, calm?.disableRemoteContent]);
 
   if (isValidUrl(contentString) && embed === undefined && !notEmbed) {
     return <HeapLoadingRow />;


### PR DESCRIPTION
Also, don't make calls to noembed on heap items if remote content has been disabled.

No issue created for this one, just something that occurred to me this morning.