### PR TITLE
mentions: fix dm patp marked as not in message

### DIFF
--- a/ui/src/components/Mention/MentionPopup.tsx
+++ b/ui/src/components/Mention/MentionPopup.tsx
@@ -38,11 +38,19 @@ const MentionList = React.forwardRef<
 
   const getMessage = useCallback(
     (ship: string) => {
+      if (ship === window.our) {
+        return null;
+      }
+
       if (match) {
         const multiDm = match && multiDms[match.params.ship || ''];
-        return !multiDm || ![...multiDm.hive, ...multiDm.team].includes(ship)
-          ? 'Not in message'
-          : null;
+        if (multiDm) {
+          return ![...multiDm.hive, ...multiDm.team].includes(ship)
+            ? 'Not in message'
+            : null;
+        }
+
+        return ship !== match.params.ship ? 'Not in message' : null;
       }
 
       return !group?.fleet[ship] ? 'Not in group' : null;


### PR DESCRIPTION
Thought I'd knock one off instead of always logging them :)

Fixes #2020 where your DM partner was labeled "Not in message" in private DMs, and your own ship was always labeled "Not in message" or "Not in group"