### PR TITLE
images: flip usewebworker back on

### DIFF
--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -107,7 +107,7 @@ export const useFileStore = create<FileStore>((set, get) => ({
 
     const compressionOptions = {
       maxSizeMB: 1,
-      useWebWorker: false,
+      useWebWorker: true,
     };
 
     // if compression fails for some reason, we'll just use the original file.


### PR DESCRIPTION
Since we determined the web worker wasn't the issue (it was the CSP changes on the hosting platform not playing nicely with Safari) we ought to go back to using the web worker for better performance on image uploads.