### PR TITLE
refs: show as unavailable when remote post data is null

### DIFF
--- a/ui/src/components/References/CurioReference.tsx
+++ b/ui/src/components/References/CurioReference.tsx
@@ -71,7 +71,7 @@ function CurioReference({
     ? `${preview.group.flag}/channels/${nest}/curio/${idCurio}`
     : undefined;
 
-  if (isError) {
+  if (isError || reference === null) {
     return <UnavailableReference time={bigInt(0)} nest={nest} preview={null} />;
   }
 

--- a/ui/src/components/References/NoteReference.tsx
+++ b/ui/src/components/References/NoteReference.tsx
@@ -64,7 +64,7 @@ function NoteReference({
     return <DiaryContent content={truncatedContent} isPreview />;
   }, [note]);
 
-  if (isError) {
+  if (isError || reference === null) {
     return <UnavailableReference nest={nest} time={bigInt(0)} preview={null} />;
   }
 

--- a/ui/src/components/References/WritBaitReference.tsx
+++ b/ui/src/components/References/WritBaitReference.tsx
@@ -18,7 +18,7 @@ export default function WritBaitReference(props: {
   const { chFlag, nest, index, isScrolling, contextApp, children } = props;
   const { reference } = useRemotePost(nest, index, isScrolling);
   const [, udId] = index.split('/');
-  if (reference === undefined) {
+  if (!reference) {
     const time = bigInt(udToDec(udId));
     return <UnavailableReference time={time} nest={nest} preview={null} />;
   }

--- a/ui/src/components/References/WritChanReference.tsx
+++ b/ui/src/components/References/WritChanReference.tsx
@@ -22,7 +22,7 @@ function WritChanReference(props: {
     idReply
   );
 
-  if (isError) {
+  if (isError || reference === null) {
     return <UnavailableReference time={bigInt(0)} nest={nest} preview={null} />;
   }
 

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -1134,6 +1134,13 @@ export function useRemotePost(
     };
   }
 
+  if (data === null) {
+    return {
+      reference: null,
+      ...rest,
+    };
+  }
+
   const { reference } = data as Said;
 
   return {


### PR DESCRIPTION
Fixes LAND-1346. The backend will return `null` for our `said` requests if we're requesting a post from a private group that we don't have access to. This change accounts for that.