### PR TITLE
chat: fix issue with loading old threads on mobile

### DIFF
--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -110,7 +110,6 @@ export default function ChatThread() {
       className="relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
     >
-      {console.log('render thread')}
       <header className={'header z-40'}>
         <div
           className={cn(

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import _ from 'lodash';
 import ob from 'urbit-ob';
+import { udToDec } from '@urbit/api';
 import cn from 'classnames';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -82,9 +83,16 @@ export default function ChatThread() {
 
   const initializeChannel = useCallback(async () => {
     setLoading(true);
-    await useChatState.getState().initialize(`${chShip}/${chName}`);
+    if (!idTime) return;
+    await useChatState
+      .getState()
+      .fetchMessagesAround(
+        `${chShip}/${chName}`,
+        '50',
+        bigInt(udToDec(idTime))
+      );
     setLoading(false);
-  }, [chName, chShip]);
+  }, [chName, chShip, idTime]);
 
   useEffect(() => {
     if (!time || !writ) {
@@ -102,6 +110,7 @@ export default function ChatThread() {
       className="relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
     >
+      {console.log('render thread')}
       <header className={'header z-40'}>
         <div
           className={cn(


### PR DESCRIPTION
Fixes LAND-682

We were previously initializing chat threads by calling `useChatState().initialize()`. This wasn't an issue if

a) you clicked into the thread on desktop, so we already loaded the relevant messages b) you navigated to it directly on mobile (via notification or similar) and the thread happened to be included in the first 50 messages in the channel

It *was* an issue if you navigated to the thread directly on mobile and the thread wasn't included in the initial 50 messages.

We actually need to fetch the messages around the thread parent ID to initialize the channel in that instance.