### PR TITLE
analytics: disable posthog decide check

### DIFF
--- a/ui/src/logic/analytics.ts
+++ b/ui/src/logic/analytics.ts
@@ -45,6 +45,7 @@ posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
   // this is to prevent accidentally capturing data. all opting is managed
   // in the activity checker in ActivityModal.
   opt_out_capturing_by_default: true,
+  advanced_disable_decide: true,
 });
 
 export const analyticsClient = posthog;


### PR DESCRIPTION
When the app initially loads posthog fires off a request to their `/decide` endpoint.  This is just a check to see if the analytics client supports certain features (none of which we use). No user data is sent with the request, but this may make users worry. We can safely disable this.

More details here: https://posthog.com/docs/libraries/js#disable-decide-endpoint