### PR TITLE
Make sure youtube/spotify links open in new tabs

### DIFF
--- a/ui/src/chat/ChatEmbedContent/SpotifyEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/SpotifyEmbed.tsx
@@ -48,6 +48,8 @@ export default function SpotifyEmbed({
         <span className="text-gray-300">&middot;</span>
         <a
           href={url}
+          target="_blank"
+          rel="noreferrer"
           className="truncate font-semibold text-gray-800 underline"
         >
           {title}

--- a/ui/src/chat/ChatEmbedContent/YouTubeEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/YouTubeEmbed.tsx
@@ -56,6 +56,8 @@ export default function YouTubeEmbed({
         <a
           href={url}
           className="truncate font-semibold text-gray-800 underline"
+          target="_blank"
+          rel="noreferrer"
         >
           {title}
         </a>
@@ -63,6 +65,8 @@ export default function YouTubeEmbed({
         <a
           href={authorUrl}
           className="truncate font-semibold text-gray-800 underline"
+          target="_blank"
+          rel="noreferrer"
         >
           {author}
         </a>


### PR DESCRIPTION
I don't think there's an issue for it, just noticed it this morning.