### PR TITLE
skip branch deep linking if no lure web link provided

### DIFF
--- a/ui/src/logic/branch.ts
+++ b/ui/src/logic/branch.ts
@@ -18,7 +18,14 @@ export const getDeepLink = async (alias: string) => {
   return url;
 };
 
-export const createDeepLink = async (canonicalUrl: string, lure: string) => {
+export const createDeepLink = async (
+  canonicalUrl: string | undefined,
+  lure: string
+) => {
+  if (!canonicalUrl) {
+    return undefined;
+  }
+
   const alias = lure.replace('~', '').replace('/', '-');
   let url = await getDeepLink(alias).catch(() => canonicalUrl);
   if (!url) {


### PR DESCRIPTION
Skips the branch deep link look-up and creation flow if the specified `canonicalUrl` (the web lure flow URL) is empty. This prevents a situation where a deep link is created without a custom desktop redirect URL, resulting in the user being able to land on a Branch-hosted app download page.