### PR TITLE
app: fix inconsistencies from previous talk/groups split

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -165,7 +165,7 @@ const appHead = (appName: string) => {
       };
     default:
       return {
-        title: 'Groups',
+        title: 'Tlon',
         icon: groupsFavicon,
       };
   }
@@ -387,7 +387,10 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                   path="channels/chat/:chShip/:chName"
                   element={<GroupChannel type="chat" />}
                 >
-                  <Route path="*" element={<ChatChannel />} />
+                  <Route
+                    path="*"
+                    element={<ChatChannel title={`• ${groupsTitle}`} />}
+                  />
                   {isSmall ? (
                     <Route path="message/:idTime" element={<ChatThread />} />
                   ) : null}

--- a/ui/src/notifications/Notifications.tsx
+++ b/ui/src/notifications/Notifications.tsx
@@ -220,9 +220,7 @@ export default function Notifications({
             <div>
               <WelcomeCard />
               <div className="mb-6 flex w-full items-center justify-between">
-                <h2 className="text-lg font-bold">
-                  {group && 'Group '}Activity{!group && ' in All Groups'}
-                </h2>
+                <h2 className="text-lg font-bold">Activity</h2>
                 {hasUnreads && MarkAsRead}
               </div>
             </div>
@@ -231,7 +229,7 @@ export default function Notifications({
             notifications.length === 0 ? (
               <div className="mt-3 flex w-full items-center justify-center">
                 <span className="text-base font-semibold text-gray-400">
-                  No notifications from {group ? 'this' : 'any'} group.
+                  No notifications
                 </span>
               </div>
             ) : (

--- a/ui/src/notifications/useNotifications.tsx
+++ b/ui/src/notifications/useNotifications.tsx
@@ -97,13 +97,7 @@ export const useNotifications = (
 
   const unreads = skeins.filter((s) => s.unread);
   const filteredSkeins = skeins.filter(filter);
-  const filteredSkeinsForDesktop = filteredSkeins.filter(
-    (s) => !isDm(s.top.rope) && !isClub(s.top.rope)
-  );
-
-  const notifications = groupSkeinsByDate(
-    isMobile ? filteredSkeins : filteredSkeinsForDesktop
-  );
+  const notifications = groupSkeinsByDate(filteredSkeins);
 
   return {
     notifications,


### PR DESCRIPTION
Fixes title so it no longer says "undefined", makes sure you can see all activity, and adjusts some copy that was confusing. Tested by opening app locally and looking at title bar, activity indicator, and notifications screen.

PR Checklist
- [ ] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context