### PR TITLE
chat: when replying, only reset the message editor if we don't already have the mention

### DIFF
--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -420,8 +420,12 @@ export default function ChatInput({
     if (replyingWrit && messageEditor && !messageEditor.isDestroyed) {
       messageEditor?.commands.focus();
       const mention = ship ? makeMention(ship.slice(1)) : null;
-      messageEditor?.commands.setContent(mention);
-      messageEditor?.commands.insertContent(': ');
+      const needsMentionInsert =
+        mention && !messageEditor.getText().includes(`${ship}:`);
+      if (needsMentionInsert) {
+        messageEditor?.commands.setContent(mention);
+        messageEditor?.commands.insertContent(': ');
+      }
       const path =
         replyingWrit[1] && 'memo' in replyingWrit[1]
           ? `/1/chan/chat/${whom}/msg/${threadParentId}/${replyingWrit[0].toString()}`


### PR DESCRIPTION
We have a bug right now where if you're replying in Chat and a new message comes in, the hook that sets the editor mention is always firing which clears away any other text you already had. 

This PR just checks to see if we actually need to set the mention before doing so.

Fixes LAND-1340