### PR TITLE
groups: home redirect and grab bag

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -264,60 +264,39 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   );
 }
 
-function HomeRoute({
-  isMobile = true,
-  isInGroups = false,
-}: {
-  isMobile: boolean;
-  isInGroups: boolean;
-}) {
-  if (!isInGroups) {
-    return <FindGroups title={`Find Groups • ${appHead('').title}`} />;
-  }
-
-  if (isMobile && isInGroups) {
-    return <MobileGroupsNavHome />;
-  }
-
-  return (
-    <Notifications
-      child={GroupNotification}
-      title={`All Notifications • ${appHead('').title}`}
-    />
-  );
-}
-
-function ActivityRoute({ isInGroups = false }: { isInGroups: boolean }) {
-  if (!isInGroups) {
-    return <FindGroups title={`Find Groups • ${appHead('').title}`} />;
-  }
-
-  return (
-    <Notifications
-      child={GroupNotification}
-      title={`All Notifications • ${appHead('').title}`}
-    />
-  );
-}
-
-function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
+function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
+  const navigate = useNavigate();
   const groups = queryClient.getQueryCache().find(['groups'])?.state.data;
   const isInGroups = groups !== undefined ? !_.isEmpty(groups) : true;
 
+  useEffect(() => {
+    if (!isInGroups) {
+      navigate('/find', { replace: true });
+    }
+  }, [isInGroups, navigate]);
+
+  if (isMobile) {
+    return <MobileGroupsNavHome />;
+  }
+
+  return null;
+}
+
+function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   return (
     <>
       <Routes location={state?.backgroundLocation || location}>
         <Route element={<GroupsNav />}>
           <Route element={isMobile ? <MobileSidebar /> : undefined}>
-            <Route
-              index
-              element={
-                <HomeRoute isMobile={isMobile} isInGroups={isInGroups} />
-              }
-            />
+            <Route index element={<HomeRoute isMobile={isMobile} />} />
             <Route
               path="/notifications"
-              element={<ActivityRoute isInGroups={isInGroups} />}
+              element={
+                <Notifications
+                  child={GroupNotification}
+                  title={`All Notifications • ${appHead('').title}`}
+                />
+              }
             />
             {/* Find by Invite URL */}
             <Route

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -264,14 +264,16 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   );
 }
 
+let redirectToFind = !window.location.pathname.startsWith('/apps/groups/find');
 function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
   const navigate = useNavigate();
   const groups = queryClient.getQueryCache().find(['groups'])?.state.data;
   const isInGroups = groups !== undefined ? !_.isEmpty(groups) : true;
 
   useEffect(() => {
-    if (!isInGroups) {
+    if (!isInGroups && redirectToFind) {
       navigate('/find', { replace: true });
+      redirectToFind = false;
     }
   }, [isInGroups, navigate]);
 
@@ -279,7 +281,12 @@ function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
     return <MobileGroupsNavHome />;
   }
 
-  return null;
+  return (
+    <Notifications
+      child={GroupNotification}
+      title={`All Notifications • ${appHead('').title}`}
+    />
+  );
 }
 
 function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {

--- a/ui/src/groups/NewGroup/NewGroup.tsx
+++ b/ui/src/groups/NewGroup/NewGroup.tsx
@@ -149,8 +149,8 @@ export default function NewGroup() {
       modal
       onOpenChange={onOpenChange}
       onInteractOutside={(e) => e.preventDefault()}
-      className="w-[500px] sm:inset-y-24"
-      containerClass="w-full h-full sm:max-w-lg"
+      className="sm:inset-y-24"
+      containerClass="w-full h-full sm:max-w-xl"
     >
       <FormProvider {...form}>
         <div className="flex flex-col">{currentStepComponent}</div>

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -135,7 +135,7 @@ export default function useMessageSelector() {
     } else {
       navigate(`/dm/new`);
     }
-  }, [existingDm, existingMultiDm, navigate, shipValues, location.pathname]);
+  }, [existingDm, existingMultiDm, navigate, location.pathname]);
 
   return {
     action,

--- a/ui/src/notifications/useNotifications.tsx
+++ b/ui/src/notifications/useNotifications.tsx
@@ -40,6 +40,7 @@ export const useNotifications = (flag?: Flag, mentionsOnly = false) => {
         notifications: [],
         mentions: [],
         count: 0,
+        loaded: skeinsStatus === 'error',
       };
     }
 
@@ -52,7 +53,7 @@ export const useNotifications = (flag?: Flag, mentionsOnly = false) => {
       notifications: groupSkeinsByDate(filteredSkeins),
       mentions: unreads.filter((s) => isMention(s.top)),
       count: unreads.length,
-      loaded: skeinsStatus === 'success',
+      loaded: skeinsStatus === 'success' || skeinsStatus === 'error',
     };
   }, [skeins, mentionsOnly, skeinsStatus]);
 };

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -468,6 +468,7 @@ export const useChatState = createState<ChatState>(
         if (isNew) {
           set((draft) => ({
             ...draft,
+            dms: [...draft.dms, whom],
             pacts: {
               ...draft.pacts,
               [whom]: { index: {}, writs: new BigIntOrderedMap() },

--- a/ui/src/state/hark.ts
+++ b/ui/src/state/hark.ts
@@ -66,6 +66,7 @@ export function useSkeins(flag?: Flag) {
     scry: flag ? `/group/${flag}/skeins` : `/desk/${window.desk}/skeins`,
     options: {
       refetchOnMount: true,
+      retry: 1,
     },
   });
 


### PR DESCRIPTION
This was mainly intended to cleanup the home behavior seen in #2446 but found a bunch of things along the way.

- if you have no notifications yet the scries for that desk will 404, we probably should fix this as well, but for now I just made it so that notifications don't look like they're perpetually loading if the skein scry fails
- Our new group dialog was getting cut off
- Starting a new DM with someone was not redirecting correctly if you sent the message without finalizing your selection in the top bar