### PR TITLE
Notebooks: Fix note headline button & date colors

### DIFF
--- a/ui/src/diary/DiaryCommenters.tsx
+++ b/ui/src/diary/DiaryCommenters.tsx
@@ -30,14 +30,15 @@ export default function DiaryCommenters({
     return (
       <IconButton
         label="comments"
-        icon={<BubbleIcon className={`h-5 w-5 text-white`} />}
+        className="hover:text-gray-400"
+        icon={<BubbleIcon className="h-5 w-5" />}
       />
     );
   };
 
   return (
     <div
-      className={`relative flex items-center text-gray-600 ${
+      className={`relative flex items-center ${
         !fullSize && commenters.length > 0 && 'rounded-lg bg-white p-1.5'
       }`}
     >
@@ -55,7 +56,7 @@ export default function DiaryCommenters({
               }}
             />
           ))}
-          <span className="ml-2">
+          <span className="ml-2 text-gray-600">
             {quipCount} {fullSize && pluralize('comment', quipCount)}
           </span>
         </>

--- a/ui/src/diary/DiaryNoteHeadline.tsx
+++ b/ui/src/diary/DiaryNoteHeadline.tsx
@@ -43,10 +43,11 @@ export default function DiaryNoteHeadline({
   const calm = useCalm();
 
   const isAdmin = useAmAdmin(flag);
+  const showImage = essay.image && !calm.disableRemoteContent;
 
   return (
     <>
-      {essay.image && !calm.disableRemoteContent && !isInGrid ? (
+      {showImage && !isInGrid ? (
         <img
           src={essay.image}
           alt=""
@@ -57,7 +58,7 @@ export default function DiaryNoteHeadline({
         <h1 className="break-words text-3xl font-medium leading-10">
           {essay.title}
         </h1>
-        <p className={cn(isInGrid ? 'text-white' : 'text-gray-400')}>
+        <p className={cn((isInList || !showImage) && 'text-gray-400')}>
           {format(essay.sent, 'LLLL do, yyyy')}
         </p>
         <div className="flex w-full items-center justify-between">
@@ -71,7 +72,7 @@ export default function DiaryNoteHeadline({
           <div
             className={cn(
               'flex items-center justify-end space-x-1',
-              isInGrid ? 'text-white' : 'text-gray-400'
+              (isInList || !showImage) && 'text-gray-400'
             )}
             onClick={(e) => e.stopPropagation()}
           >
@@ -89,7 +90,7 @@ export default function DiaryNoteHeadline({
                 </span>
                 <IconButton
                   action={onCopy}
-                  className="h-8 w-8"
+                  className="h-8 w-8 hover:text-gray-400"
                   label="Share"
                   icon={
                     didCopy ? (
@@ -105,7 +106,7 @@ export default function DiaryNoteHeadline({
                   canEdit={isAdmin || window.our === essay.author}
                 >
                   <IconButton
-                    className="h-8 w-8"
+                    className="h-8 w-8 hover:text-gray-400"
                     label="Options"
                     icon={<ElipsisIcon className={`h-5 w-5`} />}
                   />


### PR DESCRIPTION
Fixes the invisible comment button as well as a few edge cases introduced with the recent style/spacing fine tuning pass. Tried to follow the spirit of those changes while adapting them to be more resilient to dark vs light mode and note with image vs no image.

Fixes LAND-823