### PR TITLE
groups: makes saga optional in GroupActions

### DIFF
--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -56,7 +56,7 @@ export function useGroupActions(flag: string) {
 
 type GroupActionsProps = PropsWithChildren<{
   flag: string;
-  saga: Saga | null;
+  saga?: Saga | null;
   status?: ConnectionStatus;
   className?: string;
 }>;
@@ -85,7 +85,7 @@ const GroupActions = React.memo(
 
     const actions: Action[] = [];
 
-    if (isMobile) {
+    if (saga && isMobile) {
       actions.push({
         key: 'connectivity',
         keepOpenOnClick: true,


### PR DESCRIPTION
This fails in build because we require it everywhere but only use it in one place (on mobile).