### PR TITLE
Add presig to non-contact-store DM ships in Leap.

### DIFF
--- a/ui/src/components/Leap/useLeap.tsx
+++ b/ui/src/components/Leap/useLeap.tsx
@@ -198,7 +198,7 @@ export default function useLeap() {
         .concat(
           // accounting for ships not in contact store, but in DMs
           // this fix is temporary until we fix the contact store
-          dms.map((ship) => [ship, { nickname: '' } as Contact])
+          dms.map((ship) => [preSig(ship), { nickname: '' } as Contact])
         ),
       ([ship]) => ship
     );


### PR DESCRIPTION
Currently in Leap we include ships you've DM'd with previously but aren't yet in your contact store as results. I added this a few weeks back because we had just been including contact-store ships in the results previously.

I forgot to presig the patps :( . If you were to select one of these DM-but-not-in-contact-store ships it would navigate to a blank screen. This presigs the patps and fixes that issue.