### PR TITLE
Add cancel button for stuck group joins

### DIFF
--- a/ui/src/components/Sidebar/GangItem.tsx
+++ b/ui/src/components/Sidebar/GangItem.tsx
@@ -79,6 +79,21 @@ export default function GangItem(props: { flag: string }) {
                 It may take a few minutes depending on the host&apos;s and your
                 connection.
               </span>
+              <button
+                className="small-button bg-gray-50 text-gray-800"
+                onClick={handleCancel}
+              >
+                {isPending ? (
+                  <>
+                    Canceling...
+                    <LoadingSpinner className="h-5 w-4" />
+                  </>
+                ) : requested ? (
+                  'Cancel Request'
+                ) : (
+                  'Cancel Join'
+                )}
+              </button>
             </>
           )}
           {(errored || requested) && (

--- a/ui/src/components/Sidebar/GangItem.tsx
+++ b/ui/src/components/Sidebar/GangItem.tsx
@@ -83,16 +83,7 @@ export default function GangItem(props: { flag: string }) {
                 className="small-button bg-gray-50 text-gray-800"
                 onClick={handleCancel}
               >
-                {isPending ? (
-                  <>
-                    Canceling...
-                    <LoadingSpinner className="h-5 w-4" />
-                  </>
-                ) : requested ? (
-                  'Cancel Request'
-                ) : (
-                  'Cancel Join'
-                )}
+                {isPending ? <LoadingSpinner className="h-5 w-4" /> : 'Cancel'}
               </button>
             </>
           )}


### PR DESCRIPTION
There isn't an issue for this afaik, but romi saw this and I've actually seen this on one of my dev moons. If something is wrong with the host ship for the group you're trying to join you could get into a state where you're just stuck with the pending group item in your sidebar.

This adds a cancel button so you can get rid of the pending group item.