### PR TITLE
groups: Update groups protocol number

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -22,7 +22,6 @@
         odd=&
         veb=|
     ==
-  ++  okay  `epic:e`0
   ++  club-eq  2 :: reverb control: max number of forwards for clubs
   +$  current-state
     $:  %2
@@ -54,7 +53,7 @@
       abet:init:cor
     [cards this]
   ::
-  ++  on-save  !>([state okay])
+  ++  on-save  !>([state okay:c])
   ++  on-load
     |=  =vase
     ^-  (quip card _this)
@@ -94,7 +93,7 @@
     [cards this]
   --
 |_  [=bowl:gall cards=(list card)]
-+*  epos  ~(. epos-lib [bowl %chat-update okay])
++*  epos  ~(. epos-lib [bowl %chat-update okay:c])
     wood   ~(. wood-lib [bowl wood-state])
 ++  abet  [(flop cards) state]
 ++  cor   .
@@ -105,12 +104,6 @@
 ++  init
   ^+  cor
   watch-groups
-::  +mar:  mark name
-++  mar
-  |%
-  ++  act  `mark`(rap 3 %chat-action '-' (scot %ud okay) ~)
-  ++  upd  `mark`(rap 3 %chat-update '-' (scot %ud okay) ~)
-  --
 ::  +load: load next state
 ++  load
   |=  =vase
@@ -124,7 +117,7 @@
       %2
     =.  state  old      
     =.  cor  restore-missing-subs
-    ?:  =(okay cool)  cor
+    ?:  =(okay:c cool)  cor
     :: =?  cor  bad  (emit (keep !>(old)))
     %-  (note:wood %ver leaf/"New Epic" ~)
     =.  cor  (emil (drop load:epos))
@@ -372,7 +365,7 @@
       [%dm %invited ~]  ?>(from-self cor)
   ::
       [%epic ~]
-    (give %fact ~ epic+!>(okay))
+    (give %fact ~ epic+!>(okay:c))
   ::
       [%said host=@ name=@ %msg sender=@ time=@ ~]
     =/  host=ship  (slav %p host.pole)
@@ -653,7 +646,7 @@
       %-  (note:wood %odd leaf/"!!! weird fact on /epic" ~)
       cor
     =+  !<(=epic:e q.cage.sign)
-    ?.  =(epic okay)  :: is now our guy
+    ?.  =(epic okay:c)  :: is now our guy
       cor
     %+  roll  ~(tap by chats)
     |=  [[=flag:g =chat:c] out=_cor]
@@ -1190,7 +1183,7 @@
     ^+  ca-core
     ?.  ?=(%sub -.net.chat)  ca-core
     ?.  ?=(%dex -.saga.net.chat)  ca-core
-    ?.  =(okay ver.saga.net.chat)
+    ?.  =(okay:c ver.saga.net.chat)
       %-  (note:wood %ver leaf/"%future-shock {<[ver.saga.net.chat flag]>}" ~)
       ca-core
     ca-make-chi
@@ -1370,9 +1363,9 @@
     |=  her=epic:e
     ^+  ca-core
     ?>  ?=(%sub -.net.chat)
-    ?:  =(her okay)
+    ?:  =(her okay:c)
       ca-make-chi
-    ?:  (gth her okay)
+    ?:  (gth her okay:c)
       =.  saga.net.chat  dex/her
       %-  (note:wood %ver leaf/"took dex epic: {<[flag her]>}" ~)
       ca-core
@@ -1383,7 +1376,7 @@
     ^+  ca-core
     ?>  ca-can-write
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  [act:mar !>([flag update])]
+    =/  =cage  [act:mar:c !>([flag update])]
     =.  cor
       (emit %pass ca-area %agent dock %poke cage)
     ca-core
