### PR TITLE
groups: channel and dm list empty states

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -24,6 +24,7 @@ import { useIsMobile } from '@/logic/useMedia';
 import { ScrollerItemData, useMessageData } from '@/logic/useScrollerMessages';
 import { useChatState } from '@/state/chat/chat';
 import { createDevLogger } from '@/logic/utils';
+import EmptyPlaceholder from '@/components/EmptyPlaceholder';
 import ChatMessage from '../ChatMessage/ChatMessage';
 import ChatNotice from '../ChatNotice';
 import { useChatStore } from '../useChatStore';
@@ -130,7 +131,6 @@ export default function ChatScroller({
   const contentElementRef = useRef<HTMLDivElement>(null);
   const { userHasScrolled, resetUserHasScrolled } =
     useUserHasScrolled(scrollElementRef);
-  const isInverted = loadDirection === 'older';
 
   const {
     activeMessageKeys,
@@ -148,6 +148,9 @@ export default function ChatScroller({
   });
 
   const count = activeMessageEntries.length;
+  const isEmpty = count === 0 && hasLoadedNewest && hasLoadedOldest;
+  const isInverted = !isEmpty && loadDirection === 'older';
+
   // We want to render newest messages first, but we receive them oldest-first.
   // This is a simple way to reverse the order without having to reverse a big array.
   const transformIndex = useCallback(
@@ -382,6 +385,12 @@ export default function ChatScroller({
       // TODO: This now gets outlined when scrolling with keys. Should it?
       tabIndex={-1}
     >
+      {hasLoadedNewest && hasLoadedOldest && count === 0 && (
+        <EmptyPlaceholder>
+          There are no messages in this channel
+        </EmptyPlaceholder>
+      )}
+
       <div className="absolute top-0 w-full">
         <Loader show={fetchState === (isInverted ? 'bottom' : 'top')} />
       </div>

--- a/ui/src/components/EmptyPlaceholder.tsx
+++ b/ui/src/components/EmptyPlaceholder.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react';
+
+export default function EmptyPlaceholder({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div
+      className={`flex h-full w-full flex-col items-center justify-center px-4 text-center text-lg text-gray-300 sm:text-base sm:leading-5 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -6,6 +6,7 @@ import { filters, SidebarFilter } from '@/state/settings';
 import { useIsMobile } from '@/logic/useMedia';
 import { canReadChannel, whomIsDm, whomIsMultiDm } from '@/logic/utils';
 import { ChatBrief } from '@/types/chat';
+import EmptyPlaceholder from '@/components/EmptyPlaceholder';
 import {
   usePendingDms,
   useBriefs,
@@ -165,8 +166,14 @@ export default function MessagesList({
   const components = useMemo(
     () => ({
       Header: () => head,
+      EmptyPlaceholder: () =>
+        isMobile ? (
+          <EmptyPlaceholder>
+            Your direct messages will be shown here
+          </EmptyPlaceholder>
+        ) : null,
     }),
-    [head]
+    [head, isMobile]
   );
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);


### PR DESCRIPTION
Adds basic empty states for DMs tab and new channels. DM list empty state is not shown on desktop.

Empty channel (desktop)
<img width="1552" alt="Screenshot 2023-10-06 at 5 00 14 PM" src="https://github.com/tloncorp/landscape-apps/assets/357216/cdee37d6-489a-4a4d-98b8-26d0008d4487">

Empty channel (mobile)
<kbd><img width="200" style="display: block" src="https://github.com/tloncorp/landscape-apps/assets/357216/83059c82-610d-4d6a-b60f-28ffb76efbfc"> </kbd>

No DMs (mobile)
<kbd><img width="200" src="https://github.com/tloncorp/landscape-apps/assets/357216/17f58b6b-f6ad-4ea0-ab63-e9116ccd7d3a"></kbd>

Fixes LAND-1036
