### PR TITLE
chat: fix image flickering

### DIFF
--- a/ui/src/chat/ChatContent/ChatContentImage.tsx
+++ b/ui/src/chat/ChatContent/ChatContentImage.tsx
@@ -43,8 +43,8 @@ export default function ChatContentImage({
     return (
       <div className="embed-inline-block group">
         <div className="flex h-full flex-col items-center justify-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
-            <ExclamationPoint className="h-6 w-6 text-red-600" />
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+            <ExclamationPoint className="h-6 w-6 text-gray-400" />
           </div>
           <p className="mt-2 text-sm font-medium text-gray-900">
             Failed to load image

--- a/ui/src/chat/ChatContent/ChatContentImage.tsx
+++ b/ui/src/chat/ChatContent/ChatContentImage.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useCalm } from '@/state/settings';
 import LightBox from '@/components/LightBox';
+import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import { useParams } from 'react-router';
-import { useChatDialog } from '../useChatStore';
+import { useChatDialog, useChatFailedToLoadContent } from '../useChatStore';
 
 interface ChatContentImage {
   src: string;
@@ -27,11 +28,39 @@ export default function ChatContentImage({
   }>();
   const whom = `${chShip}/${chName}`;
   const calm = useCalm();
+  const { failedToLoad, setFailedToLoad } = useChatFailedToLoadContent(
+    whom,
+    writId || 'not-writ',
+    blockIndex
+  );
   const { open: showLightBox, setOpen: setShowLightBox } = useChatDialog(
     whom,
     writId || 'not-writ',
     `image-${blockIndex}`
   );
+
+  if (failedToLoad) {
+    return (
+      <div className="embed-inline-block group">
+        <div className="flex h-full flex-col items-center justify-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+            <ExclamationPoint className="h-6 w-6 text-red-600" />
+          </div>
+          <p className="mt-2 text-sm font-medium text-gray-900">
+            Failed to load image
+          </p>
+          <a
+            href={src}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 text-sm text-gray-900 underline"
+          >
+            {src}
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -39,11 +68,14 @@ export default function ChatContentImage({
       style={{ maxWidth: width ? (width > 600 ? 600 : width) : 600 }}
     >
       {calm?.disableRemoteContent ? (
-        <span>{src}</span>
+        <a ref={src} target="_blank" rel="noreferrer">
+          {src}
+        </a>
       ) : (
         <button onClick={() => setShowLightBox(true)}>
           <img
             src={src}
+            onError={() => setFailedToLoad(true)}
             className="max-w-full cursor-pointer rounded"
             height={height}
             width={width}

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -43,6 +43,10 @@ function ChatEmbedContent({ url, writId }: { url: string; writId: string }) {
       }
     };
     getOembed();
+
+    return () => {
+      setEmbed(null);
+    };
   }, [url, calm, isTrusted, isAudio]);
 
   if (isAudio) {

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -252,6 +252,7 @@ const ChatMessage = React.memo<
                       <div className="mr-2 flex flex-row-reverse">
                         {replyAuthors.map((ship, i) => (
                           <div
+                            key={ship}
                             className={cn(
                               'reply-avatar relative h-6 w-6 rounded bg-white outline outline-2 outline-white group-one-focus-within:outline-gray-50 group-one-hover:outline-gray-50',
                               i !== 0 && '-mr-3'


### PR DESCRIPTION
This fixes #2112 

It turns out that chrome was forcing this content to load via HTTPS and palfun's minio instance doesn't have an HTTPS cert. When the image fails to load the height of the message changes, causing the scroller to re-render, which causes the image to load again, resulting in a loop.

To fix it we need to handle the error when the image doesn't load, store that state globally in the chat store, and display some static content in the scroller.

This also fixes an issue where we were missing a key for the list of thread reply authors in the ChatMessage component and adds a missing cleanup function to the useEffect in the ChatEmbedContent component.

![image](https://user-images.githubusercontent.com/1221094/224702536-5a908209-1e79-4e76-a067-9e3ae5c6e2f7.png)
