### PR TITLE
channels: make reply scry response match mark type

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1083,7 +1083,7 @@
       =/  =rope:ha  (ca-rope -.kind-data.post id-post ~)
       ?:  (was-mentioned:utils content.post our.bowl)
         ?.  (want-hark %mention)
-          ca-core        
+          ca-core
         =/  cs=(list content:ha)
           ~[[%ship author.post] ' mentioned you: ' (flatten:utils content.post)]
         (emit (pass-hark (ca-spin rope cs ~)))
@@ -1369,11 +1369,11 @@
       =/  post  (get:on posts.channel `@da`time)
       ?~  post  ~
       ?~  u.post  `~
-      (ca-peek-replies replies.u.u.post rest.pole)
+      (ca-peek-replies id.u.u.post replies.u.u.post rest.pole)
     ==
   ::
   ++  ca-peek-replies
-    |=  [replies=v-replies:c =(pole knot)]
+    |=  [parent-id=id-post:c replies=v-replies:c =(pole knot)]
     ^-  (unit (unit cage))
     =*  on   on-v-replies:c
     ?+    pole  [~ ~]
@@ -1397,7 +1397,7 @@
       =/  reply  (get:on-v-replies:c replies `@da`time)
       ?~  reply  ~
       ?~  u.reply  `~
-      ``channel-reply+!>(u.u.reply)
+      ``channel-reply+!>(`reply:c`(uv-reply:utils parent-id u.u.reply))
     ==
   ::
   ++  ca-search


### PR DESCRIPTION
Scrying for a reply message would produce a noun marked with the %channel-reply mark, but the noun itself wouldn't nest in the type of that mark.

Here, we add a cast to the appropriate type, and "unversion" the reply noun that was being produced to coerce it into the correct shape.

Resolves LAND-1531.