### PR TITLE
groups: reconnect and perf

### DIFF
--- a/ui/src/groups/Groups.tsx
+++ b/ui/src/groups/Groups.tsx
@@ -18,7 +18,7 @@ import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 function Groups() {
   const navigate = useNavigate();
   const flag = useRouteGroup();
-  const group = useGroup(flag, true, true);
+  const group = useGroup(flag, true);
   const gang = useGang(flag);
   const vessel = useVessel(flag, window.our);
   const isMobile = useIsMobile();

--- a/ui/src/logic/useReactQueryScry.ts
+++ b/ui/src/logic/useReactQueryScry.ts
@@ -1,0 +1,34 @@
+import { QueryKey, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import api from '@/api';
+import useSchedulerStore from '@/state/scheduler';
+
+export default function useReactQueryScry({
+  queryKey,
+  app,
+  path,
+  priority = 3,
+  options,
+}: {
+  queryKey: QueryKey;
+  app: string;
+  path: string;
+  priority?: number;
+  options?: UseQueryOptions;
+}): ReturnType<typeof useQuery> {
+  const fetchData = async () =>
+    useSchedulerStore.getState().wait(
+      async () =>
+        api.scry({
+          app,
+          path,
+        }),
+      priority
+    );
+
+  return useQuery(queryKey, fetchData, {
+    retryOnMount: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}

--- a/ui/src/logic/useReactQuerySubscription.tsx
+++ b/ui/src/logic/useReactQuerySubscription.tsx
@@ -1,10 +1,11 @@
+import _ from 'lodash';
 import {
   QueryKey,
   useQuery,
   useQueryClient,
   UseQueryOptions,
 } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import api from '@/api';
 import useSchedulerStore from '@/state/scheduler';
 
@@ -14,8 +15,6 @@ export default function useReactQuerySubscription({
   path,
   scry,
   scryApp = app,
-  enabled = true,
-  initialData,
   priority = 3,
   options,
 }: {
@@ -24,12 +23,19 @@ export default function useReactQuerySubscription({
   path: string;
   scry: string;
   scryApp?: string;
-  enabled?: boolean;
-  initialData?: any;
   priority?: number;
   options?: UseQueryOptions;
 }): ReturnType<typeof useQuery> {
   const queryClient = useQueryClient();
+  const invalidate = useRef(
+    _.debounce(
+      () => {
+        queryClient.invalidateQueries(queryKey);
+      },
+      150,
+      { leading: true, trailing: true }
+    )
+  );
 
   const fetchData = async () =>
     useSchedulerStore.getState().wait(
@@ -45,9 +51,7 @@ export default function useReactQuerySubscription({
     api.subscribe({
       app,
       path,
-      event: () => {
-        queryClient.invalidateQueries(queryKey);
-      },
+      event: invalidate.current,
     });
   }, [app, path, queryClient, queryKey]);
 
@@ -55,8 +59,6 @@ export default function useReactQuerySubscription({
     retryOnMount: false,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
-    enabled,
-    initialData,
     ...options,
   });
 }

--- a/ui/src/logic/useReactQuerySubscription.tsx
+++ b/ui/src/logic/useReactQuerySubscription.tsx
@@ -32,7 +32,7 @@ export default function useReactQuerySubscription({
       () => {
         queryClient.invalidateQueries(queryKey);
       },
-      150,
+      300,
       { leading: true, trailing: true }
     )
   );

--- a/ui/src/logic/useReactQuerySubscription.tsx
+++ b/ui/src/logic/useReactQuerySubscription.tsx
@@ -12,7 +12,7 @@ export default function useReactQuerySubscription({
   queryKey,
   app,
   path,
-  initialScryPath,
+  scry,
   scryApp = app,
   enabled = true,
   initialData,
@@ -22,7 +22,7 @@ export default function useReactQuerySubscription({
   queryKey: QueryKey;
   app: string;
   path: string;
-  initialScryPath: string;
+  scry: string;
   scryApp?: string;
   enabled?: boolean;
   initialData?: any;
@@ -36,7 +36,7 @@ export default function useReactQuerySubscription({
       async () =>
         api.scry({
           app: scryApp,
-          path: initialScryPath,
+          path: scry,
         }),
       priority
     );

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -163,6 +163,12 @@ useLocalState.setState({
     bootstrap('reset');
 
     useLocalState.setState({ lastReconnect: Date.now() });
-    wait(() => queryClient.invalidateQueries(), 5);
+    wait(
+      () =>
+        queryClient.invalidateQueries({
+          refetchType: 'none',
+        }),
+      5
+    );
   },
 });

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -158,13 +158,10 @@ export default async function bootstrap(reset = 'initial' as Bootstrap) {
 
 useLocalState.setState({
   onReconnect: () => {
-    // let event stream finish resolving before starting requests
-    setTimeout(() => {
-      const { reset } = useSchedulerStore.getState();
-      reset();
-      bootstrap('reset');
+    const { reset } = useSchedulerStore.getState();
+    reset();
+    bootstrap('reset');
 
-      useLocalState.setState({ lastReconnect: Date.now() });
-    }, 0);
+    useLocalState.setState({ lastReconnect: Date.now() });
   },
 });

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -158,17 +158,13 @@ export default async function bootstrap(reset = 'initial' as Bootstrap) {
 
 useLocalState.setState({
   onReconnect: () => {
-    const { reset, wait } = useSchedulerStore.getState();
-    reset();
-    bootstrap('reset');
+    // let event stream finish resolving before starting requests
+    setTimeout(() => {
+      const { reset } = useSchedulerStore.getState();
+      reset();
+      bootstrap('reset');
 
-    useLocalState.setState({ lastReconnect: Date.now() });
-    wait(
-      () =>
-        queryClient.invalidateQueries({
-          refetchType: 'none',
-        }),
-      5
-    );
+      useLocalState.setState({ lastReconnect: Date.now() });
+    }, 0);
   },
 });

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -190,9 +190,9 @@ export const useChatState = createState<ChatState>(
     },
     start: async ({ briefs, chats, pins }) => {
       get().batchSet((draft) => {
-        draft.chats = chats;
-        draft.briefs = briefs;
-        draft.pins = pins;
+        draft.chats = _.assign(draft.chats, chats);
+        draft.briefs = _.assign(draft.briefs, briefs);
+        draft.pins = _.union(draft.pins, pins);
       });
 
       Object.entries(briefs).forEach(([whom, brief]) => {
@@ -279,10 +279,10 @@ export const useChatState = createState<ChatState>(
       }
 
       get().batchSet((draft) => {
-        draft.multiDms = init.clubs;
-        draft.dms = init.dms;
-        draft.pendingDms = init.invited;
-        draft.pins = init.pins;
+        draft.multiDms = _.merge(draft.multiDms, init.clubs);
+        draft.dms = _.union(draft.dms, init.dms);
+        draft.pendingDms = _.union(draft.pendingDms, init.invited);
+        draft.pins = _.union(draft.pins, init.pins);
       });
 
       api.subscribe(

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -67,6 +67,9 @@ export function useGroups() {
     app: 'groups',
     path: `/groups/ui`,
     scry: `/groups/light`,
+    options: {
+      refetchOnReconnect: false, // handled in bootstrap reconnect flow
+    },
   });
 
   if (rest.isLoading || rest.isError) {
@@ -192,6 +195,7 @@ export function useGangs() {
     options: {
       refetchOnWindowFocus: true,
       refetchOnMount: false,
+      refetchOnReconnect: false, // handled in bootstrap reconnect flow
     },
   });
 

--- a/ui/src/state/hark.ts
+++ b/ui/src/state/hark.ts
@@ -49,7 +49,7 @@ export function useBlanket(flag?: Flag) {
     scry: flag
       ? `/group/${flag}/quilt/${quilt}`
       : `/desk/${window.desk}/quilt/${quilt}`,
-    enabled: isSuccess,
+    options: { enabled: isSuccess },
   });
 
   return {

--- a/ui/src/state/hark.ts
+++ b/ui/src/state/hark.ts
@@ -26,9 +26,7 @@ export function useCarpet(flag?: Flag) {
     queryKey: ['carpet', flag],
     app: 'hark',
     path: '/ui',
-    initialScryPath: flag
-      ? `/group/${flag}/latest`
-      : `/desk/${window.desk}/latest`,
+    scry: flag ? `/group/${flag}/latest` : `/desk/${window.desk}/latest`,
   });
 
   return {
@@ -48,7 +46,7 @@ export function useBlanket(flag?: Flag) {
     queryKey: ['blanket', flag],
     app: 'hark',
     path: '/ui',
-    initialScryPath: flag
+    scry: flag
       ? `/group/${flag}/quilt/${quilt}`
       : `/desk/${window.desk}/quilt/${quilt}`,
     enabled: isSuccess,
@@ -65,9 +63,7 @@ export function useSkeins(flag?: Flag) {
     queryKey: ['skeins', flag ? flag : window.desk],
     app: 'hark',
     path: '/ui',
-    initialScryPath: flag
-      ? `/group/${flag}/skeins`
-      : `/desk/${window.desk}/skeins`,
+    scry: flag ? `/group/${flag}/skeins` : `/desk/${window.desk}/skeins`,
     options: {
       refetchOnMount: true,
     },

--- a/ui/src/state/scheduler.ts
+++ b/ui/src/state/scheduler.ts
@@ -23,7 +23,7 @@ const useSchedulerStore = create<SchedulerStore>((set, get) => ({
   phase: 0,
   waiting: {},
   reset: () => {
-    set({ phase: 0 });
+    set({ phase: 0, waiting: {} });
   },
   next: () => {
     const { waiting, phase } = get();

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -93,7 +93,7 @@ export interface SettingsState {
 
 export const useSettings = () => {
   const { data, isLoading } = useReactQuerySubscription({
-    initialScryPath: `/desk/${window.desk}`,
+    scry: `/desk/${window.desk}`,
     scryApp: 'settings-store',
     app: 'settings-store',
     path: `/desk/${window.desk}`,
@@ -113,7 +113,7 @@ export const useSettings = () => {
 
 export const useLandscapeSettings = () => {
   const { data, isLoading } = useReactQuerySubscription({
-    initialScryPath: `/desk/${lsDesk}`,
+    scry: `/desk/${lsDesk}`,
     scryApp: 'settings-store',
     app: 'settings-store',
     path: `/desk/${lsDesk}`,


### PR DESCRIPTION
This PR addresses some issues around reconnecting seen recently where things get locked up or take too long. Turns out we were doing too much here. React query handles a lot of this for us. However, because we do some of the work in the `init` scry we should turn off reconnect handling for queries updated by that.

Also when reconnecting we have a possibility of getting a large number of facts in a row. With the subscription handling as written this would cause an enormous amount of scries to happen. To combat this the subscription handling will now use a debounce that fires both on the leading and trailing edge so we get immediate response, but if a lot more is happening they all get delayed until the final call.