### PR TITLE
ops: ensure we pull from master

### DIFF
--- a/.github/helpers/deploy.sh
+++ b/.github/helpers/deploy.sh
@@ -19,9 +19,9 @@ cmds='
 source_repo=$(mktemp --dry-run /tmp/repo.janeway.XXXXXXXXX)
 git clone --depth 1 --branch '$ref' git@github.com:'$repo'.git $source_repo
 urbit_repo=$(mktemp --dry-run /tmp/repo.urbit.XXXXXXXXX)
-git clone --depth 1 git@github.com:urbit/urbit.git $urbit_repo
+git clone --depth 1 --branch master git@github.com:urbit/urbit.git $urbit_repo
 landscape_repo=$(mktemp --dry-run /tmp/repo.landscape.XXXXXXXXX)
-git clone --depth 1 git@github.com:tloncorp/landscape.git $landscape_repo
+git clone --depth 1 --branch master git@github.com:tloncorp/landscape.git $landscape_repo
 cd $source_repo
 cd /home/urb || return
 curl -s --data '\''{"source":{"dojo":"+hood/mount %'$desk'"},"sink":{"app":"hood"}}'\'' http://localhost:12321


### PR DESCRIPTION
I think something changed in the develop branch of urbit/urbit which triggered our issue. This should ensure we pull only from stable releases fixes #2392 hopefully.