### PR TITLE
fix for group icon svg that wasn't compliant with CSP on tlon.network

### DIFF
--- a/ui/src/notifications/GroupNotification.tsx
+++ b/ui/src/notifications/GroupNotification.tsx
@@ -11,6 +11,7 @@ import AddIcon16 from '@/components/icons/Add16Icon';
 import Person16Icon from '@/components/icons/Person16Icon';
 import X16Icon from '@/components/icons/X16Icon';
 import { useIsMobile } from '@/logic/useMedia';
+import DocketImage from '@/components/Grid/DocketImage';
 import Notification from './Notification';
 
 interface GroupNotificationProps {
@@ -82,7 +83,11 @@ export default function GroupNotification({ bin }: GroupNotificationProps) {
       topLine={
         <div className="flex flex-row items-center space-x-1 text-sm font-semibold text-gray-400">
           {!groupFlag ? (
-            <DefaultGroupIcon className="mr-1 h-4 w-4" />
+            <DocketImage
+              color="#EFF0F4"
+              image="https://bootstrap.urbit.org/icon-groups.svg?v=1"
+              size="xs"
+            />
           ) : (
             <GroupSubIcon rope={rope} />
           )}

--- a/ui/src/notifications/GroupNotification.tsx
+++ b/ui/src/notifications/GroupNotification.tsx
@@ -12,6 +12,7 @@ import Person16Icon from '@/components/icons/Person16Icon';
 import X16Icon from '@/components/icons/X16Icon';
 import { useIsMobile } from '@/logic/useMedia';
 import DocketImage from '@/components/Grid/DocketImage';
+import AppGroupsIcon from '@/components/icons/AppGroupsIcon';
 import Notification from './Notification';
 
 interface GroupNotificationProps {
@@ -83,11 +84,7 @@ export default function GroupNotification({ bin }: GroupNotificationProps) {
       topLine={
         <div className="flex flex-row items-center space-x-1 text-sm font-semibold text-gray-400">
           {!groupFlag ? (
-            <DocketImage
-              color="#EFF0F4"
-              image="https://bootstrap.urbit.org/icon-groups.svg?v=1"
-              size="xs"
-            />
+            <AppGroupsIcon className="mr-1 h-4 w-4 bg-[#EFF0F4] p-[5px] text-gray-200" />
           ) : (
             <GroupSubIcon rope={rope} />
           )}


### PR DESCRIPTION
tlon.network implemented a content security policy that did not allow for setting a base64 string as a src on an image, this caused the groups icon to look broken on notifications on tlon hosted ships.