### PR TITLE
groups: fetching tweaks

### DIFF
--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
-export const INITIAL_MESSAGE_FETCH_PAGE_SIZE = 50;
 export const STANDARD_MESSAGE_FETCH_PAGE_SIZE = 100;
-export const LARGE_MESSAGE_FETCH_PAGE_SIZE = 200;
+export const LARGE_MESSAGE_FETCH_PAGE_SIZE = 300;
 export const FETCH_BATCH_SIZE = 3;
 export const MAX_DISPLAYED_OPTIONS = 40;
 export const NOTE_REF_DISPLAY_LIMIT = 600;

--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -1,7 +1,12 @@
 import _ from 'lodash';
 import Urbit from '@urbit/http-api';
 import api from '@/api';
-import { asyncWithDefault, asyncWithFallback, isTalk } from '@/logic/utils';
+import {
+  asyncWithDefault,
+  asyncWithFallback,
+  isTalk,
+  nestToFlag,
+} from '@/logic/utils';
 import queryClient from '@/queryClient';
 import { Gangs, Groups } from '@/types/groups';
 import { TalkInit, GroupsInit } from '@/types/ui';
@@ -16,6 +21,7 @@ import useSchedulerStore from './scheduler';
 import { useStorage } from './storage';
 import { initializeChat } from './chat';
 import { pinsKey } from './pins';
+import { ChannnelKeys } from './channel/keys';
 
 const emptyGroupsInit: GroupsInit = {
   groups: {},
@@ -52,6 +58,17 @@ async function startGroups() {
   queryClient.setQueryData(['channels'], channels);
   queryClient.setQueryData(['unreads'], unreads);
   queryClient.setQueryData(pinsKey(), pins);
+
+  // if we have unreads for cached channels, refetch them
+  // in advance
+  Object.keys(unreads || {}).forEach((nest) => {
+    const unread = unreads[nest];
+    const queryKey = ChannnelKeys.infinitePostsKey(nest);
+    if (unread.count > 0 && queryClient.getQueryData(queryKey)) {
+      queryClient.refetchQueries(queryKey);
+    }
+  });
+
   // make sure we remove the app part from the nest before handing it over
   useChatStore
     .getState()

--- a/ui/src/state/channel/keys.ts
+++ b/ui/src/state/channel/keys.ts
@@ -12,4 +12,4 @@ export const ChannnelKeys = {
   infinitePostsKey,
 };
 
-export default channelKey;
+export default ChannnelKeys;

--- a/ui/src/state/channel/keys.ts
+++ b/ui/src/state/channel/keys.ts
@@ -1,7 +1,15 @@
+import { nestToFlag } from '@/logic/utils';
+
 export const channelKey = (...parts: string[]) => ['channel', ...parts];
+
+export const infinitePostsKey = (nest: string) => {
+  const [han, flag] = nestToFlag(nest);
+  return [han, 'posts', flag, 'infinite'];
+};
 
 export const ChannnelKeys = {
   channel: channelKey,
+  infinitePostsKey,
 };
 
 export default channelKey;

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -40,7 +40,11 @@ import { ChatStore, useChatInfo, useChatStore } from '@/chat/useChatStore';
 import useReactQueryScry from '@/logic/useReactQueryScry';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import queryClient from '@/queryClient';
-import { INITIAL_MESSAGE_FETCH_PAGE_SIZE } from '@/constants';
+import {
+  LARGE_MESSAGE_FETCH_PAGE_SIZE,
+  STANDARD_MESSAGE_FETCH_PAGE_SIZE,
+} from '@/constants';
+import { isNativeApp } from '@/logic/native';
 import { CacheId, PostStatus, TrackedPost } from '../channel/channel';
 import ChatKeys from './keys';
 import emptyMultiDm, {
@@ -50,6 +54,10 @@ import emptyMultiDm, {
   removePendingFromCache,
   removeUnreadFromCache,
 } from './utils';
+
+const CHAT_PAGE_SIZE = isNativeApp()
+  ? STANDARD_MESSAGE_FETCH_PAGE_SIZE
+  : LARGE_MESSAGE_FETCH_PAGE_SIZE;
 
 export interface State {
   trackedWrits: TrackedPost[];
@@ -1284,13 +1292,13 @@ export function useInfiniteDMs(whom: string, initialTime?: string) {
       if (pageParam) {
         const { time, direction } = pageParam;
         const ud = decToUd(time.toString());
-        path = `/${type}/${whom}/writs/${direction}/${ud}/${INITIAL_MESSAGE_FETCH_PAGE_SIZE}/light`;
+        path = `/${type}/${whom}/writs/${direction}/${ud}/${CHAT_PAGE_SIZE}/light`;
       } else if (initialTime) {
         path = `/${type}/${whom}/writs/around/${decToUd(initialTime)}/${
-          INITIAL_MESSAGE_FETCH_PAGE_SIZE / 2
+          CHAT_PAGE_SIZE / 2
         }/light`;
       } else {
-        path = `/${type}/${whom}/writs/newest/${INITIAL_MESSAGE_FETCH_PAGE_SIZE}/light`;
+        path = `/${type}/${whom}/writs/newest/${CHAT_PAGE_SIZE}/light`;
       }
 
       const response = await api.scry<PagedWrits>({


### PR DESCRIPTION
Handles a few improvements for fetching posts:

- avoids incomplete message history when navigating to a channel by only adding new messages to the cache if we've already fetched the query
- on boot, any cached post queries with unreads get refetched so new messages are immediately available upon navigating to the channel
- bumps page size to 100 in the app and 300 on desktop to prevent extra fetching on scroll and allow fewer requests on refetch

We should monitor performance after this lands on our ships. Particularly for any of us with lots of groups that are used frequently. We may need to restrict on boot cache updates to pinned groups for now if it proves too expensive. 

Fixes LAND-1473
Fixes LAND-1474