### PR TITLE
Fix scroller crash in empty channels

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -141,7 +141,7 @@ export default function ChatScroller({
   );
 
   const [anchorIndex, setAnchorIndex] = useState<number | null>(
-    scrollTo ? null : count - 1
+    scrollTo || count === 0 ? null : count - 1
   );
   const virtualizerRef = useRef<DivVirtualizer>();
   const virtualizer = useVirtualizer({

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -341,7 +341,7 @@ export default function makeWritsStore(
             oldest,
             newest,
             loadedNewest: true,
-            loadedOldest: false,
+            loadedOldest: keys.length === 0,
             latest: true,
           },
           draft.writWindows[whom]


### PR DESCRIPTION
Fixes LAND-963

Two issues here:
- We were attempting to scroll to an undefined index in empty channels
- `hasLoadedOldest` wasn't properly set for empty channels