### PR TITLE
notebook refs: more fixes

### DIFF
--- a/ui/src/diary/DiaryContent/DiaryContent.tsx
+++ b/ui/src/diary/DiaryContent/DiaryContent.tsx
@@ -66,8 +66,8 @@ export function InlineContent({ story }: InlineContentProps) {
   if (_.isArray(story)) {
     return (
       <>
-        {story.map((s) => (
-          <InlineContent story={s} />
+        {story.map((s, k) => (
+          <InlineContent story={s} key={k} />
         ))}
       </>
     );
@@ -187,9 +187,9 @@ export function ListingContent({ content }: { content: DiaryListing }) {
         <InlineContent key={i} story={con} />
       ))}
       <List>
-        {content.list.items.map((i) => (
+        {content.list.items.map((con, i) => (
           <li>
-            <ListingContent content={i} />
+            <ListingContent key={i} content={con} />
           </li>
         ))}
       </List>
@@ -228,7 +228,7 @@ export const BlockContent = React.memo(({ story }: BlockContentProps) => {
     return (
       <Tag>
         {story.header.content.map((con, i) => (
-          <InlineContent key={i} story={con} />
+          <InlineContent key={`${con}-${i}`} story={con} />
         ))}
       </Tag>
     );


### PR DESCRIPTION
This fixes #2526 by preventing refs from being rendered within a notebook reference, also: 

- fixes some issues around the way we were calculating remainingChars (it was getting reset early)
-  limits the number of images that can be rendered in a ref (to one) 
- handles header text (which users can apparently add by pasting in content from somewhere else, this is not available directly in our UI)
- adds an ellipsis to the last inline string in the truncated text
- fixes the "missing keys in list" issue in DiaryContent.

You can test this by making some fake notes with lots of text, images, references, etc., and then embedding it as a reference somewhere.