### PR TITLE
channels: don't allow multiple form submissions in new channel form

### DIFF
--- a/ui/src/channels/NewChannel/NewChannelForm.tsx
+++ b/ui/src/channels/NewChannel/NewChannelForm.tsx
@@ -26,8 +26,7 @@ export default function NewChannelForm() {
   const { compatible, text } = useGroupCompatibility(groupFlag);
   const shelf = useDiaries();
   const stash = useStash();
-  const { mutate: mutateAddChannel, status: addChannelStatus } =
-    useAddChannelMutation();
+  const { mutate: mutateAddChannel } = useAddChannelMutation();
   const { mutateAsync: createDiary } = useCreateDiaryMutation();
   const { mutateAsync: createHeap } = useCreateHeapMutation();
   const defaultValues: NewChannelFormSchema = {
@@ -188,16 +187,12 @@ export default function NewChannelForm() {
                   !compatible ||
                   !form.formState.isValid ||
                   !form.formState.isDirty ||
-                  addChannelStatus === 'loading' ||
-                  addChannelStatus === 'success' ||
-                  addChannelStatus === 'error'
+                  form.formState.isSubmitting
                 }
               >
-                {addChannelStatus === 'loading' ? (
+                {form.formState.isSubmitting ? (
                   <LoadingSpinner className="h-4 w-4" />
-                ) : addChannelStatus === 'error' ? (
-                  'Error'
-                ) : addChannelStatus === 'success' ? (
+                ) : form.formState.isSubmitted ? (
                   'Saved'
                 ) : (
                   'Add Channel'


### PR DESCRIPTION
fixes LAND-1051

We don't actually get a status change from the add channel mutation unless we're adding a channel to a zone. Rather than check statuses on each type of mutation here, we can just use react-hook-form's form state (and not allow the user to click the button while we're submitting).