### PR TITLE
always show author avatar if last post was notice

### DIFF
--- a/ui/src/logic/useScrollerMessages.ts
+++ b/ui/src/logic/useScrollerMessages.ts
@@ -1,14 +1,9 @@
 import { daToUnix } from '@urbit/api';
 import bigInt, { BigInteger } from 'big-integer';
 import { useMemo, useRef } from 'react';
-import { Writ, WritTuple } from '@/types/dms';
-import {
-  newReplyMap,
-  PageTuple,
-  Post,
-  Reply,
-  ReplyTuple,
-} from '@/types/channel';
+import { Writ } from '@/types/dms';
+import { Post, Reply } from '@/types/channel';
+import getKindDataFromEssay from './getKindData';
 
 export type WritArray = [BigInteger, Writ | Post | Reply | null][];
 
@@ -42,7 +37,9 @@ const getNewDayAndNewAuthorFromLastWrit = (
   const lastWrit = index === 0 ? undefined : messages[index - 1];
   const newAuthor =
     lastWrit && lastWrit[1]
-      ? getMessageAuthor(writ) !== getMessageAuthor(lastWrit[1])
+      ? getMessageAuthor(writ) !== getMessageAuthor(lastWrit[1]) ||
+        ('essay' in lastWrit[1] &&
+          !!getKindDataFromEssay(lastWrit[1].essay).notice)
       : true;
   const newDay =
     !lastWrit ||


### PR DESCRIPTION
Updates the `newAuthor` logic to always consider a chat message to be a new author if the last post was a notice type

<img width="484" alt="Screenshot 2023-11-27 at 5 41 17 PM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/46ea4f8c-f816-4d67-9ce8-a4aea22b86a9">
