### PR TITLE
dm threads: account for mismatched keys when checking if we have a message after refetching

### DIFF
--- a/ui/src/chat/ChatSearch/ChatSearchResult.tsx
+++ b/ui/src/chat/ChatSearch/ChatSearchResult.tsx
@@ -41,8 +41,12 @@ function ChatSearchResult({
     return writ.seal.id;
   }, [writ, time]);
   const isReply = 'parent-id' in writ.seal;
+  const replyScrollTo =
+    isReply && 'time' in writ.seal ? `?thread-msg=${writ.seal.time}` : '';
   const scrollTo = `?msg=${postId}`;
-  const to = isReply ? `${root}/message/${postId}` : `${root}${scrollTo}`;
+  const to = isReply
+    ? `${root}/message/${postId}${replyScrollTo}`
+    : `${root}${scrollTo}`;
   const content = useMemo(() => {
     if ('essay' in writ) {
       return writ.essay.content;

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -1,28 +1,28 @@
-import {
-  ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import bigInt from 'big-integer';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
 import DMUnreadAlerts from '@/chat/DMUnreadAlerts';
 import { useInfiniteDMs, useMarkDmReadMutation } from '@/state/chat';
 import ArrowS16Icon from '@/components/icons/ArrowS16Icon';
-import { log } from '@/logic/utils';
+import { getPatdaParts, log } from '@/logic/utils';
 import { useChatInfo, useChatStore } from '@/chat/useChatStore';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import { useIsScrolling } from '@/logic/scroll';
 import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
 import { udToDec } from '@urbit/api';
+import { WritTuple } from '@/types/dms';
 
 interface DmWindowProps {
   whom: string;
   root: string;
   prefixedElement?: ReactElement;
+}
+
+function checkWritMatch(writ: WritTuple, scrollTo: string) {
+  const writServerTime = writ[0].toString();
+  const { timeDec } = getPatdaParts(writ[1].seal.id);
+  return scrollTo === writServerTime || scrollTo === timeDec;
 }
 
 export default function DmWindow({
@@ -61,14 +61,14 @@ export default function DmWindow({
   const msgIdTimeIndex = useMemo(
     () =>
       scrollToId
-        ? writs.findIndex((m) => m[0].toString() === scrollToId)
+        ? writs.findIndex((writ) => checkWritMatch(writ, scrollToId))
         : latestMessageIndex,
     [scrollToId, writs, latestMessageIndex]
   );
   const msgIdTimeInMessages = useMemo(
     () =>
       scrollToId
-        ? writs.findIndex((m) => m[0].toString() === scrollToId) !== -1
+        ? writs.findIndex((writ) => checkWritMatch(writ, scrollToId)) !== -1
         : false,
     [scrollToId, writs]
   );

--- a/ui/src/dms/DmWindow.tsx
+++ b/ui/src/dms/DmWindow.tsx
@@ -58,25 +58,23 @@ export default function DmWindow({
   const navigate = useNavigate();
 
   const latestMessageIndex = writs.length - 1;
-  const msgIdTimeIndex = useMemo(
+  const scrollToIndex = useMemo(
     () =>
       scrollToId
         ? writs.findIndex((writ) => checkWritMatch(writ, scrollToId))
-        : latestMessageIndex,
-    [scrollToId, writs, latestMessageIndex]
-  );
-  const msgIdTimeInMessages = useMemo(
-    () =>
-      scrollToId
-        ? writs.findIndex((writ) => checkWritMatch(writ, scrollToId)) !== -1
-        : false,
+        : -1,
     [scrollToId, writs]
+  );
+  const scrollToInMessages = useMemo(
+    () => scrollToIndex !== -1,
+    [scrollToIndex]
   );
   const latestIsMoreThan30NewerThanScrollTo = useMemo(
     () =>
-      msgIdTimeIndex !== latestMessageIndex &&
-      latestMessageIndex - msgIdTimeIndex > 30,
-    [msgIdTimeIndex, latestMessageIndex]
+      scrollToInMessages &&
+      scrollToIndex !== latestMessageIndex &&
+      latestMessageIndex - scrollToIndex > 30,
+    [scrollToInMessages, scrollToIndex, latestMessageIndex]
   );
 
   const onAtBottom = useCallback(() => {
@@ -153,10 +151,10 @@ export default function DmWindow({
     // not in our current set of messages, that means we're scrolling to a
     // message that's not yet cached. So, we need to refetch (which would fetch
     // messages around the scrollTo time), then scroll to the message.
-    if (scrollToId && hasNextPage && !msgIdTimeInMessages) {
+    if (scrollToId && hasNextPage && !scrollToInMessages) {
       doRefetch();
     }
-  }, [scrollToId, hasNextPage, refetch, msgIdTimeInMessages, remove]);
+  }, [scrollToId, hasNextPage, refetch, scrollToInMessages, remove]);
 
   if (isLoading) {
     return (

--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -7,6 +7,7 @@ import {
   Docket,
   DocketHref,
   Treaty,
+  udToDec,
   unixToDa,
 } from '@urbit/api';
 import { formatUv } from '@urbit/aura';
@@ -313,6 +314,16 @@ export function newUv(seed = Date.now()) {
 
 export function getSectTitle(cabals: Cabals, sect: string) {
   return cabals[sect]?.meta.title || sect;
+}
+
+export function getPatdaParts(patda: string) {
+  const parts = patda.split('/');
+
+  return {
+    ship: parts[0],
+    time: parts[1],
+    timeDec: udToDec(parts[1]),
+  };
 }
 
 export function getFlagParts(flag: string) {


### PR DESCRIPTION
In `DmWindow` when refetching to get a "scroll to" message, we can get stuck in a refetch loop if for some reason we get a successful scry but still don't see the message we're looking for in the result. This can happen in DM threads where we sometimes check against the wrong key to determine whether or not we have the message in question.

This PR avoids the refetch loop in these situations by making the logic for determining whether or not we have a message more robust.

Fixes LAND-1416

To test this, run two ships against `develop` and have a DM between them which exceeds the single page limit of 50 messages (needed to trigger the conditional). If you navigate to a thread in the DM, you'll get the loop.