### PR TITLE
Fix twitter embeds in heap detail in safari

### DIFF
--- a/ui/src/heap/HeapDetail/HeapDetailEmbed.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailEmbed.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react/no-danger */
 import React from 'react';
+import cn from 'classnames';
 import EmbedContainer from 'react-oembed-container';
 import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
 
@@ -11,6 +12,7 @@ interface HeapDetailEmbedProps {
 
 export default function HeapDetailEmbed({ oembed, url }: HeapDetailEmbedProps) {
   const { html } = oembed;
+  const isTwitter = url.match(/twitter\.com/);
 
   if (!html) {
     return <EmbedFallback url={url} />;
@@ -18,7 +20,13 @@ export default function HeapDetailEmbed({ oembed, url }: HeapDetailEmbedProps) {
 
   return (
     <div className="flex h-full w-full items-center justify-center overflow-y-auto bg-gray-50">
-      <EmbedContainer className="max-h-full" markup={html}>
+      <EmbedContainer
+        className={cn('overflow-y-auto md:h-full', {
+          'w-[500px]': isTwitter,
+          'h-[500px]': isTwitter,
+        })}
+        markup={html}
+      >
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </EmbedContainer>
     </div>


### PR DESCRIPTION
Fixes #2279 by providing a definite height/width for twitter embeds like we do in the lightbox (and which safari seems to require).

Also account for scrollable content in the heapdetail (if a user were to link to a tweet in a thread, for instance)