### PR TITLE
groups: iOS touch tweaks

### DIFF
--- a/ui/src/components/NavTab.tsx
+++ b/ui/src/components/NavTab.tsx
@@ -30,7 +30,7 @@ export default function NavTab({
           to={props.to}
           className={({ isActive }) =>
             cn(
-              'flex h-full w-full flex-col items-center justify-center py-2',
+              'flex h-full w-full flex-col items-center justify-center py-2 focus:text-gray-800 active:text-gray-800',
               isActive ? 'text-gray-800' : 'text-gray-400',
               linkClass
             )
@@ -42,7 +42,7 @@ export default function NavTab({
         <a
           {...props}
           className={cn(
-            'flex h-full w-full flex-col items-center justify-center p-2 text-gray-400',
+            'flex h-full w-full flex-col items-center justify-center p-2 text-gray-400 focus:text-gray-800 active:text-gray-800',
             linkClass
           )}
         >

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -1,10 +1,18 @@
-/* Works on Firefox */
 * {
+  /* Scrollbar resizing for Firefox */
   scrollbar-width: thin;
   scrollbar-color: rgb(var(--colors-gray-200)) transparent;
+  /* Hide gray box when tapping a link on iOS */
+  -webkit-tap-highlight-color: transparent;
+  /* Disable double-tap to zoom, removes click delay */
+  touch-action: manipulation;
+  /* Better font rendering */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: subpixel-antialiased;
 }
 
-/* Works on Chrome, Edge, and Safari */
+/* Scrollbar resizing for Chrome, Edge, and Safari */
 *::-webkit-scrollbar {
   width: 10px;
 }


### PR DESCRIPTION
- Removes the gray box on touch for iOS
- Removes the double-tap-to-zoom gesture to make taps to fire faster
- Adds focus color to the mobile tab bar items for immediate feedback
- Smooths the font rendering