### PR TITLE
groups: fix issue with private groups in find groups

### DIFF
--- a/ui/src/logic/useGroupPrivacy.ts
+++ b/ui/src/logic/useGroupPrivacy.ts
@@ -1,17 +1,14 @@
-import { useGang, useGroup, useGroupPreviewFromIndex } from '@/state/groups';
+import { useGang, useGroup } from '@/state/groups';
 import { getPrivacyFromGroup, getPrivacyFromPreview } from './utils';
 
 export default function useGroupPrivacy(flag: string) {
   const group = useGroup(flag);
   const gang = useGang(flag);
-  const previewFromIndex = useGroupPreviewFromIndex(flag);
 
   const privacy = group
     ? getPrivacyFromGroup(group)
     : gang.preview
     ? getPrivacyFromPreview(gang.preview)
-    : previewFromIndex
-    ? getPrivacyFromPreview(previewFromIndex)
     : 'public';
 
   return {

--- a/ui/src/logic/useGroupPrivacy.ts
+++ b/ui/src/logic/useGroupPrivacy.ts
@@ -1,14 +1,17 @@
-import { useGang, useGroup } from '@/state/groups';
+import { useGang, useGroup, useGroupPreviewFromIndex } from '@/state/groups';
 import { getPrivacyFromGroup, getPrivacyFromPreview } from './utils';
 
 export default function useGroupPrivacy(flag: string) {
   const group = useGroup(flag);
   const gang = useGang(flag);
+  const previewFromIndex = useGroupPreviewFromIndex(flag);
 
   const privacy = group
     ? getPrivacyFromGroup(group)
     : gang.preview
     ? getPrivacyFromPreview(gang.preview)
+    : previewFromIndex
+    ? getPrivacyFromPreview(previewFromIndex)
     : 'public';
 
   return {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -28,6 +28,7 @@ import { BaitCite } from '@/types/chat';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import useReactQuerySubscribeOnce from '@/logic/useReactQuerySubscribeOnce';
 import useReactQueryScry from '@/logic/useReactQueryScry';
+import { getFlagParts } from '@/logic/utils';
 
 export const GROUP_ADMIN = 'admin';
 
@@ -954,6 +955,13 @@ export function useGroupIndex(ship: string) {
     groupIndex: data as GroupIndex,
     ...rest,
   };
+}
+
+export function useGroupPreviewFromIndex(flag: string) {
+  const { ship } = getFlagParts(flag);
+  const { groupIndex } = useGroupIndex(ship);
+
+  return groupIndex?.[flag];
 }
 
 export function useGroupBanShipsMutation() {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -210,27 +210,32 @@ export function useGangs() {
     },
   });
 
+  // this is a bit of a hack to get the group index data into the gangs
+  const groupIndexDataAsGangs: Gangs = useMemo(
+    () =>
+      (queryClient.getQueriesData(['group-index']) || []).reduce(
+        (acc, [_queryKey, indexData]) => {
+          if (indexData && typeof indexData === 'object') {
+            const newAcc = { ...acc };
+            Object.keys(indexData).forEach((key) => {
+              (newAcc as Gangs)[key] = {
+                preview: (indexData as GroupIndex)[key],
+                invite: null,
+                claim: null,
+              };
+            });
+            return newAcc;
+          }
+          return acc;
+        },
+        {}
+      ),
+    [queryClient]
+  );
+
   if (rest.isLoading || rest.isError) {
     return {} as Gangs;
   }
-
-  // this is a bit of a hack to get the group index data into the gangs
-  const groupIndexDataAsGangs: Gangs = (
-    queryClient.getQueriesData(['group-index']) || []
-  ).reduce((acc, [_queryKey, indexData]) => {
-    if (indexData && typeof indexData === 'object') {
-      const newAcc = { ...acc };
-      Object.keys(indexData).forEach((key) => {
-        (newAcc as Gangs)[key] = {
-          preview: (indexData as GroupIndex)[key],
-          invite: null,
-          claim: null,
-        };
-      });
-      return newAcc;
-    }
-    return acc;
-  }, {});
 
   return {
     ...groupIndexDataAsGangs,


### PR DESCRIPTION
Fixes #2478

We weren't properly checking the privacy of groups returned from the group index. useGroupPrivacy defaulted to `public` if we didn't have group or gang data for a particular flag, which means that we didn't show the accurate privacy setting for groups we only knew of via group index (i.e., groups we had found by searching for a ship in Find Groups).

This PR updates useGangs so that it will insert gang indexes into the cached gangs data. Also fixes an issue we had with usePendingGangs and usePendingGangsWithoutClaim returning gangs without an invite key at all.