### PR TITLE
refs: prevent joining placeholder group

### DIFF
--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -58,6 +58,10 @@ function WritBaseReference({
   }
 
   const handleOpenReferenceClick = () => {
+    // We have nowhere to navigate to if we haven't yet loaded group information
+    if (!preview?.group?.flag) {
+      return;
+    }
     if (!group) {
       navigate(`/gangs/${groupFlag}?type=chat&nest=${nest}&id=${time}`, {
         state: { backgroundLocation: location },


### PR DESCRIPTION
Currently, clicking on a post ref while metadata for its group is loading will navigate to a join dialog for `~zod/test`. Clicking `join` on that dialog will attempt to join the test group, creating a 'pending' group in the sidebar.

This PR fixes the issue by short-circuiting navigation if group metadata is not yet loaded.

A minor issue with this fix is that it'll make clicking the ref unresponsive while group metadata is loading. We could hold off on rendering the whole thing until metadata is loaded, but that'll add a potentially significant amount of time to the load. We could also pop an error message, but that too could be confusing. 

I think this fix is a pretty reasonable compromise for now. If we want to make this better, we should probably look at adding group metadata to the ref message itself. 

Fixes LAND-1165