### PR TITLE
mobile DMs: fix missing non-pinned messages header regression

### DIFF
--- a/ui/src/components/EmptyPlaceholder.tsx
+++ b/ui/src/components/EmptyPlaceholder.tsx
@@ -12,3 +12,16 @@ export default function EmptyPlaceholder({
     </div>
   );
 }
+
+export function InlineEmptyPlaceholder({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div
+      className={`flex w-full flex-col items-center justify-center px-4 text-center text-lg text-gray-300 sm:text-base sm:leading-5 ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ui/src/dms/MessagesList.tsx
+++ b/ui/src/dms/MessagesList.tsx
@@ -8,7 +8,7 @@ import { DMUnread } from '@/types/dms';
 import { useUnreads, useChats } from '@/state/channel/channel';
 import { useGroups } from '@/state/groups';
 import { canReadChannel } from '@/logic/channel';
-import EmptyPlaceholder from '@/components/EmptyPlaceholder';
+import { InlineEmptyPlaceholder } from '@/components/EmptyPlaceholder';
 import { Unread } from '@/types/channel';
 import { usePinnedChats } from '@/state/pins';
 import { useContacts } from '@/state/contact';
@@ -68,6 +68,7 @@ export default function MessagesList({
   const chats = useChats();
   const groups = useGroups();
   const allPending = pending.concat(pendingMultis);
+  const hasPending = allPending && allPending.length > 0;
   const isMobile = useIsMobile();
   const thresholds = {
     atBottomThreshold: 125,
@@ -199,13 +200,13 @@ export default function MessagesList({
     () => ({
       Header: () => head,
       EmptyPlaceholder: () =>
-        isMobile ? (
-          <EmptyPlaceholder>
+        isMobile && !hasPending ? (
+          <InlineEmptyPlaceholder className="mt-24">
             Your direct messages will be shown here
-          </EmptyPlaceholder>
+          </InlineEmptyPlaceholder>
         ) : null,
     }),
-    [head, isMobile]
+    [head, isMobile, hasPending]
   );
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);

--- a/ui/src/dms/MobileMessagesSidebar.tsx
+++ b/ui/src/dms/MobileMessagesSidebar.tsx
@@ -44,6 +44,9 @@ export default function MobileMessagesSidebar() {
                 {pinned.map((ship: string) => (
                   <MessagesSidebarItem key={ship} whom={ship} />
                 ))}
+                <h2 className="mt-2 p-2 font-sans text-gray-400">
+                  Direct Messages
+                </h2>
               </div>
             ) : null}
           </MessagesList>


### PR DESCRIPTION
OTT

Tested against a local ship.

Fixes LAND-1567

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context