### PR TITLE
chat: switch to club-action-0 for backwards compat with old clients

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -318,7 +318,7 @@
       %club-create
     cu-abet:(cu-create:cu-core !<(=create:club:c vase))
   ::
-      %club-action
+      ?(%club-action %club-action-0)
     =+  !<(=action:club:c vase)
     =/  cu  (cu-abed p.action)
     cu-abet:(cu-diff:cu q.action)

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -428,7 +428,21 @@
         diff/club-diff
     ==
   ::
+  ++  club-action-0
+    ^-  $-(json action:club:c)
+    %-  ot
+    :~  id/(se %uv)
+        diff/club-diff-0
+    ==
+  ::
   ++  club-diff
+    ^-  $-(json diff:club:c)
+    %-  ot
+    :~  echo/ni
+        delta/club-delta
+    ==
+  ::
+  ++  club-diff-0
     ^-  $-(json diff:club:c)
     %-  ot
     :~  uid/(se %uv)

--- a/desk/mar/club/action-0.hoon
+++ b/desk/mar/club/action-0.hoon
@@ -1,0 +1,14 @@
+/-  c=chat
+/+  j=chat-json
+|_  =action:club:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  action
+  --
+++  grab
+  |%
+  ++  noun  action:club:c
+  ++  json  club-action-0:dejs:j
+  --
+--

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -98,7 +98,7 @@ function dmAction(ship: string, delta: WritDelta, id: string): Poke<DmAction> {
 function multiDmAction(id: string, delta: ClubDelta): Poke<ClubAction> {
   return {
     app: 'chat',
-    mark: 'club-action',
+    mark: 'club-action-0',
     json: {
       id,
       diff: {


### PR DESCRIPTION
OTT, this helps old clients stay functional by keeping `club-action` using `echo` and we switch new clients to `club-action-0` only for sending. This does introduce somewhat of an asymmetry with the marks since `club-action-0` is only used for clients, and when `club-action` gets encoded to json it uses `uid` not `echo`. However everything still works with just this change so I'd prefer to not alter things further.