### PR TITLE
groups: unified channel headers

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -153,7 +153,7 @@ function ChannelActions({
       <Dropdown.Root open={dropdownIsOpen} onOpenChange={setDropdownIsOpen}>
         <Dropdown.Trigger asChild>
           <button
-            className="flex h-6 w-6 items-center justify-center rounded  text-gray-400 hover:bg-gray-50"
+            className="flex h-6 w-6 items-center justify-center rounded  text-gray-600 hover:bg-gray-50"
             aria-label="Channel Options"
           >
             <EllipsisIcon className="h-6 w-6" />
@@ -216,7 +216,7 @@ function HeapSortControls({
   return (
     <Dropdown.Root>
       <Dropdown.Trigger asChild>
-        <button className="flex h-6 w-6 items-center justify-center rounded  text-gray-400 hover:bg-gray-50 ">
+        <button className="flex h-6 w-6 items-center justify-center rounded  text-gray-600 hover:bg-gray-50 ">
           <SortIcon className="h-6 w-6" />
         </button>
       </Dropdown.Trigger>
@@ -251,7 +251,7 @@ function DiarySortControls({
   return (
     <Dropdown.Root>
       <Dropdown.Trigger asChild>
-        <button className="flex h-6 w-6 items-center justify-center rounded  text-gray-400 hover:bg-gray-50 ">
+        <button className="flex h-6 w-6 items-center justify-center rounded  text-gray-600 hover:bg-gray-50 ">
           <SortIcon className="h-6 w-6" />
         </button>
       </Dropdown.Trigger>
@@ -331,36 +331,36 @@ export default function ChannelHeader({
       <BackButton
         to={backTo()}
         className={cn(
-          'default-focus ellipsis inline-flex appearance-none items-center pr-2 text-lg font-bold text-gray-800 sm:text-base sm:font-semibold',
-          isMobile && ''
+          'default-focus ellipsis inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2',
+          isMobile && 'hover:bg-gray-50'
         )}
         aria-label="Open Channels Menu"
       >
         {isMobile ? (
-          <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
+          <CaretLeft16Icon className=" h-4 w-4 shrink-0 text-gray-600" />
         ) : null}
-        <div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 p-1 text-center">
-          <ChannelIcon nest={nest} className="h-5 w-5 text-gray-400" />
-        </div>
+        <ChannelIcon nest={nest} className="h-6 w-6 text-gray-600" />
         <div className="flex flex-col justify-center">
-          <span className="ellipsis line-clamp-1">{channel?.meta.title}</span>
+          <span className="ellipsis text-sm font-semibold line-clamp-1">
+            {channel?.meta.title}
+          </span>
           <span className="ellipsis text-sm font-medium text-gray-400 line-clamp-1">
             {channel?.meta.description}
           </span>
         </div>
       </BackButton>
-      <div className="flex shrink-0 flex-row items-center space-x-3 self-end">
+      <div className="flex shrink-0 flex-row items-center space-x-3">
         {isMobile && <ReconnectingSpinner />}
         {showControls && displayMode && setDisplayMode && setSortMode ? (
           <>
             {children}
             <Dropdown.Root>
               <Dropdown.Trigger asChild>
-                <button className="flex h-6 w-6 items-center justify-center rounded text-gray-400 hover:bg-gray-50 ">
+                <button className="flex h-6 w-6 items-center justify-center rounded text-gray-600 hover:bg-gray-50 ">
                   {displayMode === 'grid' ? (
-                    <GridIcon className="h-6 w-6 text-gray-400" />
+                    <GridIcon className="h-6 w-6" />
                   ) : (
-                    <ListIcon className="h-6 w-6 text-gray-400" />
+                    <ListIcon className="h-6 w-6" />
                   )}
                 </button>
               </Dropdown.Trigger>

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -325,26 +325,32 @@ export default function ChannelHeader({
   return (
     <div
       className={cn(
-        'flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4'
+        'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
       )}
     >
       <BackButton
         to={backTo()}
         className={cn(
-          'default-focus ellipsis inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2',
-          isMobile && 'hover:bg-gray-50'
+          'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
         )}
         aria-label="Open Channels Menu"
       >
         {isMobile ? (
-          <CaretLeft16Icon className=" h-4 w-4 shrink-0 text-gray-600" />
+          <div className="flex h-6 w-6 items-center justify-center">
+            <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
+          </div>
         ) : null}
-        <ChannelIcon nest={nest} className="h-6 w-6 text-gray-600" />
-        <div className="flex flex-col justify-center">
-          <span className="ellipsis text-sm font-semibold line-clamp-1">
+        <ChannelIcon nest={nest} className="h-6 w-6 shrink-0 text-gray-600" />
+        <div className="flex w-full flex-col justify-center">
+          <span
+            className={cn(
+              'ellipsis font-bold line-clamp-1 sm:font-semibold',
+              channel?.meta.description ? 'text-sm' : 'text-lg sm:text-sm'
+            )}
+          >
             {channel?.meta.title}
           </span>
-          <span className="ellipsis text-sm font-medium text-gray-400 line-clamp-1">
+          <span className="w-full break-all text-sm text-gray-400 line-clamp-1">
             {channel?.meta.description}
           </span>
         </div>

--- a/ui/src/diary/DiaryNoteHeader.tsx
+++ b/ui/src/diary/DiaryNoteHeader.tsx
@@ -22,26 +22,33 @@ export default function DiaryNoteHeader({
   return (
     <div
       className={cn(
-        'flex items-center justify-between border-b-2 border-b-2 border-gray-50 border-gray-50 bg-white px-6 py-4 sm:px-4'
+        'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
       )}
     >
       <Link
         to=".."
         className={cn(
-          'default-focus ellipsis -ml-2 -mt-2 -mb-2 inline-flex appearance-none items-center rounded-md p-2 pr-4 text-lg font-bold text-gray-800 hover:bg-gray-50 sm:text-base sm:font-semibold',
-          isMobile && ''
+          'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
         )}
         aria-label="Open Channels Menu"
       >
-        <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
-
-        <div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 p-1 text-center">
-          <ChannelIcon nest="diary" className="h-5 w-5 text-gray-400" />
+        <div className="flex h-6 w-6 items-center justify-center">
+          <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
         </div>
-        <span className="ellipsis line-clamp-1">{title}</span>
+
+        <ChannelIcon nest="diary" className="h-6 w-6 shrink-0 text-gray-600" />
+        <div className="flex w-full flex-col justify-center">
+          <span
+            className={cn(
+              'ellipsis text-lg font-bold line-clamp-1 sm:text-sm sm:font-semibold'
+            )}
+          >
+            {title}
+          </span>
+        </div>
       </Link>
 
-      <div className="flex shrink-0 flex-row items-center space-x-3 self-end">
+      <div className="flex shrink-0 flex-row items-center space-x-3">
         {isMobile && <ReconnectingSpinner />}
         {canEdit ? (
           <Link to={`../edit/${time}`} className="small-button">

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -133,26 +133,30 @@ export default function DiaryAddNote() {
       header={
         <header
           className={cn(
-            'flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4'
+            'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
           )}
         >
           <Link
             to={!editor?.getText() ? `../..` : `../../note/${id}`}
             className={cn(
-              'default-focus ellipsis -ml-2 -mt-2 -mb-2 inline-flex appearance-none items-center rounded-md p-2 pr-4 text-lg font-bold text-gray-800 hover:bg-gray-50 sm:text-base sm:font-semibold',
+              'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2',
               isMobile && ''
             )}
             aria-label="Exit Editor"
           >
-            <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
-
-            <div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 p-1 text-center">
-              <PencilIcon className="h-3 w-3 text-gray-400" />
+            <div className="flex h-6 w-6 items-center justify-center">
+              <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
             </div>
-            <span className="ellipsis line-clamp-1">Editing</span>
+
+            <div className="flex h-6 w-6 items-center justify-center">
+              <PencilIcon className="h-3 w-3 text-gray-600" />
+            </div>
+            <span className="ellipsis text-lg font-bold line-clamp-1 sm:text-sm sm:font-semibold">
+              Editing
+            </span>
           </Link>
 
-          <div className="flex shrink-0 flex-row items-center space-x-3 self-end">
+          <div className="flex shrink-0 flex-row items-center space-x-3">
             {isMobile && <ReconnectingSpinner />}
             <button
               disabled={!editor?.getText() || status === 'loading'}

--- a/ui/src/groups/MobileGroupChannelList.tsx
+++ b/ui/src/groups/MobileGroupChannelList.tsx
@@ -15,19 +15,25 @@ export default function MobileGroupChannelList() {
 
   return (
     <>
-      <header className="flex items-center justify-between border-b-2 border-gray-50 px-6 py-4">
+      <header className="flex items-center justify-between border-b-2 border-gray-50 py-2 pl-2 pr-6">
         <Link
           to="/"
-          className="default-focus inline-flex items-center text-base font-semibold text-gray-800"
+          className="default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2"
+          aria-label="Back to All Groups"
         >
-          <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
-          <GroupAvatar {...group?.meta} size="h-6 w-6" className="mr-3" />
-          <h1 className="shrink text-lg font-bold text-gray-800 line-clamp-1">
-            {group?.meta.title}
-          </h1>
+          <div className="flex h-6 w-6 items-center justify-center">
+            <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
+          </div>
+
+          <GroupAvatar {...group?.meta} size="h-6 w-6" />
+          <div className="flex w-full flex-col justify-center">
+            <h1 className="text-lg font-bold text-gray-800 line-clamp-1">
+              {group?.meta.title}
+            </h1>
+          </div>
         </Link>
 
-        <div className="flex flex-row items-center space-x-3 self-end">
+        <div className="flex flex-row items-center space-x-3">
           <ReconnectingSpinner />
           <ChannelSorter isMobile={true} />
           {isAdmin && (

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -63,33 +63,39 @@ export default function HeapDetailHeader({
       </Helmet>
       <div
         className={cn(
-          'flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4'
+          'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
         )}
       >
         <Link
-          to="../"
+          to=".."
           className={cn(
-            'default-focus ellipsis -ml-2 -mt-2 -mb-2 inline-flex max-w-md appearance-none items-center rounded-md p-2 pr-4 text-lg font-bold text-gray-800 hover:bg-gray-50 sm:text-base sm:font-semibold',
-            isMobile && ''
+            'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
           )}
-          aria-label="Back to Gallery"
+          aria-label="Open Channels Menu"
         >
-          <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
-          <div className=" mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 p-1 text-center">
-            <ChannelIcon nest="heap" className="h-5 w-5 text-gray-400" />
+          <div className="flex h-6 w-6 items-center justify-center">
+            <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
           </div>
-          <span className="whitespace-nobreak line-clamp-1">
-            {isCite ? 'Reference' : `${description()}: `}
-            {curioTitle && truncate({ str: curioTitle, n: 12 })}
-            {isImageLink && !curioTitle
-              ? truncate({ str: curioContent, n: 12 })
-              : null}
-            {!isImageLink && !curioTitle
-              ? truncate({ str: prettyDayAndTime, n: 12 })
-              : null}
-          </span>
+
+          <ChannelIcon nest="heap" className="h-6 w-6 shrink-0 text-gray-600" />
+          <div className="flex w-full flex-col justify-center">
+            <span
+              className={cn(
+                'ellipsis break-all text-lg font-bold line-clamp-1 sm:text-sm sm:font-semibold'
+              )}
+            >
+              {isCite ? 'Reference' : `${description()}: `}
+              {curioTitle && truncate({ str: curioTitle, n: 50 })}
+              {isImageLink && !curioTitle
+                ? truncate({ str: curioContent, n: 50 })
+                : null}
+              {!isImageLink && !curioTitle
+                ? truncate({ str: prettyDayAndTime, n: 50 })
+                : null}
+            </span>
+          </div>
         </Link>
-        <div className="shink-0 flex items-center space-x-3 self-end">
+        <div className="shink-0 flex items-center space-x-3">
           {isMobile && <ReconnectingSpinner />}
           {canEdit ? (
             <button onClick={onEdit} className="small-button">


### PR DESCRIPTION
Made another pass on the heels of #2476.
- Fixes an issue where URLs in descriptions would not wrap and therefore truncate artificially early (thanks to relying on line-break)
- Fixes an issue where long descriptions (particularly those with URLs) would push the content width past the viewport on mobile
- Removes the gray box around channel icons
- Ensures all headers match