### PR TITLE
unreads: mark a chat as read when we hear that fact on unreads subscription

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -1030,16 +1030,24 @@ export function useUnreads(): Unreads {
 
     if (unread !== null) {
       const [app, flag] = nestToFlag(nest);
+
       if (app === 'chat') {
-        useChatStore
-          .getState()
-          .unread(flag, unread, () => markRead({ nest: `chat/${flag}` }));
+        if (unread['unread-id'] === null && unread.count === 0) {
+          // if unread is null and count is 0, we can assume that the channel
+          // has been read and we can remove it from the unreads list
+          useChatStore.getState().read(flag);
+        } else {
+          useChatStore
+            .getState()
+            .unread(flag, unread, () => markRead({ nest: `chat/${flag}` }));
+        }
       }
 
       queryClient.setQueryData(['unreads'], (d: Unreads | undefined) => {
         if (d === undefined) {
           return undefined;
         }
+
         const newUnreads = { ...d };
         newUnreads[event.nest] = unread;
 

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -703,18 +703,26 @@ export function useDmUnreads() {
     }
 
     if (unread !== null) {
-      useChatStore.getState().unread(whom, unread, () => markDmRead({ whom }));
-      queryClient.setQueryData(dmUnreadsKey, (d: DMUnreads | undefined) => {
-        if (d === undefined) {
-          return undefined;
-        }
-
-        const newUnreads = { ...d };
-        newUnreads[event.whom] = unread;
-
-        return newUnreads;
-      });
+      if (unread['unread-id'] === null && unread.count === 0) {
+        // if unread is null and count is 0, we can assume that the channel
+        // has been read and we can remove it from the unreads list
+        useChatStore.getState().read(whom);
+      } else {
+        useChatStore
+          .getState()
+          .unread(whom, unread, () => markDmRead({ whom }));
+      }
     }
+    queryClient.setQueryData(dmUnreadsKey, (d: DMUnreads | undefined) => {
+      if (d === undefined) {
+        return undefined;
+      }
+
+      const newUnreads = { ...d };
+      newUnreads[event.whom] = unread;
+
+      return newUnreads;
+    });
   };
 
   const { data, ...query } = useReactQuerySubscription<


### PR DESCRIPTION
Fixes LAND-1354 by marking a chat as read via useChatStore's read method if we hear a fact telling us that the chat is read. Previously we just called the `unread` function from useChatStore no matter what on hearing an unread fact about a chat channel.