### PR TITLE
profiles: include pals icon & actions in modal

### DIFF
--- a/ui/src/components/PalIcon.tsx
+++ b/ui/src/components/PalIcon.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import _ from 'lodash';
+import cn from 'classnames';
 import { usePals } from '@/state/pals';
 
 const outgoingSvg = (
@@ -99,7 +100,7 @@ Z"
   </svg>
 );
 
-export default function PalIcon(props: { ship: string }) {
+export default function PalIcon(props: { ship: string; className: string }) {
   const { ship } = props;
   const pals = usePals();
 
@@ -116,29 +117,26 @@ export default function PalIcon(props: { ship: string }) {
     [ship, pals]
   );
 
+  const className = cn(
+    'h-5 w-5 p-1 rounded-full inline-block align-middle',
+    props.className
+  );
+
   if (!tags) {
     if (!incoming) {
       return null;
     }
-    return (
-      <div className="h-5 w-5 rounded-full bg-gray-100 p-1">{incomingSvg}</div>
-    );
+    return <div className={cn('bg-gray-100', className)}>{incomingSvg}</div>;
   }
   if (!incoming) {
     return (
-      <div
-        className="h-5 w-5 rounded-full bg-yellow-soft p-1"
-        title={tags.join(', ')}
-      >
+      <div className={cn('bg-yellow-soft', className)} title={tags.join(', ')}>
         {outgoingSvg}
       </div>
     );
   }
   return (
-    <div
-      className="h-5 w-5 rounded-full bg-green-100 p-1"
-      title={tags.join(', ')}
-    >
+    <div className={cn('bg-green-100', className)} title={tags.join(', ')}>
       {mutualSvg}
     </div>
   );

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -6,6 +6,8 @@ import useContactState, { useContact } from '@/state/contact';
 import Avatar from '@/components/Avatar';
 import Dialog from '@/components/Dialog';
 import ShipName from '@/components/ShipName';
+import PalIcon from '@/components/PalIcon';
+import usePalsState from '@/state/pals';
 import useNavigateByApp from '@/logic/useNavigateByApp';
 import ProfileCoverImage from './ProfileCoverImage';
 import FavoriteGroupGrid from './FavoriteGroupGrid';
@@ -18,6 +20,7 @@ export default function ProfileModal() {
   const cover = contact?.cover || '';
   const dismiss = useDismissNavigate();
   const navigateByApp = useNavigateByApp();
+  const pals = usePalsState();
 
   useEffect(() => {
     if (ship) {
@@ -104,6 +107,7 @@ export default function ProfileModal() {
           {contact.nickname ? (
             <ShipName name={ship} className="ml-2 text-gray-600" />
           ) : null}
+          <PalIcon className="ml-2" ship={ship} />
         </div>
         <ProfileBio bio={contact.bio} />
         {contact.groups.length > 0 && (
@@ -114,7 +118,22 @@ export default function ProfileModal() {
         )}
       </div>
       <footer className="flex items-center py-4 px-6">
-        <button className="secondary-button ml-auto" onClick={handleCopyClick}>
+        {pals.installed && pals.pals.outgoing[ship.slice(1)] ? (
+          <button
+            className="secondary-button ml-auto bg-red-100"
+            onClick={() => pals.removePal(ship.slice(1))}
+          >
+            Remove Pal
+          </button>
+        ) : (
+          <button
+            className="secondary-button ml-auto"
+            onClick={() => pals.addPal(ship.slice(1))}
+          >
+            Add Pal
+          </button>
+        )}
+        <button className="secondary-button ml-2" onClick={handleCopyClick}>
           {didCopy ? 'Copied!' : 'Copy Name'}
         </button>
         <button className="button ml-2" onClick={handleMessageClick}>


### PR DESCRIPTION
Includes the same `PalIcon` that's displayed in chat, and includes add/remove pal buttons if pals is installed.

![image](https://github.com/tloncorp/landscape-apps/assets/3829764/7ddfade3-083f-4fff-81ee-cee869210cb2)

Putting it by the rest of the actions felt most natural. The "remove" action gets a light red color because it's destructive. But I'm open to other options. Maybe we want a gray "Remove Pal..." instead that asks for confirmation?

![image](https://github.com/tloncorp/landscape-apps/assets/3829764/766a2185-34b0-4338-9aa5-5fd64c13d368)

I suspect we may find the color in these elements clashing with the customization in the profile modal. Maybe it's fine? Maybe it's not?

(Targeting #2665 because this builds on top of that, but once that merges we can just target develop as normal.)
