### PR TITLE
Revert "Revert "talk-cli: import chat structures v2 always""

### DIFF
--- a/talk/app/talk-cli.hoon
+++ b/talk/app/talk-cli.hoon
@@ -11,7 +11,7 @@
 ::
 ::    works best in a dedicated terminal session.
 ::
-/-  chat, cite, groups
+/-  chat=chat-2, cite, groups
 /+  shoe, default-agent, verb, dbug
 ::
 |%


### PR DESCRIPTION
We have to go deeper.

This is #3075 re-applied. /sur/chat-2 already ships with the talk desk.

Talk-cli is still gonna be broken/useless for the new backend, but at least this way it won't block the update.