### PR TITLE
groups: fix native safe area insets

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -51,6 +51,7 @@ import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { PASTEABLE_IMAGE_TYPES } from '@/constants';
+import { useSafeAreaInsets } from '@/logic/native';
 
 interface ChatInputProps {
   whom: string;
@@ -125,6 +126,7 @@ export default function ChatInput({
   );
   const [replyCite, setReplyCite] = useState<{ cite: Cite }>();
   const groupFlag = useGroupFlag();
+  const isGroupChatInput = !!groupFlag;
   const { privacy } = useGroupPrivacy(groupFlag);
   const pact = usePact(whom);
   const chatInfo = useChatInfo(id);
@@ -138,6 +140,7 @@ export default function ChatInput({
   const files = useMemo(() => uploader?.files, [uploader]);
   const mostRecentFile = uploader?.getMostRecent();
   const { setBlocks } = useChatStore.getState();
+  const safeAreaInsets = useSafeAreaInsets();
 
   const handleDrop = useCallback(
     (fileList: FileList) => {
@@ -534,7 +537,10 @@ export default function ChatInput({
   }
 
   return (
-    <div className={cn('flex w-full items-end space-x-2', className)}>
+    <div
+      className={cn('flex w-full items-end space-x-2', className)}
+      style={{ paddingBottom: isGroupChatInput ? safeAreaInsets.bottom : 0 }}
+    >
       <div
         // sometimes a race condition causes the dropzone to be removed before the drop event fires
         id={dropZoneId}

--- a/ui/src/chat/ChatSearch/ChatSearch.tsx
+++ b/ui/src/chat/ChatSearch/ChatSearch.tsx
@@ -17,6 +17,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { disableDefault } from '@/logic/utils';
 import { useChatSearch } from '@/state/chat';
 import bigInt from 'big-integer';
+import { useSafeAreaInsets } from '@/logic/native';
 import ChatSearchResults from './ChatSearchResults';
 
 interface RouteParams {
@@ -42,6 +43,7 @@ export default function ChatSearch({
   const { query } = useParams<RouteParams>();
   const isMobile = useIsMobile();
   const isSmall = useMedia('(min-width: 768px) and (max-width: 1099px)');
+  const safeAreaInsets = useSafeAreaInsets();
   const scrollerRef = React.useRef<VirtuosoHandle>(null);
   const [rawInput, setRawInput] = React.useState(query || '');
   const [selected, setSelected] = React.useState<{
@@ -128,80 +130,85 @@ export default function ChatSearch({
 
   return (
     <div
-      className={cn(
-        'flex w-full flex-1 items-center justify-between space-x-2 border-b-2 border-gray-50 bg-white p-2',
-        isSmall || isMobile ? 'p-3' : 'p-2'
-      )}
+      className="border-b-2 border-gray-50 bg-white"
+      style={{ paddingTop: safeAreaInsets.top }}
     >
-      <div className="max-w-[240px] flex-none">
-        {!isMobile && !isSmall ? children : null}
-      </div>
-      <div className="relative flex-1">
-        <label
-          className="relative flex w-full items-center"
-          onKeyDown={onKeyDown}
-        >
-          <span className="sr-only">Search</span>
-          <span className="absolute left-0 pl-2">
-            <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
-          </span>
-          <input
-            id="search"
-            type="text"
-            role="combobox"
-            aria-controls="search-results"
-            aria-owns="search-results"
-            aria-activedescendant={`search-result-${selected.time.toString()}`}
-            aria-expanded={true}
-            autoFocus
-            className="input h-8 w-full bg-gray-50 pl-8 text-lg mix-blend-multiply placeholder:font-normal dark:mix-blend-normal md:text-base"
-            value={rawInput}
-            onChange={onChange}
-            placeholder={placeholder}
-          />
-          {isSmall ? (
-            <Link
-              className="absolute right-1 flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
-              to={`${root}/search`}
-            >
-              <X16Icon className="h-4 w-4 text-gray-400" />
-            </Link>
-          ) : null}
-        </label>
-        <Dialog.Root open modal={false} onOpenChange={onDialogClose}>
-          <Dialog.Content
-            onInteractOutside={preventClose}
-            onOpenAutoFocus={disableDefault}
-            className="absolute left-0 top-[40px] z-50 w-full outline-none"
+      <div
+        className={cn(
+          'flex w-full flex-1 items-center justify-between space-x-2',
+          isSmall || isMobile ? 'p-3' : 'p-2'
+        )}
+      >
+        <div className="max-w-[240px] flex-none">
+          {!isMobile && !isSmall ? children : null}
+        </div>
+        <div className="relative flex-1">
+          <label
+            className="relative flex w-full items-center"
+            onKeyDown={onKeyDown}
           >
-            <section
-              tabIndex={0}
-              role="listbox"
-              aria-setsize={scan?.size || 0}
-              id="search-results"
-              className={cn(
-                'default-focus dialog border-2 border-transparent shadow-lg dark:border-gray-50',
-                query ? 'h-[60vh] min-h-[480px]' : 'h-[200px]'
-              )}
+            <span className="sr-only">Search</span>
+            <span className="absolute left-0 pl-2">
+              <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
+            </span>
+            <input
+              id="search"
+              type="text"
+              role="combobox"
+              aria-controls="search-results"
+              aria-owns="search-results"
+              aria-activedescendant={`search-result-${selected.time.toString()}`}
+              aria-expanded={true}
+              autoFocus
+              className="input h-8 w-full bg-gray-50 pl-8 text-lg mix-blend-multiply placeholder:font-normal dark:mix-blend-normal md:text-base"
+              value={rawInput}
+              onChange={onChange}
+              placeholder={placeholder}
+            />
+            {isSmall ? (
+              <Link
+                className="absolute right-1 flex h-6 w-6 items-center justify-center rounded hover:bg-gray-50"
+                to={`${root}/search`}
+              >
+                <X16Icon className="h-4 w-4 text-gray-400" />
+              </Link>
+            ) : null}
+          </label>
+          <Dialog.Root open modal={false} onOpenChange={onDialogClose}>
+            <Dialog.Content
+              onInteractOutside={preventClose}
+              onOpenAutoFocus={disableDefault}
+              className="absolute left-0 top-[40px] z-50 w-full outline-none"
             >
-              <ChatSearchResults
-                ref={scrollerRef}
-                whom={whom}
-                root={root}
-                scan={scan}
-                isLoading={isLoading}
-                query={query}
-                selected={selected.index}
-              />
-            </section>
-          </Dialog.Content>
-        </Dialog.Root>
+              <section
+                tabIndex={0}
+                role="listbox"
+                aria-setsize={scan?.size || 0}
+                id="search-results"
+                className={cn(
+                  'default-focus dialog border-2 border-transparent shadow-lg dark:border-gray-50',
+                  query ? 'h-[60vh] min-h-[480px]' : 'h-[200px]'
+                )}
+              >
+                <ChatSearchResults
+                  ref={scrollerRef}
+                  whom={whom}
+                  root={root}
+                  scan={scan}
+                  isLoading={isLoading}
+                  query={query}
+                  selected={selected.index}
+                />
+              </section>
+            </Dialog.Content>
+          </Dialog.Root>
+        </div>
+        {!isSmall && (
+          <Link to={backTo} className="default-focus secondary-button">
+            Cancel
+          </Link>
+        )}
       </div>
-      {!isSmall && (
-        <Link to={backTo} className="default-focus secondary-button">
-          Cancel
-        </Link>
-      )}
     </div>
   );
 }

--- a/ui/src/components/MobileHeader.tsx
+++ b/ui/src/components/MobileHeader.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { useSafeAreaInsets } from '@/logic/native';
 import CaretLeftIconMobileNav from './icons/CaretLeftIconMobileNav';
 
 export default function MobileHeader({
@@ -16,8 +17,12 @@ export default function MobileHeader({
   action?: React.ReactNode;
   secondaryAction?: React.ReactNode;
 }) {
+  const safeAreaInsets = useSafeAreaInsets();
   return (
-    <div className="grid w-full grid-cols-5 justify-between bg-white font-system-sans">
+    <div
+      className="grid w-full grid-cols-5 justify-between bg-white font-system-sans"
+      style={{ paddingTop: safeAreaInsets.top }}
+    >
       {pathBack ? (
         <div className="h-12 pl-4">
           <Link className="flex h-12 items-center" to={pathBack}>

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames';
 import { Outlet, useLocation } from 'react-router';
-import { isNativeApp, isIOSWebView } from '@/logic/native';
+import { isNativeApp, useSafeAreaInsets } from '@/logic/native';
 import { useIsDark } from '@/logic/useMedia';
 import NavTab from '../NavTab';
 import BellIcon from '../icons/BellIcon';
@@ -14,15 +14,15 @@ export default function MobileSidebar() {
   const location = useLocation();
   const isInactive = (path: string) => !location.pathname.startsWith(path);
   const isDarkMode = useIsDark();
+  const safeAreaInsets = useSafeAreaInsets();
 
   return (
-    <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white">
+    <section
+      className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white"
+      style={{ paddingBottom: safeAreaInsets.bottom }}
+    >
       <Outlet />
-      <footer
-        className={cn('flex-none border-t-2 border-gray-50', {
-          'pb-3': isIOSWebView(),
-        })}
-      >
+      <footer className={cn('flex-none border-t-2 border-gray-50')}>
         <nav>
           <ul className="flex">
             <NavTab to="/" linkClass="basis-1/5">

--- a/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -5,6 +5,7 @@ import NavTab from '@/components/NavTab';
 import HashIcon from '@/components/icons/HashIcon';
 import BellIcon from '@/components/icons/BellIcon';
 import { useIsDark } from '@/logic/useMedia';
+import { useSafeAreaInsets } from '@/logic/native';
 import GroupAvatar from '../GroupAvatar';
 
 export default function MobileGroupSidebar() {
@@ -15,9 +16,13 @@ export default function MobileGroupSidebar() {
   const matchInfo = useMatch('/groups/:ship/:name/info');
   const location = useLocation();
   const isDarkMode = useIsDark();
+  const safeAreaInsets = useSafeAreaInsets();
 
   return (
-    <section className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white">
+    <section
+      className="fixed inset-0 z-40 flex h-full w-full flex-col border-gray-50 bg-white"
+      style={{ paddingBottom: safeAreaInsets.bottom }}
+    >
       <Outlet />
       <footer className="flex-none border-t-2 border-gray-50">
         <nav>

--- a/ui/src/logic/native.ts
+++ b/ui/src/logic/native.ts
@@ -16,3 +16,9 @@ export const isIOSWebView = () => {
     !/safari/.test(userAgent)
   );
 };
+
+export const useSafeAreaInsets = () =>
+  // The native app injects safe area insets provided by `react-native-safe-area-context`
+  // If they're not present, we assume we're running in the browser, in which case we don't have
+  // to worry about 'em.
+  window.safeAreaInsets ?? { top: 0, bottom: 0, left: 0, right: 0 };

--- a/ui/src/window.ts
+++ b/ui/src/window.ts
@@ -14,6 +14,12 @@ declare global {
     markRead: Rope;
     recents: any;
     colorscheme: any;
+    safeAreaInsets?: {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    };
   }
 }
 


### PR DESCRIPTION
This PR is one half of a fix for safe area insets in the webapp. The other half involves changes to the native app repo here: https://github.com/tloncorp/talk-android/pull/31.

In order to properly render modals and various headers and footers, the webapp needs to have total control over the rendering surface. To make that possible, I've removed the native `SafeAreaView` wrapping the entire app and instead opted to inject safe area values into the webapp. The safe area values are accessed through a hook, and default to `0` values if nothing has been injected. This PR contains plumbing for that, as well as application to headers/footers where necessary.

Fixes LAND-900
