### PR TITLE
Lay the groundwork for dynamic user themes.

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -65,7 +65,7 @@ import MobileMessagesSidebar from './dms/MobileMessagesSidebar';
 import MobileSidebar from './components/Sidebar/MobileSidebar';
 import MobileGroupsNavHome from './nav/MobileRoot';
 import Leap from './components/Leap/Leap';
-import { isTalk, preSig } from './logic/utils';
+import { isTalk, preSig, updateThemeStyle } from './logic/utils';
 import bootstrap from './state/bootstrap';
 import AboutDialog from './components/AboutDialog';
 import UpdateNotice from './components/UpdateNotice';
@@ -79,6 +79,7 @@ import Dialog, { DialogContent } from './components/Dialog';
 import useIsStandaloneMode from './logic/useIsStandaloneMode';
 import queryClient from './queryClient';
 import EmojiPicker from './components/EmojiPicker';
+import defaultTheme from './defaultTheme';
 
 const Grid = React.lazy(() => import('./components/Grid/grid'));
 const TileInfo = React.lazy(() => import('./components/Grid/tileinfo'));
@@ -619,13 +620,13 @@ function RoutedApp() {
 
   useEffect(() => {
     if ((isDarkMode && theme === 'auto') || theme === 'dark') {
-      document.body.classList.add('dark');
       useLocalState.setState({ currentTheme: 'dark' });
       setUserThemeColor('#000000');
+      updateThemeStyle(defaultTheme, true);
     } else {
-      document.body.classList.remove('dark');
       useLocalState.setState({ currentTheme: 'light' });
       setUserThemeColor('#ffffff');
+      updateThemeStyle(defaultTheme, false);
     }
   }, [isDarkMode, theme]);
 

--- a/ui/src/defaultTheme.ts
+++ b/ui/src/defaultTheme.ts
@@ -1,0 +1,88 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import colors from 'tailwindcss/colors';
+
+const light = {
+  white: '#FFFFFF',
+  black: '#000000',
+  gray: {
+    50: '#F5F5F5',
+    100: '#E5E5E5',
+    200: '#CCCCCC',
+    300: '#B3B3B3',
+    400: '#999999',
+    500: '#808080',
+    600: '#666666',
+    700: '#4C4C4C',
+    800: '#333333',
+    900: '#1A1A1A',
+  },
+  red: {
+    DEFAULT: '#FF6240',
+    soft: '#FFEFEC',
+  },
+  orange: {
+    DEFAULT: '#FF9040',
+    soft: '#FFF4EC',
+  },
+  yellow: {
+    DEFAULT: '#FADE7A',
+    soft: '#FAF5D9',
+  },
+  green: {
+    DEFAULT: '#2AD546',
+    soft: '#EAFBEC',
+  },
+  blue: {
+    DEFAULT: '#008EFF',
+    soft: '#E5F4FF',
+    softer: 'rgba(0, 142, 255, 0.1)',
+  },
+  indigo: {
+    DEFAULT: '#615FD3',
+    soft: '#EFEFFB',
+  },
+};
+
+const dark = {
+  white: '#000000',
+  black: '#FFFFFF',
+  gray: {
+    50: '#1A1A1A',
+    100: '#333333',
+    200: '#4C4C4C',
+    300: '#666666',
+    400: '#808080',
+    500: '#999999',
+    600: '#B3B3B3',
+    700: '#CCCCCC',
+    800: '#E5E5E5',
+    900: '#F5F5F5',
+  },
+  red: {
+    DEFAULT: '#FF6240',
+    soft: colors.red['900'],
+  },
+  orange: {
+    DEFAULT: '#FF9040',
+    soft: colors.orange['900'],
+  },
+  yellow: {
+    DEFAULT: '#FADE7A',
+    soft: colors.yellow['900'],
+  },
+  green: {
+    DEFAULT: '#2AD546',
+    soft: colors.green['900'],
+  },
+  blue: {
+    DEFAULT: '#008EFF',
+    soft: colors.blue['900'],
+    softer: 'rgba(0, 142, 255, 0.2)',
+  },
+  indigo: {
+    DEFAULT: '#615FD3',
+    soft: colors.indigo['900'],
+  },
+};
+
+export default { light, dark };

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -20,3 +20,50 @@ declare module 'urbit-ob' {
   function isValidPatp(ship: string): boolean;
   function clan(ship: string): 'galaxy' | 'star' | 'planet' | 'moon' | 'comet';
 }
+
+interface ThemeColors {
+  white: string;
+  black: string;
+  gray: {
+    50: string;
+    100: string;
+    200: string;
+    300: string;
+    400: string;
+    500: string;
+    600: string;
+    700: string;
+    800: string;
+    900: string;
+  };
+  red: {
+    DEFAULT: string;
+    soft: string;
+  };
+  orange: {
+    DEFAULT: string;
+    soft: string;
+  };
+  yellow: {
+    DEFAULT: string;
+    soft: string;
+  };
+  green: {
+    DEFAULT: string;
+    soft: string;
+  };
+  blue: {
+    DEFAULT: string;
+    soft: string;
+    softer: string;
+  };
+  indigo: {
+    DEFAULT: string;
+    soft: string;
+  };
+}
+
+interface Theme {
+  light: ThemeColors;
+  dark: ThemeColors;
+}

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -86,7 +86,7 @@ function GroupHeader() {
       </GroupActions>
       <Link
         to=".."
-        className="h-6-w-6 absolute top-2.5 left-2 z-40 flex items-center justify-center rounded bg-white bg-transparent p-1 text-gray-400"
+        className="h-6-w-6 absolute top-2.5 left-2 z-40 flex items-center justify-center rounded bg-white p-1 text-gray-400"
       >
         <CaretLeft16Icon className="h-4 w-4" />
       </Link>

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -638,3 +638,42 @@ export function isOnlyEmojis(str: string): boolean {
 
   return stringWithoutEmojis.length === 0;
 }
+
+export function generateCustomProperties(themeColors: ThemeColors) {
+  return Object.entries(themeColors)
+    .map(([color, value]) => {
+      if (typeof value === 'object') {
+        return Object.entries(value)
+          .map(([variant, variantValue]) => {
+            if (variant === 'DEFAULT') {
+              return `--color-${color}: ${variantValue};`;
+            }
+            return `--color-${color}-${variant}: ${variantValue};`;
+          })
+          .join(' ');
+      }
+      return `--color-${color}: ${value};`;
+    })
+    .join(' ');
+}
+
+export function updateThemeStyle(theme: Theme, isDark: boolean) {
+  const styleId = 'dynamic-theme-styles';
+  const styleContent = `
+    :root {
+      ${generateCustomProperties(isDark ? theme.dark : theme.light)}
+    }
+    .dark {
+      ${generateCustomProperties(theme.dark)}
+    }
+  `;
+  let styleElement = document.getElementById(styleId) as HTMLStyleElement;
+
+  if (!styleElement) {
+    styleElement = document.createElement('style');
+    styleElement.setAttribute('id', styleId);
+    document.head.appendChild(styleElement);
+  }
+
+  styleElement.textContent = styleContent;
+}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -3,101 +3,21 @@
 const colors = require('tailwindcss/colors');
 const defaultTheme = require('tailwindcss/defaultTheme');
 
-const lightColors = {
-  white: '#FFFFFF',
-  black: '#000000',
-  gray: {
-    50: '#F5F5F5',
-    100: '#E5E5E5',
-    200: '#CCCCCC',
-    300: '#B3B3B3',
-    400: '#999999',
-    500: '#808080',
-    600: '#666666',
-    700: '#4C4C4C',
-    800: '#333333',
-    900: '#1A1A1A',
-  },
-  red: {
-    DEFAULT: '#FF6240',
-    soft: '#FFEFEC',
-  },
-  orange: {
-    DEFAULT: '#FF9040',
-    soft: '#FFF4EC',
-  },
-  yellow: {
-    DEFAULT: '#FADE7A',
-    soft: '#FAF5D9',
-  },
-  green: {
-    DEFAULT: '#2AD546',
-    soft: '#EAFBEC',
-  },
-  blue: {
-    DEFAULT: '#008EFF',
-    soft: '#E5F4FF',
-    softer: 'rgba(0, 142, 255, 0.1)',
-  },
-  indigo: {
-    DEFAULT: '#615FD3',
-    soft: '#EFEFFB',
-  },
-};
+function createColorVariants(colorName) {
+  return {
+    DEFAULT: `var(--color-${colorName})`,
+    soft: `var(--color-${colorName}-soft)`,
+    softer: `var(--color-${colorName}-softer)`,
+  };
+}
 
-const darkColors = {
-  white: '#000000',
-  black: '#FFFFFF',
-  gray: {
-    50: '#1A1A1A',
-    100: '#333333',
-    200: '#4C4C4C',
-    300: '#666666',
-    400: '#808080',
-    500: '#999999',
-    600: '#B3B3B3',
-    700: '#CCCCCC',
-    800: '#E5E5E5',
-    900: '#F5F5F5',
-  },
-  red: {
-    DEFAULT: '#FF6240',
-    soft: colors.red['900'],
-  },
-  orange: {
-    DEFAULT: '#FF9040',
-    soft: colors.orange['900'],
-  },
-  yellow: {
-    DEFAULT: '#FADE7A',
-    soft: colors.yellow['900'],
-  },
-  green: {
-    DEFAULT: '#2AD546',
-    soft: colors.green['900'],
-  },
-  blue: {
-    DEFAULT: '#008EFF',
-    soft: colors.blue['900'],
-    softer: 'rgba(0, 142, 255, 0.2)',
-  },
-  indigo: {
-    DEFAULT: '#615FD3',
-    soft: colors.indigo['900'],
-  },
-};
-
-const base = {
-  theme: {
-    colors: lightColors,
-  },
-};
-
-const dark = {
-  theme: {
-    colors: darkColors,
-  },
-};
+function createGrayVariants(colorName) {
+  const gray = {};
+  for (let i = 50; i <= 900; i += 50) {
+    gray[i] = `var(--color-${colorName}-${i})`;
+  }
+  return gray;
+}
 
 module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
@@ -132,6 +52,15 @@ module.exports = {
       colors: {
         transparent: 'transparent',
         current: 'currentColor',
+        white: createColorVariants('white'),
+        black: createColorVariants('black'),
+        gray: createGrayVariants('gray'),
+        red: createColorVariants('red'),
+        orange: createColorVariants('orange'),
+        yellow: createColorVariants('yellow'),
+        green: createColorVariants('green'),
+        blue: createColorVariants('blue'),
+        indigo: createColorVariants('indigo'),
       },
       minWidth: (theme) => theme('spacing'),
       lineHeight: {
@@ -181,12 +110,6 @@ module.exports = {
       groups: ['one', 'two'],
     }),
     require('@tailwindcss/aspect-ratio'),
-    require('tailwindcss-theme-swapper')({
-      themes: [
-        { name: 'base', selectors: [':root'], theme: base.theme },
-        { name: 'dark', selectors: ['.dark'], theme: dark.theme },
-      ],
-    }),
     require('@tailwindcss/line-clamp'),
     require('@tailwindcss/typography'),
     require('@tailwindcss/container-queries'),


### PR DESCRIPTION
This PR lays the groundwork to allow dynamic user themes by replacing our hardcoded colors in the tailwind config with CSS custom properties. At the moment, we're just using our existing "default" theme. A theme would consist of both a "light" and "dark" set of colors.

This PR does not add the actual functionality to allow the user to change the colors, but that will be straightforward. We could surface the functionality in settings and stick their theme colors in the settings store for the groups or talk desks. We could also just store their theme settings in localStorage on the browser (via zustand and persist).

Only outstanding issue I've found is the GroupHeader SidebarItem not highlighting properly. @jamesacklin, you worked on that, is there something I'm missing there?