### PR TITLE
messages: fix count in tab pt 3

### DIFF
--- a/ui/src/state/bootstrap.ts
+++ b/ui/src/state/bootstrap.ts
@@ -70,9 +70,12 @@ async function startGroups() {
   });
 
   // make sure we remove the app part from the nest before handing it over
-  useChatStore
-    .getState()
-    .update(_.mapKeys(unreads, (v, k) => k.replace(/\w*\//, '')));
+  useChatStore.getState().update(
+    _.mapKeys(
+      _.pickBy(unreads, (v, k) => k.startsWith('chat')),
+      (v, k) => k.replace(/\w*\//, '')
+    )
+  );
 }
 
 async function startTalk() {


### PR DESCRIPTION
This fixes ghost unread seen by ~mopfel-winrux. We were erroneously counting other channel types when initializing unreads on refresh.

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context