### PR TITLE
lure: provide a fallback url if branch.io is blocked (or down)

### DIFF
--- a/ui/src/logic/branch.ts
+++ b/ui/src/logic/branch.ts
@@ -20,7 +20,7 @@ export const getDeepLink = async (alias: string) => {
 
 export const createDeepLink = async (canonicalUrl: string, lure: string) => {
   const alias = lure.replace('~', '').replace('/', '-');
-  let url = await getDeepLink(alias);
+  let url = await getDeepLink(alias).catch(() => canonicalUrl);
   if (!url) {
     const response = await fetchBranchApi('/v1/url', {
       method: 'POST',
@@ -34,8 +34,9 @@ export const createDeepLink = async (canonicalUrl: string, lure: string) => {
         },
       }),
     });
+
     if (!response.ok) {
-      return undefined;
+      return canonicalUrl;
     }
 
     ({ url } = (await response.json()) as { url: string });


### PR DESCRIPTION
Fixes LAND-1047

Apparently branch.io appears on many adblock lists. (see https://github.com/BranchMetrics/web-branch-deep-linking-attribution/issues/538)

We were only returning a lure link if we could successfully create a deep link. We should return the normal/non-branch lure link if we fail to contact branch.io.