### PR TITLE
notebooks: make links blue and underlined

### DIFF
--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -153,6 +153,12 @@ module.exports = {
       typography: {
         DEFAULT: {
           css: {
+            a: {
+              color: lightColors.blue.DEFAULT,
+              textDecoration: 'underline',
+              textUnderlineOffset: '0.125em',
+              fontWeight: 'inherit',
+            },
             code: {
               display: 'inline-block',
               padding: '0 0.25rem',


### PR DESCRIPTION
<img width="693" alt="image" src="https://github.com/tloncorp/landscape-apps/assets/748181/0966947a-8f1c-4234-b40d-b3bbcb08db36">

fixes LAND-349