### PR TITLE
chat: use vercel's react-tweet to improve twitter embeds

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -103,6 +103,7 @@
         "react-router": "^6.3.0",
         "react-router-dom": "^6.3.0",
         "react-select": "^5.3.2",
+        "react-tweet": "^3.0.4",
         "react-virtuoso": "^3.1.4",
         "refractor": "^4.8.0",
         "slugify": "^1.6.6",
@@ -11316,6 +11317,14 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/aspect-ratio": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.0.tgz",
@@ -14957,6 +14966,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -15570,9 +15587,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
       "engines": {
         "node": ">=0.11"
       },
@@ -24106,6 +24126,21 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-tweet": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.0.4.tgz",
+      "integrity": "sha512-cp2O8OnW3O5unYU4Txv2AW8g8HnqMx2kpFokTB4XnGbTt65zY2pzklWVM6pAg1lIO5n1Uikreh2cKszUKdAB/g==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1",
+        "clsx": "^1.2.1",
+        "date-fns": "^2.30.0",
+        "swr": "^2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 18.0.0",
+        "react-dom": ">= 18.0.0"
+      }
+    },
     "node_modules/react-virtuoso": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-3.1.4.tgz",
@@ -25661,6 +25696,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
+      "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -35796,6 +35842,14 @@
         }
       }
     },
+    "@swc/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@tailwindcss/aspect-ratio": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.0.tgz",
@@ -38554,6 +38608,11 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -39040,9 +39099,12 @@
       }
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -45245,6 +45307,17 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-tweet": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.0.4.tgz",
+      "integrity": "sha512-cp2O8OnW3O5unYU4Txv2AW8g8HnqMx2kpFokTB4XnGbTt65zY2pzklWVM6pAg1lIO5n1Uikreh2cKszUKdAB/g==",
+      "requires": {
+        "@swc/helpers": "^0.5.1",
+        "clsx": "^1.2.1",
+        "date-fns": "^2.30.0",
+        "swr": "^2.2.0"
+      }
+    },
     "react-virtuoso": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-3.1.4.tgz",
@@ -46431,6 +46504,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "swr": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
+      "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
+      "requires": {
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -150,6 +150,7 @@
     "react-router": "^6.3.0",
     "react-router-dom": "^6.3.0",
     "react-select": "^5.3.2",
+    "react-tweet": "^3.0.4",
     "react-virtuoso": "^3.1.4",
     "refractor": "^4.8.0",
     "slugify": "^1.6.6",

--- a/ui/public/mockServiceWorker.js
+++ b/ui/public/mockServiceWorker.js
@@ -8,111 +8,111 @@
  * - Please do NOT serve this file on production.
  */
 
-const INTEGRITY_CHECKSUM = 'b3066ef78c2f9090b4ce87e874965995';
-const activeClientIds = new Set();
+const INTEGRITY_CHECKSUM = 'b3066ef78c2f9090b4ce87e874965995'
+const activeClientIds = new Set()
 
 self.addEventListener('install', function () {
-  self.skipWaiting();
-});
+  self.skipWaiting()
+})
 
 self.addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim());
-});
+  event.waitUntil(self.clients.claim())
+})
 
 self.addEventListener('message', async function (event) {
-  const clientId = event.source.id;
+  const clientId = event.source.id
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
-      });
-      break;
+      })
+      break
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
       sendToClient(client, {
         type: 'INTEGRITY_CHECK_RESPONSE',
         payload: INTEGRITY_CHECKSUM,
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId);
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
         payload: true,
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId);
-      break;
+      activeClientIds.delete(clientId)
+      break
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId);
+      activeClientIds.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId;
-      });
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 self.addEventListener('fetch', function (event) {
-  const { request } = event;
-  const accept = request.headers.get('accept') || '';
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
 
   // Bypass server-sent events.
   if (accept.includes('text/event-stream')) {
-    return;
+    return
   }
 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
-    return;
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
   if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return;
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
   // Generate unique request ID.
-  const requestId = Math.random().toString(16).slice(2);
+  const requestId = Math.random().toString(16).slice(2)
 
   event.respondWith(
     handleRequest(event, requestId).catch((error) => {
@@ -120,9 +120,9 @@ self.addEventListener('fetch', function (event) {
         console.warn(
           '[MSW] Successfully emulated a network error for the "%s %s" request.',
           request.method,
-          request.url
-        );
-        return;
+          request.url,
+        )
+        return
       }
 
       // At this point, any exception indicates an issue with the original request/response.
@@ -131,22 +131,22 @@ self.addEventListener('fetch', function (event) {
 [MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
         request.method,
         request.url,
-        `${error.name}: ${error.message}`
-      );
-    })
-  );
-});
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event);
-  const response = await getResponse(event, client, requestId);
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    (async function () {
-      const clonedResponse = response.clone();
+    ;(async function () {
+      const clonedResponse = response.clone()
       sendToClient(client, {
         type: 'RESPONSE',
         payload: {
@@ -160,11 +160,11 @@ async function handleRequest(event, requestId) {
           headers: Object.fromEntries(clonedResponse.headers.entries()),
           redirected: clonedResponse.redirected,
         },
-      });
-    })();
+      })
+    })()
   }
 
