### PR TITLE
utils: support query-string parameters on image/audio/video references

### DIFF
--- a/ui/src/logic/utils.test.ts
+++ b/ui/src/logic/utils.test.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, it } from 'vitest';
-import { normalizeUrbitColor, whomIsFlag } from './utils';
+import { IMAGE_REGEX, normalizeUrbitColor, whomIsFlag } from './utils';
 
 describe('whomIsFlag', () => {
   it('passes valid flags', () => {
@@ -84,5 +84,35 @@ describe('normalizeUrbitColor', () => {
 
   it('passes through color hexes', () => {
     expect(normalizeUrbitColor('#ffffff')).toEqual('#ffffff');
+  });
+});
+
+describe('Image URL embed regex', () => {
+  const validUrls = [
+    'https://i.imgur.com/1234567.jpg',
+    'https://i.imgur.com/1234567.png',
+    'https://i.imgur.com/1234567.gif',
+    'https://i.imgur.com/1234567.webp',
+    'https://i.imgur.com/1234567.jpeg',
+    'https://i.imgur.com/1234567.JPEG',
+    'https://i.imgur.com/1234567.JPG',
+    'https://i.imgur.com/1234567.jpg?test=123',
+    'https://i.imgur.com/1234567.jpg?test=123&test2=456',
+    'https://i.imgur.com/1234567.jpg?test=123&test2=456&test3=789'
+  ];
+
+  const invalidUrls = [
+    'https://i.imgur.com/1234567',
+    'https://i.imgur.com/1234567.',
+    'https://i.imgur.com/1234567.pdf',
+    'https://i.imgur.com/1234567.jpgg',
+  ];
+
+  it('passes valid image urls', () => {
+    validUrls.forEach((url) => expect(url.match(IMAGE_REGEX)).toBeTruthy());
+  });
+
+  it('fails invalid image urls', () => {
+    invalidUrls.forEach((url) => expect(url.match(IMAGE_REGEX)).toBeFalsy());
   });
 });

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -389,7 +389,7 @@ export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)(?:\?.*)?$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
-  /^(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|webm|svg)$/i;
+  /^(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|webm|svg)(?:\?.*)?$/i;
 export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 // sig and hep explicitly left out
 export const PUNCTUATION_REGEX = /[.,/#!$%^&*;:{}=_`()]/g;

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -383,9 +383,9 @@ export function hasKeys(obj: Record<string, unknown>) {
 }
 
 export const IMAGE_REGEX =
-  /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.webm|\.svg)$/i;
-export const AUDIO_REGEX = /(\.mp3|\.wav|\.ogg|\.m4a)$/i;
-export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$/i;
+  /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.webm|\.svg)$(?:\?.*)?/i;
+export const AUDIO_REGEX = /(\.mp3|\.wav|\.ogg|\.m4a)$(?:\?.*)?/i;
+export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$(?:\?.*)?/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -383,9 +383,9 @@ export function hasKeys(obj: Record<string, unknown>) {
 }
 
 export const IMAGE_REGEX =
-  /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.webm|\.svg)$(?:\?.*)?/i;
-export const AUDIO_REGEX = /(\.mp3|\.wav|\.ogg|\.m4a)$(?:\?.*)?/i;
-export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)$(?:\?.*)?/i;
+  /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.webm|\.svg)(?:\?.*)?$/i;
+export const AUDIO_REGEX = /(\.mp3|\.wav|\.ogg|\.m4a)(?:\?.*)?$/i;
+export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv)(?:\?.*)?$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =


### PR DESCRIPTION
Currently if a URL ends in a supported extension, it's embedded. However if there are query-string parameters afterward, e.g. `https://image-host.com/image.jpg?quality=high`, the regex fails (because the URL doesn't _end_ with an image extension) and the image is not embedded. It is not always feasible to simply remove the `?` and subsequent characters as some hosts have functional values in the query string (resulting in e.g. a 404 if the value is removed). In these cases the only option is to re-host the image elsewhere or to append a junk `&.jpg` to trick the regex.

This PR amends the regexes used to detect image/audio/video URLs to allow them to also end with an extension followed by a `?` and 0 or more other characters. That is, the following would now work:
`https://image-host.example.com/image.jpg` (currently works)
`https://image-host.example.com/image.jpg?` (currently fails)
`https://image-host.example.com/image.jpg?quality=high` (currently fails)
`https://image-host.example.com/image.jpg?quality=high&special_access_key=123456` (currently fails)

The requirement of an image extension is still present - some hosts present images at URLs that just end in a UUID, for instance - so some cases of "this URL goes direct to an image, but doesn't render as an embed" will still exist.