### PR TITLE
leap: only show tiles we have charges for

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -67,13 +67,12 @@ import Leap from './components/Leap/Leap';
 import { isTalk, preSig } from './logic/utils';
 import bootstrap from './state/bootstrap';
 import AboutDialog from './components/AboutDialog';
-import UpdateNotice from './components/UpdateNotice';
 import MobileGroupChannelList from './groups/MobileGroupChannelList';
 import LandscapeWayfinding from './components/LandscapeWayfinding';
 import { useScheduler } from './state/scheduler';
 import { LeapProvider } from './components/Leap/useLeap';
 import VitaMessage from './components/VitaMessage';
-import Dialog, { DialogContent } from './components/Dialog';
+import Dialog from './components/Dialog';
 import useIsStandaloneMode from './logic/useIsStandaloneMode';
 import Eyrie from './components/Eyrie';
 import queryClient from './queryClient';
@@ -88,10 +87,8 @@ function SuspendedModal({ children }: { children: React.ReactNode }) {
   return (
     <Suspense
       fallback={
-        <Dialog defaultOpen modal>
-          <DialogContent className="bg-transparent" containerClass="w-full">
-            <LoadingSpinner />
-          </DialogContent>
+        <Dialog defaultOpen modal className="bg-transparent" close="none">
+          <LoadingSpinner />
         </Dialog>
       }
     >

--- a/ui/src/components/Grid/grid.tsx
+++ b/ui/src/components/Grid/grid.tsx
@@ -86,14 +86,15 @@ export default function Grid() {
   const navigate = useNavigate();
   const location = useLocation();
   const charges = useCharges();
+  const chargeKeys = Object.keys(charges);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { setIsOpen: setLeapIsOpen } = useLeap();
   const { order, loaded } = useTiles();
   const { mutate } = usePutEntryMutation({ bucket: 'tiles', key: 'order' });
-  const chargesLoaded = Object.keys(charges).length > 0;
-  const tilesToDisplay = order.filter(
-    (t) => t !== 'landscape' && t !== window.desk
-  );
+  const chargesLoaded = chargeKeys.length > 0;
+  const tilesToDisplay = order
+    .filter((t) => t !== 'landscape' && t !== window.desk)
+    .filter((t) => chargeKeys.includes(t));
   const totalTiles = tilesToDisplay.length;
   const gridRef = React.useRef<HTMLDivElement>(null);
   const gridWidth = gridRef.current?.clientWidth || 0;
@@ -150,7 +151,6 @@ export default function Grid() {
 
   useEffect(() => {
     const hasKeys = order && !!order.length;
-    const chargeKeys = Object.keys(charges);
     const hasChargeKeys = chargeKeys.length > 0;
 
     if (!loaded) {
@@ -172,7 +172,7 @@ export default function Grid() {
         val: uniq(order.filter((key) => key in charges).concat(chargeKeys)),
       });
     }
-  }, [charges, order, loaded, mutate]);
+  }, [chargeKeys, charges, order, loaded, mutate]);
 
   if (!chargesLoaded) {
     return <span>Loading...</span>;


### PR DESCRIPTION
Fixes #2483

Settings store may send us a tile order including a desk name that we don't have a charge for. We need to filter these desk names out by checking against the charges we actually have.

Also fixed an issue with the SuspendedModal fallback component looking weird since it was still using DialogContent.