### PR TITLE
skeins: Use appropriate queryKeys

### DIFF
--- a/ui/src/state/hark.ts
+++ b/ui/src/state/hark.ts
@@ -62,7 +62,7 @@ export function useBlanket(flag?: Flag) {
 
 export function useSkeins(flag?: Flag) {
   const { data, ...rest } = useReactQuerySubscription({
-    queryKey: ['skeins', flag ? flag : undefined],
+    queryKey: ['skeins', flag ? flag : window.desk],
     app: 'hark',
     path: '/ui',
     initialScryPath: flag
@@ -109,11 +109,19 @@ export function useSawSeamMutation() {
     });
 
   return useMutation(mutationFn, {
-    onMutate: async () => {
-      await queryClient.cancelQueries(['skeins', null]);
+    onMutate: async (variables) => {
+      if ('group' in variables.seam) {
+        await queryClient.cancelQueries(['skeins', variables.seam.group]);
+      } else {
+        await queryClient.cancelQueries(['skeins', window.desk]);
+      }
     },
-    onSettled: async () => {
-      await queryClient.invalidateQueries(['skeins', null]);
+    onSettled: async (_data, _error, variables) => {
+      if ('group' in variables.seam) {
+        await queryClient.invalidateQueries(['skeins', variables.seam.group]);
+      } else {
+        await queryClient.invalidateQueries(['skeins', window.desk]);
+      }
     },
   });
 }


### PR DESCRIPTION
We were using 'undefined' in cases where we weren't fetching skeins for a whole desk, just a group. We should just use the desk name.

We also weren't invalidating/cancelling existing skeins queries for groups.

The first issue may have been causing some weird behavior, the second issue definitely prevented a user from marking all groups activity updates as read.

Should fix #2320