### PR TITLE
notebook: tasks bug and misc

### DIFF
--- a/desk/lib/diary-json.hoon
+++ b/desk/lib/diary-json.hoon
@@ -541,6 +541,12 @@
         tag/so
         break/ul
     ::
+      :-  %task
+      %-  ot
+      :~  checked/bo
+          content/(ar inline)
+      ==
+    ::
       :-  %block
       %-  ot
       :~  index/ni

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -191,20 +191,22 @@ class API {
     return this.withErrorHandling(
       (client) =>
         new Promise<void>((resolve, reject) => {
-          client.poke<T>({
-            ...params,
-            onError: (e) => {
-              params.onError?.(e);
-              reject();
-            },
-            onSuccess: async () => {
-              params.onSuccess?.();
-              const defaultValidator = (event: any) =>
-                _.isEqual(params.json, event);
-              await this.track(subscription, validator || defaultValidator);
-              resolve();
-            },
-          });
+          client
+            .poke<T>({
+              ...params,
+              onError: (e) => {
+                params.onError?.(e);
+                reject();
+              },
+              onSuccess: async () => {
+                params.onSuccess?.();
+                const defaultValidator = (event: any) =>
+                  _.isEqual(params.json, event);
+                await this.track(subscription, validator || defaultValidator);
+                resolve();
+              },
+            })
+            .catch(reject);
         })
     );
   }

--- a/ui/src/diary/DiaryNoteOptionsDropdown.tsx
+++ b/ui/src/diary/DiaryNoteOptionsDropdown.tsx
@@ -2,7 +2,11 @@ import React, { PropsWithChildren, useState } from 'react';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 import ConfirmationModal from '@/components/ConfirmationModal';
-import { useArrangedNotes, usePostToggler } from '@/state/diary';
+import {
+  useArrangedNotes,
+  useIsNotePending,
+  usePostToggler,
+} from '@/state/diary';
 import { useChannelCompatibility } from '@/logic/channel';
 import { getFlagParts } from '@/logic/utils';
 import ActionMenu, { Action } from '@/components/ActionMenu';
