### PR TITLE
add fallback rendering of tweet content

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16192,8 +16192,9 @@
       }
     },
     "node_modules/react-tweet": {
-      "version": "3.0.4",
-      "license": "MIT",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.1.1.tgz",
+      "integrity": "sha512-8GQLa5y0G56kvGQkN7OiaKkjFAhWYVdyFq62ioY2qVtpMrjchVU+3KnqneCyp0+BemOQZkg6WWp/qoCNeEMH6A==",
       "dependencies": {
         "@swc/helpers": "^0.5.1",
         "clsx": "^1.2.1",
@@ -28831,7 +28832,9 @@
       }
     },
     "react-tweet": {
-      "version": "3.0.4",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.1.1.tgz",
+      "integrity": "sha512-8GQLa5y0G56kvGQkN7OiaKkjFAhWYVdyFq62ioY2qVtpMrjchVU+3KnqneCyp0+BemOQZkg6WWp/qoCNeEMH6A==",
       "requires": {
         "@swc/helpers": "^0.5.1",
         "clsx": "^1.2.1",

--- a/ui/src/chat/ChatEmbedContent/TwitterEmbed.tsx
+++ b/ui/src/chat/ChatEmbedContent/TwitterEmbed.tsx
@@ -1,6 +1,7 @@
-import TwitterIcon from '@/components/icons/TwitterIcon';
+/* eslint-disable react/no-danger */
 import { Tweet, useTweet } from 'react-tweet';
 import DOMPurify from 'dompurify';
+import TwitterXIcon from '@/components/icons/TwitterXIcon';
 
 interface TwitterEmbedProps {
   embedHtml: string;
@@ -22,16 +23,23 @@ export default function TwitterEmbed({ embedHtml }: TwitterEmbedProps) {
       ?.split('?')[0] || '';
 
   const tweetIdFromUrl = tweetUrl.split('/status/')[1];
-  const { data, isLoading } = useTweet(tweetIdFromUrl);
+  const { data, isLoading, error } = useTweet(tweetIdFromUrl);
 
-  if (!isLoading && data && 'tombstone' in data) {
+  if (error || (!isLoading && data && 'tombstone' in data)) {
     return (
-      <div className="embed-inline-block items-center">
-        <TwitterIcon className="h-8 w-8" />
-        <h1>Tweet not found</h1>
-        <a href={tweetUrl} target="_blank" rel="noopener noreferrer">
-          {tweetUrl}
+      <div className="embed-inline-block items-center pr-10">
+        <a
+          href={tweetUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute bottom-2 right-2"
+          title="View on X"
+        >
+          <TwitterXIcon className="h-5 w-5 text-gray-500" />
         </a>
+        <div
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(embedHtml) }}
+        />
       </div>
     );
   }

--- a/ui/src/components/icons/TwitterXIcon.tsx
+++ b/ui/src/components/icons/TwitterXIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { IconProps } from './icon';
+
+export default function TwitterXIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M16.9947 4.14917H19.6582L13.8391 10.8007L20.6853 19.85H15.325L11.1271 14.3609L6.32265 19.85H3.65771L9.88218 12.7353L3.31464 4.14989H8.81099L12.6058 9.16711L16.9947 4.14917ZM16.0603 18.2563H17.5361L8.00905 5.65969H6.42543L16.0603 18.2563Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
- Updates `react-tweet` API fallback to display the tweet contents that we got from `noembed.com`
- Updates `react-tweet` module to the latest version
- Updates icon to use new X logo

Before

<img width="622" alt="Screenshot 2023-12-16 at 8 42 27 AM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/b7044b24-1fc6-48f6-a8a9-24e2d28d9627">

After

<img width="621" alt="Screenshot 2023-12-16 at 8 51 53 AM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/04ce58ed-ac76-41e4-85a3-297567ca3870">
