### PR TITLE
Clear uploader after submit on new curio form.

### DIFF
--- a/ui/src/heap/NewCurioForm.tsx
+++ b/ui/src/heap/NewCurioForm.tsx
@@ -79,9 +79,10 @@ export default function NewCurioForm() {
       });
 
       setDraftLink(undefined);
+      uploader?.clear();
       reset();
     },
-    [chFlag, reset]
+    [chFlag, reset, uploader]
   );
 
   const watchedContent = watch('content');
@@ -200,7 +201,7 @@ export default function NewCurioForm() {
             <input
               value={isPending ? 'Posting...' : 'Post'}
               type="submit"
-              className="button absolute bottom-3 right-3 rounded-md px-2 py-1"
+              className="button absolute bottom-3 right-3 cursor-pointer rounded-md px-2 py-1"
               disabled={isPending || !isValidInput}
             />
           </form>


### PR DESCRIPTION
Fixes #2125.
Also, add `cursor-pointer` to the "Post" button.