### PR TITLE
perf: fix cpu pegging issue in chat threads

### DIFF
--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -44,7 +44,7 @@ function ChatChannel({ title }: ViewProps) {
   const nest = `chat/${chFlag}`;
   const isMobile = useIsMobile();
   const isSmall = useMedia('(max-width: 1023px)');
-  const inThread = idShip && idTime;
+  const inThread = !!idTime;
   const inSearch = useMatch(`/groups/${groupFlag}/channels/${nest}/search/*`);
   const { mutateAsync: leaveChat } = useLeaveMutation();
   const { mutate: sendMessage } = useAddPostMutation(nest);
@@ -57,7 +57,10 @@ function ChatChannel({ title }: ViewProps) {
   const root = `/groups/${groupFlag}/channels/${nest}`;
   // We only inset the bottom for groups, since DMs display the navbar
   // underneath this view
-  const shouldApplyPaddingBottom = isGroups && isMobile && !isChatInputFocused;
+  const shouldApplyPaddingBottom = useMemo(
+    () => isGroups && isMobile && !isChatInputFocused,
+    [isMobile, isChatInputFocused]
+  );
 
   const {
     group,

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -76,17 +76,21 @@ export default function ChatThread() {
       },
     ]);
   }
-  const orderedReplies = replies?.sort((a, b) => {
-    const aTime = a[0];
-    const bTime = b[0];
-    if (aTime.greater(bTime)) {
-      return 1;
-    }
-    if (aTime.lesser(bTime)) {
-      return -1;
-    }
-    return 0;
-  });
+  const orderedReplies = useMemo(
+    () =>
+      replies?.sort((a, b) => {
+        const aTime = a[0];
+        const bTime = b[0];
+        if (aTime.greater(bTime)) {
+          return 1;
+        }
+        if (aTime.lesser(bTime)) {
+          return -1;
+        }
+        return 0;
+      }),
+    [replies]
+  );
   const navigate = useNavigate();
   const threadRef = useRef<HTMLDivElement | null>(null);
   const perms = usePerms(nest);

--- a/ui/src/logic/ChatInputFocusContext.tsx
+++ b/ui/src/logic/ChatInputFocusContext.tsx
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash';
 import React, { createContext, useMemo, useState } from 'react';
 
 export const ChatInputFocusContext = createContext<{
@@ -20,7 +21,7 @@ export function ChatInputFocusProvider({
       isChatInputFocused,
       setIsChatInputFocused,
     }),
-    [isChatInputFocused, setIsChatInputFocused]
+    [isChatInputFocused]
   );
 
   return (
@@ -35,13 +36,18 @@ export function useChatInputFocus() {
     ChatInputFocusContext
   );
 
+  const throttledSetIsChatInputFocused = useMemo(
+    () => throttle(setIsChatInputFocused, 100),
+    [setIsChatInputFocused]
+  );
+
   const handleFocus = React.useCallback(() => {
-    setIsChatInputFocused(true);
-  }, [setIsChatInputFocused]);
+    throttledSetIsChatInputFocused(true);
+  }, [throttledSetIsChatInputFocused]);
 
   const handleBlur = React.useCallback(() => {
-    setIsChatInputFocused(false);
-  }, [setIsChatInputFocused]);
+    throttledSetIsChatInputFocused(false);
+  }, [throttledSetIsChatInputFocused]);
 
   return {
     isChatInputFocused,

--- a/ui/src/logic/ChatInputFocusContext.tsx
+++ b/ui/src/logic/ChatInputFocusContext.tsx
@@ -1,5 +1,5 @@
-import { throttle } from 'lodash';
 import React, { createContext, useMemo, useState } from 'react';
+import { useIsMobile } from './useMedia';
 
 export const ChatInputFocusContext = createContext<{
   isChatInputFocused: boolean;
@@ -35,19 +35,19 @@ export function useChatInputFocus() {
   const { isChatInputFocused, setIsChatInputFocused } = React.useContext(
     ChatInputFocusContext
   );
-
-  const throttledSetIsChatInputFocused = useMemo(
-    () => throttle(setIsChatInputFocused, 100),
-    [setIsChatInputFocused]
-  );
+  const isMobile = useIsMobile();
 
   const handleFocus = React.useCallback(() => {
-    throttledSetIsChatInputFocused(true);
-  }, [throttledSetIsChatInputFocused]);
+    if (isMobile) {
+      setIsChatInputFocused(true);
+    }
+  }, [setIsChatInputFocused, isMobile]);
 
   const handleBlur = React.useCallback(() => {
-    throttledSetIsChatInputFocused(false);
-  }, [throttledSetIsChatInputFocused]);
+    if (isMobile) {
+      setIsChatInputFocused(false);
+    }
+  }, [setIsChatInputFocused, isMobile]);
 
   return {
     isChatInputFocused,


### PR DESCRIPTION
fixes LAND-1254 by ~throttling the setChatInputFocus setter in the chat input focus context. Also applied some useMemos along the way and fixed an issue where we were never detecting if we were in a thread in ChatChannels.~ by no-op'ing on chat input state changes on desktop.