### PR TITLE
group actions: fix broken connection status

### DIFF
--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -9,7 +9,12 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import EllipsisIcon from '@/components/icons/EllipsisIcon';
 import useIsGroupUnread from '@/logic/useIsGroupUnread';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
-import { citeToPath, getPrivacyFromGroup, useCopy } from '@/logic/utils';
+import {
+  citeToPath,
+  getFlagParts,
+  getPrivacyFromGroup,
+  useCopy,
+} from '@/logic/utils';
 import {
   useAmAdmin,
   useGang,
@@ -145,7 +150,7 @@ const GroupActions = React.memo(
         keepOpenOnClick: true,
         content: (
           <HostConnection
-            ship={flag}
+            ship={getFlagParts(flag).ship}
             status={status}
             saga={saga}
             type="combo"


### PR DESCRIPTION
We were passing the wrong identifier to check the host connection from the group action menu causing it to always show a connection failure. Status there will now match what's displayed in the top nav.

<img width="385" alt="Screenshot 2023-12-13 at 1 01 35 PM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/22507a1c-79c8-4232-9837-1e6b40d5afb0">

Fixes LAND-1381
