### PR TITLE
scroller: fix jumping in threads

### DIFF
--- a/ui/src/chat/ChatScroller/ChatScroller.test.tsx
+++ b/ui/src/chat/ChatScroller/ChatScroller.test.tsx
@@ -12,7 +12,8 @@ describe('ChatScroller', () => {
     const result = render(
       <ChatScroller
         messages={[]}
-        fetchState={'initial'}
+        isLoadingOlder={false}
+        isLoadingNewer={false}
         whom={'test'}
         scrollerRef={ref}
         scrollElementRef={scrollRef}

--- a/ui/src/chat/ChatScroller/ChatScrollerDebugOverlay.tsx
+++ b/ui/src/chat/ChatScroller/ChatScrollerDebugOverlay.tsx
@@ -13,26 +13,28 @@ export default function ChatScrollerDebugOverlay({
   anchorIndex,
   scrollHeight,
   scrollOffset,
+  isLoadingOlder,
+  isLoadingNewer,
   hasLoadedNewest,
   hasLoadedOldest,
   isInverted,
   loadDirection,
   isAtBottom,
   isAtTop,
-  fetchState,
   userHasScrolled,
 }: {
   count: number;
   anchorIndex?: number | null;
   scrollOffset: number;
   scrollHeight: number;
+  isLoadingOlder: boolean;
+  isLoadingNewer: boolean;
   hasLoadedNewest: boolean;
   hasLoadedOldest: boolean;
   isInverted: boolean;
   loadDirection: 'newer' | 'older';
   isAtBottom: boolean;
   isAtTop: boolean;
-  fetchState: 'initial' | 'top' | 'bottom';
   userHasScrolled: boolean;
 }) {
   return (
@@ -64,11 +66,11 @@ export default function ChatScrollerDebugOverlay({
       <label className="mt-2">Top loader</label>
       <DebugBoolean label="Selected" value={loadDirection === 'older'} />
       <DebugBoolean label="Has loaded oldest" value={hasLoadedOldest} />
-      <DebugBoolean label="Fetching" value={fetchState === 'top'} />
+      <DebugBoolean label="Fetching" value={isLoadingOlder} />
       <label className="mt-2">Bottom loader</label>
       <DebugBoolean label="Selected" value={loadDirection === 'newer'} />
       <DebugBoolean label="Has loaded newest" value={hasLoadedNewest} />
-      <DebugBoolean label="Fetching" value={fetchState === 'top'} />
+      <DebugBoolean label="Fetching" value={isLoadingNewer} />
     </div>
   );
 }

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -191,7 +191,8 @@ export default function ChatThread() {
           <ChatScroller
             key={idTime}
             messages={orderedReplies || []}
-            fetchState={'initial'}
+            isLoadingOlder={false}
+            isLoadingNewer={false}
             whom={nest}
             scrollerRef={scrollerRef}
             scrollTo={scrollTo ? bigInt(scrollTo) : undefined}

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -57,15 +57,6 @@ export default function ChatWindow({
   const { mutate: markRead } = useMarkReadMutation();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const readTimeout = useChatInfo(nest).unread?.readTimeout;
-  const fetchState = useMemo(
-    () =>
-      isFetchingNextPage
-        ? 'bottom'
-        : isFetchingPreviousPage
-        ? 'top'
-        : 'initial',
-    [isFetchingNextPage, isFetchingPreviousPage]
-  );
   const { compatible } = useChannelCompatibility(nest);
   const latestMessageIndex = messages.length - 1;
   const scrollToIndex = useMemo(
@@ -170,7 +161,8 @@ export default function ChatWindow({
            */
           key={whom}
           messages={messages}
-          fetchState={fetchState}
+          isLoadingOlder={isFetchingNextPage}
+          isLoadingNewer={isFetchingPreviousPage}
           whom={whom}
           topLoadEndMarker={prefixedElement}
           scrollTo={scrollTo}

--- a/ui/src/dms/DMThread.tsx
+++ b/ui/src/dms/DMThread.tsx
@@ -171,7 +171,8 @@ export default function DMThread() {
             key={idTime}
             messages={replies}
             whom={whom}
-            fetchState="initial"
+            isLoadingOlder={false}
+            isLoadingNewer={false}
             scrollerRef={scrollerRef}
             scrollTo={scrollTo ? bigInt(scrollTo) : undefined}
             scrollElementRef={scrollElementRef}

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -68,16 +68,6 @@ export default function DmWindow({
     [scrollToIndex, latestMessageIndex]
   );
 
-  const fetchState = useMemo(
-    () =>
-      isFetchingNextPage
-        ? 'bottom'
-        : isFetchingPreviousPage
-        ? 'top'
-        : 'initial',
-    [isFetchingNextPage, isFetchingPreviousPage]
-  );
-
   const onAtBottom = useCallback(() => {
     if (hasPreviousPage && !isFetching) {
       log('fetching previous page');
@@ -150,7 +140,8 @@ export default function DmWindow({
            */
           key={whom}
           messages={writs}
-          fetchState={fetchState}
+          isLoadingOlder={isFetchingNextPage}
+          isLoadingNewer={isFetchingPreviousPage}
           whom={whom}
           scrollTo={scrollTo}
           scrollerRef={scrollerRef}

--- a/ui/src/logic/useScrollerMessages.ts
+++ b/ui/src/logic/useScrollerMessages.ts
@@ -159,8 +159,6 @@ function useMessageItems({
   return useMemo(() => [keys, entries, messages], [keys, entries, messages]);
 }
 
-export type MessageFetchState = 'top' | 'bottom' | 'initial';
-
 export function useMessageData({
   whom,
   scrollTo,


### PR DESCRIPTION
This PR fixes scroller jumps inside threads. The root issue was that `hasLoadedNewest` and `hasLoadedOldest` didn't match reality in thread contexts. While fixing that, I realized it'd be simpler to track load direction by just passing loading parameters in directly and updating state when they change. That way, we only invert the scroller if we're *actually* loading a new page. 

Fixes LAND-1295