### PR TITLE
groups: eliminate discover/find interface

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -23,7 +23,6 @@ import useMedia, { useIsDark, useIsMobile } from '@/logic/useMedia';
 import useErrorHandler from '@/logic/useErrorHandler';
 import {
   useAnalyticsId,
-  useCalm,
   useLogActivity,
   useSettingsLoaded,
   useTheme,
@@ -42,7 +41,6 @@ import GroupInfo from '@/groups/GroupAdmin/GroupInfo';
 import ProfileModal from '@/profiles/ProfileModal';
 import MultiDMEditModal from '@/dms/MultiDMEditModal';
 import NewChannelModal from '@/channels/NewChannel/NewChannelModal';
-import FindGroups from '@/groups/FindGroups';
 import GroupPreviewModal from '@/groups/Join/GroupPreview';
 import RejectConfirmModal from '@/groups/Join/RejectConfirmModal';
 import EditProfile from '@/profiles/EditProfile/EditProfile';
@@ -257,20 +255,6 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
                 />
               )}
             </Route>
-            {/* Find by Invite URL */}
-            <Route
-              path="/find/:ship/:name"
-              element={<FindGroups title={`Discover • ${groupsTitle}`} />}
-            />
-            {/* Find by Nickname or @p */}
-            <Route
-              path="/find/:ship"
-              element={<FindGroups title={`Discover • ${groupsTitle}`} />}
-            />
-            <Route
-              path="/find"
-              element={<FindGroups title={`Discover • ${groupsTitle}`} />}
-            />
             <Route
               path="/profile/edit"
               element={<EditProfile title={`Edit Profile • ${groupsTitle}`} />}

--- a/ui/src/components/Sidebar/MobileSidebar.tsx
+++ b/ui/src/components/Sidebar/MobileSidebar.tsx
@@ -16,7 +16,6 @@ import BellIcon from '../icons/BellIcon';
 import HomeIconMobileNav from '../icons/HomeIconMobileNav';
 import MessagesIcon from '../icons/MessagesIcon';
 import Avatar from '../Avatar';
