### PR TITLE
gallery: changing tiptapToString to not have side effects

### DIFF
--- a/ui/src/logic/tiptap.ts
+++ b/ui/src/logic/tiptap.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   Inline,
   InlineKey,
@@ -88,7 +89,7 @@ export function tipTapToString(json: JSONContent): string {
   }
 
   if (json.marks && json.marks.length > 0) {
-    const first = json.marks.pop();
+    const first = _.first(json.marks);
 
     if (!first) {
       throw new Error('Unsure what this is');


### PR DESCRIPTION
Actually fixes LAND-928, our tiptapToString function was unfortunately unsafe.