### PR TITLE
bugfix: Fix copy to clipboard in safari.

### DIFF
--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -29,6 +29,7 @@ import {
 import { CurioContent, Heap, HeapBrief } from '@/types/heap';
 import { DiaryBrief, DiaryQuip, DiaryQuipMap } from '@/types/diary';
 import bigInt from 'big-integer';
+import { useCopyToClipboard } from 'usehooks-ts';
 
 export const isTalk = import.meta.env.VITE_APP === 'chat';
 
@@ -514,43 +515,16 @@ export function pathToCite(path: string): Cite | undefined {
   return undefined;
 }
 
-export function writeText(str: string | null): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const range = document.createRange();
-    range.selectNodeContents(document.body);
-    document?.getSelection()?.addRange(range);
-
-    let success = false;
-    function listener(e: any) {
-      e.clipboardData.setData('text/plain', str);
-      e.preventDefault();
-      success = true;
-    }
-    document.addEventListener('copy', listener);
-    document.execCommand('copy');
-    document.removeEventListener('copy', listener);
-
-    document?.getSelection()?.removeAllRanges();
-
-    if (success) {
-      resolve();
-    } else {
-      reject();
-    }
-  }).catch((error) => {
-    console.error(error);
-  });
-}
-
 export function useCopy(copied: string) {
   const [didCopy, setDidCopy] = useState(false);
+  const [, copy] = useCopyToClipboard();
   const doCopy = useCallback(() => {
-    writeText(copied);
+    copy(copied);
     setDidCopy(true);
     setTimeout(() => {
       setDidCopy(false);
     }, 2000);
-  }, [copied]);
+  }, [copied, copy]);
 
   return { doCopy, didCopy };
 }


### PR DESCRIPTION
Switches to usehooks-ts's useCopyToClipboard copy function rather than our own writeText function (which didn't account for safari weirdness) within our useCopy hook.

Fixes #2346
Fixes #1767