### PR TITLE
groups: add "host offline" state

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -292,6 +292,10 @@
     ?.  ?=(%known -)  (hi-and-req-gang-index ship)
     (req-gang-index ship)
   ::
+      [%hi ship=@ ~]
+    =/  =ship  (slav %p ship.pole)
+    (hi-ship ship)
+  ::
      [%gangs ship=@ name=@ rest=*]
     =/  ship=@p  (slav %p ship.pole)
     ga-abet:(ga-watch:(ga-abed:gang-core ship name.pole) rest.pole)
@@ -341,6 +345,10 @@
       [%helm *]  cor
       [?(%hark %groups %chat %heap %diary) ~]  cor
       [%cast ship=@ name=@ ~]  (take-cast [(slav %p ship.pole) name.pole] sign)
+  ::
+      [%hi ship=@ ~]
+    =/  =ship  (slav %p ship.pole)
+    (take-hi ship sign)
   ::
       [%groups ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
@@ -1590,6 +1598,27 @@
   %-  emil
   :~  [%pass hi-wire %agent hi-dock %poke %helm-hi !>('')]
       [%pass gang-wire %agent gang-dock %watch `path`gang-wire]
+  ==
+::
+++  hi-ship
+  |=  =ship
+  ^+  cor
+  =/  hi-wire=wire  /hi/(scot %p ship)
+  =/  hi-dock=dock  [ship %hood]
+  %-  emil
+  :~  [%pass hi-wire %agent hi-dock %poke %helm-hi !>('')]
+  ==
+::
+++  take-hi
+  |=  [=ship =sign:agent:gall]
+  ^+  cor
+  =/  =path  /hi/(scot %p ship)
+  ?+  -.sign  !!
+      %kick  (emit %give %kick ~[path] ~)
+   ::
+      %poke-ack
+    =.  cor  (emit [%give %fact ~[path] hi-ship+!>(ship)])
+    (emit %give %kick ~[path] ~)
   ==
 ::
 ++  take-gang-index

--- a/desk/mar/hi-ship.hoon
+++ b/desk/mar/hi-ship.hoon
@@ -1,0 +1,14 @@
+/-  g=groups
+/+  j=groups-json
+|_  =ship:g
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  ship
+  ++  json  (ship:enjs:j ship)
+  --
+++  grab
+  |%
+  ++  noun  ship:g
+  --
+--

--- a/ui/src/channels/EditChannelForm.tsx
+++ b/ui/src/channels/EditChannelForm.tsx
@@ -109,7 +109,6 @@ export default function EditChannelForm({
           await chState.delSects(channelFlag, writersToRemove);
           await chState.addSects(channelFlag, values.writers);
         }
-
       } else {
         await chState.delSects(channelFlag, sects);
       }

--- a/ui/src/components/Sidebar/GroupListPlaceholder.tsx
+++ b/ui/src/components/Sidebar/GroupListPlaceholder.tsx
@@ -20,11 +20,19 @@ function GroupItemPlaceholder() {
 
 interface GroupListPlaceholderProps {
   count: number;
+  pulse?: boolean;
 }
 
-function GroupListPlaceholder({ count }: GroupListPlaceholderProps) {
+function GroupListPlaceholder({
+  count,
+  pulse = true,
+}: GroupListPlaceholderProps) {
   return (
-    <ul className="h-full animate-pulse space-y-3 p-2 sm:space-y-0">
+    <ul
+      className={cn('h-full space-y-3 p-2 sm:space-y-0', {
+        'animate-pulse': pulse,
+      })}
+    >
       {new Array(count).fill(true).map((_, i) => (
         <GroupItemPlaceholder key={i} />
       ))}

--- a/ui/src/groups/GroupSidebar/ChannelList.test.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/state/groups', () => ({
   useGroupFlag: () => fakeFlag,
   useVessel: () => fakeVessel,
   useGroupState: () => ({}),
+  useGroupConnection: () => true,
 }));
 
 vi.mock('@/logic/useMigrationInfo', () => ({

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -11,7 +11,12 @@ import {
   isChannelImported,
 } from '@/logic/utils';
 import { useIsMobile } from '@/logic/useMedia';
-import { useGroup, useGroupFlag, useVessel } from '@/state/groups';
+import {
+  useGroup,
+  useGroupConnection,
+  useGroupFlag,
+  useVessel,
+} from '@/state/groups';
 import SortIcon from '@/components/icons/SortIcon';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import useChannelSort from '@/logic/useChannelSort';
@@ -110,6 +115,7 @@ function UnmigratedChannel({
 export default function ChannelList({ className }: ChannelListProps) {
   const flag = useGroupFlag();
   const group = useGroup(flag);
+  const connected = useGroupConnection(flag);
   const briefs = useAllBriefs();
   const pendingImports = usePendingImports();
   const { hasStarted } = useStartedMigration(flag);
@@ -126,11 +132,17 @@ export default function ChannelList({ className }: ChannelListProps) {
       <div className={cn('h-full w-full flex-1 overflow-y-auto')}>
         <h2 className="px-4 pb-0 text-sm font-bold text-gray-400">
           <div className="flex justify-between">
-            Loading Channels
-            <LoadingSpinner className="h-4 w-4 text-gray-400" />
+            {!connected ? (
+              'Host is Offline.'
+            ) : (
+              <>
+                Loading Channels
+                <LoadingSpinner className="h-4 w-4 text-gray-400" />
+              </>
+            )}
           </div>
         </h2>
-        <GroupListPlaceholder count={15} />;
+        <GroupListPlaceholder count={15} pulse={connected} />;
       </div>
     );
   }

--- a/ui/src/groups/Groups.tsx
+++ b/ui/src/groups/Groups.tsx
@@ -4,6 +4,10 @@ import _ from 'lodash';
 import {
   useGang,
   useGroup,
+  useGroupConnection,
+  useGroupConnectionState,
+  useGroupHostHi,
+  useGroupIndex,
   useRouteGroup,
   useVessel,
 } from '@/state/groups/groups';
@@ -12,7 +16,7 @@ import { useHeapState } from '@/state/heap/heap';
 import { useDiaryState } from '@/state/diary';
 import { useIsMobile } from '@/logic/useMedia';
 import useRecentChannel from '@/logic/useRecentChannel';
-import { canReadChannel } from '@/logic/utils';
+import { canReadChannel, getFlagParts } from '@/logic/utils';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 
 function Groups() {
@@ -20,6 +24,9 @@ function Groups() {
   const flag = useRouteGroup();
   const group = useGroup(flag, true);
   const gang = useGang(flag);
+  const { ship } = getFlagParts(flag);
+  const { isError, isSuccess, isLoading, ...rest } = useGroupHostHi(ship);
+  const connection = useGroupConnection(flag);
   const vessel = useVessel(flag, window.our);
   const isMobile = useIsMobile();
   const root = useMatch({
@@ -27,6 +34,17 @@ function Groups() {
     end: true,
   });
   const { recentChannel } = useRecentChannel(flag);
+
+  useEffect(() => {
+    if (isLoading) {
+      useGroupConnectionState.getState().setGroupConnected(flag, true);
+    }
+    if (isError) {
+      useGroupConnectionState.getState().setGroupConnected(flag, false);
+    } else if (isSuccess) {
+      useGroupConnectionState.getState().setGroupConnected(flag, true);
+    }
+  }, [isError, isSuccess, isLoading, flag]);
 
   useEffect(() => {
     // 1) If we've initialized and the group doesn't exist and you don't have
@@ -73,6 +91,18 @@ function Groups() {
       }
     }
   }, [root, gang, group, vessel, isMobile, recentChannel, navigate]);
+
+  if (!connection && !group) {
+    return (
+      <div className="flex min-w-0 grow items-center justify-center bg-gray-50">
+        <div className="flex items-center justify-center">
+          <span className="ml-2 text-gray-600">
+            Group host ({ship}) is offline.
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   if (!group || group.meta.title === '') {
     return (


### PR DESCRIPTION
fixes #2414

looks like this:

![image](https://github.com/tloncorp/landscape-apps/assets/1221094/9a2994e0-d9f7-44d7-9f2a-b226b86399bb)

I added a new subscription path just for `hi`ing a ship, returns the ship name if it's successful, also added some UI state around disconnected ships (using zustand on the frontend).