### PR TITLE
chat, heap, diary: send migration edits to hosts

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -100,7 +100,7 @@
         v-channels=(map nest:c v-channel-1)
     ==
   ++  v-channel-1
-    |^  ,[global local:v-channel:c]
+    |^  ,[global local]
     +$  global
       $:  posts=v-posts-1
           order=(rev:c order=arranged-posts:c)
@@ -108,7 +108,22 @@
           sort=(rev:c =sort:c)
           perm=(rev:c =perm:c)
       ==
+    +$  window    window:v-channel:c
+    +$  future    [=window diffs=(jug id-post:c u-post-1)]
+    +$  local     [=net:c log=log-1 =remark:c =window =future]
     --
+  +$  log-1           ((mop time u-channel-1) lte)
+  ++  log-on-1        ((on time u-channel-1) lte)
+  +$  u-channel-1     $%  $<(%post u-channel:c)
+                          [%post id=id-post:c u-post=u-post-1]
+                      ==
+  +$  u-post-1        $%  $<(?(%set %reply) u-post:c)
+                          [%set post=(unit v-post-1)]
+                          [%reply id=id-reply:c u-reply=u-reply-1]
+                      ==
+  +$  u-reply-1       $%  $<(%set u-reply:c)
+                          [%set reply=(unit v-reply-1)]
+                      ==
   +$  v-posts-1       ((mop id-post:c (unit v-post-1)) lte)
   ++  on-v-posts-1    ((on id-post:c (unit v-post-1)) lte)
   +$  v-post-1        [v-seal-1 (rev:c essay:c)]
@@ -121,7 +136,31 @@
     ^-  state-2
     s(- %2, v-channels (~(run by v-channels.s) v-channel-1-to-2))
   ++  v-channel-1-to-2
-    |=(v=v-channel-1 v(posts (v-posts-1-to-2 posts.v)))
+    |=  v=v-channel-1
+    %=  v
+      posts   (v-posts-1-to-2 posts.v)
+      log     (log-1-to-2 log.v)
+      future  (future-1-to-2 future.v)
+    ==
+  ++  log-1-to-2
+    |=  l=log-1
+    (run:log-on-1 l u-channel-1-to-2)
+  ++  u-channel-1-to-2
+    |=  u=u-channel-1
+    ^-  u-channel:c
+    ?.  ?=([%post *] u)  u
+    u(u-post (u-post-1-to-2 u-post.u))
+  ++  future-1-to-2
+    |=  f=future:v-channel-1
+    ^-  future:v-channel:c
+    f(diffs (~(run by diffs.f) |=(s=(set u-post-1) (~(run in s) u-post-1-to-2))))
+  ++  u-post-1-to-2
+    |=  u=u-post-1
+    ^-  u-post:c
+    ?+  u  u
+      [%set ~ *]           u(u.post (v-post-1-to-2 u.post.u))
+      [%reply * %set ~ *]  u(u.reply.u-reply (v-reply-1-to-2 u.reply.u-reply.u))
+    ==
   ++  v-posts-1-to-2
     |=  p=v-posts-1
     %+  run:on-v-posts-1  p
@@ -143,9 +182,9 @@
     ==
   ++  v-channel-0
     |^  ,[global:v-channel-1 local]
-    +$  window    (list [from=time to=time])
-    +$  future    [=window diffs=(jug id-post:c u-post:c)]
-    +$  local     [=net:c =log:c remark=remark-0 =window =future]
+    +$  window    window:v-channel:c
+    +$  future    [=window diffs=(jug id-post:c u-post-1)]
+    +$  local     [=net:c log=log-1 remark=remark-0 =window =future]
     --
   +$  remark-0  [last-read=time watching=_| unread-threads=(set id-post:c)]
   ::

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -359,8 +359,6 @@
     ::  so based off that we trigger the editing of our messages that changed.
     ::  (see also %*-migrate-refs poke handling in the old agents.)
     ::
