### PR TITLE
chat: fix emoji reactions not sticking

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -887,7 +887,7 @@
   =*  should  =(her src.bowl)
   ?-  -.delta
       %add  ?.(should | =(src.bowl author.p.delta))
-      %del  ?.(should | &)
+      %del  should
       %add-feel  =(src.bowl p.delta)
       %del-feel  =(src.bowl p.delta)
   ==

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -884,13 +884,13 @@
   |=  diff=diff:writs:c
   =*  her    p.p.diff
   =*  delta  q.diff
-  ?.  =(her src.bowl)  |
+  =*  should  =(her src.bowl)
   ?-  -.delta
-      %add  =(src.bowl author.p.delta)
-      %del  &
+      %add  ?.(should | =(src.bowl author.p.delta))
+      %del  ?.(should | &)
       %add-feel  =(src.bowl p.delta)
       %del-feel  =(src.bowl p.delta)
-  ==  
+  ==
 ::
 ++  from-self  =(our src):bowl
 ++  cu-abed  cu-abed:cu-core


### PR DESCRIPTION
When adding or deleting a feel `her` is the writ author rather than the emoji feeler. Since that's the case, we were returning %.n early and the writ is never updated. This removes the early return, and instead adds the check to the appropriate branches in the `?-`.