### PR TITLE
posthog: use persistent anonymous UUID

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -118,6 +118,7 @@
         "urbit-ob": "^5.0.1",
         "use-pwa-install": "^1.0.1",
         "usehooks-ts": "^2.6.0",
+        "uuid": "^9.0.0",
         "validator": "^13.7.0",
         "workbox-precaching": "^6.5.4",
         "zustand": "^3.7.2"
@@ -144,6 +145,7 @@
         "@types/react-dom": "^17.0.2",
         "@types/react-helmet": "^6.1.5",
         "@types/react-test-renderer": "^17.0.2",
+        "@types/uuid": "^9.0.2",
         "@types/validator": "^13.7.2",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
@@ -10478,6 +10480,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.7.5",
@@ -24455,7 +24463,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -33246,6 +33253,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
+      "dev": true
     },
     "@types/validator": {
       "version": "13.7.5",
@@ -43541,8 +43554,7 @@
     "uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -165,6 +165,7 @@
     "urbit-ob": "^5.0.1",
     "use-pwa-install": "^1.0.1",
     "usehooks-ts": "^2.6.0",
+    "uuid": "^9.0.0",
     "validator": "^13.7.0",
     "workbox-precaching": "^6.5.4",
     "zustand": "^3.7.2"
@@ -191,6 +192,7 @@
     "@types/react-dom": "^17.0.2",
     "@types/react-helmet": "^6.1.5",
     "@types/react-test-renderer": "^17.0.2",
+    "@types/uuid": "^9.0.2",
     "@types/validator": "^13.7.2",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.19.0",

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -14,6 +14,7 @@ import {
   NavigateFunction,
 } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
+import { usePostHog } from 'posthog-js/react';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import Groups from '@/groups/Groups';
 import { IS_MOCK } from '@/api';
@@ -22,7 +23,13 @@ import NewDM from '@/dms/NewDm';
 import ChatThread from '@/chat/ChatThread/ChatThread';
 import useMedia, { useIsDark, useIsMobile } from '@/logic/useMedia';
 import useErrorHandler from '@/logic/useErrorHandler';
-import { useCalm, useSettingsLoaded, useTheme } from '@/state/settings';
+import {
+  useAnalyticsId,
+  useCalm,
+  useLogActivity,
+  useSettingsLoaded,
+  useTheme,
+} from '@/state/settings';
 import { useLocalState } from '@/state/local';
 import ErrorAlert from '@/components/ErrorAlert';
 import DMHome from '@/dms/DMHome';
@@ -636,6 +643,9 @@ function RoutedApp() {
   const app = import.meta.env.VITE_APP;
   const [userThemeColor, setUserThemeColor] = useState('#ffffff');
   const isStandAlone = useIsStandaloneMode();
+  const logActivity = useLogActivity();
+  const posthog = usePostHog();
+  const analyticsId = useAnalyticsId();
   const body = document.querySelector('body');
   const colorSchemeFromNative = window.colorscheme;
 
@@ -677,6 +687,12 @@ function RoutedApp() {
       body?.style.setProperty('padding-bottom', '0px');
     }
   }, [isStandAlone, body]);
+
+  useEffect(() => {
+    if (posthog && analyticsId !== '' && logActivity) {
+      posthog.identify(analyticsId);
+    }
+  }, [posthog, analyticsId, logActivity]);
 
   return (
     <ErrorBoundary

--- a/ui/src/components/SettingsDialog.tsx
+++ b/ui/src/components/SettingsDialog.tsx
@@ -5,6 +5,7 @@ import {
   useCalmSettingMutation,
   useLogActivity,
   usePutEntryMutation,
+  useResetAnalyticsIdMutation,
   useTheme,
   useThemeMutation,
 } from '@/state/settings';
@@ -14,6 +15,7 @@ import Dialog from './Dialog';
 import Setting from './Setting';
 import SettingDropdown from './SettingDropdown';
 import Sheet, { SheetContent } from './Sheet';
+import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 
 export default function SettingsDialog() {
   const logActivity = useLogActivity();
@@ -39,6 +41,9 @@ export default function SettingsDialog() {
     useCalmSettingMutation('disableWayfinding');
   const { mutate: toggleLogActivity, status: logActivityStatus } =
     usePutEntryMutation({ bucket: window.desk, key: 'logActivity' });
+  const { mutate: resetAnalyticsId, status: resetAnalyticsIdStatus } =
+    useResetAnalyticsIdMutation();
+
   const onOpenChange = (open: boolean) => {
     if (!open) {
       dismiss();
@@ -117,6 +122,23 @@ export default function SettingsDialog() {
                 Groups experience.
               </p>
             </Setting>
+          )}
+          {isGroups && logActivity && (
+            <div className="flex flex-col items-center space-y-2">
+              <div className="flex flex-row items-center space-x-2">
+                <button
+                  onClick={() => resetAnalyticsId()}
+                  className="small-button"
+                  disabled={resetAnalyticsIdStatus === 'loading'}
+                >
+                  {resetAnalyticsIdStatus === 'loading' ? (
+                    <LoadingSpinner />
+                  ) : (
+                    'Reset Analytics ID'
+                  )}
+                </button>
+              </div>
+            </div>
           )}
           <Setting
             on={disableSpellcheck}

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { Value, PutBucket, DelEntry, DelBucket } from '@urbit/api';
 import _ from 'lodash';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -92,6 +93,7 @@ export interface SettingsState {
     hasBeenUsed: boolean;
     showActivityMessage?: boolean;
     logActivity?: boolean;
+    analyticsId?: string;
   };
   loaded: boolean;
   putEntry: (bucket: string, key: string, value: Value) => Promise<void>;
@@ -552,3 +554,58 @@ export function useThemeMutation() {
     status,
   };
 }
+
+export function createAnalyticsId() {
+  return uuidv4();
+}
+
+export function useAnalyticsIdMutation() {
+  const { mutate, status } = usePutEntryMutation({
+    bucket: 'groups',
+    key: 'analyticsId',
+  });
+
+  return {
+    mutate: (analyticsId: string) => mutate({ val: analyticsId }),
+    status,
+  };
+}
+
+export function useResetAnalyticsIdMutation() {
+  const { mutate, status } = useAnalyticsIdMutation();
+
+  const newAnalyticsId = createAnalyticsId();
+
+  return {
+    mutate: () => mutate(newAnalyticsId),
+    status,
+  };
+}
+
+export const useAnalyticsId = () => {
+  const { data, isLoading } = useMergedSettings();
+  const { mutate, status } = useAnalyticsIdMutation();
+
+  return useMemo(() => {
+    if (isLoading || data === undefined || data.groups === undefined) {
+      return '';
+    }
+
+    if (
+      status !== 'loading' &&
+      (data.groups.analyticsId === undefined || data.groups.analyticsId === '')
+    ) {
+      const newAnalyticsId = createAnalyticsId();
+
+      mutate(newAnalyticsId);
+
+      if (status !== 'success') {
+        return '';
+      }
+
+      return newAnalyticsId;
+    }
+
+    return data.groups.analyticsId;
+  }, [isLoading, data, mutate, status]);
+};


### PR DESCRIPTION
This PR stores a persistent UUID in the ship's setting store for use with posthog (we generate the UUID client-side and then store it, we can't grab the user's existing posthog ID AFAICT).

It also gives the user the ability to manually reset the UUID via a button in the Settings modal.

The latter looks like this:

https://github.com/tloncorp/landscape-apps/assets/1221094/bb472c97-14b0-4c2c-9c1e-50529beb348b

