### PR TITLE
bugfix: properly detect all emojis

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -66,6 +66,7 @@
         "cross-fetch": "^3.1.5",
         "date-fns": "^2.28.0",
         "emoji-mart": "^5.2.2",
+        "emoji-regex": "^10.2.1",
         "fast-average-color": "^9.1.1",
         "framer-motion": "^6.5.1",
         "fuzzy": "^0.1.3",
@@ -14365,10 +14366,9 @@
       "integrity": "sha512-BvcrX+Ps9MxSVEjnvxupclU3MBD6WVC4WZOY26csfC6oFdaWpFhdrzeVNVBmCLPOmzY1SE0aAsqZJRNVbZ1yhQ=="
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -15007,6 +15007,12 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -40991,10 +40997,9 @@
       "integrity": "sha512-BvcrX+Ps9MxSVEjnvxupclU3MBD6WVC4WZOY26csfC6oFdaWpFhdrzeVNVBmCLPOmzY1SE0aAsqZJRNVbZ1yhQ=="
     },
     "emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -41606,6 +41611,12 @@
             "@babel/runtime": "^7.10.2",
             "@babel/runtime-corejs3": "^7.10.2"
           }
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
         }
       }
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -104,6 +104,7 @@
     "cross-fetch": "^3.1.5",
     "date-fns": "^2.28.0",
     "emoji-mart": "^5.2.2",
+    "emoji-regex": "^10.2.1",
     "fast-average-color": "^9.1.1",
     "framer-motion": "^6.5.1",
     "fuzzy": "^0.1.3",

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import ob from 'urbit-ob';
-import { BigInteger } from 'big-integer';
+import bigInt, { BigInteger } from 'big-integer';
 import {
   BigIntOrderedMap,
   Docket,
@@ -13,7 +13,9 @@ import anyAscii from 'any-ascii';
 import { format, differenceInDays, endOfToday } from 'date-fns';
 import _ from 'lodash';
 import f from 'lodash/fp';
+import emojiRegex from 'emoji-regex';
 import { hsla, parseToHsla, parseToRgba } from 'color2k';
+import { useCopyToClipboard } from 'usehooks-ts';
 import { Chat, ChatWhom, ChatBrief, Cite } from '@/types/chat';
 import {
   Cabals,
@@ -28,8 +30,6 @@ import {
 } from '@/types/groups';
 import { CurioContent, Heap, HeapBrief } from '@/types/heap';
 import { DiaryBrief, DiaryQuip, DiaryQuipMap } from '@/types/diary';
-import bigInt from 'big-integer';
-import { useCopyToClipboard } from 'usehooks-ts';
 
 export const isTalk = import.meta.env.VITE_APP === 'chat';
 
@@ -612,19 +612,16 @@ export function getAppName(
   return app.title || app.desk;
 }
 
-export function isOnlyEmojis(str: string): boolean {
-  const emojiRegex =
-    /^\p{Emoji}(?:\p{Emoji_Modifier}?|\p{Emoji_Presentation}|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Extended_Pictographic})$/u;
-  const stringWithoutEmojis = str.replace(emojiRegex, '');
-
-  return stringWithoutEmojis.length === 0;
-}
-
 export function isSingleEmoji(input: string): boolean {
-  const emojiRegex =
-    /^\p{Emoji}(?:\p{Emoji_Modifier}?|\p{Emoji_Presentation}|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Extended_Pictographic})$/u;
+  const regex = emojiRegex();
+  const matches = input.match(regex);
 
-  return emojiRegex.test(input);
+  return (
+    (matches &&
+      matches.length === 1 &&
+      matches.length === _.split(input, '').length) ??
+    false
+  );
 }
 
 export function initializeMap<T>(items: Record<string, T>) {


### PR DESCRIPTION
The regex we were using before didn't account for Emoji ZWJ sequences (more detail on those here: https://emojipedia.org/emoji-zwj-sequence/), so there were some cases where a single emoji would not render in the scroller with the appropriate large font size.

I added the emoji-regex package which accounts for every type of emoji or emoji sequence. I also used lodash's `split` function to ensure that the message contains just a single rendered emoji (which the split function itself will detect as one element in the string, not multiple, even if it's actually a sequence, a feature added in lodash 4.9.0).