### PR TITLE
perf: tweaks to speed up sidebar transition on desktop

### DIFF
--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -1,6 +1,6 @@
 import { isValidPatp } from 'urbit-ob';
 import classNames from 'classnames';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, useMemo } from 'react';
 import '@urbit/sigil-js';
 import { Contact, cite } from '@urbit/api';
 import _ from 'lodash';
@@ -102,20 +102,32 @@ function Avatar({
   const contact = useContact(ship);
   const calm = useCalm();
   const { previewColor, previewAvatar } = previewData ?? {};
-  const previewAvatarIsValid =
-    previewAvatar && previewAvatar !== null && isValidUrl(previewAvatar);
+  const previewAvatarIsValid = useMemo(
+    () => previewAvatar && previewAvatar !== null && isValidUrl(previewAvatar),
+    [previewAvatar]
+  );
   const { color, avatar } = contact || emptyContact;
   const { hasLoaded, load } = useAvatar(
     (previewAvatarIsValid ? previewAvatar : avatar) || ''
   );
-  const showImage = loadImage || hasLoaded;
-  const { classes, size: sigilSize } = sizeMap[size];
-  const adjustedColor = themeAdjustColor(
-    normalizeUrbitColor(previewColor || color),
-    currentTheme
+  const showImage = useMemo(
+    () => loadImage || hasLoaded,
+    [loadImage, hasLoaded]
   );
-  const foregroundColor = foregroundFromBackground(adjustedColor);
-  const citedShip = cite(ship);
+  const { classes, size: sigilSize } = useMemo(() => sizeMap[size], [size]);
+  const adjustedColor = useMemo(
+    () =>
+      themeAdjustColor(
+        normalizeUrbitColor(previewColor || color),
+        currentTheme
+      ),
+    [previewColor, color, currentTheme]
+  );
+  const foregroundColor = useMemo(
+    () => foregroundFromBackground(adjustedColor),
+    [adjustedColor]
+  );
+  const citedShip = useMemo(() => cite(ship), [ship]);
   const props: SigilProps = {
     point: citedShip || '~zod',
     size: sigilSize,
@@ -124,19 +136,26 @@ function Avatar({
     background: adjustedColor,
     foreground: foregroundColor,
   };
-  const invalidShip =
-    !ship ||
-    ship === 'undefined' ||
-    !isValidPatp(ship) ||
-    citedShip.match(/[_^]/) ||
-    citedShip.length > 14;
+  const invalidShip = useMemo(
+    () =>
+      !ship ||
+      ship === 'undefined' ||
+      !isValidPatp(ship) ||
+      citedShip.match(/[_^]/) ||
+      citedShip.length > 14,
+    [ship, citedShip]
+  );
 
-  if (
-    showImage &&
-    previewAvatarIsValid &&
-    !calm.disableRemoteContent &&
-    !calm.disableAvatars
-  ) {
+  const shouldShowImage = useMemo(
+    () =>
+      showImage &&
+      previewAvatarIsValid &&
+      !calm.disableRemoteContent &&
+      !calm.disableAvatars,
+    [showImage, previewAvatarIsValid, calm]
+  );
+
+  if (shouldShowImage) {
     return (
       <img
         className={classNames(className, classes, 'object-cover')}

--- a/ui/src/components/ShipName.tsx
+++ b/ui/src/components/ShipName.tsx
@@ -1,5 +1,5 @@
 import { cite } from '@urbit/api';
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useMemo } from 'react';
 import { useCalm } from '@/state/settings';
 import { useContact } from '../state/contact';
 
@@ -17,7 +17,7 @@ export default function ShipName({
 }: ShipNameProps) {
   const contact = useContact(name);
   const separator = /([_^-])/;
-  const citedName = full ? name : cite(name);
+  const citedName = useMemo(() => (full ? name : cite(name)), [name, full]);
   const calm = useCalm();
 
   if (!citedName) {

--- a/ui/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/ui/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { useGroups } from '@/state/groups';
@@ -14,6 +14,11 @@ const GroupsSidebarItem = React.memo(({ flag }: { flag: string }) => {
   const isScrolling = useGroupsScrolling();
   const [optionsOpen, setOptionsOpen] = useState(false);
   const { action, handlers } = useLongPress();
+  const disableActions = useMemo(
+    () => isMobile || isScrolling,
+    [isMobile, isScrolling]
+  );
+  const enableImages = useMemo(() => !isScrolling, [isScrolling]);
 
   useEffect(() => {
     if (!isMobile) {
@@ -31,7 +36,7 @@ const GroupsSidebarItem = React.memo(({ flag }: { flag: string }) => {
         <GroupAvatar
           size="h-12 w-12 sm:h-6 sm:w-6 rounded-lg sm:rounded"
           {...group?.meta}
-          loadImage={!isScrolling}
+          loadImage={enableImages}
         />
       }
       actions={
@@ -39,7 +44,7 @@ const GroupsSidebarItem = React.memo(({ flag }: { flag: string }) => {
           open={optionsOpen}
           onOpenChange={setOptionsOpen}
           flag={flag}
-          triggerDisabled={isMobile}
+          triggerDisabled={disableActions}
         />
       }
       to={`/groups/${flag}`}

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,10 @@
-import { useState, useRef, useMemo, useCallback, useContext } from 'react';
+import React, {
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+} from 'react';
 import cn from 'classnames';
 import { debounce } from 'lodash';
 import { Link } from 'react-router-dom';
@@ -34,7 +40,7 @@ import SystemChrome from './SystemChrome';
 import ActionMenu, { Action } from '../ActionMenu';
 import { DesktopUpdateButton } from '../UpdateNotices';
 
-export function GroupsAppMenu() {
+export const GroupsAppMenu = React.memo(() => {
   const [menuOpen, setMenuOpen] = useState(false);
   const location = useLocation();
 
@@ -137,12 +143,16 @@ export function GroupsAppMenu() {
       </SidebarItem>
     </ActionMenu>
   );
-}
+});
+
+const UpdateOrAppMenu = React.memo(() => {
+  const { needsUpdate } = useContext(AppUpdateContext);
+  return needsUpdate ? <DesktopUpdateButton /> : <GroupsAppMenu />;
+});
 
 export default function Sidebar() {
   const isMobile = useIsMobile();
   const location = useLocation();
-  const { needsUpdate } = useContext(AppUpdateContext);
   const pendingInvites = usePendingInvites();
   const [isScrolling, setIsScrolling] = useState(false);
   const [atTop, setAtTop] = useState(true);
@@ -184,7 +194,7 @@ export default function Sidebar() {
           'bottom-shadow': !atTop,
         })}
       >
-        {needsUpdate ? <DesktopUpdateButton /> : <GroupsAppMenu />}
+        <UpdateOrAppMenu />
         <SystemChrome />
         <SidebarItem
           highlight={shipColor}

--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -3,6 +3,8 @@ import { mix } from 'color2k';
 import React, {
   ButtonHTMLAttributes,
   PropsWithChildren,
+  useCallback,
+  useMemo,
   useState,
 } from 'react';
 import { Link, LinkProps, useMatch } from 'react-router-dom';
@@ -32,21 +34,23 @@ type SidebarProps = PropsWithChildren<{
   ButtonHTMLAttributes<HTMLButtonElement> &
   Omit<LinkProps, 'to'>;
 
-function Action({
-  to,
-  children,
-  ...rest
-}: Pick<SidebarProps, 'children' | 'to'> & Record<string, unknown>) {
-  if (to) {
-    return (
-      <Link to={to} {...rest}>
-        {children}
-      </Link>
-    );
-  }
+const Action = React.memo(
+  ({
+    to,
+    children,
+    ...rest
+  }: Pick<SidebarProps, 'children' | 'to'> & Record<string, unknown>) => {
+    if (to) {
+      return (
+        <Link to={to} {...rest}>
+          {children}
+        </Link>
+      );
+    }
 
-  return <button {...rest}>{children}</button>;
-}
+    return <button {...rest}>{children}</button>;
+  }
+);
 
 const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
   (
@@ -68,17 +72,20 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
     },
     ref
   ) => {
-    const matchString = to && inexact ? `${to}/*` : to;
+    const matchString = useMemo(
+      () => (to && inexact ? `${to}/*` : to),
+      [to, inexact]
+    );
     const [hover, setHover] = useState(false);
     const matches = useMatch(
       (defaultRoute ? '/' : matchString) || 'DONT_MATCH'
     );
-    const active = !!matches;
+    const active = useMemo(() => !!matches, [matches]);
     const isMobile = useIsMobile();
     const Wrapper = 'div';
     const currentTheme = useCurrentTheme();
 
-    const hasHoverColor = () => {
+    const hasHoverColor = useCallback(() => {
       switch (highlight) {
         case 'bg-gray-50': {
           return false;
@@ -87,9 +94,9 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
           return true;
         }
       }
-    };
+    }, [highlight]);
 
-    const customHoverHiglightStyles = () => {
+    const customHoverHiglightStyles = useCallback(() => {
       if (hasHoverColor() && isColor(highlight))
         return {
           backgroundColor:
@@ -98,9 +105,9 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
               : mix(highlight, 'white', 0.85),
         };
       return null;
-    };
+    }, [currentTheme, hasHoverColor, highlight]);
 
-    const customActiveHiglightStyles = () => {
+    const customActiveHiglightStyles = useCallback(() => {
       if (hasHoverColor() && isColor(highlight))
         return {
           backgroundColor:
@@ -109,7 +116,7 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
               : mix(highlight, 'white', 0.75),
         };
       return null;
-    };
+    }, [currentTheme, hasHoverColor, highlight]);
 
     return (
       <Wrapper

--- a/ui/src/groups/GroupAvatar.tsx
+++ b/ui/src/groups/GroupAvatar.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
 import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { isColor } from '@/logic/utils';
 import { useIsDark } from '@/logic/useMedia';
@@ -44,22 +44,24 @@ export default function GroupAvatar({
   loadImage = true,
 }: GroupAvatarProps) {
   const { hasLoaded, load } = useAvatar(image || '');
-  const imageIsColor = image && isColor(image);
+  const imageIsColor = useMemo(() => image && isColor(image), [image]);
   const calm = useCalm();
-  const showImage =
-    image &&
-    !calm.disableRemoteContent &&
-    !imageIsColor &&
-    (hasLoaded || loadImage);
+  const showImage = useMemo(
+    () =>
+      image &&
+      !calm.disableRemoteContent &&
+      !imageIsColor &&
+      (hasLoaded || loadImage),
+    [image, calm.disableRemoteContent, imageIsColor, hasLoaded, loadImage]
+  );
   const dark = useIsDark();
-  let background;
   const symbols = [...(title || '')];
-
-  if (imageIsColor) {
-    background = image;
-  } else {
-    background = dark ? '#333333' : '#E5E5E5';
-  }
+  const background = useMemo(() => {
+    if (image && imageIsColor) {
+      return image;
+    }
+    return dark ? '#333333' : '#E5E5E5';
+  }, [imageIsColor, dark, image]);
 
   return showImage ? (
     <img className={cn('rounded', size, className)} src={image} onLoad={load} />

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -1,7 +1,12 @@
 import cn from 'classnames';
 import { useLocation } from 'react-router';
-import { channelHref, canReadChannel } from '@/logic/channel';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { useIsMobile } from '@/logic/useMedia';
 import {
@@ -20,6 +25,8 @@ import {
   useChannelSort,
   useCheckChannelJoined,
   useCheckChannelUnread,
+  channelHref,
+  canReadChannel,
 } from '@/logic/channel';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import HashIcon from '@/components/icons/HashIcon';
@@ -120,7 +127,7 @@ type ListItem =
 
 const virtuosoStateByFlag: Record<string, StateSnapshot> = {};
 
-export default function ChannelList({ paddingTop }: { paddingTop?: number }) {
+const ChannelList = React.memo(({ paddingTop }: { paddingTop?: number }) => {
   const flag = useGroupFlag();
   const group = useGroup(flag);
   const connected = useGroupConnection(flag);
@@ -342,4 +349,6 @@ export default function ChannelList({ paddingTop }: { paddingTop?: number }) {
       className="h-full w-full flex-1 space-y-0.5 overflow-x-hidden"
     />
   );
-}
+});
+
+export default ChannelList;

--- a/ui/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/ui/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames';
 import _ from 'lodash';
-import { useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { useIsDark } from '@/logic/useMedia';
 import {
   useAmAdmin,
@@ -30,11 +30,14 @@ function GroupHeader() {
   const group = useGroup(flag);
   const { needsUpdate } = useContext(AppUpdateContext);
   const { preview, claim } = useGang(flag);
-  const defaultImportCover = group?.meta.cover === '0x0';
+  const defaultImportCover = useMemo(
+    () => group?.meta.cover === '0x0',
+    [group?.meta.cover]
+  );
   const calm = useCalm();
   const isDark = useIsDark();
 
-  const bgStyle = () => {
+  const bgStyle = useCallback(() => {
     if (
       group &&
       !isColor(group?.meta.cover) &&
@@ -50,9 +53,9 @@ function GroupHeader() {
         backgroundColor: group?.meta.cover,
       };
     return {};
-  };
+  }, [group, defaultImportCover, calm.disableRemoteContent]);
 
-  const fgStyle = () => {
+  const fgStyle = useCallback(() => {
     if (group && !isColor(group?.meta.cover) && !defaultImportCover)
       return {
         color: 'text-white dark:text-black',
@@ -65,7 +68,7 @@ function GroupHeader() {
       return { color: `text-${fg}` };
     }
     return { color: 'text-gray-800' };
-  };
+  }, [group, defaultImportCover, isDark]);
 
   return (
     <div
@@ -119,7 +122,10 @@ export default function GroupSidebar() {
   const isDark = useIsDark();
   const location = useLocation();
   const isAdmin = useAmAdmin(flag);
-  const privacy = group ? getPrivacyFromGroup(group) : undefined;
+  const privacy = useMemo(
+    () => (group ? getPrivacyFromGroup(group) : undefined),
+    [group]
+  );
 
   return (
     <nav className="flex h-full min-w-64 flex-none flex-col bg-white">

--- a/ui/src/logic/channel.ts
+++ b/ui/src/logic/channel.ts
@@ -174,7 +174,7 @@ export function useChannelSort(defaultSort: SortMode = DEFAULT_SORT) {
 
   const { sortFn, setSortFn, sortRecordsBy } = useSidebarSort({
     sortOptions,
-    flag: groupFlag === '' ? '~' : groupFlag,
+    flag: groupFlag === '' && !group ? '~' : groupFlag,
     defaultSort,
   });
 

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -105,14 +105,19 @@ export function useGroupsWithQuery() {
     },
   });
 
-  if (rest.isLoading || rest.isError || !data) {
-    return { data: emptyGroups, ...rest };
-  }
+  const stringifiedRest = JSON.stringify(rest);
 
-  return {
-    data,
-    ...rest,
-  };
+  return useMemo(() => {
+    if (rest.isLoading || rest.isError || !data) {
+      return { data: emptyGroups, ...rest };
+    }
+
+    return {
+      data,
+      ...rest,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, stringifiedRest, rest.isLoading, rest.isError]);
 }
 
 export function useGroups() {
@@ -162,6 +167,8 @@ export function useGroup(flag: string, updating = false): Group | undefined {
       initialData: group,
       refetchOnMount: updating,
       retry: true,
+      // prevents skeleton from flashing on unmount when we have cached data
+      keepPreviousData: true,
     },
   });
 


### PR DESCRIPTION
(partially) Fixes LAND-1360 by reducing re-rendering throughout the Sidebar and GroupSidebar components and their children. 

One major source of re-rendering was the data from useGroup() getting wiped on navigating away from a group, which caused the GroupSidebar itself to re-render and show loading state/skeleton on the way out. I added `keepPreviousData` to the useGroup() query to keep current data *until* we want to load in a new group.

I also memoized as much as seemed appropriate throughout.

I played around with animationConfig settings in GroupsNav, but nothing stood out as actually improving the perceived speed.

I also attempted to use framer-motion's `useIsPresent` hook to prevent certain components from rendering (including preventing group images from loading in the sidebar), but it usually either didn't make an appreciable difference or it added too much overhead for it to be worth it.

I also realized that the number of notifications in the Activity list in the home screen has an effect on how quickly we transition from viewing a group to returning to the home screen, and attempted to mitigate this by using Virtuoso to turn the notifications list into a virtualized list. This didn't make any appreciable difference. I think we ought to think of other ways to optimize here (maybe we ought to page the notifications?).

To get a good feel of how these changes will actually feel in production, I recommend running a build, running serve, and pointing the frontend at your personal ship. If you want to see what I'm talking about, re: the notifications themselves causing it to feel slow, make sure you have a lot of notifications. You ought to also test in Safari, where the issue was most pronounced.

Here is how it looks now in that scenario:


https://github.com/tloncorp/landscape-apps/assets/1221094/ebc88f62-3cd6-4775-a2ae-e9919871a705

