### PR TITLE
hark: don't crash on empty %desks scry

### DIFF
--- a/desk/app/hark.hoon
+++ b/desk/app/hark.hoon
@@ -108,7 +108,7 @@
     (scry-rug rest.pole group/flag rug)
   ::
       [%x %desk desk=@ rest=*]
-    (scry-rug rest.pole desk/desk.pole (~(got by desks) desk.pole))
+    (scry-rug rest.pole desk/desk.pole (~(gut by desks) desk.pole *rug:h))
   ::
       [%x %yarn uid=@ ~]
     ``hark-yarn+!>((~(got by yarns) (slav %uv uid.pole)))


### PR DESCRIPTION
Was looking at some first-boot stuff, and was noticing this crash fairly frequently, eg when I refresh /apps/groups/find.  It looks to me like we're just scrying notifications from a desk (%groups) which hark has no entry for.  It seems like defaulting to an empty rug should be fine, but I don't actually know what the call-site is.  This does silence that crash, at least.