### PR TITLE
unreads: use chat store unreads for sidebar count

### DIFF
--- a/ui/src/state/channel/channel.ts
+++ b/ui/src/state/channel/channel.ts
@@ -38,7 +38,7 @@ import {
   ChannelsSubscribeResponse,
 } from '@/types/channel';
 import api from '@/api';
-import { checkNest, log, nestToFlag } from '@/logic/utils';
+import { checkNest, log, nestToFlag, whomIsFlag } from '@/logic/utils';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import useReactQueryScry from '@/logic/useReactQueryScry';
 import useReactQuerySubscribeOnce from '@/logic/useReactQuerySubscribeOnce';
@@ -1083,6 +1083,25 @@ export function useUnreads(): Unreads {
   }
 
   return data as Unreads;
+}
+
+export function useChatStoreChannelUnreads() {
+  const chats = useChatStore((s) => s.chats);
+
+  return useMemo(
+    () =>
+      Object.entries(chats).reduce((acc, [k, v]) => {
+        if (whomIsFlag(k)) {
+          const { unread } = v;
+
+          if (unread && !unread.seen) {
+            acc.push(k);
+          }
+        }
+        return acc;
+      }, [] as string[]),
+    [chats]
+  );
 }
 
 export function useIsJoined(nest: Nest) {

--- a/ui/src/state/chat/chat.ts
+++ b/ui/src/state/chat/chat.ts
@@ -1702,6 +1702,25 @@ export function useCheckDmUnread() {
   );
 }
 
+export function useChatStoreDmUnreads(): string[] {
+  const chats = useChatStore(selChats);
+
+  return useMemo(
+    () =>
+      Object.entries(chats).reduce((acc, [k, v]) => {
+        if (whomIsDm(k)) {
+          const { unread } = v;
+          if (unread && !unread.seen) {
+            acc.push(k);
+          }
+        }
+
+        return acc;
+      }, [] as string[]),
+    [chats]
+  );
+}
+
 export function useMultiDmIsPending(id: string): boolean {
   const unread = useDmUnread(id);
   const chat = useMultiDm(id);


### PR DESCRIPTION
Fixes LAND-1574.

We were using the unread state synced from the backend for the unread count on the messages tab button. This caused a delay in updating the count due to the delay in the updated state.

If we switch to using the chat store unreads, the count updates immediately (we use this same state to update the unread "blue dots").

Tested locally with livenet moon and planet messaging each other, and with pinning some active group chat channels.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context