### PR TITLE
notebook: fix kebab menu in index list items

### DIFF
--- a/ui/src/diary/DiaryNoteOptionsDropdown.tsx
+++ b/ui/src/diary/DiaryNoteOptionsDropdown.tsx
@@ -1,7 +1,6 @@
 import React, { PropsWithChildren, useState } from 'react';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { Link } from 'react-router-dom';
-import Divider from '@/components/Divider';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import useDiaryActions from './useDiaryActions';
 
@@ -38,35 +37,14 @@ export default function DiaryNoteOptionsDropdown({
           sideOffset={8}
           className="dropdown min-w-[208px] drop-shadow-lg"
         >
-          <Dropdown.Item
-            disabled
-            className="dropdown-item text-gray-400"
-            onSelect={onCopy}
-          >
-            Share Note
-          </Dropdown.Item>
           <Dropdown.Item className="dropdown-item" onSelect={onCopy}>
             {didCopy ? 'Link Copied!' : 'Copy Note Link'}
           </Dropdown.Item>
-          <Divider />
-          <Dropdown.Item
-            disabled
-            className="dropdown-item text-gray-400"
-            onSelect={onCopy}
-          >
-            Mark Read
-          </Dropdown.Item>
-          <Dropdown.Item
-            className="dropdown-item text-gray-400"
-            onSelect={onCopy}
-          >
-            Mute
-          </Dropdown.Item>
+
           {canEdit ? (
             <>
-              <Divider />
               <Dropdown.Item className="dropdown-item" asChild>
-                <Link to={`../edit/${time}`}>Edit Note</Link>
+                <Link to={`edit/${time}`}>Edit Note</Link>
               </Dropdown.Item>
               <Dropdown.Item
                 className="dropdown-item text-red"


### PR DESCRIPTION
Removes disabled (planned) items in context menu and fixes the "Edit" path (we're at the notebook root here, not in the note itself).

![image](https://user-images.githubusercontent.com/748181/229124134-531cc94c-25a1-4db3-bbf0-fef54e3a4ed0.png)

fixes #2228