### PR TITLE
app modal: fix dark mode issue

### DIFF
--- a/ui/src/components/Grid/appmodal.tsx
+++ b/ui/src/components/Grid/appmodal.tsx
@@ -26,7 +26,7 @@ export default function AppModal() {
         appModal
       >
         <iframe
-          className="mt-6 h-full w-full overflow-y-auto rounded-b-xl border-t-2 border-gray-50 bg-white"
+          className="mt-6 h-full w-full overflow-y-auto rounded-b-xl border-t-2 border-gray-50 bg-[#fff]"
           src={path}
         />
         <div className="absolute -top-2 left-0 m-4 flex items-center justify-center space-x-2">

--- a/ui/src/components/Grid/appmodal.tsx
+++ b/ui/src/components/Grid/appmodal.tsx
@@ -3,8 +3,6 @@ import { useCharge } from '@/state/docket';
 import { useNavigate, useParams } from 'react-router';
 import Dialog, { DialogContent } from '../Dialog';
 import ArrowNEIcon from '../icons/ArrowNEIcon';
-import ArrowNWIcon from '../icons/ArrowNWIcon';
-import OpenSmallIcon from '../icons/OpenSmallIcon';
 
 export default function AppModal() {
   const navigate = useNavigate();


### PR DESCRIPTION
Some apps (like %pals) don't explicitly set a background color and just expect the default white background color in the browser. I originally set the background color for the iframe to white using tailwind's `bg-white`, this caused the background to change to black automatically in dark mode. Apps like %pals then became unusable because they were using black text on our black background.

This change explicitly sets the background to `#fff` so that apps like %pals will render properly. Apps that set their own background (like groups or talk) will be unaffected.