### PR TITLE
chat: fix infinite refetch bug with scrollTo, fix chat bug, navigate to thread parent

### DIFF
--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -53,7 +53,7 @@ export default function ChatThread() {
   const groupFlag = useRouteGroup();
   const { mutate: sendMessage } = useAddReplyMutation();
   const location = useLocation();
-  const scrollTo = new URLSearchParams(location.search).get('msg');
+  const scrollTo = new URLSearchParams(location.search).get('thread-msg');
   const { mutate: markRead } = useMarkReadMutation();
   const channel = useGroupChannel(groupFlag, nest)!;
   const [searchParams, setSearchParams] = useSearchParams();

--- a/ui/src/chat/ChatUnreadAlerts.tsx
+++ b/ui/src/chat/ChatUnreadAlerts.tsx
@@ -47,7 +47,7 @@ export default function ChatUnreadAlerts({
   const to =
     threadKeys.length === 0 || topId > id
       ? `${root}?msg=${id}`
-      : `${root}/message/${topId}?msg=${threads[topId]}`;
+      : `${root}/message/${topId}?thread-msg=${threads[topId]}`;
 
   const date = new Date(daToUnix(bigInt(id)));
   const since = isToday(date)

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -93,6 +93,7 @@ export default function ChatWindow({
       setSearchParams({});
     }
     if (hasPreviousPage) {
+      remove();
       await refetch();
       setShouldGetLatest(false);
     } else {
@@ -100,6 +101,7 @@ export default function ChatWindow({
     }
   }, [
     setSearchParams,
+    remove,
     refetch,
     hasPreviousPage,
     scrollerRef,
@@ -170,10 +172,10 @@ export default function ChatWindow({
   }, [
     scrollToId,
     hasNextPage,
+    remove,
     refetch,
     msgIdTimeInMessages,
     shouldGetLatest,
-    remove,
   ]);
 
   if (isLoading) {

--- a/ui/src/chat/ChatWindow.tsx
+++ b/ui/src/chat/ChatWindow.tsx
@@ -90,6 +90,7 @@ export default function ChatWindow({
     if (hasPreviousPage) {
       // wait until next tick to avoid the race condition where refetch
       // happens before navigation completes and clears scrollToId
+      // TODO: is there a better way to handle this?
       setTimeout(() => {
         remove();
         refetch();

--- a/ui/src/chat/DMUnreadAlerts.tsx
+++ b/ui/src/chat/DMUnreadAlerts.tsx
@@ -50,7 +50,7 @@ export default function DMUnreadAlerts({ whom, root }: DMUnreadAlertsProps) {
   const to =
     entries.length === 0 || parent > time
       ? `${root}?msg=${time}`
-      : `${root}/message/${topId}?msg=${replyTime}`;
+      : `${root}/message/${topId}?thread-msg=${replyTime}`;
 
   const date = new Date(daToUnix(bigInt(time)));
   const since = isToday(date)

--- a/ui/src/dms/DMThread.tsx
+++ b/ui/src/dms/DMThread.tsx
@@ -47,7 +47,7 @@ export default function DMThread() {
   const isMobile = useIsMobile();
   const appName = useAppName();
   const [loading, setLoading] = useState(false);
-  const scrollTo = new URLSearchParams(location.search).get('msg');
+  const scrollTo = new URLSearchParams(location.search).get('thread-msg');
   const whom = ship || '';
   const id = `${idShip!}/${idTime!}`;
   const { writ, isLoading } = useWrit(whom, id);

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -37,14 +37,9 @@ export default function DmWindow({
   const [searchParams, setSearchParams] = useSearchParams();
   const [shouldGetLatest, setShouldGetLatest] = useState(false);
   const { idTime } = useParams();
-  const scrollTo = useMemo(
-    () => getScrollTo(searchParams.get('msg')),
-    [searchParams]
-  );
-  const msgIdTime = useMemo(
-    () =>
-      scrollTo ? scrollTo.toString() : idTime ? udToDec(idTime) : undefined,
-    [scrollTo, idTime]
+  const scrollToId = useMemo(
+    () => searchParams.get('msg') || (idTime ? udToDec(idTime) : undefined),
+    [searchParams, idTime]
   );
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const readTimeout = useChatInfo(whom).unread?.readTimeout;
@@ -64,23 +59,23 @@ export default function DmWindow({
     isFetching,
     isFetchingNextPage,
     isFetchingPreviousPage,
-  } = useInfiniteDMs(whom, msgIdTime, shouldGetLatest);
+  } = useInfiniteDMs(whom, scrollToId, shouldGetLatest);
   const navigate = useNavigate();
 
   const latestMessageIndex = writs.length - 1;
   const msgIdTimeIndex = useMemo(
     () =>
-      msgIdTime
-        ? writs.findIndex((m) => m[0].toString() === msgIdTime)
+      scrollToId
+        ? writs.findIndex((m) => m[0].toString() === scrollToId)
         : latestMessageIndex,
-    [msgIdTime, writs, latestMessageIndex]
+    [scrollToId, writs, latestMessageIndex]
   );
   const msgIdTimeInMessages = useMemo(
     () =>
-      msgIdTime
-        ? writs.findIndex((m) => m[0].toString() === msgIdTime) !== -1
+      scrollToId
+        ? writs.findIndex((m) => m[0].toString() === scrollToId) !== -1
         : false,
-    [msgIdTime, writs]
+    [scrollToId, writs]
   );
   const latestIsMoreThan30NewerThanScrollTo = useMemo(
     () =>
@@ -151,10 +146,10 @@ export default function DmWindow({
     // If we have a scrollTo and we have newer data that's not yet loaded, we
     // need to make sure we get the latest data the next time we fetch (i.e.,
     // when the user cliks the "Go to Latest" button).
-    if (msgIdTime && hasPreviousPage) {
+    if (scrollToId && hasPreviousPage) {
       setShouldGetLatest(true);
     }
-  }, [msgIdTime, hasPreviousPage]);
+  }, [scrollToId, hasPreviousPage]);
 
   useEffect(() => {
     const doRefetch = async () => {
@@ -168,11 +163,11 @@ export default function DmWindow({
     // messages around the scrollTo time), then scroll to the message.
     // We also need to make sure that shouldGetLatest is false, so that we don't
     // get into a loop of fetching the latest data.
-    if (msgIdTime && hasNextPage && !msgIdTimeInMessages && !shouldGetLatest) {
+    if (scrollToId && hasNextPage && !msgIdTimeInMessages && !shouldGetLatest) {
       doRefetch();
     }
   }, [
-    msgIdTime,
+    scrollToId,
     hasNextPage,
     refetch,
     msgIdTimeInMessages,
@@ -206,7 +201,7 @@ export default function DmWindow({
           isLoadingOlder={isFetchingNextPage}
           isLoadingNewer={isFetchingPreviousPage}
           whom={whom}
-          scrollTo={msgIdTime ? bigInt(msgIdTime) : undefined}
+          scrollTo={scrollToId ? bigInt(scrollToId) : undefined}
           scrollerRef={scrollerRef}
           scrollElementRef={scrollElementRef}
           isScrolling={isScrolling}
@@ -217,7 +212,8 @@ export default function DmWindow({
           hasLoadedNewest={!hasPreviousPage}
         />
       </div>
-      {msgIdTime && (hasPreviousPage || latestIsMoreThan30NewerThanScrollTo) ? (
+      {scrollToId &&
+      (hasPreviousPage || latestIsMoreThan30NewerThanScrollTo) ? (
         <div className="absolute bottom-2 left-1/2 z-20 flex w-full -translate-x-1/2 flex-wrap items-center justify-center gap-2">
           <button
             className="button bg-blue-soft text-sm text-blue dark:bg-blue-900 lg:text-base"

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -108,6 +108,7 @@ export default function DmWindow({
       setSearchParams({});
     }
     if (hasPreviousPage) {
+      remove();
       await refetch();
       setShouldGetLatest(false);
     } else {
@@ -115,6 +116,7 @@ export default function DmWindow({
     }
   }, [
     setSearchParams,
+    remove,
     refetch,
     hasPreviousPage,
     scrollerRef,

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -105,6 +105,7 @@ export default function DmWindow({
     if (hasPreviousPage) {
       // wait until next tick to avoid the race condition where refetch
       // happens before navigation completes and clears scrollToId
+      // TODO: is there a better way to handle this?
       setTimeout(() => {
         remove();
         refetch();

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -579,11 +579,7 @@ type PageParam = null | {
   direction: string;
 };
 
-export function useInfinitePosts(
-  nest: Nest,
-  initialTime?: string,
-  latest = false
-) {
+export function useInfinitePosts(nest: Nest, initialTime?: string) {
   const [han, flag] = nestToFlag(nest);
   const queryKey = useMemo(() => [han, 'posts', flag, 'infinite'], [han, flag]);
 

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -620,11 +620,11 @@ export function useInfinitePosts(
     queryFn: async ({ pageParam }: { pageParam?: PageParam }) => {
       let path = '';
 
-      if (pageParam && !latest) {
+      if (pageParam) {
         const { time, direction } = pageParam;
         const ud = decToUd(time);
         path = `/${nest}/posts/${direction}/${ud}/${INITIAL_MESSAGE_FETCH_PAGE_SIZE}/outline`;
-      } else if (initialTime && !latest) {
+      } else if (initialTime) {
         path = `/${nest}/posts/around/${decToUd(initialTime)}/${
           INITIAL_MESSAGE_FETCH_PAGE_SIZE / 2
         }/outline`;

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -1241,11 +1241,7 @@ export function checkWritsForDeliveries(writs: Writs) {
   });
 }
 
-export function useInfiniteDMs(
-  whom: string,
-  initialTime?: string,
-  latest = false
-) {
+export function useInfiniteDMs(whom: string, initialTime?: string) {
   const unread = useDmUnread(whom);
   const isDM = useMemo(() => whomIsDm(whom), [whom]);
   const type = useMemo(() => (isDM ? 'dm' : 'club'), [isDM]);
@@ -1288,11 +1284,11 @@ export function useInfiniteDMs(
     queryFn: async ({ pageParam }: { pageParam?: PageParam }) => {
       let path = '';
 
-      if (pageParam && !latest) {
+      if (pageParam) {
         const { time, direction } = pageParam;
         const ud = decToUd(time.toString());
         path = `/${type}/${whom}/writs/${direction}/${ud}/${INITIAL_MESSAGE_FETCH_PAGE_SIZE}/light`;
-      } else if (initialTime && !latest) {
+      } else if (initialTime) {
         path = `/${type}/${whom}/writs/around/${decToUd(initialTime)}/${
           INITIAL_MESSAGE_FETCH_PAGE_SIZE / 2
         }/light`;


### PR DESCRIPTION
Fixes LAND-1364, the scrollTo refetch bug issue. This was caused by the use of the `msg` param in the case of a message we wanted to highlight within a thread. We used the same param for scrollTo in the ChatWindow, and since we couldn't find the scrollTo in the existing messages (and never would since it exists outside of the main chat window, in a thread) the new useEffect that fixed search was firing in a loop. This was fixed by changing the url param for finding a thread message to `thread-msg`.

Also fixes LAND-1331 by adding the useEffect back in, this time with a new dependent variable that uses either the parent ID in the router or the id from the `msg` param. This same variable is also used to scroll to the thread parent in the main window, which is something that wasn't working on mainnet/develop before. I don't think we have an issue for this one.