### PR TITLE
groups: make sure segmented groups are filtered from the main list on mobile

### DIFF
--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -63,10 +63,12 @@ export default function Sidebar() {
   const flagsToFilter = useMemo(() => {
     const flags = new Set();
     Object.entries(pinnedGroups).forEach(([flag]) => flags.add(flag));
+    Object.entries(invitedGroups).forEach(([flag]) => flags.add(flag));
     loadingGroups.forEach(([flag]) => flags.add(flag));
     newGroups?.forEach(([flag]) => flags.add(flag));
+    gangsWithClaims.forEach((flag) => flags.add(flag));
     return flags;
-  }, [pinnedGroups, loadingGroups, newGroups]);
+  }, [pinnedGroups, loadingGroups, newGroups, gangsWithClaims, invitedGroups]);
 
   const allOtherGroups = useMemo(
     () => sortedGroups.filter(([flag, _g]) => !flagsToFilter.has(flag)),

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -59,6 +59,20 @@ export default function MobileRoot() {
   const hasNewGroups = !!newGroups.length;
   const hasPendingGangs = Object.keys(pendingGangs).length > 0;
 
+  // get all non-segmented groups
+  const flagsToFilter = useMemo(() => {
+    const flags = new Set();
+    Object.entries(pinnedGroups).forEach(([flag]) => flags.add(flag));
+    loadingGroups.forEach(([flag]) => flags.add(flag));
+    newGroups?.forEach(([flag]) => flags.add(flag));
+    return flags;
+  }, [pinnedGroups, loadingGroups, newGroups]);
+
+  const allOtherGroups = useMemo(
+    () => sortedGroups.filter(([flag, _g]) => !flagsToFilter.has(flag)),
+    [sortedGroups, flagsToFilter]
+  );
+
   return (
     <Layout
       className="flex-1 bg-white"
@@ -92,7 +106,7 @@ export default function MobileRoot() {
             </div>
           ) : (
             <GroupsScrollingContext.Provider value={isScrolling}>
-              <GroupList groups={sortedGroups} isScrolling={scroll.current}>
+              <GroupList groups={allOtherGroups} isScrolling={scroll.current}>
                 {hasPinnedGroups ||
                 hasPendingGangs ||
                 hasGangsWithClaims ||

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -63,10 +63,12 @@ export default function MobileRoot() {
   const flagsToFilter = useMemo(() => {
     const flags = new Set();
     Object.entries(pinnedGroups).forEach(([flag]) => flags.add(flag));
+    Object.entries(pendingGangs).forEach(([flag]) => flags.add(flag));
     loadingGroups.forEach(([flag]) => flags.add(flag));
     newGroups?.forEach(([flag]) => flags.add(flag));
+    gangsWithClaims.forEach((flag) => flags.add(flag));
     return flags;
-  }, [pinnedGroups, loadingGroups, newGroups]);
+  }, [pinnedGroups, loadingGroups, newGroups, gangsWithClaims, pendingGangs]);
 
   const allOtherGroups = useMemo(
     () => sortedGroups.filter(([flag, _g]) => !flagsToFilter.has(flag)),


### PR DESCRIPTION
OTT

Tested locally against a hosted ship.

Fixes LAND-1540


PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context