### PR TITLE
Handle poke-ack from adding contacts

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -458,6 +458,11 @@
     ?~  p.sign  cor
     %-  (slog leaf+"Failed to hark" u.p.sign)
     cor
+      [%contacts %join-heed]
+    ?>  ?=(%poke-ack -.sign)
+    ?~  p.sign  cor
+    %-  (slog leaf+"Failed to add contacts" u.p.sign)
+    cor
   ::
       [=kind:c ship=@ name=@ rest=*]
     =/  =ship  (slav %p ship.pole)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -458,7 +458,7 @@
     ?~  p.sign  cor
     %-  (slog leaf+"Failed to hark" u.p.sign)
     cor
-      [%contacts %join-heed]
+      [%contacts %join-heed ~]
     ?>  ?=(%poke-ack -.sign)
     ?~  p.sign  cor
     %-  (slog leaf+"Failed to add contacts" u.p.sign)


### PR DESCRIPTION
This addresses an issue from https://github.com/tloncorp/landscape-apps/pull/3169 where poke acks from adding contacts on channel join weren't handled.