### PR TITLE
fix notebook comment refs copying and replying

### DIFF
--- a/ui/src/diary/DiaryCommentField.tsx
+++ b/ui/src/diary/DiaryCommentField.tsx
@@ -164,9 +164,7 @@ export default function DiaryCommentField({
       const mention = makeMention(reply?.memo.author.slice(1));
       messageEditor?.commands.setContent(mention);
       messageEditor?.commands.insertContent(': ');
-      const path = `/1/chan/${han}/${flag}/${
-        han === 'diary' ? 'note' : 'curio'
-      }/${replyTo}/msg/${replyId}`;
+      const path = `/1/chan/${han}/${flag}/msg/${replyTo}/${replyId}`;
       const cite = path ? pathToCite(path) : undefined;
       if (cite && !replyCite) {
         setReplyCite({ cite });

--- a/ui/src/replies/ReplyMessageOptions.tsx
+++ b/ui/src/replies/ReplyMessageOptions.tsx
@@ -47,11 +47,13 @@ export default function ReplyMessageOptions(props: {
 }) {
   const { open, onOpenChange, whom, reply, openReactionDetails, showReply } =
     props;
-  const nest = `chat/${whom}`;
   const { seal, memo } = reply ?? emptyReply;
+  const threadParentId = seal['parent-id'];
+  const isParent = threadParentId === seal.id;
+  const isDMorMultiDM = useIsDmOrMultiDm(whom);
+  const nest = isDMorMultiDM || isParent ? `chat/${whom}` : whom;
   const groupFlag = useRouteGroup();
   const isAdmin = useAmAdmin(groupFlag);
-  const threadParentId = seal['parent-id'];
   const { didCopy, doCopy } = useCopy(
     `/1/chan/${nest}/msg/${threadParentId}/${seal.id}`
   );
@@ -67,11 +69,9 @@ export default function ReplyMessageOptions(props: {
   );
   // TODO: add delete mutation for parent DMs
   const { chShip, chName } = useParams();
-  const isParent = threadParentId === seal.id;
   const [, setSearchParams] = useSearchParams();
   const { load: loadEmoji } = useEmoji();
   const isMobile = useIsMobile();
-  const isDMorMultiDM = useIsDmOrMultiDm(whom);
   const perms = usePerms(isDMorMultiDM ? `fake/nest/${whom}` : nest);
   const vessel = useVessel(groupFlag, window.our);
   const group = useGroup(groupFlag);


### PR DESCRIPTION
- Fixes issue with copying notebook comment refs (`chat/` was hard-coded in the `nest` value)
- Fixes `cite` path when making a notebook/gallery comment reply to another notebook/gallery comment