### PR TITLE
profile: fix scrollbars, overflow cutoff

### DIFF
--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -181,7 +181,7 @@
 
     .body {
       width: 100vw;
-      height: 100vh;
+      max-height: 100vh;
       display: flex;
       flex-direction: column;
       align-items: center;

--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -183,11 +183,10 @@
       width: 100vw;
       height: 100vh;
       display: flex;
-      justify-content: center;
-      align-items: flex-start;
+      flex-direction: column;
+      align-items: center;
       margin: 0;
       padding: 0;
-      overflow: scroll;
       background-color: white;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
         Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -249,10 +248,10 @@
 
     .widget {
       position: relative;
-      overflow: hidden;
       box-sizing: border-box;
-      max-width: 85vw;
-      margin-top: 20px;
+      width: 100%;
+      max-width: 345px;
+      margin: 0 auto 20px;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
         Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
       color: black;

--- a/desk/app/profile/widgets.hoon
+++ b/desk/app/profile/widgets.hoon
@@ -28,8 +28,7 @@
     '''
     .hero-button {
       position: relative;
-      overflow: hidden;
-      width: 345px;
+      width: 100%;
       padding: 12px 0px;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
         Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -255,7 +254,7 @@
     }
 
     #profile-with-header {
-      margin-bottom: 20px;
+      margin: 0 auto 20px;
       position: relative;
       width: 345px;
       height: 345px;


### PR DESCRIPTION
Removes the horizontal and vertical scrollbars in the public profile view. Also makes some stricter rules about widget width and overflow, thus keeping the right edge of the 'Message me on Tlon' button from getting cut off.

Tested on a local live ship; screenshots attached.

![Screenshot 2024-02-13 at 4 20 39 PM](https://github.com/tloncorp/landscape-apps/assets/748181/e625e8b7-7bfe-4534-ba5d-276bf7ba0aa2)

![IMG_C96B62FC4D60-1](https://github.com/tloncorp/landscape-apps/assets/748181/da6cc290-d034-4acf-9776-bb9830c8b711)

Fixes LAND-1561

PR Checklist
- [x] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context