### PR TITLE
fix max-width on reference bar

### DIFF
--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -43,7 +43,7 @@ export default function ReferenceBar({
   return (
     <div
       className={cn(
-        'container flex items-center justify-between border-gray-50 group-hover:bg-gray-50',
+        'flex items-center justify-between border-gray-50 group-hover:bg-gray-50',
         {
           'border-t-2': !top,
           'py-1 px-2': reply,


### PR DESCRIPTION
Fixes #2433 

Removes `max-width` property on reference bar that was keeping it from filling up the same width as the reference content

<img width="2077" alt="Screenshot 2023-05-02 at 8 49 59 AM" src="https://user-images.githubusercontent.com/1013230/235718685-aeee75eb-1067-498d-9d78-17e9fadb485d.png">