-  return response;
+  return response
 }
 
 // Resolve the main client for the given event.
@@ -172,49 +172,49 @@ async function handleRequest(event, requestId) {
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (client.frameType === 'top-level') {
-    return client;
+    return client
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible';
+      return client.visibilityState === 'visible'
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event;
-  const clonedRequest = request.clone();
+  const { request } = event
+  const clonedRequest = request.clone()
 
   function passthrough() {
     // Clone the request because it might've been already used
     // (i.e. its body has been read and sent to the cilent).
-    const headers = Object.fromEntries(clonedRequest.headers.entries());
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
 
     // Remove MSW-specific request headers so the bypassed requests
     // comply with the server's CORS preflight check.
     // Operate with the headers as an object because request "Headers"
     // are immutable.
-    delete headers['x-msw-bypass'];
+    delete headers['x-msw-bypass']
 
-    return fetch(clonedRequest, { headers });
+    return fetch(clonedRequest, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -222,13 +222,13 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass requests with the explicit bypass header.
   // Such requests can be issued by "ctx.fetch()".
   if (request.headers.get('x-msw-bypass') === 'true') {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
@@ -251,53 +251,53 @@ async function getResponse(event, client, requestId) {
       bodyUsed: request.bodyUsed,
       keepalive: request.keepalive,
     },
-  });
+  })
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data);
+      return respondWithMock(clientMessage.data)
     }
 
     case 'MOCK_NOT_FOUND': {
-      return passthrough();
+      return passthrough()
     }
 
     case 'NETWORK_ERROR': {
-      const { name, message } = clientMessage.data;
-      const networkError = new Error(message);
-      networkError.name = name;
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
 
       // Rejecting a "respondWith" promise emulates a network error.
-      throw networkError;
+      throw networkError
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 function sendToClient(client, message) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
-    client.postMessage(message, [channel.port2]);
-  });
+    client.postMessage(message, [channel.port2])
+  })
 }
 
 function sleep(timeMs) {
   return new Promise((resolve) => {
-    setTimeout(resolve, timeMs);
-  });
+    setTimeout(resolve, timeMs)
+  })
 }
 
 async function respondWithMock(response) {
-  await sleep(response.delay);
-  return new Response(response.body, response);
+  await sleep(response.delay)
+  return new Response(response.body, response)
 }

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -99,13 +99,8 @@ function ChatEmbedContent({
 
     if (provider === 'Twitter') {
       return (
-        <div className="flex flex-col">
-          <TwitterEmbed
-            authorUrl={authorUrl}
-            author={author}
-            embedHtml={embedHtml}
-            writId={writId}
-          />
+        <div className="flex w-[300px] flex-col sm:w-full">
+          <TwitterEmbed embedHtml={embedHtml} />
         </div>
       );
     }

--- a/ui/src/chat/ChatEmbedContent/TwitterEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/TwitterEmbed.tsx
@@ -1,120 +1,23 @@
-import TwitterIcon from '@/components/icons/TwitterIcon';
-import LightBox from '@/components/LightBox';
-import { useIsMobile } from '@/logic/useMedia';
-import EmbedContainer from 'react-oembed-container';
-import React from 'react';
-import { useParams } from 'react-router';
-import { useChatDialog } from '../useChatStore';
+import { Tweet } from 'react-tweet';
 
 interface TwitterEmbedProps {
-  authorUrl: string;
-  author: string;
   embedHtml: string;
-  writId: string;
 }
 
-export default function TwitterEmbed({
-  authorUrl,
-  author,
-  embedHtml,
-  writId,
-}: TwitterEmbedProps) {
-  const { chShip, chName } = useParams<{
-    chShip: string;
-    chName: string;
-  }>();
-  const whom = `${chShip}/${chName}`;
-  const { open: showIframeModal, setOpen: setShowIframeModal } = useChatDialog(
-    whom,
-    writId,
-    'twitter'
-  );
-  const isMobile = useIsMobile();
-  const twitterHandle = authorUrl.split('/').pop();
-  // unavatar now charges for this after 50 requests per day
-  const twitterProfilePic = `https://unavatar.io/twitter/${twitterHandle}?fallback=false`;
+export default function TwitterEmbed({ embedHtml }: TwitterEmbedProps) {
   const element = document.createElement('html');
   element.innerHTML = embedHtml;
-  const baseTweetText = element.querySelector('p')?.innerHTML || '';
-  const tweetText = baseTweetText.replace(/<br\s*\/?>/gm, '\n');
-  const tweetContainsLink = tweetText.includes('<a href=');
-  const tweetTextWithoutLink = tweetText.split('<a href=')[0];
-  const tweetLink = tweetContainsLink
-    ? tweetText.split('<a href="')[1].split('">')[0]
-    : '';
-  const tweetDate =
-    Array.from(element.querySelectorAll('a')).filter(
-      (a) =>
-        a.href.includes('https://twitter.com') &&
-        !a.href.includes('pic.twitter.com')
-    )[0].innerHTML || '';
   const tweetUrl =
     Array.from(element.querySelectorAll('a'))
       .filter(
         (a) =>
           a.href.includes('https://twitter.com') &&
-          !a.href.includes('pic.twitter.com')
+          !a.href.includes('pic.twitter.com') &&
+          a.href.includes('/status/') &&
+          a.href.includes('ref_src=twsrc%5Etfw')
       )[0]
       .getAttribute('href') || '';
+  const tweetIdFromUrl = tweetUrl.split('/status/')[1].split('?')[0];
 
-  return (
-    <div className="embed-inline-block max-w-[400px]">
-      <div className="flex grow flex-col justify-center space-y-2">
-        <blockquote
-          className="cursor-pointer"
-          onClick={() => setShowIframeModal(true)}
-        >
-          {tweetContainsLink ? (
-            <>
-              <p className="whitespace-pre-wrap font-medium text-gray-900">
-                {tweetTextWithoutLink}
-              </p>
-              <p className="font-medium text-gray-900">
-                <a
-                  href={tweetLink}
-                  className="underline"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {tweetLink}
-                </a>
-              </p>
-            </>
-          ) : (
-            <p className="whitespace-pre-wrap font-medium text-gray-900">
-              {tweetText}
-            </p>
-          )}
-        </blockquote>
-        <div className="flex items-center space-x-2 text-sm">
-          <TwitterIcon className="h-4 w-4" />
-          <span className="truncate font-semibold text-black">{author}</span>
-          {!isMobile && (
-            <span className="truncate text-gray-300">@{twitterHandle}</span>
-          )}
-          <span className="text-gray-300">&middot;</span>
-          <a
-            target="_blank"
-            rel="noreferrer"
-            href={tweetUrl}
-            className="truncate text-gray-300 underline"
-          >
-            {tweetDate}
-          </a>
-        </div>
-      </div>
-      <LightBox
-        showLightBox={showIframeModal}
-        setShowLightBox={() => setShowIframeModal(false)}
-        source={tweetUrl}
-      >
-        <EmbedContainer
-          className="h-[500px] w-[500px] overflow-y-auto md:h-full"
-          markup={embedHtml}
-        >
-          <div dangerouslySetInnerHTML={{ __html: embedHtml }} />
-        </EmbedContainer>
-      </LightBox>
-    </div>
-  );
+  return <Tweet id={tweetIdFromUrl} />;
 }


### PR DESCRIPTION
No more opening a modal to view the full tweet (since our old embed would tend to garble them if they included mentions, pictures, or videos).

Requires react-18, so this is currently based on hunter's branch.

Looks like this:

![image](https://github.com/tloncorp/landscape-apps/assets/1221094/8eff8586-3769-43cc-aff8-849439b1f2f2)
![image](https://github.com/tloncorp/landscape-apps/assets/1221094/2359b96c-afe7-42e8-ae50-6d07dda003d5)
![image](https://github.com/tloncorp/landscape-apps/assets/1221094/13cf2edf-5f33-4874-be95-453cf1bbb655)
![image](https://github.com/tloncorp/landscape-apps/assets/1221094/5e7fbb00-59ea-468f-a71e-d34d90adf006)
![image](https://github.com/tloncorp/landscape-apps/assets/1221094/c75309dd-ae2e-4dd5-8e9f-104f735d293f)

Fixes LAND-741