### PR TITLE
bugfix: missing saga issues in notebooks

### DIFF
--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -120,7 +120,7 @@ export default function DiaryNote({ title }: ViewProps) {
   const brief = useDiaryBrief(chFlag);
   const sort = useDiaryCommentSortMode(chFlag);
   const perms = useDiaryPerms(chFlag);
-  const chan = useChannelSpecific(chFlag);
+  const chan = useChannelSpecific(nest);
   const saga = chan?.saga;
   const { mutateAsync: joinDiary } = useJoinDiaryMutation();
   const joinChannel = useCallback(async () => {

--- a/ui/src/diary/DiaryNoteOptionsDropdown.tsx
+++ b/ui/src/diary/DiaryNoteOptionsDropdown.tsx
@@ -25,7 +25,8 @@ export default function DiaryNoteOptionsDropdown({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const arrangedNotes = useArrangedNotes(flag);
   const { ship } = getFlagParts(flag);
-  const chan = useChannel(flag);
+  const nest = `diary/${flag}`;
+  const chan = useChannel(nest);
   const saga = chan?.saga || null;
   const {
     isOpen,


### PR DESCRIPTION
We were passing flag rather than nest into useChannel, which expects a nest, so it returned undefined and the components assumed there was a saga issue and hid the appropriate elements (comment input, dropdown options on notes for the author/admins).