-    ::TODO  figure out whether we want/need to distribute the load over time:
-    ::  (emit /migrate-refs %b %wait (add now.bowl (~(rand og our.bowl) ~h2)))
     ?>  =(our src):bowl
     =+  !<([match=? =gill:gall] vase)
     ?.  match

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -106,7 +106,7 @@
 ++  load
   |=  =vase
   |^  ^+  cor
-  =+  !<([old=versioned-state] vase)
+  =+  !<(old=versioned-state vase)
   =?  old  ?=(%0 -.old)  (state-0-to-1 old)
   =?  old  ?=(%1 -.old)  (state-1-to-2 old)
   ?>  ?=(%2 -.old)
@@ -124,7 +124,7 @@
         hidden-posts=(set id-post:c)
     ==
   ++  v-channel-1
-    |^  ,[global local:v-channel:c]
+    |^  ,[global local]
     +$  global
       $:  posts=v-posts-1
           order=(rev:c order=arranged-posts:c)
@@ -132,7 +132,22 @@
           sort=(rev:c =sort:c)
           perm=(rev:c =perm:c)
       ==
+    +$  window    window:v-channel:c
+    +$  future    [=window diffs=(jug id-post:c u-post-1)]
+    +$  local     [=net:c log=log-1 =remark:c =window =future]
     --
+  +$  log-1           ((mop time u-channel-1) lte)
+  ++  log-on-1        ((on time u-channel-1) lte)
+  +$  u-channel-1     $%  $<(%post u-channel:c)
+                          [%post id=id-post:c u-post=u-post-1]
+                      ==
+  +$  u-post-1        $%  $<(?(%set %reply) u-post:c)
+                          [%set post=(unit v-post-1)]
+                          [%reply id=id-reply:c u-reply=u-reply-1]
+                      ==
+  +$  u-reply-1       $%  $<(%set u-reply:c)
+                          [%set reply=(unit v-reply-1)]
+                      ==
   +$  v-posts-1       ((mop id-post:c (unit v-post-1)) lte)
   ++  on-v-posts-1    ((on id-post:c (unit v-post-1)) lte)
   +$  v-post-1        [v-seal-1 (rev:c essay:c)]
@@ -153,7 +168,31 @@
       hidden-posts  [hidden-posts.s pend]
     ==
   ++  v-channel-1-to-2
-    |=(v=v-channel-1 v(posts (v-posts-1-to-2 posts.v)))
+    |=  v=v-channel-1
+    %=  v
+      posts   (v-posts-1-to-2 posts.v)
+      log     (log-1-to-2 log.v)
+      future  (future-1-to-2 future.v)
+    ==
+  ++  log-1-to-2
+    |=  l=log-1
+    (run:log-on-1 l u-channel-1-to-2)
+  ++  u-channel-1-to-2
+    |=  u=u-channel-1
+    ^-  u-channel:c
+    ?.  ?=([%post *] u)  u
+    u(u-post (u-post-1-to-2 u-post.u))
+  ++  future-1-to-2
+    |=  f=future:v-channel-1
+    ^-  future:v-channel:c
+    f(diffs (~(run by diffs.f) |=(s=(set u-post-1) (~(run in s) u-post-1-to-2))))
+  ++  u-post-1-to-2
+    |=  u=u-post-1
+    ^-  u-post:c
+    ?+  u  u
+      [%set ~ *]           u(u.post (v-post-1-to-2 u.post.u))
+      [%reply * %set ~ *]  u(u.reply.u-reply (v-reply-1-to-2 u.reply.u-reply.u))
+    ==
   ++  v-posts-1-to-2
     |=  p=v-posts-1
     %+  run:on-v-posts-1  p
@@ -178,9 +217,9 @@
     ==
   ++  v-channel-0
     |^  ,[global:v-channel-1 local]
