### PR TITLE
groups: activity indicators in mobile navbar

### DIFF
--- a/ui/src/components/NavTab.tsx
+++ b/ui/src/components/NavTab.tsx
@@ -25,15 +25,12 @@ export default function NavTab({
   ...props
 }: NavTabProps) {
   return (
-    <li className={cn('flex-1 text-xs font-semibold', className)}>
+    <li className={cn('flex-1', className)}>
       {isNavLinkProps(props) ? (
         <NavLink
           {...props}
           to={props.to}
-          className={cn(
-            'flex h-full w-full flex-col items-center justify-center bg-white py-2 text-black',
-            linkClass
-          )}
+          className={cn('flex flex-col items-center pt-3 pb-3', linkClass)}
         >
           {children}
         </NavLink>
@@ -41,7 +38,7 @@ export default function NavTab({
         <a
           {...props}
           className={cn(
-            'flex h-full w-full flex-col items-center justify-center bg-white p-2 text-black',
+            'flex h-full flex-col items-center pt-3 pb-[2px]',
             linkClass
           )}
         >

--- a/ui/src/components/NavTab.tsx
+++ b/ui/src/components/NavTab.tsx
@@ -30,7 +30,10 @@ export default function NavTab({
         <NavLink
           {...props}
           to={props.to}
-          className={cn('flex flex-col items-center pt-3 pb-3', linkClass)}
+          className={cn(
+            'flex h-full w-full items-center justify-center',
+            linkClass
+          )}
         >
           {children}
         </NavLink>
@@ -38,7 +41,7 @@ export default function NavTab({
         <a
           {...props}
           className={cn(
-            'flex h-full flex-col items-center pt-3 pb-[2px]',
+            'flex h-full flex-col items-center justify-end pb-0.5',
             linkClass
           )}
         >

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -4,6 +4,7 @@ import { isNativeApp, useSafeAreaInsets } from '@/logic/native';
 import { useIsDark } from '@/logic/useMedia';
 import { useIsAnyGroupUnread } from '@/logic/useIsGroupUnread';
 import { useChannelUnreadCounts } from '@/logic/channel';
+import { useNotifications } from '@/notifications/useNotifications';
 import { useLocalState } from '@/state/local';
 import NavTab, { DoubleClickableNavTab } from '../NavTab';
 import BellIcon from '../icons/BellIcon';
@@ -83,6 +84,30 @@ function MessagesTab(props: { isInactive: boolean; isDarkMode: boolean }) {
   );
 }
 
+function ActivityTab(props: { isInactive: boolean; isDarkMode: boolean }) {
+  const navigate = useNavigate();
+  const { count } = useNotifications('', 'all');
+
+  return (
+    <DoubleClickableNavTab
+      onSingleClick={() => navigate('/notifications')}
+      onDoubleClick={() => navigate('/notifications')}
+    >
+      <BellIcon
+        isInactive={props.isInactive}
+        className="h-6 w-6"
+        isDarkMode={props.isDarkMode}
+      />
+      <div
+        className={cn(
+          'mt-[2px] h-1.5 w-1.5 rounded-full',
+          count > 0 && 'bg-blue'
+        )}
+      />
+    </DoubleClickableNavTab>
+  );
+}
+
 export default function MobileSidebar() {
   const location = useLocation();
   const isInactive = (path: string) => !location.pathname.startsWith(path);
@@ -108,13 +133,10 @@ export default function MobileSidebar() {
                 isDarkMode={isDarkMode}
               />
             )}
-            <NavTab to="/notifications">
-              <BellIcon
-                isInactive={isInactive('/notifications')}
-                className="h-6 w-6"
-                isDarkMode={isDarkMode}
-              />
-            </NavTab>
+            <ActivityTab
+              isInactive={isInactive('/notifications')}
+              isDarkMode={isDarkMode}
+            />
             <NavTab to="/find">
               <MagnifyingGlassMobileNavIcon
                 isInactive={isInactive('/find')}

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -2,10 +2,12 @@ import cn from 'classnames';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import { isNativeApp, useSafeAreaInsets } from '@/logic/native';
 import { useIsDark } from '@/logic/useMedia';
+import { useIsAnyGroupUnread } from '@/logic/useIsGroupUnread';
+import { useChannelUnreadCounts } from '@/logic/channel';
 import { useLocalState } from '@/state/local';
 import NavTab, { DoubleClickableNavTab } from '../NavTab';
 import BellIcon from '../icons/BellIcon';
-import GridIcon from '../icons/GridIcon';
+import MenuIcon from '../icons/MenuIcon';
 import HomeIconMobileNav from '../icons/HomeIconMobileNav';
 import MagnifyingGlassMobileNavIcon from '../icons/MagnifyingGlassMobileNavIcon';
 import MessagesIcon from '../icons/MessagesIcon';
@@ -14,6 +16,7 @@ import Avatar from '../Avatar';
 function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
   const navigate = useNavigate();
   const { groupsLocation } = useLocalState.getState();
+  const groupsUnread = useIsAnyGroupUnread();
 
   const onSingleClick = () => {
     if (isNativeApp()) {
@@ -29,12 +32,17 @@ function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={onSingleClick}
       onDoubleClick={() => navigate('/')}
-      linkClass="basis-1/5"
     >
       <HomeIconMobileNav
         isInactive={props.isInactive}
         isDarkMode={props.isDarkMode}
-        className="mb-0.5 h-6 w-6"
+        className="h-6 w-6"
+      />
+      <div
+        className={cn(
+          'mt-[2px] h-1.5 w-1.5 rounded-full',
+          groupsUnread && 'bg-blue'
+        )}
       />
     </DoubleClickableNavTab>
   );
@@ -43,6 +51,7 @@ function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
 function MessagesTab(props: { isInactive: boolean; isDarkMode: boolean }) {
   const navigate = useNavigate();
   const { messagesLocation } = useLocalState.getState();
+  const unreadCount = useChannelUnreadCounts({ scope: 'Direct Messages' });
 
   const onSingleClick = () => {
     if (isNativeApp()) {
@@ -62,7 +71,13 @@ function MessagesTab(props: { isInactive: boolean; isDarkMode: boolean }) {
       <MessagesIcon
         isInactive={props.isInactive}
         isDarkMode={props.isDarkMode}
-        className="mb-0.5 h-6 w-6"
+        className="h-6 w-6"
+      />
+      <div
+        className={cn(
+          'mt-[2px] h-1.5 w-1.5 rounded-full',
+          unreadCount > 0 && 'bg-blue'
+        )}
       />
     </DoubleClickableNavTab>
   );
@@ -87,39 +102,37 @@ export default function MobileSidebar() {
               isInactive={isInactive('/groups') && location.pathname !== '/'}
               isDarkMode={isDarkMode}
             />
-
             {isNativeApp() && (
               <MessagesTab
                 isInactive={isInactive('/messages') && isInactive('/dm')}
                 isDarkMode={isDarkMode}
               />
             )}
-
-            <NavTab to="/notifications" linkClass="basis-1/5">
+            <NavTab to="/notifications">
               <BellIcon
                 isInactive={isInactive('/notifications')}
-                className="mb-0.5 h-6 w-6"
+                className="h-6 w-6"
                 isDarkMode={isDarkMode}
               />
             </NavTab>
-            <NavTab to="/find" linkClass="basis-1/5">
+            <NavTab to="/find">
               <MagnifyingGlassMobileNavIcon
                 isInactive={isInactive('/find')}
                 isDarkMode={isDarkMode}
-                className="mb-0.5 h-6 w-6"
+                className="h-6 w-6"
               />
             </NavTab>
             {!isNativeApp() && (
-              <NavTab to="/leap" linkClass="basis-1/5">
-                <GridIcon
-                  className={cn('mb-0.5 h-8 w-8', {
+              <NavTab to="/leap">
+                <MenuIcon
+                  className={cn('h-6 w-6', {
                     'text-gray-200 dark:text-gray-700': isInactive('/leap'),
                   })}
                 />
               </NavTab>
             )}
-            <NavTab to="/profile" linkClass="basis-1/5">
-              <Avatar size="xs" className="mb-0.5" ship={window.our} />
+            <NavTab to="/profile">
+              <Avatar size="xs" className="" ship={window.our} />
             </NavTab>
           </ul>
         </nav>

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -126,7 +126,7 @@ export default function MobileSidebar() {
       <Outlet />
       <footer className={cn('flex-none border-t-2 border-gray-50')}>
         <nav>
-          <ul className="flex">
+          <ul className="flex h-12">
             <GroupsTab
               isInactive={isInactive('/groups') && location.pathname !== '/'}
               isDarkMode={isDarkMode}

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -33,15 +33,18 @@ function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={onSingleClick}
       onDoubleClick={() => navigate('/')}
+      linkClass="h-12"
     >
-      <HomeIconMobileNav
-        isInactive={props.isInactive}
-        isDarkMode={props.isDarkMode}
-        className="h-6 w-6"
-      />
+      <div className="flex h-8 w-8 items-center justify-center ">
+        <HomeIconMobileNav
+          isInactive={props.isInactive}
+          isDarkMode={props.isDarkMode}
+          className="h-6 w-6"
+        />
+      </div>
       <div
         className={cn(
-          'mt-[2px] h-1.5 w-1.5 rounded-full',
+          'mt-0.5 h-1.5 w-1.5 rounded-full',
           groupsUnread && 'bg-blue'
         )}
       />
@@ -68,12 +71,15 @@ function MessagesTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={onSingleClick}
       onDoubleClick={() => navigate('/messages')}
+      linkClass="h-12"
     >
-      <MessagesIcon
-        isInactive={props.isInactive}
-        isDarkMode={props.isDarkMode}
-        className="h-6 w-6"
-      />
+      <div className="flex h-8 w-8 items-center justify-center ">
+        <MessagesIcon
+          isInactive={props.isInactive}
+          isDarkMode={props.isDarkMode}
+          className="h-6 w-6"
+        />
+      </div>
       <div
         className={cn(
           'mt-[2px] h-1.5 w-1.5 rounded-full',
@@ -92,18 +98,16 @@ function ActivityTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={() => navigate('/notifications')}
       onDoubleClick={() => navigate('/notifications')}
+      linkClass="h-12"
     >
-      <BellIcon
-        isInactive={props.isInactive}
-        className="h-6 w-6"
-        isDarkMode={props.isDarkMode}
-      />
-      <div
-        className={cn(
-          'mt-[2px] h-1.5 w-1.5 rounded-full',
-          count > 0 && 'bg-blue'
-        )}
-      />
+      <div className="flex h-8 w-8 items-center justify-center ">
+        <BellIcon
+          isInactive={props.isInactive}
+          className="h-6 w-6"
+          isDarkMode={props.isDarkMode}
+        />
+      </div>
+      <div className={cn('h-1.5 w-1.5 rounded-full', count > 0 && 'bg-blue')} />
     </DoubleClickableNavTab>
   );
 }
@@ -138,19 +142,23 @@ export default function MobileSidebar() {
               isDarkMode={isDarkMode}
             />
             <NavTab to="/find">
-              <MagnifyingGlassMobileNavIcon
-                isInactive={isInactive('/find')}
-                isDarkMode={isDarkMode}
-                className="h-6 w-6"
-              />
+              <div className="flex h-8 w-8 items-center justify-center">
+                <MagnifyingGlassMobileNavIcon
+                  isInactive={isInactive('/find')}
+                  isDarkMode={isDarkMode}
+                  className="h-6 w-6"
+                />
+              </div>
             </NavTab>
             {!isNativeApp() && (
               <NavTab to="/leap">
-                <MenuIcon
-                  className={cn('h-6 w-6', {
-                    'text-gray-200 dark:text-gray-700': isInactive('/leap'),
-                  })}
-                />
+                <div className="flex h-8 w-8 items-center justify-center">
+                  <MenuIcon
+                    className={cn('h-6 w-6', {
+                      'text-gray-200 dark:text-gray-700': isInactive('/leap'),
+                    })}
+                  />
+                </div>
               </NavTab>
             )}
             <NavTab to="/profile">

--- a/ui/src/logic/useIsGroupUnread.ts
+++ b/ui/src/logic/useIsGroupUnread.ts
@@ -29,3 +29,10 @@ export default function useIsGroupUnread() {
     isGroupUnread,
   };
 }
+
+export function useIsAnyGroupUnread() {
+  const groups = useGroups();
+  const { isGroupUnread } = useIsGroupUnread();
+  if (!groups) return undefined;
+  return Object.keys(groups).some((flag) => isGroupUnread(flag));
+}


### PR DESCRIPTION
- Reformats the navbar slightly to accommodate tap targets with the intended margins, which fixes LAND-894
- Adds useIsAnyGroupUnread, a superset of what is returned by useIsGroupUnread
- Uses a variety of methods (useIsAnyGroupUnread, useChannelUnreadCounts, useNotifications) to show or hide a blue dot under the Groups, Messages, and Activity navigation items
- Converts the Activity navigation item to a DoubleClickableNavTab, since we will want to support linking to the notification context relative to the activity stream (both events are the same now, which might be premature)

Fixes LAND-945