### PR TITLE
groups: fix icon position/size for mobile nav

### DIFF
--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -14,9 +14,9 @@ import { AppUpdateContext } from '@/logic/useAppUpdates';
 import NavTab, { DoubleClickableNavTab } from '../NavTab';
 import BellIcon from '../icons/BellIcon';
 import HomeIconMobileNav from '../icons/HomeIconMobileNav';
-import MagnifyingGlassMobileNavIcon from '../icons/MagnifyingGlassMobileNavIcon';
 import MessagesIcon from '../icons/MessagesIcon';
 import Avatar from '../Avatar';
+import NavigateIcon from '../icons/NavigateIcon';
 
 function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
   const navigate = useNavigate();
@@ -37,21 +37,24 @@ function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={onSingleClick}
       onDoubleClick={() => navigate('/')}
-      linkClass="h-12"
+      linkClass="h-full !pb-0 flex flex-col items-start justify-start"
     >
-      <div className="flex h-8 w-8 items-center justify-center ">
+      <div className="flex-1" />
+      <div className="flex h-8 w-8 items-center justify-center">
         <HomeIconMobileNav
           isInactive={props.isInactive}
           isDarkMode={props.isDarkMode}
           className="h-[20px] w-[18px]"
         />
       </div>
-      <div
-        className={cn(
-          'mt-0.5 h-1.5 w-1.5 rounded-full',
-          groupsUnread && 'bg-blue'
-        )}
-      />
+      <div className="flex flex-1 items-end">
+        <div
+          className={cn(
+            'mb-0.5 h-1.5 w-1.5 rounded-full',
+            groupsUnread && 'bg-blue'
+          )}
+        />
+      </div>
     </DoubleClickableNavTab>
   );
 }
@@ -75,21 +78,24 @@ function MessagesTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={onSingleClick}
       onDoubleClick={() => navigate('/messages')}
-      linkClass="h-12"
+      linkClass="h-full !pb-0 flex flex-col items-start justify-start"
     >
-      <div className="flex h-8 w-8 items-center justify-center ">
+      <div className="flex-1" />
+      <div className="flex h-8 w-8 items-center justify-center">
         <MessagesIcon
           isInactive={props.isInactive}
           isDarkMode={props.isDarkMode}
           className="h-[20px] w-[18px]"
         />
       </div>
-      <div
-        className={cn(
-          'mt-[2px] h-1.5 w-1.5 rounded-full',
-          hasUnreads && 'bg-blue'
-        )}
-      />
+      <div className="flex flex-1 items-end">
+        <div
+          className={cn(
+            'mb-0.5 h-1.5 w-1.5 rounded-full',
+            hasUnreads && 'bg-blue'
+          )}
+        />
+      </div>
     </DoubleClickableNavTab>
   );
 }
@@ -102,16 +108,24 @@ function ActivityTab(props: { isInactive: boolean; isDarkMode: boolean }) {
     <DoubleClickableNavTab
       onSingleClick={() => navigate('/notifications')}
       onDoubleClick={() => navigate('/notifications')}
-      linkClass="h-12"
+      linkClass="h-full !pb-0 flex flex-col items-start justify-start"
     >
-      <div className="flex h-8 w-8 items-center justify-center ">
+      <div className="flex-1" />
+      <div className="flex h-8 w-8 items-center justify-center">
         <BellIcon
           isInactive={props.isInactive}
-          className="h-6 w-[18px]"
+          className="h-[20px] w-[18px]"
           isDarkMode={props.isDarkMode}
         />
       </div>
-      <div className={cn('h-1.5 w-1.5 rounded-full', count > 0 && 'bg-blue')} />
+      <div className="flex flex-1 items-end">
+        <div
+          className={cn(
+            'mb-0.5 h-1.5 w-1.5 rounded-full',
+            count > 0 && 'bg-blue'
+          )}
+        />
+      </div>
     </DoubleClickableNavTab>
   );
 }
