### PR TITLE
subscriptions: kick resub ddos protection

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -85,8 +85,9 @@
   ++  on-arvo
     |=  [=wire sign=sign-arvo]
     ^-  (quip card _this)
-    ~&  strange-diary-arvo+wire
-    `this
+    =^  cards  state
+      abet:(arvo:cor wire sign)
+    [cards this]
   --
 |_  [=bowl:gall cards=(list card)]
 ++  abet  [(flop cards) state]
@@ -567,6 +568,19 @@
       [%u =kind:c ship=@ name=@ ~]
     =/  =ship  (slav %p ship.pole)
     ``loob+!>((~(has by v-channels) kind.pole ship name.pole))
+  ==
+::
+++  arvo
+  |=  [=(pole knot) sign=sign-arvo]
+  ^+  cor
+  ?+  pole  ~|(bad-arvo-take/pole !!)
+      [%~.~ %cancel-retry rest=*]  cor
+  ::
+      [%~.~ %retry rest=*]
+    =^  card=(unit card)  subs
+      (~(handle-wakeup s [subs bowl]) pole)
+    ?~  card  cor
+    (emit u.card)
   ==
 ::
 ++  unreads

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -105,10 +105,9 @@
   |=  delay=?
   ^+  cor
   ?:  (~(has by wex.bowl) wire dock)  cor
-  =^  card=(unit card)  subs
+  =^  caz=(list card)  subs
     (~(subscribe s [subs bowl]) wire dock path delay)
-  ?~  card  cor
-  (emit u.card)
+  (emil caz)
 ::
 ++  load
   |=  =vase
@@ -146,7 +145,7 @@
     |=  s=state-2
     ^-  state-3
     %=  s  -  %3
-        pending-ref-edits  [pending-ref-edits.s ~]
+        pending-ref-edits  [pending-ref-edits.s *^subs:^s]
     ==
   ++  v-channel-1
     |^  ,[global local]
@@ -577,10 +576,9 @@
       [%~.~ %cancel-retry rest=*]  cor
   ::
       [%~.~ %retry rest=*]
-    =^  card=(unit card)  subs
+    =^  caz=(list card)  subs
       (~(handle-wakeup s [subs bowl]) pole)
-    ?~  card  cor
-    (emit u.card)
+    (emil caz)
   ==
 ::
 ++  unreads

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -266,6 +266,12 @@
   ::      happen. that way, local subs get established without issue.
   inflate-io
 ::
+++  unsubscribe
+  |=  [=wire =dock]
+  ^+  cor
+  =^  caz=(list card)  subs
+    (~(unsubscribe s [subs bowl]) wire dock)
+  (emil caz)
 ++  inflate-io
   ::  initiate version negotiation with our own channels-server
   ::
@@ -309,7 +315,7 @@
         =(wire path)
       ==
     ?:  keep  cor
-    (emit %pass pole %agent [sub-ship dude] %leave ~)
+    (unsubscribe pole [sub-ship dude])
   ::
   ::  watch all the subscriptions we expect to have
   ::
@@ -607,6 +613,9 @@
     |=  [=wire =dock =path]
     |=  delay=?
     ca-core(cor ((^safe-watch wire dock path) delay))
+  ++  unsubscribe
+    |=  [=wire =dock]
+    ca-core(cor (^unsubscribe wire dock))
   ++  ca-abet
     %_    cor
         v-channels
@@ -767,7 +776,7 @@
           ~
       =/  =path  /[kind.nest]/[name.nest]/create
       =/  =wire  (weld ca-area /create)
-      (emit %pass wire %agent [our.bowl server] %watch path)
+      ((safe-watch wire [our.bowl server] path) |)
     ::
         %kick       (ca-safe-sub &)
         %watch-ack
@@ -782,8 +791,7 @@
       =+  !<(=update:c q.cage)
       =.  ca-core  (ca-u-channels update)
       =.  ca-core  ca-give-unread
-      =.  ca-core
-        (emit %pass (weld ca-area /create) %agent [ship.nest server] %leave ~)
+      =.  ca-core  (unsubscribe (weld ca-area /create) [ship.nest server])
       (ca-safe-sub |)
     ==
   ::
@@ -852,7 +860,7 @@
     =.  ca-core  (ca-fetch-contacts chk)
     =.  ca-core  (ca-sync-backlog |)
     =/  wire  (weld ca-area /checkpoint)
-    (emit %pass wire %agent [ship.nest server] %leave ~)
+    (unsubscribe wire [ship.nest server])
   ::
   ++  ca-fetch-contacts
     |=  chk=u-checkpoint:c
@@ -905,7 +913,7 @@
     |=  chk=u-checkpoint:c
     =.  ca-core  (ca-apply-checkpoint chk |)
     =/  wire  (weld ca-area /backlog)
-    (emit %pass wire %agent [ship.nest server] %leave ~)
+    (unsubscribe wire [ship.nest server])
   ::
   ++  ca-apply-logs
     |=  =log:c
@@ -1128,7 +1136,7 @@
       =/  =rope:ha  (ca-rope -.kind-data.post id-post ~)
       ?:  (was-mentioned:utils content.post our.bowl)
         ?.  (want-hark %mention)
-          ca-core        
+          ca-core
         =/  cs=(list content:ha)
           ~[[%ship author.post] ' mentioned you: ' (flatten:utils content.post)]
         (emit (pass-hark (ca-spin rope cs ~)))
@@ -1620,7 +1628,7 @@
   ::  leave the subscription only
   ::
   ++  ca-simple-leave
-    (emit %pass ca-sub-wire %agent [ship.nest server] %leave ~)
+    (unsubscribe ca-sub-wire [ship.nest server])
   ::
   ::  Leave the subscription, tell people about it, and delete our local
   ::  state for the channel

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -5,6 +5,9 @@
 ::  XX  chat thread entries can no longer be edited.  maybe fix before
 ::      release?
 ::
+::    note: all subscriptions are handled by the subscriber library so
+::    we can have resubscribe loop protection.
+::
 /-  c=channels, g=groups, ha=hark
 /-  meta
 /+  default-agent, verb, dbug, sparse, neg=negotiate

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2,7 +2,7 @@
 /-  meta
 /-  e=epic
 /+  default-agent, verb, dbug
-/+  v=volume
+/+  v=volume, s=subscriber
 /+  of
 /+  epos-lib=saga
 ::  performance, keep warm
@@ -14,18 +14,19 @@
   +$  card  card:agent:gall
   ++  import-epoch  ~2022.10.11
   +$  current-state
-    $:  %2
+    $:  %3
         groups=net-groups:g
       ::
         $=  volume
         $:  base=level:v
             area=(map flag:g level:v)  ::  override per group
-            chan=(map nest:g level:v)  ::  override per channel
+            chan=(map nest:g level:v)  ::  override per channel            
         ==
       ::
         xeno=gangs:g
         ::  graph -> agent
         shoal=(map flag:g dude:gall)
+        =^subs:s
     ==
   ::
   --
@@ -288,12 +289,13 @@
   ?-  -.old
       %0  $(old (state-0-to-1 old))
       %1  $(old (state-1-to-2 old))
-  ::
-      %2
+      %2  $(old (state-2-to-3 old))
+    ::
+      %3
     =.  state  old
     =.  cor  restore-missing-subs
     =.  cor  (emit %pass /groups/role %agent [our.bowl dap.bowl] %poke noun+!>(%verify-cabals))
-    =.  cor  watch-contact
+    =.  cor  (watch-contact |)
     ?:  =(okay:g cool)  cor
     =.  cor  (emil (drop load:epos))
     =/  groups  ~(tap in ~(key by groups))
@@ -304,7 +306,7 @@
       go-abet:go-upgrade:(go-abed:group-core i.groups)
     $(groups t.groups)
   ==
-  +$  versioned-state  $%(current-state state-1 state-0)
+  +$  versioned-state  $%(current-state state-2 state-1 state-0)
   +$  state-0
     $:  %0
         groups=net-groups:zero
@@ -327,6 +329,20 @@
         shoal=(map flag:zero dude:gall)
     ==
   ::
+  +$  state-2
+    $:  %2
+        groups=net-groups:g
+      ::
+        $=  volume
+        $:  base=level:v
+            area=(map flag:g level:v)  ::  override per group
+            chan=(map nest:g level:v)  ::  override per channel            
+        ==
+      ::
+        xeno=gangs:g
+        ::  graph -> agent
+        shoal=(map flag:g dude:gall)
+    ==
   ++  state-0-to-1
     |=  state-0
     ^-  state-1
@@ -334,8 +350,13 @@
   ::
   ++  state-1-to-2
     |=  state-1
-    ^-  current-state
+    ^-  state-2
     [%2 (groups-1-to-2 groups) volume xeno shoal]
+  ::
+  ++  state-2-to-3
+    |=  state-2
+    ^-  current-state
+    [%3 groups volume xeno shoal ~]
   ::
   ++  groups-1-to-2
     |=  groups=net-groups:zero
@@ -588,6 +609,14 @@
   ^+  cor
   !!
 ::
+++  subscribe
+  |=  [=wire =dock =path]
+  |=  delay=?
+  =^  card=(unit card)  subs
+    (~(subscribe s [subs bowl]) wire dock path delay)
+  ?~  card  cor
+  (emit u.card)
+::
 ++  cast
   |=  [grp=flag:g gra=flag:g]
   ^+  cor
@@ -632,13 +661,13 @@
   ==
 ::
 ++  watch-contact
-  (emit %pass /contact %agent [our.bowl %contacts] %watch /contact)
+  (subscribe /contact [our.bowl %contacts] /contact)
 ::
 ++  take-contact
   |=  =sign:agent:gall
   ?+  -.sign  cor
       %kick
-    watch-contact
+    (watch-contact &)
   ::
       %watch-ack
     cor
@@ -653,20 +682,20 @@
   ==
 ::
 ++  watch-epic
-  |=  her=ship
+  |=  [her=ship delay=?]
   ^+  cor
   =/  =wire  /epic
   =/  =dock  [her dap.bowl]
   ?:  (~(has by wex.bowl) [wire dock])
     cor
-  (emit %pass wire %agent [her dap.bowl] %watch /epic)
+  ((subscribe wire dock wire) delay)
 ::
 ++  take-epic
   |=  =sign:agent:gall
   ^+  cor
   ?+    -.sign  cor
       %kick
-    (watch-epic src.bowl)
+    (watch-epic src.bowl &)
   ::
       %fact
     ?.  =(%epic p.cage.sign)
@@ -928,18 +957,16 @@
     ^+  go-core
     ?:  |(go-has-sub =(our.bowl p.flag))
       go-core
-    (go-sub init)
+    (go-sub init |)
   ::
   ++  go-sub
-    |=  init=_|
+    |=  [init=_| delay=?]
     ^+  go-core
     =/  =time
       ?.(?=(%sub -.net) *time p.net)
     =/  base=wire  (snoc go-area %updates)
     =/  =path      (snoc base ?:(init %init (scot %da time)))
-    =/  =card
-      [%pass base %agent [p.flag dap.bowl] %watch path]
-    =.  cor  (emit card)
+    =.  cor  ((subscribe base [p.flag dap.bowl] path) delay)
     go-core
   ::
   ++  go-watch
@@ -1082,11 +1109,11 @@
   ++  go-take-update
     |=  =sign:agent:gall
     ^+  go-core
-    ?+    -.sign  (go-sub |)
+    ?+    -.sign  (go-sub | &)
         %kick
       ?>  ?=(%sub -.net)
       ?.  ?=(%chi -.saga.net)  go-core
-      (go-sub !load.net)
+      (go-sub !load.net &)
     ::
         %watch-ack
       =?  cor  (~(has by xeno) flag)
@@ -1119,7 +1146,7 @@
        go-core
     ~&  "took lev epic: {<flag>}"
     =.  saga.net  lev/~
-    =.  cor  (watch-epic p.flag)
+    =.  cor  (watch-epic p.flag |)
     go-core
   ::
   ++  go-make-chi
@@ -1791,8 +1818,9 @@
       =/  =action:g  [flag now.bowl %cordon %shut %del-ships %ask ships]
       (poke-host /rescind act:mar:g !>(action))
     ++  get-preview
-      =/  =task:agent:gall  [%watch /groups/(scot %p p.flag)/[q.flag]/preview]
-      (pass-host /preview task)
+      %^  subscribe  (welp ga-area /preview)
+        [p.flag dap.bowl]
+      /groups/(scot %p p.flag)/[q.flag]/preview
     --
   ++  ga-start-join
     ^+  ga-core
@@ -1816,7 +1844,7 @@
   ++  ga-watch
     |=  =(pole knot)
     ^+  ga-core
-    =.  cor  (emit get-preview:ga-pass)
+    =.  cor  (get-preview:ga-pass |)
     ga-core
   ::
   ++  ga-give-update
@@ -1869,7 +1897,7 @@
             %kick
           ?.  (~(has by xeno) flag)  ga-core
           ?^  pev.gang  ga-core
-          ga-core(cor (emit get-preview:ga-pass))
+          ga-core(cor (get-preview:ga-pass &))
         ==
       ::
           [%join %add ~]
@@ -1885,7 +1913,7 @@
         =.  groups  (~(put by groups) flag net group)
         ::
         =.  cor
-          go-abet:(go-sub:(go-abed:group-core flag) &)
+          go-abet:(go-sub:(go-abed:group-core flag) & |)
         ga-core
           [%knock ~]
         ?>  ?=(%poke-ack -.sign)
@@ -1920,7 +1948,7 @@
   ++  ga-invite
     |=  =invite:g
     =.  vit.gang  `invite
