### PR TITLE
chat: show link custom content when rendering as plain link

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -98,7 +98,13 @@ export function InlineContent({
   }
 
   if (isLink(story)) {
-    return <ChatEmbedContent writId={writId} url={story.link.href} />;
+    return (
+      <ChatEmbedContent
+        writId={writId}
+        url={story.link.href}
+        content={story.link.content}
+      />
+    );
   }
 
   if (isBlockquote(story)) {

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -22,7 +22,15 @@ const trustedProviders = [
   },
 ];
 
-function ChatEmbedContent({ url, writId }: { url: string; writId: string }) {
+function ChatEmbedContent({
+  url,
+  content,
+  writId,
+}: {
+  url: string;
+  content: string;
+  writId: string;
+}) {
   const [embed, setEmbed] = useState<any>();
   const calm = useCalm();
   const isAudio = AUDIO_REGEX.test(url);
@@ -109,14 +117,14 @@ function ChatEmbedContent({ url, writId }: { url: string; writId: string }) {
 
     return (
       <a target="_blank" rel="noreferrer" href={url}>
-        {url}
+        {content}
       </a>
     );
   }
 
   return (
     <a target="_blank" rel="noreferrer" href={url}>
-      {url}
+      {content}
     </a>
   );
 }


### PR DESCRIPTION
Fixes #2146 

Passes custom content from `Link` inline story type to the embed renderer so the `<a>` tag can render it. Does not address the issue when the URL is a supported embed site, logged that separately in #2161 