### PR TITLE
roles: Fake out the "members" role on the frontend for channel perms

### DIFF
--- a/ui/src/channels/EditChannelForm.tsx
+++ b/ui/src/channels/EditChannelForm.tsx
@@ -70,13 +70,20 @@ export default function EditChannelForm({
 
   const onSubmit = useCallback(
     async (values: ChannelFormSchema) => {
-      const { privacy, ...nextChannel } = values;
+      const { privacy, readers, ...nextChannel } = values;
 
       if (presetSection) {
         nextChannel.zone = presetSection;
       }
       try {
-        mutateEditChannel({ flag: groupFlag, channel: nextChannel, nest });
+        mutateEditChannel({
+          flag: groupFlag,
+          channel: {
+            readers: readers.includes('members') ? [] : values.readers,
+            ...nextChannel,
+          },
+          nest,
+        });
       } catch (e) {
         console.log(e);
       }
@@ -97,12 +104,6 @@ export default function EditChannelForm({
         if (privacy === 'custom') {
           await chState.delSects(channelFlag, writersToRemove);
           await chState.addSects(channelFlag, values.writers);
-        }
-
-        if (privacy === 'read-only') {
-          // read-only for everyone but admin
-          await chState.delSects(channelFlag, writersToRemove);
-          await chState.addSects(channelFlag, ['admin']);
         }
       } else {
         await chState.delSects(channelFlag, sects);

--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { NewChannelFormSchema } from '@/types/groups';
-import { useNavigate, useParams } from 'react-router';
 import { useAddChannelMutation, useRouteGroup } from '@/state/groups';
 import { strToSym } from '@/logic/utils';
 import { useChatState } from '@/state/chat';
@@ -43,7 +43,7 @@ export default function NewChannelForm() {
 
   const onSubmit = useCallback(
     async (values: NewChannelFormSchema) => {
-      const { privacy, type, ...nextChannel } = values;
+      const { type, ...nextChannel } = values;
       const titleIsNumber = Number.isInteger(Number(values.meta.title));
       /*
         For now channel names are used as keys for pacts. Therefore we need to
@@ -99,8 +99,8 @@ export default function NewChannelForm() {
           name: channelName,
           title: values.meta.title,
           description: values.meta.description,
-          readers: values.readers,
-          writers: privacy === 'read-only' ? ['admin'] : values.writers,
+          readers: values.readers.includes('members') ? [] : values.readers,
+          writers: values.writers,
         });
       } catch (e) {
         console.log('NewChannelForm::onSubmit::createChannel', e);

--- a/ui/src/groups/ChannelsList/ChannelPermsSelector.tsx
+++ b/ui/src/groups/ChannelsList/ChannelPermsSelector.tsx
@@ -17,10 +17,6 @@ export const PRIVACY_TYPE: Record<ChannelPrivacyType, ChannelPrivacySetting> = {
     title: 'Open to All Members',
     description: 'Everyone can read and write',
   },
-  'read-only': {
-    title: 'Members Can Read Only',
-    description: 'Only admins can write',
-  },
   custom: {
     title: 'Custom',
     description: 'Specify which roles can read and write',
@@ -158,15 +154,19 @@ export default function PrivacySelector() {
   const flag = useRouteGroup();
   const group = useGroup(flag);
   const options = group?.cabals
-    ? Object.keys(group.cabals).map((c) => ({
-        value: c,
-        label: group.cabals[c].meta.title,
-      }))
+    ? Object.keys(group.cabals)
+        .map((c) => ({
+          value: c,
+          label: group.cabals[c].meta.title,
+        }))
+        .concat([{ value: 'members', label: 'Members' }])
     : [];
   const { watch, setValue, getValues } = useFormContext<ChannelFormSchema>();
   const { readers, writers } = getValues();
   const [readerRoles, setReaderRoles] = useState<RoleOption[]>(
-    options.filter((o) => readers.includes(o.value) || o.value === 'admin')
+    readers.length > 1
+      ? options.filter((o) => readers.includes(o.value) || o.value === 'admin')
+      : options
   );
   const [writerRoles, setWriterRoles] = useState<RoleOption[]>(
     options.filter((o) => writers.includes(o.value) || o.value === 'admin')

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -266,12 +266,11 @@ export function getPrivacyFromChannel(
     return 'public';
   }
 
-  if (groupChannel.readers.includes('admin')) {
+  if (
+    groupChannel.readers.includes('admin') ||
+    channel.perms.writers.includes('admin')
+  ) {
     return 'custom';
-  }
-
-  if (channel.perms.writers.includes('admin')) {
-    return 'read-only';
   }
 
   return 'public';

--- a/ui/src/types/groups.ts
+++ b/ui/src/types/groups.ts
@@ -347,7 +347,7 @@ export interface Gangs {
 
 export type PrivacyType = 'public' | 'private' | 'secret';
 
-export type ChannelPrivacyType = 'public' | 'read-only' | 'custom';
+export type ChannelPrivacyType = 'public' | 'custom';
 
 export type ChannelType = 'chat' | 'heap' | 'diary';
 


### PR DESCRIPTION
Fixes #2499

Also removes the "Members can read only" privacy type and sets the equivalent of that as the default when selecting "Custom" (user can then add/remove roles from that as necessary).