### PR TITLE
invites: fix blank screen on reject

### DIFF
--- a/ui/src/groups/GroupJoinList.tsx
+++ b/ui/src/groups/GroupJoinList.tsx
@@ -15,7 +15,8 @@ interface GroupJoinItemProps {
 function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
   const { open, reject, button, status, group, rejectStatus } = useGroupJoin(
     flag,
-    gang
+    gang,
+    true
   );
   const isMobile = useIsMobile();
   const cordon = gang.preview?.cordon || group?.cordon;

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -423,8 +423,7 @@ export const useGroupState = create<GroupState>(
             onSuccess: async () => {
               await useSubscriptionState
                 .getState()
-                .track('groups/groups/ui', (event) => {
-                  const { json } = event;
+                .track('groups/gangs/updates', (json) => {
                   if (json && flag in json) {
                     return json[flag].invite === null;
                   }


### PR DESCRIPTION
This fixes #2041 (needed to specify that we were calling useGroupJoin within a modal) and another issue I found while working on that one (we weren't tracking the right subscription path, so after clicking reject it would just spin).