### PR TITLE
gallery: generalized cleanup, better refs

### DIFF
--- a/ui/src/components/References/BaitReference.tsx
+++ b/ui/src/components/References/BaitReference.tsx
@@ -16,9 +16,13 @@ import WritBaitReference from './WritBaitReference';
 function BaitReference({
   bait,
   isScrolling,
+  contextApp,
+  children,
 }: {
   isScrolling: boolean;
   bait: BaitCite['bait'];
+  contextApp?: string;
+  children: React.ReactNode;
 }) {
   const { group, graph, where } = bait;
   const theGroup = useGroup(group);
@@ -46,8 +50,11 @@ function BaitReference({
         idCurio={id}
         chFlag={graph}
         nest={`heap/${graph}`}
+        contextApp={contextApp}
         isScrolling={isScrolling}
-      />
+      >
+        {children}
+      </CurioReference>
     );
   }
 
@@ -57,6 +64,7 @@ function BaitReference({
         chFlag={graph}
         nest={nest}
         index={where}
+        contextApp={contextApp}
         isScrolling={isScrolling}
       />
     );

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -18,12 +18,23 @@ import NoteCommentReference from './NoteCommentReference';
 function ContentReference({
   cite,
   isScrolling = false,
+  contextApp,
+  plain,
 }: {
   cite: Cite;
   isScrolling?: boolean;
+  contextApp?: string;
+  plain?: boolean;
 }) {
   if ('group' in cite) {
-    return <GroupReference flag={cite.group} isScrolling={isScrolling} />;
+    return (
+      <GroupReference
+        plain={plain}
+        contextApp={contextApp}
+        flag={cite.group}
+        isScrolling={isScrolling}
+      />
+    );
   }
 
   if ('desk' in cite) {

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -121,7 +121,10 @@ function ContentReference({
             nest={nest}
             noteId={idNote}
             quipId={idQuip}
-          />
+            contextApp={contextApp}
+          >
+            {children}
+          </NoteCommentReference>
         );
       }
 
@@ -131,7 +134,10 @@ function ContentReference({
           nest={nest}
           id={idNote}
           isScrolling={isScrolling}
-        />
+          contextApp={contextApp}
+        >
+          {children}
+        </NoteReference>
       );
     }
   }

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -6,9 +6,11 @@ import { udToDec } from '@urbit/api';
 import CurioReference from './CurioReference';
 // eslint-disable-next-line import/no-cycle
 import WritChanReference from './WritChanReference';
+// eslint-disable-next-line import/no-cycle
 import GroupReference from './GroupReference';
 // eslint-disable-next-line import/no-cycle
 import NoteReference from './NoteReference';
+// eslint-disable-next-line import/no-cycle
 import AppReference from './AppReference';
 // eslint-disable-next-line import/no-cycle
 import BaitReference from './BaitReference';
@@ -20,11 +22,13 @@ function ContentReference({
   isScrolling = false,
   contextApp,
   plain,
+  children,
 }: {
   cite: Cite;
   isScrolling?: boolean;
   contextApp?: string;
   plain?: boolean;
+  children?: React.ReactNode;
 }) {
   if ('group' in cite) {
     return (
@@ -33,7 +37,9 @@ function ContentReference({
         contextApp={contextApp}
         flag={cite.group}
         isScrolling={isScrolling}
-      />
+      >
+        {children}
+      </GroupReference>
     );
   }
 
@@ -43,7 +49,15 @@ function ContentReference({
   }
 
   if ('bait' in cite) {
-    return <BaitReference bait={cite.bait} isScrolling={isScrolling} />;
+    return (
+      <BaitReference
+        bait={cite.bait}
+        contextApp={contextApp}
+        isScrolling={isScrolling}
+      >
+        {children}
+      </BaitReference>
+    );
   }
   if ('chan' in cite) {
     const { nest, where } = cite.chan;
@@ -62,7 +76,10 @@ function ContentReference({
             idCurio={idCurio}
             idCurioComment={idCurioComment}
             isScrolling={isScrolling}
-          />
+            contextApp={contextApp}
+          >
+            {children}
+          </CurioReference>
         );
       }
 
@@ -72,7 +89,10 @@ function ContentReference({
           nest={nest}
           idCurio={idCurio}
           isScrolling={isScrolling}
-        />
+          contextApp={contextApp}
+        >
+          {children}
+        </CurioReference>
       );
     }
     if (app === 'chat') {
@@ -82,8 +102,11 @@ function ContentReference({
           isScrolling={isScrolling}
           chFlag={chFlag}
           nest={nest}
+          contextApp={contextApp}
           idWrit={idWrit}
-        />
+        >
+          {children}
+        </WritChanReference>
       );
     }
     if (app === 'diary') {

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import cn from 'classnames';
-import { useHeapState, useRemoteCurio } from '@/state/heap/heap';
+import { useRemoteCurio } from '@/state/heap/heap';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 // eslint-disable-next-line import/no-cycle
 import HeapBlock from '@/heap/HeapBlock';
@@ -15,8 +15,8 @@ import { isImageUrl } from '@/logic/utils';
 import { inlineToString } from '@/logic/tiptap';
 import ReferenceBar from './ReferenceBar';
 import ShipName from '../ShipName';
-import Sig16Icon from '../icons/Sig16Icon';
-import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
+import ReferenceInHeap from './ReferenceInHeap';
+import ShapesIcon from '../icons/ShapesIcon';
 
 function CurioReference({
   chFlag,
@@ -51,6 +51,10 @@ function CurioReference({
   const refToken = preview?.group
     ? `${preview.group.flag}/channels/${nest}/curio/${idCurio}`
     : undefined;
+  const textFallbackTitle = curio?.heart?.content.inline
+    .map((inline) => inlineToString(inline))
+    .join(' ')
+    .toString();
 
   const handleOpenReferenceClick = () => {
     if (!group) {
@@ -66,64 +70,63 @@ function CurioReference({
     return <HeapLoadingBlock reference />;
   }
 
+  if (contextApp === 'heap-row') {
+    return (
+      <ReferenceInHeap
+        contextApp={contextApp}
+        image={
+          isImageUrl(inlineToString(curio?.heart?.content?.inline[0])) ? (
+            <img
+              src={inlineToString(curio?.heart?.content?.inline[0])}
+              className={cn('h-[72px] w-[72px] rounded object-cover')}
+            />
+          ) : (
+            <ShapesIcon className="h-6 w-6 text-gray-400" />
+          )
+        }
+        title={textFallbackTitle}
+        byline={
+          <span>
+            Post by <ShipName name={curio?.heart.author} showAlias /> in{' '}
+            {preview?.meta?.title}
+          </span>
+        }
+      >
+        {children}
+      </ReferenceInHeap>
+    );
+  }
+
   if (contextApp === 'heap-block') {
     const href = inlineToString(curio?.heart?.content?.inline[0]);
+
     if (isImageUrl(href)) {
       return (
-        <img
-          src={href}
-          loading="lazy"
-          className="absolute top-0 left-0 h-full w-full object-cover"
+        <ReferenceInHeap
+          contextApp={contextApp}
+          image={
+            <img
+              src={href}
+              loading="lazy"
+              className="absolute top-0 left-0 h-full w-full object-cover"
+            />
+          }
         />
       );
     }
     return (
-      <HeapContent
-        className={cn(
-          'absolute top-0 left-0 h-full w-full py-4 px-5 leading-6 line-clamp-3'
-        )}
-        content={curio?.heart.content}
+      <ReferenceInHeap
+        type="text"
+        contextApp={contextApp}
+        image={
+          <HeapContent
+            className={cn(
+              'absolute top-0 left-0 h-full w-full py-4 px-5 leading-6 line-clamp-3'
+            )}
+            content={curio?.heart.content}
+          />
+        }
       />
-    );
-  }
-
-  if (contextApp === 'heap-row') {
-    const href = inlineToString(curio?.heart?.content?.inline[0]);
-    const textFallbackTitle = curio?.heart?.content.inline
-      .map((inline) => inlineToString(inline))
-      .join(' ')
-      .toString();
-    return (
-      <>
-        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
-          {curio?.heart?.content.inline && isImageUrl(href) ? (
-            <img
-              src={href}
-              loading="lazy"
-              className="h-[72px] w-[72px] rounded object-cover"
-            />
-          ) : (
-            <div
-              style={{ background: group?.meta.image }}
-              className="flex h-[72px] w-[72px] items-center justify-center rounded"
-            >
-              <Sig16Icon className="h-6 w-6 text-black/50" />
-            </div>
-          )}
-        </div>
-        <div className="flex grow flex-col">
-          <div className="text-lg font-semibold line-clamp-1">
-            {textFallbackTitle}
-          </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
-            <span className="">
-              Post by <ShipName name={curio?.heart.author} showAlias /> in{' '}
-              {preview?.meta?.title}
-            </span>
-          </div>
-          {children}
-        </div>
-      </>
     );
   }
 

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -4,12 +4,19 @@ import { useHeapState, useRemoteCurio } from '@/state/heap/heap';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 // eslint-disable-next-line import/no-cycle
 import HeapBlock from '@/heap/HeapBlock';
+// eslint-disable-next-line import/no-cycle
+import HeapContent from '@/heap/HeapContent';
 import { useChannelPreview, useGang } from '@/state/groups';
 import bigInt from 'big-integer';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { useLocation, useNavigate } from 'react-router';
 import useNavigateByApp from '@/logic/useNavigateByApp';
+import { isImageUrl } from '@/logic/utils';
+import { inlineToString } from '@/logic/tiptap';
 import ReferenceBar from './ReferenceBar';
+import ShipName from '../ShipName';
+import Sig16Icon from '../icons/Sig16Icon';
+import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 
 function CurioReference({
   chFlag,
@@ -17,12 +24,16 @@ function CurioReference({
   idCurio,
   idCurioComment,
   isScrolling = false,
+  contextApp,
+  children,
 }: {
   chFlag: string;
   nest: string;
   idCurio: string;
   idCurioComment?: string;
   isScrolling?: boolean;
+  contextApp?: string;
+  children?: React.ReactNode;
 }) {
   const curio = useRemoteCurio(chFlag, idCurio, isScrolling);
   const curioComment = useRemoteCurio(
@@ -54,6 +65,68 @@ function CurioReference({
   if (!curio) {
     return <HeapLoadingBlock reference />;
   }
+
+  if (contextApp === 'heap-block') {
+    const href = inlineToString(curio?.heart?.content?.inline[0]);
+    if (isImageUrl(href)) {
+      return (
+        <img
+          src={href}
+          loading="lazy"
+          className="absolute top-0 left-0 h-full w-full object-cover"
+        />
+      );
+    }
+    return (
+      <HeapContent
+        className={cn(
+          'absolute top-0 left-0 h-full w-full py-4 px-5 leading-6 line-clamp-3'
+        )}
+        content={curio?.heart.content}
+      />
+    );
+  }
+
+  if (contextApp === 'heap-row') {
+    const href = inlineToString(curio?.heart?.content?.inline[0]);
+    const textFallbackTitle = curio?.heart?.content.inline
+      .map((inline) => inlineToString(inline))
+      .join(' ')
+      .toString();
+    return (
+      <>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
+          {curio?.heart?.content.inline && isImageUrl(href) ? (
+            <img
+              src={href}
+              loading="lazy"
+              className="h-[72px] w-[72px] rounded object-cover"
+            />
+          ) : (
+            <div
+              style={{ background: group?.meta.image }}
+              className="flex h-[72px] w-[72px] items-center justify-center rounded"
+            >
+              <Sig16Icon className="h-6 w-6 text-black/50" />
+            </div>
+          )}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1">
+            {textFallbackTitle}
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+            <span className="">
+              Post by <ShipName name={curio?.heart.author} showAlias /> in{' '}
+              {preview?.meta?.title}
+            </span>
+          </div>
+          {children}
+        </div>
+      </>
+    );
+  }
+
   return (
     <div
       className={cn('heap-inline-block not-prose group', {

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -118,7 +118,7 @@ function GroupReference({
         <div className="absolute top-2 left-2 flex items-center space-x-2 rounded p-2 text-base font-bold">
           <GroupAvatar {...meta} size="h-6 w-6" />
           <span
-            className="text-white"
+            className="text-white dark:text-black"
             style={{ textShadow: 'black 0px 1px 3px' }}
           >
             {title}

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import cn from 'classnames';
 import useGroupJoin from '@/groups/useGroupJoin';
 import { useGang, useGangPreview } from '@/state/groups';
@@ -13,7 +13,7 @@ import {
 import ShipName from '@/components/ShipName';
 import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
-import Sig16Icon from '../icons/Sig16Icon';
+import ReferenceInHeap from './ReferenceInHeap';
 
 interface GroupReferenceProps {
   flag: string;
@@ -99,69 +99,66 @@ function GroupReference({
     );
   }
 
-  if (contextApp === 'heap-block') {
-    const { title, cover } = meta || {
-      title: '',
-      cover: '',
-    };
-    return (
-      <div className={cn('h-full w-full')}>
-        {isImageUrl(cover) ? (
+  if (contextApp === 'heap-row') {
+    const refImage = () => {
+      if (meta && isImageUrl(meta.image)) {
+        return (
           <img
-            src={cover}
-            loading="lazy"
-            className="absolute top-0 left-0 h-full w-full"
+            src={meta?.image}
+            className="h-[72px] w-[72px] rounded object-cover"
           />
-        ) : (
-          <div
-            style={{ background: cover }}
-            className="absolute top-0 left-0 h-full w-full"
-          />
-        )}
-        <div className="absolute top-2 left-2 flex items-center space-x-2 rounded p-2 text-base font-bold">
-          <GroupAvatar {...meta} size="h-6 w-6" />
-          <span
-            className="text-white dark:text-black"
-            style={{ textShadow: 'black 0px 1px 3px' }}
-          >
-            {title}
-          </span>
-        </div>
-      </div>
+        );
+      }
+      return (
+        <div
+          className="h-[72px] w-[72px] rounded"
+          style={{ background: meta?.image }}
+        />
+      );
+    };
+
+    return (
+      <ReferenceInHeap
+        contextApp={contextApp}
+        image={refImage()}
+        title={meta?.title}
+        byline={<span className="capitalize">{privacy} Group</span>}
+      >
+        {children}
+      </ReferenceInHeap>
     );
   }
 
-  if (contextApp === 'heap-row') {
-    const { title, image } = meta || {
-      title: '',
-      image: '',
-    };
+  if (contextApp === 'heap-block') {
     return (
-      <>
-        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
-          {isImageUrl(image) ? (
-            <img
-              src={image}
-              loading="lazy"
-              className="h-[72px] w-[72px] rounded object-cover"
-            />
-          ) : (
-            <div
-              style={{ background: image }}
-              className=" flex h-[72px] w-[72px] items-center justify-center rounded"
-            >
-              <Sig16Icon className="h-6 w-6 text-black/50" />
+      <ReferenceInHeap
+        contextApp={contextApp}
+        image={
+          <div className={cn('h-full w-full')}>
+            {meta && isImageUrl(meta.cover) ? (
+              <img
+                src={meta.cover}
+                loading="lazy"
+                className="absolute top-0 left-0 h-full w-full"
+              />
+            ) : (
+              <div
+                style={{ background: meta?.cover }}
+                className="absolute top-0 left-0 h-full w-full"
+              />
+            )}
+            <div className="absolute top-2 left-2 flex items-center space-x-2 rounded p-2 text-base font-bold">
+              <GroupAvatar {...meta} size="h-6 w-6" />
+              <span
+                className="text-white dark:text-black"
+                style={{ textShadow: 'black 0px 1px 3px' }}
+              >
+                {meta?.title}
+              </span>
             </div>
-          )}
-        </div>
-        <div className="flex grow flex-col">
-          <div className="text-lg font-semibold line-clamp-1">{title}</div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
-            <span className="capitalize">{privacy} Group</span>
           </div>
-          {children}
-        </div>
-      </>
+        }
+      />
     );
   }
 

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -13,6 +13,7 @@ import {
 import ShipName from '@/components/ShipName';
 import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
+import Sig16Icon from '../icons/Sig16Icon';
 
 interface GroupReferenceProps {
   flag: string;
@@ -21,6 +22,7 @@ interface GroupReferenceProps {
   onlyButton?: boolean;
   description?: string;
   contextApp?: string;
+  children?: React.ReactNode;
 }
 
 function GroupReference({
@@ -30,6 +32,7 @@ function GroupReference({
   onlyButton = false,
   description,
   contextApp,
+  children,
 }: GroupReferenceProps) {
   const gang = useGang(flag);
   const preview = useGangPreview(flag, isScrolling);
@@ -125,6 +128,40 @@ function GroupReference({
           </span>
         </div>
       </div>
+    );
+  }
+
+  if (contextApp === 'heap-row') {
+    const { title, image } = meta || {
+      title: '',
+      image: '',
+    };
+    return (
+      <>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
+          {isImageUrl(image) ? (
+            <img
+              src={image}
+              loading="lazy"
+              className="h-[72px] w-[72px] rounded object-cover"
+            />
+          ) : (
+            <div
+              style={{ background: image }}
+              className=" flex h-[72px] w-[72px] items-center justify-center rounded"
+            >
+              <Sig16Icon className="h-6 w-6 text-black/50" />
+            </div>
+          )}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1">{title}</div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+            <span className="capitalize">{privacy} Group</span>
+          </div>
+          {children}
+        </div>
+      </>
     );
   }
 

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -5,6 +5,7 @@ import { useGang, useGangPreview } from '@/state/groups';
 import GroupAvatar from '@/groups/GroupAvatar';
 import {
   getFlagParts,
+  isImageUrl,
   matchesBans,
   pluralRank,
   toTitleCase,
@@ -19,6 +20,7 @@ interface GroupReferenceProps {
   plain?: boolean;
   onlyButton?: boolean;
   description?: string;
+  contextApp?: string;
 }
 
 function GroupReference({
@@ -27,6 +29,7 @@ function GroupReference({
   plain = false,
   onlyButton = false,
   description,
+  contextApp,
 }: GroupReferenceProps) {
   const gang = useGang(flag);
   const preview = useGangPreview(flag, isScrolling);
@@ -93,20 +96,53 @@ function GroupReference({
     );
   }
 
+  if (contextApp === 'heap-block') {
+    const { title, cover } = meta || {
+      title: '',
+      cover: '',
+    };
+    return (
+      <div className={cn('h-full w-full')}>
+        {isImageUrl(cover) ? (
+          <img
+            src={cover}
+            loading="lazy"
+            className="absolute top-0 left-0 h-full w-full"
+          />
+        ) : (
+          <div
+            style={{ background: cover }}
+            className="absolute top-0 left-0 h-full w-full"
+          />
+        )}
+        <div className="absolute top-2 left-2 flex items-center space-x-2 rounded p-2 text-base font-bold">
+          <GroupAvatar {...meta} size="h-6 w-6" />
+          <span
+            className="text-white"
+            style={{ textShadow: 'black 0px 1px 3px' }}
+          >
+            {title}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
-        'not-prose relative mb-2 flex max-w-[300px] items-center rounded-lg bg-white text-base transition-colors hover:border-gray-100 hover:bg-white group-one-hover:border-gray-100 group-one-hover:bg-white',
+        'not-prose items-top relative flex max-w-[300px] rounded-lg bg-white text-base transition-colors hover:border-gray-100 hover:bg-white group-one-hover:border-gray-100 group-one-hover:bg-white',
         {
           'border-2 border-gray-50': !plain,
-        }
+        },
+        contextApp === 'heap-detail' ? 'mb-0 h-full border-none' : 'mb-2'
       )}
     >
       <button
         className="flex w-full items-center justify-start rounded-lg p-2 text-left"
         onClick={open}
       >
-        <div className="flex items-center space-x-3 font-semibold">
+        <div className="items-top flex space-x-3 font-semibold">
           <GroupAvatar {...meta} size="h-12 w-12" />
           <div className="overflow-hidden text-ellipsis text-sm leading-5">
             <h3 className="line-clamp-1">{meta?.title || flag} </h3>
@@ -120,17 +156,17 @@ function GroupReference({
               </span>
             )}
             {!plain && (
-              <span className="text-sm capitalize text-gray-400">
-                Group • {privacy}
-              </span>
-            )}
-            {description && (
-              <span className="text-sm text-gray-400">{description}</span>
+              <>
+                <span className="text-sm capitalize text-gray-400">
+                  Group • {privacy}
+                </span>
+                <p className="text-sm text-gray-800">{meta?.description}</p>
+              </>
             )}
           </div>
         </div>
       </button>
-      <div className="mr-2 flex flex-row">
+      <div className="mr-2 flex flex-row pt-2">
         {banned ? (
           <div className="rounded-lg bg-gray-100 p-2 text-center text-xs font-semibold leading-3 text-gray-600">
             {banned === 'ship'

--- a/ui/src/components/References/NoteCommentReference.tsx
+++ b/ui/src/components/References/NoteCommentReference.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
-import { useQuip } from '@/state/diary';
+import { useQuip, useRemoteOutline } from '@/state/diary';
 import { useChannelPreview, useGang } from '@/state/groups';
 import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
@@ -12,6 +12,8 @@ import { ChatBlock, ChatStory } from '@/types/chat';
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import { useChannelFlag } from '@/logic/channel';
 import ReferenceBar from './ReferenceBar';
+import Sig16Icon from '../icons/Sig16Icon';
+import ShipName from '../ShipName';
 
 function NoteCommentReference({
   chFlag,
@@ -19,12 +21,16 @@ function NoteCommentReference({
   noteId,
   quipId,
   isScrolling = false,
+  contextApp,
+  children,
 }: {
   chFlag: string;
   nest: string;
   noteId: string;
   quipId: string;
   isScrolling?: boolean;
+  contextApp?: string;
+  children?: React.ReactNode;
 }) {
   const preview = useChannelPreview(nest);
   const isReply = useChannelFlag() === chFlag;
@@ -35,6 +41,7 @@ function NoteCommentReference({
   const navigateByApp = useNavigateByApp();
   const navigate = useNavigate();
   const location = useLocation();
+  const outline = useRemoteOutline(chFlag, noteId, isScrolling);
 
   const handleOpenReferenceClick = () => {
     if (!group) {
@@ -57,6 +64,44 @@ function NoteCommentReference({
       (b) => 'image' in b || 'cite' in b
     ) as ChatBlock[],
   };
+
+  if (contextApp === 'heap-row') {
+    return (
+      <>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
+          <div
+            style={{ background: group?.meta.image }}
+            className="flex h-[72px] w-[72px] items-center justify-center rounded"
+          >
+            <Sig16Icon className="h-6 w-6 text-black/50" />
+          </div>
+        </div>
+        <div className="flex grow flex-col">
+          <ChatContent
+            className="text-lg font-semibold line-clamp-1"
+            story={normalizedContent}
+            isScrolling={false}
+          />
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+            <span className="">
+              Comment by <ShipName name={quip.memo.author} showAlias /> on{' '}
+              {outline.title}
+            </span>
+          </div>
+          {children}
+        </div>
+      </>
+    );
+  }
+
+  if (contextApp === 'heap-block') {
+    return (
+      <div className="absolute top-0 left-0 h-full w-full px-5 py-4">
+        <ChatContent story={normalizedContent} isScrolling={false} />
+        <div className="from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent" />
+      </div>
+    );
+  }
 
   return (
     <div className="writ-inline-block not-prose group">

--- a/ui/src/components/References/NoteCommentReference.tsx
+++ b/ui/src/components/References/NoteCommentReference.tsx
@@ -12,8 +12,9 @@ import { ChatBlock, ChatStory } from '@/types/chat';
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import { useChannelFlag } from '@/logic/channel';
 import ReferenceBar from './ReferenceBar';
-import Sig16Icon from '../icons/Sig16Icon';
 import ShipName from '../ShipName';
+import ReferenceInHeap from './ReferenceInHeap';
+import BubbleIcon from '../icons/BubbleIcon';
 
 function NoteCommentReference({
   chFlag,
@@ -67,39 +68,42 @@ function NoteCommentReference({
 
   if (contextApp === 'heap-row') {
     return (
-      <>
-        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
-          <div
-            style={{ background: group?.meta.image }}
-            className="flex h-[72px] w-[72px] items-center justify-center rounded"
-          >
-            <Sig16Icon className="h-6 w-6 text-black/50" />
-          </div>
-        </div>
-        <div className="flex grow flex-col">
+      <ReferenceInHeap
+        contextApp={contextApp}
+        image={<BubbleIcon className="h-6 w-6 text-gray-400" />}
+        title={
           <ChatContent
             className="text-lg font-semibold line-clamp-1"
             story={normalizedContent}
             isScrolling={false}
           />
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
-            <span className="">
-              Comment by <ShipName name={quip.memo.author} showAlias /> on{' '}
-              {outline.title}
-            </span>
-          </div>
-          {children}
-        </div>
-      </>
+        }
+        byline={
+          <span className="">
+            Comment by <ShipName name={quip.memo.author} showAlias /> on{' '}
+            {outline.title}
+          </span>
+        }
+      >
+        {children}
+      </ReferenceInHeap>
     );
   }
 
   if (contextApp === 'heap-block') {
     return (
-      <div className="absolute top-0 left-0 h-full w-full px-5 py-4">
-        <ChatContent story={normalizedContent} isScrolling={false} />
-        <div className="from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent" />
-      </div>
+      <ReferenceInHeap
+        type="text"
+        contextApp={contextApp}
+        image={<ChatContent story={normalizedContent} isScrolling={false} />}
+        title={
+          <h2 className="mb-2 text-lg font-semibold">
+            Comment on {outline.title}
+          </h2>
+        }
+      >
+        {children}
+      </ReferenceInHeap>
     );
   }
 

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import cn from 'classnames';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { useRemoteOutline } from '@/state/diary';
 import { useChannelPreview, useGang } from '@/state/groups';
@@ -12,17 +13,23 @@ import useNavigateByApp from '@/logic/useNavigateByApp';
 // eslint-disable-next-line import/no-cycle
 import DiaryContent from '@/diary/DiaryContent/DiaryContent';
 import ReferenceBar from './ReferenceBar';
+import ShipName from '../ShipName';
+import Sig16Icon from '../icons/Sig16Icon';
 
 function NoteReference({
   chFlag,
   nest,
   id,
   isScrolling = false,
+  contextApp,
+  children,
 }: {
   chFlag: string;
   nest: string;
   id: string;
   isScrolling?: boolean;
+  contextApp?: string;
+  children?: React.ReactNode;
 }) {
   const preview = useChannelPreview(nest, isScrolling);
   const groupFlag = preview?.group?.flag || '~zod/test';
@@ -62,6 +69,57 @@ function NoteReference({
   }
 
   const prettyDate = makePrettyDate(new Date(outline.sent));
+
+  if (contextApp === 'heap-row') {
+    return (
+      <>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
+          {outline.image ? (
+            <img
+              src={outline.image}
+              loading="lazy"
+              className="h-[72px] w-[72px] rounded object-cover"
+            />
+          ) : (
+            <div
+              style={{ background: group?.meta.image }}
+              className="flex h-[72px] w-[72px] items-center justify-center rounded"
+            >
+              <Sig16Icon className="h-6 w-6 text-black/50" />
+            </div>
+          )}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1">
+            {outline.title}
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+            <span className="">
+              Post by <ShipName name={outline.author} showAlias /> in{' '}
+              {preview?.meta?.title}
+            </span>
+          </div>
+          {children}
+        </div>
+      </>
+    );
+  }
+
+  if (contextApp === 'heap-block') {
+    return (
+      <div className={cn('absolute top-0 left-0 h-full w-full px-5 py-4')}>
+        <div className="relative z-10 mb-4 text-xl font-semibold line-clamp-1">
+          {outline.title}
+        </div>
+        {contentPreview}
+        <div
+          className={cn(
+            'from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent'
+          )}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="note-inline-block group max-w-[600px] text-base">

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -4,7 +4,12 @@ import cn from 'classnames';
 import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
 import { useRemoteOutline } from '@/state/diary';
 import { useChannelPreview, useGang } from '@/state/groups';
-import { makePrettyDate, pluralize, truncateProse } from '@/logic/utils';
+import {
+  isImageUrl,
+  makePrettyDate,
+  pluralize,
+  truncateProse,
+} from '@/logic/utils';
 import bigInt from 'big-integer';
 import Avatar from '@/components/Avatar';
 import { NOTE_REF_DISPLAY_LIMIT } from '@/constants';
@@ -14,7 +19,8 @@ import useNavigateByApp from '@/logic/useNavigateByApp';
 import DiaryContent from '@/diary/DiaryContent/DiaryContent';
 import ReferenceBar from './ReferenceBar';
 import ShipName from '../ShipName';
-import Sig16Icon from '../icons/Sig16Icon';
+import ReferenceInHeap from './ReferenceInHeap';
+import NotebookIcon from '../icons/NotebookIcon';
 
 function NoteReference({
   chFlag,
@@ -72,52 +78,39 @@ function NoteReference({
 
   if (contextApp === 'heap-row') {
     return (
-      <>
-        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
-          {outline.image ? (
+      <ReferenceInHeap
+        contextApp={contextApp}
+        image={
+          isImageUrl(outline.image) ? (
             <img
               src={outline.image}
-              loading="lazy"
               className="h-[72px] w-[72px] rounded object-cover"
             />
           ) : (
-            <div
-              style={{ background: group?.meta.image }}
-              className="flex h-[72px] w-[72px] items-center justify-center rounded"
-            >
-              <Sig16Icon className="h-6 w-6 text-black/50" />
-            </div>
-          )}
-        </div>
-        <div className="flex grow flex-col">
-          <div className="text-lg font-semibold line-clamp-1">
-            {outline.title}
-          </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
-            <span className="">
-              Post by <ShipName name={outline.author} showAlias /> in{' '}
-              {preview?.meta?.title}
-            </span>
-          </div>
-          {children}
-        </div>
-      </>
+            <NotebookIcon className="h-6 w-6 text-gray-400" />
+          )
+        }
+        title={outline.title}
+        byline={
+          <span>
+            Note by <ShipName name={outline.author} showAlias /> in{' '}
+            {preview?.meta?.title}
+          </span>
+        }
+      >
+        {children}
+      </ReferenceInHeap>
     );
   }
 
   if (contextApp === 'heap-block') {
     return (
-      <div className={cn('absolute top-0 left-0 h-full w-full px-5 py-4')}>
-        <div className="relative z-10 mb-4 text-xl font-semibold line-clamp-1">
-          {outline.title}
-        </div>
-        {contentPreview}
-        <div
-          className={cn(
-            'from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent'
-          )}
-        />
-      </div>
+      <ReferenceInHeap
+        type="text"
+        title={<h2 className="mb-2 text-lg font-semibold">{outline.title}</h2>}
+        contextApp={contextApp}
+        image={contentPreview}
+      />
     );
   }
 

--- a/ui/src/components/References/ReferenceInHeap.tsx
+++ b/ui/src/components/References/ReferenceInHeap.tsx
@@ -1,0 +1,59 @@
+import cn from 'classnames';
+
+function ReferenceInHeap({
+  contextApp,
+  type,
+  children,
+  image,
+  title,
+  byline,
+}: {
+  contextApp: string;
+  type?: string;
+  children?: React.ReactNode;
+  image?: React.ReactNode | undefined;
+  title?: React.ReactNode | string;
+  byline?: React.ReactNode | string;
+}) {
+  if (contextApp === 'heap-row') {
+    return (
+      <>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+          {image}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1">{title}</div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+            {byline}
+          </div>
+          {children}
+        </div>
+      </>
+    );
+  }
+
+  if (contextApp === 'heap-block') {
+    return (
+      <div
+        className={cn(
+          'absolute top-0 left-0 h-full w-full',
+          type === 'text' ? 'bg-white p-4' : ''
+        )}
+      >
+        {type === 'text' && title}
+        {image}
+        {type === 'text' && (
+          <div
+            className={cn(
+              'from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent'
+            )}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export default ReferenceInHeap;

--- a/ui/src/components/References/WritBaitReference.tsx
+++ b/ui/src/components/References/WritBaitReference.tsx
@@ -11,8 +11,10 @@ export default function WritBaitReference(props: {
   nest: string;
   index: string;
   isScrolling: boolean;
+  contextApp?: string;
+  children?: React.ReactNode;
 }) {
-  const { chFlag, nest, index, isScrolling } = props;
+  const { chFlag, nest, index, isScrolling, contextApp, children } = props;
   const writ = useWritByFlagAndGraphIndex(chFlag, index, isScrolling);
   const [, udId] = index.split('/');
   if (writ === 'loading') {
@@ -20,6 +22,12 @@ export default function WritBaitReference(props: {
     return <UnavailableReference time={time} nest={nest} preview={null} />;
   }
   return (
-    <WritBaseReference writ={writ === 'error' ? undefined : writ} {...props} />
+    <WritBaseReference
+      writ={writ === 'error' ? undefined : writ}
+      contextApp={contextApp}
+      {...props}
+    >
+      {children}
+    </WritBaseReference>
   );
 }

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -13,7 +13,7 @@ import { useChannelFlag } from '@/logic/channel';
 import { isImageUrl } from '@/logic/utils';
 import ReferenceBar from './ReferenceBar';
 import ShipName from '../ShipName';
-import Sig16Icon from '../icons/Sig16Icon';
+import ReferenceInHeap from './ReferenceInHeap';
 
 interface WritBaseReferenceProps {
   nest: string;
@@ -68,44 +68,42 @@ function WritBaseReference({
 
   if (contextApp === 'heap-row') {
     return (
-      <>
-        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
-          {group && isImageUrl(group.meta.image) ? (
+      <ReferenceInHeap
+        type="text"
+        contextApp={contextApp}
+        image={
+          group && isImageUrl(group.meta.image) ? (
             <img
-              src={group?.meta.image}
-              loading="lazy"
+              src={group.meta.image}
               className="h-[72px] w-[72px] rounded object-cover"
             />
           ) : (
             <div
+              className="h-[72px] w-[72px] rounded"
               style={{ background: group?.meta.image }}
-              className=" flex h-[72px] w-[72px] items-center justify-center rounded"
-            >
-              <Sig16Icon className="h-6 w-6 text-black/50" />
-            </div>
-          )}
-        </div>
-        <div className="flex grow flex-col">
-          <div className="text-lg font-semibold line-clamp-1">
-            {writ.memo.content.story.block.length > 0 ? (
-              <span>Nested content references</span>
-            ) : (
-              <ChatContent
-                className="line-clamp-1"
-                story={writ.memo.content.story}
-                isScrolling={false}
-              />
-            )}
-          </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
-            <span className="">
-              Post by <ShipName name={writ.memo.author} showAlias /> in{' '}
-              {preview?.meta?.title}
-            </span>
-          </div>
-          {children}
-        </div>
-      </>
+            />
+          )
+        }
+        title={
+          writ.memo.content.story.block.length > 0 ? (
+            <span>Nested content references</span>
+          ) : (
+            <ChatContent
+              className="line-clamp-1"
+              story={writ.memo.content.story}
+              isScrolling={false}
+            />
+          )
+        }
+        byline={
+          <span>
+            Chat message by <ShipName name={writ.memo.author} showAlias /> in{' '}
+            {preview?.meta?.title}
+          </span>
+        }
+      >
+        {children}
+      </ReferenceInHeap>
     );
   }
 

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -10,13 +10,18 @@ import useGroupJoin from '@/groups/useGroupJoin';
 import { useChatState } from '@/state/chat';
 import { unixToDa } from '@urbit/api';
 import { useChannelFlag } from '@/logic/channel';
+import { isImageUrl } from '@/logic/utils';
 import ReferenceBar from './ReferenceBar';
+import ShipName from '../ShipName';
+import Sig16Icon from '../icons/Sig16Icon';
 
 interface WritBaseReferenceProps {
   nest: string;
   chFlag: string;
   writ?: ChatWrit;
   isScrolling: boolean;
+  contextApp?: string;
+  children?: React.ReactNode;
 }
 
 function WritBaseReference({
@@ -24,6 +29,8 @@ function WritBaseReference({
   writ,
   chFlag,
   isScrolling,
+  contextApp,
+  children,
 }: WritBaseReferenceProps) {
   const isReply = useChannelFlag() === chFlag;
   const preview = useChannelPreview(nest, isScrolling);
@@ -58,6 +65,49 @@ function WritBaseReference({
     }
     navigate(`/groups/${groupFlag}/channels/${nest}?msg=${time}`);
   };
+
+  if (contextApp === 'heap-row') {
+    return (
+      <>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded">
+          {group && isImageUrl(group.meta.image) ? (
+            <img
+              src={group?.meta.image}
+              loading="lazy"
+              className="h-[72px] w-[72px] rounded object-cover"
+            />
+          ) : (
+            <div
+              style={{ background: group?.meta.image }}
+              className=" flex h-[72px] w-[72px] items-center justify-center rounded"
+            >
+              <Sig16Icon className="h-6 w-6 text-black/50" />
+            </div>
+          )}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1">
+            {writ.memo.content.story.block.length > 0 ? (
+              <span>Nested content references</span>
+            ) : (
+              <ChatContent
+                className="line-clamp-1"
+                story={writ.memo.content.story}
+                isScrolling={false}
+              />
+            )}
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+            <span className="">
+              Post by <ShipName name={writ.memo.author} showAlias /> in{' '}
+              {preview?.meta?.title}
+            </span>
+          </div>
+          {children}
+        </div>
+      </>
+    );
+  }
 
   return (
     <div

--- a/ui/src/components/References/WritChanReference.tsx
+++ b/ui/src/components/References/WritChanReference.tsx
@@ -8,10 +8,16 @@ function WritChanReference(props: {
   nest: string;
   idWrit: string;
   isScrolling: boolean;
+  contextApp?: string;
+  children?: React.ReactNode;
 }) {
-  const { chFlag, idWrit, isScrolling } = props;
+  const { chFlag, idWrit, isScrolling, contextApp, children } = props;
   const writ = useWritByFlagAndWritId(chFlag, idWrit, isScrolling);
-  return <WritBaseReference writ={writ} {...props} />;
+  return (
+    <WritBaseReference writ={writ} contextApp={contextApp} {...props}>
+      {children}
+    </WritBaseReference>
+  );
 }
 
 export default React.memo(WritChanReference);

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -26,6 +26,7 @@ import ConfirmationModal from '@/components/ConfirmationModal';
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import { useNavigate } from 'react-router';
 import useLongPress from '@/logic/useLongPress';
+import Avatar from '@/components/Avatar';
 import useCurioActions from './useCurioActions';
 
 interface CurioDisplayProps {
@@ -66,7 +67,7 @@ function TopBar({
   return (
     <div
       onClick={(e) => e.stopPropagation()}
-      className={cn('absolute w-full select-none items-center px-4', {
+      className={cn('absolute z-40 w-full select-none items-center px-4', {
         'justify-between': hasIcon || isTwitter,
         'justify-end': !hasIcon && !isTwitter,
         flex: longPress,
@@ -175,25 +176,12 @@ function TopBar({
 
 interface BottomBarProps {
   curio: HeapCurio;
-  provider: string;
-  longPress: boolean;
-  title?: string;
   asRef?: boolean;
 }
 
-function BottomBar({
-  curio,
-  provider,
-  title,
-  asRef,
-  longPress,
-}: BottomBarProps) {
-  const { content, sent } = curio.heart;
+function BottomBar({ curio, asRef }: BottomBarProps) {
+  const { sent } = curio.heart;
   const replyCount = curio.seal.replied.length;
-  const url =
-    content.inline.length > 0 && isLink(content.inline[0])
-      ? content.inline[0].link.href
-      : '';
   const prettySent = formatDistanceToNow(sent);
 
   if (asRef) {
@@ -201,31 +189,20 @@ function BottomBar({
   }
 
   return (
-    <div className="absolute bottom-0 -mx-2 h-[50px] w-full select-none">
-      <div
-        className={cn(
-          'h-[50px] w-full border-t-2 border-gray-100 bg-white p-2',
-          {
-            'hidden group-hover:block': !longPress,
-          }
-        )}
-      >
-        <div className="flex flex-col">
-          <span className="truncate font-semibold text-gray-800">
-            {title ? title : url}
-          </span>
-          <div className="items center flex justify-between">
-            <div className="flex items-center space-x-1 text-sm font-semibold">
-              <span className="text-gray-600">{provider}</span>
-              <span className="text-lg text-gray-200"> • </span>
-              <span className="text-gray-400">{prettySent} ago</span>
-            </div>
-            <div className="flex items-center space-x-1 text-sm font-semibold text-gray-400">
-              <span>{replyCount > 0 && replyCount}</span>
-              <ChatSmallIcon className="h-4 w-4" />
-            </div>
+    <div
+      className={cn(
+        'absolute bottom-2 left-2 flex w-[calc(100%-16px)] select-none items-center space-x-2 overflow-hidden rounded p-2 group-hover:bg-white/50 group-hover:backdrop-blur'
+      )}
+    >
+      <Avatar ship={curio.heart.author} size="xs" />
+      <div className="hidden w-full justify-between align-middle group-hover:flex">
+        <span className="truncate font-semibold">{prettySent} ago</span>
+        {replyCount > 0 ? (
+          <div className="flex space-x-1 align-middle font-semibold">
+            <ChatSmallIcon className="h-4 w-4" />
+            <span>{replyCount}</span>
           </div>
-        </div>
+        ) : null}
       </div>
     </div>
   );
@@ -335,11 +312,7 @@ export default function HeapBlock({
               story={{ block: content.block, inline: content.inline }}
             />
           </div>
-          <BottomBar
-            {...botBar}
-            provider="Urbit Reference"
-            title={curio.heart.title || 'Urbit Reference'}
-          />
+          <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>
     );
@@ -356,11 +329,7 @@ export default function HeapBlock({
               content={content}
             />
           </div>
-          <BottomBar
-            {...botBar}
-            provider="Urbit Reference"
-            title={curio.heart.title || 'Urbit Reference'}
-          />
+          <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>
     );
@@ -372,17 +341,12 @@ export default function HeapBlock({
         <div className={cnm()}>
           <TopBar hasIcon canEdit={canEdit} {...topBar} />
           <HeapContent
-            className={cn('leading-6', asRef ? 'mx-3 my-2 line-clamp-9' : '')}
+            className={cn('mx-3 my-2 leading-6', asRef ? 'line-clamp-9' : '')}
             leading-6
             content={content}
           />
-          <BottomBar
-            {...botBar}
-            provider="Text"
-            title={
-              curio.heart.title || _.truncate(textFallbackTitle, { length: 20 })
-            }
-          />
+          <div className="from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent" />
+          <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>
     );
@@ -400,11 +364,7 @@ export default function HeapBlock({
           }}
         >
           <TopBar canEdit={canEdit} {...topBar} />
-          <BottomBar
-            {...botBar}
-            provider="Image"
-            title={curio.heart.title || url}
-          />
+          <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>
     );
@@ -418,11 +378,7 @@ export default function HeapBlock({
           <div className="flex grow flex-col items-center justify-center">
             <MusicLargeIcon className="h-16 w-16 text-gray-300" />
           </div>
-          <BottomBar
-            {...botBar}
-            provider="Audio"
-            title={curio.heart.title || url}
-          />
+          <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>
     );
@@ -431,7 +387,7 @@ export default function HeapBlock({
   const isOembed = validOembedCheck(embed, url);
 
   if (isOembed && !calm?.disableRemoteContent) {
-    const { title, thumbnail_url: thumbnail, provider_name: provider } = embed;
+    const { thumbnail_url: thumbnail, provider_name: provider } = embed;
 
     if (thumbnail) {
       return (
@@ -443,7 +399,7 @@ export default function HeapBlock({
             }}
           >
             <TopBar canEdit={canEdit} {...topBar} />
-            <BottomBar {...botBar} provider={provider} title={title || url} />
+            <BottomBar {...botBar} />
           </div>
         </HeapBlockWrapper>
       );
@@ -465,11 +421,7 @@ export default function HeapBlock({
               <span className="font-semibold text-black">{author}</span>
               <span className="text-gray-300">@{twitterHandle}</span>
             </div>
-            <BottomBar
-              {...botBar}
-              provider={provider}
-              title={twitterHandle || url}
-            />
+            <BottomBar {...botBar} />
           </div>
         </HeapBlockWrapper>
       );
@@ -481,11 +433,7 @@ export default function HeapBlock({
           <div className="flex grow flex-col items-center justify-center">
             <LinkIcon className="h-16 w-16 text-gray-300" />
           </div>
-          <BottomBar
-            {...botBar}
-            provider={provider ? provider : 'Link'}
-            title={title || url}
-          />
+          <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>
     );
@@ -498,11 +446,7 @@ export default function HeapBlock({
         <div className="flex grow flex-col items-center justify-center">
           <LinkIcon className="h-16 w-16 text-gray-300" />
         </div>
-        <BottomBar
-          {...botBar}
-          provider="Link"
-          title={curio.heart.title || url}
-        />
+        <BottomBar {...botBar} />
       </div>
     </HeapBlockWrapper>
   );

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -445,6 +445,9 @@ export default function HeapBlock({
         <TopBar hasIcon canEdit={canEdit} {...topBar} />
         <div className="flex grow flex-col items-center justify-center">
           <LinkIcon className="h-16 w-16 text-gray-300" />
+          <div className="text-underline m-3 block break-all rounded bg-gray-50 p-2 text-center font-semibold">
+            {url}
+          </div>
         </div>
         <BottomBar {...botBar} />
       </div>

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -64,6 +64,10 @@ function TopBar({
     navigateToCurio,
   } = useCurioActions({ nest, time, refToken });
 
+  if (asRef) {
+    return null;
+  }
+
   return (
     <div
       onClick={(e) => e.stopPropagation()}
@@ -194,7 +198,7 @@ function BottomBar({ curio, asRef }: BottomBarProps) {
         'absolute bottom-2 left-2 flex w-[calc(100%-16px)] select-none items-center space-x-2 overflow-hidden rounded p-2 group-hover:bg-white/50 group-hover:backdrop-blur'
       )}
     >
-      <Avatar ship={curio.heart.author} size="xs" />
+      <Avatar ship={curio?.heart.author} size="xs" />
       <div className="hidden w-full justify-between align-middle group-hover:flex">
         <span className="truncate font-semibold">{prettySent} ago</span>
         {replyCount > 0 ? (
@@ -299,7 +303,7 @@ export default function HeapBlock({
 
   const cnm = (refClass?: string) =>
     asRef ? refClass || '' : 'heap-block group';
-  const topBar = { time, refToken, longPress };
+  const topBar = { time, asRef, refToken, longPress };
   const botBar = { curio, asRef, longPress };
 
   if (isComment) {
@@ -345,7 +349,9 @@ export default function HeapBlock({
             leading-6
             content={content}
           />
-          <div className="from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent" />
+          {!asRef && (
+            <div className="from-10% via-30% absolute top-0 left-0 h-full w-full bg-gradient-to-t from-white via-transparent" />
+          )}
           <BottomBar {...botBar} />
         </div>
       </HeapBlockWrapper>

--- a/ui/src/heap/HeapContent.tsx
+++ b/ui/src/heap/HeapContent.tsx
@@ -64,6 +64,7 @@ export function InlineContent({ inline }: InlineContentProps) {
       <a
         target="_blank"
         rel="noreferrer"
+        className="break-all text-blue underline"
         href={containsProtocol ? inline.link.href : `//${inline.link.href}`}
       >
         {inline.link.content || inline.link.href}
@@ -117,7 +118,9 @@ export default function HeapContent({ content, className }: HeapContentProps) {
     <div className={className}>
       {content.block.map((b, idx) => {
         if ('cite' in b) {
-          return <ContentReference key={idx} cite={b.cite} />;
+          return (
+            <ContentReference contextApp="heap-block" key={idx} cite={b.cite} />
+          );
         }
         return '??';
       })}

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -24,7 +24,6 @@ import useCurioFromParams from './useCurioFromParams';
 
 export default function HeapDetail({ title }: ViewProps) {
   const [joining, setJoining] = useState(false);
-  const navigate = useNavigate();
   const groupFlag = useRouteGroup();
   const { chShip, chName } = useParams<{ chShip: string; chName: string }>();
   const chFlag = `${chShip}/${chName}`;
@@ -38,8 +37,6 @@ export default function HeapDetail({ title }: ViewProps) {
   const joined = useChannelIsJoined(nest);
   const { time, curio } = useCurioFromParams();
   const [loading, setLoading] = useState(false);
-  const { isOpen: leapIsOpen } = useLeap();
-
   const { hasNext, hasPrev, nextCurio, prevCurio } = useOrderedCurios(
     chFlag,
     time || ''
@@ -86,31 +83,6 @@ export default function HeapDetail({ title }: ViewProps) {
     joining,
     initializeChannel,
   ]);
-
-  useEventListener('keydown', (e) => {
-    if (leapIsOpen) return;
-    switch (e.key) {
-      case keyMap.curio.close: {
-        navigate('..');
-        break;
-      }
-      case keyMap.curio.next: {
-        if (hasPrev) {
-          navigate(curioHref(prevCurio?.[0]));
-        }
-        break;
-      }
-      case keyMap.curio.prev: {
-        if (hasNext) {
-          navigate(curioHref(nextCurio?.[0]));
-        }
-        break;
-      }
-      default: {
-        break;
-      }
-    }
-  });
 
   useGroupsAnalyticsEvent({
     name: 'view_item',

--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -37,7 +37,10 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
     return (
       <div className="mx-auto flex h-full w-full items-center justify-center bg-gray-50 p-8 text-[18px] leading-[26px]">
         <div className="max-h-[100%] min-w-32 max-w-prose overflow-y-auto rounded-md bg-white">
-          <ContentReference cite={content.block[0].cite} />
+          <ContentReference
+            contextApp="heap-detail"
+            cite={content.block[0].cite}
+          />
         </div>
       </div>
     );

--- a/ui/src/heap/HeapLoadingBlock.tsx
+++ b/ui/src/heap/HeapLoadingBlock.tsx
@@ -10,7 +10,7 @@ export default function HeapLoadingBlock({
     <div
       className={
         reference
-          ? 'heap-inline-block h-[126px] items-center justify-center bg-gray-100'
+          ? 'heap-inline-block h-[72px] w-[72px] items-center justify-center border-0 bg-gray-100'
           : 'heap-block items-center justify-center bg-gray-100'
       }
     >

--- a/ui/src/heap/HeapRow.tsx
+++ b/ui/src/heap/HeapRow.tsx
@@ -1,167 +1,135 @@
 import _ from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { HeapCurio, isLink } from '@/types/heap';
 import cn from 'classnames';
-import CopyIcon from '@/components/icons/CopyIcon';
-import ElipsisIcon from '@/components/icons/EllipsisIcon';
-import { HeapCurio } from '@/types/heap';
-import { useCalm } from '@/state/settings';
 import { isValidUrl, validOembedCheck } from '@/logic/utils';
-import useHeapContentType from '@/logic/useHeapContentType';
+import { useCalm } from '@/state/settings';
 import useEmbedState from '@/state/embed';
-import { formatDistanceToNow } from 'date-fns';
-import TwitterIcon from '@/components/icons/TwitterIcon';
-import LinkIcon16 from '@/components/icons/LinkIcon16';
-import MusicLargeIcon from '@/components/icons/MusicLargeIcon';
-import useNest from '@/logic/useNest';
-import HeapLoadingRow from '@/heap/HeapLoadingRow';
-import CheckIcon from '@/components/icons/CheckIcon';
-import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
-import TextIcon from '@/components/icons/Text16Icon';
 import { useRouteGroup, useAmAdmin } from '@/state/groups/groups';
+// eslint-disable-next-line import/no-cycle
+import HeapContent from '@/heap/HeapContent';
+import TwitterIcon from '@/components/icons/TwitterIcon';
+import { formatDistanceToNow } from 'date-fns';
+import IconButton from '@/components/IconButton';
+import ChatSmallIcon from '@/components/icons/ChatSmallIcon';
+import ElipsisSmallIcon from '@/components/icons/EllipsisSmallIcon';
+import MusicLargeIcon from '@/components/icons/MusicLargeIcon';
+import LinkIcon from '@/components/icons/LinkIcon';
+import CopyIcon from '@/components/icons/CopyIcon';
+import useNest from '@/logic/useNest';
+import useHeapContentType from '@/logic/useHeapContentType';
+import HeapLoadingBlock from '@/heap/HeapLoadingBlock';
+import CheckIcon from '@/components/icons/CheckIcon';
 import { inlineToString } from '@/logic/tiptap';
-import { useIsMobile } from '@/logic/useMedia';
 import ConfirmationModal from '@/components/ConfirmationModal';
+// eslint-disable-next-line import/no-cycle
+import ChatContent from '@/chat/ChatContent/ChatContent';
+import { useNavigate } from 'react-router';
+import useLongPress from '@/logic/useLongPress';
+import Avatar from '@/components/Avatar';
+import ShipName from '@/components/ShipName';
+import TextIcon from '@/components/icons/Text16Icon';
+import Sig16Icon from '@/components/icons/Sig16Icon';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import useCurioActions from './useCurioActions';
 
-export default function HeapRow({
-  curio,
-  time,
-}: {
-  curio: HeapCurio;
+interface CurioDisplayProps {
   time: string;
-}) {
-  const isMobile = useIsMobile();
-  const nest = useNest();
+  asRef?: boolean;
+  refToken?: string;
+}
+
+interface TopBarProps extends CurioDisplayProps {
+  isTwitter?: boolean;
+  hasIcon?: boolean;
+  canEdit: boolean;
+  longPress: boolean;
+}
+
+function Actions({
+  hasIcon = false,
+  isTwitter = false,
+  refToken = undefined,
+  asRef = false,
+  longPress = false,
+  time,
+  canEdit,
+}: TopBarProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const { didCopy, menuOpen, setMenuOpen, onDelete, onEdit, onCopy } =
-    useCurioActions({ nest, time });
-  const [embed, setEmbed] = useState<any>();
-  const { content, sent, title } = curio.heart;
-  const { replied } = curio.seal;
-  const calm = useCalm();
-  // TODO: improve this
-  const contentString =
-    content.inline.length > 0 ? content.inline[0].toString() : '';
-  const flag = useRouteGroup();
-  const isAdmin = useAmAdmin(flag);
-  const canEdit = isAdmin || window.our === curio.heart.author;
-  const textFallbackTitle = content.inline
-    .map((inline) => inlineToString(inline))
-    .join(' ')
-    .toString();
-  const { isText, isImage, isUrl, isAudio, description } =
-    useHeapContentType(contentString);
-  const notEmbed = isImage && isAudio && isText;
-
-  useEffect(() => {
-    const getOembed = async () => {
-      if (
-        isValidUrl(contentString) &&
-        !notEmbed &&
-        !calm?.disableRemoteContent
-      ) {
-        try {
-          const oembed = await useEmbedState.getState().getEmbed(contentString);
-          setEmbed(oembed);
-        } catch (e) {
-          setEmbed(null);
-          console.log("HeapRow::getOembed: couldn't get oembed", e);
-        }
-      }
-    };
-    getOembed();
-  }, [contentString, notEmbed, calm?.disableRemoteContent]);
-
-  if (isValidUrl(contentString) && embed === undefined && !notEmbed) {
-    return <HeapLoadingRow />;
-  }
-
-  const isOembed = validOembedCheck(embed, contentString);
-
-  const otherImage = () => {
-    const thumbnail = embed?.thumbnail_url;
-    const provider = embed?.provider_name;
-    switch (true) {
-      case isOembed && provider !== 'Twitter':
-        return (
-          <div
-            className="relative inline-block h-14 w-14 cursor-pointer overflow-hidden rounded-l-lg bg-cover bg-no-repeat"
-            style={{ backgroundImage: `url(${thumbnail})` }}
-          />
-        );
-      case provider === 'Twitter':
-        return <TwitterIcon className="m-2 h-6 w-6" />;
-      case isAudio:
-        return <MusicLargeIcon className="m-2 h-6 w-6 text-gray-300" />;
-      case isUrl:
-        return <LinkIcon16 className="m-2 h-8 w-8 text-gray-300" />;
-      case isText:
-        return <TextIcon className="m-2 h-6 w-6 text-gray-300" />;
-      default:
-        return (
-          <ColorBoxIcon className="m-2 h-8 w-8" color="transparent" letter="" />
-        );
-    }
-  };
-
-  const contentDisplayed = () => {
-    switch (true) {
-      case isOembed:
-        return embed.title;
-      case isUrl:
-        return title || textFallbackTitle;
-      default:
-        return textFallbackTitle;
-    }
-  };
+  const nest = useNest();
+  const {
+    didCopy,
+    menuOpen,
+    setMenuOpen,
+    onDelete,
+    deleteStatus,
+    onEdit,
+    onCopy,
+    navigateToCurio,
+  } = useCurioActions({ nest, time, refToken });
 
   return (
-    <div className="flex w-full items-center justify-between space-x-2 rounded-lg bg-white">
-      <div className="flex space-x-2">
-        <div>
-          {isImage && !calm?.disableRemoteContent ? (
-            <div
-              className="relative inline-block h-14 w-14 cursor-pointer overflow-hidden rounded-l-lg bg-cover bg-no-repeat"
-              style={{ backgroundImage: `url(${contentString})` }}
-            />
-          ) : (
-            <div className="flex h-14 w-14 flex-col items-center justify-center rounded-l-lg bg-gray-200">
-              {otherImage()}
-            </div>
-          )}
-        </div>
-        <div className="flex flex-col justify-center space-y-1">
-          <div className="min-w-0 break-words line-clamp-1">
-            {isMobile ? _.truncate(contentDisplayed()) : contentDisplayed()}
-          </div>
-          <div className="text-sm font-semibold text-gray-600">
-            {description()} • {formatDistanceToNow(sent)} ago • {replied.length}{' '}
-            Comments
-          </div>
-        </div>
-      </div>
+    <div
+      onClick={(e) => e.stopPropagation()}
+      className={cn('', {
+        'justify-between': hasIcon || isTwitter,
+        'justify-end': !hasIcon && !isTwitter,
+        flex: longPress,
+        'group-hover:flex': !longPress,
+      })}
+    >
+      {isTwitter ? <TwitterIcon className="m-2 h-6 w-6" /> : null}
+      {hasIcon ? <div className="m-2 h-6 w-6" /> : null}
       <div
-        className="flex space-x-1 text-gray-400"
-        onClick={(e) => e.stopPropagation()}
+        className={cn('flex space-x-2 text-sm text-gray-600', {
+          'mt-2': asRef,
+          'mr-2': asRef,
+        })}
+        onMouseDown={(e) => e.stopPropagation()}
       >
-        <button
-          onClick={onCopy}
-          className={cn('icon-button bg-transparent', !canEdit ? 'mr-3' : '')}
-        >
-          {didCopy ? (
-            <CheckIcon className="h-6 w-6" />
-          ) : (
-            <CopyIcon className="h-6 w-6" />
-          )}
-        </button>
-        {canEdit ? (
-          <>
+        <div className={longPress ? 'block' : 'group-hover:block'}>
+          {asRef ? (
             <button
-              className="icon-button bg-transparent"
-              onClick={() => setMenuOpen(!menuOpen)}
+              onClick={navigateToCurio}
+              className="small-menu-button border border-gray-100 bg-white px-2 py-1"
             >
-              <ElipsisIcon className="h-6 w-6" />
+              View
             </button>
+          ) : (
+            <IconButton
+              icon={
+                didCopy ? (
+                  <CheckIcon className="h-4 w-4" />
+                ) : (
+                  <CopyIcon className="h-4 w-4" />
+                )
+              }
+              action={onCopy}
+              label="expand"
+              className="rounded bg-white"
+            />
+          )}
+        </div>
+        {canEdit && (
+          <div
+            className={longPress ? 'relative' : 'relative group-hover:block'}
+          >
+            {asRef ? (
+              <IconButton
+                icon={<ElipsisSmallIcon className="h-4 w-4" />}
+                action={() => setMenuOpen(true)}
+                label="expand"
+                className="rounded border border-gray-100 bg-white"
+                small
+              />
+            ) : (
+              <IconButton
+                icon={<ElipsisSmallIcon className="h-4 w-4" />}
+                label="options"
+                className="rounded bg-white"
+                action={() => setMenuOpen(!menuOpen)}
+              />
+            )}
             <div
               className={cn(
                 'absolute right-0 flex w-[101px] flex-col items-start rounded bg-white text-sm font-semibold text-gray-800 shadow',
@@ -169,27 +137,419 @@ export default function HeapRow({
               )}
               onMouseLeave={() => setMenuOpen(false)}
             >
-              <button onClick={onEdit} className="small-menu-button">
-                Edit
-              </button>
-              <button
-                className="small-menu-button text-red"
-                onClick={() => setDeleteOpen(true)}
-              >
-                Delete
-              </button>
+              {asRef ? (
+                <button
+                  className="small-menu-button"
+                  onClick={onCopy}
+                  disabled={didCopy}
+                >
+                  {didCopy ? 'Copied' : 'Share'}
+                </button>
+              ) : null}
+              {!asRef && canEdit ? (
+                <>
+                  <button onClick={onEdit} className="small-menu-button">
+                    Edit
+                  </button>
+                  <button
+                    className="small-menu-button text-red"
+                    onClick={() => setDeleteOpen(true)}
+                  >
+                    Delete
+                  </button>
+                </>
+              ) : null}
             </div>
-          </>
-        ) : null}
+          </div>
+        )}
       </div>
       <ConfirmationModal
         open={deleteOpen}
         setOpen={setDeleteOpen}
         onConfirm={onDelete}
+        loading={deleteStatus === 'loading'}
         confirmText="Delete"
         title="Delete Gallery Item"
         message="Are you sure you want to delete this gallery item?"
       />
+    </div>
+  );
+}
+
+interface HeapRowProps extends CurioDisplayProps {
+  curio: HeapCurio;
+  isComment?: boolean;
+}
+
+export default function HeapRow({
+  curio,
+  time,
+  asRef = false,
+  isComment = false,
+  refToken = undefined,
+}: HeapRowProps) {
+  const [embed, setEmbed] = useState<any>();
+  const [longPress, setLongPress] = useState(false);
+  const { content } = curio.heart;
+  const url =
+    content.inline.length > 0 && isLink(content.inline[0])
+      ? content.inline[0].link.href
+      : '';
+  const calm = useCalm();
+  const { isImage, isAudio, isText } = useHeapContentType(url);
+  const textFallbackTitle = content.inline
+    .map((inline) => inlineToString(inline))
+    .join(' ')
+    .toString();
+
+  const flag = useRouteGroup();
+  const isAdmin = useAmAdmin(flag);
+  const canEdit = asRef ? false : isAdmin || window.our === curio.heart.author;
+  const maybeEmbed = !isImage && !isAudio && !isText && !isComment;
+
+  useEffect(() => {
+    const getOembed = async () => {
+      if (isValidUrl(url) && maybeEmbed && !calm.disableRemoteContent) {
+        try {
+          const oembed = await useEmbedState.getState().getEmbed(url);
+          setEmbed(oembed);
+        } catch (e) {
+          setEmbed(null);
+          console.log("HeapBlock::getOembed: couldn't get embed", e);
+        }
+      }
+    };
+    getOembed();
+  }, [url, maybeEmbed, calm]);
+
+  if (
+    isValidUrl(url) &&
+    embed === undefined &&
+    maybeEmbed &&
+    !calm.disableRemoteContent
+  ) {
+    return (
+      <div
+        className={
+          'group flex h-[88px] w-full items-center justify-center space-x-2 rounded-lg bg-gray-50 p-2'
+        }
+      >
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  const cnm = (refClass?: string) =>
+    asRef
+      ? refClass || ''
+      : 'w-full bg-white rounded-lg p-2 flex space-x-2 items-center group';
+  const { sent } = curio.heart;
+  const replyCount = curio.seal.replied.length;
+  const prettySent = formatDistanceToNow(sent);
+
+  if (content.block.length > 0 && 'cite' in content.block[0]) {
+    return (
+      <div className={cnm()}>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+          <Sig16Icon className="h-6 w-6 text-gray-400" />
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1" />
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+            <span>Urbit Reference</span>
+            <span>{replyCount} comments</span>
+          </div>
+          <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+            <Avatar
+              size="xxs"
+              className="inline-block"
+              ship={curio.heart.author}
+            />
+            <ShipName
+              showAlias={!calm.disableNicknames}
+              name={curio.heart.author}
+            />
+            <span className="text-gray-400">{prettySent} ago</span>
+          </div>
+        </div>
+        <div className="shrink-0">
+          <Actions
+            longPress={false}
+            canEdit={canEdit}
+            time={curio.heart.sent.toString()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (isText) {
+    return (
+      <div className={cnm()}>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+          <TextIcon className="h-6 w-6 text-gray-400" />
+        </div>
+        <div className="flex grow flex-col">
+          <div className="text-lg font-semibold line-clamp-1">
+            <HeapContent className={cn('line-clamp-1')} content={content} />
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+            <span>Text</span>
+            <span>{replyCount} comments</span>
+          </div>
+          <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+            <Avatar
+              size="xxs"
+              className="inline-block"
+              ship={curio.heart.author}
+            />
+            <ShipName
+              showAlias={!calm.disableNicknames}
+              name={curio.heart.author}
+            />
+            <span className="text-gray-400">{prettySent} ago</span>
+          </div>
+        </div>
+        <div className="shrink-0">
+          <Actions
+            longPress={false}
+            canEdit={canEdit}
+            time={curio.heart.sent.toString()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (isImage) {
+    return (
+      <div className={cnm()}>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+          {!calm?.disableRemoteContent ? (
+            <img
+              className="h-[72px] w-[72px] rounded object-cover"
+              loading="lazy"
+              src={url}
+              alt={textFallbackTitle}
+            />
+          ) : (
+            <LinkIcon className="h-6 w-6 text-gray-400" />
+          )}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="break-all text-lg font-semibold line-clamp-1">
+            {textFallbackTitle}
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+            <span>Image</span>
+            <a href={url} target="_blank" rel="noreferrer">
+              Source
+            </a>
+            <span>{replyCount} comments</span>
+          </div>
+          <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+            <Avatar
+              size="xxs"
+              className="inline-block"
+              ship={curio.heart.author}
+            />
+            <ShipName
+              showAlias={!calm.disableNicknames}
+              name={curio.heart.author}
+            />
+            <span className="text-gray-400">{prettySent} ago</span>
+          </div>
+        </div>
+        <div className="shrink-0">
+          <Actions
+            longPress={false}
+            canEdit={canEdit}
+            time={curio.heart.sent.toString()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (isAudio && !calm?.disableRemoteContent) {
+    return (
+      <div className={cnm()}>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+          <MusicLargeIcon className="h-6 w-6 text-gray-400" />
+        </div>
+        <div className="flex grow flex-col">
+          <div className="break-all text-lg font-semibold line-clamp-1">
+            {textFallbackTitle}
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+            <span>Audio</span>
+            <a href={url} target="_blank" rel="noreferrer">
+              Source
+            </a>
+            <span>{replyCount} comments</span>
+          </div>
+          <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+            <Avatar
+              size="xxs"
+              className="inline-block"
+              ship={curio.heart.author}
+            />
+            <ShipName
+              showAlias={!calm.disableNicknames}
+              name={curio.heart.author}
+            />
+            <span className="text-gray-400">{prettySent} ago</span>
+          </div>
+        </div>
+        <div className="shrink-0">
+          <Actions
+            longPress={false}
+            canEdit={canEdit}
+            time={curio.heart.sent.toString()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const isOembed = validOembedCheck(embed, url);
+
+  if (isOembed && !calm?.disableRemoteContent) {
+    const { thumbnail_url: thumbnail, provider_name: provider, title } = embed;
+
+    if (provider === 'Twitter') {
+      const twitterHandle = embed.author_url.split('/').pop();
+      const twitterProfilePic = `https://unavatar.io/twitter/${twitterHandle}`;
+
+      return (
+        <div className={cnm()}>
+          <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+            <img
+              className="h-[72px] w-[72px] rounded object-cover"
+              src={twitterProfilePic}
+              alt={twitterHandle}
+            />
+          </div>
+          <div className="flex grow flex-col">
+            <div className="break-all text-lg font-semibold line-clamp-1">
+              Tweet by @{twitterHandle}
+            </div>
+            <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+              <span>Twitter Link</span>
+              <a href={url} target="_blank" rel="noreferrer">
+                Source
+              </a>
+              <span>{replyCount} comments</span>
+            </div>
+            <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+              <Avatar
+                size="xxs"
+                className="inline-block"
+                ship={curio.heart.author}
+              />
+              <ShipName
+                showAlias={!calm.disableNicknames}
+                name={curio.heart.author}
+              />
+              <span className="text-gray-400">{prettySent} ago</span>
+            </div>
+          </div>
+          <div className="shrink-0">
+            <Actions
+              longPress={false}
+              canEdit={canEdit}
+              time={curio.heart.sent.toString()}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className={cnm()}>
+        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+          {thumbnail && !calm?.disableRemoteContent ? (
+            <img
+              className="h-[72px] w-[72px] rounded object-cover"
+              loading="lazy"
+              src={thumbnail}
+              alt={textFallbackTitle}
+            />
+          ) : (
+            <LinkIcon className="h-6 w-6 text-gray-400" />
+          )}
+        </div>
+        <div className="flex grow flex-col">
+          <div className="break-all text-lg font-semibold line-clamp-1">
+            {title && !calm.disableRemoteContent ? title : textFallbackTitle}
+          </div>
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+            <span>Link</span>
+            <a href={url} target="_blank" rel="noreferrer">
+              Source
+            </a>
+            <span>{replyCount} comments</span>
+          </div>
+          <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+            <Avatar
+              size="xxs"
+              className="inline-block"
+              ship={curio.heart.author}
+            />
+            <ShipName
+              showAlias={!calm.disableNicknames}
+              name={curio.heart.author}
+            />
+            <span className="text-gray-400">{prettySent} ago</span>
+          </div>
+        </div>
+        <div className="shrink-0">
+          <Actions
+            longPress={false}
+            canEdit={canEdit}
+            time={curio.heart.sent.toString()}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cnm()}>
+      <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+        <LinkIcon className="h-6 w-6 text-gray-400" />
+      </div>
+      <div className="flex grow flex-col">
+        <div className="break-all text-lg font-semibold line-clamp-1">
+          {textFallbackTitle}
+        </div>
+        <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+          <span>Link</span>
+          <a href={url} target="_blank" rel="noreferrer">
+            Source
+          </a>
+          <span>{replyCount} comments</span>
+        </div>
+        <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
+          <Avatar
+            size="xxs"
+            className="inline-block"
+            ship={curio.heart.author}
+          />
+          <ShipName
+            showAlias={!calm.disableNicknames}
+            name={curio.heart.author}
+          />
+          <span className="text-gray-400">{prettySent} ago</span>
+        </div>
+      </div>
+      <div className="shrink-0">
+        <Actions
+          longPress={false}
+          canEdit={canEdit}
+          time={curio.heart.sent.toString()}
+        />
+      </div>
     </div>
   );
 }

--- a/ui/src/heap/HeapRow.tsx
+++ b/ui/src/heap/HeapRow.tsx
@@ -31,6 +31,7 @@ import ShipName from '@/components/ShipName';
 import TextIcon from '@/components/icons/Text16Icon';
 import Sig16Icon from '@/components/icons/Sig16Icon';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import ContentReference from '@/components/References/ContentReference';
 import useCurioActions from './useCurioActions';
 
 interface CurioDisplayProps {
@@ -250,15 +251,7 @@ export default function HeapRow({
   if (content.block.length > 0 && 'cite' in content.block[0]) {
     return (
       <div className={cnm()}>
-        <div className="flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
-          <Sig16Icon className="h-6 w-6 text-gray-400" />
-        </div>
-        <div className="flex grow flex-col">
-          <div className="text-lg font-semibold line-clamp-1" />
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
-            <span>Urbit Reference</span>
-            <span>{replyCount} comments</span>
-          </div>
+        <ContentReference contextApp="heap-row" cite={content.block[0].cite}>
           <div className="mt-3 flex space-x-2 text-base font-semibold text-gray-800">
             <Avatar
               size="xxs"
@@ -269,9 +262,11 @@ export default function HeapRow({
               showAlias={!calm.disableNicknames}
               name={curio.heart.author}
             />
-            <span className="text-gray-400">{prettySent} ago</span>
+            <span className="hidden text-gray-400 sm:inline">
+              {prettySent} ago
+            </span>
           </div>
-        </div>
+        </ContentReference>
         <div className="shrink-0">
           <Actions
             longPress={false}
@@ -293,7 +288,7 @@ export default function HeapRow({
           <div className="text-lg font-semibold line-clamp-1">
             <HeapContent className={cn('line-clamp-1')} content={content} />
           </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
             <span>Text</span>
             <span>{replyCount} comments</span>
           </div>
@@ -307,7 +302,9 @@ export default function HeapRow({
               showAlias={!calm.disableNicknames}
               name={curio.heart.author}
             />
-            <span className="text-gray-400">{prettySent} ago</span>
+            <span className="hidden text-gray-400 sm:inline">
+              {prettySent} ago
+            </span>
           </div>
         </div>
         <div className="shrink-0">
@@ -340,7 +337,7 @@ export default function HeapRow({
           <div className="break-all text-lg font-semibold line-clamp-1">
             {textFallbackTitle}
           </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
             <span>Image</span>
             <a href={url} target="_blank" rel="noreferrer">
               Source
@@ -357,7 +354,9 @@ export default function HeapRow({
               showAlias={!calm.disableNicknames}
               name={curio.heart.author}
             />
-            <span className="text-gray-400">{prettySent} ago</span>
+            <span className="hidden text-gray-400 sm:inline">
+              {prettySent} ago
+            </span>
           </div>
         </div>
         <div className="shrink-0">
@@ -381,7 +380,7 @@ export default function HeapRow({
           <div className="break-all text-lg font-semibold line-clamp-1">
             {textFallbackTitle}
           </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
             <span>Audio</span>
             <a href={url} target="_blank" rel="noreferrer">
               Source
@@ -398,7 +397,9 @@ export default function HeapRow({
               showAlias={!calm.disableNicknames}
               name={curio.heart.author}
             />
-            <span className="text-gray-400">{prettySent} ago</span>
+            <span className="hidden text-gray-400 sm:inline">
+              {prettySent} ago
+            </span>
           </div>
         </div>
         <div className="shrink-0">
@@ -434,8 +435,8 @@ export default function HeapRow({
             <div className="break-all text-lg font-semibold line-clamp-1">
               Tweet by @{twitterHandle}
             </div>
-            <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
-              <span>Twitter Link</span>
+            <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+              <span>Tweet</span>
               <a href={url} target="_blank" rel="noreferrer">
                 Source
               </a>
@@ -451,7 +452,9 @@ export default function HeapRow({
                 showAlias={!calm.disableNicknames}
                 name={curio.heart.author}
               />
-              <span className="text-gray-400">{prettySent} ago</span>
+              <span className="hidden text-gray-400 sm:inline">
+                {prettySent} ago
+              </span>
             </div>
           </div>
           <div className="shrink-0">
@@ -483,7 +486,7 @@ export default function HeapRow({
           <div className="break-all text-lg font-semibold line-clamp-1">
             {title && !calm.disableRemoteContent ? title : textFallbackTitle}
           </div>
-          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
             <span>Link</span>
             <a href={url} target="_blank" rel="noreferrer">
               Source
@@ -500,7 +503,9 @@ export default function HeapRow({
               showAlias={!calm.disableNicknames}
               name={curio.heart.author}
             />
-            <span className="text-gray-400">{prettySent} ago</span>
+            <span className="hidden text-gray-400 sm:inline">
+              {prettySent} ago
+            </span>
           </div>
         </div>
         <div className="shrink-0">
@@ -523,7 +528,7 @@ export default function HeapRow({
         <div className="break-all text-lg font-semibold line-clamp-1">
           {textFallbackTitle}
         </div>
-        <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400">
+        <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
           <span>Link</span>
           <a href={url} target="_blank" rel="noreferrer">
             Source
@@ -540,7 +545,9 @@ export default function HeapRow({
             showAlias={!calm.disableNicknames}
             name={curio.heart.author}
           />
-          <span className="text-gray-400">{prettySent} ago</span>
+          <span className="hidden text-gray-400 sm:inline">
+            {prettySent} ago
+          </span>
         </div>
       </div>
       <div className="shrink-0">

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -141,7 +141,7 @@
 }
 
 .heap-block {
-  @apply absolute flex h-full w-full cursor-pointer flex-col justify-between overflow-hidden rounded-lg border-2 border-gray-100 bg-white bg-cover bg-center bg-no-repeat object-cover object-center p-2 shadow;
+  @apply absolute flex h-full w-full cursor-pointer flex-col justify-between overflow-hidden rounded-lg bg-white bg-cover bg-center bg-no-repeat object-cover object-center p-2;
 }
 
 .heap-inline-block {

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -171,6 +171,53 @@ module.exports = {
             },
           },
         },
+        sm: {
+          css: {
+            h1: {
+              marginBottom: '0.5rem',
+              fontWeight: '600',
+              fontSize: '1rem',
+              paddingBottom: '0.3em',
+              borderBottom: '1px solid var(--tw-prose-hr)',
+            },
+            h2: {
+              fontWeight: '600',
+              fontSize: '1rem',
+              marginTop: '0',
+              marginBottom: '0.5rem',
+              paddingBottom: '0.3em',
+              borderBottom: '1px solid var(--tw-prose-hr)',
+            },
+            h3: {
+              fontWeight: '600',
+              fontSize: '1rem',
+              marginTop: '0',
+              marginBottom: '0.5rem',
+            },
+            h4: {
+              fontWeight: '600',
+              marginTop: '0',
+              marginBottom: '0.5rem',
+            },
+            pre: {
+              marginBottom: '1rem',
+              fontSize: '1rem',
+            },
+            hr: {
+              marginTop: '2rem',
+              marginBottom: '2rem',
+            },
+            'hr + *': {
+              marginTop: '0',
+            },
+            'h1 + *, h2 + *, h3 + *, h4 + *, hr + *': {
+              marginTop: '0',
+            },
+            '.node-diary-image + *,.node-diary-cite + *, .node-codeBlock + *': {
+              marginTop: '1.33333rem',
+            },
+          },
+        },
         lg: {
           css: {
             h1: {


### PR DESCRIPTION
- Adds a gradient mask to text HeapBlock items
- Reformats the attribution row to HeapBlock items to show poster (sigil), time, and comment count
- Refactors the HeapRow component to behave more like the HeapBlock and brings into alignment with design
- Adds a `contextApp` prop and `children` to all content references in order to:
  - Reformat group references to conform with LAND-366 in both Block and List views
  - Reformat all other references to match in both Block and List views
  - Add isomorphic curio reference rendering to Gallery (the source and destination presentation appear the same in the Block and List views; click through to see reference in situ)

Fixes LAND-366
Fixes LAND-387