### PR TITLE
notebooks: Don't show placeholder on empty channel

### DIFF
--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -41,6 +41,7 @@ import DiaryChannelListPlaceholder from './DiaryChannelListPlaceholder';
 
 function DiaryChannel() {
   const [joining, setJoining] = useState(false);
+  const [initialized, setInitialized] = useState(false);
   const { chShip, chName } = useParams();
   const chFlag = `${chShip}/${chName}`;
   const nest = `diary/${chFlag}`;
@@ -65,6 +66,7 @@ function DiaryChannel() {
 
   const initializeChannel = useCallback(async () => {
     await useDiaryState.getState().initialize(chFlag);
+    setInitialized(true);
   }, [chFlag]);
 
   useEffect(() => {
@@ -231,8 +233,8 @@ function DiaryChannel() {
         </div>
       </Toast.Provider>
       <div className="h-full">
-        {sortedNotes.length === 0 ? (
-          <DiaryChannelListPlaceholder count={30} />
+        {!initialized ? (
+          <DiaryChannelListPlaceholder count={4} />
         ) : displayMode === 'grid' ? (
           <DiaryGridView notes={sortedNotes} loadOlderNotes={loadOlderNotes} />
         ) : (


### PR DESCRIPTION
Check if channel is initialized.
Also, limit total placeholder boxes to five.
Fixes #2113 