### PR TITLE
chat, heap, diary: migrate chat refs properly

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -155,7 +155,6 @@
       %channel-migration
     ?>  =(our src):bowl
     =+  !<(new-channels=v-channels:c vase)
-    ~&  new-channels
     =.  v-channels  (~(uni by new-channels) v-channels)  ::  existing overrides migration
     %+  roll  ~(tap by v-channels)
     |=  [[=nest:c =v-channel:c] cr=_cor]

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -682,6 +682,7 @@
   |=  =path
   ^-  (unit (unit cage))
   ?+  path  [~ ~]
+    [%x %old ~]  ``noun+!>(old-chats)  ::  legacy data, for migration use
   ::
     [%x %clubs ~]  ``clubs+!>((~(run by clubs) |=(=club:c crew.club)))
   ::
@@ -896,7 +897,7 @@
       ?~  parent-time  reply-index
       =/  old-replies=v-replies:d  (~(gut by reply-index) u.parent-time *v-replies:d)
       %+  ~(put by reply-index)  u.parent-time
-      (put:on-v-replies:d old-replies time `(convert-quip old time writ))
+      (put:on-v-replies:d old-replies time `(convert-quip time writ))
     %+  gas:on-v-posts:d  *v-posts:d
     %+  murn  writs
     |=  [=time =writ:t]
@@ -906,12 +907,12 @@
     ::  by the above code.
     ::
     =/  replies=v-replies:d  (~(gut by reply-index) time *v-replies:d)
-    (some time `(convert-post old time writ replies))
+    (some time `(convert-post time writ replies))
   ::
   ++  convert-post
-    |=  [=pact:t id=@da old=writ:t replies=v-replies:d]
+    |=  [id=@da old=writ:t replies=v-replies:d]
     ^-  v-post:d
-    [[id replies (convert-feels feels.old)] %0 (convert-essay pact +.old)]
+    [[id replies (convert-feels feels.old)] %0 (convert-essay +.old)]
   ::
   ++  convert-feels
     |=  old=(map ship feel:t)
