### PR TITLE
Cache embeds

### DIFF
--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -29,9 +29,7 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
     if (isError) {
       console.log(`HeapDetailBody: embed failed to load`, error);
     }
-  });
-
-  console.log(content);
+  }, [isError, error]);
 
   if (content.block.length > 0 && 'cite' in content.block[0]) {
     return (

--- a/ui/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import useHeapContentType from '@/logic/useHeapContentType';
-import useEmbedState from '@/state/embed';
-import { isValidUrl, validOembedCheck } from '@/logic/utils';
+import { useEmbed } from '@/state/embed';
+import { validOembedCheck } from '@/logic/utils';
 import { HeapCurio, isLink } from '@/types/heap';
 import HeapContent from '@/heap/HeapContent';
 import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
@@ -15,7 +15,6 @@ import HeapVimeoPlayer from '../HeapVimeoPlayer';
 import HeapVideoPlayer from '../HeapVideoPlayer';
 
 export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
-  const [embed, setEmbed] = useState<any>();
   const calm = useCalm();
   const { content } = curio.heart;
   const url =
@@ -23,18 +22,16 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
       ? content.inline[0].link.href
       : '';
   const isMobile = useIsMobile();
+  const { embed, isError, error } = useEmbed(url, isMobile);
   const { isText, isImage, isAudio, isVideo } = useHeapContentType(url);
-  const maybeEmbed = !isImage && !isAudio && !isText;
 
   useEffect(() => {
-    const getOembed = async () => {
-      if (isValidUrl(url) && maybeEmbed && !calm.disableRemoteContent) {
-        const oembed = await useEmbedState.getState().getEmbed(url, isMobile);
-        setEmbed(oembed);
-      }
-    };
-    getOembed();
-  }, [url, isMobile, maybeEmbed, calm.disableRemoteContent]);
+    if (isError) {
+      console.log(`HeapDetailBody: embed failed to load`, error);
+    }
+  });
+
+  console.log(content);
 
   if (content.block.length > 0 && 'cite' in content.block[0]) {
     return (
@@ -77,7 +74,7 @@ export default function HeapDetailBody({ curio }: { curio: HeapCurio }) {
 
   const isOembed = validOembedCheck(embed, url);
 
-  if (isOembed && embed !== undefined && !calm.disableRemoteContent) {
+  if (isOembed && embed && !calm.disableRemoteContent) {
     const provider = embed.provider_url as string;
 
     let embedComponent = <HeapDetailEmbed oembed={embed} url={url} />;

--- a/ui/src/state/embed.ts
+++ b/ui/src/state/embed.ts
@@ -1,53 +1,36 @@
-import create from 'zustand';
-import { jsonFetch } from '@/logic/utils';
-
-export interface EmbedState {
-  embeds: {
-    [url: string]: any;
-  };
-  getEmbed: (url: string, isMobile?: boolean) => Promise<any>;
-  fetch: (url: string, isMobile?: boolean) => Promise<any>;
-}
+import { isValidUrl, jsonFetch } from '@/logic/utils';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
 
 const OEMBED_PROVIDER = 'https://noembed.com/embed';
 
-const useEmbedState = create<EmbedState>((set, get) => ({
-  embeds: {},
-  fetch: async (url: string, isMobile?: boolean) => {
-    const { embeds } = get();
-    if (url in embeds) {
-      return embeds[url];
-    }
-    const search = new URLSearchParams({
-      maxwidth: isMobile ? '320' : '600',
-      url,
-    });
-    let embed;
-    const isSpotify = url.includes('open.spotify.com');
-    if (isSpotify) {
-      // noembed doesn't support spotify
-      const urlWithoutTracker = url?.split('?')[0];
-      embed = await jsonFetch(
-        `https://open.spotify.com/oembed?url=${urlWithoutTracker}`
-      );
-      return embed;
-    }
-
-    embed = await jsonFetch(`${OEMBED_PROVIDER}?${search.toString()}`);
+export async function fetchEmbed(url: string, isMobile?: boolean) {
+  if (!url || !isValidUrl(url)) return null;
+  const search = new URLSearchParams({
+    maxwidth: isMobile ? '320' : '600',
+    url,
+  });
+  let embed;
+  const isSpotify = url.includes('open.spotify.com');
+  if (isSpotify) {
+    // noembed doesn't support spotify
+    const urlWithoutTracker = url?.split('?')[0];
+    embed = await jsonFetch(
+      `https://open.spotify.com/oembed?url=${urlWithoutTracker}`
+    );
     return embed;
-  },
-  getEmbed: async (url: string, isMobile?: boolean) => {
-    const { fetch, embeds } = get();
-    if (url in embeds) {
-      return embeds[url];
-    }
-    const { embeds: es } = get();
-    const embed = await fetch(url, isMobile).catch((reason) => {
-      throw reason;
-    });
-    set({ embeds: { ...es, [url]: embed } });
-    return embed;
-  },
-}));
+  }
 
-export default useEmbedState;
+  embed = await jsonFetch(`${OEMBED_PROVIDER}?${search.toString()}`);
+  return embed;
+}
+
+export function useEmbed(url: string, isMobile?: boolean) {
+  const queryFn = useCallback(() => fetchEmbed(url, isMobile), [url, isMobile]);
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['embed', url],
+    queryFn,
+  });
+
+  return { embed: (data as any) || null, isLoading, isError, error };
+}


### PR DESCRIPTION
Updates our embed lookups to run through `react-query` which causes them to get cached using IndexedDB.

Fixes LAND-438