### PR TITLE
Groups: fix channel manager width & loading placeholder overflow

### DIFF
--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -170,7 +170,7 @@ export default function ChatThread() {
           </div>
         </header>
       )}
-      <div className="flex flex-1 flex-col p-0 pr-2">
+      <div className="flex flex-1 flex-col overflow-hidden p-0 pr-2">
         {loading ? (
           <ChatScrollerPlaceholder count={30} />
         ) : (

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -81,7 +81,7 @@ export default function ChatWindow({ whom, prefixedElement }: ChatWindowProps) {
 
   if (!initialized) {
     return (
-      <div>
+      <div className="h-full overflow-hidden">
         <ChatScrollerPlaceholder count={30} />
       </div>
     );

--- a/ui/src/groups/ChannelsList/GroupChannelManager.tsx
+++ b/ui/src/groups/ChannelsList/GroupChannelManager.tsx
@@ -19,7 +19,7 @@ export default function GroupChannelManager({ title }: ViewProps) {
   const { data } = useConnectivityCheck(host);
 
   return (
-    <section className="flex h-full flex-col overflow-hidden bg-red">
+    <section className="flex h-full w-full flex-col overflow-hidden">
       <Helmet>
         <title>
           {group ? `Channels in ${group.meta.title} ${title}` : title}


### PR DESCRIPTION
Fixes LAND-769

also resolves the issue where the gray chat messages loading animation overflows into the input.