### PR TITLE
bugfix: properly render note references

### DIFF
--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -3,11 +3,11 @@ import { useHasMigratedChannels } from '@/logic/useMigrationInfo';
 import { useGroup, useShoal } from '@/state/groups';
 import { BaitCite } from '@/types/chat';
 import { udToDec } from '@urbit/api';
-import cn from 'classnames';
 import React from 'react';
 import ExclamationPoint from '../icons/ExclamationPoint';
 // eslint-disable-next-line import/no-cycle
 import CurioReference from './CurioReference';
+// eslint-disable-next-line import/no-cycle
 import NoteReference from './NoteReference';
 
 // eslint-disable-next-line import/no-cycle

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -7,6 +7,7 @@ import CurioReference from './CurioReference';
 // eslint-disable-next-line import/no-cycle
 import WritChanReference from './WritChanReference';
 import GroupReference from './GroupReference';
+// eslint-disable-next-line import/no-cycle
 import NoteReference from './NoteReference';
 import AppReference from './AppReference';
 // eslint-disable-next-line import/no-cycle

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -3,12 +3,14 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { useRemoteOutline } from '@/state/diary';
 import { useChannelPreview, useGang } from '@/state/groups';
-import { makePrettyDate, pluralize } from '@/logic/utils';
+import { makePrettyDate, pluralize, truncateProse } from '@/logic/utils';
 import bigInt from 'big-integer';
 import Avatar from '@/components/Avatar';
 import { NOTE_REF_DISPLAY_LIMIT } from '@/constants';
 import useGroupJoin from '@/groups/useGroupJoin';
 import useNavigateByApp from '@/logic/useNavigateByApp';
+// eslint-disable-next-line import/no-cycle
+import DiaryContent from '@/diary/DiaryContent/DiaryContent';
 import ReferenceBar from './ReferenceBar';
 
 function NoteReference({
@@ -47,28 +49,12 @@ function NoteReference({
       return '';
     }
 
-    let charCount = 0;
-    return outline.content.slice(0, 1).map((verse, index) => {
-      if ('inline' in verse) {
-        return (
-          <div key={index}>
-            {verse.inline.map((token, i) => {
-              if (charCount > NOTE_REF_DISPLAY_LIMIT) {
-                return '';
-              }
-              if (typeof token === 'string') {
-                charCount += token.length;
-                return <span key={i}>{token}</span>;
-              }
-              // TODO: handle other types of tokens
-              return '';
-            })}
-          </div>
-        );
-      }
-      // TODO: handle blocks.
-      return '';
-    });
+    const truncatedContent = truncateProse(
+      outline.content,
+      NOTE_REF_DISPLAY_LIMIT
+    );
+
+    return <DiaryContent content={truncatedContent} isPreview />;
   }, [outline]);
 
   if (!outline) {
@@ -78,7 +64,7 @@ function NoteReference({
   const prettyDate = makePrettyDate(new Date(outline.sent));
 
   return (
-    <div className="note-inline-block not-prose group">
+    <div className="note-inline-block not-prose group max-w-[600px]">
       <div
         onClick={handleOpenReferenceClick}
         className="flex cursor-pointer flex-col space-y-2 p-4 group-hover:bg-gray-50"

--- a/ui/src/diary/DiaryContent/DiaryContent.tsx
+++ b/ui/src/diary/DiaryContent/DiaryContent.tsx
@@ -31,6 +31,7 @@ refractor.register(hoon);
 
 interface DiaryContentProps {
   content: NoteContent;
+  isPreview?: boolean;
 }
 
 interface InlineContentProps {
@@ -251,9 +252,17 @@ export const BlockContent = React.memo(({ story }: BlockContentProps) => {
   throw new Error(`Unhandled message type: ${JSON.stringify(story)}`);
 });
 
-export default function DiaryContent({ content }: DiaryContentProps) {
+export default function DiaryContent({
+  content,
+  isPreview,
+}: DiaryContentProps) {
   return (
-    <article className="prose-lg prose break-words dark:prose-invert">
+    <article
+      className={cn('prose break-words dark:prose-invert', {
+        'prose-sm': isPreview,
+        'prose-lg': !isPreview,
+      })}
+    >
       {content.map((c, index) => {
         if ('block' in c) {
           return <BlockContent key={index} story={c.block} />;

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -38,6 +38,13 @@ import {
   Verse,
   VerseInline,
 } from '@/types/diary';
+import {
+  Bold,
+  InlineCode,
+  Italics,
+  Strikethrough,
+  Link,
+} from '@/types/content';
 
 export const isTalk = import.meta.env.VITE_APP === 'chat';
 
@@ -679,10 +686,50 @@ export function truncateProse(
       ]);
     }
 
+    if ('bold' in head) {
+      const truncatedString = (head.bold[0] as string).slice(0, remainingChars);
+      const truncatedBold: Bold = {
+        bold: [truncatedString],
+      };
+      return truncate(tail, remainingChars - truncatedString.length, [
+        ...acc,
+        truncatedBold,
+      ]);
+    }
+
+    if ('italics' in head) {
+      const truncatedString = (head.italics[0] as string).slice(
+        0,
+        remainingChars
+      );
+      const truncatedItalics: Italics = {
+        italics: [truncatedString],
+      };
+      return truncate(tail, remainingChars - truncatedString.length, [
+        ...acc,
+        truncatedItalics,
+      ]);
+    }
+
+    if ('strike' in head) {
+      const truncatedString = (head.strike[0] as string).slice(
+        0,
+        remainingChars
+      );
+      const truncatedStrike: Strikethrough = {
+        strike: [truncatedString],
+      };
+      return truncate(tail, remainingChars - truncatedString.length, [
+        ...acc,
+        truncatedStrike,
+      ]);
+    }
+
     return truncate(tail, remainingChars, [...acc, head]);
   };
 
   let remainingChars = maxCharacters;
+
   const truncatedContent: NoteContent = content
     .map((verse: Verse): Verse => {
       if ('inline' in verse) {


### PR DESCRIPTION
Fixes #2230

This PR updates the NoteReference component to use DiaryContent to render a truncated version of the content of a note, including formatting and block content.

Looks like this:

![image](https://github.com/tloncorp/landscape-apps/assets/1221094/afe7137b-aa2b-4b26-89b0-7acbaa283f52)
