### PR TITLE
diary: fix issue with clearing all note text

### DIFF
--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -24,6 +24,7 @@ import DiaryInlineEditor, { useDiaryInlineEditor } from './DiaryInlineEditor';
 
 export default function DiaryAddNote() {
   const { chShip, chName, id } = useParams();
+  const [loaded, setLoaded] = useState(false);
   const chFlag = `${chShip}/${chName}`;
   const group = useRouteGroup();
   const isMobile = useIsMobile();
@@ -69,11 +70,13 @@ export default function DiaryAddNote() {
       !editor.isDestroyed &&
       !loadingNote &&
       note?.essay &&
-      editor?.getText() === ''
+      editor?.isEmpty &&
+      !loaded
     ) {
+      setLoaded(true);
       editor.commands.setContent(diaryMixedToJSON(note.essay.content));
     }
-  }, [editor, loadingNote, note]);
+  }, [editor, loadingNote, note, loaded]);
 
   const publish = useCallback(async () => {
     if (!editor?.getText()) {


### PR DESCRIPTION
The useEffect we were using to load initial text into the note was overriding the user's ability to clear out all of the note text. This PR adds some local state to prevent that from happening. Also switches to using tiptap's isEmpty property to check if the notebook is empty, rather than checking for an empty string, which is what tiptap's docs suggest.

Fixes LAND-591