### PR TITLE
chat: fix excess image padding & chat message indentation

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -327,7 +327,7 @@ export default function ChatInput({
       messageSender({
         whom,
         replying,
-        editorJson: editor.getJSON(),
+        editorJson: editor.isEmpty ? {} : editor.getJSON(),
         text: editor.getText(),
         blocks,
         replyCite,

--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -390,7 +390,7 @@ const ChatMessage = React.memo<
                 openReactionDetails={handleReactionDetailsOpened}
               />
             )}
-            <div className="-ml-1 mr-1 py-2 text-xs font-semibold text-gray-400 opacity-0 sm:group-one-hover:opacity-100">
+            <div className="-ml-1 mr-1 w-[29px] py-2 text-xs font-semibold text-gray-400 opacity-0 sm:group-one-hover:opacity-100">
               {format(unix, 'HH:mm')}
             </div>
             <div className="wrap-anywhere flex w-full">


### PR DESCRIPTION
- Line breaks were being inserted for uploaded images which was causing the large amount of spacing below them. We now check if the editor is empty to avoid this.
- We aren't using a mono-space font for sent time hover preview in chat which was leading some messages to be more indented than others. This fixes the width of the time display to prevent that.

LAND-1316
LAND-1324