### PR TITLE
thread: fix input overlap

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1726,7 +1726,6 @@
         ~[[%give %fact wire writ-diff+!>(p.d)]]
       =/  response=(unit response:writs:c)
         (diff-to-response p.d pact.chat)
-      ~&  [response p.d]
       ?~  response  ~
       ~[[%give %fact wire writ-response+!>(u.response)]]
     =.  cor  (give %fact ~(tap in paths) cag)

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -103,7 +103,7 @@ export default function ChatThread() {
 
   return (
     <div
-      className="relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
+      className="relative flex h-full w-full flex-col overflow-y-auto bg-white pb-[50px] sm:pb-0 lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
     >
       {isMobile ? (


### PR DESCRIPTION
This fixes the overlap seen in threads here 

![image](https://github.com/tloncorp/landscape-apps/assets/5466421/98b5ca1e-3dca-4edb-b1df-deb59664cd09)

Also removes a sigpam that was spamming dojo