### PR TITLE
notebooks: more block content fixes

### DIFF
--- a/ui/src/diary/DiaryCiteNode.tsx
+++ b/ui/src/diary/DiaryCiteNode.tsx
@@ -15,13 +15,20 @@ function DiaryCiteComponent(props: NodeViewProps) {
     <NodeViewWrapper>
       <div className="my-4">
         <div className="mb-2 rounded-xl bg-gray-50 p-3">
-          <div className="flex items-center space-x-3 rounded-lg bg-white p-2">
+          <div className="input flex items-center space-x-3 rounded-lg bg-white p-2">
             <Sig16Icon className="h-4 w-4" />
             <input
               className="input-transparent w-full flex-1 bg-transparent leading-5"
               {...bind}
               placeholder="Add an urbit reference"
             />
+            <button
+              title="Remove"
+              className="small-button"
+              onClick={props.deleteNode}
+            >
+              Remove
+            </button>
           </div>
         </div>
         {cite && <ContentReference cite={cite} />}

--- a/ui/src/diary/DiaryImageNode.tsx
+++ b/ui/src/diary/DiaryImageNode.tsx
@@ -132,7 +132,15 @@ function DiaryImageComponent(props: NodeViewProps) {
                 Retry
               </button>
             </div>
-          ) : null}
+          ) : (
+            <button
+              title="Remove"
+              className="small-button"
+              onClick={props.deleteNode}
+            >
+              Remove
+            </button>
+          )}
         </div>
         {src && !error && !calm?.disableRemoteContent ? (
           <img

--- a/ui/src/diary/DiaryInlineEditor.tsx
+++ b/ui/src/diary/DiaryInlineEditor.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames';
 import * as Popover from '@radix-ui/react-popover';
 import { EditorView } from '@tiptap/pm/view';
 import { EditorOptions, KeyboardShortcutCommand, Range } from '@tiptap/core';
+import { useState } from 'react';
 import {
   Editor,
   EditorContent,
@@ -33,6 +34,8 @@ import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import Heading from '@tiptap/extension-heading';
 import Mention from '@tiptap/extension-mention';
 import MentionPopup from '@/components/Mention/MentionPopup';
+import AddIcon16 from '@/components/icons/Add16Icon';
+import IconButton from '@/components/IconButton';
 import ActionMenu, {
   ActionMenuBar,
   actionMenuItems,
@@ -41,9 +44,6 @@ import PrismCodeBlock from './PrismCodeBlock';
 import DiaryCiteNode from './DiaryCiteNode';
 import DiaryLinkNode from './DiaryLinkNode';
 import DiaryImageNode from './DiaryImageNode';
-import AddIcon16 from '@/components/icons/Add16Icon';
-import IconButton from '@/components/IconButton';
-import { useState } from 'react';
 
 EditorView.prototype.updateState = function updateState(state) {
   if (!(this as any).docView) return; // This prevents the matchesNode error on hot reloads

--- a/ui/src/diary/PrismCodeBlock.tsx
+++ b/ui/src/diary/PrismCodeBlock.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import CodeBlock, { CodeBlockOptions } from '@tiptap/extension-code-block';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { findChildren, NodeViewProps } from '@tiptap/core';
@@ -6,7 +7,6 @@ import { Node as ProsemirrorNode } from '@tiptap/pm/model';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { refractor } from 'refractor/lib/common.js';
 import hoon from 'refractor/lang/hoon.js';
-
 import {
   NodeViewContent,
   NodeViewWrapper,
@@ -103,29 +103,58 @@ function CodeBlockView(props: NodeViewProps) {
     value: l,
     label: l.toUpperCase(),
   }));
-  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newValue = e.target.value;
-    if (newValue) {
-      setSelectedLanguage(newValue);
-      updateAttributes({ language: newValue });
-    }
-  };
 
   return (
-    <NodeViewWrapper className={'relative'}>
-      <select
-        className="absolute top-1.5 right-1.5 w-[130px] rounded-md border border-solid border-gray-200 bg-gray-700 text-gray-50"
-        onChange={onChange}
-      >
-        {options.map((o) => (
-          <option value={o.value} selected={selectedLanguage === o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-      <pre>
-        <NodeViewContent as="code" />
-      </pre>
+    <NodeViewWrapper>
+      <div className="my-2">
+        <div className="mb-2 rounded-xl bg-gray-50 p-3">
+          <div contentEditable={false} className="flex items-center justify-between">
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger className="w-[130px] rounded-md border border-solid border-gray-200 bg-gray-700 text-gray-50">
+                {selectedLanguage.toUpperCase()}
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content className="dropdown">
+                {options.map((o) => (
+                  <DropdownMenu.Item
+                    className="dropdown-item"
+                    onSelect={() => {
+                      setSelectedLanguage(o.value);
+                      updateAttributes({ language: o.value });
+                    }}
+                  >
+                    {o.label}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Content>
+              {/*
+              <select
+                className="w-[130px] rounded-md border border-solid border-gray-200 bg-gray-700 text-gray-50"
+                onChange={onChange}
+              >
+                {options.map((o) => (
+                  <option
+                    value={o.value}
+                    selected={selectedLanguage === o.value}
+                  >
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              */}
+            </DropdownMenu.Root>
+            <button
+              title="Remove"
+              className="small-button"
+              onClick={props.deleteNode}
+            >
+              Remove
+            </button>
+          </div>
+          <pre>
+            <NodeViewContent as="code" />
+          </pre>
+        </div>
+      </div>
     </NodeViewWrapper>
   );
 }

--- a/ui/src/diary/PrismCodeBlock.tsx
+++ b/ui/src/diary/PrismCodeBlock.tsx
@@ -126,21 +126,6 @@ function CodeBlockView(props: NodeViewProps) {
                   </DropdownMenu.Item>
                 ))}
               </DropdownMenu.Content>
-              {/*
-              <select
-                className="w-[130px] rounded-md border border-solid border-gray-200 bg-gray-700 text-gray-50"
-                onChange={onChange}
-              >
-                {options.map((o) => (
-                  <option
-                    value={o.value}
-                    selected={selectedLanguage === o.value}
-                  >
-                    {o.label}
-                  </option>
-                ))}
-              </select>
-              */}
             </DropdownMenu.Root>
             <button
               title="Remove"

--- a/ui/src/diary/plugins/actionmenu.tsx
+++ b/ui/src/diary/plugins/actionmenu.tsx
@@ -28,7 +28,6 @@ export const actionMenuItems: ActionMenuItemProps[] = [
         .chain()
         .focus()
         .deleteRange(range)
-        .splitBlock()
         .insertContent([{ type: 'diary-image' }, { type: 'paragraph' }])
         .selectNodeBackward()
         .run();
@@ -51,7 +50,13 @@ export const actionMenuItems: ActionMenuItemProps[] = [
     title: 'Code block',
     icon: <CodeIcon className="mr-2 h-4 w-4 text-gray-600" />,
     command: ({ editor, range }) => {
-      editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .toggleCodeBlock()
+        .selectNodeBackward()
+        .run();
     },
   },
 ];

--- a/ui/src/diary/plugins/actionmenu.tsx
+++ b/ui/src/diary/plugins/actionmenu.tsx
@@ -56,6 +56,7 @@ export const actionMenuItems: ActionMenuItemProps[] = [
         .deleteRange(range)
         .toggleCodeBlock()
         .selectNodeBackward()
+        .insertContent([{ type: 'paragraph' }])
         .run();
     },
   },


### PR DESCRIPTION
- fixes LAND-389 with consistent "Remove" buttons for all blocks
- fixes LAND-599 by making sure we always have a cursor available after inserting a block (i.e., after the code block in particular), and making sure the image block replaces the current empty block.
- Some more style fixes (language selector dropdown in code blocks matches our other dropdowns).