### PR TITLE
Tlon desktop: move Talk functionality into main app + sidebar updates

### DIFF
--- a/ui/e2e/001-create-group-channels-invite.spec.ts
+++ b/ui/e2e/001-create-group-channels-invite.spec.ts
@@ -19,7 +19,9 @@ test('Create a group', async ({ browser }) => {
   const page = await ownerContext.newPage();
   await page.goto(ownerUrl);
   await page.getByTestId('add-group-sidebar-button').waitFor();
-  await page.getByTestId('add-group-sidebar-button').click();
+  await page.getByTestId('add-group-sidebar-button').hover();
+  await page.getByTestId('add-group-sidebar-button-icon').waitFor();
+  await page.getByTestId('add-group-sidebar-button-icon').click();
   await page.getByTestId('create-group-dropdown-button').click();
   await page.getByTestId('create-group-name-input').fill('mardev Club');
   await page.getByTestId('create-group-submit-button').click();

--- a/ui/e2e/001-create-group-channels-invite.spec.ts
+++ b/ui/e2e/001-create-group-channels-invite.spec.ts
@@ -5,7 +5,7 @@ import shipManifest from './shipManifest.json';
 // patbud is the invited ship
 
 const ownerUrl = `${shipManifest['~naldeg-mardev'].webUrl}/apps/groups/`;
-const invitedUrl = `${shipManifest['~habduc-patbud'].webUrl}/apps/groups/`;
+const invitedUrl = `${shipManifest['~habduc-patbud'].webUrl}/apps/groups/notifications`;
 const groupOwner = 'mardev';
 const invitedShip = 'patbud';
 

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -358,13 +358,18 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 />
               }
             />
-            <Route path="/messages" element={<MobileMessagesSidebar />} />
+            <Route
+              path="/messages"
+              element={isMobile ? <MobileMessagesSidebar /> : null}
+            />
             <Route path="/dm/" element={<Dms />}>
               <Route index element={<DMHome />} />
+
               <Route path="new">
                 <Route index element={<NewDM />} />
                 <Route path=":ship" element={<Message />} />
               </Route>
+
               <Route path=":ship" element={<Message />}>
                 {isSmall ? null : (
                   <Route
@@ -372,6 +377,27 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                     element={<DMThread />}
                   />
                 )}
+              </Route>
+
+              <Route path="groups/:ship/:name/*" element={<Groups />}>
+                <Route
+                  path="channels/chat/:chShip/:chName"
+                  element={<GroupChannel type="chat" />}
+                >
+                  <Route
+                    path="*"
+                    element={<ChatChannel title={` • ${appHead('').title}`} />}
+                  />
+                  {isSmall ? (
+                    <Route path="message/:idTime" element={<ChatThread />} />
+                  ) : null}
+                  {isMobile && (
+                    <Route
+                      path="search/:query?"
+                      element={<MobileChatSearch />}
+                    />
+                  )}
+                </Route>
               </Route>
               {isSmall && (
                 <Route

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -335,7 +335,20 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
       <Routes location={state?.backgroundLocation || location}>
         <Route element={<GroupsNav />}>
           <Route element={isMobile ? <MobileSidebar /> : undefined}>
-            <Route index element={isMobile ? <MobileGroupsNavHome /> : null} />
+            <Route path="/groups" element={<GroupsNav />} />
+            <Route
+              index
+              element={
+                isMobile ? (
+                  <MobileGroupsNavHome />
+                ) : (
+                  <Notifications
+                    child={GroupNotification}
+                    title={`Activity • ${groupsTitle}`}
+                  />
+                )
+              }
+            />
             <Route
               path="/notifications"
               element={

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -313,19 +313,6 @@ function ChatRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   );
 }
 
-function HomeRoute({ isMobile = true }: { isMobile: boolean }) {
-  if (isMobile) {
-    return <MobileGroupsNavHome />;
-  }
-
-  return (
-    <Notifications
-      child={GroupNotification}
-      title={`Activity • ${appHead('').title}`}
-    />
-  );
-}
-
 function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
   const groupsTitle = appHead('').title;
   const loaded = useSettingsLoaded();
@@ -348,7 +335,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
       <Routes location={state?.backgroundLocation || location}>
         <Route element={<GroupsNav />}>
           <Route element={isMobile ? <MobileSidebar /> : undefined}>
-            <Route index element={<HomeRoute isMobile={isMobile} />} />
+            <Route index element={isMobile ? <MobileGroupsNavHome /> : null} />
             <Route
               path="/notifications"
               element={
@@ -370,13 +357,16 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 <Route path=":ship" element={<Message />} />
               </Route>
 
-              <Route path=":ship" element={<Message />}>
-                {isSmall ? null : (
-                  <Route
-                    path="message/:idShip/:idTime"
-                    element={<DMThread />}
-                  />
-                )}
+              <Route path=":ship">
+                <Route index element={<Message />} />
+                <Route path="*" element={<Message />}>
+                  {isSmall ? null : (
+                    <Route
+                      path="message/:idShip/:idTime"
+                      element={<DMThread />}
+                    />
+                  )}
+                </Route>
               </Route>
 
               <Route path="groups/:ship/:name/*" element={<Groups />}>
@@ -384,10 +374,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                   path="channels/chat/:chShip/:chName"
                   element={<GroupChannel type="chat" />}
                 >
-                  <Route
-                    path="*"
-                    element={<ChatChannel title={` • ${appHead('').title}`} />}
-                  />
+                  <Route path="*" element={<ChatChannel />} />
                   {isSmall ? (
                     <Route path="message/:idTime" element={<ChatThread />} />
                   ) : null}

--- a/ui/src/channels/ChannelActions.tsx
+++ b/ui/src/channels/ChannelActions.tsx
@@ -8,6 +8,7 @@ import { Status } from '@/logic/status';
 import { useIsMobile } from '@/logic/useMedia';
 import { nestToFlag, getFlagParts } from '@/logic/utils';
 import { useRouteGroup, useDeleteChannelMutation } from '@/state/groups';
+import useActiveTab from '@/components/Sidebar/util';
 import { GroupChannel } from '@/types/groups';
 import { useIsChannelHost } from '@/logic/channel';
 import ActionMenu, { Action } from '@/components/ActionMenu';
@@ -47,6 +48,7 @@ const ChannelActions = React.memo(
     const isChannelHost = useIsChannelHost(flag);
     const { mutate: deleteChannelMutate } = useDeleteChannelMutation();
     const hasChildren = !!children;
+    const activeTab = useActiveTab();
 
     const leaveChannel = useCallback(async () => {
       try {
@@ -54,7 +56,9 @@ const ChannelActions = React.memo(
         navigate(
           isMobile
             ? `/groups/${ship}/${name}`
-            : `/groups/${ship}/${name}/channels`
+            : activeTab === 'messages'
+              ? `/messages`
+              : `/groups/${ship}/${name}/channels`
         );
       } catch (error) {
         if (error) {
@@ -62,7 +66,7 @@ const ChannelActions = React.memo(
           console.error(`[ChannelHeader:LeaveError] ${error}`);
         }
       }
-    }, [nest, ship, name, navigate, leave, isMobile]);
+    }, [nest, ship, name, navigate, leave, isMobile, activeTab]);
 
     const onDeleteChannelConfirm = useCallback(async () => {
       setDeleteStatus('loading');

--- a/ui/src/chat/ChatChannel.tsx
+++ b/ui/src/chat/ChatChannel.tsx
@@ -15,6 +15,7 @@ import useMedia, { useIsMobile } from '@/logic/useMedia';
 import ChannelTitleButton from '@/channels/ChannelTitleButton';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useFullChannel } from '@/logic/channel';
+import useActiveTab from '@/components/Sidebar/util';
 import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobileNavIcon';
 import {
   useAddPostMutation,
@@ -54,10 +55,13 @@ function ChatChannel({ title }: ViewProps) {
     () => searchParams.get('replyTo'),
     [searchParams]
   );
+  const activeTab = useActiveTab();
   const replyingWrit = useReplyPost(nest, chatReplyId);
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const isScrolling = useIsScrolling(scrollElementRef);
-  const root = `/groups/${groupFlag}/channels/${nest}`;
+  const root = `${
+    activeTab === 'messages' ? '/dm' : ''
+  }/groups/${groupFlag}/channels/${nest}`;
   // We only inset the bottom for groups, since DMs display the navbar
   // underneath this view
   const shouldApplyPaddingBottom = useMemo(

--- a/ui/src/chat/ChatSearch/ChatSearch.tsx
+++ b/ui/src/chat/ChatSearch/ChatSearch.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import * as Dialog from '@radix-ui/react-dialog';
 import { disableDefault } from '@/logic/utils';
 import { useSafeAreaInsets } from '@/logic/native';
+import useActiveTab from '@/components/Sidebar/util';
 import { ChatMap } from '@/types/channel';
 import ChatSearchResults from './ChatSearchResults';
 import { useChatSearchInput } from './useChatSearchInput';
@@ -36,6 +37,7 @@ export default function ChatSearch({
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const isSmall = useMedia('(min-width: 768px) and (max-width: 1099px)');
+  const activeTab = useActiveTab();
   const safeAreaInsets = useSafeAreaInsets();
   const scrollerRef = React.useRef<VirtuosoHandle>(null);
   const { selected, rawInput, onChange, onKeyDown } = useChatSearchInput({
@@ -67,7 +69,7 @@ export default function ChatSearch({
     }
   }, []);
 
-  const onDialogClose = useCallback(
+  const onOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
         navigate(root);
@@ -104,7 +106,11 @@ export default function ChatSearch({
               isSmall={isSmall}
             />
           </label>
-          <Dialog.Root open modal={false} onOpenChange={onDialogClose}>
+          <Dialog.Root
+            open
+            modal={activeTab === 'messages' ? true : false}
+            onOpenChange={onOpenChange}
+          >
             <Dialog.Content
               onInteractOutside={preventClose}
               onOpenAutoFocus={disableDefault}

--- a/ui/src/chat/ChatThread/ChatThread.tsx
+++ b/ui/src/chat/ChatThread/ChatThread.tsx
@@ -32,6 +32,7 @@ import {
 import { ReplyTuple } from '@/types/channel';
 import { useIsScrolling } from '@/logic/scroll';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
+import useActiveTab from '@/components/Sidebar/util';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import ChatScrollerPlaceholder from '../ChatScroller/ChatScrollerPlaceholder';
 import { chatStoreLogger, useChatInfo, useChatStore } from '../useChatStore';
@@ -109,11 +110,14 @@ export default function ChatThread() {
   const readTimeout = useChatInfo(flag).unread?.readTimeout;
   const isSmall = useMedia('(max-width: 1023px)');
   const clearOnNavRef = useRef({ isSmall, readTimeout, nest, flag, markRead });
+  const activeTab = useActiveTab();
 
   const returnURL = useCallback(
     () =>
-      `/groups/${ship}/${name}/channels/chat/${chShip}/${chName}?msg=${idTime}`,
-    [chName, chShip, name, ship, idTime]
+      `${
+        activeTab === 'messages' ? '/dm' : ''
+      }/groups/${ship}/${name}/channels/chat/${chShip}/${chName}?msg=${idTime}`,
+    [chName, chShip, name, ship, idTime, activeTab]
   );
 
   const onAtBottom = useCallback(() => {

--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -13,6 +13,7 @@ import { useAvatar } from '@/state/avatar';
 import { SigilProps } from '@/types/sigil';
 
 export type AvatarSizes =
+  | 'sidebar'
   | 'xxs'
   | 'xs'
   | 'small'
@@ -41,6 +42,7 @@ interface AvatarMeta {
 
 const sizeMap: Record<AvatarSizes, AvatarMeta> = {
   xxs: { classes: 'h-4 w-4', size: 10 },
+  sidebar: { classes: 'h-[16px] w-[16px] rounded-[3px]', size: 11 },
   xs: { classes: 'w-6 h-6 rounded', size: 12 },
   small: { classes: 'w-8 h-8 rounded', size: 16 },
   'default-sm': { classes: 'w-9 h-9 rounded-lg', size: 18 },
@@ -189,6 +191,7 @@ function Avatar({
       className={classNames(
         'relative flex flex-none items-center justify-center rounded bg-black',
         classes,
+        size === 'sidebar' && 'p-1.5',
         size === 'xs' && 'p-1.5',
         size === 'small' && 'p-2',
         size === 'default' && 'p-3',

--- a/ui/src/components/Leap/useLeap.tsx
+++ b/ui/src/components/Leap/useLeap.tsx
@@ -4,12 +4,8 @@ import { useLocation, useNavigate } from 'react-router';
 import { cite, deSig, preSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import { getFlagParts, nestToFlag } from '@/logic/utils';
-import { useGroupFlag, useGroups } from '@/state/groups';
-import {
-  usePinnedGroups,
-  usePinnedChannels,
-  usePinnedClubs,
-} from '@/state/pins';
+import { useGroupFlag, useGroups, usePinnedGroups } from '@/state/groups';
+import { usePinnedChannels, usePinnedClubs } from '@/state/pins';
 import { Group, GroupChannel } from '@/types/groups';
 import {
   LEAP_DESCRIPTION_TRUNCATE_LENGTH,

--- a/ui/src/components/Sidebar/ActivityIndicator.tsx
+++ b/ui/src/components/Sidebar/ActivityIndicator.tsx
@@ -53,8 +53,9 @@ export function ActivitySidebarItem() {
       }
       actions={count > 0 && <ActivityIndicator count={count} />}
       color={activeTab === 'notifications' ? 'text-black' : 'text-gray-600'}
-      to={`/notifications`}
+      to={`/`}
       defaultRoute
+      override
     >
       Activity
     </SidebarItem>

--- a/ui/src/components/Sidebar/ActivityIndicator.tsx
+++ b/ui/src/components/Sidebar/ActivityIndicator.tsx
@@ -45,13 +45,14 @@ export function ActivitySidebarItem() {
         <BellIcon
           className={cn(
             'm-1 h-4 w-4',
-            activeTab === 'notifications' && 'text-gray-700'
+            activeTab === 'notifications' ? 'text-black' : 'text-gray-600'
           )}
           isInactive={activeTab !== 'notifications'}
           nonNav
         />
       }
       actions={count > 0 && <ActivityIndicator count={count} />}
+      color={activeTab === 'notifications' ? 'text-black' : 'text-gray-600'}
       to={`/notifications`}
     >
       Activity

--- a/ui/src/components/Sidebar/ActivityIndicator.tsx
+++ b/ui/src/components/Sidebar/ActivityIndicator.tsx
@@ -54,6 +54,7 @@ export function ActivitySidebarItem() {
       actions={count > 0 && <ActivityIndicator count={count} />}
       color={activeTab === 'notifications' ? 'text-black' : 'text-gray-600'}
       to={`/notifications`}
+      defaultRoute
     >
       Activity
     </SidebarItem>

--- a/ui/src/components/Sidebar/ActivityIndicator.tsx
+++ b/ui/src/components/Sidebar/ActivityIndicator.tsx
@@ -1,6 +1,9 @@
 import cn from 'classnames';
-import React from 'react';
+import { useNotifications } from '@/notifications/useNotifications';
 import BulletIcon from '../icons/BulletIcon';
+import SidebarItem from './SidebarItem';
+import BellIcon from '../icons/BellIcon';
+import useActiveTab from './util';
 
 interface ActivityIndicatorProps {
   count: number;
@@ -29,5 +32,29 @@ export default function ActivityIndicator({
         count
       )}
     </div>
+  );
+}
+
+export function ActivitySidebarItem() {
+  const { count } = useNotifications();
+  const activeTab = useActiveTab();
+
+  return (
+    <SidebarItem
+      icon={
+        <BellIcon
+          className={cn(
+            'm-1 h-4 w-4',
+            activeTab === 'notifications' && 'text-gray-700'
+          )}
+          isInactive={activeTab !== 'notifications'}
+          nonNav
+        />
+      }
+      actions={count > 0 && <ActivityIndicator count={count} />}
+      to={`/notifications`}
+    >
+      Activity
+    </SidebarItem>
   );
 }

--- a/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -40,7 +40,7 @@ export default function AddGroupSidebarItem() {
         defaultRoute
         color={activeTab === 'groups' ? 'text-black' : 'text-gray-600'}
         actions={
-          <Dropdown.Trigger>
+          <Dropdown.Trigger data-testid="add-group-sidebar-button-icon">
             <AddIcon16 className="relative top-[2px] hidden h-4 w-4 group-hover:block" />
           </Dropdown.Trigger>
         }

--- a/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -29,7 +29,7 @@ export default function AddGroupSidebarItem() {
           <HomeIconMobileNav
             className={cn(
               'm-1 h-4 w-4',
-              activeTab === 'groups' && 'text-gray-700'
+              activeTab === 'groups' && 'text-black'
             )}
             asIcon
             isInactive={activeTab !== 'groups'}
@@ -38,9 +38,10 @@ export default function AddGroupSidebarItem() {
         to="/"
         override
         defaultRoute
+        color={activeTab === 'groups' ? 'text-black' : 'text-gray-600'}
         actions={
           <Dropdown.Trigger>
-            <AddIcon16 className="hidden h-4 w-4 group-hover:block" />
+            <AddIcon16 className="relative top-[2px] hidden h-4 w-4 group-hover:block" />
           </Dropdown.Trigger>
         }
       >

--- a/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -35,9 +35,7 @@ export default function AddGroupSidebarItem() {
             isInactive={activeTab !== 'groups'}
           />
         }
-        to="/"
-        override
-        defaultRoute
+        to="/groups"
         color={activeTab === 'groups' ? 'text-black' : 'text-gray-600'}
         actions={
           <Dropdown.Trigger data-testid="add-group-sidebar-button-icon">

--- a/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
+import cn from 'classnames';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { useLocation, useNavigate } from 'react-router-dom';
 import AddIcon16 from '../icons/Add16Icon';
 import HomeIconMobileNav from '../icons/HomeIconMobileNav';
 import SidebarItem from './SidebarItem';
+import useActiveTab from './util';
 
 export default function AddGroupSidebarItem() {
   const navigate = useNavigate();
   const location = useLocation();
+  const activeTab = useActiveTab();
   const [open, setOpen] = useState(false);
 
   const onOpenChange = (openChange: boolean) => {
@@ -20,14 +23,29 @@ export default function AddGroupSidebarItem() {
 
   return (
     <Dropdown.Root open={open} onOpenChange={onOpenChange}>
-      <Dropdown.Trigger>
-        <SidebarItem
-          icon={<HomeIconMobileNav className="m-1 h-4 w-4" />}
-          actions={<AddIcon16 className="h-4 w-4" />}
-        >
-          <span data-testid="add-group-sidebar-button">Groups</span>
-        </SidebarItem>
-      </Dropdown.Trigger>
+      <SidebarItem
+        className="group"
+        icon={
+          <HomeIconMobileNav
+            className={cn(
+              'm-1 h-4 w-4',
+              activeTab === 'groups' && 'text-gray-700'
+            )}
+            asIcon
+            isInactive={activeTab !== 'groups'}
+          />
+        }
+        to="/"
+        override
+        defaultRoute
+        actions={
+          <Dropdown.Trigger>
+            <AddIcon16 className="hidden h-4 w-4 group-hover:block" />
+          </Dropdown.Trigger>
+        }
+      >
+        <span data-testid="add-group-sidebar-button">Groups</span>
+      </SidebarItem>
 
       <Dropdown.Content
         className="dropdown w-[200px]"

--- a/ui/src/components/Sidebar/GangItem.tsx
+++ b/ui/src/components/Sidebar/GangItem.tsx
@@ -81,8 +81,8 @@ export default function GangItem(props: {
 
   if (requested) {
     sideBarIcon = (
-      <p className="flex items-center rounded-full bg-blue-soft px-2 py-1 text-blue">
-        Join Requested
+      <p className="flex items-center rounded-full bg-blue-soft px-2 py-1 text-sm text-blue">
+        Requested
       </p>
     );
   }

--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -21,16 +21,23 @@ function itemContent(_i: number, item: AnyListItem) {
     const record = item.data;
     if (record.type === 'group') {
       return (
-        <GroupsSidebarItem flag={record.flag} isNew={record.status === 'new'} />
+        <div className="px-4 sm:px-2">
+          <GroupsSidebarItem
+            flag={record.flag}
+            isNew={record.status === 'new'}
+          />
+        </div>
       );
     }
 
     return (
-      <GangItem
-        flag={record.flag}
-        invited={record.status === 'invited'}
-        isJoining={record.status === 'loading'}
-      />
+      <div className="px-4 sm:px-2">
+        <GangItem
+          flag={record.flag}
+          invited={record.status === 'invited'}
+          isJoining={record.status === 'loading'}
+        />
+      </div>
     );
   }
 

--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -4,15 +4,36 @@ import { useIsMobile } from '@/logic/useMedia';
 import { Group } from '@/types/groups';
 import GroupListPlaceholder from './GroupListPlaceholder';
 import GroupsSidebarItem from './GroupsSidebarItem';
+import { GroupSearchRecord, isGroupSearchRecord } from './useSearchFilter';
+import GangItem from './GangItem';
 
 type TopContentListItem = { type: 'top'; component: ReactNode };
 type GroupListItem = { type: 'group'; data: [string, Group] };
-type AnyListItem = TopContentListItem | GroupListItem;
+type SearchListItem = { type: 'search'; data: GroupSearchRecord };
+type AnyListItem = TopContentListItem | GroupListItem | SearchListItem;
 
 function itemContent(_i: number, item: AnyListItem) {
   if (item.type === 'top') {
     return item.component;
   }
+
+  if (item.type === 'search') {
+    const record = item.data;
+    if (record.type === 'group') {
+      return (
+        <GroupsSidebarItem flag={record.flag} isNew={record.status === 'new'} />
+      );
+    }
+
+    return (
+      <GangItem
+        flag={record.flag}
+        invited={record.status === 'invited'}
+        isJoining={record.status === 'loading'}
+      />
+    );
+  }
+
   const [flag] = item.data;
   return (
     <div className="px-4 sm:px-2">
@@ -25,15 +46,17 @@ function computeItemKey(_i: number, item: AnyListItem) {
   if (item.type === 'top') {
     return 'top';
   }
+
+  if (item.type === 'search') {
+    return `search:${item.data.flag}`;
+  }
+
   const [flag] = item.data;
   return flag;
 }
 
 interface GroupListProps {
-  groups: [string, Group][];
-  pinnedGroups: [string, Group][];
-  loadingGroups: [string, Group][];
-  newGroups?: [string, Group][];
+  groups: [string, Group][] | GroupSearchRecord[];
   children: React.ReactNode;
   isScrolling: (scrolling: boolean) => void;
   atTopChange?: (atTop: boolean) => void;
@@ -43,9 +66,6 @@ let virtuosoState: StateSnapshot | undefined;
 
 export default function GroupList({
   groups,
-  pinnedGroups,
-  loadingGroups,
-  newGroups,
   children,
   isScrolling,
   atTopChange,
@@ -58,19 +78,6 @@ export default function GroupList({
       ? { main: 200, reverse: 200 }
       : { main: 400, reverse: 400 },
   };
-
-  const flagsToFilter = useMemo(() => {
-    const flags = new Set();
-    pinnedGroups.forEach(([flag]) => flags.add(flag));
-    loadingGroups.forEach(([flag]) => flags.add(flag));
-    newGroups?.forEach(([flag]) => flags.add(flag));
-    return flags;
-  }, [pinnedGroups, loadingGroups, newGroups]);
-
-  const allOtherGroups = useMemo(
-    () => groups.filter(([flag, _g]) => !flagsToFilter.has(flag)),
-    [groups, flagsToFilter]
-  );
 
   const headerHeightRef = useRef<number>(0);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -93,12 +100,16 @@ export default function GroupList({
       : [];
     return [
       ...top,
-      ...allOtherGroups.map<GroupListItem>((g) => ({
-        type: 'group',
-        data: g,
-      })),
+      ...groups.map<GroupListItem | SearchListItem>((g) =>
+        isGroupSearchRecord(g)
+          ? { type: 'search', data: g }
+          : {
+              type: 'group',
+              data: g,
+            }
+      ),
     ];
-  }, [allOtherGroups, header]);
+  }, [groups, header]);
 
   useEffect(() => {
     if (!headerRef.current) {
@@ -145,7 +156,7 @@ export default function GroupList({
       computeItemKey={computeItemKey}
       itemContent={itemContent}
       restoreStateFrom={virtuosoState}
-      className="h-full w-full list-none overflow-x-hidden"
+      className="border-top-none h-full w-full list-none overflow-x-hidden"
       isScrolling={isScrolling}
       atTopStateChange={atTopChange}
     />

--- a/ui/src/components/Sidebar/MessagesSidebar.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebar.tsx
@@ -63,7 +63,7 @@ export default function MessagesSidebar({
     {
       key: 'groups',
       onClick: () => setFilterMode(filters.groups),
-      content: 'Group Talk Channels',
+      content: 'Chat Channels',
       containerClassName: cn(
         'flex items-center space-x-2 rounded-none',
         messagesFilter === filters.groups && 'bg-gray-50 text-gray-800'

--- a/ui/src/components/Sidebar/MessagesSidebar.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebar.tsx
@@ -1,130 +1,19 @@
 import { useState, useRef, useCallback, useContext } from 'react';
 import cn from 'classnames';
 import { debounce } from 'lodash';
-import { Link, useLocation } from 'react-router-dom';
-import AddIcon from '@/components/icons/AddIcon';
 import Filter16Icon from '@/components/icons/Filter16Icon';
 import { usePinnedChats } from '@/state/pins';
-import SidebarItem from '@/components/Sidebar/SidebarItem';
-import Avatar from '@/components/Avatar';
-import ShipName from '@/components/ShipName';
-import TalkIcon from '@/components/icons/TalkIcon';
-import MenuIcon from '@/components/icons/MenuIcon';
-import ArrowNWIcon from '@/components/icons/ArrowNWIcon';
 import {
   filters,
   SidebarFilter,
   useMessagesFilter,
   usePutEntryMutation,
 } from '@/state/settings';
-import ReconnectingSpinner from '@/components/ReconnectingSpinner';
-import SystemChrome from '@/components/Sidebar/SystemChrome';
 import ActionMenu, { Action } from '@/components/ActionMenu';
-import { DesktopUpdateButton } from '@/components/UpdateNotices';
 import { AppUpdateContext } from '@/logic/useAppUpdates';
 import MessagesList from '../../dms/MessagesList';
 import MessagesSidebarItem from '../../dms/MessagesSidebarItem';
 import { MessagesScrollingContext } from '../../dms/MessagesScrollingContext';
-
-export function TalkAppMenu() {
-  const [menuOpen, setMenuOpen] = useState(false);
-  const location = useLocation();
-
-  const actions: Action[] = [
-    {
-      key: 'submit',
-      type: 'prominent',
-      content: (
-        <a
-          className="no-underline"
-          href="https://airtable.com/shrflFkf5UyDFKhmW"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Submit Feedback
-        </a>
-      ),
-    },
-    {
-      key: 'about',
-      content: (
-        <Link to="/about" state={{ backgroundLocation: location }}>
-          About Talk
-        </Link>
-      ),
-    },
-    {
-      key: 'settings',
-      content: (
-        <Link
-          to="/settings"
-          className=""
-          state={{ backgroundLocation: location }}
-        >
-          App Settings
-        </Link>
-      ),
-    },
-  ];
-
-  return (
-    <ActionMenu
-      open={menuOpen}
-      onOpenChange={setMenuOpen}
-      actions={actions}
-      align="start"
-    >
-      <SidebarItem
-        className={cn(
-          menuOpen
-            ? 'bg-gray-100 text-gray-800'
-            : 'text-black hover:text-gray-800',
-          'group'
-        )}
-        icon={
-          <div className={cn('h-6 w-6 rounded group-hover:bg-gray-100')}>
-            <TalkIcon
-              className={cn(
-                'h-6 w-6',
-                menuOpen ? 'hidden' : 'group-hover:hidden'
-              )}
-            />
-            <MenuIcon
-              aria-label="Open Menu"
-              className={cn(
-                'm-1 h-4 w-4 text-gray-800',
-                menuOpen ? 'block' : 'hidden group-hover:block'
-              )}
-            />
-          </div>
-        }
-      >
-        <div className="flex items-center justify-between">
-          Talk
-          <ReconnectingSpinner className="h-4 w-4 group-hover:hidden" />
-          <a
-            title="Back to Landscape"
-            aria-label="Back to Landscape"
-            href="/apps/landscape"
-            target="_blank"
-            rel="noreferrer"
-            className={cn(
-              'h-6 w-6 no-underline',
-              menuOpen ? 'block' : 'hidden group-hover:block'
-            )}
-            // Prevents the dropdown trigger from being fired (therefore, opening the menu)
-            onPointerDown={(e) => {
-              e.stopPropagation();
-              return false;
-            }}
-          >
-            <ArrowNWIcon className="text-gray-400" />
-          </a>
-        </div>
-      </SidebarItem>
-    </ActionMenu>
-  );
-}
 
 export default function MessagesSidebar({
   searchQuery,

--- a/ui/src/components/Sidebar/MessagesSidebar.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebar.tsx
@@ -1,0 +1,222 @@
+import { useState, useRef, useCallback, useContext } from 'react';
+import cn from 'classnames';
+import { debounce } from 'lodash';
+import { Link, useLocation } from 'react-router-dom';
+import AddIcon from '@/components/icons/AddIcon';
+import Filter16Icon from '@/components/icons/Filter16Icon';
+import { usePinnedChats } from '@/state/pins';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import Avatar from '@/components/Avatar';
+import ShipName from '@/components/ShipName';
+import TalkIcon from '@/components/icons/TalkIcon';
+import MenuIcon from '@/components/icons/MenuIcon';
+import ArrowNWIcon from '@/components/icons/ArrowNWIcon';
+import {
+  filters,
+  SidebarFilter,
+  useMessagesFilter,
+  usePutEntryMutation,
+} from '@/state/settings';
+import ReconnectingSpinner from '@/components/ReconnectingSpinner';
+import SystemChrome from '@/components/Sidebar/SystemChrome';
+import ActionMenu, { Action } from '@/components/ActionMenu';
+import { DesktopUpdateButton } from '@/components/UpdateNotices';
+import { AppUpdateContext } from '@/logic/useAppUpdates';
+import MessagesList from '../../dms/MessagesList';
+import MessagesSidebarItem from '../../dms/MessagesSidebarItem';
+import { MessagesScrollingContext } from '../../dms/MessagesScrollingContext';
+
+export function TalkAppMenu() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  const actions: Action[] = [
+    {
+      key: 'submit',
+      type: 'prominent',
+      content: (
+        <a
+          className="no-underline"
+          href="https://airtable.com/shrflFkf5UyDFKhmW"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Submit Feedback
+        </a>
+      ),
+    },
+    {
+      key: 'about',
+      content: (
+        <Link to="/about" state={{ backgroundLocation: location }}>
+          About Talk
+        </Link>
+      ),
+    },
+    {
+      key: 'settings',
+      content: (
+        <Link
+          to="/settings"
+          className=""
+          state={{ backgroundLocation: location }}
+        >
+          App Settings
+        </Link>
+      ),
+    },
+  ];
+
+  return (
+    <ActionMenu
+      open={menuOpen}
+      onOpenChange={setMenuOpen}
+      actions={actions}
+      align="start"
+    >
+      <SidebarItem
+        className={cn(
+          menuOpen
+            ? 'bg-gray-100 text-gray-800'
+            : 'text-black hover:text-gray-800',
+          'group'
+        )}
+        icon={
+          <div className={cn('h-6 w-6 rounded group-hover:bg-gray-100')}>
+            <TalkIcon
+              className={cn(
+                'h-6 w-6',
+                menuOpen ? 'hidden' : 'group-hover:hidden'
+              )}
+            />
+            <MenuIcon
+              aria-label="Open Menu"
+              className={cn(
+                'm-1 h-4 w-4 text-gray-800',
+                menuOpen ? 'block' : 'hidden group-hover:block'
+              )}
+            />
+          </div>
+        }
+      >
+        <div className="flex items-center justify-between">
+          Talk
+          <ReconnectingSpinner className="h-4 w-4 group-hover:hidden" />
+          <a
+            title="Back to Landscape"
+            aria-label="Back to Landscape"
+            href="/apps/landscape"
+            target="_blank"
+            rel="noreferrer"
+            className={cn(
+              'h-6 w-6 no-underline',
+              menuOpen ? 'block' : 'hidden group-hover:block'
+            )}
+            // Prevents the dropdown trigger from being fired (therefore, opening the menu)
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              return false;
+            }}
+          >
+            <ArrowNWIcon className="text-gray-400" />
+          </a>
+        </div>
+      </SidebarItem>
+    </ActionMenu>
+  );
+}
+
+export default function MessagesSidebar({
+  searchQuery,
+}: {
+  searchQuery?: string;
+}) {
+  const { needsUpdate } = useContext(AppUpdateContext);
+  const [atTop, setAtTop] = useState(true);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const messagesFilter = useMessagesFilter();
+  const { mutate } = usePutEntryMutation({
+    bucket: 'talk',
+    key: 'messagesFilter',
+  });
+  const pinned = usePinnedChats();
+
+  const setFilterMode = (mode: SidebarFilter) => {
+    mutate({ val: mode });
+  };
+
+  const atTopChange = useCallback((top: boolean) => setAtTop(top), []);
+
+  const scroll = useRef(
+    debounce((scrolling: boolean) => setIsScrolling(scrolling), 200)
+  );
+
+  const filterActions: Action[] = [
+    {
+      key: 'all',
+      onClick: () => setFilterMode(filters.all),
+      content: 'All Messages',
+      containerClassName: cn(
+        'flex items-center space-x-2 rounded-none',
+        messagesFilter === filters.all && 'bg-gray-50 text-gray-800'
+      ),
+    },
+    {
+      key: 'direct',
+      onClick: () => setFilterMode(filters.dms),
+      content: 'Direct Messages',
+      containerClassName: cn(
+        'flex items-center space-x-2 rounded-none',
+        messagesFilter === filters.dms && 'bg-gray-50 text-gray-800'
+      ),
+    },
+    {
+      key: 'groups',
+      onClick: () => setFilterMode(filters.groups),
+      content: 'Group Talk Channels',
+      containerClassName: cn(
+        'flex items-center space-x-2 rounded-none',
+        messagesFilter === filters.groups && 'bg-gray-50 text-gray-800'
+      ),
+    },
+  ];
+
+  return (
+    <MessagesScrollingContext.Provider value={isScrolling}>
+      <MessagesList
+        filter={messagesFilter}
+        searchQuery={searchQuery}
+        atTopChange={atTopChange}
+        isScrolling={scroll.current}
+      >
+        {pinned && pinned.length > 0 ? (
+          <div className="mb-4 flex flex-col border-t-2 border-gray-50 p-2 px-2 pb-1">
+            <h2 className="my-2 px-2 text-sm font-bold text-gray-400">
+              Pinned Messages
+            </h2>
+
+            {pinned.map((ship: string) => (
+              <MessagesSidebarItem key={ship} whom={ship} />
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex h-10 items-center justify-between border-t-2 border-gray-50 px-4 pb-1 pt-2">
+          <h2 className="text-sm font-bold text-gray-400">{messagesFilter}</h2>
+          <ActionMenu
+            open={filterOpen}
+            onOpenChange={setFilterOpen}
+            actions={filterActions}
+            asChild={false}
+            triggerClassName="default-focus"
+            contentClassName="w-56 text-gray-600"
+            ariaLabel="Groups Filter Options"
+          >
+            <Filter16Icon className="w-4 text-gray-400" />
+          </ActionMenu>
+        </div>
+      </MessagesList>
+    </MessagesScrollingContext.Provider>
+  );
+}

--- a/ui/src/components/Sidebar/MessagesSidebar.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebar.tsx
@@ -191,8 +191,8 @@ export default function MessagesSidebar({
         isScrolling={scroll.current}
       >
         {pinned && pinned.length > 0 ? (
-          <div className="mb-4 flex flex-col p-2 px-2 pb-1">
-            <h2 className="my-2 px-2 text-sm font-bold text-gray-400">
+          <div className="mb-4 flex flex-col border-t-2 border-gray-50 p-2 px-2 pb-1">
+            <h2 className="my-2 px-2 text-sm font-semibold text-gray-400">
               Pinned Messages
             </h2>
 
@@ -203,7 +203,9 @@ export default function MessagesSidebar({
         ) : null}
 
         <div className="flex h-10 items-center justify-between border-t-2 border-gray-50 px-4 pb-1 pt-2">
-          <h2 className="text-sm font-bold text-gray-400">{messagesFilter}</h2>
+          <h2 className="text-sm font-semibold text-gray-400">
+            {messagesFilter}
+          </h2>
           <ActionMenu
             open={filterOpen}
             onOpenChange={setFilterOpen}

--- a/ui/src/components/Sidebar/MessagesSidebar.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebar.tsx
@@ -191,7 +191,7 @@ export default function MessagesSidebar({
         isScrolling={scroll.current}
       >
         {pinned && pinned.length > 0 ? (
-          <div className="mb-4 flex flex-col border-t-2 border-gray-50 p-2 px-2 pb-1">
+          <div className="mb-4 flex flex-col p-2 px-2 pb-1">
             <h2 className="my-2 px-2 text-sm font-bold text-gray-400">
               Pinned Messages
             </h2>

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -19,13 +19,12 @@ import {
 } from '@/state/groups';
 import { useIsMobile } from '@/logic/useMedia';
 import useGroupSort from '@/logic/useGroupSort';
-import { useNotifications } from '@/notifications/useNotifications';
 import GroupsSidebarItem from './GroupsSidebarItem';
 import SidebarSorter from './SidebarSorter';
 import GangItem from './GangItem';
 import { GroupsScrollingContext } from './GroupsScrollingContext';
 import SidebarTopMenu from './SidebarTopMenu';
-import useActiveTab, { ActiveTab } from './util';
+import useActiveTab from './util';
 import MessagesSidebar from './MessagesSidebar';
 import useSearchFilter, { GroupSearchRecord } from './useSearchFilter';
 import X16Icon from '../icons/X16Icon';

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -57,6 +57,7 @@ export default function Sidebar() {
   const gangsWithClaims = useGangsWithClaim();
   const sortedGroups = sortGroups(groups);
   const shipColor = useProfileColor(window.our);
+  const searchRef = useRef<HTMLInputElement>(null);
   const ref = useRef<HTMLDivElement>(null);
   const activeTab = useActiveTab();
 
@@ -66,6 +67,7 @@ export default function Sidebar() {
   useEffect(() => {
     // if we switch between messages & groups, clear the search
     setSearchInput('');
+    searchRef.current?.focus();
   }, [activeTab]);
 
   const atTopChange = useCallback((top: boolean) => setAtTop(top), []);
@@ -166,6 +168,7 @@ export default function Sidebar() {
       <div className="flex-auto space-y-3 overflow-x-hidden sm:space-y-1">
         <div className="relative mb-1 flex border-t-2 border-gray-50">
           <input
+            ref={searchRef}
             id="search"
             type="text"
             autoFocus

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -162,7 +162,7 @@ export default function Sidebar() {
               !atTop && 'bottom-shadow'
             )}
             placeholder={
-              activeTab === 'messages' ? 'Search Messages' : 'Search Groups'
+              activeTab === 'messages' ? 'Filter Messages' : 'Filter Groups'
             }
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -3,15 +3,10 @@ import React, {
   useRef,
   useMemo,
   useCallback,
-  useContext,
   useEffect,
 } from 'react';
 import cn from 'classnames';
 import { debounce } from 'lodash';
-import { useLocation } from 'react-router-dom';
-import ActivityIndicator, {
-  ActivitySidebarItem,
-} from '@/components/Sidebar/ActivityIndicator';
 import MobileSidebar from '@/components/Sidebar/MobileSidebar';
 import GroupList from '@/components/Sidebar/GroupList';
 import {
@@ -23,20 +18,12 @@ import {
   useNewGroups,
 } from '@/state/groups';
 import { useIsMobile } from '@/logic/useMedia';
-import SidebarItem from '@/components/Sidebar/SidebarItem';
-import ShipName from '@/components/ShipName';
-import Avatar, { useProfileColor } from '@/components/Avatar';
 import useGroupSort from '@/logic/useGroupSort';
 import { useNotifications } from '@/notifications/useNotifications';
-import { AppUpdateContext } from '@/logic/useAppUpdates';
 import GroupsSidebarItem from './GroupsSidebarItem';
 import SidebarSorter from './SidebarSorter';
 import GangItem from './GangItem';
 import { GroupsScrollingContext } from './GroupsScrollingContext';
-import { DesktopUpdateButton } from '../UpdateNotices';
-import AddGroupSidebarItem from './AddGroupSidebarItem';
-import SidebarHeader from './SidebarHeader';
-import MessagesIcon from '../icons/MessagesIcon';
 import SidebarTopMenu from './SidebarTopMenu';
 import useActiveTab, { ActiveTab } from './util';
 import MessagesSidebar from './MessagesSidebar';
@@ -48,7 +35,6 @@ export default function Sidebar() {
   const [isScrolling, setIsScrolling] = useState(false);
   const [atTop, setAtTop] = useState(true);
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
-  const { count } = useNotifications();
   const { data: groups, isLoading } = useGroupsWithQuery();
   const invitedGroups = usePendingGangsWithoutClaim();
   const pinnedGroups = usePinnedGroups();
@@ -56,7 +42,6 @@ export default function Sidebar() {
   const newGroups = useNewGroups();
   const gangsWithClaims = useGangsWithClaim();
   const sortedGroups = sortGroups(groups);
-  const shipColor = useProfileColor(window.our);
   const searchRef = useRef<HTMLInputElement>(null);
   const ref = useRef<HTMLDivElement>(null);
   const activeTab = useActiveTab();
@@ -166,7 +151,7 @@ export default function Sidebar() {
       <SidebarTopMenu />
 
       <div className="flex-auto space-y-3 overflow-x-hidden sm:space-y-1">
-        <div className="relative mb-1 flex border-t-2 border-gray-50">
+        <div className="relative mb-1 flex">
           <input
             ref={searchRef}
             id="search"
@@ -196,19 +181,18 @@ export default function Sidebar() {
           <GroupsScrollingContext.Provider value={isScrolling}>
             <GroupList
               groups={
-                searchInput
+                hasSearch
                   ? (augmentedSearchResults as GroupSearchRecord[])
                   : allOtherGroups
               }
               isScrolling={scroll.current}
               atTopChange={atTopChange}
             >
-              {!searchInput && (
+              {!hasSearch && (
                 <>
                   <SidebarTopSection
                     title="Pinned Groups"
                     empty={!hasPinnedGroups && !hasInvitedGroups}
-                    noBorder={true}
                   >
                     {hasPinnedGroups && pinnedGroupsOptions}
                     {hasInvitedGroups && invitedGroupsDisplay}
@@ -252,7 +236,7 @@ export default function Sidebar() {
                 </>
               )}
 
-              {searchInput && (
+              {hasSearch && (
                 <SidebarTopSection
                   title={
                     augmentedSearchResults.length

--- a/ui/src/components/Sidebar/SidebarHeader.tsx
+++ b/ui/src/components/Sidebar/SidebarHeader.tsx
@@ -8,6 +8,7 @@ import MenuIcon from '../icons/MenuIcon';
 import ReconnectingSpinner from '../ReconnectingSpinner';
 import ActionMenu, { Action } from '../ActionMenu';
 import TlonIcon from '../icons/TlonIcon';
+import { LeapShortcutIcon } from './SystemChrome';
 
 const SidebarHeader = React.memo(() => {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -16,7 +17,6 @@ const SidebarHeader = React.memo(() => {
   const actions: Action[] = [
     {
       key: 'submit',
-      type: 'prominent',
       content: (
         <a
           className="no-underline"
@@ -24,7 +24,20 @@ const SidebarHeader = React.memo(() => {
           target="_blank"
           rel="noreferrer"
         >
-          Submit Feedback
+          <LeapShortcutIcon className="text-indigo" />
+        </a>
+      ),
+    },
+    {
+      key: 'landscape',
+      content: (
+        <a
+          className="no-underline"
+          href="https://airtable.com/shrflFkf5UyDFKhmW"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Back to Landscape
         </a>
       ),
     },
@@ -70,6 +83,7 @@ const SidebarHeader = React.memo(() => {
       actions={actions}
       align="start"
       className="w-full"
+      contentClassName="w-[238px]"
     >
       <SidebarItem
         className={cn(
@@ -79,10 +93,14 @@ const SidebarHeader = React.memo(() => {
           'group'
         )}
         icon={
-          <div className={cn('h-6 w-6 rounded group-hover:bg-gray-100')}>
+          <div
+            className={cn(
+              'flex h-6 w-6 items-center justify-center rounded group-hover:bg-gray-100'
+            )}
+          >
             <TlonIcon
               className={cn(
-                'h-[22px] w-[22px]',
+                'm-1 h-[18px] w-[18px]',
                 menuOpen ? 'hidden' : 'group-hover:hidden'
               )}
             />

--- a/ui/src/components/Sidebar/SidebarHeader.tsx
+++ b/ui/src/components/Sidebar/SidebarHeader.tsx
@@ -31,14 +31,17 @@ const SidebarHeader = React.memo(() => {
     {
       key: 'landscape',
       content: (
-        <a
-          className="no-underline"
-          href="https://airtable.com/shrflFkf5UyDFKhmW"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Back to Landscape
-        </a>
+        <>
+          <a
+            className="dropdown-item no-underline"
+            href="https://airtable.com/shrflFkf5UyDFKhmW"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Back to Landscape
+          </a>
+          <div className="mx-0 h-[2px] w-full bg-gray-50 px-0" />
+        </>
       ),
     },
     {

--- a/ui/src/components/Sidebar/SidebarHeader.tsx
+++ b/ui/src/components/Sidebar/SidebarHeader.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import cn from 'classnames';
+import { Link } from 'react-router-dom';
+import { useLocation } from 'react-router';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import ArrowNWIcon from '../icons/ArrowNWIcon';
+import MenuIcon from '../icons/MenuIcon';
+import ReconnectingSpinner from '../ReconnectingSpinner';
+import ActionMenu, { Action } from '../ActionMenu';
+import TlonIcon from '../icons/TlonIcon';
+
+const SidebarHeader = React.memo(() => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  const actions: Action[] = [
+    {
+      key: 'submit',
+      type: 'prominent',
+      content: (
+        <a
+          className="no-underline"
+          href="https://airtable.com/shrflFkf5UyDFKhmW"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Submit Feedback
+        </a>
+      ),
+    },
+    {
+      key: 'about',
+      content: (
+        <Link to="/about" state={{ backgroundLocation: location }}>
+          About Groups
+        </Link>
+      ),
+    },
+    {
+      key: 'settings',
+      content: (
+        <Link
+          to="/settings"
+          className=""
+          state={{ backgroundLocation: location }}
+        >
+          App Settings
+        </Link>
+      ),
+    },
+    {
+      key: 'submit',
+      content: (
+        <a
+          className="no-underline"
+          href="https://airtable.com/shrflFkf5UyDFKhmW"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Submit Feedback
+        </a>
+      ),
+    },
+  ];
+
+  return (
+    <ActionMenu
+      open={menuOpen}
+      onOpenChange={setMenuOpen}
+      actions={actions}
+      align="start"
+      className="w-full"
+    >
+      <SidebarItem
+        className={cn(
+          menuOpen
+            ? 'bg-gray-100 text-gray-800'
+            : 'text-black hover:text-gray-800',
+          'group'
+        )}
+        icon={
+          <div className={cn('h-6 w-6 rounded group-hover:bg-gray-100')}>
+            <TlonIcon
+              className={cn(
+                'h-[22px] w-[22px]',
+                menuOpen ? 'hidden' : 'group-hover:hidden'
+              )}
+            />
+            <MenuIcon
+              aria-label="Open Menu"
+              className={cn(
+                'm-1 h-4 w-4 text-gray-800',
+                menuOpen ? 'block' : 'hidden group-hover:block'
+              )}
+            />
+          </div>
+        }
+      >
+        <div className="flex items-center justify-between">
+          Tlon
+          <ReconnectingSpinner
+            className={cn(
+              'h-4 w-4 group-hover:hidden',
+              menuOpen ? 'hidden' : 'block'
+            )}
+          />
+          <a
+            title="Back to Landscape"
+            aria-label="Back to Landscape"
+            href="/apps/landscape"
+            target="_blank"
+            rel="noreferrer"
+            className={cn(
+              'h-6 w-6 no-underline',
+              menuOpen ? 'block' : 'hidden group-hover:block'
+            )}
+            // Prevents the dropdown trigger from being fired (therefore, opening the menu)
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              return false;
+            }}
+          >
+            <ArrowNWIcon className="text-gray-400" />
+          </a>
+        </div>
+      </SidebarItem>
+    </ActionMenu>
+  );
+});
+
+export default SidebarHeader;

--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -16,6 +16,7 @@ import CaretRightIcon from '../icons/CaretRightIcon';
 type SidebarProps = PropsWithChildren<{
   icon: React.ReactNode | ((active: boolean) => React.ReactNode);
   to?: string;
+  override?: boolean;
   defaultRoute?: boolean;
   actions?:
     | React.ReactNode
@@ -57,6 +58,7 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
     {
       icon,
       to,
+      override = false,
       color = 'text-gray-800 sm:text-gray-600',
       highlight = 'bg-gray-50',
       fontWeight,
@@ -145,7 +147,9 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
           'group relative my-0.5 flex w-full items-center justify-between rounded-lg',
           color,
           !hasHoverColor() && !active ? `hover:${highlight}` : null,
-          !hasHoverColor() && active && to !== '/' ? 'bg-gray-100' : null
+          !hasHoverColor() && active && (to !== '/' || override)
+            ? 'bg-gray-100'
+            : null
         )}
       >
         <Action

--- a/ui/src/components/Sidebar/SidebarTopMenu.tsx
+++ b/ui/src/components/Sidebar/SidebarTopMenu.tsx
@@ -37,7 +37,7 @@ const SidebarTopMenu = React.memo(() => {
           <MessagesIcon
             className={cn(
               'm-1 h-4 w-4',
-              activeTab === 'messages' && 'text-gray-700'
+              activeTab === 'messages' && 'text-black'
             )}
             nonNav
             isInactive={activeTab !== 'messages'}
@@ -50,6 +50,7 @@ const SidebarTopMenu = React.memo(() => {
         }
         to={'/messages'}
         className="group"
+        color={activeTab === 'messages' ? 'text-black' : 'text-gray-600'}
       >
         Messages
       </SidebarItem>
@@ -58,8 +59,9 @@ const SidebarTopMenu = React.memo(() => {
 
       <SidebarItem
         highlight={shipColor}
-        icon={<Avatar size="xs" ship={window.our} />}
+        icon={<Avatar size="sidebar" className="m-1" ship={window.our} />}
         to={'/profile/edit'}
+        color={activeTab === 'profile' ? 'text-black' : 'text-gray-600'}
       >
         <ShipName showAlias name={window.our} />
       </SidebarItem>

--- a/ui/src/components/Sidebar/SidebarTopMenu.tsx
+++ b/ui/src/components/Sidebar/SidebarTopMenu.tsx
@@ -1,0 +1,70 @@
+import React, { useContext } from 'react';
+import cn from 'classnames';
+import { debounce } from 'lodash';
+import { Link, useLocation } from 'react-router-dom';
+import ActivityIndicator, {
+  ActivitySidebarItem,
+} from '@/components/Sidebar/ActivityIndicator';
+import { useIsMobile } from '@/logic/useMedia';
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import { AppUpdateContext } from '@/logic/useAppUpdates';
+import ShipName from '@/components/ShipName';
+import Avatar, { useProfileColor } from '@/components/Avatar';
+import AddGroupSidebarItem from './AddGroupSidebarItem';
+import SidebarHeader from './SidebarHeader';
+import MessagesIcon from '../icons/MessagesIcon';
+import { DesktopUpdateButton } from '../UpdateNotices';
+import useActiveTab from './util';
+import AddIcon16 from '../icons/Add16Icon';
+
+const UpdateOrAppMenu = React.memo(() => {
+  const { needsUpdate } = useContext(AppUpdateContext);
+  return needsUpdate ? <DesktopUpdateButton /> : <SidebarHeader />;
+});
+
+const SidebarTopMenu = React.memo(() => {
+  const shipColor = useProfileColor(window.our);
+  const activeTab = useActiveTab();
+
+  return (
+    <div className="flex w-full flex-col space-y-0.5 p-2">
+      <UpdateOrAppMenu />
+
+      <AddGroupSidebarItem />
+
+      <SidebarItem
+        icon={
+          <MessagesIcon
+            className={cn(
+              'm-1 h-4 w-4',
+              activeTab === 'messages' && 'text-gray-700'
+            )}
+            nonNav
+            isInactive={activeTab !== 'messages'}
+          />
+        }
+        actions={
+          <Link to="/dm/new" className="hidden group-hover:block">
+            <AddIcon16 className="h-4 w-4" />
+          </Link>
+        }
+        to={'/messages'}
+        className="group"
+      >
+        Messages
+      </SidebarItem>
+
+      <ActivitySidebarItem />
+
+      <SidebarItem
+        highlight={shipColor}
+        icon={<Avatar size="xs" ship={window.our} />}
+        to={'/profile/edit'}
+      >
+        <ShipName showAlias name={window.our} />
+      </SidebarItem>
+    </div>
+  );
+});
+
+export default SidebarTopMenu;

--- a/ui/src/components/Sidebar/SystemChrome.tsx
+++ b/ui/src/components/Sidebar/SystemChrome.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames';
 import GridIcon from '../icons/GridIcon';
 import useLeap from '../Leap/useLeap';
 
@@ -13,6 +14,27 @@ export default function SystemChrome() {
     >
       <div className="flex flex-row items-center space-x-2">
         <GridIcon className="h-8 w-8" />
+        <span className="font-semibold">Leap</span>
+        <span>({metaKey} + K)</span>
+      </div>
+    </button>
+  );
+}
+
+export function LeapShortcutIcon({ className }: { className?: string }) {
+  const metaKey = navigator.userAgent.toLowerCase().includes('mac')
+    ? '⌘'
+    : 'Ctrl';
+  const { setIsOpen } = useLeap();
+  return (
+    <button
+      onClick={() => setIsOpen((isOpen) => !isOpen)}
+      className={cn(
+        'flex w-full cursor-pointer flex-row space-x-2 text-gray-400 hover:text-gray-800',
+        className
+      )}
+    >
+      <div className="flex flex-row items-center space-x-2">
         <span className="font-semibold">Leap</span>
         <span>({metaKey} + K)</span>
       </div>

--- a/ui/src/components/Sidebar/useSearchFilter.ts
+++ b/ui/src/components/Sidebar/useSearchFilter.ts
@@ -1,0 +1,79 @@
+import fuzzy from 'fuzzy';
+import { useGangs, useGroups } from '@/state/groups';
+import { deSig } from '@urbit/api';
+import { useMemo } from 'react';
+import { Gangs, Groups } from '@/types/groups';
+import _ from 'lodash';
+
+export interface GroupSearchRecord {
+  flag: string;
+  title: string;
+  type: 'group' | 'gang';
+  status?: 'loading' | 'invited' | 'new' | undefined;
+}
+
+export function isGroupSearchRecord(record: any): record is GroupSearchRecord {
+  return 'title' in record && 'flag' in record && 'type' in record;
+}
+
+function groupsToRecords(groups: Groups): GroupSearchRecord[] {
+  return Object.entries(groups).map(([flag, group]) => ({
+    flag,
+    title: group.meta.title,
+    type: 'group',
+  }));
+}
+
+function gangsToRecords(gangs: Gangs): GroupSearchRecord[] {
+  return Object.entries(gangs).map(([flag, gang]) => ({
+    flag,
+    title: gang.preview?.meta.title || '',
+    type: 'gang',
+  }));
+}
+
+export default function useSearchFilter(query: string): GroupSearchRecord[] {
+  const groups = useGroups();
+  const gangs = useGangs();
+
+  const searchSpace = useMemo(() => {
+    const comparator = (a: GroupSearchRecord, b: GroupSearchRecord) =>
+      a.flag === b.flag;
+    return _.uniqWith(
+      [...groupsToRecords(groups), ...gangsToRecords(gangs)],
+      comparator
+    );
+  }, [groups, gangs]);
+
+  if (!query) {
+    return [];
+  }
+
+  return searchSpace.filter(
+    (record) =>
+      record.title.toLowerCase().startsWith(query.toLowerCase()) ||
+      deSig(record.flag)?.startsWith(deSig(query) || '')
+  );
+
+  // const searchSpace = useMemo(() => records.map(record => `${record.title}${record.flag}`), [records]);
+
+  // const fuzzScores = useMemo(() => (
+  //   fuzzy
+  //     .filter(query, searchSpace)
+  //     .sort((a, b) => {
+  //       const filter = deSig(query) || '';
+  //       const left = deSig(a.string)?.startsWith(filter)
+  //         ? a.score + 1
+  //         : a.score;
+  //       const right = deSig(b.string)?.startsWith(filter)
+  //         ? b.score + 1
+  //         : b.score;
+
+  //       return right - left;
+  //     })
+  // ), [query, searchSpace]);
+
+  // const results = useMemo(() => fuzzScores.map(result => records[result.index]), [fuzzScores, records]);
+
+  // return results;
+}

--- a/ui/src/components/Sidebar/useSearchFilter.ts
+++ b/ui/src/components/Sidebar/useSearchFilter.ts
@@ -54,5 +54,4 @@ export default function useSearchFilter(query: string): GroupSearchRecord[] {
       record.title.toLowerCase().startsWith(query.toLowerCase()) ||
       deSig(record.flag)?.startsWith(deSig(query) || '')
   );
-
 }

--- a/ui/src/components/Sidebar/useSearchFilter.ts
+++ b/ui/src/components/Sidebar/useSearchFilter.ts
@@ -55,25 +55,4 @@ export default function useSearchFilter(query: string): GroupSearchRecord[] {
       deSig(record.flag)?.startsWith(deSig(query) || '')
   );
 
-  // const searchSpace = useMemo(() => records.map(record => `${record.title}${record.flag}`), [records]);
-
-  // const fuzzScores = useMemo(() => (
-  //   fuzzy
-  //     .filter(query, searchSpace)
-  //     .sort((a, b) => {
-  //       const filter = deSig(query) || '';
-  //       const left = deSig(a.string)?.startsWith(filter)
-  //         ? a.score + 1
-  //         : a.score;
-  //       const right = deSig(b.string)?.startsWith(filter)
-  //         ? b.score + 1
-  //         : b.score;
-
-  //       return right - left;
-  //     })
-  // ), [query, searchSpace]);
-
-  // const results = useMemo(() => fuzzScores.map(result => records[result.index]), [fuzzScores, records]);
-
-  // return results;
 }

--- a/ui/src/components/Sidebar/util.tsx
+++ b/ui/src/components/Sidebar/util.tsx
@@ -1,0 +1,21 @@
+import { useLocation } from 'react-router';
+
+export type ActiveTab = 'messages' | 'notifications' | 'groups' | 'other';
+export default function useActiveTab(): ActiveTab {
+  const location = useLocation();
+  const isActive = (path: string) => location.pathname.startsWith(path);
+
+  if (location.pathname === '/') {
+    return 'groups';
+  }
+
+  if (isActive('/messages') || isActive('/dm')) {
+    return 'messages';
+  }
+
+  if (isActive('/notifications')) {
+    return 'notifications';
+  }
+
+  return 'other';
+}

--- a/ui/src/components/Sidebar/util.tsx
+++ b/ui/src/components/Sidebar/util.tsx
@@ -10,7 +10,7 @@ export default function useActiveTab(): ActiveTab {
   const location = useLocation();
   const isActive = (path: string) => location.pathname.startsWith(path);
 
-  if (location.pathname === '/') {
+  if (isActive('/groups')) {
     return 'groups';
   }
 
@@ -18,7 +18,7 @@ export default function useActiveTab(): ActiveTab {
     return 'messages';
   }
 
-  if (isActive('/notifications')) {
+  if (isActive('/notifications') || location.pathname === '/') {
     return 'notifications';
   }
 

--- a/ui/src/components/Sidebar/util.tsx
+++ b/ui/src/components/Sidebar/util.tsx
@@ -1,6 +1,11 @@
 import { useLocation } from 'react-router';
 
-export type ActiveTab = 'messages' | 'notifications' | 'groups' | 'other';
+export type ActiveTab =
+  | 'messages'
+  | 'notifications'
+  | 'groups'
+  | 'profile'
+  | 'other';
 export default function useActiveTab(): ActiveTab {
   const location = useLocation();
   const isActive = (path: string) => location.pathname.startsWith(path);
@@ -15,6 +20,10 @@ export default function useActiveTab(): ActiveTab {
 
   if (isActive('/notifications')) {
     return 'notifications';
+  }
+
+  if (isActive('/profile')) {
+    return 'profile';
   }
 
   return 'other';

--- a/ui/src/components/icons/BellIcon.tsx
+++ b/ui/src/components/icons/BellIcon.tsx
@@ -4,9 +4,19 @@ import { IconProps } from './icon';
 
 export default function BellIcon({
   className,
+  nonNav = false,
   isInactive,
   isDarkMode,
-}: { isInactive?: boolean; isDarkMode?: boolean } & IconProps) {
+}: {
+  isInactive?: boolean;
+  isDarkMode?: boolean;
+  nonNav?: boolean;
+} & IconProps) {
+  const opacity = {
+    dark: '.8',
+    light: nonNav ? '.4' : '.2',
+  };
+
   if (isInactive) {
     return (
       <svg
@@ -17,14 +27,14 @@ export default function BellIcon({
       >
         <path
           className="stroke-current"
-          strokeOpacity={isDarkMode ? '.8' : '.2'}
+          strokeOpacity={isDarkMode ? opacity.dark : opacity.light}
           strokeWidth="1.8"
           d="M2.757 7.946a7.93 7.93 0 0 1 15.736 0l.865 6.919A1.9 1.9 0 0 1 17.473 17H3.777a1.9 1.9 0 0 1-1.885-2.135l.865-6.92Z"
         />
         <path
           className="stroke-current"
           strokeLinecap="round"
-          strokeOpacity={isDarkMode ? '.8' : '.2'}
+          strokeOpacity={isDarkMode ? opacity.dark : opacity.light}
           strokeWidth="1.8"
           d="M13.625 18a3 3 0 1 1-6 0"
         />

--- a/ui/src/components/icons/BellIcon.tsx
+++ b/ui/src/components/icons/BellIcon.tsx
@@ -28,14 +28,14 @@ export default function BellIcon({
         <path
           className="stroke-current"
           strokeOpacity={isDarkMode ? opacity.dark : opacity.light}
-          strokeWidth="1.8"
+          strokeWidth="2"
           d="M2.757 7.946a7.93 7.93 0 0 1 15.736 0l.865 6.919A1.9 1.9 0 0 1 17.473 17H3.777a1.9 1.9 0 0 1-1.885-2.135l.865-6.92Z"
         />
         <path
           className="stroke-current"
           strokeLinecap="round"
           strokeOpacity={isDarkMode ? opacity.dark : opacity.light}
-          strokeWidth="1.8"
+          strokeWidth="2"
           d="M13.625 18a3 3 0 1 1-6 0"
         />
       </svg>

--- a/ui/src/components/icons/HomeIconMobileNav.tsx
+++ b/ui/src/components/icons/HomeIconMobileNav.tsx
@@ -12,7 +12,7 @@ export default function HomeIconMobileNav({
   asIcon?: boolean;
 } & IconProps) {
   const opacity = useMemo(
-    () => (asIcon ? '1' : isDarkMode ? '.8' : '0.2'),
+    () => (asIcon ? '.4' : isDarkMode ? '.8' : '0.2'),
     [isDarkMode, asIcon]
   );
   if (isInactive) {

--- a/ui/src/components/icons/MessagesIcon.tsx
+++ b/ui/src/components/icons/MessagesIcon.tsx
@@ -2,9 +2,19 @@ import { IconProps } from './icon';
 
 export default function MessagesIcon({
   className,
+  nonNav = false,
   isInactive,
   isDarkMode,
-}: { isInactive?: boolean; isDarkMode?: boolean } & IconProps) {
+}: {
+  isInactive?: boolean;
+  isDarkMode?: boolean;
+  nonNav?: boolean;
+} & IconProps) {
+  const opacity = {
+    dark: '.8',
+    light: nonNav ? '.4' : '.2',
+  };
+
   if (isInactive) {
     return (
       <svg
@@ -17,7 +27,7 @@ export default function MessagesIcon({
           d="M1.375 5C1.375 2.79086 3.16586 1 5.375 1H15.375C17.5841 1 19.375 2.79086 19.375 5V13C19.375 15.2091 17.5841 17 15.375 17H11.375L6.73243 20.7141C6.58839 20.8293 6.375 20.7267 6.375 20.5423V17H5.375C3.16586 17 1.375 15.2091 1.375 13V5Z"
           stroke="#CCCCCC"
           className="stroke-current"
-          strokeOpacity={isDarkMode ? '0.8' : '0.2'}
+          strokeOpacity={isDarkMode ? opacity.dark : opacity.light}
           strokeWidth="1.8"
         />
       </svg>

--- a/ui/src/dms/MessagesSidebar.tsx
+++ b/ui/src/dms/MessagesSidebar.tsx
@@ -22,6 +22,8 @@ import SystemChrome from '@/components/Sidebar/SystemChrome';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import { DesktopUpdateButton } from '@/components/UpdateNotices';
 import { AppUpdateContext } from '@/logic/useAppUpdates';
+import CautionIcon from '@/components/icons/CautionIcon';
+import { useLocalState } from '@/state/local';
 import MessagesList from './MessagesList';
 import MessagesSidebarItem from './MessagesSidebarItem';
 import { MessagesScrollingContext } from './MessagesScrollingContext';
@@ -32,8 +34,14 @@ export function TalkAppMenu() {
 
   const actions: Action[] = [
     {
+      key: 'sunset',
+      onClick: () => {
+        useLocalState.setState({ manuallyShowTalkSunset: true });
+      },
+      content: <span className="text-indigo">Talk is Sunsetting</span>,
+    },
+    {
       key: 'submit',
-      type: 'prominent',
       content: (
         <a
           className="no-underline"
@@ -100,7 +108,9 @@ export function TalkAppMenu() {
         }
       >
         <div className="flex items-center justify-between">
-          Talk
+          <span className="flex items-center justify-center">
+            Talk <CautionIcon className="ml-2 h-5 w-5 text-indigo" />
+          </span>
           <ReconnectingSpinner className="h-4 w-4 group-hover:hidden" />
           <a
             title="Back to Landscape"

--- a/ui/src/dms/MessagesSidebarItem.tsx
+++ b/ui/src/dms/MessagesSidebarItem.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import useLongPress from '@/logic/useLongPress';
 import ClubName from '@/components/ClubName';
+import useAppName from '@/logic/useAppName';
 import Avatar, { AvatarSizes } from '../components/Avatar';
 import ShipName from '../components/ShipName';
 import DmOptions from './DMOptions';
@@ -10,7 +11,7 @@ import useMedia, { useIsMobile } from '../logic/useMedia';
 import GroupAvatar from '../groups/GroupAvatar';
 import SidebarItem from '../components/Sidebar/SidebarItem';
 import MultiDmAvatar, { MultiDmAvatarSize } from './MultiDmAvatar';
-import { whomIsDm, whomIsMultiDm } from '../logic/utils';
+import { isTalk, whomIsDm, whomIsMultiDm } from '../logic/utils';
 import { useMessagesScrolling } from './MessagesScrollingContext';
 
 interface MessagesSidebarItemProps {
@@ -40,6 +41,10 @@ function ChannelSidebarItem({
   const group = useGroup(groupFlag || '');
   const isScrolling = useMessagesScrolling();
 
+  const to = isTalk
+    ? `/groups/${groupFlag}/channels/${nest}`
+    : `/dm/groups/${groupFlag}/channels/${nest}`;
+
   if (!channel) {
     return null;
   }
@@ -47,7 +52,7 @@ function ChannelSidebarItem({
   return (
     <SidebarItem
       inexact
-      to={`/groups/${groupFlag}/channels/${nest}`}
+      to={to}
       icon={
         <GroupAvatar
           size="h-12 w-12 sm:h-6 sm:w-6 rounded-lg sm:rounded"

--- a/ui/src/groups/GroupActions.tsx
+++ b/ui/src/groups/GroupActions.tsx
@@ -15,15 +15,12 @@ import {
   useGang,
   useGroup,
   useGroupCancelMutation,
+  usePinnedGroups,
 } from '@/state/groups';
+import { useAddPinMutation, useDeletePinMutation } from '@/state/pins';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import { useIsMobile } from '@/logic/useMedia';
 import VolumeSetting from '@/components/VolumeSetting';
-import {
-  useAddPinMutation,
-  useDeletePinMutation,
-  usePinnedGroups,
-} from '@/state/pins';
 import GroupHostConnection from './GroupHostConnection';
 
 const { ship } = window;

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -7,8 +7,8 @@ import {
   useGroupsWithQuery,
   usePendingGangsWithoutClaim,
   useNewGroups,
+  usePinnedGroups,
 } from '@/state/groups';
-import { usePinnedGroups } from '@/state/pins';
 import GroupList from '@/components/Sidebar/GroupList';
 import SidebarSorter from '@/components/Sidebar/SidebarSorter';
 import GroupsSidebarItem from '@/components/Sidebar/GroupsSidebarItem';
@@ -47,7 +47,7 @@ export default function MobileRoot() {
 
   const newGroupsOptions = useMemo(
     () =>
-      newGroups.map(([flag]) => (
+      Object.keys(newGroups).map(([flag]) => (
         <GroupsSidebarItem key={flag} flag={flag} isNew />
       )),
     [newGroups]
@@ -92,13 +92,7 @@ export default function MobileRoot() {
             </div>
           ) : (
             <GroupsScrollingContext.Provider value={isScrolling}>
-              <GroupList
-                groups={sortedGroups}
-                pinnedGroups={Object.entries(pinnedGroups)}
-                newGroups={newGroups}
-                loadingGroups={loadingGroups}
-                isScrolling={scroll.current}
-              >
+              <GroupList groups={sortedGroups} isScrolling={scroll.current}>
                 {hasPinnedGroups ||
                 hasPendingGangs ||
                 hasGangsWithClaims ||
@@ -120,7 +114,7 @@ export default function MobileRoot() {
                       ) : null}
 
                       {hasLoadingGroups &&
-                        loadingGroups.map(([flag, _]) => (
+                        Object.keys(loadingGroups).map(([flag, _]) => (
                           <GangItem key={flag} flag={flag} isJoining />
                         ))}
 

--- a/ui/src/nav/TalkNav.tsx
+++ b/ui/src/nav/TalkNav.tsx
@@ -2,14 +2,107 @@ import cn from 'classnames';
 import { Outlet } from 'react-router';
 import { useIsMobile } from '@/logic/useMedia';
 import MessagesSidebar from '@/dms/MessagesSidebar';
+import Dialog from '@/components/Dialog';
+import CautionIcon from '@/components/icons/CautionIcon';
+import WidgetDrawer from '@/components/WidgetDrawer';
+import { useState } from 'react';
+import {
+  usePutEntryMutation,
+  useSeenTalkSunset,
+  useSettings,
+} from '@/state/settings';
+import { useLocalState, useManuallyShowTalkSunset } from '@/state/local';
 
 export default function TalkNav() {
   const isMobile = useIsMobile();
+  const seenSunset = useSeenTalkSunset();
+  const manuallyShowSunset = useManuallyShowTalkSunset();
 
   return (
     <div className={cn('fixed flex h-full w-full')}>
       {isMobile ? null : <MessagesSidebar />}
       <Outlet />
+      {(!seenSunset || manuallyShowSunset) && <TalkSunsetNotification />}
     </div>
+  );
+}
+
+function TalkSunsetNotification() {
+  const isMobile = useIsMobile();
+  const [open, setOpen] = useState(true);
+  const { mutate } = usePutEntryMutation({
+    bucket: 'talk',
+    key: 'seenSunsetMessage',
+  });
+
+  const onOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      mutate({ val: true });
+      useLocalState.setState({ manuallyShowTalkSunset: false });
+      setOpen(false);
+    }
+  };
+
+  return (
+    <TalkSunsetContainer
+      open={open}
+      isMobile={isMobile}
+      onOpenChange={onOpenChange}
+    >
+      <div
+        className={cn(
+          'flex items-center justify-center bg-indigo py-6',
+          isMobile && 'rounded-t-[32px]'
+        )}
+      >
+        <CautionIcon className="h-6 w-6 text-white dark:text-black" />
+        <h2 className="ml-2 text-[18px] font-semibold text-white dark:text-black">
+          Talk Sunset
+        </h2>
+      </div>
+      <div className="mt-8 flex flex-col items-center">
+        <p className="mx-8 text-lg">
+          Talk is being officially retired. A similar messaging experience is
+          now available in the main Tlon app.
+          <br />
+          <br />
+          Feel free to leave Talk installed, but it will no longer receive
+          updates or ongoing support.
+        </p>
+        <button
+          className={cn('button mt-10', isMobile && 'p-4')}
+          onClick={() => onOpenChange(false)}
+        >
+          Dismiss
+        </button>
+      </div>
+    </TalkSunsetContainer>
+  );
+}
+
+function TalkSunsetContainer({
+  open,
+  onOpenChange,
+  isMobile,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (newOpen: boolean) => void;
+  isMobile: boolean;
+  children: React.ReactNode;
+}) {
+  return isMobile ? (
+    <WidgetDrawer open={open} onOpenChange={onOpenChange} className="h-[60vh]">
+      {children}
+    </WidgetDrawer>
+  ) : (
+    <Dialog
+      defaultOpen
+      onOpenChange={onOpenChange}
+      className="h-[350px] overflow-y-auto p-0"
+      containerClass="w-full sm:max-w-lg"
+    >
+      {children}
+    </Dialog>
   );
 }

--- a/ui/src/profiles/ProfileModal.tsx
+++ b/ui/src/profiles/ProfileModal.tsx
@@ -93,11 +93,7 @@ export default function ProfileModal() {
   };
 
   const handleMessageClick = () => {
-    if (isNativeApp()) {
-      navigate(`/dm/${ship}`);
-    } else {
-      navigateByApp(`/dm/${ship}`);
-    }
+    navigate(`/dm/${ship}`);
   };
 
   const handleBlockClick = () => {

--- a/ui/src/state/groups/groups.ts
+++ b/ui/src/state/groups/groups.ts
@@ -26,6 +26,7 @@ import {
   PrivacyType,
   Vessel,
   Gang,
+  isGroup,
 } from '@/types/groups';
 import api from '@/api';
 import { BaitCite, Post, Reply } from '@/types/channel';
@@ -42,6 +43,7 @@ import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import { Scope, VolumeValue } from '@/types/volume';
 import { decToUd } from '@urbit/api';
 import { useNewGroupFlags } from '../settings';
+import { useGroupPins } from '../pins';
 
 export const GROUP_ADMIN = 'admin';
 
@@ -409,6 +411,16 @@ export function usePendingGangs() {
     });
 
   return pendingGangs;
+}
+
+export function usePinnedGroups(): Groups {
+  const pins = useGroupPins();
+  const groups = useGroups();
+
+  return pins.reduce(
+    (acc, pin) => ({ ...acc, [pin]: groups[pin] }),
+    {} as Groups
+  );
 }
 
 export function usePendingGangsWithoutClaim() {

--- a/ui/src/state/local.ts
+++ b/ui/src/state/local.ts
@@ -13,6 +13,7 @@ export type SubscriptionStatus = 'connected' | 'disconnected' | 'reconnecting';
 interface LocalState {
   browserId: string;
   currentTheme: 'light' | 'dark';
+  manuallyShowTalkSunset: boolean;
   subscription: SubscriptionStatus;
   groupsLocation: string;
   messagesLocation: string;
@@ -33,6 +34,7 @@ export const useLocalState = create<LocalState>(
       subscription: 'connected',
       groupsLocation: '/',
       messagesLocation: '/messages',
+      manuallyShowTalkSunset: false,
       showDevTools: import.meta.env.DEV,
       errorCount: 0,
       airLockErrorCount: 0,
@@ -65,6 +67,11 @@ export function useBrowserId() {
 const selCurrentTheme = (s: LocalState) => s.currentTheme;
 export function useCurrentTheme() {
   return useLocalState(selCurrentTheme);
+}
+
+const selManuallyShowTalkSunset = (s: LocalState) => s.manuallyShowTalkSunset;
+export function useManuallyShowTalkSunset() {
+  return useLocalState(selManuallyShowTalkSunset);
 }
 
 export const setLocalState = (f: (s: LocalState) => void) =>

--- a/ui/src/state/pins.ts
+++ b/ui/src/state/pins.ts
@@ -5,9 +5,7 @@ import { whomIsDm, whomIsFlag, whomIsMultiDm, whomIsNest } from '@/logic/utils';
 import { useMemo } from 'react';
 import api from '@/api';
 import _ from 'lodash';
-import { Groups } from '@/types/groups';
 import { Nest } from '@/types/channel';
-import { useGroups } from './groups';
 
 export const pinsKey = () => ['groups-ui', 'pins'];
 
@@ -60,16 +58,6 @@ export function usePinnedChannels(): Nest[] {
 export function useGroupPins(): Pins {
   const allPins = usePins();
   return useMemo(() => allPins.filter((pin) => whomIsFlag(pin)), [allPins]);
-}
-
-export function usePinnedGroups(): Groups {
-  const pins = useGroupPins();
-  const groups = useGroups();
-
-  return pins.reduce(
-    (acc, pin) => ({ ...acc, [pin]: groups[pin] }),
-    {} as Groups
-  );
 }
 
 export function useAddPinMutation() {

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -92,6 +92,7 @@ export interface SettingsState {
   talk: {
     messagesFilter: SidebarFilter;
     showVitaMessage: boolean;
+    seenSunsetMessage: boolean;
   };
   groups: {
     orderedGroupPins: string[];
@@ -503,6 +504,19 @@ export function useSeenWelcomeCard() {
     }
 
     return data.groups.seenWelcomeCard ?? false;
+  }, [isLoading, data]);
+}
+
+export function useSeenTalkSunset() {
+  const { data, isLoading } = useMergedSettings();
+
+  return useMemo(() => {
+    if (isLoading || data === undefined || data.groups === undefined) {
+      console.log('returning sunset default');
+      return false;
+    }
+
+    return data.talk.seenSunsetMessage ?? false;
   }, [isLoading, data]);
 }
 

--- a/ui/src/types/groups.ts
+++ b/ui/src/types/groups.ts
@@ -411,3 +411,7 @@ export interface ChannelPreview {
   meta: GroupMeta;
   group: GroupPreview;
 }
+
+export function isGroup(obj: any): obj is Group {
+  return 'fleet' in obj && 'cabals' in obj;
+}


### PR DESCRIPTION
Adds the ability to access the core Talk sidebar from within the main app on desktop. Overhauls the way the Sidebar looks, adds Search for group/message lists, adds flow for desktop DM creation, etc.
Tested locally against self & hosted ships.

Fixes LAND-1513
Fixes LAND-1522