-    =.  cor  (emit get-preview:ga-pass)
+    =.  cor  (get-preview:ga-pass |)
     =.  cor  ga-give-update
     ga-core
   ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -356,7 +356,7 @@
   ++  state-2-to-3
     |=  state-2
     ^-  current-state
-    [%3 groups volume xeno shoal ~]
+    [%3 groups volume xeno shoal *^subs:s]
   ::
   ++  groups-1-to-2
     |=  groups=net-groups:zero
@@ -611,19 +611,17 @@
       [%~.~ %cancel-retry rest=*]  cor
   ::
       [%~.~ %retry rest=*]
-    =^  card=(unit card)  subs
+    =^  caz=(list card)  subs
       (~(handle-wakeup s [subs bowl]) pole)
-    ?~  card  cor
-    (emit u.card)
+    (emil caz)
   ==
 ::
 ++  subscribe
   |=  [=wire =dock =path]
   |=  delay=?
-  =^  card=(unit card)  subs
+  =^  caz=(list card)  subs
     (~(subscribe s [subs bowl]) wire dock path delay)
-  ?~  card  cor
-  (emit u.card)
+  (emil caz)
 ::
 ++  cast
   |=  [grp=flag:g gra=flag:g]
@@ -818,7 +816,7 @@
         (~(del by groups) flag)
       (~(put by groups) flag net group)
     ?.  gone  cor
