### PR TITLE
Prevent excess scries for DMs on ships without DMs/MultiDMs

### DIFF
--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -978,13 +978,13 @@ export function useDmIsPending(ship: string) {
 const selMultiDms = (s: ChatState) => s.multiDms;
 export function useMultiDms() {
   const dms = useChatState(selMultiDms);
+  const noDms = Object.entries(dms).length === 0;
 
   useEffect(() => {
-    if (Object.entries(dms).length === 0) {
-      console.log('fetching multi dms');
+    if (noDms) {
       useChatState.getState().fetchMultiDms();
     }
-  }, [dms]);
+  }, [noDms]);
 
   return dms;
 }
@@ -992,13 +992,13 @@ export function useMultiDms() {
 const selDms = (s: ChatState) => s.dms;
 export function useDms() {
   const dms = useChatState(selDms);
+  const noDms = Object.entries(dms).length === 0;
 
   useEffect(() => {
-    if (Object.entries(dms).length === 0) {
-      console.log('fetching dms');
+    if (noDms) {
       useChatState.getState().fetchDms();
     }
-  }, [dms]);
+  }, [noDms]);
 
   return dms;
 }


### PR DESCRIPTION
Avoid object checking in useEffect dep array