### PR TITLE
hackweek: make unreads work with threads/comments

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -12,7 +12,7 @@
   |%
   +$  card  card:agent:gall
   +$  current-state
-    $:  %0
+    $:  %1
         =v-channels:c
     ==
   --
@@ -82,11 +82,34 @@
   |=  =vase
   |^  ^+  cor
   =+  !<(old=versioned-state vase)
-  ?>  ?=(%0 -.old)
+  =?  old  ?=(%0 -.old)  (state-0-to-1 old)
+  ?>  ?=(%1 -.old)
   =.  state  old
   inflate-io
   ::
-  +$  versioned-state  $%(current-state)
+  +$  versioned-state  $%(current-state state-0)
+  +$  state-0
+    $:  %0
+        v-channels=(map nest:c v-channel-0)
+    ==
+  ++  v-channel-0
+    |^  ,[global:v-channel:c local]
+    +$  window    (list [from=time to=time])
+    +$  future    [=window diffs=(jug id-post:c u-post:c)]
+    +$  local     [=net:c =log:c remark=remark-0 =window =future]
+    --
+  +$  remark-0  [last-read=time watching=_| unread-threads=(set id-post:c)]
+  ::
+  ++  state-0-to-1
+    |=  s=state-0
+    ^-  current-state
+    s(- %1, v-channels (~(run by v-channels.s) v-channel-0-to-1))
+  ++  v-channel-0-to-1
+    |=  v=v-channel-0
+    ^-  v-channel:c
+    =/  recency=time
+      ?~(tim=(ram:on-v-posts:c posts.v) *time key.u.tim)
+    v(remark [recency remark.v])
   --
 ::
 ++  init

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -460,8 +460,12 @@
           %unwatch  remark.channel(watching |)
           %read-at  !!  ::TODO
           %read
-        =/  [=time post=(unit v-post:c)]  (need (ram:on-v-posts:c posts.channel))
-        remark.channel(last-read `@da`(add time (div ~s1 100)))
+        =/  [=time post=(unit v-post:c)]  
+          (need (ram:on-v-posts:c posts.channel))
+        %=  remark.channel
+          last-read       `@da`(add time (div ~s1 100))
+          unread-threads  *(set id-post:c)
+        ==
       ==
     =.  ca-core  ca-give-unread
     (ca-response a-remark)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -28,7 +28,7 @@
     ==
   ++  club-eq  2 :: reverb control: max number of forwards for clubs
   +$  current-state
-    $:  %5
+    $:  %6
         dms=(map ship dm:c)
         clubs=(map id:club:c club:c)
         pins=(list whom:c)
@@ -117,10 +117,11 @@
     %2  $(old (state-2-to-3 old))
     %3  $(old (state-3-to-4 old))
     %4  $(old (state-4-to-5 old))
-    %5  (emil(state old) (drop load:epos))
+    %5  $(old (state-5-to-6 old))
+    %6  (emil(state old) (drop load:epos))
   ==
   ::
-  +$  versioned-state  $%(current-state state-4 state-3 state-2 state-1 state-0)
+  +$  versioned-state  $%(current-state state-5 state-4 state-3 state-2 state-1 state-0)
   +$  state-0
     $:  %0
         chats=(map flag:zero chat:zero)
@@ -196,11 +197,54 @@
         ::  true represents imported, false pending import
         imp=(map flag:two ?)
     ==
-  +$  state-5  current-state
+  +$  state-5
+    $:  %5
+        dms=(map ship dm-5)
+        clubs=(map id:club:c club-5)
+        pins=(list whom:c)
+        bad=(set ship)
+        inv=(set ship)
+        blocked=(set ship)
+        blocked-by=(set ship)
+        hidden-messages=(set id:c)
+        old-chats=(map flag:two:old:c chat:two:old:c)  :: for migration
+        old-pins=(list whom:two:old:c)
+    ==
+  +$  club-5    [heard:club:c remark=remark-5 =pact:c crew:club:c]
+  +$  dm-5      [=pact:c remark=remark-5 net:dm:c pin=_|]
+  +$  remark-5  [last-read=time watching=_| unread-threads=(set id:c)]
+  +$  state-6  current-state
   ++  zero     zero:old:c
   ++  one      one:old:c
   ++  two      two:old:c
   ++  three    c
+  ++  state-5-to-6
+    |=  s=state-5
+    ^-  state-6
+    s(- %6, dms (dms-5-to-6 dms.s), clubs (clubs-5-to-6 clubs.s))
+  ::
+  ++  dms-5-to-6
+    |=  dms=(map ship dm-5)
+    ^-  (map ship dm:c)
+    %-  ~(run by dms)
+    |=  dm=dm-5
+    ^-  dm:c
+    dm(remark (remark-5-to-6 wit.pact.dm remark.dm))
+  ::
+  ++  clubs-5-to-6
+    |=  clubs=(map id:club:c club-5)
+    ^-  (map id:club:c club:c)
+    %-  ~(run by clubs)
+    |=  club=club-5
+    ^-  club:c
+    club(remark (remark-5-to-6 wit.pact.club remark.club))
+  ::
+  ++  remark-5-to-6
+    |=  [=writs:c remark=remark-5]
+    ^-  remark:c
+    :_  remark
+    ?~(tim=(ram:on:writs:c writs) *time key.u.tim)
+  ::
   ++  state-4-to-5
     |=  state-4
     ^-  state-5
@@ -217,15 +261,15 @@
   ::
   ++  dms-4-to-5
     |=  dms=(map ship dm:two)
-    ^-  (map ship dm:c)
+    ^-  (map ship dm-5)
     %-  ~(run by dms)
     |=  dm:two
-    ^-  dm:c
+    ^-  dm-5
     [(pact-4-to-5 pact) remark net pin]
   ::
   ++  clubs-4-to-5
     |=  clubs=(map id:club:two club:two)
-    ^-  (map id:club:c club:c)
+    ^-  (map id:club:c club-5)
     %-  ~(run by clubs)
     |=  club:two
     [heard remark (pact-4-to-5 pact) crew]
@@ -515,7 +559,7 @@
 ++  watch
   |=  =(pole knot)
   ^+  cor
-  ?+    pole  ~|(bad-watch-path/path !!)
+  ?+    pole  ~|(bad-watch-path+`path`pole !!)
       [%clubs ~]  ?>(from-self cor)
       [%unreads ~]  ?>(from-self cor)
       ~  ?>(from-self cor)
@@ -779,7 +823,8 @@
         posts   posts
         log     ?.(log ~ (convert-log pact.chat posts perm.chat log.chat))
         perm    [0 perm.chat]
-        remark  remark.chat
+        remark  :_  remark.chat
+                ?~(tim=(ram:on-v-posts:d posts) *time key.u.tim)
         net
       ?-  -.net.chat
         %pub  [*ship &]
