### PR TITLE
groups: fix state wipe on load from recheck/leave-old-channels pokes

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -280,27 +280,28 @@
     =/  groups-path  /(scot %p our.bowl)/groups/(scot %da now.bowl)/groups/noun
     =/  groups  .^(groups:g %gx groups-path)
     =/  chat-flags-from-groups
-      %-  zing
       %+  turn  ~(tap by groups)
-      |=  [* =group:g]
-      %+  murn
-        ~(tap by channels.group)
+    |=  [group-flag=flag:g group=group:g]
+      %+  turn
+        %+  skim  ~(tap by channels.group)
+        |=  [=nest:g *]
+        ?:(=(%chat p.nest) %.y %.n)
       |=  [=nest:g *]
-      ?.(=(%chat p.nest) ~ (some q.nest))
+      q.nest
     =/  chats-without-groups
       %+  skim  ~(tap in ~(key by chats))
-      |=  chat=flag:g
-      =((find [chat]~ chat-flags-from-groups) ~)
+      |=  =flag:g
+      ?:(=((find [flag]~ (zing chat-flags-from-groups)) ~) %.y %.n)
     %+  roll
       chats-without-groups
     |=  [=flag:g core=_cor]
-    ca-abet:ca-leave:(ca-abed:ca-core flag)
+    ca-abet:ca-leave:(ca-abed:ca-core:core flag)
   ::
       %recheck-all-perms
     %+  roll
       ~(tap by chats)
     |=  [[=flag:c *] core=_cor]
-    =/  ca  (ca-abed:ca-core flag)
+    =/  ca  (ca-abed:ca-core:core flag)
     ca-abet:(ca-recheck:ca ~)
   ::
       %chat-draft

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1397,10 +1397,12 @@
     =?  cor  &(!=(sects ~) =(p.flag our.bowl))
       =/  =cage  [act:mar:c !>([flag now.bowl %del-sects sects])]
       (emit %pass ca-area %agent [our.bowl dap.bowl] %poke cage)
-    ::  if our read permissions restored, re-subscribe
-    =?  ca-core  (ca-can-read our.bowl)  ca-safe-sub
-    ::  if we can't read, leave the chat
-    =?  ca-core  !(ca-can-read our.bowl)  ca-leave
+    ::  if our read permissions restored, re-subscribe. If not, leave.
+    =/  wecanread  (ca-can-read our.bowl)
+    =.  ca-core
+      ?:  wecanread
+        ca-safe-sub
+      ca-leave
     ::  if subs read permissions removed, kick
     %+  roll  ~(tap in ca-subscriptions)
     |=  [[=ship =path] ca=_ca-core]

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -814,10 +814,12 @@
     =?  cor  &(!=(sects ~) =(p.flag our.bowl))
       =/  =cage  [act:mar:d !>([flag now.bowl %del-sects sects])]
       (emit %pass di-area %agent [our.bowl dap.bowl] %poke cage)
-    ::  if our read permissions restored, re-subscribe
-    =?  di-core  (di-can-read our.bowl)  di-safe-sub
-    ::  if we can't read, leave the diary
-    =?  di-core  !(di-can-read our.bowl)  di-leave
+    ::  if our read permissions restored, re-subscribe. If not, leave.
+    =/  wecanread  (di-can-read our.bowl)
+    =.  di-core
+      ?:  wecanread
+        di-safe-sub
+      di-leave
     ::  if subs read permissions removed, kick
     %+  roll  ~(tap in di-subscriptions)
     |=  [[=ship =path] di=_di-core]

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -220,21 +220,22 @@
     =/  groups-path  /(scot %p our.bowl)/groups/(scot %da now.bowl)/groups/noun
     =/  groups  .^(groups:g %gx groups-path)
     =/  diary-flags-from-groups
-      %-  zing
       %+  turn  ~(tap by groups)
-      |=  [* group=group:g]
-      %+  murn
-        ~(tap by channels.group)
+      |=  [group-flag=flag:g group=group:g]
+      %+  turn
+        %+  skim  ~(tap by channels.group)
+        |=  [=nest:g *]
+        ?:(=(%diary p.nest) %.y %.n)
       |=  [=nest:g *]
-      ?.(=(%diary p.nest) ~ (some q.nest))
+      q.nest
     =/  diaries-without-groups
       %+  skim  ~(tap by shelf)
-      |=  diary=[=flag:g *]
-      =((find [diary]~ diary-flags-from-groups) ~)
+      |=  [=flag:g *]
+      ?:(=((find [flag]~ (zing diary-flags-from-groups)) ~) %.y %.n)
     %+  roll
       diaries-without-groups
     |=  [[=flag:g *] core=_cor]
-    di-abet:di-leave:(di-abed:di-core flag)
+    di-abet:di-leave:(di-abed:di-core:core flag)
   ::
       %recheck-all-perms
     %+  roll