@@ -1418,8 +1411,7 @@
       ?~  path  log.chat
       =/  =time  (slav %da i.path)
       (lot:log-on:c log.chat `time ~)
-    =/  =cage  chat-logs+!>(logs)
-    =.  cor  (give %fact ~ cage)
+    =.  cor  (give %fact ~ log:mar:c !>(logs))
     ca-core
   ::
   ++  ca-safe-sub
@@ -1485,10 +1477,10 @@
       %-  ~(gas in *(set path))
       (turn ~(tap in ca-subscriptions) tail)
     =.  paths  (~(put in paths) (snoc ca-area %ui))
-    =/  cag=cage  [upd:mar !>([time d])]
+    =/  cag=cage  [upd:mar:c !>([time d])]
     =.  cor
       (give %fact ~(tap in paths) cag)
-    =.  cor  (give %fact ~[/ui] act:mar !>([flag [time d]]))
+    =.  cor  (give %fact ~[/ui] act:mar:c !>([flag [time d]]))
     =?  cor  ?=(%writs -.d)
       =/  =cage  writ-diff+!>(p.d)
       (give %fact ~[(welp ca-area /ui/writs)] writ-diff+!>(p.d))

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -2,6 +2,7 @@
 /-  meta
 /-  ha=hark
 /-  e=epic
+/-  contacts
 /+  default-agent, verb-lib=verb, dbug
 /+  chat-json
 /+  pac=dm
@@ -1691,7 +1692,7 @@
     =/  =path  (snoc di-area %ui)
     =.  cor  (emit %give %fact ~[path] writ-diff+!>(diff))
     =/  =wire  /contacts/(scot %p ship)
-    =/  =cage  contact-action-0+!>([%heed ~[ship]])
+    =/  =cage  [act:mar:contacts !>(`action:contacts`[%heed ~[ship]])]
     =.  cor  (emit %pass wire %agent [our.bowl %contacts] %poke cage)
     =/  old-brief  di-brief
     =.  pact.dm  (reduce:di-pact now.bowl diff)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -453,7 +453,7 @@
       (slog tank u.p.sign)
     ::
         %fact
-      ?.  =(%group-action-0 p.cage.sign)  cor
+      ?.  =(act:mar:g p.cage.sign)  cor
       (take-groups !<(=action:g q.cage.sign))
     ==
   ==
@@ -1215,7 +1215,7 @@
       =/  =dock      [our.bowl %groups]  :: XX: which ship?
       =/  =wire      (snoc ca-area term)
       =.  cor
-        (emit %pass wire %agent dock %poke group-action-0+!>(action))
+        (emit %pass wire %agent dock %poke act:mar:g !>(action))
       ca-core
     ::
     ++  create-channel

--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -2,33 +2,6 @@
 /+  default-agent, dbug, verb
 ::
 |%
-::  [compat] protocol-versioning scheme
-::
-::    adopted from :groups, slightly modified.
-::
-::    for our action/update marks, we
-::      - *must* support our version (+okay)
-::      - *should* support previous versions (especially actions)
-::      - but *can't* support future versions
-::
-::    in the case of updates at unsupported protocol versions,
-::    we backoff and subscribe for version changes (/epic).
-::    (this alone is unlikely to help with future versions,
-::    but perhaps our peer will downgrade. in the meantime,
-::    we wait to be upgraded.)
-::
-+|  %compat
-++  okay  `epic`0
-++  mar
-  |%
-  ++  base
-    |%
-    +$  act  %contact-action
-    +$  upd  %contact-update
-    --
-  ++  act  `mark`^~((rap 3 *act:base '-' (scot %ud okay) ~))
-  ++  upd  `mark`^~((rap 3 *upd:base '-' (scot %ud okay) ~))
-  --
 ::  conventions
 ::
 ::    .con: a contact
@@ -173,7 +146,7 @@
         ++  fact
           |=  [pat=(set path) u=update]
           ^-  gift:agent:gall
-          [%fact ~(tap in pat) %contact-update-0 !>(u)]
+          [%fact ~(tap in pat) upd:mar !>(u)]
         --
     ::
     |%

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -11,7 +11,6 @@
 ^-  agent:gall
 =>
   |%
-  ++  okay  `epic:e`0
   +$  card  card:agent:gall
   +$  current-state
     $:  %0
@@ -36,7 +35,7 @@
       abet:init:cor
     [cards this]
   ::
-  ++  on-save  !>([state okay])
+  ++  on-save  !>([state okay:d])
   ++  on-load
     |=  =vase
     ^-  (quip card _this)
@@ -76,7 +75,7 @@
     [cards this]
   --
 |_  [=bowl:gall cards=(list card)]
-+*  epos  ~(. epos-lib [bowl %diary-update okay])
++*  epos  ~(. epos-lib [bowl %diary-update okay:d])
 ++  abet  [(flop cards) state]
 ++  cor   .
 ++  emit  |=(=card cor(cards [card cards]))
@@ -85,11 +84,6 @@
 ++  init
   ^+  cor
   watch-groups
-++  mar
-  |%
-  ++  act  `mark`(rap 3 %diary-action '-' (scot %ud okay) ~)
-  ++  upd  `mark`(rap 3 %diary-update '-' (scot %ud okay) ~)
-  --
 ++  load
   |=  =vase
   |^  ^+  cor
@@ -135,7 +129,7 @@
       ~&  '!!! weird fact on /epic'
       cor
     =+  !<(=epic:e q.cage.sign)
-    ?.  =(epic okay)
+    ?.  =(epic okay:d)
       cor
     ~&  >>  "good news everyone!"
     %+  roll  ~(tap by shelf)
@@ -358,7 +352,7 @@
       [%ui ~]      ?>(from-self cor)
       [%imp ~]      ?>(from-self cor)
     ::
-      [%epic ~]    (give %fact ~ epic+!>(okay))
+      [%epic ~]    (give %fact ~ epic+!>(okay:d))
     ::
       [%diary ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
@@ -453,7 +447,7 @@
     ::
         %watch-ack
       ?~  p.sign
-       (give %fact ~ epic+!>(okay))
+       (give %fact ~ epic+!>(okay:d))
       =/  =tank
         leaf/"Failed groups subscription in {<dap.bowl>}, unexpected"
       ((slog tank u.p.sign) cor)
@@ -599,7 +593,7 @@
       di-core
     ?.  ?=(%dex -.saga.net.diary)
       di-core
-    ?.  =(okay ver.saga.net.diary)
+    ?.  =(okay:d ver.saga.net.diary)
       ~&  future-shock/[ver.saga.net.diary flag]
       di-core
     =>  .(saga.net.diary `saga:e`saga.net.diary)
@@ -738,9 +732,9 @@
     |=  her=epic:e
     ^+  di-core
     ?>  ?=(%sub -.net.diary)
-    ?:  =(her okay)
+    ?:  =(her okay:d)
       di-core
-    ?:  (gth her okay)
+    ?:  (gth her okay:d)
       =.  saga.net.diary  dex+her
       di-core
     di-make-lev
@@ -783,7 +777,7 @@
     ^+  di-core
     ?>  di-can-write
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  [act:mar !>([flag update])]
+    =/  =cage  [act:mar:d !>([flag update])]
     =.  cor
       (emit %pass di-area %agent dock %poke cage)
     di-core
@@ -818,8 +812,7 @@
       ?~  path  log.diary
       =/  =time  (slav %da i.path)
       (lot:log-on:d log.diary `time ~)
