### PR TITLE
chat: fix issue with clicking on app references in chat

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -249,7 +249,10 @@ function ChatMessageOptions(props: {
       {isMobile ? (
         <ActionMenu open={open} onOpenChange={onOpenChange} actions={actions} />
       ) : (
-        <div className="absolute right-2 -top-5 z-10 h-full" ref={containerRef}>
+        <div
+          className="absolute right-2 -top-5 z-10 min-h-fit"
+          ref={containerRef}
+        >
           <div
             data-testid="chat-message-options"
             className="relative top-0 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle"

--- a/ui/src/components/References/AppReference.tsx
+++ b/ui/src/components/References/AppReference.tsx
@@ -29,7 +29,7 @@ function AppReference({ flag, isScrolling }: AppReferenceProps) {
   }, [treaty, ship, isScrolling, deskId]);
 
   return (
-    <div className="relative flex items-center rounded-lg border-2 border-gray-50 text-base transition-colors hover:border-gray-100 hover:bg-white group-one-hover:border-gray-100 group-one-hover:bg-white">
+    <div className="relative flex min-w-[300px] max-w-[600px] items-center rounded-lg border-2 border-gray-50 text-base transition-colors hover:border-gray-100 hover:bg-white group-one-hover:border-gray-100 group-one-hover:bg-white">
       {treaty ? (
         <div className="flex w-full flex-row flex-wrap items-center justify-between">
           <div className="flex items-center justify-start rounded-lg p-2 text-left">


### PR DESCRIPTION
Fixes LAND-974, which was caused by:

1) the parent div for chat message options had height set to 100%, so they created an invisible box blocking the content underneath.
2) the app reference was set to width 100%, unlike our other refs which have a max width of 600px.

Tagging @dnbrwstr since I noticed you had set the h-full on the chat message options. Did this solve some particular problem? Can we safely set it to min-h-fit? 