@@ -150,7 +164,8 @@ export default function MobileSidebar() {
       <footer
         className={cn(
           'navbar-transition z-50 flex-none border-t-2 border-gray-50 bg-white',
-          isChatInputFocused && 'translate-y-[200%] opacity-0'
+          isChatInputFocused && 'translate-y-[200%] opacity-0',
+          !isNativeApp() && 'pb-1'
         )}
       >
         <nav>
@@ -167,27 +182,47 @@ export default function MobileSidebar() {
               isInactive={isInactive('/notifications')}
               isDarkMode={isDarkMode}
             />
-            <NavTab to="/find">
+            <NavTab
+              to="/find"
+              linkClass="h-full !pb-0 flex flex-col items-start justify-start"
+            >
+              <div className="flex-1" />
               <div className="flex h-8 w-8 items-center justify-center">
-                <MagnifyingGlassMobileNavIcon
+                <NavigateIcon
                   isInactive={isInactive('/find')}
                   isDarkMode={isDarkMode}
-                  className="h-6 w-[18px]"
+                  className="h-[20px] w-[18px]"
                 />
               </div>
+              <div className="flex-1" />
             </NavTab>
             {needsUpdate ? (
               <NavTab
                 to="/update-needed"
                 state={{ backgroundLocation: location }}
+                linkClass="h-full !pb-0 flex flex-col items-start justify-start"
               >
-                <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-yellow">
-                  <Asterisk16Icon className="h-4 w-4 text-black dark:text-white" />
+                <div className="flex-1" />
+                <div className="flex h-8 w-8 items-center justify-center">
+                  <div className="flex h-[20px] w-[20px] items-center justify-center rounded-[3px] bg-yellow">
+                    <Asterisk16Icon className="h-4 w-4 text-black dark:text-white" />
+                  </div>
                 </div>
+                <div className="flex-1" />
               </NavTab>
             ) : (
-              <NavTab to="/profile">
-                <Avatar size="xs" className="" ship={window.our} />
+              <NavTab
+                to="/profile"
+                linkClass="h-full !pb-0 flex flex-col items-start justify-start"
+              >
+                <div className="flex-1" />
+                <div className="flex h-8 w-8 items-center justify-center">
+                  <Avatar
+                    className="h-[20px] w-[20px] rounded-[3px]"
+                    ship={window.our}
+                  />
+                </div>
+                <div className="flex-1" />
               </NavTab>
             )}
           </ul>

--- a/ui/src/components/icons/BellIcon.tsx
+++ b/ui/src/components/icons/BellIcon.tsx
@@ -11,7 +11,7 @@ export default function BellIcon({
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        className={cn(className, 'pb-1')}
+        className={className}
         viewBox="0 0 21 22"
         fill="none"
       >
@@ -35,7 +35,7 @@ export default function BellIcon({
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      className={cn(className, 'pb-1')}
+      className={className}
       viewBox="0 0 21 22"
       fill="none"
     >

--- a/ui/src/components/icons/NavigateIcon.tsx
+++ b/ui/src/components/icons/NavigateIcon.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function NavigateIcon({
+  className,
+  isInactive,
+  isDarkMode,
+}: { isInactive?: boolean; isDarkMode?: boolean } & IconProps) {
+  let opacity = '1';
+  if (isInactive) {
+    opacity = isDarkMode ? '.8' : '.2';
+  }
+
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <circle
+        cx="10"
+        cy="10"
+        r="9"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stroke-current"
+        opacity={opacity}
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M13.971 5.6174C14.2388 5.45671 14.5433 5.76119 14.3826 6.02899L11.2886 11.1857C11.2633 11.2279 11.2279 11.2633 11.1857 11.2886L6.02899 14.3826C5.76119 14.5433 5.45671 14.2388 5.61739 13.971L8.71141 8.81431C8.73675 8.77209 8.77209 8.73675 8.81431 8.71141L13.971 5.6174Z"
+        className="fill-current"
+        opacity={opacity}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
OTT

Also: 
- updates the "Discover" icon to match the Figma mock 
- fixes touch targets for Discover & Profile (were unintentionally smaller than the others)

<img width="713" alt="Screenshot 2023-10-23 at 3 44 00 AM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/d17077b4-ca8b-4fa2-b438-aefdaa1d192e">

Fixes LAND-1074