### PR TITLE
groups: respect permissions before auto join

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1049,12 +1049,18 @@
     =.  group  gr
     =.  net  [%sub time & %chi ~]
     =/  create=diff:g  [%create group]
+    =/  readable-channels
+      %-  ~(gas in *(set nest:g))
+      %+  murn  ~(tap in channels.group)
+      |=  [ch=nest:g =channel:g]
+      ?.  (go-can-read our.bowl channel)  ~
+      [~ ch]
     =.  cor
       (give %fact ~[/groups /groups/ui] act:mar !>(`action:g`[flag now.bowl create]))
     =.  cor
       (give %fact ~[/groups /groups/ui] gang-gone+!>(flag))
     =.  cor
-      (emil (join-channels:go-pass ~(tap in ~(key by channels.group))))
+      (emil (join-channels:go-pass ~(tap in readable-channels)))
     go-core
   ::
   ++  go-give-update

--- a/ui/src/groups/ChannelsList/ChannelsList.tsx
+++ b/ui/src/groups/ChannelsList/ChannelsList.tsx
@@ -40,7 +40,6 @@ export default function ChannelsList() {
     return sectionedChannels;
   }, [group, vessel]);
 
-  console.log({ channels: getSectionedChannels });
 
   const getFilteredSectionedChannels = useCallback(() => {
     const filteredSectionedChannels: SectionMap = {};

--- a/ui/src/groups/ChannelsList/ChannelsList.tsx
+++ b/ui/src/groups/ChannelsList/ChannelsList.tsx
@@ -47,7 +47,6 @@ export default function ChannelsList() {
       return Object.entries(getSectionedChannels).reduce(
         (acc, [key, section]) => {
           const filteredChannels = section.channels.filter((channelItem) => {
-            console.log({ channelItem });
             const { channel } = channelItem;
             const title = channel?.meta.title.toLowerCase();
             const description = channel?.meta.description.toLowerCase();

--- a/ui/src/groups/ChannelsList/ChannelsList.tsx
+++ b/ui/src/groups/ChannelsList/ChannelsList.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useMemo } from 'react';
-import { useGroup, useRouteGroup } from '@/state/groups';
+import { useGroup, useRouteGroup, useVessel } from '@/state/groups';
+import { canReadChannel } from '@/logic/utils';
 import ChannelsListDropContext from './ChannelsListDropContext';
 import { SectionMap } from './types';
 import useChannelSearch from './useChannelSearch';
 
 export default function ChannelsList() {
   const flag = useRouteGroup();
+  const vessel = useVessel(flag, window.our);
   const group = useGroup(flag);
   const { searchInput } = useChannelSearch();
 
@@ -27,14 +29,18 @@ export default function ChannelsList() {
         }));
         if (sectionedChannels[key]) {
           sectionedChannels[key].channels = orderedChannels.filter(
-            (channelItem) => key === channelItem.channel?.zone
+            (channelItem) =>
+              key === channelItem.channel?.zone &&
+              canReadChannel(channelItem.channel, vessel, group.bloc)
           );
         }
       });
     }
 
     return sectionedChannels;
-  }, [group]);
+  }, [group, vessel]);
+
+  console.log({ channels: getSectionedChannels });
 
   const getFilteredSectionedChannels = useCallback(() => {
     const filteredSectionedChannels: SectionMap = {};
@@ -42,6 +48,7 @@ export default function ChannelsList() {
       return Object.entries(getSectionedChannels).reduce(
         (acc, [key, section]) => {
           const filteredChannels = section.channels.filter((channelItem) => {
+            console.log({ channelItem });
             const { channel } = channelItem;
             const title = channel?.meta.title.toLowerCase();
             const description = channel?.meta.description.toLowerCase();


### PR DESCRIPTION
Fixes #2226 by filtering the channels passed to `join-channels` on the backend to those the user actually has read-access to. Also fixes ChannelList so that it doesn't display channels a user can't read.