### PR TITLE
gallery: Use existing curios as initial data in HeapDetail

### DIFF
--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { formatDistanceToNow } from 'date-fns';
-import { HeapCurio, isLink } from '@/types/heap';
+import { Heap, HeapCurio, isLink } from '@/types/heap';
 import { isValidUrl, validOembedCheck } from '@/logic/utils';
 import { useCalm } from '@/state/settings';
 import { useEmbed } from '@/state/embed';
@@ -213,17 +213,19 @@ function HeapBlockWrapper({
   time,
   setLongPress,
   children,
+  curio,
 }: React.PropsWithChildren<{
   time: string;
   setLongPress: (b: boolean) => void;
+  curio: HeapCurio;
 }>) {
   const navigate = useNavigate();
   const { action, handlers } = useLongPress();
   const navigateToDetail = useCallback(
     (blockTime: string) => {
-      navigate(`curio/${blockTime}`);
+      navigate(`curio/${blockTime}`, { state: { initialCurio: curio } });
     },
-    [navigate]
+    [navigate, curio]
   );
 
   useEffect(() => {
@@ -301,7 +303,7 @@ export default function HeapBlock({
 
   if (isComment) {
     return (
-      <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+      <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
         <div className={cnm()}>
           <TopBar hasIcon canEdit={canEdit} {...topBar} />
           <div className="flex grow flex-col">
@@ -317,7 +319,7 @@ export default function HeapBlock({
 
   if (content.block.length > 0 && 'cite' in content.block[0]) {
     return (
-      <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+      <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
         <div className={cnm()}>
           <TopBar hasIcon canEdit={canEdit} {...topBar} />
           <div className="flex grow flex-col items-center justify-center">
@@ -334,7 +336,7 @@ export default function HeapBlock({
 
   if (isText) {
     return (
-      <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+      <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
         <div className={cnm()}>
           <TopBar hasIcon canEdit={canEdit} {...topBar} />
           <HeapContent
@@ -353,7 +355,7 @@ export default function HeapBlock({
 
   if (isImage && !calm?.disableRemoteContent) {
     return (
-      <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+      <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
         <div
           className={cnm(
             'h-full w-full bg-gray-50 bg-contain bg-center bg-no-repeat'
@@ -371,7 +373,7 @@ export default function HeapBlock({
 
   if (isAudio && !calm?.disableRemoteContent) {
     return (
-      <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+      <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
         <div className={cnm()}>
           <TopBar hasIcon canEdit={canEdit} {...topBar} />
           <div className="flex grow flex-col items-center justify-center">
@@ -390,7 +392,7 @@ export default function HeapBlock({
 
     if (thumbnail) {
       return (
-        <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+        <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
           <div
             className={cnm('h-full w-full bg-cover bg-center bg-no-repeat')}
             style={{
@@ -408,7 +410,7 @@ export default function HeapBlock({
       const twitterHandle = embed.author_url.split('/').pop();
       const twitterProfilePic = `https://unavatar.io/twitter/${twitterHandle}`;
       return (
-        <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+        <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
           <div className={cnm()}>
             <TopBar isTwitter canEdit={canEdit} {...topBar} />
             <div className="flex grow flex-col items-center justify-center space-y-2">
@@ -426,7 +428,7 @@ export default function HeapBlock({
       );
     }
     return (
-      <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+      <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
         <div className={cnm()}>
           <TopBar hasIcon canEdit={canEdit} {...topBar} />
           <div className="flex grow flex-col items-center justify-center">
@@ -439,7 +441,7 @@ export default function HeapBlock({
   }
 
   return (
-    <HeapBlockWrapper time={time} setLongPress={setLongPress}>
+    <HeapBlockWrapper time={time} curio={curio} setLongPress={setLongPress}>
       <div className={cnm()}>
         <TopBar hasIcon canEdit={canEdit} {...topBar} />
         <div className="flex grow flex-col items-center justify-center">

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { formatDistanceToNow } from 'date-fns';
-import { Heap, HeapCurio, isLink } from '@/types/heap';
+import { HeapCurio, isLink } from '@/types/heap';
 import { isValidUrl, validOembedCheck } from '@/logic/utils';
 import { useCalm } from '@/state/settings';
 import { useEmbed } from '@/state/embed';

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
@@ -4,17 +4,21 @@ import { useGroup, useRouteGroup, useVessel } from '@/state/groups/groups';
 import { useHeapPerms } from '@/state/heap/heap';
 import { canWriteChannel, nestToFlag } from '@/logic/utils';
 import { HeapCurioMap } from '@/types/heap';
+import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import HeapDetailCommentField from './HeapDetailCommentField';
 import HeapComment from './HeapComment';
 
 interface HeapDetailCommentsProps {
   time: BigInteger;
-  comments: HeapCurioMap;
+  comments?: HeapCurioMap;
+  loading: boolean;
 }
 
 export default function HeapDetailComments({
   time,
   comments,
+  loading,
 }: HeapDetailCommentsProps) {
   const nest = useNest();
   const flag = useRouteGroup();
@@ -24,19 +28,32 @@ export default function HeapDetailComments({
   const perms = useHeapPerms(chFlag);
   const vessel = useVessel(flag, window.our);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
-  const sortedComments = Array.from(comments).sort(([a], [b]) => a.compare(b));
+  const sortedComments = comments
+    ? Array.from(comments).sort(([a], [b]) => a.compare(b))
+    : [];
 
   return (
     <>
       <div className="mx-4 mb-2 flex flex-col space-y-2 overflow-y-auto lg:flex-1">
-        {sortedComments.map(([id, curio]) => (
-          <HeapComment
-            key={id.toString()}
-            curio={curio}
-            parentTime={stringTime}
-            time={id.toString()}
-          />
-        ))}
+        {!loading ? (
+          sortedComments.map(([id, curio]) => (
+            <HeapComment
+              key={id.toString()}
+              curio={curio}
+              parentTime={stringTime}
+              time={id.toString()}
+            />
+          ))
+        ) : (
+          <>
+            <div className="hidden overflow-y-auto lg:block">
+              <ChatScrollerPlaceholder count={20} />
+            </div>
+            <div className="flex w-full items-center justify-center py-4 sm:flex lg:hidden">
+              <LoadingSpinner />
+            </div>
+          </>
+        )}
       </div>
       {canWrite ? <HeapDetailCommentField /> : null}
     </>


### PR DESCRIPTION
Updates the `HeapDetail` view to use existing data from the main grid query as an initial value while fetching the full curio with comments in the background. This should make sure it's always snappy when clicking into a block from the channel view.

Fixes LAND-841