### PR TITLE
emojis: fix route issue on mobile

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -253,6 +253,10 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 element={<EmojiPicker />}
               />
               <Route
+                path="/groups/:ship/:name/channels/chat/:chShip/:chName/message/:idShip/:idTime/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
+              <Route
                 path="/dm/:ship/picker/:writShip/:writTime"
                 element={<EmojiPicker />}
               />
@@ -486,10 +490,16 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
           />
           <Route path="/profile/:ship" element={<ProfileModal />} />
           {isMobile ? (
-            <Route
-              path="/groups/:ship/:name/channels/chat/:chShip/:chName/picker/:writShip/:writTime"
-              element={<EmojiPicker />}
-            />
+            <>
+              <Route
+                path="/groups/:ship/:name/channels/chat/:chShip/:chName/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
+              <Route
+                path="/groups/:ship/:name/channels/chat/:chShip/:chName/message/:idShip/:idTime/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
+            </>
           ) : null}
         </Routes>
       ) : null}

--- a/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
+++ b/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatInput > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/chat/ChatMessage/ChatMessage.test.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.test.tsx
@@ -1,18 +1,72 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import React from 'react';
+import { describe, it, expect, beforeEach, SpyInstance } from 'vitest';
+import React, { ReactPortal } from 'react';
 import { unixToDa } from '@urbit/api';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
+import { makeFakeChatWrit, unixToDaStr } from '@/mocks/chat';
+import * as useMedia from '@/logic/useMedia';
 import ChatMessage from './ChatMessage';
