### PR TITLE
chat: properly clear refs

### DIFF
--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -17,7 +17,11 @@ import HardBreak from '@tiptap/extension-hard-break';
 import { useIsMobile } from '@/logic/useMedia';
 import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
 import { refPasteRule, Shortcuts } from '@/logic/tiptap';
-import { useChatBlocks, useChatStore } from '@/chat/useChatStore';
+import {
+  chatStoreLogger,
+  useChatBlocks,
+  useChatStore,
+} from '@/chat/useChatStore';
 import { useCalm } from '@/state/settings';
 import Mention from '@tiptap/extension-mention';
 import { PASTEABLE_IMAGE_TYPES } from '@/constants';
@@ -70,6 +74,7 @@ export function useMessageEditor({
         return;
       }
       setBlocks(whom, [...chatBlocks, { cite: r }]);
+      chatStoreLogger.log('onReference', { whom, r, chatBlocks });
     },
     [chatBlocks, setBlocks, whom]
   );

--- a/ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar/Sidebar.test.tsx
@@ -47,6 +47,9 @@ vi.mock('@/logic/utils', () => ({
   storageVersion: () => 0,
   clearStorageMigration: () => ({}),
   isTalk: () => false,
+  createDevLogger: () => ({
+    log: () => ({}),
+  }),
 }));
 
 describe('Sidebar', () => {


### PR DESCRIPTION
This is a really weird one, but I think we either were assigning to the `emptyInfo` or `delayedRead` was using stale data. But what seemed to trigger this was an incoming brief triggering `unread` from another channel while in a new channel you'd not visited yet. Hopefully fixes LAND-425