### PR TITLE
chat: add full-text and mentions search

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1243,9 +1243,32 @@
   ++  ca-peek
     |=  =(pole knot)
     ^-  (unit (unit cage))
-    ?+  pole  [~ ~]
-      [%writs rest=*]  (peek:ca-pact rest.pole)
-      [%perm ~]        ``chat-perm+!>(perm.chat)
+    ?+    pole  [~ ~]
+        [%writs rest=*]
+      (peek:ca-pact rest.pole)
+    ::
+        [%perm ~]
+      ``chat-perm+!>(perm.chat)
+    ::
+        [%search %text skip=@ count=@ nedl=@ ~]
+      %-  some
+      %-  some
+      :-  %chat-scan
+      !>
+      %^    text:search:ca-pact
+          (slav %ud skip.pole)
+        (slav %ud count.pole)
+      nedl.pole
+    ::
+        [%search %mention skip=@ count=@ nedl=@ ~]
+      %-  some
+      %-  some
+      :-  %chat-scan
+      !>
+      %^    mention:search:ca-pact
+          (slav %ud skip.pole)
+        (slav %ud count.pole)
+      (slav %p nedl.pole)
     ==
   ::
   ++  ca-revoke
@@ -1730,10 +1753,31 @@
     ==
   ::
   ++  di-peek
-    |=  =path
+    |=  =(pole knot)
     ^-  (unit (unit cage))
-    ?+  path  [~ ~]
-      [%writs *]  (peek:di-pact t.path)
+    ?+    pole  [~ ~]
+        [%writs rest=*]
+      (peek:di-pact rest.pole)
+    ::
+        [%search %text skip=@ count=@ nedl=@ ~]
+      %-  some
+      %-  some
+      :-  %chat-scan
+      !>
+      %^    text:search:di-pact
+          (slav %ud skip.pole)
+        (slav %ud count.pole)
+      nedl.pole
+    ::
+        [%search %mention skip=@ count=@ nedl=@ ~]
+      %-  some
+      %-  some
+      :-  %chat-scan
+      !>
+      %^    mention:search:di-pact
+          (slav %ud skip.pole)
+        (slav %ud count.pole)
+      (slav %p nedl.pole)
     ==
   ::
   ++  di-brief  (brief:di-pact our.bowl last-read.remark.dm)

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -113,4 +113,93 @@
     =/  time  (slav %ud time.pole)
     ``writ+!>((got ship `@da`time))
   ==
+::
+++  search
+  =<
+    |%
+    ++  mention
+      |=  [sip=@ud len=@ud nedl=^ship]
+      ^-  scan:c
+      (scour sip len (mntn nedl))
+    ++  text
+      |=  [sip=@ud len=@ud nedl=@t]
+      ^-  scan:c
+      (scour sip len (txt nedl))
+    --
+  |%
+  +$  query
+    $:  skip=@ud
+        more=@ud
+        =scan:c
+    ==
+  ++  scour
+    |=  [sip=@ud len=@ud matc=$-(writ:c ?)]
+    ?>  (gth len 0)
+    ^-  scan:c
+    %-  flop
+    =<  scan.-
+    %^    (dip:on:writs:c query)
+        wit.pac
+      [sip len ~]
+    |=  $:  =query
+            time
+            =writ:c
+        ==
+    ^-  [(unit writ:c) stop=? _query]
+    :-  ~
+    ?:  (matc writ)
+      ?:  =(0 skip.query)
+        :-  =(1 more.query)
+        query(more (dec more.query), scan [writ scan.query])
+      [| query(skip (dec skip.query))]
+    [| query]
+  ++  mntn
+    |=  nedl=ship
+    ^-  $-(writ:c ?)
+    |=  =writ:c
+    ^-  ?
+    ?.  ?=(%story -.content.writ)
+      |
+    =/  ls=(list inline:c)   q.p.content.writ
+    |-
+    ?~  ls    |
+    ?@  i.ls  $(ls t.ls)
+    ?+  -.i.ls  $(ls t.ls)
+      %ship                                  =(nedl p.i.ls)
+      ?(%bold %italics %strike %blockquote)  |($(ls p.i.ls) $(ls t.ls))
+    ==
+  ::
+  ++  txt
+    |=  nedl=@t
+    ^-  $-(writ:c ?)
+    |=  =writ:c
+    ^-  ?
+    ?.  ?=(%story -.content.writ)
+      |
+    |^
+      =/  ls=(list inline:c)  q.p.content.writ
+      |-
+      ?~  ls  |
+      ?@  i.ls
+        |((find nedl i.ls) $(ls t.ls))
+      ?.  ?=(?(%bold %italics %strike %blockquote) -.i.ls)
+        $(ls t.ls)
+      |($(ls p.i.ls) $(ls t.ls))
+    ++  find
+      |=  [nedl=@t hay=@t]
+      ^-  ?
+      =/  nlen  (met 3 nedl)
+      =/  hlen  (met 3 hay)
+      ?:  (lth hlen nlen)
+        |
+      =/  pos  0
+      =/  lim  (sub hlen nlen)
+      |-
+      ?:  (gth pos lim)
+        |
+      ?:  =(nedl (cut 3 [pos nlen] hay))
+        &
+      $(pos +(pos))
+    --
+  --
 --

