### PR TITLE
app: temporarily disable disconnect checks until further work

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -471,8 +471,6 @@ function App() {
 
   const state = location.state as { backgroundLocation?: Location } | null;
 
-  useConnectionChecker();
-
   useEffect(() => {
     if (
       (errorCount > 4 || airLockErrorCount > 1) &&


### PR DESCRIPTION
Simply a stop the bleeding measure until we can figure out a method that works better with ships that are under heavy load