### PR TITLE
landscape: update /grid paths --> /landscape

### DIFF
--- a/ui/e2e/auth.setup.ts
+++ b/ui/e2e/auth.setup.ts
@@ -10,7 +10,7 @@ setup('authenticate', async ({ page }) => {
     .getByPlaceholder('sampel-ticlyt-migfun-falmel')
     .fill((shipManifest as Record<string, any>)[ship].code);
   await page.getByRole('button', { name: 'Continue' }).click();
-  await page.waitForURL('http://localhost:3000/apps/grid/');
+  await page.waitForURL('http://localhost:3000/apps/landscape/');
   await page.context().storageState({ path: authFile });
   await page.getByRole('link', { name: 'Groups' }).waitFor();
 });

--- a/ui/src/components/References/AppReference.tsx
+++ b/ui/src/components/References/AppReference.tsx
@@ -16,7 +16,7 @@ function AppReference({ flag, isScrolling }: AppReferenceProps) {
   const treaty = useTreaty(ship, deskId);
   const calm = useCalm();
   const dark = useIsDark();
-  const href = `/apps/grid/search/${ship}/apps/${ship}/${deskId}`;
+  const href = `/apps/landscape/search/${ship}/apps/${ship}/${deskId}`;
 
   function openLink() {
     window.open(`${window.location.origin}${href}`);

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -116,7 +116,7 @@ export function GroupsAppMenu() {
           <a
             title="Back to Landscape"
             aria-label="Back to Landscape"
-            href="/apps/grid"
+            href="/apps/landscape"
             target="_blank"
             rel="noreferrer"
             className={cn(

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -106,7 +106,7 @@ export function TalkAppMenu() {
           <a
             title="Back to Landscape"
             aria-label="Back to Landscape"
-            href="/apps/grid"
+            href="/apps/landscape"
             target="_blank"
             rel="noreferrer"
             className={cn(


### PR DESCRIPTION
In light of the recent migration from `/grid` --> `/landscape` for 412k, this updates remaining path references throughout the project. 

- `AppReference` - when rendering a link to an app, it now deep links to Landscape instead of Grid
- `Sidebar` & `MessagesSidebar` - both have a 'Back to Landscape' button that now points to `/apps/landscape`  instead of `/apps/grid`

If we're lucky, this might also be a step in the direction of fixing e2e tests (currently broken on `develop`)