### PR TITLE
mobile: fix stuck chat input focus state on navigate away

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -475,6 +475,12 @@ export default function ChatInput({
         handleBlur();
       }
     }
+
+    return () => {
+      if (isChatInputFocused) {
+        handleBlur();
+      }
+    };
   }, [
     isChatInputFocused,
     messageEditor,


### PR DESCRIPTION
We weren't properly clearing the chat input focus context on unmount of the chat input component, this makes sure the chat input context is properly reset if the component unmounts.

Fixes LAND-1032