### PR TITLE
fix simple typo in settings dialog text

### DIFF
--- a/ui/src/components/SettingsDialog.tsx
+++ b/ui/src/components/SettingsDialog.tsx
@@ -84,8 +84,8 @@ export default function SettingsDialog() {
             name="Disable wayfinding"
           >
             <p className="leading-5 text-gray-600">
-              Turn off the "wayfinding" helper menu menu in the bottom left of
-              the {isTalk ? 'Talk' : 'Groups'} sidebar
+              Turn off the "wayfinding" helper menu in the bottom left of the{' '}
+              {isTalk ? 'Talk' : 'Groups'} sidebar
             </p>
           </Setting>
         </div>


### PR DESCRIPTION
Fixes typo in settings dialog that said "helper menu menu"