### PR TITLE
curio: detail view fixes

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -124,7 +124,7 @@ export default function HeapDetail() {
     </div>
   ) : (
     <Layout
-      className="flex-1 bg-gray-50"
+      className="flex-1 bg-white"
       header={
         <HeapDetailHeader
           flag={groupFlag}
@@ -133,8 +133,8 @@ export default function HeapDetail() {
         />
       }
     >
-      <div className="flex h-full w-full flex-col overflow-y-auto lg:flex-row">
-        <div className="group relative flex flex-1">
+      <div className="flex h-full flex-col overflow-y-auto lg:flex-row">
+        <div className="flex flex-1">
           {hasNext ? (
             <div className="absolute top-0 left-0 flex h-full w-16 flex-col justify-center">
               <Link
@@ -165,7 +165,7 @@ export default function HeapDetail() {
             </div>
           ) : null}
         </div>
-        <div className="flex w-full flex-col border-gray-50 bg-white sm:mt-5 lg:mt-0 lg:h-full lg:w-72 lg:border-l-2 xl:w-96">
+        <div className="flex w-full flex-col justify-items-stretch space-y-2 p-2 lg:h-full lg:w-72 xl:w-96">
           {curio && time ? (
             <>
               <HeapDetailSidebarInfo curio={curio} />

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -165,7 +165,7 @@ export default function HeapDetail() {
             </div>
           ) : null}
         </div>
-        <div className="flex w-full flex-col justify-items-stretch space-y-2 p-2 lg:h-full lg:w-72 xl:w-96">
+        <div className="flex w-full flex-col lg:h-full lg:w-72 lg:border-l-2 lg:border-gray-50 xl:w-96">
           {curio && time ? (
             <>
               <HeapDetailSidebarInfo curio={curio} />

--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -31,8 +31,8 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
 
   if (content.block.length > 0 && 'cite' in content.block[0]) {
     return (
-      <div className="mx-auto flex h-full w-full items-center justify-center p-8 text-[18px] leading-[26px]">
-        <div className="max-h-[100%] min-w-32 max-w-prose overflow-y-auto">
+      <div className="mx-auto flex h-full w-full items-center justify-center bg-gray-50 p-8 text-[18px] leading-[26px]">
+        <div className="max-h-[100%] min-w-32 max-w-prose overflow-y-auto rounded-md bg-white">
           <ContentReference cite={content.block[0].cite} />
         </div>
       </div>
@@ -41,7 +41,7 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
 
   if (isText) {
     return (
-      <div className="mx-auto flex h-full w-full items-center justify-center p-8 text-[18px] leading-[26px]">
+      <div className="mx-auto flex h-full w-full items-center justify-center bg-gray-50 p-8 text-[18px] leading-[26px]">
         <div className="max-h-[100%] max-w-prose overflow-y-auto">
           <HeapContent content={content} />
         </div>
@@ -59,7 +59,7 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
 
   if (isImage) {
     return (
-      <div className="flex h-full w-full justify-center">
+      <div className="flex justify-center bg-gray-50 lg:h-full lg:w-full">
         <img className="object-contain" src={url} alt="" />
       </div>
     );

--- a/ui/src/heap/HeapDetail/HeapDetailEmbed.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailEmbed.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable react/no-danger */
 import React from 'react';
 import EmbedContainer from 'react-oembed-container';
 import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
@@ -15,8 +17,8 @@ export default function HeapDetailEmbed({ oembed, url }: HeapDetailEmbedProps) {
   }
 
   return (
-    <div className="flex h-full w-full items-center justify-center overflow-y-scroll">
-      <EmbedContainer className="max-h-full w-[500px]" markup={html}>
+    <div className="flex h-full w-full items-center justify-center overflow-y-auto bg-gray-50">
+      <EmbedContainer className="max-h-full" markup={html}>
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </EmbedContainer>
     </div>

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -45,10 +45,13 @@ export default function HeapDetailHeader({
     new Date(curio?.heart.sent || Date.now())
   );
   const isImageLink = isImageUrl(curioContent);
+  const isCite = content.block.length > 0 && 'cite' in content.block[0];
   const curioTitle = curio?.heart.title;
   const { onEdit, onCopy, didCopy } = useCurioActions({ nest, time: idCurio });
 
-  const isCite = content.block.length > 0 && 'cite' in content.block[0];
+  function truncate({ str, n }: { str: string; n: number }) {
+    return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+  }
 
   return (
     <>
@@ -75,11 +78,15 @@ export default function HeapDetailHeader({
           <div className=" mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 p-1 text-center">
             <ChannelIcon nest="heap" className="h-5 w-5 text-gray-400" />
           </div>
-          <span className="ellipsis line-clamp-1">
+          <span className="whitespace-nobreak line-clamp-1">
             {isCite ? 'Reference' : `${description()}: `}
-            {curioTitle && curioTitle}
-            {isImageLink && !curioTitle ? curioContent : null}
-            {!isImageLink && !curioTitle ? prettyDayAndTime : null}
+            {curioTitle && truncate({ str: curioTitle, n: 12 })}
+            {isImageLink && !curioTitle
+              ? truncate({ str: curioContent, n: 12 })
+              : null}
+            {!isImageLink && !curioTitle
+              ? truncate({ str: prettyDayAndTime, n: 12 })
+              : null}
           </span>
         </Link>
         <div className="shink-0 flex items-center space-x-3 self-end">

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
@@ -22,10 +22,10 @@ export default function HeapComment({
   const flag = useChannelFlag();
 
   return (
-    <div className="group-one flex w-full flex-col">
+    <div className="group-one flex w-full flex-col space-y-0 p-2">
       <Author ship={author} date={unixDate} timeOnly />
-      <div className="relative flex w-full flex-col space-y-2 rounded py-1 pl-3 pr-2 group-one-hover:bg-gray-50">
-        <HeapContent className="ml-9 break-words" content={content} />
+      <div className="relative ml-[28px] rounded-md p-2 group-one-hover:bg-gray-50 ">
+        <HeapContent className="break-words" content={content} />
         <HeapCommentOptions
           whom={flag || ''}
           curio={curio}

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
@@ -25,7 +25,7 @@ export default function HeapComment({
     <div className="group-one flex w-full flex-col space-y-0 p-2">
       <Author ship={author} date={unixDate} timeOnly />
       <div className="relative ml-[28px] rounded-md p-2 group-one-hover:bg-gray-50 ">
-        <HeapContent className="break-words" content={content} />
+        <HeapContent className="break-words leading-5" content={content} />
         <HeapCommentOptions
           whom={flag || ''}
           curio={curio}

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
@@ -22,7 +22,7 @@ export default function HeapComment({
   const flag = useChannelFlag();
 
   return (
-    <div className="group-one flex w-full flex-col space-y-0 p-2">
+    <div className="group-one flex w-full flex-col pb-2">
       <Author ship={author} date={unixDate} timeOnly />
       <div className="relative ml-[28px] rounded-md p-2 group-one-hover:bg-gray-50 ">
         <HeapContent className="break-words leading-5" content={content} />

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapCommentReactions.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapCommentReactions.tsx
@@ -32,7 +32,7 @@ export default function HeapCommentReactions({
   const openPicker = useCallback(() => setPickerOpen(true), [setPickerOpen]);
 
   return (
-    <div className="my-2 flex items-center space-x-2">
+    <div className="mt-2 flex items-center space-x-2">
       {Object.entries(feels).map(([feel, ships]) => (
         <HeapCommentReaction
           key={feel}

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
@@ -14,13 +14,12 @@ export default function HeapDetailCommentField() {
   const replyToTime = idCurio ? decToUd(idCurio) : undefined;
 
   return (
-    <div className="flex-end">
+    <div className="px-2 lg:absolute lg:bottom-0 lg:w-full">
       <HeapTextInput
         flag={chFlag}
         draft={draftText}
         setDraft={setDraftText}
         replyTo={replyToTime}
-        className="flex-1"
         placeholder="Comment"
         comment={true}
       />

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
@@ -14,7 +14,7 @@ export default function HeapDetailCommentField() {
   const replyToTime = idCurio ? decToUd(idCurio) : undefined;
 
   return (
-    <div className="px-2 lg:absolute lg:bottom-0 lg:w-full">
+    <div className="border-t-2 border-gray-50 p-3 sm:p-4">
       <HeapTextInput
         flag={chFlag}
         draft={draftText}

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
@@ -22,42 +22,24 @@ export default function HeapDetailComments({ time }: HeapDetailCommentsProps) {
   const [, chFlag] = nestToFlag(nest);
   const stringTime = time.toString();
   const comments = useComments(chFlag, stringTime);
-  const isSmall = useMedia('(max-width: 1023px)');
   const perms = useHeapPerms(chFlag);
   const vessel = useVessel(flag, window.our);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
   const sortedComments = Array.from(comments).sort(([a], [b]) => a.compare(b));
 
-  const computeItemKey = (
-    _i: number,
-    [t, _curio]: [bigInt.BigInteger, HeapCurio]
-  ) => t.toString();
-
-  const itemContent = (index: number, id: BigInteger, curio: HeapCurio) => (
-    <HeapComment
-      key={id.toString()}
-      curio={curio}
-      parentTime={stringTime}
-      time={id.toString()}
-    />
-  );
-
   return (
-    <div className="space-y-2 lg:relative lg:h-full lg:space-y-0">
-      <Virtuoso
-        useWindowScroll={isSmall}
-        data={sortedComments}
-        computeItemKey={computeItemKey}
-        itemContent={(i, [id, curio]) => itemContent(i, id, curio)}
-        followOutput={true}
-        style={{
-          height: '100%',
-          width: '100%',
-          maxHeight: 'calc(100% - 2.5rem)',
-        }}
-      />
-
+    <>
+      <div className="mx-4 mb-2 flex flex-col space-y-2 overflow-y-auto lg:flex-1">
+        {sortedComments.map(([id, curio]) => (
+          <HeapComment
+            key={id.toString()}
+            curio={curio}
+            parentTime={stringTime}
+            time={id.toString()}
+          />
+        ))}
+      </div>
       {canWrite ? <HeapDetailCommentField /> : null}
-    </div>
+    </>
   );
 }

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
@@ -7,6 +7,7 @@ import { useGroup, useRouteGroup, useVessel } from '@/state/groups/groups';
 import { useComments, useHeapPerms } from '@/state/heap/heap';
 import { canWriteChannel, nestToFlag } from '@/logic/utils';
 import { HeapCurio } from '@/types/heap';
+import useMedia from '@/logic/useMedia';
 import HeapDetailCommentField from './HeapDetailCommentField';
 import HeapComment from './HeapComment';
 
@@ -21,7 +22,7 @@ export default function HeapDetailComments({ time }: HeapDetailCommentsProps) {
   const [, chFlag] = nestToFlag(nest);
   const stringTime = time.toString();
   const comments = useComments(chFlag, stringTime);
-
+  const isSmall = useMedia('(max-width: 1023px)');
   const perms = useHeapPerms(chFlag);
   const vessel = useVessel(flag, window.our);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
@@ -42,21 +43,20 @@ export default function HeapDetailComments({ time }: HeapDetailCommentsProps) {
   );
 
   return (
-    <div className="flex h-full flex-col justify-between p-4 sm:overflow-y-auto">
-      <div
-        className={cn(
-          'flex h-full flex-col space-y-2',
-          comments.size !== 0 && 'mb-4'
-        )}
-      >
-        <Virtuoso
-          data={sortedComments}
-          computeItemKey={computeItemKey}
-          itemContent={(i, [id, curio]) => itemContent(i, id, curio)}
-          followOutput={true}
-          style={{ height: '100%', width: '100%', paddingTop: '1rem' }}
-        />
-      </div>
+    <div className="space-y-2 lg:relative lg:h-full lg:space-y-0">
+      <Virtuoso
+        useWindowScroll={isSmall}
+        data={sortedComments}
+        computeItemKey={computeItemKey}
+        itemContent={(i, [id, curio]) => itemContent(i, id, curio)}
+        followOutput={true}
+        style={{
+          height: '100%',
+          width: '100%',
+          maxHeight: 'calc(100% - 2.5rem)',
+        }}
+      />
+
       {canWrite ? <HeapDetailCommentField /> : null}
     </div>
   );

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import { URL_REGEX } from '@/logic/utils';
+import { URL_REGEX, makePrettyDay } from '@/logic/utils';
 import { inlineToString } from '@/logic/tiptap';
 import { HeapCurio } from '@/types/heap';
 import Author from '@/chat/ChatMessage/Author';
@@ -22,29 +22,30 @@ export default function HeapDetailSidebarInfo({
   const isURL = URL_REGEX.test(stringContent);
 
   return (
-    <div className="flex w-full flex-col space-y-4 break-words border-b-2 border-gray-50 p-4">
-      <div className="flex flex-col space-y-1">
-        {title ||
-          (!isURL && (
-            <h2 className="text-ellipsis break-all font-semibold text-gray-800 line-clamp-1">
-              {title && title}
-              {!title && !isURL ? textPreview : null}
-            </h2>
-          ))}
-        {isURL && (
-          <a
-            href={stringContent}
-            target="_blank"
-            rel="noreferrer"
-            className="text-ellipsis break-all font-semibold text-gray-800 underline line-clamp-1"
-          >
-            {stringContent}
-          </a>
-        )}
-      </div>
-      <div className="text-ellipsis break-all line-clamp-1">
-        <Author ship={author} date={unixDate} timeOnly />
-      </div>
+    <div className="flex flex-col space-y-4 rounded-lg bg-gray-50 p-4">
+      {title ||
+        (!isURL && (
+          <h2 className="break-all text-base font-semibold text-gray-800 line-clamp-1">
+            {title && title}
+            {!title && !isURL ? textPreview : null}
+          </h2>
+        ))}
+      {isURL && (
+        <a
+          href={stringContent}
+          target="_blank"
+          rel="noreferrer"
+          className="break-all text-base font-semibold text-gray-800 line-clamp-1"
+        >
+          {stringContent}
+        </a>
+      )}
+
+      <time className="text-base font-semibold text-gray-400">
+        {makePrettyDay(unixDate)}
+      </time>
+
+      <Author ship={author} />
     </div>
   );
 }

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
@@ -23,23 +23,10 @@ export default function HeapDetailSidebarInfo({
 
   return (
     <div className="flex flex-col space-y-4 rounded-lg bg-gray-50 p-4">
-      {title ||
-        (!isURL && (
-          <h2 className="break-all text-base font-semibold text-gray-800 line-clamp-1">
-            {title && title}
-            {!title && !isURL ? textPreview : null}
-          </h2>
-        ))}
-      {isURL && (
-        <a
-          href={stringContent}
-          target="_blank"
-          rel="noreferrer"
-          className="break-all text-base font-semibold text-gray-800 line-clamp-1"
-        >
-          {stringContent}
-        </a>
-      )}
+      <h2 className="break-all text-base font-semibold text-gray-800 line-clamp-1">
+        {title && title}
+        {!title && !isURL ? textPreview : null}
+      </h2>
 
       <time className="text-base font-semibold text-gray-400">
         {makePrettyDay(unixDate)}

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo.tsx
@@ -22,7 +22,7 @@ export default function HeapDetailSidebarInfo({
   const isURL = URL_REGEX.test(stringContent);
 
   return (
-    <div className="flex flex-col space-y-4 rounded-lg bg-gray-50 p-4">
+    <div className="m-4 flex flex-col space-y-4 rounded-lg bg-gray-50 p-4">
       <h2 className="break-all text-base font-semibold text-gray-800 line-clamp-1">
         {title && title}
         {!title && !isURL ? textPreview : null}


### PR DESCRIPTION
Cleans a bunch of things up w/r/t layout in the curio detail view.

- Stacks content and comments vertically for smaller viewports.
- Uses the window scroll in Virtuoso for smaller viewports (eliminates any scroll-within-scroll problems).
- Realigns the comment content.
- Brings the sidebar metadata up to spec (https://www.figma.com/file/sCFYLlAGjehlYXUkT2rarg/Product-Handoffs?node-id=2799-114533&t=v23dQDf7A7iGe9BC-4).
- Manually truncates the "back" button in the header to avoid the line-clamp bug which destroys the layout on smaller screenss.


https://user-images.githubusercontent.com/748181/227311717-533ee2b5-aa31-4459-b3d9-ab251ae0ec5e.mov


https://user-images.githubusercontent.com/748181/227311731-8117dbb1-c01d-466d-b540-a9d829e7ab9e.mov

