### PR TITLE
diary: dont crash in update path

### DIFF
--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -1087,7 +1087,12 @@
       =.  notes.diary  (reduce:di-notes time p.dif)
       =.  cor  (give-brief flag di-brief)
       =/  cons=(list (list content:ha))
-        (hark:di-notes [flag bowl p.dif])
+        ::  when using time, we need to use the new time if we're adding,
+        ::  otherwise the time on the diff is correct
+        =-  (hark:di-notes [flag bowl - q.p.dif])
+        ?+  -.q.p.dif  p.p.dif
+          %add  time
+        ==
       =/  rope
         ?:  =(%quips -.q.p.dif)
           /note/(rsh 4 (scot %ui p.p.dif))

--- a/desk/lib/notes.hoon
+++ b/desk/lib/notes.hoon
@@ -109,57 +109,49 @@
   |=  [=flag:d =bowl:gall =time =delta:notes:d]
   ^-  (list (list content:ha))
   ?.  ?=(%quips -.delta)
-    ?.  ?=(%add -.delta)
+    ?.  ?=(%add -.delta)  ~
+    ?.  (want-hark [flag %msg bowl])  ~
+    =/  =essay:d  p.+.delta
+    =/  from-me  =(author.essay our.bowl)
+    ?:  from-me  ~
+    =/  content
+      %+  turn
+        content.essay
+      |=  =verse:d
+      ?.  ?=(%block -.verse)
+        p.+.verse
       ~
-    ?:  (want-hark [flag %msg bowl])
-      =/  =essay:d  p.+.delta
-      =/  from-me  =(author.essay our.bowl)
-      ?:  from-me  ~
-      =/  content
-        %+  turn
-          content.essay
-        |=  =verse:d
-        ?.  ?=(%block -.verse)
-          p.+.verse
-        ~
-      =-  ~[-]
-      :~  [%ship author.essay]
-          ' published a note: '
-          [%emph title.essay]
-          ' '
-          (flatten (zing content))
-      ==
-    ~
-  =/  [@ =note:d]  (got time)
-  ~!  q.p.delta
-  ?.  ?=(%add -.q.p.delta)
-    ~
+    =-  ~[-]
+    :~  [%ship author.essay]
+        ' published a note: '
+        [%emph title.essay]
+        ' '
+        (flatten (zing content))
+    ==
+  ?.  ?=(%add -.q.p.delta)  ~
+  ::  let's be extra safe here
+  =/  entry=(unit [@ =note:d])  (get time)
+  ?~  entry  ~
+  =*  note  note.u.entry
   =/  =memo:d  p.q.p.delta
   =/  in-replies
     %+  lien  (tap:on:quips:d quips.note)
     |=  [=^time =quip:d]
     =(author.quip our.bowl)
-  ?:  (want-hark [flag %msg bowl])
-    =-  ~[-]
-    :~  [%ship author.memo]
-        ' commented on '
-        [%emph title.note]
-        ': '
-        [%ship author.memo]
-        ': '
-        (flatten q.content.memo)
-    ==
+  =/  contents
+      :~  :~  [%ship author.memo]
+              ' commented on '
+              [%emph title.note]
+              ': '
+              [%ship author.memo]
+              ': '
+              (flatten q.content.memo)
+      ==  ==
+  ?:  (want-hark [flag %msg bowl])  contents
   ?:  |(=(author.memo our.bowl) &(!in-replies !=(author.note our.bowl)))  ~
   ?.  (want-hark [flag %to-us bowl])  ~
-  =-  ~[-]
-  :~  [%ship author.memo]
-      ' commented on '
-      [%emph title.note]
-      ': '
-      [%ship author.memo]
-      ': '
-      (flatten q.content.memo)
-  ==
+  contents
+::
 ::  +trace: turn note into outline
 ::
 ::    XX: should trim actual note contents, probably

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -342,9 +342,7 @@ export default function Notification({
       )}
       <div className="absolute right-5 flex-none p-1">
         <div className="flex items-center space-x-1">
-          {bin.unread ? (
-            <Bullet16Icon className="h-4 w-4 text-red sm:text-blue" />
-          ) : null}
+          {bin.unread ? <Bullet16Icon className="h-4 w-4 text-blue" /> : null}
           <span className="text-sm font-semibold">
             {makePrettyTime(new Date(bin.time))}
           </span>


### PR DESCRIPTION
This should fix LAND-1061 by safely accessing notes when we try to make notifications. I'm not sure however of the cause of why one might not have the note being commented on, but seems highly possible with funny permissions.

Also put a little rider in here to fix the notification dot color.