### PR TITLE
chat: load favorite groups preview data when not available

### DIFF
--- a/ui/src/profiles/FavoriteGroup.tsx
+++ b/ui/src/profiles/FavoriteGroup.tsx
@@ -3,7 +3,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { useNavigate, useLocation } from 'react-router';
 import { useModalNavigate } from '@/logic/routing';
-import { useGang, useGroup } from '@/state/groups';
+import { useGang, useGangPreview, useGroup } from '@/state/groups';
 
 interface FavoriteGroupProps {
   groupFlag: string;
@@ -15,6 +15,7 @@ export default function FavoriteGroup({ groupFlag }: FavoriteGroupProps) {
   const group = useGroup(noShipGroupFlag);
   const location = useLocation();
   const gang = useGang(noShipGroupFlag);
+  const preview = useGangPreview(noShipGroupFlag, !!group);
   const navigate = useNavigate();
   const modalNavigate = useModalNavigate();
 
@@ -45,7 +46,11 @@ export default function FavoriteGroup({ groupFlag }: FavoriteGroupProps) {
     <Tooltip.Root>
       <Tooltip.Trigger asChild>
         <div onClick={onGroupClick} className="cursor-pointer">
-          <GroupAvatar {...group?.meta} image={data.image} size="h-14 w-14" />
+          <GroupAvatar
+            {...(group?.meta ?? preview?.meta)}
+            image={data.image}
+            size="h-14 w-14"
+          />
         </div>
       </Tooltip.Trigger>
       <Tooltip.Content

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -246,13 +246,13 @@ export function useGang(flag: string) {
   return data?.[flag] || defGang;
 }
 
-export const useGangPreview = (flag: string, isScrolling?: boolean) => {
+export const useGangPreview = (flag: string, disabled = false) => {
   const { data, ...rest } = useReactQuerySubscribeOnce<GroupPreview>({
     queryKey: ['gang-preview', flag],
     app: 'groups',
     path: `/gangs/${flag}/preview`,
     options: {
-      enabled: !isScrolling,
+      enabled: !disabled,
     },
   });
 


### PR DESCRIPTION
Resolves #2457 

Loads favorite Group metadata using gang preview if Group data is not present