### PR TITLE
groups: redesign group options sheet

### DIFF
--- a/ui/src/channels/HostConnection.tsx
+++ b/ui/src/channels/HostConnection.tsx
@@ -11,6 +11,7 @@ import { Saga } from '@/types/groups';
 import Bullet16Icon from '@/components/icons/Bullet16Icon';
 import Tooltip from '@/components/Tooltip';
 import { useNegotiate } from '@/state/negotiation';
+import { get } from 'lodash';
 
 interface HostConnectionProps {
   ship: string;
@@ -85,7 +86,14 @@ export default function HostConnection({
             <Bullet16Icon
               className={cn(
                 'h-4 w-4 flex-none',
-                `text-${getHostConnectionColor(saga, status, matched)}-400`
+                getHostConnectionColor(saga, status, matched) === 'red' &&
+                  'text-red-400',
+                getHostConnectionColor(saga, status, matched) === 'yellow' &&
+                  'text-yellow-400',
+                getHostConnectionColor(saga, status, matched) === 'green' &&
+                  'text-green-400',
+                getHostConnectionColor(saga, status, matched) === 'gray' &&
+                  'text-gray-400'
               )}
             />
           </span>
@@ -95,7 +103,14 @@ export default function HostConnection({
         <Bullet16Icon
           className={cn(
             'h-4 w-4 flex-none',
-            `text-${getHostConnectionColor(saga, status, matched)}-400`
+            getHostConnectionColor(saga, status, matched) === 'red' &&
+              'text-red-400',
+            getHostConnectionColor(saga, status, matched) === 'yellow' &&
+              'text-yellow-400',
+            getHostConnectionColor(saga, status, matched) === 'green' &&
+              'text-green-400',
+            getHostConnectionColor(saga, status, matched) === 'gray' &&
+              'text-gray-400'
           )}
         />
       )}
@@ -106,9 +121,15 @@ export default function HostConnection({
       {type === 'row' && (
         <div
           className={cn(
-            'h-full w-full rounded-xl px-6 py-4 leading-6',
-            `text-${getHostConnectionColor(saga, status, matched)}-500`,
-            `bg-${getHostConnectionColor(saga, status, matched)}-50`
+            'h-full w-full rounded-xl border px-6 py-3 leading-6',
+            getHostConnectionColor(saga, status, matched) === 'red' &&
+              'border-red-400 bg-red-50 text-red-500',
+            getHostConnectionColor(saga, status, matched) === 'yellow' &&
+              'border-yellow-400 bg-yellow-50 text-yellow-500',
+            getHostConnectionColor(saga, status, matched) === 'green' &&
+              'border-green-200 bg-green-50 text-green-500',
+            getHostConnectionColor(saga, status, matched) === 'gray' &&
+              'border-gray-400 bg-gray-50 text-gray-500'
           )}
         >
           {getText(saga, ship, status, matched)}

--- a/ui/src/channels/HostConnection.tsx
+++ b/ui/src/channels/HostConnection.tsx
@@ -16,7 +16,7 @@ interface HostConnectionProps {
   ship: string;
   saga: Saga | null;
   status?: ConnectionStatus;
-  type?: 'default' | 'combo' | 'text' | 'bullet';
+  type?: 'default' | 'combo' | 'text' | 'bullet' | 'row';
   className?: string;
 }
 
@@ -27,7 +27,7 @@ export function getText(
   negotiationMatch?: boolean
 ) {
   if (ship === window.our) {
-    return 'You are the host';
+    return 'You are the host.';
   }
 
   if (saga && !('synced' in saga)) {
@@ -35,7 +35,7 @@ export function getText(
   }
 
   if (negotiationMatch === false) {
-    return 'Your version of groups does not match the host.';
+    return 'Your version of Tlon does not match the host.';
   }
 
   return !status
@@ -101,6 +101,17 @@ export default function HostConnection({
       )}
       {(type === 'combo' || type === 'text') && (
         <span>{getText(saga, ship, status, matched)}</span>
+      )}
+
+      {type === 'row' && (
+        <div
+          className={cn(
+            'leading-6',
+            getHostConnectionColor(saga, status, matched)
+          )}
+        >
+          {getText(saga, ship, status, matched)}
+        </div>
       )}
     </span>
   );

--- a/ui/src/channels/HostConnection.tsx
+++ b/ui/src/channels/HostConnection.tsx
@@ -51,15 +51,15 @@ function getHostConnectionColor(
   negotiationMatch?: boolean
 ) {
   if (saga && !('synced' in saga)) {
-    return 'text-red-400';
+    return 'red';
   }
 
   if (negotiationMatch === false) {
-    return 'text-red-400';
+    return 'red';
   }
 
   const color = getConnectionColor(status);
-  return color === 'text-red-400' ? 'text-gray-400' : color;
+  return color === 'red' ? 'gray' : color;
 }
 
 export default function HostConnection({
@@ -85,7 +85,7 @@ export default function HostConnection({
             <Bullet16Icon
               className={cn(
                 'h-4 w-4 flex-none',
-                getHostConnectionColor(saga, status, matched)
+                `text-${getHostConnectionColor(saga, status, matched)}-400`
               )}
             />
           </span>
@@ -95,7 +95,7 @@ export default function HostConnection({
         <Bullet16Icon
           className={cn(
             'h-4 w-4 flex-none',
-            getHostConnectionColor(saga, status, matched)
+            `text-${getHostConnectionColor(saga, status, matched)}-400`
           )}
         />
       )}
@@ -106,8 +106,10 @@ export default function HostConnection({
       {type === 'row' && (
         <div
           className={cn(
-            'leading-6',
-            getHostConnectionColor(saga, status, matched)
+            'h-full w-full rounded-xl border px-6 py-4 leading-6',
+            `border-${getHostConnectionColor(saga, status, matched)}-100`,
+            `text-${getHostConnectionColor(saga, status, matched)}-500`,
+            `bg-${getHostConnectionColor(saga, status, matched)}-50`
           )}
         >
           {getText(saga, ship, status, matched)}

--- a/ui/src/channels/HostConnection.tsx
+++ b/ui/src/channels/HostConnection.tsx
@@ -106,8 +106,7 @@ export default function HostConnection({
       {type === 'row' && (
         <div
           className={cn(
-            'h-full w-full rounded-xl border px-6 py-4 leading-6',
-            `border-${getHostConnectionColor(saga, status, matched)}-100`,
+            'h-full w-full rounded-xl px-6 py-4 leading-6',
             `text-${getHostConnectionColor(saga, status, matched)}-500`,
             `bg-${getHostConnectionColor(saga, status, matched)}-50`
           )}

--- a/ui/src/components/ActionMenu.tsx
+++ b/ui/src/components/ActionMenu.tsx
@@ -80,7 +80,7 @@ const ActionMenu = React.memo(
             )}
             <Drawer.Portal>
               <Drawer.Overlay className="fixed inset-0 z-[49] bg-black/20" />
-              <Drawer.Content className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] py-[16px] pb-16 after:!bg-transparent">
+              <Drawer.Content className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pt-4 pb-8 after:!bg-transparent">
                 {actions.map((action) => (
                   <div
                     key={action.key}

--- a/ui/src/components/ActionMenu.tsx
+++ b/ui/src/components/ActionMenu.tsx
@@ -80,7 +80,7 @@ const ActionMenu = React.memo(
             )}
             <Drawer.Portal>
               <Drawer.Overlay className="fixed inset-0 z-[49] bg-black/20" />
-              <Drawer.Content className="fixed inset-x-[32px] bottom-[32px] z-[49] flex flex-col rounded-[32px] bg-white px-[32px] py-[16px] after:!bg-transparent">
+              <Drawer.Content className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] py-[16px] pb-16 after:!bg-transparent">
                 {actions.map((action) => (
                   <div
                     key={action.key}
@@ -94,7 +94,8 @@ const ActionMenu = React.memo(
                     }
                     className={cn(
                       classNameForType(action.type),
-                      'select-none py-[16px]'
+                      action.containerClassName,
+                      'select-none rounded-xl py-4 px-6'
                     )}
                   >
                     {typeof action.content === 'string' ? (

--- a/ui/src/components/ShipConnection.tsx
+++ b/ui/src/components/ShipConnection.tsx
@@ -33,7 +33,7 @@ export default function ShipConnection({
   const color = isSelf
     ? 'text-green-400'
     : matchedOrPending
-    ? `text-${getConnectionColor(status)}-400`
+    ? getConnectionColor(status) === 'yellow' && 'text-yellow-400'
     : 'text-red-400';
   const text = isSelf
     ? 'This is you'

--- a/ui/src/components/ShipConnection.tsx
+++ b/ui/src/components/ShipConnection.tsx
@@ -33,7 +33,7 @@ export default function ShipConnection({
   const color = isSelf
     ? 'text-green-400'
     : matchedOrPending
-    ? getConnectionColor(status)
+    ? `text-${getConnectionColor(status)}-400`
     : 'text-red-400';
   const text = isSelf
     ? 'This is you'

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -171,7 +171,6 @@ const GroupActions = React.memo(
             status={status}
             saga={saga}
             type="row"
-            className=""
           />
         ),
       });
@@ -188,7 +187,7 @@ const GroupActions = React.memo(
             to={`/groups/${flag}/invite`}
             state={{ backgroundLocation: location }}
           >
-            Invite People
+            Invite people
           </Link>
         ),
       });

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -154,7 +154,7 @@ const GroupActions = React.memo(
             <div className="text-gray-800">
               {group?.meta.title || `~${flag}`}
             </div>
-            <div className="font-[17px] text-gray-400">Quick actions</div>
+            <div className="font-normal text-gray-400">Quick actions</div>
           </div>
         ),
       });
@@ -200,7 +200,7 @@ const GroupActions = React.memo(
           >
             Group settings
             {isMobile && (
-              <div className="pt-1.5 text-[14px] text-gray-400">
+              <div className="pt-1.5 text-[14px] font-normal text-gray-400">
                 Configure group details and privacy
               </div>
             )}
@@ -219,7 +219,7 @@ const GroupActions = React.memo(
           <div>
             {isPinned ? 'Unpin' : 'Pin'}
             {isMobile && (
-              <div className="pt-1.5 text-[14px] text-gray-400">
+              <div className="pt-1.5 text-[14px] font-normal text-gray-400">
                 {isPinned ? 'Unpin this group from' : 'Pin this group to'} the
                 top of your Groups list
               </div>
@@ -238,7 +238,7 @@ const GroupActions = React.memo(
           <div>
             {copyItemText}
             {isMobile && (
-              <div className="pt-1.5 text-[14px] text-gray-400">
+              <div className="pt-1.5 text-[14px] font-normal text-gray-400">
                 Copy a link to this group
               </div>
             )}
@@ -254,7 +254,7 @@ const GroupActions = React.memo(
           <Link to={`/groups/${flag}/members`}>
             Group members{' '}
             {isMobile && (
-              <div className="pt-1.5 text-[14px] text-gray-400">
+              <div className="pt-1.5 text-[14px] font-normal text-gray-400">
                 View all members and roles
               </div>
             )}
@@ -270,7 +270,7 @@ const GroupActions = React.memo(
           <Link to={`/groups/${flag}/channels`}>
             Channels{' '}
             {isMobile && (
-              <div className="pt-1.5 text-[14px] text-gray-400">
+              <div className="pt-1.5 text-[14px] font-normal text-gray-400">
                 View all channels and sections you have visibility towards
               </div>
             )}
@@ -294,7 +294,7 @@ const GroupActions = React.memo(
           <div>
             Group notification settings
             {isMobile && (
-              <div className="pt-1.5 text-[14px] text-gray-400">
+              <div className="pt-1.5 text-[14px] font-normal text-gray-400">
                 Configure your notifications for this group
               </div>
             )}
@@ -309,7 +309,7 @@ const GroupActions = React.memo(
         <div className="-mx-2 flex flex-col space-y-6">
           <div className="flex flex-col space-y-1">
             <span className="text-lg text-gray-800">Notification Settings</span>
-            <span className="font-[17px] text-gray-400">
+            <span className="font-normal text-gray-400">
               {group?.meta.title || `~${flag}`}
             </span>
           </div>

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -319,7 +319,7 @@ const GroupActions = React.memo(
       keepOpenOnClick: true,
     });
 
-    if (!flag.includes(ship)) {
+    if (!flag.includes(ship) && !isAdmin) {
       actions.push({
         key: 'leave',
         type: 'destructive',

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -24,7 +24,7 @@ import {
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import { Saga } from '@/types/groups';
 import { ConnectionStatus } from '@/state/vitals';
-// import HostConnection from '@/channels/HostConnection';
+import HostConnection from '@/channels/HostConnection';
 import { useIsMobile } from '@/logic/useMedia';
 import VolumeSetting from '@/components/VolumeSetting';
 import {
@@ -63,7 +63,7 @@ export function useGroupActions({
   }, [open, setIsOpen]);
 
   const { doCopy } = useCopy(citeToPath({ group: flag }));
-  const [copyItemText, setCopyItemText] = useState('Copy group link');
+  const [copyItemText, setCopyItemText] = useState('Copy group reference');
   const pinned = usePinnedGroups();
   const isPinned = Object.keys(pinned).includes(flag);
 
@@ -71,7 +71,7 @@ export function useGroupActions({
     doCopy();
     setCopyItemText('Copied!');
     setTimeout(() => {
-      setCopyItemText('Copy Group Link');
+      setCopyItemText('Copy group reference');
       handleOpenChange(false);
     }, 2000);
   }, [doCopy, handleOpenChange]);
@@ -160,15 +160,22 @@ const GroupActions = React.memo(
       });
     }
 
-    // if (saga && isMobile) {
-    //   actions.push({
-    //     key: 'connectivity',
-    //     keepOpenOnClick: true,
-    //     content: (
-
-    //     ),
-    //   });
-    // }
+    if (saga && isMobile) {
+      actions.push({
+        key: 'connection',
+        keepOpenOnClick: true,
+        containerClassName: 'border border-gray-100 rounded-xl mb-4',
+        content: (
+          <HostConnection
+            ship={getFlagParts(flag).ship}
+            status={status}
+            saga={saga}
+            type="row"
+            className=""
+          />
+        ),
+      });
+    }
 
     if (privacy === 'public' || isAdmin) {
       actions.push({
@@ -239,7 +246,7 @@ const GroupActions = React.memo(
             {copyItemText}
             {isMobile && (
               <div className="pt-1.5 text-[14px] font-normal text-gray-400">
-                Copy a link to this group
+                Copy an in-Urbit link to this group
               </div>
             )}
           </div>

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -164,7 +164,7 @@ const GroupActions = React.memo(
       actions.push({
         key: 'connection',
         keepOpenOnClick: true,
-        containerClassName: 'border border-gray-100 rounded-xl mb-4',
+        containerClassName: '!p-0 mb-4',
         content: (
           <HostConnection
             ship={getFlagParts(flag).ship}

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -24,7 +24,7 @@ import {
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import { Saga } from '@/types/groups';
 import { ConnectionStatus } from '@/state/vitals';
-import HostConnection from '@/channels/HostConnection';
+// import HostConnection from '@/channels/HostConnection';
 import { useIsMobile } from '@/logic/useMedia';
 import VolumeSetting from '@/components/VolumeSetting';
 import {
@@ -63,7 +63,7 @@ export function useGroupActions({
   }, [open, setIsOpen]);
 
   const { doCopy } = useCopy(citeToPath({ group: flag }));
-  const [copyItemText, setCopyItemText] = useState('Copy Group Link');
+  const [copyItemText, setCopyItemText] = useState('Copy group link');
   const pinned = usePinnedGroups();
   const isPinned = Object.keys(pinned).includes(flag);
 
@@ -144,26 +144,38 @@ const GroupActions = React.memo(
     const actions: Action[] = [];
     const notificationActions: Action[] = [];
 
-    if (saga && isMobile) {
+    if (isMobile) {
       actions.push({
-        key: 'connectivity',
+        key: 'header',
         keepOpenOnClick: true,
+        containerClassName: '!px-2 !py-0 mt-4 mb-6',
         content: (
-          <HostConnection
-            ship={getFlagParts(flag).ship}
-            status={status}
-            saga={saga}
-            type="combo"
-            className="-ml-1 text-[17px] font-medium text-gray-800"
-          />
+          <div className="leading-6">
+            <div className="text-gray-800">
+              {group?.meta.title || `~${flag}`}
+            </div>
+            <div className="font-[17px] text-gray-400">Quick actions</div>
+          </div>
         ),
       });
     }
+
+    // if (saga && isMobile) {
+    //   actions.push({
+    //     key: 'connectivity',
+    //     keepOpenOnClick: true,
+    //     content: (
+
+    //     ),
+    //   });
+    // }
 
     if (privacy === 'public' || isAdmin) {
       actions.push({
         key: 'invite',
         type: 'prominent',
+        containerClassName:
+          'border border-blue-soft mb-4 md:mb-0 md:border-none',
         content: (
           <Link
             to={`/groups/${flag}/invite`}
@@ -175,23 +187,96 @@ const GroupActions = React.memo(
       });
     }
 
-    notificationActions.push({
-      key: 'volume',
-      content: (
-        <div className="-mx-2 flex flex-col space-y-6">
-          <div className="flex flex-col space-y-1">
-            <span className="text-lg text-gray-800">Notification Settings</span>
-            <span className="font-normal font-[17px] text-gray-400">
-              {group?.meta.title || `~${flag}`}
-            </span>
-          </div>
-          <VolumeSetting scope={{ group: flag }} />
-        </div>
-      ),
-      keepOpenOnClick: true,
-    });
+    if (isAdmin) {
+      actions.push({
+        key: 'settings',
+        onClick: () => setIsOpen(false),
+        containerClassName:
+          'border border-gray-100 md:border-none mb-4 md:mb-0',
+        content: (
+          <Link
+            to={`/groups/${flag}/edit`}
+            state={{ backgroundLocation: location }}
+          >
+            Group settings
+            {isMobile && (
+              <div className="pt-1.5 text-[14px] text-gray-400">
+                Configure group details and privacy
+              </div>
+            )}
+          </Link>
+        ),
+      });
+    }
 
     actions.push(
+      {
+        key: 'pin',
+        onClick: onPinClick,
+        containerClassName:
+          'border border-gray-100 md:border-none rounded-b-none',
+        content: (
+          <div>
+            {isPinned ? 'Unpin' : 'Pin'}
+            {isMobile && (
+              <div className="pt-1.5 text-[14px] text-gray-400">
+                {isPinned ? 'Unpin this group from' : 'Pin this group to'} the
+                top of your Groups list
+              </div>
+            )}
+          </div>
+        ),
+      },
+
+      {
+        key: 'copy',
+        onClick: onCopySelect,
+        keepOpenOnClick: true,
+        containerClassName:
+          'border border-gray-100 border-t-0 md:border-none rounded-t-none rounded-b-none',
+        content: (
+          <div>
+            {copyItemText}
+            {isMobile && (
+              <div className="pt-1.5 text-[14px] text-gray-400">
+                Copy a link to this group
+              </div>
+            )}
+          </div>
+        ),
+      },
+      {
+        key: 'members',
+        onClick: () => setIsOpen(false),
+        containerClassName:
+          'border border-gray-100 border-t-0 md:border-none rounded-t-none rounded-b-none',
+        content: (
+          <Link to={`/groups/${flag}/members`}>
+            Group members{' '}
+            {isMobile && (
+              <div className="pt-1.5 text-[14px] text-gray-400">
+                View all members and roles
+              </div>
+            )}
+          </Link>
+        ),
+      },
+      {
+        key: 'channels',
+        onClick: () => setIsOpen(false),
+        containerClassName:
+          'border border-gray-100 border-t-0 md:border-none rounded-t-none rounded-b-none',
+        content: (
+          <Link to={`/groups/${flag}/channels`}>
+            Channels{' '}
+            {isMobile && (
+              <div className="pt-1.5 text-[14px] text-gray-400">
+                View all channels and sections you have visibility towards
+              </div>
+            )}
+          </Link>
+        ),
+      },
       {
         key: 'notifications',
         onClick: () => {
@@ -203,50 +288,48 @@ const GroupActions = React.memo(
             });
           }
         },
-        content: 'Notifications',
-      },
-      {
-        key: 'copy',
-        onClick: onCopySelect,
-        content: copyItemText,
-        keepOpenOnClick: true,
-      },
-      {
-        key: 'pin',
-        onClick: onPinClick,
-        content: isPinned ? 'Unpin' : 'Pin',
-      },
-      {
-        key: 'settings',
-        onClick: () => setIsOpen(false),
-        content: isAdmin ? (
-          <Link
-            to={`/groups/${flag}/edit`}
-            state={{ backgroundLocation: location }}
-          >
-            Group Settings
-          </Link>
-        ) : (
-          <Link
-            to={`/groups/${flag}/info`}
-            state={{ backgroundLocation: location }}
-          >
-            Group Members & Info
-          </Link>
+        containerClassName:
+          'border border-gray-100 border-t-0 md:border-none rounded-t-none',
+        content: (
+          <div>
+            Group notification settings
+            {isMobile && (
+              <div className="pt-1.5 text-[14px] text-gray-400">
+                Configure your notifications for this group
+              </div>
+            )}
+          </div>
         ),
       }
     );
+
+    notificationActions.push({
+      key: 'volume',
+      content: (
+        <div className="-mx-2 flex flex-col space-y-6">
+          <div className="flex flex-col space-y-1">
+            <span className="text-lg text-gray-800">Notification Settings</span>
+            <span className="font-[17px] text-gray-400">
+              {group?.meta.title || `~${flag}`}
+            </span>
+          </div>
+          <VolumeSetting scope={{ group: flag }} />
+        </div>
+      ),
+      keepOpenOnClick: true,
+    });
 
     if (!flag.includes(ship)) {
       actions.push({
         key: 'leave',
         type: 'destructive',
+        containerClassName: 'border border-red-soft md:border-none mt-4',
         content: (
           <Link
             to={`/groups/${flag}/leave`}
             state={{ backgroundLocation: location }}
           >
-            Leave Group
+            Leave group
           </Link>
         ),
       });
@@ -256,11 +339,12 @@ const GroupActions = React.memo(
       actions.push({
         key: 'cancel_join',
         type: 'destructive',
+        containerClassName: 'border border-red-soft md:border-none mt-4',
         onClick: () => {
           cancelJoinMutation({ flag });
           setIsOpen(false);
         },
-        content: 'Cancel Join',
+        content: 'Cancel join',
       });
     }
 

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -201,48 +201,9 @@ const ChannelList = React.memo(({ paddingTop }: { paddingTop?: number }) => {
     if (!isMobile) {
       return <ChannelSorter isMobile={false} />;
     }
-
-    return (
-      <div className={cn('mx-4 sm:mx-2', paddingTop && `pt-${paddingTop}`)}>
-        <SidebarItem
-          icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-50">
-              <HashIcon className="m-1 h-6 w-6 text-gray-800" />
-            </div>
-          }
-          to={`/groups/${flag}/channels`}
-          actions={<CaretRightIcon className="h-6 w-6 text-gray-800" />}
-        >
-          Channels
-        </SidebarItem>
-        <SidebarItem
-          icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-50">
-              <SmileIcon className="m-1 h-6 w-6 text-gray-800" />
-            </div>
-          }
-          to="./members"
-          actions={<CaretRightIcon className="h-6 w-6 text-gray-800" />}
-        >
-          Members
-        </SidebarItem>
-        <SidebarItem
-          color="text-blue"
-          highlight="bg-blue-soft"
-          icon={
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-soft">
-              <PlaneIcon className="h-6 w-6" />
-            </div>
-          }
-          to={`/groups/${flag}/invite`}
-          state={{ backgroundLocation: location }}
-          actions={<ElipsisIcon className="h-6 w-6 text-blue" />}
-        >
-          Invite People
-        </SidebarItem>
-      </div>
-    );
-  }, [isMobile, flag, location, paddingTop]);
+    // TODO: Add welcome message to group for admins and non-admins
+    return <div className={cn(paddingTop && `pt-${paddingTop}`)} />;
+  }, [isMobile, paddingTop]);
 
   const renderSectionHeader = useCallback(
     (section: string) => <Divider isMobile={isMobile}>{section}</Divider>,

--- a/ui/src/groups/GroupSidebar/ChannelList.tsx
+++ b/ui/src/groups/GroupSidebar/ChannelList.tsx
@@ -1,5 +1,4 @@
 import cn from 'classnames';
-import { useLocation } from 'react-router';
 import React, {
   useCallback,
   useEffect,
@@ -29,16 +28,11 @@ import {
   canReadChannel,
 } from '@/logic/channel';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
-import HashIcon from '@/components/icons/HashIcon';
 import useFilteredSections from '@/logic/useFilteredSections';
 import GroupListPlaceholder from '@/components/Sidebar/GroupListPlaceholder';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import FilterIconMobileNav from '@/components/icons/FilterIconMobileNav';
-import CaretRightIcon from '@/components/icons/CaretRightIcon';
-import ElipsisIcon from '@/components/icons/EllipsisIcon';
-import SmileIcon from '@/components/icons/SmileIcon';
-import PlaneIcon from '@/components/icons/PlaneIcon';
 import { DEFAULT_SORT } from '@/constants';
 
 const UNZONED = 'default';
@@ -139,8 +133,6 @@ const ChannelList = React.memo(({ paddingTop }: { paddingTop?: number }) => {
   const vessel = useVessel(flag, window.our);
   const isChannelJoined = useCheckChannelJoined();
   const isChannelUnread = useCheckChannelUnread();
-  const location = useLocation();
-
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   useEffect(() => {

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -1088,14 +1088,14 @@ export function getPendingText(status: ConnectionPendingStatus, ship: string) {
 
 export function getConnectionColor(status?: ConnectionStatus) {
   if (!status) {
-    return 'text-gray-400';
+    return 'gray';
   }
 
   if ('pending' in status) {
-    return 'text-yellow-400';
+    return 'yellow';
   }
 
-  return status.complete === 'yes' ? 'text-green-400' : 'text-red-400';
+  return status.complete === 'yes' ? 'green' : 'red';
 }
 
 export function getCompatibilityText(saga: Saga | null) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -97,7 +97,7 @@
 }
 
 .dropdown-item {
-  @apply cursor-pointer rounded p-2 text-left text-[17px] no-underline ring-gray-200 hover:bg-gray-50 focus:outline-none sm:text-sm;
+  @apply cursor-pointer rounded p-2 text-left text-[17px] font-medium no-underline ring-gray-200 hover:bg-gray-50 focus:outline-none sm:text-sm;
 }
 
 .dropdown-item > a {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -97,7 +97,7 @@
 }
 
 .dropdown-item {
-  @apply cursor-pointer rounded p-2 text-left text-[17px] font-medium no-underline ring-gray-200 hover:bg-gray-50 focus:outline-none sm:text-sm;
+  @apply cursor-pointer rounded p-2 text-left text-[17px] no-underline ring-gray-200 hover:bg-gray-50 focus:outline-none sm:text-sm;
 }
 
 .dropdown-item > a {


### PR DESCRIPTION
Fixes LAND-1397. 

Brings GroupActions into alignment with the design linked in LAND-1397:
- Adds a "row" mode to HostConnection to fit the sheet design
- Groups common actions together and adds spacing between groups
- Adds subtitles to each action
- Conditionally hides/shows the "Leave group" option for members (vs admins, who should 'delete' the group or ask to have their role removed)
- Removes the "Channels" | "Members" | "Invite People" items from the top of the mobile ChannelList and adds a TODO to add the welcome bubble for admins who have created a new group.

Note that this PR converts all ActionMenus to use the "sheet" treatment on mobile (full-width, no gutter, attached to screen bottom). This PR also only touches the contents of the GroupActions dropdown/sheet.

This PR does *not* unify the GroupActions dropdown/sheet with any other dropdown/sheet (LAND-1221). We will need to update all action dropdown/sheets to match this new design (search in the codebase for `actions.push({` for an idea of the scope of change involved).

Revised group home with no options other than channels:
![image](https://github.com/tloncorp/landscape-apps/assets/748181/89e23144-f020-460f-88ad-31d762b761db)

A group we don't administrate with no public invites:
![image](https://github.com/tloncorp/landscape-apps/assets/748181/ad2320ea-2991-40bb-b906-8df417deb907)

A group we don't administrate with public invites:
![image](https://github.com/tloncorp/landscape-apps/assets/748181/81ae36ac-d1d2-4015-98f6-c8b42b303058)

A group we administrate (doesn't matter if invites are on/off, we're administrators and can enable links if we want to using the "Invite People" menu):
![image](https://github.com/tloncorp/landscape-apps/assets/748181/b7668fa1-e209-42c2-a50a-ef242b131bce)


