### PR TITLE
gallery: fixes squished groupref images in block view

### DIFF
--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -139,7 +139,7 @@ function GroupReference({
               <img
                 src={meta.cover}
                 loading="lazy"
-                className="absolute top-0 left-0 h-full w-full"
+                className="absolute top-0 left-0 h-full w-full object-cover"
               />
             ) : (
               <div


### PR DESCRIPTION
An oversight on my part.