### PR TITLE
groups: eliminate scrollbars in invite dialog on desktop

### DIFF
--- a/ui/src/groups/GroupInviteDialog.tsx
+++ b/ui/src/groups/GroupInviteDialog.tsx
@@ -168,7 +168,7 @@ export default function GroupInviteDialog() {
       open={true}
       onOpenChange={(isOpen) => !isOpen && dismiss()}
       containerClass="w-full max-w-xl"
-      className="mb-64 bg-transparent p-0"
+      className="bg-transparent p-0"
       close="none"
     >
       {renderContent()}


### PR DESCRIPTION
Part of GRO-615

Review notes:

* Scrollbar still appears at small resolutions near the mobile breakpoint but gone at most window sizes in between.
* I don't know this app enough to tell if removing that margin-bottom class has other side effects.
* The main issue of the flickering is still in progress. More in comment later.


<img width="1054" alt="no-scrollbar" src="https://github.com/tloncorp/landscape-apps/assets/1731775/4240cc24-d0d6-4efa-a8a9-8076ccbd3d1d">

