### PR TITLE
groups: fix group header color in dark mode

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -62,7 +62,7 @@ function GroupHeader() {
           color={
             group && isColor(group.meta.cover)
               ? `text-${foregroundFromBackground(group.meta.cover)}`
-              : 'text-white'
+              : 'text-white dark:text-black'
           }
           highlight="#666666"
           className={cn(


### PR DESCRIPTION
I don't work at night enough to notice these things, I guess.

Before:

![image](https://user-images.githubusercontent.com/748181/227668719-d29179e2-4e25-467a-b43e-7cf35fdccad2.png)

After:

![image](https://user-images.githubusercontent.com/748181/227668676-ed809d35-dae7-4d94-a78b-658c2fd05eb1.png)