@@ -816,7 +817,7 @@
     ::  if our read permissions restored, re-subscribe
     =?  di-core  (di-can-read our.bowl)  di-safe-sub
     ::  if we can't read, leave the diary
-    =?  di-core  (di-can-read our.bowl)  di-leave
+    =?  di-core  !(di-can-read our.bowl)  di-leave
     ::  if subs read permissions removed, kick
     %+  roll  ~(tap in di-subscriptions)
     |=  [[=ship =path] di=_di-core]

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -199,7 +199,7 @@
   =+  !<([old=versioned-state cool=epic:e] vase)
   =.  state  old
   =.  cor  restore-missing-subs
-  :: =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
+  =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
   =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %leave-old-channels !>(0))
   ?:  =(okay:h cool)  cor
   ::  speak the good news
@@ -740,18 +740,12 @@
     =?  cor  &(!=(sects ~) =(p.flag our.bowl))
       =/  =cage  [act:mar:h !>([flag now.bowl %del-sects sects])]
       (emit %pass he-area %agent [our.bowl dap.bowl] %poke cage)
-    ::  if our read permissions restored, re-subscribe
+    ::  if our read permissions restored, re-subscribe. If not, leave.
     =/  wecanread  (he-can-read our.bowl)
-    ~&  "{<flag>} {<wecanread>}"
     =.  he-core
       ?:  wecanread
-        ~&  "restoring {<flag>}"
         he-safe-sub
-      ~&  "leaving {<flag>}"
       he-leave
-    :: =?  he-core  (he-can-read our.bowl)  he-safe-sub
-    :: ::  if we can't read, leave the heap
-    :: =?  he-core  !(he-can-read our.bowl)  he-leave
     ::  if subs read permissions removed, kick
     %+  roll  ~(tap in he-subscriptions)
     |=  [[=ship =path] he=_he-core]

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -122,21 +122,22 @@
     =/  groups-path  /(scot %p our.bowl)/groups/(scot %da now.bowl)/groups/noun
     =/  groups  .^(groups:g %gx groups-path)
     =/  heap-flags-from-groups
-      %-  zing
       %+  turn  ~(tap by groups)
-      |=  [* group=group:g]
-      %+  murn
-        ~(tap by channels.group)
+      |=  [group-flag=flag:g group=group:g]
+      %+  turn
+        %+  skim  ~(tap by channels.group)
+        |=  [=nest:g *]
+        ?:(=(%heap p.nest) %.y %.n)
       |=  [=nest:g *]
-      ?.(=(%heap p.nest) ~ (some q.nest))
+      q.nest
     =/  heaps-without-groups
       %+  skim  ~(tap by stash)
-      |=  heap=[=flag:g *]
-      =((find [heap]~ heap-flags-from-groups) ~)
+      |=  [=flag:g *]
+      ?:(=((find [flag]~ (zing heap-flags-from-groups)) ~) %.y %.n)
     %+  roll
       heaps-without-groups
     |=  [[=flag:g *] core=_cor]
-    he-abet:he-leave:(he-abed:he-core flag)
+    he-abet:he-leave:(he-abed:he-core:core flag)
   ::
      %recheck-all-perms
     %+  roll
@@ -198,7 +199,7 @@
   =+  !<([old=versioned-state cool=epic:e] vase)
   =.  state  old
   =.  cor  restore-missing-subs
-  =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
+  :: =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
   =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %leave-old-channels !>(0))
   ?:  =(okay:h cool)  cor
   ::  speak the good news
@@ -740,9 +741,17 @@
       =/  =cage  [act:mar:h !>([flag now.bowl %del-sects sects])]
       (emit %pass he-area %agent [our.bowl dap.bowl] %poke cage)
     ::  if our read permissions restored, re-subscribe
-    =?  he-core  (he-can-read our.bowl)  he-safe-sub
-    ::  if we can't read, leave the heap
-    =?  he-core  (he-can-read our.bowl)  he-leave
+    =/  wecanread  (he-can-read our.bowl)
+    ~&  "{<flag>} {<wecanread>}"
+    =.  he-core
+      ?:  wecanread
+        ~&  "restoring {<flag>}"
+        he-safe-sub
+      ~&  "leaving {<flag>}"
+      he-leave
+    :: =?  he-core  (he-can-read our.bowl)  he-safe-sub
+    :: ::  if we can't read, leave the heap
+    :: =?  he-core  !(he-can-read our.bowl)  he-leave
     ::  if subs read permissions removed, kick
     %+  roll  ~(tap in he-subscriptions)
     |=  [[=ship =path] he=_he-core]


### PR DESCRIPTION
Fixes the issue with our recheck functions actually leaving users from channels that shouldn't be left.

Fixes various issues with the leave-old-channels poke that also caused incorrect channels to be left.

Fixes LAND-853.