### PR TITLE
notebook: prevent create/editing on saga mismatch

### DIFF
--- a/ui/src/components/ShipConnection.tsx
+++ b/ui/src/components/ShipConnection.tsx
@@ -16,6 +16,18 @@ interface ShipConnectionProps {
   className?: string;
 }
 
+export function getText(ship: string, status?: ConnectionStatus) {
+  if (ship === window.our) {
+    return 'This is you';
+  }
+
+  return !status
+    ? 'No connection data'
+    : 'pending' in status
+    ? getPendingText(status, ship)
+    : getCompletedText(status, ship);
+}
+
 export default function ShipConnection({
   status,
   ship,
@@ -24,28 +36,28 @@ export default function ShipConnection({
 }: ShipConnectionProps) {
   const isSelf = ship === window.our;
   const color = isSelf ? 'text-green-400' : getConnectionColor(status);
-  const text = isSelf
-    ? 'This is you'
-    : !status
-    ? 'No connection data'
-    : 'pending' in status
-    ? getPendingText(status, ship)
-    : getCompletedText(status, ship);
 
   return (
-    <span className={cn('flex items-start space-x-1 font-semibold', className)}>
+    <span
+      className={cn(
+        'relative flex items-start space-x-1 font-semibold',
+        className
+      )}
+    >
       {type === 'default' && (
-        <Tooltip content={text}>
-          <Bullet16Icon
-            className={cn('h-4 w-4 flex-none', color)}
-            tabIndex={0}
-          />
+        <Tooltip content={getText(ship, status)}>
+          <span tabIndex={0}>
+            <Bullet16Icon
+              className={cn('h-4 w-4 flex-none', color)}
+              tabIndex={0}
+            />
+          </span>
         </Tooltip>
       )}
       {type === 'combo' && (
         <Bullet16Icon className={cn('h-4 w-4 flex-none', color)} />
       )}
-      {type !== 'default' && <span>{text}</span>}
+      {type !== 'default' && <span>{getText(ship, status)}</span>}
     </span>
   );
 }

--- a/ui/src/components/ShipConnection.tsx
+++ b/ui/src/components/ShipConnection.tsx
@@ -49,7 +49,6 @@ export default function ShipConnection({
           <span tabIndex={0}>
             <Bullet16Icon
               className={cn('h-4 w-4 flex-none', color)}
-              tabIndex={0}
             />
           </span>
         </Tooltip>

--- a/ui/src/components/ShipConnection.tsx
+++ b/ui/src/components/ShipConnection.tsx
@@ -16,18 +16,6 @@ interface ShipConnectionProps {
   className?: string;
 }
 
-export function getText(ship: string, status?: ConnectionStatus) {
-  if (ship === window.our) {
-    return 'This is you';
-  }
-
-  return !status
-    ? 'No connection data'
-    : 'pending' in status
-    ? getPendingText(status, ship)
-    : getCompletedText(status, ship);
-}
-
 export default function ShipConnection({
   status,
   ship,
@@ -36,6 +24,13 @@ export default function ShipConnection({
 }: ShipConnectionProps) {
   const isSelf = ship === window.our;
   const color = isSelf ? 'text-green-400' : getConnectionColor(status);
+  const text = isSelf
+    ? 'This is you'
+    : !status
+    ? 'No connection data'
+    : 'pending' in status
+    ? getPendingText(status, ship)
+    : getCompletedText(status, ship);
 
   return (
     <span
@@ -45,18 +40,16 @@ export default function ShipConnection({
       )}
     >
       {type === 'default' && (
-        <Tooltip content={getText(ship, status)}>
+        <Tooltip content={text}>
           <span tabIndex={0}>
-            <Bullet16Icon
-              className={cn('h-4 w-4 flex-none', color)}
-            />
+            <Bullet16Icon className={cn('h-4 w-4 flex-none', color)} />
           </span>
         </Tooltip>
       )}
       {type === 'combo' && (
         <Bullet16Icon className={cn('h-4 w-4 flex-none', color)} />
       )}
-      {type !== 'default' && <span>{getText(ship, status)}</span>}
+      {type !== 'default' && <span>{text}</span>}
     </span>
   );
 }

--- a/ui/src/diary/DiaryHeader.tsx
+++ b/ui/src/diary/DiaryHeader.tsx
@@ -4,6 +4,7 @@ import ChannelHeader from '@/channels/ChannelHeader';
 import SortIcon from '@/components/icons/SortIcon';
 import DisplayDropdown from '@/channels/DisplayDropdown';
 import { useDiary, useLeaveDiaryMutation } from '@/state/diary';
+import { useChannel as useChannelSpecific } from '@/logic/channel';
 import {
   setChannelSetting,
   DiarySetting,
@@ -14,6 +15,7 @@ import { DiaryDisplayMode } from '@/types/diary';
 import { nestToFlag } from '@/logic/utils';
 import { Link } from 'react-router-dom';
 import AddIcon16 from '@/components/icons/Add16Icon';
+import { useChannel } from '@/state/groups';
 
 interface DiaryHeaderProps {
   flag: string;
@@ -31,6 +33,8 @@ export default function DiaryHeader({
   display,
 }: DiaryHeaderProps) {
   const [, chFlag] = nestToFlag(nest);
+  const chan = useChannelSpecific(nest);
+  const saga = chan?.saga || null;
   const settings = useDiarySettings();
   const { mutateAsync: leaveDiary } = useLeaveDiaryMutation();
   const { mutate } = usePutEntryMutation({
@@ -69,7 +73,7 @@ export default function DiaryHeader({
       prettyAppName="Notebook"
       leave={(ch) => leaveDiary({ flag: ch })}
     >
-      {canWrite ? (
+      {canWrite && saga && 'synced' in saga ? (
         <Link
           to="edit"
           className={'small-button shrink-0 bg-blue px-1 text-white sm:px-2'}

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -29,7 +29,10 @@ import {
   DiaryQuip,
 } from '@/types/diary';
 import { useDiaryCommentSortMode } from '@/state/settings';
-import { useChannelIsJoined } from '@/logic/channel';
+import {
+  useChannelIsJoined,
+  useChannel as useChannelSpecific,
+} from '@/logic/channel';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { ViewProps } from '@/types/groups';
 import { useConnectivityCheck } from '@/state/vitals';
@@ -111,6 +114,8 @@ export default function DiaryNote({ title }: ViewProps) {
   const brief = useDiaryBrief(chFlag);
   const sort = useDiaryCommentSortMode(chFlag);
   const perms = useDiaryPerms(chFlag);
+  const chan = useChannelSpecific(chFlag);
+  const saga = chan?.saga;
   const { mutateAsync: joinDiary } = useJoinDiaryMutation();
   const joinChannel = useCallback(async () => {
     await joinDiary({ group: groupFlag, chan: chFlag });
@@ -179,6 +184,7 @@ export default function DiaryNote({ title }: ViewProps) {
             title={'Loading note...'}
             time={noteId}
             canEdit={false}
+            nest={nest}
           />
         }
       >
@@ -210,6 +216,7 @@ export default function DiaryNote({ title }: ViewProps) {
           title={note.essay.title}
           time={noteId}
           canEdit={isAdmin || window.our === note.essay.author}
+          nest={nest}
         />
       }
     >
@@ -250,7 +257,7 @@ export default function DiaryNote({ title }: ViewProps) {
                 </h2>
               </Divider>
             </div>
-            {canWrite ? (
+            {canWrite && saga && 'synced' in saga ? (
               <DiaryCommentField
                 flag={chFlag}
                 groupFlag={groupFlag}

--- a/ui/src/diary/DiaryNoteHeader.tsx
+++ b/ui/src/diary/DiaryNoteHeader.tsx
@@ -5,19 +5,25 @@ import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import { Link } from 'react-router-dom';
 import { useIsMobile } from '@/logic/useMedia';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
+import { useChannel as useChannelSpecific } from '@/logic/channel';
 
 export interface DiaryNoteHeaderProps {
   title: string;
   time: string;
   canEdit: boolean;
+  nest: string;
 }
 
 export default function DiaryNoteHeader({
   title,
   time,
   canEdit,
+  nest,
 }: DiaryNoteHeaderProps) {
   const isMobile = useIsMobile();
+
+  const chan = useChannelSpecific(nest);
+  const saga = chan?.saga || null;
 
   return (
     <div
@@ -50,7 +56,7 @@ export default function DiaryNoteHeader({
 
       <div className="flex shrink-0 flex-row items-center space-x-3">
         {isMobile && <ReconnectingSpinner />}
-        {canEdit ? (
+        {canEdit && saga && 'synced' in saga ? (
           <Link to={`../edit/${time}`} className="small-button">
             Edit
           </Link>

--- a/ui/src/diary/DiaryNoteOptionsDropdown.tsx
+++ b/ui/src/diary/DiaryNoteOptionsDropdown.tsx
@@ -4,6 +4,7 @@ import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { Link } from 'react-router-dom';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { useArrangedNotes } from '@/state/diary';
+import { useChannel } from '@/logic/channel';
 import useDiaryActions from './useDiaryActions';
 
 type DiaryNoteOptionsDropdownProps = PropsWithChildren<{
@@ -22,6 +23,8 @@ export default function DiaryNoteOptionsDropdown({
 }: DiaryNoteOptionsDropdownProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const arrangedNotes = useArrangedNotes(flag);
+  const chan = useChannel(flag);
+  const saga = chan?.saga || null;
   const {
     isOpen,
     didCopy,
@@ -51,7 +54,7 @@ export default function DiaryNoteOptionsDropdown({
             {didCopy ? 'Link Copied!' : 'Copy Note Link'}
           </Dropdown.Item>
 
-          {canEdit ? (
+          {canEdit && saga && 'synced' in saga ? (
             <>
               {arrangedNotes?.includes(time) ? (
                 <>


### PR DESCRIPTION
Hides Add, Edit, Pin, Delete, and Comment capabilities for notebooks where you are not in sync with the host's version.

Also fixes the ShipConnection component to show the tooltip correctly.