### PR TITLE
chat: prevent action menu from covering image dialog

### DIFF
--- a/ui/src/chat/ChatMessage/ChatMessage.tsx
+++ b/ui/src/chat/ChatMessage/ChatMessage.tsx
@@ -343,7 +343,7 @@ const ChatMessage = React.memo<
           <div className="group-one relative z-0 flex w-full select-none sm:select-auto">
             {isDelivered && (
               <ChatMessageOptions
-                open={optionsOpen || hasDialogsOpen}
+                open={optionsOpen || (hasDialogsOpen && !isMobile)}
                 onOpenChange={setOptionsOpen}
                 hideThreadReply={hideReplies}
                 whom={whom}


### PR DESCRIPTION
Fixes LAND-1406, we shouldn't need to take into account the dialogs on mobile since `ChatMessageOptions` is rendered always on mobile.