### PR TITLE
emoji picker: use only controlled hover, no css

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -84,7 +84,7 @@ export default function ChatMessageOptions(props: {
 
   const navigate = useNavigate();
   return (
-    <div className="absolute right-2 -top-5 z-10 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle opacity-0 group-one-hover:opacity-100">
+    <div className="absolute right-2 -top-5 z-10 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle">
       {canWrite ? (
         <EmojiPicker
           open={pickerOpen}


### PR DESCRIPTION
It looks like we forgot to take out the CSS hover stuff when we switched to a controlled hover state for the chat message options, so we had both the JS hover state and the CSS hover state clashing with each other. Now we just use the JS state.
Fixes #2108
Also fixes the issue where the message options wouldn't appear on first hover.