### PR TITLE
groups: react-query on-mount refresh not scrying for settings

### DIFF
--- a/ui/src/logic/useReactQuerySubscription.tsx
+++ b/ui/src/logic/useReactQuerySubscription.tsx
@@ -55,7 +55,7 @@ export default function useReactQuerySubscription({
   }, [app, path, queryClient, queryKey]);
 
   return useQuery(queryKey, fetchData, {
-    staleTime: 20 * 60 * 1000,
+    staleTime: 60 * 1000,
     ...options,
   });
 }

--- a/ui/src/logic/useReactQuerySubscription.tsx
+++ b/ui/src/logic/useReactQuerySubscription.tsx
@@ -55,8 +55,7 @@ export default function useReactQuerySubscription({
   }, [app, path, queryClient, queryKey]);
 
   return useQuery(queryKey, fetchData, {
-    retryOnMount: false,
-    refetchOnMount: false,
+    staleTime: 20 * 60 * 1000,
     ...options,
   });
 }


### PR DESCRIPTION
Fixes LAND-750

The fix is to set `staleTime` _(20 mins)_ to prevent infinite loop of refetching/re-rendering

Please, feel free to say your arguments against it or the potential drawbacks of this approach.