--- a/desk/mar/chat/scan.hoon
+++ b/desk/mar/chat/scan.hoon
@@ -1,0 +1,14 @@
+/-  c=chat
+/+  j=chat-json
+|_  =scan:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  scan
+  ++  json  a/(turn scan writ:enjs:j)
+  --
+++  grab
+  |%
+  +$  noun  scan:c
+  --
+--

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -11,6 +11,8 @@
   ++  one  uno
   --
 ::
+::  $scan: search results
++$  scan  (list writ)
 ::  $writ: a chat message
 +$  writ   [seal memo]
 ::  $id: an identifier for chat messages


### PR DESCRIPTION
Extended version of the code originally published by @liam-fitzgerald in #1278.

Tested on a set of moons for DMs + chat, then tested on my own ship. Tests documented below. All times are the average of 10 runs.

| dm / chat        | # messages |
|------------------|------------|
| `~master-morzod` | `1.010`    |
| `~datder-sonnet` | `6.997`    |
| Tlon Watercooler | `41.119`   |

| test | dm / chat | Avg. Time (ms) |
|------|-----------|----------------|
| find all instances of 3-character string that doesn't exist | `~master-morzod` | 142 |
| find all instances of 15-character string that doesn't exist | `~master-morzod` | 123 |
| find first 1000 messages that contain the letter 'e' | `~master-morzod` | 29 * |
| find all instances of 3-character string that doesn't exist | `~datder-sonnet` | 754 |
| find all instances of 15-character string that doesn't exist | `~datder-sonnet` | 640 |
| find first 1000 messages that contain the letter 'e' | `~datder-sonnet` | 34 * |
| find all instances of 3-character string that doesn't exist | Tlon Watercooler | 4.303 |
| find all instances of 15-character string that doesn't exist | Tlon Watercooler | 3.307 |
| find first 1000 messages that contain the letter 'e' | Tlon Watercooler | 32 * |
| find first 10 mentions of `~ravmel-ropdyl` | Tlon Watercooler | 86 |

*: That's how long it took to find the results, but mark conversion and rendering to dojo took significantly longer

Example scries:
```
=chat-types -build-file /=groups=/sur/chat/hoon
.^((list writ:chat-types) %gx /=chat=/dm/(scot %p ~datder-sonnet)/search/text/0/5/['012345678901234']/chat-scan)
.^((list writ:chat-types) %gx /=chat=/dm/(scot %p ~datder-sonnet)/search/text/0/(scot %ud 1.000)/['e']/chat-scan)
.^((list writ:chat-types) %gx /=chat=/chat/(scot %p ~bolbex-fogdys)/['watercooler-4926']/search/text/0/100/['yzy']/chat-scan)
.^((list writ:chat-types) %gx /=chat=/chat/(scot %p ~bolbex-fogdys)/['watercooler-4926']/search/mention/0/10/(scot %p ~ravmel-ropdyl)/chat-scan)
```
Prepend with `~>  %bout` to measure wall-clock run time of scry.

Notes:
- Currently, the scry path searches from oldest to newest
- Search was useful for its own testing; I forgot how to measure wall-clock run time of arbitrary Hoon in dojo, but I remembered that `~master-morzod` had told me, so I was able to search my chat history for the answer
- Empty string input (`''`) for the text search matches all messages