### PR TITLE
fix take photo flow in mobile safari

### DIFF
--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -180,6 +180,9 @@ const emptyUploader = (key: string, bucket: string): Uploader => ({
       useFileStore.getState().uploadFiles(key, files, bucket);
       input.remove();
     });
+    // Add to DOM for mobile Safari support
+    input.classList.add('hidden');
+    document.body.appendChild(input);
     input.click();
   },
 });


### PR DESCRIPTION
Fixes the "Take a Photo" flow in mobile Safari (and therefore the Groups app webview) by appending the file input to the DOM during file selection