### PR TITLE
references: fix issue with reference paths causing notebook/gallery comment references to display improperly

### DIFF
--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -51,7 +51,7 @@ function ContentReference({
 
     if (app === 'heap') {
       const idCurio = udToDec(segments[2]);
-      const idReply = segments[4];
+      const idReply = segments[3];
 
       if (idReply) {
         return (
@@ -96,7 +96,15 @@ function ContentReference({
     }
     if (app === 'diary') {
       const idNote = udToDec(segments[2]);
-      const idReply = segments[3] ? udToDec(segments[3]) : null;
+      const idReply =
+        // we have to do this because the paths for migrated note comments
+        // are different than the paths for new/post-migration note comments
+        // this is just papering over the issue.
+        segments[3] && segments[3] !== 'msg'
+          ? udToDec(segments[3])
+          : segments[4]
+          ? udToDec(segments[4])
+          : null;
 
       if (idReply) {
         return (


### PR DESCRIPTION
Fixes LAND-1226 by papering over the issue on the frontend in the notebook comments case and fixing a bug in the gallery comments case (we were looking at the wrong position in the segments array).