### PR TITLE
pkgs: revert theme swapper to 0.9.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -195,7 +195,7 @@
         "rollup-plugin-analyzer": "^4.0.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "tailwindcss": "^3.2.7",
-        "tailwindcss-theme-swapper": "^0.10.0",
+        "tailwindcss-theme-swapper": "^0.9.0",
         "tar-fs": "^3.0.4",
         "tsc-files": "^1.1.3",
         "typescript": "^4.6.3",
@@ -9592,6 +9592,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "license": "MIT",
@@ -9602,6 +9615,34 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/color2k": {
       "version": "2.0.0",
@@ -18039,6 +18080,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "dev": true,
@@ -18644,11 +18700,12 @@
       }
     },
     "node_modules/tailwindcss-theme-swapper": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss-theme-swapper/-/tailwindcss-theme-swapper-0.10.0.tgz",
-      "integrity": "sha512-dqcEGyXvrzJmL5uBdMcvGHrKGk6P22tsefZhN9PkpQAaZ7NLYPHuNjpUnQURabw0937gY/smYxtTi3cdBCJCVA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-theme-swapper/-/tailwindcss-theme-swapper-0.9.0.tgz",
+      "integrity": "sha512-n44COmaX958o1HMQyuZIcb0lxckJ3pHJi1r3xuRkkY12eG1iP2eLWNrGP4RQkinsWnIOHnnSbFXW5kKjsqz4cQ==",
       "dev": true,
       "dependencies": {
+        "color": "^4.2.3",
         "postcss": "^8.4.21",
         "tailwindcss": "^3.3.1"
       }
@@ -26252,6 +26309,33 @@
     "clsx": {
       "version": "1.2.1"
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "requires": {
@@ -26260,6 +26344,16 @@
     },
     "color-name": {
       "version": "1.1.3"
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "color2k": {
       "version": "2.0.0"
@@ -31659,6 +31753,23 @@
       "version": "3.0.7",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "dev": true
@@ -32087,11 +32198,12 @@
       "requires": {}
     },
     "tailwindcss-theme-swapper": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss-theme-swapper/-/tailwindcss-theme-swapper-0.10.0.tgz",
-      "integrity": "sha512-dqcEGyXvrzJmL5uBdMcvGHrKGk6P22tsefZhN9PkpQAaZ7NLYPHuNjpUnQURabw0937gY/smYxtTi3cdBCJCVA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-theme-swapper/-/tailwindcss-theme-swapper-0.9.0.tgz",
+      "integrity": "sha512-n44COmaX958o1HMQyuZIcb0lxckJ3pHJi1r3xuRkkY12eG1iP2eLWNrGP4RQkinsWnIOHnnSbFXW5kKjsqz4cQ==",
       "dev": true,
       "requires": {
+        "color": "^4.2.3",
         "postcss": "^8.4.21",
         "tailwindcss": "^3.3.1"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -242,7 +242,7 @@
     "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-visualizer": "^5.6.0",
     "tailwindcss": "^3.2.7",
-    "tailwindcss-theme-swapper": "^0.10.0",
+    "tailwindcss-theme-swapper": "^0.9.0",
     "tar-fs": "^3.0.4",
     "tsc-files": "^1.1.3",
     "typescript": "^4.6.3",


### PR DESCRIPTION
Fixes LAND-1481, had too many people affected and wasn't currently broken so I've just reverted to a previous version that doesn't use `color-mix`.

Tested by downloading Chrome 110, the last version that didn't support `color-mix`.

PR Checklist
- [ ] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [X] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context