### PR TITLE
chat: fix unread banner

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -950,6 +950,18 @@
       %del-feel  =(src.bowl p.delta)
   ==
 ::
+++  diff-to-response
+  |=  [=diff:writs:c =pact:c]
+  ^-  (unit response:writs:c)
+  =;  delta
+    ?~  delta  ~
+    `[p.diff delta]
+  ?+  -.q.diff  q.diff
+      %add
+    =/  time=(unit time)  (~(get by dex.pact) p.diff)
+    ?~  time  ~
+    [%add p.q.diff u.time]
+  ==
 ++  from-self  =(our src):bowl
 ++  cu-abed  cu-abed:cu-core
 ::
@@ -1055,6 +1067,11 @@
     =.  cor
       =/  =cage  writ-diff+!>(diff)
       (emit %give %fact ~[(welp cu-area /ui/writs)] cage)
+    =/  response=(unit response:writs:c)  (diff-to-response diff pact.club)
+    ?~  response  cu-core
+    =.  cor
+      =/  =cage  writ-response+!>(u.response)
+      (emit %give %fact ~[(welp cu-area /ui/writs)] cage)
     cu-core
   ::
   ++  cu-diff
@@ -1069,7 +1086,7 @@
     =.  cor  (emil (gossip:cu-pass diff))
     =.  cu-core
       ?+  -.delta  (cu-give-action [id diff])
-          %writ  (cu-give-writs-diff diff.delta)
+          %writ  cu-core
       ==
     ?-    -.delta
     ::
@@ -1093,15 +1110,15 @@
         %writ
       =.  pact.club  (reduce:cu-pact now.bowl diff.delta)
       ?-  -.q.diff.delta
-          ?(%del %add-feel %del-feel)  cu-core
+          ?(%del %add-feel %del-feel)  (cu-give-writs-diff diff.delta)
           %add
         =/  memo=memo:c  p.q.diff.delta
         =?  remark.club  =(author.memo our.bowl)
           remark.club(last-read `@da`(add now.bowl (div ~s1 100)))
         =.  cor  (give-brief club/id cu-brief)
-        ?:  =(our.bowl author.memo)  cu-core
+        ?:  =(our.bowl author.memo)  (cu-give-writs-diff diff.delta)
         ?-  -.content.memo
-            %notice  cu-core
+            %notice  (cu-give-writs-diff diff.delta)
             %story
           =/  new-yarn
             %+  cu-spin
@@ -1112,7 +1129,7 @@
             ~
           =?  cor  (want-hark ~ %to-us)
             (emit (pass-hark new-yarn))
-          cu-core
+          (cu-give-writs-diff diff.delta)
         ==
       ==
     ::
@@ -1606,8 +1623,14 @@
     =/  cag=cage  [upd:mar:c !>([time d])]
     =.  cor  (give %fact ~[/ui] act:mar:c !>([flag [time d]]))
     =?  cor  ?=(%writs -.d)
-      =/  =cage  writ-diff+!>(p.d)
-      (give %fact ~[(welp ca-area /ui/writs)] writ-diff+!>(p.d))
+      =/  wire  ~[(welp ca-area /ui/writs)]
+      %-  emil
+      %+  welp
+        ~[[%give %fact wire writ-diff+!>(p.d)]]
+      =/  response=(unit response:writs:c)
+        (diff-to-response p.d pact.chat)
+      ?~  response  ~
+      ~[[%give %fact wire writ-response+!>(u.response)]]
     =.  cor  (give %fact ~(tap in paths) cag)
     ca-core
   ::
@@ -1899,6 +1922,11 @@
     =.  cor  (emit %pass wire %agent [our.bowl %contacts] %poke cage)
     =/  old-brief  di-brief
     =.  pact.dm  (reduce:di-pact now.bowl diff)
+    =/  response=(unit response:writs:c)  (diff-to-response diff pact.dm)
+    ~&  response
+    =.  cor
+      ?~  response   cor
+      (give %fact ~[path] writ-response+!>(u.response))
     =?  cor  &(=(net.dm %invited) !=(ship our.bowl))
       (give-invites ship)
     =.  di-core

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1629,6 +1629,7 @@
         ~[[%give %fact wire writ-diff+!>(p.d)]]
       =/  response=(unit response:writs:c)
         (diff-to-response p.d pact.chat)
+      ~&  [response p.d]
       ?~  response  ~
       ~[[%give %fact wire writ-response+!>(u.response)]]
     =.  cor  (give %fact ~(tap in paths) cag)
@@ -1661,7 +1662,9 @@
     =.  log.chat
       (put:log-on:c log.chat time d)
     =.  ca-core
-      (ca-give-updates time d)
+      ?+  -.d  (ca-give-updates time d)
+        %writs  ca-core
+      ==
     ?-    -.d
         %add-sects
       ?>  ca-from-host
@@ -1689,6 +1692,7 @@
               &(ca-am-host (check-writ-ownership p.d))
           ==
       =.  pact.chat  (reduce:ca-pact time p.d)
+      =.  ca-core  (ca-give-updates time d)
       ?-  -.delta
           ?(%del %add-feel %del-feel)  ca-core
           %add

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -10,6 +10,9 @@
     ^-  json
     s/(rap 3 (scot %p p.f) '/' q.f ~)
   ::
+  ++  time-id
+    |=  =@da
+    s+`@t`(rsh 4 (scot %ui da))
   ++  said
     |=  s=said:c
     ^-  json
@@ -207,6 +210,26 @@
       %del       ~
       %add-feel  (add-feel +.delta)
       %del-feel  (ship p.delta)
+    ==
+  ++  writs-response
+    |=  =response:writs:c
+    %-  pairs
+    :~  id/(id id.response)
+        response/(response-delta response.response)
+    ==
+  ::
+  ++  response-delta
+    |=  delta=response-delta:writs:c
+    %+  frond  -.delta
+    ?-  -.delta
+        %del       ~
+        %add-feel  (add-feel [ship feel]:delta)
+        %del-feel  (ship ship.delta)
+        %add
+      %-  pairs
+      :~  memo+(memo memo.delta)
+          time+(time-id time.delta)
+      ==
     ==
   ++  add-feel
     |=  [her=@p =feel:c]

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -195,6 +195,12 @@
       %del-sects  a/(turn ~(tap in p.diff) (lead %s))
     ==
   ::
+  ++  writ-entry
+    |=  [tim=^time w=writ:c]
+    %-  pairs
+    :~  time/(time-id tim)
+        writ/(writ w)
+    ==
   ++  writs-diff
     |=  =diff:writs:c
     %-  pairs

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -91,6 +91,17 @@
     writ(feels (~(del by feels.writ) p.del))
   ==
 ::
+++  get-around
+  |=  [=time count=@ud]
+  ^-  (unit (unit cage))
+  =/  older  (bat:mope wit.pac `time count)
+  =/  newer  (tab:on:writs:c wit.pac `time count)
+  =/  writ   (get:on:writs:c wit.pac time)
+  =-  ``chat-writs+!>(-)
+  %+  gas:on:writs:c  *writs:c
+  ?~  writ
+    (welp older newer)
+  (welp (snoc older [time u.writ]) newer)
 ++  peek
   |=  [care=@tas =(pole knot)]
   ^-  (unit (unit cage))
@@ -112,16 +123,17 @@
     ``chat-writs+!>((gas:on *writs:c (tab:on wit.pac `start count)))
   ::
       [%around time=@ count=@ ~]
