### PR TITLE
Groups e2e: add/edit note using markdown Land-1240

### DIFF
--- a/ui/E2E.md
+++ b/ui/E2E.md
@@ -8,11 +8,17 @@ The script:
 
 1. fetches fake ships piers from GCS
 2. downloads the urbit binaries for the local architecture
-3. boots the ships
+3. boots the test planets and sponsors
 4. executes the tests against the current ui code version
 5. kills spawned processes
 
 Test specs are in the `e2e/` directory.
+
+Each File can run in parallel, and they will while there are available workers.
+
+Number of workers is configured in ui/playwright.config.ts
+
+Specs in one file run in sequence.
 
 ## Running locally
 
@@ -22,20 +28,33 @@ After installing  this project's dependencies with `npm install`,
 npm run e2e
 ```
 
+### Adding tests
+
+Create a new spec file in the `e2e/` directory.
+
+The file name should be descriptive of the test suite.
+
+Add data-testid attributes to the components you want to test and accessthem using `page.getByTestId()`.
+
+If the tests need preexisting conditions, such asgroups,channels or messages already present, the piers may need to be updated.
+
+To do this, boot them manually, make the changes, exit, and then
+
+1. `tar czvf rube-naldeg-mardev6.tgz naldeg-mardev` (or whatever the pier name is) from the parent folder
+2. `gcloud storage cp ./rube-naldeg-mardev6.tgz gs://bootstrap.urbit.org`
+
 ### Debugging tests
 
 ```
 npm run e2e:debug
 ```
 
-Currently, tests utilize two fake ships, `~zod` and `~bus`.
+Currently, tests utilize two fake planets, `~habduc-patbud` and `~naldeg-mardev`.
 
+Their sponsoring fake galaxies `~zod` and `~bus` are also booted to enable packet routing between the ships.
 
-To debug only tests from one of the ships, use for example 
+The script will kill all processes on exit.
 
+In some cases though, such as when debugging if a playwright assertion fails, http processes may be left running causing Vite to fail to start the next time.
 
-```
-npm run e2e:debug:bus
-```
-
-The script will kill all processes on exit, but in some cases a localhost may be left running and generate an error when trying to run again. If this happens, find it with `ps aux | grep localhost` and kill from cmd line.
+If this happens, find the processes with `ps aux | grep localhost` or `lsof -Pi :3001 -sTCP:LISTEN` (and `3000`) and kill from cmd line.

--- a/ui/e2e/001-create-group-channels-invite.spec.ts
+++ b/ui/e2e/001-create-group-channels-invite.spec.ts
@@ -1,22 +1,27 @@
 import { test, expect } from '@playwright/test';
 import shipManifest from './shipManifest.json';
 
