### PR TITLE
groups, talk: use loading spinner in sidebar for reconnected state

### DIFF
--- a/talk/desk.docket-0
+++ b/talk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Send encrypted direct messages to one or many friends. Talk is a simple chat tool for catching up, getting work done, and everything in between.'
     color+0x10.5ec7
     image+'https://bootstrap.urbit.org/icon-talk.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v5.9j3sr.6erl7.b5564.20b7b.ejvmd.glob' 0v5.9j3sr.6erl7.b5564.20b7b.ejvmd]
+    glob-http+['https://bootstrap.urbit.org/glob-0vrm2ll.rb77u.cu64a.tvm0c.bq1u2.glob' 0vrm2ll.rb77u.cu64a.tvm0c.bq1u2]
     base+'talk'
     version+[2 8 1]
     website+'https://tlon.io'

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -485,9 +485,7 @@ function App() {
   return (
     <div className="flex h-full w-full flex-col">
       {!disableWayfinding && <LandscapeWayfinding />}
-      {subscription === 'disconnected' || subscription === 'reconnecting' ? (
-        <DisconnectNotice />
-      ) : null}
+      {subscription === 'disconnected' ? <DisconnectNotice /> : null}
       {needsUpdate ? <UpdateNotice /> : null}
       {isTalk ? (
         <>

--- a/ui/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/ui/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -7,7 +7,7 @@ export default function LoadingSpinner({
   className = 'h-4 w-4',
 }: IconProps) {
   return (
-    <svg className={className} fill="none" viewBox={'0 0 16 16'}>
+    <svg className={className} fill="current" viewBox={'0 0 16 16'}>
       <path
         className={secondary ? secondary : 'fill-gray-50'}
         fillRule="evenodd"

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -98,7 +98,10 @@ export function GroupsAppMenu() {
           <LoadingSpinner
             primary="fill-gray-600"
             secondary="fill-gray-600 opacity-50"
-            className="h-4 w-4 group-hover:hidden"
+            className={cn(
+              'h-4 w-4 group-hover:hidden',
+              menuOpen ? 'hidden' : 'block'
+            )}
           />
         ) : null}
         <a

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -18,6 +18,7 @@ import ShipName from '@/components/ShipName';
 import Avatar, { useProfileColor } from '@/components/Avatar';
 import useGroupSort from '@/logic/useGroupSort';
 import { useNotifications } from '@/notifications/useNotifications';
+import { useSubscriptionStatus } from '@/state/local';
 import ArrowNWIcon from '../icons/ArrowNWIcon';
 import MenuIcon from '../icons/MenuIcon';
 import AsteriskIcon from '../icons/Asterisk16Icon';
@@ -25,10 +26,13 @@ import GroupsSidebarItem from './GroupsSidebarItem';
 import SidebarSorter from './SidebarSorter';
 import GangItem from './GangItem';
 import { GroupsScrollingContext } from './GroupsScrollingContext';
+import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 
 export function GroupsAppMenu() {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
+  const subscription = useSubscriptionStatus();
+
   return (
     <SidebarItem
       div
@@ -90,6 +94,13 @@ export function GroupsAppMenu() {
     >
       <div className="flex items-center justify-between">
         Groups
+        {subscription === 'reconnecting' ? (
+          <LoadingSpinner
+            primary="fill-gray-600"
+            secondary="fill-gray-600 opacity-50"
+            className="h-4 w-4 group-hover:hidden"
+          />
+        ) : null}
         <a
           title="Back to Landscape"
           aria-label="Back to Landscape"

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -22,6 +22,8 @@ import { Link, useLocation } from 'react-router-dom';
 import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import { whomIsDm, whomIsMultiDm } from '@/logic/utils';
 import { useGroupState } from '@/state/groups';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import { useSubscriptionStatus } from '@/state/local';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
 import { MessagesScrollingContext } from './MessagesScrollingContext';
@@ -33,6 +35,8 @@ const selMessagesFilter = (s: SettingsState) => ({
 export function TalkAppMenu() {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
+  const subscription = useSubscriptionStatus();
+
   return (
     <SidebarItem
       div
@@ -94,6 +98,13 @@ export function TalkAppMenu() {
     >
       <div className="flex items-center justify-between">
         Talk
+        {subscription === 'reconnecting' ? (
+          <LoadingSpinner
+            primary="fill-gray-600"
+            secondary="fill-gray-600 opacity-50"
+            className="h-4 w-4 group-hover:hidden"
+          />
+        ) : null}
         <a
           title="Back to Landscape"
           aria-label="Back to Landscape"

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -14,10 +14,12 @@ import { foregroundFromBackground } from '@/components/Avatar';
 import ChannelList from '@/groups/GroupSidebar/ChannelList';
 import GroupAvatar from '@/groups/GroupAvatar';
 import GroupActions from '@/groups/GroupActions';
-import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import HashIcon from '@/components/icons/HashIcon';
 import AddIcon from '@/components/icons/AddIcon';
 import { Link, useLocation } from 'react-router-dom';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
+import { useSubscriptionStatus } from '@/state/local';
 
 function GroupHeader() {
   const flag = useGroupFlag();
@@ -33,6 +35,7 @@ function GroupHeader() {
   const hoverFallbackBackground = dark ? '#333333' : '#CCCCCC';
   const calm = useCalm();
   const defaultImportCover = group?.meta.cover === '0x0';
+  const subscription = useSubscriptionStatus();
 
   const onError = useCallback(() => {
     setNoCors(true);
@@ -171,10 +174,21 @@ function GroupHeader() {
             >
               {group?.meta.title}
             </div>
-            <ElipsisIcon
-              aria-label="Open Menu"
-              className={cn('h-6 w-6 opacity-0 group-hover:opacity-100')}
-            />
+
+            <div style={coverTitleStyles()}>
+              {subscription === 'reconnecting' ? (
+                <LoadingSpinner
+                  fill={`fill-${coverTitleStyles().color}`}
+                  primary={`fill-${coverTitleStyles().color}`}
+                  secondary={`fill-${coverTitleStyles().color} opacity-25`}
+                  className="h-4 w-4 group-hover:hidden"
+                />
+              ) : null}
+              <CaretDown16Icon
+                aria-label="Open Menu"
+                className={cn('hidden h-4 w-4 group-hover:block')}
+              />
+            </div>
           </button>
         </GroupActions>
       </div>


### PR DESCRIPTION
Relocates the reconnecting spinner to the sidebar (desktop only, mobile channel header PR forthcoming). 

At the Groups and Talk app level:

![reconnecting-groups](https://user-images.githubusercontent.com/748181/223236885-06334ad4-8864-40eb-936e-e6a29c4c3747.gif)

In groups of various customization:

![reconnecting-group-1](https://user-images.githubusercontent.com/748181/223237248-01882e5b-d65d-4e29-b0e6-b64c9e0c2ab9.gif)

![reconnecting-group-2](https://user-images.githubusercontent.com/748181/223237251-6c25059e-a1ab-488d-9160-80edcc4555b7.gif)

![reconnecting-group-3](https://user-images.githubusercontent.com/748181/223237254-8c184f42-3379-405e-b529-247dfd1e1119.gif)

#2077