### PR TITLE
Gallery: Speed up group refs

### DIFF
--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -272,7 +272,6 @@ export const useGangPreview = (
   flag: string,
   disabled = false
 ): GroupPreview | null => {
-  const [mustFetch, setMustFetch] = useState(false);
   const gangs = useGangs();
 
   const { data, ...rest } = useReactQuerySubscribeOnce<GroupPreview>({
@@ -280,17 +279,10 @@ export const useGangPreview = (
     app: 'groups',
     path: `/gangs/${flag}/preview`,
     options: {
-      enabled: mustFetch && !disabled,
+      enabled: !disabled,
+      initialData: gangs[flag]?.preview || undefined,
     },
   });
-
-  if (gangs[flag]?.preview) {
-    return gangs[flag].preview;
-  }
-
-  if (!mustFetch) {
-    setMustFetch(true);
-  }
 
   if (rest.isLoading || rest.isError) {
     return null;

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { useParams } from 'react-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import create from 'zustand';
 import {
   MutationFunction,

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { useParams } from 'react-router';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import create from 'zustand';
 import {
   MutationFunction,
@@ -268,15 +268,28 @@ export function useGang(flag: string) {
   return data?.[flag] || defGang;
 }
 
-export const useGangPreview = (flag: string, disabled = false) => {
+export const useGangPreview = (
+  flag: string,
+  disabled = false
+): GroupPreview | null => {
+  const [needToFetch, setNeedToFetch] = useState(false);
+  const gangs = useGangs();
+
   const { data, ...rest } = useReactQuerySubscribeOnce<GroupPreview>({
     queryKey: ['gang-preview', flag],
     app: 'groups',
     path: `/gangs/${flag}/preview`,
     options: {
-      enabled: !disabled,
+      enabled: needToFetch && !disabled,
     },
   });
+
+  if (gangs[flag]?.preview) {
+    return gangs[flag].preview;
+  }
+  if (needToFetch === false) {
+    setNeedToFetch(true);
+  }
 
   if (rest.isLoading || rest.isError) {
     return null;

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -272,7 +272,7 @@ export const useGangPreview = (
   flag: string,
   disabled = false
 ): GroupPreview | null => {
-  const [needToFetch, setNeedToFetch] = useState(false);
+  const [mustFetch, setMustFetch] = useState(false);
   const gangs = useGangs();
 
   const { data, ...rest } = useReactQuerySubscribeOnce<GroupPreview>({
@@ -280,15 +280,16 @@ export const useGangPreview = (
     app: 'groups',
     path: `/gangs/${flag}/preview`,
     options: {
-      enabled: needToFetch && !disabled,
+      enabled: mustFetch && !disabled,
     },
   });
 
   if (gangs[flag]?.preview) {
     return gangs[flag].preview;
   }
-  if (needToFetch === false) {
-    setNeedToFetch(true);
+
+  if (!mustFetch) {
+    setMustFetch(true);
   }
 
   if (rest.isLoading || rest.isError) {


### PR DESCRIPTION
Updates our gang preview to check for existing data before issuing a new fetch. 

Believe this is what was slowing down refs in the "Local Directory" channel, but let me know if you guys are still seeing lag there.

Fixes LAND-794