### PR TITLE
mobile: fix padding in about and settings views

### DIFF
--- a/ui/src/components/About/AboutView.tsx
+++ b/ui/src/components/About/AboutView.tsx
@@ -46,7 +46,7 @@ export default function AboutView({ title }: ViewProps) {
         exit="out"
         variants={pageAnimationVariants}
         transition={pageTransition}
-        className="h-screen overflow-y-scroll pt-8"
+        className="overflow-y-scroll px-6 pt-8"
       >
         <About />
       </motion.div>

--- a/ui/src/components/Settings/SettingsView.tsx
+++ b/ui/src/components/Settings/SettingsView.tsx
@@ -35,7 +35,7 @@ export default function SettingsView({ title }: ViewProps) {
       header={
         isMobile ? <MobileHeader title="Settings" pathBack="/profile" /> : null
       }
-      className="h-full flex-1 px-4"
+      className="flex flex-col overflow-y-auto px-4"
     >
       <Helmet>
         <title>{title}</title>
@@ -47,7 +47,7 @@ export default function SettingsView({ title }: ViewProps) {
         exit="out"
         variants={pageAnimationVariants}
         transition={pageTransition}
-        className="h-full overflow-y-scroll px-8 pt-8"
+        className="px-8 pt-8"
       >
         <Settings />
       </motion.div>


### PR DESCRIPTION
![Screenshot 2023-09-19 at 11 12 06 AM](https://github.com/tloncorp/landscape-apps/assets/748181/0f773d21-5da6-4281-99d7-dc20ef343cbc)

![image](https://github.com/tloncorp/landscape-apps/assets/748181/4975921c-52bd-4269-950a-af1ac622931c)

Fixes LAND-933