### PR TITLE
groups: fix issue with deleting gallery item from item page

### DIFF
--- a/ui/src/heap/useCurioActions.ts
+++ b/ui/src/heap/useCurioActions.ts
@@ -1,7 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { decToUd } from '@urbit/api';
-import { Status } from '@/logic/status';
 import { nestToFlag, citeToPath, useCopy } from '@/logic/utils';
 import { useGroupFlag } from '@/state/groups';
 import { useDeletePostMutation, usePostToggler } from '@/state/channel/channel';
@@ -32,19 +31,17 @@ export default function useCurioActions({
 
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const delMutation = useDeletePostMutation();
+  const { mutateAsync, isLoading: isDeleteLoading } = useDeletePostMutation();
 
   const onDelete = useCallback(async () => {
     setMenuOpen(false);
-    delMutation.mutate(
-      { nest, time: decToUd(time) },
-      {
-        onSuccess: () => {
-          navigate(`/groups/${flag}/channels/heap/${chFlag}`);
-        },
-      }
-    );
-  }, [chFlag, time, delMutation, flag, navigate, nest]);
+    try {
+      await mutateAsync({ nest, time: decToUd(time) });
+      navigate(`/groups/${flag}/channels/heap/${chFlag}`);
+    } catch (err) {
+      console.error('Failed to delete curio:', err);
+    }
+  }, [chFlag, time, mutateAsync, flag, navigate, nest]);
 
   const onEdit = useCallback(() => {
     setMenuOpen(false);
@@ -77,7 +74,7 @@ export default function useCurioActions({
     menuOpen,
     setMenuOpen,
     onDelete,
-    isDeleteLoading: delMutation.isLoading,
+    isDeleteLoading,
     onEdit,
     onCopy,
     navigateToCurio,

--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -706,9 +706,13 @@ function removePostFromInfiniteQuery(nest: string, time: string) {
   const deletedId = decToUd(time);
   const currentData = queryClient.getQueryData(queryKey) as any;
   const newPages =
-    currentData?.pages.map((page: any) =>
-      page.filter(([id]: any) => id !== deletedId)
-    ) ?? [];
+    currentData?.pages.map((page: any) => {
+      if (Array.isArray(page)) {
+        return page.filter(([id]: any) => id !== deletedId);
+      }
+
+      return page;
+    }) ?? [];
   queryClient.setQueryData(queryKey, (data: any) => ({
     pages: newPages,
     pageParams: data.pageParams,
@@ -1565,7 +1569,7 @@ export function useDeletePostMutation() {
         if ('post' in event.response) {
           const { id, 'r-post': postResponse } = event.response.post;
           return (
-            id === variables.time &&
+            decToUd(id) === variables.time &&
             'set' in postResponse &&
             postResponse.set === null
           );


### PR DESCRIPTION
- Fixes issue with gallery item not able to be deleted from the item details page
- Fixes the `useDeletePostMutation` hook never firing `onSuccess` because of mismatched time formats