-    =/  =cage  diary-logs+!>(log)
-    =.  cor  (give %fact ~ cage)
+    =.  cor  (give %fact ~ log:mar:d !>(log))
     di-core
   ::
   ++  di-sub
@@ -877,8 +870,8 @@
       %-  ~(gas in *(set path))
       (turn ~(tap in di-subscriptions) tail)
     =.  paths  (~(put in paths) (snoc di-area %ui))
-    =.  cor  (give %fact ~[/ui] act:mar !>([flag [time d]]))
-    =/  cag=cage  [upd:mar !>([time d])]
+    =.  cor  (give %fact ~[/ui] act:mar:^d !>([flag [time d]]))
+    =/  cag=cage  [upd:mar:^d !>([time d])]
     =.  cor
       (give %fact ~(tap in paths) cag)
     di-core

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -459,7 +459,7 @@
       ((slog tank u.p.sign) cor)
     ::
         %fact
-      ?.  =(%group-action-0 p.cage.sign)  cor
+      ?.  =(act:mar:g p.cage.sign)  cor
       (take-groups !<(=action:g q.cage.sign))
     ==
   ==
@@ -656,7 +656,7 @@
       =/  =dock      [our.bowl %groups] :: [p.p.action %groups] XX: check?
       =/  =wire      (snoc di-area term)
       =.  cor
-        (emit %pass wire %agent dock %poke group-action-0+!>(action))
+        (emit %pass wire %agent dock %poke act:mar:g !>(action))
       di-core
     ::
     ++  create-channel

--- a/desk/app/grouper.hoon
+++ b/desk/app/grouper.hoon
@@ -108,7 +108,8 @@
         :-  now.bowl
         :-  %cordon
         [%shut [%add-ships %pending (~(gas in *(set ship)) ~[joiner.bite])]]
-      ~[[%pass /invite %agent [our.bowl %groups] %poke %group-action !>(action)]]
+      :_  ~
+      [%pass /invite %agent [our.bowl %groups] %poke act:mar:groups !>(action)]
     ==
   ==
 ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -212,7 +212,7 @@
       =/  =action:c  [+.nest [now.bowl [%del-sects writers.perms]]]
       =/  =wire  /chat
       =/  =dock  [our.bowl %chat]
-      =/  =cage  chat-action-0+!>(action)
+      =/  =cage  [act:mar:c !>(action)]
       [%pass wire %agent dock %poke cage]
     ::
         %diary

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -11,7 +11,7 @@
 ^-  agent:gall
 =>
   |%
-  ++  okay  `epic:e`0
+  ++  okay  `epic:e`1
   +$  card  card:agent:gall
   ++  import-epoch  ~2022.10.11
   +$  current-state
@@ -139,7 +139,7 @@
     =.  cor  (give-invites flag ~(key by members.create))
     go-abet:(go-init:(go-abed:group-core flag) ~)
   ::
-      ?(%group-action %group-action-0)
+      ?(%group-action-1 %group-action-0)
     =+  !<(=action:g vase)
     =.  p.q.action  now.bowl
     =/  group-core  (go-abed:group-core p.action)
@@ -986,10 +986,10 @@
       =*  cage  cage.sign
       ::  XX: does init need to be handled specially?
       ?+  p.cage  (go-odd-update p.cage)
-        %epic                             (go-take-epic !<(epic:e q.cage))
-        ?(%group-log-0 %group-log)        (go-apply-log !<(log:g q.cage))
-        ?(%group-update-0 %group-update)  (go-update !<(update:g q.cage))
-        ?(%group-init-0 %group-init)      (go-fact-init !<(init:g q.cage))
+        %epic            (go-take-epic !<(epic:e q.cage))
+        %group-log-1     (go-apply-log !<(log:g q.cage))
+        %group-update-1  (go-update !<(update:g q.cage))
+        %group-init-1    (go-fact-init !<(init:g q.cage))
       ==
     ==
   ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -230,7 +230,7 @@
       =/  =action:h  [+.nest [now.bowl [%del-sects writers.perms]]]
       =/  =wire  /heap
       =/  =dock  [our.bowl %heap]
-      =/  =cage  heap-action-0+!>(action)
+      =/  =cage  [act:mar:h !>(action)]
       [%pass wire %agent dock %poke cage]
     ==
   core

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -11,7 +11,6 @@
 ^-  agent:gall
 =>
   |%
-  ++  okay  `epic:e`1
   +$  card  card:agent:gall
   ++  import-epoch  ~2022.10.11
   +$  current-state
