### PR TITLE
storage: hardcode s3 url

### DIFF
--- a/ui/src/env.d.ts
+++ b/ui/src/env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv
   readonly VITE_POSTHOG_KEY: string;
   readonly VITE_BRANCH_KEY: string;
   readonly VITE_BRANCH_DOMAIN: string;
+  readonly VITE_SHIP_URL: string;
 }
 
 interface ImportMeta {

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -53,8 +53,21 @@ import type {
 
 export const isTalk = import.meta.env.VITE_APP === 'chat';
 export const isGroups = import.meta.env.VITE_APP === 'groups';
+export const isStagingHosted =
+  import.meta.env.DEV &&
+  (import.meta.env.VITE_SHIP_URL.endsWith('.test.tlon.systems') ||
+    window.location.hostname.endsWith('.test.tlon.systems'));
 export const isHosted =
-  import.meta.env.DEV || window.location.hostname.endsWith('.tlon.network');
+  isStagingHosted ||
+  (import.meta.env.DEV &&
+    (import.meta.env.VITE_SHIP_URL.endsWith('.tlon.network') ||
+      window.location.hostname.endsWith('.tlon.network')));
+
+export const hostingUploadURL = isStagingHosted
+  ? 'https://memex.test.tlon.systems'
+  : isHosted
+  ? 'https://memex.tlon.network'
+  : '';
 
 export const dmListPath = isTalk ? '/' : '/messages';
 

--- a/ui/src/state/local.ts
+++ b/ui/src/state/local.ts
@@ -43,9 +43,10 @@ export const useLocalState = create<LocalState>(
       name: createStorageKey('local'),
       version: storageVersion,
       migrate: clearStorageMigration,
-      partialize: ({ currentTheme, browserId }) => ({
+      partialize: ({ currentTheme, browserId, showDevTools }) => ({
         currentTheme,
         browserId,
+        showDevTools,
       }),
     }
   )

--- a/ui/src/state/storage/reducer.ts
+++ b/ui/src/state/storage/reducer.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import _ from 'lodash';
+import { hostingUploadURL } from '@/logic/utils';
 import { StorageUpdate, BaseStorageState } from './type';
 import { BaseState } from '../base';
 
@@ -28,7 +29,7 @@ const configuration = (
       region: data.region,
       // if landscape is not up to date we need to default these so the
       // client init logic still works
-      presignedUrl: data.presignedUrl || '',
+      presignedUrl: data.presignedUrl || hostingUploadURL,
       service: data.service || 'credentials',
     };
   }

--- a/ui/src/state/storage/storage.ts
+++ b/ui/src/state/storage/storage.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { enableMapSet } from 'immer';
+import { hostingUploadURL, isHosted } from '@/logic/utils';
 import { BaseStorageState } from './type';
 import reduce from './reducer';
 import {
@@ -24,7 +25,7 @@ export const useStorage = createState<BaseStorageState>(
         buckets: new Set(),
         currentBucket: '',
         region: '',
-        presignedUrl: '',
+        presignedUrl: hostingUploadURL,
         service: 'credentials',
       },
       credentials: null,
@@ -42,7 +43,25 @@ export const useStorage = createState<BaseStorageState>(
         }
         numLoads += 1;
         if (numLoads === 2) {
-          set({ loaded: true });
+          const {
+            s3: { credentials, configuration },
+          } = get();
+
+          if (!credentials?.endpoint && isHosted) {
+            set({
+              loaded: true,
+              s3: {
+                credentials,
+                configuration: {
+                  ...configuration,
+                  presignedUrl: configuration.presignedUrl || hostingUploadURL,
+                  service: 'presigned-url',
+                },
+              },
+            });
+          } else {
+            set({ loaded: true });
+          }
         }
       }),
   ]


### PR DESCRIPTION
We're going to add a hardcoded URL so that we don't have to poke all ships with the presigned URL endpoint. This makes it so that any hosted ship which has not set S3 credentials gets defaulted to the presigned flow. Will mimic these changes in Landscape.

This also improves hosting checks so that we can specifically target staging vs prod based on the vite ship url you pass and persists show/hide dev tools.