### PR TITLE
Land-1253 chat search doesn't work

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -106,6 +106,7 @@ import GroupVolumeDialog from './groups/GroupVolumeDialog';
 import ChannelVolumeDialog from './channels/ChannelVolumeDialog';
 import DMThread from './dms/DMThread';
 import MobileChatSearch from './chat/ChatSearch/MobileChatSearch';
+import MobileDmSearch from './dms/MobileDmSearch';
 import BlockedUsersView from './components/Settings/BlockedUsersView';
 import BlockedUsersDialog from './components/Settings/BlockedUsersDialog';
 import { ChatInputFocusProvider } from './logic/ChatInputFocusContext';
@@ -217,10 +218,7 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
               />
             )}
             {isMobile && (
-              <Route
-                path=":ship/search/:query?"
-                element={<MobileChatSearch />}
-              />
+              <Route path=":ship/search/:query?" element={<MobileDmSearch />} />
             )}
           </Route>
 

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -373,7 +373,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
               {isSmall && (
                 <Route
                   path=":ship/search/:query?"
-                  element={<MobileChatSearch />}
+                  element={<MobileDmSearch />}
                 />
               )}
               {isSmall && (

--- a/ui/src/dms/MobileDmSearch.tsx
+++ b/ui/src/dms/MobileDmSearch.tsx
@@ -4,12 +4,12 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { useSafeAreaInsets } from '@/logic/native';
 import SearchBar from '@/chat/ChatSearch/SearchBar';
 import ChatSearchResults from '@/chat/ChatSearch/ChatSearchResults';
-import { useChannelSearch } from '@/state/channel/channel';
+import { useInfiniteChatSearch } from '@/state/chat/search';
 import useDebounce from '@/logic/useDebounce';
 import { VirtuosoHandle } from 'react-virtuoso';
 import { useSearchState } from '@/state/chat/search';
 
-export default function MobileChatSearch() {
+export default function MobileDmSearch() {
   const params = useParams<{
     chShip?: string;
     chName?: string;
@@ -26,8 +26,8 @@ export default function MobileChatSearch() {
     params.chShip && params.chName
       ? `${params.chShip}/${params.chName}`
       : params.ship!;
-  const { scan, isLoading, fetchNextPage } = useChannelSearch(
-    `chat/${whom}`,
+  const { scan, isLoading, fetchNextPage } = useInfiniteChatSearch(
+    whom,
     params.query || ''
   );
   const history = useSearchState.getState().history[whom];

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -2210,10 +2210,13 @@ export function useDeleteReplyReactMutation() {
 export function useChannelSearch(nest: string, query: string) {
   const { data, ...rest } = useInfiniteQuery({
     queryKey: ['channel', 'search', nest, query],
+    enabled: query !== '',
     queryFn: async ({ pageParam = 0 }) => {
       const res = await api.scry<ChannelScan>({
         app: 'channels',
-        path: `/${nest}/search/text/${decToUd(pageParam)}/20/${query}`,
+        path: `/${nest}/search/text/${
+          decToUd(pageParam.toString()) || '0'
+        }/20/${query}`,
       });
       return res;
     },

--- a/ui/src/state/chat/search.ts
+++ b/ui/src/state/chat/search.ts
@@ -116,11 +116,14 @@ export function updateSearchHistory(
 export function useInfiniteChatSearch(whom: string, query: string) {
   const type = whomIsDm(whom) ? 'dm' : whomIsMultiDm(whom) ? 'club' : 'chat';
   const { data, ...rest } = useInfiniteQuery({
+    enabled: query !== '',
     queryKey: ['chat', 'search', whom, query],
     queryFn: async ({ pageParam = 0 }) => {
       const res = await api.scry<ChatScan>({
         app: 'chat',
-        path: `/${type}/${whom}/search/text/${decToUd(pageParam)}/20/${query}`,
+        path: `/${type}/${whom}/search/text/${
+          decToUd(pageParam.toString()) || '0'
+        }/20/${query}`,
       });
       return res;
     },


### PR DESCRIPTION
- Ensure decToUd() receives a string type arg
- Default to '0' (decToUd returns empty string when a '0' is passed)
- Avoid running query if search term is empty

before:
<img width="638" alt="Screenshot 2023-11-27 at 7 34 53 PM" src="https://github.com/tloncorp/landscape-apps/assets/1731775/7a9a979b-4da1-4d0c-9f99-ce6401a2ec5d">
