### PR TITLE
set emoji picker theme based on current theme

### DIFF
--- a/ui/src/components/EmojiPicker.tsx
+++ b/ui/src/components/EmojiPicker.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect } from 'react';
 import Picker from '@emoji-mart/react';
 import * as Popover from '@radix-ui/react-popover';
+import { useParams } from 'react-router';
 import useEmoji from '@/state/emoji';
 import { useDismissNavigate } from '@/logic/routing';
 import { useIsMobile } from '@/logic/useMedia';
-import { useParams } from 'react-router';
 import { useChatState } from '@/state/chat';
+import { useCurrentTheme } from '@/state/local';
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 
 interface EmojiPickerProps extends Record<string, any> {
@@ -30,6 +31,7 @@ export default function EmojiPicker({
     writShip: string;
     writTime: string;
   }>();
+  const currentTheme = useCurrentTheme();
   const whom = chShip ? `${chShip}/${chName}` : ship;
   const writId = `${writShip}/${writTime}`;
   const isMobile = useIsMobile();
@@ -84,6 +86,7 @@ export default function EmojiPicker({
                 autoFocus={isMobile}
                 perLine={isMobile ? mobilePerLineCount : 9}
                 previewPosition="none"
+                theme={currentTheme}
                 onEmojiSelect={isMobile ? onEmojiSelect : undefined}
                 {...props}
               />


### PR DESCRIPTION
Resolves https://github.com/tloncorp/talk-android/issues/7

Uses value from `useCurrentTheme` hook to set the emoji picker's theme