@@ -29,6 +33,7 @@ export default function DiaryNoteOptionsDropdown({
   const { ship } = getFlagParts(flag);
   const nest = `diary/${flag}`;
   const { compatible } = useChannelCompatibility(nest);
+  const isPending = useIsNotePending(time);
   const {
     isOpen,
     didCopy,
@@ -54,7 +59,7 @@ export default function DiaryNoteOptionsDropdown({
     },
   ];
 
-  if ((canEdit && ship === window.our) || (canEdit && compatible)) {
+  if (!isPending && canEdit && (ship === window.our || compatible)) {
     if (arrangedNotes.includes(time)) {
       actions.push(
         {

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -31,12 +31,12 @@ import { useIsMobile } from '@/logic/useMedia';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
-import asyncCallWithTimeout from '@/logic/asyncWithTimeout';
 import Setting from '@/components/Settings/Setting';
 import { useMarkdownInDiaries, usePutEntryMutation } from '@/state/settings';
 import { useChannelCompatibility } from '@/logic/channel';
 import Tooltip from '@/components/Tooltip';
 import MobileHeader from '@/components/MobileHeader';
+import { isFirstDayOfMonth } from 'date-fns';
 import DiaryInlineEditor, { useDiaryInlineEditor } from './DiaryInlineEditor';
 import DiaryMarkdownEditor from './DiaryMarkdownEditor';
 
@@ -59,11 +59,16 @@ export default function DiaryAddNote() {
     isLoading: loadingNote,
     fetchStatus,
   } = useNote(chFlag, id || '0', !id);
-  const { mutateAsync: editNote, status: editStatus } = useEditNoteMutation();
+  const {
+    mutateAsync: editNote,
+    status: editStatus,
+    reset: resetEdit,
+  } = useEditNoteMutation();
   const {
     data: returnTime,
     mutateAsync: addNote,
     status: addStatus,
+    reset: resetAdd,
   } = useAddNoteMutation();
   const { mutate: toggleMarkdown, status: toggleMarkdownStatus } =
     usePutEntryMutation({ bucket: 'diary', key: 'markdown' });
@@ -94,6 +99,15 @@ export default function DiaryAddNote() {
     content: '',
     placeholder: '',
     onEnter: () => false,
+    onUpdate: useCallback(() => {
+      if (addStatus === 'error') {
+        resetAdd();
+      }
+
+      if (editStatus === 'error') {
+        resetEdit();
+      }
+    }, [addStatus, editStatus, resetAdd, resetEdit]),
   });
 
   const setEditorContent = useCallback(
@@ -148,7 +162,7 @@ export default function DiaryAddNote() {
 
     try {
       if (id) {
-        await editNote({
+        editNote({
           flag: chFlag,
           time: id,
           essay: {
@@ -158,19 +172,6 @@ export default function DiaryAddNote() {
           },
         });
       } else {
-        await asyncCallWithTimeout(
-          addNote({
-            initialTime,
-            flag: chFlag,
-            essay: {
-              ...values,
-              content: noteContent,
-              author: window.our,
-              sent: daToUnix(bigInt(initialTime)),
-            },
-          }),
-          3000
-        );
         captureGroupsAnalyticsEvent({
           name: 'post_item',
           groupFlag: flag,
@@ -178,11 +179,19 @@ export default function DiaryAddNote() {
           channelType: 'diary',
           privacy,
         });
-      }
 
-      reset();
+        addNote({
+          initialTime,
+          flag: chFlag,
+          essay: {
+            ...values,
+            content: noteContent,
+            author: window.our,
+            sent: daToUnix(bigInt(initialTime)),
+          },
+        });
+      }
     } catch (error) {
-      navigate(`/groups/${flag}/channels/diary/${chFlag}`);
       console.error(error);
     }
   }, [
@@ -193,11 +202,9 @@ export default function DiaryAddNote() {
     getValues,
     id,
     note,
-    reset,
     addNote,
     editNote,
     initialTime,
-    navigate,
     watchedTitle,
   ]);
 
@@ -208,6 +215,9 @@ export default function DiaryAddNote() {
       navigate(`/groups/${flag}/channels/diary/${chFlag}?new=${returnTime}`);
     }
   }, [addStatus, chFlag, editStatus, flag, navigate, returnTime]);
+
+  const isLoading = addStatus === 'loading' || editStatus === 'loading';
+  const isError = addStatus === 'error' || editStatus === 'error';
 
   return (
     <Layout
@@ -230,8 +240,7 @@ export default function DiaryAddNote() {
                     disabled={
                       !compatible ||
                       !editor?.getText() ||
-                      editStatus === 'loading' ||
-                      addStatus === 'loading' ||
+                      isLoading ||
                       watchedTitle === ''
                     }
                     className={cn(
@@ -239,9 +248,9 @@ export default function DiaryAddNote() {
                     )}
                     onClick={publish}
                   >
-                    {editStatus === 'loading' || addStatus === 'loading' ? (
+                    {isLoading ? (
                       <LoadingSpinner className="h-4 w-4" />
-                    ) : editStatus === 'error' || addStatus === 'error' ? (
+                    ) : isError ? (
                       'Error'
                     ) : (
                       'Save'
@@ -278,23 +287,29 @@ export default function DiaryAddNote() {
             </Link>
 
             <div className="flex shrink-0 flex-row items-center space-x-3">
-              <Tooltip content={text} open={compatible ? false : undefined}>
+              <Tooltip
+                content={isError ? 'Your note was unable to be saved' : text}
+                open={compatible ? (isError ? undefined : false) : undefined}
+              >
                 <button
                   disabled={
                     !compatible ||
                     !editor?.getText() ||
-                    editStatus === 'loading' ||
-                    addStatus === 'loading' ||
+                    isLoading ||
                     watchedTitle === ''
                   }
                   className={cn(
-                    'small-button bg-blue text-white disabled:bg-gray-200 disabled:text-gray-400 dark:disabled:text-gray-400'
+                    'small-button min-w-16 text-white disabled:bg-gray-200 disabled:text-gray-400 dark:disabled:text-gray-400',
+                    {
+                      'bg-blue': !isError,
+                      'bg-red': isError,
+                    }
                   )}
                   onClick={publish}
                 >
-                  {editStatus === 'loading' || addStatus === 'loading' ? (
+                  {isLoading ? (
                     <LoadingSpinner className="h-4 w-4" />
-                  ) : editStatus === 'error' || addStatus === 'error' ? (
+                  ) : isError ? (
                     'Error'
                   ) : (
                     'Save'

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -108,7 +108,8 @@ export default function DiaryAddNote() {
 
   useEffect(() => {
     if (editor && !loadingNote && note?.essay && editor.isEmpty && !loaded) {
-      editor.commands.setContent(diaryMixedToJSON(note?.essay?.content || []));
+      const content = diaryMixedToJSON(note?.essay?.content || []);
+      editor.commands.setContent(content);
       setLoaded(true);
     }
   }, [editor, loadingNote, note, loaded]);

--- a/ui/src/logic/tiptap.ts
+++ b/ui/src/logic/tiptap.ts
@@ -10,6 +10,7 @@ import {
   isShip,
   isStrikethrough,
   Link,
+  Task,
 } from '@/types/content';
 import { reduce, isEqual } from 'lodash';
 import { JSONContent } from '@tiptap/react';
@@ -578,6 +579,18 @@ export const inlineToContent = (
     };
   }
 
+  if ('task' in inline) {
+    return {
+      type: 'taskItem',
+      attrs: {
+        checked: inline.task.checked,
+      },
+      content: wrapParagraphs(
+        inline.task.content.map((i) => inlineToContent(i))
+      ),
+    };
+  }
+
   if ('break' in inline) {
     return makeParagraph();
   }
@@ -611,16 +624,43 @@ export const inlineToContent = (
   return makeParagraph();
 };
 
+export function makeTask(inline: Task): JSONContent {
+  return {
+    type: 'taskItem',
+    attrs: {
+      checked: inline.task.checked,
+    },
+    content: wrapParagraphs(inline.task.content.map((i) => inlineToContent(i))),
+  };
+}
+
 export function makeListing(listing: DiaryListing): JSONContent {
   if ('list' in listing) {
     const { list } = listing;
 
     const returnList = {
-      type: list.type === 'ordered' ? 'orderedList' : 'bulletList',
+      type:
+        list.type === 'ordered'
+          ? 'orderedList'
+          : list.type === 'unordered'
+          ? 'bulletList'
+          : 'taskList',
       content: list.items.map((item) => makeListing(item)),
     };
 
     if (list.contents.length > 0) {
+      const task = list.contents.find(
+        (i) => typeof i === 'object' && 'task' in i
+      ) as Task | undefined;
+      if (task) {
+        const item = makeTask(task);
+
+        return {
+          ...item,
+          content: [...(item.content || []), returnList],
+        };
+      }
+
       return {
         type: 'listItem',
         content: [
@@ -631,10 +671,16 @@ export function makeListing(listing: DiaryListing): JSONContent {
     }
     return returnList;
   }
-  return {
-    type: 'listItem',
-    content: wrapParagraphs(listing.item.map((i) => inlineToContent(i))),
-  };
+
+  const task = listing.item.find(
+    (i) => typeof i === 'object' && 'task' in i
+  ) as Task | undefined;
+  return task
+    ? makeTask(task)
+    : {
+        type: 'listItem',
+        content: wrapParagraphs(listing.item.map((i) => inlineToContent(i))),
+      };
 }
 
 export const blockToContent = (content: DiaryBlock): JSONContent => {


### PR DESCRIPTION
This fixes LAND-1075 LAND-1076 and LAND-1077. Tasks were missing from the incoming json parser so that was added in. We also missed a place where we let people try to edit a pending note. The biggest chunk here was letting notes actually error out so that people can at least save a backup somewhere else (or change the content), previously we were just navigating away.