### PR TITLE
storage: don't break existing functionality if landscape not up to date

### DIFF
--- a/ui/src/state/storage/reducer.ts
+++ b/ui/src/state/storage/reducer.ts
@@ -26,8 +26,10 @@ const configuration = (
       buckets: new Set(data.buckets),
       currentBucket: data.currentBucket,
       region: data.region,
-      presignedUrl: data.presignedUrl,
-      service: data.service,
+      // if landscape is not up to date we need to default these so the
+      // client init logic still works
+      presignedUrl: data.presignedUrl || '',
+      service: data.service || 'credentials',
     };
   }
   return state;

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -30,7 +30,9 @@ export const useStorage = createState<BaseStorageState>(
       credentials: null,
     },
   }),
-  {},
+  {
+    partialize: () => ({}),
+  },
   [
     (set, get) =>
       createSubscription('storage', '/all', (e) => {


### PR DESCRIPTION
This fixes LAND-1096 by making sure we default the new values even if Landscape doesn't send them to us. This ensures that uploads still work until Landscape is updated. This also clears credentials from being stored in local storage.