### PR TITLE
ui: Edit Profile layout for large devices

### DIFF
--- a/ui/src/profiles/EditProfile/EditProfile.tsx
+++ b/ui/src/profiles/EditProfile/EditProfile.tsx
@@ -233,7 +233,7 @@ export default function EditProfile({ title }: ViewProps) {
           />
         ) : null
       }
-      className="bg-gray-50"
+      className="w-full bg-gray-50"
     >
       <Helmet>
         <title>{title}</title>


### PR DESCRIPTION
This PR adds a style tweak to ensure that the Edit Profile view renders at full width on larger screens. Previously (on `0vp.gv2u9.9hg31.7jgob.84vt5.jobhe.he7k6.kfnia.95i4b.00vu4.eaocr`) it was rendering the content at the mobile width, with extraneous space to the right like so:

<img width="905" alt="image" src="https://github.com/tloncorp/landscape-apps/assets/16504501/886436cd-b152-4376-8776-a887affcbdc7">
