### PR TITLE
images: fix drag and drop in chat threads

### DIFF
--- a/ui/src/logic/DragAndDropContext.tsx
+++ b/ui/src/logic/DragAndDropContext.tsx
@@ -162,9 +162,9 @@ export function useDragAndDrop(targetId: string) {
 
   const handleDropWithTarget = useCallback(
     (e: DragEvent) => {
-      handleDrop(e, targetId);
+      handleDrop(e, currentTargetId);
     },
-    [handleDrop, targetId]
+    [handleDrop, currentTargetId]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes LAND-1110. We weren't using the currentTargetId in the handleDropWithTarget handler, we were just using whichever targetId we received in the parameters for the hook itself.