### PR TITLE
Fix position of Talk/Groups containers

### DIFF
--- a/ui/src/nav/GroupsNav.tsx
+++ b/ui/src/nav/GroupsNav.tsx
@@ -53,7 +53,7 @@ export function DesktopNav() {
 export default function GroupsNav() {
   const isMobile = useIsMobile();
   return (
-    <div className="flex h-full w-full">
+    <div className="fixed flex h-full w-full">
       {isMobile ? null : <DesktopNav />}
       <Outlet />
     </div>

--- a/ui/src/nav/GroupsNav.tsx
+++ b/ui/src/nav/GroupsNav.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { matchPath, Outlet, useLocation, useMatch } from 'react-router';
 import { motion, AnimatePresence } from 'framer-motion';
 import Sidebar from '@/components/Sidebar/Sidebar';

--- a/ui/src/nav/TalkNav.tsx
+++ b/ui/src/nav/TalkNav.tsx
@@ -7,7 +7,7 @@ export default function TalkNav() {
   const isMobile = useIsMobile();
 
   return (
-    <div className="flex h-full w-full">
+    <div className="fixed flex h-full w-full">
       {isMobile ? null : <MessagesSidebar />}
       <Outlet />
     </div>

--- a/ui/src/nav/TalkNav.tsx
+++ b/ui/src/nav/TalkNav.tsx
@@ -1,6 +1,5 @@
 import MessagesSidebar from '@/dms/MessagesSidebar';
 import { useIsMobile } from '@/logic/useMedia';
-import React from 'react';
 import { Outlet } from 'react-router';
 
 export default function TalkNav() {


### PR DESCRIPTION
Fixes LAND-702

Small update that fixes the position of the container components that wrap Talk and Groups. Apart from hopefully resolving the scroll issue referenced, this should help the mobile app feel more native by ensuring navigational elements can't be dragged out of position. 

Give it a spin and let me know what y'all think. If we want to preserve the existing feel on desktop, I can add a mobile check.