### PR TITLE
groups: remove mobile redirects

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -101,6 +101,7 @@ import NewGroupView from './groups/NewGroup/NewGroupView';
 import EyrieMenu from './eyrie/EyrieMenu';
 import GroupVolumeDialog from './groups/GroupVolumeDialog';
 import ChannelVolumeDialog from './channels/ChannelVolumeDialog';
+import { isNativeApp } from './logic/native';
 
 const ReactQueryDevtoolsProduction = React.lazy(() =>
   import('@tanstack/react-query-devtools/build/lib/index.prod.js').then(
@@ -296,19 +297,7 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   );
 }
 
-let redirectToFind = !window.location.pathname.startsWith('/apps/groups/find');
 function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
-  const navigate = useNavigate();
-  const groups = queryClient.getQueryCache().find(['groups'])?.state.data;
-  const isInGroups = groups !== undefined ? !_.isEmpty(groups) : true;
-
-  useEffect(() => {
-    if (!isInGroups && redirectToFind) {
-      navigate('/find', { replace: true });
-      redirectToFind = false;
-    }
-  }, [isInGroups, navigate]);
-
   if (isMobile) {
     return <MobileGroupsNavHome />;
   }
@@ -604,6 +593,10 @@ function authRedirect() {
 }
 
 function checkIfLoggedIn() {
+  if (isNativeApp()) {
+    return;
+  }
+
   if (IS_MOCK) {
     return;
   }

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -7,7 +7,11 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import ActivityIndicator from '@/components/Sidebar/ActivityIndicator';
 import MobileSidebar from '@/components/Sidebar/MobileSidebar';
 import GroupList from '@/components/Sidebar/GroupList';
-import { useGangList, useGroups, usePendingInvites } from '@/state/groups';
+import {
+  useGangList,
+  useGroupsWithQuery,
+  usePendingInvites,
+} from '@/state/groups';
 import { useIsMobile } from '@/logic/useMedia';
 import AppGroupsIcon from '@/components/icons/AppGroupsIcon';
 import MagnifyingGlass from '@/components/icons/MagnifyingGlass16Icon';
@@ -142,7 +146,7 @@ export default function Sidebar() {
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
   const pendingInvitesCount = pendingInvites.length;
   const { count } = useNotifications();
-  const groups = useGroups();
+  const { data: groups, isLoading } = useGroupsWithQuery();
   const gangs = useGangList();
   const pinnedGroups = usePinnedGroups();
   const sortedGroups = sortGroups(groups);
@@ -239,7 +243,7 @@ export default function Sidebar() {
                 </div>
               </div>
 
-              {!sortedGroups.length && (
+              {!sortedGroups.length && !isLoading && (
                 <div className="mx-4 my-2 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
                   Check out <strong>Discovery</strong> above to find new groups
                   in your network or view group invites.

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { debounce } from 'lodash';
 import useGroupSort from '@/logic/useGroupSort';
 import { usePinnedGroups } from '@/state/chat';
-import { useGangList, useGroups } from '@/state/groups';
+import { useGangList, useGroupsWithQuery } from '@/state/groups';
 import GroupList from '@/components/Sidebar/GroupList';
 import SidebarSorter from '@/components/Sidebar/SidebarSorter';
 import GroupsSidebarItem from '@/components/Sidebar/GroupsSidebarItem';
@@ -13,6 +13,7 @@ import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import MobileHeader from '@/components/MobileHeader';
 import Layout from '@/components/Layout/Layout';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
 
 export default function MobileRoot() {
   const [isScrolling, setIsScrolling] = useState(false);
@@ -20,7 +21,7 @@ export default function MobileRoot() {
     debounce((scrolling: boolean) => setIsScrolling(scrolling), 200)
   );
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
-  const groups = useGroups();
+  const { data: groups, isLoading } = useGroupsWithQuery();
   const gangs = useGangList();
   const pinnedGroups = usePinnedGroups();
   const sortedGroups = sortGroups(groups);
@@ -59,33 +60,41 @@ export default function MobileRoot() {
     >
       <nav className="flex h-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
         <div className="flex-1">
-          <GroupsScrollingContext.Provider value={isScrolling}>
-            <GroupList
-              groups={sortedGroups}
-              pinnedGroups={Object.entries(pinnedGroups)}
-              isScrolling={scroll.current}
-            >
-              {Object.entries(pinnedGroups).length > 0 && (
-                <>
-                  <div className="px-4">
-                    <h2 className="mb-0.5 p-2 font-system-sans  text-gray-900">
-                      Pinned Groups
+          {sortedGroups.length === 0 && !isLoading ? (
+            <div className="mx-4 my-2 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
+              Tap the <span className="sr-only">find icon</span>
+              <MagnifyingGlass16Icon className="inline-flex h-4 w-4" /> below to
+              find new groups in your network or view group invites.
+            </div>
+          ) : (
+            <GroupsScrollingContext.Provider value={isScrolling}>
+              <GroupList
+                groups={sortedGroups}
+                pinnedGroups={Object.entries(pinnedGroups)}
+                isScrolling={scroll.current}
+              >
+                {Object.entries(pinnedGroups).length > 0 && (
+                  <>
+                    <div className="px-4">
+                      <h2 className="mb-0.5 p-2 font-system-sans  text-gray-900">
+                        Pinned Groups
+                      </h2>
+                      {pinnedGroupsOptions}
+                    </div>
+                    <h2 className="my-2 ml-2 p-2 pl-4 font-system-sans  text-gray-900">
+                      All Groups
                     </h2>
-                    {pinnedGroupsOptions}
-                  </div>
-                  <h2 className="my-2 ml-2 p-2 pl-4 font-system-sans  text-gray-900">
-                    All Groups
-                  </h2>
-                </>
-              )}
+                  </>
+                )}
 
-              <div className="px-4">
-                {gangs.map((flag) => (
-                  <GangItem key={flag} flag={flag} />
-                ))}
-              </div>
-            </GroupList>
-          </GroupsScrollingContext.Provider>
+                <div className="px-4">
+                  {gangs.map((flag) => (
+                    <GangItem key={flag} flag={flag} />
+                  ))}
+                </div>
+              </GroupList>
+            </GroupsScrollingContext.Provider>
+          )}
         </div>
       </nav>
     </Layout>

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -92,8 +92,9 @@ export function useGroupConnection(flag: string) {
   return useGroupConnectionState((state) => state.groups[flag] ?? true);
 }
 
-export function useGroups() {
-  const { data, ...rest } = useReactQuerySubscription({
+const emptyGroups: Groups = {};
+export function useGroupsWithQuery() {
+  const { data, ...rest } = useReactQuerySubscription<Groups>({
     queryKey: [GROUPS_KEY],
     app: 'groups',
     path: `/groups/ui`,
@@ -103,11 +104,32 @@ export function useGroups() {
     },
   });
 
-  if (rest.isLoading || rest.isError) {
-    return {} as Groups;
+  if (rest.isLoading || rest.isError || !data) {
+    return { data: emptyGroups, ...rest };
   }
 
-  return data as Groups;
+  return {
+    data,
+    ...rest,
+  };
+}
+
+export function useGroups() {
+  const { data, ...rest } = useReactQuerySubscription<Groups>({
+    queryKey: [GROUPS_KEY],
+    app: 'groups',
+    path: `/groups/ui`,
+    scry: `/groups/light/v0`,
+    options: {
+      refetchOnReconnect: false, // handled in bootstrap reconnect flow
+    },
+  });
+
+  if (!data || rest.isLoading || rest.isError) {
+    return emptyGroups;
+  }
+
+  return data;
 }
 
 export function useGroup(flag: string, updating = false): Group | undefined {


### PR DESCRIPTION
This fixes both LAND-902 and LAND-897 by removing the redirects. For 902 we also add in a prompt to go to the find tab since we no longer have a redirect. This is a stopgap until we have a better empty state.

<img width="453" alt="image" src="https://github.com/tloncorp/landscape-apps/assets/5466421/b10f1d25-1bde-43c9-a037-3907c155a3f6">

Fixes LAND-902
Fixes LAND-897
