### PR TITLE
chat: only allow "safe" URL protocols in links

### DIFF
--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -49,6 +49,14 @@ function ChatEmbedContent({
   }, [isError, error]);
 
   if (url !== content) {
+    // secure URL protocol regex borrowed from dompurify:
+    // https://github.com/cure53/DOMPurify/blob/main/src/regexp.js#L9-L11
+    const IS_ALLOWED_URI =
+      /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i; // eslint-disable-line no-useless-escape
+    if (!IS_ALLOWED_URI.test(url)) {
+      // disallow javascript: urls and other risky protocols
+      return <a href="#">{content}</a>;
+    }
     return (
       <a target="_blank" rel="noreferrer" href={url}>
         {content}


### PR DESCRIPTION
Currently, users can post links with `javascript:` URLs. Although links open in a new tab by default, there are several tricky ways to turn this into XSS. Viz,

<img width="696" alt="Screenshot 2023-12-01 at 0 58 39" src="https://github.com/tloncorp/landscape-apps/assets/104947308/2cf1552c-e4ef-428b-9c77-e790c1ece93f">


This change borrows a [regex from dompurify](https://github.com/cure53/DOMPurify/blob/main/src/regexp.js#L9-L11) to only allow safe protocols in links. "Bad" protocols are simple replaced with a blank link. Even when Tlon implements a stronger CSP, it's worthwhile to prevent `javascript:` links, because some users run Landscape apps outside of Tlon (eg red horizon). They should be protected, even if their hosting environment lacks a strong CSP.

Really this PR is a chance for me to practice interacting with this repo, so I invite any criticism you may have. I'm excited to tackle bigger bugs, thanks!