-    +$  window    (list [from=time to=time])
-    +$  future    [=window diffs=(jug id-post:c u-post:c)]
-    +$  local     [=net:c =log:c remark=remark-0 =window =future]
+    +$  window    window:v-channel:c
+    +$  future    [=window diffs=(jug id-post:c u-post-1)]
+    +$  local     [=net:c log=log-1 remark=remark-0 =window =future]
     --
   +$  remark-0  [last-read=time watching=_| unread-threads=(set id-post:c)]
   ::

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -374,13 +374,14 @@
   ?.  (~(has by v-channels) nest)
     =/  wire  (said-wire nest plan)
     (safe-watch wire [ship.nest server] wire)
+  ::TODO  not guaranteed to resolve, we might have partial backlog
   ca-abet:(ca-said:(ca-abed:ca-core nest) plan)
 ::
 ++  said-wire
   |=  [=nest:c =plan:c]
   ^-  wire
   %+  welp
-    /said/[kind.nest]/(scot %p ship.nest)/[name.nest]/(scot %ud p.plan)
+    /said/[kind.nest]/(scot %p ship.nest)/[name.nest]/post/(scot %ud p.plan)
   ?~(q.plan / /(scot %ud u.q.plan))
 ::
 ++  take-said

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -881,10 +881,7 @@
       ?.  ?=(%story -.content.writ)  |
       %+  lien  p.p.content.writ
       |=  =block:old
-      ?&  ?=([%cite %chan [%chat *] *] block)
-          ::NOTE  optimization, host should've ran the edit locally already
-          !=(p.flag p.q.nest.cite.block)
-      ==
+      ?=([%cite %chan [%chat *] *] block)
     =/  command=(unit c-post:d)
       ?~  edit  ~
       ?~  replying.writ

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -929,7 +929,7 @@
   ++  convert-quip
     |=  [id=@da old=writ:t]
     ^-  v-reply:d
-    [[id (convert-feels feels.old)] (convert-memo +.old)]
+    [[id (convert-feels feels.old)] %0 (convert-memo +.old)]
   ::
   ++  convert-memo
     |=  old=memo:t

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -510,6 +510,11 @@
       %chat-dm-archive  di-abet:di-archive:(di-abed:di-core !<(ship vase))
       %chat-migrate-server  ?>(from-self server:migrate)
       %chat-migrate         ?>(from-self client:migrate)
+  ::
+      %chat-migrate-refs
+    ?>  from-self
+    =+  !<(flag=[ship term] vase)
+    (refs:migrate flag)
   ::  backwards compatibility
   ::
       %dm-rsvp
@@ -856,6 +861,42 @@
     =.  cor  (emit %pass /migrate %agent [our.bowl %channels] %poke cage)
     =/  =^cage  [%channel-migration-pins !>((convert-pins old-pins))]
     (emit %pass /migrate %agent [our.bowl %channels] %poke cage)
+  ::
+  ++  refs
+    |=  =flag:old
+    ?~  old-chat=(~(get by old-chats) flag)  cor
+    %-  emil
+    ::  iterate over all chats and, for every message/reply authored by us,
+    ::  containing a chat reference that we have (almost certainly) converted,
+    ::  send the new version of the message/reply as an edit to the host.
+    ::
+    %+  murn  (tap:on:writs:old wit.pact.u.old-chat)
+    |=  [=time =writ:old]
+    ^-  (unit card)
+    ?.  =(our.bowl author.writ)  ~
+    =/  edit=(unit essay:d)
+      =;  contains-chat-ref=?
+        ?.  contains-chat-ref  ~
+        `(convert-essay +.writ)
+      ?.  ?=(%story -.content.writ)  |
+      %+  lien  p.p.content.writ
+      |=  =block:old
+      ?&  ?=([%cite %chan [%chat *] *] block)
+          ::NOTE  optimization, host should've ran the edit locally already
+          !=(p.flag p.q.nest.cite.block)
+      ==
+    =/  command=(unit c-post:d)
+      ?~  edit  ~
+      ?~  replying.writ
+        `[%edit time u.edit]
+      =/  parent-time  (~(get by dex.pact.u.old-chat) u.replying.writ)
+      ?~  parent-time  ~
+      `[%reply u.parent-time %edit time -.u.edit]
+    ?~  command  ~
+    =/  =cage
+      :-  %channel-action
+      !>(`a-channels:d`[%channel [%chat flag] %post u.command])
+    `[%pass /migrate %agent [our.bowl %channels] %poke cage]
   ::
   ++  convert-pins
     |=  pins=(list whom:t)

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -596,10 +596,7 @@
         `(convert-memo +.quip)
       %+  lien  p.content.quip
       |=  =block:a
-      ?&  ?=([%cite %chan [%chat *] *] block)
-          ::NOTE  optimization, host should've ran the edit locally already
-          !=(p.flag p.q.nest.cite.block)
-      ==
+      ?=([%cite %chan [%chat *] *] block)
     =/  command=(unit c-post:d)
       ?~  edit  ~
       `[%reply time %edit rtime u.edit]

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -603,7 +603,7 @@
   ++  convert-quip
     |=  [id=@da old=quip:a]
     ^-  v-reply:d
