### PR TITLE
groups: properly remove left groups

### DIFF
--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -675,12 +675,13 @@ export function useGroupLeaveMutation() {
     {
       onSettled: (_data, _error, variables) => {
         queryClient.removeQueries({
-          queryKey: ['group', variables.flag],
+          queryKey: ['groups', variables.flag],
           exact: true,
         });
         queryClient.invalidateQueries(['groups']);
         queryClient.invalidateQueries(['gangs']);
         queryClient.invalidateQueries(['gangs', variables.flag]);
+        queryClient.invalidateQueries(['gang-preview', variables.flag]);
       },
     }
   );


### PR DESCRIPTION
PR #2308 fixed some issues around leaves/joins,
This fixes some remaining issues by invalidating the gang-preview associated with the group and properly removing the query for the group from the cache (the queryKey was ['group', flag], should have been ['groups', flag]).

Should fix #2322.