### PR TITLE
refs: fix issue with clicking links in refs

### DIFF
--- a/ui/src/chat/ChatContent/ChatContent.tsx
+++ b/ui/src/chat/ChatContent/ChatContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { findLastIndex } from 'lodash';
 import cn from 'classnames';
 import { Link } from 'react-router-dom';
@@ -34,6 +34,8 @@ interface ChatContentProps {
   isScrolling?: boolean;
   className?: string;
   writId?: string;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  isInReference?: boolean;
 }
 
 interface InlineContentProps {
@@ -190,6 +192,8 @@ function ChatContent({
   isScrolling = false,
   className = '',
   writId = 'not-writ',
+  onClick,
+  isInReference,
 }: ChatContentProps) {
   const storyInlines = (
     story.filter((s) => 'inline' in s) as VerseInline[]
@@ -210,8 +214,38 @@ function ChatContent({
     return 0;
   });
 
+  useEffect(() => {
+    // If we have an onClick handler (as we would in the case of this component
+    // being use in a reference), we need to add a click listener to the chat
+    // content. This is to prevent the click handler from firing when clicking
+    // on a link within the chat content.
+    // This will *NOT* work if you just pass the onClick handler directly to the
+    // chat content. You need to wrap it in a function that checks the target
+    // element.
+
+    if (onClick) {
+      const handleClick = (e: MouseEvent) => {
+        const target = e.target as HTMLElement | null;
+
+        if (target && target.id === `${writId}-chat-content`) {
+          onClick(e as unknown as React.MouseEvent<HTMLAnchorElement>);
+        }
+      };
+      document.addEventListener('click', handleClick);
+      return () => {
+        document.removeEventListener('click', handleClick);
+      };
+    }
+
+    return () => ({});
+  }, [onClick, writId]);
+
   return (
-    <div className={cn('leading-6', className)}>
+    <div
+      data-in-reference={isInReference}
+      id={`${writId}-chat-content`}
+      className={cn('leading-6', className)}
+    >
       {blockLength > 0 ? (
         <>
           {blockContent

--- a/ui/src/components/References/WritBaseReference.tsx
+++ b/ui/src/components/References/WritBaseReference.tsx
@@ -160,15 +160,13 @@ function WritBaseReference({
 
   if (contextApp === 'heap-comment') {
     return (
-      <div
-        onClick={handleOpenReferenceClick}
-        className="cursor-pointer rounded-lg border-2 border-gray-50 text-base"
-      >
+      <div className="cursor-pointer rounded-lg border-2 border-gray-50 text-base">
         <ReferenceInHeap type="text" contextApp={contextApp}>
           <ChatContent
             className="line-clamp-1 p-2"
             story={content}
             isScrolling={false}
+            onClick={handleOpenReferenceClick}
           />
           {children}
           <ReferenceBar
@@ -192,11 +190,15 @@ function WritBaseReference({
         'mb-2': isReply,
       })}
     >
-      <div
-        onClick={handleOpenReferenceClick}
-        className={'cursor-pointer p-2 group-hover:bg-gray-50'}
-      >
-        <ChatContent className="p-2" story={content} isScrolling={false} />
+      <div className={'cursor-pointer p-2 group-hover:bg-gray-50'}>
+        <ChatContent
+          className="p-2"
+          story={content}
+          isScrolling={false}
+          onClick={handleOpenReferenceClick}
+          writId={noteId}
+          isInReference
+        />
       </div>
       <ReferenceBar
         nest={nest}


### PR DESCRIPTION
Fixes LAND-1409.

Fixes the issue where clicking a link within a ref would both follow the link and navigate to the ref.

Fix consists of making sure the user is actually clicking on the ref itself, not the link.

Further explanation in in-line comments.

Tested locally on livenet dev moons by making some refs with links in them.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context