### PR TITLE
roles: fix issue with 'members' in channel writers

### DIFF
--- a/ui/src/channels/EditChannelForm.tsx
+++ b/ui/src/channels/EditChannelForm.tsx
@@ -96,15 +96,20 @@ export default function EditChannelForm({
           : useDiaryState.getState();
 
       if (privacy !== 'public') {
+        const writersIncludesMembers = values.writers.includes('members');
+
         const writersToRemove = _.difference(
           chan?.perms.writers || [],
           values.writers
         );
 
-        if (privacy === 'custom') {
+        if (writersIncludesMembers) {
+          await chState.delSects(channelFlag, sects);
+        } else {
           await chState.delSects(channelFlag, writersToRemove);
           await chState.addSects(channelFlag, values.writers);
         }
+
       } else {
         await chState.delSects(channelFlag, sects);
       }


### PR DESCRIPTION
Fixes #2511 by ensuring that we remove all sects from channel writer perms if "members" are allowed to write to a channel (e.g., putting us back in to "Open to All").