### PR TITLE
dms: ensure rsvp'ing for a pending dm triggers an update

### DIFF
--- a/ui/src/state/chat/keys.ts
+++ b/ui/src/state/chat/keys.ts
@@ -1,0 +1,9 @@
+const pending = () => ['dms', 'pending'];
+const unreads = () => ['dms', 'unreads'];
+
+const ChatQueryKeys = {
+  pending,
+  unreads,
+};
+
+export default ChatQueryKeys;


### PR DESCRIPTION
Right now you can get a double "joined the chat" message if you accept a DM invite in multiple places (on your phone and on desktop for example). This is because the `chat` agent isn't sending an update on the `dm/invited` subscription when an rvsp is processed.

We do however emit an unread notification for the chat. This PR just updates the unread logic to check if the message we received corresponds to a pending DM and invalidate pending data if it does. This causes the pending state to update successfully across clients.

Fixes LAND-1281