### PR TITLE
deeplinks: defend against Branch link poisoning 

### DIFF
--- a/ui/src/logic/branch.ts
+++ b/ui/src/logic/branch.ts
@@ -1,3 +1,6 @@
+import { isValidPatp } from 'urbit-ob';
+import { whomIsFlag } from './utils';
+
 const fetchBranchApi = async (path: string, init?: RequestInit) =>
   fetch(`https://api2.branch.io${path}`, init);
 
@@ -18,30 +21,60 @@ export const getDeepLink = async (alias: string) => {
   return url;
 };
 
-export type DeeepLinkType = 'lure' | 'wer';
+export type DeepLinkType = 'lure' | 'wer';
+interface DeepLinkData {
+  $desktop_url: string;
+  $canonical_url: string;
+  lure?: string;
+  wer?: string;
+}
 
 export const createDeepLink = async (
   fallbackUrl: string | undefined,
-  type: DeeepLinkType,
+  type: DeepLinkType,
   path: string
 ) => {
-  if (!fallbackUrl) {
+  if (!fallbackUrl || !path) {
     return undefined;
   }
 
+  console.log(fallbackUrl);
+  console.log(path);
+
+  if (type === 'lure' && !whomIsFlag(path)) {
+    return undefined;
+  }
+
+  if (type === 'wer') {
+    const [location, ship] = path.split('/');
+    const locationInvalid = !location || location !== 'dm';
+    const shipInvalid = !ship || !isValidPatp(ship);
+
+    if (locationInvalid || shipInvalid) {
+      return undefined;
+    }
+  }
+
   const alias = path.replace('~', '').replace('/', '-');
+  const data: DeepLinkData = {
+    $desktop_url: fallbackUrl,
+    $canonical_url: fallbackUrl,
+  };
+  if (type === 'lure') {
+    data.lure = path;
+  } else {
+    data.wer = path;
+  }
+
   let url = await getDeepLink(alias).catch(() => fallbackUrl);
   if (!url) {
+    console.log(`no deep link for ${alias}, creating new one`);
     const response = await fetchBranchApi('/v1/url', {
       method: 'POST',
       body: JSON.stringify({
         branch_key: import.meta.env.VITE_BRANCH_KEY,
         alias,
-        data: {
-          $desktop_url: fallbackUrl,
-          $canonical_url: fallbackUrl,
-          [type]: path,
-        },
+        data,
       }),
     });
 

--- a/ui/src/logic/branch.ts
+++ b/ui/src/logic/branch.ts
@@ -38,9 +38,6 @@ export const createDeepLink = async (
     return undefined;
   }
 
-  console.log(fallbackUrl);
-  console.log(path);
-
   if (type === 'lure' && !whomIsFlag(path)) {
     return undefined;
   }

--- a/ui/src/logic/branch.ts
+++ b/ui/src/logic/branch.ts
@@ -65,7 +65,7 @@ export const createDeepLink = async (
 
   let url = await getDeepLink(alias).catch(() => fallbackUrl);
   if (!url) {
-    console.log(`no deep link for ${alias}, creating new one`);
+    console.log(`No existing deeplink for ${alias}, creating new one`);
     const response = await fetchBranchApi('/v1/url', {
       method: 'POST',
       body: JSON.stringify({

--- a/ui/src/profiles/Profile.tsx
+++ b/ui/src/profiles/Profile.tsx
@@ -259,7 +259,9 @@ export default function Profile({ title }: ViewProps) {
               navigatorTitle={`Connect with ${window.our}`}
             />
           ) : (
-            <LoadingSpinner className="h-4 w-4" />
+            <div className="flex w-full justify-center pt-12">
+              <LoadingSpinner className="h-4 w-4" />
+            </div>
           )}
         </div>
       </WidgetDrawer>

--- a/ui/src/state/lure/lure.ts
+++ b/ui/src/state/lure/lure.ts
@@ -161,7 +161,12 @@ export const useLureState = create<LureState>(
             false
           ),
         ]);
-        const deepLinkUrl = await createDeepLink(url, 'lure', flag);
+
+        let deepLinkUrl: string | undefined;
+        if (enabled && url) {
+          deepLinkUrl = await createDeepLink(url, 'lure', flag);
+        }
+
         set(
           produce((draft: LureState) => {
             draft.lures[flag] = {


### PR DESCRIPTION
If branch links are initially malformed when created, they can never be automatically updated. We make no attempt to do so right now, and changing our logic to fix them would need to happen elsewhere since it requires the Branch private key.

This means it's really important not to create one with bad data. This PR adds checks to `createDeepLink` to ensure it has a valid `lure` or `wer` link before attempting creation. It also updates the lure logic to avoid calling `createDeepLink` altogether unless we have the requisite info to do so.

If your reviewing this, please confirm you can still create both types locally.

Fixes LAND-1106