### PR TITLE
groups: add SoundCloud embeds

### DIFF
--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -8,6 +8,7 @@ import DOMPurify from 'dompurify';
 import YouTubeEmbed from './YouTubeEmbed';
 import TwitterEmbed from './TwitterEmbed';
 import SpotifyEmbed from './SpotifyEmbed';
+import SoundcloudEmbed from './SoundcloudEmbed';
 import AudioPlayer from './AudioPlayer';
 
 const trustedProviders = [
@@ -22,6 +23,10 @@ const trustedProviders = [
   {
     name: 'Spotify',
     regex: /^https:\/\/open\.spotify\.com\//,
+  },
+  {
+    name: 'SoundCloud',
+    regex: /^https:\/\/soundcloud\.com\//,
   },
 ];
 
@@ -133,6 +138,15 @@ function ChatEmbedContent({
           />
         </div>
       );
+    }
+
+    if (provider === 'SoundCloud') {
+      // SoundCloud offers an iframe we can embed, so we have to explicitly allow
+      // that via DOMPurify.
+      const embedIframe = DOMPurify.sanitize(rawEmbedHtml, {
+        ADD_TAGS: ['iframe'],
+      });
+      return <SoundcloudEmbed iframe={embedIframe} />;
     }
 
     return (

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -141,8 +141,8 @@ function ChatEmbedContent({
     }
 
     if (provider === 'SoundCloud') {
-      // SoundCloud offers an iframe we can embed, so we have to explicitly allow
-      // that via DOMPurify.
+      // SoundCloud makes their API url available in an iframe,
+      // so we need to leave that unsanitized
       const embedIframe = DOMPurify.sanitize(rawEmbedHtml, {
         ADD_TAGS: ['iframe'],
       });

--- a/ui/src/chat/ChatEmbedContent/SoundcloudEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/SoundcloudEmbed.tsx
@@ -7,6 +7,24 @@ interface SoundcloudEmbedProps {
 export default function SoundcloudEmbed({
   iframe: rawIframe,
 }: SoundcloudEmbedProps) {
-  const iframe = DOMPurify.sanitize(rawIframe, { ADD_TAGS: ['iframe'] });
-  return <div dangerouslySetInnerHTML={{ __html: iframe }} />;
+  const element = document.createElement('html');
+  element.innerHTML = DOMPurify.sanitize(rawIframe, {
+    ALLOWED_TAGS: ['iframe'],
+  });
+  const soundcloudApiUrl =
+    Array.from(element.querySelectorAll('iframe'))
+      .filter((iframe) =>
+        iframe.src.startsWith('https://w.soundcloud.com/player/')
+      )[0]
+      .getAttribute('src') || '';
+
+  return (
+    <iframe
+      width="600"
+      height="400"
+      scrolling="no"
+      frameBorder="no"
+      src={soundcloudApiUrl}
+    />
+  );
 }

--- a/ui/src/chat/ChatEmbedContent/SoundcloudEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/SoundcloudEmbed.tsx
@@ -1,0 +1,12 @@
+import DOMPurify from 'dompurify';
+
+interface SoundcloudEmbedProps {
+  iframe: string;
+}
+
+export default function SoundcloudEmbed({
+  iframe: rawIframe,
+}: SoundcloudEmbedProps) {
+  const iframe = DOMPurify.sanitize(rawIframe, { ADD_TAGS: ['iframe'] });
+  return <div dangerouslySetInnerHTML={{ __html: iframe }} />;
+}

--- a/ui/src/chat/ChatEmbedContent/SoundcloudEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/SoundcloudEmbed.tsx
@@ -20,8 +20,8 @@ export default function SoundcloudEmbed({
 
   return (
     <iframe
-      width="600"
-      height="400"
+      width="300"
+      height="200"
       scrolling="no"
       frameBorder="no"
       src={soundcloudApiUrl}

--- a/ui/src/state/embed.ts
+++ b/ui/src/state/embed.ts
@@ -32,6 +32,12 @@ export async function fetchEmbed(inputUrl: string, isMobile?: boolean) {
     return embed;
   }
 
+  const isTumblr = /^https:\/\/[^\.]+\.tumblr\.com\/post\/[0-9]+/.test(url); // eslint-disable-line no-useless-escape
+  if (isTumblr) {
+    // noembed doesn't support tumblr
+    embed = await jsonFetch(`https://www.tumblr.com/oembed/1.0?url=${url}`);
+    return embed;
+  }
   embed = await jsonFetch(`${OEMBED_PROVIDER}?${search.toString()}`);
   return embed;
 }

--- a/ui/src/state/embed.ts
+++ b/ui/src/state/embed.ts
@@ -32,12 +32,6 @@ export async function fetchEmbed(inputUrl: string, isMobile?: boolean) {
     return embed;
   }
 
-  const isTumblr = /^https:\/\/[^\.]+\.tumblr\.com\/post\/[0-9]+/.test(url); // eslint-disable-line no-useless-escape
-  if (isTumblr) {
-    // noembed doesn't support tumblr
-    embed = await jsonFetch(`https://www.tumblr.com/oembed/1.0?url=${url}`);
-    return embed;
-  }
   embed = await jsonFetch(`${OEMBED_PROVIDER}?${search.toString()}`);
   return embed;
 }


### PR DESCRIPTION
SoundCloud already works via Noembed, so supporting it in groups is very simple. Here's what it looks like:

![Screenshot 2023-12-15 at 3 08 52](https://github.com/tloncorp/landscape-apps/assets/104947308/834004c9-2d27-4808-abbb-beedca04dba4)

Originally, I rendered whatever `iframe` SoundCloud gave me, like so...

```typescript
  const iframe = DOMPurify.sanitize(rawIframe, { ADD_TAGS: ['iframe'] });
  return <div dangerouslySetInnerHTML={{ __html: iframe }} />;
```

Bad! What if a sneaky hacker snuck some untrusted HTML into the `SoundcloudEmbed` component somehow? They could load any iframe they want! 

So we can either:

1. Hope there's no way to sneak in a malicious `iframe`, or
2. Make the iframe myself from the URL

Option 2 is the right option. However, maybe my implementation of option 2 is really bad! That's okay, criticism is welcome.

---

PS - Tumblr and DeviantArt also support oembed (though not via noembed) and I added them. But I removed them for this PR, because I perceived that maybe they wouldn't be as desirable as SoundCloud. If I miscalculated, let me know, and I can add them back in.