### PR TITLE
profiles: hide pals action if not installed

### DIFF
--- a/talk/desk.docket-0
+++ b/talk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Send encrypted direct messages to one or many friends. Talk is a simple chat tool for catching up, getting work done, and everything in between.'
     color+0x10.5ec7
     image+'https://bootstrap.urbit.org/icon-talk.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v5.vr155.gath2.mitgr.5rfih.bladm.glob' 0v5.vr155.gath2.mitgr.5rfih.bladm]
+    glob-http+['https://bootstrap.urbit.org/glob-0v4.61qh1.hj8gd.aqomm.ul2ad.qkfc4.glob' 0v4.61qh1.hj8gd.aqomm.ul2ad.qkfc4]
     base+'talk'
     version+[4 0 1]
     website+'https://tlon.io'

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -84,33 +84,28 @@ export default function ProfileModal() {
           </div>
         )}
       </div>
-      <footer className="flex items-center py-4 px-6">
+      <footer className="flex items-center justify-end space-x-2 py-4 px-6">
         {pals.installed &&
           ship !== window.our &&
           (pals.pals.outgoing[ship.slice(1)] ? (
             <button
-              className="secondary-button ml-auto bg-red-100 dark:bg-red dark:text-white"
+              className="secondary-button bg-red-100 dark:bg-red dark:text-white"
               onClick={() => pals.removePal(ship.slice(1))}
             >
               Remove Pal
             </button>
           ) : (
             <button
-              className="secondary-button ml-auto"
+              className="secondary-button"
               onClick={() => pals.addPal(ship.slice(1))}
             >
               Add Pal
             </button>
           ))}
-        <button
-          className={`secondary-button ${
-            pals.installed && ship !== window.our ? 'ml-2' : 'ml-auto'
-          }`}
-          onClick={handleCopyClick}
-        >
+        <button className="secondary-button" onClick={handleCopyClick}>
           {didCopy ? 'Copied!' : 'Copy Name'}
         </button>
-        <button className="button ml-2" onClick={handleMessageClick}>
+        <button className="button" onClick={handleMessageClick}>
           Message
         </button>
       </footer>

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -89,7 +89,7 @@ export default function ProfileModal() {
           ship !== window.our &&
           (pals.pals.outgoing[ship.slice(1)] ? (
             <button
-              className="secondary-button ml-auto bg-red-100"
+              className="secondary-button ml-auto bg-red-100 dark:bg-red dark:text-white"
               onClick={() => pals.removePal(ship.slice(1))}
             >
               Remove Pal

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -53,42 +53,6 @@ export default function ProfileModal() {
     onCopy();
   };
 
-  if (!contact) {
-    return (
-      <Dialog
-        defaultOpen
-        onOpenChange={onOpenChange}
-        className="overflow-y-auto p-0"
-        containerClass="w-full sm:max-w-lg"
-      >
-        <ProfileCoverImage className="flex items-end" cover={cover}>
-          <Avatar
-            ship={ship}
-            icon={false}
-            size="huge"
-            className="translate-y-9"
-          />
-        </ProfileCoverImage>
-        <div className="p-5 pt-14">
-          <div className="text-lg font-bold">
-            <ShipName name={ship} showAlias />
-          </div>
-        </div>
-        <footer className="flex items-center py-4 px-6">
-          <button
-            className="secondary-button ml-auto"
-            onClick={handleCopyClick}
-          >
-            {didCopy ? 'Copied!' : 'Copy Name'}
-          </button>
-          <button className="button ml-2" onClick={handleMessageClick}>
-            Message
-          </button>
-        </footer>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog
       defaultOpen
@@ -107,13 +71,13 @@ export default function ProfileModal() {
       <div className="p-5 pt-14">
         <div className="text-lg font-bold">
           <ShipName name={ship} showAlias />
-          {contact.nickname ? (
+          {contact && contact.nickname ? (
             <ShipName name={ship} className="ml-2 text-gray-600" />
           ) : null}
           <PalIcon className="ml-2" ship={ship} />
         </div>
-        <ProfileBio bio={contact.bio} />
-        {contact.groups.length > 0 && (
+        {contact && <ProfileBio bio={contact.bio} />}
+        {contact && contact.groups.length > 0 && (
           <div className="mt-5">
             <h2 className="mb-3 font-semibold">Favorite Groups</h2>
             <FavoriteGroupGrid groupFlags={contact.groups} />
@@ -121,22 +85,29 @@ export default function ProfileModal() {
         )}
       </div>
       <footer className="flex items-center py-4 px-6">
-        {pals.installed && pals.pals.outgoing[ship.slice(1)] ? (
-          <button
-            className="secondary-button ml-auto bg-red-100"
-            onClick={() => pals.removePal(ship.slice(1))}
-          >
-            Remove Pal
-          </button>
-        ) : (
-          <button
-            className="secondary-button ml-auto"
-            onClick={() => pals.addPal(ship.slice(1))}
-          >
-            Add Pal
-          </button>
-        )}
-        <button className="secondary-button ml-2" onClick={handleCopyClick}>
+        {pals.installed &&
+          ship !== window.our &&
+          (pals.pals.outgoing[ship.slice(1)] ? (
+            <button
+              className="secondary-button ml-auto bg-red-100"
+              onClick={() => pals.removePal(ship.slice(1))}
+            >
+              Remove Pal
+            </button>
+          ) : (
+            <button
+              className="secondary-button ml-auto"
+              onClick={() => pals.addPal(ship.slice(1))}
+            >
+              Add Pal
+            </button>
+          ))}
+        <button
+          className={`secondary-button ${
+            pals.installed && ship !== window.our ? 'ml-2' : 'ml-auto'
+          }`}
+          onClick={handleCopyClick}
+        >
           {didCopy ? 'Copied!' : 'Copy Name'}
         </button>
         <button className="button ml-2" onClick={handleMessageClick}>


### PR DESCRIPTION
The conditional for this was implemented incorrectly. Additionally, the styling would not account for it.

Alongside the fix, we refactor the `!contacts` branch into a single main rendering branch, within which we check that condition to decide whether to include a component. Doing so prevents us from duplicating the now slightly more complex button rendering logic, and will make additions and modifications easier going forward.

This seems to behave correctly now, but please scrutinize closely. This is the best factoring I could come up with, but maybe it was deliberately not done like this initially.

Fixes LAND-643.