### PR TITLE
settings: use landscape settings by default

### DIFF
--- a/ui/src/components/SettingDropdown.tsx
+++ b/ui/src/components/SettingDropdown.tsx
@@ -1,0 +1,78 @@
+import React, { HTMLAttributes } from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import slugify from 'slugify';
+import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
+import CaretDownIcon from './icons/CaretDownIcon';
+import CheckIcon from './icons/CheckIcon';
+
+type SettingProps = {
+  name: string;
+  selected: { label: string; value: string };
+  options: { label: string; value: string }[];
+  disabled?: boolean;
+  status?: 'loading' | 'error' | 'success' | 'idle';
+  onChecked: (value: string) => void;
+} & HTMLAttributes<HTMLDivElement>;
+
+export default function SettingDropdown({
+  name,
+  selected,
+  options,
+  disabled = false,
+  className,
+  children,
+  status,
+  onChecked,
+}: SettingProps) {
+  const id = slugify(name);
+
+  return (
+    <section className={className}>
+      <div className="flex space-x-2">
+        <DropdownMenu.Root aria-labelledby={id}>
+          <DropdownMenu.Trigger
+            className="default-focus input flex h-7 items-center rounded text-base font-semibold hover:bg-gray-50 sm:p-1"
+            aria-label="Theme Options"
+          >
+            <span className="flex space-x-2 text-gray-600">
+              {selected.label}
+              {status === 'loading' && (
+                <LoadingSpinner className="ml-2 h-4 w-4" />
+              )}
+            </span>
+            <CaretDownIcon className="ml-2 h-4 w-4" />
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal className="z-50">
+            <DropdownMenu.Content className="dropdown z-50 text-gray-800">
+              <DropdownMenu.RadioGroup>
+                {options.map((option) => (
+                  <DropdownMenu.CheckboxItem
+                    className="dropdown-item flex items-center pl-6"
+                    disabled={disabled}
+                    key={option.value}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        onChecked(option.value);
+                      }
+                    }}
+                  >
+                    {selected.value === option.value ? (
+                      <CheckIcon className="h-4 w-4" />
+                    ) : (
+                      <span className="h-4 w-4" />
+                    )}
+                    <span className="ml-2 text-gray-600">{option.label}</span>
+                  </DropdownMenu.CheckboxItem>
+                ))}
+              </DropdownMenu.RadioGroup>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+        <div className="flex flex-1 flex-col justify-center">
+          <h3 className="flex items-center font-semibold leading-6">{name}</h3>
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/src/components/SettingsDialog.tsx
+++ b/ui/src/components/SettingsDialog.tsx
@@ -1,8 +1,15 @@
 import { useDismissNavigate } from '@/logic/routing';
-import { useCalm, useCalmSettingMutation } from '@/state/settings';
+import {
+  Theme,
+  useCalm,
+  useCalmSettingMutation,
+  useTheme,
+  useThemeMutation,
+} from '@/state/settings';
 import { isTalk } from '@/logic/utils';
 import Dialog from './Dialog';
 import Setting from './Setting';
+import SettingDropdown from './SettingDropdown';
 
 export default function SettingsDialog() {
   const {
@@ -12,6 +19,8 @@ export default function SettingsDialog() {
     disableRemoteContent,
     disableWayfinding,
   } = useCalm();
+  const theme = useTheme();
+  const { mutate, status } = useThemeMutation();
   const dismiss = useDismissNavigate();
   const { mutate: toggleAvatars, status: avatarStatus } =
     useCalmSettingMutation('disableAvatars');
@@ -112,6 +121,31 @@ export default function SettingsDialog() {
               appearing to have content missing.
             </p>
           </Setting>
+        </div>
+        <div className="inner-section relative space-y-2">
+          <div className="flex flex-col">
+            <h2 className="mb-2 text-lg font-bold">Theme</h2>
+          </div>
+          <SettingDropdown
+            name="Set your theme"
+            selected={{
+              label: theme.charAt(0).toUpperCase() + theme.slice(1),
+              value: theme,
+            }}
+            onChecked={(value) => {
+              mutate(value as Theme);
+            }}
+            options={[
+              { label: 'Auto', value: 'auto' },
+              { label: 'Light', value: 'light' },
+              { label: 'Dark', value: 'dark' },
+            ]}
+            status={status}
+          >
+            <p className="leading-5 text-gray-600">
+              Change the color scheme of the {isTalk ? 'Talk' : 'Groups'}{' '}
+            </p>
+          </SettingDropdown>
         </div>
       </div>
     </Dialog>


### PR DESCRIPTION
this was branched off of master, with the changes from #2377 cherry-picked onto it.

This PR allows us to set the landscape (garden) desk settings as default by using useMergedSettings().

If a user already has a setting set in %garden, it will be honored in groups/talk until the user overrides it.

This also adds a dropdown to set the theme (auto, light, dark).

https://user-images.githubusercontent.com/1221094/234275998-7824e33b-9bb4-46ee-9530-6d15ebe3c4e0.mov