### PR TITLE
groups: appropriate null-groups routing

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,6 +1,7 @@
 import cookies from 'browser-cookies';
 import React, { Suspense, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
+import _ from 'lodash';
 import {
   BrowserRouter as Router,
   Routes,
@@ -77,6 +78,7 @@ import LandscapeWayfinding from './components/LandscapeWayfinding';
 import { useScheduler } from './state/scheduler';
 import chatmanifestURL from './assets/chatmanifest.json?url';
 import manifestURL from './assets/manifest.json?url';
+import { useGroups } from './state/groups';
 
 const DiaryAddNote = React.lazy(() => import('./diary/diary-add-note'));
 const SuspendedDiaryAddNote = (
@@ -202,7 +204,54 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   );
 }
 
+function HomeRoute({
+  isMobile = true,
+  isInGroups = false,
+}: {
+  isMobile: boolean;
+  isInGroups: boolean;
+}) {
+  if (!isInGroups) {
+    return <FindGroups title={`Find Groups • ${appHead('').title}`} />;
+  }
+
+  if (isMobile && isInGroups) {
+    return <MobileGroupsNavHome />;
+  }
+
+  return (
+    <Notifications
+      child={GroupNotification}
+      title={`All Notifications • ${appHead('').title}`}
+    />
+  );
+}
+
+function ActivityRoute({
+  isMobile = true,
+  isInGroups = false,
+}: {
+  isMobile: boolean;
+  isInGroups: boolean;
+}) {
+  if (!isInGroups) {
+    return <FindGroups title={`Find Groups • ${appHead('').title}`} />;
+  }
+
+  return (
+    <MainWrapper isMobile={isMobile}>
+      <Notifications
+        child={GroupNotification}
+        title={`All Notifications • ${appHead('').title}`}
+      />
+    </MainWrapper>
+  );
+}
+
 function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
+  const groups = useGroups();
+  const isInGroups = _.isEmpty(groups) ? false : true;
+
   return (
     <>
       <Routes location={state?.backgroundLocation || location}>
@@ -211,22 +260,13 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
             <Route
               index
               element={
-                isMobile ? (
-                  <MobileGroupsNavHome />
-                ) : (
-                  <FindGroups title={`Find Groups • ${appHead('').title}`} />
-                )
+                <HomeRoute isMobile={isMobile} isInGroups={isInGroups} />
               }
             />
             <Route
               path="/notifications"
               element={
-                <MainWrapper isMobile={isMobile}>
-                  <Notifications
-                    child={GroupNotification}
-                    title={`All Notifications • ${appHead('').title}`}
-                  />
-                </MainWrapper>
+                <ActivityRoute isMobile={isMobile} isInGroups={isInGroups} />
               }
             />
             {/* Find by Invite URL */}


### PR DESCRIPTION
I got sick of having to hit Groups in the nav every time I opened the app on my phone.

For `/apps/groups`:
- If you aren't in any groups, you get routed to Find Groups, no matter what kind of device you're on. This should cover the first-run/newbie case.
- If you're in at least one group and you're on a mobile device, you get routed to the list of groups you're in.
- If you're in at least one group and you're **not** on a mobile device, you get routed to Activity ("All Notifications"), since there's a list of groups within view in the sidebar. @ashelkovnykov said something about this last week/the week before.

For `/apps/groups/notifications`:
- If you aren't in any groups, you get routed to Find Groups, which theoretically prevents us from showing the empty list at all for first-runners/newbies.
- If you're in at least one group, you get routed to Activity ("All Notifications").

This has the side effect of disallowing most navigation away from Find Groups on mobile on a fresh ship. However, we lack a "Don't see a group you want to join? Create your own" CTA bubble on Find Groups. Maybe @urcades has an opinion here?