### PR TITLE
bugfix: land-736

### DIFF
--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -91,8 +91,8 @@ export default function DiaryAddNote() {
   // expand title to 2 rows if needed, beyond that we can scroll
   useEffect(() => {
     if (extraTitleRow) return;
-    const { scrollHeight, clientHeight } = titleRef.current!;
-    if (scrollHeight > clientHeight) {
+    if (!titleRef.current) return;
+    if (titleRef.current.scrollHeight > titleRef.current.clientHeight) {
       setExtraTitleRow(true);
     }
   }, [watchedTitle, extraTitleRow]);


### PR DESCRIPTION
Apparently using destructuring to pull values out of this ref could be interpreted as attempting to assign a value to the ref. Eliminated the destructuring and added a check to make sure we have a ref.