### PR TITLE
clubs: more invite fixes

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1028,7 +1028,9 @@
     ::
         %hive
       ?:  add.delta
-        ?:  (~(has in hive.crew.club) for.delta)
+        ?:  ?|  (~(has in hive.crew.club) for.delta)
+                (~(has in team.crew.club) for.delta)
+            ==
           cu-core
         =.  hive.crew.club   (~(put in hive.crew.club) for.delta)
         =^  new-uid  cu-core

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -861,15 +861,24 @@
   +*  cu-pact  ~(. pac pact.club)
   ++  cu-core  .
   ++  cu-abet
-  =.  clubs
-    ?:  gone
-      (~(del by clubs) id)
-    (~(put by clubs) id club)
-  cor
+    ::  shouldn't need cleaning, but just in case
+    =.  cu-core  cu-clean
+    =.  clubs
+      ?:  gone
+        (~(del by clubs) id)
+      (~(put by clubs) id club)
+    cor
   ++  cu-abed
     |=  i=id:club:c
     ~|  no-club/i
     cu-core(id i, club (~(gut by clubs) i *club:c))
+  ++  cu-clean
+    =.  hive.crew.club
+      %-  ~(rep in hive.crew.club)
+      |=  [=ship hive=(set ship)]
+      ?:  (~(has in team.crew.club) ship)  hive
+      (~(put in hive) ship)
+    cu-core
   ++  cu-out  (~(del in cu-circle) our.bowl)
   ++  cu-circle
     (~(uni in team.crew.club) hive.crew.club)


### PR DESCRIPTION
Turns out we had a bug in both the frontend and backend around inviting more ships to a chat. The frontend allowed you to invite someone already in the members list, and the backend also was not checking whether someone was in the team only the hive. 

I added logic to prevent both of those and also have an error client side if someone does accidentally included a member already in the chat. Also added a cleanup step in any club action to ensure that you can't both be in the hive and team at the same time.