### PR TITLE
LAND-1138 Fix e2e tests (update fakes tars and outdated locators)

### DIFF
--- a/ui/e2e/001-create-group.spec.ts
+++ b/ui/e2e/001-create-group.spec.ts
@@ -4,7 +4,7 @@ test('Create a group', async ({ page }) => {
   test.skip(process.env.SHIP === '~zod', 'skip on ~zod');
   test.skip(process.env.APP === 'chat', 'skip on talk');
   await page.goto('');
-  await page.getByText('Some Good Groups').waitFor();
+  await page.getByRole('link', { name: 'Create Group' }).waitFor();
   await page.getByRole('link', { name: 'Create Group' }).click();
   await page.getByPlaceholder('e.g. Urbit Fan Club').click();
   await page.getByPlaceholder('e.g. Urbit Fan Club').fill('Bus Club');

--- a/ui/e2e/005-accept-group-invite.spec.ts
+++ b/ui/e2e/005-accept-group-invite.spec.ts
@@ -4,8 +4,14 @@ test('accept group invite', async ({ page }) => {
   test.skip(process.env.SHIP === '~bus', 'skip on ~bus');
   test.skip(process.env.APP === 'chat', 'skip on talk');
   await page.goto('');
-  await page.getByText('Pending Invites').waitFor();
-  await page.getByRole('button', { name: 'Join Group' }).first().click();
+  await page
+    .getByTestId('group-invite')
+    .filter({ hasText: 'Bus Club' })
+    .waitFor();
+  const groupInvite = page
+    .getByTestId('group-invite')
+    .filter({ hasText: 'Bus Club' });
+  await groupInvite.getByRole('button', { name: 'Accept' }).first().click();
   await page.getByText('Join This Group').waitFor();
   await page.getByRole('button', { name: 'Join Group' }).first().click();
   await page.getByText('bus chat').first().waitFor();

--- a/ui/rube/index.ts
+++ b/ui/rube/index.ts
@@ -29,8 +29,8 @@ const ships: Record<
   }
 > = {
   zod: {
-    url: 'https://bootstrap.urbit.org/rube-zod4.tgz',
-    savePath: path.join(__dirname, 'rube-zod4.tgz'),
+    url: 'https://bootstrap.urbit.org/rube-zod5.tgz',
+    savePath: path.join(__dirname, 'rube-zod5.tgz'),
     extractPath: path.join(__dirname, 'zod'),
     ship: 'zod',
     code: 'lidlut-tabwed-pillex-ridrup',
@@ -38,8 +38,8 @@ const ships: Record<
     loopbackPort: '',
   },
   bus: {
-    url: 'https://bootstrap.urbit.org/rube-bus4.tgz',
-    savePath: path.join(__dirname, 'rube-bus4.tgz'),
+    url: 'https://bootstrap.urbit.org/rube-bus5.tgz',
+    savePath: path.join(__dirname, 'rube-bus5.tgz'),
     extractPath: path.join(__dirname, 'bus'),
     ship: 'bus',
     code: 'riddec-bicrym-ridlev-pocsef',
@@ -502,7 +502,10 @@ const shipsAreReadyForTests = async () => {
         return true;
       }
 
-      console.log(`~${ship.ship} is not ready`);
+      console.log(`~${ship.ship} is not ready`, {
+        groups: json.groups.hash,
+        talk: json.talk.hash,
+      });
 
       return false;
     })

--- a/ui/src/notifications/Notification.tsx
+++ b/ui/src/notifications/Notification.tsx
@@ -258,7 +258,10 @@ export default function Notification({
       {inviteBool ? (
         <div className="flex w-full min-w-0 flex-1 space-x-3">
           <div className="relative flex-none self-start">{avatar}</div>
-          <div className="min-w-0 grow-0 break-words p-1">
+          <div
+            className="min-w-0 grow-0 break-words p-1"
+            data-testid="group-invite"
+          >
             {topLine}
             <div className="my-2 leading-5">
               {bin.top && (


### PR DESCRIPTION
Tests were not running because the tar files with the fake ships images had the same groups and talk hashes as after committing desks, which we use to verify if the ships are ready to start testing.
Fixed by uploading new tars.

This commit also updates a couple of locators.