@@ -1093,8 +1138,9 @@
           %add
         =.  time.q.diff.delta  (~(get by dex.pact.club) p.diff.delta)
         =*  memo  memo.q.diff.delta
-        =?  remark.club  =(author.memo our.bowl)
-          remark.club(last-read `@da`(add now.bowl (div ~s1 100)))
+        =?  last-read.remark.club  =(author.memo our.bowl)
+          (add now.bowl (div ~s1 100))
+        =.  recency.remark.club  now.bowl
         =.  cor  (give-unread club/id cu-unread)
         ?:  =(our.bowl author.memo)  (cu-give-writs-diff diff.delta)
         ?^  kind.q.diff.delta  (cu-give-writs-diff diff.delta)
@@ -1132,6 +1178,7 @@
             (add now.bowl (div ~s1 100))
           =?  unread-threads.remark.club  !=(our.bowl author.memo)
             (~(put in unread-threads.remark.club) p.diff.delta)
+          =.  recency.remark.club  now.bowl
           =.  cor  (give-unread club/id cu-unread)
           ?:  =(our.bowl author.memo)  (cu-give-writs-diff diff.delta)
           ?~  entry  (cu-give-writs-diff diff.delta)
@@ -1361,8 +1408,9 @@
         %add
       =.  time.q.diff  (~(get by dex.pact.dm) p.diff)
       =*  memo  memo.q.diff
-      =?  remark.dm  =(author.memo our.bowl)
-        remark.dm(last-read `@da`(add now.bowl (div ~s1 100)))
+      =?  last-read.remark.dm  =(author.memo our.bowl)
+        (add now.bowl (div ~s1 100))
+      =.  recency.remark.dm  now.bowl
       =?  cor  &(!=(old-unread di-unread) !=(net.dm %invited))
         (give-unread ship/ship di-unread)
       ?:  from-self    (di-give-writs-diff diff)
@@ -1399,8 +1447,9 @@
         =*  memo  memo.delt
         =?  unread-threads.remark.dm  !=(our.bowl author.memo)
             (~(put in unread-threads.remark.dm) p.diff)
-        =?  remark.dm  =(author.memo our.bowl)
-          remark.dm(last-read `@da`(add now.bowl (div ~s1 100)))
+        =?  last-read.remark.dm  =(author.memo our.bowl)
+          (add now.bowl (div ~s1 100))
+        =.  recency.remark.dm  now.bowl
         =?  cor  &(!=(old-unread di-unread) !=(net.dm %invited))
           (give-unread ship/ship di-unread)
         ?:  =(our.bowl author.memo)  (di-give-writs-diff diff)

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -654,7 +654,7 @@
     =/  loyal  (~(has in team.crew.club) our.bowl)
     =/  invited  (~(has in hive.crew.club) our.bowl)
     ?:  &(!loyal !invited)
-      [club/id *time 0 ~]
+      [club/id *time 0 ~ ~]
     =/  cu  (cu-abed id)
     [club/id cu-unread:cu]
   %+  murn  ~(tap in ~(key by dms))
@@ -1002,7 +1002,9 @@
       [*heard:club:c *remark:c *pact:c (silt our.bowl ~) hive.create *data:meta net |]
     cu-core(id id.create, club clab)
   ::
-  ++  cu-unread  (unread:cu-pact our.bowl last-read.remark.club)
+  ++  cu-unread
+    %+  unread:cu-pact  our.bowl
+    [last-read unread-threads]:remark.club
   ::
   ++  cu-create
     |=  =create:club:c
@@ -1126,8 +1128,10 @@
             ?(%del %add-react %del-react)  (cu-give-writs-diff diff.delta)
             %add
           =*  memo  memo.delt
-          =?  remark.club  =(author.memo our.bowl)
-            remark.club(last-read `@da`(add now.bowl (div ~s1 100)))
+          =?  last-read.remark.club  =(author.memo our.bowl)
+            (add now.bowl (div ~s1 100))
+          =?  unread-threads.remark.club  !=(our.bowl author.memo)
+            (~(put in unread-threads.remark.club) p.diff.delta)
           =.  cor  (give-unread club/id cu-unread)
           ?:  =(our.bowl author.memo)  (cu-give-writs-diff diff.delta)
           ?~  entry  (cu-give-writs-diff diff.delta)
@@ -1505,7 +1509,9 @@
       (slav %p nedl.pole)
     ==
   ::
-  ++  di-unread  (unread:di-pact our.bowl last-read.remark.dm)
+  ++  di-unread
+    %+  unread:di-pact  our.bowl
+    [last-read unread-threads]:remark.dm
   ++  di-remark-diff
     |=  diff=remark-diff:c
     ^+  di-core

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1397,6 +1397,8 @@
           ?(%del %add-react %del-react)  (di-give-writs-diff diff)
           %add
         =*  memo  memo.delt
+        =?  unread-threads.remark.dm  !=(our.bowl author.memo)
+            (~(put in unread-threads.remark.dm) p.diff)
         =?  remark.dm  =(author.memo our.bowl)
           remark.dm(last-read `@da`(add now.bowl (div ~s1 100)))
         =?  cor  &(!=(old-unread di-unread) !=(net.dm %invited))
@@ -1521,7 +1523,11 @@
         %unwatch  remark.dm(watching |)
         %read-at  !! ::  ca-core(last-read.remark.chat p.diff)
       ::
-          %read   remark.dm(last-read now.bowl)
+          %read   
+        %=  remark.dm
+          last-read  now.bowl
+          unread-threads  *(set id:c)
+        ==
   ::    =/  [=time =writ:c]  (need (ram:on:writs:c writs.chat))
   ::    =.  last-read.remark.chat  time
   ::    ca-core

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -560,7 +560,8 @@
         sort    [0 sort.diary]
         perm    [0 perm.diary]
         log     ?.(log ~ (convert-log notes.diary posts perm.diary log.diary))
-        remark  remark.diary
+        remark  :_  remark.diary
+                ?~(tim=(ram:on-v-posts:d posts) *time key.u.tim)
         net
       ?-  -.net.diary
         %pub  [*ship &]

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -543,7 +543,8 @@
         log     ?.(log ~ (convert-log curios.heap posts perm.heap log.heap))
         view    [0 view.heap]
         perm    [0 perm.heap]
-        remark  remark.heap
+        remark  :_  remark.heap
+                ?~(tim=(ram:on-v-posts:c posts) *time key.u.tim)
         net
       ?-  -.net.heap
         %pub  [*ship &]

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -344,10 +344,18 @@
   ++  unread
     |=  b=unread:c
     %-  pairs
-    :~  last/(id last.b)
+    :~  recency/(id recency.b)
         count/(numb count.b)
