### PR TITLE
dms: fix empty scroller on new DMs

### DIFF
--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -492,7 +492,6 @@ export const useChatState = createState<ChatState>(
     },
     sendMessage: async (whom, mem) => {
       const isDM = whomIsDm(whom);
-      const isMultiDm = whomIsMultiDm(whom);
       // ensure time and ID match up
       const { id, time } = makeId();
       const memo: ChatMemo = {
@@ -725,17 +724,9 @@ export function useMessagesForChat(whom: string, near?: BigInteger) {
   const writs = useChatState(useCallback((s) => s.pacts[whom]?.writs, [whom]));
 
   return useMemo(() => {
-    let messages;
-
-    if (window) {
-      messages = writs
-        ? newWritMap(writs.getRange(window.oldest, window.newest, true))
-        : emptyWrits;
-    } else {
-      messages = writs ? writs : emptyWrits;
-    }
-
-    return messages;
+    return window && writs
+      ? newWritMap(writs.getRange(window.oldest, window.newest, true))
+      : writs || emptyWrits;
   }, [writs, window]);
 }
 

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -725,10 +725,16 @@ export function useMessagesForChat(whom: string, near?: BigInteger) {
   const writs = useChatState(useCallback((s) => s.pacts[whom]?.writs, [whom]));
 
   return useMemo(() => {
-    const messages =
-      window && writs
+    let messages;
+
+    if (window) {
+      messages = writs
         ? newWritMap(writs.getRange(window.oldest, window.newest, true))
         : emptyWrits;
+    } else {
+      messages = writs ? writs : emptyWrits;
+    }
+
     return messages;
   }, [writs, window]);
 }

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -79,7 +79,7 @@ function extendCurrentWindow(
 ) {
   if (!windows) {
     return {
-      latest: newWindow.latest ? newWindow : undefined,
+      latest: newWindow.latest || !time ? newWindow : undefined,
       windows: [newWindow],
     };
   }


### PR DESCRIPTION
At the point at which we create a new dm, a writWindow does not yet exist in state. In that case, we can just show the writs we have.

Fixes LAND-630.

I could not repro the DM not appearing in the sidebar, but it would be a separate issue afaict.