### PR TITLE
chat: fixing duplicate message issues

### DIFF
--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -50,6 +50,7 @@ export default function ChatWindow({
     refetch,
     fetchNextPage,
     isLoading,
+    isFetching,
     isFetchingNextPage,
     isFetchingPreviousPage,
   } = useInfinitePosts(nest, scrollTo?.toString(), shouldGetLatest);
@@ -83,13 +84,13 @@ export default function ChatWindow({
 
   const goToLatest = useCallback(async () => {
     setSearchParams({});
-    if (hasNextPage) {
+    if (hasPreviousPage) {
       await refetch();
       setShouldGetLatest(false);
     } else {
       scrollerRef.current?.scrollToIndex({ index: 'LAST', align: 'end' });
     }
-  }, [setSearchParams, refetch, hasNextPage, scrollerRef]);
+  }, [setSearchParams, refetch, hasPreviousPage, scrollerRef]);
 
   useEffect(() => {
     useChatStore.getState().setCurrent(nest);
@@ -103,24 +104,18 @@ export default function ChatWindow({
     const { bottom, delayedRead } = useChatStore.getState();
     bottom(true);
     delayedRead(nest, () => markRead({ nest }));
-    if (hasPreviousPage && !isFetchingPreviousPage) {
+    if (hasPreviousPage && !isFetching) {
       log('fetching previous page');
       fetchPreviousPage();
     }
-  }, [
-    nest,
-    markRead,
-    fetchPreviousPage,
-    hasPreviousPage,
-    isFetchingPreviousPage,
-  ]);
+  }, [nest, markRead, fetchPreviousPage, hasPreviousPage, isFetching]);
 
   const onAtTop = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
+    if (hasNextPage && !isFetching) {
       log('fetching next page');
       fetchNextPage();
     }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [fetchNextPage, hasNextPage, isFetching]);
 
   useEffect(
     () => () => {
@@ -133,10 +128,10 @@ export default function ChatWindow({
   );
 
   useEffect(() => {
-    if (scrollTo && hasNextPage) {
+    if (scrollTo && hasPreviousPage) {
       setShouldGetLatest(true);
     }
-  }, [scrollTo, hasNextPage]);
+  }, [scrollTo, hasPreviousPage]);
 
   if (isLoading) {
     return (
@@ -188,7 +183,7 @@ export default function ChatWindow({
           hasLoadedNewest={!hasPreviousPage}
         />
       </div>
-      {scrollTo && (hasNextPage || latestIsMoreThan30NewerThanScrollTo) ? (
+      {scrollTo && (hasPreviousPage || latestIsMoreThan30NewerThanScrollTo) ? (
         <div className="absolute bottom-2 left-1/2 z-20 flex w-full -translate-x-1/2 flex-wrap items-center justify-center gap-2">
           <button
             className="button bg-blue-soft text-sm text-blue dark:bg-blue-900 lg:text-base"

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -50,6 +50,7 @@ export default function DmWindow({
     isLoading,
     fetchNextPage,
     fetchPreviousPage,
+    isFetching,
     isFetchingNextPage,
     isFetchingPreviousPage,
   } = useInfiniteDMs(whom, scrollTo?.toString(), shouldGetLatest);
@@ -78,28 +79,28 @@ export default function DmWindow({
   );
 
   const onAtBottom = useCallback(() => {
-    if (hasPreviousPage && !isFetchingPreviousPage) {
+    if (hasPreviousPage && !isFetching) {
       log('fetching previous page');
       fetchPreviousPage();
     }
-  }, [fetchPreviousPage, hasPreviousPage, isFetchingPreviousPage]);
+  }, [fetchPreviousPage, hasPreviousPage, isFetching]);
 
   const onAtTop = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
+    if (hasNextPage && !isFetching) {
       log('fetching next page');
       fetchNextPage();
     }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [fetchNextPage, hasNextPage, isFetching]);
 
   const goToLatest = useCallback(async () => {
     setSearchParams({});
-    if (hasNextPage) {
+    if (hasPreviousPage) {
       await refetch();
       setShouldGetLatest(false);
     } else {
       scrollerRef.current?.scrollToIndex({ index: 'LAST', align: 'end' });
     }
-  }, [setSearchParams, refetch, hasNextPage, scrollerRef]);
+  }, [setSearchParams, refetch, hasPreviousPage, scrollerRef]);
 
   useEffect(() => {
     useChatStore.getState().setCurrent(whom);
@@ -121,10 +122,10 @@ export default function DmWindow({
   );
 
   useEffect(() => {
-    if (scrollTo && hasNextPage) {
+    if (scrollTo && hasPreviousPage) {
       setShouldGetLatest(true);
     }
-  }, [scrollTo, hasNextPage]);
+  }, [scrollTo, hasPreviousPage]);
 
   if (isLoading) {
     return (
@@ -162,7 +163,7 @@ export default function DmWindow({
           hasLoadedNewest={!hasPreviousPage}
         />
       </div>
-      {scrollTo && (hasNextPage || latestIsMoreThan30NewerThanScrollTo) ? (
+      {scrollTo && (hasPreviousPage || latestIsMoreThan30NewerThanScrollTo) ? (
         <div className="absolute bottom-2 left-1/2 z-20 flex w-full -translate-x-1/2 flex-wrap items-center justify-center gap-2">
           <button
             className="button bg-blue-soft text-sm text-blue dark:bg-blue-900 lg:text-base"

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -579,24 +579,24 @@ export function useInfinitePosts(
     retry: false,
   });
 
-  if (data === undefined || data.pages.length === 0) {
-    return {
-      posts: [] as PageTuple[],
-      data,
-      ...rest,
-    };
-  }
+  const posts: PageTuple[] = useMemo(() => {
+    if (data === undefined || data.pages.length === 0) {
+      return [];
+    }
 
-  const posts: PageTuple[] = data.pages
-    .map((page) => {
-      const pagePosts = Object.entries(page.posts).map(
-        ([k, v]) => [bigInt(udToDec(k)), v] as PageTuple
-      );
+    return _.uniqBy(
+      data.pages
+        .map((page) => {
+          const pagePosts = Object.entries(page.posts).map(
+            ([k, v]) => [bigInt(udToDec(k)), v] as PageTuple
+          );
 
-      return pagePosts;
-    })
-    .flat()
-    .sort(([a], [b]) => a.compare(b));
+          return pagePosts;
+        })
+        .flat(),
+      ([k]) => k.toString()
+    ).sort(([a], [b]) => a.compare(b));
+  }, [data]);
 
   return {
     data,

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -1408,15 +1408,17 @@ export function useInfiniteDMs(
 
   const writs: WritTuple[] = useMemo(
     () =>
-      data?.pages
-        ?.map((page) => {
-          const writPages = Object.entries(page.writs).map(
-            ([k, v]) => [bigInt(udToDec(k)), v] as WritTuple
-          );
-          return writPages;
-        })
-        .flat()
-        .sort(([a], [b]) => a.compare(b)) ?? [],
+      _.uniqBy(
+        data?.pages
+          ?.map((page) => {
+            const writPages = Object.entries(page.writs).map(
+              ([k, v]) => [bigInt(udToDec(k)), v] as WritTuple
+            );
+            return writPages;
+          })
+          .flat() || [],
+        ([k]) => k.toString()
+      ).sort(([a], [b]) => a.compare(b)),
 
     [data]
   );


### PR DESCRIPTION
This should fix LAND-1258. We ensure that we de-dupe messages at all times. We also guard against any fetching while other fetching is happening.