### PR TITLE
Po/fix group membership issues

### DIFF
--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -12,8 +12,8 @@ import { useChatState, usePinnedGroups } from '@/state/chat';
 import LeaveIcon from '@/components/icons/LeaveIcon';
 import useIsGroupUnread from '@/logic/useIsGroupUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
-import { citeToPath, useCopy } from '@/logic/utils';
-import { useAmAdmin } from '@/state/groups';
+import { citeToPath, getPrivacyFromGroup, useCopy } from '@/logic/utils';
+import { useAmAdmin, useGroup } from '@/state/groups';
 
 const { ship } = window;
 
@@ -63,6 +63,8 @@ const GroupActions = React.memo(
     const { isGroupUnread } = useIsGroupUnread();
     const location = useLocation();
     const hasActivity = isGroupUnread(flag);
+    const group = useGroup(flag);
+    const privacy = group ? getPrivacyFromGroup(group) : 'public';
     const isAdmin = useAmAdmin(flag);
 
     const { isOpen, setIsOpen, isPinned, copyItemText, onCopy, onPinClick } =
@@ -102,7 +104,7 @@ const GroupActions = React.memo(
             )}
           </DropdownMenu.Trigger>
           <DropdownMenu.Content className="dropdown min-w-52 text-gray-800">
-            {isAdmin && (
+            {(privacy === 'public' || isAdmin) && (
               <DropdownMenu.Item
                 asChild
                 className="dropdown-item text-blue hover:bg-blue-soft hover:dark:bg-blue-900"

--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -13,6 +13,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useGroup, useRouteGroup } from '@/state/groups/groups';
 import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
 import { useAmAdmin } from '@/state/groups';
+import { getPrivacyFromGroup } from '@/logic/utils';
 import MemberScroller from './MemberScroller';
 
 export default function GroupMemberManager() {
@@ -22,6 +23,7 @@ export default function GroupMemberManager() {
   const [rawInput, setRawInput] = useState('');
   const [search, setSearch] = useState('');
   const amAdmin = useAmAdmin(flag);
+  const privacy = group ? getPrivacyFromGroup(group) : 'public';
   const members = useMemo(() => {
     if (!group) {
       return [];
@@ -76,11 +78,11 @@ export default function GroupMemberManager() {
     <div className={cn(!amAdmin && 'card', 'flex h-full grow flex-col')}>
       <div
         className={cn(
-          amAdmin && 'mt-2',
+          (privacy === 'public' || amAdmin) && 'mt-2',
           'mb-4 flex w-full items-center justify-between'
         )}
       >
-        {amAdmin && (
+        {(privacy === 'public' || amAdmin) && (
           <Link
             to={`/groups/${flag}/invite`}
             state={{ backgroundLocation: location }}

--- a/ui/src/groups/Groups.tsx
+++ b/ui/src/groups/Groups.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Outlet, useMatch, useNavigate } from 'react-router';
 import {
   useGang,
@@ -77,7 +77,7 @@ function Groups() {
     let id = null as number | null;
     useGroupState
       .getState()
-      .initialize(flag)
+      .initialize(flag, true)
       .then((i) => {
         id = i;
       });

--- a/ui/src/state/groups/type.ts
+++ b/ui/src/state/groups/type.ts
@@ -26,7 +26,7 @@ export interface GroupState {
   };
   fetchShoal: (b: BaitCite['bait']) => Promise<string | null>;
   gangs: Gangs;
-  initialize: (flag: string) => Promise<number>;
+  initialize: (flag: string, getMembers?: boolean) => Promise<number>;
   delRole: (flag: string, sect: string) => Promise<void>;
   banShips: (flag: string, ships: string[]) => Promise<void>;
   unbanShips: (flag: string, ships: string[]) => Promise<void>;


### PR DESCRIPTION
Fixes #2129

Allow group members in public groups to invite new members.

Also, load members into group store on navigating to a group. It looks like this was caused by changes in #2100. To improve initial load, we don't load all members for all groups, but we have the option to load them for a particular group when necessary, we just didn't update Groups.tsx to reflect this. This also fixes the issue that Zach first noticed where the mention pop-up shows "not in group" for group members.