### PR TITLE
s3: allow video uploads

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -20,7 +20,7 @@ import ChatContentImage from '@/chat/ChatContent/ChatContentImage';
 import ContentReference from '@/components/References/ContentReference';
 import ShipName from '@/components/ShipName';
 import ChatEmbedContent from '@/chat/ChatEmbedContent/ChatEmbedContent';
-import { isSingleEmoji } from '@/logic/utils';
+import { isSingleEmoji, VIDEO_REGEX } from '@/logic/utils';
 import {
   Story,
   Block,
@@ -167,6 +167,23 @@ export function BlockContent({
   blockIndex,
 }: BlockContentProps) {
   if (isImage(story)) {
+    // The `image` block type sent from the backend can be a video or an image.
+    // We need to check the src to determine which it is.
+    // TODO: add an 'video' block type on the backend to make this more explicit,
+    // or rename the 'image' block type to 'media' or something similar.
+    const isVideoFile = VIDEO_REGEX.test(story.image.src);
+
+    if (isVideoFile) {
+      return (
+        <ChatEmbedContent
+          writId={writId}
+          url={story.image.src}
+          // content in this case is the video URL
+          content={story.image.src}
+        />
+      );
+    }
+
     return (
       <ChatContentImage
         src={story.image.src}

--- a/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/ui/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { BigPlayButton, Player } from 'video-react';
 import { AUDIO_REGEX, validOembedCheck, VIDEO_REGEX } from '@/logic/utils';
 import { useIsMobile } from '@/logic/useMedia';
 import { useCalm } from '@/state/settings';
 import { useEmbed } from '@/state/embed';
-import DOMPurify from 'dompurify';
 import YouTubeEmbed from './YouTubeEmbed';
 import TwitterEmbed from './TwitterEmbed';
 import SpotifyEmbed from './SpotifyEmbed';

--- a/ui/src/chat/ChatInput/ChatInput.tsx
+++ b/ui/src/chat/ChatInput/ChatInput.tsx
@@ -43,13 +43,14 @@ import {
   URL_REGEX,
   createStorageKey,
   useThreadParentId,
+  VIDEO_REGEX,
 } from '@/logic/utils';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useGroupFlag } from '@/state/groups';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
-import { PASTEABLE_IMAGE_TYPES } from '@/constants';
+import { PASTEABLE_MEDIA_TYPES } from '@/constants';
 import {
   Nest,
   PostEssay,
@@ -190,7 +191,7 @@ export default function ChatInput({
 
       if (
         localUploader &&
-        Array.from(fileList).some((f) => PASTEABLE_IMAGE_TYPES.includes(f.type))
+        Array.from(fileList).some((f) => PASTEABLE_MEDIA_TYPES.includes(f.type))
       ) {
         localUploader.uploadFiles(fileList);
         useFileStore.getState().setUploadType(uploadKey, 'drag');
@@ -603,28 +604,39 @@ export default function ChatInput({
       >
         {imageBlocks.length > 0 ? (
           <div className="mb-2 flex flex-wrap items-center">
-            {imageBlocks.map((img, idx) => (
-              <div key={idx} className="relative p-1.5">
-                <button
-                  onClick={() => onRemove(idx)}
-                  className="icon-button absolute right-4 top-4"
-                >
-                  <X16Icon className="h-4 w-4" />
-                </button>
-                {IMAGE_REGEX.test(img.image.src) ? (
-                  <img
-                    title={img.image.alt}
-                    src={img.image.src}
-                    className="h-32 w-32 object-cover"
-                  />
-                ) : (
-                  <div
-                    title={img.image.alt}
-                    className="h-32 w-32 animate-pulse bg-gray-200"
-                  />
-                )}
-              </div>
-            ))}
+            {imageBlocks.map((img, idx) => {
+              const isVideo = VIDEO_REGEX.test(img.image.src);
+              const isImage = IMAGE_REGEX.test(img.image.src);
+
+              return (
+                <div key={idx} className="relative p-1.5">
+                  <button
+                    onClick={() => onRemove(idx)}
+                    className="icon-button absolute right-4 top-4"
+                  >
+                    <X16Icon className="h-4 w-4" />
+                  </button>
+                  {isImage ? (
+                    <img
+                      title={img.image.alt}
+                      src={img.image.src}
+                      className="h-32 w-32 object-cover"
+                    />
+                  ) : isVideo ? (
+                    <video
+                      title={img.image.alt}
+                      src={img.image.src}
+                      className="h-32 w-32 object-cover"
+                    />
+                  ) : (
+                    <div
+                      title={img.image.alt}
+                      className="h-32 w-32 animate-pulse bg-gray-200"
+                    />
+                  )}
+                </div>
+              );
+            })}
           </div>
         ) : null}
 
@@ -632,7 +644,7 @@ export default function ChatInput({
           <div className="mb-4 flex items-center justify-start font-semibold">
             <span className="mr-2 text-gray-600">Attached: </span>
             {chatInfo.blocks.length}{' '}
-            {chatInfo.blocks.every((b) => 'image' in b) ? 'image' : 'reference'}
+            {chatInfo.blocks.every((b) => 'image' in b) ? 'file' : 'reference'}
             {chatInfo.blocks.length === 1 ? '' : 's'}
             <button className="icon-button ml-auto" onClick={clearAttachments}>
               <X16Icon className="h-4 w-4" />

--- a/ui/src/components/MessageEditor.tsx
+++ b/ui/src/components/MessageEditor.tsx
@@ -26,7 +26,7 @@ import {
   useChatStore,
 } from '@/chat/useChatStore';
 import { useCalm } from '@/state/settings';
-import { PASTEABLE_IMAGE_TYPES } from '@/constants';
+import { PASTEABLE_MEDIA_TYPES } from '@/constants';
 import { useFileStore } from '@/state/storage';
 import { Cite } from '@/types/channel';
 import getMentionPopup from './Mention/MentionPopup';
@@ -90,7 +90,7 @@ export function useMessageEditor({
         uploader &&
         event.clipboardData &&
         Array.from(event.clipboardData.files).some((f) =>
-          PASTEABLE_IMAGE_TYPES.includes(f.type)
+          PASTEABLE_MEDIA_TYPES.includes(f.type)
         )
       ) {
         // TODO should blocks first be updated here to show the loading state?

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -9,7 +9,7 @@ export const LEAP_RESULT_TRUNCATE_SIZE = 5;
 export const LEAP_RESULT_SCORE_THRESHOLD = 10;
 export const CURIO_PAGE_SIZE = 250;
 
-export const PASTEABLE_IMAGE_TYPES = [
+export const PASTEABLE_MEDIA_TYPES = [
   'image/gif',
   'image/jpeg',
   'image/jpg',
@@ -17,6 +17,10 @@ export const PASTEABLE_IMAGE_TYPES = [
   'image/svg',
   'image/tif',
   'image/webp',
+  'video/mp4',
+  'video/webm',
+  'video/ogg',
+  'video/quicktime',
 ];
 
 export const AUTHORS = [

--- a/ui/src/heap/AddCurioModal.tsx
+++ b/ui/src/heap/AddCurioModal.tsx
@@ -7,7 +7,7 @@ import { createCurioHeart } from '@/logic/heap';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { tipTapToString } from '@/logic/tiptap';
 import { useFileStore, useUploader } from '@/state/storage';
-import { PASTEABLE_IMAGE_TYPES } from '@/constants';
+import { PASTEABLE_MEDIA_TYPES } from '@/constants';
 import { useAddPostMutation } from '@/state/channel/channel';
 import { useIsMobile } from '@/logic/useMedia';
 import NewCurioInput, { EditorUpdate } from './NewCurioInput';
@@ -172,7 +172,7 @@ export default function AddCurioModal({
         return;
       }
       const uploadFile = Array.from(files).find((file) =>
-        PASTEABLE_IMAGE_TYPES.includes(file.type)
+        PASTEABLE_MEDIA_TYPES.includes(file.type)
       );
 
       if (uploadFile) {

--- a/ui/src/heap/HeapChannel.tsx
+++ b/ui/src/heap/HeapChannel.tsx
@@ -15,7 +15,7 @@ import useDismissChannelNotifications from '@/logic/useDismissChannelNotificatio
 import { useIsMobile } from '@/logic/useMedia';
 import { useFullChannel } from '@/logic/channel';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
-import { PASTEABLE_IMAGE_TYPES } from '@/constants';
+import { PASTEABLE_MEDIA_TYPES } from '@/constants';
 import { useUploader } from '@/state/storage';
 import X16Icon from '@/components/icons/X16Icon';
 import getKindDataFromEssay from '@/logic/getKindData';
@@ -124,7 +124,7 @@ function HeapChannel({ title }: ViewProps) {
 
   const handleDrop = useCallback((fileList: FileList) => {
     const uploadFile = Array.from(fileList).find((file) =>
-      PASTEABLE_IMAGE_TYPES.includes(file.type)
+      PASTEABLE_MEDIA_TYPES.includes(file.type)
     );
     if (uploadFile) {
       setDraggedFile(uploadFile);

--- a/ui/src/state/storage/upload.ts
+++ b/ui/src/state/storage/upload.ts
@@ -32,6 +32,18 @@ function imageSize(url: string) {
   return size;
 }
 
+function videoSize(url: string) {
+  const video = document.createElement('video');
+  video.src = url;
+  video.load();
+  const size = new Promise<[number, number]>((resolve) => {
+    video.addEventListener('loadedmetadata', () => {
+      resolve([video.videoWidth, video.videoHeight]);
+    });
+  });
+  return size;
+}
+
 function isImageFile(file: File) {
   const acceptedImageTypes = [
     'image/jpeg',
@@ -42,6 +54,16 @@ function isImageFile(file: File) {
     'image/bmp',
   ];
   return acceptedImageTypes.includes(file.type);
+}
+
+function isVideoFile(file: File) {
+  const acceptedVideoTypes = [
+    'video/mp4',
+    'video/webm',
+    'video/ogg',
+    'video/quicktime',
+  ];
+  return acceptedVideoTypes.includes(file.type);
 }
 
 export const useFileStore = create<FileStore>((set, get) => ({
@@ -173,17 +195,31 @@ export const useFileStore = create<FileStore>((set, get) => ({
               return '';
             });
             updateStatus(uploader, key, 'success');
-            imageSize(fileUrl)
-              .then((s) =>
-                updateFile(uploader, key, {
-                  size: s,
-                  url: fileUrl,
-                })
-              )
-              .catch((e) => {
-                console.log('failed to get image size', { e });
-                return '';
-              });
+            if (isImageFile(file)) {
+              imageSize(fileUrl)
+                .then((s) =>
+                  updateFile(uploader, key, {
+                    size: s,
+                    url: fileUrl,
+                  })
+                )
+                .catch((e) => {
+                  console.log('failed to get image size', { e });
+                  return '';
+                });
+            } else if (isVideoFile(file)) {
+              videoSize(fileUrl)
+                .then((s) =>
+                  updateFile(uploader, key, {
+                    size: s,
+                    url: fileUrl,
+                  })
+                )
+                .catch((e) => {
+                  console.log('failed to get video size', { e });
+                  return '';
+                });
+            }
           })
           .catch((error: any) => {
             updateStatus(
@@ -229,17 +265,31 @@ export const useFileStore = create<FileStore>((set, get) => ({
         .send(command)
         .then(() => {
           updateStatus(uploader, key, 'success');
-          imageSize(url)
-            .then((s) =>
-              updateFile(uploader, key, {
-                size: s,
-                url,
-              })
-            )
-            .catch((e) => {
-              console.log('failed to get image size', { e });
-              return '';
-            });
+          if (isImageFile(file)) {
+            imageSize(url)
+              .then((s) =>
+                updateFile(uploader, key, {
+                  size: s,
+                  url,
+                })
+              )
+              .catch((e) => {
+                console.log('failed to get image size', { e });
+                return '';
+              });
+          } else if (isVideoFile(file)) {
+            videoSize(url)
+              .then((s) =>
+                updateFile(uploader, key, {
+                  size: s,
+                  url,
+                })
+              )
+              .catch((e) => {
+                console.log('failed to get video size', { e });
+                return '';
+              });
+          }
         })
         .catch((error: any) => {
           updateStatus(


### PR DESCRIPTION
This PR fixes LAND-1480 by allowing users to upload videos.

We already supported rendering video content in chat and galleries, we just didn't support user uploads for it.

This PR simply adds similar functionality to what we already had for image uploads, for video. As in, you can pick it from the file picker, drag and drop it, or paste it.

There is on hacky part, you'll see a TODO about it in ChatContent.tsx.

Tested on both a local moon for regular s3 storage, and by distributing from a moon to a hosted ship to test tlon storage.

Not sure that we can test this automatically e2e without some pretty detailed setup to get tlon storage working in our e2e tests.

Looks like this:

https://github.com/tloncorp/landscape-apps/assets/1221094/d804e54f-8184-42fd-a9b8-dcbd48fcd7ac

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context