### PR TITLE
groups: fix bad logic in light groups scry

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -314,10 +314,9 @@
     %-  ~(run by groups)
     |=  [=net:g =group:g]
     =.  fleet.group
-      ::  not sure how this would be the case, but better to be safe
-      ?.  (~(has by fleet.group) our.bowl)
-        *fleet:g
-      (~(put by *fleet:g) our.bowl (~(got by fleet.group) our.bowl))
+      %+  ~(put by *fleet:g)
+        our.bowl
+      (~(gut by fleet.group) our.bowl *vessel:fleet:g)
     group
   ::
       [%x %gangs ~]


### PR DESCRIPTION
OTT this fixes the infinite loading in empty group state and when trying to create a group from said state, mentioned in #2023 at the end.