-    =/  count  (slav %ud count.pole)
-    =/  time  (slav %ud time.pole)
-    =/  older  (bat:mope wit.pac `time count)
-    =/  newer  (tab:on:writs:c wit.pac `time count)
-    =/  writ   (get:on:writs:c wit.pac time)
-    =-  ``chat-writs+!>(-)
-    %+  gas:on  *writs:c
-    ?~  writ
-      (welp older newer)
-    (welp (snoc older [time u.writ]) newer)
+    =/  time    (slav %ud time.pole)
+    =/  count   (slav %ud count.pole)
+    (get-around time count)
+  ::
+      [%around ship=@ time=@ count=@ ~]
+    =/  ship    (slav %p ship.pole)
+    =/  time    (slav %ud time.pole)
+    =/  count   (slav %ud count.pole)
+    =/  entry   (get ship `@da`time)
+    ?~  entry  ``chat-writs+!>(*writs:c)
+    (get-around time.u.entry count)
   ::
       [%writ %id ship=@ time=@ ~]
     =/  ship  (slav %p ship.pole)

--- a/desk/mar/writ-response.hoon
+++ b/desk/mar/writ-response.hoon
@@ -1,0 +1,14 @@
+/-  c=chat
+/+  j=chat-json
+|_  =response:writs:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  response
+  ++  json  (writs-response:enjs:j response)
+  --
+++  grab
+  |%
+  ++  noun  response:writs:c
+  --
+--

