### PR TITLE
groups: fix re-routing issue on some modals

### DIFF
--- a/ui/e2e/005-accept-group-invite.spec.ts
+++ b/ui/e2e/005-accept-group-invite.spec.ts
@@ -8,6 +8,8 @@ test('accept group invite', async ({ page }) => {
   await page.getByRole('button', { name: 'Join Group' }).first().click();
   await page.getByText('Join This Group').waitFor();
   await page.getByRole('button', { name: 'Join Group' }).first().click();
+  await page.getByRole('button', { name: 'Go' }).first().waitFor();
+  await page.getByRole('button', { name: 'Go' }).first().click();
   await page.getByText('bus chat').first().waitFor();
   await page.getByText('bus chat').first().click();
   await page.getByText("hi, it's me, ~bus").waitFor();

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,7 +39,7 @@
     "e2e": "npm run rube",
     "e2e:debug:zod": "cross-env DEBUG_PLAYWRIGHT=true SHIP_NAME=zod npm run e2e",
     "e2e:debug:bus": "cross-env DEBUG_PLAYWRIGHT=true SHIP_NAME=bus npm run e2e",
-    "e2e:debug": "cross-env DEBUG_PLAYWRIGHT=true SHIP_NAME=bus npm run e2e && cross-env DEBUG_PLAYWRIGHT=true SHIP_NAME=zod npm run e2e",
+    "e2e:debug": "cross-env DEBUG_PLAYWRIGHT=true npm run e2e",
     "e2e:chat": "cross-env SHIP_NAME=zod APP=chat npm run e2e && cross-env SHIP_NAME=bus APP=chat npm run e2e",
     "tsc": "tsc --noEmit",
     "postinstall": "patch-package",

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -75,7 +75,9 @@ import { isTalk, preSig } from '@/logic/utils';
 import bootstrap from '@/state/bootstrap';
 import AboutDialog from '@/components/About/AboutDialog';
 import MobileGroupChannelList from '@/groups/MobileGroupChannelList';
-import LandscapeWayfinding from '@/components/LandscapeWayfinding';
+import LandscapeWayfinding, {
+  LandscapeWayfindingModal,
+} from '@/components/LandscapeWayfinding';
 import { useScheduler } from '@/state/scheduler';
 import { LeapProvider } from '@/components/Leap/useLeap';
 import VitaMessage from '@/components/VitaMessage';
@@ -233,6 +235,7 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
         <Routes>
           <Route path="/about" element={<AboutDialog />} />
           <Route path="/settings" element={<SettingsDialog />} />
+          <Route path="/wayfinding" element={<LandscapeWayfindingModal />} />
           <Route
             path="/grid"
             element={
@@ -486,6 +489,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
           <Route path="/about" element={<AboutDialog />} />
           <Route path="/privacy" element={<PrivacyNotice />} />
           <Route path="/settings" element={<SettingsDialog />} />
+          <Route path="/wayfinding" element={<LandscapeWayfindingModal />} />
           <Route path="/activity-collection" element={<ActivityModal />} />
           <Route
             path="/grid"

--- a/ui/src/components/LandscapeWayfinding.tsx
+++ b/ui/src/components/LandscapeWayfinding.tsx
@@ -87,7 +87,7 @@ export default function LandscapeWayfinding() {
   const isMobile = useIsMobile();
   const app = useAppName();
   const gang = useGang('~nibset-napwyn/tlon');
-  const { open } = useGroupJoin('~nibset-napwyn/tlon', gang);
+  const { open } = useGroupJoin('~nibset-napwyn/tlon', gang, true);
   const location = useLocation();
   const { mutate } = useCalmSettingMutation('disableWayfinding');
 
@@ -98,7 +98,8 @@ export default function LandscapeWayfinding() {
   // Don't show the wayfinding button in DMs or Channels pages on mobile
   if (
     (isMobile && location.pathname.includes('dm')) ||
-    location.pathname.includes('channels/')
+    location.pathname.includes('channels/') ||
+    location.pathname.includes('profile/')
   ) {
     return null;
   }

--- a/ui/src/components/LandscapeWayfinding.tsx
+++ b/ui/src/components/LandscapeWayfinding.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import cn from 'classnames';
 import ob from 'urbit-ob';
 import { NavLink, useLocation } from 'react-router-dom';
@@ -10,6 +9,7 @@ import useGroupJoin from '@/groups/useGroupJoin';
 import { useCalmSettingMutation } from '@/state/settings';
 import { useIsMobile } from '@/logic/useMedia';
 import { isTalk } from '@/logic/utils';
+import { useDismissNavigate } from '@/logic/routing';
 import Dialog from './Dialog';
 
 function GroupsDescription() {
@@ -83,9 +83,7 @@ function TalkDescription() {
 }
 
 export default function LandscapeWayfinding() {
-  const [showModal, setShowModal] = useState(false);
   const isMobile = useIsMobile();
-  const app = useAppName();
   const gang = useGang('~nibset-napwyn/tlon');
   const { open } = useGroupJoin('~nibset-napwyn/tlon', gang, true);
   const location = useLocation();
@@ -123,9 +121,13 @@ export default function LandscapeWayfinding() {
           className="dropdown mx-4 flex w-[208px] flex-col rounded-lg  drop-shadow-lg"
         >
           <Dropdown.Item asChild className="dropdown-item-blue">
-            <span onClick={() => setShowModal(true)} className="cursor-pointer">
+            <NavLink
+              to="/wayfinding"
+              state={{ backgroundLocation: location }}
+              className="cursor-pointer"
+            >
               Basic Wayfinding
-            </span>
+            </NavLink>
           </Dropdown.Item>
           <Dropdown.Separator asChild>
             <hr className="my-2 border-[1px] border-gray-50" />
@@ -136,9 +138,9 @@ export default function LandscapeWayfinding() {
             </NavLink>
           </Dropdown.Item>
           <Dropdown.Item asChild className="dropdown-item">
-            <span className="cursor-pointer" onClick={open}>
+            <button className="cursor-pointer" onClick={open}>
               Help & Support
-            </span>
+            </button>
           </Dropdown.Item>
           <Dropdown.Item asChild className="dropdown-item">
             <a
@@ -151,21 +153,34 @@ export default function LandscapeWayfinding() {
             </a>
           </Dropdown.Item>
           <Dropdown.Item asChild className="dropdown-item">
-            <span className="cursor-pointer" onClick={handleHide}>
+            <button className="cursor-pointer" onClick={handleHide}>
               Hide This Button
-            </span>
+            </button>
           </Dropdown.Item>
         </Dropdown.Content>
       </div>
-      <Dialog
-        open={showModal}
-        onOpenChange={(o) => setShowModal(o)}
-        containerClass="md:w-1/2 w-full z-50"
-        close="none"
-      >
-        {app === 'Groups' && <GroupsDescription />}
-        {app === 'Talk' && <TalkDescription />}
-      </Dialog>
     </Dropdown.Root>
+  );
+}
+
+export function LandscapeWayfindingModal() {
+  const app = useAppName();
+  const dismiss = useDismissNavigate();
+  const onOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      dismiss();
+    }
+  };
+
+  return (
+    <Dialog
+      defaultOpen
+      onOpenChange={onOpenChange}
+      containerClass="md:w-1/2 w-full z-50"
+      close="none"
+    >
+      {app === 'Groups' && <GroupsDescription />}
+      {app === 'Talk' && <TalkDescription />}
+    </Dialog>
   );
 }

--- a/ui/src/components/References/GroupReference.tsx
+++ b/ui/src/components/References/GroupReference.tsx
@@ -39,7 +39,8 @@ function GroupReference({
   const preview = useGangPreview(flag, isScrolling);
   const { group, privacy, open, reject, button, status } = useGroupJoin(
     flag,
-    gang
+    gang,
+    plain
   );
   const { ship } = getFlagParts(flag);
   const cordon = preview?.cordon || group?.cordon;
@@ -91,7 +92,7 @@ function GroupReference({
             ) : (
               <button
                 className="small-button ml-3 whitespace-nowrap bg-blue-soft text-blue dark:text-black"
-                onClick={button.action}
+                onClick={open}
                 disabled={button.disabled || status === 'error'}
               >
                 {status === 'error' ? 'Errored' : button.text}
@@ -229,7 +230,7 @@ function GroupReference({
             ) : (
               <button
                 className="small-button whitespace-nowrap bg-blue-softer text-blue dark:text-black"
-                onClick={open}
+                onClick={plain ? button.action : open}
                 disabled={button.disabled || status === 'error'}
               >
                 {status === 'error' ? 'Errored' : button.text}

--- a/ui/src/groups/useGroupJoin.ts
+++ b/ui/src/groups/useGroupJoin.ts
@@ -41,7 +41,9 @@ export default function useGroupJoin(
 ) {
   const location = useLocation();
   const navigate = useNavigate();
-  const modalIsOpen = !!location.state?.backgroundLocation;
+  const modalIsOpen =
+    !!location.state?.backgroundLocation &&
+    location.pathname.includes('gangs/');
   const navigateByApp = useNavigateByApp();
   const modalNavigate = useModalNavigate();
   const dismiss = useDismissNavigate();
@@ -152,7 +154,7 @@ export default function useGroupJoin(
   ]);
 
   useEffect(() => {
-    if (group && modalIsOpen) {
+    if (group && modalIsOpen && !inModal) {
       if (redirectItem) {
         if (redirectItem.type === 'chat') {
           navigateByApp(
@@ -167,7 +169,7 @@ export default function useGroupJoin(
         navigateByApp(`/groups/${flag}`);
       }
     }
-  }, [group, navigateByApp, flag, redirectItem, modalIsOpen]);
+  }, [group, navigateByApp, flag, redirectItem, modalIsOpen, inModal]);
 
   return {
     group,


### PR DESCRIPTION
Fixes LAND-786. Was caused by the "Help & Support" button in the wayfinding bug menu. Also cleaned up a few other group join spots and prevented the wayfinding bug from appearing while the profile modal is open.

Found another issue in the process, when the wayfinding modal is closed the user is unable to click anything. Will fix that before merging.