### PR TITLE
talk: unify DM and club headers

### DIFF
--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -17,22 +17,6 @@ import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import MessageSelector from './MessageSelector';
 
-function BackLink({
-  children,
-  mobile,
-}: {
-  children: React.ReactNode;
-  mobile: boolean;
-}) {
-  return mobile ? (
-    <Link className="no-underline" to="/">
-      {children}
-    </Link>
-  ) : (
-    <div>{children}</div>
-  );
-}
-
 export default function Dm() {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const ship = useParams<{ ship: string }>().ship!;
@@ -69,43 +53,51 @@ export default function Dm() {
           isSelecting ? (
             <MessageSelector />
           ) : (
-            <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4">
-              <BackLink mobile={isMobile}>
-                <BackButton
-                  to="/"
-                  className={cn(
-                    'default-focus ellipsis inline-flex appearance-none items-center pr-2 text-lg font-bold text-gray-800 sm:text-base sm:font-semibold'
-                  )}
-                  aria-label={isMobile ? 'Open Messages Menu' : undefined}
-                >
-                  {isMobile ? (
-                    <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
-                  ) : null}
-                  <div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 text-center">
-                    <Avatar size="xs" ship={ship} />
+            <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4">
+              <BackButton
+                to="/"
+                className={cn(
+                  'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
+                )}
+                aria-label="Open Messages Menu"
+              >
+                {isMobile ? (
+                  <div className="flex h-6 w-6 items-center justify-center">
+                    <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
                   </div>
-                  <span className="ellipsis text-gray-200 line-clamp-1">
-                    {contact?.nickname ? (
-                      <>
-                        <span className="text-gray-800">
-                          {contact.nickname}
-                        </span>
-                        <span className="ml-2 text-gray-400">{ship}</span>
-                      </>
-                    ) : (
-                      <span className="text-gray-800">{ship}</span>
-                    )}
-                  </span>
-                </BackButton>
-              </BackLink>
-              <div className="flex shrink-0 flex-row items-center space-x-3 self-end">
+                ) : null}
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-center">
+                  <Avatar size="xs" ship={ship} />
+                </div>
+                <div className="flex w-full flex-col justify-center">
+                  {contact?.nickname ? (
+                    <>
+                      <span
+                        className={cn(
+                          'ellipsis text-sm font-bold line-clamp-1 sm:font-semibold'
+                        )}
+                      >
+                        {contact.nickname}
+                      </span>
+                      <span className="w-full break-all text-sm text-gray-400 line-clamp-1">
+                        {ship}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-sm font-bold text-gray-800 sm:font-semibold">
+                      {ship}
+                    </span>
+                  )}
+                </div>
+              </BackButton>
+              <div className="flex shrink-0 flex-row items-center space-x-3">
                 {isMobile && <ReconnectingSpinner />}
                 {canStart ? (
                   <DmOptions
                     whom={ship}
                     pending={!isAccepted}
                     alwaysShowEllipsis
-                    className="text-gray-400"
+                    className="text-gray-600"
                   />
                 ) : null}
               </div>

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -15,6 +15,7 @@ import DMHero from '@/dms/DMHero';
 import useMessageSelector from '@/logic/useMessageSelector';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
+import ShipName from '@/components/ShipName';
 import MessageSelector from './MessageSelector';
 
 export default function Dm() {
@@ -79,14 +80,18 @@ export default function Dm() {
                       >
                         {contact.nickname}
                       </span>
-                      <span className="w-full break-all text-sm text-gray-400 line-clamp-1">
-                        {ship}
-                      </span>
+                      <ShipName
+                        full
+                        name={ship}
+                        className="w-full break-all text-sm text-gray-400 line-clamp-1"
+                      />
                     </>
                   ) : (
-                    <span className="text-sm font-bold text-gray-800 sm:font-semibold">
-                      {ship}
-                    </span>
+                    <ShipName
+                      full
+                      name={ship}
+                      className="text-sm font-bold text-gray-800 sm:font-semibold"
+                    />
                   )}
                 </div>
               </BackButton>

--- a/ui/src/dms/MultiDMPendingIndicator.tsx
+++ b/ui/src/dms/MultiDMPendingIndicator.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+
+export default function PendingIndicator({ hive }: { hive: string[] }) {
+  return (
+    <Tooltip.Root delayDuration={100} disableHoverableContent>
+      <Tooltip.Portal>
+        <Tooltip.Content asChild sideOffset={5} hideWhenDetached>
+          <div className="pointer-events-none z-40 justify-items-center rounded">
+            <div className="fit z-40 max-w-[10rem] cursor-none rounded bg-gray-400 px-4 py-2">
+              <label className="break-words font-semibold text-white">
+                {hive.map((ship) => `${ship}`).join(', ')}{' '}
+              </label>
+            </div>
+            <Tooltip.Arrow asChild>
+              <svg
+                width="17"
+                height="8"
+                viewBox="0 0 17 8"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.5 0L0.5 0L7.08579 6.58579C7.86684 7.36684 9.13316 7.36684 9.91421 6.58579L16.5 0Z"
+                  className="fill-gray-400"
+                />
+              </svg>
+            </Tooltip.Arrow>
+          </div>
+        </Tooltip.Content>
+      </Tooltip.Portal>
+      <Tooltip.Trigger asChild>
+        <span className="cursor-pointer text-blue"> {hive.length} Pending</span>
+      </Tooltip.Trigger>
+    </Tooltip.Root>
+  );
+}

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -21,6 +21,7 @@ import MultiDmAvatar from './MultiDmAvatar';
 import MultiDmHero from './MultiDmHero';
 import DmOptions from './DMOptions';
 import MessageSelector from './MessageSelector';
+import PendingIndicator from './MultiDMPendingIndicator';
 
 export default function MultiDm() {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -51,8 +52,7 @@ export default function MultiDm() {
   }
 
   const count = club.team.length;
-  const pendingCount = club.hive.length;
-  const hasPending = pendingCount > 0;
+  const hasPending = club.hive.length > 0;
   const groupName = club.meta.title || club.team.concat(club.hive).join(', ');
   const BackButton = isMobile ? Link : 'div';
 
@@ -64,40 +64,46 @@ export default function MultiDm() {
           isSelecting ? (
             <MessageSelector />
           ) : (
-            <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white px-6 py-4 sm:px-4">
+            <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4">
               <BackButton
                 to="/"
                 className={cn(
-                  'default-focus ellipsis inline-flex appearance-none items-center pr-2 text-lg font-bold text-gray-800 sm:text-base sm:font-semibold'
+                  'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
                 )}
-                aria-label={isMobile ? 'Open Messages Menu' : undefined}
+                aria-label="Open Messages Menu"
               >
                 {isMobile ? (
-                  <CaretLeft16Icon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
+                  <div className="flex h-6 w-6 items-center justify-center">
+                    <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
+                  </div>
                 ) : null}
-                <div className="mr-3 flex h-6 w-6 shrink-0 items-center justify-center rounded bg-gray-100 text-center">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-center">
                   <MultiDmAvatar {...club.meta} size="xs" />
                 </div>
-                <span className="ellipsis text-gray-400 line-clamp-1">
-                  <span className="text-gray-800">{groupName}</span>
-                  <span className="ml-2 text-gray-400">
+                <div className="flex w-full flex-col justify-center">
+                  <span
+                    className={cn(
+                      'ellipsis text-sm font-bold line-clamp-1 sm:font-semibold'
+                    )}
+                  >
+                    {groupName}
+                  </span>
+                  <span className="w-full break-all text-sm text-gray-400 line-clamp-1">
                     <span>{`${count} ${pluralize('Member', count)}${
                       hasPending ? ',' : ''
                     }`}</span>
-                    {hasPending ? (
-                      <span className="text-blue"> {pendingCount} Pending</span>
-                    ) : null}
+                    {hasPending ? <PendingIndicator hive={club.hive} /> : null}
                   </span>
-                </span>
+                </div>
               </BackButton>
-              <div className="flex shrink-0 flex-row items-center space-x-3 self-end">
+              <div className="flex shrink-0 flex-row items-center space-x-3">
                 {isMobile && <ReconnectingSpinner />}
                 <DmOptions
                   whom={clubId}
                   pending={!isAccepted}
                   isMulti
                   alwaysShowEllipsis
-                  className="text-gray-400"
+                  className="text-gray-600"
                 />
               </div>
             </div>

--- a/ui/src/dms/MultiDmHero.tsx
+++ b/ui/src/dms/MultiDmHero.tsx
@@ -4,6 +4,7 @@ import { pluralize } from '../logic/utils';
 import { Club } from '../types/chat';
 import MultiDmAvatar from './MultiDmAvatar';
 import ShipName from '../components/ShipName';
+import PendingIndicator from './MultiDMPendingIndicator';
 
 interface MultiDMHeroProps {
   club: Club;
@@ -46,9 +47,7 @@ export default function MultiDmHero({ club }: MultiDMHeroProps) {
         <span>{`${count} ${pluralize('Member', count)}${
           hasPending ? ',' : ''
         }`}</span>
-        {hasPending ? (
-          <span className="text-blue"> {pendingCount} Pending</span>
-        ) : null}
+        {hasPending ? <PendingIndicator hive={club.hive} /> : null}
       </div>
     </div>
   );


### PR DESCRIPTION
Unifies the Talk headers to match what I did in #2543.

Also (finally) lists the ships that are pending in a club behind the blue "Pending" label. 

![image](https://github.com/tloncorp/landscape-apps/assets/748181/8c35b27f-e094-4429-9145-80108badddf5)
