### PR TITLE
remove outdated useNest hook

### DIFF
--- a/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
+++ b/ui/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
@@ -1,23 +1,17 @@
-import React, { useState } from 'react';
 import { useParams } from 'react-router';
-import { JSONContent } from '@tiptap/core';
-import useNest from '@/logic/useNest';
-import { nestToFlag } from '@/logic/utils';
 import { useRouteGroup } from '@/state/groups';
 import DiaryCommentField from '@/diary/DiaryCommentField';
+import { useChannelFlag } from '@/logic/channel';
 
 export default function HeapDetailCommentField() {
-  const nest = useNest();
   const { idTime } = useParams();
   const groupFlag = useRouteGroup();
-  const [, chFlag] = nestToFlag(nest);
-  const [draftText, setDraftText] = useState<JSONContent>();
-
+  const chFlag = useChannelFlag();
   return (
     <div className="border-t-2 border-gray-50 p-3 sm:p-4">
       <DiaryCommentField
         groupFlag={groupFlag}
-        flag={chFlag}
+        flag={chFlag || ''}
         han="heap"
         replyTo={idTime || ''}
       />

--- a/ui/src/logic/useNest.ts
+++ b/ui/src/logic/useNest.ts
@@ -1,8 +1,0 @@
-import { useParams } from 'react-router';
-
-export default function useNest() {
-  const { app, chShip, chName } = useParams();
-
-  const chFlag = `${chShip}/${chName}`;
-  return `${app}/${chFlag}`;
-}


### PR DESCRIPTION
Removes the outdated `useNest` hook as discussed in #3148, since the `app` param is no longer defined on any routes