-    =?  cor  !=(p.flag our.bowl)  (emit leave:go-pass)
+    =?  cor  !=(p.flag our.bowl)  (emil leave:go-pass)
     =/  =action:g  [flag now.bowl %del ~]
     (give %fact ~[/groups/ui] act:mar:g !>(action))
   ++  go-abed
@@ -868,10 +866,12 @@
   ++  go-pass
     |%
     ++  leave
-      ^-  card
+      ^-  (list card)
       =/  =wire  (snoc go-area %updates)
       =/  =dock  [p.flag dap.bowl]
-      [%pass wire %agent dock %leave ~]
+      =^  caz=(list card)  subs
+        (~(unsubscribe s [subs bowl]) wire dock)
+      caz
     ::
     ++  remove-self
       ^-  card

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -102,8 +102,6 @@
     ?+  q.vase  !!
       %reset-all-perms  reset-all-perms
       %verify-cabals  verify-cabals
-      %test-loop  test-loop
-      %cancel-loop  cancel-loop
     ==
   ::
       %reset-group-perms
@@ -281,25 +279,6 @@
   =/  cmd=c-channels:d  [%channel nest %del-writers diff]
   =/  cage  [%channel-command !>(cmd)]
   cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
-++  test-loop
-  =/  =wire  /test-loop
-  =/  =dock  [our.bowl dap.bowl]
-  (emit [%pass wire %agent dock %watch wire])
-++  take-loop
-  |=  =sign:agent:gall
-  ^+  cor
-  ?+  -.sign  cor
-      %kick
-    ((subscribe /test-loop [our.bowl dap.bowl] /test-loop) &)
-  ::
-      %watch-ack
-    cor
-  ==
-++  cancel-loop
-  =^  card=(unit card)  subs
-    (~(cancel s [subs bowl]) /test-loop)
-  ?~  card  cor
-  (emit u.card)
 ::
 ::  +load: load next state
 ++  load
