### PR TITLE
Chat: Fix DM reacts on mobile

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -573,6 +573,14 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 path="/groups/:ship/:name/channels/chat/:chShip/:chName/message/:idShip/:idTime/picker/:writShip/:writTime"
                 element={<EmojiPicker />}
               />
+              <Route
+                path="/dm/:ship/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
+              <Route
+                path="/dm/:ship/message/:idShip/:idTime/picker/:writShip/:writTime"
+                element={<EmojiPicker />}
+              />
             </>
           ) : null}
         </Routes>


### PR DESCRIPTION
OTT

We just needed to move the picker paths for DMs over to the Groups router now that chat is embedded there for mobile.

Fixes LAND-835