### PR TITLE
chat: lift chat hover state to chat store, use router for emoji picker open state on mobile

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -78,6 +78,7 @@ import VitaMessage from './components/VitaMessage';
 import Dialog, { DialogContent } from './components/Dialog';
 import useIsStandaloneMode from './logic/useIsStandaloneMode';
 import queryClient from './queryClient';
+import EmojiPicker from './components/EmojiPicker';
 
 const Grid = React.lazy(() => import('./components/Grid/grid'));
 const TileInfo = React.lazy(() => import('./components/Grid/tileinfo'));
@@ -467,6 +468,12 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
             element={<NewChannelModal />}
           />
           <Route path="/profile/:ship" element={<ProfileModal />} />
+          {isMobile ? (
+            <Route
+              path="/groups/:ship/:name/channels/chat/:chShip/:chName/picker/:writShip/:writTime"
+              element={<EmojiPicker />}
+            />
+          ) : null}
         </Routes>
       ) : null}
     </>

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -242,6 +242,18 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
             path="/gangs/:ship/:name/reject"
             element={<RejectConfirmModal />}
           />
+          {isMobile ? (
+            <>
+              <Route
+                path="/groups/:ship/:name/channels/chat/:chShip/:chName/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
+              <Route
+                path="/dm/:ship/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
+            </>
+          ) : null}
         </Routes>
       ) : null}
     </>

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -26,7 +26,7 @@ import Avatar from '@/components/Avatar';
 import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { whomIsDm, whomIsMultiDm } from '@/logic/utils';
