### PR TITLE
app modal: always close to background location

### DIFF
--- a/ui/src/components/Grid/appmodal.tsx
+++ b/ui/src/components/Grid/appmodal.tsx
@@ -1,18 +1,21 @@
 import { getAppHref } from '@/logic/utils';
 import { useCharge } from '@/state/docket';
-import { useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import Dialog, { DialogContent } from '../Dialog';
 import ArrowNEIcon from '../icons/ArrowNEIcon';
 
 export default function AppModal() {
   const navigate = useNavigate();
+  const {
+    state: { backgroundLocation },
+  } = useLocation();
   const { desk } = useParams<{ desk: string }>();
   const { href, title, image, color } = useCharge(desk || '');
   const path = getAppHref(href);
 
   const onOpenChange = (open: boolean) => {
     if (!open) {
-      navigate(-1);
+      navigate(backgroundLocation);
     }
   };
 

--- a/ui/src/components/Grid/grid.tsx
+++ b/ui/src/components/Grid/grid.tsx
@@ -176,8 +176,7 @@ export default function Grid() {
 
   const onOpenChange = (open: boolean) => {
     if (!open) {
-      setLeapIsOpen(true);
-      navigate(-1);
+      navigate(location.state.backgroundLocation);
     }
   };
 

--- a/ui/src/components/Leap/useLeap.tsx
+++ b/ui/src/components/Leap/useLeap.tsx
@@ -120,7 +120,7 @@ export default function useLeap() {
           ...o,
           onSelect: () => {
             if (app === 'Groups' && o.title === 'Messages') {
-              window.open(`${window.location.origin}/apps/talk`, '_blank');
+              window.open(`${window.location.origin}/apps/talk/`, '_blank');
             } else if (app === 'Groups' && o.title === 'Create New Group') {
               modalNavigate(`/groups/new`, {
                 state: { backgroundLocation: location },
@@ -130,10 +130,7 @@ export default function useLeap() {
             } else if (app === 'Groups' && o.title === 'Profile') {
               navigate('/profile/edit');
             } else if (app === 'Talk' && o.title === 'Groups') {
-              window.open(
-                `${window.location.origin}/apps/groups/find`,
-                '_blank'
-              );
+              window.open(`${window.location.origin}/apps/groups/`, '_blank');
             } else {
               navigate(o.to, { state: { backgroundLocation: location } });
             }


### PR DESCRIPTION
This makes some changes that ensure that the user is always redirected to the background location upon closing an AppModal (which seems more natural, less annoying than having to go back through Grid and Leap).

It does the same thing for closing Grid.

Also fixes the app links in Leap for opening a new tab for groups/talk.