### PR TITLE
state: update channel.ts to address inaccessible remote post embeds

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -1127,11 +1127,19 @@ export function useRemotePost(
     },
   });
 
-  if (rest.isLoading || rest.isError || data === undefined) {
+  if (rest.isLoading) {
     return {
       reference: undefined,
       ...rest,
     };
+  }
+
+  if (rest.isError || data === undefined || data === null) {
+    rest.isError = true;
+    return {
+      reference: undefined,
+      ...rest
+    }
   }
 
   const { reference } = data as Said;


### PR DESCRIPTION
Per issue #3095, embedded remote groups posts crash Groups when they are inaccessible (because the group is deleted, the embed is malformed in certain ways, the group is secret, etc).

![Screenshot 2023-12-06 at 22 41 10](https://github.com/tloncorp/landscape-apps/assets/104947308/e8beb302-9909-4854-8160-082df2aff581)

By checking for this scenario, we can prevent the crash and present a reasonable error message to the user.

![Screenshot 2023-12-06 at 22 53 09](https://github.com/tloncorp/landscape-apps/assets/104947308/6ed45a64-f741-4fe3-a7fe-b425ddb1e652)

I'm skeptical whether I'm doing the right thing when I manually set `isError` in `rest` like this:

```typescript
    rest.isError = true;
```

It seems likely that this error should be detected earlier, such that `rest.isError` would already be true. Ie, our current approach for detecting that this won't be an error is inadequate, so really we should fix _that_. In that case, this PR is just a starting point towards developing a proper fix.

Otherwise, this will at least let people talk about Nock in Hooniverse again :)

Fixes #3095