### PR TITLE
dms: fix new multidm negotiation blocking

### DIFF
--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -427,6 +427,9 @@
   |=  [=mark =vase]
   |^  ^+  cor
   ?+    mark  ~|(bad-poke/mark !!)
+      %chat-negotiate
+    ::TODO  arguably should just be a /mar/negotiate
+    (emit (initiate:neg !<(@p vase) dap.bowl))
   ::
       %chat-dm-rsvp
     =+  !<(=rsvp:dm:c vase)

--- a/desk/mar/chat/negotiate.hoon
+++ b/desk/mar/chat/negotiate.hoon
@@ -1,0 +1,12 @@
+|_  who=@p
+++  grad  %ship
+++  grow
+  |%
+  ++  noun  who
+  --
+++  grab
+  |%
+  ++  noun  @p
+  ++  json  (su:dejs:format ;~(pfix sig fed:ag))
+  --
+--

--- a/ui/src/dms/NewDm.tsx
+++ b/ui/src/dms/NewDm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import cn from 'classnames';
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import Layout from '@/components/Layout/Layout';
@@ -9,10 +9,19 @@ import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { dmListPath } from '@/logic/utils';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MessageSelector from './MessageSelector';
 
 export default function NewDM() {
-  const { sendDm, validShips, whom } = useMessageSelector();
+  const {
+    sendDm,
+    validShips,
+    whom,
+    isMultiDm,
+    existingMultiDm,
+    multiDmVersionMismatch,
+    haveAllNegotiations,
+  } = useMessageSelector();
   const dropZoneId = 'chat-new-dm-input-dropzone';
   const { isDragging, isOver } = useDragAndDrop(dropZoneId);
   const isMobile = useIsMobile();
@@ -20,6 +29,8 @@ export default function NewDM() {
   const isScrolling = useIsScrolling(scrollElementRef);
   const { isChatInputFocused } = useChatInputFocus();
   const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
+  const shouldBlockInput =
+    isMultiDm && !existingMultiDm && multiDmVersionMismatch;
 
   return (
     <Layout
@@ -31,20 +42,36 @@ export default function NewDM() {
         isMobile && <MobileHeader title="New Message" pathBack={dmListPath} />
       }
       footer={
-        <div
-          className={cn(
-            isDragging || isOver ? '' : 'border-t-2 border-gray-50 p-4'
-          )}
-        >
-          <ChatInput
-            whom={whom}
-            showReply
-            sendDisabled={!validShips}
-            sendDm={sendDm}
-            dropZoneId={dropZoneId}
-            isScrolling={isScrolling}
-          />
-        </div>
+        shouldBlockInput ? (
+          <div className="flex items-center justify-center border-2 border-transparent bg-gray-50 py-1 px-2 leading-5 text-gray-600">
+            {haveAllNegotiations ? (
+              'Your version of the app does not match some of the members of this chat.'
+            ) : (
+              <>
+                {' '}
+                <LoadingSpinner />{' '}
+                <span className="ml-2">
+                  Checking version compatibility
+                </span>{' '}
+              </>
+            )}
+          </div>
+        ) : (
+          <div
+            className={cn(
+              isDragging || isOver ? '' : 'border-t-2 border-gray-50 p-4'
+            )}
+          >
+            <ChatInput
+              whom={whom}
+              showReply
+              sendDisabled={!validShips}
+              sendDm={sendDm}
+              dropZoneId={dropZoneId}
+              isScrolling={isScrolling}
+            />
+          </div>
+        )
       }
     >
       <MessageSelector />

--- a/ui/src/dms/NewDm.tsx
+++ b/ui/src/dms/NewDm.tsx
@@ -48,11 +48,8 @@ export default function NewDM() {
               'Your version of the app does not match some of the members of this chat.'
             ) : (
               <>
-                {' '}
-                <LoadingSpinner />{' '}
-                <span className="ml-2">
-                  Checking version compatibility
-                </span>{' '}
+                <LoadingSpinner />
+                <span className="ml-2">Checking version compatibility</span>
               </>
             )}
           </div>

--- a/ui/src/dms/NewDm.tsx
+++ b/ui/src/dms/NewDm.tsx
@@ -12,14 +12,7 @@ import { dmListPath } from '@/logic/utils';
 import MessageSelector from './MessageSelector';
 
 export default function NewDM() {
-  const {
-    sendDm,
-    validShips,
-    whom,
-    isMultiDm,
-    confirmedMultiDmMismatch,
-    existingMultiDm,
-  } = useMessageSelector();
+  const { sendDm, validShips, whom } = useMessageSelector();
   const dropZoneId = 'chat-new-dm-input-dropzone';
   const { isDragging, isOver } = useDragAndDrop(dropZoneId);
   const isMobile = useIsMobile();
@@ -27,8 +20,6 @@ export default function NewDM() {
   const isScrolling = useIsScrolling(scrollElementRef);
   const { isChatInputFocused } = useChatInputFocus();
   const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
-  const shouldBlockInput =
-    isMultiDm && !existingMultiDm && confirmedMultiDmMismatch;
 
   return (
     <Layout
@@ -40,27 +31,20 @@ export default function NewDM() {
         isMobile && <MobileHeader title="New Message" pathBack={dmListPath} />
       }
       footer={
-        shouldBlockInput ? (
-          <div className="rounded-lg border-2 border-transparent bg-gray-50 py-1 px-2 leading-5 text-gray-600">
-            Your version of the app does not match some of the members of this
-            chat.
-          </div>
-        ) : (
-          <div
-            className={cn(
-              isDragging || isOver ? '' : 'border-t-2 border-gray-50 p-4'
-            )}
-          >
-            <ChatInput
-              whom={whom}
-              showReply
-              sendDisabled={!validShips}
-              sendDm={sendDm}
-              dropZoneId={dropZoneId}
-              isScrolling={isScrolling}
-            />
-          </div>
-        )
+        <div
+          className={cn(
+            isDragging || isOver ? '' : 'border-t-2 border-gray-50 p-4'
+          )}
+        >
+          <ChatInput
+            whom={whom}
+            showReply
+            sendDisabled={!validShips}
+            sendDm={sendDm}
+            dropZoneId={dropZoneId}
+            isScrolling={isScrolling}
+          />
+        </div>
       }
     >
       <MessageSelector />

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -11,6 +11,7 @@ import {
   useMultiDms,
   useSendMessage,
 } from '@/state/chat';
+import { useInitShipNegotiation, useNegotiateMulti } from '@/state/negotiation';
 import { createStorageKey, newUv } from './utils';
 
 export default function useMessageSelector() {
@@ -27,6 +28,18 @@ export default function useMessageSelector() {
   const { data: unreads } = useDmUnreads();
   const { mutate: sendMessage } = useSendMessage();
   const { mutateAsync: createMultiDm } = useCreateMultiDm();
+
+  useInitShipNegotiation(shipValues, 'chat');
+  const {
+    match: negotiationMatch,
+    isLoading: negotiationLoading,
+    haveAllNegotiations,
+  } = useNegotiateMulti(
+    ships.map((option) => option.value),
+    'chat',
+    'chat'
+  );
+  const multiDmVersionMismatch = !negotiationLoading && !negotiationMatch;
 
   const existingDm = useMemo(() => {
     if (ships.length !== 1) {
@@ -161,6 +174,8 @@ export default function useMessageSelector() {
 
   return {
     isMultiDm,
+    multiDmVersionMismatch,
+    haveAllNegotiations,
     action,
     existingDm,
     existingMultiDm,

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -11,7 +11,10 @@ import {
   useMultiDms,
   useSendMessage,
 } from '@/state/chat';
-import { useInitShipNegotiation, useNegotiateMulti } from '@/state/negotiation';
+import {
+  useForceNegotiationUpdate,
+  useNegotiateMulti,
+} from '@/state/negotiation';
 import { createStorageKey, newUv } from './utils';
 
 export default function useMessageSelector() {
@@ -29,7 +32,7 @@ export default function useMessageSelector() {
   const { mutate: sendMessage } = useSendMessage();
   const { mutateAsync: createMultiDm } = useCreateMultiDm();
 
-  useInitShipNegotiation(shipValues, 'chat');
+  useForceNegotiationUpdate(shipValues, 'chat');
   const {
     match: negotiationMatch,
     isLoading: negotiationLoading,

--- a/ui/src/logic/useMessageSelector.ts
+++ b/ui/src/logic/useMessageSelector.ts
@@ -11,7 +11,6 @@ import {
   useMultiDms,
   useSendMessage,
 } from '@/state/chat';
-import { useNegotiateMulti } from '@/state/negotiation';
 import { createStorageKey, newUv } from './utils';
 
 export default function useMessageSelector() {
@@ -28,13 +27,6 @@ export default function useMessageSelector() {
   const { data: unreads } = useDmUnreads();
   const { mutate: sendMessage } = useSendMessage();
   const { mutateAsync: createMultiDm } = useCreateMultiDm();
-  const { match: negotiationMatch, isLoading: negotiationLoading } =
-    useNegotiateMulti(
-      ships.map((option) => option.value),
-      'chat',
-      'chat'
-    );
-  const confirmedMultiDmMismatch = !negotiationLoading && !negotiationMatch;
 
   const existingDm = useMemo(() => {
     if (ships.length !== 1) {
@@ -169,7 +161,6 @@ export default function useMessageSelector() {
 
   return {
     isMultiDm,
-    confirmedMultiDmMismatch,
     action,
     existingDm,
     existingMultiDm,

--- a/ui/src/state/negotiation.ts
+++ b/ui/src/state/negotiation.ts
@@ -115,12 +115,16 @@ export function useNegotiateMulti(ships: string[], app: string, agent: string) {
   return { ...rest, match: allShipsMatch, haveAllNegotiations };
 }
 
-// If we haven't already interacted with a ship, but need to know its
-// negotiation status, we have to inititate negotiation manually
-export function useInitShipNegotiation(ships: string[], app: string) {
+export function useForceNegotiationUpdate(ships: string[], app: string) {
   const { data } = useNegotiation(app, app);
   const unknownShips = useMemo(
-    () => ships.filter((ship) => `${ship}/${app}` in (data || {}) === false),
+    () =>
+      ships.filter(
+        (ship) =>
+          !data ||
+          !(`${ship}/${app}` in data) ||
+          data[`${ship}/${app}`] !== 'match'
+      ),
     [ships, app, data]
   );
   const negotiateUnknownShips = useCallback(

--- a/ui/src/state/negotiation.ts
+++ b/ui/src/state/negotiation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
 import api from '@/api';
@@ -99,13 +99,50 @@ export function useNegotiateMulti(ships: string[], app: string, agent: string) {
   const { data, ...rest } = useNegotiation(app, agent);
 
   if (rest.isLoading || rest.isError || data === undefined) {
-    return { ...rest, match: false };
+    return { ...rest, match: false, haveAllNegotiations: false };
   }
 
-  const allShipsMatch = ships
+  const shipKeys = ships
     .filter((ship) => ship !== window.our)
-    .map((ship) => `${ship}/${agent}`)
-    .every((ship) => ship in data && data[ship] === 'match');
+    .map((ship) => `${ship}/${agent}`);
 
-  return { ...rest, match: allShipsMatch };
+  const allShipsMatch = shipKeys.every(
+    (ship) => ship in data && data[ship] === 'match'
+  );
+
+  const haveAllNegotiations = shipKeys.every((ship) => ship in data);
+
+  return { ...rest, match: allShipsMatch, haveAllNegotiations };
+}
+
+// If we haven't already interacted with a ship, but need to know its
+// negotiation status, we have to inititate negotiation manually
+export function useInitShipNegotiation(ships: string[], app: string) {
+  const { data } = useNegotiation(app, app);
+  const unknownShips = useMemo(
+    () => ships.filter((ship) => `${ship}/${app}` in (data || {}) === false),
+    [ships, app, data]
+  );
+  const negotiateUnknownShips = useCallback(
+    async (shipsToCheck: string[]) => {
+      const responses: Promise<number>[] = [];
+      shipsToCheck.forEach((ship) => {
+        responses.push(
+          api.poke({
+            app,
+            mark: 'chat-negotiate',
+            json: ship,
+          })
+        );
+      });
+      await Promise.all(responses);
+    },
+    [app]
+  );
+
+  useEffect(() => {
+    if (unknownShips.length > 0) {
+      negotiateUnknownShips(unknownShips);
+    }
+  }, [unknownShips, negotiateUnknownShips]);
 }


### PR DESCRIPTION
Previously, you could not set up a new multi DM if you hadn't already messaged with the ships in question because they wouldn't have negotiation status and we're blocking the input if we don't have a match.

This PR updates the backend to allow a poke that initiates negotiation and updates the frontend to send that poke when attempting to create a new multi dm. The UI will indicate that it's loading while that negotiation happens and inform the user if they can't create the DM because of a version mismatch.

Fixes LAND-1307



