### PR TITLE
mobile: fix mention suggestion positioning

### DIFF
--- a/ui/src/components/Mention/MentionPopup.tsx
+++ b/ui/src/components/Mention/MentionPopup.tsx
@@ -11,6 +11,7 @@ import { isValidPatp, clan } from 'urbit-ob';
 import { ReactRenderer } from '@tiptap/react';
 import { SuggestionOptions, SuggestionProps } from '@tiptap/suggestion';
 import tippy from 'tippy.js';
+import { isNativeApp } from '@/logic/native';
 import { deSig } from '@urbit/api';
 import useContactState, { useContacts } from '@/state/contact';
 import { useGroup, useGroupFlag } from '@/state/groups';
@@ -107,7 +108,12 @@ const MentionList = React.forwardRef<
   }));
 
   return (
-    <div className="dropdown min-w-80 p-1">
+    <div
+      className={cn(
+        'dropdown mb-2 p-1',
+        isNativeApp() ? 'w-[100vw]' : 'min-w-80'
+      )}
+    >
       <ul className="w-full">
         {(props.items || []).map((i, index) => (
           <li key={i.id} className="w-full">
@@ -234,7 +240,19 @@ const MentionPopup: Partial<SuggestionOptions> = {
           showOnCreate: true,
           interactive: true,
           trigger: 'manual',
-          placement: 'top-start',
+          placement: isNativeApp() ? 'top' : 'top-start',
+          onMount: ({ popperInstance }) => {
+            popperInstance?.setOptions({
+              placement: isNativeApp() ? 'top' : 'top-start',
+              modifiers: [{ name: 'flip', enabled: false }],
+            });
+          },
+          onAfterUpdate: ({ popperInstance }) => {
+            popperInstance?.setOptions({
+              placement: 'top',
+              modifiers: [{ name: 'flip', enabled: false }],
+            });
+          },
         });
       },
       onUpdate: (props) => {

--- a/ui/src/components/Mention/MentionPopup.tsx
+++ b/ui/src/components/Mention/MentionPopup.tsx
@@ -82,7 +82,7 @@ const MentionList = React.forwardRef<
     selectItem(selectedIndex);
   };
 
-  useEffect(() => setSelectedIndex(0), [props.items]);
+  useEffect(() => setSelectedIndex(props.items.length - 1), [props.items]);
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
@@ -115,7 +115,7 @@ const MentionList = React.forwardRef<
       )}
     >
       <ul className="w-full">
-        {(props.items || []).map((i, index) => (
+        {(props.items || []).map((i: any, index: number) => (
           <li key={i.id} className="w-full">
             <button
               className={cn(
@@ -211,6 +211,7 @@ const MentionPopup: Partial<SuggestionOptions> = {
 
     const items = fuzzyNames
       .slice(0, 5)
+      .reverse()
       .map((entry) => ({ id: contactNames[entry.index] }));
 
     return items;

--- a/ui/src/components/Mention/MentionPopup.tsx
+++ b/ui/src/components/Mention/MentionPopup.tsx
@@ -82,7 +82,10 @@ const MentionList = React.forwardRef<
     selectItem(selectedIndex);
   };
 
-  useEffect(() => setSelectedIndex(props.items.length - 1), [props.items]);
+  useEffect(
+    () => setSelectedIndex(isNativeApp() ? props.items.length - 1 : 0),
+    [props.items]
+  );
 
   useImperativeHandle(ref, () => ({
     onKeyDown: (event) => {
@@ -211,8 +214,11 @@ const MentionPopup: Partial<SuggestionOptions> = {
 
     const items = fuzzyNames
       .slice(0, 5)
-      .reverse()
       .map((entry) => ({ id: contactNames[entry.index] }));
+
+    if (isNativeApp()) {
+      items.reverse();
+    }
 
     return items;
   },
@@ -250,7 +256,7 @@ const MentionPopup: Partial<SuggestionOptions> = {
           },
           onAfterUpdate: ({ popperInstance }) => {
             popperInstance?.setOptions({
-              placement: 'top',
+              placement: isNativeApp() ? 'top' : 'top-start',
               modifiers: [{ name: 'flip', enabled: false }],
             });
           },


### PR DESCRIPTION
Fixes mentions to appear above the input bar on mobile and reverses result order so the best suggestion is easier to click.

Fixes LAND-929

https://github.com/tloncorp/landscape-apps/assets/90741358/8f6632de-8da3-4834-b4d4-832e57756957