@@ -432,7 +411,6 @@
     [%groups ~]           cor
     [%groups %ui ~]       cor
     [%gangs %updates ~]   cor
-    [%test-loop ~]        (give %kick ~[/test-loop] ~)
   ::
     [%epic ~]  (give %fact ~ epic+!>(okay:g))
   ::
@@ -588,7 +566,6 @@
       [%epic ~]  (take-epic sign)
       [%helm *]  cor
       [%groups %role ~]  cor
-      [%test-loop ~]  (take-loop sign)
       [?(%hark %groups %chat %heap %diary) ~]  cor
       [%cast ship=@ name=@ ~]  (take-cast [(slav %p ship.pole) name.pole] sign)
   ::

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -102,6 +102,8 @@
     ?+  q.vase  !!
       %reset-all-perms  reset-all-perms
       %verify-cabals  verify-cabals
+      %test-loop  test-loop
+      %cancel-loop  cancel-loop
     ==
   ::
       %reset-group-perms
@@ -279,6 +281,25 @@
   =/  cmd=c-channels:d  [%channel nest %del-writers diff]
   =/  cage  [%channel-command !>(cmd)]
   cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
+++  test-loop
+  =/  =wire  /test-loop
+  =/  =dock  [our.bowl dap.bowl]
+  (emit [%pass wire %agent dock %watch wire])
+++  take-loop
+  |=  =sign:agent:gall
+  ^+  cor
+  ?+  -.sign  cor
+      %kick
+    ((subscribe /test-loop [our.bowl dap.bowl] /test-loop) &)
+  ::
+      %watch-ack
+    cor
+  ==
+++  cancel-loop
+  =^  card=(unit card)  subs
+    (~(cancel s [subs bowl]) /test-loop)
+  ?~  card  cor
+  (emit u.card)
 ::
 ::  +load: load next state
 ++  load
@@ -411,6 +432,7 @@
     [%groups ~]           cor
     [%groups %ui ~]       cor
     [%gangs %updates ~]   cor
+    [%test-loop ~]        (give %kick ~[/test-loop] ~)
   ::
     [%epic ~]  (give %fact ~ epic+!>(okay:g))
   ::
@@ -566,6 +588,7 @@
       [%epic ~]  (take-epic sign)
       [%helm *]  cor
       [%groups %role ~]  cor
