### PR TITLE
mobile: don't show superfluous telemetry notice in the app

### DIFF
--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -512,7 +512,8 @@ export function useShowActivityMessage() {
       isLoading ||
       data === undefined ||
       window.desk !== 'groups' ||
-      import.meta.env.DEV
+      import.meta.env.DEV ||
+      isNativeApp()
     ) {
       return false;
     }


### PR DESCRIPTION
Fixes LAND-981