### PR TITLE
calm: respect calm settings for wayfinding button

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -19,7 +19,7 @@ import NewDM from '@/dms/NewDm';
 import ChatThread from '@/chat/ChatThread/ChatThread';
 import useMedia, { useIsDark, useIsMobile } from '@/logic/useMedia';
 import useErrorHandler from '@/logic/useErrorHandler';
-import { useCalm, useTheme } from '@/state/settings';
+import { useCalm, useSettingsLoaded, useTheme } from '@/state/settings';
 import { useLocalState } from '@/state/local';
 import ErrorAlert from '@/components/ErrorAlert';
 import DMHome from '@/dms/DMHome';
@@ -539,6 +539,7 @@ function App() {
   const location = useLocation();
   const isMobile = useIsMobile();
   const isSmall = useMedia('(max-width: 1023px)');
+  const settingsLoaded = useSettingsLoaded();
   const { disableWayfinding } = useCalm();
 
   useEffect(() => {
@@ -560,7 +561,7 @@ function App() {
 
   return (
     <div className="flex h-full w-full flex-col">
-      {!disableWayfinding && <LandscapeWayfinding />}
+      {settingsLoaded && !disableWayfinding && <LandscapeWayfinding />}
       <DisconnectNotice />
       <UpdateNotice />
       <LeapProvider>

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -208,11 +208,13 @@ export function useCalm() {
   return useSettingsState(selCalm);
 }
 
-export function setCalmSetting(
+export async function setCalmSetting(
   key: keyof SettingsState['calmEngine'],
   val: boolean
 ) {
-  useSettingsState.getState().putEntry('calmEngine', key, val);
+  // use garden desk for calm settings so that they're universal.
+  const poke = doPutEntry('garden', 'calmEngine', key, val);
+  await pokeOptimisticallyN(useSettingsState, poke, reduceUpdate);
 }
 
 export function parseSettings<T>(settings: Stringified<T[]>): T[] {
@@ -303,4 +305,10 @@ export function useShowVitaMessage() {
     (s) => s[window.desk as 'groups' | 'talk']?.showVitaMessage
   );
   return setting;
+}
+
+const selLoaded = (s: SettingsState) => s.loaded;
+export function useSettingsLoaded() {
+  const loaded = useSettingsState(selLoaded);
+  return loaded;
 }


### PR DESCRIPTION
This fixes #2159 by making sure that updates to the calm settings from groups/talk are persisted using the "garden" desk key in the settings store. 
Doing this ensures that we are actually making the setting "global". 

On initialization, groups/talk loads the settings store and merges the settings for the current desk with the landscape (garden) desk. If we have a setting for the current desk that is different than what is set for the landscape desk, we override it. Since we were updating the calm settings for *just* the groups/talk desk, it was being overridden by the landscape setting (which was `false`).