### PR TITLE
clipboard: add fallback function for non-secure contexts

### DIFF
--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -607,11 +607,28 @@ export function useCopy(copied: string) {
   const [didCopy, setDidCopy] = useState(false);
   const [, copy] = useCopyToClipboard();
 
+  const copyFallback = async (text: string) => {
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return true;
+    } catch (error) {
+      console.warn('Fallback copy failed', error);
+      return false;
+    }
+  };
+
   const doCopy = useCallback(async () => {
     let success = false;
     if (isNativeApp()) {
       postActionToNativeApp('copy', copied);
       success = true;
+    } else if (!navigator.clipboard) {
+      success = await copyFallback(copied);
     } else {
       success = await copy(copied);
     }


### PR DESCRIPTION
Fixes LAND-1349. I had thought useCopyToClipboard did this for us, but apparently not.