### PR TITLE
gallery: don't show loading indicator if remote content is disabled.

### DIFF
--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -292,11 +292,11 @@ export default function HeapBlock({
   const flag = useRouteGroup();
   const isAdmin = useAmAdmin(flag);
   const canEdit = asRef ? false : isAdmin || window.our === curio.heart.author;
-  const notEmbed = isImage && isAudio && isText && isComment;
+  const maybeEmbed = !isImage && !isAudio && !isText && !isComment;
 
   useEffect(() => {
     const getOembed = async () => {
-      if (isValidUrl(url) && !notEmbed && !calm.disableRemoteContent) {
+      if (isValidUrl(url) && maybeEmbed && !calm.disableRemoteContent) {
         try {
           const oembed = await useEmbedState.getState().getEmbed(url);
           setEmbed(oembed);
@@ -307,9 +307,14 @@ export default function HeapBlock({
       }
     };
     getOembed();
-  }, [url, notEmbed, calm]);
+  }, [url, maybeEmbed, calm]);
 
-  if (isValidUrl(url) && embed === undefined && !notEmbed) {
+  if (
+    isValidUrl(url) &&
+    embed === undefined &&
+    maybeEmbed &&
+    !calm.disableRemoteContent
+  ) {
     return <HeapLoadingBlock />;
   }
 


### PR DESCRIPTION
Fixes #2376 by skipping the loading indicator if remote content is disabled.

Also renames/refactors "notEmbed" to "maybeEmbed" for better readability.