-    [[id (convert-feels feels.old)] (convert-memo +.old)]
+    [[id (convert-feels feels.old)] %0 (convert-memo +.old)]
   ::
   ++  convert-essay
     |=  old=essay:a

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -274,6 +274,11 @@
   ::
       %diary-migrate-server  ?>(from-self server:migrate)
       %diary-migrate         ?>(from-self client:migrate)
+  ::
+      %diary-migrate-refs
+    ?>  from-self
+    =+  !<(flag=[ship term] vase)
+    (refs:migrate flag)
   ==
   ++  join
     |=  =join:d
@@ -543,6 +548,66 @@
     =/  =v-channels:d  (convert-channels | shelf)
     =/  =cage  [%channel-migration !>(v-channels)]
     (emit %pass /migrate %agent [our.bowl %channels] %poke cage)
+  ::
+  ++  refs
+    |=  =flag:a
+    ?~  old-heap=(~(get by shelf) flag)  cor
+    %-  emil
+    ::  iterate over all notebooks and, for every post/comment authored by us,
+    ::  containing a chat reference that we have (almost certainly) converted,
+    ::  send the new version of the post/comment as an edit to the host.
+    ::
+    %-  zing
+    %+  turn  (tap:on:notes:a notes.u.old-heap)
+    |=  [=time =note:a]
+    ^-  (list card)
+    %+  weld
+      ::  first, for the post itself
+      ::
+      ^-  (list card)
+      ?.  =(our.bowl author.note)  ~
+      =/  edit=(unit essay:d)
+        =;  contains-chat-ref=?
+          ?.  contains-chat-ref  ~
+          `(convert-essay +.note)
+        %+  lien  content.note
+        |=  =verse:a
+        ?&  ?=([%block %cite %chan [%chat *] *] verse)
+            ::NOTE  optimization, host should've ran the edit locally already
+            !=(p.flag p.q.nest.cite.p.verse)
+        ==
+      =/  command=(unit c-post:d)
+        ?~  edit  ~
+        `[%edit time u.edit]
+      ?~  command  ~
+      =/  =cage
+        :-  %channel-action
+        !>(`a-channels:d`[%channel [%chat flag] %post u.command])
+      [%pass /migrate %agent [our.bowl %channels] %poke cage]~
+    ::  then, repeat for the quips on the post
+    ::
+    %+  murn  (tap:on:quips:a quips.note)
+    |=  [rtime=^time =quip:a]
+    ^-  (unit card)
+    ?.  =(our.bowl author.quip)  ~
+    =/  edit=(unit memo:d)
+      =;  contains-chat-ref=?
+        ?.  contains-chat-ref  ~
+        `(convert-memo +.quip)
+      %+  lien  p.content.quip
+      |=  =block:a
+      ?&  ?=([%cite %chan [%chat *] *] block)
+          ::NOTE  optimization, host should've ran the edit locally already
+          !=(p.flag p.q.nest.cite.block)
+      ==
+    =/  command=(unit c-post:d)
+      ?~  edit  ~
+      `[%reply time %edit rtime u.edit]
+    ?~  command  ~
+    =/  =cage
+      :-  %channel-action
+      !>(`a-channels:d`[%channel [%chat flag] %post u.command])
+    `[%pass /migrate %agent [our.bowl %channels] %poke cage]
   ::
   ++  old-chats
     =>  [c2=c2 bowl=bowl ..zuse]  ~+

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -572,10 +572,7 @@
           `(convert-essay +.note)
         %+  lien  content.note
         |=  =verse:a
