### PR TITLE
fix code block and task list eating previous paragraph

### DIFF
--- a/ui/src/diary/plugins/actionmenu.tsx
+++ b/ui/src/diary/plugins/actionmenu.tsx
@@ -56,8 +56,8 @@ export const actionMenuItems: ActionMenuItemProps[] = [
         .focus()
         .deleteRange(range)
         .toggleCodeBlock()
-        .selectNodeBackward()
         .insertContent([{ type: 'paragraph' }])
+        .selectNodeBackward()
         .run();
     },
   },
@@ -70,8 +70,8 @@ export const actionMenuItems: ActionMenuItemProps[] = [
         .focus()
         .deleteRange(range)
         .toggleTaskList()
-        .selectNodeBackward()
         .insertContent([{ type: 'paragraph' }])
+        .selectNodeBackward()
         .run();
     },
   },


### PR DESCRIPTION
Fixes issue with code block and task list insertion eating previous paragraph when editing notes with the WYSIWYG editor

https://github.com/tloncorp/landscape-apps/assets/1013230/cb4c05c4-cfc6-4ea7-bf0e-015ed402c27b

