### PR TITLE
channels: update cache when we hear a fact about showing/hiding a post

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -819,7 +819,7 @@ export function useChannels(): Channels {
         ['channels', 'hidden'],
         (d: HiddenPosts | undefined) => {
           if (d === undefined) {
-            return undefined;
+            return [event.hide];
           }
 
           const newHidden = [...d, event.hide];

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -36,6 +36,7 @@ import {
   newChatMap,
   HiddenPosts,
   TogglePost,
+  ChannelsSubscribeResponse,
 } from '@/types/channel';
 import api from '@/api';
 import { checkNest, log, nestToFlag } from '@/logic/utils';
@@ -591,7 +592,8 @@ export function useInfinitePosts(
       (event: ChannelsResponse) => {
         queryClient.invalidateQueries({
           queryKey,
-          refetchType: 'posts' in event.response ? 'active' : 'none',
+          refetchType:
+            event.response && 'posts' in event.response ? 'active' : 'none',
         });
       },
       300,
@@ -798,7 +800,9 @@ export function useChannels(): Channels {
   const invalidate = useRef(
     _.debounce(
       (event: ChannelsResponse) => {
-        const postEvent = 'post' in event.response || 'posts' in event.response;
+        const postEvent =
+          event.response &&
+          ('post' in event.response || 'posts' in event.response);
         queryClient.invalidateQueries({
           queryKey: channelKey(),
           refetchType: postEvent ? 'none' : 'active',
@@ -809,13 +813,43 @@ export function useChannels(): Channels {
     )
   );
 
-  const eventHandler = useCallback((event: ChannelsResponse) => {
+  const eventHandler = useCallback((event: ChannelsSubscribeResponse) => {
+    if ('hide' in event) {
+      queryClient.setQueryData<HiddenPosts>(
+        ['channels', 'hidden'],
+        (d: HiddenPosts | undefined) => {
+          if (d === undefined) {
+            return undefined;
+          }
+
+          const newHidden = [...d, event.hide];
+
+          return newHidden;
+        }
+      );
+    }
+
+    if ('show' in event) {
+      queryClient.setQueryData<HiddenPosts>(
+        ['channels', 'hidden'],
+        (d: HiddenPosts | undefined) => {
+          if (d === undefined) {
+            return undefined;
+          }
+
+          const newHidden = d.filter((h) => h !== event.show);
+
+          return newHidden;
+        }
+      );
+    }
+
     invalidate.current(event);
   }, []);
 
   const { data, ...rest } = useReactQuerySubscription<
     Channels,
-    ChannelsResponse
+    ChannelsSubscribeResponse
   >({
     queryKey: channelKey(),
     app: 'channels',

--- a/ui/src/types/channel.ts
+++ b/ui/src/types/channel.ts
@@ -429,6 +429,11 @@ export interface ChannelsResponse {
   response: Response;
 }
 
+export interface ChannelsSubscribeResponse extends ChannelsResponse {
+  show: string;
+  hide: string;
+}
+
 export function isCite(s: Block): boolean {
   if ('cite' in s) {
     return true;


### PR DESCRIPTION
We were ignoring updates about showing/hiding posts, and we were also failing on hearing an update that didn't match the ChannelsResponse type.

Fixes LAND-1321