### PR TITLE
fix positioning of options on long reply messages

### DIFF
--- a/ui/src/replies/ReplyMessageOptions.tsx
+++ b/ui/src/replies/ReplyMessageOptions.tsx
@@ -337,7 +337,7 @@ export default function ReplyMessageOptions(props: {
       {isMobile ? (
         <ActionMenu open={open} onOpenChange={onOpenChange} actions={actions} />
       ) : (
-        <div className="absolute right-2 -top-5 z-10 h-full">
+        <div className="absolute right-2 -top-5 z-10">
           <div
             data-testid="chat-message-options"
             className="sticky top-0 flex space-x-0.5 rounded-lg border border-gray-100 bg-white p-[1px] align-middle"


### PR DESCRIPTION
Fixes positioning of reply message options on long thread replies

<img width="552" alt="Screenshot 2024-01-01 at 10 52 04 AM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/8b31b2a3-b724-4190-b681-365c3ac68288">
