### PR TITLE
groups + talk: sidebar spacing fixes

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -221,14 +221,13 @@ export default function Sidebar() {
                   />
                 </div>
               </div>
-              <div className="relative">
-                {!sortedGroups.length && (
-                  <div className="mt-4 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
-                    Check out <strong>Find Groups</strong> above to find new
-                    groups in your network or view group invites.
-                  </div>
-                )}
-              </div>
+
+              {!sortedGroups.length && (
+                <div className="mx-4 my-2 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
+                  Check out <strong>Find Groups</strong> above to find new
+                  groups in your network or view group invites.
+                </div>
+              )}
             </div>
             {gangs.map((flag) => (
               <GangItem key={flag} flag={flag} />

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -105,7 +105,9 @@ export default function MessagesList({
         {allPending &&
           filter !== filters.groups &&
           allPending.map((whom) => (
-            <MessagesSidebarItem pending key={whom} whom={whom} />
+            <div key={whom} className="px-4 sm:px-2">
+              <MessagesSidebarItem pending key={whom} whom={whom} />
+            </div>
           ))}
       </>
     ),

--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -114,17 +114,13 @@ export function MultiDMSidebarItem({
     <SidebarItem
       to={`/dm/${whom}`}
       icon={
-        pending ? (
-          <UnknownAvatarIcon className="h-12 w-12 rounded-lg text-blue sm:rounded-md md:h-6 md:w-6" />
-        ) : (
-          <MultiDmAvatar
-            {...club?.meta}
-            title={groupName}
-            className="h-12 w-12 rounded-lg sm:h-6 sm:w-6 sm:rounded"
-            loadImage={!isScrolling}
-            {...avatarSize()}
-          />
-        )
+        <MultiDmAvatar
+          {...club?.meta}
+          title={groupName}
+          className="h-12 w-12 rounded-lg sm:h-6 sm:w-6 sm:rounded"
+          loadImage={!isScrolling}
+          {...avatarSize()}
+        />
       }
       actions={<DmOptions whom={whom} pending={!!pending} isMulti />}
     >


### PR DESCRIPTION
- Addresses some misalignments in the Talk sidebar for incoming DM requests
- Addresses a misalignment in the empty Groups sidebar (first run)
- Eliminates the blue [?] box for incoming multi-DM requests
 
Before:

![Screenshot 2023-03-29 at 4 11 51 PM](https://user-images.githubusercontent.com/748181/228661788-def519b9-befc-487f-a9f5-c079fcb0b5a6.png)

![image](https://user-images.githubusercontent.com/748181/228661260-39207c41-b639-4155-a061-883d4b9ba64d.png)

---

After:

![Screenshot 2023-03-29 at 4 12 56 PM](https://user-images.githubusercontent.com/748181/228661846-cb57648b-e283-4230-a98f-cfa249bf5734.png)

![image](https://user-images.githubusercontent.com/748181/228661541-5b9e9a21-d400-4e23-a045-9a741d37e3a9.png)