### PR TITLE
heap: consistent curio delete behavior

### DIFF
--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -843,6 +843,8 @@
   ::
   ++  he-am-host  =(our.bowl p.flag)
   ++  he-from-host  |(=(p.flag src.bowl) =(p.group.perm.heap src.bowl))
+  ++  he-is-admin
+    .^(? %gx (welp he-groups-scry /fleet/(scot %p src.bowl)/is-bloc/loob))
   ++  he-can-write
     ?:  he-from-host  &
     =/  =path
@@ -971,11 +973,22 @@
         %add-feel  =(src.bowl p.delta)
         %del-feel  =(src.bowl p.delta)
       ::
-          %del  ?~(entry | =(src.bowl author.curio.u.entry))
+          %del
+        ::  if no curio, then fail
+        ?~  entry  |
+        ::  only author or admin can delete
+        ?|  =(src.bowl author.curio.u.entry)
+            he-is-admin
+        ==
       ::
           %edit
-        ?&  =(src.bowl author.p.delta)
-            ?~(entry | =(src.bowl author.curio.u.entry))
+        ::  if no curio, then fail
+        ?~  entry  |
+        ::  author should always be the same
+        ?.  =(author.p.delta author.curio.u.entry)  |
+        ::  only author or admin can edit
+        ?|  =(src.bowl author.p.delta)
+            he-is-admin
         ==
     ==
   ::

--- a/ui/src/components/ConfirmationModal.tsx
+++ b/ui/src/components/ConfirmationModal.tsx
@@ -9,7 +9,9 @@ export interface ConfirmationModalProps {
   message: string;
   confirmText?: string;
   onConfirm: () => void;
+  closeOnClickOutside?: boolean;
   loading?: boolean;
+  succeeded?: boolean;
 }
 
 export default function ConfirmationModal({
@@ -19,12 +21,16 @@ export default function ConfirmationModal({
   message,
   confirmText = 'Confirm',
   onConfirm,
+  closeOnClickOutside = false,
   loading = false,
+  succeeded = false,
 }: ConfirmationModalProps) {
+  const onOpenChange = closeOnClickOutside ? () => setOpen(false) : undefined;
+
   return (
     <Dialog
       open={open}
-      onOpenChange={() => setOpen(false)}
+      onOpenChange={onOpenChange}
       close="none"
       containerClass="z-50"
     >
@@ -39,11 +45,11 @@ export default function ConfirmationModal({
             Cancel
           </button>
           <button
-            disabled={loading}
+            disabled={loading || succeeded}
             className="button center-items flex w-24 bg-red"
             onClick={onConfirm}
           >
-            {loading ? <LoadingSpinner /> : confirmText}
+            {loading ? <LoadingSpinner /> : succeeded ? 'Success' : confirmText}
           </button>
         </div>
       </div>

--- a/ui/src/components/ConfirmationModal.tsx
+++ b/ui/src/components/ConfirmationModal.tsx
@@ -22,7 +22,12 @@ export default function ConfirmationModal({
   loading = false,
 }: ConfirmationModalProps) {
   return (
-    <Dialog open={open} close="none" containerClass="z-50">
+    <Dialog
+      open={open}
+      onOpenChange={() => setOpen(false)}
+      close="none"
+      containerClass="z-50"
+    >
       <div className="flex flex-col">
         <h1 className="mb-4 text-lg font-bold">{title}</h1>
         <p>{message}</p>

--- a/ui/src/heap/EditCurioForm.tsx
+++ b/ui/src/heap/EditCurioForm.tsx
@@ -226,6 +226,8 @@ export default function EditCurioForm() {
         open={deleteOpen}
         onConfirm={onDelete}
         setOpen={setDeleteOpen}
+        closeOnClickOutside={true}
+        loading={delMutation.isLoading}
         title="Delete Gallery Item"
         confirmText="Delete"
         message="Are you sure you want to delete this gallery item?"

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -174,7 +174,9 @@ function TopBar({
         open={deleteOpen}
         setOpen={setDeleteOpen}
         onConfirm={onDelete}
+        closeOnClickOutside={true}
         loading={deleteStatus === 'loading'}
+        succeeded={deleteStatus === 'success'}
         confirmText="Delete"
         title="Delete Gallery Item"
         message="Are you sure you want to delete this gallery item?"

--- a/ui/src/state/heap/heap.ts
+++ b/ui/src/state/heap/heap.ts
@@ -667,7 +667,17 @@ export function useDelCurioMutation() {
     time: string;
   }) => {
     const ud = decToUd(time);
-    await api.poke(heapCurioDiff(flag, ud, { del: null }));
+    await api.trackedPoke<HeapAction, HeapUpdate>(
+      heapCurioDiff(flag, ud, { del: null }),
+      { app: 'heap', path: `/heap/${flag}/ui` },
+      (event) => {
+        if ('curios' in event.diff) {
+          const curioDiff = event.diff.curios;
+          return curioDiff.time === time && 'del' in curioDiff.delta;
+        }
+        return false;
+      }
+    );
   };
 
   return useMutation({
@@ -682,7 +692,12 @@ export function useDelCurioMutation() {
       ]);
     },
     onSettled: (_data, _error, variables) => {
-      queryClient.refetchQueries(['heap', variables.flag, 'curios']);
+      queryClient.refetchQueries([
+        'heap',
+        variables.flag,
+        'curios',
+        'infinite',
+      ]);
     },
   });
 }


### PR DESCRIPTION
A few fixes to ensure curio deletion works as expected:
- make sure you always have permission to delete if the option is shown in the UI
- properly track the delete and spin while waiting
- successful delete triggers consistent removal from cache and query invalidation

Also updates the delete curio modal to close when you click outside of it.

Fixes LAND-839