### PR TITLE
groups: sane intra-group nav

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -259,9 +259,8 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
           </Route>
           <Route path="/groups/:ship/:name" element={<Groups />}>
             <Route element={isMobile ? <MobileGroupSidebar /> : undefined}>
-              <Route index element={isMobile ? <MobileGroupRoot /> : null} />
               <Route
-                path="channellist"
+                index
                 element={isMobile ? <MobileGroupChannelList /> : null}
               />
               <Route

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -272,7 +272,6 @@ function DiarySortControls({
             'dropdown-item',
             sortMode === 'quip-asc' && 'bg-gray-100 hover:bg-gray-100'
           )}
-          // onClick={() => setSortMode('quip-asc')}
         >
           <span className="font-semibold text-gray-400">
             New Comments First
@@ -283,7 +282,6 @@ function DiarySortControls({
             'dropdown-item',
             sortMode === 'quip-dsc' && 'bg-gray-100 hover:bg-gray-100'
           )}
-          // onClick={() => setSortMode('quip-dsc')}
         >
           <span className="font-semibold text-gray-400">
             Old Comments First
@@ -334,9 +332,6 @@ export default function ChannelHeader({
   function backTo() {
     if (isMobile && isTalk) {
       return '/';
-    }
-    if (isMobile && !isTalk) {
-      return `/groups/${flag}/channellist`;
     }
     return `/groups/${flag}`;
   }

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -20,12 +20,12 @@ export default function MobileGroupSidebar() {
         <nav>
           <ul className="flex items-center">
             <NavTab to={`.`} end>
-              <BellIcon className="mb-0.5 h-6 w-6" />
-              Activity
-            </NavTab>
-            <NavTab to={`/groups/${flag}/channellist`} end>
               <HashIcon className="mb-0.5 h-6 w-6" />
               Channels
+            </NavTab>
+            <NavTab to={`/groups/${flag}/activity`}>
+              <BellIcon className="mb-0.5 h-6 w-6" />
+              Activity
             </NavTab>
             <NavTab to={`/groups/${flag}/info`}>
               <GroupAvatar


### PR DESCRIPTION
This makes some similar changes as #2119.

- If you're on a mobile device, as you navigate into the group, you get dropped into the Channels list. Tapping into a channel and "back out" navigates you to the group root, rather than the named `/channellist` route (in case we change this in the future).
- If you're *not* on a mobile device, as you navigate into the group, you're either navigated to the most recent channel or Activity (current behavior).

![mobile-nav](https://user-images.githubusercontent.com/748181/225022098-e4edfb11-5259-4acf-9771-a2a3ed5593c5.gif)