### PR TITLE
groups: make sidebar resizable

### DIFF
--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -112,7 +112,7 @@ export default function GroupSidebar() {
   const privacy = group ? getPrivacyFromGroup(group) : 'public';
 
   return (
-    <nav className="flex h-full w-64 flex-none flex-col bg-white">
+    <nav className="flex h-full min-w-64 flex-none flex-col bg-white">
       <div className="flex min-h-0 flex-col">
         <div className="flex flex-col space-y-0.5 px-2 pt-2 pb-4">
           <GroupHeader />

--- a/ui/src/nav/GroupsNav.tsx
+++ b/ui/src/nav/GroupsNav.tsx
@@ -20,7 +20,7 @@ export function DesktopNav() {
   };
 
   return (
-    <div className="relative flex h-full w-64 flex-none overflow-hidden border-r-2 border-gray-50 bg-white">
+    <div className="relative flex h-full min-w-64 flex-none resize-x overflow-hidden border-r-2 border-gray-50 bg-white">
       <AnimatePresence initial={false}>
         {match || backgroundLocationMatch ? (
           <motion.div


### PR DESCRIPTION
As a user I want to be able to easily see full names for channels/groups when they are longer than the sidebar width. This is especially annoying when there is important information cut off from names.

#### Changes:
- Make groups sidebar resizable using [tailwind resize class](https://tailwindcss.com/docs/resize)

#### Before:
Some channel names are not fully visible. The full name of the channel can only be viewed by hovering over channel name or by navigating to a channel.
![image](https://github.com/tloncorp/landscape-apps/assets/48297104/8db6ec10-1057-48d6-9be6-0df2f503ec26)

#### After:
Sidebar can be resized to view full names for all the channels. 


https://github.com/tloncorp/landscape-apps/assets/48297104/b0d053b9-03bf-48d1-a9e6-2ce7e34c9c0b

