### PR TITLE
notifications: make sure user is routed to appropriate path from a reply notification

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1093,7 +1093,11 @@
       =;  cs=(unit (list content:ha))
         ?~  cs  ca-core
         =/  =path
-          /post/(rsh 4 (scot %ui id-post))/(rsh 4 (scot %ui id.reply))
+          ?-    -.kind-data.post
+            %diary  /note/(rsh 4 (scot %ui id-post))/(rsh 4 (scot %ui id.reply))
+            %heap   /curio/(rsh 4 (scot %ui id-post))/(rsh 4 (scot %ui id.reply))
+            %chat   /message/(rsh 4 (scot %ui id-post))/(rsh 4 (scot %ui id.reply))
+          ==
         (emit (pass-hark (ca-spin path u.cs ~)))
       ::  notify because we wrote the post the reply responds to
       ::

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1056,9 +1056,15 @@
       ?:  (was-mentioned:utils content.post our.bowl)
         ?.  (want-hark %mention)
           ca-core
+        =/  =path
+          ?-    -.kind-data.post
+            %diary  /note/(rsh 4 (scot %ui id-post))
+            %heap   /curio/(rsh 4 (scot %ui id-post))
+            %chat   /message/(rsh 4 (scot %ui id-post))
+          ==
         =/  cs=(list content:ha)
           ~[[%ship author.post] ' mentioned you: ' (flatten:utils content.post)]
-        (emit (pass-hark (ca-spin /post/(rsh 4 (scot %ui id-post)) cs ~)))
+        (emit (pass-hark (ca-spin path cs ~)))
       ::
       ::TODO  if we (want-hark %any), notify
       ca-core

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -453,11 +453,17 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                   element={<ChatChannel title={` • ${groupsTitle}`} />}
                 >
                   {isSmall ? null : (
-                    <Route path="message/:idTime" element={<ChatThread />} />
+                    <Route
+                      path="message/:idTime/:idReplyTime?"
+                      element={<ChatThread />}
+                    />
                   )}
                 </Route>
                 {isSmall ? (
-                  <Route path="message/:idTime" element={<ChatThread />} />
+                  <Route
+                    path="message/:idTime/:idReplyTime?"
+                    element={<ChatThread />}
+                  />
                 ) : null}
                 {isMobile && (
                   <Route path="search/:query?" element={<MobileChatSearch />} />
@@ -472,7 +478,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                   element={<HeapChannel title={` • ${groupsTitle}`} />}
                 />
                 <Route
-                  path="curio/:idTime"
+                  path="curio/:idTime/:idReplyTime?"
                   element={<HeapDetail title={` • ${groupsTitle}`} />}
                 />
               </Route>
@@ -485,7 +491,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                   element={<DiaryChannel title={` • ${groupsTitle}`} />}
                 />
                 <Route
-                  path="note/:noteId"
+                  path="note/:noteId/:idReplyTime?"
                   element={<DiaryNote title={` • ${groupsTitle}`} />}
                 />
                 <Route path="edit">

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -178,7 +178,10 @@ function ChatChannel({ title }: ViewProps) {
       </Layout>
       <Routes>
         {isSmall ? null : (
-          <Route path="message/:idTime" element={<ChatThread />} />
+          <Route
+            path="message/:idTime/:idReplyTime?"
+            element={<ChatThread />}
+          />
         )}
       </Routes>
     </>

--- a/ui/src/replies/ReplyMessageOptions.tsx
+++ b/ui/src/replies/ReplyMessageOptions.tsx
@@ -47,7 +47,12 @@ export default function ReplyMessageOptions(props: {
 }) {
   const { open, onOpenChange, whom, reply, openReactionDetails, showReply } =
     props;
-  const nest = `chat/${whom}`;
+  const whomParts = whom.split('/');
+  const alreadyHaveHan =
+    whomParts[0] === 'chat' ||
+    whomParts[0] === 'heap' ||
+    whomParts[0] === 'diary';
+  const nest = alreadyHaveHan ? whom : `chat/${whom}`;
   const { seal, memo } = reply ?? emptyReply;
   const groupFlag = useRouteGroup();
   const isAdmin = useAmAdmin(groupFlag);


### PR DESCRIPTION
This fixes LAND-1271, which was an issue where clicking on a reply notification would route the user to either a blank page (for notebooks and galleries) or the parent chat channel (without opening the thread pane).

The backend was sending a generic path that looks like this:
`/post/{postId}/{replyId}`

This was a problem for the frontend for two reasons:
1) The router does not expect anything at /post/ in any channel.
2) The router also doesn't expect anything after the {postId} token.

This PR updates the backend to send a path that includes the appropriate post type in the path (e.g., `note`, `curio`, `message`) for reply notifications.

It also updates the router to allow an optional param after the {postId}, which I called `idReplyTime`. We currently don't use it on the frontend, but we could use it in the future, so I decided to leave that in the path on the backend.

It also adds a backcompat function in Notification.tsx to fix the routes for any previously sent reply notifications for %channels.

It also fixes an issue with ReplyMessageOptions that can occur with replies to notes or gallery items. We were hardcoding chat (because we pass the channel flag as `whom` to the chat scroller in the ChatThread and ChatWindow components) and this was breaking for gallery item and note replies.