### PR TITLE
notebooks: properly handle code blocks

### DIFF
--- a/ui/src/diary/diary-add-note.tsx
+++ b/ui/src/diary/diary-add-note.tsx
@@ -129,7 +129,7 @@ export default function DiaryAddNote() {
     const data = JSONToInlines(editor?.getJSON(), false, true);
     const values = getValues();
 
-    const noteContent = constructStory(data);
+    const noteContent = constructStory(data, true);
     const now = Date.now();
     const cacheId = {
       author: window.our,

--- a/ui/src/types/channel.ts
+++ b/ui/src/types/channel.ts
@@ -552,7 +552,10 @@ export const emptyReply: Reply = {
   },
 };
 
-export function constructStory(data: (Inline | Block)[]): Story {
+export function constructStory(
+  data: (Inline | Block)[],
+  codeAsBlock?: boolean
+): Story {
   const isBlock = (c: Inline | Block) =>
     [
       'image',
@@ -564,6 +567,7 @@ export function constructStory(data: (Inline | Block)[]): Story {
       'header',
       'rule',
       'cite',
+      codeAsBlock ? 'code' : '',
     ].some((k) => typeof c !== 'string' && k in c);
   const postContent: Story = [];
   let index = 0;


### PR DESCRIPTION
Fixes LAND-1404 by making sure we send code blocks as `blocks` in notebook posts.

Only handled as blocks in notebook posts, nothing changes for chat posts.

Inline and block code still render correctly in chat messages, and now both render correctly in notebook posts.

Tested locally on a livenet moon.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context