### PR TITLE
chat: fix crash on private group diary references

### DIFF
--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -404,7 +404,7 @@ export function useRemoteOutline(
     },
   });
 
-  if (rest.isLoading || rest.isError || data === undefined) {
+  if (rest.isLoading || rest.isError || !data) {
     return {} as DiaryOutline;
   }
 

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -408,9 +408,7 @@ export function useRemoteOutline(
     return {} as DiaryOutline;
   }
 
-  const { outline } = data as DiarySaid;
-
-  return outline as DiaryOutline;
+  return ((data as DiarySaid)?.outline ?? {}) as DiaryOutline;
 }
 
 export function useMarkReadDiaryMutation() {

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -408,7 +408,9 @@ export function useRemoteOutline(
     return {} as DiaryOutline;
   }
 
-  return ((data as DiarySaid)?.outline ?? {}) as DiaryOutline;
+  const { outline } = data as DiarySaid;
+
+  return outline as DiaryOutline;
 }
 
 export function useMarkReadDiaryMutation() {


### PR DESCRIPTION
Fixes crash when someone shares a diary reference to a group you don't have access to. `data` is `null` in this case, so `data === undefined` doesn't catch it

<img width="775" alt="Screenshot 2023-06-04 at 8 36 17 PM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/2bd7c5b0-d4f6-43b4-84f8-dd9c82713a16">
