### PR TITLE
chat: reappearing dm invites

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -39,7 +39,7 @@ function ChatChannel({ title }: ViewProps) {
   const nest = `chat/${chFlag}`;
   const groupFlag = useRouteGroup();
   const { setRecentChannel } = useRecentChannel(groupFlag);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [joining, setJoining] = useState(false);
   const messages = useMessagesForChat(chFlag);
   const perms = useChatPerms(chFlag);

--- a/ui/src/chat/ChatMessage/Author.tsx
+++ b/ui/src/chat/ChatMessage/Author.tsx
@@ -70,7 +70,7 @@ export default function Author({
             <ShipName
               name={ship}
               showAlias
-              className="text-md font-semibold line-clamp-1"
+              className="text-md font-semibold leading-6 line-clamp-1"
             />
           )}
         </div>
@@ -103,7 +103,7 @@ export default function Author({
           <ShipName
             name={ship}
             showAlias
-            className="text-md break-all font-semibold line-clamp-1"
+            className="text-md break-all font-semibold leading-6 line-clamp-1"
           />
         )}
       </div>

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`ChatMessage > renders as expected 1`] = `
         class="text-md shrink cursor-pointer font-semibold"
       >
         <span
-          class="text-md break-all font-semibold line-clamp-1"
+          class="text-md break-all font-semibold leading-6 line-clamp-1"
         >
           <span
             aria-hidden="true"

--- a/ui/src/queryClient.ts
+++ b/ui/src/queryClient.ts
@@ -4,6 +4,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       cacheTime: Infinity,
+      refetchOnWindowFocus: !import.meta.env.DEV,
     },
   },
 });

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -190,9 +190,9 @@ export const useChatState = createState<ChatState>(
     },
     start: async ({ briefs, chats, pins }) => {
       get().batchSet((draft) => {
-        draft.chats = _.assign(draft.chats, chats);
-        draft.briefs = _.assign(draft.briefs, briefs);
-        draft.pins = _.union(draft.pins, pins);
+        draft.chats = chats;
+        draft.briefs = briefs;
+        draft.pins = pins;
       });
 
       Object.entries(briefs).forEach(([whom, brief]) => {
@@ -279,10 +279,10 @@ export const useChatState = createState<ChatState>(
       }
 
       get().batchSet((draft) => {
-        draft.multiDms = _.merge(draft.multiDms, init.clubs);
-        draft.dms = _.union(draft.dms, init.dms);
-        draft.pendingDms = _.union(draft.pendingDms, init.invited);
-        draft.pins = _.union(draft.pins, init.pins);
+        draft.multiDms = init.clubs;
+        draft.dms = init.dms;
+        draft.pendingDms = init.invited;
+        draft.pins = init.pins;
       });
 
       api.subscribe(


### PR DESCRIPTION
This should fix the issue people are seeing where DMs have to be accepted multiple times. We had added functionality for people to be able to load the apps offline which would load locally stored state, but that was erroneously getting merged with latest state even if you weren't offline. This rips that functionality out since we aren't remotely offline compatible yet.

Also throws in a few things, like setting a line-height on the Authors where we're doing line-clamping so it doesn't cut off things like tall emoji, and also stops channels from showing a loader when unnecessary like moving from a dm to a channel that was previously already loaded.