### PR TITLE
notebooks: fix caching edge case for saving a new note

### DIFF
--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -533,15 +533,26 @@ export function useAddNoteMutation() {
       ]);
 
       if (notes !== undefined) {
+        // for the unlikely case that the user navigates away from the editor
+        // before the mutation is complete, we update the cache optimistically
         queryClient.setQueryData<DiaryOutline>(
           ['diary', 'notes', variables.flag],
           {
             ...notes,
-            [timePosted]: variables.essay,
-            quipCount: 0,
-            quippers: [],
-            title: variables.essay.title,
-            image: variables.essay.image,
+            // this time will be wrong if the mutation fails or doesn't complete
+            // but it will be corrected when fact returns on the subscription.
+            // as long as the user doesn't try to immediately navigate to
+            // the note, this will be fine.
+            [timePosted ?? variables.essay.sent]: {
+              content: variables.essay.content,
+              author: variables.essay.author,
+              quipCount: 0,
+              quippers: [],
+              title: variables.essay.title,
+              image: variables.essay.image,
+              sent: variables.essay.sent,
+              type: 'outline',
+            },
           }
         );
       }


### PR DESCRIPTION
fixes LAND-604

This PR fixes an issue where if a user were to create a new note and then attempt to navigate back to the notebook before the note was saved, they would get an error about quipCount being an invalid integer (or similar).

This was happening because we weren't properly inserting an outline into the cache optimistically (data had the wrong shape).

It wasn't noticed on the last pass of this code because the cached outline would get replaced by the real one when the mutation was completed (fact comes back and we refetch).

Note that while this will allow for the outline to be displayed in the notebook itself, if the user were to then try to *immediately* visit the note they just added (before the fact returns on the subscription), they won't be able to since the time we used to index the outline in the cached map is the sent time rather than the time returned from the server.

If the user waits just a little bit, it will work fine without them noticing. If they do get an error message upon viewing the note, they'll probably need to just click "try again", navigate back to the notebook, and they should be able to click on the note.

We could try to come up with some UI to handle this edge case. If we add some logic to useNote that checks to see if the noteID is the exact same time as the sent time, we'll know that this is just a cached outline and that the real one needs to be fetched, and that the user needs to be routed to the real note.