### PR TITLE
groups: adds role badges to Author component

### DIFF
--- a/ui/src/chat/ChatMessage/Author.tsx
+++ b/ui/src/chat/ChatMessage/Author.tsx
@@ -10,6 +10,7 @@ import { useLocation } from 'react-router';
 import { useModalNavigate } from '@/logic/routing';
 import Avatar from '@/components/Avatar';
 import ShipName from '@/components/ShipName';
+import RoleBadges from '@/components/RoleBadges';
 
 interface AuthorProps {
   ship: string;
@@ -74,6 +75,7 @@ export default function Author({
             />
           )}
         </div>
+        <RoleBadges ship={ship} />
       </div>
     );
   }
@@ -107,7 +109,7 @@ export default function Author({
           />
         )}
       </div>
-
+      <RoleBadges ship={ship} />
       {hideTime ? (
         <span className="-mb-0.5 hidden shrink-0 text-sm font-semibold text-gray-500 group-two-hover:block">
           {prettyDayAndTime}

--- a/ui/src/components/RoleBadges.tsx
+++ b/ui/src/components/RoleBadges.tsx
@@ -1,0 +1,73 @@
+import { getSectTitle } from '@/logic/utils';
+import { useGroup, useGroupFlag, useVessel } from '@/state/groups';
+import * as Tooltip from '@radix-ui/react-tooltip';
+
+export default function RoleBadges(props: { ship: string }) {
+  const { ship } = props;
+  const flag = useGroupFlag();
+  const group = useGroup(flag);
+  const { sects } = useVessel(flag, ship);
+
+  if (group && sects.length) {
+    if (sects.length >= 3) {
+      return (
+        <Tooltip.Provider>
+          <Tooltip.Root delayDuration={0}>
+            <Tooltip.Trigger asChild>
+              <div className="relative shrink-0 cursor-pointer rounded-full bg-gray-100 py-0.5 px-1.5 text-xs font-medium">
+                {sects.length}
+              </div>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content asChild>
+                <div className="z-50">
+                  <div className="z-[100] w-fit cursor-none rounded bg-gray-400 px-4 py-2">
+                    <label className="whitespace-nowrap font-semibold text-white">
+                      {sects.map((sect) => {
+                        if (sect !== 'member') {
+                          return <li>{getSectTitle(group.cabals, sect)}</li>;
+                        }
+                        return null;
+                      })}
+                    </label>
+                  </div>
+                  <Tooltip.Arrow asChild>
+                    <svg
+                      width="17"
+                      height="8"
+                      viewBox="0 0 17 8"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16.5 0L0.5 0L7.08579 6.58579C7.86684 7.36684 9.13316 7.36684 9.91421 6.58579L16.5 0Z"
+                        // fill="#999999"
+                        className="fill-gray-400"
+                      />
+                    </svg>
+                  </Tooltip.Arrow>
+                </div>
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>
+      );
+    }
+    return (
+      <div className="flex items-center space-x-1 overflow-auto">
+        {sects.map((sect) => {
+          if (sect !== 'member') {
+            return (
+              <span className="shrink-0 rounded-full bg-gray-100 py-0.5 px-1.5 text-xs font-medium">
+                {getSectTitle(group.cabals, sect)}
+              </span>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/ui/src/components/RoleBadges.tsx
+++ b/ui/src/components/RoleBadges.tsx
@@ -16,6 +16,7 @@ export default function RoleBadges(props: { ship: string }) {
             <Tooltip.Trigger asChild>
               <div className="relative shrink-0 cursor-pointer rounded-full bg-gray-100 py-0.5 px-1.5 text-xs font-medium">
                 {sects.length}
+                <span className="sr-only">Roles</span>
               </div>
             </Tooltip.Trigger>
             <Tooltip.Portal>


### PR DESCRIPTION
Adds visible role badges to the Author component. Ignores 'member' and overflows 3+ roles with a tooltip.

![image](https://github.com/tloncorp/landscape-apps/assets/748181/98caede1-292c-499d-b541-6fe96b8d867b)

![image](https://github.com/tloncorp/landscape-apps/assets/748181/5ae091ab-4b40-476a-b5cc-690465582725)
