### PR TITLE
groups: only allow self or host to join a channel

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1330,11 +1330,11 @@
     |=  sects=(set sect:g)
     ::  if we have sects, we need to delete them from writers
     =?  cor  &(!=(sects ~) =(p.flag our.bowl))
-      =/  =cage  [act:mar:c !>([flag now.bowl %del-sects sects])]  
+      =/  =cage  [act:mar:c !>([flag now.bowl %del-sects sects])]
       (emit %pass ca-area %agent [our.bowl dap.bowl] %poke cage)
     ::  if our read permissions restored, re-subscribe
     =?  ca-core  (ca-can-read our.bowl)  ca-safe-sub
-    ::  if subs read permissions removed, kick 
+    ::  if subs read permissions removed, kick
     %+  roll  ~(tap in ca-subscriptions)
     |=  [[=ship =path] ca=_ca-core]
     ?:  (ca-can-read:ca ship)  ca
@@ -1472,6 +1472,7 @@
   ++  ca-join
     |=  j=join:c
     ^+  ca-core
+    ?>  |(=(p.group.j src.bowl) =(src.bowl our.bowl))
     =.  chats  (~(put by chats) chan.j *chat:c)
     =.  ca-core  (ca-abed chan.j)
     =.  last-read.remark.chat  now.bowl

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -728,11 +728,11 @@
     |=  sects=(set sect:g)
     ::  if we have sects, we need to delete them from writers
     =?  cor  &(!=(sects ~) =(p.flag our.bowl))
-      =/  =cage  [act:mar:d !>([flag now.bowl %del-sects sects])]  
+      =/  =cage  [act:mar:d !>([flag now.bowl %del-sects sects])]
       (emit %pass di-area %agent [our.bowl dap.bowl] %poke cage)
     ::  if our read permissions restored, re-subscribe
     =?  di-core  (di-can-read our.bowl)  di-safe-sub
-    ::  if subs read permissions removed, kick 
+    ::  if subs read permissions removed, kick
     %+  roll  ~(tap in di-subscriptions)
     |=  [[=ship =path] di=_di-core]
     ?:  (di-can-read:di ship)  di
@@ -843,6 +843,7 @@
   ++  di-join
     |=  j=join:d
     ^+  di-core
+    ?>  |(=(p.group.j src.bowl) =(src.bowl our.bowl))
     =.  shelf  (~(put by shelf) chan.j *diary:d)
     =.  di-core  (di-abed chan.j)
     =.  group.perm.diary  group.j

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1691,6 +1691,7 @@
       ^-  card
       [%pass (welp ga-area wire) %agent [p.flag dap.bowl] task]
     ++  add-self
+      ?>  =(src.bowl our.bowl)
       =/  =vessel:fleet:g  [~ now.bowl]
       =/  =action:g  [flag now.bowl %fleet (silt ~[our.bowl]) %add ~]
       (poke-host /join/add act:mar:g !>(action))

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -704,11 +704,11 @@
     |=  sects=(set sect:g)
     ::  if we have sects, we need to delete them from writers
     =?  cor  &(!=(sects ~) =(p.flag our.bowl))
-      =/  =cage  [act:mar:h !>([flag now.bowl %del-sects sects])]  
+      =/  =cage  [act:mar:h !>([flag now.bowl %del-sects sects])]
       (emit %pass he-area %agent [our.bowl dap.bowl] %poke cage)
     ::  if our read permissions restored, re-subscribe
     =?  he-core  (he-can-read our.bowl)  he-safe-sub
-    ::  if subs read permissions removed, kick 
+    ::  if subs read permissions removed, kick
     %+  roll  ~(tap in he-subscriptions)
     |=  [[=ship =path] he=_he-core]
     ?:  (he-can-read:he ship)  he
@@ -843,6 +843,7 @@
   ++  he-join
     |=  j=join:h
     ^+  he-core
+    ?>  |(=(p.group.j src.bowl) =(src.bowl our.bowl))
     =.  stash  (~(put by stash) chan.j *heap:h)
     =.  he-core  (he-abed chan.j)
     =.  group.perm.heap  group.j


### PR DESCRIPTION
fixes LAND-671

Prevents anyone other than ourselves or a group host from joining our ship to a channel.