-import { makeFakeChatWrit } from '../../mocks/chat';
-import { render } from '../../../test/utils';
+import { render, userEvent, fireEvent, screen } from '../../../test/utils';
+
+vi.mock('lodash/debounce', () => ({
+  default: (fn: any) => fn,
+}));
+
+vi.mock('@/state/emoji', () => ({
+  default: () => ({
+    data: undefined,
+    load: (fn: any) => fn,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const mod = await vi.importActual('react-router-dom');
+  const date = new Date(2021, 1, 1, 13);
+
+  return {
+    ...(mod as any),
+    useParams: () => ({
+      idShip: '~finned-palmer',
+      idTime: unixToDaStr(date.valueOf()),
+    }),
+  };
+});
+
+vi.mock('react-dom', () => {
+  const mod = vi.importActual('react-dom');
+  return {
+    ...(mod as any),
+    createPortal: (node: React.ReactNode) => node as ReactPortal,
+  };
+});
+
+class MockPointerEvent extends Event {
+  button: number;
+
+  ctrlKey: boolean;
+
+  pointerType: string;
+
+  constructor(type: string, props: PointerEventInit) {
+    super(type, props);
+    this.button = props.button || 0;
+    this.ctrlKey = props.ctrlKey || false;
+    this.pointerType = props.pointerType || 'mouse';
+  }
+}
+
+window.PointerEvent = MockPointerEvent as any;
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+window.HTMLElement.prototype.hasPointerCapture = vi.fn();
 
 describe('ChatMessage', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    // vi.useFakeTimers();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    // vi.useRealTimers();
+    vi.resetAllMocks();
   });
   it('renders as expected', () => {
     const date = new Date(2021, 1, 1, 13);
@@ -32,5 +86,146 @@ describe('ChatMessage', () => {
       </TooltipProvider>
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders the ChatMessageOptions when hovered', async () => {
+    const date = new Date(2021, 1, 1, 13);
+    const writ = makeFakeChatWrit(
+      1,
+      '~finned-palmer',
+      {
+        block: [],
+        inline: [{ bold: ['A bold test message'] }, 'with some more text'],
+      },
+      undefined
+    );
+    const da = unixToDa(date.valueOf());
+    const { getByTestId, queryByTestId, findByTestId } = render(
+      <TooltipProvider>
+        <ChatMessage time={da} whom="~zod/test" writ={writ} newAuthor newDay />
+      </TooltipProvider>
+    );
+    const chatMessage = getByTestId('chat-message');
+    const chatMessageOptions = queryByTestId('chat-message-options');
+
+    expect(chatMessage).toBeInTheDocument();
+    expect(chatMessageOptions).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(chatMessage);
+
+    const chatMessageOptionsAfterHover = await findByTestId(
+      'chat-message-options'
+    );
+
+    expect(chatMessageOptionsAfterHover).toBeInTheDocument();
+  });
+
+  it('renders the ChatMessageOptions when the message is clicked', async () => {
+    const date = new Date(2021, 1, 1, 13);
+    const writ = makeFakeChatWrit(
+      1,
+      '~finned-palmer',
+      {
+        block: [],
+        inline: [{ bold: ['A bold test message'] }, 'with some more text'],
+      },
+      undefined
+    );
+    const da = unixToDa(date.valueOf());
+    const { getByTestId, queryByTestId, findByTestId } = render(
+      <TooltipProvider>
+        <ChatMessage time={da} whom="~zod/test" writ={writ} newAuthor newDay />
+      </TooltipProvider>
+    );
+    const chatMessage = getByTestId('chat-message');
+    const chatMessageOptions = queryByTestId('chat-message-options');
+
+    expect(chatMessage).toBeInTheDocument();
+    expect(chatMessageOptions).not.toBeInTheDocument();
+
+    fireEvent.click(chatMessage);
+
+    const chatMessageOptionsAfterHover = await findByTestId(
+      'chat-message-options'
+    );
+
+    expect(chatMessageOptionsAfterHover).toBeInTheDocument();
+  });
+
+  it("does not render ChatMesssageOptions when the message is a thread op, we're in a thread and we're not on mobile", async () => {
+    const date = new Date(2021, 1, 1, 13);
+    const da = unixToDa(date.valueOf());
+    const writ = makeFakeChatWrit(
+      1,
+      '~finned-palmer',
+      {
+        block: [],
+        inline: [{ bold: ['A bold test message'] }, 'with some more text'],
+      },
+      undefined,
+      date
+    );
+    const { getByTestId, queryByTestId } = render(
+      <TooltipProvider>
+        <ChatMessage
+          time={da}
+          whom="~zod/test"
+          writ={writ}
+          newAuthor
+          newDay
+          hideReplies
+        />
+      </TooltipProvider>
+    );
+    const chatMessage = getByTestId('chat-message');
+    const chatMessageOptions = queryByTestId('chat-message-options');
+
+    expect(chatMessage).toBeInTheDocument();
+    expect(chatMessageOptions).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(chatMessage);
+
+    expect(chatMessageOptions).not.toBeInTheDocument();
+  });
+
+  it('renders the ChatMessageOptions when the message is a thread op and we are in a thread on mobile', async () => {
+    vi.spyOn(useMedia, 'useIsMobile').mockReturnValue(true);
+    const date = new Date(2021, 1, 1, 13);
+    const da = unixToDa(date.valueOf());
+    const writ = makeFakeChatWrit(
+      1,
+      '~finned-palmer',
+      {
+        block: [],
+        inline: [{ bold: ['A bold test message'] }, 'with some more text'],
+      },
+      undefined,
+      date
+    );
+    const { getByTestId, queryByTestId, findByTestId } = render(
+      <TooltipProvider>
+        <ChatMessage
+          time={da}
+          whom="~zod/test"
+          writ={writ}
+          newAuthor
+          newDay
+          hideReplies
+        />
+      </TooltipProvider>
+    );
+    const chatMessage = getByTestId('chat-message');
+    const chatMessageOptions = queryByTestId('chat-message-options');
+
+    expect(chatMessage).toBeInTheDocument();
+    expect(chatMessageOptions).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(chatMessage);
+
+    const chatMessageOptionsAfterHover = await findByTestId(
+      'chat-message-options'
+    );
+
+    expect(chatMessageOptionsAfterHover).toBeInTheDocument();
   });
 });

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/no-unused-prop-types */
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 import cn from 'classnames';
-import _, { debounce } from 'lodash';
+import _ from 'lodash';
+import debounce from 'lodash/debounce';
 import f from 'lodash/fp';
-import bigInt, { BigInteger } from 'big-integer';
-import { daToUnix, udToDec } from '@urbit/api';
+import { BigInteger } from 'big-integer';
+import { daToUnix } from '@urbit/api';
 import { format, formatDistanceToNow, formatRelative, isToday } from 'date-fns';
 import { NavLink, useParams } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
@@ -26,6 +27,7 @@ import Avatar from '@/components/Avatar';
 import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { whomIsDm, whomIsMultiDm } from '@/logic/utils';
+import { useIsMobile } from '@/logic/useMedia';
 import { useChatHovering, useChatInfo, useChatStore } from '../useChatStore';
 
 export interface ChatMessageProps {
@@ -86,6 +88,8 @@ const ChatMessage = React.memo<
       const isThread = idShip && idTime;
       const threadOpId = isThread ? `${idShip}/${idTime}` : '';
       const isThreadOp = threadOpId === seal.id && hideReplies;
+      const isMobile = useIsMobile();
+      const isThreadOnMobile = isThread && isMobile;
       const chatInfo = useChatInfo(whom);
       const unread = chatInfo?.unread;
       const unreadId = unread?.brief['read-id'];
@@ -182,14 +186,14 @@ const ChatMessage = React.memo<
       );
       const onOver = useCallback(() => {
         // If we're already hovering, don't do anything
-        // If we're the thread op, don't do anything
+        // If we're the thread op and this isn't on mobile, don't do anything
         // This is necessary to prevent the hover from appearing
         // in the thread when the user hovers in the main scroll window.
-        if (hover.current === false && !isThreadOp) {
+        if (hover.current === false && (!isThreadOp || isThreadOnMobile)) {
           hover.current = true;
           setHover.current();
         }
-      }, [isThreadOp]);
+      }, [isThreadOp, isThreadOnMobile]);
       const onOut = useRef(
         debounce(
           () => {
@@ -211,6 +215,7 @@ const ChatMessage = React.memo<
           onMouseEnter={onOver}
           onClick={onOver}
           onMouseLeave={onOut.current}
+          data-testid="chat-message"
         >
           {unread && briefMatches(unread.brief, writ.seal.id) ? (
             <DateDivider
@@ -227,7 +232,7 @@ const ChatMessage = React.memo<
             !hovering ||
             // If we're the thread op, don't show options.
             // Options are shown for the threadOp in the main scroll window.
-            isThreadOp ? null : (
+            (isThreadOp && !isThreadOnMobile) ? null : (
               <ChatMessageOptions
                 hideThreadReply={hideReplies}
                 whom={whom}

--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -95,7 +95,10 @@ export default function ChatMessageOptions(props: {
   }, [isMobile, loadEmoji]);
 
   return (
-    <div className="absolute right-2 -top-5 z-10 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle">
+    <div
+      data-testid="chat-message-options"
+      className="absolute right-2 -top-5 z-10 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle"
+    >
       {canWrite && !isMobile ? (
         <EmojiPicker
           open={pickerOpen}
@@ -107,6 +110,7 @@ export default function ChatMessageOptions(props: {
             icon={<FaceIcon className="h-6 w-6 text-gray-400" />}
             label="React"
             showTooltip
+            aria-label="React"
             action={openPicker}
           />
         </EmojiPicker>
@@ -115,6 +119,7 @@ export default function ChatMessageOptions(props: {
         <IconButton
           icon={<FaceIcon className="h-6 w-6 text-gray-400" />}
           label="React"
+          aria-label="React"
           showTooltip
           action={() =>
             navigate(`picker/${writ.seal.id}`, {

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -1,9 +1,10 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatMessage > renders as expected 1`] = `
 <DocumentFragment>
   <div
     class="flex flex-col break-words pt-3"
+    data-testid="chat-message"
   >
     <div
       class="flex w-full items-center pt-4 pb-6"

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -76,6 +76,7 @@ export default function EmojiPicker({
           sideOffset={30}
           collisionPadding={15}
           onInteractOutside={isMobile ? () => dismss() : undefined}
+          data-testid="emoji-picker"
         >
           <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (

--- a/ui/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/ui/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Layout > renders as expected 1`] = `
 <div

--- a/ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar/Sidebar.test.tsx
@@ -45,6 +45,9 @@ vi.mock('@/logic/utils', () => ({
   normalizeUrbitColor: () => '#ffffff',
   hasKeys: () => false,
   randomElement: (a: any[]) => a[0],
+  storageVersion: () => 0,
+  clearStorageMigration: () => ({}),
+  isTalk: () => false,
 }));
 
 describe('Sidebar', () => {

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Sidebar > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/groups/ChannelsList/ChannelsList.tsx
+++ b/ui/src/groups/ChannelsList/ChannelsList.tsx
@@ -40,7 +40,6 @@ export default function ChannelsList() {
     return sectionedChannels;
   }, [group, vessel]);
 
-
   const getFilteredSectionedChannels = useCallback(() => {
     const filteredSectionedChannels: SectionMap = {};
     if (searchInput !== '') {

--- a/ui/src/groups/GangPreview/__snapshots__/GangPreview.test.tsx.snap
+++ b/ui/src/groups/GangPreview/__snapshots__/GangPreview.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`GangPreview > renders preview 1`] = `
 <DocumentFragment>

--- a/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChannelList > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/mocks/chat.ts
+++ b/ui/src/mocks/chat.ts
@@ -12,6 +12,13 @@ import {
   ChatNotice,
 } from '../types/chat';
 
+const getUnix = (count: number, setTime?: Date) =>
+  count > 1
+    ? subMinutes(setTime ? setTime : new Date(), count * 5).getTime()
+    : setTime
+    ? setTime.getTime()
+    : new Date().getTime();
+
 export const makeFakeChatWrit = (
   count: number,
   author: string,
@@ -19,7 +26,7 @@ export const makeFakeChatWrit = (
   feels?: Record<string, string>,
   setTime?: Date
 ): ChatWrit => {
-  const unix = subMinutes(setTime ? setTime : new Date(), count * 5).getTime();
+  const unix = getUnix(count, setTime);
   const time = unixToDa(unix);
   const da = decToUd(time.toString());
   return {
@@ -45,7 +52,7 @@ export const makeFakeChatNotice = (
   notice: ChatNotice,
   setTime?: Date
 ): ChatWrit => {
-  const unix = subMinutes(setTime ? setTime : new Date(), count * 5).getTime();
+  const unix = getUnix(count, setTime);
   const time = unixToDa(unix);
   const da = decToUd(time.toString());
   return {


### PR DESCRIPTION
Fixes #2445 by accounting for routing to the emoji picker from within a thread on mobile.

Also adds some RTL tests around ChatMessageOptions. Attempted to test for showing/hiding the emoji picker itself, but it ended up being a rabbit hole. Going to attempt to write those tests using playwright in another PR.