### PR TITLE
chat, heap, diary: tighter epic logic

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -126,6 +126,11 @@
     =.  cor  restore-missing-subs
     =.  cor  (emit %pass ca-area:ca-core:cor %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
     =.  cor  (emit %pass ca-area:ca-core:cor %agent [our.bowl dap.bowl] %poke %leave-old-channels !>(0))
+    =.  cor
+      %+  roll  ~(tap in `(set @p)`(~(run in ~(key by chats)) head))
+      |=  [=ship cr=_cor]
+      ?:  =(ship our.bowl)  cr
+      (watch-epic:cr ship &)
     ?:  =(okay:c cool)  cor
     :: =?  cor  bad  (emit (keep !>(old)))
     %-  (note:wood %ver leaf/"New Epic" ~)
@@ -303,10 +308,15 @@
   (emit %pass /groups %agent [our.bowl %groups] %watch /groups)
 ::
 ++  watch-epic
-  |=  her=ship
+  |=  [her=ship leave=?]
   ^+  cor
   =/  =wire  /epic
   =/  =dock  [her dap.bowl]
+  ?:  leave
+    %-  emil
+    :~  [%pass wire %agent [her dap.bowl] %leave ~]
+        [%pass wire %agent [her dap.bowl] %watch /epic]
+    ==
   ?:  (~(has by wex.bowl) [wire dock])
     cor
   (emit %pass wire %agent [her dap.bowl] %watch /epic)
@@ -837,15 +847,13 @@
   ^+  cor
   ?+    -.sign  cor
       %kick
-    (watch-epic src.bowl)
+    (watch-epic src.bowl |)
   ::
       %fact
     ?.  =(%epic p.cage.sign)
       %-  (note:wood %odd leaf/"!!! weird fact on /epic" ~)
       cor
     =+  !<(=epic:e q.cage.sign)
-    ?.  =(epic okay:c)  :: is now our guy
-      cor
     %+  roll  ~(tap by chats)
     |=  [[=flag:g =chat:c] out=_cor]
     ?.  =(src.bowl p.flag)
@@ -1628,7 +1636,7 @@
       ca-core
     ::
         %watch-ack
-      =.  net.chat  [%sub src.bowl & %chi ~]
+      =?  net.chat  ?=(%sub -.net.chat)  net.chat(load ?=(~ p.sign))
       ?~  p.sign  ca-core
       %-  (slog leaf/"Failed subscription" u.p.sign)
       ::  =.  gone  &
@@ -1656,7 +1664,7 @@
        ca-core
     %-  (note:wood %ver leaf/"took lev epic: {<flag>}" ~)
     =.  saga.net.chat  lev/~
-    =.  cor  (watch-epic p.flag)
+    =.  cor  (watch-epic p.flag |)
     ca-core
   ::
   ++  ca-make-chi
@@ -1754,12 +1762,17 @@
     |=  j=join:c
     ^+  ca-core
     ?>  |(=(p.group.j src.bowl) =(src.bowl our.bowl))
-    =.  chats  (~(put by chats) chan.j *chat:c)
+    =|  =chat:c
+    =.  net.chat
+      ?:  =(our.bowl p.chan.j)  [%pub ~]
+      [%sub p.chan.j | %chi ~]
+    =.  chats  (~(put by chats) chan.j chat)
     =.  ca-core  (ca-abed chan.j)
     =.  last-read.remark.chat  now.bowl
     =.  group.perm.chat  group.j
     =.  cor  (give-brief flag/flag ca-brief)
-    ca-sub
+    =.  cor  (watch-epic p.flag &)
+    ca-core
   ::
   ++  ca-leave
     =/  =dock  [p.flag dap.bowl]

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -880,7 +880,7 @@
       di-core
     ::
         %watch-ack
-      =.  net.diary  [%sub src.bowl & [%chi ~]]
+      =?  net.diary  ?=(%sub -.net.diary)  net.diary(load ?=(~ p.sign))
       ?~  p.sign  di-core
       %-  (slog leaf/"Failed subscription" u.p.sign)
       :: =.  gone  &
@@ -971,13 +971,17 @@
     |=  j=join:d
     ^+  di-core
     ?>  |(=(p.group.j src.bowl) =(src.bowl our.bowl))
-    =.  shelf  (~(put by shelf) chan.j *diary:d)
+    =|  diary:d
+    =.  net.diary
+      ?:  =(our.bowl p.chan.j)  [%pub ~]
+      [%sub p.chan.j | %chi ~]
+    =.  shelf  (~(put by shelf) chan.j diary)
     =.  di-core  (di-abed chan.j)
     =.  group.perm.diary  group.j
     =.  last-read.remark.diary  now.bowl
     =.  cor  (give-brief flag di-brief)
     =.  cor  (watch-epic p.flag &)
-    di-sub
+    di-core
   ::
   ++  di-leave
     =/  =dock  [p.flag dap.bowl]

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -223,6 +223,11 @@
     =.  cor  restore-missing-subs
     =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %recheck-all-perms !>(0))
     =.  cor  (emit %pass he-area:he-core:cor %agent [our.bowl dap.bowl] %poke %leave-old-channels !>(0))
