### PR TITLE
scroller: fix loading newer messages after jump

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -28,7 +28,7 @@ import {
   useMessageData,
 } from '@/logic/useScrollerMessages';
 import { useChatState } from '@/state/chat/chat';
-import { createDevLogger } from '@/logic/utils';
+import { createDevLogger, useObjectChangeLogging } from '@/logic/utils';
 import EmptyPlaceholder from '@/components/EmptyPlaceholder';
 import { ChatWrit } from '@/types/chat';
 import ChatMessage from '../ChatMessage/ChatMessage';
@@ -182,13 +182,10 @@ export default function ChatScroller({
     replying,
   });
 
-  useEffect(() => {
-    logger.log('hasLoadedNewest', hasLoadedNewest);
-  }, [hasLoadedNewest]);
-
-  useEffect(() => {
-    logger.log('hasLoadedOldest', hasLoadedOldest);
-  }, [hasLoadedOldest]);
+  useObjectChangeLogging(
+    { hasLoadedNewest, hasLoadedOldest, isAtTop, isAtBottom },
+    logger
+  );
 
   const topItem: CustomScrollItemData | null = useMemo(
     () =>

--- a/ui/src/logic/useScrollerMessages.ts
+++ b/ui/src/logic/useScrollerMessages.ts
@@ -1,12 +1,6 @@
 import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import BTree from 'sorted-btree';
 
 import { STANDARD_MESSAGE_FETCH_PAGE_SIZE } from '@/constants';
@@ -215,22 +209,13 @@ export function useMessageData({
       scrollTo,
     });
 
-  const [hasEverLoadedNewest, setHasEverLoadedNewest] = useState(false);
-  const nextHasLoadedNewest =
-    hasLoadedNewest || replying || hasEverLoadedNewest;
-  useEffect(() => {
-    if (nextHasLoadedNewest) {
-      setHasEverLoadedNewest(true);
-    }
-  }, [nextHasLoadedNewest]);
-
   return {
     activeMessages,
     activeMessageKeys,
     activeMessageEntries,
     fetchMessages,
     fetchState,
-    hasLoadedNewest: nextHasLoadedNewest,
+    hasLoadedNewest,
     hasLoadedOldest: replying ? true : hasLoadedOldest,
   };
 }

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import ob from 'urbit-ob';
 import bigInt, { BigInteger } from 'big-integer';
 import isURL from 'validator/es/lib/isURL';
@@ -73,6 +73,23 @@ export function log(...args: any[]) {
   if (import.meta.env.DEV) {
     console.log(...args);
   }
+}
+
+/**
+ * Logs a message when any property of an object changes. Uses shallow equality
+ * check to determine whether a change has occurred.
+ */
+export function useObjectChangeLogging(
+  o: Record<string, unknown>,
+  logger: Console = window.console
+) {
+  const lastValues = useRef(o);
+  Object.entries(o).forEach(([k, v]) => {
+    if (v !== lastValues.current[k]) {
+      logger.log('[change]', k);
+      lastValues.current[k] = v;
+    }
+  });
 }
 
 export function logTime(...args: any[]) {


### PR DESCRIPTION
Fixes message loading after jumping to a new scroll position by removing `hasEverLoadedNewest` hack in `useScrollerMessages`. The need for `hasEverLoadedNewest` should have been removed by improvements to `hasLoadedNewest` statefulness in the writ window, but we should keep an eye on this to see whether we're getting unnecessary loads.

This pr also adds a nice lil debug helper: `useObjectChangeLogging`, in `utils.ts`. It'll log a message when any property of the object you pass changes. Useful for tracking down excessive re-rendering.

Fixes LAND-1035.