### PR TITLE
analytics: limit capturing even further

### DIFF
--- a/ui/src/logic/analytics.ts
+++ b/ui/src/logic/analytics.ts
@@ -1,6 +1,7 @@
 import posthog, { Properties } from 'posthog-js';
 import { PrivacyType } from '@/types/groups';
-import { log } from './utils';
+import { isTalk, log } from './utils';
+import { isNativeApp } from './native';
 
 export type AnalyticsEventName =
   | 'app_open'
@@ -49,21 +50,46 @@ if (import.meta.env.DEV) {
 
 export const analyticsClient = posthog;
 
+// Once someone is opted in this will fire no matter what so we need
+// additional guarding here to prevent accidentally capturing data.
 export const captureAnalyticsEvent = (
   name: AnalyticsEventName,
   properties?: Properties
 ) => {
+  // Do not capture any analytics events for Talk
+  if (isTalk || isNativeApp()) {
+    return;
+  }
+
   log('Attempting to capture analytics event', name);
   const captureProperties: Properties = {
+    ...(properties || {}),
     // The following default properties stop PostHog from auto-logging the URL,
     // which can inadvertently reveal private info on Urbit
+    $host: null,
     $current_url: null,
+    $initial_current_url: null,
     $pathname: null,
     $set_once: null,
-    ...(properties || {}),
+    $referrer: null,
+    $initial_referrer_url: null,
+    $referring_domain: null,
+    $initial_referring_domain: null,
+    $unset: [
+      'initial_referrer_url',
+      'initial_referring_domain',
+      'initial_current_url',
+      'current_url',
+      'pathname',
+      'host',
+      'referrer',
+      'referring_domain',
+    ],
   };
 
-  posthog.capture(name, captureProperties);
+  posthog.capture(name, captureProperties, {
+    $set_once: {},
+  });
 };
 
 export const captureGroupsAnalyticsEvent = ({

--- a/ui/src/logic/analytics.ts
+++ b/ui/src/logic/analytics.ts
@@ -66,12 +66,12 @@ export const captureAnalyticsEvent = (
     ...(properties || {}),
     // The following default properties stop PostHog from auto-logging the URL,
     // which can inadvertently reveal private info on Urbit
-    $host: null,
     $current_url: null,
-    $initial_current_url: null,
     $pathname: null,
     $set_once: null,
+    $host: null,
     $referrer: null,
+    $initial_current_url: null,
     $initial_referrer_url: null,
     $referring_domain: null,
     $initial_referring_domain: null,
@@ -88,7 +88,16 @@ export const captureAnalyticsEvent = (
   };
 
   posthog.capture(name, captureProperties, {
-    $set_once: {},
+    $set_once: {
+      $host: null,
+      $referrer: null,
+      $current_url: null,
+      $pathname: null,
+      $initial_current_url: null,
+      $initial_referrer_url: null,
+      $referring_domain: null,
+      $initial_referring_domain: null,
+    },
   });
 };
 


### PR DESCRIPTION
I though that opt-ins were more session based, but they are persistent and also span the origin. So that means that the talk check that I moved was incorrect and needed to stay since once you're cookied the captures will fire no matter what. 

In addition I've made some attempts at limiting the URL properties that get sent, it seems to be working, but I'm unsure if it was the `unset` or the `setOnce` that did it. Either way we seem to properly hide that information now.