### PR TITLE
utils: better IMAGE_URL_REGEX

### DIFF
--- a/ui/src/logic/utils.ts
+++ b/ui/src/logic/utils.ts
@@ -466,7 +466,7 @@ export const VIDEO_REGEX = /(\.mov|\.mp4|\.ogv|\.webm)(?:\?.*)?$/i;
 export const URL_REGEX = /(https?:\/\/[^\s]+)/i;
 export const PATP_REGEX = /(~[a-z0-9-]+)/i;
 export const IMAGE_URL_REGEX =
-  /^(http(s?):)([/|.|\w|\s|-]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|svg)(?:\?.*)?$/i;
+  /^(http(s?):)([/.\w\s-:]|%2*)*\.(?:jpg|img|png|gif|tiff|jpeg|webp|svg)(?:\?.*)?$/i;
 export const REF_REGEX = /\/1\/(chan|group|desk)\/[^\s]+/g;
 export const REF_URL_REGEX = /^\/1\/(chan|group|desk)\/[^\s]+/;
 // sig and hep explicitly left out


### PR DESCRIPTION
This dude had a s3 bucket with urls that always contain a `:` and talk wasn't rendering them inline. This fixes the problem.

Also, `|` is not the or condition inside a character set.