### PR TITLE
bugfix: check for group.cordon before checking for shut

### DIFF
--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -32,7 +32,7 @@ export default function GroupMemberManager() {
       return [];
     }
     return Object.keys(group.fleet).filter((k) => {
-      if ('shut' in group.cordon) {
+      if (group.cordon && 'shut' in group.cordon) {
         return (
           !group.cordon.shut.ask.includes(k) &&
           !group.cordon.shut.pending.includes(k)

--- a/ui/src/groups/GroupAdmin/GroupPendingManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupPendingManager.tsx
@@ -67,7 +67,7 @@ export default function GroupPendingManager() {
         .map(([k]) => k)
     );
 
-    if ('shut' in group.cordon) {
+    if (group.cordon && 'shut' in group.cordon) {
       members = group.cordon.shut.ask.concat(group.cordon.shut.pending);
     }
 
@@ -177,9 +177,13 @@ export default function GroupPendingManager() {
       <ul className="space-y-6 py-2">
         {results.map((m) => {
           const inAsk =
-            'shut' in group.cordon && group.cordon.shut.ask.includes(m);
+            group.cordon &&
+            'shut' in group.cordon &&
+            group.cordon.shut.ask.includes(m);
           const inPending =
-            'shut' in group.cordon && group.cordon.shut.pending.includes(m);
+            group.cordon &&
+            'shut' in group.cordon &&
+            group.cordon.shut.pending.includes(m);
           const contact = contacts[m];
 
           return (

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -217,7 +217,7 @@ export function getFlagParts(flag: string) {
 }
 
 export function getPrivacyFromCordon(cordon: Cordon): PrivacyType {
-  if ('shut' in cordon) {
+  if (cordon && 'shut' in cordon) {
     return 'private';
   }
 


### PR DESCRIPTION
Partial fix for #2431 

This should fix the second issue that the user saw. I think the issue was actually caused by getPrivacyFromCordon which is ultimately being called by useGroupJoin, which is called by FindGroups. I went ahead and added checks for the existence of group.cordon elsewhere. 

Still not sure where the 'Cannot read property 'title' of  undefined' error was coming from. 

I'll let him know to update the ticket if he sees the first issue again and can produce repro steps.