### PR TITLE
channels: allow admins to delete posts

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -539,7 +539,7 @@
       =/  post  (get:on-v-posts:c posts.channel id.c-post)
       ?~  post  `(put:on-v-posts:c posts.channel id.c-post ~)
       ?~  u.post  `posts.channel
-      ?>  =(src.bowl author.u.u.post)
+      ?>  |(=(src.bowl author.u.u.post) (is-admin:ca-perms src.bowl))
       :-  `[%post id.c-post %set ~]
       (put:on-v-posts:c posts.channel id.c-post ~)
     ::


### PR DESCRIPTION
We were only allowing a post to be deleted if the ship attempting to delete it was the author, we need to allow admins to delete posts too.

Fixes LAND-1317