### PR TITLE
groups: mobile cleanup

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Groups is a decentralized platform that integrates with Talk, Notebook, and Gallery for a full, communal suite of tools.'
     color+0xef.f0f4
     image+'https://bootstrap.urbit.org/icon-groups.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v3.5qg7u.ofvcg.a9cjo.fhv8d.j6h0p.glob' 0v3.5qg7u.ofvcg.a9cjo.fhv8d.j6h0p]
+    glob-http+['https://bootstrap.urbit.org/glob-0v4.vlvmt.lndsi.dceiq.9q3if.u1iqr.glob' 0v4.vlvmt.lndsi.dceiq.9q3if.u1iqr]
     base+'groups'
     version+[4 3 0]
     website+'https://tlon.io'

--- a/ui/src/channels/ChannelActions.tsx
+++ b/ui/src/channels/ChannelActions.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { useNavigate } from 'react-router';
 import EllipsisIcon from '@/components/icons/EllipsisIcon';
@@ -10,6 +10,7 @@ import { nestToFlag, getFlagParts } from '@/logic/utils';
 import { useRouteGroup, useDeleteChannelMutation } from '@/state/groups';
 import { GroupChannel } from '@/types/groups';
 import { useIsChannelHost } from '@/logic/channel';
+import ActionMenu, { Action } from '@/components/ActionMenu';
 
 interface ChannelActionsProps {
   nest: string;
@@ -19,122 +20,122 @@ interface ChannelActionsProps {
   leave: (flag: string) => Promise<void>;
 }
 
-export default function ChannelActions({
-  nest,
-  prettyAppName,
-  channel,
-  isAdmin,
-  leave,
-}: ChannelActionsProps) {
-  const navigate = useNavigate();
-  const isMobile = useIsMobile();
-  const [_app, flag] = nestToFlag(nest);
-  const groupFlag = useRouteGroup();
-  const { ship, name } = getFlagParts(groupFlag);
-  const [dropdownIsOpen, setDropdownIsOpen] = useState(false);
-  const [editIsOpen, setEditIsOpen] = useState(false);
-  const [deleteChannelIsOpen, setDeleteChannelIsOpen] = useState(false);
-  const [deleteStatus, setDeleteStatus] = useState<Status>('initial');
-  const isChannelHost = useIsChannelHost(flag);
-  const { mutate: deleteChannelMutate } = useDeleteChannelMutation();
+const ChannelActions = React.memo(
+  ({ nest, prettyAppName, channel, isAdmin, leave }: ChannelActionsProps) => {
+    const navigate = useNavigate();
+    const isMobile = useIsMobile();
+    const [_app, flag] = nestToFlag(nest);
+    const groupFlag = useRouteGroup();
+    const { ship, name } = getFlagParts(groupFlag);
+    const [isOpen, setIsOpen] = useState(false);
+    const [editIsOpen, setEditIsOpen] = useState(false);
+    const [deleteChannelIsOpen, setDeleteChannelIsOpen] = useState(false);
+    const [deleteStatus, setDeleteStatus] = useState<Status>('initial');
+    const isChannelHost = useIsChannelHost(flag);
+    const { mutate: deleteChannelMutate } = useDeleteChannelMutation();
 
-  const leaveChannel = useCallback(async () => {
-    try {
-      leave(flag);
-      navigate(
-        isMobile
-          ? `/groups/${ship}/${name}`
-          : `/groups/${ship}/${name}/channels`
-      );
-    } catch (error) {
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.error(`[ChannelHeader:LeaveError] ${error}`);
+    const leaveChannel = useCallback(async () => {
+      try {
+        leave(flag);
+        navigate(
+          isMobile
+            ? `/groups/${ship}/${name}`
+            : `/groups/${ship}/${name}/channels`
+        );
+      } catch (error) {
+        if (error) {
+          // eslint-disable-next-line no-console
+          console.error(`[ChannelHeader:LeaveError] ${error}`);
+        }
       }
-    }
-  }, [flag, ship, name, navigate, leave, isMobile]);
+    }, [flag, ship, name, navigate, leave, isMobile]);
 
-  const onDeleteChannelConfirm = useCallback(async () => {
-    setDeleteStatus('loading');
-    try {
-      deleteChannelMutate({ flag: groupFlag, nest });
-      navigate(
-        isMobile
-          ? `/groups/${ship}/${name}`
-          : `/groups/${ship}/${name}/channels`
+    const onDeleteChannelConfirm = useCallback(async () => {
+      setDeleteStatus('loading');
+      try {
+        deleteChannelMutate({ flag: groupFlag, nest });
+        navigate(
+          isMobile
+            ? `/groups/${ship}/${name}`
+            : `/groups/${ship}/${name}/channels`
+        );
+        setDeleteStatus('success');
+        setDeleteChannelIsOpen(!deleteChannelIsOpen);
+      } catch (error) {
+        setDeleteStatus('error');
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
+    }, [
+      deleteChannelIsOpen,
+      groupFlag,
+      nest,
+      deleteChannelMutate,
+      isMobile,
+      name,
+      navigate,
+      ship,
+    ]);
+
+    const actions: Action[] = [];
+
+    if (isAdmin) {
+      actions.push(
+        {
+          key: 'edit',
+          content: `Edit ${prettyAppName}`,
+          onClick: () => setEditIsOpen(!editIsOpen),
+        },
+        {
+          key: 'delete',
+          content: `Delete ${prettyAppName}`,
+          onClick: () => setDeleteChannelIsOpen(!deleteChannelIsOpen),
+          type: 'destructive',
+        }
       );
-      setDeleteStatus('success');
-      setDeleteChannelIsOpen(!deleteChannelIsOpen);
-    } catch (error) {
-      setDeleteStatus('error');
-      // eslint-disable-next-line no-console
-      console.error(error);
     }
-  }, [
-    deleteChannelIsOpen,
-    groupFlag,
-    nest,
-    deleteChannelMutate,
-    isMobile,
-    name,
-    navigate,
-    ship,
-  ]);
 
-  return (
-    <>
-      <Dropdown.Root open={dropdownIsOpen} onOpenChange={setDropdownIsOpen}>
-        <Dropdown.Trigger asChild>
+    if (!isChannelHost) {
+      actions.push({
+        key: 'leave',
+        content: `Leave ${prettyAppName}`,
+        onClick: leaveChannel,
+        type: 'destructive',
+      });
+    }
+
+    return (
+      <>
+        <ActionMenu open={isOpen} onOpenChange={setIsOpen} actions={actions}>
           <button
             className="flex h-8 w-8 items-center justify-center rounded text-gray-800 hover:bg-gray-50 sm:h-6 sm:w-6 sm:text-gray-600"
             aria-label="Channel Options"
           >
             <EllipsisIcon className="h-8 w-8 p-1 sm:h-6 sm:w-6 sm:p-0" />
           </button>
-        </Dropdown.Trigger>
-        <Dropdown.Content className="dropdown">
-          {isAdmin && (
-            <>
-              <Dropdown.Item
-                className="dropdown-item"
-                onClick={() => setEditIsOpen(!editIsOpen)}
-              >
-                Edit {prettyAppName}
-              </Dropdown.Item>
-              <Dropdown.Item
-                className="dropdown-item-red"
-                onClick={() => setDeleteChannelIsOpen(!deleteChannelIsOpen)}
-              >
-                Delete {prettyAppName}
-              </Dropdown.Item>
-            </>
-          )}
-          {!isChannelHost && (
-            <Dropdown.Item className="dropdown-item-red" onClick={leaveChannel}>
-              Leave {prettyAppName}
-            </Dropdown.Item>
-          )}
-        </Dropdown.Content>
-      </Dropdown.Root>
-      {channel && (
-        <>
-          <EditChannelModal
-            editIsOpen={editIsOpen}
-            setEditIsOpen={setEditIsOpen}
-            nest={nest}
-            channel={channel}
-            setDeleteChannelIsOpen={setDeleteChannelIsOpen}
-            app={_app}
-          />
-          <DeleteChannelModal
-            deleteChannelIsOpen={deleteChannelIsOpen}
-            onDeleteChannelConfirm={onDeleteChannelConfirm}
-            setDeleteChannelIsOpen={setDeleteChannelIsOpen}
-            channel={channel}
-            deleteStatus={deleteStatus}
-          />
-        </>
-      )}
-    </>
-  );
-}
+        </ActionMenu>
+        {channel && (
+          <>
+            <EditChannelModal
+              editIsOpen={editIsOpen}
+              setEditIsOpen={setEditIsOpen}
+              nest={nest}
+              channel={channel}
+              setDeleteChannelIsOpen={setDeleteChannelIsOpen}
+              app={_app}
+            />
+            <DeleteChannelModal
+              deleteChannelIsOpen={deleteChannelIsOpen}
+              onDeleteChannelConfirm={onDeleteChannelConfirm}
+              setDeleteChannelIsOpen={setDeleteChannelIsOpen}
+              channel={channel}
+              deleteStatus={deleteStatus}
+            />
+          </>
+        )}
+      </>
+    );
+  }
+);
+
+export default ChannelActions;

--- a/ui/src/channels/ChannelActions.tsx
+++ b/ui/src/channels/ChannelActions.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { useNavigate } from 'react-router';
+import cn from 'classnames';
 import EllipsisIcon from '@/components/icons/EllipsisIcon';
 import DeleteChannelModal from '@/groups/ChannelsList/DeleteChannelModal';
 import EditChannelModal from '@/groups/ChannelsList/EditChannelModal';
@@ -18,10 +19,18 @@ interface ChannelActionsProps {
   channel: GroupChannel | undefined;
   isAdmin: boolean | undefined;
   leave: (flag: string) => Promise<void>;
+  children?: React.ReactNode | undefined;
 }
 
 const ChannelActions = React.memo(
-  ({ nest, prettyAppName, channel, isAdmin, leave }: ChannelActionsProps) => {
+  ({
+    nest,
+    prettyAppName,
+    channel,
+    isAdmin,
+    leave,
+    children,
+  }: ChannelActionsProps) => {
     const navigate = useNavigate();
     const isMobile = useIsMobile();
     const [_app, flag] = nestToFlag(nest);
@@ -33,6 +42,7 @@ const ChannelActions = React.memo(
     const [deleteStatus, setDeleteStatus] = useState<Status>('initial');
     const isChannelHost = useIsChannelHost(flag);
     const { mutate: deleteChannelMutate } = useDeleteChannelMutation();
+    const hasChildren = !!children;
 
     const leaveChannel = useCallback(async () => {
       try {
@@ -106,12 +116,25 @@ const ChannelActions = React.memo(
 
     return (
       <>
-        <ActionMenu open={isOpen} onOpenChange={setIsOpen} actions={actions}>
+        <ActionMenu
+          className="w-full"
+          open={isOpen}
+          onOpenChange={setIsOpen}
+          actions={actions}
+        >
           <button
-            className="flex h-8 w-8 items-center justify-center rounded text-gray-800 hover:bg-gray-50 sm:h-6 sm:w-6 sm:text-gray-600"
+            className={cn(
+              hasChildren
+                ? ''
+                : 'flex h-8 w-8 items-center justify-center rounded text-gray-900 hover:bg-gray-50 sm:h-6 sm:w-6 sm:text-gray-600'
+            )}
             aria-label="Channel Options"
           >
-            <EllipsisIcon className="h-8 w-8 p-1 sm:h-6 sm:w-6 sm:p-0" />
+            {hasChildren ? (
+              children
+            ) : (
+              <EllipsisIcon className="h-8 w-8 p-1 sm:h-6 sm:w-6 sm:p-0" />
+            )}
           </button>
         </ActionMenu>
         {channel && (

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -39,7 +39,7 @@ export default function ChannelHeader({
         title={<ChannelIcon nest={nest} className="h-6 w-6 text-gray-600" />}
         secondaryTitle={
           <ChannelActions {...{ nest, prettyAppName, channel, isAdmin, leave }}>
-            <h1 className="flex items-center text-[18px] text-gray-800">
+            <h1 className="flex max-w-xs items-center truncate px-4 text-[18px] leading-5 text-gray-800">
               {channel?.meta.title}
               <HostConnection
                 className="ml-1 inline-flex"

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -38,22 +38,15 @@ export default function ChannelHeader({
   if (isMobile) {
     return (
       <MobileHeader
-        title={
-          <div className="flex flex-col items-center space-y-2">
-            <ChannelIcon
-              nest={nest}
-              className="h-7 w-7 shrink-0 px-0.5 pb-0.5 pt-1 text-gray-600"
-            />
-            <div className="flex w-full items-center justify-center space-x-1">
-              <h1 className="text-[18px] text-gray-800 line-clamp-1">
-                {channel?.meta.title}
-              </h1>
-              <HostConnection ship={host} status={data?.status} saga={saga} />
-            </div>
+        title={<ChannelIcon nest={nest} className="h-6 w-6 text-gray-600" />}
+        secondaryTitle={
+          <div className="-mr-4 flex w-full items-center justify-center space-x-1">
+            <h1 className="text-[18px] text-gray-800">{channel?.meta.title}</h1>
+            <HostConnection ship={host} status={data?.status} saga={saga} />
           </div>
         }
         action={
-          <div className="flex flex-row space-x-3">
+          <div className="flex h-12 flex-row items-center justify-end space-x-2">
             <ReconnectingSpinner />
             <Link
               to="search/"

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -48,9 +48,11 @@ export default function ChannelHeader({
         action={
           <div className="flex h-12 flex-row items-center justify-end space-x-2">
             <ReconnectingSpinner />
-            <Link to="search/" aria-label="Search Chat">
-              <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-900" />
-            </Link>
+            {prettyAppName === 'Chat' && (
+              <Link to="search/" aria-label="Search Chat">
+                <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-900" />
+              </Link>
+            )}
             <ChannelActions
               {...{ nest, prettyAppName, channel, isAdmin, leave }}
             />

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -48,12 +48,8 @@ export default function ChannelHeader({
         action={
           <div className="flex h-12 flex-row items-center justify-end space-x-2">
             <ReconnectingSpinner />
-            <Link
-              to="search/"
-              className="flex h-8 w-8 rounded hover:bg-gray-50"
-              aria-label="Search Chat"
-            >
-              <MagnifyingGlassMobileNavIcon className="h-8 w-8 p-1 text-gray-900" />
+            <Link to="search/" aria-label="Search Chat">
+              <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-900" />
             </Link>
             <ChannelActions
               {...{ nest, prettyAppName, channel, isAdmin, leave }}

--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -1,5 +1,4 @@
 import React, { PropsWithChildren } from 'react';
-import { Link } from 'react-router-dom';
 import cn from 'classnames';
 import { useIsMobile } from '@/logic/useMedia';
 import { useChannel, useAmAdmin, useGroup } from '@/state/groups';
@@ -7,7 +6,6 @@ import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import MobileHeader from '@/components/MobileHeader';
 import { getFlagParts, isTalk } from '@/logic/utils';
 import { useConnectivityCheck } from '@/state/vitals';
-import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobileNavIcon';
 import ChannelActions from './ChannelActions';
 import ChannelTitleButton from './ChannelTitleButton';
 import HostConnection from './HostConnection';
@@ -40,22 +38,22 @@ export default function ChannelHeader({
       <MobileHeader
         title={<ChannelIcon nest={nest} className="h-6 w-6 text-gray-600" />}
         secondaryTitle={
-          <div className="-mr-4 flex w-full items-center justify-center space-x-1">
-            <h1 className="text-[18px] text-gray-800">{channel?.meta.title}</h1>
-            <HostConnection ship={host} status={data?.status} saga={saga} />
-          </div>
+          <ChannelActions {...{ nest, prettyAppName, channel, isAdmin, leave }}>
+            <h1 className="flex items-center text-[18px] text-gray-800">
+              {channel?.meta.title}
+              <HostConnection
+                className="ml-1 inline-flex"
+                ship={host}
+                status={data?.status}
+                saga={saga}
+              />
+            </h1>
+          </ChannelActions>
         }
         action={
           <div className="flex h-12 flex-row items-center justify-end space-x-2">
             <ReconnectingSpinner />
-            {prettyAppName === 'Chat' && (
-              <Link to="search/" aria-label="Search Chat">
-                <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-900" />
-              </Link>
-            )}
-            <ChannelActions
-              {...{ nest, prettyAppName, channel, isAdmin, leave }}
-            />
+            {children}
           </div>
         }
         pathBack={isTalk ? '/' : `/groups/${flag}`}

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -109,7 +109,7 @@ function ChatChannel({ title }: ViewProps) {
   return (
     <>
       <Layout
-        className="flex-1 bg-white pt-4 sm:pt-0"
+        className="flex-1 bg-white"
         header={
           <Routes>
             <Route

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -19,10 +19,11 @@ import { canReadChannel, canWriteChannel, isTalk } from '@/logic/utils';
 import { useLastReconnect } from '@/state/local';
 import { Link } from 'react-router-dom';
 import MagnifyingGlassIcon from '@/components/icons/MagnifyingGlassIcon';
-import useMedia from '@/logic/useMedia';
+import useMedia, { useIsMobile } from '@/logic/useMedia';
 import ChannelTitleButton from '@/channels/ChannelTitleButton';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useChannelCompatibility, useChannelIsJoined } from '@/logic/channel';
+import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobileNavIcon';
 import ChatSearch from './ChatSearch/ChatSearch';
 import ChatThread from './ChatThread/ChatThread';
 
@@ -58,6 +59,7 @@ function ChatChannel({ title }: ViewProps) {
   const lastReconnect = useLastReconnect();
   const isSmall = useMedia('(max-width: 1023px)');
   const { compatible, text } = useChannelCompatibility(nest);
+  const isMobile = useIsMobile();
 
   const joinChannel = useCallback(async () => {
     setJoining(true);
@@ -146,10 +148,18 @@ function ChatChannel({ title }: ViewProps) {
                 >
                   <Link
                     to="search/"
-                    className="flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
+                    className={cn(
+                      isMobile
+                        ? ''
+                        : 'flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50'
+                    )}
                     aria-label="Search Chat"
                   >
-                    <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
+                    {isMobile ? (
+                      <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-800" />
+                    ) : (
+                      <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
+                    )}
                   </Link>
                 </ChannelHeader>
               }

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -16,11 +16,11 @@ import X16Icon from '@/components/icons/X16Icon';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import { whomIsFlag } from '@/logic/utils';
 import useLeap from '@/components/Leap/useLeap';
-import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import { useIsMobile } from '@/logic/useMedia';
 import keyMap from '@/keyMap';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useChannelCompatibility, useChannelFlag } from '@/logic/channel';
+import MobileHeader from '@/components/MobileHeader';
 import ChatScrollerPlaceholder from '../ChatScroller/ChatScrollerPlaceholder';
 
 export default function ChatThread() {
@@ -114,43 +114,49 @@ export default function ChatThread() {
       className="relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
     >
-      <header className={'header z-40'}>
-        <div
-          className={cn(
-            'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
-          )}
-        >
-          <BackButton
-            to={returnURL()}
-            aria-label="Close"
+      {isMobile ? (
+        <MobileHeader
+          title={<BranchIcon className="h-6 w-6 text-gray-600" />}
+          secondaryTitle={
+            <div className="flex w-full items-center justify-center space-x-1">
+              <h1 className="text-[18px] text-gray-800">
+                Thread: {threadTitle}
+              </h1>
+            </div>
+          }
+          pathBack={returnURL()}
+        />
+      ) : (
+        <header className={'header z-40'}>
+          <div
             className={cn(
-              'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
+              'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
             )}
           >
-            {isMobile ? (
+            <BackButton
+              to={returnURL()}
+              aria-label="Close"
+              className={cn(
+                'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2'
+              )}
+            >
               <div className="flex h-6 w-6 items-center justify-center">
-                <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
+                <BranchIcon className="h-6 w-6 text-gray-600" />
               </div>
-            ) : null}
-            <div className="flex h-6 w-6 items-center justify-center">
-              <BranchIcon className="h-6 w-6 text-gray-600" />
-            </div>
+              <div className="flex w-full flex-col justify-center">
+                <span
+                  className={cn(
+                    'ellipsis text-sm font-bold line-clamp-1 sm:font-semibold'
+                  )}
+                >
+                  Thread
+                </span>
+                <span className="w-full break-all text-sm text-gray-400 line-clamp-1">
+                  {threadTitle}
+                </span>
+              </div>
+            </BackButton>
 
-            <div className="flex w-full flex-col justify-center">
-              <span
-                className={cn(
-                  'ellipsis text-sm font-bold line-clamp-1 sm:font-semibold'
-                )}
-              >
-                Thread
-              </span>
-              <span className="w-full break-all text-sm text-gray-400 line-clamp-1">
-                {threadTitle}
-              </span>
-            </div>
-          </BackButton>
-
-          {!isMobile && (
             <Link
               to={returnURL()}
               aria-label="Close"
@@ -158,9 +164,9 @@ export default function ChatThread() {
             >
               <X16Icon className="h-4 w-4 text-gray-600" />
             </Link>
-          )}
-        </div>
-      </header>
+          </div>
+        </header>
+      )}
       <div className="flex flex-1 flex-col p-0 pr-2">
         {loading ? (
           <ChatScrollerPlaceholder count={30} />

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -21,6 +21,7 @@ import keyMap from '@/keyMap';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useChannelCompatibility, useChannelFlag } from '@/logic/channel';
 import MobileHeader from '@/components/MobileHeader';
+import useAppName from '@/logic/useAppName';
 import ChatScrollerPlaceholder from '../ChatScroller/ChatScrollerPlaceholder';
 
 export default function ChatThread() {
@@ -34,6 +35,7 @@ export default function ChatThread() {
   }>();
   const [loading, setLoading] = useState(false);
   const isMobile = useIsMobile();
+  const appName = useAppName();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const flag = useChannelFlag()!;
   const whom = flag || ship || '';
@@ -120,7 +122,8 @@ export default function ChatThread() {
           secondaryTitle={
             <div className="flex w-full items-center justify-center space-x-1">
               <h1 className="text-[18px] text-gray-800">
-                Thread: {threadTitle}
+                Thread
+                {appName === 'Groups' && <span>: {threadTitle}</span>}
               </h1>
             </div>
           }

--- a/ui/src/components/Divider.tsx
+++ b/ui/src/components/Divider.tsx
@@ -13,7 +13,9 @@ export default function Divider({
 }: DividerProps) {
   if (isMobile) {
     return (
-      <h2 className="mb-0.5 p-2 text-lg font-bold text-gray-400">{children}</h2>
+      <h2 className="mb-0.5 p-2 font-system-sans text-lg text-gray-400">
+        {children}
+      </h2>
     );
   }
 

--- a/ui/src/components/Mention/MentionPopup.tsx
+++ b/ui/src/components/Mention/MentionPopup.tsx
@@ -107,13 +107,13 @@ const MentionList = React.forwardRef<
   }));
 
   return (
-    <div className="dropdown min-w-96 p-1">
+    <div className="dropdown min-w-80 p-1">
       <ul className="w-full">
         {(props.items || []).map((i, index) => (
           <li key={i.id} className="w-full">
             <button
               className={cn(
-                'dropdown-item flex w-full items-center space-x-2 text-left',
+                'dropdown-item flex w-full items-center space-x-2 text-left text-sm',
                 index === selectedIndex && 'bg-gray-50'
               )}
               onClick={() => selectItem(index)}

--- a/ui/src/components/MobileHeader.tsx
+++ b/ui/src/components/MobileHeader.tsx
@@ -23,7 +23,7 @@ export default function MobileHeader({
           <Link className="flex h-12 items-center" to={pathBack}>
             <CaretLeftIconMobileNav className="h-8 w-8 text-gray-900" />
             {pathBackText && (
-              <span className="text-[17px] leading-6 text-gray-800">
+              <span className="text-[17px] leading-6 text-gray-900">
                 {pathBackText}
               </span>
             )}

--- a/ui/src/components/MobileHeader.tsx
+++ b/ui/src/components/MobileHeader.tsx
@@ -3,43 +3,52 @@ import CaretLeftIconMobileNav from './icons/CaretLeftIconMobileNav';
 
 export default function MobileHeader({
   title,
+  secondaryTitle,
   pathBack,
   pathBackText,
   action,
   secondaryAction,
 }: {
   title: string | React.ReactNode;
+  secondaryTitle?: string | React.ReactNode;
   pathBack?: string;
   pathBackText?: string;
   action?: React.ReactNode;
   secondaryAction?: React.ReactNode;
 }) {
   return (
-    <div className="grid max-h-[72px] min-h-[48px] w-full grid-cols-4 justify-between bg-white p-2 font-system-sans">
+    <div className="grid w-full grid-cols-4 justify-between bg-white font-system-sans">
       {pathBack ? (
-        <Link className="flex items-center" to={pathBack}>
-          <CaretLeftIconMobileNav className="h-8 w-8 text-gray-900" />
-          {pathBackText && (
-            <span className="text-[17px] leading-6 text-gray-800">
-              {pathBackText}
-            </span>
-          )}
-        </Link>
+        <div className="h-12 pl-4">
+          <Link className="flex h-12 items-center" to={pathBack}>
+            <CaretLeftIconMobileNav className="h-8 w-8 text-gray-900" />
+            {pathBackText && (
+              <span className="text-[17px] leading-6 text-gray-800">
+                {pathBackText}
+              </span>
+            )}
+          </Link>
+        </div>
       ) : (
-        <div className="h-6 w-6" />
+        <div className="h-12 w-12" />
       )}
-      <div className="col-span-2 flex items-center justify-center">
-        <span className="items-center text-center text-[18px] leading-6 text-gray-800 line-clamp-1">
+      <div className="col-span-2 text-center text-[18px] leading-6 text-gray-800 line-clamp-1">
+        <div className="flex h-full w-full flex-col items-center justify-center">
           {title}
-        </span>
+        </div>
       </div>
       {action ? (
-        <div className="flex justify-end space-x-3">
+        <div className="h-12  pr-4">
           {action}
           {secondaryAction}
         </div>
       ) : (
-        <div className="h-6 w-6" />
+        <div className="h-12 w-12" />
+      )}
+      {secondaryTitle && (
+        <div className="col-span-4 flex h-6 items-center justify-center pb-2 text-center">
+          {secondaryTitle}
+        </div>
       )}
     </div>
   );

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -16,7 +16,7 @@ export default function MobileSidebar() {
   const isDarkMode = useIsDark();
 
   return (
-    <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white pt-4">
+    <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white">
       <Outlet />
       <footer className="flex-none border-t-2 border-gray-50">
         <nav>

--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -154,9 +154,9 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
             title={typeof children === 'string' ? children : undefined}
             className={cn(
               'max-w-full flex-1 text-left sm:text-base',
-              isMobile ? 'line-clamp-1' : 'truncate',
+              isMobile ? 'font-system-sans line-clamp-1' : 'truncate',
               actions && 'pr-4',
-              !fontWeight ? 'font-bold sm:font-semibold' : fontWeight,
+              !fontWeight ? 'sm:font-semibold' : fontWeight,
               !color ? 'text-gray-800 sm:text-gray-600' : color,
               !fontSize ? 'text-lg' : fontSize
             )}

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -266,7 +266,7 @@ function DiaryChannel({ title }: ViewProps) {
   return (
     <Layout
       stickyHeader
-      className="flex-1 bg-white pt-4 sm:pt-0"
+      className="flex-1 bg-white sm:pt-0"
       aside={<Outlet />}
       header={
         <DiaryHeader

--- a/ui/src/diary/DiaryHeader.tsx
+++ b/ui/src/diary/DiaryHeader.tsx
@@ -1,8 +1,7 @@
+import React, { useState } from 'react';
 import cn from 'classnames';
-import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import ChannelHeader from '@/channels/ChannelHeader';
 import SortIcon from '@/components/icons/SortIcon';
-import DisplayDropdown from '@/channels/DisplayDropdown';
 import { useLeaveDiaryMutation } from '@/state/diary';
 import { useChannel as useChannelSpecific } from '@/logic/channel';
 import {
@@ -14,9 +13,10 @@ import {
 import { DiaryDisplayMode } from '@/types/diary';
 import { getFlagParts, nestToFlag } from '@/logic/utils';
 import { Link } from 'react-router-dom';
-import AddIcon16 from '@/components/icons/Add16Icon';
 import { useIsMobile } from '@/logic/useMedia';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
+import FilterIconMobileNav from '@/components/icons/FilterIconMobileNav';
+import ActionMenu, { Action } from '@/components/ActionMenu';
 
 interface DiaryHeaderProps {
   flag: string;
@@ -26,112 +26,122 @@ interface DiaryHeaderProps {
   display: DiaryDisplayMode;
 }
 
-export default function DiaryHeader({
-  flag,
-  nest,
-  canWrite,
-  sort,
-  display,
-}: DiaryHeaderProps) {
-  const [, chFlag] = nestToFlag(nest);
-  const chan = useChannelSpecific(nest);
-  const { ship } = getFlagParts(flag);
-  const isMobile = useIsMobile();
-  const saga = chan?.saga || null;
-  const settings = useDiarySettings();
-  const { mutateAsync: leaveDiary } = useLeaveDiaryMutation();
-  const { mutate } = usePutEntryMutation({
-    bucket: 'diary',
-    key: 'settings',
-  });
-
-  const setDisplayMode = async (view: DiaryDisplayMode) => {
-    const newSettings = setChannelSetting<DiarySetting>(
-      settings,
-      { displayMode: view },
-      chFlag
-    );
-    mutate({
-      val: JSON.stringify(newSettings),
+const DiaryHeader = React.memo(
+  ({ flag, nest, canWrite, sort, display }: DiaryHeaderProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [, chFlag] = nestToFlag(nest);
+    const chan = useChannelSpecific(nest);
+    const { ship } = getFlagParts(flag);
+    const isMobile = useIsMobile();
+    const saga = chan?.saga || null;
+    const settings = useDiarySettings();
+    const { mutateAsync: leaveDiary } = useLeaveDiaryMutation();
+    const { mutate } = usePutEntryMutation({
+      bucket: 'diary',
+      key: 'settings',
     });
-  };
 
-  const setSortMode = (
-    setting: 'arranged' | 'time-dsc' | 'quip-dsc' | 'time-asc' | 'quip-asc'
-  ) => {
-    const newSettings = setChannelSetting<DiarySetting>(
-      settings,
-      { sortMode: setting },
-      chFlag
+    const setDisplayMode = async (view: DiaryDisplayMode) => {
+      const newSettings = setChannelSetting<DiarySetting>(
+        settings,
+        { displayMode: view },
+        chFlag
+      );
+      mutate({
+        val: JSON.stringify(newSettings),
+      });
+    };
+
+    const setSortMode = (
+      setting: 'arranged' | 'time-dsc' | 'quip-dsc' | 'time-asc' | 'quip-asc'
+    ) => {
+      const newSettings = setChannelSetting<DiarySetting>(
+        settings,
+        { sortMode: setting },
+        chFlag
+      );
+      mutate({
+        val: JSON.stringify(newSettings),
+      });
+    };
+
+    const actions: Action[] = [
+      {
+        content: 'Display: List',
+        key: 'display-list',
+        onClick: () => (setDisplayMode ? setDisplayMode('list') : null),
+        type: display === 'list' ? 'prominent' : 'default',
+      },
+      {
+        content: 'Display: Grid',
+        key: 'display-grid',
+        onClick: () => (setDisplayMode ? setDisplayMode('grid') : null),
+        type: display === 'grid' ? 'prominent' : 'default',
+      },
+      {
+        content: 'Sort: Arranged',
+        key: 'sort-arranged',
+        onClick: () => (setSortMode ? setSortMode('arranged') : null),
+        type: sort === 'arranged' ? 'prominent' : 'default',
+      },
+      {
+        content: 'Sort: New Posts First',
+        key: 'sort-time-dsc',
+        onClick: () => (setSortMode ? setSortMode('time-dsc') : null),
+        type: sort === 'time-dsc' ? 'prominent' : 'default',
+      },
+      {
+        content: 'Sort: Old Posts First',
+        key: 'sort-time-asc',
+        onClick: () => (setSortMode ? setSortMode('time-asc') : null),
+        type: sort === 'time-asc' ? 'prominent' : 'default',
+      },
+      {
+        content: 'Sort: New Comments First',
+        key: 'sort-quip-dsc',
+        onClick: () => (setSortMode ? setSortMode('quip-dsc') : null),
+        type: sort === 'quip-dsc' ? 'prominent' : 'default',
+      },
+    ];
+
+    return (
+      <ChannelHeader
+        flag={flag}
+        nest={nest}
+        prettyAppName="Notebook"
+        leave={(ch) => leaveDiary({ flag: ch })}
+      >
+        <div className="flex h-12 items-center justify-end space-x-2 sm:h-auto">
+          <ActionMenu open={isOpen} onOpenChange={setIsOpen} actions={actions}>
+            <button>
+              {isMobile ? (
+                <FilterIconMobileNav className="mt-0.5 h-8 w-8 text-gray-900" />
+              ) : (
+                <SortIcon className="h-6 w-6 text-gray-600" />
+              )}
+            </button>
+          </ActionMenu>
+          {(canWrite && ship === window.our) ||
+          (canWrite && saga && 'synced' in saga) ? (
+            <Link
+              to="edit"
+              className={cn(
+                isMobile
+                  ? ''
+                  : 'small-button shrink-0 bg-blue px-1 text-white sm:px-2'
+              )}
+            >
+              {isMobile ? (
+                <AddIconMobileNav className="h-8 w-8 text-black" />
+              ) : (
+                <span className="hidden sm:inline">Add Note</span>
+              )}
+            </Link>
+          ) : null}
+        </div>
+      </ChannelHeader>
     );
-    mutate({
-      val: JSON.stringify(newSettings),
-    });
-  };
+  }
+);
 
-  return (
-    <ChannelHeader
-      flag={flag}
-      nest={nest}
-      prettyAppName="Notebook"
-      leave={(ch) => leaveDiary({ flag: ch })}
-    >
-      {(canWrite && ship === window.our) ||
-      (canWrite && saga && 'synced' in saga) ? (
-        <Link
-          to="edit"
-          className={cn(
-            isMobile
-              ? ''
-              : 'small-button shrink-0 bg-blue px-1 text-white sm:px-2'
-          )}
-        >
-          {isMobile ? (
-            <AddIconMobileNav className="h-8 w-8 text-black" />
-          ) : (
-            <AddIcon16 className="h-4 w-4 sm:hidden" />
-          )}
-
-          {!isMobile && <span className="hidden sm:inline">Add Note</span>}
-        </Link>
-      ) : null}
-      <DisplayDropdown displayMode={display} setDisplayMode={setDisplayMode} />
-      <Dropdown.Root>
-        <Dropdown.Trigger asChild>
-          <button className="flex h-6 w-6 items-center justify-center rounded  text-gray-600 hover:bg-gray-50 ">
-            <SortIcon className="h-6 w-6" />
-          </button>
-        </Dropdown.Trigger>
-        <Dropdown.Content className="dropdown">
-          <Dropdown.Item
-            className={cn(
-              'dropdown-item',
-              sort === 'arranged' && 'bg-gray-100 hover:bg-gray-100'
-            )}
-            onClick={() => (setSortMode ? setSortMode('arranged') : null)}
-          >
-            Arranged
-          </Dropdown.Item>
-          <Dropdown.Item
-            className={cn(
-              'dropdown-item',
-              sort === 'time-dsc' && 'bg-gray-100 hover:bg-gray-100'
-            )}
-            onClick={() => (setSortMode ? setSortMode('time-dsc') : null)}
-          >
-            New Posts First
-          </Dropdown.Item>
-          <Dropdown.Item
-            className={cn(
-              'dropdown-item',
-              sort === 'time-asc' && 'bg-gray-100 hover:bg-gray-100'
-            )}
-            onClick={() => (setSortMode ? setSortMode('time-asc') : null)}
-          >
-            Old Posts First
-          </Dropdown.Item>
-        </Dropdown.Content>
-      </Dropdown.Root>
-    </ChannelHeader>
-  );
-}
+export default DiaryHeader;

--- a/ui/src/diary/DiaryHeader.tsx
+++ b/ui/src/diary/DiaryHeader.tsx
@@ -15,6 +15,8 @@ import { DiaryDisplayMode } from '@/types/diary';
 import { getFlagParts, nestToFlag } from '@/logic/utils';
 import { Link } from 'react-router-dom';
 import AddIcon16 from '@/components/icons/Add16Icon';
+import { useIsMobile } from '@/logic/useMedia';
+import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
 
 interface DiaryHeaderProps {
   flag: string;
@@ -34,6 +36,7 @@ export default function DiaryHeader({
   const [, chFlag] = nestToFlag(nest);
   const chan = useChannelSpecific(nest);
   const { ship } = getFlagParts(flag);
+  const isMobile = useIsMobile();
   const saga = chan?.saga || null;
   const settings = useDiarySettings();
   const { mutateAsync: leaveDiary } = useLeaveDiaryMutation();
@@ -77,10 +80,19 @@ export default function DiaryHeader({
       (canWrite && saga && 'synced' in saga) ? (
         <Link
           to="edit"
-          className={'small-button shrink-0 bg-blue px-1 text-white sm:px-2'}
+          className={cn(
+            isMobile
+              ? ''
+              : 'small-button shrink-0 bg-blue px-1 text-white sm:px-2'
+          )}
         >
-          <AddIcon16 className="h-4 w-4 sm:hidden" />
-          <span className="hidden sm:inline">Add Note</span>
+          {isMobile ? (
+            <AddIconMobileNav className="h-8 w-8 text-black" />
+          ) : (
+            <AddIcon16 className="h-4 w-4 sm:hidden" />
+          )}
+
+          {!isMobile && <span className="hidden sm:inline">Add Note</span>}
         </Link>
       ) : null}
       <DisplayDropdown displayMode={display} setDisplayMode={setDisplayMode} />

--- a/ui/src/diary/DiaryNoteHeader.tsx
+++ b/ui/src/diary/DiaryNoteHeader.tsx
@@ -32,7 +32,11 @@ export default function DiaryNoteHeader({
       <MobileHeader
         title={<ChannelIcon nest="diary" className="h-6 w-6 text-gray-600" />}
         secondaryTitle={
-          <h1 className={cn('ellipsis break-all px-4 text-lg line-clamp-1')}>
+          <h1
+            className={cn(
+              'max-w-xs truncate px-4 text-[18px] leading-5 text-gray-800'
+            )}
+          >
             {title}
           </h1>
         }

--- a/ui/src/diary/DiaryNoteHeader.tsx
+++ b/ui/src/diary/DiaryNoteHeader.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from '@/logic/useMedia';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import { useChannel as useChannelSpecific } from '@/logic/channel';
 import { getNestShip } from '@/logic/utils';
+import MobileHeader from '@/components/MobileHeader';
 
 export interface DiaryNoteHeaderProps {
   title: string;
@@ -25,6 +26,30 @@ export default function DiaryNoteHeader({
   const ship = getNestShip(nest);
   const chan = useChannelSpecific(nest);
   const saga = chan?.saga || null;
+
+  if (isMobile) {
+    return (
+      <MobileHeader
+        title={<ChannelIcon nest="diary" className="h-6 w-6 text-gray-600" />}
+        secondaryTitle={
+          <h1 className={cn('ellipsis break-all px-4 text-lg line-clamp-1')}>
+            {title}
+          </h1>
+        }
+        pathBack=".."
+        action={
+          <div className="flex h-12 items-center justify-end space-x-2">
+            <ReconnectingSpinner />
+            {canEdit ? (
+              <Link to={`../edit/${time}`} className="no-underline">
+                Edit
+              </Link>
+            ) : null}
+          </div>
+        }
+      />
+    );
+  }
 
   return (
     <div

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -36,6 +36,7 @@ import Setting from '@/components/Settings/Setting';
 import { useMarkdownInDiaries, usePutEntryMutation } from '@/state/settings';
 import { useChannelCompatibility } from '@/logic/channel';
 import Tooltip from '@/components/Tooltip';
+import MobileHeader from '@/components/MobileHeader';
 import DiaryInlineEditor, { useDiaryInlineEditor } from './DiaryInlineEditor';
 import DiaryMarkdownEditor from './DiaryMarkdownEditor';
 
@@ -220,58 +221,99 @@ export default function DiaryAddNote() {
       className="align-center w-full flex-1 bg-white"
       mainClass="overflow-y-auto"
       header={
-        <header
-          className={cn(
-            'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
-          )}
-        >
-          <Link
-            to={!editor?.getText() && !id ? `../..` : `../../note/${id}`}
-            className={cn(
-              'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2',
-              isMobile && ''
-            )}
-            aria-label="Exit Editor"
-          >
-            <div className="flex h-6 w-6 items-center justify-center">
-              <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
-            </div>
-
-            <div className="flex h-6 w-6 items-center justify-center">
-              <PencilIcon className="h-3 w-3 text-gray-600" />
-            </div>
-            <span className="ellipsis text-lg font-bold line-clamp-1 sm:text-sm sm:font-semibold">
-              Editing
-            </span>
-          </Link>
-
-          <div className="flex shrink-0 flex-row items-center space-x-3">
-            {isMobile && <ReconnectingSpinner />}
-            <Tooltip content={text} open={compatible ? false : undefined}>
-              <button
-                disabled={
-                  !compatible ||
-                  !editor?.getText() ||
-                  editStatus === 'loading' ||
-                  addStatus === 'loading' ||
-                  watchedTitle === ''
-                }
-                className={cn(
-                  'small-button bg-blue text-white disabled:bg-gray-200 disabled:text-gray-400 dark:disabled:text-gray-400'
-                )}
-                onClick={publish}
+        isMobile ? (
+          <MobileHeader
+            title={<PencilIcon className="h-6 w-6 text-gray-600" />}
+            secondaryTitle={
+              <h1
+                className={cn('ellipsis break-all px-4 text-lg line-clamp-1')}
               >
-                {editStatus === 'loading' || addStatus === 'loading' ? (
-                  <LoadingSpinner className="h-4 w-4" />
-                ) : editStatus === 'error' || addStatus === 'error' ? (
-                  'Error'
-                ) : (
-                  'Save'
-                )}
-              </button>
-            </Tooltip>
-          </div>
-        </header>
+                Editing
+              </h1>
+            }
+            pathBack=".."
+            action={
+              <div className="flex h-12 items-center justify-end space-x-2">
+                <ReconnectingSpinner />
+                <Tooltip content={text} open={compatible ? false : undefined}>
+                  <button
+                    disabled={
+                      !compatible ||
+                      !editor?.getText() ||
+                      editStatus === 'loading' ||
+                      addStatus === 'loading' ||
+                      watchedTitle === ''
+                    }
+                    className={cn(
+                      'disabled:text-gray-400 dark:disabled:text-gray-400'
+                    )}
+                    onClick={publish}
+                  >
+                    {editStatus === 'loading' || addStatus === 'loading' ? (
+                      <LoadingSpinner className="h-4 w-4" />
+                    ) : editStatus === 'error' || addStatus === 'error' ? (
+                      'Error'
+                    ) : (
+                      'Save'
+                    )}
+                  </button>
+                </Tooltip>
+              </div>
+            }
+          />
+        ) : (
+          <header
+            className={cn(
+              'flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4'
+            )}
+          >
+            <Link
+              to={!editor?.getText() && !id ? `../..` : `../../note/${id}`}
+              className={cn(
+                'default-focus ellipsis w-max-sm inline-flex h-10 appearance-none items-center justify-center space-x-2 rounded p-2',
+                isMobile && ''
+              )}
+              aria-label="Exit Editor"
+            >
+              <div className="flex h-6 w-6 items-center justify-center">
+                <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
+              </div>
+
+              <div className="flex h-6 w-6 items-center justify-center">
+                <PencilIcon className="h-3 w-3 text-gray-600" />
+              </div>
+              <span className="ellipsis text-lg font-bold line-clamp-1 sm:text-sm sm:font-semibold">
+                Editing
+              </span>
+            </Link>
+
+            <div className="flex shrink-0 flex-row items-center space-x-3">
+              <Tooltip content={text} open={compatible ? false : undefined}>
+                <button
+                  disabled={
+                    !compatible ||
+                    !editor?.getText() ||
+                    editStatus === 'loading' ||
+                    addStatus === 'loading' ||
+                    watchedTitle === ''
+                  }
+                  className={cn(
+                    'small-button bg-blue text-white disabled:bg-gray-200 disabled:text-gray-400 dark:disabled:text-gray-400'
+                  )}
+                  onClick={publish}
+                >
+                  {editStatus === 'loading' || addStatus === 'loading' ? (
+                    <LoadingSpinner className="h-4 w-4" />
+                  ) : editStatus === 'error' || addStatus === 'error' ? (
+                    'Error'
+                  ) : (
+                    'Save'
+                  )}
+                </button>
+              </Tooltip>
+            </div>
+          </header>
+        )
       }
     >
       {loadingNote && fetchStatus !== 'idle' ? (

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -23,6 +23,8 @@ import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import useAppName from '@/logic/useAppName';
 import ShipConnection from '@/components/ShipConnection';
 import { useConnectivityCheck } from '@/state/vitals';
+import MobileHeader from '@/components/MobileHeader';
+import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobileNavIcon';
 import MessageSelector from './MessageSelector';
 
 function TitleButton({
@@ -96,7 +98,9 @@ export default function Dm() {
   const { isDragging, isOver } = useDragAndDrop(dropZoneId);
   const { sendMessage } = useChatState.getState();
   const contact = useContact(ship);
+  const { data, showConnection } = useConnectivityCheck(ship || '');
   const isMobile = useIsMobile();
+  const appName = useAppName();
   const inSearch = useMatch(`/dm/${ship}/search/*`);
   const isAccepted = !useDmIsPending(ship);
   const canStart = useChatState(
@@ -145,31 +149,72 @@ export default function Dm() {
               <Route
                 path="*"
                 element={
-                  <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4">
-                    <TitleButton
-                      ship={ship}
-                      contact={contact}
-                      isMobile={isMobile}
+                  isMobile ? (
+                    <MobileHeader
+                      title={
+                        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-center">
+                          <Avatar size="xs" ship={ship} />
+                        </div>
+                      }
+                      secondaryTitle={
+                        <div className="-mr-4 flex w-full items-center justify-center space-x-1">
+                          <h1 className="text-[18px] text-gray-800">
+                            {contact.nickname ? (
+                              contact.nickname
+                            ) : (
+                              <ShipName full name={ship} />
+                            )}
+                          </h1>
+                          <ShipConnection ship={ship} status={data?.status} />
+                        </div>
+                      }
+                      pathBack={
+                        appName === 'Groups' && isMobile ? '/messages' : '/'
+                      }
+                      action={
+                        <div className="flex h-12 flex-row items-center justify-end space-x-3">
+                          <ReconnectingSpinner />
+                          <Link to="search/" aria-label="Search Chat">
+                            <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-800" />
+                          </Link>
+                          {canStart ? (
+                            <DmOptions
+                              whom={ship}
+                              pending={!isAccepted}
+                              alwaysShowEllipsis
+                              className="text-gray-800"
+                            />
+                          ) : null}
+                        </div>
+                      }
                     />
-                    <div className="flex shrink-0 flex-row items-center space-x-3">
-                      {isMobile && <ReconnectingSpinner />}
-                      <Link
-                        to="search/"
-                        className="flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
-                        aria-label="Search Chat"
-                      >
-                        <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
-                      </Link>
-                      {canStart ? (
-                        <DmOptions
-                          whom={ship}
-                          pending={!isAccepted}
-                          alwaysShowEllipsis
-                          className="text-gray-600"
-                        />
-                      ) : null}
+                  ) : (
+                    <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4">
+                      <TitleButton
+                        ship={ship}
+                        contact={contact}
+                        isMobile={isMobile}
+                      />
+                      <div className="flex shrink-0 flex-row items-center space-x-3">
+                        {isMobile && <ReconnectingSpinner />}
+                        <Link
+                          to="search/"
+                          className="flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
+                          aria-label="Search Chat"
+                        >
+                          <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
+                        </Link>
+                        {canStart ? (
+                          <DmOptions
+                            whom={ship}
+                            pending={!isAccepted}
+                            alwaysShowEllipsis
+                            className="text-gray-600"
+                          />
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
+                  )
                 }
               />
             </Routes>

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -157,8 +157,8 @@ export default function Dm() {
                         </div>
                       }
                       secondaryTitle={
-                        <div className="-mr-4 flex w-full items-center justify-center space-x-1">
-                          <h1 className="text-[18px] text-gray-800">
+                        <div className="-mr-4 flex w-full items-center justify-center space-x-1 px-4">
+                          <h1 className="max-w-xs truncate text-[18px] leading-5 text-gray-800">
                             {contact.nickname ? (
                               contact.nickname
                             ) : (

--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -58,7 +58,7 @@ export default function MobileMessagesSidebar() {
       type: messagesFilter === filters.all ? 'prominent' : 'default',
       onClick: () => setFilterMode(filters.all),
       content: (
-        <div className="flex">
+        <div className="flex items-center">
           <ChatSmallIcon className="mr-2 h-4 w-4" />
           All Messages
         </div>
@@ -69,7 +69,7 @@ export default function MobileMessagesSidebar() {
       type: messagesFilter === filters.dms ? 'prominent' : 'default',
       onClick: () => setFilterMode(filters.dms),
       content: (
-        <div className="flex">
+        <div className="flex items-center">
           <PersonSmallIcon className="mr-2 h-4 w-4" />
           Direct Messages
         </div>
@@ -80,7 +80,7 @@ export default function MobileMessagesSidebar() {
       type: messagesFilter === filters.groups ? 'prominent' : 'default',
       onClick: () => setFilterMode(filters.groups),
       content: (
-        <div className="flex">
+        <div className="flex items-center">
           <CmdSmallIcon className="mr-2 h-4 w-4" />
           Group Talk Channels
         </div>
@@ -93,7 +93,7 @@ export default function MobileMessagesSidebar() {
       <MobileHeader
         title="Messages"
         action={
-          <>
+          <div className="flex h-12 items-center justify-end space-x-2">
             <ReconnectingSpinner />
             {appName === 'Talk' ? (
               <ActionMenu
@@ -114,7 +114,7 @@ export default function MobileMessagesSidebar() {
             >
               <AddIconMobileNav className="h-8 w-8 text-black" />
             </Link>
-          </>
+          </div>
         }
       />
       <nav className={cn('flex h-full w-full flex-col bg-white')}>
@@ -123,7 +123,7 @@ export default function MobileMessagesSidebar() {
             {filteredPins && filteredPins.length > 0 ? (
               <>
                 <div className="px-4">
-                  <h2 className="my-0.5 p-2 text-lg font-bold text-gray-400 sm:text-base">
+                  <h2 className="my-0.5 p-2 font-system-sans text-lg text-gray-400 sm:text-base">
                     Pinned Messages
                   </h2>
                   {pinned.map((ship: string) => (
@@ -131,7 +131,7 @@ export default function MobileMessagesSidebar() {
                   ))}
                 </div>
                 <div className="flex flex-row items-center justify-between px-4">
-                  <h2 className="my-0.5 p-2 text-lg font-bold text-gray-400 sm:text-base">
+                  <h2 className="my-0.5 p-2 font-system-sans text-lg text-gray-400 sm:text-base">
                     {messagesFilter}
                   </h2>
                 </div>

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -126,11 +126,9 @@ export default function MultiDm() {
                         </div>
                       }
                       secondaryTitle={
-                        <div className="flex w-full items-center justify-center space-x-1">
-                          <h1 className="max-w-xs truncate text-[18px] leading-5 text-gray-800">
-                            {groupName}
-                          </h1>
-                        </div>
+                        <h1 className="max-w-xs truncate px-4 text-[18px] leading-5 text-gray-800">
+                          {groupName}
+                        </h1>
                       }
                       pathBack={
                         appName === 'Groups' && isMobile ? '/messages' : '/'

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -13,9 +13,11 @@ import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import { Club } from '@/types/chat';
 import MagnifyingGlassIcon from '@/components/icons/MagnifyingGlassIcon';
+import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobileNavIcon';
 import ChatSearch from '@/chat/ChatSearch/ChatSearch';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import useAppName from '@/logic/useAppName';
+import MobileHeader from '@/components/MobileHeader';
 import MultiDmInvite from './MultiDmInvite';
 import MultiDmAvatar from './MultiDmAvatar';
 import MultiDmHero from './MultiDmHero';
@@ -38,11 +40,6 @@ function TitleButton({ club, isMobile }: { club: Club; isMobile: boolean }) {
       )}
       aria-label="Open Messages Menu"
     >
-      {isMobile ? (
-        <div className="flex h-6 w-6 items-center justify-center">
-          <CaretLeft16Icon className="h-5 w-5 shrink-0 text-gray-600" />
-        </div>
-      ) : null}
       <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-center">
         <MultiDmAvatar {...club.meta} size="xs" />
       </div>
@@ -74,6 +71,8 @@ export default function MultiDm() {
   const inSearch = useMatch(`/dm/${clubId}/search/*`);
   const isAccepted = !useMultiDmIsPending(clubId);
   const club = useMultiDm(clubId);
+  const appName = useAppName();
+  const groupName = club?.meta.title || club?.team.concat(club.hive).join(', ');
 
   const {
     isSelectingMessage,
@@ -119,26 +118,60 @@ export default function MultiDm() {
               <Route
                 path="*"
                 element={
-                  <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4">
-                    <TitleButton club={club} isMobile={isMobile} />
-                    <div className="flex shrink-0 flex-row items-center space-x-3">
-                      {isMobile && <ReconnectingSpinner />}
-                      <Link
-                        to="search/"
-                        className="flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
-                        aria-label="Search Chat"
-                      >
-                        <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
-                      </Link>
-                      <DmOptions
-                        whom={clubId}
-                        pending={!isAccepted}
-                        isMulti
-                        alwaysShowEllipsis
-                        className="text-gray-600"
-                      />
+                  isMobile ? (
+                    <MobileHeader
+                      title={
+                        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-center">
+                          <MultiDmAvatar {...club.meta} size="xs" />
+                        </div>
+                      }
+                      secondaryTitle={
+                        <div className="flex w-full items-center justify-center space-x-1">
+                          <h1 className="max-w-xs truncate text-[18px] leading-5 text-gray-800">
+                            {groupName}
+                          </h1>
+                        </div>
+                      }
+                      pathBack={
+                        appName === 'Groups' && isMobile ? '/messages' : '/'
+                      }
+                      action={
+                        <div className="flex h-12 flex-row items-center justify-end space-x-3">
+                          <ReconnectingSpinner />
+                          <Link to="search/" aria-label="Search Chat">
+                            <MagnifyingGlassMobileNavIcon className="h-6 w-6 text-gray-800" />
+                          </Link>
+                          <DmOptions
+                            whom={clubId}
+                            pending={!isAccepted}
+                            isMulti
+                            alwaysShowEllipsis
+                            className="text-gray-800"
+                          />
+                        </div>
+                      }
+                    />
+                  ) : (
+                    <div className="flex items-center justify-between border-b-2 border-gray-50 bg-white py-2 pl-2 pr-4">
+                      <TitleButton club={club} isMobile={isMobile} />
+                      <div className="flex shrink-0 flex-row items-center space-x-3">
+                        <Link
+                          to="search/"
+                          className="flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
+                          aria-label="Search Chat"
+                        >
+                          <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
+                        </Link>
+                        <DmOptions
+                          whom={clubId}
+                          pending={!isAccepted}
+                          isMulti
+                          alwaysShowEllipsis
+                          className="text-gray-600"
+                        />
+                      </div>
                     </div>
-                  </div>
+                  )
                 }
               />
             </Routes>

--- a/ui/src/groups/ChannelsList/GroupChannelManager.tsx
+++ b/ui/src/groups/ChannelsList/GroupChannelManager.tsx
@@ -4,8 +4,11 @@ import { ViewProps } from '@/types/groups';
 import { useRouteGroup, useGroup } from '@/state/groups/groups';
 import { useIsMobile } from '@/logic/useMedia';
 import MobileHeader from '@/components/MobileHeader';
+// import HostConnection from '@/channels/HostConnection';
+import Layout from '@/components/Layout/Layout';
 import ChannelsList from './ChannelsList';
 import { ChannelSearchProvider } from './useChannelSearch';
+import GroupAvatar from '../GroupAvatar';
 
 export default function GroupChannelManager({ title }: ViewProps) {
   const flag = useRouteGroup();
@@ -13,16 +16,27 @@ export default function GroupChannelManager({ title }: ViewProps) {
   const isMobile = useIsMobile();
 
   return (
-    <section className="flex w-full grow flex-col overflow-y-scroll">
+    <section className="flex h-full flex-col overflow-hidden bg-red">
       <Helmet>
         <title>
           {group ? `Channels in ${group.meta.title} ${title}` : title}
         </title>
       </Helmet>
+
       {isMobile && (
-        <MobileHeader title="All Channels" pathBack={`/groups/${flag}`} />
+        <MobileHeader
+          title={<GroupAvatar image={group?.meta.image} />}
+          secondaryTitle={
+            <div className="flex w-full items-center justify-center space-x-1">
+              <h1 className="text-[18px] text-gray-800 line-clamp-1">
+                All Channels
+              </h1>
+            </div>
+          }
+          pathBack={`/groups/${flag}`}
+        />
       )}
-      <div className="flex grow flex-col bg-gray-50 px-2 sm:px-6">
+      <div className="flex grow flex-col overflow-auto bg-gray-50 px-2 sm:px-6">
         <ChannelSearchProvider>
           <ChannelsList />
         </ChannelSearchProvider>

--- a/ui/src/groups/ChannelsList/GroupChannelManager.tsx
+++ b/ui/src/groups/ChannelsList/GroupChannelManager.tsx
@@ -4,8 +4,9 @@ import { ViewProps } from '@/types/groups';
 import { useRouteGroup, useGroup } from '@/state/groups/groups';
 import { useIsMobile } from '@/logic/useMedia';
 import MobileHeader from '@/components/MobileHeader';
-// import HostConnection from '@/channels/HostConnection';
-import Layout from '@/components/Layout/Layout';
+import HostConnection from '@/channels/HostConnection';
+import { useConnectivityCheck } from '@/state/vitals';
+import { getFlagParts } from '@/logic/utils';
 import ChannelsList from './ChannelsList';
 import { ChannelSearchProvider } from './useChannelSearch';
 import GroupAvatar from '../GroupAvatar';
@@ -14,6 +15,8 @@ export default function GroupChannelManager({ title }: ViewProps) {
   const flag = useRouteGroup();
   const group = useGroup(flag);
   const isMobile = useIsMobile();
+  const host = getFlagParts(flag).ship;
+  const { data } = useConnectivityCheck(host);
 
   return (
     <section className="flex h-full flex-col overflow-hidden bg-red">
@@ -27,10 +30,11 @@ export default function GroupChannelManager({ title }: ViewProps) {
         <MobileHeader
           title={<GroupAvatar image={group?.meta.image} />}
           secondaryTitle={
-            <div className="flex w-full items-center justify-center space-x-1">
+            <div className="-mr-4 flex w-full items-center justify-center space-x-1">
               <h1 className="text-[18px] text-gray-800 line-clamp-1">
                 All Channels
               </h1>
+              <HostConnection ship={host} status={data?.status} saga={null} />
             </div>
           }
           pathBack={`/groups/${flag}`}

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -181,11 +181,11 @@ export default function FindGroups({ title }: ViewProps) {
     val ? ob.isValidPatp(preSig(val)) || whomIsFlag(val) : false;
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div className="flex h-full w-full flex-col overflow-hidden">
       {isMobile && (
         <MobileHeader title="Find Groups" action={<ReconnectingSpinner />} />
       )}
-      <div className={cn('flex grow overflow-y-auto bg-gray-50')}>
+      <div className={cn('grow overflow-y-auto bg-gray-50')}>
         <Helmet>
           <title>{title ? title : document.title}</title>
         </Helmet>

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -13,6 +13,7 @@ import LinkIcon from '@/components/icons/LinkIcon';
 import LeaveIcon from '@/components/icons/LeaveIcon';
 import PersonIcon from '@/components/icons/PersonIcon';
 import { getPrivacyFromGroup } from '@/logic/utils';
+import { useIsDark } from '@/logic/useMedia';
 import GroupAvatar from '../GroupAvatar';
 import { useGroupActions } from '../GroupActions';
 
@@ -21,25 +22,35 @@ export default function MobileGroupSidebar() {
   const flag = useGroupFlag();
   const group = useGroup(flag);
   const privacy = group ? getPrivacyFromGroup(group) : 'public';
-  const match = useMatch('/groups/:ship/:name/info');
+  const matchHome = useMatch('/groups/:ship/:name');
+  const matchActivity = useMatch('/groups/:ship/:name/activity');
+  const matchInfo = useMatch('/groups/:ship/:name/info');
   const location = useLocation();
   const [showSheet, setShowSheet] = useState(false);
   const { onCopy, copyItemText } = useGroupActions(flag);
   const isAdmin = useAmAdmin(flag);
+  const isDarkMode = useIsDark();
 
   return (
-    <section className="flex h-full w-full flex-col overflow-x-hidden bg-white ">
+    <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white">
       <Outlet />
-      <footer className="mt-auto flex-none border-t-2 border-gray-50">
+      <footer className="flex-none border-t-2 border-gray-50">
         <nav>
-          <ul className="flex items-center">
+          <ul className="flex h-[50px] items-center">
             <NavTab to={`.`} className="basis-1/4">
-              <HashIcon className="mb-0.5 h-6 w-6" />
-              Channels
+              <HashIcon
+                className={cn(
+                  ' h-6 w-6',
+                  !matchHome && 'text-gray-200 dark:text-gray-600'
+                )}
+              />
             </NavTab>
             <NavTab to={`/groups/${flag}/activity`} className="basis-1/4">
-              <BellIcon className="mb-0.5 h-6 w-6" />
-              Activity
+              <BellIcon
+                isDarkMode={isDarkMode}
+                isInactive={!matchActivity}
+                className={'h-6 w-6'}
+              />
             </NavTab>
             <NavTab
               to={`/groups/${flag}/info`}
@@ -49,13 +60,11 @@ export default function MobileGroupSidebar() {
               <GroupAvatar
                 {...group?.meta}
                 size="h-6 w-6"
-                className={cn('mb-0.5', !match && 'opacity-50 grayscale')}
+                className={cn('', !matchInfo && 'opacity-50 grayscale')}
               />
-              Group Info
             </NavTab>
             <NavTab onClick={() => setShowSheet(true)} className="basis-1/4">
-              <ElipsisIcon className="mb-0.5 h-6 w-6" />
-              Options
+              <ElipsisIcon className="h-6 w-6 text-gray-200 dark:text-gray-600" />
             </NavTab>
           </ul>
           <Sheet open={showSheet} onOpenChange={(o) => setShowSheet(o)}>

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -28,7 +28,7 @@ export default function MobileGroupSidebar() {
   const isAdmin = useAmAdmin(flag);
 
   return (
-    <section className="flex h-full w-full flex-col overflow-x-hidden bg-white pt-4">
+    <section className="flex h-full w-full flex-col overflow-x-hidden bg-white ">
       <Outlet />
       <footer className="mt-auto flex-none border-t-2 border-gray-50">
         <nav>

--- a/ui/src/groups/MobileGroupChannelList.tsx
+++ b/ui/src/groups/MobileGroupChannelList.tsx
@@ -22,24 +22,20 @@ export default function MobileGroupChannelList() {
   return (
     <>
       <MobileHeader
-        title={
-          <div className="flex flex-col items-center space-y-2">
-            <GroupAvatar image={group?.meta.image} />
-            <div className="flex w-full items-center justify-center space-x-1">
-              <h1 className="text-[18px] text-gray-800 line-clamp-1">
-                {group?.meta.title}
-              </h1>
-              <HostConnection ship={host} status={data?.status} saga={saga} />
-            </div>
+        title={<GroupAvatar image={group?.meta.image} />}
+        secondaryTitle={
+          <div className="flex w-full items-center justify-center space-x-1">
+            <h1 className="text-[18px] text-gray-800">{group?.meta.title}</h1>
+            <HostConnection ship={host} status={data?.status} saga={saga} />
           </div>
         }
         action={
-          <div className="flex flex-row space-x-3">
+          <div className="flex h-12 items-center justify-end space-x-2">
             <ReconnectingSpinner />
             <ChannelSorter isMobile={true} />
             {isAdmin && (
               <Link
-                className="default-focus flex p-1 text-base"
+                className="default-focus flex text-base"
                 to={`/groups/${flag}/channels/new`}
                 state={{ backgroundLocation: location }}
               >

--- a/ui/src/groups/NewGroup/NewGroupView.tsx
+++ b/ui/src/groups/NewGroup/NewGroupView.tsx
@@ -8,9 +8,9 @@ export default function NewGroupView() {
       header={
         <MobileHeader title="New Group" pathBack="/" pathBackText="Cancel" />
       }
-      className="flex-1 px-4"
+      className=""
     >
-      <div className="pt-4">
+      <div className="p-4">
         <NewGroup />
       </div>
     </Layout>

--- a/ui/src/groups/NewGroup/NewGroupView.tsx
+++ b/ui/src/groups/NewGroup/NewGroupView.tsx
@@ -1,18 +1,13 @@
-import Layout from '@/components/Layout/Layout';
 import MobileHeader from '@/components/MobileHeader';
 import NewGroup from './NewGroup';
 
 export default function NewGroupView() {
   return (
-    <Layout
-      header={
-        <MobileHeader title="New Group" pathBack="/" pathBackText="Cancel" />
-      }
-      className=""
-    >
-      <div className="p-4">
+    <div className="flex h-full w-full flex-col">
+      <MobileHeader title="New Group" pathBack="/" pathBackText="Cancel" />
+      <div className="grow overflow-y-auto p-4">
         <NewGroup />
       </div>
-    </Layout>
+    </div>
   );
 }

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -203,7 +203,7 @@ function HeapChannel({ title }: ViewProps) {
 
   return (
     <Layout
-      className="flex-1 bg-white pt-4 sm:pt-0"
+      className="flex-1 bg-white sm:pt-0"
       aside={<Outlet />}
       header={
         <HeapHeader

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -13,6 +13,7 @@ import { isLink } from '@/types/heap';
 import useHeapContentType from '@/logic/useHeapContentType';
 import useNest from '@/logic/useNest';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
+import MobileHeader from '@/components/MobileHeader';
 import useCurioActions from '../useCurioActions';
 
 export interface ChannelHeaderProps {
@@ -51,6 +52,45 @@ export default function HeapDetailHeader({
     return str.length > n ? `${str.slice(0, n - 1)}…` : str;
   }
 
+  if (isMobile) {
+    return (
+      <MobileHeader
+        title={<ChannelIcon nest="heap" className="h-6 w-6 text-gray-600" />}
+        secondaryTitle={
+          <h1 className={cn('ellipsis break-all px-4 text-lg line-clamp-1')}>
+            {isCite ? 'Reference' : `${description()}: `}
+            {curioTitle && truncate({ str: curioTitle, n: 50 })}
+            {isImageLink && !curioTitle
+              ? truncate({ str: curioContent, n: 50 })
+              : null}
+            {!isImageLink && !curioTitle
+              ? truncate({ str: prettyDayAndTime.asString, n: 50 })
+              : null}
+          </h1>
+        }
+        pathBack=".."
+        action={
+          <div className="flex h-12 items-center justify-end space-x-2">
+            <ReconnectingSpinner />
+            <button
+              className="h-6 w-6 rounded text-gray-800"
+              aria-controls="copy"
+              onClick={onCopy}
+              aria-label="Copy Link"
+            >
+              {didCopy ? (
+                <CheckIcon className="h-6 w-6" />
+              ) : (
+                <CopyIcon className="h-6 w-6" />
+              )}
+            </button>
+            {canEdit ? <button onClick={onEdit}>Edit</button> : null}
+          </div>
+        }
+      />
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -87,7 +127,6 @@ export default function HeapDetailHeader({
         </div>
       </Link>
       <div className="shink-0 flex items-center space-x-3">
-        {isMobile && <ReconnectingSpinner />}
         {canEdit ? (
           <button onClick={onEdit} className="small-button">
             Edit

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -57,7 +57,11 @@ export default function HeapDetailHeader({
       <MobileHeader
         title={<ChannelIcon nest="heap" className="h-6 w-6 text-gray-600" />}
         secondaryTitle={
-          <h1 className={cn('ellipsis break-all px-4 text-lg line-clamp-1')}>
+          <h1
+            className={cn(
+              'ellipsis max-w-xs truncate px-4 text-[18px] leading-5 text-gray-800'
+            )}
+          >
             {isCite ? 'Reference' : `${description()}: `}
             {curioTitle && truncate({ str: curioTitle, n: 50 })}
             {isImageLink && !curioTitle

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -39,22 +39,20 @@ export default function MobileRoot() {
         <MobileHeader
           title="All Groups"
           action={
-            <>
+            <div className="flex h-12 items-center justify-end space-x-2">
               <ReconnectingSpinner />
               <SidebarSorter
                 sortFn={sortFn}
                 setSortFn={setSortFn}
                 sortOptions={sortOptions}
               />
-            </>
-          }
-          secondaryAction={
-            <Link
-              className="default-focus flex text-base"
-              to="/groups/new-mobile"
-            >
-              <AddIconMobileNav className="h-8 w-8 text-black" />
-            </Link>
+              <Link
+                className="default-focus flex text-base"
+                to="/groups/new-mobile"
+              >
+                <AddIconMobileNav className="h-8 w-8 text-black" />
+              </Link>
+            </div>
           }
         />
       }
@@ -70,12 +68,12 @@ export default function MobileRoot() {
               {Object.entries(pinnedGroups).length > 0 && (
                 <>
                   <div className="px-4">
-                    <h2 className="mb-0.5 p-2 text-lg font-bold text-gray-400">
+                    <h2 className="mb-0.5 p-2 font-system-sans text-lg text-gray-400">
                       Pinned Groups
                     </h2>
                     {pinnedGroupsOptions}
                   </div>
-                  <h2 className="my-2 ml-2 p-2 pl-4 text-lg font-bold text-gray-400">
+                  <h2 className="my-2 ml-2 p-2 pl-4 font-system-sans text-lg text-gray-400">
                     All Groups
                   </h2>
                 </>

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -118,12 +118,9 @@ export default function Notifications({
   const MobileMarkAsRead = (
     <button
       disabled={isMarkReadPending || !hasUnreads}
-      className={cn(
-        'whitespace-nowrap text-[17px] font-normal leading-6 text-blue',
-        {
-          'bg-gray-400 text-gray-800': isMarkReadPending || !hasUnreads,
-        }
-      )}
+      className={cn('whitespace-nowrap text-[17px] font-normal text-blue', {
+        'bg-gray-400 text-gray-800': isMarkReadPending || !hasUnreads,
+      })}
       onClick={markAllRead}
     >
       Mark as Read
@@ -136,10 +133,10 @@ export default function Notifications({
         <MobileHeader
           title="Activity"
           action={
-            <>
+            <div className="flex h-12 items-center justify-end space-x-2">
               <ReconnectingSpinner />
               {hasUnreads && MobileMarkAsRead}
-            </>
+            </div>
           }
         />
       )}

--- a/ui/src/profiles/Profile.tsx
+++ b/ui/src/profiles/Profile.tsx
@@ -41,23 +41,21 @@ export default function Profile({ title }: ViewProps) {
   const contact = useOurContact();
 
   return (
-    <Layout
-      header={isMobile ? <MobileHeader title="Profile" /> : null}
-      className="flex-1 px-4 font-system-sans"
-    >
+    <div className="flex h-full flex-col overflow-hidden">
       <Helmet>
         <title>{title}</title>
       </Helmet>
+      {isMobile ? <MobileHeader title="Profile" /> : null}
       <motion.div
         initial="initial"
         animate="in"
         exit="out"
         variants={pageAnimationVariants}
         transition={pageTransition}
-        className="flex flex-col justify-center space-y-4 pt-[10px]"
+        className="grow overflow-y-auto bg-white"
       >
         <ProfileCoverImage
-          className="flex h-[345px] w-full shadow-2xl"
+          className="m-auto h-[345px] w-[calc(100%-32px)] shadow-2xl"
           cover={contact.cover || ''}
         >
           <Link
@@ -100,7 +98,7 @@ export default function Profile({ title }: ViewProps) {
             </div>
           </Link>
         </ProfileCoverImage>
-        <nav className="flex flex-col space-y-1">
+        <nav className="flex flex-col space-y-1 px-4">
           <Link to="/profile/settings" className="no-underline">
             <SidebarItem
               color="text-gray-900"
@@ -177,6 +175,6 @@ export default function Profile({ title }: ViewProps) {
           </a>
         </nav>
       </motion.div>
-    </Layout>
+    </div>
   );
 }

--- a/ui/src/profiles/Profile.tsx
+++ b/ui/src/profiles/Profile.tsx
@@ -55,7 +55,7 @@ export default function Profile({ title }: ViewProps) {
         className="grow overflow-y-auto bg-white"
       >
         <ProfileCoverImage
-          className="m-auto h-[345px] w-[calc(100%-32px)] shadow-2xl"
+          className="m-auto h-[345px] w-[90%] shadow-2xl"
           cover={contact.cover || ''}
         >
           <Link

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -97,7 +97,7 @@
 }
 
 .dropdown-item {
-  @apply cursor-pointer rounded p-2 text-left text-base font-semibold no-underline ring-gray-200 hover:bg-gray-50 focus:outline-none sm:text-xs;
+  @apply cursor-pointer rounded p-2 text-left text-lg font-semibold no-underline ring-gray-200 hover:bg-gray-50 focus:outline-none sm:text-sm;
 }
 
 .dropdown-item > a {


### PR DESCRIPTION
General mobile-readiness cleanup.

- Unifies the position of all MobileHeader elements between views
- Adds a secondaryTitle prop to the MobileHeader. This allows for longer titles than what the center-half column previously allowed by introducing a second row of the header
- Adds MobileHeader to the mobile thread view in Chat
- Knocks the font-size of mobile sidebar items down; uses system-sans
- Uses MobileHeader in Dm and MultiDm
- Uses an ActionMenu for ChannelActions (tap on channel name)
- Modifies MobileHeader to use children for channel-specific actions (add, sort)
- Removes the text labels in the in-group bottom nav 
- Uses MobileHeader in Notebook items (view + edit)
- Uses MobileHeader in Gallery detail headers
- Uses ActionMenus for display options in Notebooks and Galleries
- Fixes the Profile view to show the nav bar
- Fixes Find Groups screen to show the nav bar
- Fixes the New Group screen to scroll


https://github.com/tloncorp/landscape-apps/assets/748181/ca347526-8654-4dc3-8d5f-8ad6095ecfa6

