### PR TITLE
drag & drop: prevent getting stuck in drag state

### DIFF
--- a/ui/src/logic/DragAndDropContext.tsx
+++ b/ui/src/logic/DragAndDropContext.tsx
@@ -73,6 +73,8 @@ export function DragAndDropProvider({
   const handleDragEnter = useCallback((e: DragEvent) => {
     preventDefault(e);
 
+    if (document.visibilityState !== 'visible') return;
+
     // prevent drag enter from firing multiple times
     dragCounter.current += 1;
     setIsDragging(true);
@@ -99,6 +101,8 @@ export function DragAndDropProvider({
 
   const handleDragOver = useCallback((e: DragEvent) => {
     preventDefault(e);
+    if (document.visibilityState !== 'visible') return;
+
     setIsOver(true);
     dragLogger.log('drag over', dragCounter.current);
   }, []);

--- a/ui/src/logic/DragAndDropContext.tsx
+++ b/ui/src/logic/DragAndDropContext.tsx
@@ -8,12 +8,15 @@ import React, {
 } from 'react';
 import { uniq } from 'lodash';
 import { useIsMobile } from './useMedia';
+import { createDevLogger } from './utils';
 
 interface DragTargetContext {
   targetIdStack: string[];
   pushTargetID: (id: string) => void;
   popTargetID: (id: string) => void;
 }
+
+export const dragLogger = createDevLogger('DragAndDrop', false);
 
 export const DragTargetContext = createContext<DragTargetContext>({
   targetIdStack: [],
@@ -73,6 +76,7 @@ export function DragAndDropProvider({
     // prevent drag enter from firing multiple times
     dragCounter.current += 1;
     setIsDragging(true);
+    dragLogger.log('drag enter', dragCounter.current);
   }, []);
 
   const handleDragLeave = useCallback((e: DragEvent) => {
@@ -80,16 +84,23 @@ export function DragAndDropProvider({
 
     // prevent drag leave from firing multiple times
     dragCounter.current -= 1;
+    dragLogger.log('drag leave', dragCounter.current);
 
     if (dragCounter.current === 0) {
       setIsDragging(false);
       setIsOver(false);
+    } else if (e.relatedTarget === null) {
+      // drag has left the window and we should reset regardless of counter
+      setIsDragging(false);
+      setIsOver(false);
+      dragCounter.current = 0;
     }
   }, []);
 
   const handleDragOver = useCallback((e: DragEvent) => {
     preventDefault(e);
     setIsOver(true);
+    dragLogger.log('drag over', dragCounter.current);
   }, []);
 
   const handleDrop = useCallback(
@@ -100,10 +111,10 @@ export function DragAndDropProvider({
 
       setIsDragging(false);
       setIsOver(false);
+      dragLogger.log('handle drop');
 
       const targetElement = recurseNode || (e.target as HTMLElement);
 
-      // if (targetElement && targetElement.id !== dropZone) return;
       if (targetElement && targetElement.id !== dropZone) {
         if (targetElement.parentElement) {
           handleDrop(e, dropZone, targetElement.parentElement);


### PR DESCRIPTION
The main issue I was able to reproduce while testing was that events would fire more often than expected which prevented us from triggering the logic to end the drag when it detects a `dragleave` event. This updates it to always cancel the drag if it leaves the window. Also prevents a drag from being initiated if the document isn't visible. 

Together this seemed to fix any issues I found locally, but we'll need to see if the bug persists after merging since it presents sporadically.

Tested locally against self & hosted ships.

Fixes LAND-1463

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context