-        read-id/?~(read-id.b ~ (id u.read-id.b))
+        unread-id/?~(unread-id.b ~ (id u.unread-id.b))
+        threads/(unread-threads threads.b)
     ==
+  ::
+  ++  unread-threads
+    |=  u=(map id-post:c id-reply:c)
+    %-  pairs
+    %+  turn  ~(tap by u)
+    |=  [p=id-post:c r=id-reply:c]
+    [+:(id p) (id r)]
   ::
   ++  pins
     |=  ps=(list nest:c)

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -142,10 +142,18 @@
   ++  unread
     |=  b=unread:unreads:c
     %-  pairs
-    :~  last/(time last.b)
+    :~  recency/(time recency.b)
         count/(numb count.b)
-        read-id/?~(read-id.b ~ (id u.read-id.b))
+        unread-id/?~(unread-id.b ~ (id u.unread-id.b))
+        threads/(unread-threads threads.b)
     ==
+  ::
+  ++  unread-threads
+    |=  u=(map id:c id:c)
+    %-  pairs
+    %+  turn  ~(tap by u)
+    |=  [p=id:c r=id:c]
+    [+:(id p) (id r)]
   ::
   ++  pins
     |=  ps=(list whom:c)

--- a/desk/lib/chat-json.hoon
+++ b/desk/lib/chat-json.hoon
@@ -144,16 +144,27 @@
     %-  pairs
     :~  recency/(time recency.b)
         count/(numb count.b)
-        unread-id/?~(unread-id.b ~ (id u.unread-id.b))
         threads/(unread-threads threads.b)
+    ::
+      :-  %unread-id
+      ?~  unread-id.b  ~
+      %-  pairs
+      :~  id/(id id.u.unread-id.b)
+          time/(time-id time.u.unread-id.b)
+      ==
     ==
   ::
   ++  unread-threads
-    |=  u=(map id:c id:c)
+    |=  u=(map message-key:c message-key:c)
     %-  pairs
     %+  turn  ~(tap by u)
-    |=  [p=id:c r=id:c]
-    [+:(id p) (id r)]
+    |=  [top=message-key:c unread=message-key:c]
+    :-  (rap 3 (scot %p p.id.top) '/' (scot %ud q.id.top) ~)
+    %-  pairs
+    :~  parent-time/(time-id time.top)
+        id/(id id.unread)
+        time/(time-id time.unread)
+    ==
   ::
   ++  pins
     |=  ps=(list whom:c)

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -17,18 +17,36 @@
   ==
 ::
 ++  unread
-  |=  [our=ship last-read=time]
+  |=  [our=ship last-read=time unread-threads=(set id:c)]
   ^-  unread:unreads:c
   =/  =time
     ?~  tim=(ram:on:writs:c wit.pac)  *time
     key.u.tim
   =/  unreads
     (lot:on:writs:c wit.pac `last-read ~)
-  =/  read-id=(unit id:c)
+  =/  unread-id=(unit id:c)
+    ::TODO  in the ~ case, we could traverse further up, to better handle
+    ::      cases where the most recent message was deleted.
     (bind (pry:on:writs:c unreads) |=([key=@da val=writ:c] id.val))
   =/  count
     (lent (skim ~(tap by unreads) |=([tim=^time =writ:c] !=(author.writ our))))
-  [time count read-id]
+  ::  now do the same for all unread threads
+  ::
+  =/  [sum=@ud threads=(map id:c id:c)]
+    %+  roll  ~(tap in unread-threads)
+    |=  [=id:c sum=@ud threads=(map id:c id:c)]
+    =/  parent   (get id)
+    ?~  parent   [sum threads]
+    =/  unreads  (lot:on:replies:c replies.writ.u.parent `last-read ~)
+    :-  %+  add  sum
+        %-  lent
+        %+  skim  ~(tap by unreads)
+        |=([* =reply:c] !=(author.reply our))
+    =/  reply-id=(unit id:c)
+      (bind (pry:on:replies:c unreads) |=([* reply:c] id))
+    ?~  reply-id  threads
+    (~(put by threads) id u.reply-id)
+  [time (add count sum) unread-id threads]
 ::
 ++  get
   |=  =id:c

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -24,17 +24,17 @@
     key.u.tim
   =/  unreads
     (lot:on:writs:c wit.pac `last-read ~)
-  =/  unread-id=(unit id:c)
+  =/  unread-id=(unit message-key:c)
     ::TODO  in the ~ case, we could traverse further up, to better handle
     ::      cases where the most recent message was deleted.
-    (bind (pry:on:writs:c unreads) |=([key=@da val=writ:c] id.val))
+    (bind (pry:on:writs:c unreads) |=([key=@da val=writ:c] [id time]:val))
   =/  count
     (lent (skim ~(tap by unreads) |=([tim=^time =writ:c] !=(author.writ our))))
   ::  now do the same for all unread threads
   ::
-  =/  [sum=@ud threads=(map id:c id:c)]
+  =/  [sum=@ud threads=(map message-key:c message-key:c)]
     %+  roll  ~(tap in unread-threads)
-    |=  [=id:c sum=@ud threads=(map id:c id:c)]
+    |=  [=id:c sum=@ud threads=(map message-key:c message-key:c)]
     =/  parent   (get id)
     ?~  parent   [sum threads]
     =/  unreads  (lot:on:replies:c replies.writ.u.parent `last-read ~)
@@ -42,10 +42,10 @@
         %-  lent
         %+  skim  ~(tap by unreads)
         |=([* =reply:c] !=(author.reply our))
-    =/  reply-id=(unit id:c)
-      (bind (pry:on:replies:c unreads) |=([* reply:c] id))
+    =/  reply-id=(unit message-key:c)
+      (bind (pry:on:replies:c unreads) |=([* reply:c] [id time]))
     ?~  reply-id  threads
-    (~(put by threads) id u.reply-id)
+    (~(put by threads) [id time]:writ.u.parent u.reply-id)
   [time (add count sum) unread-id threads]
 ::
 ++  get

--- a/desk/sur/channel.hoon
+++ b/desk/sur/channel.hoon
@@ -217,16 +217,26 @@
 ::
 +$  net  [p=ship load=_|]
 ::
-::  $unreads: a map of channel unread information
-::
-::    unread: the last time a channel was read, how many posts since,
-::    and the id of the last read post
+::  $unreads: a map of channel unread information, for clients
+::  $unread: unread data for a specific channel, for clients
+::    recency:   time of most recent message
+::    count:     how many posts are unread
+::    unread-id: the id of the first unread top-level post
+::    threads:   for each unread thread, the id of the first unread reply
 ::
 +$  unreads  (map nest unread)
