### PR TITLE
radiogroup: ensure left-aligned options

### DIFF
--- a/ui/src/components/RadioGroup.tsx
+++ b/ui/src/components/RadioGroup.tsx
@@ -23,7 +23,7 @@ export default function RadioGroup({
 }) {
   return (
     <RadioGroupPrimitive.Root
-      className="flex w-full flex-col items-start justify-start font-system-sans text-[17px]"
+      className="flex w-full flex-col rounded-xl border border-gray-200 font-system-sans text-[17px]"
       value={value}
       defaultValue={defaultOption}
       onValueChange={(val: string) => {
@@ -39,31 +39,31 @@ export default function RadioGroup({
           value={option.value}
           aria-label={option.ariaLabel ?? option.label}
           className={cn(
-            'flex h-14 w-full cursor-pointer items-center justify-between gap-4 border border-gray-100 py-2 px-6',
+            'flex h-14 cursor-pointer items-center justify-between border-b border-gray-200 py-2 px-6 text-left',
             index === 0 ? 'rounded-t-xl' : '',
-            index === options.length - 1 ? 'rounded-b-xl' : '',
+            index === options.length - 1 ? 'rounded-b-xl border-b-0' : '',
             index !== 0 && index !== options.length - 1 ? 'border-t-0' : '',
             index === options.length - 1 ? 'border-t-0' : '',
             value === option.value ? 'bg-gray-50' : 'bg-white'
           )}
         >
-          <div className="flex flex-col items-start justify-start space-y-1">
-            <label htmlFor={option.value}>
-              <span className="line-clamp-1">{option.label}</span>
+          <div>
+            <label className="block line-clamp-1" htmlFor={option.value}>
+              {option.label}
             </label>
             {option.secondaryLabel && (
-              <span className="whitespace-break-spaces text-base font-normal text-gray-600 line-clamp-1">
+              <p className="mt-[4px] text-sm font-normal text-gray-600 line-clamp-1">
                 {option.secondaryLabel}
-              </span>
+              </p>
             )}
           </div>
           <RadioGroupPrimitive.Indicator
             className={cn(
-              'h-6 w-6 rounded-full',
+              'flex h-5 w-5 shrink-0 items-center justify-center rounded-full',
               value === option.value ? 'bg-blue-500' : 'bg-white'
             )}
           >
-            <CheckIcon className="h-6 w-6 text-white" />
+            <CheckIcon className="h-4 w-4 text-white" />
           </RadioGroupPrimitive.Indicator>
         </RadioGroupPrimitive.Item>
       ))}


### PR DESCRIPTION
Adjusts the structure of the `RadioGroup` component and ensures left-alignment of all options in all cases. (The Radix primitive renders a `<button>`, which had a center-aligned label.) Also knocks the size of the helper text down a bit to better fit the entire label on a small screen in its non-selected state.

Previews:

**Channel settings with an unset group**
![Screenshot 2023-09-11 at 3 39 15 PM](https://github.com/tloncorp/landscape-apps/assets/748181/d06ba51b-2cb6-4240-ae5e-71099e4aa3fc)
![Screenshot 2023-09-11 at 3 39 20 PM](https://github.com/tloncorp/landscape-apps/assets/748181/994d62b4-7f4a-4758-bda4-36ac15831f79)
![Screenshot 2023-09-11 at 3 39 25 PM](https://github.com/tloncorp/landscape-apps/assets/748181/d6afb9b3-1964-4704-937f-5a2d0f493aaa)

**Channel settings with a group set**
![Screenshot 2023-09-11 at 3 40 13 PM](https://github.com/tloncorp/landscape-apps/assets/748181/9a2a16cc-c951-42b6-a1df-59e023326538)
![Screenshot 2023-09-11 at 3 40 17 PM](https://github.com/tloncorp/landscape-apps/assets/748181/f514c2ce-693c-4231-81b6-58b45d3d885b)
![Screenshot 2023-09-11 at 3 40 22 PM](https://github.com/tloncorp/landscape-apps/assets/748181/76ca0dab-beea-48c2-9e3f-12bebdeb2a9e)
![Screenshot 2023-09-11 at 3 40 26 PM](https://github.com/tloncorp/landscape-apps/assets/748181/961d1da3-a09c-4879-ba2e-542c565aa84e)

**Group settings with unset global**
![Screenshot 2023-09-11 at 3 41 03 PM](https://github.com/tloncorp/landscape-apps/assets/748181/800deb83-56e4-4c26-a71d-0c4c0b3bb531)
![Screenshot 2023-09-11 at 3 41 08 PM](https://github.com/tloncorp/landscape-apps/assets/748181/36e9551e-d5a2-481a-8f8a-7116ff8b9495)
![Screenshot 2023-09-11 at 3 41 11 PM](https://github.com/tloncorp/landscape-apps/assets/748181/86b973be-47b9-4a77-be74-d659ebb58def)
![Screenshot 2023-09-11 at 3 41 18 PM](https://github.com/tloncorp/landscape-apps/assets/748181/bf13359c-ad8f-495d-9673-60f2f651d4ee)

**Group settings with set global**
![Screenshot 2023-09-11 at 3 41 58 PM](https://github.com/tloncorp/landscape-apps/assets/748181/2d0cb45d-b809-45b4-a30f-fd5481aef44b)
![Screenshot 2023-09-11 at 3 42 06 PM](https://github.com/tloncorp/landscape-apps/assets/748181/b5951d19-2a0c-4b91-b11d-89c57fe0d3e7)
![Screenshot 2023-09-11 at 3 42 11 PM](https://github.com/tloncorp/landscape-apps/assets/748181/15b0a34b-a686-4480-b30c-d6495637a34e)
![Screenshot 2023-09-11 at 3 42 15 PM](https://github.com/tloncorp/landscape-apps/assets/748181/da8cc2c2-85b3-4efb-b92b-e481376ba73e)



Fixes LAND-887