### PR TITLE
fix bad cache issue with buster param

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -44,6 +44,7 @@ render(
       client={queryClient}
       persistOptions={{
         persister: indexedDBPersistor(`${window.our}-landscape`),
+        buster: `${window.our}-landscape-4.0.1`,
       }}
     >
       <UpdateNotice />


### PR DESCRIPTION
Added the buster param to PersistQueryClientProvider, if any client doesn't have `${window.our}-landscape-4.0.1` as their buster string their cache will be cleared. Will fix the bad notebook cache issue.