+      [%test-loop ~]  (take-loop sign)
       [?(%hark %groups %chat %heap %diary) ~]  cor
       [%cast ship=@ name=@ ~]  (take-cast [(slav %p ship.pole) name.pole] sign)
   ::
@@ -605,9 +628,17 @@
   ==
 ::
 ++  arvo
-  |=  [=wire sign=sign-arvo]
+  |=  [=(pole knot) sign=sign-arvo]
   ^+  cor
-  !!
+  ?+  pole  ~|(bad-arvo-take/pole !!)
+      [%~.~ %cancel-retry rest=*]  cor
+  ::
+      [%~.~ %retry rest=*]
+    =^  card=(unit card)  subs
+      (~(handle-wakeup s [subs bowl]) pole)
+    ?~  card  cor
+    (emit u.card)
+  ==
 ::
 ++  subscribe
   |=  [=wire =dock =path]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1,3 +1,8 @@
+::  groups: agent for managing group membership, metadata and permissions
+::
+::    note: all subscriptions are handled by the subscriber library so
+::    we can have resubscribe loop protection.
+::
 /-  g=groups, zero=groups-0, ha=hark, h=heap, d=channels, c=chat, tac=contacts
 /-  meta
 /-  e=epic

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -20,7 +20,7 @@
         $=  volume
         $:  base=level:v
             area=(map flag:g level:v)  ::  override per group
-            chan=(map nest:g level:v)  ::  override per channel            
+            chan=(map nest:g level:v)  ::  override per channel
         ==
       ::
         xeno=gangs:g
@@ -336,7 +336,7 @@
         $=  volume
         $:  base=level:v
             area=(map flag:g level:v)  ::  override per group
-            chan=(map nest:g level:v)  ::  override per channel            
+            chan=(map nest:g level:v)  ::  override per channel
         ==
       ::
         xeno=gangs:g

--- a/desk/lib/subscriber.hoon
+++ b/desk/lib/subscriber.hoon
@@ -1,0 +1,30 @@
+=<  subscriber
+|%
++$  sub
+  $:  =dock
+      =path
+  ==
+::
++$  subs  (map wire sub)
+::
+++  subscriber
+  |_  [=subs bowl:gall]
+  ++  interval  ~s30
+  ++  handle-wakeup
+    |=  =wire
+    ^-  [(unit card:agent:gall) _subs]
+    ?>  ?=([%~.~ %retry *] wire)
+    =/  sub  (~(get by subs) t.t.wire)
+    ?~  sub  [~ subs]
+    :-  `[%pass t.wire %agent dock.u.sub %watch path.u.sub]
+    (~(del by subs) t.t.wire)
+  ++  subscribe
+    |=  [=wire =dock =path delay=?]
+    ^-  [(unit card:agent:gall) _subs]
+    ?:  (~(has by subs) wire)
+      ((slog 'Duplicate subscription' >[wire dock]< ~) [~ subs])
+    ?.  delay  [`[%pass wire %agent dock %watch path] subs]
+    :_  (~(put by subs) wire [dock path])
+    `[%pass (weld /~/retry wire) %arvo %b %wait (add now interval)]
+  --
+--

--- a/desk/lib/subscriber.hoon
+++ b/desk/lib/subscriber.hoon
@@ -14,33 +14,34 @@
   ++  interval  ~s30
   ++  handle-wakeup
     |=  =wire
-    ^-  [(unit card:agent:gall) _subs]
+    ^-  [(list card:agent:gall) _subs]
     ?>  ?=([%~.~ %retry *] wire)
     ~?  verb  ['waking up' wire]
     =/  sub  (~(get by subs) t.t.wire)
     ?~  sub  [~ subs]
-    :-  `[%pass t.t.wire %agent dock.u.sub %watch path.u.sub]
+    :-  ~[[%pass t.t.wire %agent dock.u.sub %watch path.u.sub]]
     (~(del by subs) t.t.wire)
   ++  subscribe
     |=  [=wire =dock =path delay=?]
-    ^-  [(unit card:agent:gall) _subs]
+    ^-  [(list card:agent:gall) _subs]
     ?:  (~(has by subs) wire)
       ((slog 'Duplicate subscription' >[wire dock]< ~) [~ subs])
