### PR TITLE
groups: don't crash on missing data

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1575,12 +1575,14 @@
       go-core
     ::
         %zone
+      ?.  (has:by-ch ch)  go-core
       =/  =channel:g  (got:by-ch ch)
       =.  zones.group
         %+  ~(jab by zones.group)  zone.channel
         |=(=realm:zone:g realm(ord (~(del of ord.realm) ch)))
       =.  zone.channel   zone.diff
       =.  channels.group  (put:by-ch ch channel)
+      ?.  (~(has by zones.group) zone.diff)  go-core
       =/  =realm:zone:g  (~(got by zones.group) zone.diff)
       =.  ord.realm  (~(push of ord.realm) ch)
       =.  zones.group  (~(put by zones.group) zone.diff realm)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1828,7 +1828,7 @@
   ::
   ++  ga-watched
     |=  p=(unit tang)
-    ?>  ?=(^ cam.gang)
+    ?~  cam.gang  ga-core
     ?^  p
       %-  (slog leaf/"Failed to join" u.p)
       =.  progress.u.cam.gang  %error

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1488,12 +1488,10 @@
     ^+  go-core
     ?>  go-is-bloc
     =*  by-ch  ~(. by channels.group)
+    ?.  |(=(-.diff %add) (has:by-ch ch))  go-core
     ?-    -.diff
         %add
-      =/  =zone:g  zone.channel.diff
-      =.  zones.group
-        %+  ~(jab by zones.group)  zone
-        |=(=realm:zone:g realm(ord (~(push of ord.realm) ch)))
+      =.  zones.group  (go-bump-zone ch channel.diff)
       =.  channels.group  (put:by-ch ch channel.diff)
       ?:  from-self  go-core
       =/  link  (go-link /channels)
@@ -1514,10 +1512,7 @@
     ::
         %edit
       =/  prev=channel:g  (got:by-ch ch)
-      =/  =zone:g  zone.channel.diff
-      =.  zones.group
-        %+  ~(jab by zones.group)  zone
-        |=(=realm:zone:g realm(ord (~(push of ord.realm) ch)))
+      =.  zones.group  (go-bump-zone ch channel.diff)
       =.  channels.group  (put:by-ch ch channel.diff)
       ?:  from-self  go-core
       =/  link  (go-link /channels)
@@ -1539,9 +1534,9 @@
       go-core
     ::
         %del
-      ?.  (has:by-ch ch)  go-core
       =/  =channel:g   (got:by-ch ch)
       =.  zones.group
+        ?.  (~(has by zones.group) zone.channel)  zones.group
         %+  ~(jab by zones.group)  zone.channel
         |=(=realm:zone:g realm(ord (~(del of ord.realm) ch)))
       =.  channels.group  (del:by-ch ch)
@@ -1576,14 +1571,13 @@
       go-core
     ::
         %zone
-      ?.  (has:by-ch ch)  go-core
       =/  =channel:g  (got:by-ch ch)
+      ?.  (~(has by zones.group) zone.diff)  go-core
       =.  zones.group
         %+  ~(jab by zones.group)  zone.channel
         |=(=realm:zone:g realm(ord (~(del of ord.realm) ch)))
       =.  zone.channel   zone.diff
       =.  channels.group  (put:by-ch ch channel)
-      ?.  (~(has by zones.group) zone.diff)  go-core
       =/  =realm:zone:g  (~(got by zones.group) zone.diff)
       =.  ord.realm  (~(push of ord.realm) ch)
       =.  zones.group  (~(put by zones.group) zone.diff realm)
@@ -1595,6 +1589,12 @@
       =.  channels.group  (put:by-ch ch channel)
       go-core
     ==
+  ++  go-bump-zone
+    |=  [ch=nest:g =channel:g]
+    =/  =zone:g  zone.channel
+    ?.  (~(has by zones.group) zone)  zones.group
+    %+  ~(jab by zones.group)  zone
+    |=(=realm:zone:g realm(ord (~(push of ord.realm) ch)))
   --
 ::
 ++  res-gang-index

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1188,8 +1188,9 @@
       go-core
     ::
         %mov-nest
+      ?.  (~(has by zones.group) zone)  go-core
       =/  =realm:zone:g  (~(got by zones.group) zone)
-      ?>  (~(has of ord.realm) nest.delta)
+      ?.  (~(has of ord.realm) nest.delta)  go-core
       =.  ord.realm
         (~(into of ord.realm) [idx nest]:delta)
       =.  zones.group    (~(put by zones.group) zone realm)


### PR DESCRIPTION
Fixes the primary issue with LAND-700 by preventing us from crashing on missing data.

Fixes LAND-700