### PR TITLE
dms: fix loading placeholder

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.tsx
@@ -484,12 +484,6 @@ export default function ChatScroller({
         </EmptyPlaceholder>
       )}
 
-      {fetchState !== 'initial' && count === 0 && (
-        <div className="h-full overflow-hidden">
-          <ChatScrollerPlaceholder count={30} />
-        </div>
-      )}
-
       <div
         className="l-0 absolute top-0 w-full"
         ref={contentElementRef}

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -127,13 +127,11 @@ export default function DmWindow({
   }, [scrollTo, hasNextPage]);
 
   if (isLoading) {
-    if (isLoading) {
-      return (
-        <div className="h-full overflow-hidden">
-          <ChatScrollerPlaceholder count={30} />
-        </div>
-      );
-    }
+    return (
+      <div className="h-full overflow-hidden">
+        <ChatScrollerPlaceholder count={30} />
+      </div>
+    );
   }
 
   return (

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -16,6 +16,7 @@ import { log } from '@/logic/utils';
 import { useChatInfo, useChatStore } from '@/chat/useChatStore';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import { useIsScrolling } from '@/logic/scroll';
+import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
 
 interface DmWindowProps {
   whom: string;
@@ -124,6 +125,16 @@ export default function DmWindow({
       setShouldGetLatest(true);
     }
   }, [scrollTo, hasNextPage]);
+
+  if (isLoading) {
+    if (isLoading) {
+      return (
+        <div className="h-full overflow-hidden">
+          <ChatScrollerPlaceholder count={30} />
+        </div>
+      );
+    }
+  }
 
   return (
     <div className="relative h-full">


### PR DESCRIPTION
We'd moved this into ChatScroller, but the logic was broken. After fixing the logic, there are still display issues with it overlapping content that's set in the parent component. Clawing back the placeholder to it's original location in `DmWindow`.

Fixes LAND-1234