### PR TITLE
talk: fix pending message position

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -289,10 +289,10 @@ const ChatMessage = React.memo<
                   </NavLink>
                 ) : null}
               </div>
-              <div className="flex items-end rounded-r group-one-hover:bg-gray-50">
+              <div className="relative flex w-5 items-end rounded-r group-one-hover:bg-gray-50">
                 {!isMessageDelivered && (
                   <DoubleCaretRightIcon
-                    className="h-5 w-5"
+                    className="absolute left-0 bottom-2 h-5 w-5"
                     primary={isMessagePosted ? 'text-black' : 'text-gray-200'}
                     secondary="text-gray-200"
                   />

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`ChatMessage > renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="flex items-end rounded-r group-one-hover:bg-gray-50"
+          class="relative flex w-5 items-end rounded-r group-one-hover:bg-gray-50"
         />
       </div>
     </div>


### PR DESCRIPTION
Adds a right-side gutter to chat messages (we needed it), which reserves enough space for the pending indicator to appear and hide without altering the width of the message container (causing some jumping-around with long lines of text).

![loaders](https://user-images.githubusercontent.com/748181/223122543-13b3b985-23e1-4466-8b98-7e8ec738f4ec.gif)
