### PR TITLE
emojis: fix issue when picker appears below message

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -28,7 +28,12 @@ import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { whomIsDm, whomIsMultiDm } from '@/logic/utils';
 import { useIsMobile } from '@/logic/useMedia';
-import { useChatHovering, useChatInfo, useChatStore } from '../useChatStore';
+import {
+  useChatDialog,
+  useChatHovering,
+  useChatInfo,
+  useChatStore,
+} from '../useChatStore';
 
 export interface ChatMessageProps {
   whom: string;
@@ -94,6 +99,7 @@ const ChatMessage = React.memo<
       const unread = chatInfo?.unread;
       const unreadId = unread?.brief['read-id'];
       const { hovering, setHovering } = useChatHovering(whom, writ.seal.id);
+      const { open: pickerOpen } = useChatDialog(whom, writ.seal.id, 'picker');
       const { ref: viewRef } = useInView({
         threshold: 1,
         onChange: useCallback(
@@ -228,8 +234,8 @@ const ChatMessage = React.memo<
           {newAuthor ? <Author ship={memo.author} date={unix} /> : null}
           <div className="group-one relative z-0 flex w-full">
             {hideOptions ||
-            (isScrolling && !hovering) ||
-            !hovering ||
+            isScrolling ||
+            (!hovering && !pickerOpen) ||
             // If we're the thread op, don't show options.
             // Options are shown for the threadOp in the main scroll window.
             (isThreadOp && !isThreadOnMobile) ? null : (

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -270,9 +270,13 @@ export default function ChatScroller({
   }, [scrollTo?.toString()]);
 
   const updateScroll = useRef(
-    debounce((e: boolean) => {
-      setIsScrolling(e);
-    }, 1000)
+    debounce(
+      (e: boolean) => {
+        setIsScrolling(e);
+      },
+      300,
+      { leading: true, trailing: true }
+    )
   );
 
   /**

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -71,7 +71,7 @@ export default function EmojiPicker({
       )}
       <Popover.Portal>
         <Popover.Content
-          className={isMobile ? '' : 'pl-[100px] pt-[100px]'}
+          className={isMobile ? '' : 'pl-[100px]'}
           side="bottom"
           sideOffset={30}
           collisionPadding={15}

--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -71,7 +71,6 @@ export default function EmojiPicker({
       )}
       <Popover.Portal>
         <Popover.Content
-          className={isMobile ? '' : 'pl-[100px]'}
           side="bottom"
           sideOffset={30}
           collisionPadding={15}


### PR DESCRIPTION
Fixes #2489 by removing the extra top padding around the picker.

I added the top padding in an attempt to prevent the picker from disappearing when a user accidentally moved their mouse above the picker while the picker was rendered *above* the message they are trying to react to, but didn't account for the fact that the picker sometimes renders below the message. When it appears below the message, this extra padding just pushes the picker too far and allows for a user to hover over another message and thus closes the picker.