-+$  unread   [last=time count=@ud read-id=(unit time)]
-::  $remark: a marker representing the last post I've read
++$  unread
+  $:  recency=time
+      count=@ud
+      unread-id=(unit id-post)
+      threads=(map id-post id-reply)
+  ==
+::  $remark: markers representing unread state
+::    last-read:      time at which the user last read this channel
+::    watching:       unused, intended for disabling unread accumulation
+::    unread-threads: threads that contain unread messages
 ::
-+$  remark  [last-read=time watching=_| ~]
++$  remark  [last-read=time watching=_| unread-threads=(set id-post)]
 ::
 ::  $perm: represents the permissions for a channel and gives a
 ::  pointer back to the group it belongs to.

--- a/desk/sur/channel.hoon
+++ b/desk/sur/channel.hoon
@@ -236,7 +236,7 @@
 ::    watching:       unused, intended for disabling unread accumulation
 ::    unread-threads: threads that contain unread messages
 ::
-+$  remark  [last-read=time watching=_| unread-threads=(set id-post)]
++$  remark  [recency=time last-read=time watching=_| unread-threads=(set id-post)]
 ::
 ::  $perm: represents the permissions for a channel and gives a
 ::  pointer back to the group it belongs to.

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -229,10 +229,12 @@
       [%club p=id:club]
   ==
 ::
++$  message-key  [=id =time]
+::
 ::  $unreads: a map of club/dm unread information
 ::
-::    unread: the last time a message was read, how many messages since,
-::    and the id of the last read message
+::    unread: the time of the most recent message, how many messages since,
+::    the id of the last read message, and the set of unread threads
 ::
 ++  unreads
   =<  unreads
@@ -242,8 +244,8 @@
   +$  unread
     $:  recency=time
         count=@ud
-        unread-id=(unit id)
-        threads=(map id id)
+        unread-id=(unit message-key)
+        threads=(map message-key message-key)
     ==
   +$  update
     (pair whom unread)

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -252,7 +252,7 @@
   --
 ::
 +$  remark
-  [last-read=time watching=_| unread-threads=(set id)]
+  [recency=time last-read=time watching=_| unread-threads=(set id)]
 ::
 +$  remark-action
   (pair whom remark-diff)

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -240,13 +240,17 @@
   +$  unreads
     (map whom unread)
   +$  unread
-    [last=time count=@ud read-id=(unit id)]
+    $:  recency=time
+        count=@ud
+        unread-id=(unit id)
+        threads=(map id id)
+    ==
   +$  update
     (pair whom unread)
   --
 ::
 +$  remark
-  [last-read=time watching=_| ~]
+  [last-read=time watching=_| unread-threads=(set id)]
 ::
 +$  remark-action
   (pair whom remark-diff)

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -354,7 +354,9 @@ const ChatMessage = React.memo<
               ref={viewRef}
             />
           ) : null}
-          {newDay ? <DateDivider date={unix} /> : null}
+          {newDay && unreadDisplay === 'none' ? (
+            <DateDivider date={unix} />
+          ) : null}
           {newAuthor ? (
             <Author ship={essay.author} date={unix} hideRoles={isThread} />
           ) : null}

--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -157,7 +157,7 @@ const loaderPadding = {
   bottom: 0,
 };
 
