### PR TITLE
author: useNavigate() for profile modal

### DIFF
--- a/ui/src/chat/ChatMessage/Author.tsx
+++ b/ui/src/chat/ChatMessage/Author.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import cn from 'classnames';
 import { makePrettyDayAndDateAndTime, useCopy } from '@/logic/utils';
-import { useLocation } from 'react-router';
-import { useModalNavigate } from '@/logic/routing';
+import { useLocation, useNavigate } from 'react-router';
 import Avatar from '@/components/Avatar';
 import ShipName from '@/components/ShipName';
 import RoleBadges from '@/components/RoleBadges';
@@ -30,11 +29,11 @@ export default function Author({
 }: AuthorProps) {
   const location = useLocation();
   const { didCopy, doCopy } = useCopy(ship);
-  const modalNavigate = useModalNavigate();
+  const navigate = useNavigate();
   const timeDisplay = date ? makePrettyDayAndDateAndTime(date) : undefined;
 
   const handleProfileClick = () => {
-    modalNavigate(`/profile/${ship}`, {
+    navigate(`/profile/${ship}`, {
       state: { backgroundLocation: location },
     });
   };


### PR DESCRIPTION
Changes the `Author` component to use useNavigate instead of useModalNavigate. This fixes LAND-953 (where the useModalNavigate hook would direct you to the profile modal without the matching backgroundState, resulting in a blank white screen). 

Note that this is global to `Author`. I checked it everywhere I could possibly find an `Author` with no regression, but would appreciate a second look.