### PR TITLE
edit-channel: restore writer editing

### DIFF
--- a/ui/src/channels/EditChannelForm.tsx
+++ b/ui/src/channels/EditChannelForm.tsx
@@ -93,8 +93,20 @@ export default function EditChannelForm({
         console.log(e);
       }
 
-      const chState =
-        app === 'chat' ? useChatState.getState() : useHeapState.getState();
+      const addSects =
+        app === 'diary'
+          ? (flag: string, writers: string[]) =>
+              addDiarySects({ flag, writers })
+          : app === 'heap'
+          ? useHeapState.getState().addSects
+          : useChatState.getState().addSects;
+      const delSects =
+        app === 'diary'
+          ? (flag: string, writers: string[]) =>
+              delDiarySects({ flag, writers })
+          : app === 'heap'
+          ? useHeapState.getState().delSects
+          : useChatState.getState().delSects;
 
       if (privacy !== 'public') {
         const writersIncludesMembers = values.writers.includes('members');
@@ -104,25 +116,13 @@ export default function EditChannelForm({
           values.writers
         );
 
-        if (writersIncludesMembers) {
-          if (app === 'diary') {
-            await delDiarySects({
-              flag: channelFlag,
-              writers: writersToRemove,
-            });
-          } else {
-            await chState.delSects(channelFlag, sects);
-          }
-        } else if (app === 'diary') {
-          await addDiarySects({
-            flag: channelFlag,
-            writers: values.writers,
-          });
-        } else {
-          await chState.delSects(channelFlag, writersToRemove);
-        }
+        await addSects(channelFlag, values.writers);
+        await delSects(
+          channelFlag,
+          writersIncludesMembers ? sects : writersToRemove
+        );
       } else {
-        await chState.delSects(channelFlag, sects);
+        await delSects(channelFlag, sects);
       }
 
       if (retainRoute === true && setEditIsOpen) {


### PR DESCRIPTION
During the notebooks refactor we deleted the role add for other channel types. This normalizes the way we do add/delete so that they always flow the same way so all channels have the same functionality.