### PR TITLE
connection: update http api

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -59,7 +59,7 @@
         "@types/marked": "^4.3.0",
         "@urbit/api": "^2.2.0",
         "@urbit/aura": "^0.4.0",
-        "@urbit/http-api": "^2.4.5-debug",
+        "@urbit/http-api": "^3.0.0",
         "@urbit/sigil-js": "^2.1.0",
         "any-ascii": "^0.3.1",
         "big-integer": "^1.6.51",
@@ -7971,8 +7971,9 @@
       "license": "MIT"
     },
     "node_modules/@urbit/http-api": {
-      "version": "2.4.5-debug",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@urbit/http-api/-/http-api-3.0.0.tgz",
+      "integrity": "sha512-EmyPbWHWXhfYQ/9wWFcLT53VvCn8ct9ljd6QEe+UBjNPEhUPOFBLpDsDp3iPLQgg8ykSU8JMMHxp95LHCorExA==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "browser-or-node": "^1.3.0",
@@ -24137,7 +24138,9 @@
       "dev": true
     },
     "@urbit/http-api": {
-      "version": "2.4.5-debug",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@urbit/http-api/-/http-api-3.0.0.tgz",
+      "integrity": "sha512-EmyPbWHWXhfYQ/9wWFcLT53VvCn8ct9ljd6QEe+UBjNPEhUPOFBLpDsDp3iPLQgg8ykSU8JMMHxp95LHCorExA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "browser-or-node": "^1.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -106,7 +106,7 @@
     "@types/marked": "^4.3.0",
     "@urbit/api": "^2.2.0",
     "@urbit/aura": "^0.4.0",
-    "@urbit/http-api": "^2.4.5-debug",
+    "@urbit/http-api": "^3.0.0",
     "@urbit/sigil-js": "^2.1.0",
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.51",

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -111,9 +111,6 @@ class API {
       if (onReconnect) {
         onReconnect();
       }
-      useLocalState.setState((state) => ({
-        subscription: 'connected',
-      }));
     };
 
     this.client.onRetry = () => {
@@ -258,7 +255,9 @@ class API {
               // should only happen once since we call this each invocation
               // and onReconnect will set the lastReconnect time
               const { lastReconnect, onReconnect } = useLocalState.getState();
-              const threshold = 12 * 60 * 60 * 1000; // 12 hours
+              const threshold = import.meta.env.DEV
+                ? 60 * 1000
+                : 12 * 60 * 60 * 1000; // 12 hours
               if (Date.now() - lastReconnect >= threshold && onReconnect) {
                 onReconnect();
               }

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -254,6 +254,14 @@ class API {
                 ...params,
                 event: eventListener(params.event),
               });
+
+              // should only happen once since we call this each invocation
+              // and onReconnect will set the lastReconnect time
+              const { lastReconnect, onReconnect } = useLocalState.getState();
+              const threshold = 12 * 60 * 60 * 1000; // 12 hours
+              if (Date.now() - lastReconnect >= threshold && onReconnect) {
+                onReconnect();
+              }
             },
           })
         ),

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -1,15 +1,9 @@
 import Urbit from '@urbit/http-api';
 import api from '@/api';
-import {
-  asyncWithDefault,
-  asyncWithFallback,
-  isTalk,
-  log,
-} from '@/logic/utils';
+import { asyncWithDefault, asyncWithFallback, isTalk } from '@/logic/utils';
 import queryClient from '@/queryClient';
 import { Gangs, Groups } from '@/types/groups';
 import { TalkInit, GroupsInit } from '@/types/ui';
-import { isNativeApp } from '@/logic/native';
 import { useChatState } from './chat';
 import useContactState from './contact';
 import useDocketState from './docket';


### PR DESCRIPTION
This should resolve both LAND-844 and LAND-996. It updates the http-api to the latest 3.0 version which has channel reap handling. It also adds a delay to scrying all "auxiliary" data like contacts, storage, kiln, docket, etc. when reconnecting so that opening your phone and constant reconnects doesn't incur as much fetching.