### PR TITLE
messages: adds MobileHeader

### DIFF
--- a/ui/src/dms/NewDm.tsx
+++ b/ui/src/dms/NewDm.tsx
@@ -4,6 +4,8 @@ import ChatInput from '@/chat/ChatInput/ChatInput';
 import Layout from '@/components/Layout/Layout';
 import useMessageSelector from '@/logic/useMessageSelector';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
+import { isNativeApp } from '@/logic/native';
+import MobileHeader from '@/components/MobileHeader';
 import MessageSelector from './MessageSelector';
 
 export default function NewDM() {
@@ -14,6 +16,11 @@ export default function NewDM() {
   return (
     <Layout
       className="flex-1"
+      header={
+        isNativeApp() && (
+          <MobileHeader title="New Message" pathBack="/messages" />
+        )
+      }
       footer={
         <div
           className={cn(


### PR DESCRIPTION
Fixes LAND-933 again by adding a MobileHeader to the new DM screen (if you're in the mobile app). The Back button goes back to the Messages index.

![image](https://github.com/tloncorp/landscape-apps/assets/748181/c024664e-11c3-48bc-96ba-3f9324a7f672)
