### PR TITLE
chat: restore missing DM invites

### DIFF
--- a/talk/mar/ui/init.hoon
+++ b/talk/mar/ui/init.hoon
@@ -13,8 +13,8 @@
         briefs/(briefs:enjs:cj briefs.init)
         chats/(chats:enjs:cj chats.init)
         clubs/(clubs:enjs:cj clubs.init)
-        dms/a/(turn ~(tap in dms.init) ship)
-        invited/a/(turn ~(tap in invited.init) ship)
+        dms/a/(turn ~(tap in dms.init) ship:enjs:gj)
+        invited/a/(turn ~(tap in invited.init) ship:enjs:gj)
         pins/a/(turn pins.init (cork whom:enjs:cj (lead %s)))
     ==
   --


### PR DESCRIPTION
While building the marks for the new UI init scries I forgot to change the ship gate which oddly converts patps without the sig. Because this didn't error since it's in `enjs:format` I didn't realize, and previous DMs still showed up so everything looked fine. Possibly the cause of #2235 and maybe also Jack's issue in the support email?