### PR TITLE
groups: fix infinite loop on mark read in diaries/heaps

### DIFF
--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -58,7 +58,7 @@ function DiaryChannel({ title }: ViewProps) {
   const queryClient = useQueryClient();
   const loadingOlderNotes = useOlderNotes(chFlag, 30, shouldLoadOlderNotes);
   const { mutateAsync: joinDiary } = useJoinDiaryMutation();
-  const { mutateAsync: markRead } = useMarkReadDiaryMutation();
+  const { mutate: markRead, isLoading: isMarking } = useMarkReadDiaryMutation();
   const location = useLocation();
   const navigate = useNavigate();
   const { setRecentChannel } = useRecentChannel(flag);
@@ -203,6 +203,7 @@ function DiaryChannel({ title }: ViewProps) {
   useDismissChannelNotifications({
     nest,
     markRead: useCallback(() => markRead({ flag: chFlag }), [markRead, chFlag]),
+    isMarking,
   });
 
   const sortedNotes = Array.from(letters).sort(([a], [b]) => {

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -54,7 +54,8 @@ function HeapChannel({ title }: ViewProps) {
   const sortMode = useHeapSortMode(chFlag);
   const { curios, fetchNextPage, hasNextPage, isLoading } =
     useInfiniteCurioBlocks(chFlag);
-  const { mutateAsync: markRead } = useMarkHeapReadMutation();
+  const { mutate: markRead, isLoading: isMarking } =
+    useMarkHeapReadMutation();
   const { mutateAsync: joinHeap } = useJoinHeapMutation();
   const perms = useHeapPerms(chFlag);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
@@ -119,6 +120,7 @@ function HeapChannel({ title }: ViewProps) {
   useDismissChannelNotifications({
     nest,
     markRead: useCallback(() => markRead({ flag: chFlag }), [markRead, chFlag]),
+    isMarking,
   });
 
   const renderCurio = useCallback(

--- a/ui/src/logic/useDismissChannelNotifications.ts
+++ b/ui/src/logic/useDismissChannelNotifications.ts
@@ -8,11 +8,13 @@ import { nestToFlag } from './utils';
 interface UseDismissChannelProps {
   nest: string;
   markRead: (flag: string) => Promise<void> | void;
+  isMarking: boolean;
 }
 
 export default function useDismissChannelNotifications({
   nest,
   markRead,
+  isMarking,
 }: UseDismissChannelProps) {
   const flag = useRouteGroup();
   const [, chFlag] = nestToFlag(nest);
@@ -29,7 +31,7 @@ export default function useDismissChannelNotifications({
    */
   // dismiss unread notifications while viewing channel
   useEffect(() => {
-    if (nest && unread) {
+    if (nest && unread && !isMarking) {
       // dismiss brief
       markRead(chFlag);
       // iterate bins, saw each rope
@@ -45,5 +47,13 @@ export default function useDismissChannelNotifications({
         });
       });
     }
-  }, [nest, chFlag, markRead, unread, notifications, sawRopeMutation]);
+  }, [
+    nest,
+    chFlag,
+    markRead,
+    unread,
+    notifications,
+    sawRopeMutation,
+    isMarking,
+  ]);
 }

--- a/ui/src/state/diary/diary.ts
+++ b/ui/src/state/diary/diary.ts
@@ -445,6 +445,8 @@ export function useRemoteOutline(
 }
 
 export function useMarkReadDiaryMutation() {
+  const queryClient = useQueryClient();
+
   const mutationFn = async (variables: { flag: string }) => {
     await api.poke({
       app: 'diary',
@@ -458,6 +460,9 @@ export function useMarkReadDiaryMutation() {
 
   return useMutation({
     mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['diary', 'briefs']);
+    },
   });
 }
 

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -701,6 +701,7 @@ export function useEditCurioMutation() {
 }
 
 export function useMarkHeapReadMutation() {
+  const queryClient = useQueryClient();
   const mutationFn = async ({ flag }: { flag: HeapFlag }) => {
     await api.poke({
       app: 'heap',
@@ -714,6 +715,9 @@ export function useMarkHeapReadMutation() {
 
   return useMutation({
     mutationFn,
+    onSuccess: () => {
+      queryClient.refetchQueries(['heap', 'briefs']);
+    },
   });
 }
 


### PR DESCRIPTION
markRead was getting fired in an infinite loop via the useEffect in useDismissChannelNotifications. We need to prevent it from firing while the initial call is still loading and we need to invalidate the cache on success to keep it from firing again after the first call completes.

Also, mutateAsync was unnecessary here, mutate is fine.

Fixes LAND-842