### PR TITLE
notifications: fix mention links

### DIFF
--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
 import { useEventListener } from 'usehooks-ts';
+import bigInt from 'big-integer';
 import { useChannelFlag } from '@/hooks';
 import { useChatState, useReplies, useWrit, useChatPerms } from '@/state/chat';
 import { useChannel, useRouteGroup, useVessel } from '@/state/groups/groups';
@@ -36,6 +37,7 @@ export default function ChatThread() {
   const groupFlag = useRouteGroup();
   const { sendMessage } = useChatState.getState();
   const location = useLocation();
+  const scrollTo = new URLSearchParams(location.search).get('msg');
   const channel = useChannel(groupFlag, `chat/${flag}`)!;
   const { isOpen: leapIsOpen } = useLeap();
   const id = `${idShip!}/${idTime!}`;
@@ -140,6 +142,7 @@ export default function ChatThread() {
             whom={whom}
             scrollerRef={scrollerRef}
             replying
+            scrollTo={scrollTo ? bigInt(scrollTo) : undefined}
           />
         )}
       </div>

--- a/ui/src/logic/usePathFromHark.ts
+++ b/ui/src/logic/usePathFromHark.ts
@@ -3,10 +3,6 @@ import { useWritByFlagAndWritId } from '@/state/chat';
 import { Skein } from '@/types/hark';
 
 export default function usePathFromHark(bin: Skein, isMention: boolean) {
-  if (!isMention) {
-    return bin.top?.wer || '';
-  }
-
   const writId = bin.top?.wer.split('/')[10];
   const ship =
     typeof bin.top.con[0] !== 'string' && 'ship' in bin.top.con[0]
@@ -16,10 +12,13 @@ export default function usePathFromHark(bin: Skein, isMention: boolean) {
     bin.top?.wer.split('/')[7]
   }`;
   const idWrit = `${ship}/${writId}`;
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const replyToWrit = useWritByFlagAndWritId(channelFlag, idWrit || '', false)
     ?.memo.replying;
   const wer = bin.top?.wer;
+
+  if (!isMention) {
+    return wer;
+  }
 
   if (replyToWrit) {
     // if the mention is within a thread, we need to go to the thread and scroll to the message.

--- a/ui/src/logic/usePathFromHark.ts
+++ b/ui/src/logic/usePathFromHark.ts
@@ -16,30 +16,31 @@ export default function usePathFromHark(bin: Skein, isMention: boolean) {
     ?.memo.replying;
   const wer = bin.top?.wer;
 
-  if (isMention) {
-    if (replyToWrit) {
-      // if the mention is within a thread, we need to go to the thread and scroll to the message.
-      const split = wer.split('/');
-      const msg = split[split.length - 1];
-      const newPath = split
-        .slice(0, 9)
-        .join('/')
-        .concat(`/${replyToWrit}`)
-        .concat(`?msg=${udToDec(msg)}`);
-      return newPath;
-    }
+  if (!isMention) {
+    return wer;
+  }
 
-    // if the mention is in a normal message, we need to go to the chat channel and scroll to the message.
-    // the backend sends the mention path as /message/@p/message/@ud
-    // we need to convert it to ?msg=@t
+  if (replyToWrit) {
+    // if the mention is within a thread, we need to go to the thread and scroll to the message.
     const split = wer.split('/');
     const msg = split[split.length - 1];
-    const newPath = wer
-      .split('/')
-      .slice(0, 8)
+    const newPath = split
+      .slice(0, 9)
       .join('/')
+      .concat(`/${replyToWrit}`)
       .concat(`?msg=${udToDec(msg)}`);
     return newPath;
   }
-  return wer;
+
+  // if the mention is in a normal message, we need to go to the chat channel and scroll to the message.
+  // the backend sends the mention path as /message/@p/message/@ud
+  // we need to convert it to ?msg=@t
+  const split = wer.split('/');
+  const msg = split[split.length - 1];
+  const newPath = wer
+    .split('/')
+    .slice(0, 8)
+    .join('/')
+    .concat(`?msg=${udToDec(msg)}`);
+  return newPath;
 }

--- a/ui/src/logic/usePathFromHark.ts
+++ b/ui/src/logic/usePathFromHark.ts
@@ -1,0 +1,45 @@
+import { udToDec } from '@urbit/api';
+import { useWritByFlagAndWritId } from '@/state/chat';
+import { Skein } from '@/types/hark';
+
+export default function usePathFromHark(bin: Skein, isMention: boolean) {
+  const writId = bin.top?.wer.split('/')[10];
+  const ship =
+    typeof bin.top.con[0] !== 'string' && 'ship' in bin.top.con[0]
+      ? bin.top?.con[0].ship
+      : '';
+  const channelFlag = `${bin.top?.wer.split('/')[6]}/${
+    bin.top?.wer.split('/')[7]
+  }`;
+  const idWrit = `${ship}/${writId}`;
+  const replyToWrit = useWritByFlagAndWritId(channelFlag, idWrit || '', false)
+    ?.memo.replying;
+  const wer = bin.top?.wer;
+
+  if (isMention) {
+    if (replyToWrit) {
+      // if the mention is within a thread, we need to go to the thread and scroll to the message.
+      const split = wer.split('/');
+      const msg = split[split.length - 1];
+      const newPath = split
+        .slice(0, 9)
+        .join('/')
+        .concat(`/${replyToWrit}`)
+        .concat(`?msg=${udToDec(msg)}`);
+      return newPath;
+    }
+
+    // if the mention is in a normal message, we need to go to the chat channel and scroll to the message.
+    // the backend sends the mention path as /message/@p/message/@ud
+    // we need to convert it to ?msg=@t
+    const split = wer.split('/');
+    const msg = split[split.length - 1];
+    const newPath = wer
+      .split('/')
+      .slice(0, 8)
+      .join('/')
+      .concat(`?msg=${udToDec(msg)}`);
+    return newPath;
+  }
+  return wer;
+}

--- a/ui/src/logic/usePathFromHark.ts
+++ b/ui/src/logic/usePathFromHark.ts
@@ -3,6 +3,10 @@ import { useWritByFlagAndWritId } from '@/state/chat';
 import { Skein } from '@/types/hark';
 
 export default function usePathFromHark(bin: Skein, isMention: boolean) {
+  if (!isMention) {
+    return bin.top?.wer || '';
+  }
+
   const writId = bin.top?.wer.split('/')[10];
   const ship =
     typeof bin.top.con[0] !== 'string' && 'ship' in bin.top.con[0]
@@ -12,13 +16,10 @@ export default function usePathFromHark(bin: Skein, isMention: boolean) {
     bin.top?.wer.split('/')[7]
   }`;
   const idWrit = `${ship}/${writId}`;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const replyToWrit = useWritByFlagAndWritId(channelFlag, idWrit || '', false)
     ?.memo.replying;
   const wer = bin.top?.wer;
-
-  if (!isMention) {
-    return wer;
-  }
 
   if (replyToWrit) {
     // if the mention is within a thread, we need to go to the thread and scroll to the message.

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -4,13 +4,13 @@ import React, { ReactNode, useCallback } from 'react';
 import ob from 'urbit-ob';
 import { Link } from 'react-router-dom';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import { udToDec } from '@urbit/api';
 import Bullet16Icon from '@/components/icons/Bullet16Icon';
 import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 import ShipName from '@/components/ShipName';
 import { makePrettyTime, PUNCTUATION_REGEX } from '@/logic/utils';
 import { useSawRopeMutation } from '@/state/hark';
 import { Skein, YarnContent } from '@/types/hark';
+import usePathFromHark from '@/logic/usePathFromHark';
 import { isComment, isMention, isReply } from './useNotifications';
 
 interface NotificationProps {
@@ -122,22 +122,7 @@ export default function Notification({
   const mentionBool = isMention(bin.top);
   const commentBool = isComment(bin.top);
   const replyBool = isReply(bin.top);
-  const formattedLink = (wer: string) => {
-    if (mentionBool) {
-      // the backend sends the mention path as /message/@p/message/@ud
-      // we need to convert it to ?msg=@t
-      const split = wer.split('/');
-      const msg = split[split.length - 1];
-      const newPath = wer
-        .split('/')
-        .slice(0, 8)
-        .join('/')
-        .concat(`?msg=${udToDec(msg)}`);
-      return newPath;
-    }
-    return wer;
-  };
-
+  const path = usePathFromHark(bin, mentionBool);
   const onClick = useCallback(() => {
     sawRopeMutation({ rope });
   }, [rope, sawRopeMutation]);
@@ -150,7 +135,7 @@ export default function Notification({
       )}
     >
       <Link
-        to={formattedLink(bin.top?.wer || '')}
+        to={path}
         className="flex w-full min-w-0 flex-1 space-x-3"
         onClick={onClick}
       >

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, useCallback } from 'react';
 import ob from 'urbit-ob';
 import { Link } from 'react-router-dom';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import { udToDec } from '@urbit/api';
 import Bullet16Icon from '@/components/icons/Bullet16Icon';
 import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 import ShipName from '@/components/ShipName';
@@ -121,6 +122,21 @@ export default function Notification({
   const mentionBool = isMention(bin.top);
   const commentBool = isComment(bin.top);
   const replyBool = isReply(bin.top);
+  const formattedLink = (wer: string) => {
+    if (mentionBool) {
+      // the backend sends the mention path as /message/@p/message/@ud
+      // we need to convert it to ?msg=@t
+      const split = wer.split('/');
+      const msg = split[split.length - 1];
+      const newPath = wer
+        .split('/')
+        .slice(0, 8)
+        .join('/')
+        .concat(`?msg=${udToDec(msg)}`);
+      return newPath;
+    }
+    return wer;
+  };
 
   const onClick = useCallback(() => {
     sawRopeMutation({ rope });
@@ -134,7 +150,7 @@ export default function Notification({
       )}
     >
       <Link
-        to={bin.top?.wer || ''}
+        to={formattedLink(bin.top?.wer || '')}
         className="flex w-full min-w-0 flex-1 space-x-3"
         onClick={onClick}
       >


### PR DESCRIPTION
fixes #2263 by opening up the thread and scrolling to the mention in question.

Also: for normal mentions (i.e., mentions in the main chat window), this routes the user to the mention within the chat window rather than prompting the user to start a new thread for the mention.