### PR TITLE
groups: don't ask for tracking on first run

### DIFF
--- a/ui/src/groups/Groups.tsx
+++ b/ui/src/groups/Groups.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import cookies from 'browser-cookies';
 import { Outlet, useMatch, useNavigate } from 'react-router';
 import _ from 'lodash';
 import {
@@ -22,6 +23,7 @@ import useGroupPrivacy from '@/logic/useGroupPrivacy';
 
 function Groups() {
   const navigate = useNavigate();
+  const hasUsedGroupsCount = parseInt(cookies.get('hasUsedGroups') || '0', 10);
   const flag = useRouteGroup();
   const group = useGroup(flag, true);
   const gang = useGang(flag);
@@ -72,6 +74,8 @@ function Groups() {
     if (!group && !gang) {
       navigate('/');
     } else if (group && root) {
+      cookies.set('hasUsedGroups', (hasUsedGroupsCount + 1).toString());
+
       const found = Object.entries(group.channels).find(
         ([nest, _c]) => recentChannel === nest
       );
@@ -108,6 +112,7 @@ function Groups() {
     recentChannel,
     navigate,
     diaryBriefs,
+    hasUsedGroupsCount,
   ]);
 
   useGroupsAnalyticsEvent({

--- a/ui/src/logic/useReactQuerySubscription.tsx
+++ b/ui/src/logic/useReactQuerySubscription.tsx
@@ -56,8 +56,6 @@ export default function useReactQuerySubscription({
   }, [app, path, queryClient, queryKey]);
 
   return useQuery(queryKey, fetchData, {
-    retryOnMount: false,
-    refetchOnMount: false,
     ...options,
   });
 }

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -504,14 +504,24 @@ export function useSideBarSortMode() {
 
 export function useShowActivityMessage() {
   const { data, isLoading } = useMergedSettings();
+  const { mutate } = usePutEntryMutation({
+    bucket: 'groups',
+    key: 'hasBeenUsed',
+  });
 
   return useMemo(() => {
     if (isLoading || data === undefined || window.desk !== 'groups') {
       return false;
     }
 
+    if (!data.groups?.hasBeenUsed && data.groups?.showActivityMessage) {
+      mutate({ val: true });
+
+      return false;
+    }
+
     return data.groups?.showActivityMessage || false;
-  }, [isLoading, data]);
+  }, [isLoading, data, mutate]);
 }
 
 export function useShowVitaMessage() {

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import cookies from 'browser-cookies';
 import { v4 as uuidv4 } from 'uuid';
 import { Value, PutBucket, DelEntry, DelBucket } from '@urbit/api';
 import _ from 'lodash';
@@ -504,24 +505,27 @@ export function useSideBarSortMode() {
 
 export function useShowActivityMessage() {
   const { data, isLoading } = useMergedSettings();
-  const { mutate } = usePutEntryMutation({
-    bucket: 'groups',
-    key: 'hasBeenUsed',
-  });
+  const cookie = cookies.get('hasUsedGroups');
 
   return useMemo(() => {
     if (isLoading || data === undefined || window.desk !== 'groups') {
       return false;
     }
 
-    if (!data.groups?.hasBeenUsed && data.groups?.showActivityMessage) {
-      mutate({ val: true });
-
+    if ((!cookie || cookie === '1') && data.groups?.showActivityMessage) {
       return false;
     }
 
+    if (
+      cookie &&
+      cookie !== '1' &&
+      data.groups?.showActivityMessage === undefined
+    ) {
+      return true;
+    }
+
     return data.groups?.showActivityMessage || false;
-  }, [isLoading, data, mutate]);
+  }, [isLoading, data, cookie]);
 }
 
 export function useShowVitaMessage() {


### PR DESCRIPTION
Wait until user has opened groups a second time.

Separately: there is something wrong with the %settings initialization. showActivityMessage is not getting initialized to `true`, so I've hacked around that for now.