### PR TITLE
Check bait URL for invite links more often

### DIFF
--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -154,7 +154,7 @@ const selLure = (flag: string) => (s: LureState) => ({
   lure: s.lures[flag] || { fetched: false, url: '' },
   bait: s.bait,
 });
-const { shouldLoad, newAttempt, finished } = getPreviewTracker();
+const { shouldLoad, newAttempt, finished } = getPreviewTracker(30 * 1000);
 export function useLure(flag: string, disableLoading = false) {
   const { bait, lure } = useLureState(selLure(flag));
 


### PR DESCRIPTION
Fixes https://github.com/tloncorp/lure/issues/49

Currently this checks every 30 seconds. If that feels slow we can make it more often.