### PR TITLE
groups: allow users to navigate to "joining" state groups

### DIFF
--- a/ui/src/components/Sidebar/GangItem.tsx
+++ b/ui/src/components/Sidebar/GangItem.tsx
@@ -1,3 +1,4 @@
+import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { useIsMobile } from '@/logic/useMedia';
 import {
@@ -34,6 +35,27 @@ export default function GangItem(props: { flag: string }) {
     }
   };
 
+  if (!requested && !errored) {
+    return (
+      <SidebarItem
+        icon={
+          <GroupAvatar
+            {...preview?.meta}
+            size="h-12 w-12 sm:h-6 sm:w-6"
+            className="opacity-60"
+          />
+        }
+        actions={<GroupActions flag={flag} />}
+        className="px-4"
+        to={`/groups/${flag}`}
+      >
+        <span className="inline-block w-full truncate opacity-60">
+          {preview ? preview.meta.title : flag}
+        </span>
+      </SidebarItem>
+    );
+  }
+
   return (
     <Popover.Root>
       <Popover.Anchor>
@@ -46,6 +68,7 @@ export default function GangItem(props: { flag: string }) {
                 className="opacity-60"
               />
             }
+            className="px-4"
           >
             <span className="inline-block w-full truncate opacity-60">
               {preview ? preview.meta.title : flag}

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -12,7 +12,14 @@ import LeaveIcon from '@/components/icons/LeaveIcon';
 import useIsGroupUnread from '@/logic/useIsGroupUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { citeToPath, getPrivacyFromGroup, useCopy } from '@/logic/utils';
-import { useAmAdmin, useGroup } from '@/state/groups';
+import {
+  useAmAdmin,
+  useGang,
+  useGroup,
+  useGroupCancelMutation,
+} from '@/state/groups';
+import IconButton from '@/components/IconButton';
+import XIcon from '@/components/icons/XIcon';
 
 const { ship } = window;
 
@@ -59,11 +66,14 @@ type GroupActionsProps = PropsWithChildren<{
 const GroupActions = React.memo(
   ({ flag, className, children }: GroupActionsProps) => {
     const { isGroupUnread } = useIsGroupUnread();
+    const { preview, claim } = useGang(flag);
     const location = useLocation();
     const hasActivity = isGroupUnread(flag);
     const group = useGroup(flag);
     const privacy = group ? getPrivacyFromGroup(group) : 'public';
     const isAdmin = useAmAdmin(flag);
+    const { mutate: cancelJoinMutation, status: cancelJoinStatus } =
+      useGroupCancelMutation();
 
     const { isOpen, setIsOpen, isPinned, copyItemText, onCopy, onPinClick } =
       useGroupActions(flag);
@@ -153,6 +163,15 @@ const GroupActions = React.memo(
                   <LeaveIcon className="h-6 w-6" />
                   <span className="pr-2">Leave Group</span>
                 </Link>
+              </DropdownMenu.Item>
+            )}
+            {claim && (
+              <DropdownMenu.Item
+                className="dropdown-item flex items-center space-x-2 text-red hover:bg-red-soft hover:dark:bg-red-900"
+                onSelect={() => cancelJoinMutation({ flag })}
+              >
+                <XIcon className="h-6 w-6" />
+                <span className="pr-2">Cancel Join</span>
               </DropdownMenu.Item>
             )}
           </DropdownMenu.Content>

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -2,7 +2,12 @@ import cn from 'classnames';
 import _ from 'lodash';
 import React from 'react';
 import { useIsDark } from '@/logic/useMedia';
-import { useAmAdmin, useGroup, useGroupFlag } from '@/state/groups/groups';
+import {
+  useAmAdmin,
+  useGang,
+  useGroup,
+  useGroupFlag,
+} from '@/state/groups/groups';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import BellIcon from '@/components/icons/BellIcon';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
@@ -21,6 +26,7 @@ import InviteIcon from '@/components/icons/InviteIcon';
 function GroupHeader() {
   const flag = useGroupFlag();
   const group = useGroup(flag);
+  const { preview, claim } = useGang(flag);
   const defaultImportCover = group?.meta.cover === '0x0';
   const calm = useCalm();
   const isDark = useIsDark();
@@ -80,7 +86,9 @@ function GroupHeader() {
           icon={<GroupAvatar {...group?.meta} />}
           {...fgStyle()}
         >
-          <div className="max-w-[130px] truncate">{group?.meta.title}</div>
+          <div className="max-w-[130px] truncate">
+            {claim ? preview?.meta.title : group?.meta.title}
+          </div>
           <CaretDown16Icon className="absolute top-3 right-2 h-4 w-4" />
         </SidebarItem>
       </GroupActions>

--- a/ui/src/groups/Groups.tsx
+++ b/ui/src/groups/Groups.tsx
@@ -7,7 +7,6 @@ import {
   useGroupConnection,
   useGroupConnectionState,
   useGroupHostHi,
-  useGroupIndex,
   useRouteGroup,
   useVessel,
 } from '@/state/groups/groups';
@@ -25,7 +24,7 @@ function Groups() {
   const group = useGroup(flag, true);
   const gang = useGang(flag);
   const { ship } = getFlagParts(flag);
-  const { isError, isSuccess, isLoading, ...rest } = useGroupHostHi(ship);
+  const { isError, isSuccess, isLoading } = useGroupHostHi(ship);
   const connection = useGroupConnection(flag);
   const vessel = useVessel(flag, window.our);
   const isMobile = useIsMobile();
@@ -95,10 +94,18 @@ function Groups() {
   if (!connection && !group) {
     return (
       <div className="flex min-w-0 grow items-center justify-center bg-gray-50">
-        <div className="flex items-center justify-center">
+        <div className="flex flex-col items-center justify-center space-y-4">
           <span className="ml-2 text-gray-600">
             Group host ({ship}) is offline.
           </span>
+          <button
+            className="small-button"
+            onClick={() =>
+              useGroupConnectionState.getState().setGroupConnected(flag, true)
+            }
+          >
+            Retry
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes #2413 by allowing for users to navigate into a group that is currently in a "joining" state. Also:

- adds "Cancel Join" button to group actions (available from either the sidebar or the dropdown in the group header).
- adds "Retry" button to the "Group host is offline" screen.
- Fixes some CSS issues with "joining" groups listed in the sidebar.
- Shows the group's title from the gang preview in the group header if the group is in the "joining" state.