### PR TITLE
chat: streamline text selection colors; fix code block selection

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -125,7 +125,7 @@ export function InlineContent({
 
   if (isInlineCode(story)) {
     return (
-      <code className="inline-block rounded bg-gray-50 px-1.5 dark:bg-gray-100">
+      <code className="inline-block rounded bg-gray-100 px-1.5">
         {typeof story['inline-code'] === 'object' ? (
           <InlineContent story={story['inline-code']} />
         ) : (
@@ -137,7 +137,7 @@ export function InlineContent({
 
   if (isBlockCode(story)) {
     return (
-      <pre className="overflow-x-auto bg-gray-50 px-4 dark:bg-gray-100">
+      <pre className="overflow-x-auto bg-gray-100 px-4">
         <code>{story.code}</code>
       </pre>
     );
@@ -229,7 +229,7 @@ function ChatContent({
             if (firstBlockCode === 0 && firstBlockCode === lastBlockCode) {
               return (
                 <div
-                  className="rounded bg-gray-50 py-2 dark:bg-gray-100"
+                  className="rounded bg-gray-100 py-2"
                   style={{ maxWidth: 'calc(100% - 2rem)' }}
                 >
                   <InlineContent
@@ -243,7 +243,7 @@ function ChatContent({
             if (index === firstBlockCode) {
               return (
                 <div
-                  className="rounded bg-gray-50 pt-2 dark:bg-gray-100"
+                  className="rounded bg-gray-100 pt-2"
                   style={{ maxWidth: 'calc(100% - 2rem)' }}
                 >
                   <InlineContent
@@ -256,7 +256,7 @@ function ChatContent({
             if (index === lastBlockCode) {
               return (
                 <div
-                  className="rounded bg-gray-50 pb-2 dark:bg-gray-100"
+                  className="rounded bg-gray-100 pb-2"
                   style={{ maxWidth: 'calc(100% - 2rem)' }}
                 >
                   <InlineContent

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -45,7 +45,7 @@ a:not([class]) {
 }
 
 ::selection {
-  @apply bg-gray-100;
+  @apply bg-gray-200;
 }
 
 .alt-highlight::selection {
@@ -57,7 +57,7 @@ _::-webkit-full-page-media,
 _:future,
 :root .safari_only,
 body.dark ::selection {
-  @apply bg-gray-800;
+  @apply bg-gray-200;
 }
 
 button,


### PR DESCRIPTION
Resolves #2429 

Streamlines the text selection and code block background colors for both light and dark mode to enable the following:
- Code block background colors are not the same color as the on-hover message state
- Selection color is not the same color as code block background color

This enables visible selection in code blocks for both light and dark modes:

https://github.com/tloncorp/landscape-apps/assets/1013230/7c94358c-5250-4628-a9fb-b656a0ca8de8

