### PR TITLE
fix crash when navigating to deleted reply from activity

### DIFF
--- a/ui/src/replies/ReplyMessage.tsx
+++ b/ui/src/replies/ReplyMessage.tsx
@@ -111,7 +111,7 @@ const ReplyMessage = React.memo<
       }: ReplyMessageProps,
       ref
     ) => {
-      const { seal, memo } = reply ?? emptyReply;
+      const { seal, memo } = reply.seal.id ? reply : emptyReply;
       const container = useRef<HTMLDivElement>(null);
       const isThreadOp = seal['parent-id'] === seal.id;
       const isMobile = useIsMobile();

--- a/ui/src/replies/ReplyMessageOptions.tsx
+++ b/ui/src/replies/ReplyMessageOptions.tsx
@@ -53,7 +53,7 @@ export default function ReplyMessageOptions(props: {
     whomParts[0] === 'heap' ||
     whomParts[0] === 'diary';
   const nest = alreadyHaveHan ? whom : `chat/${whom}`;
-  const { seal, memo } = reply ?? emptyReply;
+  const { seal, memo } = reply.seal.id ? reply : emptyReply;
   const groupFlag = useRouteGroup();
   const isAdmin = useAmAdmin(groupFlag);
   const threadParentId = seal['parent-id'];


### PR DESCRIPTION
Fixes crash when you click into an activity notification for a thread reply that was deleted. It still navigates you to a weirdly empty thread, but that can be addressed with better UX at a different time