### PR TITLE
posts: prevent actions on undelivered posts

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -373,15 +373,17 @@ const ChatMessage = React.memo<
             <Author ship={essay.author} date={unix} hideRoles={isThread} />
           ) : null}
           <div className="group-one relative z-0 flex w-full select-none sm:select-auto">
-            <ChatMessageOptions
-              open={optionsOpen}
-              onOpenChange={setOptionsOpen}
-              hideThreadReply={hideReplies}
-              whom={whom}
-              writ={writ}
-              hideReply={whomIsDm(whom) || whomIsMultiDm(whom) || hideReplies}
-              openReactionDetails={handleReactionDetailsOpened}
-            />
+            {isDelivered && (
+              <ChatMessageOptions
+                open={optionsOpen}
+                onOpenChange={setOptionsOpen}
+                hideThreadReply={hideReplies}
+                whom={whom}
+                writ={writ}
+                hideReply={whomIsDm(whom) || whomIsMultiDm(whom) || hideReplies}
+                openReactionDetails={handleReactionDetailsOpened}
+              />
+            )}
             <div className="-ml-1 mr-1 py-2 text-xs font-semibold text-gray-400 opacity-0 sm:group-one-hover:opacity-100">
               {format(unix, 'HH:mm')}
             </div>

--- a/ui/src/diary/DiaryChannel.tsx
+++ b/ui/src/diary/DiaryChannel.tsx
@@ -186,14 +186,8 @@ function DiaryChannel({ title }: ViewProps) {
         <div className="relative flex flex-col items-center">
           <Toast.Root duration={3000} defaultOpen={false} open={showToast}>
             <Toast.Description asChild>
-              <div className="absolute z-10 flex w-[415px] -translate-x-2/4 items-center justify-between space-x-2 rounded-lg bg-white font-semibold text-black shadow-xl dark:bg-gray-200">
+              <div className="absolute z-10 flex -translate-x-2/4 items-center justify-between space-x-2 rounded-lg bg-white font-semibold text-black shadow-xl dark:bg-gray-200">
                 <span className="py-2 px-4">Note successfully published</span>
-                <button
-                  onClick={onCopy}
-                  className="-mx-4 -my-2 w-[135px] rounded-r-lg bg-blue py-2 px-4 text-white dark:text-black"
-                >
-                  {didCopy ? 'Copied' : 'Copy Note Link'}
-                </button>
               </div>
             </Toast.Description>
           </Toast.Root>

--- a/ui/src/diary/DiaryList/DiaryGridItem.tsx
+++ b/ui/src/diary/DiaryList/DiaryGridItem.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { Post } from '@/types/channel';
 import { useCalm } from '@/state/settings';
 import getKindDataFromEssay from '@/logic/getKindData';
-import { usePostToggler } from '@/state/channel/channel';
+import { useIsPostUndelivered, usePostToggler } from '@/state/channel/channel';
 import DiaryNoteHeadline from '../DiaryNoteHeadline';
 
 interface DiaryGridItemProps {
@@ -19,6 +19,7 @@ export default function DiaryGridItem({ note, time }: DiaryGridItemProps) {
   const hasImage = image?.length !== 0;
   const { replyCount, lastRepliers } = note.seal.meta;
   const { isHidden } = usePostToggler(time.toString());
+  const isUndelivered = useIsPostUndelivered(note);
 
   return (
     <div
@@ -44,6 +45,7 @@ export default function DiaryGridItem({ note, time }: DiaryGridItemProps) {
         lastRepliers={lastRepliers}
         replyCount={replyCount}
         essay={essay}
+        isUndelivered={isUndelivered}
         time={time}
         isInGrid
       />

--- a/ui/src/diary/DiaryList/DiaryListItem.tsx
+++ b/ui/src/diary/DiaryList/DiaryListItem.tsx
@@ -2,7 +2,11 @@ import cn from 'classnames';
 import { useNavigate } from 'react-router';
 import { Post } from '@/types/channel';
 import DiaryNoteHeadline from '@/diary/DiaryNoteHeadline';
-import { useIsPostPending, usePostToggler } from '@/state/channel/channel';
+import {
+  useIsPostPending,
+  useIsPostUndelivered,
+  usePostToggler,
+} from '@/state/channel/channel';
 
 interface DiaryListItemProps {
   note: Post;
@@ -19,6 +23,7 @@ export default function DiaryListItem({ note, time }: DiaryListItemProps) {
   const { essay } = note;
   const { lastRepliers, replyCount } = note.seal.meta;
   const { isHidden } = usePostToggler(time.toString());
+  const isUndelivered = useIsPostUndelivered(note);
 
   return (
     <div
@@ -36,6 +41,7 @@ export default function DiaryListItem({ note, time }: DiaryListItemProps) {
         essay={essay}
         time={time}
         isInList
+        isUndelivered={isUndelivered}
       />
     </div>
   );

--- a/ui/src/diary/DiaryNoteHeadline.tsx
+++ b/ui/src/diary/DiaryNoteHeadline.tsx
@@ -23,6 +23,7 @@ interface DiaryListItemProps {
   time: bigInt.BigInteger;
   isInList?: boolean;
   isInGrid?: boolean;
+  isUndelivered?: boolean;
 }
 
 export default function DiaryNoteHeadline({
@@ -32,6 +33,7 @@ export default function DiaryNoteHeadline({
   time,
   isInList,
   isInGrid,
+  isUndelivered,
 }: DiaryListItemProps) {
   const { title, image } = getKindDataFromEssay(essay);
   const chFlag = useChannelFlag();
@@ -117,7 +119,7 @@ export default function DiaryNoteHeadline({
             )}
             onClick={(e) => e.stopPropagation()}
           >
-            {isInList || isInGrid ? (
+            {isInList || isInGrid || isUndelivered ? (
               <>
                 <span
                   role="link"

--- a/ui/src/heap/AddCurioModal.tsx
+++ b/ui/src/heap/AddCurioModal.tsx
@@ -93,9 +93,8 @@ export default function AddCurioModal({
   const addCurio = useCallback(
     async (input: JSONContent | string) => {
       const heart = await createCurioHeart(input);
-      const now = Date.now();
       const cacheId = {
-        sent: now,
+        sent: heart.sent,
         author: window.our,
       };
 

--- a/ui/src/heap/HeapDetail.tsx
+++ b/ui/src/heap/HeapDetail.tsx
@@ -3,7 +3,11 @@ import cn from 'classnames';
 import { Helmet } from 'react-helmet';
 import { Link, useLocation } from 'react-router-dom';
 import { useParams } from 'react-router';
-import { usePost, useOrderedPosts } from '@/state/channel/channel';
+import {
+  usePost,
+  useOrderedPosts,
+  useIsPostUndelivered,
+} from '@/state/channel/channel';
 import Layout from '@/components/Layout/Layout';
 import { useRouteGroup } from '@/state/groups';
 import CaretRightIcon from '@/components/icons/CaretRightIcon';
@@ -48,6 +52,7 @@ export default function HeapDetail({ title }: ViewProps) {
   } = useOrderedPosts(nest, idTime || '');
   const initialNote = location.state?.initialCurio as Post | undefined;
   const essay = note?.essay || initialNote?.essay;
+  const isUndelivered = useIsPostUndelivered(initialNote);
 
   const curioHref = (id?: bigInt.BigInteger) => {
     if (!id) {
@@ -83,6 +88,7 @@ export default function HeapDetail({ title }: ViewProps) {
       header={
         <HeapDetailHeader
           nest={nest}
+          isUndelivered={isUndelivered}
           idCurio={idTime || ''}
           essay={essay}
           groupFlag={groupFlag}

--- a/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -19,12 +19,14 @@ export interface HeapDetailHeaderProps {
   nest: string;
   idCurio: string;
   essay: PostEssay;
+  isUndelivered?: boolean;
   groupFlag: string;
 }
 
 export default function HeapDetailHeader({
   nest,
   idCurio,
+  isUndelivered = false,
   essay,
   groupFlag,
 }: HeapDetailHeaderProps) {
@@ -78,19 +80,23 @@ export default function HeapDetailHeader({
         action={
           <div className="flex h-12 items-center justify-end space-x-2">
             <ReconnectingSpinner />
-            <button
-              className="h-6 w-6 rounded text-gray-800"
-              aria-controls="copy"
-              onClick={onCopy}
-              aria-label="Copy Link"
-            >
-              {didCopy ? (
-                <CheckIcon className="h-6 w-6" />
-              ) : (
-                <CopyIcon className="h-6 w-6" />
-              )}
-            </button>
-            {canEdit ? <button onClick={onEdit}>Edit</button> : null}
+            {!isUndelivered && (
+              <>
+                <button
+                  className="h-6 w-6 rounded text-gray-800"
+                  aria-controls="copy"
+                  onClick={onCopy}
+                  aria-label="Copy Link"
+                >
+                  {didCopy ? (
+                    <CheckIcon className="h-6 w-6" />
+                  ) : (
+                    <CopyIcon className="h-6 w-6" />
+                  )}
+                </button>
+                {canEdit ? <button onClick={onEdit}>Edit</button> : null}
+              </>
+            )}
           </div>
         }
       />
@@ -132,26 +138,28 @@ export default function HeapDetailHeader({
           </span>
         </div>
       </Link>
-      <div className="shink-0 flex items-center space-x-3">
-        {canEdit ? (
-          <button onClick={onEdit} className="small-button">
-            Edit
-          </button>
-        ) : null}
+      {!isUndelivered && (
+        <div className="shink-0 flex items-center space-x-3">
+          {canEdit ? (
+            <button onClick={onEdit} className="small-button">
+              Edit
+            </button>
+          ) : null}
 
-        <button
-          className="h-6 w-6 rounded text-gray-400 hover:bg-gray-50"
-          aria-controls="copy"
-          onClick={onCopy}
-          aria-label="Copy Link"
-        >
-          {didCopy ? (
-            <CheckIcon className="h-6 w-6" />
-          ) : (
-            <CopyIcon className="h-6 w-6" />
-          )}
-        </button>
-      </div>
+          <button
+            className="h-6 w-6 rounded text-gray-400 hover:bg-gray-50"
+            aria-controls="copy"
+            onClick={onCopy}
+            aria-label="Copy Link"
+          >
+            {didCopy ? (
+              <CheckIcon className="h-6 w-6" />
+            ) : (
+              <CopyIcon className="h-6 w-6" />
+            )}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -179,6 +179,16 @@ export function useTrackedPostStatus(cacheId: CacheId) {
   );
 }
 
+export function useIsPostUndelivered(post: Post | undefined) {
+  const stubbedCacheId = { author: '~zod', sent: 0 };
+  const cacheId =
+    post && post.essay
+      ? { author: post.essay.author, sent: post.essay.sent }
+      : stubbedCacheId;
+  const status = useTrackedPostStatus(cacheId);
+  return status !== 'delivered';
+}
+
 export function usePostsOnHost(
   nest: Nest,
   enabled: boolean


### PR DESCRIPTION
Hides actions (threading, copying, replying, etc.) on posts which aren't yet delivered. Since we're updating all post types optimistically right now, this PR takes a totalizing blunt approach rather than targeting specific problematic interactions.

 In the common case, the change shouldn't be noticeable for end users. If performance issues cause delayed delivery, this will defend against any unexpected hiccups interacting with manually cached posts.

Fixes LAND-1264