### PR TITLE
diary/heap: fix initialization and stabilize refs

### DIFF
--- a/desk/lib/diary-json.hoon
+++ b/desk/lib/diary-json.hoon
@@ -22,6 +22,7 @@
         sent+(time sent.o)
         'quipCount'^(numb quips.o)
         quippers/a/(turn ~(tap in quippers.o) ship)
+        type/s/%outline
     ==
   ::
   ++  outlines
@@ -285,6 +286,7 @@
     %-  pairs
     :~  seal+(seal -.note)
         essay+(essay +.note)
+        type/s/%note
     ==
   ::
   ++  cork

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -117,7 +117,6 @@ function DiaryChannel() {
     ? canReadChannel(channel, vessel, group?.bloc)
     : false;
 
-  console.log(letters.size, joined, joining, channel, canRead);
 
   useEffect(() => {
     if (!joined) {

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -10,7 +10,7 @@ import {
   useVessel,
 } from '@/state/groups/groups';
 import {
-  useNotesForDiary,
+  useNotes,
   useDiaryState,
   useDiaryDisplayMode,
   useDiaryPerms,
@@ -49,7 +49,7 @@ function DiaryChannel() {
   const nest = `diary/${chFlag}`;
   const flag = useRouteGroup();
   const vessel = useVessel(flag, window.our);
-  const letters = useNotesForDiary(chFlag);
+  const letters = useNotes(chFlag);
   const location = useLocation();
   const navigate = useNavigate();
   const { setRecentChannel } = useRecentChannel(flag);
@@ -60,6 +60,7 @@ function DiaryChannel() {
     ? isChannelJoined(nest, briefs)
     : true;
   const lastReconnect = useLastReconnect();
+  const needsLoader = letters.size === 0;
 
   const joinChannel = useCallback(async () => {
     setJoining(true);
@@ -116,6 +117,8 @@ function DiaryChannel() {
     ? canReadChannel(channel, vessel, group?.bloc)
     : false;
 
+  console.log(letters.size, joined, joining, channel, canRead);
+
   useEffect(() => {
     if (!joined) {
       joinChannel();
@@ -134,7 +137,6 @@ function DiaryChannel() {
     joined,
     initializeChannel,
     joining,
-    briefs,
     channel,
     canRead,
     lastReconnect,
@@ -240,7 +242,7 @@ function DiaryChannel() {
         </div>
       </Toast.Provider>
       <div className="h-full">
-        {!initialized ? (
+        {!initialized && needsLoader ? (
           <DiaryChannelListPlaceholder count={4} />
         ) : displayMode === 'grid' ? (
           <DiaryGridView notes={sortedNotes} loadOlderNotes={loadOlderNotes} />

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -116,7 +116,7 @@ export default function DiaryNote() {
   );
 
   const load = useCallback(async () => {
-    await useDiaryState.getState().initialize(chFlag);
+    useDiaryState.getState().initialize(chFlag);
     try {
       await useDiaryState.getState().fetchNote(chFlag, noteId);
     } catch (e) {

--- a/ui/src/groups/Groups.tsx
+++ b/ui/src/groups/Groups.tsx
@@ -17,7 +17,7 @@ import { canReadChannel } from '@/logic/utils';
 function Groups() {
   const navigate = useNavigate();
   const flag = useRouteGroup();
-  const group = useGroup(flag, true);
+  const group = useGroup(flag, true, true);
   const gang = useGang(flag);
   const vessel = useVessel(flag, window.our);
   const isMobile = useIsMobile();

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -11,11 +11,7 @@ import {
   useGroup,
   useVessel,
 } from '@/state/groups/groups';
-import {
-  useCuriosForHeap,
-  useHeapState,
-  useHeapPerms,
-} from '@/state/heap/heap';
+import { useCurios, useHeapState, useHeapPerms } from '@/state/heap/heap';
 import { VirtuosoGrid } from 'react-virtuoso';
 import ChannelHeader from '@/channels/ChannelHeader';
 import {
@@ -59,7 +55,7 @@ function HeapChannel({ title }: ViewProps) {
   // for now sortMode is not actually doing anything.
   // need input from design/product on what we want it to actually do, it's not spelled out in figma.
   const sortMode = useHeapSortMode(chFlag);
-  const curios = useCuriosForHeap(chFlag);
+  const curios = useCurios(chFlag);
   const perms = useHeapPerms(chFlag);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
   const canRead = channel

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -1,7 +1,13 @@
 import { useState, useCallback } from 'react';
 import ob from 'urbit-ob';
 import { BigInteger } from 'big-integer';
-import { Docket, DocketHref, Treaty, unixToDa } from '@urbit/api';
+import {
+  BigIntOrderedMap,
+  Docket,
+  DocketHref,
+  Treaty,
+  unixToDa,
+} from '@urbit/api';
 import { formatUv } from '@urbit/aura';
 import anyAscii from 'any-ascii';
 import { format, differenceInDays, endOfToday } from 'date-fns';
@@ -22,6 +28,7 @@ import {
 } from '@/types/groups';
 import { CurioContent, Heap, HeapBrief } from '@/types/heap';
 import { DiaryBrief, DiaryQuip, DiaryQuipMap } from '@/types/diary';
+import bigInt from 'big-integer';
 
 export const isTalk = import.meta.env.VITE_APP === 'chat';
 
@@ -644,4 +651,30 @@ export function isSingleEmoji(input: string): boolean {
     /^\p{Emoji}(?:\p{Emoji_Modifier}?|\p{Emoji_Presentation}|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Extended_Pictographic})$/u;
 
   return emojiRegex.test(input);
+}
+
+export function initializeMap<T>(items: Record<string, T>) {
+  let map = new BigIntOrderedMap<T>();
+  Object.entries(items).forEach(([k, v]) => {
+    map = map.set(bigInt(k), v as T);
+  });
+
+  return map;
+}
+
+export function restoreMap<T>(obj: any): BigIntOrderedMap<T> {
+  const empty = new BigIntOrderedMap<T>();
+  if (!obj) {
+    return empty;
+  }
+
+  if ('has' in obj) {
+    return obj;
+  }
+
+  if ('root' in obj) {
+    return initializeMap(obj.root);
+  }
+
+  return empty;
 }

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom';
 import produce, { setAutoFreeze } from 'immer';
 import { BigIntOrderedMap, decToUd, udToDec, unixToDa } from '@urbit/api';
@@ -713,7 +714,20 @@ export const useChatState = createState<ChatState>(
       ).initialize();
     },
   }),
-  ['chats', 'dms', 'pendingDms', 'briefs', 'multiDms', 'pins'],
+  {
+    partialize: (state) => {
+      const saved = _.pick(state, [
+        'chats',
+        'dms',
+        'pendingDms',
+        'briefs',
+        'multiDms',
+        'pins',
+      ]);
+
+      return saved;
+    },
+  },
   []
 );
 

--- a/ui/src/state/contact.ts
+++ b/ui/src/state/contact.ts
@@ -86,7 +86,9 @@ const useContactState = createState<BaseContactState>(
       });
     },
   }),
-  ['contacts'],
+  {
+    partialize: ({ contacts }) => ({ contacts }),
+  },
   []
 );
 

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -75,7 +75,7 @@ export function useGroups() {
   return data as Groups;
 }
 
-export function useGroup(flag: string, withMembers = false) {
+export function useGroup(flag: string, withMembers = false, subscribe = false) {
   const initialData = useGroups();
   const group = initialData?.[flag];
   const { data, ...rest } = useReactQuerySubscription({
@@ -83,7 +83,7 @@ export function useGroup(flag: string, withMembers = false) {
     app: 'groups',
     path: `/groups/${flag}/ui`,
     initialScryPath: `/groups/${flag}`,
-    enabled: !!flag && flag !== '' && withMembers,
+    enabled: !!flag && flag !== '' && withMembers && subscribe,
     initialData: group,
     options: {
       refetchOnWindowFocus: withMembers,

--- a/ui/src/state/heap/curios.ts
+++ b/ui/src/state/heap/curios.ts
@@ -8,6 +8,7 @@ import {
   HeapFlag,
   HeapUpdate,
 } from '@/types/heap';
+import { restoreMap } from '@/logic/utils';
 import api from '../../api';
 import { HeapState } from './type';
 
@@ -76,11 +77,17 @@ export default function makeCuriosStore(
       );
       const sta = get();
       sta.batchSet((draft) => {
-        let curioMap = new BigIntOrderedMap<HeapCurio>();
+        let curioMap = restoreMap<HeapCurio>(draft.curios[flag]);
 
-        Object.keys(curios).forEach((key) => {
-          const curio = curios[key];
-          const tim = bigInt(udToDec(key));
+        const diff = Object.entries(curios)
+          .map(([k, curio]) => ({ tim: bigInt(udToDec(k)), curio }))
+          .filter(({ tim }) => !curioMap.has(tim));
+
+        if (diff.length === 0) {
+          return;
+        }
+
+        diff.forEach(({ tim, curio }) => {
           curioMap = curioMap.set(tim, curio);
         });
 

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   SettingsUpdate,
   Value,
@@ -5,7 +6,6 @@ import {
   getDeskSettings,
   DeskData,
 } from '@urbit/api';
-import _ from 'lodash';
 import { lsDesk } from '@/constants';
 import { HeapDisplayMode, HeapSortMode } from '@/types/heap';
 import {
@@ -177,7 +177,19 @@ export const useSettingsState = createState<BaseSettingsState>(
       set(newState);
     },
   }),
-  ['display', 'heaps', 'diary', 'groups', 'talk'],
+  {
+    partialize: (state) => {
+      const saved = _.pick(state, [
+        'display',
+        'heaps',
+        'diary',
+        'groups',
+        'talk',
+      ]);
+
+      return saved;
+    },
+  },
   [
     (set, get) =>
       createSubscription('settings-store', `/desk/${window.desk}`, (e) => {

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -29,7 +29,7 @@ export const useStorage = createState<BaseStorageState>(
       credentials: null,
     },
   }),
-  [],
+  {},
   [
     (set, get) =>
       createSubscription('s3-store', '/all', (e) => {


### PR DESCRIPTION
There were multiple issues here. First of all outlines and notes were missing the type property which is what we were using to differentiate between the two. Second of all, we were persisting our rich map types, but those weren't rehydrating when the app opens so we weren't actually getting any benefit from those. 

The main issue though was that the initialize call was not gated anymore because we were implicitly using the "is subbed" flag previously to also prevent subsequent initializations. However to work with the new reconnect behavior we needed allow it to be called multiple times. So to stabilize it, I've made it check to see if it already has all the new values and if it does it simply doesn't update the map and therefore won't trigger new renders.

Also I found a huge source of slowness, groups were too aggressively subscribing we should probably be cautious about granular subscriptions and default them to off.

I'm still working on a few things here, but this should fix the issues we were seeing.