### PR TITLE
ops: remove working-directory keys from uploads

### DIFF
--- a/.github/workflows/deploy-groups.yml
+++ b/.github/workflows/deploy-groups.yml
@@ -30,12 +30,10 @@ jobs:
         with:
           name: 'ui-dist'
           path:  ui/dist
-        working-directory: ./
       - uses: actions/upload-artifact@v3
         with:
           name: 'target-docket'
           path: desk
-        working-directory: ./
   glob:
     runs-on: ubuntu-latest
     name: 'Make a glob'

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -30,12 +30,10 @@ jobs:
         with:
           name: 'ui-dist'
           path:  ui/dist
-        working-directory: ./
       - uses: actions/upload-artifact@v3
         with:
           name: 'target-docket'
           path: talk
-        working-directory: ./
   glob:
     runs-on: ubuntu-latest
     name: 'Make a glob'


### PR DESCRIPTION
Those were unnecessary (and invalid in that context)