### PR TITLE
groups: fix chat input jump

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -126,7 +126,6 @@ export default function ChatInput({
   );
   const [replyCite, setReplyCite] = useState<{ cite: Cite }>();
   const groupFlag = useGroupFlag();
-  const isGroupChatInput = !!groupFlag;
   const { privacy } = useGroupPrivacy(groupFlag);
   const pact = usePact(whom);
   const chatInfo = useChatInfo(id);
@@ -140,7 +139,6 @@ export default function ChatInput({
   const files = useMemo(() => uploader?.files, [uploader]);
   const mostRecentFile = uploader?.getMostRecent();
   const { setBlocks } = useChatStore.getState();
-  const safeAreaInsets = useSafeAreaInsets();
 
   const handleDrop = useCallback(
     (fileList: FileList) => {
@@ -513,10 +511,6 @@ export default function ChatInput({
     [id, uploader]
   );
 
-  if (!messageEditor) {
-    return null;
-  }
-
   // @ts-expect-error tsc is not tracking the type narrowing in the filter
   const imageBlocks: ChatImage[] = chatInfo.blocks.filter((b) => 'image' in b);
 
@@ -596,15 +590,17 @@ export default function ChatInput({
           {!isMobile && (
             <Avatar size="xs" ship={window.our} className="mr-2 mb-1" />
           )}
-          <MessageEditor
-            editor={messageEditor}
-            className={cn(
-              'w-full break-words',
-              uploader && !uploadError && mostRecentFile?.status !== 'loading'
-                ? 'pr-8'
-                : ''
-            )}
-          />
+          {messageEditor && (
+            <MessageEditor
+              editor={messageEditor}
+              className={cn(
+                'w-full break-words',
+                uploader && !uploadError && mostRecentFile?.status !== 'loading'
+                  ? 'pr-8'
+                  : ''
+              )}
+            />
+          )}
           {uploader && !uploadError && mostRecentFile?.status !== 'loading' ? (
             <button
               title={'Upload an image'}
@@ -635,7 +631,8 @@ export default function ChatInput({
           mostRecentFile?.status === 'loading' ||
           mostRecentFile?.status === 'error' ||
           mostRecentFile?.url === '' ||
-          (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
+          !messageEditor ||
+          (messageEditor?.getText() === '' && chatInfo.blocks.length === 0)
         }
         onMouseDown={(e) => {
           e.preventDefault();


### PR DESCRIPTION
Fixes [LAND-803](https://linear.app/tlon/issue/LAND-803/chat-apparent-flicker-between-chat-channels-on-mobile)

The message editor is initially null when rendering the input, which means that the input is never rendered on the first pass. Currently, this causes content to jump up immediately after the first render. This PR fixes that by rendering the input HTML before the editor is initialized.