### PR TITLE
Optimize unread initialization

### DIFF
--- a/ui/src/chat/useChatStore.ts
+++ b/ui/src/chat/useChatStore.ts
@@ -42,6 +42,7 @@ export interface ChatStore {
   unread: (whom: string, brief: ChatBrief) => void;
   bottom: (atBottom: boolean) => void;
   setCurrent: (whom: string) => void;
+  batchUnread: (unreadChats: { whom: string; brief: ChatBrief }[]) => void;
 }
 
 const emptyInfo: ChatInfo = {
@@ -55,6 +56,24 @@ const emptyInfo: ChatInfo = {
 
 export const useChatStore = create<ChatStore>((set, get) => ({
   chats: {},
+  batchUnread: (unreadChats) => {
+    set(
+      produce((draft: ChatStore) => {
+        unreadChats.forEach(({ whom, brief }) => {
+          const chat = draft.chats[whom] || emptyInfo;
+
+          draft.chats[whom] = {
+            ...chat,
+            unread: {
+              seen: false,
+              readTimeout: 0,
+              brief,
+            },
+          };
+        });
+      })
+    );
+  },
   atBottom: false,
   current: '',
   setBlocks: (whom, blocks) => {

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -195,12 +195,11 @@ export const useChatState = createState<ChatState>(
         draft.pins = pins;
       });
 
-      Object.entries(briefs).forEach(([whom, brief]) => {
-        const isUnread = brief.count > 0 && brief['read-id'];
-        if (isUnread) {
-          useChatStore.getState().unread(whom, brief);
-        }
-      });
+      const unreadChats = Object.entries(briefs)
+        .filter(([, brief]) => brief.count > 0 && brief['read-id'])
+        .map(([whom, brief]) => ({ whom, brief }));
+
+      useChatStore.getState().batchUnread(unreadChats);
 
       api.subscribe(
         {


### PR DESCRIPTION
This PR optimizes initialization by reducing the time taken to iterate over the briefs map and update the state in ChatStore.

I replaced the forEach with a filter/map, which should be more performant.

I also added a new batchUnread action to the ChatStore that uses produce() to update unread state in one shot, rather than calling unread on each unread brief.

This particular issue effected ships that were subscribed to a lot of channels, so it wasn't easily caught in development where we use fakezods and dev moons. On my personal ship, this saved about 15 seconds of loading time for the initial data.