### PR TITLE
bugfix: drag and drop could get stuck in "drag" mode

### DIFF
--- a/ui/src/logic/DragAndDropContext.tsx
+++ b/ui/src/logic/DragAndDropContext.tsx
@@ -154,10 +154,6 @@ export function useDragAndDrop(targetId: string) {
 
   const handleDropWithTarget = useCallback(
     (e: DragEvent) => {
-      const targetElement = e.target as HTMLElement;
-
-      if (targetElement && targetElement.id !== targetId) return;
-
       handleDrop(e, targetId);
     },
     [handleDrop, targetId]


### PR DESCRIPTION
I originally had an unnecessary early return before we get to the setIsDragging(false) and setIsOver(false) calls.

This removes that.