### PR TITLE
fix issue with joining/leaving groups containing custom channels

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -875,32 +875,32 @@
     ++  leave-channels
       |=  nests=(list nest:g)
       ^-  (list card)
-      %+  turn
+      %+  murn
           nests
       |=  nes=nest:g
-      ^-  card
+      ^-  (unit card)
+      ?.  ?=(?(%chat %diary %heap) p.nes)
+        ~
       =/  =dock  [our.bowl %channels]
-      =/  action=a-channels:d
-        ?>  ?=(?(%chat %diary %heap) p.nes)
-        [%channel nes %leave ~]
+      =/  action=a-channels:d  [%channel nes %leave ~]
       =/  =cage  channel-action+!>(action)
       =/  =wire  (snoc go-area %leave-channels)
-      [%pass wire %agent dock %poke cage]
+      `[%pass wire %agent dock %poke cage]
     ::
     ++  join-channels
       |=  nests=(list nest:g)
       ^-  (list card)
-      %+  turn
+      %+  murn
           nests
       |=  nes=nest:g
-      ^-  card
+      ^-  (unit card)
+      ?.  ?=(?(%chat %diary %heap) p.nes)
+        ~
       =/  =dock  [our.bowl %channels]
-      =/  action=a-channels:d
-        ?>  ?=(?(%chat %diary %heap) p.nes)
-        [%channel nes %join flag]
+      =/  action=a-channels:d  [%channel nes %join flag]
       =/  =cage  ['channel-action' !>(action)]
       =/  =wire  (snoc go-area %join-channels)
-      [%pass wire %agent dock %poke cage]
+      `[%pass wire %agent dock %poke cage]
     --
   ::
   ++  go-leave


### PR DESCRIPTION
These changes fix a bug reported by `~darted-laster` in `~tommur-dostyn/tlon-studio/~tommur-dostyn/support` about new ships being unable to join groups containing a custom channel.

Please note that I've only tested the following workflows:

1. Joining a group containing a custom channel (i.e. `~hiddev-dannut/new-hooniverse`) on the livenet from a comet
2. Leaving the same group on the livenet from a comet

Please let me know if other workflows should be testing before merging.