### PR TITLE
tests: check for tiles after login in auth setup

### DIFF
--- a/ui/e2e/auth.setup.ts
+++ b/ui/e2e/auth.setup.ts
@@ -12,4 +12,5 @@ setup('authenticate', async ({ page }) => {
   await page.getByRole('button', { name: 'Continue' }).click();
   await page.waitForURL('http://localhost:3000/apps/grid/');
   await page.context().storageState({ path: authFile });
+  await page.getByRole('link', { name: 'Menu Groups' }).click();
 });


### PR DESCRIPTION
We need to make sure the tiles actually load on landscape, this seems like a good place to do that. 

Note that this will only tell us if landscape/garden is working *with the version installed on the fake ships*, which is not updated before running this test. Also note that landscape/garden lives in a different repo, so I'm not sure how we want to handle copying/building landscape on these fake ships.

cc @jamesacklin 