### PR TITLE
threads: account for the fact that we sometimes only hear facts via the subscription in useChannels

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -844,6 +844,16 @@ export function useChannels(): Channels {
       );
     }
 
+    if ('response' in event && 'post' in event.response) {
+      // We call infinitePostUpdater here because there are situations where we
+      // are only listening to useChannels and not useInfinitePosts. This is
+      // the case in threads on mobile in particular.
+      const { nest } = event;
+      const [han, flag] = nestToFlag(nest);
+      const infinitePostQueryKey = [han, 'posts', flag, 'infinite'];
+      infinitePostUpdater(infinitePostQueryKey, event);
+    }
+
     invalidate.current(event);
   }, []);
 


### PR DESCRIPTION
Sometimes (such as viewing a thread in mobile, after you've directly navigated to it via a notification or similar), we don't get updates via the subscription in useInfinitePosts, but we do via the subscription in useChannels. This PR adds a call to infinitePostsUpdater in the onEvent handler in useChannels so that we can be sure to update the cache appropriately when we hear these facts.

Calling it in both places shouldn't cause an issue, and doesn't seem to in my testing.

Fixes LAND-1338