### PR TITLE
ops: sync bosdev and doznec simultaneously

### DIFF
--- a/.github/workflows/deploy-external-groups.yml
+++ b/.github/workflows/deploy-external-groups.yml
@@ -6,6 +6,11 @@ on:
         type: string
         required: true
         description: Enter the tag to deploy
+      kernel:
+        type: boolean
+        required: false
+        default: true
+        description: Also deploy to kernel integration moon
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,6 +27,15 @@ jobs:
         name: Deploy
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps groups doznec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+          URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}
+      - id: deploy-kernel
+        name: Deploy Kernel Moon
+        if: ${{ github.event.inputs.kernel == 'true' }}
+        run:
+          ./.github/helpers/deploy.sh tloncorp/landscape-apps groups bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}

--- a/.github/workflows/deploy-external-talk.yml
+++ b/.github/workflows/deploy-external-talk.yml
@@ -6,6 +6,11 @@ on:
         type: string
         required: true
         description: Enter the tag to deploy
+      kernel:
+        type: boolean
+        required: false
+        default: true
+        description: Also deploy to kernel integration moon
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,6 +27,15 @@ jobs:
         name: Deploy
         run:
           ./.github/helpers/deploy.sh tloncorp/landscape-apps talk doznec-dozzod-marnus us-central1-a mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+          URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}
+      - id: deploy-kernel
+        name: Deploy Kernel Moon
+        if: ${{ github.event.inputs.kernel == 'true' }}
+        run:
+          ./.github/helpers/deploy.sh tloncorp/landscape-apps groups bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
         env:
           SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
           SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}

--- a/.github/workflows/deploy-kernel-groups.yml
+++ b/.github/workflows/deploy-kernel-groups.yml
@@ -8,62 +8,8 @@ on:
         default: develop
         description: Enter the tag to deploy
 jobs:
-  build-frontend:
-    runs-on: ubuntu-latest
-    name: 'Build Frontend'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.REPO_TOKEN }}
-          ref: ${{ github.event.inputs.tag }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: ./ui/.nvmrc
-      - working-directory: ./ui
-        run: |
-          npm ci
-          npm run build
-      - uses: actions/upload-artifact@v3
-        with:
-          name: 'ui-dist'
-          path:  ui/dist
-  glob:
-    runs-on: ubuntu-latest
-    name: 'Make a glob'
-    needs: build-frontend
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.REPO_TOKEN }}
-          ref: ${{ github.event.inputs.tag }}
-      - uses: actions/download-artifact@v3
-        with:
-          name: 'ui-dist'
-          path: ui/dist
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: 'glob'
-        uses: ./.github/actions/glob
-        with:
-          folder: 'ui/dist/*'
-          docket: 'desk/desk.docket-0'
-      - name: Commit and Push Glob
-        run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-          git add desk/desk.docket-0
-          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
-          INPUT=${{ github.event.inputs.tag }}
-          BRANCH=${INPUT:-"develop"}
-          git pull origin $BRANCH --rebase --autostash
-          git push
   deploy:
     runs-on: ubuntu-latest
-    needs: glob
     name: "Deploy Groups to ~bosdev-dozzod-marnus (kernel integration)"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-kernel-talk.yml
+++ b/.github/workflows/deploy-kernel-talk.yml
@@ -8,63 +8,8 @@ on:
         default: develop
         description: Enter the tag to deploy
 jobs:
-  build-frontend:
-    runs-on: ubuntu-latest
-    name: 'Build Frontend'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.REPO_TOKEN }}
-          ref: ${{ github.event.inputs.tag }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: ./ui/.nvmrc
-      - working-directory: ./ui
-        run: |
-          npm ci
-          npm run build:chat
-      - uses: actions/upload-artifact@v3
-        with:
-          name: 'ui-dist'
-          path:  ui/dist
-  glob:
-    runs-on: ubuntu-latest
-    name: 'Make a glob'
-    needs: build-frontend
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.REPO_TOKEN }}
-          ref: ${{ github.event.inputs.tag }}
-      - uses: actions/download-artifact@v3
-        with:
-          name: 'ui-dist'
-          path: ui/dist
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: 'glob'
-        uses: ./.github/actions/glob
-        with:
-          folder: 'ui/dist/*'
-          docket: 'talk/desk.docket-0'
-      - name: Commit and Push Glob
-        run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
-          git add talk/desk.docket-0
-          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
-          sleep 10
-          INPUT=${{ github.event.inputs.tag }}
-          BRANCH=${INPUT:-"develop"}
-          git pull origin $BRANCH --rebase --autostash
-          git push
   deploy:
     runs-on: ubuntu-latest
