### PR TITLE
groups: use existence checks to ensure we can scry

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -771,14 +771,18 @@
   ::
       [%u %dm @ *]
     =/  =ship  (slav %p i.t.t.path)
-    ?.  (~(has by dms) ship)
+    =/  has  (~(has by dms) ship)
+    ?.  has
       ``loob+!>(|)
+    ?~  t.t.t.path  ``loob+!>(has)
     (di-peek:(di-abed:di-core ship) %u t.t.t.path)
   ::
       [%u %club @ *]
     =/  =id:club:c  (slav %uv i.t.t.path)
-    ?.  (~(has by clubs) id)
+    =/  has  (~(has by clubs) id)
+    ?.  has
       ``loob+!>(|)
+    ?~  t.t.t.path  ``loob+!>(has)
     (cu-peek:(cu-abed:cu-core id) %u t.t.t.path)
   ::
       [%u %chat @ @ *]

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -772,21 +772,23 @@
       [%u %dm @ *]
     =/  =ship  (slav %p i.t.t.path)
     ?.  (~(has by dms) ship)
-      ``flag+!>(|)
+      ``loob+!>(|)
     (di-peek:(di-abed:di-core ship) %u t.t.t.path)
   ::
       [%u %club @ *]
     =/  =id:club:c  (slav %uv i.t.t.path)
     ?.  (~(has by clubs) id)
-      ``flag+!>(|)
+      ``loob+!>(|)
     (cu-peek:(cu-abed:cu-core id) %u t.t.t.path)
   ::
       [%u %chat @ @ *]
     =/  =flag:c
       :-  (slav %p i.t.t.path)
       (slav %tas i.t.t.t.path)
-    ?.  (~(has by chats) flag)
-      ``flag+!>(|)
+    =/  has  (~(has by chats) flag)
+    ?.  has
+      ``loob+!>(|)
+    ?~  t.t.t.t.path  ``loob+!>(has)
     (ca-peek:(ca-abed:ca-core flag) %u t.t.t.t.path)
   ::
   ==

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -503,21 +503,23 @@
   ~&  arvo/wire
   cor
 ++  peek
-  |=  =path
+  |=  =(pole knot)
   ^-  (unit (unit cage))
-  ?+  path  [~ ~]
+  ?+  pole  [~ ~]
   ::
     [%x %imp ~]    ``migrate-map+!>(imp)
     [%x %shelf ~]  ``shelf+!>(shelf)
     [%x %init ~]   ``noun+!>([briefs shelf])
     [%x %briefs ~]  ``diary-briefs+!>(briefs)
   ::
-      [%x %diary @ @ *]
-    =/  =ship  (slav %p i.t.t.path)
-    =*  name   i.t.t.t.path
-    (di-peek:(di-abed:di-core ship name) t.t.t.t.path)
+      [%x %diary ship=@ name=@ rest=*]
+    =/  =ship  (slav %p ship.pole)
+    (di-peek:(di-abed:di-core ship name.pole) rest.pole)
     ::
-
+      [%u %diary ship=@ name=@ ~]
+    =/  =ship  (slav %p ship.pole)
+    ``loob+!>((~(has by shelf) [ship name.pole]))
+  ::
   ==
 ::
 ++  briefs

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -254,6 +254,8 @@
     ?.  (gth ~(wyt in readers) 0)  cr
     =/  action  [flag now.bowl %channel nest %del-sects readers]
     cr(cards [[%pass /groups/role %agent [our.bowl dap.bowl] %poke [act:mar:g !>(action)]] cards.cr])
+  =+  .^(has=? %gu (welp (channel-scry nest) ~))
+  ?.  has  cr
   =+  .^([writers=(set sect:g) *] %gx (welp (channel-scry nest) /perm/noun))
   =/  diff  (~(dif in writers) ~(key by cabals.group))
   ?.  (gth ~(wyt in diff) 0)  cr

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -135,7 +135,7 @@
     =.  cor  (give-invites flag ~(key by members.create))
     go-abet:(go-init:(go-abed:group-core flag) ~)
   ::
-      ?(%group-action-1 %group-action-0)
+      ?(%group-action-2 %group-action-1 %group-action-0)
     =+  !<(=action:g vase)
     =.  p.q.action  now.bowl
     =/  group-core  (go-abed:group-core p.action)
