### PR TITLE
desktop sidebar: fix double scrollbar and persist nav location when tab switching

### DIFF
--- a/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -44,6 +44,7 @@ export default function GroupSidebarItem() {
         }
         onClick={onClick}
         color={activeTab === 'groups' ? 'text-black' : 'text-gray-600'}
+        highlightPath="/groups"
         actions={
           <Dropdown.Trigger data-testid="add-group-sidebar-button-icon">
             <AddIcon16 className="relative top-[2px] hidden h-4 w-4 group-hover:block" />

--- a/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/ui/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -5,13 +5,14 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import AddIcon16 from '../icons/Add16Icon';
 import HomeIconMobileNav from '../icons/HomeIconMobileNav';
 import SidebarItem from './SidebarItem';
-import useActiveTab from './util';
+import useActiveTab, { useNavToTab } from './util';
 
-export default function AddGroupSidebarItem() {
+export default function GroupSidebarItem() {
   const navigate = useNavigate();
   const location = useLocation();
   const activeTab = useActiveTab();
   const [open, setOpen] = useState(false);
+  const navToTab = useNavToTab();
 
   const onOpenChange = (openChange: boolean) => {
     setOpen(openChange);
@@ -19,6 +20,12 @@ export default function AddGroupSidebarItem() {
 
   const navigateToModal = (path: string) => {
     navigate(path, { state: { backgroundLocation: location } });
+  };
+
+  const onClick = () => {
+    if (activeTab !== 'groups') {
+      navToTab('groups');
+    }
   };
 
   return (
@@ -35,7 +42,7 @@ export default function AddGroupSidebarItem() {
             isInactive={activeTab !== 'groups'}
           />
         }
-        to="/groups"
+        onClick={onClick}
         color={activeTab === 'groups' ? 'text-black' : 'text-gray-600'}
         actions={
           <Dropdown.Trigger data-testid="add-group-sidebar-button-icon">

--- a/ui/src/components/Sidebar/GroupList.tsx
+++ b/ui/src/components/Sidebar/GroupList.tsx
@@ -14,14 +14,14 @@ type AnyListItem = TopContentListItem | GroupListItem | SearchListItem;
 
 function itemContent(_i: number, item: AnyListItem) {
   if (item.type === 'top') {
-    return item.component;
+    return <div className="min-h-[1px]">{item.component}</div>;
   }
 
   if (item.type === 'search') {
     const record = item.data;
     if (record.type === 'group') {
       return (
-        <div className="px-4 sm:px-2">
+        <div className="min-h-[1px] px-4 sm:px-2">
           <GroupsSidebarItem
             flag={record.flag}
             isNew={record.status === 'new'}
@@ -31,7 +31,7 @@ function itemContent(_i: number, item: AnyListItem) {
     }
 
     return (
-      <div className="px-4 sm:px-2">
+      <div className="min-h-[1px] px-4 sm:px-2">
         <GangItem
           flag={record.flag}
           invited={record.status === 'invited'}
@@ -43,7 +43,7 @@ function itemContent(_i: number, item: AnyListItem) {
 
   const [flag] = item.data;
   return (
-    <div className="px-4 sm:px-2">
+    <div className="min-h-[1px] px-4 sm:px-2">
       <GroupsSidebarItem key={flag} flag={flag} />
     </div>
   );

--- a/ui/src/components/Sidebar/MessagesSidebarItem.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebarItem.tsx
@@ -48,6 +48,7 @@ export default function MessagesSidebarItem() {
           </Link>
         </div>
       }
+      highlightPath="/messages"
       onClick={onClick}
       className="group"
       color={activeTab === 'messages' ? 'text-black' : 'text-gray-600'}

--- a/ui/src/components/Sidebar/MessagesSidebarItem.tsx
+++ b/ui/src/components/Sidebar/MessagesSidebarItem.tsx
@@ -3,13 +3,20 @@ import { Link } from 'react-router-dom';
 import useMessagesUnreadCount from '@/logic/useMessagesUnreadCount';
 import MessagesIcon from '../icons/MessagesIcon';
 import SidebarItem from './SidebarItem';
-import useActiveTab from './util';
+import useActiveTab, { useNavToTab } from './util';
 import AddIcon16 from '../icons/Add16Icon';
 import ActivityIndicator from './ActivityIndicator';
 
 export default function MessagesSidebarItem() {
   const activeTab = useActiveTab();
   const unreadCount = useMessagesUnreadCount();
+  const navToTab = useNavToTab();
+
+  const onClick = () => {
+    if (activeTab !== 'messages') {
+      navToTab('messages');
+    }
+  };
 
   return (
     <SidebarItem
@@ -41,7 +48,7 @@ export default function MessagesSidebarItem() {
           </Link>
         </div>
       }
-      to={'/messages'}
+      onClick={onClick}
       className="group"
       color={activeTab === 'messages' ? 'text-black' : 'text-gray-600'}
     >

--- a/ui/src/components/Sidebar/Sidebar.tsx
+++ b/ui/src/components/Sidebar/Sidebar.tsx
@@ -151,33 +151,34 @@ export default function Sidebar() {
     <nav className="flex h-full w-full flex-none flex-col bg-white">
       <SidebarTopMenu />
 
+      <div className="relative mb-1 flex">
+        <input
+          ref={searchRef}
+          id="search"
+          type="text"
+          autoFocus
+          className={cn(
+            'input w-full border-none bg-white py-3 pl-4 pr-8 mix-blend-multiply placeholder:text-sm placeholder:font-medium dark:mix-blend-normal',
+            !atTop && 'bottom-shadow'
+          )}
+          placeholder={
+            activeTab === 'messages' ? 'Filter Messages' : 'Filter Groups'
+          }
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+        />
+        <button
+          className={cn(
+            'absolute right-3 top-3.5 h-4 w-4 text-gray-400',
+            !searchInput && 'hidden'
+          )}
+          onClick={() => setSearchInput('')}
+        >
+          <X16Icon />
+        </button>
+      </div>
+
       <div className="flex-auto space-y-3 overflow-x-hidden sm:space-y-1">
-        <div className="relative mb-1 flex">
-          <input
-            ref={searchRef}
-            id="search"
-            type="text"
-            autoFocus
-            className={cn(
-              'input w-full border-none bg-white py-3 pl-4 pr-8 mix-blend-multiply placeholder:text-sm placeholder:font-medium dark:mix-blend-normal',
-              !atTop && 'bottom-shadow'
-            )}
-            placeholder={
-              activeTab === 'messages' ? 'Filter Messages' : 'Filter Groups'
-            }
-            value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-          />
-          <button
-            className={cn(
-              'absolute right-3 top-3.5 h-4 w-4 text-gray-400',
-              !searchInput && 'hidden'
-            )}
-            onClick={() => setSearchInput('')}
-          >
-            <X16Icon />
-          </button>
-        </div>
         {activeTab !== 'messages' && (
           <GroupsScrollingContext.Provider value={isScrolling}>
             <GroupList

--- a/ui/src/components/Sidebar/SidebarItem.tsx
+++ b/ui/src/components/Sidebar/SidebarItem.tsx
@@ -27,6 +27,7 @@ type SidebarProps = PropsWithChildren<{
   inexact?: boolean;
   color?: string;
   highlight?: string;
+  highlightPath?: string;
   transparent?: boolean;
   fontWeight?: string;
   fontSize?: string;
@@ -61,6 +62,7 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
       override = false,
       color = 'text-gray-800 sm:text-gray-600',
       highlight = 'bg-gray-50',
+      highlightPath,
       fontWeight,
       fontSize = 'text-lg',
       actions,
@@ -82,6 +84,7 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
     const matches = useMatch(
       (defaultRoute ? '/' : matchString) || 'DONT_MATCH'
     );
+    const highlightMatch = useMatch(highlightPath || 'DONT_MATCH');
     const active = useMemo(() => !!matches, [matches]);
     const isMobile = useIsMobile();
     const Wrapper = 'div';
@@ -147,7 +150,8 @@ const SidebarItem = React.forwardRef<HTMLDivElement, SidebarProps>(
           'group relative my-0.5 flex w-full items-center justify-between rounded-lg',
           color,
           !hasHoverColor() && !active ? `hover:${highlight}` : null,
-          !hasHoverColor() && active && (to !== '/' || override)
+          (!hasHoverColor() && active && (to !== '/' || override)) ||
+            highlightMatch
             ? 'bg-gray-100'
             : null
         )}

--- a/ui/src/components/Sidebar/SidebarTopMenu.tsx
+++ b/ui/src/components/Sidebar/SidebarTopMenu.tsx
@@ -4,7 +4,7 @@ import SidebarItem from '@/components/Sidebar/SidebarItem';
 import { AppUpdateContext } from '@/logic/useAppUpdates';
 import ShipName from '@/components/ShipName';
 import Avatar, { useProfileColor } from '@/components/Avatar';
-import AddGroupSidebarItem from './AddGroupSidebarItem';
+import GroupsSidebarItem from './AddGroupSidebarItem';
 import SidebarHeader from './SidebarHeader';
 import { DesktopUpdateButton } from '../UpdateNotices';
 import useActiveTab from './util';
@@ -23,7 +23,7 @@ const SidebarTopMenu = React.memo(() => {
     <div className="flex w-full flex-col space-y-0.5 p-2">
       <UpdateOrAppMenu />
 
-      <AddGroupSidebarItem />
+      <GroupsSidebarItem />
       <MessagesSidebarItem />
       <ActivitySidebarItem />
 

--- a/ui/src/components/Sidebar/util.tsx
+++ b/ui/src/components/Sidebar/util.tsx
@@ -1,4 +1,6 @@
-import { useLocation } from 'react-router';
+import { useNavState, usePutEntryMutation } from '@/state/settings';
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 
 export type ActiveTab =
   | 'messages'
@@ -27,4 +29,47 @@ export default function useActiveTab(): ActiveTab {
   }
 
   return 'other';
+}
+
+export function useNavToTab() {
+  const navState = useNavState();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (tab: 'messages' | 'groups') => {
+      if (tab === 'groups') {
+        navigate(navState.groups || '/groups');
+      }
+
+      if (tab === 'messages') {
+        navigate(navState.messages || '/messages');
+      }
+    },
+    [navState, navigate]
+  );
+}
+
+export function useSaveNavState() {
+  const { mutate: mutateMessages } = usePutEntryMutation({
+    bucket: 'groups',
+    key: 'messagesNavState',
+  });
+
+  const { mutate: mutateGroups } = usePutEntryMutation({
+    bucket: 'groups',
+    key: 'groupsNavState',
+  });
+
+  return useCallback(
+    (tab: ActiveTab, path: string) => {
+      if (tab === 'groups') {
+        mutateGroups({ val: path });
+      }
+
+      if (tab === 'messages') {
+        mutateMessages({ val: path });
+      }
+    },
+    [mutateGroups, mutateMessages]
+  );
 }

--- a/ui/src/nav/GroupsNav.tsx
+++ b/ui/src/nav/GroupsNav.tsx
@@ -4,9 +4,20 @@ import { motion, AnimatePresence } from 'framer-motion';
 import Sidebar from '@/components/Sidebar/Sidebar';
 import GroupSidebar from '@/groups/GroupSidebar/GroupSidebar';
 import { useIsMobile } from '@/logic/useMedia';
+import { useEffect, useState } from 'react';
+import useActiveTab, {
+  ActiveTab,
+  useSaveNavState,
+} from '@/components/Sidebar/util';
 
 export function DesktopNav() {
   const location = useLocation();
+  const activeTab = useActiveTab();
+  const saveNavState = useSaveNavState();
+  const [lastLocation, setLastLocation] = useState<{
+    tab: ActiveTab;
+    pathname: string;
+  }>({ tab: activeTab, pathname: location.pathname });
   const state = location.state as { backgroundLocation?: Location } | null;
   const match = useMatch('/groups/:ship/:name/*');
   const backgroundLocationMatch = matchPath(
@@ -18,6 +29,20 @@ export function DesktopNav() {
     stiffness: 2880,
     damping: 120,
   };
+
+  // if we switch tabs from messages or groups, save the nav state
+  useEffect(() => {
+    if (lastLocation.tab !== activeTab) {
+      // TODO: we only save messages state for now since unclear how to do with groups
+      // given existing sidebar
+      if (['messages'].includes(lastLocation.tab)) {
+        saveNavState(lastLocation.tab, lastLocation.pathname);
+      }
+      setLastLocation({ tab: activeTab, pathname: location.pathname });
+    } else if (lastLocation.pathname !== location.pathname) {
+      setLastLocation({ tab: activeTab, pathname: location.pathname });
+    }
+  }, [activeTab, lastLocation, location.pathname, saveNavState]);
 
   return (
     <div className="relative flex h-full min-w-64 flex-none resize-x overflow-hidden border-r-2 border-gray-50 bg-white">

--- a/ui/src/state/settings.ts
+++ b/ui/src/state/settings.ts
@@ -104,6 +104,8 @@ export interface SettingsState {
     analyticsId?: string;
     seenWelcomeCard?: boolean;
     newGroupFlags: string[];
+    groupsNavState?: string;
+    messagesNavState?: string;
   };
   loaded: boolean;
   putEntry: (bucket: string, key: string, value: Value) => Promise<void>;
@@ -507,12 +509,24 @@ export function useSeenWelcomeCard() {
   }, [isLoading, data]);
 }
 
+export function useNavState() {
+  const { data, isLoading } = useMergedSettings();
+
+  if (isLoading || data === undefined || data.groups === undefined) {
+    return { groups: '', messages: '' };
+  }
+
+  return {
+    groups: data.groups.groupsNavState ?? '',
+    messages: data.groups.messagesNavState ?? '',
+  };
+}
+
 export function useSeenTalkSunset() {
   const { data, isLoading } = useMergedSettings();
 
   return useMemo(() => {
     if (isLoading || data === undefined || data.talk === undefined) {
-      console.log('returning sunset default');
       return false;
     }
 


### PR DESCRIPTION
Moves search up into the top section of the sidebar to avoid double scroller after adjusting the viewport. Also adds logic to save the navigation state for the groups and messages tabs so you can pick up where you left off when returning to the tab. 

Right now this is only enabled for messages since it's unclear how this should work for groups given the current in-group sidebar transition and back behavior. It's a one line change to add it to groups as well if we figure out a way to go that route.

Fixes LAND-1553
Fixes LAND-1554

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context