### PR TITLE
notebooks: allow admins to edit posts they didn't author

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -542,12 +542,12 @@
       (put:on-v-posts:c posts.channel id ~ new)
     ::
         %edit
-      ?>  =(src.bowl author.essay.c-post)
+      ?>  |(=(src.bowl author.essay.c-post) (is-admin:ca-perms src.bowl))
       ?>  =(kind.nest -.kind-data.essay.c-post)
       =/  post  (get:on-v-posts:c posts.channel id.c-post)
       ?~  post  `posts.channel
       ?~  u.post  `posts.channel
-      ?>  =(src.bowl author.u.u.post)
+      ?>  |(=(src.bowl author.u.u.post) (is-admin:ca-perms src.bowl))
       ::TODO  could optimize and no-op if the edit is identical to current
       =/  new=v-post:c  [-.u.u.post +(rev.u.u.post) essay.c-post]
       :-  `[%post id.c-post %set ~ new]


### PR DESCRIPTION
Fixes LAND-1436, which was an issue where one writer couldn't edit another writer's post. I don't think we actually want writers to be able to edit other writer's posts (at the moment this would mean that anyone who has write access to the notebook at all, such as commenters, could edit the post, it would also mean that we couldn't use %edit for editing chat messages with the perms as-is, as it would allow anyone to edit anyone else's messages).

Instead of allowing writers to edit other writers' posts we can allow admins to edit any post.

In general, notebook perms need to be fleshed out a bit more (and probably treated separately from chat and gallery perms). This is a bandaid on that problem.

Tested with two livenet moons, locally.

PR Checklist
- [x] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context