### PR TITLE
channels: fix channel checking

### DIFF
--- a/ui/src/channels/ChannelTitleButton.tsx
+++ b/ui/src/channels/ChannelTitleButton.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames';
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import { useIsMobile } from '@/logic/useMedia';
-import { getFlagParts, isTalk } from '@/logic/utils';
+import { getFlagParts, isTalk, nestToFlag } from '@/logic/utils';
 import { useChannel } from '@/state/groups';
 import { useChannel as useChannelSpecific } from '@/logic/channel';
 import { Link } from 'react-router-dom';
@@ -21,7 +21,8 @@ export default function ChannelTitleButton({
 }: ChannelTitleButtonProps) {
   const isMobile = useIsMobile();
   const channel = useChannel(flag, nest);
-  const { ship } = getFlagParts(flag);
+  const [, chFlag] = nestToFlag(nest);
+  const { ship } = getFlagParts(chFlag);
   const BackButton = isMobile ? Link : 'div';
   const { data } = useConnectivityCheck(ship || '');
   const chan = useChannelSpecific(nest);

--- a/ui/src/state/vitals.ts
+++ b/ui/src/state/vitals.ts
@@ -113,7 +113,7 @@ export function useConnectivityCheck(
     waitToDisplay = 700,
   } = options || {};
   const self = window.our === ship;
-  const [subbed, setSubbed] = useState(false);
+  const [subbed, setSubbed] = useState<string | undefined>(undefined);
   const [showConnection, setShowConnection] = useState(false);
   const queryClient = useQueryClient();
   const query = useQuery(
@@ -145,7 +145,7 @@ export function useConnectivityCheck(
       return resp;
     },
     {
-      enabled: enabled && subbed && !self,
+      enabled: enabled && !!subbed && !self,
       cacheTime: 0,
       initialData: self
         ? {
@@ -163,7 +163,7 @@ export function useConnectivityCheck(
   );
 
   useEffect(() => {
-    if (subbed || self) {
+    if (self) {
       return;
     }
 
@@ -174,7 +174,8 @@ export function useConnectivityCheck(
         queryClient.setQueryData(['vitals', ship], data);
       },
     });
-    setSubbed(true);
+
+    setSubbed(ship);
   }, [ship, subbed, self, queryClient]);
 
   useEffect(() => {


### PR DESCRIPTION
This was using the wrong ship for channels, the group host instead of the channel host, and also it wasn't properly subscribing to new ships when still mounted. This fixes the issue where I was only ever seeing "Checking connection...", and now properly gives us the updates.

Should go out with 4.2