### PR TITLE
curio ref: pass cite nest along since we cant get it from the nav params

### DIFF
--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -153,7 +153,13 @@ function CurioReference({
         onClick={handleOpenReferenceClick}
         className="flex h-full cursor-pointer flex-col justify-between p-2"
       >
-        <HeapBlock post={note} time={idCurio} refToken={refToken} asRef />
+        <HeapBlock
+          post={note}
+          citeNest={nest}
+          time={idCurio}
+          refToken={refToken}
+          asRef
+        />
       </div>
       <ReferenceBar
         nest={nest}

--- a/ui/src/heap/HeapBlock.tsx
+++ b/ui/src/heap/HeapBlock.tsx
@@ -47,6 +47,7 @@ interface TopBarProps extends CurioDisplayProps {
   isUndelivered?: boolean;
   linkFromNotification?: string;
   author: string;
+  citeNest?: string;
 }
 
 function TopBar({
@@ -58,13 +59,14 @@ function TopBar({
   linkFromNotification,
   longPress = false,
   isUndelivered = false,
+  citeNest,
   time,
   canEdit,
   author,
 }: TopBarProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const chFlag = useChannelFlag();
-  const nest = `heap/${chFlag}`;
+  const nest = citeNest || `heap/${chFlag}`;
   const {
     didCopy,
     menuOpen,
@@ -293,6 +295,7 @@ function HeapBlockWrapper({
 
 interface HeapBlockProps extends CurioDisplayProps {
   post: Post;
+  citeNest?: string;
   linkFromNotification?: string;
 }
 
@@ -308,6 +311,7 @@ const hiddenPostContent: Story = [
 
 export default function HeapBlock({
   post,
+  citeNest,
   time,
   asRef = false,
   asMobileNotification = false,
@@ -359,6 +363,7 @@ export default function HeapBlock({
     linkFromNotification,
     refToken,
     longPress,
+    citeNest,
     author: post.essay.author,
   };
   const botBar = { post, asRef, asMobileNotification, longPress };


### PR DESCRIPTION
We explode in dev and silently error in prod for curio references right now. In HeapBlock, a nest is required as part of the logic but is only loaded from nav params. This fails when we're not actually in the correct channel.

This updates the cite nest to be passed along as an optional prop to HeapBlock which it can use instead in the case of references.

Fixes LAND-1330