### PR TITLE
Fix @ mentions. Remove name from tiptap Mention.extend LAND-1448

### DIFF
--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -165,8 +165,14 @@ export function useMessageEditor({
         suggestion: getMentionPopup('~'),
       })
     );
+    // Extending like this generates a warning
+    // Duplicate extension names found: ['mention']. This can lead to issues.
+    // But the extend method's documentation says the name can'tbe changed
+    // https://tiptap.dev/docs/editor/guide/custom-extensions#extend-existing-extensions
+    // If we add a name: property, the @ mentions stop working
+    // Needs more research but opting to make it work over a warning for now
     extensions.unshift(
-      Mention.extend({ priority: 999, name: 'at-mention' }).configure({
+      Mention.extend({ priority: 999 }).configure({
         HTMLAttributes: {
           class: 'inline-block rounded bg-blue-soft px-1.5 py-0 text-blue',
         },


### PR DESCRIPTION
## Reported issue:

`@` mentions look normal in the chat input but don't make it into the message content after send.
`~` mentions work fine.

Steps to reproduce:

1. Go to any chat channel.
2. Make an @ mention in the chat input (with some other text, as a user normally would)
3. Send the message
4. Notice that the mention isn't there in the message in the chat scroller.

## Fix:

The name was added apparently to remove a warning. "Duplicate extension names found: ['mention']. This can lead to issues."

But the extend method's documentation says the name can't be changed

https://tiptap.dev/docs/editor/guide/custom-extensions#extend-existing-extensions

If we add a name: property, the @ mentions stop working

Needs more research but opting to make it work over a warning for now

See: https://github.com/ueberdosis/tiptap/discussions/1768#discussioncomment-7952132

Fixes LAND-1448