### PR TITLE
scroller: fix bottom anchoring for new messages

### DIFF
--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -165,7 +165,7 @@ export function writsReducer(whom: string) {
         {
           oldest: time,
           newest: time,
-          loadedNewest: false,
+          loadedNewest: true,
           loadedOldest: false,
         },
         draft.writWindows[whom]


### PR DESCRIPTION
This fixes bottom anchoring of the chat scroller by ensuring that it doesn't flip into "newer" loading mode when a new message arrives.