### PR TITLE
emojis: fix issues with adding emojis in chat

### DIFF
--- a/ui/src/replies/ReplyReactions/ReplyReaction.tsx
+++ b/ui/src/replies/ReplyReactions/ReplyReaction.tsx
@@ -35,7 +35,12 @@ export default function ReplyReaction({
   const isMine = ships.includes(window.our);
   const count = ships.length;
   const isParent = noteId === replyId;
-  const nest = whom;
+  const whomParts = whom.split('/');
+  const alreadyHaveHan =
+    whomParts[0] === 'chat' ||
+    whomParts[0] === 'heap' ||
+    whomParts[0] === 'diary';
+  const nest = alreadyHaveHan ? whom : `chat/${whom}`;
   const { mutateAsync: addReplyFeel } = useAddReplyReactMutation();
   const { mutateAsync: addChatFeel } = useAddPostReactMutation();
   const { mutateAsync: delReplyFeel } = useDeleteReplyReactMutation();
@@ -100,8 +105,11 @@ export default function ReplyReaction({
             <button
               onClick={editReact}
               className={cn(
-                'group relative flex items-center space-x-2 rounded border border-solid border-transparent bg-gray-50 px-2 py-1 text-sm font-semibold leading-4 text-gray-600 group-one-hover:border-gray-100',
-                isMine && 'bg-blue-softer group-one-hover:border-blue-soft'
+                'group relative flex items-center space-x-2 rounded border border-solid border-transparent px-2 py-1 text-sm font-semibold leading-4 text-gray-600',
+                {
+                  'bg-gray-50 sm:group-one-hover:bg-gray-200': !isMine,
+                  'bg-blue-softer sm:group-one-hover:border-blue-soft': isMine,
+                }
               )}
               aria-label={
                 isMine ? 'Remove reaction' : `Add ${react.replaceAll(':', '')}`

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -2131,16 +2131,6 @@ export function useAddPostReactMutation() {
 
       await updatePostsInCache(variables, postsUpdater);
     },
-    onSettled: async (_data, _error, variables) => {
-      const [han, flag] = nestToFlag(variables.nest);
-      await queryClient.invalidateQueries([han, 'posts', flag]);
-      await queryClient.invalidateQueries([
-        han,
-        'posts',
-        flag,
-        variables.postId,
-      ]);
-    },
   });
 }
 

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -2113,7 +2113,7 @@ export function useAddPostReactMutation() {
         const prevReacts = prevPost.seal.reacts;
         const newReacts = {
           ...prevReacts,
-          [unixToDa(Date.now()).toString()]: variables.react,
+          [window.our]: variables.react,
         };
 
         const updatedPost: PostDataResponse = {
@@ -2236,16 +2236,6 @@ export function useDeletePostReactMutation() {
 
       await updatePostInCache(variables, postUpdater);
       await updatePostsInCache(variables, postsUpdater);
-    },
-    onSettled: async (_data, _error, variables) => {
-      const [han, flag] = nestToFlag(variables.nest);
-      await queryClient.invalidateQueries([han, 'posts', flag]);
-      await queryClient.invalidateQueries([
-        han,
-        'posts',
-        flag,
-        variables.postId,
-      ]);
     },
   });
 }


### PR DESCRIPTION
This fixes LAND-1309.

There were several issues:

1) ReplyReaction's call to addReplyFeel was broken due to a bad nest. This caused adding +1 reactions to fail.
2) We were calling onSettled in useAddPostReact, which would cause an unnecessary re-scry which could temporarily make it look as if your reaction was not successful in the main chat window.
3) We weren't appropriately highlighting *your* reaction, which may make it look like the reaction didn't go through.