### PR TITLE
Chat: don't prefix all links with http/https

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -98,13 +98,7 @@ export function InlineContent({
   }
 
   if (isLink(story)) {
-    const containsProtocol = story.link.href.match(/https?:\/\//);
-    return (
-      <ChatEmbedContent
-        writId={writId}
-        url={containsProtocol ? story.link.href : `http://${story.link.href}`}
-      />
-    );
+    return <ChatEmbedContent writId={writId} url={story.link.href} />;
   }
 
   if (isBlockquote(story)) {


### PR DESCRIPTION
Fixes #2145
Not clear to me why we were prefixing them in the first place. If we have link content here, it's because tiptap gave us a link.