### PR TITLE
notebooks: visual edits

### DIFF
--- a/ui/src/diary/DiaryCiteNode.tsx
+++ b/ui/src/diary/DiaryCiteNode.tsx
@@ -13,14 +13,19 @@ function DiaryCiteComponent(props: NodeViewProps) {
 
   return (
     <NodeViewWrapper>
-      <div className="my-4">
-        <div className="mb-2 rounded-xl bg-gray-50 p-3">
+      <div className="not-prose my-4">
+        <div className="rounded-xl bg-gray-100 p-3">
+          {cite && (
+            <div className="mb-2 text-base">
+              <ContentReference cite={cite} />
+            </div>
+          )}
           <div className="input flex items-center space-x-3 rounded-lg bg-white p-2">
             <Sig16Icon className="h-4 w-4" />
             <input
               className="input-transparent w-full flex-1 bg-transparent leading-5"
               {...bind}
-              placeholder="Add an urbit reference"
+              placeholder="Paste an urbit reference"
             />
             <button
               title="Remove"
@@ -31,7 +36,6 @@ function DiaryCiteComponent(props: NodeViewProps) {
             </button>
           </div>
         </div>
-        {cite && <ContentReference cite={cite} />}
       </div>
     </NodeViewWrapper>
   );

--- a/ui/src/diary/DiaryCiteNode.tsx
+++ b/ui/src/diary/DiaryCiteNode.tsx
@@ -13,28 +13,26 @@ function DiaryCiteComponent(props: NodeViewProps) {
 
   return (
     <NodeViewWrapper>
-      <div className="not-prose my-4">
-        <div className="rounded-xl bg-gray-100 p-3">
-          {cite && (
-            <div className="mb-2 text-base">
-              <ContentReference cite={cite} />
-            </div>
-          )}
-          <div className="input flex items-center space-x-3 rounded-lg bg-white p-2">
-            <Sig16Icon className="h-4 w-4" />
-            <input
-              className="input-transparent w-full flex-1 bg-transparent leading-5"
-              {...bind}
-              placeholder="Paste an urbit reference"
-            />
-            <button
-              title="Remove"
-              className="small-button"
-              onClick={props.deleteNode}
-            >
-              Remove
-            </button>
+      <div className="not-prose rounded-xl bg-gray-100 p-3">
+        {cite && (
+          <div className="mb-2 text-base">
+            <ContentReference cite={cite} />
           </div>
+        )}
+        <div className="input flex items-center space-x-3 rounded-lg bg-white p-2">
+          <Sig16Icon className="h-4 w-4" />
+          <input
+            className="input-transparent w-full flex-1 bg-transparent leading-5"
+            {...bind}
+            placeholder="Paste an urbit reference"
+          />
+          <button
+            title="Remove"
+            className="small-button"
+            onClick={props.deleteNode}
+          >
+            Remove
+          </button>
         </div>
       </div>
     </NodeViewWrapper>

--- a/ui/src/diary/DiaryContent/DiaryContentImage.tsx
+++ b/ui/src/diary/DiaryContent/DiaryContentImage.tsx
@@ -20,7 +20,7 @@ export default function DiaryContentImage({
 
   return (
     <div
-      className="group relative w-full py-2"
+      className="group relative w-full"
       style={{ maxWidth: width ? (width > 600 ? 600 : w) : 600 }}
     >
       <a href={src} target="_blank" rel="noreferrer">
@@ -29,32 +29,13 @@ export default function DiaryContentImage({
         ) : (
           <img
             src={src}
-            className="max-w-full rounded"
+            className="max-w-full rounded-lg"
             height={h}
             width={w}
             alt={altText ? altText : 'A Diary image'}
           />
         )}
       </a>
-      {/*
-        TODO: put these icons back in after they've been finalized by design.
-        <div className="absolute top-5 right-[11px] flex space-x-2 text-white opacity-0 group-hover:opacity-100">
-          <a
-            className="h-[18px] w-[18px] cursor-pointer"
-            href={src}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <ExpandIcon />
-          </a>
-          <button
-            className="h-[18px] w-[18px] cursor-pointer"
-            onClick={() => console.log('hi')}
-          >
-            <ElipsisCircleIcon />
-          </button>
-        </div>
-      */}
     </div>
   );
 }

--- a/ui/src/diary/DiaryImageNode.tsx
+++ b/ui/src/diary/DiaryImageNode.tsx
@@ -83,76 +83,87 @@ function DiaryImageComponent(props: NodeViewProps) {
     <NodeViewWrapper>
       <div
         className={cn(
-          'not-prose min-h-12 br-1 relative flex w-full items-center justify-center rounded-xl bg-gray-100 bg-cover bg-center',
+          'not-prose relative w-full rounded-xl bg-gray-100 bg-cover bg-center',
           className
         )}
       >
-        <div className="input absolute inset-x-4 bottom-4 flex h-8 items-center space-x-2 rounded-lg border border-gray-100 bg-white px-2">
-          <LinkIcon className="h-4 w-4" />
-          <input
-            className="input-transparent grow"
-            type="text"
-            {...bind}
-            onKeyDown={onKeyDown}
-            placeholder="Enter an image/embed/web URL"
-          />
-          {uploader ? (
-            <button
-              title={'Upload an image'}
-              className="small-button whitespace-nowrap"
-              aria-label="Add attachment"
-              onClick={(e) => {
-                e.preventDefault();
-                uploader.prompt();
-              }}
-            >
-              {mostRecentFile && mostRecentFile.status === 'loading' ? (
-                <LoadingSpinner secondary="black" className="h-4 w-4" />
-              ) : (
-                'Upload Image'
-              )}
-            </button>
-          ) : null}
-          {uploadError ? (
-            <div className="absolute mr-2">
-              <UploadErrorPopover
-                errorMessage={uploadError}
-                setUploadError={setUploadError}
-              />
-            </div>
-          ) : null}
-          {error ? (
-            <div className="flex space-x-2">
-              <AsteriskIcon className="h-4 w-4" />
-              <div className="grow">Failed to Load</div>
-              <button type="button" onClick={props.deleteNode}>
-                Cancel
-              </button>
-              <button type="button" onClick={onRetry}>
-                Retry
-              </button>
-            </div>
-          ) : (
-            <button
-              title="Remove"
-              className="small-button"
-              onClick={props.deleteNode}
-            >
-              Remove
-            </button>
-          )}
-        </div>
         {src && !error && !calm?.disableRemoteContent ? (
           <img
             ref={image}
-            className="rounded-xl"
+            className="w-full rounded-xl object-cover"
             src={src}
             onError={onError}
             onLoad={onLoad}
           />
         ) : (
-          <div className="h-16 w-full" />
+          <div />
         )}
+        <div
+          className={cn(
+            'w-full p-3',
+            src && !error && !calm?.disableRemoteContent && 'absolute bottom-0'
+          )}
+        >
+          <div
+            className={cn(
+              'input relative flex w-full items-center space-x-2 rounded-lg border border-gray-100 bg-white p-2'
+            )}
+          >
+            <LinkIcon className="h-4 w-4" />
+            <input
+              className="input-transparent grow"
+              type="text"
+              {...bind}
+              onKeyDown={onKeyDown}
+              placeholder="Enter an image/embed/web URL"
+            />
+            {uploader ? (
+              <button
+                title={'Upload an image'}
+                className="small-button whitespace-nowrap"
+                aria-label="Add attachment"
+                onClick={(e) => {
+                  e.preventDefault();
+                  uploader.prompt();
+                }}
+              >
+                {mostRecentFile && mostRecentFile.status === 'loading' ? (
+                  <LoadingSpinner secondary="black" className="h-4 w-4" />
+                ) : (
+                  'Upload Image'
+                )}
+              </button>
+            ) : null}
+            {uploadError ? (
+              <div className="absolute mr-2">
+                <UploadErrorPopover
+                  errorMessage={uploadError}
+                  setUploadError={setUploadError}
+                />
+              </div>
+            ) : null}
+            {error ? (
+              <div className="flex space-x-2">
+                <AsteriskIcon className="h-4 w-4" />
+                <div className="grow">Failed to Load</div>
+                <button type="button" onClick={props.deleteNode}>
+                  Cancel
+                </button>
+                <button type="button" onClick={onRetry}>
+                  Retry
+                </button>
+              </div>
+            ) : (
+              <button
+                title="Remove"
+                className="small-button"
+                onClick={props.deleteNode}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+        </div>
       </div>
     </NodeViewWrapper>
   );

--- a/ui/src/diary/DiaryInlineEditor.tsx
+++ b/ui/src/diary/DiaryInlineEditor.tsx
@@ -178,6 +178,7 @@ export default function DiaryInlineEditor({
                       command,
                     }: {
                       command: ({
+                        // eslint-disable-next-line no-shadow
                         editor,
                         range,
                       }: {

--- a/ui/src/diary/DiaryInlineEditor.tsx
+++ b/ui/src/diary/DiaryInlineEditor.tsx
@@ -103,7 +103,7 @@ export function useDiaryInlineEditor({
         Paragraph,
         Placeholder.configure({
           placeholder:
-            'Start writing here. Highlight text to add formatting, click the "+" button on the left, or type the forward slash (/) to insert block content.',
+            'Start writing here, or click the menu to add a link block',
           showOnlyCurrent: true,
           showOnlyWhenEditable: false,
           includeChildren: true,

--- a/ui/src/diary/PrismCodeBlock.css
+++ b/ui/src/diary/PrismCodeBlock.css
@@ -1,8 +1,10 @@
 .ProseMirror pre {
   background-color: rgba(0, 0, 0, 0.7);
   overflow-x: auto;
-  padding: 7px;
-  border-radius: 8px;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  margin-top: 1rem;
+  margin-bottom: 0;
 }
 
 .ProseMirror pre code {

--- a/ui/src/diary/PrismCodeBlock.tsx
+++ b/ui/src/diary/PrismCodeBlock.tsx
@@ -119,7 +119,7 @@ function CodeBlockView(props: NodeViewProps) {
                 <CaretDown16Icon className="ml-2 h-4 w-4" />
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
-                <DropdownMenu.Content className="dropdown max-h-64 overflow-y-auto">
+                <DropdownMenu.Content className="dropdown max-h-64 w-48 overflow-y-auto">
                   {options.map((o) => (
                     <DropdownMenu.Item
                       className="dropdown-item"

--- a/ui/src/diary/PrismCodeBlock.tsx
+++ b/ui/src/diary/PrismCodeBlock.tsx
@@ -107,45 +107,43 @@ function CodeBlockView(props: NodeViewProps) {
 
   return (
     <NodeViewWrapper>
-      <div className="my-2">
-        <div className="mb-2 rounded-xl bg-gray-100 p-3">
-          <div
-            contentEditable={false}
-            className="flex items-center justify-between"
+      <div className="not-prose rounded-xl bg-gray-100 p-3">
+        <div
+          contentEditable={false}
+          className="flex items-center justify-between"
+        >
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger className="small-button">
+              {selectedLanguage.toUpperCase()}
+              <CaretDown16Icon className="ml-2 h-4 w-4" />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className="dropdown max-h-64 w-48 overflow-y-auto">
+                {options.map((o) => (
+                  <DropdownMenu.Item
+                    className="dropdown-item"
+                    onSelect={() => {
+                      setSelectedLanguage(o.value);
+                      updateAttributes({ language: o.value });
+                    }}
+                  >
+                    {o.label}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+          <button
+            title="Remove"
+            className="small-button"
+            onClick={props.deleteNode}
           >
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger className="small-button">
-                {selectedLanguage.toUpperCase()}
-                <CaretDown16Icon className="ml-2 h-4 w-4" />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content className="dropdown max-h-64 w-48 overflow-y-auto">
-                  {options.map((o) => (
-                    <DropdownMenu.Item
-                      className="dropdown-item"
-                      onSelect={() => {
-                        setSelectedLanguage(o.value);
-                        updateAttributes({ language: o.value });
-                      }}
-                    >
-                      {o.label}
-                    </DropdownMenu.Item>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-            <button
-              title="Remove"
-              className="small-button"
-              onClick={props.deleteNode}
-            >
-              Remove
-            </button>
-          </div>
-          <pre className="not-prose">
-            <NodeViewContent spellcheck="false" as="code" />
-          </pre>
+            Remove
+          </button>
         </div>
+        <pre className="not-prose">
+          <NodeViewContent spellcheck="false" as="code" />
+        </pre>
       </div>
     </NodeViewWrapper>
   );

--- a/ui/src/diary/PrismCodeBlock.tsx
+++ b/ui/src/diary/PrismCodeBlock.tsx
@@ -13,6 +13,7 @@ import {
   ReactNodeViewRenderer,
 } from '@tiptap/react';
 import './PrismCodeBlock.css';
+import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 
 export interface CodeBlockPrismOptions extends CodeBlockOptions {
   defaultLanguage: string | null | undefined;
@@ -107,25 +108,31 @@ function CodeBlockView(props: NodeViewProps) {
   return (
     <NodeViewWrapper>
       <div className="my-2">
-        <div className="mb-2 rounded-xl bg-gray-50 p-3">
-          <div contentEditable={false} className="flex items-center justify-between">
+        <div className="mb-2 rounded-xl bg-gray-100 p-3">
+          <div
+            contentEditable={false}
+            className="flex items-center justify-between"
+          >
             <DropdownMenu.Root>
-              <DropdownMenu.Trigger className="w-[130px] rounded-md border border-solid border-gray-200 bg-gray-700 text-gray-50">
+              <DropdownMenu.Trigger className="small-button">
                 {selectedLanguage.toUpperCase()}
+                <CaretDown16Icon className="ml-2 h-4 w-4" />
               </DropdownMenu.Trigger>
-              <DropdownMenu.Content className="dropdown">
-                {options.map((o) => (
-                  <DropdownMenu.Item
-                    className="dropdown-item"
-                    onSelect={() => {
-                      setSelectedLanguage(o.value);
-                      updateAttributes({ language: o.value });
-                    }}
-                  >
-                    {o.label}
-                  </DropdownMenu.Item>
-                ))}
-              </DropdownMenu.Content>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className="dropdown max-h-64 overflow-y-auto">
+                  {options.map((o) => (
+                    <DropdownMenu.Item
+                      className="dropdown-item"
+                      onSelect={() => {
+                        setSelectedLanguage(o.value);
+                        updateAttributes({ language: o.value });
+                      }}
+                    >
+                      {o.label}
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
             </DropdownMenu.Root>
             <button
               title="Remove"
@@ -135,8 +142,8 @@ function CodeBlockView(props: NodeViewProps) {
               Remove
             </button>
           </div>
-          <pre>
-            <NodeViewContent as="code" />
+          <pre className="not-prose">
+            <NodeViewContent spellcheck="false" as="code" />
           </pre>
         </div>
       </div>

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -171,6 +171,49 @@ module.exports = {
             },
           },
         },
+        lg: {
+          css: {
+            h1: {
+              marginBottom: '1rem',
+              fontWeight: '600',
+              fontSize: '2rem',
+              paddingBottom: '0.3em',
+              borderBottom: '1px solid var(--tw-prose-hr)',
+            },
+            h2: {
+              fontWeight: '600',
+              fontSize: '1.5rem',
+              marginTop: '0',
+              marginBottom: '1rem',
+              paddingBottom: '0.3em',
+              borderBottom: '1px solid var(--tw-prose-hr)',
+            },
+            h3: {
+              fontWeight: '600',
+              fontSize: '1.25rem',
+              marginTop: '0',
+              marginBottom: '1rem',
+            },
+            h4: {
+              fontWeight: '600',
+              marginTop: '0',
+              marginBottom: '1rem',
+            },
+            pre: {
+              marginBottom: '1rem',
+              fontSize: '1rem',
+            },
+            'hr + *': {
+              marginTop: '0',
+            },
+            'h1 + *, h2 + *, h3 + *, h4 + *, hr + *': {
+              marginTop: '0',
+            },
+            '.node-diary-image + *,.node-diary-cite + *, .node-codeBlock + *': {
+              marginTop: '1.33333rem',
+            },
+          },
+        },
       },
     },
   },

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -203,6 +203,10 @@ module.exports = {
               marginBottom: '1rem',
               fontSize: '1rem',
             },
+            hr: {
+              marginTop: '2rem',
+              marginBottom: '2rem',
+            },
             'hr + *': {
               marginTop: '0',
             },


### PR DESCRIPTION
- Fixes an issue with the language selection dropdown of PrismCodeBlock running off the bottom of the screen and adds a caret to the trigger button
- Cleans up the layout of DiaryImageNode
- Brings the layout of DiaryCiteNode into visual alignment with DiaryImageNode
- Truncates the paragraph block placeholder to one line
- Abstracts all margin rules from PrismCodeBlock, DiaryImageNode, and DiaryCiteNode out to the Tailwind theme, where it belongs
- Emulates GitHub's margin/style rules for diary elements (headers, images, our embedded content) in the Tailwind theme

Image previews:
![image](https://github.com/tloncorp/landscape-apps/assets/748181/c0bbe5aa-bd6b-4665-a6b4-581fa9d76c9d)
![image](https://github.com/tloncorp/landscape-apps/assets/748181/3dddab64-a56f-4607-ad66-ad9a1ea5279f)
![image](https://github.com/tloncorp/landscape-apps/assets/748181/c2d3802d-b5d4-4d38-8781-28a1ca41ea7a)

Fixes LAND-599