### PR TITLE
dms: optimistically update cache on hearing sub facts, fix duplicate chat messages on send

### DIFF
--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -289,7 +289,8 @@ function infiniteDMsUpdater(queryKey: QueryKey, data: WritDiff | WritResponse) {
         writs: newWrits,
       };
 
-      const cachedWrit = lastPage.writs[decToUd(unixToDa(writ.essay.sent).toString())];
+      const cachedWrit =
+        lastPage.writs[decToUd(unixToDa(writ.essay.sent).toString())];
 
       if (
         cachedWrit &&
@@ -1255,8 +1256,8 @@ export function useInfiniteDMs(
             checkResponseForDeliveries(response);
           }
 
-          // for now, let's avoid updating data in place and always refetch
-          // when we hear a fact
+          infiniteDMsUpdater(queryKey, data);
+
           invalidate.current(queryKey);
         },
       });


### PR DESCRIPTION
We weren't converting the dec to a ud for the writ id for finding the cached writ.

Edit: this now adds infiniteDmsUpdater back to the event method in the useInfiniteDms subscription so that we can update the cache based on facts we hear on the subscription wire (rather than waiting for scries to complete). 