### PR TITLE
notebooks: fix two issues from markdown work

### DIFF
--- a/ui/src/diary/DiaryMarkdownEditor.tsx
+++ b/ui/src/diary/DiaryMarkdownEditor.tsx
@@ -255,7 +255,7 @@ export default function DiaryMarkdownEditor({
   const [markdownInput, setMarkdownInput] = useState<string | null>(null);
 
   useEffect(() => {
-    if (editorContent && markdownInput === null && loaded) {
+    if (editorContent && (markdownInput === null || loaded)) {
       const markdown = serialize(schema, editorContent);
       setMarkdownInput(markdown);
     }

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -432,7 +432,12 @@ export function useDiarySettings(): DiarySetting[] {
   const { data, isLoading } = useMergedSettings();
 
   return useMemo(() => {
-    if (isLoading || data === undefined || data.diary === undefined) {
+    if (
+      isLoading ||
+      data === undefined ||
+      data.diary === undefined ||
+      data.diary.settings === undefined
+    ) {
       return [];
     }
 


### PR DESCRIPTION
This updates the conditions for hydrating the markdown editor which fixes an issue where if the user started writing a new note using tiptap and then switched to markdown they wouldn't see anything in the markdown editor.

Also fixes another issue in a settings.ts hook where we attempted to parse diary.settings when it didn't exist because we didn't need to check that before (if we didn't have a diary key in settings before, we would just early return, if we did then we assumed we had the settings key within it, now there can be cases where wee don't have the settings key because we can have {diary: { markdown: true }}, which exists outside of the per-notebook {diary: {settings: ['flag', 'settingName', 'value']}} structure).