### PR TITLE
images: compress images (and strip exif data) prior to upload

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -64,6 +64,7 @@
         "any-ascii": "^0.3.1",
         "big-integer": "^1.6.51",
         "browser-cookies": "^1.2.0",
+        "browser-image-compression": "^2.0.2",
         "classnames": "^2.3.1",
         "clipboard-copy": "^4.0.1",
         "color2k": "^2.0.0",
@@ -9052,6 +9053,14 @@
     "node_modules/browser-cookies": {
       "version": "1.2.0",
       "license": "Unlicence"
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
     },
     "node_modules/browser-or-node": {
       "version": "1.3.0",
@@ -18215,6 +18224,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "dev": true,
@@ -24854,6 +24868,14 @@
     "browser-cookies": {
       "version": "1.2.0"
     },
+    "browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "requires": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "browser-or-node": {
       "version": "1.3.0"
     },
@@ -30503,6 +30525,11 @@
     },
     "uuid": {
       "version": "9.0.0"
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -111,6 +111,7 @@
     "any-ascii": "^0.3.1",
     "big-integer": "^1.6.51",
     "browser-cookies": "^1.2.0",
+    "browser-image-compression": "^2.0.2",
     "classnames": "^2.3.1",
     "clipboard-copy": "^4.0.1",
     "color2k": "^2.0.0",

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -107,7 +107,6 @@ export const useFileStore = create<FileStore>((set, get) => ({
 
     const compressionOptions = {
       maxSizeMB: 1,
-      maxWidthOrHeight: 1920,
       useWebWorker: true,
     };
 

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -29,6 +29,18 @@ function imageSize(url: string) {
   return size;
 }
 
+function isImageFile(file: File) {
+  const acceptedImageTypes = [
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'image/tiff',
+    'image/bmp',
+  ];
+  return acceptedImageTypes.includes(file.type);
+}
+
 export const useFileStore = create<FileStore>((set, get) => ({
   client: null,
   uploaders: {},
@@ -100,10 +112,12 @@ export const useFileStore = create<FileStore>((set, get) => ({
     };
 
     // if compression fails for some reason, we'll just use the original file.
-    let compressedFile: File | Blob = file;
+    let compressedFile: File = file;
 
     try {
-      compressedFile = await imageCompression(file, compressionOptions);
+      if (isImageFile(file)) {
+        compressedFile = await imageCompression(file, compressionOptions);
+      }
     } catch (error) {
       console.log({ error });
     }

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -5,6 +5,7 @@ import { formatDa, unixToDa, deSig } from '@urbit/aura';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getImageSize } from 'react-image-size';
+import imageCompression from 'browser-image-compression';
 import { useCallback, useEffect, useState } from 'react';
 import api from '@/api';
 import { Status } from '@/logic/status';
@@ -92,6 +93,21 @@ export const useFileStore = create<FileStore>((set, get) => ({
     const { key, file } = upload;
     updateStatus(uploader, key, 'loading');
 
+    const compressionOptions = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 1920,
+      useWebWorker: true,
+    };
+
+    // if compression fails for some reason, we'll just use the original file.
+    let compressedFile: File | Blob = file;
+
+    try {
+      compressedFile = await imageCompression(file, compressionOptions);
+    } catch (error) {
+      console.log({ error });
+    }
+
     // Logic for uploading with Tlon Hosting storage.
     if (config.service === 'presigned-url' && config.presignedUrl) {
       // The first step is to send the PUT request to the proxy, which will
@@ -101,9 +117,9 @@ export const useFileStore = create<FileStore>((set, get) => ({
       const requestOptions = {
         method: 'PUT',
         headers: {
-          'Content-Type': file.type,
+          'Content-Type': compressedFile.type,
         },
-        body: file,
+        body: compressedFile,
       };
       const { presignedUrl } = config;
       const url = `${presignedUrl}/${key}`;
@@ -148,9 +164,9 @@ export const useFileStore = create<FileStore>((set, get) => ({
       const command = new PutObjectCommand({
         Bucket: config.currentBucket,
         Key: key,
-        Body: file,
-        ContentType: file.type,
-        ContentLength: file.size,
+        Body: compressedFile,
+        ContentType: compressedFile.type,
+        ContentLength: compressedFile.size,
         ACL: 'public-read',
       });
 


### PR DESCRIPTION
fixes LAND-1092

I added a new library called `browser-image-compression` that uses web workers to compress images in a performant way. It also removes all exif data by default.

To test just upload a large image with exif data, then download the image after uploading/posting it and notice that it's much smaller and doesn't have exif data.

The library: https://github.com/Donaldcwl/browser-image-compression