### PR TITLE
ops: upload only necessary files to artifacts

### DIFF
--- a/.github/workflows/deploy-groups.yml
+++ b/.github/workflows/deploy-groups.yml
@@ -28,8 +28,14 @@ jobs:
           npm run build
       - uses: actions/upload-artifact@v3
         with:
-          name: 'repo'
-          path: .
+          name: 'ui-dist'
+          path:  ui/dist
+        working-directory: ./
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'target-docket'
+          path: desk
+        working-directory: ./
   glob:
     runs-on: ubuntu-latest
     name: 'Make a glob'
@@ -37,8 +43,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: 'repo'
-          path: .
+          name: 'ui-dist'
+          path: ui/dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'target-docket'
+          path: desk
       - name: 'glob'
         uses: ./.github/actions/glob
         with:

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -28,8 +28,14 @@ jobs:
           npm run build:chat
       - uses: actions/upload-artifact@v3
         with:
-          name: 'repo'
-          path: .
+          name: 'ui-dist'
+          path:  ui/dist
+        working-directory: ./
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'target-docket'
+          path: talk
+        working-directory: ./
   glob:
     runs-on: ubuntu-latest
     name: 'Make a glob'
@@ -37,8 +43,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
         with:
-          name: 'repo'
-          path: .
+          name: 'ui-dist'
+          path: ui/dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'target-docket'
+          path: talk
       - name: 'glob'
         uses: ./.github/actions/glob
         with:


### PR DESCRIPTION
Avoids uploading JS source and node modules to github artifacts.