### PR TITLE
join modal: don't automatically navigate after join if in Talk

### DIFF
--- a/ui/src/groups/Join/JoinGroupModal.tsx
+++ b/ui/src/groups/Join/JoinGroupModal.tsx
@@ -15,6 +15,7 @@ import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import {
   getFlagParts,
   getPrivacyFromPreview,
+  isTalk,
   matchesBans,
   pluralRank,
   toTitleCase,
@@ -63,7 +64,7 @@ export default function JoinGroupModal() {
   const readyToNavigate = group && !groupIsInitializing(group);
 
   useEffect(() => {
-    if (readyToNavigate) {
+    if (readyToNavigate && !isTalk) {
       navigate(`/groups/${flag}`);
     }
   }, [readyToNavigate, flag, navigate]);


### PR DESCRIPTION
When you join a group through a reference in Talk, it navigates to a blank page since the path only works in Groups. 

This updates it to not navigate automatically. Instead the group modal will stop spinning and show a "Go" button which navigates correctly.

Fixes LAND-1320