### PR TITLE
gallery: fix refs in gallery comments

### DIFF
--- a/ui/src/chat/ChatMessage/Author.tsx
+++ b/ui/src/chat/ChatMessage/Author.tsx
@@ -13,6 +13,7 @@ interface AuthorProps {
   date?: Date;
   timeOnly?: boolean;
   hideTime?: boolean;
+  hideRoles?: boolean;
   isReply?: boolean;
   isRef?: boolean;
   className?: string;
@@ -22,6 +23,7 @@ export default function Author({
   date,
   timeOnly,
   hideTime,
+  hideRoles = false,
   className,
   isReply = false,
   isRef = false,
@@ -67,7 +69,7 @@ export default function Author({
             />
           )}
         </div>
-        <RoleBadges ship={ship} />
+        {hideRoles ? null : <RoleBadges ship={ship} />}
       </div>
     );
   }
@@ -102,7 +104,7 @@ export default function Author({
         )}
       </div>
       <PalIcon ship={ship} />
-      <RoleBadges ship={ship} />
+      {hideRoles ? null : <RoleBadges ship={ship} />}
       {hideTime ? (
         <span className="-mb-0.5 hidden shrink-0 text-sm font-semibold text-gray-500 group-two-hover:block">
           {timeDisplay.day} <span role="presentation">&#x2022;</span>{' '}

--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -114,6 +114,7 @@ function CurioReference({
         />
       );
     }
+
     return (
       <ReferenceInHeap
         type="text"
@@ -160,6 +161,7 @@ function CurioReference({
         groupImage={group?.meta.image}
         groupTitle={preview?.group.meta.title}
         channelTitle={preview?.meta?.title}
+        heapComment={contextApp === 'heap-comment'}
       />
     </div>
   );

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -103,6 +103,42 @@ function NoteReference({
     );
   }
 
+  if (contextApp === 'heap-comment') {
+    return (
+      <div
+        onClick={handleOpenReferenceClick}
+        className="cursor-pointer rounded-lg border-2 border-gray-50 text-base"
+      >
+        <ReferenceInHeap
+          contextApp={contextApp}
+          image={
+            isImageUrl(outline.image) ? (
+              <img
+                src={outline.image}
+                className="h-[72px] w-[72px] rounded object-cover"
+              />
+            ) : (
+              <NotebookIcon className="h-6 w-6 text-gray-400" />
+            )
+          }
+          title={outline.title}
+        >
+          {children}
+          <ReferenceBar
+            nest={nest}
+            time={bigInt(id)}
+            author={outline.author}
+            groupFlag={preview?.group.flag}
+            groupImage={group?.meta.image}
+            groupTitle={preview?.group.meta.title}
+            channelTitle={preview?.meta?.title}
+            heapComment
+          />
+        </ReferenceInHeap>
+      </div>
+    );
+  }
+
   if (contextApp === 'heap-block') {
     return (
       <ReferenceInHeap

--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -17,6 +17,7 @@ interface ReferenceBarProps {
   author?: string;
   top?: boolean;
   comment?: boolean;
+  heapComment?: boolean;
   reply?: boolean;
 }
 
@@ -30,6 +31,7 @@ export default function ReferenceBar({
   author,
   top = false,
   comment = false,
+  heapComment = false,
   reply = false,
 }: ReferenceBarProps) {
   const groupFlagOrZod = groupFlag || '~zod/test';
@@ -51,7 +53,7 @@ export default function ReferenceBar({
         }
       )}
     >
-      {author ? (
+      {author && !heapComment ? (
         <Author
           className="peer"
           ship={author}
@@ -61,7 +63,41 @@ export default function ReferenceBar({
           isRef
         />
       ) : null}
-      {top || reply ? null : (
+      {author && heapComment ? (
+        <div className="flex flex-col space-y-2">
+          <Author
+            className="peer !py-0"
+            ship={author}
+            hideRoles
+            isReply={reply}
+            isRef
+          />
+          <div
+            onClick={navigateToChannel}
+            className="flex shrink-0 cursor-pointer items-center whitespace-nowrap text-gray-400 group-hover:text-gray-600 peer-hover:hidden lg:peer-hover:flex"
+          >
+            <GroupAvatar
+              className="rounded-sm lg:order-5"
+              size="w-4 h-4"
+              image={groupImage}
+              title={groupTitle}
+            />
+            <span className="ml-2 font-semibold lg:order-6 lg:inline">
+              {groupTitle}
+            </span>
+          </div>
+          <div className="flex shrink-0 cursor-pointer items-center whitespace-nowrap text-gray-400 group-hover:text-gray-600 peer-hover:hidden lg:peer-hover:flex">
+            <ChannelIcon
+              nest={nest}
+              className="h-4 w-4 lg:order-2 lg:block"
+            />
+            <span className="ml-2 font-semibold lg:order-3">
+              {channelTitle}
+            </span>
+          </div>
+        </div>
+      ) : null}
+      {top || reply || heapComment ? null : (
         <div
           onClick={navigateToChannel}
           className="flex shrink-0 cursor-pointer items-center whitespace-nowrap text-gray-400 group-hover:text-gray-600 peer-hover:hidden lg:peer-hover:flex"

--- a/ui/src/components/References/ReferenceInHeap.tsx
+++ b/ui/src/components/References/ReferenceInHeap.tsx
@@ -32,6 +32,29 @@ function ReferenceInHeap({
     );
   }
 
+  if (contextApp === 'heap-comment') {
+    return (
+      <>
+        {image ? (
+          <div className="m-2 flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded bg-gray-100">
+            {image}
+          </div>
+        ) : null}
+        <div className="flex grow flex-col">
+          {title && (
+            <div className="p-2 text-lg font-semibold line-clamp-1">
+              {title}
+            </div>
+          )}
+          <div className="mt-1 flex space-x-2 text-base font-semibold text-gray-400 line-clamp-1">
+            {byline}
+          </div>
+          {children}
+        </div>
+      </>
+    );
+  }
+
   if (contextApp === 'heap-block') {
     return (
       <div

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -14,6 +14,7 @@ import { isImageUrl } from '@/logic/utils';
 import ReferenceBar from './ReferenceBar';
 import ShipName from '../ShipName';
 import ReferenceInHeap from './ReferenceInHeap';
+import BubbleIcon from '../icons/BubbleIcon';
 
 interface WritBaseReferenceProps {
   nest: string;
@@ -104,6 +105,37 @@ function WritBaseReference({
       >
         {children}
       </ReferenceInHeap>
+    );
+  }
+
+  if (contextApp === 'heap-comment') {
+    return (
+      <div
+        onClick={handleOpenReferenceClick}
+        className="cursor-pointer rounded-lg border-2 border-gray-50 text-base"
+      >
+        <ReferenceInHeap
+          type="text"
+          contextApp={contextApp}
+        >
+          <ChatContent
+            className="line-clamp-1 p-2"
+            story={writ.memo.content.story}
+            isScrolling={false}
+          />
+          {children}
+          <ReferenceBar
+            nest={nest}
+            time={time}
+            author={writ.memo.author}
+            groupFlag={preview?.group.flag}
+            groupImage={group?.meta.image}
+            groupTitle={preview?.group.meta.title}
+            channelTitle={preview?.meta?.title}
+            heapComment
+          />
+        </ReferenceInHeap>
+      </div>
     );
   }
 

--- a/ui/src/heap/HeapContent.tsx
+++ b/ui/src/heap/HeapContent.tsx
@@ -17,6 +17,7 @@ import ContentReference from '@/components/References/ContentReference';
 interface HeapContentProps {
   content: CurioContent;
   className?: string;
+  isComment?: boolean;
 }
 
 interface InlineContentProps {
@@ -111,7 +112,11 @@ export function InlineContent({ inline }: InlineContentProps) {
   throw new Error(`Unhandled message type: ${JSON.stringify(inline)}`);
 }
 
-export default function HeapContent({ content, className }: HeapContentProps) {
+export default function HeapContent({
+  content,
+  className,
+  isComment,
+}: HeapContentProps) {
   const inlineLength = content.inline.length;
 
   return (
@@ -119,7 +124,11 @@ export default function HeapContent({ content, className }: HeapContentProps) {
       {content.block.map((b, idx) => {
         if ('cite' in b) {
           return (
-            <ContentReference contextApp="heap-block" key={idx} cite={b.cite} />
+            <ContentReference
+              contextApp={isComment ? 'heap-comment' : 'heap-block'}
+              key={idx}
+              cite={b.cite}
+            />
           );
         }
         return '??';

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapComment.tsx
@@ -25,7 +25,7 @@ export default function HeapComment({
     <div className="group-one flex w-full flex-col pb-2">
       <Author ship={author} date={unixDate} timeOnly />
       <div className="relative ml-[28px] rounded-md p-2 group-one-hover:bg-gray-50 ">
-        <HeapContent className="break-words leading-5" content={content} />
+        <HeapContent className="break-words leading-5" isComment content={content} />
         <HeapCommentOptions
           whom={flag || ''}
           curio={curio}


### PR DESCRIPTION
Styles the refs so that they can be displayed sanely in heap comments.

Fixes LAND-718.

Looks like this on desktop:

![image](https://github.com/tloncorp/landscape-apps/assets/1221094/792bd777-f03f-4eb6-97a9-30a7ecf43a63)

Looks like this on mobile:

https://github.com/tloncorp/landscape-apps/assets/1221094/399f7ec8-6357-4d1a-b565-3aa322a4e306