@@ -1012,9 +1012,9 @@
       ::  XX: does init need to be handled specially?
       ?+  p.cage  (go-odd-update p.cage)
         %epic            (go-take-epic !<(epic:e q.cage))
-        %group-log-1     (go-apply-log !<(log:g q.cage))
-        %group-update-1  (go-update !<(update:g q.cage))
-        %group-init-1    (go-fact-init !<(init:g q.cage))
+        %group-log-2     (go-apply-log !<(log:g q.cage))
+        %group-update-2  (go-update !<(update:g q.cage))
+        %group-init-2    (go-fact-init !<(init:g q.cage))
       ==
     ==
   ::

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -379,20 +379,23 @@
   ~&  arvo/wire
   cor
 ++  peek
-  |=  =path
+  |=  =(pole knot)
   ^-  (unit (unit cage))
-  ?+  path  [~ ~]
+  ?+  pole  [~ ~]
   ::
     [%x %stash ~]  ``stash+!>(stash)
     [%x %imp ~]    ``migrate-map+!>(imp)
     [%x %init ~]  ``noun+!>([briefs stash])
     [%x %briefs ~]  ``heap-briefs+!>(briefs)
   ::
-      [%x %heap @ @ *]
-    =/  =ship  (slav %p i.t.t.path)
-    =*  name   i.t.t.t.path
-    (he-peek:(he-abed:he-core ship name) t.t.t.t.path)
-    ::
+      [%x %heap ship=@ name=@ rest=*]
+    =/  =ship  (slav %p ship.pole)
+    (he-peek:(he-abed:he-core ship name.pole) rest.pole)
+  ::
+      [%u %heap ship=@ name=@ ~]
+    =/  =ship  (slav %p ship.pole)
+    ``loob+!>((~(has by stash) [ship name.pole]))
+  ::
   ==
 ::
 ++  briefs

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -128,7 +128,7 @@
     =/  time  (slav %ud time.pole)
     ?.  ?=(%u care)
       ``writ+!>((got ship `@da`time))
-    ``flag+!>(?~((get ship `@da`time) | &))
+    ``loob+!>(?~((get ship `@da`time) | &))
   ==
 ::
 ++  search

--- a/desk/mar/group/action-2.hoon
+++ b/desk/mar/group/action-2.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/action-0
 mark

--- a/desk/mar/group/action-3.hoon
+++ b/desk/mar/group/action-3.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/group/init-2.hoon
+++ b/desk/mar/group/init-2.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/init-0
 mark

--- a/desk/mar/group/init-3.hoon
+++ b/desk/mar/group/init-3.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/group/log-2.hoon
+++ b/desk/mar/group/log-2.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/log-0
 mark

--- a/desk/mar/group/log-3.hoon
+++ b/desk/mar/group/log-3.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/mar/group/update-2.hoon
+++ b/desk/mar/group/update-2.hoon
@@ -1,2 +1,2 @@
-/=  mark  /mar/dummy
+/=  mark  /mar/group/update-0
 mark

--- a/desk/mar/group/update-3.hoon
+++ b/desk/mar/group/update-3.hoon
@@ -1,0 +1,2 @@
+/=  mark  /mar/dummy
+mark

--- a/desk/sur/groups.hoon
+++ b/desk/sur/groups.hoon
@@ -3,7 +3,7 @@
 /-  grp=group-store
 /-  metadata-store
 |%
-++  okay  `epic:e`1
+++  okay  `epic:e`2
 ++  mar
   |%
   ++  act  `mark`(rap 3 %group-action '-' (scot %ud okay) ~)

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -152,7 +152,7 @@ const groups: Handler[] = [
   {
     action: 'poke',
     app: 'groups',
-    mark: 'group-action-1',
+    mark: 'group-action-2',
     returnSubscription: specificGroupSub,
     dataResponder: (req: Message & Poke<GroupAction>) =>
       createResponse(req, 'diff', {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -38,7 +38,7 @@ export const GROUPS_KEY = 'groups';
 function groupAction(flag: string, diff: GroupDiff): Poke<GroupAction> {
   return {
     app: 'groups',
-    mark: 'group-action-1',
+    mark: 'group-action-2',
     json: {
       flag,
       update: {


### PR DESCRIPTION
We weren't checking whether or not a channel existed before scrying so this caused any updates that deleted roles to crash, causing a kick-resubscribe loop. This should fix the resubscribe loop for those who are receiving updates.  

Fixes LAND-675