### PR TITLE
groups: use useGroups in sidebar rather than useGroup

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -45,6 +45,7 @@ import EditProfile from '@/profiles/EditProfile/EditProfile';
 import HeapDetail from '@/heap/HeapDetail';
 import groupsFavicon from '@/assets/groups.svg';
 import talkFavicon from '@/assets/talk.svg';
+import { usePendingGangsWithoutClaim } from '@/state/groups/groups';
 import GroupInvitesPrivacy from './groups/GroupAdmin/GroupInvitesPrivacy';
 import Notifications, { MainWrapper } from './notifications/Notifications';
 import ChatChannel from './chat/ChatChannel';
@@ -83,10 +84,7 @@ import SettingsDialog from './components/SettingsDialog';
 import { captureAnalyticsEvent } from './logic/analytics';
 import GroupChannel from './groups/GroupChannel';
 import PrivacyNotice from './groups/PrivacyNotice';
-import {
-  usePendingGangsWithoutClaim,
-} from '@/state/groups/groups';
-import useAutoJoinLureInvites from './groups/autoJoinLureInvites'
+import useAutoJoinLureInvites from './groups/autoJoinLureInvites';
 import ActivityModal, { ActivityChecker } from './components/ActivityModal';
 
 const Grid = React.lazy(() => import('./components/Grid/grid'));
@@ -282,7 +280,7 @@ function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
     if (Object.keys(pendingGangsWithoutClaim).length) {
       autojoin(pendingGangsWithoutClaim);
     }
-  }, [pendingGangsWithoutClaim]);
+  }, [pendingGangsWithoutClaim, autojoin]);
 
   useEffect(() => {
     if (!isInGroups && redirectToFind) {

--- a/ui/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/ui/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -2,7 +2,7 @@ import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { useHasMigratedChannels } from '@/logic/useMigrationInfo';
 import { getFlagParts } from '@/logic/utils';
-import { useGroup } from '@/state/groups';
+import { useGroups } from '@/state/groups';
 import React from 'react';
 import Bullet16Icon from '../icons/Bullet16Icon';
 import MigrationTooltip from '../MigrationTooltip';
@@ -10,7 +10,8 @@ import { useGroupsScrolling } from './GroupsScrollingContext';
 import SidebarItem from './SidebarItem';
 
 const GroupsSidebarItem = React.memo(({ flag }: { flag: string }) => {
-  const group = useGroup(flag);
+  const groups = useGroups();
+  const group = groups[flag];
   const { ship } = getFlagParts(flag);
   const isMigrated = useHasMigratedChannels(flag);
   const isScrolling = useGroupsScrolling();

--- a/ui/src/groups/autoJoinLureInvites.tsx
+++ b/ui/src/groups/autoJoinLureInvites.tsx
@@ -1,8 +1,6 @@
 import cookies from 'browser-cookies';
 import { Gangs } from '@/types/groups';
-import {
-  useGroupJoinMutation,
-} from '@/state/groups';
+import { useGroupJoinMutation } from '@/state/groups';
 import useNavigateByApp from '@/logic/useNavigateByApp';
 
 export default function useAutoJoinLureInvites() {
@@ -15,11 +13,13 @@ export default function useAutoJoinLureInvites() {
 
       if (!gang.claim) {
         if (cookies.get(cookieName)) {
-          await joinMutation({flag});
-          cookies.erase(cookieName)
+          await joinMutation({ flag });
+          cookies.erase(cookieName);
           return navigateByApp(`/groups/${flag}`);
         }
       }
-    })
-  }
+
+      return null;
+    });
+  };
 }


### PR DESCRIPTION
Our sidebar items were using useGroup rather than useGroups, and there were some situations where data did not exist for useGroup that did exist in useGroups. I'm not certain, but I think this may fix LAND-650. Either way, this implementation makes more sense.