### PR TITLE
groups: fix infinite loop when marking diary as read

### DIFF
--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -121,7 +121,7 @@ function DiaryChannel() {
 
   useDismissChannelNotifications({
     nest,
-    markRead: () => markRead({ flag: chFlag }),
+    markRead: useCallback(() => markRead({ flag: chFlag }), [markRead, chFlag]),
   });
 
   const sortedNotes = Array.from(letters).sort(([a], [b]) => {


### PR DESCRIPTION
Fixes behavior seen in the video of an infinite loop while marking a notebook as read due to non-memoized `markRead` function triggering the `useDismissChannelNotifications` hook on every re-render

https://github.com/tloncorp/landscape-apps/assets/1013230/99ce499a-033d-4dd8-89b4-61d923775beb

Fixes LAND-556

