### PR TITLE
chat: remove useMemo, make sure reacts is defined before calling object.keys() in ChatSearchResult

### DIFF
--- a/ui/src/chat/ChatSearch/ChatSearchResult.tsx
+++ b/ui/src/chat/ChatSearch/ChatSearchResult.tsx
@@ -64,7 +64,7 @@ function ChatSearchResult({
 
     return '';
   }, [writ]);
-  const reacts = useMemo(() => writ.seal.reacts, [writ]);
+  const { reacts } = writ.seal;
 
   return (
     <Link
@@ -81,7 +81,8 @@ function ChatSearchResult({
       <Author ship={author} date={unix} />
       <div className="group-one wrap-anywhere relative z-0 flex w-full flex-col space-y-2 py-1 pl-9">
         <ChatContent story={content} isScrolling={isScrolling} />
-        {Object.keys(reacts).length > 0 &&
+        {reacts &&
+          Object.keys(reacts).length > 0 &&
           ('parent-id' in writ.seal ? (
             <ReplyReactions
               time={time.toString()}


### PR DESCRIPTION
I think this was caused by an unnecessary useMemo that had the writ object in the dependency array. React can't diff an object like that. If we need a useMemo here we could stringify the object.

fixes LAND-1368.