-    ?.  delay  [`[%pass wire %agent dock %watch path] subs]
+    ?.  delay  [~[[%pass wire %agent dock %watch path]] subs]
     ~?  verb  ['subscribing with delay' wire]
     =/  fires-at  (add now interval)
     :_  (~(put by subs) wire [dock path fires-at])
-    `[%pass (weld /~/retry wire) %arvo %b %wait fires-at]
+    ~[[%pass (weld /~/retry wire) %arvo %b %wait fires-at]]
   ++  unsubscribe
-    |=  =wire
+    |=  [=wire =dock]
     ^-  [(list card:agent:gall) _subs]
+    =/  leave  [%pass wire %agent dock %leave ~]
     =/  sub  (~(get by subs) wire)
     ?~  sub
       ((slog 'No such subscription' >[wire]< ~) [~ subs])
     ~?  verb  ['cancelling' wire]
     :_  (~(del by subs) wire)
-    :~  [%pass (weld /~/cancel-retry wire) %arvo %b %rest fires-at.u.sub]
-        [%pass wire %agent dock.u.sub %leave ~]
+    :~  [%pass (weld /~/retry wire) %arvo %b %rest fires-at.u.sub]
+        leave
     ==
   --
 --

--- a/desk/lib/subscriber.hoon
+++ b/desk/lib/subscriber.hoon
@@ -37,7 +37,7 @@
     =/  leave  [%pass wire %agent dock %leave ~]
     =/  sub  (~(get by subs) wire)
     ?~  sub
-      ((slog 'No such subscription' >[wire]< ~) [~ subs])
+      ((slog 'No such subscription' >[wire]< ~) [~[leave] subs])
     ~?  verb  ['cancelling' wire]
     :_  (~(del by subs) wire)
     :~  [%pass (weld /~/retry wire) %arvo %b %rest fires-at.u.sub]

--- a/desk/lib/subscriber.hoon
+++ b/desk/lib/subscriber.hoon
@@ -8,6 +8,7 @@
 ::
 +$  subs  (map wire sub)
 ::
+++  verb  |
 ++  subscriber
   |_  [=subs bowl:gall]
   ++  interval  ~s30
@@ -15,7 +16,7 @@
     |=  =wire
     ^-  [(unit card:agent:gall) _subs]
     ?>  ?=([%~.~ %retry *] wire)
-    :: ~&  ['waking up' wire]
+    ~?  verb  ['waking up' wire]
     =/  sub  (~(get by subs) t.t.wire)
     ?~  sub  [~ subs]
     :-  `[%pass t.t.wire %agent dock.u.sub %watch path.u.sub]
@@ -26,18 +27,20 @@
     ?:  (~(has by subs) wire)
       ((slog 'Duplicate subscription' >[wire dock]< ~) [~ subs])
     ?.  delay  [`[%pass wire %agent dock %watch path] subs]
-    :: ~&  ['subscribing with delay' wire]
+    ~?  verb  ['subscribing with delay' wire]
     =/  fires-at  (add now interval)
     :_  (~(put by subs) wire [dock path fires-at])
     `[%pass (weld /~/retry wire) %arvo %b %wait fires-at]
-  ++  cancel
+  ++  unsubscribe
     |=  =wire
-    ^-  [(unit card:agent:gall) _subs]
+    ^-  [(list card:agent:gall) _subs]
     =/  sub  (~(get by subs) wire)
     ?~  sub
       ((slog 'No such subscription' >[wire]< ~) [~ subs])
-    :: ~&  ['cancelling' wire]
+    ~?  verb  ['cancelling' wire]
     :_  (~(del by subs) wire)
-    `[%pass (weld /~/cancel-retry wire) %arvo %b %rest fires-at.u.sub]
+    :~  [%pass (weld /~/cancel-retry wire) %arvo %b %rest fires-at.u.sub]
+        [%pass wire %agent dock.u.sub %leave ~]
+    ==
   --
 --

--- a/desk/lib/subscriber.hoon
+++ b/desk/lib/subscriber.hoon
@@ -3,6 +3,7 @@
 +$  sub
   $:  =dock
       =path
+      fires-at=@da
   ==
 ::
 +$  subs  (map wire sub)
@@ -14,9 +15,10 @@
     |=  =wire
     ^-  [(unit card:agent:gall) _subs]
     ?>  ?=([%~.~ %retry *] wire)
+    :: ~&  ['waking up' wire]
     =/  sub  (~(get by subs) t.t.wire)
     ?~  sub  [~ subs]
-    :-  `[%pass t.wire %agent dock.u.sub %watch path.u.sub]
+    :-  `[%pass t.t.wire %agent dock.u.sub %watch path.u.sub]
     (~(del by subs) t.t.wire)
   ++  subscribe
     |=  [=wire =dock =path delay=?]
