### PR TITLE
welcome card: update style, copy, and behavior

### DIFF
--- a/ui/src/components/WelcomeCard.tsx
+++ b/ui/src/components/WelcomeCard.tsx
@@ -1,42 +1,68 @@
-import { Link } from 'react-router-dom';
-import { useLocalStorage } from 'usehooks-ts';
-
-import { createStorageKey } from '@/logic/utils';
+import { usePutEntryMutation, useSeenWelcomeCard } from '@/state/settings';
+import { useCallback, useState } from 'react';
+import { useIsMobile } from '@/logic/useMedia';
+import X16Icon from './icons/X16Icon';
 
 export default function WelcomeCard() {
-  const [isWelcomeSeen, setIsWelcomeSeen] = useLocalStorage<boolean>(
-    createStorageKey('welcome-seen'),
-    false
-  );
+  const isMobile = useIsMobile();
+  const alreadySeen = useSeenWelcomeCard();
+  const { mutate } = usePutEntryMutation({
+    bucket: 'groups',
+    key: 'seenWelcomeCard',
+  });
+  const [optimisticallyHide, setOptimisticallyHide] = useState(false);
 
-  if (isWelcomeSeen) {
+  const close = useCallback(() => {
+    setOptimisticallyHide(true);
+    mutate({ val: true });
+  }, [mutate]);
+
+  if (alreadySeen || optimisticallyHide) {
     return null;
   }
 
-  return (
-    <div className="mx-4 mt-1 mb-4 space-y-4 rounded-2xl bg-blue-soft p-4 text-blue-700 dark:text-black">
-      <h3 className="text-lg font-medium">Welcome to our pilot program</h3>
-      <p className="leading-5">
-        Tlon is built on an open source, user-owned network. This presents
-        unique development challenges. You may encounter turbulence while we
-        make the experience as smooth as any other app. Help us improve by
-        providing feedback.
-      </p>
-      <div className="space-x-3 text-right font-medium">
-        <button
-          className="rounded-lg bg-transparent px-4 py-2.5 active:opacity-90"
-          onClick={() => setIsWelcomeSeen(true)}
-        >
-          Close
-        </button>
-        <Link
-          to="/profile"
-          className="rounded-lg bg-blue-700 px-4 py-2.5 text-blue-soft active:opacity-90  dark:bg-black"
-          onClick={() => setIsWelcomeSeen(true)}
-        >
-          Go to Profile
-        </Link>
+  if (isMobile) {
+    return (
+      <div className="mx-6 mt-2 mb-4 space-y-4 rounded-[32px] bg-green-soft py-6 px-8">
+        <h3 className="text-lg font-medium">Welcome to Tlon</h3>
+        <p className="leading-5">
+          This is Tlon: An app for messaging friends and constructing
+          communities.
+        </p>
+        <p className="leading-5">
+          Visit the{' '}
+          <span className="font-semibold dark:font-bold">Tlon Studio</span>{' '}
+          group to learn more about what we&#39;re working on now
+        </p>
+        <div className="space-x-3 text-right font-medium">
+          <button
+            className="mt-2 rounded-lg py-2 px-3 active:opacity-90 dark:bg-green-800"
+            onClick={() => close()}
+          >
+            Close
+          </button>
+        </div>
       </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 mb-8 max-w-[800px] space-y-2 rounded-xl bg-green-soft p-6">
+      <div className="flex w-full justify-between">
+        <h3 className="text-lg font-medium">Welcome to Tlon</h3>
+        <button
+          className="relative bottom-3 left-3 rounded-full p-1 dark:bg-green-800"
+          onClick={() => close()}
+        >
+          <X16Icon className="h-4 w-4" />
+        </button>
+      </div>
+      <p className="leading-5">
+        This is Tlon: An app for messaging friends and constructing communities.
+        Visit the{' '}
+        <span className="font-semibold dark:font-bold">Tlon Studio</span> group
+        to learn more about what we&#39;re working on now.
+      </p>
     </div>
   );
 }

--- a/ui/src/components/WelcomeCard.tsx
+++ b/ui/src/components/WelcomeCard.tsx
@@ -1,10 +1,12 @@
 import { usePutEntryMutation, useSeenWelcomeCard } from '@/state/settings';
 import { useCallback, useState } from 'react';
 import { useIsMobile } from '@/logic/useMedia';
+import { Link, useLocation } from 'react-router-dom';
 import X16Icon from './icons/X16Icon';
 
 export default function WelcomeCard() {
   const isMobile = useIsMobile();
+  const location = useLocation();
   const alreadySeen = useSeenWelcomeCard();
   const { mutate } = usePutEntryMutation({
     bucket: 'groups',
@@ -16,6 +18,18 @@ export default function WelcomeCard() {
     setOptimisticallyHide(true);
     mutate({ val: true });
   }, [mutate]);
+
+  const TlonStudioLink = useCallback(() => {
+    return (
+      <Link
+        className="font-semibold no-underline dark:font-bold"
+        to="/gangs/~tommur-dostyn/tlon-studio"
+        state={{ backgroundLocation: location }}
+      >
+        Tlon Studio
+      </Link>
+    );
+  }, [location]);
 
   if (alreadySeen || optimisticallyHide) {
     return null;
@@ -30,9 +44,8 @@ export default function WelcomeCard() {
           communities.
         </p>
         <p className="leading-5">
-          Visit the{' '}
-          <span className="font-semibold dark:font-bold">Tlon Studio</span>{' '}
-          group to learn more about what we&#39;re working on now
+          Visit the <TlonStudioLink /> group to learn more about what we&#39;re
+          working on now
         </p>
         <div className="space-x-3 text-right font-medium">
           <button
@@ -59,9 +72,8 @@ export default function WelcomeCard() {
       </div>
       <p className="leading-5">
         This is Tlon: An app for messaging friends and constructing communities.
-        Visit the{' '}
-        <span className="font-semibold dark:font-bold">Tlon Studio</span> group
-        to learn more about what we&#39;re working on now.
+        Visit the <TlonStudioLink /> group to learn more about what we&#39;re
+        working on now.
       </p>
     </div>
   );

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -76,7 +76,7 @@ export default function MobileRoot() {
       }
     >
       <nav className="flex h-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
-        {isNativeApp() ? <WelcomeCard /> : null}
+        <WelcomeCard />
         <div className="flex-1">
           {sortedGroups.length === 0 && !isLoading ? (
             <div className="mx-4 my-2 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -13,6 +13,7 @@ import { Skein } from '@/types/hark';
 import GroupSummary from '@/groups/GroupSummary';
 import MobileHeader from '@/components/MobileHeader';
 import ToggleGroup from '@/components/ToggleGroup';
+import WelcomeCard from '@/components/WelcomeCard';
 import { NotificationFilterType, useNotifications } from './useNotifications';
 
 export interface NotificationsProps {
@@ -216,11 +217,14 @@ export default function Notifications({
 
         <div className="card pt-6">
           {!isMobile && (
-            <div className="mb-6 flex w-full items-center justify-between">
-              <h2 className="text-lg font-bold">
-                {group && 'Group '}Activity{!group && ' in All Groups'}
-              </h2>
-              {hasUnreads && MarkAsRead}
+            <div>
+              <WelcomeCard />
+              <div className="mb-6 flex w-full items-center justify-between">
+                <h2 className="text-lg font-bold">
+                  {group && 'Group '}Activity{!group && ' in All Groups'}
+                </h2>
+                {hasUnreads && MarkAsRead}
+              </div>
             </div>
           )}
           {loaded ? (

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -101,6 +101,7 @@ export interface SettingsState {
     showActivityMessage?: boolean;
     logActivity?: boolean;
     analyticsId?: string;
+    seenWelcomeCard?: boolean;
   };
   loaded: boolean;
   putEntry: (bucket: string, key: string, value: Value) => Promise<void>;
@@ -488,6 +489,19 @@ export function useGroupSideBarSort(): Record<string, SidebarSortMode> {
     const { groups } = data;
 
     return JSON.parse(groups.groupSideBarSort ?? '{"~": "A → Z"}');
+  }, [isLoading, data]);
+}
+
+export function useSeenWelcomeCard() {
+  const { data, isLoading } = useMergedSettings();
+
+  return useMemo(() => {
+    if (isLoading || data === undefined || data.groups === undefined) {
+      console.log('returning default');
+      return true;
+    }
+
+    return data.groups.seenWelcomeCard ?? false;
   }, [isLoading, data]);
 }
 


### PR DESCRIPTION
This brings the welcome card up to date with the copy and styling in Figma. Adapts it to be shown on desktop views as well, positioned above the activity feed on the home screen.

Closed status is no longer stored locally on the frontend, instead its tracked in the settings agent. This means closing the card once will hide it on all clients.

<img width="389" alt="Screenshot 2023-12-18 at 10 13 12 AM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/839650e4-df0c-45f1-a204-8e40bd3d08f8">

<img width="387" alt="Screenshot 2023-12-18 at 10 13 55 AM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/72150b2a-bc4e-4979-af30-fac83b50457b">

<img width="1139" alt="Screenshot 2023-12-18 at 10 15 24 AM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/adf924ba-e76d-423e-8755-18bbc5fa0e09">

<img width="1138" alt="Screenshot 2023-12-18 at 10 14 50 AM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/386502ab-d7b5-441c-9b83-92a0480055e0">



Fixes LAND-1399