### PR TITLE
notebooks: various fixes (and fix tests)

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.test.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.test.tsx
@@ -39,6 +39,14 @@ vi.mock('react-dom', () => {
   };
 });
 
+vi.mock('posthog-js', () => ({
+  default: {
+    capture: vi.fn(),
+    debug: vi.fn(),
+    init: vi.fn(),
+  },
+}));
+
 class MockPointerEvent extends Event {
   button: number;
 

--- a/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
+++ b/ui/src/chat/ChatMessage/__snapshots__/ChatMessage.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatMessage > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/diary/DiaryMarkdownEditor.tsx
+++ b/ui/src/diary/DiaryMarkdownEditor.tsx
@@ -247,19 +247,21 @@ export default function DiaryMarkdownEditor({
   editorContent,
   setEditorContent,
   loaded,
+  newNote,
 }: {
   editorContent: JSONContent | null;
   setEditorContent: (content: JSONContent) => void;
   loaded: boolean;
+  newNote: boolean;
 }) {
   const [markdownInput, setMarkdownInput] = useState<string | null>(null);
 
   useEffect(() => {
-    if (editorContent && (markdownInput === null || loaded)) {
+    if (editorContent && markdownInput === null && (newNote || loaded)) {
       const markdown = serialize(schema, editorContent);
       setMarkdownInput(markdown);
     }
-  }, [editorContent, markdownInput, loaded]);
+  }, [editorContent, markdownInput, newNote, loaded]);
 
   useEffect(() => {
     if (markdownInput === null) {

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -196,7 +196,7 @@ export default function DiaryAddNote() {
           )}
         >
           <Link
-            to={!editor?.getText() ? `../..` : `../../note/${id}`}
+            to={!editor?.getText() && !id ? `../..` : `../../note/${id}`}
             className={cn(
               'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2',
               isMobile && ''

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -61,7 +61,8 @@ export default function DiaryAddNote() {
     },
   });
 
-  const { reset, register, getValues, setValue } = form;
+  const { reset, register, getValues, setValue, watch } = form;
+  const watchedTitle = watch('title');
 
   useEffect(() => {
     const { title, image } = getValues();
@@ -95,7 +96,7 @@ export default function DiaryAddNote() {
   }, [editor, loadingNote, note, loaded]);
 
   const publish = useCallback(async () => {
-    if (!editor?.getText()) {
+    if (!editor?.getText() || watchedTitle === '') {
       return;
     }
 
@@ -173,6 +174,7 @@ export default function DiaryAddNote() {
     reset,
     addNote,
     editNote,
+    watchedTitle,
   ]);
 
   useEffect(() => {
@@ -219,7 +221,8 @@ export default function DiaryAddNote() {
               disabled={
                 !editor?.getText() ||
                 editStatus === 'loading' ||
-                addStatus === 'loading'
+                addStatus === 'loading' ||
+                watchedTitle === ''
               }
               className={cn(
                 'small-button bg-blue text-white disabled:bg-gray-200 disabled:text-gray-400 dark:disabled:text-gray-400'

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -280,6 +280,7 @@ export default function DiaryAddNote() {
                     editorContent={editor.getJSON()}
                     setEditorContent={setEditorContent}
                     loaded={loaded}
+                    newNote={!id}
                   />
                 ) : null}
                 {!editWithMarkdown && editor ? (

--- a/ui/src/diary/schema.ts
+++ b/ui/src/diary/schema.ts
@@ -1,4 +1,4 @@
-import { Mark, Node, Schema } from '@tiptap/pm/model';
+import { Mark, Node, Schema, SchemaSpec } from '@tiptap/pm/model';
 
 const schema = new Schema({
   nodes: {
@@ -116,23 +116,24 @@ const schema = new Schema({
           default: 0,
         },
       },
-    },
-    parseDOM: [
-      {
-        tag: 'img[src]',
-        getAttrs: (node: string | HTMLElement) => {
-          if (typeof node === 'string') {
-            return {};
-          }
-          return {
-            src: node.getAttribute('src'),
-            alt: node.getAttribute('alt'),
-          };
+      parseDOM: [
+        {
+          tag: 'img[src]',
+          getAttrs: (node: string | HTMLElement) => {
+            if (typeof node === 'string') {
+              return {};
+            }
+            return {
+              src: node.getAttribute('src'),
+              alt: node.getAttribute('alt'),
+            };
+          },
         },
+      ],
+
+      toDOM({ attrs }: { attrs: any }) {
+        return ['img', attrs];
       },
-    ],
-    toDOM({ attrs }: { attrs: any }) {
-      return ['img', attrs];
     },
     text: {
       group: 'inline',


### PR DESCRIPTION
Fixes all issues in LAND-707, also fixes an issue with navigating back from a new note to the notebook and issues with jest tests failing around posthog imports.

The react suspense/lazy routing thing I mentioned in standup was a red herring, the issue was actually caused by a bad schema spec (and somehow we only hit this error in safari, which is odd).