### PR TITLE
notifications: add support for receiving a notification for all messages in a channel

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1066,7 +1066,16 @@
           ~[[%ship author.post] ' mentioned you: ' (flatten:utils content.post)]
         (emit (pass-hark (ca-spin path cs ~)))
       ::
-      ::TODO  if we (want-hark %any), notify
+      ?:  (want-hark %any)
+        =/  =path
+          ?-    -.kind-data.post
+            %diary  /note/(rsh 4 (scot %ui id-post))
+            %heap   /curio/(rsh 4 (scot %ui id-post))
+            %chat   /message/(rsh 4 (scot %ui id-post))
+          ==
+        =/  cs=(list content:ha)
+          ~[[%ship author.post] ' sent a message: ' (flatten:utils content.post)]
+        (emit (pass-hark (ca-spin path cs ~)))
       ca-core
     ::
     ++  on-reply


### PR DESCRIPTION
fixes LAND-1313

If the user selects "All messages" in the notification settings for a channel, they will now receive notifications for all messages.