-import { useChatInfo, useChatStore } from '../useChatStore';
+import { useChatHovering, useChatInfo, useChatStore } from '../useChatStore';
 
 export interface ChatMessageProps {
   whom: string;
@@ -82,7 +82,7 @@ const ChatMessage = React.memo<
       const chatInfo = useChatInfo(whom);
       const unread = chatInfo?.unread;
       const unreadId = unread?.brief['read-id'];
-      const [hovering, setHovering] = useState(false);
+      const { hovering, setHovering } = useChatHovering(whom, writ.seal.id);
       const { ref: viewRef } = useInView({
         threshold: 1,
         onChange: useCallback(
@@ -168,8 +168,10 @@ const ChatMessage = React.memo<
         }, 100)
       );
       const onOver = useCallback(() => {
-        hover.current = true;
-        setHover.current();
+        if (hover.current === false) {
+          hover.current = true;
+          setHover.current();
+        }
       }, []);
       const onOut = useRef(
         debounce(
@@ -203,7 +205,7 @@ const ChatMessage = React.memo<
           {newDay ? <DateDivider date={unix} /> : null}
           {newAuthor ? <Author ship={memo.author} date={unix} /> : null}
           <div className="group-one relative z-0 flex w-full">
-            {hideOptions || isScrolling || !hovering ? null : (
+            {hideOptions || (isScrolling && !hovering) || !hovering ? null : (
               <ChatMessageOptions
                 hideThreadReply={hideReplies}
                 whom={whom}

--- a/ui/src/chat/ChatReactions/ChatReactions.tsx
+++ b/ui/src/chat/ChatReactions/ChatReactions.tsx
@@ -1,8 +1,10 @@
 import EmojiPicker from '@/components/EmojiPicker';
 import AddReactIcon from '@/components/icons/AddReactIcon';
+import { useIsMobile } from '@/logic/useMedia';
 import { useChatState } from '@/state/chat';
 import _ from 'lodash';
 import React, { useCallback, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 import { ChatSeal } from '../../types/chat';
 import ChatReaction from './ChatReaction';
 
@@ -14,6 +16,9 @@ interface ChatReactionsProps {
 export default function ChatReactions({ whom, seal }: ChatReactionsProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const feels = _.invertBy(seal.feels);
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const onEmoji = useCallback(
     (emoji: { shortcodes: string }) => {
@@ -36,19 +41,33 @@ export default function ChatReactions({ whom, seal }: ChatReactionsProps) {
           whom={whom}
         />
       ))}
-      <EmojiPicker
-        open={pickerOpen}
-        setOpen={setPickerOpen}
-        onEmojiSelect={onEmoji}
-      >
+      {!isMobile ? (
+        <EmojiPicker
+          open={pickerOpen}
+          setOpen={setPickerOpen}
+          onEmojiSelect={onEmoji}
+        >
+          <button
+            className="appearance-none border-none bg-transparent"
+            onClick={openPicker}
+            aria-label="Add Reaction"
+          >
+            <AddReactIcon className="h-6 w-6 text-gray-400" />
+          </button>
+        </EmojiPicker>
+      ) : (
         <button
           className="appearance-none border-none bg-transparent"
-          onClick={openPicker}
+          onClick={() =>
+            navigate(`picker/${seal.id}`, {
+              state: { backgroundLocation: location },
+            })
+          }
           aria-label="Add Reaction"
         >
           <AddReactIcon className="h-6 w-6 text-gray-400" />
         </button>
-      </EmojiPicker>
+      )}
     </div>
   );
 }

--- a/ui/src/chat/useChatStore.ts
+++ b/ui/src/chat/useChatStore.ts
@@ -12,7 +12,7 @@ export interface ChatInfo {
     brief: ChatBrief; // lags behind actual brief, only gets update if unread
   };
   dialogs: Record<string, Record<string, boolean>>;
-  hovering: Record<string, boolean>;
+  hovering: string;
   failedToLoadContent: Record<string, Record<number, boolean>>;
 }
 
@@ -49,7 +49,7 @@ const emptyInfo: ChatInfo = {
   blocks: [],
   unread: undefined,
   dialogs: {},
-  hovering: {},
+  hovering: '',
   failedToLoadContent: {},
 };
 
@@ -102,7 +102,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           draft.chats[whom] = emptyInfo;
         }
 
-        draft.chats[whom].hovering[writId] = hovering;
+        draft.chats[whom].hovering = hovering ? writId : '';
       })
     );
   },
@@ -245,10 +245,7 @@ export function useChatHovering(
 ): { hovering: boolean; setHovering: (hovering: boolean) => void } {
   const { setHovering } = useChatStore.getState();
   const hovering = useChatStore(
-    useCallback(
-      (s) => s.chats[whom]?.hovering?.[writId] || false,
-      [whom, writId]
-    )
+    useCallback((s) => s.chats[whom]?.hovering === writId, [whom, writId])
   );
 
   return {

--- a/ui/src/chat/useChatStore.ts
+++ b/ui/src/chat/useChatStore.ts
@@ -12,6 +12,7 @@ export interface ChatInfo {
     brief: ChatBrief; // lags behind actual brief, only gets update if unread
   };
   dialogs: Record<string, Record<string, boolean>>;
+  hovering: Record<string, boolean>;
   failedToLoadContent: Record<string, Record<number, boolean>>;
 }
 
@@ -34,6 +35,7 @@ export interface ChatStore {
     blockIndex: number,
     failureState: boolean
   ) => void;
+  setHovering: (whom: string, writId: string, hovering: boolean) => void;
   seen: (whom: string) => void;
   read: (whom: string) => void;
   delayedRead: (whom: string, callback: () => void) => void;
@@ -47,6 +49,7 @@ const emptyInfo: ChatInfo = {
   blocks: [],
   unread: undefined,
   dialogs: {},
+  hovering: {},
   failedToLoadContent: {},
 };
 
@@ -89,6 +92,17 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
         draft.chats[whom].failedToLoadContent[writId][blockIndex] =
           failureState;
+      })
+    );
+  },
+  setHovering: (whom, writId, hovering) => {
+    set(
+      produce((draft) => {
+        if (!draft.chats[whom]) {
+          draft.chats[whom] = emptyInfo;
+        }
+
+        draft.chats[whom].hovering[writId] = hovering;
       })
     );
   },
