### PR TITLE
groups: improve group list rendering performance

### DIFF
--- a/ui/src/logic/useGroupSort.ts
+++ b/ui/src/logic/useGroupSort.ts
@@ -1,5 +1,5 @@
 import { get } from 'lodash';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Group, Groups } from '@/types/groups';
 import useSidebarSort, {
   ALPHABETICAL,
@@ -25,26 +25,30 @@ export default function useGroupSort() {
   });
   const { sortChannels } = useChannelSort();
 
-  function sortGroups(groups?: Groups) {
-    const accessors: Record<string, (k: string, v: Group) => string> = {
-      [ALPHABETICAL]: (_flag: string, group: Group) => get(group, 'meta.title'),
-      [RECENT]: (flag: string, group: Group) => {
-        /**
-         * Use the latest channel flag associated with the Group; otherwise
-         * fallback to the Group flag itself, which won't be in the briefs and
-         * thus use INFINITY by default
-         */
-        const channels = sortChannels(group.channels);
-        return channels.length > 0 ? channels[0][0] : flag;
-      },
-    };
+  const sortGroups = useCallback(
+    (groups?: Groups) => {
+      const accessors: Record<string, (k: string, v: Group) => string> = {
+        [ALPHABETICAL]: (_flag: string, group: Group) =>
+          get(group, 'meta.title'),
+        [RECENT]: (flag: string, group: Group) => {
+          /**
+           * Use the latest channel flag associated with the Group; otherwise
+           * fallback to the Group flag itself, which won't be in the briefs and
+           * thus use INFINITY by default
+           */
+          const channels = sortChannels(group.channels);
+          return channels.length > 0 ? channels[0][0] : flag;
+        },
+      };
 
-    return sortRecordsBy(
-      groups || {},
-      accessors[sortFn] || accessors[ALPHABETICAL],
-      sortFn === RECENT
-    );
-  }
+      return sortRecordsBy(
+        groups || {},
+        accessors[sortFn] || accessors[ALPHABETICAL],
+        sortFn === RECENT
+      );
+    },
+    [sortChannels, sortFn, sortRecordsBy]
+  );
 
   return {
     setSortFn,

--- a/ui/src/logic/useSidebarSort.ts
+++ b/ui/src/logic/useSidebarSort.ts
@@ -96,22 +96,25 @@ export default function useSidebarSort({
    * @param reverse Whether to reverse the sorted list (ASC --> DEC)
    * @returns [string, T][]
    */
-  function sortRecordsBy<T>(
-    records: Record<string, T>,
-    accessor: (k: string, v: T) => string,
-    reverse = false
-  ) {
-    const entries = Object.entries(records);
-    entries.sort(([aKey, aObj], [bKey, bObj]) => {
-      const aVal = accessor(aKey, aObj);
-      const bVal = accessor(bKey, bObj);
+  const sortRecordsBy = useCallback(
+    <T>(
+      records: Record<string, T>,
+      accessor: (k: string, v: T) => string,
+      reverse = false
+    ) => {
+      const entries = Object.entries(records);
+      entries.sort(([aKey, aObj], [bKey, bObj]) => {
+        const aVal = accessor(aKey, aObj);
+        const bVal = accessor(bKey, bObj);
 
-      const sorter = sortOptions[sortFn] ?? sortOptions[ALPHABETICAL];
-      return sorter(aVal, bVal);
-    });
+        const sorter = sortOptions[sortFn] ?? sortOptions[ALPHABETICAL];
+        return sorter(aVal, bVal);
+      });
 
-    return reverse ? entries.reverse() : entries;
-  }
+      return reverse ? entries.reverse() : entries;
+    },
+    [sortFn, sortOptions]
+  );
 
   const setSortFn = useMemo(
     () => (mode: string) =>

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -280,14 +280,16 @@ export function useGangs() {
     [queryClient]
   );
 
-  if (rest.isLoading || rest.isError) {
-    return {} as Gangs;
-  }
+  return useMemo(() => {
+    if (rest.isLoading || rest.isError) {
+      return {} as Gangs;
+    }
 
-  return {
-    ...groupIndexDataAsGangs,
-    ...(data as Gangs),
-  };
+    return {
+      ...groupIndexDataAsGangs,
+      ...(data as Gangs),
+    };
+  }, [data, groupIndexDataAsGangs, rest.isLoading, rest.isError]);
 }
 
 export function useGang(flag: string) {
@@ -321,7 +323,7 @@ export const useGangPreview = (
 
 export function useGangList() {
   const data = useGangs();
-  return Object.keys(data || {});
+  return useMemo(() => Object.keys(data || {}), [data]);
 }
 
 export function useChannel(


### PR DESCRIPTION
I noticed that when scrolling the main list of groups on both mobile + desktop, we were sending new requests for all group avatars on pretty much each scroll event.

After some investigation, it turned out that this was related to the `Head` component being passed to the `Virtuoso` scroller. Because that component was being dynamically generated, every time its children changed the whole tree under it was getting wiped and recreated, rather than just updated as we'd really want. 

In order to prevent recreating all the list items, I replumbed the list to display child content as an element in the list, rather than using the header component prop. It would be a little more elegant to just pass all the individual pinned groups as list items and render all items + section headers in `itemContent`, but I kept it simple for this pass.

In investigating this, I added a number of `useMemo` and `useCallback`s to reduce rerenders. They should be strictly better for performance + not have side effects, so I've left them in. 

Fixes LAND-1038.