### PR TITLE
lure: UI updates to checking interaction

### DIFF
--- a/ui/src/groups/LureInviteBlock.tsx
+++ b/ui/src/groups/LureInviteBlock.tsx
@@ -104,7 +104,7 @@ export default function LureInviteBlock({
               </span>
             </div>
           )}
-          {url !== '' && good === false && (
+          {url !== '' && !good && (
             <>
               <input
                 value="Link cannot be displayed"

--- a/ui/src/groups/LureInviteBlock.tsx
+++ b/ui/src/groups/LureInviteBlock.tsx
@@ -119,7 +119,7 @@ export default function LureInviteBlock({
               </button>
             </>
           )}
-          {url !== '' && good === true && (
+          {url !== '' && good && (
             <>
               <input
                 value={url}

--- a/ui/src/groups/LureInviteBlock.tsx
+++ b/ui/src/groups/LureInviteBlock.tsx
@@ -1,6 +1,5 @@
 import cn from 'classnames';
 import { useLure, useLureLinkChecked } from '@/state/lure/lure';
-import TlonIcon from '@/components/icons/TlonIcon';
 import { getFlagParts, isGroupHost, useCopy } from '@/logic/utils';
 import CheckIcon from '@/components/icons/CheckIcon';
 import { Group } from '@/types/groups';
@@ -20,23 +19,6 @@ const emptyMeta = {
   cover: '',
 };
 
-function LureLinkChecked({ flag, url }: { flag: string, url: string }) {
-  const { didCopy, doCopy } = useCopy(url);
-  const good = useLureLinkChecked(flag);
-
-  return <>
-  {!good ? <div>
-    <LoadingSpinner/>
-  </div> : null}
-  {good ? <span className="button ml-auto self-start bg-blue-soft uppercase text-blue mix-blend-multiply dark:bg-blue-softer dark:mix-blend-normal">
-    ✓
-  </span> : null}
-  {good ? <button className="button bg-blue" onClick={doCopy}>
-    {didCopy ? 'Copied!' : 'Copy'}
-  </button> : null}
-  </>
-}
-
 export default function LureInviteBlock({
   flag,
   group,
@@ -44,6 +26,8 @@ export default function LureInviteBlock({
 }: LureInviteBlock) {
   const { supported, fetched, enabled, enableAcked, url, toggle } =
     useLure(flag);
+  const good = useLureLinkChecked(flag);
+  const { didCopy, doCopy } = useCopy(url);
 
   if (!supported) {
     return null;
@@ -63,59 +47,90 @@ export default function LureInviteBlock({
         </p>
       </div>
       <p className="leading-5">
-        Have friends, family or collaborators who aren't on Urbit?
+        Have friends, family or collaborators who aren&rsquo;t on Urbit?
       </p>
       <p className="leading-5">
         You can now gift them an Urbit ID and onboard them to your group all in
         one free and easy sweep. Just copy and share the link below.
       </p>
       {isGroupHost(flag) && (
-        <div className="flex flex-row">
-          <label
-            className={
-              'flex cursor-pointer items-start justify-between space-x-2 py-2'
-            }
-          >
-            <div className="flex items-center">
-              {enabled ? (
-                <div className="flex h-4 w-4 items-center rounded-sm border-2 border-gray-400">
-                  <CheckIcon className="h-4 w-4" />
-                </div>
-              ) : (
-                <div className="h-4 w-4 rounded-sm border-2 border-gray-200" />
-              )}
-            </div>
+        <>
+          <div className="flex flex-row">
+            <label
+              className={
+                'flex cursor-pointer items-start justify-between space-x-2 py-2'
+              }
+            >
+              <div className="flex items-center">
+                {enabled ? (
+                  <div className="flex h-4 w-4 items-center rounded-sm border-2 border-gray-400">
+                    <CheckIcon className="h-4 w-4" />
+                  </div>
+                ) : (
+                  <div className="h-4 w-4 rounded-sm border-2 border-gray-200" />
+                )}
+              </div>
 
-            <div className="flex w-full flex-col">
-              <div className="flex flex-row space-x-2">
-                <div className="flex w-full flex-col justify-start text-left">
-                  <span className="font-semibold">Invite Link Enabled</span>
+              <div className="flex w-full flex-col">
+                <div className="flex flex-row space-x-2">
+                  <div className="flex w-full flex-col justify-start text-left">
+                    <span className="font-semibold">Invite Links</span>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <input
-              checked={enabled}
-              onChange={toggle(group?.meta || emptyMeta)}
-              className="sr-only"
-              type="checkbox"
-            />
-          </label>
-        </div>
+              <input
+                checked={enabled}
+                onChange={toggle(group?.meta || emptyMeta)}
+                className="sr-only"
+                type="checkbox"
+              />
+            </label>
+          </div>
+          {!enabled && (
+            <div className="flex w-full flex-1 rounded-lg border-2 border-gray-100 bg-gray-100 py-1 px-2 text-lg font-semibold  leading-5 text-gray-600 mix-blend-multiply focus:outline-none dark:mix-blend-screen sm:text-base sm:leading-5">
+              Enable to view invite link
+            </div>
+          )}
+        </>
       )}
       {enabled && enableAcked ? (
-        <div className="flex items-center space-x-2">
-          <div className="relative max-w-md flex-1">
-            {url === '' ? (
-              <LoadingSpinner className="absolute right-2 my-2 h-4 w-4" />
-            ) : null}
-            <input
-              value={url}
-              readOnly
-              className="flex w-full flex-1 rounded-lg border-2 border-blue-soft bg-blue-soft py-1 px-2 text-lg font-semibold  leading-5 text-blue caret-blue-400 mix-blend-multiply focus:outline-none dark:mix-blend-screen sm:text-base sm:leading-5"
-            />
-          </div>
-          <LureLinkChecked flag={flag} url={url} />
+        <div className="relative flex flex-1 items-center space-x-2">
+          {url === '' && !good && (
+            <div className="flex w-full items-center space-x-2 rounded-lg border-2 border-blue-soft bg-blue-soft py-1 px-2 text-lg font-semibold leading-5 text-blue mix-blend-multiply dark:mix-blend-screen sm:text-base sm:leading-5">
+              <LoadingSpinner className="h-4 w-4 text-blue" />
+              <span className="font-semibold text-blue">
+                Generating link...
+              </span>
+            </div>
+          )}
+          {url !== '' && good === false && (
+            <>
+              <input
+                value="Link cannot be displayed"
+                readOnly
+                className="flex w-full flex-1 rounded-lg border-2 border-gray-100 bg-gray-100 py-1 px-2 text-lg font-semibold  leading-5 text-gray-600 mix-blend-multiply focus:outline-none dark:mix-blend-screen sm:text-base sm:leading-5"
+              />
+              <button
+                className="button"
+                onClick={toggle(group?.meta || emptyMeta)}
+              >
+                Retry
+              </button>
+            </>
+          )}
+          {url !== '' && good === true && (
+            <>
+              <input
+                value={url}
+                readOnly
+                className="flex w-full flex-1 rounded-lg border-2 border-blue-soft bg-blue-soft py-1 px-2 text-lg font-semibold  leading-5 text-blue caret-blue-400 mix-blend-multiply focus:outline-none dark:mix-blend-screen sm:text-base sm:leading-5"
+              />
+              <button className="button bg-blue" onClick={doCopy}>
+                {didCopy ? 'Copied!' : 'Copy'}
+              </button>
+            </>
+          )}
         </div>
       ) : !isGroupHost(flag) ? (
         <div className="flex items-center space-x-2 font-semibold">


### PR DESCRIPTION
fixes GRO-600

Addresses the following feedback on #2738:

> A simple idea here, if I understand this problem correctly (ignore the greater context, focus on the form field itself)
> 
> ![Lure Link Generation](https://user-images.githubusercontent.com/1195363/256929848-fc47d517-ba51-4062-b785-05c812f0090e.png)
> 
> This recommendation basically splits up the lure link generation process into three discrete steps:
> 
> 1. Disabled form, indicating that it must be enabled to show a link
> 2. If enabled, Lure Link is "generated" and indicates it needs time before it can display
> 3. Only when we've able to render a link that actually works, do we complete the "generation" process and show a working link that can be copied
> 4. If the generation process fails, or we can't reliably surface a working link, we should error out the form and provide people the opportunity to retry the generation process