-        ?&  ?=([%block %cite %chan [%chat *] *] verse)
-            ::NOTE  optimization, host should've ran the edit locally already
-            !=(p.flag p.q.nest.cite.p.verse)
-        ==
+        ?=([%block %cite %chan [%chat *] *] verse)
       =/  command=(unit c-post:d)
         ?~  edit  ~
         `[%edit time u.edit]

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -582,7 +582,7 @@
       ?~  command  ~
       =/  =cage
         :-  %channel-action
-        !>(`a-channels:d`[%channel [%chat flag] %post u.command])
+        !>(`a-channels:d`[%channel [%diary flag] %post u.command])
       [%pass /migrate %agent [our.bowl %channels] %poke cage]~
     ::  then, repeat for the quips on the post
     ::
@@ -606,7 +606,7 @@
     ?~  command  ~
     =/  =cage
       :-  %channel-action
-      !>(`a-channels:d`[%channel [%chat flag] %post u.command])
+      !>(`a-channels:d`[%channel [%diary flag] %post u.command])
     `[%pass /migrate %agent [our.bowl %channels] %poke cage]
   ::
   ++  old-chats

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -572,7 +572,7 @@
     ?~  command  ~
     =/  =cage
       :-  %channel-action
-      !>(`a-channels:c`[%channel [%chat flag] %post u.command])
+      !>(`a-channels:c`[%channel [%heap flag] %post u.command])
     `[%pass /migrate %agent [our.bowl %channels] %poke cage]
   ::
   ++  old-chats

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -601,7 +601,7 @@
   ++  convert-reply
     |=  [id=@da old=curio:h]
     ^-  v-reply:c
-    [[id (convert-feels feels.old)] (convert-memo +.old)]
+    [[id (convert-feels feels.old)] %0 (convert-memo +.old)]
   ::
   ++  convert-memo
     |=  old=heart:h

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -560,10 +560,7 @@
         `(convert-essay +.curio)
       %+  lien  p.content.curio
       |=  =block:h
-      ?&  ?=([%cite %chan [%chat *] *] block)
-          ::NOTE  optimization, host should've ran the edit locally already
-          !=(p.flag p.q.nest.cite.block)
-      ==
+      ?=([%cite %chan [%chat *] *] block)
     =/  command=(unit c-post:c)
       ?~  edit  ~
       ?~  replying.curio

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -159,6 +159,11 @@
   ::
       %heap-migrate-server  ?>(from-self server:migrate)
       %heap-migrate         ?>(from-self client:migrate)
+  ::
+      %heap-migrate-refs
+    ?>  from-self
+    =+  !<(flag=[ship term] vase)
+    (refs:migrate flag)
   ==
   ++  join
     |=  =join:h
@@ -536,6 +541,39 @@
     =/  =v-channels:c  (convert-channels | stash)
     =/  =cage  [%channel-migration !>(v-channels)]
     (emit %pass /migrate %agent [our.bowl %channels] %poke cage)
