### PR TITLE
ops: split deploy workflow steps into jobs

### DIFF
--- a/.github/workflows/deploy-groups.yml
+++ b/.github/workflows/deploy-groups.yml
@@ -11,9 +11,9 @@ on:
     branches:
       - 'develop'
 jobs:
-  deploy:
+  build-frontend:
     runs-on: ubuntu-latest
-    name: "Create and deploy a glob to ~wannec-dozzod-marzod (devstream)"
+    name: 'Build Frontend'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,18 +22,24 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ./ui/.nvmrc
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Build Frontend
-        working-directory: ./ui
+      - working-directory: ./ui
         run: |
           npm ci
           npm run build
-      - id: glob
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'repo'
+          path: .
+  glob:
+    runs-on: ubuntu-latest
+    name: 'Make a glob'
+    needs: build-frontend
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'repo'
+          path: .
+      - name: 'glob'
         uses: ./.github/actions/glob
         with:
           folder: 'ui/dist/*'
@@ -48,6 +54,17 @@ jobs:
           BRANCH=${INPUT:-"develop"}
           git pull origin $BRANCH --rebase --autostash
           git push
+  deploy:
+    runs-on: ubuntu-latest
+    needs: glob
+    name: "Deploy a glob to ~wannec-dozzod-marzod (devstream)"
+    steps:
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
         name: Deploy
         run:

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -57,7 +57,7 @@ jobs:
           git push
   deploy:
     runs-on: ubuntu-latest
-    name: "Create and deploy a glob to ~wannec-dozzod-marzod (devstream)"
+    name: "Deploy a glob to ~wannec-dozzod-marzod (devstream)"
     needs: glob
     steps:
       - id: 'auth'

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -50,6 +50,7 @@ jobs:
           git config --global user.email github-actions@github.com
           git add talk/desk.docket-0
           git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
+          sleep 10
           INPUT=${{ github.event.inputs.tag }}
           BRANCH=${INPUT:-"develop"}
           git pull origin $BRANCH --rebase --autostash

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -11,9 +11,9 @@ on:
     branches:
       - 'develop'
 jobs:
-  deploy:
+  build-frontend:
     runs-on: ubuntu-latest
-    name: "Create and deploy a glob to ~wannec-dozzod-marzod (devstream)"
+    name: 'Build Frontend'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,18 +22,24 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ./ui/.nvmrc
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Build Frontend
-        working-directory: ./ui
+      - working-directory: ./ui
         run: |
           npm ci
           npm run build:chat
-      - id: glob
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'repo'
+          path: .
+  glob:
+    runs-on: ubuntu-latest
+    name: 'Make a glob'
+    needs: build-frontend
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'repo'
+          path: .
+      - name: 'glob'
         uses: ./.github/actions/glob
         with:
           folder: 'ui/dist/*'
@@ -43,12 +49,22 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
           git add talk/desk.docket-0
-          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]"  || echo "No changes to commit"
-          sleep 10
+          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
           INPUT=${{ github.event.inputs.tag }}
           BRANCH=${INPUT:-"develop"}
           git pull origin $BRANCH --rebase --autostash
           git push
+  deploy:
+    runs-on: ubuntu-latest
+    name: "Create and deploy a glob to ~wannec-dozzod-marzod (devstream)"
+    needs: glob
+    steps:
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
         name: Deploy
         run:


### PR DESCRIPTION
This PR updates our base deploy workflows to improve organization and maintainability.

This new approach splits the existing single-job workflows into three separate jobs `build-frontend`, `glob`, and `deploy`. This change provides better separation of concerns and makes it easier to understand the purpose of each job.

Right now this doesn't get us much other than better organization and maintainability, but in the future we could run jobs in parallel (one workflow for both talk and groups deploys, or other future apps) or introduce better error handling based on job failures.

Key changes in this PR:

- Extracted build-frontend job to handle frontend building steps for both deploy-talk and deploy-groups.
- Created a separate glob job for generating and committing glob files.
- Updated the deploy job to focus solely on the deployment process.
- Added artifact upload and download steps to pass the built files between jobs.
- Ensured that jobs run sequentially, maintaining the original behavior.