@@ -36,7 +35,7 @@
     ^-  (quip card _this)
     `this
   ::
-  ++  on-save  !>([state okay])
+  ++  on-save  !>([state okay:g])
   ++  on-load
     |=  =vase
     ^-  (quip card _this)
@@ -76,7 +75,7 @@
     [cards this]
   --
 |_  [=bowl:gall cards=(list card)]
-+*  epos  ~(. epos-lib [bowl %group-update okay])
++*  epos  ~(. epos-lib [bowl %group-update okay:g])
 ++  abet  [(flop cards) state]
 ++  cor   .
 ++  emit  |=(=card cor(cards [card cards]))
@@ -87,11 +86,6 @@
   ^-  ?(%alien %known)
   =-  (fall (~(get by -) ship) %alien)
   .^((map ^ship ?(%alien %known)) %ax /(scot %p our.bowl)//(scot %da now.bowl)/peers)
-++  mar
-  |%
-  ++  act  `mark`(rap 3 %group-action '-' (scot %ud okay) ~)
-  ++  upd  `mark`(rap 3 %group-update '-' (scot %ud okay) ~)
-  --
 ++  poke
   |=  [=mark =vase]
   ^+  cor
@@ -208,7 +202,7 @@
       =/  wire  /groups
       =/  dock  [our.bowl dap.bowl]
       =/  =action:g  [flag [now.bowl [%channel nest [%del-sects readers.channel]]]]
-      =/  cage  group-action+!>(action)
+      =/  cage  [act:mar:g !>(action)]
       [%pass wire %agent dock %poke cage]
     ^-  card
     ?+  -.nest  *card
@@ -218,7 +212,7 @@
       =/  =action:c  [+.nest [now.bowl [%del-sects writers.perms]]]
       =/  =wire  /chat
       =/  =dock  [our.bowl %chat]
-      =/  =cage  chat-action+!>(action)
+      =/  =cage  chat-action-0+!>(action)
       [%pass wire %agent dock %poke cage]
     ::
         %diary
@@ -227,7 +221,7 @@
       =/  =action:d  [+.nest [now.bowl [%del-sects writers.perms]]]
       =/  =wire  /diary
       =/  =dock  [our.bowl %diary]
-      =/  =cage  diary-action+!>(action)
+      =/  =cage  diary-action-0+!>(action)
       [%pass wire %agent dock %poke cage]
     ::
         %heap
@@ -236,7 +230,7 @@
       =/  =action:h  [+.nest [now.bowl [%del-sects writers.perms]]]
       =/  =wire  /heap
       =/  =dock  [our.bowl %heap]
-      =/  =cage  heap-action+!>(action)
+      =/  =cage  heap-action-0+!>(action)
       [%pass wire %agent dock %poke cage]
     ==
   core
@@ -248,7 +242,7 @@
   =+  !<([old=versioned-state cool=epic:e] vase)
   =.  state  old
   =.  cor  restore-missing-subs
-  ?:  =(okay cool)  cor
+  ?:  =(okay:g cool)  cor
   =.  cor  (emil (drop load:epos))
   =/  groups  ~(tap in ~(key by groups))
   |-
@@ -275,7 +269,7 @@
     [%groups %ui ~]       cor
     [%gangs %updates ~]   cor
   ::
-    [%epic ~]  (give %fact ~ epic+!>(okay))
+    [%epic ~]  (give %fact ~ epic+!>(okay:g))
   ::
       [%bait s=@ n=@ gs=@ gn=@ ~]
     =,(pole (cast [(slav %p gs) gn] [(slav %p s) n]))
@@ -365,8 +359,6 @@
     =/  =ship  (slav %p ship.pole)
     =/  =nest:g  [app.pole ship name.pole]
     (take-chan nest sign)
-
-
   ==
 ::
 ++  arvo
@@ -438,7 +430,7 @@
       ~&  [p.cage.sign '!!! weird fact on /epic']
       cor
     =+  !<(=epic:e q.cage.sign)
-    ?.  =(epic okay)  cor
+    ?.  =(epic okay:g)  cor
     ~&  >>  "good news everyone!"
     %+  roll  ~(tap by groups)
     |=  [[=flag:g =net:g =group:g] out=_cor]
@@ -525,7 +517,7 @@
     =/  cage  group-invite+!>(`invite:g`[flag ship])
     =/  line  `wire`/gangs/(scot %p p.flag)/[q.flag]/invite
     [%pass line %agent [ship dap.bowl] %poke cage]
-
+::
 ++  import-groups
   |=  =imports:g
   ^+  cor
@@ -625,7 +617,6 @@
     %graph-validator-link     `%heap
     %graph-validator-publish  `%diary
   ==
-
   ::
   ++  graph-meta-to-agent
     |=  =metadatum:m-one
@@ -684,7 +675,7 @@
     %^  scry  %gx  %metadata-store
     `path`[%group (snoc old-flag-path %noun)]
   --
-
+::
 ++  group-core
   |_  [=flag:g =net:g =group:g gone=_|]
   ++  go-core  .
@@ -696,7 +687,7 @@
     ?.  gone  cor
     =?  cor  !=(p.flag our.bowl)  (emit leave:go-pass)
     =/  =action:g  [flag now.bowl %del ~]
-    (give %fact ~[/groups/ui] act:mar !>(action))
+    (give %fact ~[/groups/ui] act:mar:g !>(action))
   ++  go-abed
     |=  f=flag:g
     ^+  go-core
@@ -754,7 +745,7 @@
       =/  =wire  (snoc go-area %proxy)
       =/  =dock  [p.flag dap.bowl]
       =/  =cage
-        :-  act:mar
+        :-  act:mar:g
         !>  ^-  action:g
         [flag now.bowl %fleet (silt our.bowl ~) %del ~]
       [%pass wire %agent dock %poke cage]
@@ -950,7 +941,7 @@
     ^+  go-core
     ?.  ?=(%sub -.net)       go-core
     ?.  ?=(%dex -.saga.net)  go-core
-    ?.  =(okay ver.saga.net)
+    ?.  =(okay:g ver.saga.net)
       ~&  future-shock/[ver.saga.net flag]
       go-core
     go-make-chi
@@ -959,9 +950,9 @@
     |=  her=epic:e
     ^+  go-core
     ?>  ?=(%sub -.net)
-    ?:  =(her okay)
+    ?:  =(her okay:g)
       go-make-chi
-    ?:  (gth her okay)
+    ?:  (gth her okay:g)
       =.  saga.net  dex+her
       go-core
     go-make-lev
@@ -1024,7 +1015,7 @@
     ?>  ?|(go-is-bloc ?&(?=(%fleet -.diff) ?=([%add ~] q.diff)))
     =/  =wire  (snoc go-area %proxy)
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  group-action+!>([flag update])
+    =/  =cage  [act:mar:g !>([flag update])]
     =.  cor  (emit %pass wire %agent dock %poke cage)
     go-core
   ::
@@ -1037,12 +1028,12 @@
       go-core
     ?:  ?=([%init ~] path)
       =/  [=time *]  (need (ram:log-on:g p.net))
-      group-init+!>([time group])
+      [int:mar:g !>([time group])]
     ?>  ?=([@ ~] path)
     =/  =time  (slav %da i.path)
     =/  =log:g
       (lot:log-on:g p.net `time ~)
