### PR TITLE
vita: account for ships with previous ~ state

### DIFF
--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -6,6 +6,7 @@
   +$  card  card:agent:gall
   +$  state-0  [%0 first-load=?]
   +$  current-state  state-0
+  +$  versioned-state  $%(~ current-state)
   --
 =|  current-state
 =*  state  -
@@ -80,9 +81,8 @@
 ++  load
   |=  =vase
   ^+  cor
-  =+  !<(old=current-state vase)
-  =.  state  old
-  ~&  state
+  =+  !<(old=versioned-state vase)
+  =.  state  ?~(old *current-state old)
   =/  =cage  settings-event+!>([%put-entry %groups %groups %'showVitaMessage' [%b &]])  
   =?  cor  first-load  (emit %pass /set-vita %agent [our.bowl %settings-store] %poke cage)
   =.  first-load  |

--- a/desk/app/groups-ui.hoon
+++ b/desk/app/groups-ui.hoon
@@ -73,6 +73,9 @@
 ::
 ++  init
   ^+  cor
+  =/  =cage  settings-event+!>([%put-entry %groups %groups %'showVitaMessage' [%b &]])
+  =?  cor  first-load  (emit %pass /set-vita %agent [our.bowl %settings-store] %poke cage)
+  =.  first-load  |
   %-  emil 
   :~  [%pass /build %arvo [%c %warp our.bowl q.byk.bowl ~ %sing %c da+now.bowl /ui-init/json]]
       [%pass /build %arvo [%c %warp our.bowl q.byk.bowl ~ %sing %c da+now.bowl /ui-migration/json]]
@@ -83,13 +86,7 @@
   ^+  cor
   =+  !<(old=versioned-state vase)
   =.  state  ?~(old *current-state old)
-  =/  =cage  settings-event+!>([%put-entry %groups %groups %'showVitaMessage' [%b &]])  
-  =?  cor  first-load  (emit %pass /set-vita %agent [our.bowl %settings-store] %poke cage)
-  =.  first-load  |
-  %-  emil 
-  :~  [%pass /build %arvo [%c %warp our.bowl q.byk.bowl ~ %sing %c da+now.bowl /ui-init/json]]
-      [%pass /build %arvo [%c %warp our.bowl q.byk.bowl ~ %sing %c da+now.bowl /ui-migration/json]]
-  ==
+  init
 ::
 ++  peek
   |=  =(pole knot)

--- a/talk/app/talk-ui.hoon
+++ b/talk/app/talk-ui.hoon
@@ -6,6 +6,7 @@
   +$  card  card:agent:gall
   +$  state-0  [%0 first-load=?]
   +$  current-state  state-0
+  +$  versioned-state  $%(~ current-state)
   --
 =|  current-state
 =*  state  -
@@ -77,8 +78,8 @@
 ++  load
   |=  =vase
   ^+  cor
-  =+  !<(old=current-state vase)
-  =.  state  old
+  =+  !<(old=versioned-state vase)
+  =.  state  ?~(old *current-state old)
   =/  =cage  settings-event+!>([%put-entry %talk %talk %'showVitaMessage' [%b &]])  
   =?  cor  first-load  (emit %pass /set-vita %agent [our.bowl %settings-store] %poke cage)
   =.  first-load  |

--- a/talk/app/talk-ui.hoon
+++ b/talk/app/talk-ui.hoon
@@ -73,6 +73,9 @@
 ::
 ++  init
   ^+  cor
+  =/  =cage  settings-event+!>([%put-entry %talk %talk %'showVitaMessage' [%b &]])  
+  =?  cor  first-load  (emit %pass /set-vita %agent [our.bowl %settings-store] %poke cage)
+  =.  first-load  |
   (emit %pass /build %arvo [%c %warp our.bowl q.byk.bowl ~ %sing %c da+now.bowl /ui-init/json])
 ::
 ++  load
@@ -80,10 +83,7 @@
   ^+  cor
   =+  !<(old=versioned-state vase)
   =.  state  ?~(old *current-state old)
-  =/  =cage  settings-event+!>([%put-entry %talk %talk %'showVitaMessage' [%b &]])  
-  =?  cor  first-load  (emit %pass /set-vita %agent [our.bowl %settings-store] %poke cage)
-  =.  first-load  |
-  (emit %pass /build %arvo [%c %warp our.bowl q.byk.bowl ~ %sing %c da+now.bowl /ui-init/json])
+  init
 ::
 ++  peek
   |=  =(pole knot)

--- a/talk/mar/dummy.hoon
+++ b/talk/mar/dummy.hoon
@@ -1,0 +1,1 @@
+../../desk/mar/dummy.hoon


### PR DESCRIPTION
This should fix the issue @patosullivan saw earlier about the missing mark. The state transition didn't work for ships who previously had the groups/talk ui agents. Too much fakezod juggling meant this didn't happen locally when I was developing it.