### PR TITLE
Fix issue with leaving chat from channel header

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -114,7 +114,7 @@ function ChannelActions({
 
   const leaveChannel = useCallback(async () => {
     try {
-      await leave(flag);
+      leave(flag);
       navigate(
         isMobile
           ? `/groups/${ship}/${name}`


### PR DESCRIPTION
OTT. Issue was caused by an errant `await` (we're already awaiting within `leave`).