### PR TITLE
chat: fix issues with leaving clubs

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -958,9 +958,8 @@
   ^-  briefs:c
   %-  ~(gas by *briefs:c)
   %+  welp
-    %+  turn  ~(tap in ~(key by clubs))
-    |=  =id:club:c
-    =/  =club:c  (~(got by clubs) id)
+    %+  turn  ~(tap by clubs)
+    |=  [=id:club:c =club:c]
     =/  loyal  (~(has in team.crew.club) our.bowl)
     =/  invited  (~(has in hive.crew.club) our.bowl)
     ?:  &(!loyal !invited)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -960,6 +960,11 @@
   %+  welp
     %+  turn  ~(tap in ~(key by clubs))
     |=  =id:club:c
+    =/  =club:c  (~(got by clubs) id)
+    =/  loyal  (~(has in team.crew.club) our.bowl)
+    =/  invited  (~(has in hive.crew.club) our.bowl)
+    ?:  &(!loyal !invited)
+      [club/id *time 0 ~]
     =/  cu  (cu-abed id)
     [club/id cu-brief:cu]
   %+  welp
@@ -1205,6 +1210,10 @@
       cu-core
     ::
         %writ
+      =/  loyal  (~(has in team.crew.club) our.bowl)
+      =/  invited  (~(has in hive.crew.club) our.bowl)
+      ?:  &(!loyal !invited)
+         cu-core
       =.  pact.club  (reduce:cu-pact now.bowl diff.delta)
       ?-  -.q.diff.delta
           ?(%del %add-feel %del-feel)  (cu-give-writs-diff diff.delta)

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -13,6 +13,7 @@ import {
   usePendingMultiDms,
   usePinned,
   useChats,
+  useChatState,
 } from '../state/chat';
 import MessagesSidebarItem from './MessagesSidebarItem';
 
@@ -66,6 +67,20 @@ export default function MessagesList({
         const group = groups[groupFlag || ''];
         const vessel = group?.fleet[window.our];
         const channel = group?.channels[`chat/${b}`];
+        const club = useChatState.getState().multiDms[b];
+        const dm = useChatState.getState().dms.filter((d) => d === b)[0];
+
+        if (whomIsMultiDm(b) && !club) {
+          return false;
+        }
+
+        if (whomIsMultiDm(b) && !club.team.includes(window.our)) {
+          return false;
+        }
+
+        if (whomIsDm(b) && !dm) {
+          return false;
+        }
 
         if (
           channel &&

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -13,7 +13,8 @@ import {
   usePendingMultiDms,
   usePinned,
   useChats,
-  useChatState,
+  useDms,
+  useMultiDms,
 } from '../state/chat';
 import MessagesSidebarItem from './MessagesSidebarItem';
 
@@ -48,6 +49,8 @@ export default function MessagesList({
   const { sortMessages } = useMessageSort();
   const briefs = useBriefs();
   const chats = useChats();
+  const dms = useDms();
+  const multiDms = useMultiDms();
   const groups = useGroups();
   const allPending = pending.concat(pendingMultis);
   const isMobile = useIsMobile();
@@ -67,8 +70,8 @@ export default function MessagesList({
         const group = groups[groupFlag || ''];
         const vessel = group?.fleet[window.our];
         const channel = group?.channels[`chat/${b}`];
-        const club = useChatState.getState().multiDms[b];
-        const dm = useChatState.getState().dms.filter((d) => d === b)[0];
+        const club = multiDms[b];
+        const dm = dms.filter((d) => d === b)[0];
 
         if (whomIsMultiDm(b) && !club) {
           return false;
@@ -112,7 +115,17 @@ export default function MessagesList({
 
         return true; // is all
       }),
-    [allPending, briefs, chats, filter, groups, pinned, sortMessages]
+    [
+      allPending,
+      briefs,
+      chats,
+      filter,
+      groups,
+      pinned,
+      sortMessages,
+      dms,
+      multiDms,
+    ]
   );
 
   const headerHeightRef = useRef<number>(0);

--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -171,6 +171,7 @@ export function MultiDMSidebarItem({
           whom={whom}
           pending={!!pending}
           isHovered={hover}
+          isMulti
           triggerDisabled={isMobile}
         />
       )}


### PR DESCRIPTION
Fixes LAND-1001 and possibly other issues.

The reason the blue dot wasn't going away on the Messages icon was because we were still getting briefs for a club we already left. This PR updates briefs so that when we scry for briefs we just send an empty brief for a club that we're neither a member of or invited to. It also makes sure we don't hear about writ updates for the club if we're not invited or a member.

There were two other issues I found while working on this:

1) If you rejected a club invite this would actually cause the messages list to not render at all, since the MessagesSideBarItem would return null and the virtualscroller wouldn't be able to calculate heights. A user might just assume that they lost all of their messages. (I'm currently effected by this bug on my ship, I rejected an invite from a test club). This PR updates the filter that creates `organizedBriefs` in the MessagesList component to filter out briefs for clubs we're not a member of, so they won't appear in the list (clubs we're invited to will still show up).

2) Leaving a club/rejecting an invite wouldn't work from the options dropdown for clubs because we were calling the dmRsvp function rather than multiDmRsvp (because we were not passing the `isMulti` prop into DmOptions). You could only do it via the DmInvite component. This PR passes `isMulti` for that case and now it's fine.