### PR TITLE
chat: use correct ship for notice

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1655,7 +1655,7 @@
   ::
   ++  di-post-notice
     |=  text=cord
-    =/  =delta:writs:c  (make-notice our.bowl text)
+    =/  =delta:writs:c  (make-notice ?:(from-self our.bowl ship) text)
     (di-ingest-diff [our now]:bowl delta)
   ::
   ++  di-rsvp


### PR DESCRIPTION
Fixes LAND-1282 by adjusting which ship is in the noticed based on who the join is coming from