### PR TITLE
bugfix: use correct lastReply for chat reply time

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames';
 import _, { debounce } from 'lodash';
 import f from 'lodash/fp';
 import { BigInteger } from 'big-integer';
-import { daToUnix } from '@urbit/api';
+import { daToUnix, udToDec } from '@urbit/api';
 import { format, formatDistanceToNow, formatRelative, isToday } from 'date-fns';
 import { NavLink } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
@@ -153,8 +153,14 @@ const ChatMessage = React.memo<
         f.uniq,
         f.take(3)
       )(seal.replied);
-      const lastReply = seal.replied.length ? _.last(seal.replied)! : '';
-      const lastReplyWrit = useWrit(whom, lastReply)!;
+      const repliesSortedByTime = seal.replied.sort((a, b) => {
+        const aTime = udToDec(a.split('/')[1]);
+        const bTime = udToDec(b.split('/')[1]);
+
+        return parseInt(aTime, 10) - parseInt(bTime, 10);
+      });
+      const lastReply = _.last(repliesSortedByTime);
+      const lastReplyWrit = useWrit(whom, lastReply ?? '')!;
       const lastReplyTime = lastReplyWrit
         ? new Date(daToUnix(lastReplyWrit[0]))
         : new Date();

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -154,14 +154,10 @@ const ChatMessage = React.memo<
         f.take(3)
       )(seal.replied);
       const repliesSortedByTime = seal.replied.sort((a, b) => {
-        const aTime = udToDec(
-          useChatState.getState().getTime(whom, a).toString()
-        );
-        const bTime = udToDec(
-          useChatState.getState().getTime(whom, b).toString()
-        );
+        const aTime = useChatState.getState().getTime(whom, a);
+        const bTime = useChatState.getState().getTime(whom, b);
 
-        return parseInt(aTime, 10) - parseInt(bTime, 10);
+        return aTime.compare(bTime);
       });
       const lastReply = _.last(repliesSortedByTime);
       const lastReplyWrit = useWrit(whom, lastReply ?? '')!;

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import cn from 'classnames';
 import _, { debounce } from 'lodash';
 import f from 'lodash/fp';
-import { BigInteger } from 'big-integer';
+import bigInt, { BigInteger } from 'big-integer';
 import { daToUnix, udToDec } from '@urbit/api';
 import { format, formatDistanceToNow, formatRelative, isToday } from 'date-fns';
 import { NavLink } from 'react-router-dom';
@@ -154,8 +154,12 @@ const ChatMessage = React.memo<
         f.take(3)
       )(seal.replied);
       const repliesSortedByTime = seal.replied.sort((a, b) => {
-        const aTime = udToDec(a.split('/')[1]);
-        const bTime = udToDec(b.split('/')[1]);
+        const aTime = udToDec(
+          useChatState.getState().getTime(whom, a).toString()
+        );
+        const bTime = udToDec(
+          useChatState.getState().getTime(whom, b).toString()
+        );
 
         return parseInt(aTime, 10) - parseInt(bTime, 10);
       });


### PR DESCRIPTION
Fixes #1868 by sorting replies by time client-side.