### PR TITLE
groups: expose "can-read" as gate through scry

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -343,7 +343,7 @@
     |=  [=nest:c co=_cor]
     ^+  cor
     %+  roll  ~(tap in p.diff)
-    |=  [=ship ci=_cor]
+    |=  [=ship ci=_co]
     ^+  cor
     =/  ca  (ca-abed:ca-core:ci nest)
     ca-abet:(ca-revoke:ca ship)

--- a/desk/app/diary.hoon
+++ b/desk/app/diary.hoon
@@ -4,7 +4,7 @@
 /+  default-agent, verb, dbug
 /+  not=notes
 /+  qup=quips
-/+  volume
+/+  volume, cutils=channel-utils
 /+  epos-lib=saga
 ::  performance, keep warm
 /+  diary-json
@@ -1033,11 +1033,8 @@
     !=(~ (~(int in writers.perm.diary) sects.perms))
   ::
   ++  di-can-read
-    |=  her=ship
-    =/  =path
-      %+  welp  di-groups-scry
-      /channel/[dap.bowl]/(scot %p p.flag)/[q.flag]/can-read/(scot %p her)/loob
-    .^(? %gx path)
+    %~  can-read  perms:cutils
+    [our.bowl now.bowl [%diary flag] group.perm.diary]
   ::
   ++  di-pub
     |=  =path

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1049,6 +1049,13 @@
         :-  bloc=(~(has in go-bloc-who) member)
         sects=sects:(~(got by fleet.group) member)
       ==
+      ::
+        [%can-read ~]
+      :+  ~  %noun
+      !>  ^-  $-([ship nest:g] ?)
+      |=  [=ship =nest:g]
+      ?~  cha=(~(get by channels.group) nest)  |
+      (go-can-read ship u.cha)
     ==
   ::
   ++  go-can-read

--- a/desk/app/heap.hoon
+++ b/desk/app/heap.hoon
@@ -2,7 +2,7 @@
 /-  meta
 /+  default-agent, verb, dbug
 /+  cur=curios
-/+  volume
+/+  volume, cutils=channel-utils
 /+  epos-lib=saga
 ::  performance, keep warm
 /+  heap-json
@@ -979,11 +979,8 @@
     !=(~ (~(int in writers.perm.heap) sects.perms))
   ::
   ++  he-can-read
-    |=  her=ship
-    =/  =path
-      %+  welp  he-groups-scry
-      /channel/[dap.bowl]/(scot %p p.flag)/[q.flag]/can-read/(scot %p her)/loob
-    .^(? %gx path)
+    %~  can-read  perms:cutils
+    [our.bowl now.bowl [%heap flag] group.perm.heap]
   ::
   ++  he-pub
     |=  =path

--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -240,8 +240,10 @@
     ?:  =(our her)  &
     =/  =path
       %+  welp  groups-scry
-      :+  %channel  kind.nest
-      /(scot %p ship.nest)/[name.nest]/can-read/(scot %p her)/loob
-    .^(? %gx path)
+      /can-read/noun
+    =/  test=$-([ship nest:g] ?)
+      =>  [path=path nest=nest:g ..zuse]  ~+
+      .^($-([ship nest] ?) %gx path)
+    (test her nest)
   --
 --


### PR DESCRIPTION
The groups agents (channels-server, diary, heap) do some dumb stuff. Specifically, whenever permissions change _at all_, they re-run permission checks for _all subscribers_ to _all channels_ in the group where the change happened.

This is dumb, and they should be smarter about it, but urbit is fast, it shouldn't be a _huge_ deal. Except, "running a permission check" involves scrying into the groups agent, which has non-trivial overhead.

The fix is equally dumb: don't improve the logic, just remove the overhead. This brings us down from "tens of milliseconds per subscriber" to "tens of _microseconds_ per subscriber".

Instead of only exposing a per-channel per-ship scry endpoint for checking read permissions, groups now also exposes a generic endpoint that produces a gate. This gate can be used to run a read permissions check with varying arguments repeatedly.

We update the `+can-read:perms` helper from `/lib/channel-utils` to use this gate, and make sure its scry of the gate is memoized. This removes the scry overhead for subsequent invocations within the same event.

There's light concerns here around the context of the gate being used to exfiltrate otherwise-private data from the groups agent. However, two reasons not to care:
- These endpoints are only accessible locally.
- The groups agent already exposes nearly all of its state on other scry endpoints, and userspace permissions don't exist yet, so this won't be "leaking" data that isn't already accessible.

That second point will not hold indefinitely, and so we will want to revisit this in the near future. Concretely, groups (and its clients) should be reconsidered to improve the ergonomics around reacting to permissions. This will likely be part of the groups agent refactor coming up next year.

Until then though, this should rid us of exceedingly painful performance when managing roles/permissions. 

Possibly fixes LAND-1343