### PR TITLE
version negotiation: make additional info accessible in the hooks

### DIFF
--- a/ui/src/channels/HostConnection.tsx
+++ b/ui/src/channels/HostConnection.tsx
@@ -69,7 +69,11 @@ export default function HostConnection({
   saga,
   className,
 }: HostConnectionProps) {
-  const negotiationMatch = useNegotiation(ship, 'channels', 'channels-server');
+  const { match: negotiationMatch } = useNegotiation(
+    ship,
+    'channels',
+    'channels-server'
+  );
 
   return (
     <span className={cn('flex items-center space-x-1', className)}>

--- a/ui/src/components/ShipConnection.tsx
+++ b/ui/src/components/ShipConnection.tsx
@@ -23,7 +23,7 @@ export default function ShipConnection({
   type = 'default',
   className,
 }: ShipConnectionProps) {
-  const negotiationMatch = useNegotiation(ship, 'chat', 'chat');
+  const { match: negotiationMatch } = useNegotiation(ship, 'chat', 'chat');
   const isSelf = ship === window.our;
   const color = isSelf
     ? 'text-green-400'

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -123,7 +123,8 @@ export default function Dm() {
   const canStart = ship && !!unread;
   const root = `/dm/${ship}`;
   const shouldApplyPaddingBottom = isGroups && isMobile && !isChatInputFocused;
-  const negotiationMatch = useNegotiation(ship, 'chat', 'chat');
+  const { match: negotiationMatch, isLoading: negotiationLoading } =
+    useNegotiation(ship, 'chat', 'chat');
 
   const {
     isSelectingMessage,
@@ -276,7 +277,7 @@ export default function Dm() {
                 isScrolling={isScrolling}
               />
             </div>
-          ) : !negotiationMatch ? (
+          ) : !negotiationLoading && !negotiationMatch ? (
             <div className="rounded-lg border-2 border-transparent bg-gray-50 py-1 px-2 leading-5 text-gray-600">
               Your version does not match the other party's version.
             </div>

--- a/ui/src/dms/Dm.tsx
+++ b/ui/src/dms/Dm.tsx
@@ -125,6 +125,7 @@ export default function Dm() {
   const shouldApplyPaddingBottom = isGroups && isMobile && !isChatInputFocused;
   const { match: negotiationMatch, isLoading: negotiationLoading } =
     useNegotiation(ship, 'chat', 'chat');
+  const confirmedMismatch = !negotiationLoading && !negotiationMatch;
 
   const {
     isSelectingMessage,
@@ -261,7 +262,7 @@ export default function Dm() {
           )
         }
         footer={
-          isAccepted && negotiationMatch ? (
+          isAccepted && !confirmedMismatch ? (
             <div
               className={cn(
                 isDragging || isOver ? '' : 'border-t-2 border-gray-50 p-4'
@@ -277,7 +278,7 @@ export default function Dm() {
                 isScrolling={isScrolling}
               />
             </div>
-          ) : !negotiationLoading && !negotiationMatch ? (
+          ) : confirmedMismatch ? (
             <div className="rounded-lg border-2 border-transparent bg-gray-50 py-1 px-2 leading-5 text-gray-600">
               Your version does not match the other party's version.
             </div>

--- a/ui/src/dms/MultiDm.tsx
+++ b/ui/src/dms/MultiDm.tsx
@@ -89,7 +89,9 @@ export default function MultiDm() {
   const isScrolling = useIsScrolling(scrollElementRef);
   const shouldApplyPaddingBottom = isGroups && isMobile && !isChatInputFocused;
   const dmParticipants = [...(club?.team ?? []), ...(club?.hive ?? [])];
-  const negotiationMatch = useNegotiateMulti(dmParticipants, 'chat', 'chat');
+  const { match: negotiationMatch, isLoading: negotiationLoading } =
+    useNegotiateMulti(dmParticipants, 'chat', 'chat');
+  const confirmedMismatch = !negotiationLoading && !negotiationMatch;
   const { mutate: sendMessage } = useSendMessage();
 
   const {
@@ -199,7 +201,7 @@ export default function MultiDm() {
           )
         }
         footer={
-          isAccepted && negotiationMatch ? (
+          isAccepted && !confirmedMismatch ? (
             <div
               className={cn(
                 isDragging || isOver ? '' : 'border-t-2 border-gray-50 p-4'
@@ -215,7 +217,7 @@ export default function MultiDm() {
                 isScrolling={isScrolling}
               />
             </div>
-          ) : !negotiationMatch ? (
+          ) : confirmedMismatch ? (
             <div className="rounded-lg border-2 border-transparent bg-gray-50 py-1 px-2 leading-5 text-gray-600">
               Your version of the app does not match some of the members of this
               chat.

--- a/ui/src/logic/channel.ts
+++ b/ui/src/logic/channel.ts
@@ -252,7 +252,7 @@ export function useCheckChannelJoined() {
 export function useChannelCompatibility(nest: string) {
   const [, chan] = nestToFlag(nest);
   const { ship } = getFlagParts(chan);
-  const match = useNegotiation(ship, 'channels', 'channels-server');
+  const { match } = useNegotiation(ship, 'channels', 'channels-server');
 
   return {
     compatible: match,

--- a/ui/src/state/negotiation.ts
+++ b/ui/src/state/negotiation.ts
@@ -35,7 +35,7 @@ export function useNegotiateMulti(ships: string[], app: string, agent: string) {
   });
 
   if (rest.isLoading || rest.isError || data === undefined) {
-    return undefined;
+    return { ...rest, match: false };
   }
 
   const allShipsMatch = ships
@@ -43,5 +43,5 @@ export function useNegotiateMulti(ships: string[], app: string, agent: string) {
     .map((ship) => `${ship}/${agent}`)
     .every((ship) => ship in data && data[ship] === true);
 
-  return allShipsMatch;
+  return { ...rest, match: allShipsMatch };
 }

--- a/ui/src/state/negotiation.ts
+++ b/ui/src/state/negotiation.ts
@@ -14,16 +14,16 @@ export default function useNegotiation(
   });
 
   if (rest.isLoading || rest.isError || data === undefined) {
-    return undefined;
+    return { ...rest, match: false };
   }
 
   const isInData = `${ship}/${agent}` in data;
 
   if (isInData) {
-    return data[`${ship}/${agent}`];
+    return { ...rest, match: data[`${ship}/${agent}`] };
   }
 
-  return isInData;
+  return { ...rest, match: false };
 }
 
 export function useNegotiateMulti(ships: string[], app: string, agent: string) {


### PR DESCRIPTION
Makes `isLoading` and other react query goodies accessible from the `useNegotiation` hook. We need this for DMs where we're initially showing an erroneous mismatch warning. Now it will display normally if the negotiation is still loading.

Fixes LAND-1224