### PR TITLE
navigation: allow user to navigate to last route from back button

### DIFF
--- a/ui/src/channels/ChannelHeader.tsx
+++ b/ui/src/channels/ChannelHeader.tsx
@@ -71,7 +71,7 @@ export default function ChannelHeader({
             {children}
           </div>
         }
-        pathBack={isTalk ? '/' : `/groups/${groupFlag}`}
+        goBack
       />
     );
   }

--- a/ui/src/components/MobileHeader.tsx
+++ b/ui/src/components/MobileHeader.tsx
@@ -7,6 +7,7 @@ export default function MobileHeader({
   secondaryTitle,
   pathBack,
   pathBackText,
+  goBack,
   action,
   secondaryAction,
 }: {
@@ -15,6 +16,7 @@ export default function MobileHeader({
   pathBack?: string;
   pathBackText?: string;
   action?: React.ReactNode;
+  goBack?: boolean;
   secondaryAction?: React.ReactNode;
 }) {
   const safeAreaInsets = useSafeAreaInsets();
@@ -23,7 +25,18 @@ export default function MobileHeader({
       className="grid w-full grid-cols-5 justify-between bg-white font-system-sans"
       style={{ paddingTop: safeAreaInsets.top }}
     >
-      {pathBack ? (
+      {goBack ? (
+        <div className="h-12 pl-4">
+          <Link className="flex h-12 items-center" to={-1 as any}>
+            <CaretLeftIconMobileNav className="h-8 w-8 text-gray-900" />
+            {pathBackText && (
+              <span className="text-[17px] leading-6 text-gray-900">
+                {pathBackText}
+              </span>
+            )}
+          </Link>
+        </div>
+      ) : pathBack ? (
         <div className="h-12 pl-4">
           <Link className="flex h-12 items-center" to={pathBack}>
             <CaretLeftIconMobileNav className="h-8 w-8 text-gray-900" />

--- a/ui/src/groups/ChannelsList/GroupChannelManager.tsx
+++ b/ui/src/groups/ChannelsList/GroupChannelManager.tsx
@@ -46,7 +46,7 @@ export default function GroupChannelManager({ title }: ViewProps) {
               </button>
             </GroupActions>
           }
-          pathBack={`/groups/${flag}`}
+          goBack
         />
       )}
       <div className="flex grow flex-col overflow-auto bg-gray-50 px-2 sm:px-6">

--- a/ui/src/groups/Members.tsx
+++ b/ui/src/groups/Members.tsx
@@ -7,11 +7,11 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import fuzzy from 'fuzzy';
 import { Virtuoso } from 'react-virtuoso';
 import { deSig } from '@urbit/api';
 import { useLocation, useNavigate } from 'react-router';
 import ActionMenu, { Action } from '@/components/ActionMenu';
-import fuzzy from 'fuzzy';
 import Avatar from '@/components/Avatar';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import Divider from '@/components/Divider';
@@ -366,7 +366,7 @@ export default function Members() {
             />
           )
         }
-        pathBack=".."
+        goBack
         action={
           <div className="flex h-12 flex-row items-center justify-end space-x-2">
             <button onClick={() => setToggleSearch(!toggleSearch)}>

--- a/ui/src/groups/MobileGroupChannelList.tsx
+++ b/ui/src/groups/MobileGroupChannelList.tsx
@@ -56,7 +56,7 @@ export default function MobileGroupChannelList() {
             )}
           </div>
         }
-        pathBack="/"
+        goBack
       />
       <ChannelList />
     </>


### PR DESCRIPTION
Fixes LAND-920 by having back buttons in particular components just navigate back to the last route with react-router's `-1` utility.