### PR TITLE
replies: don't refetch in onsettled, caused rescry that squashed cached sent message

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -1864,21 +1864,6 @@ export function useAddReplyMutation() {
         usePostsStore.getState().updateStatus(variables.cacheId, 'sent');
       }
     },
-    onSettled: async (_data, _error, variables) => {
-      const [han, flag] = nestToFlag(variables.nest);
-      setTimeout(async () => {
-        // TODO: this is a hack to make sure the post is updated before refetching
-        // the queries. We need to figure out why the post is not updated immediately.
-        await queryClient.refetchQueries([
-          han,
-          'posts',
-          flag,
-          variables.postId,
-        ]);
-
-        usePostsStore.getState().updateStatus(variables.cacheId, 'delivered');
-      }, 300);
-    },
   });
 }
 


### PR DESCRIPTION
fixes LAND-1322

This onSettled method was unnecessary and was causing cached sent posts to be dropped from the cache.