### PR TITLE
chat: fix for embeds overriding formatted links.

### DIFF
--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -57,6 +57,14 @@ function ChatEmbedContent({
     };
   }, [url, calm, isTrusted, isAudio]);
 
+  if (url !== content) {
+    return (
+      <a target="_blank" rel="noreferrer" href={url}>
+        {content}
+      </a>
+    );
+  }
+
   if (isAudio) {
     return <AudioPlayer url={url} embed writId={writId} />;
   }


### PR DESCRIPTION
Fixes #2161

If a user specifically formats some text as a link we should just show that, even if it's a link to embed-able content.