### PR TITLE
emoji picker: fix closing immediately on mobile

### DIFF
--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -36,18 +36,16 @@ export default function EmojiPicker({
       ) : (
         children
       )}
-      {(isMobile || !withTrigger) && (
-        <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-12' : ''} />
-      )}
+      {(isMobile || !withTrigger) && <Popover.Anchor />}
       <Popover.Portal>
         <Popover.Content side="bottom" sideOffset={30} collisionPadding={15}>
           <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (
               <Picker
                 data={data}
-                autoFocus={isMobile}
                 perLine={isMobile ? mobilePerLineCount : 9}
                 previewPosition="none"
+                searchPosition={isMobile ? 'none' : 'top'}
                 {...props}
               />
             ) : (


### PR DESCRIPTION
This stops the emoji picker from closing immediately on mobile by removing the search input.

Disabling autoFocus for the input isn't enough, if the user selects the input the picker will still close.

This stops the bleeding while we figure out what is causing the picker to close when the search within the picker is focused (or we switch to another picker or another method for displaying the picker).

Also pops the picker up closer to the message itself since we don't have to worry about the keyboard anymore.

Fixes #2253 