### PR TITLE
drag & drop: fix dragging Mac screenshots into galleries

### DIFF
--- a/ui/src/logic/DragAndDropContext.tsx
+++ b/ui/src/logic/DragAndDropContext.tsx
@@ -9,6 +9,7 @@ import React, {
 import { uniq } from 'lodash';
 import { useIsMobile } from './useMedia';
 import { createDevLogger } from './utils';
+import { isSafari } from './native';
 
 interface DragTargetContext {
   targetIdStack: string[];
@@ -51,7 +52,7 @@ export function DragAndDropProvider({
   const [isOver, setIsOver] = useState(false);
   const [droppedFiles, setDroppedFiles] = useState<Record<string, FileList>>();
   const [targetIdStack, setTargetIdStack] = useState<string[]>([]);
-  const dragCounter = useRef(0);
+  const safariDragCounter = useRef(0);
 
   const pushTargetID = useCallback((id: string) => {
     setTargetIdStack((stack) =>
@@ -76,26 +77,39 @@ export function DragAndDropProvider({
     if (document.visibilityState !== 'visible') return;
 
     // prevent drag enter from firing multiple times
-    dragCounter.current += 1;
+    safariDragCounter.current += 1;
     setIsDragging(true);
-    dragLogger.log('drag enter', dragCounter.current);
+    dragLogger.log('drag enter', safariDragCounter.current);
   }, []);
 
   const handleDragLeave = useCallback((e: DragEvent) => {
     preventDefault(e);
 
     // prevent drag leave from firing multiple times
-    dragCounter.current -= 1;
-    dragLogger.log('drag leave', dragCounter.current);
+    safariDragCounter.current -= 1;
+    dragLogger.log('drag leave', safariDragCounter.current);
 
-    if (dragCounter.current === 0) {
-      setIsDragging(false);
-      setIsOver(false);
+    if (isSafari()) {
+      // Safari has a bug where event.relatedTarget is always null on dragleave.
+      // So instead, we have attempt to use a counter to determine when the drag
+      // truly leaves the window
+      if (safariDragCounter.current === 0) {
+        setIsDragging(false);
+        setIsOver(false);
+      }
     } else if (e.relatedTarget === null) {
-      // drag has left the window and we should reset regardless of counter
       setIsDragging(false);
       setIsOver(false);
-      dragCounter.current = 0;
+      safariDragCounter.current = 0;
+    }
+  }, []);
+
+  // This is a backup for Safari in case the drag counter gets out of sync
+  const handleSafariMouseLeave = useCallback((e: MouseEvent) => {
+    if (isSafari()) {
+      e.preventDefault();
+      setIsDragging(false);
+      setIsOver(false);
     }
   }, []);
 
@@ -104,7 +118,7 @@ export function DragAndDropProvider({
     if (document.visibilityState !== 'visible') return;
 
     setIsOver(true);
-    dragLogger.log('drag over', dragCounter.current);
+    dragLogger.log('drag over', safariDragCounter.current);
   }, []);
 
   const handleDrop = useCallback(
@@ -138,13 +152,21 @@ export function DragAndDropProvider({
     window.addEventListener('dragenter', handleDragEnter);
     window.addEventListener('dragleave', handleDragLeave);
     window.addEventListener('dragover', handleDragOver);
+    window.addEventListener('mouseleave', handleSafariMouseLeave);
 
     return () => {
       window.removeEventListener('dragenter', handleDragEnter);
       window.removeEventListener('dragleave', handleDragLeave);
       window.removeEventListener('dragover', handleDragOver);
+      window.removeEventListener('mouseleave', handleSafariMouseLeave);
     };
-  }, [handleDragEnter, handleDragLeave, handleDragOver, handleDrop]);
+  }, [
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDrop,
+    handleSafariMouseLeave,
+  ]);
 
   const value = useMemo(
     () => ({ isDragging, isOver, droppedFiles, setDroppedFiles, handleDrop }),

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -84,9 +84,9 @@ export const useFileStore = create<FileStore>((set, get) => ({
 
     const fileList = [...files].map((file) => ({
       file,
-      key: `${window.ship}/${deSig(formatDa(unixToDa(new Date().getTime())))}-${
-        file.name
-      }`,
+      key: `${window.ship}/${deSig(
+        formatDa(unixToDa(new Date().getTime()))
+      )}-${file.name.split(' ').join('-')}`,
       status: 'initial' as Status,
       url: '',
       size: [0, 0] as [number, number],


### PR DESCRIPTION
This seems to just have been an issue with spaces in the filename as expected. Uploading screenshots on Mac should now work in Safari.

While testing this, I noticed a regression with the drag & drop fix from the other day as well. There's a long outstanding bug with handling a key `dragleave` event property in Safari which was causing the drag hover state to flicker or fail. This PR also smuggles in a way to combat that while leaving in place the fix for other browsers.

Worked locally against a self-hosted ship in Safari & Chrome. Whoever tests  this, please verify drag & drop works in both gallery and chat contexts on both browsers.

Fixes LAND-1446

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context