### PR TITLE
fix leap launch button in sidebar

### DIFF
--- a/ui/src/components/Sidebar/SystemChrome.tsx
+++ b/ui/src/components/Sidebar/SystemChrome.tsx
@@ -8,7 +8,7 @@ export default function SystemChrome() {
   const { setIsOpen } = useLeap();
   return (
     <button
-      onClick={() => setIsOpen((curr) => !curr)}
+      onClick={() => setIsOpen((isOpen) => !isOpen)}
       className="flex w-full cursor-pointer flex-row space-x-2 px-1 text-gray-400 hover:text-gray-800"
     >
       <div className="flex flex-row items-center space-x-2">

--- a/ui/src/components/Sidebar/SystemChrome.tsx
+++ b/ui/src/components/Sidebar/SystemChrome.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
 import GridIcon from '../icons/GridIcon';
 import useLeap from '../Leap/useLeap';
 
 export default function SystemChrome() {
-  const metaKey = navigator.platform.includes('Mac') ? '⌘ ' : 'Ctrl';
-  // const { isOpen, setIsOpen } = useLeap();
+  const metaKey = navigator.userAgent.toLowerCase().includes('mac')
+    ? '⌘'
+    : 'Ctrl';
+  const { setIsOpen } = useLeap();
   return (
     <button
-      // onClick={() => setIsOpen(!isOpen)}
+      onClick={() => setIsOpen((curr) => !curr)}
       className="flex w-full cursor-pointer flex-row space-x-2 px-1 text-gray-400 hover:text-gray-800"
     >
       <div className="flex flex-row items-center space-x-2">


### PR DESCRIPTION
- Hooks up the Leap launch button in the sidebar again
- Updates OS detection to drop deprecated `navigator.platform` check