### PR TITLE
members view: fix role selection on desktop

### DIFF
--- a/ui/src/groups/RoleInput/RoleSelector.tsx
+++ b/ui/src/groups/RoleInput/RoleSelector.tsx
@@ -1,0 +1,80 @@
+import { MouseEvent, useCallback, useState } from 'react';
+import { getSectTitle } from '@/logic/utils';
+import {
+  useGroup,
+  useGroupFlag,
+  useVessel,
+  useGroupSectMutation,
+} from '@/state/groups';
+import { Vessel } from '@/types/groups';
+import CheckIcon from '@/components/icons/CheckIcon';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import ExclamationPoint from '@/components/icons/ExclamationPoint';
+
+export default function RoleSelect({
+  role,
+  member,
+}: {
+  role: string;
+  member: string;
+}) {
+  const flag = useGroupFlag();
+  const group = useGroup(flag);
+  const vessel = useVessel(flag, member);
+  const [sectLoading, setSectLoading] = useState('');
+  const [isOwner, setIsOwner] = useState(false);
+  const { mutateAsync: sectMutation } = useGroupSectMutation();
+
+  const toggleSect = useCallback(
+    (ship: string, sect: string, v: Vessel) => async (event: MouseEvent) => {
+      event.preventDefault();
+
+      const inSect = v.sects.includes(sect);
+
+      if (inSect && sect === 'admin' && flag.includes(ship)) {
+        setIsOwner(true);
+        return;
+      }
+      if (inSect) {
+        try {
+          setSectLoading(sect);
+          await sectMutation({ flag, ship, sects: [sect], operation: 'del' });
+          setSectLoading('');
+        } catch (e) {
+          console.error(e);
+        }
+      } else {
+        try {
+          setSectLoading(sect);
+          await sectMutation({ flag, ship, sects: [sect], operation: 'add' });
+          setSectLoading('');
+        } catch (e) {
+          console.log(e);
+        }
+      }
+    },
+    [flag, sectMutation]
+  );
+
+  if (!group) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={toggleSect(member, role, vessel)}
+      className="flex items-center"
+    >
+      <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-200">
+        {sectLoading === role ? (
+          <LoadingSpinner className="h-4 w-4" />
+        ) : isOwner ? (
+          <ExclamationPoint className="h-4 w-4 text-red" />
+        ) : vessel.sects.includes(role) ? (
+          <CheckIcon className="h-4 w-4" />
+        ) : null}
+      </div>
+      <span className="ml-4">{getSectTitle(group.cabals, role)}</span>
+    </button>
+  );
+}

--- a/ui/src/groups/RoleInput/SetRolesDialog.tsx
+++ b/ui/src/groups/RoleInput/SetRolesDialog.tsx
@@ -21,7 +21,7 @@ export default function SetRolesDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange} className={className}>
-      <h3 className="mt-1 font-bold">Set Roles</h3>
+      <h3 className="mt-1 font-bold">Edit Roles</h3>
       <div className="my-5 flex flex-col items-center justify-center">
         <Avatar ship={member} size="small" className="mb-2" />
         {contact?.nickname ? (
@@ -35,11 +35,13 @@ export default function SetRolesDialog({
           </span>
         )}
       </div>
-      {roles.map((role) => (
-        <div className="my-2">
-          <RoleSelect role={role} member={member} />
-        </div>
-      ))}
+      <div className="max-h-[300px] overflow-auto">
+        {roles.map((role) => (
+          <div className="my-2">
+            <RoleSelect role={role} member={member} />
+          </div>
+        ))}
+      </div>
     </Dialog>
   );
 }

--- a/ui/src/groups/RoleInput/SetRolesDialog.tsx
+++ b/ui/src/groups/RoleInput/SetRolesDialog.tsx
@@ -36,9 +36,9 @@ export default function SetRolesDialog({
         )}
       </div>
       <div className="max-h-[300px] overflow-auto">
-        {roles.map((role, index) => (
-          <div className="my-2">
-            <RoleSelect key={index} role={role} member={member} />
+        {roles.map((role) => (
+          <div className="my-2" key={role}>
+            <RoleSelect role={role} member={member} />
           </div>
         ))}
       </div>

--- a/ui/src/groups/RoleInput/SetRolesDialog.tsx
+++ b/ui/src/groups/RoleInput/SetRolesDialog.tsx
@@ -1,0 +1,45 @@
+import Dialog from '@/components/Dialog';
+import { useContact } from '@/state/contact';
+import ShipName from '@/components/ShipName';
+import Avatar from '@/components/Avatar';
+import RoleSelect from './RoleSelector';
+
+export default function SetRolesDialog({
+  roles,
+  member,
+  open,
+  onOpenChange,
+  className,
+}: {
+  roles: string[];
+  member: string;
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  className?: string;
+}) {
+  const contact = useContact(member);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} className={className}>
+      <h3 className="mt-1 font-bold">Set Roles</h3>
+      <div className="my-5 flex flex-col items-center justify-center">
+        <Avatar ship={member} size="small" className="mb-2" />
+        {contact?.nickname ? (
+          <div className="flex">
+            <span className="mr-2 font-medium">{contact.nickname}</span>
+            <ShipName name={member} full className="text-gray-400" />
+          </div>
+        ) : (
+          <span className="font-medium">
+            <ShipName name={member} full />
+          </span>
+        )}
+      </div>
+      {roles.map((role) => (
+        <div className="my-2">
+          <RoleSelect role={role} member={member} />
+        </div>
+      ))}
+    </Dialog>
+  );
+}

--- a/ui/src/groups/RoleInput/SetRolesDialog.tsx
+++ b/ui/src/groups/RoleInput/SetRolesDialog.tsx
@@ -36,9 +36,9 @@ export default function SetRolesDialog({
         )}
       </div>
       <div className="max-h-[300px] overflow-auto">
-        {roles.map((role) => (
+        {roles.map((role, index) => (
           <div className="my-2">
-            <RoleSelect role={role} member={member} />
+            <RoleSelect key={index} role={role} member={member} />
           </div>
         ))}
       </div>


### PR DESCRIPTION
When the members view got overhauled for mobile, the desktop version had broken role selection. This adds a corresponding dialog to be used when not on mobile.

<img width="600" alt="Screenshot 2024-01-26 at 10 45 41 AM" src="https://github.com/tloncorp/landscape-apps/assets/90741358/a3fb4381-5a04-4083-9a18-f6388aef88c8">

Tested locally against a hosted ship.

Fixes LAND-1482

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context