### PR TITLE
vita: missing handling root wire

### DIFF
--- a/talk/app/talk-ui.hoon
+++ b/talk/app/talk-ui.hoon
@@ -114,6 +114,7 @@
   |=  [=(pole knot) =sign:agent:gall]
   ^+  cor
   ?+    pole  ~|(bad-agent-take/pole !!)
+    ~  cor
     [%set-vita ~]  cor
     [%vita-toggle ~]  cor
   ==


### PR DESCRIPTION
OTT, not handling this causes stuff like this to appear in dojo: https://pastebin.com/zAtDAL8P reported by Luke. We handled in groups but forgot to add to talk.