### PR TITLE
groups: add group home, assorted fixes

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -287,7 +287,7 @@ function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
   return (
     <Notifications
       child={GroupNotification}
-      title={`All Notifications • ${appHead('').title}`}
+      title={`Activity • ${appHead('').title}`}
     />
   );
 }
@@ -304,7 +304,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
               element={
                 <Notifications
                   child={GroupNotification}
-                  title={`All Notifications • ${appHead('').title}`}
+                  title={`Activity • ${appHead('').title}`}
                 />
               }
             />

--- a/ui/src/components/Leap/MenuOptions.tsx
+++ b/ui/src/components/Leap/MenuOptions.tsx
@@ -39,7 +39,7 @@ export const groupsMenuOptions: IMenuOption[] = [
     modal: true,
   },
   {
-    title: 'Notifications',
+    title: 'Activity',
     subtitle: '',
     to: '/notifications',
     icon: CommandBadge,

--- a/ui/src/components/ShipSelector.tsx
+++ b/ui/src/components/ShipSelector.tsx
@@ -154,7 +154,7 @@ function NoShipsMessage() {
     <div className="flex content-center space-x-1 px-2 py-3">
       <ExclamationPoint className="mr-2 w-[18px] text-gray-300" />
       <span className="italic">
-        This is not a known alias or valid ship name.
+        This is not a known nickname or valid ship name (~sampel-palnet).
       </span>
     </div>
   );

--- a/ui/src/components/Sidebar/ActivityIndicator.tsx
+++ b/ui/src/components/Sidebar/ActivityIndicator.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames';
 import React from 'react';
-import BulletIcon from '../icons/BulletIcon';
+import BellIcon from '../icons/BellIcon';
 
 interface ActivityIndicatorProps {
   count: number;
@@ -17,12 +17,13 @@ export default function ActivityIndicator({
     <div
       className={cn(
         'flex h-6 w-6 items-center justify-center rounded text-sm font-semibold',
+        count === 0 ? 'bg-transparent' : 'bg-gray-100',
         bg,
         className
       )}
     >
       {count === 0 ? (
-        <BulletIcon className="m-0.5 h-5 w-5" />
+        <BellIcon className="m-0.5 h-5 w-5" />
       ) : count > 99 ? (
         '99+'
       ) : (

--- a/ui/src/components/Sidebar/ActivityIndicator.tsx
+++ b/ui/src/components/Sidebar/ActivityIndicator.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames';
 import React from 'react';
-import BellIcon from '../icons/BellIcon';
+import BulletIcon from '../icons/BulletIcon';
 
 interface ActivityIndicatorProps {
   count: number;
@@ -17,13 +17,12 @@ export default function ActivityIndicator({
     <div
       className={cn(
         'flex h-6 w-6 items-center justify-center rounded text-sm font-semibold',
-        count === 0 ? 'bg-transparent' : 'bg-gray-100',
         bg,
         className
       )}
     >
       {count === 0 ? (
-        <BellIcon className="m-0.5 h-5 w-5" />
+        <BulletIcon className="m-0.5 h-5 w-5" />
       ) : count > 99 ? (
         '99+'
       ) : (

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -165,7 +165,7 @@ export default function Sidebar() {
           to={`/notifications`}
           defaultRoute
         >
-          Notifications
+          Activity
         </SidebarItem>
         <SidebarItem
           icon={<MagnifyingGlass className="m-1 h-4 w-4" />}

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`Sidebar > renders as expected 1`] = `
           href="/notifications"
         >
           <div
-            class="flex h-6 w-6 items-center justify-center rounded text-sm font-semibold bg-gray-100"
+            class="flex h-6 w-6 items-center justify-center rounded text-sm font-semibold bg-transparent bg-gray-100"
           >
             <svg
               class="m-0.5 h-5 w-5"
@@ -244,21 +244,19 @@ exports[`Sidebar > renders as expected 1`] = `
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <rect
+              <path
                 class="fill-current"
-                height="8"
-                rx="4"
-                width="8"
-                x="8"
-                y="8"
+                clip-rule="evenodd"
+                d="M6 11a6.002 6.002 0 0 1 5-5.917V3h2v2.083c2.838.476 5 2.944 5 5.917v2.382l.764.382a2.236 2.236 0 0 1-1 4.236H15a3 3 0 1 1-6 0H6.236a2.236 2.236 0 0 1-1-4.236L6 13.382V11Zm5 7a1 1 0 1 0 2 0h-2Zm-3-7a4 4 0 1 1 8 0v2.902c0 .439.248.84.64 1.036l1.23.615a.236.236 0 0 1-.106.447H6.236a.236.236 0 0 1-.106-.447l1.23-.615c.392-.196.64-.597.64-1.036V11Z"
+                fill-rule="evenodd"
               />
             </svg>
           </div>
           <div
             class="max-w-full flex-1 text-left text-lg font-bold sm:text-base sm:font-semibold  truncate text-gray-800 sm:text-gray-600"
-            title="Notifications"
+            title="Activity"
           >
-            Notifications
+            Activity
           </div>
         </a>
       </div>

--- a/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/ui/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`Sidebar > renders as expected 1`] = `
           href="/notifications"
         >
           <div
-            class="flex h-6 w-6 items-center justify-center rounded text-sm font-semibold bg-transparent bg-gray-100"
+            class="flex h-6 w-6 items-center justify-center rounded text-sm font-semibold bg-gray-100"
           >
             <svg
               class="m-0.5 h-5 w-5"
@@ -244,11 +244,13 @@ exports[`Sidebar > renders as expected 1`] = `
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <path
+              <rect
                 class="fill-current"
-                clip-rule="evenodd"
-                d="M6 11a6.002 6.002 0 0 1 5-5.917V3h2v2.083c2.838.476 5 2.944 5 5.917v2.382l.764.382a2.236 2.236 0 0 1-1 4.236H15a3 3 0 1 1-6 0H6.236a2.236 2.236 0 0 1-1-4.236L6 13.382V11Zm5 7a1 1 0 1 0 2 0h-2Zm-3-7a4 4 0 1 1 8 0v2.902c0 .439.248.84.64 1.036l1.23.615a.236.236 0 0 1-.106.447H6.236a.236.236 0 0 1-.106-.447l1.23-.615c.392-.196.64-.597.64-1.036V11Z"
-                fill-rule="evenodd"
+                height="8"
+                rx="4"
+                width="8"
+                x="8"
+                y="8"
               />
             </svg>
           </div>

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -251,8 +251,15 @@ export default function FindGroups({ title }: ViewProps) {
             <div>
               <h1 className="text-lg font-bold">Join With Code</h1>
               <p className="mt-4 mb-8 leading-6 text-gray-600">
-                If you know the host id or shortcode of a public group, you can
-                enter it here to join.
+                If you know the{' '}
+                <abbr title="~sampel-palnet" className="cursor-help">
+                  host ID
+                </abbr>{' '}
+                or{' '}
+                <abbr title="~sampel-palnet/group-name" className="cursor-help">
+                  shortcode
+                </abbr>{' '}
+                of a public group, you can enter it here to join.
               </p>
               <label htmlFor="flag" className="mb-2 block font-semibold">
                 Host ID or Shortcode

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -22,6 +22,7 @@ import AddIcon from '@/components/icons/AddIcon';
 import { Link, useLocation } from 'react-router-dom';
 import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 import InviteIcon from '@/components/icons/InviteIcon';
+import HomeIcon from '@/components/icons/HomeIcon';
 
 function GroupHeader() {
   const flag = useGroupFlag();
@@ -117,7 +118,7 @@ export default function GroupSidebar() {
           <GroupHeader />
           <SidebarItem
             icon={
-              <BellIcon
+              <HomeIcon
                 className={cn('h-6 w-6 rounded', {
                   'mix-blend-multiply': !isDark,
                 })}
@@ -125,7 +126,7 @@ export default function GroupSidebar() {
             }
             to={`/groups/${flag}/activity`}
           >
-            Activity
+            Home
           </SidebarItem>
           <SidebarItem
             icon={

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -41,7 +41,11 @@ export default function MobileGroupSidebar() {
               <BellIcon className="mb-0.5 h-6 w-6" />
               Activity
             </NavTab>
-            <NavTab to={`/groups/${flag}/info`} className="basis-1/4">
+            <NavTab
+              to={`/groups/${flag}/info`}
+              className="basis-1/4"
+              state={{ backgroundLocation: location }}
+            >
               <GroupAvatar
                 {...group?.meta}
                 size="h-6 w-6"

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -146,7 +146,7 @@ export default function Notification({
     <div
       className={cn(
         'relative flex space-x-3 rounded-xl p-3 text-gray-600',
-        bin.unread ? 'bg-blue-soft dark:bg-blue-900' : 'bg-white'
+        bin.unread ? 'bg-blue-soft dark:bg-blue-900' : 'bg-gray-50'
       )}
     >
       <Link
@@ -176,7 +176,7 @@ export default function Notification({
           {mentionBool || commentBool || replyBool ? (
             <p
               className={cn(
-                'small-button bg-gray-50 text-gray-800',
+                'small-button bg-blue-soft text-blue',
                 moreCount > 0 ? 'mt-2' : 'mt-0'
               )}
             >

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -101,12 +101,9 @@ export default function Notifications({
   const MarkAsRead = (
     <button
       disabled={isMarkReadPending || !hasUnreads}
-      className={cn(
-        'small-button whitespace-nowrap text-sm',
-        {
-          'bg-gray-400 text-gray-800': isMarkReadPending || !hasUnreads,
-        }
-      )}
+      className={cn('small-button whitespace-nowrap text-sm', {
+        'bg-gray-400 text-gray-800': isMarkReadPending || !hasUnreads,
+      })}
       onClick={markAllRead}
     >
       {isMarkReadPending ? (
@@ -129,9 +126,11 @@ export default function Notifications({
         </header>
       )}
       <section className="flex h-full w-full flex-col space-y-6 overflow-y-scroll bg-gray-50 p-6">
-        <Helmet>
-          <title>{group ? `${group?.meta?.title} ${title}` : title}</title>
-        </Helmet>
+        {group && (
+          <Helmet>
+            <title>{group ? `${group.meta.title} ${title}` : title}</title>
+          </Helmet>
+        )}
 
         {group && (
           <div className="card">
@@ -158,7 +157,7 @@ export default function Notifications({
           {!isMobile && (
             <div className="mb-6 flex w-full items-center justify-between">
               <h2 className="text-lg font-bold">
-                {group && 'Group '} Activity {!group && ' in All Groups'}
+                {group && 'Group '}Activity{!group && ' in All Groups'}
               </h2>
               {hasUnreads && MarkAsRead}
             </div>

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -6,7 +6,7 @@ import React, {
   PropsWithChildren,
 } from 'react';
 import { Helmet } from 'react-helmet';
-import { useRouteGroup, useGroup } from '@/state/groups';
+import { useRouteGroup, useGroup, useAmAdmin } from '@/state/groups';
 import { ViewProps } from '@/types/groups';
 import { useSawRopeMutation, useSawSeamMutation } from '@/state/hark';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
@@ -14,6 +14,8 @@ import { useIsMobile } from '@/logic/useMedia';
 import { randomElement, randomIntInRange } from '@/logic/utils';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import { Skein } from '@/types/hark';
+import GroupSummary from '@/groups/GroupSummary';
+import { Link, useLocation } from 'react-router-dom';
 import { useNotifications } from './useNotifications';
 
 export interface NotificationsProps {
@@ -68,6 +70,8 @@ export default function Notifications({
   const flag = useRouteGroup();
   const group = useGroup(flag);
   const isMobile = useIsMobile();
+  const isAdmin = useAmAdmin(flag);
+  const location = useLocation();
   const [showMentionsOnly, setShowMentionsOnly] = useState(false);
   const { loaded, notifications, mentions, count } = useNotifications(
     flag,
@@ -98,11 +102,10 @@ export default function Notifications({
     <button
       disabled={isMarkReadPending || !hasUnreads}
       className={cn(
-        'whitespace-nowrap text-sm',
+        'small-button whitespace-nowrap text-sm',
         isMobile ? 'small-button' : 'button',
         {
           'bg-gray-400 text-gray-800': isMarkReadPending || !hasUnreads,
-          'bg-blue text-white': !isMarkReadPending && hasUnreads,
         }
       )}
       onClick={markAllRead}
@@ -126,57 +129,41 @@ export default function Notifications({
           </div>
         </header>
       )}
-      <section className="h-full w-full overflow-y-scroll bg-gray-50">
+      <section className="flex h-full w-full flex-col space-y-6 overflow-y-scroll bg-gray-50 p-6">
         <Helmet>
-          <title>
-            {group
-              ? `All Notifications for ${group?.meta?.title} ${title}`
-              : title}
-          </title>
+          <title>{group ? `${group?.meta?.title} ${title}` : title}</title>
         </Helmet>
 
-        <div className="p-6">
-          <div className="flex w-full items-center justify-between">
-            <div
-              className={cn('flex flex-row', {
-                'w-full justify-center': isMobile,
-              })}
-            >
-              <button
-                onClick={() => setShowMentionsOnly(false)}
-                className={cn(
-                  'button whitespace-nowrap rounded-r-none text-sm',
-                  {
-                    'bg-gray-800 text-white': !showMentionsOnly,
-                    'bg-white text-gray-800 ': showMentionsOnly,
-                    'small-button grow': isMobile,
-                  }
-                )}
-              >
-                All{' '}
-                <span className="hidden sm:inline">
-                  &nbsp;Notifications&nbsp;
-                </span>
-                {hasUnreads ? ` • ${count} New` : null}
-              </button>
-              <button
-                onClick={() => setShowMentionsOnly(true)}
-                className={cn(
-                  'button whitespace-nowrap rounded-l-none text-sm',
-                  {
-                    'bg-gray-800 text-white': showMentionsOnly,
-                    'bg-white text-gray-800': !showMentionsOnly,
-                    'small-button grow': isMobile,
-                  }
-                )}
-              >
-                Mentions Only
-                {mentions.length ? ` • ${mentions.length} New` : null}
-              </button>
+        {group && (
+          <div className="card">
+            <div className="flex w-full items-center justify-between">
+              <h2 className="mb-6 text-lg font-bold">Group Info</h2>
+              {isAdmin && (
+                <Link
+                  to={`/groups/${flag}/edit`}
+                  state={{ backgroundLocation: location }}
+                  className="small-button"
+                >
+                  Edit Group Details
+                </Link>
+              )}
             </div>
-
-            {!isMobile && hasUnreads && MarkAsRead}
+            <GroupSummary flag={flag} preview={{ ...group, flag }} />
+            <p className="prose-sm mt-4 leading-5 lg:max-w-sm">
+              {group?.meta.description}
+            </p>
           </div>
+        )}
+
+        <div className="card">
+          {!isMobile && (
+            <div className="mb-6 flex w-full items-center justify-between">
+              <h2 className="text-lg font-bold">
+                {group && 'Group '} Activity {!group && ' in All Groups'}
+              </h2>
+              {hasUnreads && MarkAsRead}
+            </div>
+          )}
 
           {loaded ? (
             notifications.length === 0 ? (
@@ -188,10 +175,12 @@ export default function Notifications({
             ) : (
               notifications.map((grouping) => (
                 <div key={grouping.date}>
-                  <h2 className="my-4 text-lg font-bold text-gray-400">
-                    {grouping.date}
-                  </h2>
-                  <ul className="space-y-2">
+                  {grouping.date !== 'Today' && (
+                    <h2 className="mb-4 text-lg font-bold text-gray-400">
+                      {grouping.date}
+                    </h2>
+                  )}
+                  <ul className="mb-4 space-y-2">
                     {grouping.skeins.map((b) => (
                       <li key={b.time}>
                         <Notification bin={b} />

--- a/ui/src/profiles/EditProfile/ProfileFields.tsx
+++ b/ui/src/profiles/EditProfile/ProfileFields.tsx
@@ -110,9 +110,8 @@ export default function ProfileFields() {
           Bio
         </label>
         <textarea
-          // TODO: set sane maxLength
           {...register('bio', { maxLength: 1000 })}
-          className="input"
+          className="input h-44"
           placeholder="Add a bio"
           spellCheck={`${!calm.disableSpellcheck}`}
         />


### PR DESCRIPTION
- Fixes #2554 by adjusting the in-group Activity feed to include the group summary, description, and an edit info button for admins. Also brings the notification list up to current design spec.
- Fixes #1369 by setting a height to the profile bio field somewhere around the max character count (1000).
- Fixes #2276 in Discover (ne Find) by adjusting the not-found error message and adding syntactic samples to the helper text above the field.
- Fixes an untracked bug brought about by #2492 where the Group Info nav item on mobile would not pop the group info dialog.

Preview of the group home for an admin (members don't see the "Edit Group Info" button):
![image](https://github.com/tloncorp/landscape-apps/assets/748181/e4ac4648-d045-48fe-8733-b06095848520)

---

Fixes LAND-235
Fixes LAND-277
