### PR TITLE
desktop nav: fix crashing error in new messages nav tab count

### DIFF
--- a/ui/src/logic/useMessagesUnreadCount.ts
+++ b/ui/src/logic/useMessagesUnreadCount.ts
@@ -35,7 +35,7 @@ export default function useMessagesUnreadCount(): number {
         .filter((pin) => whomIsDm(pin) || whomIsMultiDm(pin))
         .reduce((accum, whom) => {
           const unread = dmUnreads[whom];
-          return unread.count > 0 ? accum + 1 : accum;
+          return unread?.count > 0 ? accum + 1 : accum;
         }, 0),
     [pins, dmUnreads]
   );
@@ -46,7 +46,7 @@ export default function useMessagesUnreadCount(): number {
         .filter((pin) => whomIsNest(pin))
         .reduce((accum, whom) => {
           const unread = dmUnreads[whom];
-          return unread.count > 0 ? accum + 1 : accum;
+          return unread?.count > 0 ? accum + 1 : accum;
         }, 0),
     [pins, dmUnreads]
   );


### PR DESCRIPTION
OTT

Was noticing a bug with the new nav messages tab count PR that sometimes causes a crashing bug on desktop. Need to check that pins have an actual unread before reading their `count` prop

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context