### PR TITLE
chat: prevent gap in message history when viewing scrollback

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -51,6 +51,7 @@ import { useChatStore } from '@/chat/useChatStore';
 import asyncCallWithTimeout from '@/logic/asyncWithTimeout';
 import { isNativeApp } from '@/logic/native';
 import { channelKey } from './keys';
+import shouldAddPostToCache from './util';
 
 const POST_PAGE_SIZE = isNativeApp()
   ? STANDARD_MESSAGE_FETCH_PAGE_SIZE
@@ -852,7 +853,11 @@ export function useChannels(): Channels {
       const [han, flag] = nestToFlag(nest);
       const infinitePostQueryKey = [han, 'posts', flag, 'infinite'];
       const existingQueryData = queryClient.getQueryData(infinitePostQueryKey);
-      if (existingQueryData) {
+      if (
+        shouldAddPostToCache(
+          existingQueryData as { pages: PagedPosts[] } | undefined
+        )
+      ) {
         infinitePostUpdater(infinitePostQueryKey, event);
       }
     }

--- a/ui/src/state/channel/util.ts
+++ b/ui/src/state/channel/util.ts
@@ -1,0 +1,27 @@
+import { PagedPosts } from '@/types/channel';
+
+type QueryData = {
+  pages: PagedPosts[];
+};
+
+type InfinitePostsQueryData = undefined | QueryData;
+
+export default function shouldAddPostToCache(
+  queryData: InfinitePostsQueryData
+): boolean {
+  // if we have no data, don't add to cache since you'd see incomplete message history when
+  // navigating to the channel
+  if (!queryData) {
+    return false;
+  }
+
+  // if we have data, but not the newest, we must be viewing a scrollback. We shouldn't add
+  // the post to the cache since you'd have a gap between the new messages and the scrollback
+  // history until the refetch completes
+  const hasNewer = queryData.pages && queryData.pages[0]?.newer;
+  if (hasNewer) {
+    return false;
+  }
+
+  return true;
+}

--- a/ui/src/state/channel/util.ts
+++ b/ui/src/state/channel/util.ts
@@ -15,7 +15,7 @@ export default function shouldAddPostToCache(
     return false;
   }
 
-  // if we have data, but not the newest, we must be viewing a scrollback. We shouldn't add
+  // if we have data but not the newest, we must be viewing a scrollback. We shouldn't add
   // the post to the cache since you'd have a gap between the new messages and the scrollback
   // history until the refetch completes
   const hasNewer = queryData.pages && queryData.pages[0]?.newer;


### PR DESCRIPTION
If a new message comes in while you're viewing a scroll-back (search or message ref clicked), it will be added to the cache directly after the loaded message history. This can lead to a weird gap between new messages and the point in the history you were viewing. An automated refetch is fired which resolves the situation, but it can take a bit depending on network conditions leaving you in a weird state until the refetch completes.

This prevents that scenario by checking to see if you have the newest messages before adding incoming ones to the cache.

Fixes LAND-1478

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context