### PR TITLE
channels: fix various cache issues, and then some.

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -569,7 +569,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
             element={<RejectConfirmModal />}
           />
           <Route
-            path="/groups/:ship/:name/channels/heap/:chShip/:chName/curio/:idCurio/edit"
+            path="/groups/:ship/:name/channels/heap/:chShip/:chName/curio/:idTime/edit"
             element={<EditCurioModal />}
           />
           <Route

--- a/ui/src/diary/DiaryNote.tsx
+++ b/ui/src/diary/DiaryNote.tsx
@@ -150,8 +150,16 @@ export default function DiaryNote({ title }: ViewProps) {
 
   const { replies } = note.seal;
   const replyArray = replies
-    ? replies.filter(([k, v]) => v !== null).reverse()
-    : []; // natural reading order
+    ? replies
+        .filter(([k, v]) => v !== null)
+        .sort(([a], [b]) => {
+          if (sort === 'asc') {
+            return a.toString().localeCompare(b.toString());
+          }
+
+          return b.toString().localeCompare(a.toString());
+        })
+    : [];
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
   const { title: noteTitle, image } = getKindDataFromEssay(note.essay);
   const groupedReplies = setNewDaysForReplies(

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -143,7 +143,11 @@ export default function DiaryAddNote() {
           time: id,
           essay: {
             ...note.essay,
-            ...values,
+            'kind-data': {
+              diary: {
+                ...values,
+              },
+            },
             content: noteContent,
           },
         });

--- a/ui/src/heap/EditCurioForm.tsx
+++ b/ui/src/heap/EditCurioForm.tsx
@@ -18,6 +18,7 @@ import { useChannelFlag } from '@/logic/channel';
 import { useRouteGroup } from '@/state/groups';
 import { chatStoryFromStory, storyFromChatStory } from '@/types/channel';
 import getKindDataFromEssay from '@/logic/getKindData';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import HeapTextInput from './HeapTextInput';
 
 type EditCurioFormSchema = {
@@ -176,6 +177,14 @@ export default function EditCurioForm() {
       setDraftText(parsed);
     }
   }, [isLoading, isLinkMode, contentAsChatStory.inline, draftText]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <>

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -85,7 +85,7 @@ function HeapChannel({ title }: ViewProps) {
 
   const empty = useMemo(() => posts.length === 0, [posts]);
   const sortedPosts = posts
-    .filter((k, v) => v !== null)
+    .filter(([k, v]) => v !== null)
     .sort(([a], [b]) => {
       if (sortMode === 'time') {
         return b.compare(a);

--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
@@ -29,10 +29,17 @@ export default function HeapDetailComments({
   const vessel = useVessel(groupFlag, window.our);
   const canWrite = canWriteChannel(perms, vessel, group?.bloc);
   const unread = useUnread(nest);
+  const sortedComments =
+    comments?.sort(([a], [b]) => {
+      if (sort === 'asc') {
+        return a.toString().localeCompare(b.toString());
+      }
+      return b.toString().localeCompare(a.toString());
+    }) ?? [];
   const groupedReplies = !comments
     ? []
     : setNewDaysForReplies(
-        groupReplies(time, comments, unread).sort(([a], [b]) => {
+        groupReplies(time, sortedComments, unread).sort(([a], [b]) => {
           if (sort === 'asc') {
             return a.localeCompare(b);
           }

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -1480,9 +1480,9 @@ export function useEditPostMutation() {
         queryKey: [han, 'posts', flag, variables.time],
         refetchType: 'none',
       });
-      // await queryClient.invalidateQueries({
-      // queryKey: [han, 'posts', flag, 'infinite'],
-      // });
+      await queryClient.invalidateQueries({
+        queryKey: [han, 'posts', flag, 'infinite'],
+      });
     },
   });
 }

--- a/ui/src/types/channel.ts
+++ b/ui/src/types/channel.ts
@@ -217,22 +217,22 @@ export interface Replies {
   [id: string]: Reply;
 }
 
-interface PageActionAdd {
+interface PostActionAdd {
   add: PostEssay;
 }
 
-interface PageActionEdit {
+interface PostActionEdit {
   edit: {
     id: string;
     essay: PostEssay;
   };
 }
 
-interface PageActionDel {
+interface PostActionDel {
   del: string;
 }
 
-interface PageActionAddReact {
+interface PostActionAddReact {
   'add-react': {
     id: string;
     react: string;
@@ -240,7 +240,7 @@ interface PageActionAddReact {
   };
 }
 
-interface PageActionDelReact {
+interface PostActionDelReact {
   'del-react': {
     id: string;
     ship: string;
@@ -271,11 +271,11 @@ interface PostActionReply {
 }
 
 export type PostAction =
-  | PageActionAdd
-  | PageActionEdit
-  | PageActionDel
-  | PageActionAddReact
-  | PageActionDelReact
+  | PostActionAdd
+  | PostActionEdit
+  | PostActionDel
+  | PostActionAddReact
+  | PostActionDelReact
   | PostActionReply;
 
 export interface DiffView {
@@ -300,8 +300,8 @@ export interface ReplyActionDel {
 export type ReplyAction =
   | ReplyActionAdd
   | ReplyActionDel
-  | PageActionAddReact
-  | PageActionDelReact;
+  | PostActionAddReact
+  | PostActionDelReact;
 
 export type DisplayMode = 'list' | 'grid';
 


### PR DESCRIPTION
Fixes LAND-1154
Fixes LAND-1156
Fixes LAND-1151
Fixes LAND-1152
Fixes LAND-1153

Also fixes issues with type names and comment ordering.

Most of this fell out from the changes around using page cursors from the backend in useInfinitePosts.

I also tried to simplify things a bit and remove some dead code. We could still stand to reduce some duplicate code, but this should fix all of the above issues for now.

Please pull it down and test against a ship running the `hm/hackweek` branch.