### PR TITLE
groups: echo invites in groups list

### DIFF
--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -168,7 +168,7 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
           )}
         </Action>
         {actions ? (
-          <div className={cn('absolute right-2 sm:right-1')}>
+          <div className={cn('absolute right-2')}>
             {typeof actions === 'function' ? actions({ hover }) : actions}
           </div>
         ) : null}

--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -128,15 +128,15 @@ export default function MobileMessagesSidebar() {
             {filteredPins && filteredPins.length > 0 ? (
               <>
                 <div className="px-4">
-                  <h2 className="my-0.5 p-2 font-system-sans text-lg text-gray-400 sm:text-base">
-                    Pinned Messages
+                  <h2 className="mb-0.5 p-2 font-system-sans text-gray-400">
+                    Pinned
                   </h2>
                   {filteredPins.map((ship: string) => (
                     <MessagesSidebarItem key={ship} whom={ship} />
                   ))}
                 </div>
                 <div className="flex flex-row items-center justify-between px-4">
-                  <h2 className="my-0.5 p-2 font-system-sans text-lg text-gray-400 sm:text-base">
+                  <h2 className="mb-0.5 p-2 font-system-sans text-gray-400">
                     {messagesFilter}
                   </h2>
                 </div>

--- a/ui/src/groups/FindGroups.tsx
+++ b/ui/src/groups/FindGroups.tsx
@@ -13,14 +13,12 @@ import ShipSelector, { ShipOption } from '@/components/ShipSelector';
 import { Gangs, ViewProps } from '@/types/groups';
 import { hasKeys, preSig, whomIsFlag } from '@/logic/utils';
 import { useModalNavigate } from '@/logic/routing';
-import GroupReference from '@/components/References/GroupReference';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import ShipConnection from '@/components/ShipConnection';
 import { useConnectivityCheck } from '@/state/vitals';
 import MobileHeader from '@/components/MobileHeader';
-import GroupJoinList from './GroupJoinList';
+import GroupJoinList, { GroupJoinItem } from './GroupJoinList';
 import GroupJoinListPlaceholder from './GroupJoinListPlaceholder';
-import GroupAvatar from './GroupAvatar';
 
 export default function FindGroups({ title }: ViewProps) {
   const { ship, name } = useParams<{ ship: string; name: string }>();
@@ -191,13 +189,9 @@ export default function FindGroups({ title }: ViewProps) {
         </Helmet>
         <div className="w-full p-6">
           {hasKeys(pendingGangs) ? (
-            <section className={cn('card mb-6 space-y-4')}>
-              <h1
-                className={cn('font-bold', isMobile ? 'text-base' : 'text-lg')}
-              >
-                Pending Invites
-              </h1>
-              <GroupJoinList gangs={pendingGangs} />
+            <section className={cn('card mb-6')}>
+              <h1 className={cn('mb-4 text-lg font-bold')}>Pending Invites</h1>
+              <GroupJoinList highlightAll gangs={pendingGangs} />
             </section>
           ) : null}
           {!selectedShip && (
@@ -206,58 +200,33 @@ export default function FindGroups({ title }: ViewProps) {
               <p className="mb-2 mt-4 leading-6 text-gray-600">
                 Here are some groups we like.
               </p>
-              <p className="mt-2 mb-8 leading-6 text-gray-600">
-                You can find many more in the Urbit Foundation’s{' '}
-                <a
-                  href="https://urbit.org/ecosystem?type=groups"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  directory
-                </a>
-                .
-              </p>
-              <div className="grid grid-cols-1 gap-4">
-                <div className="flex items-center justify-between">
-                  <GroupAvatar
-                    image="https://interstellar.nyc3.digitaloceanspaces.com/battus-datsun/2022.11.07..19.39.22-Sig.png"
-                    size="h-12 w-12 shrink-0"
-                  />
-                  <div className="mx-2 grow space-y-2">
-                    <h2 className="text-base font-semibold">
-                      Urbit Foundation
-                    </h2>
-                    <p className="text-gray-400">
-                      Learn about the Urbit project
-                    </p>
-                  </div>
-                  <GroupReference flag="~halbex-palheb/uf-public" onlyButton />
-                </div>
-                <div className="flex items-center justify-between">
-                  <GroupAvatar
-                    image="https://www.door.link/logowhite.svg"
-                    size="h-12 w-12 shrink-0"
-                  />
-                  <div className="mx-2 grow space-y-2">
-                    <h2 className="text-base font-semibold">door.link</h2>
-                    <p className="text-gray-400">A cult of music lovers</p>
-                  </div>
-                  <GroupReference flag="~natnex-ronret/door-link" onlyButton />
-                </div>
-                <div className="flex items-center justify-between">
-                  <GroupAvatar
-                    image="https://nyc3.digitaloceanspaces.com/fabled-faster/fabled-faster/2023.4.06..02.45.53-tlon-local-pin.svg"
-                    size="h-12 w-12 shrink-0"
-                  />
-                  <div className="mx-2 grow space-y-2">
-                    <h2 className="text-base font-semibold">Tlon Local</h2>
-                    <p className="text-gray-400">
-                      Updates, announcements, and broadcasts from Tlon.
-                    </p>
-                  </div>
-                  <GroupReference flag="~nibset-napwyn/tlon" onlyButton />
-                </div>
-              </div>
+              <GroupJoinItem
+                flag="~halbex-palheb/uf-public"
+                preload={{
+                  title: 'UF',
+                  image:
+                    'https://interstellar.nyc3.digitaloceanspaces.com/battus-datsun/2022.11.07..19.39.22-Sig.png',
+                  description: 'The latest from the Urbit Foundation',
+                }}
+              />
+              <GroupJoinItem
+                flag="~natnex-ronret/door-link"
+                preload={{
+                  title: 'door.link',
+                  image: 'https://www.door.link/logowhite.svg',
+                  description: 'sound/silence cult',
+                }}
+              />
+              <GroupJoinItem
+                flag="~nibset-napwyn/tlon"
+                preload={{
+                  title: 'Tlon Local',
+                  image:
+                    'https://fabled-faster.nyc3.cdn.digitaloceanspaces.com/tlon-locals.svg',
+                  description:
+                    'Updates, announcements, and broadcasts from Tlon',
+                }}
+              />
             </section>
           )}
           <section className={cn('card mb-6 space-y-8')}>
@@ -292,8 +261,10 @@ export default function FindGroups({ title }: ViewProps) {
               </div>
             </div>
             {selectedShip || (ship && name) ? (
-              <section className="space-y-3">
-                <p className="font-semibold text-gray-400">{resultsTitle()}</p>
+              <section>
+                <p className="mb-3 font-semibold text-gray-400">
+                  {resultsTitle()}
+                </p>
                 {fetchStatus === 'fetching' ? (
                   <GroupJoinListPlaceholder />
                 ) : hasResults ? (

--- a/ui/src/groups/GroupJoinList.tsx
+++ b/ui/src/groups/GroupJoinList.tsx
@@ -1,101 +1,95 @@
 import cn from 'classnames';
-import { useIsMobile } from '@/logic/useMedia';
 import { Gang, Gangs } from '@/types/groups';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import { matchesBans, pluralRank, toTitleCase } from '@/logic/utils';
-import GroupSummary from './GroupSummary';
+import { matchesBans } from '@/logic/utils';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import { useGang } from '@/state/groups';
 import useGroupJoin from './useGroupJoin';
+import GroupAvatar from './GroupAvatar';
 
 interface GroupJoinItemProps {
   flag: string;
-  gang: Gang;
+  highlight?: boolean;
+  preload?: {
+    title?: string;
+    description?: string;
+    image?: string;
+  };
 }
 
-function GroupJoinItem({ flag, gang }: GroupJoinItemProps) {
-  const { open, reject, button, status, group, rejectStatus } = useGroupJoin(
-    flag,
-    gang,
-    true
-  );
-  const isMobile = useIsMobile();
+export function GroupJoinItem({
+  flag,
+  highlight,
+  preload,
+}: GroupJoinItemProps) {
+  const gang: Gang = useGang(flag);
+  const { open, button, status, group } = useGroupJoin(flag, gang, true);
   const cordon = gang.preview?.cordon || group?.cordon;
   const banned = cordon ? matchesBans(cordon, window.our) : null;
 
   return (
-    <li className="relative mb-2 flex items-center sm:mb-0">
-      <button
-        className="flex w-full items-center justify-start rounded-xl bg-gray-50 p-2 text-left hover:bg-gray-50 sm:bg-transparent"
-        onClick={open}
-      >
-        <GroupSummary
-          flag={flag}
-          preview={gang.preview}
-          size={'small'}
-          check={false}
-        />
-      </button>
-      <div className="absolute right-2 flex flex-row">
-        {banned ? (
-          <span className="inline-block px-2 font-semibold text-gray-600">
-            {banned === 'ship'
-              ? "You've been banned from this group"
-              : `${toTitleCase(pluralRank(banned))} are banned`}
-          </span>
+    <SidebarItem
+      onClick={() => open()}
+      className={highlight ? 'bg-blue-soft dark:bg-blue-900' : ''}
+      icon={
+        !gang.preview && preload ? (
+          <GroupAvatar {...preload} className="flex-none" size={'h-12 w-12'} />
         ) : (
-          <>
-            {gang.invite && status !== 'loading' ? (
-              <button
-                className={cn(
-                  'bg-red-soft text-red mix-blend-multiply dark:bg-red-900 dark:mix-blend-screen',
-                  isMobile ? 'small-button' : 'button'
-                )}
-                onClick={reject}
-                disabled={
-                  rejectStatus === 'loading' || rejectStatus === 'error'
-                }
-              >
-                {rejectStatus === 'loading' ? (
-                  <LoadingSpinner className="h-4 w-4" />
-                ) : rejectStatus === 'error' ? (
-                  'Errored'
-                ) : (
-                  'Reject'
-                )}
-              </button>
-            ) : null}
-            {status === 'loading' ? (
-              <div className="flex items-center justify-center space-x-2">
-                <LoadingSpinner className="h-4 w-4" />
-              </div>
-            ) : (
-              <button
-                className={cn(
-                  'ml-2 bg-blue-soft text-blue mix-blend-multiply disabled:bg-gray-100 dark:bg-blue-900 dark:mix-blend-screen dark:disabled:bg-gray-100',
-                  isMobile ? 'small-button' : 'button'
-                )}
-                onClick={open}
-              >
-                {status === 'error' ? 'Errored' : button.text}
-              </button>
+          <GroupAvatar
+            {...gang.preview?.meta}
+            className="flex-none"
+            size={'h-12 w-12'}
+          />
+        )
+      }
+      actions={
+        banned ? (
+          <div className="rounded-full bg-red-soft py-1 px-2 text-sm font-medium text-red ">
+            Banned
+          </div>
+        ) : status === 'loading' ? (
+          <div className="flex items-center justify-center space-x-2">
+            <LoadingSpinner className="h-4 w-4" />
+          </div>
+        ) : (
+          <button
+            className={cn(
+              'rounded-full bg-blue-soft py-1 px-2 text-sm font-medium text-blue mix-blend-multiply disabled:bg-gray-100  dark:bg-blue-500 dark:text-black dark:mix-blend-screen dark:disabled:bg-gray-100 '
             )}
-          </>
+            onClick={open}
+          >
+            {status === 'error' ? 'Errored' : button.text}
+          </button>
+        )
+      }
+    >
+      <div className="flex h-12 flex-col justify-center">
+        <h2>{gang.preview?.meta.title || preload?.title || flag}</h2>
+        {preload?.description && (
+          <p className="pr-12 text-sm font-normal text-gray-400 line-clamp-1 sm:mt-1">
+            {preload?.description}
+          </p>
         )}
       </div>
-    </li>
+    </SidebarItem>
   );
 }
 
 interface GroupJoinListProps {
   gangs: Gangs;
+  highlightAll?: boolean;
 }
 
-export default function GroupJoinList({ gangs }: GroupJoinListProps) {
+export default function GroupJoinList({
+  gangs,
+  highlightAll,
+}: GroupJoinListProps) {
   const gangEntries = Object.entries(gangs);
   return (
-    <ul>
-      {gangEntries.map(([flag, gang]) => (
-        <GroupJoinItem key={flag} flag={flag} gang={gang} />
+    <>
+      {gangEntries.map(([flag]) => (
+        <GroupJoinItem highlight={highlightAll} key={flag} flag={flag} />
       ))}
-    </ul>
+    </>
   );
 }

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -3,7 +3,11 @@ import { Link } from 'react-router-dom';
 import { debounce } from 'lodash';
 import useGroupSort from '@/logic/useGroupSort';
 import { usePinnedGroups } from '@/state/chat';
-import { useGangList, useGroupsWithQuery } from '@/state/groups';
+import {
+  useGangList,
+  useGroupsWithQuery,
+  usePendingGangsWithoutClaim,
+} from '@/state/groups';
 import GroupList from '@/components/Sidebar/GroupList';
 import SidebarSorter from '@/components/Sidebar/SidebarSorter';
 import GroupsSidebarItem from '@/components/Sidebar/GroupsSidebarItem';
@@ -14,6 +18,7 @@ import MobileHeader from '@/components/MobileHeader';
 import Layout from '@/components/Layout/Layout';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
 import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
+import GroupJoinList from '@/groups/GroupJoinList';
 
 export default function MobileRoot() {
   const [isScrolling, setIsScrolling] = useState(false);
@@ -23,6 +28,7 @@ export default function MobileRoot() {
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
   const { data: groups, isLoading } = useGroupsWithQuery();
   const gangs = useGangList();
+  const pendingGangs = usePendingGangsWithoutClaim();
   const pinnedGroups = usePinnedGroups();
   const sortedGroups = sortGroups(groups);
   const pinnedGroupsOptions = useMemo(
@@ -38,7 +44,7 @@ export default function MobileRoot() {
       className="flex-1 bg-white"
       header={
         <MobileHeader
-          title="All Groups"
+          title="Groups"
           action={
             <div className="flex h-12 items-center justify-end space-x-2">
               <ReconnectingSpinner />
@@ -74,18 +80,28 @@ export default function MobileRoot() {
                 isScrolling={scroll.current}
               >
                 {Object.entries(pinnedGroups).length > 0 && (
-                  <>
-                    <div className="px-4">
-                      <h2 className="mb-0.5 p-2 font-system-sans  text-gray-900">
-                        Pinned Groups
-                      </h2>
-                      {pinnedGroupsOptions}
-                    </div>
-                    <h2 className="my-2 ml-2 p-2 pl-4 font-system-sans  text-gray-900">
-                      All Groups
+                  <div className="px-4">
+                    <h2 className="mb-0.5 p-2 font-system-sans text-gray-400">
+                      Pinned
                     </h2>
-                  </>
+                    {pinnedGroupsOptions}
+                  </div>
                 )}
+                {Object.entries(pendingGangs).length > 0 && (
+                  <div className="px-4">
+                    <h2 className="mb-0.5 p-2 font-system-sans text-gray-400">
+                      Invites
+                    </h2>
+                    <GroupJoinList highlightAll gangs={pendingGangs} />
+                  </div>
+                )}
+
+                {Object.entries(pinnedGroups).length > 0 ||
+                Object.entries(pendingGangs).length > 0 ? (
+                  <h2 className="my-2 ml-2 p-2 pl-4 font-system-sans text-gray-400">
+                    All Groups
+                  </h2>
+                ) : null}
 
                 <div className="px-4">
                   {gangs.map((flag) => (


### PR DESCRIPTION
- Reuses GroupJoinList in MobileRoot, which fixes LAND-947
- Shifts GroupJoinItem to use SidebarItem to allow them to slot in to the Groups list with uniform appearance
- Adds an optional highlightAll prop to GroupJoinList, which is passed down to GroupJoinItem to show a blue-soft background
- Adds an optional "preload" prop to GroupJoinItem for pre-filling the group item with static data until the gang data arrives; used in the "Find Groups" screen for the UF, door, and Tlon Local suggestions
- Unifies the separators in the Messages list with the Groups list
- Does NOT remove the "Find Groups" screen from the nav or invites from the Activity stream; meant to be an incremental change