-    group-log+!>(log)
+    [log:mar:g !>(log)]
   ::
   ++  go-apply-log
     |=  =log:g
@@ -1064,7 +1055,7 @@
       ?.  (go-can-read our.bowl channel)  ~
       [~ ch]
     =.  cor
-      (give %fact ~[/groups /groups/ui] act:mar !>(`action:g`[flag now.bowl create]))
+      (give %fact ~[/groups /groups/ui] act:mar:g !>(`action:g`[flag now.bowl create]))
     =.  cor
       (give %fact ~[/groups /groups/ui] gang-gone+!>(flag))
     =.  cor
@@ -1082,9 +1073,9 @@
       (~(put in out) path)
     =.  paths  (~(put in paths) (snoc go-area %ui))
     =.  cor
-      (give %fact ~(tap in paths) upd:mar !>(`update:g`[time diff]))
+      (give %fact ~(tap in paths) upd:mar:g !>(`update:g`[time diff]))
     =.  cor
-      (give %fact ~[/groups /groups/ui] act:mar !>(`action:g`[flag time diff]))
+      (give %fact ~[/groups /groups/ui] act:mar:g !>(`action:g`[flag time diff]))
     go-core
   ::
   ++  go-tell-update
@@ -1667,16 +1658,16 @@
     ++  add-self
       =/  =vessel:fleet:g  [~ now.bowl]
       =/  =action:g  [flag now.bowl %fleet (silt ~[our.bowl]) %add ~]
-      (poke-host /join/add act:mar !>(action))
+      (poke-host /join/add act:mar:g !>(action))
     ::
     ++  knock
       =/  ships=(set ship)  (~(put in *(set ship)) our.bowl)
       =/  =action:g  [flag now.bowl %cordon %shut %add-ships %ask ships]
-      (poke-host /knock act:mar !>(action))
+      (poke-host /knock act:mar:g !>(action))
     ++  rescind
       =/  ships=(set ship)  (~(put in *(set ship)) our.bowl)
       =/  =action:g  [flag now.bowl %cordon %shut %del-ships %ask ships]
-      (poke-host /rescind act:mar !>(action))
+      (poke-host /rescind act:mar:g !>(action))
     ++  get-preview
       =/  =task:agent:gall  [%watch /groups/(scot %p p.flag)/[q.flag]/preview]
       (pass-host /preview task)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -221,7 +221,7 @@
       =/  =action:d  [+.nest [now.bowl [%del-sects writers.perms]]]
       =/  =wire  /diary
       =/  =dock  [our.bowl %diary]
-      =/  =cage  diary-action-0+!>(action)
+      =/  =cage  [act:mar:d !>(action)]
       [%pass wire %agent dock %poke cage]
     ::
         %heap

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -302,7 +302,7 @@
       (slog tank u.p.sign)
     ::
         %fact
-      ?.  =(%group-action-0 p.cage.sign)  cor
+      ?.  =(act:mar:g p.cage.sign)  cor
       (take-groups !<(=action:g q.cage.sign))
     ==
   ==
@@ -627,7 +627,7 @@
       =/  =dock      [our.bowl %groups] :: XX which ship
       =/  =wire      (snoc he-area term)
       =.  cor
