### PR TITLE
mobile: show copy text button on chat message options

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -23,6 +23,7 @@ import { useIsMobile } from '@/logic/useMedia';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import AddReactIcon from '@/components/icons/AddReactIcon';
+import { inlineToString } from '@/logic/tiptap';
 
 function ChatMessageOptions(props: {
   open: boolean;
@@ -47,6 +48,11 @@ function ChatMessageOptions(props: {
   const { didCopy, doCopy } = useCopy(
     `/1/chan/chat/${whom}/msg/${writ.seal.id}`
   );
+  const messageText =
+    'story' in writ.memo.content && 'inline' in writ.memo.content.story
+      ? writ.memo.content.story.inline.map((i) => inlineToString(i)).join('')
+      : '';
+  const { didCopy: didCopyText, doCopy: doCopyText } = useCopy(messageText);
   const { open: pickerOpen, setOpen: setPickerOpen } = useChatDialog(
     whom,
     writ.seal.id,
@@ -100,6 +106,16 @@ function ChatMessageOptions(props: {
       }, 2000);
     }
   }, [doCopy, isMobile, onOpenChange]);
+
+  const onCopyText = useCallback(() => {
+    doCopyText();
+
+    if (isMobile) {
+      setTimeout(() => {
+        onOpenChange(false);
+      }, 2000);
+    }
+  }, [doCopyText, isMobile, onOpenChange]);
 
   const reply = useCallback(() => {
     setSearchParams({ chat_reply: writ.seal.id }, { replace: true });
@@ -205,13 +221,29 @@ function ChatMessageOptions(props: {
           ) : (
             <CopyIcon className="mr-2 h-6 w-6" />
           )}
-          {didCopy ? 'Copied!' : 'Copy'}
+          {didCopy ? 'Copied!' : 'Copy Link'}
         </div>
       ),
       onClick: onCopy,
       keepOpenOnClick: true,
     });
   }
+
+  actions.push({
+    key: 'copyText',
+    content: (
+      <div className="flex items-center">
+        {didCopyText ? (
+          <CheckIcon className="mr-2 h-6 w-6" />
+        ) : (
+          <CopyIcon className="mr-2 h-6 w-6" />
+        )}
+        {didCopyText ? 'Copied!' : 'Copy Text'}
+      </div>
+    ),
+    onClick: onCopyText,
+    keepOpenOnClick: true,
+  });
 
   if (showDeleteAction) {
     actions.push({

--- a/ui/src/components/ActionMenu.tsx
+++ b/ui/src/components/ActionMenu.tsx
@@ -92,7 +92,10 @@ const ActionMenu = React.memo(
                             action.onClick?.(event);
                           }
                     }
-                    className={cn(classNameForType(action.type), 'py-[16px]')}
+                    className={cn(
+                      classNameForType(action.type),
+                      'select-none py-[16px]'
+                    )}
                   >
                     {typeof action.content === 'string' ? (
                       <span>{action.content}</span>


### PR DESCRIPTION
Adds a "Copy Text" button to the ActionMenu on mobile, fixes LAND-972. Also applies 'select-none' to the actions in the ActionMenu so that users don't accidentally select the button text rather than just pressing the button (not sure if we have an issue for that, couldn't find one).

I intentionally did not add it to desktop since a) it's superfluous b) we would be using a duplicate icon without an easily apparent label.