-import NavigateIcon from '../icons/NavigateIcon';
 
 function GroupsTab(props: { isInactive: boolean; isDarkMode: boolean }) {
   const navigate = useNavigate();
@@ -182,20 +181,6 @@ export default function MobileSidebar() {
               isInactive={isInactive('/notifications')}
               isDarkMode={isDarkMode}
             />
-            <NavTab
-              to="/find"
-              linkClass="h-full !pb-0 flex flex-col items-start justify-start"
-            >
-              <div className="flex-1" />
-              <div className="flex h-8 w-8 items-center justify-center">
-                <NavigateIcon
-                  isInactive={isInactive('/find')}
-                  isDarkMode={isDarkMode}
-                  className="h-[20px] w-[18px]"
-                />
-              </div>
-              <div className="flex-1" />
-            </NavTab>
             {needsUpdate ? (
               <NavTab
                 to="/update-needed"

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -34,7 +34,7 @@ export default function Sidebar() {
   const [isScrolling, setIsScrolling] = useState(false);
   const [atTop, setAtTop] = useState(true);
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
-  const { data: groups, isLoading } = useGroupsWithQuery();
+  const { data: groups } = useGroupsWithQuery();
   const invitedGroups = usePendingGangsWithoutClaim();
   const pinnedGroups = usePinnedGroups();
   const loadingGroups = useLoadingGroups();
@@ -223,13 +223,6 @@ export default function Sidebar() {
 
                     {hasNewGroups && (
                       <div className="mx-2">{newGroupsDisplay}</div>
-                    )}
-
-                    {!sortedGroups.length && !hasNewGroups && !isLoading && (
-                      <div className="mx-4 my-2 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
-                        Check out <strong>Discover</strong> above to find new
-                        groups in your network or view group invites.
-                      </div>
                     )}
                   </div>
                 </>

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -19,7 +19,6 @@ import MobileHeader from '@/components/MobileHeader';
 import Layout from '@/components/Layout/Layout';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
 import GroupJoinList from '@/groups/GroupJoinList';
-import NavigateIcon from '@/components/icons/NavigateIcon';
 import WelcomeCard from '@/components/WelcomeCard';
 import AddGroupSheet from '@/groups/AddGroupSheet';
 

--- a/ui/src/nav/MobileRoot.tsx
+++ b/ui/src/nav/MobileRoot.tsx
@@ -35,7 +35,7 @@ export default function MobileRoot() {
   const loadingGroups = useLoadingGroups();
   const newGroups = useNewGroups();
   const gangsWithClaims = useGangsWithClaim();
-  const { data: groups, isLoading } = useGroupsWithQuery();
+  const { data: groups } = useGroupsWithQuery();
   const sortedGroups = sortGroups(groups);
   const pinnedGroupsOptions = useMemo(
     () =>
@@ -84,56 +84,48 @@ export default function MobileRoot() {
       <nav className="flex h-full flex-1 flex-col overflow-y-auto overflow-x-hidden">
         <WelcomeCard />
         <div className="flex-1">
-          {sortedGroups.length === 0 && !isLoading ? (
-            <div className="mx-4 my-2 rounded-lg bg-indigo-50 p-4 leading-5 text-gray-700 dark:bg-indigo-900/50">
-              Tap the <span className="sr-only">find icon</span>
-              <NavigateIcon className="inline-flex h-4 w-4" /> below to find new
-              groups in your network or view group invites.
-            </div>
-          ) : (
-            <GroupsScrollingContext.Provider value={isScrolling}>
-              <GroupList groups={sortedGroups} isScrolling={scroll.current}>
-                {hasPinnedGroups ||
-                hasPendingGangs ||
-                hasGangsWithClaims ||
-                hasLoadingGroups ||
-                hasNewGroups ? (
-                  <>
-                    <div className="px-4">
-                      {hasPinnedGroups ? (
-                        <>
-                          <h2 className="mb-0.5 p-2 font-sans text-gray-400">
-                            Pinned
-                          </h2>
-                          {pinnedGroupsOptions}
+          <GroupsScrollingContext.Provider value={isScrolling}>
+            <GroupList groups={sortedGroups} isScrolling={scroll.current}>
+              {hasPinnedGroups ||
+              hasPendingGangs ||
+              hasGangsWithClaims ||
+              hasLoadingGroups ||
+              hasNewGroups ? (
+                <>
+                  <div className="px-4">
+                    {hasPinnedGroups ? (
+                      <>
+                        <h2 className="mb-0.5 p-2 font-sans text-gray-400">
+                          Pinned
+                        </h2>
+                        {pinnedGroupsOptions}
 
-                          <h2 className="my-2 p-2 font-sans text-gray-400">
-                            All Groups
-                          </h2>
-                        </>
-                      ) : null}
+                        <h2 className="my-2 p-2 font-sans text-gray-400">
+                          All Groups
+                        </h2>
+                      </>
+                    ) : null}
 
-                      {hasLoadingGroups &&
-                        Object.keys(loadingGroups).map(([flag, _]) => (
-                          <GangItem key={flag} flag={flag} isJoining />
-                        ))}
+                    {hasLoadingGroups &&
+                      Object.keys(loadingGroups).map(([flag, _]) => (
+                        <GangItem key={flag} flag={flag} isJoining />
+                      ))}
 
-                      {hasGangsWithClaims &&
-                        gangsWithClaims.map((flag) => (
-                          <GangItem key={flag} flag={flag} />
-                        ))}
+                    {hasGangsWithClaims &&
+                      gangsWithClaims.map((flag) => (
+                        <GangItem key={flag} flag={flag} />
+                      ))}
 
-                      {hasNewGroups && newGroupsOptions}
-                    </div>
+                    {hasNewGroups && newGroupsOptions}
+                  </div>
 
-                    {hasPendingGangs && (
-                      <GroupJoinList highlightAll gangs={pendingGangs} />
-                    )}
-                  </>
-                ) : null}
-              </GroupList>
-            </GroupsScrollingContext.Provider>
-          )}
+                  {hasPendingGangs && (
+                    <GroupJoinList highlightAll gangs={pendingGangs} />
+                  )}
+                </>
+              ) : null}
+            </GroupList>
+          </GroupsScrollingContext.Provider>
           <AddGroupSheet open={addGroupOpen} onOpenChange={setAddGroupOpen} />
         </div>
       </nav>


### PR DESCRIPTION
Removes the "Find Groups" or "Discover" tab from the mobile navbar and the desktop sidebar. This also removes the empty-state notices that point the user to said "Discover" tab or "Find Groups" page.

Tested locally with a moon in zero groups and locally with a planet in >50 groups.

The below screenshots show a new, self-hosted moon (the absolute base case). A new hosted planet will be joined to Tlon Studio and Tlon Local; the green banner will still be present.

![Screenshot 2024-02-09 at 1 25 24 PM](https://github.com/tloncorp/landscape-apps/assets/748181/8eafadbf-0998-41fa-b250-9cd024473b43)

![Screenshot 2024-02-09 at 1 25 07 PM](https://github.com/tloncorp/landscape-apps/assets/748181/b4ef1e6f-fd95-436c-aeba-107ce7920726)

Fixes LAND-1197

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context