### PR TITLE
chat: fix duplicate %proxy cases in +di-agent

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1745,7 +1745,7 @@
     |=  [=wire =sign:agent:gall]
     ^+  di-core
     ?+    wire  ~|(bad-dm-take/wire !!)
-        [%proxy ~]
+        [%hark ~]
       ?>  ?=(%poke-ack -.sign)
       ?~  p.sign  di-core
       ::  TODO: handle?


### PR DESCRIPTION
When receiving a dm the `wire` in `+di-agent` (`app/chat.hoon`) is `/hark`.  When sending a dm the `wire` is `/proxy`.  You can see there were two `[%proxy ~]` cases in the `?+` when one of them should have been `[%hark ~]`.  (Shouldn't the compiler detect this?)

I tested this with a recent _released_ version of `%groups` (`fu6ca`), not the `HEAD` of the repository.  I wasn't able to `npm install` in `ui/`.
```
$ npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: landscape-apps@2.3.2
npm ERR! notsup Not compatible with your version of node/npm: landscape-apps@2.3.2
npm ERR! notsup Required: {"node":"16.19.1","npm":"8.19.3"}
npm ERR! notsup Actual:   {"npm":"9.6.4","node":"v20.0.0"}
```
This addresses https://github.com/tloncorp/landscape-apps/issues/2011.
I left a comment there about an issue creating a dm channel that I'm still looking into.