### PR TITLE
chat: make sure we make blue dots on refresh

### DIFF
--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -173,6 +173,8 @@ export function initializeChat({
   queryClient.setQueryData(['dms', 'multi'], () => clubs || {});
   queryClient.setQueryData(ChatKeys.pending(), () => invited || []);
   queryClient.setQueryData(ChatKeys.unreads(), () => unreads || {});
+
+  useChatStore.getState().update(unreads);
 }
 
 interface PageParam {


### PR DESCRIPTION
Fixes LAND-1426 because we forgot to create the unread state after initializing DM unreads, would happen both for refresh and reconnects.