### PR TITLE
groups: fix rendering of group list with no pins

### DIFF
--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -66,20 +66,30 @@ export default function GroupList({
   const headerHeightRef = useRef<number>(0);
   const headerRef = useRef<HTMLDivElement>(null);
   const header = useMemo(
-    () => <div ref={headerRef}>{children}</div>,
+    // Re: min-h below: if virtuoso ever encounters a 0-height element, its
+    // whole render will fail. This min height ensures that no matter what's
+    // passed, it'll have at least 1px of height.
+    () =>
+      children ? (
+        <div className="min-h-[1px]" ref={headerRef}>
+          {children}
+        </div>
+      ) : null,
     [children]
   );
 
-  const listItems: AnyListItem[] = useMemo(
-    () => [
-      { type: 'top', component: header },
+  const listItems: AnyListItem[] = useMemo(() => {
+    const top: TopContentListItem[] = header
+      ? [{ type: 'top', component: header }]
+      : [];
+    return [
+      ...top,
       ...groupsWithoutPinned.map<GroupListItem>((g) => ({
         type: 'group',
         data: g,
       })),
-    ],
-    [groupsWithoutPinned, header]
-  );
+    ];
+  }, [groupsWithoutPinned, header]);
 
   useEffect(() => {
     if (!headerRef.current) {

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -39,6 +39,9 @@ export default function MobileRoot() {
     [pinnedGroups]
   );
 
+  const hasPinnedGroups = !!pinnedGroupsOptions.length;
+  const hasPendingGangs = !!pendingGangs.length;
+
   return (
     <Layout
       className="flex-1 bg-white"
@@ -79,35 +82,34 @@ export default function MobileRoot() {
                 pinnedGroups={Object.entries(pinnedGroups)}
                 isScrolling={scroll.current}
               >
-                {Object.entries(pinnedGroups).length > 0 && (
-                  <div className="px-4">
-                    <h2 className="mb-0.5 p-2 font-sans text-gray-400">
-                      Pinned
-                    </h2>
-                    {pinnedGroupsOptions}
-                  </div>
-                )}
-                {Object.entries(pendingGangs).length > 0 && (
-                  <div className="px-4">
-                    <h2 className="mb-0.5 p-2 font-sans text-gray-400">
-                      Invites
-                    </h2>
-                    <GroupJoinList highlightAll gangs={pendingGangs} />
-                  </div>
-                )}
+                {hasPinnedGroups || hasPendingGangs ? (
+                  <>
+                    {hasPinnedGroups ? (
+                      <div className="px-4">
+                        <h2 className="mb-0.5 p-2 font-sans text-gray-400">
+                          Pinned
+                        </h2>
+                        {pinnedGroupsOptions}
+                      </div>
+                    ) : null}
 
-                {Object.entries(pinnedGroups).length > 0 ||
-                Object.entries(pendingGangs).length > 0 ? (
-                  <h2 className="my-2 ml-2 p-2 pl-4 font-sans text-gray-400">
-                    All Groups
-                  </h2>
+                    {hasPendingGangs ? (
+                      <div className="px-4">
+                        <h2 className="mb-0.5 p-2 font-sans text-gray-400">
+                          Invites
+                        </h2>
+                        <GroupJoinList highlightAll gangs={pendingGangs} />
+                      </div>
+                    ) : null}
+
+                    <h2 className="my-2 ml-2 p-2 pl-4 font-sans text-gray-400">
+                      All Groups
+                    </h2>
+                    {gangs.length
+                      ? gangs.map((flag) => <GangItem key={flag} flag={flag} />)
+                      : null}
+                  </>
                 ) : null}
-
-                <div className="px-4">
-                  {gangs.map((flag) => (
-                    <GangItem key={flag} flag={flag} />
-                  ))}
-                </div>
               </GroupList>
             </GroupsScrollingContext.Provider>
           )}


### PR DESCRIPTION
This PR fixes the rendering of the groups list when the user has no pinned items or pending invitations. Previously, that would result in an empty header being rendered, which, since it was 0px high, would cause Virtuoso's render cycle to fail. 

This PR deals with that in two ways:
- It prevents `MobileRoot` from passing in an empty header component. 
- It wraps any header element in a 1px min-height dive, to ensure that whatever is passed in will have some height.