### PR TITLE
groups: poke %channels-server, not old agents

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -250,6 +250,8 @@
 ++  verify-group-cabals
   |=  [[=flag:g [* =group:g]] core=_cor]
   =.  core
+    ::  repair members as needed
+    ::
     %+  roll
       ~(tap by fleet.group)
     |=  [[s=ship =vessel:fleet:g] cre=_core]
@@ -261,19 +263,23 @@
     ~(tap by channels.group)
   |=  [[=nest:g =channel:g] cr=_core]
   =.  cr
+    ::  repair readers as needed
+    ::
     =/  readers  (~(dif in readers.channel) ~(key by cabals.group))
     ?.  (gth ~(wyt in readers) 0)  cr
     =/  action  [flag now.bowl %channel nest %del-sects readers]
     cr(cards [[%pass /groups/role %agent [our.bowl dap.bowl] %poke [act:mar:g !>(action)]] cards.cr])
+  ::  repair writers as needed
+  ::
   =+  .^(has=? %gu (channel-scry nest))
   ?.  has  cr
   =+  .^([writers=(set sect:g) *] %gx (welp (channel-scry nest) /perm/noun))
   =/  diff  (~(dif in writers) ~(key by cabals.group))
   ?.  (gth ~(wyt in diff) 0)  cr
-  ?.  =(p.nest ?(%chat %heap %diary))  cr
-  =/  update  [q.nest [now.bowl [%del-sects diff]]]
-  =/  cage  [%channels-action !>(update)]
-  cr(cards [[%pass /groups/role %agent [p.q.nest p.nest] %poke cage] cards.cr])
+  ?.  ?=(?(%chat %heap %diary) p.nest)  cr
+  =/  cmd=c-channels:d  [%channel nest %del-writers diff]
+  =/  cage  [%channel-command !>(cmd)]
+  cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
 ::
 ::  +load: load next state
 ++  load


### PR DESCRIPTION
+verify-group-cabals was still poking agents using the names given in the nest, but those have been deprecated in favor of channels-server. Here, we make sure to always poke channels-server with a new-style channel-command instead.

Somewhat untested, somehow I couldn't get into this branch of the code (or even get the role deletion to stick). @arthyn this is probably better than "100% certainly broken", but we should probably pair on actually running the new code here.