### PR TITLE
groups: improve "Share with Friends" action on mobile

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -50,7 +50,6 @@
         "@tiptap/pm": "^2.0.3",
         "@tiptap/react": "^2.0.3",
         "@tiptap/suggestion": "^2.0.3",
-        "@tloncorp/eyrie": "^0.0.14",
         "@tloncorp/mock-http-api": "^1.2.0",
         "@types/marked": "^4.3.0",
         "@urbit/api": "^2.2.0",
@@ -90,6 +89,7 @@
         "prosemirror-state": "~1.3.4",
         "prosemirror-transform": "~1.4.2",
         "prosemirror-view": "~1.23.13",
+        "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-colorful": "^5.5.1",
@@ -6822,57 +6822,6 @@
         "eslint-plugin-tailwindcss": "*",
         "prettier": "*",
         "prettier-plugin-tailwindcss": "*"
-      }
-    },
-    "node_modules/@tloncorp/eyrie": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@tloncorp/eyrie/-/eyrie-0.0.14.tgz",
-      "integrity": "sha512-UkiZVEqZryOvI4/HScFOHPtBcQD2B4+X6tFDYrLzXx0w+Jl2W1dLwM3SYYRh6LgWxySs1K5HGMtvRAhPZpmHjA==",
-      "dependencies": {
-        "@radix-ui/react-accordion": "^1.1.1",
-        "@radix-ui/react-popover": "^1.0.5",
-        "@urbit/api": "^2.2.0",
-        "@urbit/http-api": "^2.4.0-debug",
-        "classnames": "^2.3.2",
-        "immer": "^9.0.19",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "zustand": "^4.3.3"
-      }
-    },
-    "node_modules/@tloncorp/eyrie/node_modules/@urbit/http-api": {
-      "version": "2.4.0-dev",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "browser-or-node": "^1.3.0",
-        "core-js": "^3.19.1"
-      }
-    },
-    "node_modules/@tloncorp/eyrie/node_modules/zustand": {
-      "version": "4.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "1.2.0"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tloncorp/mock-http-api": {
@@ -15333,6 +15282,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "dev": true,
@@ -22833,38 +22790,6 @@
       "dev": true,
       "requires": {}
     },
-    "@tloncorp/eyrie": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@tloncorp/eyrie/-/eyrie-0.0.14.tgz",
-      "integrity": "sha512-UkiZVEqZryOvI4/HScFOHPtBcQD2B4+X6tFDYrLzXx0w+Jl2W1dLwM3SYYRh6LgWxySs1K5HGMtvRAhPZpmHjA==",
-      "requires": {
-        "@radix-ui/react-accordion": "^1.1.1",
-        "@radix-ui/react-popover": "^1.0.5",
-        "@urbit/api": "^2.2.0",
-        "@urbit/http-api": "^2.4.0-debug",
-        "classnames": "^2.3.2",
-        "immer": "^9.0.19",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "zustand": "^4.3.3"
-      },
-      "dependencies": {
-        "@urbit/http-api": {
-          "version": "2.4.0-dev",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "browser-or-node": "^1.3.0",
-            "core-js": "^3.19.1"
-          }
-        },
-        "zustand": {
-          "version": "4.4.1",
-          "requires": {
-            "use-sync-external-store": "1.2.0"
-          }
-        }
-      }
-    },
     "@tloncorp/mock-http-api": {
       "version": "1.2.0",
       "requires": {
@@ -28182,6 +28107,12 @@
     "punycode": {
       "version": "2.1.1",
       "dev": true
+    },
+    "qrcode.react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
+      "requires": {}
     },
     "qs": {
       "version": "6.11.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -136,6 +136,7 @@
     "prosemirror-state": "~1.3.4",
     "prosemirror-transform": "~1.4.2",
     "prosemirror-view": "~1.23.13",
+    "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-colorful": "^5.5.1",

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -68,15 +68,15 @@ export default function MobileGroupSidebar() {
             </NavTab>
           </ul>
           <Sheet open={showSheet} onOpenChange={(o) => setShowSheet(o)}>
-            <SheetContent showClose={true}>
-              <div className="flex flex-col pt-4">
+            <SheetContent showClose={false}>
+              <div className="flex flex-col">
                 {(privacy === 'public' || isAdmin) && (
                   <SidebarItem
                     onClick={() => setShowSheet(false)}
                     to={`/groups/${flag}/invite`}
                     state={{ backgroundLocation: location }}
                     icon={
-                      <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-md">
                         <InviteIcon className="h-6 w-6" />
                       </div>
                     }
@@ -86,7 +86,7 @@ export default function MobileGroupSidebar() {
                 )}
                 <SidebarItem
                   icon={
-                    <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-md">
                       <LinkIcon className="h-6 w-6" />
                     </div>
                   }
@@ -100,7 +100,7 @@ export default function MobileGroupSidebar() {
                     to={`/groups/${flag}/edit`}
                     state={{ backgroundLocation: location }}
                     icon={
-                      <div className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-50">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-md">
                         <PersonIcon className="h-6 w-6" />
                       </div>
                     }
@@ -115,7 +115,7 @@ export default function MobileGroupSidebar() {
                     state={{ backgroundLocation: location }}
                     color="text-red"
                     icon={
-                      <div className="flex h-12 w-12 items-center justify-center rounded-md bg-red-soft dark:bg-red-800">
+                      <div className="flex h-12 w-12 items-center justify-center rounded-md">
                         <LeaveIcon className="h-6 w-6" />
                       </div>
                     }

--- a/ui/src/profiles/Profile.tsx
+++ b/ui/src/profiles/Profile.tsx
@@ -1,9 +1,10 @@
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { QRCodeSVG } from 'qrcode.react';
 import { ViewProps } from '@/types/groups';
-import Layout from '@/components/Layout/Layout';
-import { useIsMobile } from '@/logic/useMedia';
+import { useIsDark, useIsMobile } from '@/logic/useMedia';
 import { useOurContact } from '@/state/contact';
 import Avatar from '@/components/Avatar';
 import ShipName from '@/components/ShipName';
@@ -13,6 +14,8 @@ import GiftIcon from '@/components/icons/GiftIcon';
 import InfoIcon from '@/components/icons/InfoIcon';
 import AsteriskIcon from '@/components/icons/AsteriskIcon';
 import MobileHeader from '@/components/MobileHeader';
+import Sheet, { SheetContent } from '@/components/Sheet';
+import clipboardCopy from 'clipboard-copy';
 import ProfileCoverImage from './ProfileCoverImage';
 
 const pageAnimationVariants = {
@@ -37,8 +40,42 @@ const pageTransition = {
 };
 
 export default function Profile({ title }: ViewProps) {
+  const [showSheet, setShowSheet] = useState(false);
+  const [showQR, setShowQR] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const isDark = useIsDark();
   const isMobile = useIsMobile();
   const contact = useOurContact();
+
+  const resetSheet = () => {
+    setShowSheet(false);
+    setShowQR(false);
+  };
+
+  const handleSharing = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: 'Join Tlon Local',
+          url: 'https://tlon.network/lure/~nibset-napwyn/tlon',
+          text: 'Join me in Tlon Local, where the future is always under construction.',
+        });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log(error);
+      }
+    } else {
+      setCopied(true);
+      clipboardCopy('https://tlon.network/lure/~nibset-napwyn/tlon');
+    }
+  };
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+    return () => clearTimeout(timeout);
+  }, [copied]);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -54,50 +91,52 @@ export default function Profile({ title }: ViewProps) {
         transition={pageTransition}
         className="grow overflow-y-auto bg-white"
       >
-        <ProfileCoverImage
-          className="m-auto h-[345px] w-[90%] shadow-2xl"
-          cover={contact.cover || ''}
-        >
-          <Link
-            to="/profile/edit"
-            className="absolute inset-0 flex h-[345px] w-full flex-col justify-between rounded-[36px] bg-black/30 px-6 pt-6 font-normal dark:bg-white/30"
+        <div className="px-4">
+          <ProfileCoverImage
+            className="m-auto h-[345px] w-full shadow-2xl"
+            cover={contact.cover || ''}
           >
-            <div className="flex w-full justify-end">
-              <Link
-                to="/profile/edit"
-                className="text-[18px] font-normal text-white dark:text-black"
-              >
-                Edit
-              </Link>
-            </div>
-            <div className="flex flex-col space-y-6">
-              <div className="flex space-x-2">
-                <Avatar size="big" icon={false} ship={window.our} />
-                <div className="flex flex-col items-start justify-center space-y-1">
-                  <ShipName
-                    className="text-[18px] font-normal text-white dark:text-black"
-                    name={window.our}
-                    showAlias
-                  />
-                  <ShipName
-                    className="text-[17px] font-normal leading-snug text-white opacity-60 dark:text-black"
-                    name={window.our}
-                  />
-                </div>
+            <Link
+              to="/profile/edit"
+              className="absolute inset-0 flex h-[345px] w-full flex-col justify-between rounded-[36px] bg-black/30 px-6 pt-6 font-normal dark:bg-white/30"
+            >
+              <div className="flex w-full justify-end">
+                <Link
+                  to="/profile/edit"
+                  className="text-[18px] font-normal text-white dark:text-black"
+                >
+                  Edit
+                </Link>
               </div>
-              {contact.bio && (
-                <div className="flex flex-col space-y-3">
-                  <span className="text-[18px] font-normal text-white opacity-60 dark:text-black">
-                    Info
-                  </span>
-                  <span className="h-[84px] bg-gradient-to-b from-white via-gray-50 bg-clip-text text-[17px] leading-snug text-transparent dark:from-black">
-                    {contact.bio}
-                  </span>
+              <div className="flex flex-col space-y-6">
+                <div className="flex space-x-2">
+                  <Avatar size="big" icon={false} ship={window.our} />
+                  <div className="flex flex-col items-start justify-center space-y-1">
+                    <ShipName
+                      className="text-[18px] font-normal text-white dark:text-black"
+                      name={window.our}
+                      showAlias
+                    />
+                    <ShipName
+                      className="text-[17px] font-normal leading-snug text-white opacity-60 dark:text-black"
+                      name={window.our}
+                    />
+                  </div>
                 </div>
-              )}
-            </div>
-          </Link>
-        </ProfileCoverImage>
+                {contact.bio && (
+                  <div className="flex flex-col space-y-3">
+                    <span className="text-[18px] font-normal text-white opacity-60 dark:text-black">
+                      Info
+                    </span>
+                    <span className="h-[84px] bg-gradient-to-b from-white via-gray-50 bg-clip-text text-[17px] leading-snug text-transparent dark:from-black">
+                      {contact.bio}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </Link>
+          </ProfileCoverImage>
+        </div>
         <nav className="flex flex-col space-y-1 px-4">
           <Link to="/profile/settings" className="no-underline">
             <SidebarItem
@@ -152,29 +191,60 @@ export default function Profile({ title }: ViewProps) {
               Submit Feedback
             </SidebarItem>
           </a>
-          <a
-            className="no-underline"
-            href="https://tlon.network/lure/~nibset-napwyn/tlon?id=186c283508814a3-073b187e44f6fa-1f525634-384000-186c28350892a15"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Share with Friends"
+          <SidebarItem
+            color="text-gray-900"
+            fontWeight="font-normal"
+            fontSize="text-[18px]"
+            className="leading-5"
+            icon={
+              <div className="flex h-12 w-12 items-center justify-center">
+                <GiftIcon className="h-6 w-6 -rotate-12 text-gray-400" />
+              </div>
+            }
+            onClick={() => setShowSheet(true)}
           >
-            <SidebarItem
-              color="text-gray-900"
-              fontWeight="font-normal"
-              fontSize="text-[18px]"
-              className="leading-5"
-              icon={
-                <div className="flex h-12 w-12 items-center justify-center">
-                  <GiftIcon className="h-6 w-6 -rotate-12 text-gray-400" />
-                </div>
-              }
-            >
-              Share with Friends
-            </SidebarItem>
-          </a>
+            Share with Friends
+          </SidebarItem>
         </nav>
       </motion.div>
+      <Sheet open={showSheet} onOpenChange={() => resetSheet()}>
+        <SheetContent showClose={false}>
+          {!showQR && (
+            <div>
+              <SidebarItem
+                color="text-gray-900"
+                fontWeight="font-normal"
+                icon={null}
+                className="py-3"
+                onClick={() => setShowQR(true)}
+              >
+                Scan QR code
+              </SidebarItem>
+              <SidebarItem
+                color="text-gray-900"
+                fontWeight="font-normal"
+                icon={null}
+                className="py-3"
+                onClick={() => handleSharing()}
+              >
+                {copied ? 'Link copied to clipboard' : 'Share invite link'}
+              </SidebarItem>
+            </div>
+          )}
+          {showQR && (
+            <div className="py-3">
+              <QRCodeSVG
+                value={'https://tlon.network/lure/~nibset-napwyn/tlon'}
+                size={264}
+                bgColor={isDark ? '#000000' : '#ffffff'}
+                fgColor={isDark ? '#ffffff' : '#000000'}
+                level={'H'}
+                includeMargin={false}
+              />
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -85,7 +85,7 @@
 }
 
 .sheet {
-  @apply relative max-h-[75vh] w-full rounded-t-xl bg-white p-6 pb-12;
+  @apply fixed inset-x-[32px] bottom-[32px] z-[49] flex flex-col rounded-[32px] bg-white px-[32px] py-[16px] after:!bg-transparent;
 }
 
 .dialog-inner-container {


### PR DESCRIPTION
Adds a QR code and a system share action (with clipboard copy fallback) to the "Share with Friends" action in the mobile profile menu.

This view has become slightly overwrought and we likely want to do the same for all groups, so I'm leaving this as a draft.

https://github.com/tloncorp/landscape-apps/assets/748181/7b6fcb26-6c9b-4a96-816e-58b1da8f99c6

