### PR TITLE
note reference cleanup

### DIFF
--- a/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
+++ b/ui/src/chat/ChatInput/__snapshots__/ChatInput.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`ChatInput > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`ChatMessage > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/ui/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`Layout > renders as expected 1`] = `
 <div

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -64,7 +64,7 @@ function NoteReference({
   const prettyDate = makePrettyDate(new Date(outline.sent));
 
   return (
-    <div className="note-inline-block not-prose group max-w-[600px]">
+    <div className="note-inline-block group max-w-[600px]">
       <div
         onClick={handleOpenReferenceClick}
         className="flex cursor-pointer flex-col space-y-2 p-4 group-hover:bg-gray-50"

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -64,7 +64,7 @@ function NoteReference({
   const prettyDate = makePrettyDate(new Date(outline.sent));
 
   return (
-    <div className="note-inline-block group max-w-[600px]">
+    <div className="note-inline-block group max-w-[600px] text-base">
       <div
         onClick={handleOpenReferenceClick}
         className="flex cursor-pointer flex-col space-y-2 p-4 group-hover:bg-gray-50"

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`Sidebar > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/groups/GangPreview/__snapshots__/GangPreview.test.tsx.snap
+++ b/ui/src/groups/GangPreview/__snapshots__/GangPreview.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`GangPreview > renders preview 1`] = `
 <DocumentFragment>

--- a/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Vitest Snapshot v1
 
 exports[`ChannelList > renders as expected 1`] = `
 <DocumentFragment>


### PR DESCRIPTION
This fixes several issues with the new note references:

1) node types can be nested, so we need to ensure that we are truncating an actual string before calling slice. 
2) list items need to be truncated.
3) `not-prose` class should not be used on the NoteReference container as this will cause weird issues with the way we render the note (also...it is prose).