### PR TITLE
refs: hardcode tlon local ref to open to support

### DIFF
--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -252,7 +252,7 @@ export default function FindGroups({ title }: ViewProps) {
                 </div>
                 <div className="flex items-center justify-between">
                   <GroupAvatar
-                    image="https://sfo3.digitaloceanspaces.com/zurbit-images/dovsem-bornyl/2022.6.16..19.11.20-flooring.jpeg"
+                    image="https://nyc3.digitaloceanspaces.com/fabled-faster/fabled-faster/2023.4.06..02.45.53-tlon-local-pin.svg"
                     size="h-12 w-12 shrink-0"
                   />
                   <div className="mx-2 grow">

--- a/ui/src/groups/useGroupJoin.ts
+++ b/ui/src/groups/useGroupJoin.ts
@@ -58,6 +58,12 @@ export default function useGroupJoin(
   const { mutate: sawRopeMutation } = useSawRopeMutation();
 
   const open = useCallback(() => {
+    if (flag === '~nibset-napwyn/tlon') {
+      return navigateByApp(
+        '/groups/~nibset-napwyn/tlon/channels/chat/~nibset-napwyn/support'
+      );
+    }
+
     if (group) {
       return navigateByApp(`/groups/${flag}`);
     }


### PR DESCRIPTION
Fixes #1979

Also updates the image for the hardcoded tlon local group ref on the Find Groups page with the new group image.