### PR TITLE
Fix bottom spacing issues on PWAs

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -12,7 +12,7 @@
       data-react-helmet="true"
     />
     <link rel="apple-touch-icon" href="/src/assets/apple-touch-icon.png" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
   </head>
   <body
     class="bg-white font-sans text-base font-normal text-gray-800 antialiased"

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -600,9 +600,9 @@ function RoutedApp() {
 
     switch (appName) {
       case 'chat':
-        return '/apps/talk';
+        return '/apps/talk/';
       default:
-        return '/apps/groups';
+        return '/apps/groups/';
     }
   };
 

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -2,7 +2,6 @@ import cookies from 'browser-cookies';
 import React, { Suspense, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import _ from 'lodash';
-import cn from 'classnames';
 import {
   BrowserRouter as Router,
   Routes,

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -2,6 +2,7 @@ import cookies from 'browser-cookies';
 import React, { Suspense, useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import _ from 'lodash';
+import cn from 'classnames';
 import {
   BrowserRouter as Router,
   Routes,
@@ -76,6 +77,8 @@ import { LeapProvider } from './components/Leap/useLeap';
 import VitaMessage from './components/VitaMessage';
 import { useGroups } from './state/groups';
 import Dialog, { DialogContent } from './components/Dialog';
+import useIsStandaloneMode from './logic/useIsStandaloneMode';
+import useIsIOSSafariPWA from './logic/useIsIOSSfari';
 
 const Grid = React.lazy(() => import('./components/Grid/grid'));
 const TileInfo = React.lazy(() => import('./components/Grid/tileinfo'));
@@ -524,6 +527,9 @@ function App() {
   const isSmall = useMedia('(max-width: 1023px)');
   const settingsLoaded = useSettingsLoaded();
   const { disableWayfinding } = useCalm();
+  const isStandAlone = useIsStandaloneMode();
+  const isIOSSafariPWA = useIsIOSSafariPWA();
+  const body = document.querySelector('body');
 
   useEffect(() => {
     handleError(() => {
@@ -537,6 +543,16 @@ function App() {
       bootstrap();
     })();
   }, [handleError]);
+
+  useEffect(() => {
+    if (isStandAlone) {
+      if (!isIOSSafariPWA) {
+        body?.style.setProperty('padding-bottom', '0px');
+      } else {
+        body?.style.setProperty('padding-bottom', '16px');
+      }
+    }
+  }, [isStandAlone, isIOSSafariPWA, body]);
 
   const state = location.state as { backgroundLocation?: Location } | null;
 

--- a/ui/src/assets/chatmanifest.json
+++ b/ui/src/assets/chatmanifest.json
@@ -2,7 +2,8 @@
   "name": "Talk",
   "short_name": "Talk",
   "start_url": "/apps/talk/",
-  "scope": "./",
+  "scope": "/apps/talk/",
+  "id": "/apps/talk/",
   "icons": [
     {
       "src": "/apps/talk/talk.svg",

--- a/ui/src/assets/manifest.json
+++ b/ui/src/assets/manifest.json
@@ -2,7 +2,8 @@
   "name": "Groups",
   "short_name": "Groups",
   "start_url": "/apps/groups/",
-  "scope": "./",
+  "scope": "/apps/groups/",
+  "id": "/apps/groups/",
   "icons": [
     {
       "src": "/apps/groups/android-chrome-512x512.png",

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import cn from 'classnames';
 import { Outlet, useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
+import useIsIOSSafariPWA from '@/logic/useIsIOSSfari';
+import useIsStandaloneMode from '@/logic/useIsStandaloneMode';
 import NavTab from '../NavTab';
 import AppGroupsIcon from '../icons/AppGroupsIcon';
 import ElipsisIcon from '../icons/EllipsisIcon';
@@ -14,27 +16,16 @@ import SidebarItem from './SidebarItem';
 
 export default function MobileSidebar() {
   const [showSheet, setShowSheet] = useState(false);
-  const [displayMode, setDisplayMode] = useState('browser tab');
   const location = useLocation();
-
-  useEffect(() => {
-    // check if we're in safari on ios and if we're in a standalone app
-    const ua = window.navigator.userAgent;
-    const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
-    const webkit = !!ua.match(/WebKit/i);
-    const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
-
-    if (iOSSafari && matchMedia('(display-mode: standalone)').matches) {
-      setDisplayMode('ios');
-    }
-  }, []);
+  const isIOSSafari = useIsIOSSafariPWA();
+  const isStandAlone = useIsStandaloneMode();
 
   return (
     <section className="fixed inset-0 z-40 flex h-full w-full flex-col  border-gray-50 bg-white">
       <Outlet />
       <footer
         className={cn('flex-none border-t-2 border-gray-50', {
-          'pb-4': displayMode === 'ios',
+          'pb-4': isIOSSafari && isStandAlone,
         })}
       >
         <nav>

--- a/ui/src/logic/useIsIOSSfari.ts
+++ b/ui/src/logic/useIsIOSSfari.ts
@@ -1,0 +1,8 @@
+export default function useIsIOSSafariPWA() {
+  const ua = window.navigator.userAgent;
+  const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+  const webkit = !!ua.match(/WebKit/i);
+  const iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+
+  return iOSSafari;
+}

--- a/ui/src/logic/useIsStandaloneMode.ts
+++ b/ui/src/logic/useIsStandaloneMode.ts
@@ -1,0 +1,5 @@
+export default function useIsStandaloneMode() {
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+
+  return isStandalone;
+}


### PR DESCRIPTION
Fixes the issue where non-IOS PWAs were getting extra bottom padding, also ensure that we *always* have bottom padding on iOS PWA to avoid colliding with the home bar.

Also fixes an issue where navigating back to the "home" route would appear as navigating to an external route in the PWA (by updating manifest settings and making sure our basename in app.tsx includes a trailing slash).