@@ -221,6 +235,26 @@ export function useChatDialog(
     open: dialogs[dialog] || false,
     setOpen: (open: boolean) => {
       setDialogs(whom, writId, { ...dialogs, [dialog]: open });
+    },
+  };
+}
+
+export function useChatHovering(
+  whom: string,
+  writId: string
+): { hovering: boolean; setHovering: (hovering: boolean) => void } {
+  const { setHovering } = useChatStore.getState();
+  const hovering = useChatStore(
+    useCallback(
+      (s) => s.chats[whom]?.hovering?.[writId] || false,
+      [whom, writId]
+    )
+  );
+
+  return {
+    hovering,
+    setHovering: (hover: boolean) => {
+      setHovering(whom, writId, hover);
     },
   };
 }

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useEffect } from 'react';
 import Picker from '@emoji-mart/react';
 import * as Popover from '@radix-ui/react-popover';
 import useEmoji from '@/state/emoji';
+import { useDismissNavigate } from '@/logic/routing';
 import { useIsMobile } from '@/logic/useMedia';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import { useChatState } from '@/state/chat';
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 
@@ -22,18 +23,18 @@ export default function EmojiPicker({
   ...props
 }: EmojiPickerProps) {
   const { data, load } = useEmoji();
-  const { chName, chShip, writShip, writTime } = useParams<{
+  const { ship, chName, chShip, writShip, writTime } = useParams<{
+    ship: string;
     chName: string;
     chShip: string;
     writShip: string;
     writTime: string;
   }>();
-  const navigate = useNavigate();
-  const whom = `${chShip}/${chName}`;
+  const whom = chShip ? `${chShip}/${chName}` : ship;
   const writId = `${writShip}/${writTime}`;
-  const { state: backgroundLocation } = useLocation();
   const isMobile = useIsMobile();
   const width = window.innerWidth;
+  const dismss = useDismissNavigate();
   const mobilePerLineCount = Math.floor((width - 10) / 36);
 
   useEffect(() => {
@@ -42,16 +43,16 @@ export default function EmojiPicker({
 
   const mobileOnOpenChange = (o: boolean) => {
     if (o) {
-      navigate(backgroundLocation);
+      dismss();
     }
   };
 
   const onEmojiSelect = useCallback(
     (emoji: { shortcodes: string }) => {
-      useChatState.getState().addFeel(whom, writId, emoji.shortcodes);
-      navigate(backgroundLocation);
+      useChatState.getState().addFeel(whom!, writId, emoji.shortcodes);
+      dismss();
     },
-    [whom, writId, backgroundLocation, navigate]
+    [whom, writId, dismss]
   );
 
   return (
@@ -74,9 +75,7 @@ export default function EmojiPicker({
           side="bottom"
           sideOffset={30}
           collisionPadding={15}
-          onInteractOutside={
-            isMobile ? () => navigate(backgroundLocation) : undefined
-          }
+          onInteractOutside={isMobile ? () => dismss() : undefined}
         >
           <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -39,7 +39,12 @@ export default function EmojiPicker({
         <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-12' : ''} />
       )}
       <Popover.Portal>
-        <Popover.Content side="bottom" sideOffset={30} collisionPadding={15}>
+        <Popover.Content
+          className="pl-[100px] pt-[100px]"
+          side="bottom"
+          sideOffset={30}
+          collisionPadding={15}
+        >
           <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (
               <Picker

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -1,14 +1,16 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import Picker from '@emoji-mart/react';
 import * as Popover from '@radix-ui/react-popover';
 import useEmoji from '@/state/emoji';
 import { useIsMobile } from '@/logic/useMedia';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useChatState } from '@/state/chat';
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 
 interface EmojiPickerProps extends Record<string, any> {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  children: React.ReactChild;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
+  children?: React.ReactChild;
   withTrigger?: boolean;
 }
 
@@ -20,6 +22,16 @@ export default function EmojiPicker({
   ...props
 }: EmojiPickerProps) {
   const { data, load } = useEmoji();
+  const { chName, chShip, writShip, writTime } = useParams<{
+    chName: string;
+    chShip: string;
+    writShip: string;
+    writTime: string;
+  }>();
+  const navigate = useNavigate();
+  const whom = `${chShip}/${chName}`;
+  const writId = `${writShip}/${writTime}`;
+  const { state: backgroundLocation } = useLocation();
   const isMobile = useIsMobile();
   const width = window.innerWidth;
   const mobilePerLineCount = Math.floor((width - 10) / 36);
@@ -28,15 +40,33 @@ export default function EmojiPicker({
     load();
   }, [load]);
 
+  const mobileOnOpenChange = (o: boolean) => {
+    if (o) {
+      navigate(backgroundLocation);
+    }
+  };
+
+  const onEmojiSelect = useCallback(
+    (emoji: { shortcodes: string }) => {
+      useChatState.getState().addFeel(whom, writId, emoji.shortcodes);
+      navigate(backgroundLocation);
+    },
+    [whom, writId, backgroundLocation, navigate]
+  );
+
   return (
-    <Popover.Root open={open} onOpenChange={setOpen}>
-      {withTrigger ? (
+    <Popover.Root
+      defaultOpen={isMobile}
+      open={isMobile ? undefined : open}
+      onOpenChange={isMobile ? mobileOnOpenChange : setOpen}
+    >
+      {withTrigger && !isMobile ? (
         <Popover.Trigger asChild>{children}</Popover.Trigger>
-      ) : (
+      ) : !isMobile ? (
         children
-      )}
+      ) : null}
       {(isMobile || !withTrigger) && (
-        <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-12' : ''} />
+        <Popover.Anchor className={isMobile ? 'fixed inset-x-0 top-10' : ''} />
       )}
       <Popover.Portal>
         <Popover.Content
@@ -44,6 +74,9 @@ export default function EmojiPicker({
           side="bottom"
           sideOffset={30}
           collisionPadding={15}
+          onInteractOutside={
+            isMobile ? () => navigate(backgroundLocation) : undefined
+          }
         >
           <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (
@@ -52,6 +85,7 @@ export default function EmojiPicker({
                 autoFocus={isMobile}
                 perLine={isMobile ? mobilePerLineCount : 9}
                 previewPosition="none"
+                onEmojiSelect={isMobile ? onEmojiSelect : undefined}
                 {...props}
               />
             ) : (

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import Picker from '@emoji-mart/react';
 import * as Popover from '@radix-ui/react-popover';
-import * as Dialog from '@radix-ui/react-dialog';
 import useEmoji from '@/state/emoji';
 import { useIsMobile } from '@/logic/useMedia';
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -40,7 +40,7 @@ export default function EmojiPicker({
       )}
       <Popover.Portal>
         <Popover.Content
-          className="pl-[100px] pt-[100px]"
+          className={isMobile ? '' : 'pl-[100px] pt-[100px]'}
           side="bottom"
           sideOffset={30}
           collisionPadding={15}

--- a/ui/src/logic/routing.ts
+++ b/ui/src/logic/routing.ts
@@ -31,7 +31,9 @@ export function useDismissNavigate() {
 
   return useCallback(() => {
     if (state?.backgroundLocation) {
-      navigate(state.backgroundLocation);
+      // we want to replace the current location with the background location
+      // so that the user won't navigate back to the modal if they hit the back button
+      navigate(state.backgroundLocation, { replace: true });
     }
   }, [navigate, state]);
 }


### PR DESCRIPTION
- Fixes the issue where the emoji picker would disappear if you hovered slightly out of/away from the chat message that spawned it by lifting hover state up into the chat store
- Adds 100px of padding on the left and the top of the emoji picker to prevent it from accidentally closing if the user hovers over another message outside of the picker.
- Fixes #2253, the issue where users on latest android couldn't use the emoji picker on mobile