### PR TITLE
groups: disable wayfinding block on mobile

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -689,7 +689,7 @@ function App() {
 
   return (
     <div className="flex h-full w-full flex-col">
-      {!disableWayfinding && <LandscapeWayfinding />}
+      {!disableWayfinding && !isMobile && <LandscapeWayfinding />}
       <DisconnectNotice />
       <LeapProvider>
         <DragAndDropProvider>


### PR DESCRIPTION
Currently, the wayfinding block on mobile:

- Overlaps with the bottom nav
- Has stale content
- Duplicates content in settings + discover tabs

We could fix some of these things, but I don't think we lose much by just removing it for now. 