### PR TITLE
dms: smoother joins & leaves

### DIFF
--- a/ui/src/state/chat/utils.ts
+++ b/ui/src/state/chat/utils.ts
@@ -7,6 +7,7 @@ import {
 } from '@/types/channel';
 import {
   Club,
+  DMUnreads,
   PagedWrits,
   ReplyDelta,
   Writ,
@@ -15,6 +16,7 @@ import {
   WritMemo,
   WritSeal,
 } from '@/types/dms';
+import { QueryClient } from '@tanstack/react-query';
 import { udToDec } from '@urbit/api';
 import { formatUd, unixToDa } from '@urbit/aura';
 import bigInt from 'big-integer';
@@ -31,6 +33,34 @@ export default function emptyMultiDm(): Club {
       cover: '',
     },
   };
+}
+
+export function removePendingFromCache(queryClient: QueryClient, id: string) {
+  queryClient.setQueryData(
+    ['dms', 'pending'],
+    (pending: string[] | undefined) => {
+      if (!pending) {
+        return pending;
+      }
+      return pending.filter((p) => p !== id);
+    }
+  );
+}
+
+export function removeUnreadFromCache(queryClient: QueryClient, id: string) {
+  queryClient.setQueryData(
+    ['dms', 'unreads'],
+    (unreads: DMUnreads | undefined) => {
+      if (!unreads) {
+        return unreads;
+      }
+
+      const newUnreads = { ...unreads };
+      delete newUnreads[id];
+
+      return newUnreads;
+    }
+  );
 }
 
 interface PageParam {


### PR DESCRIPTION
Should fix the issue on the latest hackweek deploy where joining and leaving DMs and multi DMs succeed, but doesn't update the interface.

Fixes LAND-1225