### PR TITLE
notebook: fix issue with creating notes with refs

### DIFF
--- a/ui/src/types/channel.ts
+++ b/ui/src/types/channel.ts
@@ -558,6 +558,7 @@ export function constructStory(data: (Inline | Block)[]): Story {
       'header',
       'rule',
       'code',
+      'cite',
     ].some((k) => typeof c !== 'string' && k in c);
   const postContent: Story = [];
   let index = 0;


### PR DESCRIPTION
Fixes LAND-1287 by adding 'cite' to the list of types we consider blocks in constructStory.