### PR TITLE
refs: don't show roles in bar

### DIFF
--- a/ui/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/ui/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Layout > renders as expected 1`] = `
 <div

--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -58,6 +58,7 @@ export default function ReferenceBar({
           className="peer"
           ship={author}
           date={unix}
+          hideRoles
           hideTime
           isReply={reply}
           isRef

--- a/ui/src/groups/GangPreview/__snapshots__/GangPreview.test.tsx.snap
+++ b/ui/src/groups/GangPreview/__snapshots__/GangPreview.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`GangPreview > renders preview 1`] = `
 <DocumentFragment>

--- a/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
+++ b/ui/src/groups/GroupSidebar/__snapshots__/ChannelList.test.tsx.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChannelList > renders as expected 1`] = `
 <DocumentFragment>

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -54,8 +54,7 @@ function HeapChannel({ title }: ViewProps) {
   const sortMode = useHeapSortMode(chFlag);
   const { curios, fetchNextPage, hasNextPage, isLoading } =
     useInfiniteCurioBlocks(chFlag);
-  const { mutate: markRead, isLoading: isMarking } =
-    useMarkHeapReadMutation();
+  const { mutate: markRead, isLoading: isMarking } = useMarkHeapReadMutation();
   const { mutateAsync: joinHeap } = useJoinHeapMutation();
   const perms = useHeapPerms(chFlag);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);


### PR DESCRIPTION
They get crowded too easily imo and you can always click the person's profile.