### PR TITLE
docket: better app tile contrast in dark mode

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -1,6 +1,6 @@
 :~  title+'Tlon'
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
-    color+0xef.f0f4
+    color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.png'
     glob-http+['https://bootstrap.urbit.org/glob-0v3.nij55.hp25l.fkcb4.umj7o.bug8q.glob' 0v3.nij55.hp25l.fkcb4.umj7o.bug8q]
     base+'groups'


### PR DESCRIPTION
Fixes LAND-1573.

Before, in dark mode. Note that you can't really even see the boundaries of the app tile rectangle, much less the T-block inside:

![Screenshot 2024-02-14 at 6 44 49 PM](https://github.com/tloncorp/landscape-apps/assets/748181/229c07a8-5f6e-4b07-b115-d5cd922b70a1)

After:

![Screenshot 2024-02-14 at 6 45 52 PM](https://github.com/tloncorp/landscape-apps/assets/748181/89d4325e-0529-4732-bbe0-6915b4dba8b3)

Light mode before/after:

![Screenshot 2024-02-14 at 6 46 35 PM](https://github.com/tloncorp/landscape-apps/assets/748181/256a1f65-e95c-444d-b007-def73559ae46)

![Screenshot 2024-02-14 at 6 46 14 PM](https://github.com/tloncorp/landscape-apps/assets/748181/0b74867d-42aa-43c8-9ee5-4f84e3da7433)


Tested locally with a livenet moon.

PR Checklist
- [x] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context