-        (emit %pass wire %agent dock %poke group-action-0+!>(action))
+        (emit %pass wire %agent dock %poke act:mar:g !>(action))
       he-core
     ::
     ++  create-channel

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -8,7 +8,6 @@
 ^-  agent:gall
 =>
   |%
-  ++  okay  `epic:e`0
   +$  card  card:agent:gall
   +$  current-state
     $:  %0
@@ -34,7 +33,7 @@
       abet:init:cor
     [cards this]
   ::
-  ++  on-save  !>([state okay])
+  ++  on-save  !>([state okay:h])
   ++  on-load
     |=  =vase
     ^-  (quip card _this)
@@ -74,7 +73,7 @@
     [cards this]
   --
 |_  [=bowl:gall cards=(list card)]
-+*  epos  ~(. epos-lib [bowl %heap-update okay])
++*  epos  ~(. epos-lib [bowl %heap-update okay:h])
 ++  abet  [(flop cards) state]
 ++  cor   .
 ++  emit  |=(=card cor(cards [card cards]))
@@ -87,12 +86,6 @@
 ++  watch-groups
   ^+  cor
   (emit %pass /groups %agent [our.bowl %groups] %watch /groups)
-::
-++  mar
-  |%
-  ++  act  `mark`(rap 3 %heap-action '-' (scot %ud okay) ~)
-  ++  upd  `mark`(rap 3 %heap-update '-' (scot %ud okay) ~)
-  --
 ::
 ++  poke
   |=  [=mark =vase]
@@ -177,7 +170,7 @@
   =+  !<([old=versioned-state cool=epic:e] vase)
   =.  state  old
   =.  cor  restore-missing-subs
-  ?:  =(okay cool)  cor
+  ?:  =(okay:h cool)  cor
   ::  speak the good news
   =.  cor  (emil (drop load:epos))
   =/  heaps  ~(tap in ~(key by stash))
@@ -205,7 +198,7 @@
       [%ui ~]      ?>(from-self cor)
       [%imp ~]     ?>(from-self cor)
     ::
-      [%epic ~]    (give %fact ~ epic+!>(okay))
+      [%epic ~]    (give %fact ~ epic+!>(okay:h))
     ::
       [%heap ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)
@@ -327,7 +320,7 @@
       ~&  '!!! weird fact on /epic'
       cor
     =+  !<(=epic:e q.cage.sign)
-    ?.  =(epic okay)
+    ?.  =(epic okay:h)
       cor
     ~&  >>  "good news everyone!"
     %+  roll  ~(tap by stash)
@@ -593,7 +586,7 @@
     ^+  he-core
     ?.  ?=(%sub -.net.heap)  he-core
     ?.  ?=(%dex -.saga.net.heap)  he-core
-    ?.  =(okay ver.saga.net.heap)
+    ?.  =(okay:h ver.saga.net.heap)
       ~&  future-shock/[ver.saga.net.heap flag]
       he-core
     he-make-chi
@@ -715,9 +708,9 @@
     |=  her=epic:e
     ^+  he-core
     ?>  ?=(%sub -.net.heap)
-    ?:  =(her okay)
+    ?:  =(her okay:h)
       he-make-chi
-    ?:  (gth her okay)
+    ?:  (gth her okay:h)
       =.  saga.net.heap  dex+her
       he-core
     he-make-lev
@@ -775,7 +768,7 @@
     ^+  he-core
     ?>  he-can-write
     =/  =dock  [p.flag dap.bowl]
-    =/  =cage  [act:mar !>([flag update])]
+    =/  =cage  [act:mar:h !>([flag update])]
     =.  cor
       (emit %pass he-area %agent dock %poke cage)
     he-core
