### PR TITLE
reconnects: make sure we restart channel if too much time has passed

### DIFF
--- a/ui/src/state/local.ts
+++ b/ui/src/state/local.ts
@@ -36,7 +36,7 @@ export const useLocalState = create<LocalState>(
       showDevTools: import.meta.env.DEV,
       errorCount: 0,
       airLockErrorCount: 0,
-      lastReconnect: 0,
+      lastReconnect: Date.now(),
       onReconnect: null,
     }),
     {


### PR DESCRIPTION
Changes the behavior of our airlock to always start a new channel instead of reconnecting after a minute on mobile or an hour on desktop.

Should fix LAND-968 also address instances where the urbit channel gets reaped aka after 12hrs of no events which currently isn't handled by the @urbit/js-http-api package. This is super hard to test in dev, so I think it's best just to ship and test in real conditions. 