### PR TITLE
notes: fix useArrangedNotes map of undefined crash

### DIFF
--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -273,7 +273,7 @@ const defaultPerms = {
 export function useArrangedNotes(flag: DiaryFlag) {
   const diary = useDiary(flag);
 
-  if (diary === undefined) {
+  if (diary === undefined || diary['arranged-notes'] === undefined) {
     return [];
   }
 


### PR DESCRIPTION
We weren't handling the case where arranged notes were undefined.