### PR TITLE
channels: fix issue with posting code blocks

### DIFF
--- a/ui/src/types/channel.ts
+++ b/ui/src/types/channel.ts
@@ -557,7 +557,6 @@ export function constructStory(data: (Inline | Block)[]): Story {
       'listing',
       'header',
       'rule',
-      'code',
       'cite',
     ].some((k) => typeof c !== 'string' && k in c);
   const postContent: Story = [];


### PR DESCRIPTION
fixes LAND-1297 by removing code blocks from the list of content types we expect to store as "block" content (confusingly, these are stored and rendered as inlines).