### PR TITLE
groups: bump lure fetch timeouts

### DIFF
--- a/ui/src/groups/LureInviteBlock.tsx
+++ b/ui/src/groups/LureInviteBlock.tsx
@@ -26,6 +26,10 @@ export default function LureInviteBlock({
 }: LureInviteBlock) {
   const { status, shareUrl, toggle } = useLureLinkStatus(flag);
 
+  console.log(`Invite block:`);
+  console.log(`status: ${status}`);
+  console.log(`shareUrl: ${shareUrl}`);
+
   if (status === 'unsupported') {
     return null;
   }

--- a/ui/src/groups/LureInviteBlock.tsx
+++ b/ui/src/groups/LureInviteBlock.tsx
@@ -5,6 +5,7 @@ import CheckIcon from '@/components/icons/CheckIcon';
 import { Group } from '@/types/groups';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import QRWidget from '@/components/QRWidget';
+import { useEffect } from 'react';
 
 interface LureInviteBlock {
   flag: string;
@@ -26,9 +27,11 @@ export default function LureInviteBlock({
 }: LureInviteBlock) {
   const { status, shareUrl, toggle } = useLureLinkStatus(flag);
 
-  console.log(`Invite block:`);
-  console.log(`status: ${status}`);
-  console.log(`shareUrl: ${shareUrl}`);
+  useEffect(() => {
+    console.log(`Invite block for ${flag}`);
+    console.log(`status: ${status}`);
+    console.log(`shareUrl: ${shareUrl}`);
+  }, [flag, status, shareUrl]);
 
   if (status === 'unsupported') {
     return null;

--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -46,6 +46,8 @@ interface LureState {
   start: () => Promise<void>;
 }
 
+const LURE_REQUEST_TIMEOUT = 30 * 1000;
+
 function groupsDescribe(meta: GroupMeta) {
   return {
     tag: 'groups-0',
@@ -126,14 +128,18 @@ export const useLureState = create<LureState>(
               api.subscribeOnce<boolean>(
                 'grouper',
                 `/group-enabled/${flag}`,
-                12500
+                LURE_REQUEST_TIMEOUT
               ),
             prevLure?.enabled
           ),
           // url
           asyncWithDefault(
             () =>
-              api.subscribeOnce<string>('reel', `/token-link/${flag}`, 12500),
+              api.subscribeOnce<string>(
+                'reel',
+                `/token-link/${flag}`,
+                LURE_REQUEST_TIMEOUT
+              ),
             prevLure?.url
           ),
           // metadata
@@ -182,7 +188,8 @@ const selLure = (flag: string) => (s: LureState) => ({
   lure: s.lures[flag] || { fetched: false, url: '' },
   bait: s.bait,
 });
-const { shouldLoad, newAttempt, finished } = getPreviewTracker(30 * 1000);
+const { shouldLoad, newAttempt, finished } =
+  getPreviewTracker(LURE_REQUEST_TIMEOUT);
 export function useLure(flag: string, disableLoading = false) {
   const { bait, lure } = useLureState(selLure(flag));
 


### PR DESCRIPTION
Adjusts the timeouts for checking if lure links are enabled and fetching the url to 30 seconds.

Also add diagnostic logging for invite screen

Fixes LAND-1105