### PR TITLE
images: turn off webworker, fixes issue on safari on hosted ships

### DIFF
--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -107,7 +107,7 @@ export const useFileStore = create<FileStore>((set, get) => ({
 
     const compressionOptions = {
       maxSizeMB: 1,
-      useWebWorker: true,
+      useWebWorker: false,
     };
 
     // if compression fails for some reason, we'll just use the original file.


### PR DESCRIPTION
fixes LAND-1117 by disabling the web worker for compression.

Tlon Hosting's CSP doesn't allow for blobs from a web worker. Other browsers fallback to just using the main thread if the web worker fails, Safari does not for some reason, so hosted users either using Safari (or using the mobile app) could not upload images.