### PR TITLE
refs: show user when reference content is unavailable

### DIFF
--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -18,6 +18,7 @@ import ShipName from '@/components/ShipName';
 import getHeapContentType from '@/logic/useHeapContentType';
 import ReferenceBar from './ReferenceBar';
 import ReferenceInHeap from './ReferenceInHeap';
+import UnavailableReference from './UnavailableReference';
 
 function CurioReference({
   nest,
@@ -34,7 +35,12 @@ function CurioReference({
   contextApp?: string;
   children?: React.ReactNode;
 }) {
-  const reference = useRemotePost(nest, idCurio, isScrolling, idReply);
+  const { reference, isError } = useRemotePost(
+    nest,
+    idCurio,
+    isScrolling,
+    idReply
+  );
   const preview = useChannelPreview(nest, isScrolling);
   const location = useLocation();
   const navigate = useNavigate();
@@ -64,6 +70,10 @@ function CurioReference({
   const refToken = preview?.group
     ? `${preview.group.flag}/channels/${nest}/curio/${idCurio}`
     : undefined;
+
+  if (isError) {
+    return <UnavailableReference time={bigInt(0)} nest={nest} preview={null} />;
+  }
 
   if (!content || !note) {
     return <HeapLoadingBlock reference />;

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -21,6 +21,7 @@ import ReferenceBar from './ReferenceBar';
 import ShipName from '../ShipName';
 import ReferenceInHeap from './ReferenceInHeap';
 import NotebookIcon from '../icons/NotebookIcon';
+import UnavailableReference from './UnavailableReference';
 
 function NoteReference({
   nest,
@@ -39,7 +40,7 @@ function NoteReference({
   const groupFlag = preview?.group?.flag || '~zod/test';
   const gang = useGang(groupFlag);
   const { group } = useGroupJoin(groupFlag, gang);
-  const reference = useRemotePost(nest, id, isScrolling);
+  const { reference, isError } = useRemotePost(nest, id, isScrolling);
   const navigateByApp = useNavigateByApp();
   const navigate = useNavigate();
   const location = useLocation();
@@ -62,6 +63,10 @@ function NoteReference({
 
     return <DiaryContent content={truncatedContent} isPreview />;
   }, [note]);
+
+  if (isError) {
+    return <UnavailableReference nest={nest} time={bigInt(0)} preview={null} />;
+  }
 
   if (!note || !note.essay?.content) {
     return <HeapLoadingBlock reference />;

--- a/ui/src/components/References/ReferenceBar.tsx
+++ b/ui/src/components/References/ReferenceBar.tsx
@@ -34,13 +34,13 @@ export default function ReferenceBar({
   heapComment = false,
   reply = false,
 }: ReferenceBarProps) {
-  const groupFlagOrZod = groupFlag || '~zod/test';
   const navigateByApp = useNavigateByApp();
   const unix = new Date(daToUnix(time));
 
   const navigateToChannel = useCallback(() => {
-    navigateByApp(`/groups/${groupFlagOrZod}/channels/${nest}`);
-  }, [nest, groupFlagOrZod, navigateByApp]);
+    if (!groupFlag) return;
+    navigateByApp(`/groups/${groupFlag}/channels/${nest}`);
+  }, [nest, groupFlag, navigateByApp]);
 
   return (
     <div

--- a/ui/src/components/References/WritBaitReference.tsx
+++ b/ui/src/components/References/WritBaitReference.tsx
@@ -16,14 +16,14 @@ export default function WritBaitReference(props: {
   children?: React.ReactNode;
 }) {
   const { chFlag, nest, index, isScrolling, contextApp, children } = props;
-  const note = useRemotePost(nest, index, isScrolling);
+  const { reference } = useRemotePost(nest, index, isScrolling);
   const [, udId] = index.split('/');
-  if (note === undefined) {
+  if (reference === undefined) {
     const time = bigInt(udToDec(udId));
     return <UnavailableReference time={time} nest={nest} preview={null} />;
   }
   return (
-    <WritBaseReference reference={note} contextApp={contextApp} {...props}>
+    <WritBaseReference reference={reference} contextApp={contextApp} {...props}>
       {children}
     </WritBaseReference>
   );

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import bigInt from 'big-integer';
 import cn from 'classnames';
-import { unixToDa } from '@urbit/api';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useChannelPreview, useGang } from '@/state/groups';
 // eslint-disable-next-line import/no-cycle
@@ -14,7 +13,6 @@ import { ReferenceResponse } from '@/types/channel';
 import ReferenceBar from './ReferenceBar';
 import ShipName from '../ShipName';
 import ReferenceInHeap from './ReferenceInHeap';
-import BubbleIcon from '../icons/BubbleIcon';
 
 interface WritBaseReferenceProps {
   nest: string;

--- a/ui/src/components/References/WritChanReference.tsx
+++ b/ui/src/components/References/WritChanReference.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import bigInt from 'big-integer';
 import { useRemotePost } from '@/state/channel/channel';
 // eslint-disable-next-line import/no-cycle
 import WritBaseReference from './WritBaseReference';
+// eslint-disable-next-line import/no-cycle
+import UnavailableReference from './UnavailableReference';
 
 function WritChanReference(props: {
   nest: string;
@@ -12,7 +15,17 @@ function WritChanReference(props: {
   children?: React.ReactNode;
 }) {
   const { nest, idWrit, idReply, isScrolling, contextApp, children } = props;
-  const reference = useRemotePost(nest, idWrit, isScrolling, idReply);
+  const { reference, isError } = useRemotePost(
+    nest,
+    idWrit,
+    isScrolling,
+    idReply
+  );
+
+  if (isError) {
+    return <UnavailableReference time={bigInt(0)} nest={nest} preview={null} />;
+  }
+
   return (
     <WritBaseReference reference={reference} contextApp={contextApp} {...props}>
       {children}

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -1085,13 +1085,19 @@ export function useRemotePost(
     },
   });
 
-  if (rest.isLoading || rest.isError || !data) {
-    return {} as ReferenceResponse;
+  if (rest.isLoading || rest.isError || data === undefined) {
+    return {
+      reference: undefined,
+      ...rest,
+    };
   }
 
   const { reference } = data as Said;
 
-  return reference as ReferenceResponse;
+  return {
+    reference,
+    ...rest,
+  };
 }
 
 export function usePostKeys(nest: Nest) {


### PR DESCRIPTION
fixes LAND-1262 by showing the UnavailableReference component when we get an error on fetching the referenced post.

Looks like this:

![image](https://github.com/tloncorp/landscape-apps/assets/1221094/3fe51a4b-912f-44e9-b9c7-2e7d0442e95c)
