### PR TITLE
groups: fix cannot read properties of undefined (title) issue

### DIFF
--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -128,7 +128,7 @@ export default function Notifications({
       <section className="flex h-full w-full flex-col space-y-6 overflow-y-scroll bg-gray-50 p-6">
         {group && (
           <Helmet>
-            <title>{group ? `${group.meta.title} ${title}` : title}</title>
+            <title>{group ? `${group?.meta?.title} ${title}` : title}</title>
           </Helmet>
         )}
 


### PR DESCRIPTION
Apparently the `meta` property returned on a Group from useGroups could be undefined in some cases.

Fixes LAND-601