### PR TITLE
grouper: use add-ships for shut cordon

### DIFF
--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -79,8 +79,23 @@
     ?>  (~(has in enabled-groups) token.bite)
     ?>  ?=([%bite-1 *] bite)
     =/  =invite:groups  [[our.bowl token.bite] joiner.bite]
-    :_  this  
-    ~[[%pass /invite %agent [our.bowl %groups] %poke %group-invite !>(invite)]]
+    :_  this
+    =/  our  (scot %p our.bowl)
+    =/  =path  /[our]/groups/(scot %da now.bowl)/groups/[our]/[token.bite]
+    =+  .^(=group:groups %gx path)
+    ?+  -.cordon.group  ~
+        %open
+      ~[[%pass /invite %agent [our.bowl %groups] %poke %group-invite !>(invite)]]
+    ::
+        %shut
+      ~&  ['inviting' joiner.bite]
+      =/  =action:groups  
+        :-  [our.bowl token.bite]
+        :-  now.bowl
+        :-  %cordon
+        [%shut [%add-ships %pending (~(gas in *(set ship)) ~[joiner.bite])]]
+      ~[[%pass /invite %agent [our.bowl %groups] %poke %group-action !>(action)]]
+    ==
   ==
 ::
 ++  on-fail

--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -2,8 +2,12 @@
 /+  default-agent, verb, dbug
 ::
 |%
+++  dev-mode  |
 ++  enabled-groups  (set cord)
 ++  outstanding-pokes  (set (pair ship cord))
+++  bite-subscribe
+  |=  =bowl:gall
+  [%pass /bite-wire %agent [our.bowl %reel] %watch /bites]
 +$  card  card:agent:gall
 +$  versioned-state
   $%  state-1
@@ -24,13 +28,16 @@
 ::
 ++  on-init
   :_  this
-  ~[[%pass /bite-wire %agent [our.bowl %reel] %watch /bites]]
+  ~[(bite-subscribe bowl)]
 ++  on-poke
   |=  [=mark =vase]
   ^-  (quip card _this)
   ?+  mark  (on-poke:def mark vase)
     %leave  :_  this  ~[[%pass /bite-wire %agent [our.bowl %reel] %leave ~]]
-    %watch  :_  this  ~[[%pass /bite-wire %agent [our.bowl %reel] %watch /bites]]
+      %watch  
+    :_  this  
+    ?:  (~(has by wex.bowl) [/bite-wire our.bowl %reel])  ~
+    ~[(bite-subscribe bowl)]
     ::
       %grouper-enable
     =+  !<(name=cord vase)
@@ -73,22 +80,29 @@
   ?-  -.sign
       %poke-ack   `this
       %watch-ack  `this
-      %kick       `this
+      %kick       
+    :_  this
+    ~[(bite-subscribe bowl)]
+    ::
       %fact
     =+  !<(=bite:reel q.cage.sign)
+    ~?  dev-mode  [bite (~(has in enabled-groups) token.bite)]
     ?>  (~(has in enabled-groups) token.bite)
     ?>  ?=([%bite-1 *] bite)
+    ~?  dev-mode  'inviting'
     =/  =invite:groups  [[our.bowl token.bite] joiner.bite]
     :_  this
     =/  our  (scot %p our.bowl)
-    =/  =path  /[our]/groups/(scot %da now.bowl)/groups/[our]/[token.bite]
+    =/  =path  /[our]/groups/(scot %da now.bowl)/groups/[our]/[token.bite]/noun
     =+  .^(=group:groups %gx path)
+    ~?  dev-mode  cordon.group
     ?+  -.cordon.group  ~
         %open
+      ~?  dev-mode  ['inviting to public' joiner.bite]  
       ~[[%pass /invite %agent [our.bowl %groups] %poke %group-invite !>(invite)]]
     ::
         %shut
-      ~&  ['inviting' joiner.bite]
+      ~?  dev-mode  ['inviting to private/secret' joiner.bite]
       =/  =action:groups  
         :-  [our.bowl token.bite]
         :-  now.bowl
@@ -113,7 +127,9 @@
   =/  old  !<(versioned-state old-state)
   ?-  -.old
       %1
-    `this(state old)
+    :_  this(state old)
+    ?:  (~(has by wex.bowl) [/bite-wire our.bowl %reel])  ~
+    ~[(bite-subscribe bowl)]
       %0
     `this(state *state-1)
   ==

--- a/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
+++ b/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
@@ -178,9 +178,9 @@ export default function GroupInfoEditor({ title }: ViewProps) {
           </footer>
         </form>
       </FormProvider>
-      {/* {group && (
+      {group && (
         <LureInviteBlock flag={groupFlag} group={group} className="mb-4" />
-      )} */}
+      )}
       <div className="card">
         <h2 className="mb-1 text-lg font-bold">Delete Group</h2>
         <p className="mb-4">

--- a/ui/src/groups/GroupInviteDialog.tsx
+++ b/ui/src/groups/GroupInviteDialog.tsx
@@ -73,7 +73,7 @@ export default function GroupInviteDialog() {
       close="none"
     >
       <div className="flex flex-col space-y-6">
-        {/* {group && <LureInviteBlock flag={flag} group={group} />} */}
+        {group && <LureInviteBlock flag={flag} group={group} />}
         <div className="card">
           <h2 className="mb-1 text-lg font-bold">Invite by Urbit ID</h2>
           <p className="mb-4 text-gray-600">


### PR DESCRIPTION
This fixes the lure invites for private/secret groups. We should likely change the flow of invites so that they all flow through the group-invite mark instead of forcing people to know about the cordon add-ships stuff. Also re-enables lure on the frontend.

Also adds resubscribing to reel in case it gets dropped.