### PR TITLE
bugfix: message selector aggressively rerouting

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -156,7 +156,10 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
           />
           <Route path="/dm/" element={<Dms />}>
             <Route index element={<DMHome />} />
-            <Route path="new" element={<NewDM />} />
+            <Route path="new">
+              <Route index element={<NewDM />} />
+              <Route path=":ship" element={<Message />} />
+            </Route>
             <Route path=":ship" element={<Message />}>
               {isSmall ? null : (
                 <Route

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -44,8 +44,13 @@ export default function Dm() {
     useCallback((s) => ship && Object.keys(s.briefs).includes(ship), [ship])
   );
 
-  const { isSelectingMessage, sendDm: sendDmFromMessageSelector } =
-    useMessageSelector();
+  const {
+    isSelectingMessage,
+    sendDm: sendDmFromMessageSelector,
+    existingDm,
+  } = useMessageSelector();
+
+  const isSelecting = isSelectingMessage && existingDm === ship;
 
   useEffect(() => {
     if (ship && canStart) {
@@ -61,7 +66,7 @@ export default function Dm() {
       <Layout
         className="h-full grow"
         header={
-          isSelectingMessage ? (
+          isSelecting ? (
             <MessageSelector />
           ) : (
             <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4">
@@ -114,10 +119,10 @@ export default function Dm() {
                 key={ship}
                 whom={ship}
                 sendMessage={
-                  isSelectingMessage ? sendDmFromMessageSelector : sendMessage
+                  isSelecting ? sendDmFromMessageSelector : sendMessage
                 }
                 showReply
-                autoFocus={!isSelectingMessage}
+                autoFocus={!isSelecting}
               />
             </div>
           ) : null

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -165,7 +165,11 @@ export default function MessagesSidebar() {
         >
           <ShipName showAlias name={window.our} />
         </SidebarItem>
-        <SidebarItem to="/dm/new" icon={<AddIcon className="m-1 h-4 w-4" />}>
+        <SidebarItem
+          to="/dm/new"
+          inexact
+          icon={<AddIcon className="m-1 h-4 w-4" />}
+        >
           New Message
         </SidebarItem>
       </div>

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -29,8 +29,13 @@ export default function MultiDm() {
   const isAccepted = !useMultiDmIsPending(clubId);
   const club = useMultiDm(clubId);
 
-  const { isSelectingMessage, sendDm: sendDmFromMessageSelector } =
-    useMessageSelector();
+  const {
+    isSelectingMessage,
+    sendDm: sendDmFromMessageSelector,
+    existingMultiDm,
+  } = useMessageSelector();
+
+  const isSelecting = isSelectingMessage && existingMultiDm === clubId;
 
   useEffect(() => {
     if (clubId && club) {
@@ -56,7 +61,7 @@ export default function MultiDm() {
       <Layout
         className="h-full grow"
         header={
-          isSelectingMessage ? (
+          isSelecting ? (
             <MessageSelector />
           ) : (
             <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4">
@@ -105,10 +110,10 @@ export default function MultiDm() {
                 key={clubId}
                 whom={clubId}
                 sendMessage={
-                  isSelectingMessage ? sendDmFromMessageSelector : sendMessage
+                  isSelecting ? sendDmFromMessageSelector : sendMessage
                 }
                 showReply
-                autoFocus={!isSelectingMessage}
+                autoFocus={!isSelecting}
               />
             </div>
           ) : null

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -43,6 +43,11 @@ export default function useMessageSelector() {
     const { briefs } = useChatState.getState();
     const clubId = Object.entries(multiDms).reduce<string>((key, [k, v]) => {
       const theShips = [...v.hive, ...v.team].filter((s) => s !== window.our);
+      if (theShips.length < 2) {
+        // not a valid multi-DM
+        return key;
+      }
+
       const sameDM =
         difference(shipValues, theShips).length === 0 &&
         shipValues.length === theShips.length;
@@ -61,10 +66,10 @@ export default function useMessageSelector() {
 
   const onEnter = useCallback(
     async (invites: ShipOption[]) => {
-      if (existingMultiDm) {
-        navigate(`/dm/${existingMultiDm}`);
-      } else if (existingDm) {
+      if (existingDm) {
         navigate(`/dm/${existingDm}`);
+      } else if (existingMultiDm) {
+        navigate(`/dm/${existingMultiDm}`);
       } else if (isMultiDm) {
         await createClub(
           newClubId,
@@ -127,7 +132,7 @@ export default function useMessageSelector() {
       navigate(`/dm/new/${existingDm}`);
     } else if (existingMultiDm) {
       navigate(`/dm/new/${existingMultiDm}`);
-    } else if (shipValues.length > 0) {
+    } else {
       navigate(`/dm/new`);
     }
   }, [existingDm, existingMultiDm, navigate, shipValues, location.pathname]);

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -1,7 +1,7 @@
 import { difference } from 'lodash';
 import ob from 'urbit-ob';
 import { useCallback, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { useLocalStorage } from 'usehooks-ts';
 import { ShipOption } from '@/components/ShipSelector';
 import { useChatState, useMultiDms } from '@/state/chat';
@@ -11,6 +11,7 @@ import { createStorageKey, newUv } from './utils';
 
 export default function useMessageSelector() {
   const navigate = useNavigate();
+  const location = useLocation();
   const newClubId = useMemo(() => newUv(), []);
   const [ships, setShips] = useLocalStorage<ShipOption[]>(
     createStorageKey('new-dm-ships'),
@@ -114,14 +115,22 @@ export default function useMessageSelector() {
   const isSelectingMessage = useMemo(() => ships.length > 0, [ships]);
 
   useEffect(() => {
+    if (!location.pathname.includes('/dm/new')) {
+      if (existingMultiDm && location.pathname.includes(existingMultiDm)) {
+        navigate(`/dm/new/${existingMultiDm}`);
+      } else if (existingDm && location.pathname.includes(existingDm)) {
+        navigate(`/dm/new/${existingDm}`);
+      }
+      return;
+    }
     if (existingDm) {
-      navigate(`/dm/${existingDm}`);
+      navigate(`/dm/new/${existingDm}`);
     } else if (existingMultiDm) {
-      navigate(`/dm/${existingMultiDm}`);
+      navigate(`/dm/new/${existingMultiDm}`);
     } else if (shipValues.length > 0) {
       navigate(`/dm/new`);
     }
-  }, [existingDm, existingMultiDm, navigate, shipValues]);
+  }, [existingDm, existingMultiDm, navigate, shipValues, location.pathname]);
 
   return {
     action,


### PR DESCRIPTION
This fixes #1883 by only allowing the message selector to handle navigation if we're within a 'new' route (i.e., `/dms/new/~finned-palmer` or `/dms/new/0v4.00000.qcmja.49khd.1pb08.64jei`), allowing the user to navigate between normal dm routes and the new dm they're constructing without an issue.

Also updates Dm and MultiDm components to only show selecting-related components if that dm/multiDm itself is the one currently selected by useMessageSelector.