### PR TITLE
mobile: hide nav on gallery item and diary note comment input focus

### DIFF
--- a/ui/src/diary/DiaryCommentField.tsx
+++ b/ui/src/diary/DiaryCommentField.tsx
@@ -17,6 +17,7 @@ import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import { useChannelCompatibility } from '@/logic/channel';
 import Tooltip from '@/components/Tooltip';
+import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 
 interface DiaryCommentFieldProps {
   flag: string;
@@ -44,6 +45,7 @@ export default function DiaryCommentField({
   const { mutateAsync: addQuip } = useAddQuipMutation();
   const { privacy } = useGroupPrivacy(groupFlag);
   const { compatible, text } = useChannelCompatibility(`diary/${chFlag}`);
+  const { handleFocus, handleBlur, isChatInputFocused } = useChatInputFocus();
 
   /**
    * This handles submission for new Curios; for edits, see EditCurioForm
@@ -150,6 +152,30 @@ export default function DiaryCommentField({
     flag,
     messageEditor,
     quipReply,
+  ]);
+
+  useEffect(() => {
+    if (messageEditor && !messageEditor.isDestroyed) {
+      if (!isChatInputFocused && messageEditor.isFocused) {
+        handleFocus();
+      }
+
+      if (isChatInputFocused && !messageEditor.isFocused) {
+        handleBlur();
+      }
+    }
+
+    return () => {
+      if (isChatInputFocused) {
+        handleBlur();
+      }
+    };
+  }, [
+    isChatInputFocused,
+    messageEditor,
+    messageEditor?.isFocused,
+    handleFocus,
+    handleBlur,
   ]);
 
   const onClick = useCallback(

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -38,6 +38,8 @@ import { useChannelCompatibility, useChannelIsJoined } from '@/logic/channel';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { ViewProps } from '@/types/groups';
 import { useConnectivityCheck } from '@/state/vitals';
+import { useIsMobile } from '@/logic/useMedia';
+import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import DiaryComment, { DiaryCommentProps } from './DiaryComment';
 import DiaryCommentField from './DiaryCommentField';
 import DiaryContent from './DiaryContent/DiaryContent';
@@ -117,6 +119,9 @@ export default function DiaryNote({ title }: ViewProps) {
   const brief = useDiaryBrief(chFlag);
   const sort = useDiaryCommentSortMode(chFlag);
   const perms = useDiaryPerms(chFlag);
+  const isMobile = useIsMobile();
+  const { isChatInputFocused } = useChatInputFocus();
+  const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
   const { compatible } = useChannelCompatibility(nest);
   const { mutateAsync: joinDiary } = useJoinDiaryMutation();
   const joinChannel = useCallback(async () => {
@@ -180,6 +185,9 @@ export default function DiaryNote({ title }: ViewProps) {
   if (!note.essay || status === 'loading') {
     return (
       <Layout
+        style={{
+          paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        }}
         className="h-full flex-1 bg-white"
         header={
           <DiaryNoteHeader

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -20,6 +20,7 @@ import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { ViewProps } from '@/types/groups';
 import { useIsMobile } from '@/logic/useMedia';
 import { HeapCurio } from '@/types/heap';
+import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import HeapDetailSidebarInfo from './HeapDetail/HeapDetailSidebar/HeapDetailSidebarInfo';
 import HeapDetailComments from './HeapDetail/HeapDetailSidebar/HeapDetailComments';
 import HeapDetailHeader from './HeapDetail/HeapDetailHeader';
@@ -43,6 +44,8 @@ export default function HeapDetail({ title }: ViewProps) {
     ? canReadChannel(channel, vessel, group?.bloc)
     : false;
   const isMobile = useIsMobile();
+  const { isChatInputFocused } = useChatInputFocus();
+  const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
   const joined = useChannelIsJoined(nest);
   const { mutateAsync: joinHeap } = useJoinHeapMutation();
   const {
@@ -97,7 +100,7 @@ export default function HeapDetail({ title }: ViewProps) {
   return (
     <Layout
       style={{
-        paddingBottom: isMobile ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
       }}
       className="padding-bottom-transition flex-1 bg-white"
       header={

--- a/ui/src/heap/HeapTextInput.tsx
+++ b/ui/src/heap/HeapTextInput.tsx
@@ -5,7 +5,6 @@ import { reduce } from 'lodash';
 import { HeapInline, CurioHeart, HeapInlineKey } from '@/types/heap';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MessageEditor, { useMessageEditor } from '@/components/MessageEditor';
-import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
 import { useIsMobile } from '@/logic/useMedia';
 import { useAddCurioMutation } from '@/state/heap/heap';
 import useRequestState from '@/logic/useRequestState';
@@ -21,6 +20,7 @@ import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import Tooltip from '@/components/Tooltip';
 import { useChannelCompatibility } from '@/logic/channel';
+import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 
 interface HeapTextInputProps {
   flag: string;
@@ -91,6 +91,7 @@ export default function HeapTextInput({
   const { privacy } = useGroupPrivacy(groupFlag);
   const { compatible, text } = useChannelCompatibility(`heap/${flag}`);
   const { mutate } = useAddCurioMutation();
+  const { handleFocus, handleBlur, isChatInputFocused } = useChatInputFocus();
 
   /**
    * This handles submission for new Curios; for edits, see EditCurioForm
@@ -198,6 +199,31 @@ export default function HeapTextInput({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messageEditor]);
 
+  useEffect(() => {
+    if (messageEditor && !messageEditor.isDestroyed) {
+      if (!isChatInputFocused && messageEditor.isFocused && comment) {
+        handleFocus();
+      }
+
+      if (isChatInputFocused && !messageEditor.isFocused && comment) {
+        handleBlur();
+      }
+    }
+
+    return () => {
+      if (isChatInputFocused) {
+        handleBlur();
+      }
+    };
+  }, [
+    comment,
+    isChatInputFocused,
+    messageEditor,
+    messageEditor?.isFocused,
+    handleFocus,
+    handleBlur,
+  ]);
+
   const onClick = useCallback(
     () => messageEditor && onSubmit(messageEditor),
     [messageEditor, onSubmit]
@@ -209,67 +235,61 @@ export default function HeapTextInput({
 
   // TODO: Set a sane length limit for comments
   return (
-    <>
-      <div
-        className={cn('items-end', className)}
-        onClick={() => messageEditor.commands.focus()}
-      >
-        {chatInfo.blocks.length > 0 ? (
-          <div className="my-2 flex w-full items-center justify-start font-semibold">
-            <span className="mr-2 text-gray-600">Attached: </span>
-            {chatInfo.blocks.length} reference
-            {chatInfo.blocks.length === 1 ? '' : 's'}
-            <button
-              className="icon-button ml-auto"
-              onClick={() => useChatStore.getState().setBlocks(flag, [])}
-            >
-              <X16Icon className="h-4 w-4" />
-            </button>
-          </div>
-        ) : null}
-        <div
-          className={cn(
-            'w-full',
-            comment ? 'flex flex-row items-end' : 'relative flex h-full'
-          )}
-        >
-          <MessageEditor
-            editor={messageEditor}
-            className={cn('w-full rounded-lg', inputClass)}
-            inputClassName={cn(
-              // Since TipTap simulates an input using a <p> tag, only style
-              // the fake placeholder when the field is empty
-              messageEditor.getText() === '' ? 'text-gray-400' : ''
-            )}
-          />
-          {!sendDisabled ? (
-            <Tooltip content={text} open={compatible ? false : undefined}>
-              <button
-                className={cn(
-                  'button rounded-md px-2 py-1',
-                  comment ? 'ml-2 shrink-0' : 'absolute bottom-3 right-3'
-                )}
-                disabled={
-                  isPending ||
-                  !compatible ||
-                  (messageEditor.getText() === '' &&
-                    chatInfo.blocks.length === 0)
-                }
-                onClick={onClick}
-              >
-                {isPending ? (
-                  <LoadingSpinner secondary="black" />
-                ) : (
-                  <SubmitLabel comment={comment} />
-                )}
-              </button>
-            </Tooltip>
-          ) : null}
+    <div
+      className={cn('items-end', className)}
+      onClick={() => messageEditor.commands.focus()}
+    >
+      {chatInfo.blocks.length > 0 ? (
+        <div className="my-2 flex w-full items-center justify-start font-semibold">
+          <span className="mr-2 text-gray-600">Attached: </span>
+          {chatInfo.blocks.length} reference
+          {chatInfo.blocks.length === 1 ? '' : 's'}
+          <button
+            className="icon-button ml-auto"
+            onClick={() => useChatStore.getState().setBlocks(flag, [])}
+          >
+            <X16Icon className="h-4 w-4" />
+          </button>
         </div>
-      </div>
-      {isMobile && messageEditor.isFocused ? (
-        <ChatInputMenu editor={messageEditor} />
       ) : null}
-    </>
+      <div
+        className={cn(
+          'w-full',
+          comment ? 'flex flex-row items-end' : 'relative flex h-full'
+        )}
+      >
+        <MessageEditor
+          editor={messageEditor}
+          className={cn('w-full rounded-lg', inputClass)}
+          inputClassName={cn(
+            // Since TipTap simulates an input using a <p> tag, only style
+            // the fake placeholder when the field is empty
+            messageEditor.getText() === '' ? 'text-gray-400' : ''
+          )}
+        />
+        {!sendDisabled ? (
+          <Tooltip content={text} open={compatible ? false : undefined}>
+            <button
+              className={cn(
+                'button rounded-md px-2 py-1',
+                comment ? 'ml-2 shrink-0' : 'absolute bottom-3 right-3'
+              )}
+              disabled={
+                isPending ||
+                !compatible ||
+                (messageEditor.getText() === '' && chatInfo.blocks.length === 0)
+              }
+              onClick={onClick}
+            >
+              {isPending ? (
+                <LoadingSpinner secondary="black" />
+              ) : (
+                <SubmitLabel comment={comment} />
+              )}
+            </button>
+          </Tooltip>
+        ) : null}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Fixes LAND-1118. Looks like the issue with the nav still appearing on a new DM was already fixed, but I removed it from the comment input on gallery items and diary notes.