### PR TITLE
analytics: fix url info logged during opt in event

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -85,7 +85,11 @@ import Dialog from '@/components/Dialog';
 import useIsStandaloneMode from '@/logic/useIsStandaloneMode';
 import EmojiPicker from '@/components/EmojiPicker';
 import SettingsDialog from '@/components/Settings/SettingsDialog';
-import { captureAnalyticsEvent, captureError } from '@/logic/analytics';
+import {
+  ANALYTICS_DEFAULT_PROPERTIES,
+  captureAnalyticsEvent,
+  captureError,
+} from '@/logic/analytics';
 import GroupChannel from '@/groups/GroupChannel';
 import PrivacyNotice from '@/groups/PrivacyNotice';
 import ActivityModal, { ActivityChecker } from '@/components/ActivityModal';
@@ -804,7 +808,7 @@ function RoutedApp() {
 
   useEffect(() => {
     if (posthog && analyticsId !== '' && logActivity) {
-      posthog.identify(analyticsId);
+      posthog.identify(analyticsId, ANALYTICS_DEFAULT_PROPERTIES);
     }
   }, [posthog, analyticsId, logActivity]);
 

--- a/ui/src/components/ActivityModal.tsx
+++ b/ui/src/components/ActivityModal.tsx
@@ -10,7 +10,10 @@ import {
 import { useGroups } from '@/state/groups';
 import React, { useEffect } from 'react';
 import { isHosted } from '@/logic/utils';
-import { analyticsClient } from '@/logic/analytics';
+import {
+  ANALYTICS_DEFAULT_PROPERTIES,
+  analyticsClient,
+} from '@/logic/analytics';
 import { PrivacyContents } from '@/groups/PrivacyNotice';
 import Dialog from './Dialog';
 
@@ -24,7 +27,9 @@ export function ActivityChecker() {
   useEffect(() => {
     // manage analytics opt-in/out based on settings
     if (analyticsClient.has_opted_out_capturing() && logActivity) {
-      analyticsClient.opt_in_capturing();
+      analyticsClient.opt_in_capturing({
+        capture_properties: ANALYTICS_DEFAULT_PROPERTIES,
+      });
     } else if (analyticsClient.has_opted_in_capturing() && !logActivity) {
       analyticsClient.opt_out_capturing();
     }

--- a/ui/src/logic/analytics.ts
+++ b/ui/src/logic/analytics.ts
@@ -50,6 +50,30 @@ posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
 
 export const analyticsClient = posthog;
 
+export const ANALYTICS_DEFAULT_PROPERTIES: Properties = {
+  // The following default properties stop PostHog from auto-logging the URL,
+  // which can inadvertently reveal private info on Urbit
+  $current_url: null,
+  $pathname: null,
+  $set_once: null,
+  $host: null,
+  $referrer: null,
+  $initial_current_url: null,
+  $initial_referrer_url: null,
+  $referring_domain: null,
+  $initial_referring_domain: null,
+  $unset: [
+    'initial_referrer_url',
+    'initial_referring_domain',
+    'initial_current_url',
+    'current_url',
+    'pathname',
+    'host',
+    'referrer',
+    'referring_domain',
+  ],
+};
+
 // Once someone is opted in this will fire no matter what so we need
 // additional guarding here to prevent accidentally capturing data.
 export const captureAnalyticsEvent = (
@@ -64,27 +88,7 @@ export const captureAnalyticsEvent = (
   log('Attempting to capture analytics event', name);
   const captureProperties: Properties = {
     ...(properties || {}),
-    // The following default properties stop PostHog from auto-logging the URL,
-    // which can inadvertently reveal private info on Urbit
-    $current_url: null,
-    $pathname: null,
-    $set_once: null,
-    $host: null,
-    $referrer: null,
-    $initial_current_url: null,
-    $initial_referrer_url: null,
-    $referring_domain: null,
-    $initial_referring_domain: null,
-    $unset: [
-      'initial_referrer_url',
-      'initial_referring_domain',
-      'initial_current_url',
-      'current_url',
-      'pathname',
-      'host',
-      'referrer',
-      'referring_domain',
-    ],
+    ...ANALYTICS_DEFAULT_PROPERTIES,
   };
 
   posthog.capture(name, captureProperties, {


### PR DESCRIPTION
Fixes an issue where the current browser URL was logged to the analytics provider on the opt in event (updated on the identify event as well for good measure)