### PR TITLE
chat: fix reaction/deletion updates

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -124,7 +124,6 @@ export default function ChatScroller({
 
   const [keys, entries]: [bigInt.BigInteger[], ChatScrollerItemProps[]] =
     useMemo(() => {
-      debugger;
       const messagesWithoutReplies = messages.filter((k) => {
         if (replying) {
           return true;

--- a/ui/src/state/base.ts
+++ b/ui/src/state/base.ts
@@ -157,7 +157,6 @@ export const createState = <T extends Record<string, unknown>>(
             subscriptions.map((sub) => airlock.subscribe(sub(set, get)))
           );
         },
-        set: (fn) => stateSetter(fn, set, get),
         optSet: (fn) => optStateSetter(fn, set, get),
         patches: {},
         addPatch: (id: string, patch: Patch[]) => {

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -32,7 +32,7 @@ export interface WritWindows {
 }
 
 export interface ChatState {
-  set: (fn: (sta: BasedChatState) => void) => void;
+  // set: (fn: (sta: BasedChatState) => void) => void;
   batchSet: (fn: (sta: BasedChatState) => void) => void;
   chats: Chats;
   multiDms: Clubs;

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -177,7 +177,7 @@ export function writsReducer(whom: string) {
     } else if ('del' in delta && pact.index[id]) {
       const time = pact.index[id];
       const old = pact.writs.get(time);
-      pact.writs.delete(time);
+      pact.writs = pact.writs.without(time);
       delete pact.index[id];
       if (old && old.memo.replying) {
         const replyTime = pact.index[old.memo.replying];
@@ -197,15 +197,8 @@ export function writsReducer(whom: string) {
       const { ship, feel } = delta['add-feel'];
 
       if (msg) {
-        debugger;
-
-        pact.writs = pact.writs.with(
-          time,
-          produce(msg, (draftMsg) => {
-            // eslint-disable-next-line no-param-reassign
-            draftMsg.seal.feels[ship] = feel;
-          })
-        );
+        msg.seal.feels[ship] = feel;
+        pact.writs = pact.writs.with(time, msg);
       }
     } else if ('del-feel' in delta && pact.index[id]) {
       const time = pact.index[id];
@@ -356,13 +349,11 @@ export default function makeWritsStore(
         event: (data: WritDiff) => {
           set((draft) => {
             writsReducer(whom)(data, draft);
-            draft.sentMessages = draft.sentMessages.filter(
-              (id) => id !== data.id
-            );
 
             return {
               pacts: { ...draft.pacts },
               writWindows: { ...draft.writWindows },
+              sentMessages: draft.sentMessages.filter((id) => id !== data.id),
             };
           });
         },


### PR DESCRIPTION
This fixes issues seen in recent updates that prevent reacts from showing up or being deleted until refresh. This seems to also improve the performance of sending/receiving chats based on the `ChatScroller` changes.

Fixes LAND-585