@@ -921,22 +922,22 @@
     [%0 `react]
   ::
   ++  convert-quip
-    |=  [=pact:t id=@da old=writ:t]
+    |=  [id=@da old=writ:t]
     ^-  v-reply:d
-    [[id (convert-feels feels.old)] (convert-memo pact +.old)]
+    [[id (convert-feels feels.old)] (convert-memo +.old)]
   ::
   ++  convert-memo
-    |=  [=pact:t old=memo:t]
+    |=  old=memo:t
     ^-  memo:d
-    [(convert-story pact author.old content.old) author.old sent.old]
+    [(convert-story author.old content.old) author.old sent.old]
   ::
   ++  convert-essay
-    |=  [=pact:t old=memo:t]
+    |=  old=memo:t
     ^-  essay:d
-    [(convert-memo pact old) %chat ?-(-.content.old %story ~, %notice [%notice ~])]
+    [(convert-memo old) %chat ?-(-.content.old %story ~, %notice [%notice ~])]
   ::
   ++  convert-story
-    |=  [pact:t =ship old=content:t]
+    |=  [=ship old=content:t]
     ^-  story:d
     ?-    -.old
         %notice  ~[%inline pfix.p.old ship+ship sfix.p.old]~
@@ -950,9 +951,14 @@
       =;  new=(unit path)
         ?~  new  block
         block(wer.cite u.new)
+      =,  cite.block
+      ?.  ?=(%chat p.nest)                     ~
+      ?~  old=(~(get by old-chats) q.nest)     ~
+      =*  dex  dex.pact.u.old
+      =*  wit  wit.pact.u.old
       ?.  ?=([%msg @ @ ~] wer.cite.block)      ~
-      ?~  who=(slaw %p i.t.wer.cite.block)     ~
-      ?~  tim=(slaw %ud i.t.t.wer.cite.block)  ~
+      ?~  who=(slaw %p i.t.wer)                ~
+      ?~  tim=(slaw %ud i.t.t.wer)             ~
       ?~  id=(~(get by dex) [u.who u.tim])     ~
       =*  single  `/msg/(crip (a-co:co u.id))
       ?~  ret=(get:on:writs:t wit u.id)        single

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -637,6 +637,11 @@
     %-  (slog 'Failed to do chat data migration' u.p.sign)
     cor
   ::
+      [%said *]
+    ::  old chat used to fetch previews, we don't do those here anymore
+    ::
+    cor
+  ::
       [%groups ~]
     ::  old chat used to watch groups. we no longer want/need to.
     ::

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -1,4 +1,4 @@
-/-  d=diary, g=groups, ha=hark, channels
+/-  d=diary, g=groups, ha=hark, channels, c2=chat-2
 /-  meta
 /-  e=epic
 /+  default-agent, verb, dbug
@@ -544,6 +544,13 @@
     =/  =cage  [%channel-migration !>(v-channels)]
     (emit %pass /migrate %agent [our.bowl %channels] %poke cage)
   ::
+  ++  old-chats
+    =>  [c2=c2 bowl=bowl ..zuse]  ~+
+    .^  (map flag:c2 chat:c2)
+      %gx
+      /(scot %p our.bowl)/chat/(scot %da now.bowl)/old/noun
+    ==
+  ::
   ++  convert-channels
     |=  [log=? =shelf:a]
     ^-  v-channels:d
@@ -601,7 +608,14 @@
   ++  convert-essay
     |=  old=essay:a
     ^-  essay:d
-    [[content.old author.old sent.old] %diary title.old image.old]
+    =-  [[- author.old sent.old] %diary title.old image.old]
+    %+  turn  content.old
+    |=  v=verse:a
+    ^-  verse:d
+    ?-  -.v
+      %block   (convert-block +.v)
+      %inline  v
+    ==
   ::
   ++  convert-memo
     |=  old=memo:a
@@ -611,9 +625,30 @@
   ++  convert-story
     |=  old=story:a
     ^-  story:d
-    %+  welp
-      (turn p.old |=(=block:a [%block block]))
-    [%inline q.old]~
+    (snoc (turn p.old convert-block) [%inline q.old])
+  ::
+  ++  convert-block
+    |=  =block:a
+    ^-  verse:d
+    :-  %block
+    ?.  ?=([%cite %chan *] block)  block
+    =;  new=(unit path)
+      ?~  new  block
+      block(wer.cite u.new)
+    =,  cite.block
+    ?.  ?=(%chat p.nest)                     ~
+    ?~  old=(~(get by old-chats) q.nest)     ~
+    =*  dex  dex.pact.u.old
+    =*  wit  wit.pact.u.old
+    ?.  ?=([%msg @ @ ~] wer.cite.block)      ~
+    ?~  who=(slaw %p i.t.wer)                ~
+    ?~  tim=(slaw %ud i.t.t.wer)             ~
+    ?~  id=(~(get by dex) [u.who u.tim])     ~
+    =*  single  `/msg/(crip (a-co:co u.id))
+    ?~  ret=(get:on:writs:c2 wit u.id)       single
+    ?~  replying.u.ret                       single
+    ?~  td=(~(get by dex) u.replying.u.ret)  single
+    `/msg/(crip (a-co:co u.td))/(crip (a-co:co u.id))
   ::
   ++  convert-feels
     |=  old=(map ship feel:a)

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -1,4 +1,4 @@
-/-  h=heap, c=channels, g=groups, ha=hark, e=epic
+/-  h=heap, c=channels, g=groups, ha=hark, e=epic, c2=chat-2
 /-  meta
 /+  default-agent, verb, dbug
 /+  cur=curios
@@ -537,6 +537,13 @@
     =/  =cage  [%channel-migration !>(v-channels)]
     (emit %pass /migrate %agent [our.bowl %channels] %poke cage)
   ::
+  ++  old-chats
+    =>  [c2=c2 bowl=bowl ..zuse]  ~+
+    .^  (map flag:c2 chat:c2)
+      %gx
+      /(scot %p our.bowl)/chat/(scot %da now.bowl)/old/noun
+    ==
+  ::
   ++  convert-channels
     |=  [log=? =stash:h]
     ^-  v-channels:c
@@ -609,9 +616,29 @@
   ++  convert-story
     |=  old=content:h
     ^-  story:c
-    %+  welp
-      (turn p.old |=(=block:h [%block block]))
-    [%inline q.old]~
+    =-  (snoc - [%inline q.old])
+    %+  turn  p.old
+    |=  =block:h
+    ^-  verse:c
+    :-  %block
+    ?.  ?=([%cite %chan *] block)  block
+    =;  new=(unit path)
+      ?~  new  block
+      block(wer.cite u.new)
+    =,  cite.block
+    ?.  ?=(%chat p.nest)                     ~
+    ?~  old=(~(get by old-chats) q.nest)     ~
+    =*  dex  dex.pact.u.old
+    =*  wit  wit.pact.u.old
+    ?.  ?=([%msg @ @ ~] wer.cite.block)      ~
+    ?~  who=(slaw %p i.t.wer)                ~
+    ?~  tim=(slaw %ud i.t.t.wer)             ~
+    ?~  id=(~(get by dex) [u.who u.tim])     ~
+    =*  single  `/msg/(crip (a-co:co u.id))
+    ?~  ret=(get:on:writs:c2 wit u.id)       single
+    ?~  replying.u.ret                       single
+    ?~  td=(~(get by dex) u.replying.u.ret)  single
+    `/msg/(crip (a-co:co u.td))/(crip (a-co:co u.id))
   ::
   ++  convert-log
     |=  [=curios:h posts=v-posts:c =perm:c =log:h]

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -575,7 +575,7 @@
       %+  roll  curios
       |=  [[=time =curio:h] index=(map @da v-replies:c)]
       ?~  replying.curio  index
-      =/  old-replies=v-replies:c  (~(gut by index) time *v-replies:c)
+      =/  old-replies=v-replies:c  (~(gut by index) u.replying.curio *v-replies:c)
       %+  ~(put by index)  u.replying.curio
       (put:on-v-replies:c old-replies time `(convert-reply time curio))
     %+  gas:on-v-posts:c  *v-posts:c

--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -96,15 +96,7 @@ function ContentReference({
     }
     if (app === 'diary') {
       const idNote = udToDec(segments[2]);
-      const idReply =
-        // we have to do this because the paths for migrated note comments
-        // are different than the paths for new/post-migration note comments
-        // this is just papering over the issue.
-        segments[3] && segments[3] !== 'msg'
-          ? udToDec(segments[3])
-          : segments[4]
-          ? udToDec(segments[4])
-          : null;
+      const idReply = segments[3] ? udToDec(segments[3]) : null;
 
       if (idReply) {
         return (


### PR DESCRIPTION
Chat was migrating refs largely correctly, but wasn't accounting for
cases where the referenced message lives outside of the channel where
the reference was posted.

Heap and diary were not migrating refs correctly at all. Since
converting old chat ids into new ones requires chat's lookup maps, we
expose those for old chat state through a new /old scry endpoint in
chat. We cache the scry, to avoid overhead for large/reference-heavy
backlogs.

Diary was not modifying references in top-level posts at all, which we
also correct for here.

All the above fixes LAND-1245. We also tack on two small, unrelated patches.