### PR TITLE
chat: fix various clicking issues

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -189,9 +189,7 @@ export default function ChatInput({
   }, [id, uploadKey, closeReply, replyCite]);
 
   useEffect(() => {
-    console.log('droppedFiles', droppedFiles);
     if (droppedFiles && droppedFiles[dropZoneId]) {
-      console.log('droppedFiles[dropZoneId]', droppedFiles[dropZoneId]);
       handleDrop(droppedFiles[dropZoneId]);
       setDidDrop(true);
     }

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -213,7 +213,7 @@ const ChatMessage = React.memo<
       );
 
       const [optionsOpen, setOptionsOpen] = useState(false);
-      const { action, handlers } = useLongPress(true);
+      const { action, handlers } = useLongPress();
 
       useEffect(() => {
         if (!isMobile) {

--- a/ui/src/logic/DragAndDropContext.tsx
+++ b/ui/src/logic/DragAndDropContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
 } from 'react';
 import { uniq } from 'lodash';
+import { useIsMobile } from './useMedia';
 
 interface DragTargetContext {
   targetIdStack: string[];
@@ -145,6 +146,8 @@ export function DragAndDropProvider({
 }
 
 export function useDragAndDrop(targetId: string) {
+  const isMobile = useIsMobile();
+
   const { pushTargetID, popTargetID, targetIdStack } =
     React.useContext(DragTargetContext);
   const currentTargetId = targetIdStack[targetIdStack.length - 1];
@@ -160,6 +163,9 @@ export function useDragAndDrop(targetId: string) {
   );
 
   useEffect(() => {
+    if (isMobile) {
+      return () => ({});
+    }
     pushTargetID(targetId);
 
     window.addEventListener('drop', handleDropWithTarget);
@@ -168,7 +174,16 @@ export function useDragAndDrop(targetId: string) {
       popTargetID(targetId);
       window.removeEventListener('drop', handleDropWithTarget);
     };
-  }, [handleDropWithTarget, popTargetID, pushTargetID, targetId]);
+  }, [handleDropWithTarget, popTargetID, pushTargetID, targetId, isMobile]);
+
+  if (isMobile)
+    return {
+      isDragging: false,
+      isOver: false,
+      droppedFiles: undefined,
+      setDroppedFiles: () => ({}),
+      targetId: '',
+    };
 
   return {
     isDragging,

--- a/ui/src/logic/useLongPress.ts
+++ b/ui/src/logic/useLongPress.ts
@@ -1,37 +1,23 @@
 import React, { useEffect, useState } from 'react';
+import { useIsMobile } from './useMedia';
 
-export default function useLongPress(waitForUpEvent = false) {
+export default function useLongPress() {
   const [action, setAction] = useState('');
+  const isMobile = useIsMobile();
   const timerRef = React.useRef<ReturnType<typeof setTimeout>>();
   const isLongPress = React.useRef(false);
-  const downPoint = React.useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
   const start = () => {
-    setAction('');
-
+    isLongPress.current = false;
     timerRef.current = setTimeout(() => {
       isLongPress.current = true;
-      if (!waitForUpEvent) {
-        setAction('longpress');
-      }
+      setAction('longpress');
     }, 300);
   };
 
-  const stop = (point: { x: number; y: number }) => {
+  const stop = () => {
     clearTimeout(timerRef.current);
-
-    if (
-      waitForUpEvent &&
-      isLongPress.current &&
-      Math.abs(point.x - downPoint.current.x) < 10 &&
-      Math.abs(point.y - downPoint.current.y) < 10
-    ) {
-      setAction('longpress');
-    } else {
-      setAction('');
-    }
-
-    isLongPress.current = false;
+    setAction('');
   };
 
   const onClick = () => {
@@ -41,29 +27,26 @@ export default function useLongPress(waitForUpEvent = false) {
     setAction('click');
   };
 
-  const onMouseDown = (e: React.MouseEvent) => {
-    downPoint.current = { x: e.pageX, y: e.pageY };
+  const onMouseDown = () => {
     start();
   };
 
-  const onMouseUp = (e: React.MouseEvent) => {
-    stop({ x: e.pageX, y: e.pageY });
+  const onMouseUp = () => {
+    stop();
   };
 
-  const onTouchStart = (e: React.TouchEvent) => {
-    downPoint.current = {
-      x: e.changedTouches[0].pageX,
-      y: e.changedTouches[0].pageY,
-    };
+  const onTouchStart = () => {
     start();
   };
 
-  const onTouchEnd = (e: React.TouchEvent) => {
-    stop({ x: e.changedTouches[0].pageX, y: e.changedTouches[0].pageY });
+  const onTouchEnd = () => {
+    stop();
   };
 
   const onContextMenu = (e: React.MouseEvent) => {
-    e.preventDefault();
+    if (isMobile && action === 'longpress') {
+      e.preventDefault();
+    }
   };
 
   useEffect(

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -61,6 +61,10 @@ export function log(...args: any[]) {
   }
 }
 
+export function logTime(...args: any[]) {
+  return log(...[performance.now(), ...args]);
+}
+
 type App = 'chat' | 'heap' | 'diary';
 
 export function nestToFlag(nest: string): [App, string] {


### PR DESCRIPTION
Fixes both LAND-801 and LAND-802, in addition to switching to a normal long press for long presses (rather than mouseUp).

Also cleans up a few errant console.logs().

Drag and drop still works normally on desktop.

Fixes LAND-801
Fixes LAND-802