### PR TITLE
chat input: fix focus loss on mobile.

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -191,13 +191,17 @@ export default function ChatInput({
         sendDisabled ||
         mostRecentFile?.status === 'loading' ||
         mostRecentFile?.status === 'error' ||
-        mostRecentFile?.url === '' ||
-        (editor.getText() === '' && chatInfo.blocks.length === 0)
+        mostRecentFile?.url === ''
       )
         return;
 
       const blocks = fetchChatBlocks(id);
-      if (!editor.getText() && !blocks.length && !replyCite) {
+      if (
+        !editor.getText() &&
+        !blocks.length &&
+        !replyCite &&
+        chatInfo.blocks.length === 0
+      ) {
         return;
       }
 
@@ -279,7 +283,7 @@ export default function ChatInput({
       sendDisabled,
       replyCite,
       reply,
-      chatInfo.blocks,
+      chatInfo.blocks.length,
       mostRecentFile?.status,
       mostRecentFile?.url,
     ]


### PR DESCRIPTION
Not clear why this isn't always triggered on desktop, but adding `chatInfo.blocks` to the dependency array for the onSubmit useCallback was causing the ChatInput to lose focus after send on mobile after every message. I changed the dependency to `chatInfo.blocks.length` and that seems to have solved it. I also cleaned up the if statements at the top of onSubmit.

Fixes #2506