@@ -24,7 +26,18 @@
     ?:  (~(has by subs) wire)
       ((slog 'Duplicate subscription' >[wire dock]< ~) [~ subs])
     ?.  delay  [`[%pass wire %agent dock %watch path] subs]
-    :_  (~(put by subs) wire [dock path])
-    `[%pass (weld /~/retry wire) %arvo %b %wait (add now interval)]
+    :: ~&  ['subscribing with delay' wire]
+    =/  fires-at  (add now interval)
+    :_  (~(put by subs) wire [dock path fires-at])
+    `[%pass (weld /~/retry wire) %arvo %b %wait fires-at]
+  ++  cancel
+    |=  =wire
+    ^-  [(unit card:agent:gall) _subs]
+    =/  sub  (~(get by subs) wire)
+    ?~  sub
+      ((slog 'No such subscription' >[wire]< ~) [~ subs])
+    :: ~&  ['cancelling' wire]
+    :_  (~(del by subs) wire)
+    `[%pass (weld /~/cancel-retry wire) %arvo %b %rest fires-at.u.sub]
   --
 --

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -1,0 +1,78 @@
+/-  g=groups, c=channels
+/+  *test-agent
+/=  channels-agent  /app/channels
+|%
+++  dap  %channels-test
+++  server-dap  %channels-test-server
+++  negotiate  /~/negotiate/inner-watch/~zod/[server-dap]
+++  sub-wire  /chat/(scot %p ~zod)/test
+++  negotiate-wire  (weld negotiate /chat/(scot %p ~zod)/test)
+++  chk-wire  (weld negotiate-wire /checkpoint)
+++  chk-path  /chat/test/checkpoint/before/100
+++  the-dock  [~zod server-dap]
+++  the-nest  [%chat ~zod %test]
+++  the-group  [~zod %test]
+++  test-checkpoint-sub
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  channel-join
+  =/  retry  (weld /~/retry (weld sub-wire /checkpoint))
+  (check-subscription-loop chk-wire chk-wire the-dock chk-path retry)
+++  test-updates-sub
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  channel-join
+  ::  get checkpoint and start updates
+  =/  =cage  [%channel-checkpoint !>(*u-checkpoint:c)]
+  ;<  *  bind:m  (do-agent chk-wire the-dock %fact cage)
+  =/  updates-wire  (weld negotiate-wire /updates)
+  ::  kicking updates retries back to checkpoint
+  =/  updates-retry  (weld /~/retry (weld sub-wire /checkpoint))
+  ;<  *  bind:m  (do-agent updates-wire the-dock %watch-ack ~)
+  (check-subscription-loop updates-wire chk-wire the-dock chk-path updates-retry)
+++  test-backlog-sub
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ;<  *  bind:m  channel-join
+  ;<  bw=bowl  bind:m  get-bowl
+  ::  get checkpoint and start updates
+  =/  last-post-time  (add now.bw 1)
+  =/  last-post=v-post:c
+    :-  [last-post-time ~ ~]
+    [0 [[~ ~dev last-post-time] %chat ~]]
+  =/  posts=v-posts:c
+    (gas:on-v-posts:c *v-posts:c ~[[last-post-time `last-post]])
+  =/  checkpoint  *u-checkpoint:c
+  =/  =cage  [%channel-checkpoint !>(checkpoint(posts posts))]
+  ;<  *  bind:m  (do-agent chk-wire the-dock %fact cage)
+  =/  backlog-wire  (weld negotiate-wire /backlog)
+  =/  backlog-path
+    %+  welp  /chat/test/checkpoint/time-range
+    /(scot %da *@da)/(scot %da last-post-time)
+  =/  backlog-retry  (weld /~/retry (weld sub-wire /backlog))
+  ;<  *  bind:m  (do-agent backlog-wire the-dock %watch-ack ~)
+  (check-subscription-loop backlog-wire backlog-wire the-dock backlog-path backlog-retry)
+++  check-subscription-loop
+  |=  [sub=wire resub=wire =dock =path retry-wire=wire]
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  now=time  now.bw
+  ::  kick & resubscribe with delay
+  ;<  caz=(list card)  bind:m  (do-agent sub dock %kick ~)
+  =/  next=time  (add now ~s30)
+  ;<  *  bind:m
+  (ex-cards caz (ex-arvo retry-wire %b %wait next) ~)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(now next)))
+  ::  wakeup & resubscribe no delay
+  ;<  caz=(list card)  bind:m  (do-arvo retry-wire %behn %wake ~)
+  (ex-cards caz (ex-task resub dock %watch path) ~)
+++  channel-join
+  =/  m  (mare ,(list card))
+  ^-  form:m
+  ::  join channel
+  ;<  *  bind:m  (do-init dap channels-agent)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  *  bind:m  (do-poke %channel-action !>([%channel the-nest %join the-group]))
+  (do-agent chk-wire the-dock %watch-ack ~)
+--

--- a/desk/tests/app/groups.hoon
+++ b/desk/tests/app/groups.hoon
@@ -1,0 +1,32 @@
+/-  g=groups
+/+  *test-agent
+/=  groups-agent  /app/groups
+|%
+++  dap  %groups-test
+++  the-wire  /groups/(scot %p ~zod)/test/updates
+++  the-path  (weld the-wire /init)
+++  the-dock  [~zod dap]
+++  the-group  [%test 'test' '' '' '' [%open ~ ~] ~ |]
+++  retry  (weld /~/retry the-wire)
+++  test-subscription-loop
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ::  init and add group
+  ;<  *  bind:m  (do-init %groups-test groups-agent)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  *  bind:m  (do-poke %group-join !>([[~zod %test] &]))
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~zod)))
+  ;<  *  bind:m  (do-agent /gangs/(scot %p ~zod)/test/join/add the-dock %poke-ack ~)
+  ;<  *  bind:m  (do-agent the-wire the-dock %watch-ack ~)
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  now=time  now.bw
+  ::  kick & resubscribe with delay
+  ;<  caz=(list card)  bind:m  (do-agent the-wire the-dock %kick ~)
+  =/  next=time  (add now ~s30)
+  ;<  *  bind:m
+  (ex-cards caz (ex-arvo retry %b %wait next) ~)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(now next)))
+  ::  wakeup & resubscribe no delay
+  ;<  caz=(list card)  bind:m  (do-arvo retry %behn %wake ~)
+  (ex-cards caz (ex-task the-wire the-dock %watch the-path) ~)
+--

--- a/desk/tests/app/groups.hoon
+++ b/desk/tests/app/groups.hoon
@@ -3,30 +3,56 @@
 /=  groups-agent  /app/groups
 |%
 ++  dap  %groups-test
-++  the-wire  /groups/(scot %p ~zod)/test/updates
-++  the-path  (weld the-wire /init)
+++  the-wire  /groups/(scot %p ~zod)/test
+++  updates-wire  (weld the-wire /updates)
+++  the-path  (weld updates-wire /init)
 ++  the-dock  [~zod dap]
 ++  the-group  [%test 'test' '' '' '' [%open ~ ~] ~ |]
-++  retry  (weld /~/retry the-wire)
+++  flag  [~zod %test]
+++  retry  (weld /~/retry updates-wire)
 ++  test-subscription-loop
   %-  eval-mare
   =/  m  (mare ,~)
   ::  init and add group
   ;<  *  bind:m  (do-init %groups-test groups-agent)
   ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
-  ;<  *  bind:m  (do-poke %group-join !>([[~zod %test] &]))
+  ;<  *  bind:m  (do-poke %group-join !>([flag &]))
   ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~zod)))
   ;<  *  bind:m  (do-agent /gangs/(scot %p ~zod)/test/join/add the-dock %poke-ack ~)
-  ;<  *  bind:m  (do-agent the-wire the-dock %watch-ack ~)
+  ;<  *  bind:m  (do-agent updates-wire the-dock %watch-ack ~)
   ;<  bw=bowl  bind:m  get-bowl
   =/  now=time  now.bw
   ::  kick & resubscribe with delay
-  ;<  caz=(list card)  bind:m  (do-agent the-wire the-dock %kick ~)
+  ;<  caz=(list card)  bind:m  (do-agent updates-wire the-dock %kick ~)
   =/  next=time  (add now ~s30)
   ;<  *  bind:m
   (ex-cards caz (ex-arvo retry %b %wait next) ~)
   ;<  *  bind:m  (jab-bowl |=(b=bowl b(now next)))
   ::  wakeup & resubscribe no delay
   ;<  caz=(list card)  bind:m  (do-arvo retry %behn %wake ~)
-  (ex-cards caz (ex-task the-wire the-dock %watch the-path) ~)
+  (ex-cards caz (ex-task updates-wire the-dock %watch the-path) ~)
+++  test-unsubscribe
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ::  init and add group
+  ;<  *  bind:m  (do-init %groups-test groups-agent)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  *  bind:m  (do-poke %group-join !>([flag &]))
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~zod)))
+  ;<  *  bind:m  (do-agent /gangs/(scot %p ~zod)/test/join/add the-dock %poke-ack ~)
+  ;<  *  bind:m  (do-agent updates-wire the-dock %watch-ack ~)
+  ;<  bw=bowl  bind:m  get-bowl
+  =/  now=time  now.bw
+  ::  kick & resubscribe with delay
+  ;<  caz=(list card)  bind:m  (do-agent updates-wire the-dock %kick ~)
+  =/  next=time  (add now ~s30)
+  ;<  caz=(list card)  bind:m  (do-poke %group-leave !>(flag))
+  =/  remove-vase  !>([flag now %fleet (silt ~dev ~) %del ~])
+  %+  ex-cards  caz
+  :~  (ex-poke (weld the-wire /proxy) the-dock act:mar:g remove-vase)
+      (ex-fact ~[/groups /groups/ui] %group-leave !>(flag))
+      (ex-arvo retry %b %rest next)
+      (ex-task updates-wire the-dock %leave ~)
+      (ex-fact ~[/groups/ui] act:mar:g !>([flag now %del ~]))
+  ==
 --


### PR DESCRIPTION
Fixes LAND-1527 by adding a library with a mechanism for us to delay resubscriptions by 30 seconds to ensure that we don't take up all CPU/event throughput of a ship when in a kick + resubscribe loop. This was added to only groups and channels, but could stand to be applied elsewhere.

PR Checklist
- [X] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [X] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context