### PR TITLE
groups: group join loading on mobile

### DIFF
--- a/ui/src/groups/useGroupJoin.ts
+++ b/ui/src/groups/useGroupJoin.ts
@@ -48,7 +48,25 @@ export default function useGroupJoin(
   const { privacy } = useGroupPrivacy(flag);
   const requested = gang?.claim?.progress === 'knocking';
   const invited = gang?.invite;
-  const { mutate: joinMutation, status } = useGroupJoinMutation();
+
+  function handleJoinSuccess() {
+    if (!redirectItem) {
+      return navigateByApp(`/groups/${flag}`);
+    }
+
+    if (redirectItem.type === 'chat') {
+      return navigateByApp(
+        `/groups/${flag}/channels/${redirectItem.nest}?msg=${redirectItem.id}`
+      );
+    }
+
+    return navigateByApp(
+      `/groups/${flag}/channels/${redirectItem.nest}/${redirectItem.type}/${redirectItem.id}`
+    );
+  }
+
+  const { mutate: joinMutation, status } =
+    useGroupJoinMutation(handleJoinSuccess);
   const { mutate: knockMutation, status: knockStatus } =
     useGroupKnockMutation();
   const { mutate: rescindMutation, status: rescindStatus } =
@@ -92,17 +110,6 @@ export default function useGroupJoin(
 
       try {
         joinMutation({ flag });
-        if (redirectItem) {
-          if (redirectItem.type === 'chat') {
-            return navigateByApp(
-              `/groups/${flag}/channels/${redirectItem.nest}?msg=${redirectItem.id}`
-            );
-          }
-          return navigateByApp(
-            `/groups/${flag}/channels/${redirectItem.nest}/${redirectItem.type}/${redirectItem.id}`
-          );
-        }
-        return navigateByApp(`/groups/${flag}`);
       } catch (e) {
         if (requested) {
           rescindMutation({ flag });
@@ -118,7 +125,6 @@ export default function useGroupJoin(
     invited,
     flag,
     requested,
-    redirectItem,
     navigateByApp,
     joinMutation,
     knockMutation,

--- a/ui/src/notifications/useNotifications.tsx
+++ b/ui/src/notifications/useNotifications.tsx
@@ -40,7 +40,8 @@ export const isLeave = (yarn: Yarn) =>
 export const isRoleChange = (yarn: Yarn) =>
   yarn.con.some((con) => con === ' is now a(n) ');
 
-export const isGroupMeta = (yarn: Yarn) => isJoin(yarn) || isRoleChange(yarn) || isLeave(yarn);
+export const isGroupMeta = (yarn: Yarn) =>
+  isJoin(yarn) || isRoleChange(yarn) || isLeave(yarn);
 
 export const useNotifications = (flag?: Flag, mentionsOnly = false) => {
   const { data: skeins, status: skeinsStatus } = useSkeins(flag);

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -709,7 +709,7 @@ export function useDeleteGroupMutation() {
   return useGroupMutation(mutationFn);
 }
 
-export function useGroupJoinMutation() {
+export function useGroupJoinMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();
 
   const mutationFn = (variables: { flag: string }) =>
@@ -737,6 +737,7 @@ export function useGroupJoinMutation() {
       queryClient.invalidateQueries(['gangs']);
       queryClient.invalidateQueries(['gangs', variables.flag]);
       queryClient.invalidateQueries([GROUPS_KEY]);
+      onSuccess?.();
     },
   });
 }


### PR DESCRIPTION
Fixes LAND-647.

Considering that the loading screen is part of the `Groups` component, which is trying to load groups by flag that the user may not have joined yet or whose owner's ship might be offline, etc. It's going to be complicated trying to handle all those cases with some kind of header that is trying to get the info from wherever possible.

So, after several attempts to do that, I decided that it might be worth just holding the user on the page where he tries to join the group and waiting until the join operation is done. And only after it's successful, we navigate to the group page.
This way, we don't leave the context until the operation under this context is done.

Feel free to bring your arguments against this approach 🙏