--- a/desk/mar/writ.hoon
+++ b/desk/mar/writ.hoon
@@ -1,0 +1,14 @@
+/-  c=chat
+/+  j=chat-json
+|_  [=time =writ:c]
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  [time writ]
+  ++  json  (writ-entry:enjs:j time writ)
+  --
+++  grab
+  |%
+  ++  noun  [time writ:c]
+  --
+--

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -181,6 +181,13 @@
         [%add-feel p=ship q=feel]
         [%del-feel p=ship]
     ==
+  +$  response  [=id response=response-delta]
+  +$  response-delta
+    $%  [%add =memo =time]
+        [%del ~]
+        [%add-feel =ship =feel]
+        [%del-feel =ship]
+    ==
   --
 ::
 ::  $dm: a direct line of communication between two ships
@@ -199,11 +206,11 @@
         =net
         pin=_|
     ==
-  +$  net     ?(%inviting %invited %archive %done)
-  +$  id      (pair ship time)
-  +$  diff    diff:writs
-  +$  action  (pair ship diff)
-  +$  rsvp    [=ship ok=?]
+  +$  net       ?(%inviting %invited %archive %done)
+  +$  id        (pair ship time)
+  +$  diff      diff:writs
+  +$  action    (pair ship diff)
+  +$  rsvp      [=ship ok=?]
   --
 ::
 ::  $log: a time ordered map of all modifications to chats

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -66,6 +66,7 @@ function ChatChannel({ title }: ViewProps) {
   // We only inset the bottom for groups, since DMs display the navbar
   // underneath this view
   const bottomInset = group ? safeAreaInsets.bottom : 0;
+  const root = `/groups/${groupFlag}/channels/${nest}`;
 
   const joinChannel = useCallback(async () => {
     setJoining(true);
@@ -126,7 +127,7 @@ function ChatChannel({ title }: ViewProps) {
                 <>
                   <ChatSearch
                     whom={chFlag}
-                    root={`/groups/${groupFlag}/channels/${nest}`}
+                    root={root}
                     placeholder={
                       channel ? `Search in ${channel.meta.title}` : 'Search'
                     }
@@ -208,7 +209,7 @@ function ChatChannel({ title }: ViewProps) {
               : title}
           </title>
         </Helmet>
-        <ChatWindow whom={chFlag} />
+        <ChatWindow whom={chFlag} root={root} />
       </Layout>
       <Routes>
         {isSmall ? null : (

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -179,7 +179,7 @@ const ChatMessage = React.memo<
         return aTime.compare(bTime);
       });
       const lastReply = _.last(repliesSortedByTime);
-      const lastReplyWrit = useWrit(whom, lastReply ?? '')!;
+      const { entry: lastReplyWrit } = useWrit(whom, lastReply ?? '');
       const lastReplyTime = lastReplyWrit
         ? new Date(daToUnix(lastReplyWrit[0]))
         : new Date();

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -42,7 +42,8 @@ export default function ChatThread() {
   const groupFlag = useRouteGroup();
   const { sendMessage } = useChatState.getState();
   const location = useLocation();
-  const scrollTo = new URLSearchParams(location.search).get('msg');
+  const msg = new URLSearchParams(location.search).get('msg');
+  const scrollTo = msg ? bigInt(msg) : undefined;
   const channel = useChannel(groupFlag, `chat/${flag}`)!;
   const { isOpen: leapIsOpen } = useLeap();
   const id = `${idShip!}/${idTime!}`;
@@ -90,11 +91,13 @@ export default function ChatThread() {
   );
   useEventListener('keydown', onEscape, threadRef);
 
-  // useEffect(() => {
-  //   if (whom && id) {
-  //     useChatState.getState().fetchMessagesAround(whom, '50', id);
-  //   }
-  // }, [whom, id]);
+  useEffect(() => {
+    if (scrollTo && !replies.has(scrollTo)) {
+      useChatState.getState().fetchMessagesAround(whom, '25', scrollTo);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollTo?.toString(), replies]);
 
   const BackButton = isMobile ? Link : 'div';
 
@@ -167,7 +170,7 @@ export default function ChatThread() {
             whom={whom}
             scrollerRef={scrollerRef}
             replying
-            scrollTo={scrollTo ? bigInt(scrollTo) : undefined}
+            scrollTo={scrollTo}
           />
         )}
       </div>

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -1,94 +1,45 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { format, isToday } from 'date-fns';
-import { daToUnix, udToDec } from '@urbit/api';
-import bigInt, { BigInteger } from 'big-integer';
-import { VirtuosoHandle } from 'react-virtuoso';
+import { daToUnix } from '@urbit/api';
+import { Link } from 'react-router-dom';
 import XIcon from '@/components/icons/XIcon';
 import { pluralize } from '@/logic/utils';
-import {
-  useChatKeys,
-  useChatState,
-  useGetFirstUnreadID,
-  useWrit,
-} from '@/state/chat';
+import { useChatState, useWrit } from '@/state/chat';
 import { useChatInfo, useChatStore } from './useChatStore';
 
 interface ChatUnreadAlertsProps {
-  scrollerRef: React.RefObject<VirtuosoHandle>;
   whom: string;
+  root: string;
 }
 
 export default function ChatUnreadAlerts({
-  scrollerRef,
   whom,
+  root,
 }: ChatUnreadAlertsProps) {
   const chatInfo = useChatInfo(whom);
-  const maybeWrit = useWrit(whom, chatInfo?.unread?.brief['read-id'] || '');
-  let replyToId: BigInteger = bigInt(0);
-  if (maybeWrit) {
-    const [_, writ] = maybeWrit;
-    const replyTo = writ.memo.replying || '';
-    replyToId =
-      replyTo !== ''
-        ? bigInt(replyTo.split('/')[1].replaceAll('.', ''))
-        : bigInt(0);
-  }
+  const id = chatInfo?.unread?.brief['read-id'] || '';
+  const { entry: maybeWrit } = useWrit(whom, id);
   const markRead = useCallback(() => {
     useChatState.getState().markRead(whom);
     useChatStore.getState().read(whom);
   }, [whom]);
 
-  // TODO: how to handle replies?
-  const firstUnreadID = useGetFirstUnreadID(whom);
-  const keys = useChatKeys({ whom, replying: false });
-  const goToFirstUnread = useCallback(() => {
-    if (!scrollerRef.current) {
-      return;
-    }
-
-    if (replyToId !== bigInt(0)) {
-      const idx = keys.findIndex((k) => k.greaterOrEquals(replyToId));
-      if (idx === -1) {
-        return;
-      }
-
-      scrollerRef.current.scrollToIndex({
-        index: idx,
-        align: 'start',
-        behavior: 'auto',
-      });
-    }
-
-    if (!firstUnreadID) {
-      return;
-    }
-
-    const idx = keys.findIndex((k) => k.greaterOrEquals(firstUnreadID));
-    if (idx === -1) {
-      return;
-    }
-
-    scrollerRef.current.scrollToIndex({
-      index: idx,
-      align: 'start',
-      behavior: 'auto',
-    });
-  }, [firstUnreadID, keys, scrollerRef, replyToId]);
-
-  if (!chatInfo.unread || chatInfo.unread.seen) {
+  const [time, writ] = maybeWrit ?? [null, null];
+  if (!time || !writ || !chatInfo.unread || chatInfo.unread.seen) {
     return null;
   }
 
-  const { brief } = chatInfo.unread;
-  const readId = brief['read-id'];
-  const udTime = readId
-    ? daToUnix(bigInt(udToDec(readId.split('/')[1])))
-    : null;
-  const date = udTime ? new Date(udTime) : new Date();
+  const scrollTo = `?msg=${time.toString()}`;
+  const to = writ.memo.replying
+    ? `${root}/message/${writ.memo.replying}${scrollTo}`
+    : `${root}${scrollTo}`;
+
+  const date = new Date(daToUnix(time));
   const since = isToday(date)
     ? `${format(date, 'HH:mm')} today`
     : format(date, 'LLLL d');
 
+  const { brief } = chatInfo.unread;
   const unreadMessage =
     brief &&
     `${brief.count} new ${pluralize('message', brief.count)} since ${since}`;
@@ -100,14 +51,14 @@ export default function ChatUnreadAlerts({
   return (
     <>
       <div className="absolute top-2 left-1/2 z-20 flex w-full -translate-x-1/2 flex-wrap items-center justify-center gap-2">
-        <button
+        <Link
+          to={to}
           className="button whitespace-nowrap bg-blue-soft text-sm text-blue dark:bg-blue-900 lg:text-base"
-          onClick={goToFirstUnread}
         >
           <span className="whitespace-nowrap font-normal">
             {unreadMessage}&nbsp;&mdash;&nbsp;Click to View
           </span>
-        </button>
+        </Link>
         <button
           className="button whitespace-nowrap bg-blue-soft px-2 text-sm text-blue dark:bg-blue-900 lg:text-base"
           onClick={markRead}

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -59,12 +59,12 @@ export default function ChatWindow({
   }, [setSearchParams]);
 
   useEffect(() => {
-    if (scrollTo && !messages.has(scrollTo) && !thread) {
+    if (scrollTo && !thread) {
       useChatState.getState().fetchMessagesAround(whom, '25', scrollTo);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollTo?.toString(), messages, thread]);
+  }, [scrollTo?.toString(), thread]);
 
   useEffect(() => {
     useChatStore.getState().setCurrent(whom);

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { ReactNode, useCallback, useEffect, useRef } from 'react';
 import _ from 'lodash';
 import bigInt from 'big-integer';
 import { useMatch, useSearchParams } from 'react-router-dom';
@@ -16,14 +10,15 @@ import {
   useMessagesForChat,
   useWritWindow,
 } from '@/state/chat';
+import { useRouteGroup } from '@/state/groups';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import ArrowS16Icon from '@/components/icons/ArrowS16Icon';
-import { useRouteGroup } from '@/state/groups';
 import { useChatInfo, useChatStore } from './useChatStore';
 import ChatScrollerPlaceholder from './ChatScroller/ChatScrollerPlaceholder';
 
 interface ChatWindowProps {
   whom: string;
+  root: string;
   prefixedElement?: ReactNode;
 }
 
@@ -40,13 +35,18 @@ function getScrollTo(
   return msg ? bigInt(msg) : undefined;
 }
 
-export default function ChatWindow({ whom, prefixedElement }: ChatWindowProps) {
+export default function ChatWindow({
+  whom,
+  root,
+  prefixedElement,
+}: ChatWindowProps) {
   const flag = useRouteGroup();
   const thread = useMatch(
     `/groups/${flag}/channels/chat/${whom}/message/:idShip/:idTime`
   );
   const [searchParams, setSearchParams] = useSearchParams();
-  const scrollTo = getScrollTo(whom, thread, searchParams.get('msg'));
+  const msg = searchParams.get('msg');
+  const scrollTo = getScrollTo(whom, thread, msg);
   const initialized = useChatInitialized(whom);
   const messages = useMessagesForChat(whom, scrollTo);
   const window = useWritWindow(whom);
@@ -59,12 +59,12 @@ export default function ChatWindow({ whom, prefixedElement }: ChatWindowProps) {
   }, [setSearchParams]);
 
   useEffect(() => {
-    if (scrollTo && !messages.has(scrollTo)) {
+    if (scrollTo && !messages.has(scrollTo) && !thread) {
       useChatState.getState().fetchMessagesAround(whom, '25', scrollTo);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scrollTo?.toString(), messages]);
+  }, [scrollTo?.toString(), messages, thread]);
 
   useEffect(() => {
     useChatStore.getState().setCurrent(whom);
@@ -89,7 +89,7 @@ export default function ChatWindow({ whom, prefixedElement }: ChatWindowProps) {
 
   return (
     <div className="relative h-full">
-      <ChatUnreadAlerts whom={whom} scrollerRef={scrollerRef} />
+      <ChatUnreadAlerts whom={whom} root={root} />
       <div className="flex h-full w-full flex-col overflow-hidden">
         <ChatScroller
           /**

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -106,6 +106,7 @@ export default function Dm() {
   const canStart = useChatState(
     useCallback((s) => ship && Object.keys(s.briefs).includes(ship), [ship])
   );
+  const root = `/dm/${ship}`;
 
   const {
     isSelectingMessage,
@@ -135,7 +136,7 @@ export default function Dm() {
                 element={
                   <ChatSearch
                     whom={ship}
-                    root={`/dm/${ship}`}
+                    root={root}
                     placeholder="Search Messages"
                   >
                     <TitleButton
@@ -246,6 +247,7 @@ export default function Dm() {
         {isAccepted ? (
           <ChatWindow
             whom={ship}
+            root={root}
             prefixedElement={
               <div className="pt-4 pb-12">
                 <DMHero ship={ship} contact={contact} />

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -73,6 +73,7 @@ export default function MultiDm() {
   const club = useMultiDm(clubId);
   const appName = useAppName();
   const groupName = club?.meta.title || club?.team.concat(club.hive).join(', ');
+  const root = `/dm/${clubId}`;
 
   const {
     isSelectingMessage,
@@ -108,7 +109,7 @@ export default function MultiDm() {
                 element={
                   <ChatSearch
                     whom={clubId}
-                    root={`/dm/${clubId}`}
+                    root={root}
                     placeholder="Search Messages"
                   >
                     <TitleButton club={club} isMobile={isMobile} />
@@ -198,6 +199,7 @@ export default function MultiDm() {
         {isAccepted ? (
           <ChatWindow
             whom={clubId}
+            root={root}
             prefixedElement={
               <div className="pt-4 pb-12">
                 <MultiDmHero club={club} />

--- a/ui/src/state/chat/type.ts
+++ b/ui/src/state/chat/type.ts
@@ -70,16 +70,17 @@ export interface ChatState {
   startTalk: (init: TalkChatInit, startBase?: boolean) => Promise<void>;
   dmRsvp: (ship: string, ok: boolean) => Promise<void>;
   getDraft: (whom: string) => void;
+  fetchMessage: (whom: string, id: string) => Promise<void>;
   fetchMessages: (
-    ship: string,
+    whom: string,
     count: string,
     dir: 'newer' | 'older',
     time?: BigInteger
   ) => Promise<boolean>;
   fetchMessagesAround: (
-    ship: string,
+    whom: string,
     count: string,
-    time: BigInteger
+    timeOrId: BigInteger | string
   ) => Promise<void>;
   draft: (whom: string, story: ChatStory) => Promise<void>;
   joinChat: (groupFlag: string, flag: string) => Promise<void>;

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -149,6 +149,24 @@ export interface WritDiff {
   delta: WritDelta;
 }
 
+export interface WritResponseAdd {
+  add: {
+    memo: ChatMemo;
+    time: string;
+  };
+}
+
+export type WritResponseDelta =
+  | WritResponseAdd
+  | WritDeltaDel
+  | WritDeltaAddFeel
+  | WritDeltaDelFeel;
+
+export interface WritResponse {
+  id: string;
+  response: WritResponseDelta;
+}
+
 export interface ChatDiffCreate {
   create: Chat;
 }

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -362,9 +362,9 @@ export interface TalkChatInit extends ChatInit {
   pins: string[];
 }
 
-export interface ChatScanItem {
+export interface ChatWritEntry {
   time: string;
   writ: ChatWrit;
 }
 
-export type ChatScan = ChatScanItem[];
+export type ChatScan = ChatWritEntry[];


### PR DESCRIPTION
Fixes LAND-970 and LAND-977. This involved adding a few things to the backend: 
- Times on the subscription fact of all "added" writs. This ensures that times for new messages exist and are correct.
- A scry endpoint for fetch around id, since briefs only gives us an ID we needed a way to make sure we can get messages near the unread
- Changing when we give updates about writs so that it's always after we've resolved the pact
- Adding a missing mark for a single writ, there's a few places we ask for a single writ which were relying on the messages existing already, instead we just scry for them

So now if you have an unread:
- we fetch around the message
- if it's in a thread we also fetch around the thread OP