+    =.  cor
+      %+  roll  ~(tap in `(set @p)`(~(run in ~(key by stash)) head))
+      |=  [=ship cr=_cor]
+      ?:  =(ship our.bowl)  cr
+      (watch-epic:cr ship &)
     ?:  =(okay:h cool)  cor
     ::  speak the good news
     =.  cor  (emil (drop load:epos))
@@ -374,10 +379,15 @@
     ==
   ==
 ++  watch-epic
-  |=  her=ship
+  |=  [her=ship leave=?]
   ^+  cor
   =/  =wire  /epic
   =/  =dock  [her dap.bowl]
+  ?:  leave
+    %-  emil
+    :~  [%pass wire %agent [her dap.bowl] %leave ~]
+        [%pass wire %agent [her dap.bowl] %watch /epic]
+    ==
   ?:  (~(has by wex.bowl) [wire dock])
     cor
   (emit %pass wire %agent [her dap.bowl] %watch /epic)
@@ -387,20 +397,18 @@
   ^+  cor
   ?+    -.sign  cor
       %kick
-    (watch-epic src.bowl)
+    (watch-epic src.bowl |)
   ::
       %fact
     ?.  =(%epic p.cage.sign)
       ~&  '!!! weird fact on /epic'
       cor
     =+  !<(=epic:e q.cage.sign)
-    ?.  =(epic okay:h)
-      cor
-    ~&  >>  "good news everyone!"
     %+  roll  ~(tap by stash)
     |=  [[=flag:g =heap:h] out=_cor]
-    ?>  =(src.bowl p.flag)
+    ?.  =(src.bowl p.flag)  out
     he-abet:(he-take-epic:(he-abed:he-core:out flag) epic)
+  ::
       %watch-ack
     %.  cor
     ?~  p.sign  same
@@ -821,7 +829,7 @@
       he-core
     ~&  make-lev/flag
     =.  saga.net.heap  lev+~
-    =.  cor  (watch-epic p.flag)
+    =.  cor  (watch-epic p.flag |)
     he-core
   ::
   ++  he-make-chi
@@ -841,7 +849,7 @@
       he-core
     ::
         %watch-ack
-      =.  net.heap  [%sub src.bowl & [%chi ~]]
+      =?  net.heap  ?=(%sub -.net.heap)  net.heap(load ?=(~ p.sign))
       ?~  p.sign  he-core
       %-  (slog leaf/"Failed subscription" u.p.sign)
       ::  =.  gone  &
@@ -943,12 +951,17 @@
     |=  j=join:h
     ^+  he-core
     ?>  |(=(p.group.j src.bowl) =(src.bowl our.bowl))
-    =.  stash  (~(put by stash) chan.j *heap:h)
+    =|  =heap:h
+    =.  net.heap
+      ?:  =(our.bowl p.chan.j)  [%pub ~]
+      [%sub p.chan.j | %chi ~]
+    =.  stash  (~(put by stash) chan.j heap)
     =.  he-core  (he-abed chan.j)
     =.  group.perm.heap  group.j
     =.  last-read.remark.heap  now.bowl
     =.  cor  (give-brief flag he-brief)
-    he-sub
+    =.  cor  (watch-epic p.flag &)
+    he-core
   ::
   ++  he-leave
     =/  =dock  [p.flag dap.bowl]


### PR DESCRIPTION
When joining channels for the first time, these agents were failing to keep version negotiation state for their host around properly. Here, we make a couple of changes that help them keep the channel status straight. (`/app/diary` already had many of these changes. Now they're all consistent with each other.)

- During `+*-join`, explicitly initialize the $net as appropriate, instead of always bunting it to be %pub.
- During `+*-join`, do not subscribe to the channel right away, instead send an /epic version negotiation subscription first. Only once versions match do we open the subscription for the channel (in `+*-make-chi`).
- When receiving an `/epic` `%fact`, always call into `+*-take-epic` for all affected channels, regardless of what the state of the new epic is.
- In `+*-take-update`, don't change the version negotiation state, only touch up the load.net, and base that value off of watch ack vs nack.
- In `+load`, re-establish `/epic` subscriptions for all channel hosts. This lets ships in bad states because of the previously-broken logic recover.

For LAND-1195. This does unfortunately mean that we're going to need this big, bulky backend change to go out as an appetizer. On the bright side, it's not a strictly necessary appetizer, it only improves the UX for a subset of the "I'm behind the channel host" cases, and shouldn't affect behavior of the migration itself at all.