### PR TITLE
heap: fix for authors not receiving notifications for comments

### DIFF
--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -952,9 +952,8 @@
           ~
         =/  am-op-author  =(author.curio.u.op our.bowl)
         =/  am-author  =(author.heart our.bowl)
-        ?:  |(&(!am-author in-replies) &(am-op-author !am-author))
-          =.  cor  (emit (pass-hark & & yarn))
-        he-core
+        =?  cor  |(&(!am-author in-replies) &(am-op-author !am-author))
+          (emit (pass-hark & & yarn))
         he-core
       ==
     ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -933,7 +933,6 @@
             =/  curio  (~(get cur curios.heap) time)
             ?~  curio  %.n
             =(author.curio.u.curio our.bowl)
-        ?:  |(=(author.heart our.bowl) !in-replies)  he-core
         =/  content  (trip (flatten q.content.curio))
         =/  title
           ?:  !=(title.heart ~)  (need title.heart)
@@ -951,7 +950,11 @@
                 (flatten q.content.heart)
             ==
           ~
-        =.  cor  (emit (pass-hark & & yarn))
+        =/  am-op-author  =(author.curio.u.op our.bowl)
+        =/  am-author  =(author.heart our.bowl)
+        ?:  |(&(!am-author in-replies) &(am-op-author !am-author))
+          =.  cor  (emit (pass-hark & & yarn))
+        he-core
         he-core
       ==
     ::


### PR DESCRIPTION
Fixes #1872 by making sure that we emit a yarn in this particular instance. They would receive notifications if they were to follow up to the comment, but they weren't getting notified on the initial comment because their patp wasn't in the replies. Now they'll always be notified on any comment on their heap posts.

One question for @arthyn about why it's necessary to return he-core twice for this to compile.