### PR TITLE
channels: make sure we use unique timestamps

### DIFF
--- a/desk/lib/curios.hoon
+++ b/desk/lib/curios.hoon
@@ -41,19 +41,21 @@
   ?-  -.del
       %add
     =/  =seal:h  [new ~ ~]
-    ?:  (~(has by cur) new)
-      cur
     ~|  curio-failed-validation/p.del
     ?>  ?|  ?=(^ replying.p.del)
             ?&  ?=(^ title.p.del)
                 |(?=([~ ^] content.p.del) ?=([[* ~] ~] content.p.del))
             ==
         ==
-    =.  cur
-      (put:on:curios:h cur new [seal p.del])
-    ?~  replying.p.del  cur
-    =*  replying  u.replying.p.del
-    (jab replying |=(curio:h +<(replied (~(put in replied) new))))
+    |-
+    =/  curio  (get new)
+    ?~  curio
+      =.  cur  (put:on:curios:h cur new [seal p.del])
+      ?~  replying.p.del  cur
+      =*  replying  u.replying.p.del
+      (jab replying |=(curio:h +<(replied (~(put in replied) new))))
+    ?:  =(+.+.u.curio p.del)  cur
+    $(new `@da`(add new ^~((div ~s1 (bex 16)))))
   ::
       %edit
     =/  curio  (get existing)

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -59,6 +59,9 @@
     =/  =seal:c  [id ~ ~]
     ?:  (~(has by dex.pac) id)
       pac
+    |-
+    ?:  (has:on:writs:c wit.pac now)  
+      $(now `@da`(add now ^~((div ~s1 (bex 16)))))
     =.  wit.pac
       (put:on:writs:c wit.pac now seal p.del)
     =.  dex.pac  (~(put by dex.pac) id now)

--- a/desk/lib/notes.hoon
+++ b/desk/lib/notes.hoon
@@ -42,9 +42,11 @@
   ?-  -.del
       %add
     =/  =seal:d  [new ~ ~]
-    ?:  (~(has by not) new)
-      not
-    (put:on:notes:d not new [seal p.del])
+    |-
+    =/  note  (get new)
+    ?~  note  (put:on:notes:d not new [seal p.del])
+    ?:  =(+.+.u.note p.del)  not
+    $(new `@da`(add new ^~((div ~s1 (bex 16)))))
   ::
       %edit
     =/  note  (get existing)

--- a/desk/lib/quips.hoon
+++ b/desk/lib/quips.hoon
@@ -30,9 +30,11 @@
   ?-  -.del
       %add
     =/  =cork:d  [time ~]
-    ?:  (~(has by qup) time)
-      qup
-    (put:on:quips:d qup time [cork p.del])
+    |-
+    =/  quip  (get time)
+    ?~  quip  (put:on:quips:d qup time [cork p.del])
+    ?:  =(+.+.u.quip p.del)  qup
+    $(time `@da`(add time ^~((div ~s1 (bex 16)))))
   ::
       %del
     =^  no=(unit quip:d)  qup


### PR DESCRIPTION
This addresses #2544 by ensuring we have unique timestamps and we're not overriding previous messages. 