### PR TITLE
groups: show members outside of routed group

### DIFF
--- a/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -27,7 +27,7 @@ export default function GroupMemberManager({
 }: GroupManagerProps) {
   const location = useLocation();
   const flag = useRouteGroup();
-  const group = useGroup(flag);
+  const group = useGroup(flag, true);
   const [rawInput, setRawInput] = useState('');
   const [search, setSearch] = useState('');
   const amAdmin = useAmAdmin(flag);

--- a/ui/src/groups/GroupAdmin/GroupPendingManager.tsx
+++ b/ui/src/groups/GroupAdmin/GroupPendingManager.tsx
@@ -19,7 +19,7 @@ const DA_BEGIN = daToUnix(bigInt('170141184492615420181573981275213004800'));
 
 export default function GroupPendingManager() {
   const flag = useRouteGroup();
-  const group = useGroup(flag);
+  const group = useGroup(flag, true);
   const [rawInput, setRawInput] = useState('');
   const [search, setSearch] = useState('');
 


### PR DESCRIPTION
Fixes an untracked bug caused by #2492 where accessing the group info or edit modals from outside the group context (i.e. via a group sidebar item in the the All Groups view) would only show you as a member.