### PR TITLE
bugfix: make send button in heap detail clickable

### DIFF
--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -128,7 +128,7 @@ export default function HeapDetail() {
       }
     >
       <div className="flex h-full flex-col overflow-y-auto lg:flex-row">
-        <div className="flex flex-1">
+        <div className="group relative flex flex-1">
           {hasNext ? (
             <div className="absolute top-0 left-0 flex h-full w-16 flex-col justify-center">
               <Link


### PR DESCRIPTION
A previous change to heap detail styles made it so that the div containing the CaretRightIcon/previous button was occluding the send button in heap detail. The div containing the left/right carets (next/prev buttons) should have had group and relative classes in order for the child divs to render/behave properly, i.e., set opacity to 100 on hover and appear on the sides of the HeapDetailBody (and not occlude the items on the far left of the screen, including the send button).

Fixes #2342