### PR TITLE
groups: proper GroupCover text colors

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -84,9 +84,7 @@ function GroupHeader() {
           icon={<GroupAvatar {...group?.meta} />}
           {...fgStyle()}
         >
-          <span className="inline-block max-w-[130px] truncate">
-            {group?.meta.title}
-          </span>
+          <div className="max-w-[130px] truncate">{group?.meta.title}</div>
           <CaretDown16Icon className="absolute top-3 right-2 h-4 w-4" />
         </SidebarItem>
       </GroupActions>

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -27,6 +27,7 @@ function GroupHeader() {
   const group = useGroup(flag);
   const defaultImportCover = group?.meta.cover === '0x0';
   const calm = useCalm();
+  const isDark = useIsDark();
 
   const bgStyle = () => {
     if (
@@ -46,6 +47,21 @@ function GroupHeader() {
     return {};
   };
 
+  const fgStyle = () => {
+    if (group && !isColor(group?.meta.cover) && !defaultImportCover)
+      return {
+        color: 'text-white dark:text-black',
+        style: { textShadow: '0px 1px 3px black' },
+      };
+    if (group && isColor(group?.meta.cover) && !defaultImportCover) {
+      const fg = foregroundFromBackground(group?.meta.cover);
+      if (fg === 'white' && isDark) return { color: 'text-gray-800' };
+      if (fg === 'black' && isDark) return { color: 'text-gray-50' };
+      return { color: `text-${fg}` };
+    }
+    return { color: 'text-gray-800' };
+  };
+
   return (
     <div
       className={cn(
@@ -59,11 +75,6 @@ function GroupHeader() {
         flag={flag}
       >
         <SidebarItem
-          color={
-            group && isColor(group.meta.cover)
-              ? `text-${foregroundFromBackground(group.meta.cover)}`
-              : 'text-white dark:text-black'
-          }
           highlight="#666666"
           className={cn(
             'relative pl-11',
@@ -71,14 +82,9 @@ function GroupHeader() {
           )}
           transparent={true}
           icon={<GroupAvatar {...group?.meta} />}
+          {...fgStyle()}
         >
-          <span
-            style={
-              group && !isColor(group.meta.cover)
-                ? { textShadow: '0px 1px 3px black' }
-                : {}
-            }
-          >
+          <span className="inline-block max-w-[130px] truncate">
             {group?.meta.title}
           </span>
           <CaretDown16Icon className="absolute top-3 right-2 h-4 w-4" />


### PR DESCRIPTION
All together now.

Light mode, with cover image:
![image](https://user-images.githubusercontent.com/748181/228012809-9966e996-b172-4055-8146-38c31ca995f6.png)

Dark mode, with cover image:
![image](https://user-images.githubusercontent.com/748181/228012890-222d0c78-2562-44b0-8cba-ed14b8a03985.png)

Light mode, no cover image, light color:
![image](https://user-images.githubusercontent.com/748181/228012986-49451852-6d60-46a9-a70e-5ab179d14312.png)

Dark mode, no cover image, light color:
![image](https://user-images.githubusercontent.com/748181/228013042-46f66207-df58-4d20-85f6-43b0e120b8af.png)

Light mode, no cover image, dark color:
![image](https://user-images.githubusercontent.com/748181/228014551-23a09d3f-2a78-419d-8214-4a4148a16d57.png)

Dark mode, no cover image, dark color:
![image](https://user-images.githubusercontent.com/748181/228013168-17597954-f97e-4d0c-bed4-64741b6f1364.png)
