### PR TITLE
groups: add channel descriptions

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -342,7 +342,12 @@ export default function ChannelHeader({
         <div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 p-1 text-center">
           <ChannelIcon nest={nest} className="h-5 w-5 text-gray-400" />
         </div>
-        <span className="ellipsis line-clamp-1">{channel?.meta.title}</span>
+        <div className="flex flex-col justify-center">
+          <span className="ellipsis line-clamp-1">{channel?.meta.title}</span>
+          <span className="ellipsis text-sm font-medium text-gray-400 line-clamp-1">
+            {channel?.meta.description}
+          </span>
+        </div>
       </BackButton>
       <div className="flex shrink-0 flex-row items-center space-x-3 self-end">
         {isMobile && <ReconnectingSpinner />}

--- a/ui/src/channels/EditChannelForm.tsx
+++ b/ui/src/channels/EditChannelForm.tsx
@@ -160,6 +160,14 @@ export default function EditChannelForm({
           />
         </label>
         <label className="mb-3 font-semibold">
+          Channel Description
+          <input
+            {...form.register('meta.description')}
+            className="input my-2 block w-full p-1"
+            type="text"
+          />
+        </label>
+        <label className="mb-3 font-semibold">
           Channel Permissions
           <ChannelPermsSelector />
         </label>

--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -143,6 +143,14 @@ export default function NewChannelForm() {
           />
         </label>
         <label className="mb-3 font-semibold">
+          Channel Description
+          <input
+            {...form.register('meta.description')}
+            className="input my-2 block w-full p-1"
+            type="text"
+          />
+        </label>
+        <label className="mb-3 font-semibold">
           Channel Permissions
           <ChannelPermsSelector />
         </label>


### PR DESCRIPTION
This fixes #2476 by surfacing up channel descriptions in the channel headers and the new/edit channel forms.

Looks like this:

![image](https://github.com/tloncorp/landscape-apps/assets/1221094/0cac231c-999d-4c3b-97c0-20fd58636eeb)
