### PR TITLE
chat: fix copying root message from thread view

### DIFF
--- a/ui/src/components/References/ContentReference.tsx
+++ b/ui/src/components/References/ContentReference.tsx
@@ -82,13 +82,14 @@ function ContentReference({
     if (app === 'chat') {
       const idWrit = segments[2];
       const idReply = segments[3];
+      const isThreadParent = idWrit === idReply;
       return (
         <WritChanReference
           isScrolling={isScrolling}
           nest={nest}
           contextApp={contextApp}
           idWrit={idWrit}
-          idReply={idReply}
+          idReply={isThreadParent ? undefined : idReply}
         >
           {children}
         </WritChanReference>

--- a/ui/src/replies/ReplyMessageOptions.tsx
+++ b/ui/src/replies/ReplyMessageOptions.tsx
@@ -66,7 +66,9 @@ export default function ReplyMessageOptions(props: {
   const isAdmin = useAmAdmin(groupFlag);
   const threadParentId = seal['parent-id'];
   const { didCopy, doCopy } = useCopy(
-    `/1/chan/${nest}/msg/${threadParentId}/${seal.id}`
+    `/1/chan/${nest}/msg/${
+      threadParentId === seal.id ? seal.id : `${threadParentId}/${seal.id}`
+    }`
   );
   const { open: pickerOpen, setOpen: setPickerOpen } = useChatDialog(
     whom,


### PR DESCRIPTION
Updates the logic for calculating ref paths in chat reply options. If the message being copied is the root, link to it as a top level message rather than as a thread reply.

Also updates ref display logic to account for previously malformed paths. Old broken ones will show correctly now as well.

Tested against a local ship. For review, worth checking that normal messages, thread replies, and thread reply parents all work as expected.

Fixes LAND-1557

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context