+  ::
+  ++  refs
+    |=  =flag:h
+    ?~  old-heap=(~(get by stash) flag)  cor
+    %-  emil
+    ::  iterate over all heaps and, for every item/comment authored by us,
+    ::  containing a chat reference that we have (almost certainly) converted,
+    ::  send the new version of the item/comment as an edit to the host.
+    ::
+    %+  murn  (tap:on:curios:h curios.u.old-heap)
+    |=  [=time =curio:h]
+    ^-  (unit card)
+    ?.  =(our.bowl author.curio)  ~
+    =/  edit=(unit essay:c)
+      =;  contains-chat-ref=?
+        ?.  contains-chat-ref  ~
+        `(convert-essay +.curio)
+      %+  lien  p.content.curio
+      |=  =block:h
+      ?&  ?=([%cite %chan [%chat *] *] block)
+          ::NOTE  optimization, host should've ran the edit locally already
+          !=(p.flag p.q.nest.cite.block)
+      ==
+    =/  command=(unit c-post:c)
+      ?~  edit  ~
+      ?~  replying.curio
+        `[%edit time u.edit]
+      `[%reply u.replying.curio %edit time -.u.edit]
+    ?~  command  ~
+    =/  =cage
+      :-  %channel-action
+      !>(`a-channels:c`[%channel [%chat flag] %post u.command])
+    `[%pass /migrate %agent [our.bowl %channels] %poke cage]
   ::
   ++  old-chats
     =>  [c2=c2 bowl=bowl ..zuse]  ~+

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -70,7 +70,7 @@
 ++  uv-reply
   |=  [parent-id=id-reply:c =v-reply:c]
   ^-  reply:c
-  :_  +.v-reply
+  :_  +>.v-reply
   [id.v-reply parent-id (uv-reacts reacts.v-reply)]
 ::
 ++  uv-reacts

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -71,7 +71,7 @@
 ++  mo-v-posts  ((mp id-post (unit v-post)) lte)
 ::  $v-reply: a post comment
 ::
-+$  v-reply       [v-reply-seal memo]
++$  v-reply       [v-reply-seal (rev memo)]
 +$  id-reply      time
 +$  v-replies     ((mop id-reply (unit v-reply)) lte)
 ++  on-v-replies  ((on id-reply (unit v-reply)) lte)
@@ -355,6 +355,7 @@
 ::
 +$  c-reply
   $%  [%add =memo]
+      [%edit id=id-reply =memo]
       [%del id=id-reply]
       c-react
   ==


### PR DESCRIPTION
During migration, chat identifiers change. As a consequence, references
to chat messages must change if they want to stay pointing to the same
message. However, the old ref alone is not sufficient for constructing
the new ref: you need to know the message being referenced.

Previously, we were doing this transformation during migration strictly
locally. This meant that chat hosts, not uncommonly only aware of the
messages in their own channels, were unable to migrate the chat
references correctly. Newcomers joining the channels would find "bad"
chat references in the backlog, and would be stuck with these forever.

The fix implemented herein depends on the assumption that the author of
a message containing a reference is the one most likely to be able to
resolve the reference successfully. After all, they had already seen the
message previously.

Using this assumption, we further depend on message authors to notify
channel hosts about the updated versions of their own messages. This way
the host can learn of the correctly-migrated reference, and share it
with its subscribers, without needing to chase down the reference itself
(which would require building entirely new pipelines).

The behavior here is as follows: on a per-host basis, when a subscriber
learns about a version match with the host (crucially guaranteeing that
the host has already migrated itself), it goes through its pre-migration
content again, looking for posts/replies authored by itself, containing
references to chat messages. We re-migrate those messages, but instead
of injecting them into the local %channels agent directly, we send an
action, signalling an edit of the original message (in chat's case, with
the new id), that must be sent to the channel host. This then goes on to
resolve as normal, as if the user had manually edited the content
through the ui.

The changes in 56569eb enable support for editing replies. This is a required part of this solution, because replies may contain references also. Previously, only top-level messages could be edited in-place.

Obvious caveat here is that this depends on message authors being online
and running the migration. An acceptable "risk" for p2p software.

Less obvious is the potential network load introduced by this. Each
affected message results in an individual edit, which the host must echo
out to all its subscribers. We don't expect gigantic numbers here, but
it will be a little stress test nonetheless. There are options for
spreading the load slightly, but unclear as of yet whether the
complexity required for that is a worthwhile tradeoff. Investigation
into the numbers on this to follow.

Logic herein untested at this time, further patches might follow.

For LAND-1261.