### PR TITLE
chat: allow admins to delete replies

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -611,7 +611,7 @@
       =/  reply  (get:on-v-replies:c replies id.c-reply)
       ?~  reply  `(put:on-v-replies:c replies id.c-reply ~)
       ?~  u.reply  `replies
-      ?>  =(src.bowl author.u.u.reply)
+      ?>  |(=(src.bowl author.u.u.reply) (is-admin:ca-perms src.bowl))
       :-  `[%reply id.c-reply %set ~]
       (put:on-v-replies:c replies id.c-reply ~)
     ::


### PR DESCRIPTION
Currently the delete reply arm asserted that you were the author in order to delete a reply. It should instead also allow the action if you're an admin. This PR just updates that line accordingly.

This also explains why it was working for top level posts, but not replies (the top level post arm already had both checks).

Tested with a local ship, deleting replies from a hosted ship.

Fixes LAND-1483

PR Checklist
- [x] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context