### PR TITLE
fix lure link toggling when check request times out

### DIFF
--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -210,13 +210,14 @@ export function useLure(flag: string, disableLoading = false) {
 }
 
 export function useLureLinkChecked(flag: string, enabled: boolean) {
+  const [wasGood, setWasGood] = useState(false);
   const { data, ...query } = useQuery(
     ['lure-check', flag],
     () =>
       asyncWithDefault(
         () =>
           api.subscribeOnce<boolean>('grouper', `/check-link/${flag}`, 4500),
-        false
+        undefined
       ),
     {
       enabled,
@@ -224,9 +225,15 @@ export function useLureLinkChecked(flag: string, enabled: boolean) {
     }
   );
 
+  useEffect(() => {
+    if (data) {
+      setWasGood(data);
+    }
+  }, [data]);
+
   return {
     ...query,
-    good: data,
+    good: data === undefined ? wasGood : data,
     checked: query.isFetched && !query.isLoading,
   };
 }


### PR DESCRIPTION
Fixes issue with lure link toggling / popping in and out on the "invite people" dialog, which was occurring because the API call would time out and default to `false`. Now it will default to the previously returned value if a timeout occurs.