### PR TITLE
chat: mobile search overhaul

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -102,6 +102,7 @@ import EyrieMenu from './eyrie/EyrieMenu';
 import GroupVolumeDialog from './groups/GroupVolumeDialog';
 import ChannelVolumeDialog from './channels/ChannelVolumeDialog';
 import { isNativeApp } from './logic/native';
+import MobileChatSearch from './chat/ChatSearch/MobileChatSearch';
 
 const ReactQueryDevtoolsProduction = React.lazy(() =>
   import('@tanstack/react-query-devtools/build/lib/index.prod.js').then(
@@ -359,6 +360,12 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
               </Route>
               {isSmall && (
                 <Route
+                  path=":ship/search/:query?"
+                  element={<MobileChatSearch />}
+                />
+              )}
+              {isSmall && (
+                <Route
                   path=":ship/message/:idShip/:idTime"
                   element={<ChatThread />}
                 />
@@ -437,6 +444,9 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                   />
                 )}
               </Route>
+              {isSmall && (
+                <Route path="search/:query?" element={<MobileChatSearch />} />
+              )}
               {isSmall ? (
                 <Route
                   path="message/:idShip/:idTime"
@@ -797,7 +807,7 @@ function RoutedApp() {
           <Scheduler />
         </TooltipProvider>
         <LureAutojoiner />
-        {showDevTools && (
+        {false && (
           <>
             <React.Suspense fallback={null}>
               <ReactQueryDevtoolsProduction />

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -807,7 +807,7 @@ function RoutedApp() {
           <Scheduler />
         </TooltipProvider>
         <LureAutojoiner />
-        {false && (
+        {showDevTools && (
           <>
             <React.Suspense fallback={null}>
               <ReactQueryDevtoolsProduction />

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -453,10 +453,10 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                     element={<ChatThread />}
                   />
                 ) : null}
+                {isMobile && (
+                  <Route path="search/:query?" element={<MobileChatSearch />} />
+                )}
               </Route>
-              {isSmall && (
-                <Route path="search/:query?" element={<MobileChatSearch />} />
-              )}
               <Route
                 path="channels/heap/:chShip/:chName"
                 element={<GroupChannel type="heap" />}

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Route, Routes, useMatch, useNavigate, useParams } from 'react-router';
 import { Helmet } from 'react-helmet';
 import ChatInput from '@/chat/ChatInput/ChatInput';
@@ -120,29 +120,31 @@ function ChatChannel({ title }: ViewProps) {
         className="flex-1 bg-white"
         header={
           <Routes>
-            <Route
-              path="search/:query?"
-              element={
-                <>
-                  <ChatSearch
-                    whom={chFlag}
-                    root={`/groups/${groupFlag}/channels/${nest}`}
-                    placeholder={
-                      channel ? `Search in ${channel.meta.title}` : 'Search'
-                    }
-                  >
-                    <ChannelTitleButton flag={groupFlag} nest={nest} />
-                  </ChatSearch>
-                  <Helmet>
-                    <title>
-                      {channel && group
-                        ? `${channel.meta.title} in ${group.meta.title} Search`
-                        : 'Search'}
-                    </title>
-                  </Helmet>
-                </>
-              }
-            />
+            {!isSmall && (
+              <Route
+                path="search/:query?"
+                element={
+                  <>
+                    <ChatSearch
+                      whom={chFlag}
+                      root={`/groups/${groupFlag}/channels/${nest}`}
+                      placeholder={
+                        channel ? `Search in ${channel.meta.title}` : 'Search'
+                      }
+                    >
+                      <ChannelTitleButton flag={groupFlag} nest={nest} />
+                    </ChatSearch>
+                    <Helmet>
+                      <title>
+                        {channel && group
+                          ? `${channel.meta.title} in ${group.meta.title} Search`
+                          : 'Search'}
+                      </title>
+                    </Helmet>
+                  </>
+                }
+              />
+            )}
             <Route
               path="*"
               element={

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -121,7 +121,7 @@ function ChatChannel({ title }: ViewProps) {
         className="flex-1 bg-white"
         header={
           <Routes>
-            {!isSmall && (
+            {!isMobile && (
               <Route
                 path="search/:query?"
                 element={

--- a/ui/src/chat/ChatSearch/ChatSearchResults.tsx
+++ b/ui/src/chat/ChatSearch/ChatSearchResults.tsx
@@ -16,6 +16,8 @@ interface ChatSearchResultsProps {
   isLoading: boolean;
   query?: string;
   selected?: number;
+  withHeader?: boolean;
+  endReached: () => void;
 }
 
 interface ChatSearchResultEntry {
@@ -38,109 +40,126 @@ function itemContent(_i: number, entry: ChatSearchResultEntry) {
 const ChatSearchResults = React.forwardRef<
   VirtuosoHandle,
   ChatSearchResultsProps
->(({ whom, root, scan, isLoading, selected, query }, scrollerRef) => {
-  const [delayedLoading, setDelayedLoading] = useState(false);
-  const reallyLoading = isLoading && query && query !== '';
-  const isMobile = useIsMobile();
-  const thresholds = {
-    atBottomThreshold: 125,
-    atTopThreshold: 125,
-    overscan: isMobile
-      ? { main: 200, reverse: 200 }
-      : { main: 400, reverse: 400 },
-  };
-
-  const loadMsgs = useMemo(() => {
-    return debounce(
-      (time: BigInteger) => {
-        useChatState.getState().fetchMessagesAround(whom, '25', time);
-      },
-      200,
-      { trailing: true }
-    );
-  }, [whom]);
-
-  const msgLoad = useCallback(
-    (time: BigInteger, type: 'click' | 'hover') => {
-      loadMsgs(time);
-
-      if (type === 'click') {
-        loadMsgs.flush();
-      }
+>(
+  (
+    {
+      whom,
+      root,
+      scan,
+      isLoading,
+      selected,
+      endReached,
+      withHeader = true,
+      query,
     },
-    [loadMsgs]
-  );
-
-  const entries = useMemo(() => {
-    return scan
-      ? scan.toArray().map(
-          ([int, writ], i): ChatSearchResultEntry => ({
-            whom,
-            root,
-            time: int,
-            writ,
-            selected: i === selected,
-            msgLoad,
-          })
-        )
-      : [];
-  }, [scan, whom, root, selected, msgLoad]);
-
-  useEffect(() => {
-    let timeout = 0;
-
-    if (reallyLoading) {
-      timeout = setTimeout(() => {
-        setDelayedLoading(true);
-      }, 150) as unknown as number;
-    } else {
-      clearTimeout(timeout);
-      setDelayedLoading(false);
-    }
-
-    return () => {
-      clearTimeout(timeout);
+    scrollerRef
+  ) => {
+    const [delayedLoading, setDelayedLoading] = useState(false);
+    const reallyLoading = isLoading && query && query !== '';
+    const isMobile = useIsMobile();
+    const thresholds = {
+      atBottomThreshold: 125,
+      atTopThreshold: 125,
+      overscan: isMobile
+        ? { main: 200, reverse: 200 }
+        : { main: 400, reverse: 400 },
     };
-  }, [reallyLoading]);
 
-  return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
-      <div className="mb-6 flex items-center justify-between text-sm text-gray-400">
-        {query && (
-          <strong>
-            Search Results for &ldquo;
-            <span className="text-gray-800">{query}</span>&rdquo;
-          </strong>
+    const loadMsgs = useMemo(() => {
+      return debounce(
+        (time: BigInteger) => {
+          useChatState.getState().fetchMessagesAround(whom, '25', time);
+        },
+        200,
+        { trailing: true }
+      );
+    }, [whom]);
+
+    const msgLoad = useCallback(
+      (time: BigInteger, type: 'click' | 'hover') => {
+        loadMsgs(time);
+
+        if (type === 'click') {
+          loadMsgs.flush();
+        }
+      },
+      [loadMsgs]
+    );
+
+    const entries = useMemo(() => {
+      return scan
+        ? scan.toArray().map(
+            ([int, writ], i): ChatSearchResultEntry => ({
+              whom,
+              root,
+              time: int,
+              writ,
+              selected: i === selected,
+              msgLoad,
+            })
+          )
+        : [];
+    }, [scan, whom, root, selected, msgLoad]);
+
+    useEffect(() => {
+      let timeout = 0;
+
+      if (reallyLoading) {
+        timeout = setTimeout(() => {
+          setDelayedLoading(true);
+        }, 150) as unknown as number;
+      } else {
+        clearTimeout(timeout);
+        setDelayedLoading(false);
+      }
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [reallyLoading]);
+
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {withHeader && (
+          <div className="mb-6 flex items-center justify-between text-sm text-gray-400">
+            {query && (
+              <strong>
+                Search Results for &ldquo;
+                <span className="text-gray-800">{query}</span>&rdquo;
+              </strong>
+            )}
+            {entries.length > 0 && (
+              <strong>
+                Sorted by <span className="text-gray-800">Most Recent</span>
+              </strong>
+            )}
+          </div>
         )}
-        {entries.length > 0 && (
-          <strong>
-            Sorted by <span className="text-gray-800">Most Recent</span>
-          </strong>
+        {delayedLoading ? (
+          <div className="-mx-4 flex-1">
+            <ChatScrollerPlaceholder count={30} />
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center">
+            <div className="font-semibold text-gray-600">
+              {query ? 'No results found' : 'Enter a search to get started'}
+            </div>
+          </div>
+        ) : (
+          <Virtuoso
+            {...thresholds}
+            tabIndex={-1}
+            ref={scrollerRef}
+            data={entries}
+            itemContent={itemContent}
+            computeItemKey={(i, item) => item.time.toString()}
+            endReached={() => endReached()}
+            className="h-full w-full list-none overflow-x-hidden overflow-y-scroll"
+          />
         )}
       </div>
-      {delayedLoading ? (
-        <div className="-mx-4 flex-1">
-          <ChatScrollerPlaceholder count={30} />
-        </div>
-      ) : entries.length === 0 ? (
-        <div className="flex h-full flex-col items-center justify-center">
-          <div className="font-semibold text-gray-600">
-            {query ? 'No results found' : 'Enter a search to get started'}
-          </div>
-        </div>
-      ) : (
-        <Virtuoso
-          {...thresholds}
-          tabIndex={-1}
-          ref={scrollerRef}
-          data={entries}
-          itemContent={itemContent}
-          computeItemKey={(i, item) => item.time.toString()}
-          className="h-full w-full list-none overflow-x-hidden overflow-y-scroll"
-        />
-      )}
-    </div>
-  );
-});
+    );
+  }
+);
 
 export default ChatSearchResults;

--- a/ui/src/chat/ChatSearch/MobileChatSearch.tsx
+++ b/ui/src/chat/ChatSearch/MobileChatSearch.tsx
@@ -7,7 +7,6 @@ import ChatSearchResults from '@/chat/ChatSearch/ChatSearchResults';
 import { useInfiniteChatSearch } from '@/state/chat/search';
 import useDebounce from '@/logic/useDebounce';
 import { VirtuosoHandle } from 'react-virtuoso';
-import bigInt from 'big-integer';
 import { useSearchState } from '@/state/chat/search';
 
 export default function MobileChatSearch() {
@@ -21,11 +20,7 @@ export default function MobileChatSearch() {
   const location = useLocation();
   const insets = useSafeAreaInsets();
   const scrollerRef = useRef<VirtuosoHandle>(null);
-  const [searchInput, setSearchInput] = useState('');
-  const [selected, setSelected] = useState<{
-    index: number;
-    time: bigInt.BigInteger;
-  }>({ index: -1, time: bigInt.zero });
+  const [searchInput, setSearchInput] = useState(params.query || '');
 
   const whom =
     params.chShip && params.chName
@@ -35,7 +30,7 @@ export default function MobileChatSearch() {
     whom,
     params.query || ''
   );
-  const history = useSearchState.getState().history?.get(whom);
+  const history = useSearchState.getState().history[whom];
 
   const root = location.pathname.split('/search')[0];
   const debouncedSearch = useDebounce((input: string) => {
@@ -115,7 +110,7 @@ export default function MobileChatSearch() {
           query={
             showRecentResults ? history.lastQuery.query : params.query || ''
           }
-          selected={selected.index}
+          selected={-1}
           withHeader={!showRecentResults}
           endReached={() => fetchNextPage()}
         />

--- a/ui/src/chat/ChatSearch/MobileChatSearch.tsx
+++ b/ui/src/chat/ChatSearch/MobileChatSearch.tsx
@@ -1,0 +1,125 @@
+import { useState, useRef } from 'react';
+import Layout from '@/components/Layout/Layout';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useSafeAreaInsets } from '@/logic/native';
+import SearchBar from '@/chat/ChatSearch/SearchBar';
+import ChatSearchResults from '@/chat/ChatSearch/ChatSearchResults';
+import { useInfiniteChatSearch } from '@/state/chat/search';
+import useDebounce from '@/logic/useDebounce';
+import { VirtuosoHandle } from 'react-virtuoso';
+import bigInt from 'big-integer';
+import { useSearchState } from '@/state/chat/search';
+
+export default function MobileChatSearch() {
+  const params = useParams<{
+    chShip?: string;
+    chName?: string;
+    ship?: string;
+    query?: string;
+  }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const insets = useSafeAreaInsets();
+  const scrollerRef = useRef<VirtuosoHandle>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const [selected, setSelected] = useState<{
+    index: number;
+    time: bigInt.BigInteger;
+  }>({ index: -1, time: bigInt.zero });
+
+  const whom =
+    params.chShip && params.chName
+      ? `${params.chShip}/${params.chName}`
+      : params.ship!;
+  const { scan, isLoading, fetchNextPage } = useInfiniteChatSearch(
+    whom,
+    params.query || ''
+  );
+  const history = useSearchState.getState().history?.get(whom);
+
+  const root = location.pathname.split('/search')[0];
+  const debouncedSearch = useDebounce((input: string) => {
+    if (!input) {
+      navigate(`${root}/search`);
+      return;
+    }
+
+    navigate(`${root}/search/${input}`);
+  }, 500);
+
+  const setValue = (newValue: string) => {
+    setSearchInput(newValue);
+    debouncedSearch(newValue);
+  };
+
+  const repeatRecentSearch = (query: string) => {
+    setSearchInput(query);
+    navigate(`${root}/search/${query}`);
+  };
+
+  const showRecentQueries =
+    !params.query && history && history.queries.length > 0;
+  const showRecentResults =
+    !params.query && history && history.lastQuery && history.lastQuery.result;
+
+  return (
+    <Layout
+      className="flex-1 bg-white px-4"
+      header={
+        <div className="mt-2 flex" style={{ paddingTop: insets.top }}>
+          <SearchBar
+            value={searchInput}
+            setValue={setValue}
+            placeholder="Search "
+            isSmall={true}
+          />
+          <button
+            className="ml-4 text-lg font-semibold"
+            onClick={() => navigate(root)}
+          >
+            Cancel
+          </button>
+        </div>
+      }
+    >
+      <div className="z-30 flex h-full w-full flex-col pt-4">
+        {showRecentQueries && (
+          <div className="mb-4 flex flex-col items-start">
+            <p className="mb-4 text-sm font-semibold text-gray-400">
+              Recent Searches
+            </p>
+            {history.queries.map((query, i) => (
+              <button
+                key={i}
+                className="mb-2 rounded-md bg-gray-50 px-3 py-2 text-lg hover:bg-gray-100 focus:bg-gray-100"
+                onClick={() => repeatRecentSearch(query)}
+              >
+                "{query}"
+              </button>
+            ))}
+          </div>
+        )}
+
+        {showRecentResults && (
+          <p className="mb-4 text-sm font-semibold text-gray-400">
+            Recent Search for "{history.lastQuery.query}"
+          </p>
+        )}
+
+        <ChatSearchResults
+          ref={scrollerRef}
+          whom={whom}
+          root={root}
+          scan={showRecentResults ? history.lastQuery.result : scan}
+          isLoading={!showRecentResults && isLoading}
+          query={
+            showRecentResults ? history.lastQuery.query : params.query || ''
+          }
+          selected={selected.index}
+          withHeader={!showRecentResults}
+          endReached={() => fetchNextPage()}
+        />
+      </div>
+    </Layout>
+  );
+}

--- a/ui/src/chat/ChatSearch/SearchBar.tsx
+++ b/ui/src/chat/ChatSearch/SearchBar.tsx
@@ -1,0 +1,54 @@
+import { ChangeEvent, useRef } from 'react';
+import MagnifyingGlassIcon from '@/components/icons/MagnifyingGlassIcon';
+import X16Icon from '@/components/icons/X16Icon';
+
+interface SearchBarProps {
+  value: string;
+  setValue: (newValue: string) => void;
+  placeholder: string;
+  isSmall: boolean;
+}
+
+function SearchBar({ value, setValue, placeholder, isSmall }: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  const onClear = () => {
+    inputRef.current?.focus();
+    setValue('');
+  };
+
+  return (
+    <div className="w-full">
+      <label className="relative flex w-full items-center">
+        <span className="sr-only">Search</span>
+        <span className="absolute left-0 pl-2">
+          <MagnifyingGlassIcon className="h-6 w-6 text-gray-400" />
+        </span>
+        <input
+          id="search"
+          ref={inputRef}
+          type="text"
+          autoFocus
+          className="input w-full bg-gray-50 py-2 pl-8 pr-8 mix-blend-multiply placeholder:font-normal dark:mix-blend-normal md:text-base"
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+        />
+        {isSmall && value !== '' ? (
+          <button
+            className="absolute right-3 flex h-4 w-4 items-center justify-center rounded-full bg-gray-500"
+            onClick={onClear}
+          >
+            <X16Icon className="h-3 w-3 text-gray-50" />
+          </button>
+        ) : null}
+      </label>
+    </div>
+  );
+}
+
+export default SearchBar;

--- a/ui/src/state/chat/search.ts
+++ b/ui/src/state/chat/search.ts
@@ -1,0 +1,83 @@
+import api from '@/api';
+import { whomIsDm, whomIsMultiDm } from '@/logic/utils';
+import { ChatScan, ChatWrit, newWritMap } from '@/types/chat';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { udToDec } from '@urbit/api';
+import bigInt from 'big-integer';
+import { useMemo } from 'react';
+import BTree from 'sorted-btree';
+import create from 'zustand';
+
+type Whom = string;
+type SearchResult = BTree<bigInt.BigInteger, ChatWrit>;
+
+interface QueryHistory {
+  queries: string[];
+  lastQuery: {
+    query: string;
+    result: SearchResult;
+  };
+}
+
+interface SearchState {
+  history: Map<Whom, QueryHistory>;
+}
+
+export const useSearchState = create<SearchState>(() => ({
+  history: new Map(),
+}));
+
+export function updateSearchHistory(
+  whom: string,
+  query: string,
+  result: SearchResult
+) {
+  useSearchState.setState((state) => {
+    const history = state.history || new Map();
+    const queryHistory = history.get(whom) || { queries: [] };
+    const queries = [query, ...queryHistory.queries.filter((q) => q !== query)];
+    if (queries.length > 3) {
+      queries.pop();
+    }
+    const lastQuery = { query, result };
+    return {
+      history: new Map(state.history).set(whom, { queries, lastQuery }),
+    };
+  });
+}
+
+export function useInfiniteChatSearch(whom: string, query: string) {
+  const type = whomIsDm(whom) ? 'dm' : whomIsMultiDm(whom) ? 'club' : 'chat';
+  const { data, ...rest } = useInfiniteQuery({
+    queryKey: ['chat', 'search', whom, query],
+    queryFn: async ({ pageParam = 0 }) => {
+      const res = await api.scry<ChatScan>({
+        app: 'chat',
+        path: `/${type}/${whom}/search/text/${pageParam}/20/${query}`,
+      });
+      return res;
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length === 0) return undefined;
+      return allPages.length * 20;
+    },
+  });
+
+  const scan = useMemo(() => {
+    return newWritMap(
+      (data?.pages || [])
+        .flat()
+        .map(({ time, writ }) => [bigInt(udToDec(time)), writ]),
+      true
+    );
+  }, [data]);
+
+  if (query !== '' && data?.pages.length === 1) {
+    updateSearchHistory(whom, query, scan);
+  }
+
+  return {
+    scan,
+    ...rest,
+  };
+}


### PR DESCRIPTION
- Updates search on mobile to take up the whole page
- Displays previous few queries and the last set of results
- Changes the search function to fetch fewer results for faster initial load and populates more infinitely as you scroll
- Works across channels, DMs, and group chats

Fixes LAND-923


https://github.com/tloncorp/landscape-apps/assets/90741358/bb1fdacc-e3df-4742-ae1c-e1fdbeabf3f3

* note in the vid it hesitates on loading the thread when the search result is clicked. This is normally instantaneous, investigating