### PR TITLE
notebooks: fix bad notebook cache issue

### DIFF
--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -128,6 +128,18 @@ export const useDiaryState = createState<DiaryState>(
 );
 
 export function useNotes(flag: DiaryFlag) {
+  const queryClient = useQueryClient();
+  const existingNotes = queryClient.getQueryData(['diary', 'notes', flag]);
+  // account for the fact that we accidentally stored these as a map of
+  // full notes instead of outlines for a time
+  const existingNotesAreOutlines = Object.values(existingNotes ?? {}).every(
+    (note) => note?.type === 'outline'
+  );
+
+  if (existingNotes && !existingNotesAreOutlines) {
+    queryClient.setQueryData(['diary', 'notes', flag], {});
+  }
+
   const { data, ...rest } = useReactQuerySubscription({
     queryKey: ['diary', 'notes', flag],
     app: 'diary',


### PR DESCRIPTION
Some users were still seeing the missing quipCount/quippers issue because we had accidentally stored full notes instead of outlines in some situations previously. Now, when we call useNotes, we'll check to see if they have a non-outline note and then clear out the cache for that query key if they do.