### PR TITLE
update workflows to not reference janeway

### DIFF
--- a/.github/workflows/deploy-canary-groups.yml
+++ b/.github/workflows/deploy-canary-groups.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps groups binnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-canary-talk.yml
+++ b/.github/workflows/deploy-canary-talk.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps talk binnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-external-groups.yml
+++ b/.github/workflows/deploy-external-groups.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps groups doznec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-external-talk.yml
+++ b/.github/workflows/deploy-external-talk.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps talk doznec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-groups.yml
+++ b/.github/workflows/deploy-groups.yml
@@ -46,7 +46,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - name: 'glob'
@@ -76,7 +76,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -84,6 +84,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps groups wannec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-internal-groups.yml
+++ b/.github/workflows/deploy-internal-groups.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps groups marnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-internal-talk.yml
+++ b/.github/workflows/deploy-internal-talk.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps talk marnec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-livenet-groups.yml
+++ b/.github/workflows/deploy-livenet-groups.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps groups sogryp-dister-dozzod-dozzod us-central1-a mainnet ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-livenet-talk.yml
+++ b/.github/workflows/deploy-livenet-talk.yml
@@ -15,7 +15,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -23,6 +23,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps talk sogryp-dister-dozzod-dozzod us-central1-a mainnet ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -46,7 +46,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - name: 'glob'
@@ -77,7 +77,7 @@ jobs:
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.JANEWAY_SERVICE_KEY }}'
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - id: deploy
@@ -85,6 +85,6 @@ jobs:
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps talk wannec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
-          SSH_SEC_KEY: ${{ secrets.JANEWAY_SSH_SEC_KEY }}
-          SSH_PUB_KEY: ${{ secrets.JANEWAY_SSH_PUB_KEY }}
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
           URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}


### PR DESCRIPTION
We're not using the janeway service account anymore, so this changes out the references to be more generic. 