### PR TITLE
bugfix: Fix for clicking on names in ship ShipSelector

### DIFF
--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -456,7 +456,6 @@ export default function ShipSelector({
         handleEnter={handleEnter}
         ref={selectRef}
         formatCreateLabel={AddNewOption}
-        menuPortalTarget={document.body}
         autoFocus={autoFocus}
         className={containerClassName}
         styles={{
@@ -467,10 +466,6 @@ export default function ShipSelector({
             borderColor: '',
             zIndex: 50,
             backgroundColor: 'inherit',
-          }),
-          menuPortal: (base) => ({
-            ...base,
-            zIndex: 50,
           }),
           input: (base) => ({
             ...base,
@@ -552,16 +547,11 @@ export default function ShipSelector({
       formatCreateLabel={AddNewOption}
       autoFocus
       isMulti
-      menuPortalTarget={document.body}
       className={containerClassName}
       styles={{
         control: (base) => ({}),
         menuList: ({ padding, paddingTop, paddingBottom, ...base }) => ({
           ...base,
-        }),
-        menuPortal: (base) => ({
-          ...base,
-          zIndex: 50,
         }),
         menu: ({
           paddingTop,

--- a/ui/src/dms/DmInviteDialog.tsx
+++ b/ui/src/dms/DmInviteDialog.tsx
@@ -42,9 +42,10 @@ export default function DmInviteDialog({
     <Dialog
       open={inviteIsOpen}
       onOpenChange={setInviteIsOpen}
-      containerClass="w-full sm:max-w-lg"
+      containerClass="w-full sm:max-w-xl"
+      className="mb-64 bg-transparent p-0"
     >
-      <div>
+      <div className="card">
         <div className="flex flex-col">
           <h2 className="mb-4 text-lg font-bold">Invite to Chat</h2>
           <div className="w-full py-3 px-4">

--- a/ui/src/groups/GroupInviteDialog.tsx
+++ b/ui/src/groups/GroupInviteDialog.tsx
@@ -69,7 +69,7 @@ export default function GroupInviteDialog() {
       open={true}
       onOpenChange={(isOpen) => !isOpen && dismiss()}
       containerClass="w-full max-w-xl"
-      className="bg-transparent p-0"
+      className="mb-64 bg-transparent p-0"
       close="none"
     >
       <div className="flex flex-col space-y-6">


### PR DESCRIPTION
react-select's built in 'menuPortal' feature somehow prevented the user from being able to click on items in the menu.

I added the menuPortal changes because the menu's opening would cause the dialogs containing the ShipSelector to move, causing the ShipSelector itself to move out of view.

Rather than use the menuPortal feature, we can just add bottom margin to the dialog container. This fixes both issues.

Fixes #2341