### PR TITLE
groups: all group joins must be via join modal

### DIFF
--- a/ui/e2e/005-accept-group-invite.spec.ts
+++ b/ui/e2e/005-accept-group-invite.spec.ts
@@ -6,9 +6,8 @@ test('accept group invite', async ({ page }) => {
   await page.goto('');
   await page.getByText('Pending Invites').waitFor();
   await page.getByRole('button', { name: 'Join Group' }).first().click();
-  await page
-    .getByText('Fetching messages from group host. This might take a minute...')
-    .waitFor();
+  await page.getByText('Join This Group').waitFor();
+  await page.getByRole('button', { name: 'Join Group' }).first().click();
   await page.getByText('bus chat').first().waitFor();
   await page.getByText('bus chat').first().click();
   await page.getByText("hi, it's me, ~bus").waitFor();

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -229,7 +229,7 @@ function GroupReference({
             ) : (
               <button
                 className="small-button whitespace-nowrap bg-blue-softer text-blue dark:text-black"
-                onClick={button.action}
+                onClick={open}
                 disabled={button.disabled || status === 'error'}
               >
                 {status === 'error' ? 'Errored' : button.text}

--- a/ui/src/groups/GroupJoinList.tsx
+++ b/ui/src/groups/GroupJoinList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cn from 'classnames';
 import { useIsMobile } from '@/logic/useMedia';
 import { Gang, Gangs } from '@/types/groups';
@@ -74,8 +73,7 @@ function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
                   'ml-2 bg-blue-soft text-blue mix-blend-multiply disabled:bg-gray-100 dark:bg-blue-900 dark:mix-blend-screen dark:disabled:bg-gray-100',
                   isMobile ? 'small-button' : 'button'
                 )}
-                onClick={button.action}
-                disabled={button.disabled || status === 'error'}
+                onClick={open}
               >
                 {status === 'error' ? 'Errored' : button.text}
               </button>

--- a/ui/src/groups/GroupSummary.tsx
+++ b/ui/src/groups/GroupSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ShipName from '@/components/ShipName';
 import Lock16Icon from '@/components/icons/Lock16Icon';
 import Private16Icon from '@/components/icons/Private16Icon';
@@ -37,7 +36,7 @@ export default function GroupSummary({
   if (!meta) {
     return (
       <div className="flex h-full w-full items-center justify-center">
-        <LoadingSpinner />
+        <LoadingSpinner /> <span className="ml-2">Loading...</span>
       </div>
     );
   }

--- a/ui/src/groups/Join/JoinGroupModal.tsx
+++ b/ui/src/groups/Join/JoinGroupModal.tsx
@@ -1,11 +1,17 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import Dialog from '@/components/Dialog';
 import { useGang, useGangPreview, useRouteGroup } from '@/state/groups';
 import GroupSummary from '@/groups/GroupSummary';
 import useGroupJoin from '@/groups/useGroupJoin';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import { matchesBans, pluralRank, toTitleCase } from '@/logic/utils';
+import {
+  getFlagParts,
+  matchesBans,
+  pluralRank,
+  toTitleCase,
+} from '@/logic/utils';
+import { useConnectivityCheck } from '@/state/vitals';
 
 export default function JoinGroupModal() {
   const navigate = useNavigate();
@@ -14,6 +20,8 @@ export default function JoinGroupModal() {
   const id = new URLSearchParams(window.location.search).get('id');
   const type = new URLSearchParams(window.location.search).get('type');
   const gang = useGang(flag);
+  const { ship } = getFlagParts(flag);
+  const { data } = useConnectivityCheck(ship, { enabled: true });
   const { group, dismiss, reject, button, status } = useGroupJoin(
     flag,
     gang,
@@ -25,10 +33,10 @@ export default function JoinGroupModal() {
   const banned = cordon ? matchesBans(cordon, window.our) : null;
 
   useEffect(() => {
-    if (group) {
+    if (group && data && data.status && 'complete' in data.status) {
       navigate(`/groups/${flag}`);
     }
-  }, [group, flag, navigate]);
+  }, [group, flag, navigate, data]);
 
   return (
     <Dialog

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -151,7 +151,7 @@ export default function Notification({
   const { recentChannel } = useRecentChannel(rope.group || '');
   const group = useGroup(rope.group || '');
   const gang = useGang(rope.group || '');
-  const { join, reject } = useGroupJoin(rope.group || '', gang);
+  const { open, reject } = useGroupJoin(rope.group || '', gang);
 
   return (
     <div className="relative flex space-x-3 rounded-xl bg-white p-2 text-gray-400">
@@ -174,13 +174,13 @@ export default function Notification({
             {gang && !group && (
               <div className="mt-2 flex space-x-2">
                 <button
-                  onClick={() => join()}
+                  onClick={open}
                   className="small-button bg-blue-soft text-blue"
                 >
                   Accept
                 </button>
                 <button
-                  onClick={() => reject()}
+                  onClick={reject}
                   className="small-button bg-gray-50 text-gray-800"
                 >
                   Reject


### PR DESCRIPTION
fixes LAND-647 to force all group joins to go through the group join modal flow. Also does not redirect the user to the joined group until the data for the group has already been loaded.