### PR TITLE
app: better update banners

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -565,7 +565,6 @@ function App() {
     <div className="flex h-full w-full flex-col">
       {!disableWayfinding && <LandscapeWayfinding />}
       <DisconnectNotice />
-      <UpdateNotice />
       <LeapProvider>
         {isTalk ? (
           <>

--- a/ui/src/components/UpdateNotice.tsx
+++ b/ui/src/components/UpdateNotice.tsx
@@ -4,6 +4,8 @@ import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import { isTalk } from '@/logic/utils';
 import useKilnState, { usePike } from '@/state/kiln';
 
+type UpdateStatus = 'none' | 'glob' | 'sw';
+
 export default function UpdateNotice() {
   const appName = isTalk ? 'Talk' : 'Groups';
   const {
@@ -12,7 +14,7 @@ export default function UpdateNotice() {
   } = useRegisterSW();
   const pike = usePike(appName.toLocaleLowerCase());
   const [baseHash, setBaseHash] = useState('');
-  const [needsUpdate, setNeedsUpdate] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('none');
 
   const fetchPikes = useCallback(async () => {
     try {
@@ -33,13 +35,18 @@ export default function UpdateNotice() {
   }, [fetchPikes]);
 
   useEffect(() => {
-    if (pike && pike.hash !== baseHash && baseHash !== '' && !needsUpdate) {
-      setNeedsUpdate(true);
+    if (needRefresh) {
+      setUpdateStatus('sw');
     }
-    if (needRefresh && !needsUpdate) {
-      setNeedsUpdate(true);
+    if (
+      pike &&
+      pike.hash !== baseHash &&
+      baseHash !== '' &&
+      updateStatus === 'none'
+    ) {
+      setUpdateStatus('glob');
     }
-  }, [pike, baseHash, needsUpdate, needRefresh]);
+  }, [pike, baseHash, updateStatus, needRefresh]);
 
   const onClick = useCallback(() => {
     if (needRefresh) {
@@ -49,7 +56,7 @@ export default function UpdateNotice() {
     }
   }, [needRefresh, updateServiceWorker]);
 
-  if (!needsUpdate) {
+  if (updateStatus === 'none') {
     return null;
   }
 
@@ -57,12 +64,17 @@ export default function UpdateNotice() {
     <div className="z-50 flex items-center justify-between bg-yellow py-1 px-2 text-sm font-medium text-black dark:text-white">
       <div className="flex items-center">
         <AsteriskIcon className="mr-3 h-4 w-4" />
-        <span className="mr-1">
-          {appName} has updated in the background. Please reload.
-        </span>
+        {updateStatus === 'glob' && (
+          <span className="mr-1">
+            {appName} has updated in the background. Please reload.
+          </span>
+        )}
+        {updateStatus === 'sw' && (
+          <span className="mr-1">{appName} has updates waiting.</span>
+        )}
       </div>
       <button className="py-1 px-2" onClick={onClick}>
-        Reload
+        {updateStatus === 'sw' ? 'Update' : 'Reload'}
       </button>
     </div>
   );

--- a/ui/src/components/UpdateNotice.tsx
+++ b/ui/src/components/UpdateNotice.tsx
@@ -1,62 +1,51 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 import AsteriskIcon from '@/components/icons/Asterisk16Icon';
 import { isTalk } from '@/logic/utils';
-import useKilnState, { usePike } from '@/state/kiln';
 
-type UpdateStatus = 'none' | 'glob' | 'sw';
+const updateInterval =
+  import.meta.env.MODE === 'sw' ? 10 * 1000 : 5 * 60 * 1000;
 
 export default function UpdateNotice() {
   const appName = isTalk ? 'Talk' : 'Groups';
   const {
     needRefresh: [needRefresh],
     updateServiceWorker,
-  } = useRegisterSW();
-  const pike = usePike(appName.toLocaleLowerCase());
-  const [baseHash, setBaseHash] = useState('');
-  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('none');
+  } = useRegisterSW({
+    onRegisteredSW(swUrl, r) {
+      if (!r) {
+        return;
+      }
 
-  const fetchPikes = useCallback(async () => {
-    try {
-      await useKilnState.getState().fetchPikes();
-    } catch (e) {
-      console.error(e);
-    }
-  }, []);
+      setInterval(async () => {
+        if (r.installing || !navigator) {
+          return;
+        }
 
-  useEffect(() => {
-    if (pike && baseHash === '') {
-      setBaseHash(pike.hash);
-    }
-  }, [pike, baseHash]);
+        if ('connection' in navigator && !navigator.onLine) {
+          return;
+        }
 
-  useEffect(() => {
-    setInterval(fetchPikes, 1000 * 60 * 5);
-  }, [fetchPikes]);
+        const resp = await fetch(swUrl, {
+          cache: 'no-store',
+          headers: {
+            cache: 'no-store',
+            'cache-control': 'no-cache',
+          },
+        });
 
-  useEffect(() => {
-    if (needRefresh) {
-      setUpdateStatus('sw');
-    }
-    if (
-      pike &&
-      pike.hash !== baseHash &&
-      baseHash !== '' &&
-      updateStatus === 'none'
-    ) {
-      setUpdateStatus('glob');
-    }
-  }, [pike, baseHash, updateStatus, needRefresh]);
+        if (resp?.status === 200) {
+          await r.update();
+        }
+      }, updateInterval);
+    },
+  });
 
   const onClick = useCallback(() => {
-    if (needRefresh) {
-      updateServiceWorker(true);
-    } else {
-      window.location.reload();
-    }
-  }, [needRefresh, updateServiceWorker]);
+    updateServiceWorker(true);
+  }, [updateServiceWorker]);
 
-  if (updateStatus === 'none') {
+  if (!needRefresh) {
     return null;
   }
 
@@ -64,17 +53,13 @@ export default function UpdateNotice() {
     <div className="z-50 flex items-center justify-between bg-yellow py-1 px-2 text-sm font-medium text-black dark:text-white">
       <div className="flex items-center">
         <AsteriskIcon className="mr-3 h-4 w-4" />
-        {updateStatus === 'glob' && (
-          <span className="mr-1">
-            {appName} has updated in the background. Please reload.
-          </span>
-        )}
-        {updateStatus === 'sw' && (
-          <span className="mr-1">{appName} has updates waiting.</span>
-        )}
+        <span className="mr-1">
+          {appName} has updated in the background. Please click update to load
+          the latest version.
+        </span>
       </div>
       <button className="py-1 px-2" onClick={onClick}>
-        {updateStatus === 'sw' ? 'Update' : 'Reload'}
+        Update
       </button>
     </div>
   );

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -25,6 +25,7 @@ import './styles/index.css';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import queryClient from './queryClient';
 import indexedDBPersistor from './indexedDBPersistor';
+import UpdateNotice from './components/UpdateNotice';
 
 const IS_MOCK =
   import.meta.env.MODE === 'mock' || import.meta.env.MODE === 'staging';
@@ -45,6 +46,7 @@ render(
         persister: indexedDBPersistor(`${window.our}-landscape`),
       }}
     >
+      <UpdateNotice />
       <App />
     </PersistQueryClientProvider>
   </React.StrictMode>,


### PR DESCRIPTION
Should fix #2328 by only requiring you to interact once. This changes the behavior so that we only look for service worker updates which should indicate that the app has updated. The language also now reflects more clearly that you need to click update and can't just reload.