### PR TITLE
groups: fix group editing

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -56,7 +56,7 @@
         "@types/prosemirror-view": "^1.23.3",
         "@urbit/api": "^2.2.0",
         "@urbit/aura": "^0.4.0",
-        "@urbit/http-api": "^2.4.3-debug",
+        "@urbit/http-api": "^2.4.4-debug",
         "any-ascii": "^0.3.1",
         "big-integer": "^1.6.51",
         "browser-cookies": "^1.2.0",
@@ -9788,9 +9788,9 @@
       "dev": true
     },
     "node_modules/@urbit/http-api": {
-      "version": "2.4.3-debug",
-      "resolved": "https://registry.npmjs.org/@urbit/http-api/-/http-api-2.4.3-debug.tgz",
-      "integrity": "sha512-LiZfI7HlybvkVTDp9kMQttz/hEtu7Q27QN49x57ZDCCzLPv7NHewAGCOJt2dDthLDOQFuJTly3LRuk9nvUIkVQ==",
+      "version": "2.4.4-debug",
+      "resolved": "https://registry.npmjs.org/@urbit/http-api/-/http-api-2.4.4-debug.tgz",
+      "integrity": "sha512-0LyIHx7a36dxdFA4czuC5VD8ejKAkVgGQtO+k4naeRGjrHteUTbUpLnxpDfwQ26fBKYTE+34Ym7FyR/5CuNuSg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "browser-or-node": "^1.3.0",
@@ -37412,9 +37412,9 @@
       "dev": true
     },
     "@urbit/http-api": {
-      "version": "2.4.3-debug",
-      "resolved": "https://registry.npmjs.org/@urbit/http-api/-/http-api-2.4.3-debug.tgz",
-      "integrity": "sha512-LiZfI7HlybvkVTDp9kMQttz/hEtu7Q27QN49x57ZDCCzLPv7NHewAGCOJt2dDthLDOQFuJTly3LRuk9nvUIkVQ==",
+      "version": "2.4.4-debug",
+      "resolved": "https://registry.npmjs.org/@urbit/http-api/-/http-api-2.4.4-debug.tgz",
+      "integrity": "sha512-0LyIHx7a36dxdFA4czuC5VD8ejKAkVgGQtO+k4naeRGjrHteUTbUpLnxpDfwQ26fBKYTE+34Ym7FyR/5CuNuSg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "browser-or-node": "^1.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -94,7 +94,7 @@
     "@types/prosemirror-view": "^1.23.3",
     "@urbit/api": "^2.2.0",
     "@urbit/aura": "^0.4.0",
-    "@urbit/http-api": "^2.4.3-debug",
+    "@urbit/http-api": "^2.4.4-debug",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.51",
     "browser-cookies": "^1.2.0",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -189,8 +189,8 @@ class API {
     this.subscriptions.add(subId);
 
     const eventListener =
-      (listener?: (event: any, mark: string) => void) =>
-      (event: any, mark: string) => {
+      (listener?: (event: any, mark: string, id: number) => void) =>
+      (event: any, mark: string, id?: number) => {
         const path = params.app + params.path;
         const relevantWatchers = this.watchers[path];
 
@@ -204,7 +204,7 @@ class API {
         }
 
         if (listener) {
-          listener(event, mark);
+          listener(event, mark, id || 0);
         }
       };
 

--- a/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
+++ b/ui/src/groups/GroupAdmin/GroupInfoEditor.tsx
@@ -81,7 +81,10 @@ export default function GroupInfoEditor({ title }: ViewProps) {
   }, [groupFlag, navigate, deleteMutation]);
 
   const onSubmit = useCallback(
-    async (values: GroupMeta & { privacy: PrivacyType }) => {
+    async ({
+      privacy: newPrivacy,
+      ...values
+    }: GroupMeta & { privacy: PrivacyType }) => {
       try {
         editMutation({ flag: groupFlag, metadata: values });
 
@@ -89,12 +92,12 @@ export default function GroupInfoEditor({ title }: ViewProps) {
           describe(values);
         }
 
-        const privacyChanged = values.privacy !== privacy;
+        const privacyChanged = newPrivacy !== privacy;
         if (privacyChanged) {
           swapCordonMutation({
             flag: groupFlag,
             cordon:
-              values.privacy === 'public'
+              newPrivacy === 'public'
                 ? {
                     open: {
                       ships: [],
@@ -111,12 +114,13 @@ export default function GroupInfoEditor({ title }: ViewProps) {
 
           setSecretMutation({
             flag: groupFlag,
-            isSecret: values.privacy === 'secret',
+            isSecret: newPrivacy === 'secret',
           });
         }
         if (privacyChanged) {
           form.reset({
             ...values,
+            privacy: newPrivacy,
           });
         }
       } catch (e) {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -31,6 +31,8 @@ import useReactQueryScry from '@/logic/useReactQueryScry';
 
 export const GROUP_ADMIN = 'admin';
 
+export const GROUPS_KEY = 'groups';
+
 function groupAction(flag: string, diff: GroupDiff): Poke<GroupAction> {
   return {
     app: 'groups',
@@ -63,7 +65,7 @@ function groupTrackedPoke(action: Poke<GroupAction>) {
 
 export function useGroups() {
   const { data, ...rest } = useReactQuerySubscription({
-    queryKey: ['groups'],
+    queryKey: [GROUPS_KEY],
     app: 'groups',
     path: `/groups/ui`,
     scry: `/groups/light`,
@@ -83,7 +85,7 @@ export function useGroup(flag: string, updating = false) {
   const queryClient = useQueryClient();
   const initialData = useGroups();
   const group = initialData?.[flag];
-  const queryKey = useMemo(() => ['groups', flag], [flag]);
+  const queryKey = useMemo(() => [GROUPS_KEY, flag], [flag]);
   const subscribe = useCallback(() => {
     api.subscribe({
       app: 'groups',
@@ -126,7 +128,7 @@ export function useGroup(flag: string, updating = false) {
 }
 
 export function useGroupIsLoading(flag: string) {
-  return useQueryClient().getQueryState(['groups', flag]);
+  return useQueryClient().getQueryState([GROUPS_KEY, flag]);
 }
 
 export function useRouteGroup() {
@@ -357,16 +359,16 @@ export function useGroupMutation<TResponse>(
   return useMutation({
     mutationFn,
     onMutate: async (variables) => {
-      await queryClient.cancelQueries(['group', variables.flag]);
+      await queryClient.cancelQueries([GROUPS_KEY, variables.flag]);
 
-      const data = await queryClient.getQueryData(['group', variables.flag]);
+      const data = await queryClient.getQueryData([GROUPS_KEY, variables.flag]);
       const previousGroup = data as Group;
 
       const { zone, nest, idx, meta, index, metadata } = variables;
 
       if (metadata) {
         // edit group metadata
-        queryClient.setQueryData(['group', variables.flag], {
+        queryClient.setQueryData([GROUPS_KEY, variables.flag], {
           ...previousGroup,
           meta: {
             ...previousGroup.meta,
@@ -385,7 +387,7 @@ export function useGroupMutation<TResponse>(
               (z) => z !== zone
             );
             newZoneOrd.splice(index, 0, zone);
-            queryClient.setQueryData(['group', variables.flag], {
+            queryClient.setQueryData([GROUPS_KEY, variables.flag], {
               ...previousGroup,
               'zone-ord': newZoneOrd,
             });
@@ -393,7 +395,7 @@ export function useGroupMutation<TResponse>(
 
           if (meta) {
             // edit zone metadata
-            queryClient.setQueryData(['group', variables.flag], {
+            queryClient.setQueryData([GROUPS_KEY, variables.flag], {
               ...previousGroup,
               zones: {
                 ...previousGroup.zones,
@@ -413,7 +415,7 @@ export function useGroupMutation<TResponse>(
             const newIdxArray = previousZone.idx.filter((n) => n !== nest);
             newIdxArray.splice(idx, 0, nest);
 
-            queryClient.setQueryData(['group', variables.flag], {
+            queryClient.setQueryData([GROUPS_KEY, variables.flag], {
               ...previousGroup,
               zones: {
                 ...previousGroup.zones,
@@ -429,7 +431,7 @@ export function useGroupMutation<TResponse>(
           // add a new zone
           const newZoneOrd = previousGroup['zone-ord'];
           newZoneOrd.splice(1, 0, zone);
-          queryClient.setQueryData(['group', variables.flag], {
+          queryClient.setQueryData([GROUPS_KEY, variables.flag], {
             ...previousGroup,
             zones: {
               ...previousGroup.zones,
@@ -446,10 +448,10 @@ export function useGroupMutation<TResponse>(
       return data;
     },
     onError: (err, variables, previousGroup) => {
-      queryClient.setQueryData(['group', variables.flag], previousGroup);
+      queryClient.setQueryData([GROUPS_KEY, variables.flag], previousGroup);
     },
     onSettled: (_data, _error, variables) =>
-      queryClient.invalidateQueries(['group', variables.flag]),
+      queryClient.invalidateQueries([GROUPS_KEY, variables.flag]),
     ...options,
   });
 }
@@ -616,10 +618,20 @@ export function useGroupMoveChannelMutation() {
 
 export function useEditGroupMutation(options: UseMutationOptions = {}) {
   const mutationFn = (variables: { flag: string; metadata: GroupMeta }) =>
-    api.trackedPoke(groupAction(variables.flag, { meta: variables.metadata }), {
-      app: 'groups',
-      path: '/groups/ui',
-    });
+    api.trackedPoke(
+      groupAction(variables.flag, { meta: variables.metadata }),
+      {
+        app: 'groups',
+        path: '/groups/ui',
+      },
+      (event) => {
+        return (
+          event.flag === variables.flag &&
+          'meta' in event.update.diff &&
+          _.isEqual(event.update.diff.meta, variables.metadata)
+        );
+      }
+    );
 
   return useGroupMutation(mutationFn, options);
 }
@@ -683,7 +695,7 @@ export function useGroupJoinMutation() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries(['gangs']);
       queryClient.invalidateQueries(['gangs', variables.flag]);
-      queryClient.invalidateQueries(['groups']);
+      queryClient.invalidateQueries([GROUPS_KEY]);
     },
   });
 }
@@ -701,10 +713,10 @@ export function useGroupLeaveMutation() {
     {
       onSettled: (_data, _error, variables) => {
         queryClient.removeQueries({
-          queryKey: ['groups', variables.flag],
+          queryKey: [GROUPS_KEY, variables.flag],
           exact: true,
         });
-        queryClient.invalidateQueries(['groups']);
+        queryClient.invalidateQueries([GROUPS_KEY]);
         queryClient.invalidateQueries(['gangs']);
         queryClient.invalidateQueries(['gangs', variables.flag]);
         queryClient.invalidateQueries(['gang-preview', variables.flag]);


### PR DESCRIPTION
This fixes a latent race condition in @urbit/http-api that causes an error when `subscribeOnce` tries to unsubscribe because the fact came in too quickly. This also fixes our group mutations so that they all use the same key and adjusts the validator for the edit group mutation so that it actually looks for the correct status.