### PR TITLE
talk-cli: import chat structures v2 always

### DIFF
--- a/talk/app/talk-cli.hoon
+++ b/talk/app/talk-cli.hoon
@@ -11,7 +11,7 @@
 ::
 ::    works best in a dedicated terminal session.
 ::
-/-  chat, cite, groups
+/-  chat=chat-2, cite, groups
 /+  shoe, default-agent, verb, dbug
 ::
 |%


### PR DESCRIPTION
Otherwise, post-migration, it imports the new chat types, which are slightly different.