### PR TITLE
chat: fix video player size bug

### DIFF
--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { BigPlayButton, Player } from 'video-react';
 import { AUDIO_REGEX, validOembedCheck, VIDEO_REGEX } from '@/logic/utils';
+import { useIsMobile } from '@/logic/useMedia';
 import { useCalm } from '@/state/settings';
 import { useEmbed } from '@/state/embed';
 import YouTubeEmbed from './YouTubeEmbed';
@@ -34,6 +35,7 @@ function ChatEmbedContent({
 }) {
   const { embed, isError, error } = useEmbed(url);
   const calm = useCalm();
+  const isMobile = useIsMobile();
   const isAudio = AUDIO_REGEX.test(url);
   const isVideo = VIDEO_REGEX.test(url);
   const isTrusted = trustedProviders.some((provider) =>
@@ -57,7 +59,12 @@ function ChatEmbedContent({
   if (isVideo) {
     return (
       <div className="flex max-h-[340px] max-w-[600px] flex-col">
-        <Player playsInline src={url} fluid={false} width={600}>
+        <Player
+          playsInline
+          src={url}
+          fluid={false}
+          width={isMobile ? 300 : 600}
+        >
           <BigPlayButton position="center" />
         </Player>
       </div>

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -56,8 +56,8 @@ function ChatEmbedContent({
 
   if (isVideo) {
     return (
-      <div className="flex max-w-[600px] max-h-[340px] flex-col">
-        <Player playsInline src={url}>
+      <div className="flex max-h-[340px] max-w-[600px] flex-col">
+        <Player playsInline src={url} fluid={false} width={600}>
           <BigPlayButton position="center" />
         </Player>
       </div>


### PR DESCRIPTION
Needed to pass an explicit `fluid={false}` prop and set a width on the video player itself.

Fixes LAND-810

Test it by posting a tall video followed by another message.