-export interface DmScrollerProps {
+export interface ChatScrollerProps {
   whom: string;
   messages: PageTuple[] | WritTuple[] | ReplyTuple[];
   onAtTop?: () => void;
@@ -187,7 +187,7 @@ export default function ChatScroller({
   scrollerRef,
   scrollElementRef,
   isScrolling,
-}: DmScrollerProps) {
+}: ChatScrollerProps) {
   const isMobile = useIsMobile();
   const scrollTo = useBigInt(rawScrollTo);
   const [loadDirection, setLoadDirection] = useState<'newer' | 'older'>(

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -34,7 +34,7 @@ export default function ChatUnreadAlerts({
   }
 
   const { threads } = unread;
-  const threadKeys = Object.keys(threads).sort();
+  const threadKeys = Object.keys(threads).sort((a, b) => a.localeCompare(b));
 
   const topId = threadKeys[0];
   const to =

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -28,11 +28,11 @@ export default function ChatUnreadAlerts({
   }
 
   const { unread } = chatInfo.unread;
-  if (unread.count === 0 || !unread['unread-id']) {
+  const id = unread['unread-id'];
+  if (unread.count === 0 || !id || typeof id === 'object') {
     return null;
   }
 
-  const id = unread['unread-id'];
   const { threads } = unread;
   const threadKeys = Object.keys(threads).sort();
 

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -38,7 +38,7 @@ export default function ChatUnreadAlerts({
 
   const topId = threadKeys[0];
   const to =
-    threadKeys.length === 0
+    threadKeys.length === 0 || topId > id
       ? `${root}?msg=${id}`
       : `${root}/message/${topId}?msg=${threads[topId]}`;
 

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -28,12 +28,19 @@ export default function ChatUnreadAlerts({
   }
 
   const { unread } = chatInfo.unread;
-  if (unread.count === 0 || !unread['read-id']) {
+  if (unread.count === 0 || !unread['unread-id']) {
     return null;
   }
 
-  const id = unread['read-id'];
-  const to = `${root}?msg=${id}`;
+  const id = unread['unread-id'];
+  const { threads } = unread;
+  const threadKeys = Object.keys(threads).sort();
+
+  const topId = threadKeys[0];
+  const to =
+    threadKeys.length === 0
+      ? `${root}?msg=${id}`
+      : `${root}/message/${topId}?msg=${threads[topId]}`;
 
   const date = new Date(daToUnix(bigInt(id)));
   const since = isToday(date)

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -93,10 +93,11 @@ export default function ChatWindow({
   useEffect(
     () => () => {
       if (readTimeout !== undefined && readTimeout !== 0) {
-        useChatStore.getState().read(whom);
+        useChatStore.getState().read(nest);
+        markRead({ nest });
       }
     },
-    [readTimeout, whom]
+    [readTimeout, nest, markRead]
   );
 
   if (isLoading) {

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -70,24 +70,18 @@ export default function ChatWindow({
   }, [setSearchParams]);
 
   useEffect(() => {
-    useChatStore.getState().setCurrent(whom);
-  }, [whom]);
-
-  useEffect(
-    () => () => {
-      if (readTimeout !== undefined && readTimeout !== 0) {
-        markRead({ nest });
-      }
-    },
-    [readTimeout, markRead, nest]
-  );
+    useChatStore.getState().setCurrent(nest);
+  }, [nest]);
 
   const onAtBottom = useCallback(() => {
+    const { bottom, delayedRead } = useChatStore.getState();
+    bottom(true);
+    delayedRead(nest, () => markRead({ nest }));
     if (hasNextPage && !isFetchingNextPage) {
       log('fetching next page');
       fetchNextPage();
     }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [nest, markRead, fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const onAtTop = useCallback(() => {
     if (hasPreviousPage && !isFetchingPreviousPage) {

--- a/ui/src/chat/DMUnreadAlerts.tsx
+++ b/ui/src/chat/DMUnreadAlerts.tsx
@@ -5,7 +5,8 @@ import { daToUnix } from '@urbit/api';
 import { Link } from 'react-router-dom';
 import XIcon from '@/components/icons/XIcon';
 import { pluralize } from '@/logic/utils';
-import { useChatState, useWrit } from '@/state/chat';
+import { useChatState } from '@/state/chat';
+import { DMUnread } from '@/types/dms';
 import { useChatInfo, useChatStore } from './useChatStore';
 
 interface DMUnreadAlertsProps {
@@ -15,28 +16,41 @@ interface DMUnreadAlertsProps {
 
 export default function DMUnreadAlerts({ whom, root }: DMUnreadAlertsProps) {
   const chatInfo = useChatInfo(whom);
-  const id = chatInfo?.unread?.unread['unread-id'] || '';
-  const { writ } = useWrit(whom, id);
   const markRead = useCallback(() => {
     useChatState.getState().markDmRead(whom);
     useChatStore.getState().read(whom);
   }, [whom]);
 
-  if (!writ || !chatInfo.unread || chatInfo.unread.seen) {
+  if (!chatInfo?.unread || chatInfo.unread.seen) {
+    return null;
+  }
+  const { unread } = chatInfo.unread;
+  if (typeof unread['unread-id'] !== 'object' || !unread['unread-id']) {
     return null;
   }
 
-  const { time } = writ.seal;
-  const scrollTo = `?msg=${time}`;
-  // TODO: what do we do about threads/replies now?
-  const to = `${root}${scrollTo}`;
+  const { time } = unread['unread-id'];
+
+  if (!Object.values(unread.threads).some((t) => typeof t === 'object')) {
+    return null;
+  }
+
+  const threads = unread.threads as DMUnread['threads'];
+  const entries = Object.entries(threads).sort(([, a], [, b]) =>
+    a['parent-time'].localeCompare(b['parent-time'])
+  );
+
+  const [topId, { 'parent-time': parent, time: replyTime }] = entries[0];
+  const to =
+    entries.length === 0 || parent > time
+      ? `${root}?msg=${time}`
+      : `${root}/message/${topId}?msg=${replyTime}`;
 
   const date = new Date(daToUnix(bigInt(time)));
   const since = isToday(date)
     ? `${format(date, 'HH:mm')} today`
     : format(date, 'LLLL d');
 
-  const { unread } = chatInfo.unread;
   const unreadMessage =
     unread &&
     `${unread.count} new ${pluralize('message', unread.count)} since ${since}`;

--- a/ui/src/chat/DMUnreadAlerts.tsx
+++ b/ui/src/chat/DMUnreadAlerts.tsx
@@ -15,7 +15,7 @@ interface DMUnreadAlertsProps {
 
 export default function DMUnreadAlerts({ whom, root }: DMUnreadAlertsProps) {
   const chatInfo = useChatInfo(whom);
-  const id = chatInfo?.unread?.unread['read-id'] || '';
+  const id = chatInfo?.unread?.unread['unread-id'] || '';
   const { writ } = useWrit(whom, id);
   const markRead = useCallback(() => {
     useChatState.getState().markDmRead(whom);

--- a/ui/src/chat/useChatStore.ts
+++ b/ui/src/chat/useChatStore.ts
@@ -2,7 +2,7 @@ import { createDevLogger } from '@/logic/utils';
 import produce from 'immer';
 import { useCallback } from 'react';
 import create from 'zustand';
-import { Block, Unread } from '@/types/channel';
+import { Block, Unread, Unreads } from '@/types/channel';
 import { DMUnread, DMUnreads } from '@/types/dms';
 
 export interface ChatInfo {
@@ -11,7 +11,7 @@ export interface ChatInfo {
   unread?: {
     readTimeout: number;
     seen: boolean;
-    unread: DMUnread; // lags behind actual unread, only gets update if unread
+    unread: DMUnread | Unread; // lags behind actual unread, only gets update if unread
   };
   dialogs: Record<string, Record<string, boolean>>;
   hovering: string;
@@ -43,12 +43,12 @@ export interface ChatStore {
   delayedRead: (whom: string, callback: () => void) => void;
   unread: (
     whom: string,
-    unread: DMUnread,
+    unread: Unread | DMUnread,
     markRead: (whm: string) => void
   ) => void;
   bottom: (atBottom: boolean) => void;
   setCurrent: (whom: string) => void;
-  update: (unreads: DMUnreads) => void;
+  update: (unreads: Unreads | DMUnreads) => void;
 }
 
 const emptyInfo: () => ChatInfo = () => ({
@@ -62,7 +62,7 @@ const emptyInfo: () => ChatInfo = () => ({
 
 export const chatStoreLogger = createDevLogger('ChatStore', false);
 
-export function isUnread(unread: Unread): boolean {
+export function isUnread(unread: Unread | DMUnread): boolean {
   const hasThreads = Object.keys(unread.threads || {}).length > 0;
   return unread.count > 0 && (!!unread['unread-id'] || hasThreads);
 }

--- a/ui/src/chat/useChatStore.ts
+++ b/ui/src/chat/useChatStore.ts
@@ -66,7 +66,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         Object.entries(unreads).forEach(([whom, unread]) => {
           const chat = draft.chats[whom];
           chatStoreLogger.log('update', whom, chat, unread, draft.chats);
-          if (unread.count > 0 && unread['read-id']) {
+          const hasThreads = Object.keys(unread.threads || {}).length > 0;
+          if (unread.count > 0 && (unread['unread-id'] || hasThreads)) {
             draft.chats[whom] = {
               ...(chat || emptyInfo()),
               unread: {
@@ -159,7 +160,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
         const chat = draft.chats[whom];
         const unread = chat.unread || {
-          unread: { last: 0, count: 0, 'read-id': '' },
+          unread: {
+            recency: 0,
+            count: 0,
+            'unread-id': '',
+            threads: {},
+          },
           readTimeout: 0,
         };
 

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -106,6 +106,7 @@ export default function DmWindow({
     () => () => {
       if (readTimeout !== undefined && readTimeout !== 0) {
         useChatStore.getState().read(whom);
+        useChatState.getState().markDmRead(whom);
       }
     },
     [readTimeout, whom]

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -9,6 +9,7 @@ import { useUnreads, useChats } from '@/state/channel/channel';
 import { useGroups } from '@/state/groups';
 import { canReadChannel } from '@/logic/channel';
 import EmptyPlaceholder from '@/components/EmptyPlaceholder';
+import { Unread } from '@/types/channel';
 import {
   usePendingDms,
   usePendingMultiDms,
@@ -23,7 +24,7 @@ type MessagesListProps = PropsWithChildren<{
   isScrolling?: (scrolling: boolean) => void;
 }>;
 
-function itemContent(_i: number, [whom, _unread]: [string, DMUnread]) {
+function itemContent(_i: number, [whom, _unread]: [string, Unread | DMUnread]) {
   return (
     <div className="px-4 sm:px-2">
       <MessagesSidebarItem key={whom} whom={whom} />
@@ -31,8 +32,10 @@ function itemContent(_i: number, [whom, _unread]: [string, DMUnread]) {
   );
 }
 
-const computeItemKey = (_i: number, [whom, _unread]: [string, DMUnread]) =>
-  whom;
+const computeItemKey = (
+  _i: number,
+  [whom, _unread]: [string, Unread | DMUnread]
+) => whom;
 
 let virtuosoState: StateSnapshot | undefined;
 

--- a/ui/src/dms/TalkHead.tsx
+++ b/ui/src/dms/TalkHead.tsx
@@ -32,7 +32,7 @@ export default function TalkHead() {
     }
 
     return true;
-  });
+  }) as [string, { count: number }][]; // so the types below merge cleanly
 
   const unreads = useMemo(() => {
     switch (messagesFilter) {

--- a/ui/src/logic/channel.ts
+++ b/ui/src/logic/channel.ts
@@ -99,7 +99,7 @@ function channelUnread(
   unreads: Unreads,
   chats: ChatStore['chats']
 ) {
-  const [app, chFlag] = nestToFlag(nest);
+  const [app] = nestToFlag(nest);
   const unread = chats[nest]?.unread;
 
   if (app === 'chat') {

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -53,7 +53,7 @@ export default function useMessageSelector() {
       const unread = unreads[key];
       const newUnread = unreads[k];
       const newer =
-        !unread || (unread && newUnread && newUnread.last > unread.last);
+        !unread || (unread && newUnread && newUnread.recency > unread.recency);
       if (sameDM && newer) {
         return k;
       }

--- a/ui/src/logic/useMessageSort.ts
+++ b/ui/src/logic/useMessageSort.ts
@@ -1,4 +1,5 @@
-import { DMUnread, DMUnreads } from '@/types/dms';
+import { DMUnread } from '@/types/dms';
+import { Unread } from '@/types/channel';
 import useSidebarSort, {
   RECENT,
   Sorter,
@@ -15,9 +16,12 @@ export default function useMessageSort() {
     sortOptions,
   });
 
-  function sortMessages(unreads: DMUnreads) {
-    const accessors: Record<string, (k: string, v: DMUnread) => string> = {
-      [RECENT]: (flag: string, _unread: DMUnread) => `chat/${flag}`,
+  function sortMessages(unreads: Record<string, Unread | DMUnread>) {
+    const accessors: Record<
+      string,
+      (k: string, v: Unread | DMUnread) => string
+    > = {
+      [RECENT]: (flag: string, _unread: Unread | DMUnread) => `chat/${flag}`,
     };
 
     return sortRecordsBy(unreads, accessors[sortFn], true);

--- a/ui/src/logic/useSidebarSort.ts
+++ b/ui/src/logic/useSidebarSort.ts
@@ -27,8 +27,8 @@ export function useRecentSort() {
   const unreads = useUnreads();
   const sortRecent = useCallback(
     (aNest: string, bNest: string) => {
-      const aLast = unreads[aNest]?.last ?? Number.NEGATIVE_INFINITY;
-      const bLast = unreads[bNest]?.last ?? Number.NEGATIVE_INFINITY;
+      const aLast = unreads[aNest]?.recency ?? Number.NEGATIVE_INFINITY;
+      const bLast = unreads[bNest]?.recency ?? Number.NEGATIVE_INFINITY;
       if (aLast < bLast) {
         return -1;
       }

--- a/ui/src/mocks/chat.ts
+++ b/ui/src/mocks/chat.ts
@@ -132,44 +132,52 @@ export const chatKeys = ['~zod/test'];
 
 export const dmList: DMUnreads = {
   '~fabled-faster': {
-    last: 0,
+    recency: 0,
     count: 0,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
   '~nocsyx-lassul': {
-    last: 1652302200000,
+    recency: 1652302200000,
     count: 3,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
   '~fallyn-balfus': {
-    last: 0,
+    recency: 0,
     count: 0,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
   '~finned-palmer': {
-    last: 1652302200000,
+    recency: 1652302200000,
     count: 2,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
   '~datder-sonnet': {
-    last: 1652302200000,
+    recency: 1652302200000,
     count: 1,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
   '~hastuc-dibtux': {
-    last: 0,
+    recency: 0,
     count: 0,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
   '~rilfun-lidlen': {
-    last: 0,
+    recency: 0,
     count: 0,
-    'read-id': 'null',
+    'unread-id': 'null',
+    threads: {},
   },
   '~mister-dister-dozzod-dozzod': {
-    last: 0,
+    recency: 0,
     count: 0,
-    'read-id': null,
+    'unread-id': null,
+    threads: {},
   },
 };
 

--- a/ui/src/mocks/chat.ts
+++ b/ui/src/mocks/chat.ts
@@ -170,7 +170,7 @@ export const dmList: DMUnreads = {
   '~rilfun-lidlen': {
     recency: 0,
     count: 0,
-    'unread-id': 'null',
+    'unread-id': null,
     threads: {},
   },
   '~mister-dister-dozzod-dozzod': {

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -227,9 +227,10 @@ const chat: Handler[] = [
       Object.values(mockGroups).forEach((group) =>
         Object.entries(group.channels).forEach(([k]) => {
           unreads[k] = {
-            last: 1652302200000,
+            recency: 1652302200000,
             count: 1,
-            'read-id': null,
+            'unread-id': null,
+            threads: {},
           };
         })
       );
@@ -238,14 +239,16 @@ const chat: Handler[] = [
         ...unarchived,
         ...unreads,
         '0v4.00000.qcas9.qndoa.7loa7.loa7l': {
-          last: 1652302200000,
+          recency: 1652302200000,
           count: 1,
-          'read-id': null,
+          'unread-id': null,
+          threads: {},
         },
         '~zod/test': {
-          last: 1652302200000,
+          recency: 1652302200000,
           count: 1,
-          'read-id': null,
+          'unread-id': null,
+          threads: {},
         },
       };
     },
@@ -282,7 +285,12 @@ const chat: Handler[] = [
     ) =>
       createResponse(req, 'diff', {
         whom: req.json.whom,
-        unread: { last: 0, count: 0, 'read-id': null },
+        unread: {
+          recency: 0,
+          count: 0,
+          'unread-id': null,
+          threads: {},
+        },
       }),
   },
 ];
@@ -439,9 +447,10 @@ const dms: Handler[] = [
     ) => {
       if (!Object.keys(dmList).includes(req.json.ship)) {
         const unread = {
-          last: 1652302200000,
+          recency: 1652302200000,
           count: 1,
-          'read-id': null,
+          'unread-id': null,
+          threads: {},
         };
         dmList[req.json.ship] = unread;
 

--- a/ui/src/mocks/heaps.ts
+++ b/ui/src/mocks/heaps.ts
@@ -178,7 +178,7 @@ export const heapUnreadsScry: ScryHandler = {
     '~zod/testHeap': {
       last: unixTime,
       count: 1,
-      'read-id': null,
+      'unread-id': null,
     },
   }),
 };

--- a/ui/src/replies/ReplyMessage.tsx
+++ b/ui/src/replies/ReplyMessage.tsx
@@ -60,7 +60,7 @@ export interface ReplyMessageProps {
 }
 
 function unreadMatches(unread: DMUnread, id: string): boolean {
-  return unread['read-id'] === id;
+  return unread['unread-id'] === id;
 }
 
 const mergeRefs =
@@ -113,7 +113,7 @@ const ReplyMessage = React.memo<
       const isThreadOnMobile = isMobile;
       const chatInfo = useChatInfo(whom);
       const unread = chatInfo?.unread;
-      const unreadId = unread?.unread['read-id'];
+      const isUnread = unread?.unread.threads[seal['parent-id']] === seal.id;
       const { hovering, setHovering } = useChatHovering(whom, seal.id);
       const { open: pickerOpen } = useChatDialog(whom, seal.id, 'picker');
       const isDMOrMultiDM = useIsDmOrMultiDm(whom);
@@ -153,7 +153,7 @@ const ReplyMessage = React.memo<
                doing so. we don't want to accidentally clear unreads when
                the state has changed
             */
-            if (inView && unreadMatches(brief, seal.id) && !seen) {
+            if (inView && isUnread && !seen) {
               markSeen(whom);
               delayedRead(whom, () => {
                 if (isDMOrMultiDM) {
@@ -172,7 +172,7 @@ const ReplyMessage = React.memo<
               markDmRead(whom);
             }
           },
-          [unread, whom, seal.id, isDMOrMultiDM, markChatRead]
+          [unread, whom, isUnread, isDMOrMultiDM, markChatRead]
         ),
       });
 
@@ -275,7 +275,7 @@ const ReplyMessage = React.memo<
           id="chat-message-target"
           {...handlers}
         >
-          {unread && unreadMatches(unread.unread, seal.id) ? (
+          {unread && isUnread ? (
             <DateDivider
               date={unix}
               unreadCount={unread.unread.count}

--- a/ui/src/replies/ReplyMessage.tsx
+++ b/ui/src/replies/ReplyMessage.tsx
@@ -22,7 +22,6 @@ import {
   useTrackedMessageStatus,
 } from '@/state/chat';
 import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
-import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import { useIsMobile } from '@/logic/useMedia';
 import useLongPress from '@/logic/useLongPress';
 import {
@@ -30,7 +29,7 @@ import {
   usePostToggler,
   useTrackedPostStatus,
 } from '@/state/channel/channel';
-import { emptyReply, Reply, Story } from '@/types/channel';
+import { emptyReply, Reply, Story, Unread } from '@/types/channel';
 import { useIsDmOrMultiDm } from '@/logic/utils';
 import {
   useChatDialog,
@@ -39,6 +38,7 @@ import {
   useChatStore,
 } from '@/chat/useChatStore';
 import ReactionDetails from '@/chat/ChatReactions/ReactionDetails';
+import { DMUnread } from '@/types/dms';
 import ReplyReactions from './ReplyReactions/ReplyReactions';
 import ReplyMessageOptions from './ReplyMessageOptions';
 
@@ -53,6 +53,19 @@ export interface ReplyMessageProps {
   isLinked?: boolean;
   isScrolling?: boolean;
   showReply?: boolean;
+}
+
+function amUnread(unread?: Unread | DMUnread, parent?: string, id?: string) {
+  if (!unread || !parent || !id) {
+    return false;
+  }
+
+  const thread = unread.threads[parent];
+  if (typeof thread === 'object') {
+    return thread.id === id;
+  }
+
+  return thread === id;
 }
 
 const mergeRefs =
@@ -104,11 +117,11 @@ const ReplyMessage = React.memo<
       const isMobile = useIsMobile();
       const isThreadOnMobile = isMobile;
       const chatInfo = useChatInfo(whom);
+      const isDMOrMultiDM = useIsDmOrMultiDm(whom);
       const unread = chatInfo?.unread;
-      const isUnread = unread?.unread.threads[seal['parent-id']] === seal.id;
+      const isUnread = amUnread(unread?.unread, seal['parent-id'], seal.id);
       const { hovering, setHovering } = useChatHovering(whom, seal.id);
       const { open: pickerOpen } = useChatDialog(whom, seal.id, 'picker');
-      const isDMOrMultiDM = useIsDmOrMultiDm(whom);
       const { mutate: markChatRead } = useMarkReadMutation();
       const { isHidden: isMessageHidden } = useMessageToggler(seal.id);
       const { isHidden: isPostHidden } = usePostToggler(seal.id);

--- a/ui/src/replies/ReplyMessage.tsx
+++ b/ui/src/replies/ReplyMessage.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable react/no-unused-prop-types */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import cn from 'classnames';
 import debounce from 'lodash/debounce';
 import { BigInteger } from 'big-integer';
@@ -14,6 +20,7 @@ import ChatContent from '@/chat/ChatContent/ChatContent';
 import DateDivider from '@/chat/ChatMessage/DateDivider';
 import {
   useChatState,
+  useMessageToggler,
   useTrackedMessageStatus,
   // useIsMessageDelivered,
   // useIsMessagePosted,
@@ -24,9 +31,10 @@ import { useIsMobile } from '@/logic/useMedia';
 import useLongPress from '@/logic/useLongPress';
 import {
   useMarkReadMutation,
+  usePostToggler,
   useTrackedPostStatus,
 } from '@/state/channel/channel';
-import { emptyReply, Reply } from '@/types/channel';
+import { emptyReply, Reply, Story } from '@/types/channel';
 import { useIsDmOrMultiDm } from '@/logic/utils';
 import {
   useChatDialog,
@@ -68,6 +76,17 @@ const mergeRefs =
     });
   };
 
+const hiddenMessage: Story = [
+  {
+    inline: [
+      {
+        italics: [
+          'You have hidden this message. You can unhide it from the options menu.',
+        ],
+      },
+    ],
+  },
+];
 const ReplyMessage = React.memo<
   ReplyMessageProps & React.RefAttributes<HTMLDivElement>
 >(
@@ -99,6 +118,12 @@ const ReplyMessage = React.memo<
       const { open: pickerOpen } = useChatDialog(whom, seal.id, 'picker');
       const isDMOrMultiDM = useIsDmOrMultiDm(whom);
       const { mutate: markChatRead } = useMarkReadMutation();
+      const { isHidden: isMessageHidden } = useMessageToggler(seal.id);
+      const { isHidden: isPostHidden } = usePostToggler(seal.id);
+      const isHidden = useMemo(
+        () => isMessageHidden || isPostHidden,
+        [isMessageHidden, isPostHidden]
+      );
       const { ref: viewRef } = useInView({
         threshold: 1,
         onChange: useCallback(
@@ -282,7 +307,13 @@ const ReplyMessage = React.memo<
                   isLinked && 'bg-blue-softer'
                 )}
               >
-                {memo.content ? (
+                {isHidden ? (
+                  <ChatContent
+                    story={hiddenMessage}
+                    isScrolling={isScrolling}
+                    writId={seal.id}
+                  />
+                ) : memo.content ? (
                   <ChatContent
                     story={memo.content}
                     isScrolling={isScrolling}

--- a/ui/src/replies/ReplyMessage.tsx
+++ b/ui/src/replies/ReplyMessage.tsx
@@ -11,9 +11,7 @@ import debounce from 'lodash/debounce';
 import { BigInteger } from 'big-integer';
 import { daToUnix } from '@urbit/api';
 import { format } from 'date-fns';
-import { useParams } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
-import { DMUnread } from '@/types/dms';
 import Author from '@/chat/ChatMessage/Author';
 // eslint-disable-next-line import/no-cycle
 import ChatContent from '@/chat/ChatContent/ChatContent';
@@ -22,8 +20,6 @@ import {
   useChatState,
   useMessageToggler,
   useTrackedMessageStatus,
-  // useIsMessageDelivered,
-  // useIsMessagePosted,
 } from '@/state/chat';
 import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
@@ -57,10 +53,6 @@ export interface ReplyMessageProps {
   isLinked?: boolean;
   isScrolling?: boolean;
   showReply?: boolean;
-}
-
-function unreadMatches(unread: DMUnread, id: string): boolean {
-  return unread['unread-id'] === id;
 }
 
 const mergeRefs =

--- a/ui/src/replies/replies.ts
+++ b/ui/src/replies/replies.ts
@@ -56,7 +56,7 @@ export function groupReplies(
     const newAuthor =
       prev && prev[1] !== null ? author !== prev[1].memo.author : true;
     const unreadUnread =
-      unread && unread['read-id'] === q.seal.id ? unread : undefined;
+      unread && unread['unread-id'] === q.seal.id ? unread : undefined;
 
     if (newAuthor) {
       currentTime = time;

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -849,7 +849,6 @@ export function useUnreads(): Unreads {
   );
 
   const eventHandler = (event: UnreadUpdate) => {
-    invalidate.current();
     const { unread } = event;
 
     if (unread !== null) {
@@ -864,6 +863,8 @@ export function useUnreads(): Unreads {
         return newUnreads;
       });
     }
+
+    invalidate.current();
   };
 
   const { data, ...rest } = useReactQuerySubscription<Unreads, UnreadUpdate>({
@@ -1035,7 +1036,7 @@ export function useGetFirstUnreadID(nest: Nest) {
   const keys = usePostKeys(nest);
   const unread = useUnread(nest);
 
-  const { 'read-id': lastRead } = unread;
+  const { 'unread-id': lastRead } = unread;
 
   if (!lastRead) {
     return null;

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -41,7 +41,7 @@ import {
 } from '@/types/channel';
 import api from '@/api';
 import { whomIsDm, whomIsMultiDm, whomIsFlag, whomIsNest } from '@/logic/utils';
-import { useChatStore } from '@/chat/useChatStore';
+import { useChatInfo, useChatStore } from '@/chat/useChatStore';
 import { getPreviewTracker } from '@/logic/subscriptionTracking';
 import useReactQueryScry from '@/logic/useReactQueryScry';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
@@ -1111,9 +1111,9 @@ export function useDeleteDMReplyReactMutation() {
 }
 
 export function useIsDmUnread(whom: string) {
-  const { data: unreads } = useDmUnreads();
-  const unread = unreads[whom];
-  return Boolean(unread?.count > 0 && unread['unread-id']);
+  const chatInfo = useChatInfo(whom);
+  const unread = chatInfo?.unread;
+  return Boolean(unread && !unread.seen);
 }
 
 const selPendingDms = (s: ChatState) => s.pendingDms;

--- a/ui/src/state/chat/writs.ts
+++ b/ui/src/state/chat/writs.ts
@@ -332,6 +332,8 @@ export default function makeWritsStore(
             return;
           }
 
+          queryClient.invalidateQueries(['dms', whom, 'writs', data.id]);
+
           set((draft) => {
             writsReducer(whom)(data as WritResponse, draft);
             return {

--- a/ui/src/types/channel.ts
+++ b/ui/src/types/channel.ts
@@ -320,9 +320,10 @@ export interface Channels {
 }
 
 export interface Unread {
-  last: number;
+  recency: number;
   count: number;
-  'read-id': string | null;
+  'unread-id': string | null;
+  threads: Record<string, string>;
 }
 
 export interface Unreads {

--- a/ui/src/types/dms.ts
+++ b/ui/src/types/dms.ts
@@ -202,9 +202,10 @@ export interface PagedWritsMap extends Omit<PagedWrits, 'writs'> {
 }
 
 export interface DMUnread {
-  last: number;
+  recency: number;
   count: number;
-  'read-id': string | null;
+  'unread-id': string | null;
+  threads: Record<string, string>;
 }
 
 export interface DMUnreads {

--- a/ui/src/types/dms.ts
+++ b/ui/src/types/dms.ts
@@ -201,11 +201,20 @@ export interface PagedWritsMap extends Omit<PagedWrits, 'writs'> {
   writs: WritPageMap;
 }
 
+export interface MessageKey {
+  id: string;
+  time: string;
+}
+
+export interface UnreadThread extends MessageKey {
+  'parent-time': string;
+}
+
 export interface DMUnread {
   recency: number;
   count: number;
-  'unread-id': string | null;
-  threads: Record<string, string>;
+  'unread-id': MessageKey | null;
+  threads: Record<string, UnreadThread>;
 }
 
 export interface DMUnreads {


### PR DESCRIPTION
This makes unreads work with threads/comments now that those are stored separately, fixing LAND-1180. We needed to add tracking of unread threads upon hearing new replies so that we could efficiently calculate unreads without going over the entire message log and then pass which threads are unread to the frontend so that we could mimic the current behavior on mainnet. The type changes here unlock the ability to make thread unread state be completely separate from the main window if we want. 

Works for both DMs and channels.