### PR TITLE
chat: make sure we load in appropriate data when scrolling to a message outside of our current messages

### DIFF
--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -48,6 +48,7 @@ export default function ChatWindow({
     hasPreviousPage,
     fetchPreviousPage,
     refetch,
+    remove,
     fetchNextPage,
     isLoading,
     isFetching,
@@ -134,6 +135,7 @@ export default function ChatWindow({
 
   useEffect(() => {
     const doRefetch = async () => {
+      remove();
       await refetch();
     };
 
@@ -146,7 +148,14 @@ export default function ChatWindow({
     if (scrollTo && hasNextPage && !scrollToInMessages && !shouldGetLatest) {
       doRefetch();
     }
-  }, [scrollTo, hasNextPage, refetch, scrollToInMessages, shouldGetLatest]);
+  }, [
+    scrollTo,
+    hasNextPage,
+    refetch,
+    scrollToInMessages,
+    shouldGetLatest,
+    remove,
+  ]);
 
   if (isLoading) {
     return (

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -59,6 +59,11 @@ export default function ChatWindow({
   const readTimeout = useChatInfo(whom).unread?.readTimeout;
   const { compatible } = useChannelCompatibility(nest);
   const latestMessageIndex = messages.length - 1;
+  const scrollToInMessages = useMemo(
+    () =>
+      scrollTo ? messages.findIndex((m) => m[0].eq(scrollTo)) !== -1 : false,
+    [scrollTo, messages]
+  );
   const scrollToIndex = useMemo(
     () =>
       scrollTo
@@ -119,10 +124,29 @@ export default function ChatWindow({
   );
 
   useEffect(() => {
+    // If we have a scrollTo and we have newer data that's not yet loaded, we
+    // need to make sure we get the latest data the next time we fetch (i.e.,
+    // when the user cliks the "Go to Latest" button).
     if (scrollTo && hasPreviousPage) {
       setShouldGetLatest(true);
     }
   }, [scrollTo, hasPreviousPage]);
+
+  useEffect(() => {
+    const doRefetch = async () => {
+      await refetch();
+    };
+
+    // If we have a scrollTo, we have a next page, and the scrollTo message is
+    // not in our current set of messages, that means we're scrolling to a
+    // message that's not yet cached. So, we need to refetch (which would fetch
+    // messages around the scrollTo time), then scroll to the message.
+    // We also need to make sure that shouldGetLatest is false, so that we don't
+    // get into a loop of fetching the latest data.
+    if (scrollTo && hasNextPage && !scrollToInMessages && !shouldGetLatest) {
+      doRefetch();
+    }
+  }, [scrollTo, hasNextPage, refetch, scrollToInMessages, shouldGetLatest]);
 
   if (isLoading) {
     return (

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -47,6 +47,7 @@ export default function DmWindow({
     hasNextPage,
     hasPreviousPage,
     refetch,
+    remove,
     isLoading,
     fetchNextPage,
     fetchPreviousPage,
@@ -129,6 +130,7 @@ export default function DmWindow({
 
   useEffect(() => {
     const doRefetch = async () => {
+      remove();
       await refetch();
     };
 
@@ -141,7 +143,14 @@ export default function DmWindow({
     if (scrollTo && hasNextPage && !scrollToInMessages && !shouldGetLatest) {
       doRefetch();
     }
-  }, [scrollTo, hasNextPage, refetch, scrollToInMessages, shouldGetLatest]);
+  }, [
+    scrollTo,
+    hasNextPage,
+    refetch,
+    scrollToInMessages,
+    shouldGetLatest,
+    remove,
+  ]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Fixes LAND-1331 (and any other case where our scrollTo message falls outside of currently loaded messages).

Previously, the scroller would just scroll to the top of what we currently have and useInfinitePosts wouldn't refetch to get messages around the message in question.

I also added a comment to another, related useEffect to make things a bit clearer.