-    needs: glob
     name: "Deploy Talk to ~bosdev-dozzod-marnus (kernel integration)"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/glob-and-deploy-kernel-groups.yml
+++ b/.github/workflows/glob-and-deploy-kernel-groups.yml
@@ -1,0 +1,86 @@
+name: Glob and Deploy Groups (Kernel Integration)
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: develop
+        description: Enter the tag to deploy
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    name: 'Build Frontend'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          ref: ${{ github.event.inputs.tag }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ./ui/.nvmrc
+      - working-directory: ./ui
+        run: |
+          npm ci
+          npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'ui-dist'
+          path:  ui/dist
+  glob:
+    runs-on: ubuntu-latest
+    name: 'Make a glob'
+    needs: build-frontend
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          ref: ${{ github.event.inputs.tag }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'ui-dist'
+          path: ui/dist
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: 'glob'
+        uses: ./.github/actions/glob
+        with:
+          folder: 'ui/dist/*'
+          docket: 'desk/desk.docket-0'
+      - name: Commit and Push Glob
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+          git add desk/desk.docket-0
+          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
+          INPUT=${{ github.event.inputs.tag }}
+          BRANCH=${INPUT:-"develop"}
+          git pull origin $BRANCH --rebase --autostash
+          git push
+  deploy:
+    runs-on: ubuntu-latest
+    needs: glob
+    name: "Deploy Groups to ~bosdev-dozzod-marnus (kernel integration)"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          ref: ${{ github.event.inputs.tag }}
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: deploy
+        name: Deploy
+        run:
+          ./.github/helpers/deploy.sh tloncorp/landscape-apps groups bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+          URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG_KERNEL }}

--- a/.github/workflows/glob-and-deploy-kernel-talk.yml
+++ b/.github/workflows/glob-and-deploy-kernel-talk.yml
@@ -1,0 +1,87 @@
+name: Glob and Deploy Talk (Kernel Integration)
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: develop
+        description: Enter the tag to deploy
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    name: 'Build Frontend'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          ref: ${{ github.event.inputs.tag }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ./ui/.nvmrc
+      - working-directory: ./ui
+        run: |
+          npm ci
+          npm run build:chat
+      - uses: actions/upload-artifact@v3
+        with:
+          name: 'ui-dist'
+          path:  ui/dist
+  glob:
+    runs-on: ubuntu-latest
+    name: 'Make a glob'
+    needs: build-frontend
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          ref: ${{ github.event.inputs.tag }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: 'ui-dist'
+          path: ui/dist
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: 'glob'
+        uses: ./.github/actions/glob
+        with:
+          folder: 'ui/dist/*'
+          docket: 'talk/desk.docket-0'
+      - name: Commit and Push Glob
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+          git add talk/desk.docket-0
+          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
+          sleep 10
+          INPUT=${{ github.event.inputs.tag }}
+          BRANCH=${INPUT:-"develop"}
+          git pull origin $BRANCH --rebase --autostash
+          git push
+  deploy:
+    runs-on: ubuntu-latest
+    needs: glob
+    name: "Deploy Talk to ~bosdev-dozzod-marnus (kernel integration)"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          ref: ${{ github.event.inputs.tag }}
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: deploy
+        name: Deploy
+        run:
+          ./.github/helpers/deploy.sh tloncorp/landscape-apps talk bosdev-dozzod-marnus us-central1-b mainnet-tlon-other-2d ${{ github.event.inputs.tag }}
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+          URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG_KERNEL }}


### PR DESCRIPTION
Refactors our actions a bit so we have more flexibility around kernel integration deploys and also combines the "external" step to also deploy to kernel moon as the default case. IF we're in the middle of a kernel integration then we can run that step with the deploy off (since it will fail).