@@ -810,8 +803,7 @@
       ?~  path  log.heap
       =/  =time  (slav %da i.path)
       (lot:log-on:h log.heap `time ~)
-    =/  =cage  heap-logs+!>(log)
-    =.  cor  (give %fact ~ cage)
+    =.  cor  (give %fact ~ log:mar:h !>(log))
     he-core
   ::
   ++  he-has-sub
@@ -878,10 +870,10 @@
       %-  ~(gas in *(set path))
       (turn ~(tap in he-subscriptions) tail)
     =.  paths  (~(put in paths) (snoc he-area %ui))
-    =/  cag=cage  [upd:mar !>([time d])]
+    =/  cag=cage  [upd:mar:h !>([time d])]
     =.  cor
       (give %fact ~(tap in paths) cag)
-    =.  cor  (give %fact ~[/ui] act:mar !>([flag [time d]]))
+    =.  cor  (give %fact ~[/ui] act:mar:h !>([flag [time d]]))
     he-core
   ::
   ++  he-remark-diff

--- a/desk/gen/chat/delete.hoon
+++ b/desk/gen/chat/delete.hoon
@@ -6,7 +6,7 @@
         [[[her=ship name=term] =id:c ~] ~]
     ==
 ::
-:-  %chat-action
+:-  act:mar:c
 ^-  action:c
 :-  [her name]
 :-  now

--- a/desk/gen/chat/react.hoon
+++ b/desk/gen/chat/react.hoon
@@ -6,7 +6,7 @@
         [[[her=ship name=term] =id:c =term ~] ~]
     ==
 ::
-:-  %chat-action
+:-  act:mar:c
 ^-  action:c
 :-  [her name]
 :-  now

--- a/desk/gen/chat/send.hoon
+++ b/desk/gen/chat/send.hoon
@@ -10,7 +10,7 @@
   [~ mess]
 =/  =memo:c
   [~ p.beak now story/story]
-:-  %chat-action
+:-  act:mar:c
 ^-  action:c
 :-  [her name]
 :-  now

--- a/desk/gen/diary/migrate.hoon
+++ b/desk/gen/diary/migrate.hoon
@@ -13,7 +13,7 @@
       p.beak
       now
   ==
-:-  %diary-action
+:-  act:mar:d
 ^-  action:d
 :-  [her name]
 :-  now

--- a/desk/gen/groups/add-member.hoon
+++ b/desk/gen/groups/add-member.hoon
@@ -6,7 +6,7 @@
     ==
 ::
 =|  =vessel:fleet:g
-:-  %group-action
+:-  act:mar:g
 ^-  action:g
 :-  [her name]
 :-  now

--- a/desk/gen/groups/add-zone.hoon
+++ b/desk/gen/groups/add-zone.hoon
@@ -7,7 +7,7 @@
     ==
 ::
 =|  =vessel:fleet:g
-:-  %group-action
+:-  act:mar:g
 ^-  action:g
 =/  meta=data:meta  ['title' 'description' '' '']
 :-  [her name]

--- a/desk/gen/groups/ban-ship.hoon
+++ b/desk/gen/groups/ban-ship.hoon
@@ -5,7 +5,7 @@
         [[[her=ship name=term] =ship ~] ~]
     ==
 ::
-:-  %group-action
+:-  act:mar:g
 ^-  action:g
 :-  [her name]
 :-  now

--- a/desk/gen/groups/rm-member.hoon
+++ b/desk/gen/groups/rm-member.hoon
@@ -6,7 +6,7 @@
     ==
 ::
 =|  =vessel:fleet:g
-:-  %group-action
+:-  act:mar:g
 ^-  action:g
 :-  [her name]
 :-  now

--- a/desk/gen/groups/update-cordon.hoon
+++ b/desk/gen/groups/update-cordon.hoon
@@ -5,7 +5,7 @@
         [[[her=ship name=term] =diff:cordon:g ~] ~]
     ==
 ::
-:-  %group-action
+:-  act:mar:g
 ^-  action:g
 :-  [her name]
 :-  now

--- a/desk/gen/heap/edit.hoon
+++ b/desk/gen/heap/edit.hoon
@@ -4,7 +4,7 @@
         [[[her=ship name=term] id=time title=@t mess=(list inline:h) ~] ~]
     ==
 ::
-:-  %heap-action
+:-  act:mar:h
 ^-  action:h
 =/  cur=diff:curios:h
   :-  id

--- a/desk/gen/heap/pile.hoon
+++ b/desk/gen/heap/pile.hoon
@@ -4,7 +4,7 @@
         [[[her=ship name=term] mess=(list inline:c) op=(unit time) ~] ~]
     ==
 ::
-:-  %heap-action
+:-  act:mar:h
 ^-  action:h
 =/  curio
   :-  [now *(map ship feel:h) *(set time)]

--- a/desk/lib/saga.hoon
+++ b/desk/lib/saga.hoon
@@ -24,6 +24,3 @@
   |=  =mark
   =(upd (end [3 (met 3 upd)] mark))
 --
-  
-
-

--- a/desk/mar/group/action-1.hoon
+++ b/desk/mar/group/action-1.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/action-0
 mark

--- a/desk/mar/group/action-2.hoon
+++ b/desk/mar/group/action-2.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/group/init-1.hoon
+++ b/desk/mar/group/init-1.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/init-0
 mark

--- a/desk/mar/group/init-2.hoon
+++ b/desk/mar/group/init-2.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/group/log-1.hoon
+++ b/desk/mar/group/log-1.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/log-0
 mark

--- a/desk/mar/group/log-2.hoon
+++ b/desk/mar/group/log-2.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/group/update-1.hoon
+++ b/desk/mar/group/update-1.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/update-0
 mark

--- a/desk/mar/group/update-2.hoon
+++ b/desk/mar/group/update-2.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -10,6 +10,14 @@
   ++  zero  zer
   ++  one  uno
   --
+::  +mar:  mark name
+++  okay  `epic:e`0
+++  mar
+  |%
+  ++  act  `mark`(rap 3 %chat-action '-' (scot %ud okay) ~)
+  ++  upd  `mark`(rap 3 %chat-update '-' (scot %ud okay) ~)
+  ++  log  `mark`(rap 3 %chat-logs '-' (scot %ud okay) ~)
+  --
 ::
 ::  $scan: search results
 +$  scan  (list writ)

--- a/desk/sur/contacts.hoon
+++ b/desk/sur/contacts.hoon
@@ -1,5 +1,35 @@
 /-  e=epic, g=groups
 |%
+::  [compat] protocol-versioning scheme
+::
+::    adopted from :groups, slightly modified.
+::
+::    for our action/update marks, we
+::      - *must* support our version (+okay)
+::      - *should* support previous versions (especially actions)
+::      - but *can't* support future versions
+::
+::    in the case of updates at unsupported protocol versions,
+::    we backoff and subscribe for version changes (/epic).
+::    (this alone is unlikely to help with future versions,
+::    but perhaps our peer will downgrade. in the meantime,
+::    we wait to be upgraded.)
+::
++|  %compat
+++  okay  `epic`0
+++  mar
+  |%
+  ++  base
+    |%
+    +$  act  %contact-action
+    +$  upd  %contact-update
+    --
+  ::
+  ++  act  `mark`^~((rap 3 *act:base '-' (scot %ud okay) ~))
+  ++  upd  `mark`^~((rap 3 *upd:base '-' (scot %ud okay) ~))
+  --
+::
++|  %types
 +$  contact
   $:  nickname=@t
       bio=@t

--- a/desk/sur/diary.hoon
+++ b/desk/sur/diary.hoon
@@ -2,6 +2,13 @@
 /-  metadata-store
 /+  lib-graph=graph-store
 |%
+++  okay  `epic:e`0
+++  mar
+  |%
+  ++  act  `mark`(rap 3 %diary-action '-' (scot %ud okay) ~)
+  ++  upd  `mark`(rap 3 %diary-update '-' (scot %ud okay) ~)
+  ++  log  `mark`(rap 3 %diary-logs '-' (scot %ud okay) ~)
+  --
 ::  $flag: identifier for a diary channel
 +$  flag  (pair ship term)
 ::  $feel: either an emoji identifier like :diff or a URL for custom

--- a/desk/sur/groups.hoon
+++ b/desk/sur/groups.hoon
@@ -3,6 +3,14 @@
 /-  grp=group-store
 /-  metadata-store
 |%
+++  okay  `epic:e`1
+++  mar
+  |%
+  ++  act  `mark`(rap 3 %group-action '-' (scot %ud okay) ~)
+  ++  upd  `mark`(rap 3 %group-update '-' (scot %ud okay) ~)
+  ++  log  `mark`(rap 3 %group-log '-' (scot %ud okay) ~)
+  ++  int  `mark`(rap 3 %group-init '-' (scot %ud okay) ~)
+  --
 ::  $flag: ID for a group
 ::
 +$  flag  (pair ship term)

--- a/desk/sur/heap.hoon
+++ b/desk/sur/heap.hoon
@@ -4,6 +4,13 @@
 /-  metadata-store
 /+  lib-graph=graph-store
 |%
+++  okay  `epic:e`0
+++  mar
+  |%
+  ++  act  `mark`(rap 3 %heap-action '-' (scot %ud okay) ~)
+  ++  upd  `mark`(rap 3 %heap-update '-' (scot %ud okay) ~)
+  ++  log  `mark`(rap 3 %heap-logs '-' (scot %ud okay) ~)
+  --
 ::  $flag: identifier for a heap channel
 +$  flag  (pair ship term)
 ::  $feel: either an emoji identifier like :wave or a URL for custom

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -121,7 +121,7 @@ const contactSub = {
   path: '/all',
   initialResponder: (req) =>
     createResponse(req, 'diff', {
-      'contact-update': {
+      'contact-update-0': {
         initial: {
           'is-public': false,
           rolodex: mockContacts,
@@ -152,7 +152,7 @@ const groups: Handler[] = [
   {
     action: 'poke',
     app: 'groups',
-    mark: 'group-action-0',
+    mark: 'group-action-1',
     returnSubscription: specificGroupSub,
     dataResponder: (req: Message & Poke<GroupAction>) =>
       createResponse(req, 'diff', {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -38,7 +38,7 @@ export const GROUPS_KEY = 'groups';
 function groupAction(flag: string, diff: GroupDiff): Poke<GroupAction> {
   return {
     app: 'groups',
-    mark: 'group-action-0',
+    mark: 'group-action-1',
     json: {
       flag,
       update: {


### PR DESCRIPTION
This addresses a live issue on the network, where group hosts use 100% CPU because of a resubscribe loop when their subscribers haven't received recent groups OTAs.

The solution is to update the protocol version number for groups subscriptions.  This is expected to happen every time the groups subscriptions result type changes.  It changed a little while ago with the addition of group roles, but we forgot to update the version.

This includes a small refactor of how those protocol numbers are used to make it easier to keep them in sync across the desk.  This refactor applies to groups, chat, diary, heap, and contacts.  We move the version handling into the sur file, so that anything using these apps will automatically use the most recent version (as long as the values still match the types).

Expected impact:
- As soon as either a host or joiner receives this OTA, the 100% CPU usage bug should subside.
- If you're in a group, then during the time when either you or the host have received this OTA but the other has not, the group metadata will not update, and there will be no notification about this in the UI.  This means you will not see updates to the group description, roles, or channel list.  You will, however, be able to use chat channels, notebooks, and galleries like normal.  Once both you and and the host have received this OTA, you will receive the backlog of group metadata changes, and everything will continue as normal.
- If you attempt to join a group while either you or the host have received this OTA but the other has not, the UI will hang on a spinner with the text "Wait a sec".  If you go back to the top of groups, you will see an grayed-out entry in the sidebar for this group (it may be blank or have the ship and group name in it, eg "~ship/group").  This will not automatically resume when the other party receives this OTA.  Instead, you should either "cancel join" or "leave group", and then when you're both up-to-date, you will be able to join the group successfully.

Fixes LAND-531