### PR TITLE
chat: prevent overfetching from scroller

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -241,16 +241,30 @@ export default function ChatScroller({
   // The main place this happens is when there are a bunch of replies in the recent chat history.
   const contentHeight = virtualizer.getTotalSize();
   useEffect(() => {
-    if (contentHeight < window.innerHeight && fetchState === 'initial') {
+    if (
+      contentHeight < window.innerHeight &&
+      fetchState === 'initial' &&
+      // don't try to load more in threads, because their content is already fetched by main window
+      !replying
+    ) {
       const loadingNewer = loadDirection === 'newer';
       if (
         (loadingNewer && !hasLoadedNewest) ||
         (!loadingNewer && !hasLoadedOldest)
       ) {
         fetchMessages(loadingNewer);
+        console.log(
+          contentHeight,
+          window.innerHeight,
+          fetchState,
+          loadDirection,
+          hasLoadedNewest,
+          hasLoadedOldest
+        );
       }
     }
   }, [
+    replying,
     contentHeight,
     fetchMessages,
     fetchState,

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -253,14 +253,6 @@ export default function ChatScroller({
         (!loadingNewer && !hasLoadedOldest)
       ) {
         fetchMessages(loadingNewer);
-        console.log(
-          contentHeight,
-          window.innerHeight,
-          fetchState,
-          loadDirection,
-          hasLoadedNewest,
-          hasLoadedOldest
-        );
       }
     }
   }, [

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -314,7 +314,7 @@ export default function ChatScroller({
   useEffect(() => {
     if (fetchState !== 'initial' || !userHasScrolled) return;
     const chatStore = useChatStore.getState();
-    if (isAtTop) {
+    if (isAtTop && !hasLoadedOldest) {
       setLoadDirection('older');
       chatStore.bottom(false);
       fetchMessages(false);
@@ -330,6 +330,7 @@ export default function ChatScroller({
     isAtBottom,
     fetchMessages,
     whom,
+    hasLoadedOldest,
     hasLoadedNewest,
     userHasScrolled,
   ]);

--- a/ui/src/logic/useScrollerMessages.ts
+++ b/ui/src/logic/useScrollerMessages.ts
@@ -1,7 +1,13 @@
 import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import { isSameDay } from 'date-fns';
-import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import BTree from 'sorted-btree';
 
 import { STANDARD_MESSAGE_FETCH_PAGE_SIZE } from '@/constants';
@@ -187,7 +193,8 @@ export function useMessageData({
     });
 
   const [hasEverLoadedNewest, setHasEverLoadedNewest] = useState(false);
-  const nextHasLoadedNewest = hasLoadedNewest || replying || hasEverLoadedNewest;
+  const nextHasLoadedNewest =
+    hasLoadedNewest || replying || hasEverLoadedNewest;
   useEffect(() => {
     if (nextHasLoadedNewest) {
       setHasEverLoadedNewest(true);
@@ -200,7 +207,7 @@ export function useMessageData({
     activeMessageEntries,
     fetchMessages,
     fetchState,
-    hasLoadedNewest:nextHasLoadedNewest,
+    hasLoadedNewest: nextHasLoadedNewest,
     hasLoadedOldest: replying ? true : hasLoadedOldest,
   };
 }

--- a/ui/src/logic/useScrollerMessages.ts
+++ b/ui/src/logic/useScrollerMessages.ts
@@ -1,7 +1,7 @@
 import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import { isSameDay } from 'date-fns';
-import React, { ReactNode, useCallback, useMemo, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import BTree from 'sorted-btree';
 
 import { STANDARD_MESSAGE_FETCH_PAGE_SIZE } from '@/constants';
@@ -73,7 +73,7 @@ function getMessageItems({
 
 export type MessageFetchState = 'top' | 'bottom' | 'initial';
 
-const DEBUG_FETCH = false;
+const DEBUG_FETCH = true;
 
 function fetchDebugMessage(...args: unknown[]) {
   if (DEBUG_FETCH) {
@@ -141,6 +141,7 @@ export default function useFetchMessages({
     },
     [whom, messages, scrollTo, writWindow]
   );
+
   return useMemo(
     () => ({
       fetchMessages,
@@ -185,13 +186,21 @@ export function useMessageData({
       scrollTo,
     });
 
+  const [hasEverLoadedNewest, setHasEverLoadedNewest] = useState(false);
+  const nextHasLoadedNewest = hasLoadedNewest || replying || hasEverLoadedNewest;
+  useEffect(() => {
+    if (nextHasLoadedNewest) {
+      setHasEverLoadedNewest(true);
+    }
+  }, [nextHasLoadedNewest]);
+
   return {
     activeMessages,
     activeMessageKeys,
     activeMessageEntries,
     fetchMessages,
     fetchState,
-    hasLoadedNewest,
-    hasLoadedOldest,
+    hasLoadedNewest:nextHasLoadedNewest,
+    hasLoadedOldest: replying ? true : hasLoadedOldest,
   };
 }

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -302,7 +302,12 @@ export default function makeWritsStore(
         {
           oldest,
           newest,
-          loadedNewest: dir === 'newer' ? !updates : window.loadedNewest,
+          loadedNewest:
+            dir === 'newer'
+              ? updates
+                ? newest.eq(window.newest)
+                : true
+              : window.loadedNewest,
           loadedOldest: dir === 'older' ? !updates : window.loadedOldest,
         },
         draft.writWindows[whom],


### PR DESCRIPTION
We were missing a few stops so that we didn't just continuously fetch.