### PR TITLE
bugfix: no duplicate message options on thread OPs

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -6,7 +6,7 @@ import f from 'lodash/fp';
 import { BigInteger } from 'big-integer';
 import { daToUnix } from '@urbit/api';
 import { format, formatDistanceToNow, formatRelative, isToday } from 'date-fns';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useParams } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
 import { ChatBrief, ChatWrit } from '@/types/chat';
 import Author from '@/chat/ChatMessage/Author';
@@ -79,10 +79,18 @@ const ChatMessage = React.memo<
     ) => {
       const { seal, memo } = writ;
       const container = useRef<HTMLDivElement>(null);
+      const { idShip, idTime } = useParams<{
+        idShip: string;
+        idTime: string;
+      }>();
+      const isThread = idShip && idTime;
+      const threadOpId = isThread ? `${idShip}/${idTime}` : '';
+      const isThreadOp = threadOpId === seal.id && hideReplies;
       const chatInfo = useChatInfo(whom);
       const unread = chatInfo?.unread;
       const unreadId = unread?.brief['read-id'];
       const { hovering, setHovering } = useChatHovering(whom, writ.seal.id);
+      console.log({ hovering, whom, id: writ.seal.id });
       const { ref: viewRef } = useInView({
         threshold: 1,
         onChange: useCallback(
@@ -168,11 +176,15 @@ const ChatMessage = React.memo<
         }, 100)
       );
       const onOver = useCallback(() => {
-        if (hover.current === false) {
+        // If we're already hovering, don't do anything
+        // If we're the thread op, don't do anything
+        // This is necessary to prevent the hover from appearing
+        // in the thread when the user hovers in the main scroll window.
+        if (hover.current === false && !isThreadOp) {
           hover.current = true;
           setHover.current();
         }
-      }, []);
+      }, [isThreadOp]);
       const onOut = useRef(
         debounce(
           () => {
@@ -205,7 +217,12 @@ const ChatMessage = React.memo<
           {newDay ? <DateDivider date={unix} /> : null}
           {newAuthor ? <Author ship={memo.author} date={unix} /> : null}
           <div className="group-one relative z-0 flex w-full">
-            {hideOptions || (isScrolling && !hovering) || !hovering ? null : (
+            {hideOptions ||
+            (isScrolling && !hovering) ||
+            !hovering ||
+            // If we're the thread op, don't show options.
+            // Options are shown for the threadOp in the main scroll window.
+            isThreadOp ? null : (
               <ChatMessageOptions
                 hideThreadReply={hideReplies}
                 whom={whom}

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -90,7 +90,6 @@ const ChatMessage = React.memo<
       const unread = chatInfo?.unread;
       const unreadId = unread?.brief['read-id'];
       const { hovering, setHovering } = useChatHovering(whom, writ.seal.id);
-      console.log({ hovering, whom, id: writ.seal.id });
       const { ref: viewRef } = useInView({
         threshold: 1,
         onChange: useCallback(


### PR DESCRIPTION
We need to check whether the message we're rendering is a thread OP and not allow for it to display message options unless it's being rendered in the main chat scroller, otherwise ChatMessageOptions renders twice and the user won't be able to react to the message.

Fixes #2383