### PR TITLE
negotiation: host connection should always be matched, shouldn't assume

### DIFF
--- a/ui/src/channels/HostConnection.tsx
+++ b/ui/src/channels/HostConnection.tsx
@@ -69,21 +69,23 @@ export default function HostConnection({
   saga,
   className,
 }: HostConnectionProps) {
-  const { matchedOrPending } = useNegotiate(
+  const { status: negotiationStatus } = useNegotiate(
     ship,
     'channels',
     'channels-server'
   );
 
+  const matched = negotiationStatus === 'match';
+
   return (
     <span className={cn('flex items-center space-x-1', className)}>
       {type === 'default' && (
-        <Tooltip content={getText(saga, ship, status, matchedOrPending)}>
+        <Tooltip content={getText(saga, ship, status, matched)}>
           <span tabIndex={0} className="default-focus rounded-md">
             <Bullet16Icon
               className={cn(
                 'h-4 w-4 flex-none',
-                getHostConnectionColor(saga, status, matchedOrPending)
+                getHostConnectionColor(saga, status, matched)
               )}
             />
           </span>
@@ -93,12 +95,12 @@ export default function HostConnection({
         <Bullet16Icon
           className={cn(
             'h-4 w-4 flex-none',
-            getHostConnectionColor(saga, status, matchedOrPending)
+            getHostConnectionColor(saga, status, matched)
           )}
         />
       )}
       {(type === 'combo' || type === 'text') && (
-        <span>{getText(saga, ship, status, matchedOrPending)}</span>
+        <span>{getText(saga, ship, status, matched)}</span>
       )}
     </span>
   );

--- a/ui/src/logic/channel.ts
+++ b/ui/src/logic/channel.ts
@@ -251,15 +251,13 @@ export function useCheckChannelJoined() {
 export function useChannelCompatibility(nest: string) {
   const [, chan] = nestToFlag(nest);
   const { ship } = getFlagParts(chan);
-  const { matchedOrPending } = useNegotiate(
-    ship,
-    'channels',
-    'channels-server'
-  );
+  const { status } = useNegotiate(ship, 'channels', 'channels-server');
+
+  const matched = status === 'matched';
 
   return {
-    compatible: matchedOrPending,
-    text: matchedOrPending
+    compatible: matched,
+    text: matched
       ? "You're synced with the host."
       : 'Your version of the app does not match the host.',
   };


### PR DESCRIPTION
We were assuming it was fine to allow DMs to the old world, but we shouldn't do it for group hosts.