### PR TITLE
talk: add inexact prop to desktop MessagesSidebarItem

### DIFF
--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -45,6 +45,7 @@ function ChannelSidebarItem({
 
   return (
     <SidebarItem
+      inexact
       to={`/groups/${groupFlag}/channels/${nest}`}
       icon={
         <GroupAvatar


### PR DESCRIPTION
Fixes LAND-952 by adding an active state to sidebar items in the Talk desktop sidebar. This bypasses the strict path-checking regex and lights up the sidebar item as active when navigating into a Chat thread.

![image](https://github.com/tloncorp/landscape-apps/assets/748181/34841347-b0d3-4aeb-918a-df02ef5aa0f0)
