### PR TITLE
chat: thread fix omnibus

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -189,7 +189,8 @@
   ?~  reply  $(entries +.entries)
   ?:  (~(has in replyers) author.u.reply)
     $(entries +.entries)
-  (~(put in replyers) author.u.reply)
+  =.  replyers  (~(put in replyers) author.u.reply)
+  $(entries +.entries)
 ++  perms
   |_  [our=@p now=@da =nest:c group=flag:g]
   ++  am-host  =(our ship.nest)

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -172,10 +172,22 @@
 ++  get-reply-meta
   |=  post=v-post:c
   ^-  reply-meta:c
-  :*  (wyt:on-v-replies:c replies.post)
+  :*  (get-non-null-reply-count replies.post)
       (get-last-repliers post)
       (biff (ram:on-v-replies:c replies.post) |=([=time *] `time))
   ==
+::
+++  get-non-null-reply-count
+  |=  replies=v-replies:c
+  ^-  @ud
+  =/  entries=(list [time (unit v-reply:c)])  (bap:on-v-replies:c replies)
+  =/  count  0
+  |-  ^-  @ud
+  ?:  =(~ entries)
+    count
+  =/  [* reply=(unit v-reply:c)]  -.entries
+  ?~  reply  $(entries +.entries)
+  $(entries +.entries, count +(count))
 ::
 ++  get-last-repliers
   |=  post=v-post:c  ::TODO  could just take =v-replies

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -586,16 +586,12 @@ export function useInfinitePosts(
   const stringifiedData = data ? JSON.stringify(data) : JSON.stringify({});
 
   const posts: PageTuple[] = useMemo(() => {
-    const parsedData: {
-      pages: PagedPosts[];
-    } = JSON.parse(stringifiedData);
-
-    if (parsedData.pages === undefined || parsedData.pages.length === 0) {
+    if (data === undefined || data.pages.length === 0) {
       return [];
     }
 
     return _.uniqBy(
-      parsedData.pages
+      data.pages
         .map((page) => {
           const pagePosts = Object.entries(page.posts).map(
             ([k, v]) => [bigInt(udToDec(k)), v] as PageTuple
@@ -606,7 +602,10 @@ export function useInfinitePosts(
         .flat(),
       ([k]) => k.toString()
     ).sort(([a], [b]) => a.compare(b));
-  }, [stringifiedData]);
+    // we disable exhaustive deps here because we add stringifiedData
+    // to the dependency array to force a re-render when the data changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stringifiedData, data]);
 
   return {
     data,

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -421,11 +421,45 @@ const infinitePostUpdater = (
 
     const replyQueryKey = [han, 'posts', flag, udToDec(time.toString())];
 
-    if ('set' in reply && 'memo' in reply.set) {
+    if (reply && 'set' in reply && 'memo' in reply.set) {
+      const newReply = reply.set;
+
+      updatePostInCache(
+        { nest, postId: udToDec(time.toString()) },
+        (post: PostDataResponse | undefined) => {
+          if (post === undefined) {
+            return undefined;
+          }
+
+          const existingReplies = post.seal.replies ?? {};
+
+          const newReplies = {
+            ...existingReplies,
+            [newReply.seal.id]: newReply,
+          };
+
+          const newPost = {
+            ...post,
+            seal: {
+              ...post.seal,
+              replies: newReplies,
+              meta: {
+                ...post.seal.meta,
+                replyCount,
+                lastReply,
+                lastRepliers,
+              },
+            },
+          };
+
+          return newPost;
+        }
+      );
+
       usePostsStore.getState().updateStatus(
         {
-          author: reply.set.memo.author,
-          sent: reply.set.memo.sent,
+          author: newReply.memo.author,
+          sent: newReply.memo.sent,
         },
         'delivered'
       );


### PR DESCRIPTION
Fixes LAND-1273

Count was not updating because of the use of useMemo on `posts` in useInfinitePosts. React doesn't do a deep comparison on objects passed into the dependency array. I assume we want to keep the useMemo here, so I stringified the object and used that in the useMemo.

And we weren't getting more than one avatar for threads because last-repliers always returned just one ship, this was due to a bug in `get-last-repliers` in channel-utils. We weren't actually modifying the replyers face.