-const busUrl = `${shipManifest['~bus'].webUrl}/apps/groups/`;
-const zodUrl = `${shipManifest['~zod'].webUrl}/apps/groups/`;
+// mardev is the owner of the group
+// patbud is the invited ship
+
+const ownerUrl = `${shipManifest['~naldeg-mardev'].webUrl}/apps/groups/`;
+const invitedUrl = `${shipManifest['~habduc-patbud'].webUrl}/apps/groups/`;
+const groupOwner = 'mardev';
+const invitedShip = 'patbud';
 
 test('Create a group', async ({ browser }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
 
-  // Authenticate as bus
-  const busContext = await browser.newContext({
-    storageState: shipManifest['~bus'].authFile,
+  // Authenticate as mardev
+  const ownerContext = await browser.newContext({
+    storageState: shipManifest['~naldeg-mardev'].authFile,
   });
-  const page = await busContext.newPage();
-  await page.goto(busUrl);
+  const page = await ownerContext.newPage();
+  await page.goto(ownerUrl);
   await page.getByRole('link', { name: 'Create Group' }).waitFor();
   await page.getByRole('link', { name: 'Create Group' }).click();
   await page.getByPlaceholder('e.g. Urbit Fan Club').click();
-  await page.getByPlaceholder('e.g. Urbit Fan Club').fill('Bus Club');
+  await page.getByPlaceholder('e.g. Urbit Fan Club').fill('mardev Club');
   await page.locator('textarea[name="description"]').click();
   await page.locator('textarea[name="description"]').fill('Get in.');
   await page.getByRole('button', { name: 'Next: Privacy' }).click();
@@ -28,14 +33,14 @@ test('Create a group', async ({ browser }) => {
 test('Create a chat channel', async ({ browser }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
 
-  // Authenticate as bus
-  const busContext = await browser.newContext({
-    storageState: shipManifest['~bus'].authFile,
+  // Authenticate as mardev
+  const ownerContext = await browser.newContext({
+    storageState: shipManifest['~naldeg-mardev'].authFile,
   });
-  const page = await busContext.newPage();
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'B Bus Club' }).waitFor();
-  await page.getByRole('link', { name: 'B Bus Club' }).click();
+  const page = await ownerContext.newPage();
+  await page.goto(ownerUrl);
+  await page.getByRole('link', { name: 'mardev Club' }).waitFor();
+  await page.getByRole('link', { name: 'mardev Club' }).click();
   await page.getByRole('heading', { name: 'or drag a Channel here' }).waitFor();
   await page.getByRole('link', { name: 'New Channel' }).nth(1).click();
   await page
@@ -43,32 +48,32 @@ test('Create a chat channel', async ({ browser }) => {
     .filter({ hasText: 'ChatA simple, standard text chat' })
     .click();
   await page.getByLabel('Channel Name*').click();
-  await page.getByLabel('Channel Name*').fill('bus chat');
+  await page.getByLabel('Channel Name*').fill('mardev chat');
   await page.getByLabel('Channel Description').click();
   await page.getByLabel('Channel Description').fill('the bus is coming');
   await page.getByRole('button', { name: 'Add Channel' }).click();
-  await page.getByRole('link', { name: 'bus chat' }).waitFor();
-  await page.getByRole('link', { name: 'bus chat' }).click();
+  await page.getByRole('link', { name: 'mardev chat' }).waitFor();
+  await page.getByRole('link', { name: 'mardev chat' }).click();
   await page.getByLabel('Send message').waitFor();
   await page.locator('.ProseMirror').click();
-  await page.locator('.ProseMirror').fill("hi, it's me, ~bus");
+  await page.locator('.ProseMirror').fill("hi, it's me, ~naldeg-mardev");
   // first enter is for the mention
   await page.locator('.ProseMirror').press('Enter');
   await page.locator('.ProseMirror').press('Enter');
-  await expect(page.getByText("hi, it's me, ~bus")).toBeVisible();
+  await expect(page.getByText("hi, it's me, ~naldeg-mardev")).toBeVisible();
 });
 
 test('Create a notebook channel and post to it.', async ({ browser }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
 
-  // Authenticate as bus
-  const busContext = await browser.newContext({
-    storageState: shipManifest['~bus'].authFile,
+  // Authenticate as owner
+  const ownerContext = await browser.newContext({
+    storageState: shipManifest['~naldeg-mardev'].authFile,
   });
-  const page = await busContext.newPage();
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'B Bus Club' }).waitFor();
-  await page.getByRole('link', { name: 'B Bus Club' }).click();
+  const page = await ownerContext.newPage();
+  await page.goto(ownerUrl);
+  await page.getByRole('link', { name: 'mardev Club' }).waitFor();
+  await page.getByRole('link', { name: 'mardev Club' }).click();
   await page.getByRole('link', { name: 'All Channels' }).click();
   await page.getByRole('link', { name: 'New Channel' }).click();
   await page
@@ -76,12 +81,12 @@ test('Create a notebook channel and post to it.', async ({ browser }) => {
     .filter({ hasText: 'NotebookLongform publishing and discussion' })
     .click();
   await page.getByLabel('Channel Name*').click();
-  await page.getByLabel('Channel Name*').fill('bus notes');
+  await page.getByLabel('Channel Name*').fill('mardev notes');
   await page.getByLabel('Channel Description').click();
   await page.getByLabel('Channel Description').fill('news from the bus');
   await page.getByRole('button', { name: 'Add Channel' }).click();
-  await page.getByRole('link', { name: 'bus notes' }).waitFor();
-  await page.getByRole('link', { name: 'bus notes' }).click();
+  await page.getByRole('link', { name: 'mardev notes' }).waitFor();
+  await page.getByRole('link', { name: 'mardev notes' }).click();
   await page.getByRole('link', { name: 'Add Note' }).waitFor();
   await page.getByRole('link', { name: 'Add Note' }).click();
   await page.getByPlaceholder('New Title').click();
@@ -97,50 +102,50 @@ test('Create a notebook channel and post to it.', async ({ browser }) => {
 test('Invite to a group', async ({ browser }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
 
-  // Authenticate as bus
-  const busContext = await browser.newContext({
-    storageState: shipManifest['~bus'].authFile,
+  // Authenticate as owner
+  const ownerContext = await browser.newContext({
+    storageState: shipManifest['~naldeg-mardev'].authFile,
   });
-  const page = await busContext.newPage();
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'B Bus Club' }).waitFor();
-  await page.getByRole('link', { name: 'B Bus Club' }).click();
+  const page = await ownerContext.newPage();
+  await page.goto(ownerUrl);
+  await page.getByRole('link', { name: 'mardev Club' }).waitFor();
+  await page.getByRole('link', { name: 'mardev Club' }).click();
   await page.getByRole('link', { name: 'Invite People' }).waitFor();
   await page.getByRole('link', { name: 'Invite People' }).click();
   await page.getByLabel('Ships').click({ force: true });
-  await page.getByRole('combobox', { name: 'Ships' }).fill('~zod');
-  await page.getByText('zod', { exact: true }).click();
+  await page.getByRole('combobox', { name: 'Ships' }).fill('~habduc-patbud');
+  await page.getByText('~habduc-patbud', { exact: true }).click();
   await page.getByRole('button', { name: 'Send Invites' }).click();
   await page.getByRole('button', { name: 'Cancel' }).click();
-  await page.getByRole('button', { name: 'B Bus Club' }).click();
+  await page.getByRole('button', { name: 'mardev Club' }).click();
   await page.getByRole('menuitem', { name: 'Group Settings' }).click();
   await page.getByRole('link', { name: 'Members' }).click();
   await page
     .getByRole('region', { name: 'Members' })
-    .getByText('zod')
+    .getByText('habduc-patbud')
     .waitFor();
 });
 
 test('Accept group invite', async ({ browser }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
 
-  // Authenticate as zod
-  const zodContext = await browser.newContext({
-    storageState: shipManifest['~zod'].authFile,
+  // Authenticate as habduc-patbud
+  const invitedContext = await browser.newContext({
+    storageState: shipManifest['~habduc-patbud'].authFile,
   });
-  const page = await zodContext.newPage();
-  await page.goto(zodUrl);
+  const page = await invitedContext.newPage();
+  await page.goto(invitedUrl);
   await page
     .getByTestId('group-invite')
-    .filter({ hasText: 'Bus Club' })
+    .filter({ hasText: 'mardev Club' })
     .waitFor();
   const groupInvite = page
     .getByTestId('group-invite')
-    .filter({ hasText: 'Bus Club' });
+    .filter({ hasText: 'mardev Club' });
   await groupInvite.getByRole('button', { name: 'Accept' }).first().click();
   await page.getByText('Join This Group').waitFor();
   await page.getByRole('button', { name: 'Join Group' }).first().click();
-  await page.getByText('bus chat').first().waitFor();
-  await page.getByText('bus chat').first().click();
-  await page.getByText("hi, it's me, ~bus").waitFor();
+  await page.getByText('mardev chat').first().waitFor();
+  await page.getByText('mardev chat').first().click();
+  await page.getByText("hi, it's me, ~naldeg-mardev").waitFor();
 });

--- a/ui/e2e/002-non-admin-post-to-channels.spec.ts
+++ b/ui/e2e/002-non-admin-post-to-channels.spec.ts
@@ -1,18 +1,22 @@
 import { test, expect } from '@playwright/test';
 import shipManifest from './shipManifest.json';
 
-const busUrl = `${shipManifest['~bus'].webUrl}/apps/groups/`;
+// mardev is the owner of the group
+// patbud is the testing ship
 
-// Authenticate as bus
-test.use({ storageState: 'e2e/.auth/bus.json' });
+const testUrl = `${shipManifest['~habduc-patbud'].webUrl}/apps/groups/`;
+const groupOwner = 'mardev';
+
+// Authenticate as patbud
+test.use({ storageState: 'e2e/.auth/habduc-patbud.json' });
 
 test('Navigate to group chat', async ({ page }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
-  await page.getByRole('link', { name: 'Zod test group' }).click();
-  await page.getByTestId('sidebar-item-text-Zod chat').waitFor();
-  await page.getByTestId('sidebar-item-text-Zod chat').click();
+  await page.goto(testUrl);
+  await page.getByRole('link', { name: `${groupOwner} test group` }).waitFor();
+  await page.getByRole('link', { name: `${groupOwner} test group` }).click();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} chat`).waitFor();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} chat`).click();
   await page.locator('.ProseMirror').click();
   await page.locator('.ProseMirror').fill('hi there');
   await page.locator('.ProseMirror').press('Enter');
@@ -21,11 +25,11 @@ test('Navigate to group chat', async ({ page }) => {
 
 test('Add Block to existing gallery channel', async ({ page }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
-  await page.getByRole('link', { name: 'Zod test group' }).click();
-  await page.getByTestId('sidebar-item-text-Zod gallery').waitFor();
-  await page.getByTestId('sidebar-item-text-Zod gallery').click();
+  await page.goto(testUrl);
+  await page.getByRole('link', { name: `${groupOwner} test group` }).waitFor();
+  await page.getByRole('link', { name: `${groupOwner} test group` }).click();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} gallery`).waitFor();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} gallery`).click();
   await page.getByTestId('add-block-button').waitFor();
   await page.getByTestId('add-block-button').click();
   await page.locator('.ProseMirror').click();
@@ -38,11 +42,11 @@ test('Add Block to existing gallery channel', async ({ page }) => {
 
 test('Add Note to existing notebook channel', async ({ page }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
-  await page.getByRole('link', { name: 'Zod test group' }).click();
-  await page.getByTestId('sidebar-item-text-Zod notebook').waitFor();
-  await page.getByTestId('sidebar-item-text-Zod notebook').click();
+  await page.goto(testUrl);
+  await page.getByRole('link', { name: `${groupOwner} test group` }).waitFor();
+  await page.getByRole('link', { name: `${groupOwner} test group` }).click();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} notebook`).waitFor();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} notebook`).click();
   await page.getByTestId('add-note-button').waitFor();
   await page.getByTestId('add-note-button').click();
   await page.getByTestId('note-title-input').waitFor();

--- a/ui/e2e/003-post-note-with-markdown.spec.ts
+++ b/ui/e2e/003-post-note-with-markdown.spec.ts
@@ -1,18 +1,22 @@
 import { test, expect } from '@playwright/test';
 import shipManifest from './shipManifest.json';
 
-const busUrl = `${shipManifest['~bus'].webUrl}/apps/groups/`;
+// mardev is the owner of the group
+// patbud is the testing ship
 
-// Authenticate as bus
-test.use({ storageState: 'e2e/.auth/bus.json' });
+const testUrl = `${shipManifest['~habduc-patbud'].webUrl}/apps/groups/`;
+const groupOwner = 'mardev';
 
-test('Add Note to existing notebook channel', async ({ page }) => {
+// Authenticate as patbud
+test.use({ storageState: 'e2e/.auth/habduc-patbud.json' });
+
+test('Add markdown note to existing notebook channel', async ({ page }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
-  await page.getByRole('link', { name: 'Zod test group' }).click();
-  await page.getByTestId('sidebar-item-text-Zod notebook').waitFor();
-  await page.getByTestId('sidebar-item-text-Zod notebook').click();
+  await page.goto(testUrl);
+  await page.getByRole('link', { name: `${groupOwner} test group` }).waitFor();
+  await page.getByRole('link', { name: `${groupOwner} test group` }).click();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} notebook`).waitFor();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} notebook`).click();
   await page.getByTestId('add-note-button').waitFor();
   await page.getByTestId('add-note-button').click();
   await page.getByTestId('note-title-input').waitFor();
@@ -44,11 +48,11 @@ test('Add Note to existing notebook channel', async ({ page }) => {
 
 test('Edit markdown note', async ({ page }) => {
   test.skip(process.env.APP === 'chat', 'skip on talk');
-  await page.goto(busUrl);
-  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
-  await page.getByRole('link', { name: 'Zod test group' }).click();
-  await page.getByTestId('sidebar-item-text-Zod notebook').waitFor();
-  await page.getByTestId('sidebar-item-text-Zod notebook').click();
+  await page.goto(testUrl);
+  await page.getByRole('link', { name: `${groupOwner} test group` }).waitFor();
+  await page.getByRole('link', { name: `${groupOwner} test group` }).click();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} notebook`).waitFor();
+  await page.getByTestId(`sidebar-item-text-${groupOwner} notebook`).click();
   await page.getByRole('heading', { name: 'Markdown note' }).waitFor();
   await page.getByRole('heading', { name: 'Markdown note' }).click();
   await page.getByTestId('button-edit-note').waitFor();
@@ -59,7 +63,6 @@ test('Edit markdown note', async ({ page }) => {
   await page.getByTestId('save-note-button').click();
   await page.getByRole('heading', { name: 'Markdown note' }).waitFor();
   await page.getByRole('heading', { name: 'Markdown note' }).click();
-  const locator = page.locator('article > a').first();
-  await expect(locator).toHaveText('tlon corp');
+  const locator = page.getByRole('link', { name: 'tlon corp' });
   await expect(locator).toHaveAttribute('href', 'https://tlon.io/');
 });

--- a/ui/e2e/003-post-note-with-markdown.spec.ts
+++ b/ui/e2e/003-post-note-with-markdown.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import shipManifest from './shipManifest.json';
+
+const busUrl = `${shipManifest['~bus'].webUrl}/apps/groups/`;
+
+// Authenticate as bus
+test.use({ storageState: 'e2e/.auth/bus.json' });
+
+test('Add Note to existing notebook channel', async ({ page }) => {
+  test.skip(process.env.APP === 'chat', 'skip on talk');
+  await page.goto(busUrl);
+  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
+  await page.getByRole('link', { name: 'Zod test group' }).click();
+  await page.getByTestId('sidebar-item-text-Zod notebook').waitFor();
+  await page.getByTestId('sidebar-item-text-Zod notebook').click();
+  await page.getByTestId('add-note-button').waitFor();
+  await page.getByTestId('add-note-button').click();
+  await page.getByTestId('note-title-input').waitFor();
+  await page.getByTestId('note-title-input').click();
+  await page.getByTestId('note-title-input').fill('Markdown note');
+
+  // Markdown option by default should be false
+  await expect(
+    page.getByTestId('edit-with-markdown-toggle').getByRole('button')
+  ).toHaveAttribute('aria-pressed', 'false');
+
+  await page
+    .getByTestId('edit-with-markdown-toggle')
+    .getByRole('button')
+    .click();
+  await expect(
+    page.getByTestId('edit-with-markdown-toggle').getByRole('button')
+  ).toHaveAttribute('aria-pressed', 'true');
+
+  await page.getByTestId('note-markdown-editor').click();
+  await page.getByTestId('note-markdown-editor').fill('## Heading level 2');
+  await page.getByTestId('save-note-button').click();
+  await page.getByRole('heading', { name: 'Markdown note' }).waitFor();
+  await page.getByRole('heading', { name: 'Markdown note' }).click();
+  await expect(page.locator('article > h2').first()).toHaveText(
+    'Heading level 2'
+  );
+});
+
+test('Edit markdown note', async ({ page }) => {
+  test.skip(process.env.APP === 'chat', 'skip on talk');
+  await page.goto(busUrl);
+  await page.getByRole('link', { name: 'Zod test group' }).waitFor();
+  await page.getByRole('link', { name: 'Zod test group' }).click();
+  await page.getByTestId('sidebar-item-text-Zod notebook').waitFor();
+  await page.getByTestId('sidebar-item-text-Zod notebook').click();
+  await page.getByRole('heading', { name: 'Markdown note' }).waitFor();
+  await page.getByRole('heading', { name: 'Markdown note' }).click();
+  await page.getByTestId('button-edit-note').waitFor();
+  await page.getByTestId('button-edit-note').click();
+  await page
+    .getByTestId('note-markdown-editor')
+    .fill('[tlon corp](https://tlon.io/)');
+  await page.getByTestId('save-note-button').click();
+  await page.getByRole('heading', { name: 'Markdown note' }).waitFor();
+  await page.getByRole('heading', { name: 'Markdown note' }).click();
+  const locator = page.locator('article > a').first();
+  await expect(locator).toHaveText('tlon corp');
+  await expect(locator).toHaveAttribute('href', 'https://tlon.io/');
+});

--- a/ui/e2e/auth.setup.ts
+++ b/ui/e2e/auth.setup.ts
@@ -1,24 +1,32 @@
 import { test as setup } from '@playwright/test';
 import shipManifest from './shipManifest.json';
 
-setup('authenticate zod', async ({ page }) => {
-  await page.goto(`${shipManifest['~zod'].webUrl}/~/login`);
+setup('authenticate patbud', async ({ page }) => {
+  await page.goto(`${shipManifest['~habduc-patbud'].webUrl}/~/login`);
   await page
     .getByPlaceholder('sampel-ticlyt-migfun-falmel')
-    .fill((shipManifest as Record<string, any>)['~zod'].code);
+    .fill((shipManifest as Record<string, any>)['~habduc-patbud'].code);
   await page.getByRole('button', { name: 'Continue' }).click();
-  await page.waitForURL(`${shipManifest['~zod'].webUrl}/apps/landscape/`);
-  await page.context().storageState({ path: shipManifest['~zod'].authFile });
+  await page.waitForURL(
+    `${shipManifest['~habduc-patbud'].webUrl}/apps/landscape/`
+  );
+  await page
+    .context()
+    .storageState({ path: shipManifest['~habduc-patbud'].authFile });
   await page.getByRole('link', { name: 'Groups' }).waitFor();
 });
 
-setup('authenticate bus', async ({ page }) => {
-  await page.goto(`${shipManifest['~bus'].webUrl}/~/login`);
+setup('authenticate mardev', async ({ page }) => {
+  await page.goto(`${shipManifest['~naldeg-mardev'].webUrl}/~/login`);
   await page
     .getByPlaceholder('sampel-ticlyt-migfun-falmel')
-    .fill((shipManifest as Record<string, any>)['~bus'].code);
+    .fill((shipManifest as Record<string, any>)['~naldeg-mardev'].code);
   await page.getByRole('button', { name: 'Continue' }).click();
-  await page.waitForURL(`${shipManifest['~bus'].webUrl}/apps/landscape/`);
-  await page.context().storageState({ path: shipManifest['~bus'].authFile });
+  await page.waitForURL(
+    `${shipManifest['~naldeg-mardev'].webUrl}/apps/landscape/`
+  );
+  await page
+    .context()
+    .storageState({ path: shipManifest['~naldeg-mardev'].authFile });
   await page.getByRole('link', { name: 'Groups' }).waitFor();
 });

--- a/ui/e2e/shipManifest.json
+++ b/ui/e2e/shipManifest.json
@@ -18,5 +18,25 @@
     "httpPort": "36963",
     "loopbackPort": "",
     "webUrl": "http://localhost:3001"
+  },
+  "~habduc-patbud": {
+    "authFile": "e2e/.auth/habduc-patbud.json",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-habduc-patbud6.tgz",
+    "url": "http://localhost:35553",
+    "ship": "habduc-patbud",
+    "code": "bisrym-lomwep-binbyr-tidwed",
+    "httpPort": "35553",
+    "loopbackPort": "",
+    "webUrl": "http://localhost:3000"
+  },
+  "~naldeg-mardev": {
+    "authFile": "e2e/.auth/naldeg-mardev.json",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-naldeg-mardev6.tgz",
+    "url": "http://localhost:36663",
+    "ship": "naldeg-mardev",
+    "code": "hadbyn-savfel-lanlur-ronped",
+    "httpPort": "36663",
+    "loopbackPort": "",
+    "webUrl": "http://localhost:3001"
   }
 }

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -96,13 +96,13 @@ export default defineConfig({
   webServer: [
     {
       command: `cross-env SHIP_URL=${
-        (shipManifest as Record<string, any>)['~zod'].url
+        (shipManifest as Record<string, any>)['~habduc-patbud'].url
       } npm run dev-no-ssl`,
       url: 'http://localhost:3000/apps/groups/',
     },
     {
       command: `cross-env SHIP_URL=${
-        (shipManifest as Record<string, any>)['~bus'].url
+        (shipManifest as Record<string, any>)['~naldeg-mardev'].url
       } E2E_PORT_3001=true npm run dev-no-ssl`,
       url: 'http://localhost:3001/apps/groups/',
     },

--- a/ui/rube/index.ts
+++ b/ui/rube/index.ts
@@ -56,6 +56,22 @@ const ships: Record<
     ), // eslint-disable-line
     extractPath: path.join(__dirname, 'bus'),
   },
+  'habduc-patbud': {
+    ...shipManifest['~habduc-patbud'],
+    savePath: path.join(
+      __dirname,
+      shipManifest['~habduc-patbud'].downloadUrl.split('/').pop()!
+    ), // eslint-disable-line
+    extractPath: path.join(__dirname, 'habduc-patbud'),
+  },
+  'naldeg-mardev': {
+    ...shipManifest['~naldeg-mardev'],
+    savePath: path.join(
+      __dirname,
+      shipManifest['~naldeg-mardev'].downloadUrl.split('/').pop()!
+    ), // eslint-disable-line
+    extractPath: path.join(__dirname, 'naldeg-mardev'),
+  },
 };
 
 const targetShip = process.env.SHIP_NAME;

--- a/ui/src/components/Settings/Setting.tsx
+++ b/ui/src/components/Settings/Setting.tsx
@@ -11,6 +11,7 @@ type SettingProps = {
   toggle: (open: boolean) => void;
   status: 'loading' | 'error' | 'success' | 'idle';
   labelClassName?: string;
+  dataTestid?: string;
 } & HTMLAttributes<HTMLDivElement>;
 
 export default function Setting({
@@ -22,11 +23,12 @@ export default function Setting({
   labelClassName,
   toggle,
   status,
+  dataTestid,
 }: SettingProps) {
   const id = slugify(name);
 
   return (
-    <section className={className}>
+    <section className={className} data-testid={dataTestid || undefined}>
       <div className="flex space-x-2">
         <Toggle
           aria-labelledby={id}

--- a/ui/src/diary/DiaryMarkdownEditor.tsx
+++ b/ui/src/diary/DiaryMarkdownEditor.tsx
@@ -321,6 +321,7 @@ export default function DiaryMarkdownEditor({
       onChange={(e) => setMarkdownInput(e.target.value)}
       className="input-transparent block h-full w-full resize-none pt-2 font-mono text-lg leading-8 placeholder:h-0 placeholder:text-[17px] placeholder:leading-8 placeholder:text-gray-400"
       placeholder="Start writing markdown here."
+      data-testid="note-markdown-editor"
     />
   );
 }

--- a/ui/src/diary/DiaryNoteHeader.tsx
+++ b/ui/src/diary/DiaryNoteHeader.tsx
@@ -83,7 +83,11 @@ export default function DiaryNoteHeader({
       <div className="flex shrink-0 flex-row items-center space-x-3">
         {isMobile && <ReconnectingSpinner />}
         {showEditButton ? (
-          <Link to={`../edit/${time}`} className="small-button">
+          <Link
+            to={`../edit/${time}`}
+            className="small-button"
+            data-testid="button-edit-note"
+          >
             Edit
           </Link>
         ) : null}

--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -360,6 +360,7 @@ export default function DiaryAddNote() {
                   name="Edit with Markdown"
                   status={toggleMarkdownStatus}
                   className="mb-4"
+                  dataTestid="edit-with-markdown-toggle"
                 />
                 {editWithMarkdown && editor ? (
                   <DiaryMarkdownEditor


### PR DESCRIPTION
This PR:

- Adds configuration to boot two fake planets (from pre-saved piers in gcloud) for e2e tests
- Keeps the two galaxies we were using (~zod and ~bus) to enable "fake" routing between the two planets
- Updates existing tests to use the two new planets instead of ~zod and ~bus
- Adds new specs file 003 to cover markdown and editing notes
- Updates the readme