### PR TITLE
chore: fix some monorepo issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Build Shared Packages
+        run: npm run build:shared
+
       - name: Run Lint
         run: npm run lint --workspaces --if-present
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - "develop"
-env: 
+env:
   tag: ${{ github.event.inputs.tag || 'develop' }}
 jobs:
   build-frontend:
@@ -25,6 +25,8 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Dependencies
         run: npm ci
+      - name: Build Shared Packages
+        run: npm run build:shared
       - working-directory: ./apps/tlon-web
         run: npm run build
       - uses: actions/upload-artifact@v3

--- a/apps/tlon-web/.prettierrc.js
+++ b/apps/tlon-web/.prettierrc.js
@@ -39,7 +39,7 @@ module.exports = {
   tailwindConfig: './tailwind.config.js',
   semi: true,
   trailingComma: 'es5',
-  importOrder: ['<THIRD_PARTY_MODULES>', '^[./]'],
+  importOrder: ['<THIRD_PARTY_MODULES>', '^@/(.*)', '^[./]'],
   importOrderSeparation: true,
   importOrderSortSpecifiers: true,
 };

--- a/apps/tlon-web/src/api.ts
+++ b/apps/tlon-web/src/api.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-cycle */
-import { useLocalState } from '@/state/local';
 import type UrbitMock from '@tloncorp/mock-http-api';
 import UrbitBase, {
   Message,
@@ -12,6 +11,8 @@ import UrbitBase, {
   UrbitHttpApiEventType,
 } from '@urbit/http-api';
 import _ from 'lodash';
+
+import { useLocalState } from '@/state/local';
 
 import { actionDrill, isHosted, parseKind } from './logic/utils';
 import { useEyreState } from './state/eyre';

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -1,4 +1,20 @@
 // Copyright 2022, Tlon Corporation
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+import cookies from 'browser-cookies';
+import { usePostHog } from 'posthog-js/react';
+import React, { Suspense, useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Helmet } from 'react-helmet';
+import {
+  Location,
+  NavigateFunction,
+  Route,
+  BrowserRouter as Router,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+
 import { IS_MOCK } from '@/api';
 import tlonFavicon from '@/assets/favicon.ico';
 import NewChannelModal from '@/channels/NewChannel/NewChannelModal';
@@ -73,21 +89,6 @@ import {
   useSettingsLoaded,
   useTheme,
 } from '@/state/settings';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
-import cookies from 'browser-cookies';
-import { usePostHog } from 'posthog-js/react';
-import React, { Suspense, useEffect, useMemo, useState } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
-import { Helmet } from 'react-helmet';
-import {
-  Location,
-  NavigateFunction,
-  Route,
-  BrowserRouter as Router,
-  Routes,
-  useLocation,
-  useNavigate,
-} from 'react-router-dom';
 
 import ChannelVolumeDialog from './channels/ChannelVolumeDialog';
 import MobileChatSearch from './chat/ChatSearch/MobileChatSearch';

--- a/apps/tlon-web/src/channels/ChannelActions.tsx
+++ b/apps/tlon-web/src/channels/ChannelActions.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { PropsWithChildren, useCallback, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import useActiveTab from '@/components/Sidebar/util';
 import VolumeSetting from '@/components/VolumeSetting';
@@ -10,9 +14,6 @@ import { useIsMobile } from '@/logic/useMedia';
 import { getFlagParts, nestToFlag } from '@/logic/utils';
 import { useDeleteChannelMutation, useRouteGroup } from '@/state/groups';
 import { GroupChannel } from '@/types/groups';
-import cn from 'classnames';
-import React, { PropsWithChildren, useCallback, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 import ChannelHostConnection from './ChannelHostConnection';
 

--- a/apps/tlon-web/src/channels/ChannelHeader.tsx
+++ b/apps/tlon-web/src/channels/ChannelHeader.tsx
@@ -1,9 +1,10 @@
+import cn from 'classnames';
+import { PropsWithChildren } from 'react';
+
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import { useIsMobile } from '@/logic/useMedia';
 import { useAmAdmin, useGroupChannel } from '@/state/groups';
-import cn from 'classnames';
-import { PropsWithChildren } from 'react';
 
 import ChannelActions, { ChannelActionsProps } from './ChannelActions';
 import ChannelHostConnection from './ChannelHostConnection';

--- a/apps/tlon-web/src/channels/ChannelIcon.tsx
+++ b/apps/tlon-web/src/channels/ChannelIcon.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
+
 import BubbleIcon from '@/components/icons/BubbleIcon';
 import NotebookIcon from '@/components/icons/NotebookIcon';
 import ShapesIcon from '@/components/icons/ShapesIcon';
 import UnknownAvatarIcon from '@/components/icons/UnknownAvatarIcon';
 import { nestToFlag } from '@/logic/utils';
-import React from 'react';
 
 interface ChannelIconProps extends React.HTMLAttributes<SVGElement> {
   nest: string;

--- a/apps/tlon-web/src/channels/ChannelSearch.tsx
+++ b/apps/tlon-web/src/channels/ChannelSearch.tsx
@@ -1,6 +1,7 @@
+import { useParams } from 'react-router';
+
 import ChatSearch, { ChatSearchProps } from '@/chat/ChatSearch/ChatSearch';
 import { useChannelSearch } from '@/state/channel/channel';
-import { useParams } from 'react-router';
 
 export default function ChannelSearch(
   props: Omit<ChatSearchProps, 'scan' | 'query' | 'isLoading' | 'endReached'>

--- a/apps/tlon-web/src/channels/ChannelSortSelector.tsx
+++ b/apps/tlon-web/src/channels/ChannelSortSelector.tsx
@@ -1,5 +1,6 @@
-import { ChannelFormSchema } from '@/types/groups';
 import { useFormContext } from 'react-hook-form';
+
+import { ChannelFormSchema } from '@/types/groups';
 
 interface SortSettingRowProps {
   type: 'time' | 'arranged';

--- a/apps/tlon-web/src/channels/ChannelTitleButton.tsx
+++ b/apps/tlon-web/src/channels/ChannelTitleButton.tsx
@@ -1,8 +1,9 @@
+import cn from 'classnames';
+import { Link } from 'react-router-dom';
+
 import CaretLeft16Icon from '@/components/icons/CaretLeft16Icon';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroupChannel } from '@/state/groups';
-import cn from 'classnames';
-import { Link } from 'react-router-dom';
 
 import ChannelHostConnection from './ChannelHostConnection';
 import ChannelIcon from './ChannelIcon';

--- a/apps/tlon-web/src/channels/ChannelTypeSelector.tsx
+++ b/apps/tlon-web/src/channels/ChannelTypeSelector.tsx
@@ -1,10 +1,11 @@
+import cn from 'classnames';
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
 import BubbleIcon from '@/components/icons/BubbleIcon';
 import NotebookIcon from '@/components/icons/NotebookIcon';
 import ShapesIcon from '@/components/icons/ShapesIcon';
 import { ChannelType, NewChannelFormSchema } from '@/types/groups';
-import cn from 'classnames';
-import React from 'react';
-import { useFormContext } from 'react-hook-form';
 
 interface ChannelTypeMetadata {
   title: string;

--- a/apps/tlon-web/src/channels/ChannelViewSelector.tsx
+++ b/apps/tlon-web/src/channels/ChannelViewSelector.tsx
@@ -1,5 +1,6 @@
-import { ChannelFormSchema } from '@/types/groups';
 import { useFormContext } from 'react-hook-form';
+
+import { ChannelFormSchema } from '@/types/groups';
 
 interface ViewSettingRowProps {
   type: 'grid' | 'list';

--- a/apps/tlon-web/src/channels/ChannelVolumeDialog.tsx
+++ b/apps/tlon-web/src/channels/ChannelVolumeDialog.tsx
@@ -1,10 +1,11 @@
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router';
+
 import Dialog from '@/components/Dialog';
 import VolumeSetting from '@/components/VolumeSetting';
 import { useDismissNavigate } from '@/logic/routing';
 import { useGroupChannel, useRouteGroup } from '@/state/groups';
 import { ViewProps } from '@/types/groups';
-import { Helmet } from 'react-helmet';
-import { useParams } from 'react-router';
 
 export default function ChannelVolumeDialog({ title }: ViewProps) {
   const { chType, chShip, chName } = useParams<{

--- a/apps/tlon-web/src/channels/DisplayDropdown.tsx
+++ b/apps/tlon-web/src/channels/DisplayDropdown.tsx
@@ -1,8 +1,9 @@
+import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import cn from 'classnames';
+
 import GridIcon from '@/components/icons/GridIcon';
 import ListIcon from '@/components/icons/ListIcon';
 import { DisplayMode } from '@/types/channel';
-import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import cn from 'classnames';
 
 interface DisplayDropdownProps {
   displayMode: DisplayMode;

--- a/apps/tlon-web/src/channels/EditChannelForm.tsx
+++ b/apps/tlon-web/src/channels/EditChannelForm.tsx
@@ -1,3 +1,9 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import _ from 'lodash';
+import React, { useCallback } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ChannelPermsSelector from '@/groups/ChannelsList/ChannelPermsSelector';
 import { channelHref, prettyChannelTypeName } from '@/logic/channel';
@@ -17,11 +23,6 @@ import {
 } from '@/state/groups';
 import { SortMode } from '@/types/channel';
 import { ChannelFormSchema, GroupChannel } from '@/types/groups';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import _ from 'lodash';
-import React, { useCallback } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
 
 import ChannelSortSelector from './ChannelSortSelector';
 import ChannelViewSelector from './ChannelViewSelector';

--- a/apps/tlon-web/src/channels/NewChannel/NewChannelForm.tsx
+++ b/apps/tlon-web/src/channels/NewChannel/NewChannelForm.tsx
@@ -1,3 +1,8 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { useCallback } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router';
+
 import ChannelTypeSelector from '@/channels/ChannelTypeSelector';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import Tooltip from '@/components/Tooltip';
@@ -11,10 +16,6 @@ import {
   useRouteGroup,
 } from '@/state/groups';
 import { NewChannelFormSchema } from '@/types/groups';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { useCallback } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate, useParams } from 'react-router';
 
 export default function NewChannelForm() {
   const { section } = useParams<{ section: string }>();

--- a/apps/tlon-web/src/channels/NewChannel/NewChannelModal.tsx
+++ b/apps/tlon-web/src/channels/NewChannel/NewChannelModal.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import Dialog from '@/components/Dialog';
 import { useDismissNavigate } from '@/logic/routing';
-import React from 'react';
 
 import NewChannelForm from './NewChannelForm';
 

--- a/apps/tlon-web/src/chat/ChatChannel.tsx
+++ b/apps/tlon-web/src/chat/ChatChannel.tsx
@@ -1,3 +1,9 @@
+import cn from 'classnames';
+import React, { useMemo, useRef } from 'react';
+import { Helmet } from 'react-helmet';
+import { Route, Routes, useMatch, useParams } from 'react-router';
+import { Link, useSearchParams } from 'react-router-dom';
+
 import ChannelHeader from '@/channels/ChannelHeader';
 import ChannelSearch from '@/channels/ChannelSearch';
 import ChannelTitleButton from '@/channels/ChannelTitleButton';
@@ -19,11 +25,6 @@ import {
 } from '@/state/channel/channel';
 import { useRouteGroup } from '@/state/groups/groups';
 import { ViewProps } from '@/types/groups';
-import cn from 'classnames';
-import React, { useMemo, useRef } from 'react';
-import { Helmet } from 'react-helmet';
-import { Route, Routes, useMatch, useParams } from 'react-router';
-import { Link, useSearchParams } from 'react-router-dom';
 
 import ChatThread from './ChatThread/ChatThread';
 

--- a/apps/tlon-web/src/chat/ChatContent/ChatContent.tsx
+++ b/apps/tlon-web/src/chat/ChatContent/ChatContent.tsx
@@ -1,3 +1,9 @@
+import cn from 'classnames';
+import { findLastIndex } from 'lodash';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router';
+import { Link } from 'react-router-dom';
+
 import ChatContentImage from '@/chat/ChatContent/ChatContentImage';
 import ChatEmbedContent from '@/chat/ChatEmbedContent/ChatEmbedContent';
 // eslint-disable-next-line import/no-cycle
@@ -25,11 +31,6 @@ import {
   isShip,
   isStrikethrough,
 } from '@/types/content';
-import cn from 'classnames';
-import { findLastIndex } from 'lodash';
-import React, { useEffect } from 'react';
-import { useLocation } from 'react-router';
-import { Link } from 'react-router-dom';
 
 interface ChatContentProps {
   story: Story;

--- a/apps/tlon-web/src/chat/ChatContent/ChatContentImage.tsx
+++ b/apps/tlon-web/src/chat/ChatContent/ChatContentImage.tsx
@@ -1,8 +1,9 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router';
+
 import LightBox from '@/components/LightBox';
 import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import { useCalm } from '@/state/settings';
-import React, { useState } from 'react';
-import { useParams } from 'react-router';
 
 import { useChatDialog, useChatFailedToLoadContent } from '../useChatStore';
 

--- a/apps/tlon-web/src/chat/ChatEmbedContent/AudioPlayer.tsx
+++ b/apps/tlon-web/src/chat/ChatEmbedContent/AudioPlayer.tsx
@@ -1,4 +1,3 @@
-import LightBox from '@/components/LightBox';
 import React, {
   MouseEvent,
   useCallback,
@@ -7,6 +6,8 @@ import React, {
   useState,
 } from 'react';
 import { useParams } from 'react-router';
+
+import LightBox from '@/components/LightBox';
 
 import { useChatDialog } from '../useChatStore';
 

--- a/apps/tlon-web/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
+++ b/apps/tlon-web/src/chat/ChatEmbedContent/ChatEmbedContent.tsx
@@ -1,10 +1,11 @@
+import DOMPurify from 'dompurify';
+import React, { useEffect } from 'react';
+import { BigPlayButton, Player } from 'video-react';
+
 import { useIsMobile } from '@/logic/useMedia';
 import { AUDIO_REGEX, VIDEO_REGEX, validOembedCheck } from '@/logic/utils';
 import { useEmbed } from '@/state/embed';
 import { useCalm } from '@/state/settings';
-import DOMPurify from 'dompurify';
-import React, { useEffect } from 'react';
-import { BigPlayButton, Player } from 'video-react';
 
 import AudioPlayer from './AudioPlayer';
 import SpotifyEmbed from './SpotifyEmbed';

--- a/apps/tlon-web/src/chat/ChatEmbedContent/SpotifyEmbed.tsx
+++ b/apps/tlon-web/src/chat/ChatEmbedContent/SpotifyEmbed.tsx
@@ -1,7 +1,8 @@
-import LightBox from '@/components/LightBox';
-import CaretRightIcon from '@/components/icons/CaretRightIcon';
 import React from 'react';
 import { useParams } from 'react-router';
+
+import LightBox from '@/components/LightBox';
+import CaretRightIcon from '@/components/icons/CaretRightIcon';
 
 import { useChatDialog } from '../useChatStore';
 

--- a/apps/tlon-web/src/chat/ChatEmbedContent/TwitterEmbed.tsx
+++ b/apps/tlon-web/src/chat/ChatEmbedContent/TwitterEmbed.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-danger */
-import TwitterXIcon from '@/components/icons/TwitterXIcon';
 import DOMPurify from 'dompurify';
 import { Tweet, useTweet } from 'react-tweet';
+
+import TwitterXIcon from '@/components/icons/TwitterXIcon';
 
 interface TwitterEmbedProps {
   embedHtml: string;

--- a/apps/tlon-web/src/chat/ChatEmbedContent/YouTubeEmbed.tsx
+++ b/apps/tlon-web/src/chat/ChatEmbedContent/YouTubeEmbed.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
+import { useParams } from 'react-router';
+
 import LightBox from '@/components/LightBox';
 import CaretRightIcon from '@/components/icons/CaretRightIcon';
 import { useIsMobile } from '@/logic/useMedia';
-import React from 'react';
-import { useParams } from 'react-router';
 
 import { useChatDialog } from '../useChatStore';
 

--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -1,3 +1,17 @@
+import * as Popover from '@radix-ui/react-popover';
+import { Editor } from '@tiptap/react';
+import cn from 'classnames';
+import _, { debounce } from 'lodash';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useLocalStorage } from 'usehooks-ts';
+
 import {
   chatStoreLogger,
   fetchChatBlocks,
@@ -50,19 +64,6 @@ import {
   ReplyTuple,
 } from '@/types/channel';
 import { WritTuple } from '@/types/dms';
-import * as Popover from '@radix-ui/react-popover';
-import { Editor } from '@tiptap/react';
-import cn from 'classnames';
-import _, { debounce } from 'lodash';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { useLocalStorage } from 'usehooks-ts';
 
 interface ChatInputProps {
   whom: string;

--- a/apps/tlon-web/src/chat/ChatInputMenu/ChatInputMenu.tsx
+++ b/apps/tlon-web/src/chat/ChatInputMenu/ChatInputMenu.tsx
@@ -1,5 +1,3 @@
-import useLeap from '@/components/Leap/useLeap';
-import keyMap from '@/keyMap';
 import * as Popover from '@radix-ui/react-popover';
 import { Editor as CoreEditor } from '@tiptap/core';
 import {
@@ -15,6 +13,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
+
+import useLeap from '@/components/Leap/useLeap';
+import keyMap from '@/keyMap';
 
 import { useIsMobile } from '../../logic/useMedia';
 import ChatInputMenuToolbar, {

--- a/apps/tlon-web/src/chat/ChatInputMenu/ChatInputMenuToolbar.tsx
+++ b/apps/tlon-web/src/chat/ChatInputMenu/ChatInputMenuToolbar.tsx
@@ -1,3 +1,8 @@
+import { Editor as CoreEditor } from '@tiptap/core';
+import React, { KeyboardEvent } from 'react';
+import { useForm } from 'react-hook-form';
+import isURL from 'validator/es/lib/isURL';
+
 import ChatInputMenuButton from '@/chat/ChatInputMenu/ChatInputMenuButton';
 import BlockquoteIcon from '@/components/icons/BlockquoteIcon';
 import BoldIcon from '@/components/icons/BoldIcon';
@@ -9,10 +14,6 @@ import LinkIcon from '@/components/icons/LinkIcon';
 import StrikeIcon from '@/components/icons/StrikeIcon';
 import X16Icon from '@/components/icons/X16Icon';
 import { useIsMobile } from '@/logic/useMedia';
-import { Editor as CoreEditor } from '@tiptap/core';
-import React, { KeyboardEvent } from 'react';
-import { useForm } from 'react-hook-form';
-import isURL from 'validator/es/lib/isURL';
 
 export type MenuState = 'closed' | 'open' | 'editing-link' | 'link-hover';
 

--- a/apps/tlon-web/src/chat/ChatMessage/Author.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/Author.tsx
@@ -1,11 +1,12 @@
+import cn from 'classnames';
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import Avatar from '@/components/Avatar';
 import PalIcon from '@/components/PalIcon';
 import RoleBadges from '@/components/RoleBadges';
 import ShipName from '@/components/ShipName';
 import { makePrettyDayAndDateAndTime, useCopy } from '@/logic/utils';
-import cn from 'classnames';
-import React from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 interface AuthorProps {
   ship: string;

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.test.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.test.tsx
@@ -1,9 +1,10 @@
-import * as useMedia from '@/logic/useMedia';
-import { makeFakeChatWrit, unixToDaStr } from '@/mocks/chat';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { unixToDa } from '@urbit/api';
 import React, { ReactPortal } from 'react';
 import { SpyInstance, beforeEach, describe, expect, it } from 'vitest';
+
+import * as useMedia from '@/logic/useMedia';
+import { makeFakeChatWrit, unixToDaStr } from '@/mocks/chat';
 
 import { fireEvent, render, screen, userEvent } from '../../../test/utils';
 import ChatMessage from './ChatMessage';

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessage.tsx
@@ -1,5 +1,20 @@
 /* eslint-disable react/no-unused-prop-types */
 // eslint-disable-next-line import/no-cycle
+import { daToUnix } from '@urbit/api';
+import { BigInteger } from 'big-integer';
+import cn from 'classnames';
+import { format, formatDistanceToNow, formatRelative, isToday } from 'date-fns';
+import debounce from 'lodash/debounce';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useInView } from 'react-intersection-observer';
+import { NavLink, useParams } from 'react-router-dom';
+
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import Author from '@/chat/ChatMessage/Author';
 import ChatMessageOptions from '@/chat/ChatMessage/ChatMessageOptions';
@@ -23,20 +38,6 @@ import {
 } from '@/state/chat';
 import { Post, Story, Unread } from '@/types/channel';
 import { DMUnread } from '@/types/dms';
-import { daToUnix } from '@urbit/api';
-import { BigInteger } from 'big-integer';
-import cn from 'classnames';
-import { format, formatDistanceToNow, formatRelative, isToday } from 'date-fns';
-import debounce from 'lodash/debounce';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { useInView } from 'react-intersection-observer';
-import { NavLink, useParams } from 'react-router-dom';
 
 import ReactionDetails from '../ChatReactions/ReactionDetails';
 import { getUnreadStatus, threadIsOlderThanLastRead } from '../unreadUtils';

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -1,3 +1,15 @@
+import { decToUd } from '@urbit/api';
+import cn from 'classnames';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
+
 import { useChatDialog } from '@/chat/useChatStore';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import ConfirmationModal from '@/components/ConfirmationModal';
@@ -39,17 +51,6 @@ import {
   useVessel,
 } from '@/state/groups';
 import { Post, emptyPost } from '@/types/channel';
-import { decToUd } from '@urbit/api';
-import cn from 'classnames';
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
 
 function ChatMessageOptions(props: {
   open: boolean;

--- a/apps/tlon-web/src/chat/ChatMessage/DateDivider.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/DateDivider.tsx
@@ -1,6 +1,7 @@
-import { makePrettyDay, pluralize } from '@/logic/utils';
 import cn from 'classnames';
 import React, { Ref } from 'react';
+
+import { makePrettyDay, pluralize } from '@/logic/utils';
 
 interface DateDividerProps {
   date: Date;

--- a/apps/tlon-web/src/chat/ChatNotice.tsx
+++ b/apps/tlon-web/src/chat/ChatNotice.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import AddPersonIcon from '@/components/icons/AddPersonIcon';
 import { Post } from '@/types/channel';
-import React from 'react';
 
 import ChatContent from './ChatContent/ChatContent';
 import DateDivider from './ChatMessage/DateDivider';

--- a/apps/tlon-web/src/chat/ChatReactions/ChatReaction.tsx
+++ b/apps/tlon-web/src/chat/ChatReactions/ChatReaction.tsx
@@ -1,3 +1,7 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+import cn from 'classnames';
+import React, { useCallback, useEffect } from 'react';
+
 import ShipName from '@/components/ShipName';
 import X16Icon from '@/components/icons/X16Icon';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
@@ -11,9 +15,6 @@ import { useAddDmReactMutation, useDelDmReactMutation } from '@/state/chat';
 import useEmoji from '@/state/emoji';
 import { useRouteGroup } from '@/state/groups';
 import { PostSeal, ReplySeal } from '@/types/channel';
-import * as Tooltip from '@radix-ui/react-tooltip';
-import cn from 'classnames';
-import React, { useCallback, useEffect } from 'react';
 
 interface ChatReactionProps {
   whom: string;

--- a/apps/tlon-web/src/chat/ChatReactions/ChatReactions.tsx
+++ b/apps/tlon-web/src/chat/ChatReactions/ChatReactions.tsx
@@ -1,3 +1,7 @@
+import _ from 'lodash';
+import { useCallback, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import EmojiPicker from '@/components/EmojiPicker';
 import AddReactIcon from '@/components/icons/AddReactIcon';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
@@ -8,9 +12,6 @@ import { useAddPostReactMutation } from '@/state/channel/channel';
 import { useAddDmReactMutation } from '@/state/chat';
 import { useRouteGroup } from '@/state/groups';
 import { PostSeal } from '@/types/channel';
-import _ from 'lodash';
-import { useCallback, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 import ChatReaction from './ChatReaction';
 

--- a/apps/tlon-web/src/chat/ChatReactions/ReactionsWidget.tsx
+++ b/apps/tlon-web/src/chat/ChatReactions/ReactionsWidget.tsx
@@ -1,9 +1,10 @@
-import Avatar from '@/components/Avatar';
-import ShipName from '@/components/ShipName';
 import * as Tabs from '@radix-ui/react-tabs';
 import cn from 'classnames';
 import _ from 'lodash';
 import { useMemo, useState } from 'react';
+
+import Avatar from '@/components/Avatar';
+import ShipName from '@/components/ShipName';
 
 function byShortcode(a: [string, string], b: [string, string]) {
   const aCode = a[1];

--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -1,3 +1,21 @@
+import { Virtualizer, useVirtualizer } from '@tanstack/react-virtual';
+import { BigInteger } from 'big-integer';
+import React, {
+  PropsWithChildren,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  FlatIndexLocationWithAlign,
+  FlatScrollIntoViewLocation,
+  VirtuosoHandle,
+} from 'react-virtuoso';
+
 import ChatMessage from '@/chat/ChatMessage/ChatMessage';
 import ChatNotice from '@/chat/ChatNotice';
 import EmptyPlaceholder from '@/components/EmptyPlaceholder';
@@ -17,23 +35,6 @@ import ReplyMessage from '@/replies/ReplyMessage';
 import { useShowDevTools } from '@/state/local';
 import { PageTuple, ReplyTuple } from '@/types/channel';
 import { WritTuple } from '@/types/dms';
-import { Virtualizer, useVirtualizer } from '@tanstack/react-virtual';
-import { BigInteger } from 'big-integer';
-import React, {
-  PropsWithChildren,
-  ReactElement,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import {
-  FlatIndexLocationWithAlign,
-  FlatScrollIntoViewLocation,
-  VirtuosoHandle,
-} from 'react-virtuoso';
 
 import ChatScrollerDebugOverlay from './ChatScrollerDebugOverlay';
 

--- a/apps/tlon-web/src/chat/ChatScroller/ChatScrollerPlaceholder.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScrollerPlaceholder.tsx
@@ -1,6 +1,7 @@
-import { randomElement } from '@/logic/utils';
 import cn from 'classnames';
 import * as React from 'react';
+
+import { randomElement } from '@/logic/utils';
 
 function ChatItemPlaceholder() {
   const background = `bg-gray-${randomElement([100, 200, 400])}`;

--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearch.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearch.tsx
@@ -1,14 +1,15 @@
-import useActiveTab from '@/components/Sidebar/util';
-import { useSafeAreaInsets } from '@/logic/native';
-import useMedia, { useIsMobile } from '@/logic/useMedia';
-import { disableDefault } from '@/logic/utils';
-import { ChatMap } from '@/types/channel';
 import * as Dialog from '@radix-ui/react-dialog';
 import cn from 'classnames';
 import React, { PropsWithChildren, useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
+
+import useActiveTab from '@/components/Sidebar/util';
+import { useSafeAreaInsets } from '@/logic/native';
+import useMedia, { useIsMobile } from '@/logic/useMedia';
+import { disableDefault } from '@/logic/utils';
+import { ChatMap } from '@/types/channel';
 
 import ChatSearchResults from './ChatSearchResults';
 import SearchBar from './SearchBar';

--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearchResult.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearchResult.tsx
@@ -1,11 +1,12 @@
-import ReplyReactions from '@/replies/ReplyReactions/ReplyReactions';
-import { Post, Reply } from '@/types/channel';
-import { Writ } from '@/types/dms';
 import { daToUnix } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import cn from 'classnames';
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+
+import ReplyReactions from '@/replies/ReplyReactions/ReplyReactions';
+import { Post, Reply } from '@/types/channel';
+import { Writ } from '@/types/dms';
 
 import ChatContent from '../ChatContent/ChatContent';
 import Author from '../ChatMessage/Author';

--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearchResults.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearchResults.tsx
@@ -1,9 +1,10 @@
-import { useIsMobile } from '@/logic/useMedia';
-import { ChatMap, Post, Reply } from '@/types/channel';
-import { Writ } from '@/types/dms';
 import { BigInteger } from 'big-integer';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+
+import { useIsMobile } from '@/logic/useMedia';
+import { ChatMap, Post, Reply } from '@/types/channel';
+import { Writ } from '@/types/dms';
 
 import ChatScrollerPlaceholder from '../ChatScroller/ChatScrollerPlaceholder';
 import ChatSearchResult from './ChatSearchResult';

--- a/apps/tlon-web/src/chat/ChatSearch/MobileChatSearch.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/MobileChatSearch.tsx
@@ -1,3 +1,7 @@
+import { useRef, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { VirtuosoHandle } from 'react-virtuoso';
+
 import ChatSearchResults from '@/chat/ChatSearch/ChatSearchResults';
 import SearchBar from '@/chat/ChatSearch/SearchBar';
 import Layout from '@/components/Layout/Layout';
@@ -5,9 +9,6 @@ import { useSafeAreaInsets } from '@/logic/native';
 import useDebounce from '@/logic/useDebounce';
 import { useChannelSearch } from '@/state/channel/channel';
 import { useSearchState } from '@/state/chat/search';
-import { useRef, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import { VirtuosoHandle } from 'react-virtuoso';
 
 export default function MobileChatSearch() {
   const params = useParams<{

--- a/apps/tlon-web/src/chat/ChatSearch/SearchBar.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/SearchBar.tsx
@@ -1,6 +1,7 @@
+import { ChangeEvent, useRef } from 'react';
+
 import MagnifyingGlassIcon from '@/components/icons/MagnifyingGlassIcon';
 import X16Icon from '@/components/icons/X16Icon';
-import { ChangeEvent, useRef } from 'react';
 
 interface SearchBarProps {
   value: string;

--- a/apps/tlon-web/src/chat/ChatSearch/useChatSearchInput.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/useChatSearchInput.tsx
@@ -1,8 +1,9 @@
-import useDebounce from '@/logic/useDebounce';
-import { ChatMap } from '@/types/channel';
 import bigInt from 'big-integer';
 import { ChangeEvent, KeyboardEvent, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
+
+import useDebounce from '@/logic/useDebounce';
+import { ChatMap } from '@/types/channel';
 
 export interface Selection {
   index: number;

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -1,3 +1,12 @@
+import bigInt from 'big-integer';
+import cn from 'classnames';
+import _ from 'lodash';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { Link, useSearchParams } from 'react-router-dom';
+import { VirtuosoHandle } from 'react-virtuoso';
+import { useEventListener } from 'usehooks-ts';
+
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import useLeap from '@/components/Leap/useLeap';
@@ -24,14 +33,6 @@ import {
   useVessel,
 } from '@/state/groups/groups';
 import { ReplyTuple } from '@/types/channel';
-import bigInt from 'big-integer';
-import cn from 'classnames';
-import _ from 'lodash';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import { Link, useSearchParams } from 'react-router-dom';
-import { VirtuosoHandle } from 'react-virtuoso';
-import { useEventListener } from 'usehooks-ts';
 
 import ChatScrollerPlaceholder from '../ChatScroller/ChatScrollerPlaceholder';
 import { chatStoreLogger, useChatInfo, useChatStore } from '../useChatStore';

--- a/apps/tlon-web/src/chat/ChatUnreadAlerts.tsx
+++ b/apps/tlon-web/src/chat/ChatUnreadAlerts.tsx
@@ -1,12 +1,13 @@
-import XIcon from '@/components/icons/XIcon';
-import { nestToFlag, pluralize } from '@/logic/utils';
-import { useMarkReadMutation } from '@/state/channel/channel';
-import { Unread, UnreadPoint } from '@/types/channel';
 import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import { format, isToday } from 'date-fns';
 import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
+
+import XIcon from '@/components/icons/XIcon';
+import { nestToFlag, pluralize } from '@/logic/utils';
+import { useMarkReadMutation } from '@/state/channel/channel';
+import { Unread, UnreadPoint } from '@/types/channel';
 
 import { getUnreadStatus, threadIsOlderThanLastRead } from './unreadUtils';
 import { useChatInfo, useChatStore } from './useChatStore';

--- a/apps/tlon-web/src/chat/ChatWindow.tsx
+++ b/apps/tlon-web/src/chat/ChatWindow.tsx
@@ -1,10 +1,3 @@
-import ChatScroller from '@/chat/ChatScroller/ChatScroller';
-import ChatUnreadAlerts from '@/chat/ChatUnreadAlerts';
-import EmptyPlaceholder from '@/components/EmptyPlaceholder';
-import ArrowS16Icon from '@/components/icons/ArrowS16Icon';
-import { useChannelCompatibility } from '@/logic/channel';
-import { log } from '@/logic/utils';
-import { useInfinitePosts, useMarkReadMutation } from '@/state/channel/channel';
 import bigInt from 'big-integer';
 import React, {
   ReactElement,
@@ -16,6 +9,14 @@ import React, {
 } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
+
+import ChatScroller from '@/chat/ChatScroller/ChatScroller';
+import ChatUnreadAlerts from '@/chat/ChatUnreadAlerts';
+import EmptyPlaceholder from '@/components/EmptyPlaceholder';
+import ArrowS16Icon from '@/components/icons/ArrowS16Icon';
+import { useChannelCompatibility } from '@/logic/channel';
+import { log } from '@/logic/utils';
+import { useInfinitePosts, useMarkReadMutation } from '@/state/channel/channel';
 
 import ChatScrollerPlaceholder from './ChatScroller/ChatScrollerPlaceholder';
 import { useChatInfo, useChatStore } from './useChatStore';

--- a/apps/tlon-web/src/chat/DMUnreadAlerts.tsx
+++ b/apps/tlon-web/src/chat/DMUnreadAlerts.tsx
@@ -1,12 +1,13 @@
-import XIcon from '@/components/icons/XIcon';
-import { pluralize } from '@/logic/utils';
-import { useMarkDmReadMutation } from '@/state/chat';
-import { DMUnread, UnreadThread } from '@/types/dms';
 import { daToUnix } from '@urbit/api';
 import bigInt from 'big-integer';
 import { format, isToday } from 'date-fns';
 import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
+
+import XIcon from '@/components/icons/XIcon';
+import { pluralize } from '@/logic/utils';
+import { useMarkDmReadMutation } from '@/state/chat';
+import { DMUnread, UnreadThread } from '@/types/dms';
 
 import { getUnreadStatus, threadIsOlderThanLastRead } from './unreadUtils';
 import { useChatInfo, useChatStore } from './useChatStore';

--- a/apps/tlon-web/src/chat/unreadUtils.ts
+++ b/apps/tlon-web/src/chat/unreadUtils.ts
@@ -1,6 +1,7 @@
+import bigInt from 'big-integer';
+
 import { Unread } from '@/types/channel';
 import { DMUnread } from '@/types/dms';
-import bigInt from 'big-integer';
 
 export function threadIsOlderThanLastRead(
   unread: DMUnread | Unread,

--- a/apps/tlon-web/src/chat/useChatStore.ts
+++ b/apps/tlon-web/src/chat/useChatStore.ts
@@ -1,9 +1,10 @@
-import { createDevLogger } from '@/logic/utils';
-import { Block, Unread, Unreads } from '@/types/channel';
-import { DMUnread, DMUnreads } from '@/types/dms';
 import produce from 'immer';
 import { useCallback } from 'react';
 import create from 'zustand';
+
+import { createDevLogger } from '@/logic/utils';
+import { Block, Unread, Unreads } from '@/types/channel';
+import { DMUnread, DMUnreads } from '@/types/dms';
 
 export interface ChatInfo {
   replying: string | null;

--- a/apps/tlon-web/src/components/About/AboutView.tsx
+++ b/apps/tlon-web/src/components/About/AboutView.tsx
@@ -1,6 +1,7 @@
+import { Helmet } from 'react-helmet';
+
 import { useIsMobile } from '@/logic/useMedia';
 import { ViewProps } from '@/types/groups';
-import { Helmet } from 'react-helmet';
 
 import Layout from '../Layout/Layout';
 import MobileHeader from '../MobileHeader';

--- a/apps/tlon-web/src/components/About/__fixtures__/AboutDialog.fixture.tsx
+++ b/apps/tlon-web/src/components/About/__fixtures__/AboutDialog.fixture.tsx
@@ -1,5 +1,6 @@
-import AboutDialog from '@/components/About/AboutDialog';
 import { MemoryRouter } from 'react-router';
+
+import AboutDialog from '@/components/About/AboutDialog';
 
 export default function AboutDialogFixture() {
   return (

--- a/apps/tlon-web/src/components/ActionMenu.tsx
+++ b/apps/tlon-web/src/components/ActionMenu.tsx
@@ -1,8 +1,9 @@
-import { useIsMobile } from '@/logic/useMedia';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import cn from 'classnames';
 import React, { PropsWithChildren, ReactNode } from 'react';
 import { Drawer } from 'vaul';
+
+import { useIsMobile } from '@/logic/useMedia';
 
 export type ActionType =
   | 'default'

--- a/apps/tlon-web/src/components/ActivityModal.tsx
+++ b/apps/tlon-web/src/components/ActivityModal.tsx
@@ -1,3 +1,7 @@
+import * as Collapsible from '@radix-ui/react-collapsible';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import { PrivacyContents } from '@/groups/PrivacyNotice';
 import {
   ANALYTICS_DEFAULT_PROPERTIES,
@@ -12,9 +16,6 @@ import {
   usePutEntryMutation,
   useShowActivityMessage,
 } from '@/state/settings';
-import * as Collapsible from '@radix-ui/react-collapsible';
-import React, { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import Dialog from './Dialog';
 

--- a/apps/tlon-web/src/components/Avatar.tsx
+++ b/apps/tlon-web/src/components/Avatar.tsx
@@ -1,9 +1,3 @@
-import { isValidUrl, normalizeUrbitColor } from '@/logic/utils';
-import { useAvatar } from '@/state/avatar';
-import { useContact } from '@/state/contact';
-import { useCurrentTheme } from '@/state/local';
-import { useCalm } from '@/state/settings';
-import { SigilProps } from '@/types/sigil';
 import { Contact, cite } from '@urbit/api';
 import '@urbit/sigil-js';
 import classNames from 'classnames';
@@ -11,6 +5,13 @@ import { darken, lighten, parseToHsla } from 'color2k';
 import _ from 'lodash';
 import React, { CSSProperties, useMemo } from 'react';
 import { isValidPatp } from 'urbit-ob';
+
+import { isValidUrl, normalizeUrbitColor } from '@/logic/utils';
+import { useAvatar } from '@/state/avatar';
+import { useContact } from '@/state/contact';
+import { useCurrentTheme } from '@/state/local';
+import { useCalm } from '@/state/settings';
+import { SigilProps } from '@/types/sigil';
 
 export type AvatarSizes =
   | 'sidebar'

--- a/apps/tlon-web/src/components/ColorPicker.tsx
+++ b/apps/tlon-web/src/components/ColorPicker.tsx
@@ -1,4 +1,3 @@
-import { isColor } from '@/logic/utils';
 import * as Popover from '@radix-ui/react-popover';
 import classNames from 'classnames';
 import React from 'react';
@@ -11,6 +10,8 @@ import {
   PathValue,
   useFormContext,
 } from 'react-hook-form';
+
+import { isColor } from '@/logic/utils';
 
 interface ColorPickerProps {
   color: string;

--- a/apps/tlon-web/src/components/CoverImageInput.tsx
+++ b/apps/tlon-web/src/components/CoverImageInput.tsx
@@ -1,10 +1,11 @@
+import cn from 'classnames';
+import React, { MouseEvent, useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
 import { UploadErrorPopover } from '@/chat/ChatInput/ChatInput';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useCalm } from '@/state/settings';
 import { useUploader } from '@/state/storage';
-import cn from 'classnames';
-import React, { MouseEvent, useEffect, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
 
 interface CoverImageInputProps {
   className?: string;

--- a/apps/tlon-web/src/components/DisconnectNotice.tsx
+++ b/apps/tlon-web/src/components/DisconnectNotice.tsx
@@ -1,7 +1,8 @@
+import { useCallback } from 'react';
+
 import Asterisk16Icon from '@/components/icons/Asterisk16Icon';
 import bootstrap from '@/state/bootstrap';
 import { useLocalState, useSubscriptionStatus } from '@/state/local';
-import { useCallback } from 'react';
 
 export default function DisconnectNotice() {
   const { subscription, errorCount } = useSubscriptionStatus();

--- a/apps/tlon-web/src/components/EmojiPicker.tsx
+++ b/apps/tlon-web/src/components/EmojiPicker.tsx
@@ -1,3 +1,8 @@
+import Picker from '@emoji-mart/react';
+import * as Popover from '@radix-ui/react-popover';
+import React, { useCallback, useEffect } from 'react';
+import { useParams } from 'react-router';
+
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import { useDismissNavigate } from '@/logic/routing';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
@@ -18,10 +23,6 @@ import {
 import useEmoji from '@/state/emoji';
 import { useRouteGroup } from '@/state/groups';
 import { useCurrentTheme } from '@/state/local';
-import Picker from '@emoji-mart/react';
-import * as Popover from '@radix-ui/react-popover';
-import React, { useCallback, useEffect } from 'react';
-import { useParams } from 'react-router';
 
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 

--- a/apps/tlon-web/src/components/ErrorAlert.tsx
+++ b/apps/tlon-web/src/components/ErrorAlert.tsx
@@ -1,7 +1,8 @@
+import cn from 'classnames';
+
 import { useCharge } from '@/state/docket';
 import { usePike } from '@/state/kiln';
 import useVereState from '@/state/vere';
-import cn from 'classnames';
 
 import Dialog, { DialogClose } from './Dialog';
 

--- a/apps/tlon-web/src/components/Grid/AppInfo.tsx
+++ b/apps/tlon-web/src/components/Grid/AppInfo.tsx
@@ -1,9 +1,10 @@
-import { getAppHref, getAppName } from '@/logic/utils';
-import useDocketState, { ChargeWithDesk, useTreaty } from '@/state/docket';
 import { Pike, Treaty, chadIsRunning } from '@urbit/api';
 import cn from 'classnames';
 import clipboardCopy from 'clipboard-copy';
 import React, { useCallback, useState } from 'react';
+
+import { getAppHref, getAppName } from '@/logic/utils';
+import useDocketState, { ChargeWithDesk, useTreaty } from '@/state/docket';
 
 import Dialog, { DialogClose, DialogContent, DialogTrigger } from '../Dialog';
 import { Button, PillButton } from './Button';

--- a/apps/tlon-web/src/components/Grid/DocketHeader.tsx
+++ b/apps/tlon-web/src/components/Grid/DocketHeader.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import { getAppName } from '@/logic/utils';
 import { DocketWithDesk } from '@/state/docket';
-import React from 'react';
 
 import DocketImage from './DocketImage';
 

--- a/apps/tlon-web/src/components/Grid/Tile.tsx
+++ b/apps/tlon-web/src/components/Grid/Tile.tsx
@@ -1,11 +1,12 @@
-import { getAppHref } from '@/logic/utils';
-import { ChargeWithDesk } from '@/state/docket';
-import { usePike } from '@/state/kiln';
 import { chadIsRunning } from '@urbit/api';
 import classNames from 'classnames';
 import React from 'react';
 import { useDrag } from 'react-dnd';
 import { Link, useLocation } from 'react-router-dom';
+
+import { getAppHref } from '@/logic/utils';
+import { ChargeWithDesk } from '@/state/docket';
+import { usePike } from '@/state/kiln';
 
 import BulletIcon from '../icons/BulletIcon';
 import Spinner from './Spinner';

--- a/apps/tlon-web/src/components/Grid/TileMenu.tsx
+++ b/apps/tlon-web/src/components/Grid/TileMenu.tsx
@@ -1,12 +1,13 @@
-import { useIsMobile } from '@/logic/useMedia';
-import { disableDefault, handleDropdownLink } from '@/logic/utils';
-import useDocketState from '@/state/docket';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { Chad, chadIsRunning } from '@urbit/api';
 import classNames from 'classnames';
 import React, { ReactElement, useCallback, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useEventListener } from 'usehooks-ts';
+
+import { useIsMobile } from '@/logic/useMedia';
+import { disableDefault, handleDropdownLink } from '@/logic/utils';
+import useDocketState from '@/state/docket';
 
 export interface TileMenuProps {
   desk: string;

--- a/apps/tlon-web/src/components/Grid/appmodal.tsx
+++ b/apps/tlon-web/src/components/Grid/appmodal.tsx
@@ -1,6 +1,7 @@
+import { useLocation, useNavigate, useParams } from 'react-router';
+
 import { getAppHref } from '@/logic/utils';
 import { useCharge } from '@/state/docket';
-import { useLocation, useNavigate, useParams } from 'react-router';
 
 import Dialog, { DialogContent } from '../Dialog';
 import ArrowNEIcon from '../icons/ArrowNEIcon';

--- a/apps/tlon-web/src/components/Grid/grid.tsx
+++ b/apps/tlon-web/src/components/Grid/grid.tsx
@@ -1,13 +1,14 @@
-import useLeap from '@/components/Leap/useLeap';
-import keyMap from '@/keyMap';
-import { ChargeWithDesk, useCharges } from '@/state/docket';
-import { SettingsState, usePutEntryMutation, useTiles } from '@/state/settings';
 import produce from 'immer';
 import { remove, take, uniq } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useEventListener } from 'usehooks-ts';
 import create from 'zustand';
+
+import useLeap from '@/components/Leap/useLeap';
+import keyMap from '@/keyMap';
+import { ChargeWithDesk, useCharges } from '@/state/docket';
+import { SettingsState, usePutEntryMutation, useTiles } from '@/state/settings';
 
 import Dialog from '../Dialog';
 // eslint-disable-next-line import/no-cycle

--- a/apps/tlon-web/src/components/Grid/tileinfo.tsx
+++ b/apps/tlon-web/src/components/Grid/tileinfo.tsx
@@ -1,7 +1,8 @@
-import { useCharge } from '@/state/docket';
-import { usePike } from '@/state/kiln';
 import React from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
+import { useCharge } from '@/state/docket';
+import { usePike } from '@/state/kiln';
 
 import Dialog, { DialogContent } from '../Dialog';
 import AppInfo from './AppInfo';

--- a/apps/tlon-web/src/components/Grid/useTileColor.tsx
+++ b/apps/tlon-web/src/components/Grid/useTileColor.tsx
@@ -1,5 +1,3 @@
-import { getDarkColor } from '@/logic/utils';
-import { useCurrentTheme } from '@/state/local';
 import {
   darken,
   hsla,
@@ -7,6 +5,9 @@ import {
   parseToHsla,
   readableColorIsBlack,
 } from 'color2k';
+
+import { getDarkColor } from '@/logic/utils';
+import { useCurrentTheme } from '@/state/local';
 
 function bgAdjustedColor(color: string, darkBg: boolean): string {
   return darkBg ? lighten(color, 0.1) : darken(color, 0.1);

--- a/apps/tlon-web/src/components/GroupSelector.tsx
+++ b/apps/tlon-web/src/components/GroupSelector.tsx
@@ -1,10 +1,3 @@
-import ExclamationPoint from '@/components/icons/ExclamationPoint';
-import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
-import X16Icon from '@/components/icons/X16Icon';
-import { MAX_DISPLAYED_OPTIONS } from '@/constants';
-import GroupAvatar from '@/groups/GroupAvatar';
-import { preSig, whomIsFlag } from '@/logic/utils';
-import { useGroup, useGroups } from '@/state/groups';
 import { deSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import React, { useMemo, useRef, useState } from 'react';
@@ -28,6 +21,14 @@ import {
 } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import ob from 'urbit-ob';
+
+import ExclamationPoint from '@/components/icons/ExclamationPoint';
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
+import X16Icon from '@/components/icons/X16Icon';
+import { MAX_DISPLAYED_OPTIONS } from '@/constants';
+import GroupAvatar from '@/groups/GroupAvatar';
+import { preSig, whomIsFlag } from '@/logic/utils';
+import { useGroup, useGroups } from '@/state/groups';
 
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 import ShipName from './ShipName';

--- a/apps/tlon-web/src/components/HostConnection.tsx
+++ b/apps/tlon-web/src/components/HostConnection.tsx
@@ -1,3 +1,5 @@
+import cn from 'classnames';
+
 import Tooltip from '@/components/Tooltip';
 import Bullet16Icon from '@/components/icons/Bullet16Icon';
 import {
@@ -8,7 +10,6 @@ import {
   redConnection,
 } from '@/logic/utils';
 import { ConnectionStatus } from '@/state/vitals';
-import cn from 'classnames';
 
 export interface HostConnectionProps {
   ship: string;

--- a/apps/tlon-web/src/components/ImageOrColorField.tsx
+++ b/apps/tlon-web/src/components/ImageOrColorField.tsx
@@ -1,7 +1,8 @@
-import { isColor, isValidUrl } from '@/logic/utils';
 import cn from 'classnames';
 import React, { useEffect, useState } from 'react';
 import { FieldPath, FieldValues, useFormContext } from 'react-hook-form';
+
+import { isColor, isValidUrl } from '@/logic/utils';
 
 import { ColorPickerField } from './ColorPicker';
 import ImageURLUploadField from './ImageURLUploadField';

--- a/apps/tlon-web/src/components/ImageURLUploadField.tsx
+++ b/apps/tlon-web/src/components/ImageURLUploadField.tsx
@@ -1,11 +1,12 @@
+import cn from 'classnames';
+import React, { useEffect, useState } from 'react';
+import { UseFormRegister, UseFormSetValue } from 'react-hook-form';
+
 import { UploadErrorPopover } from '@/chat/ChatInput/ChatInput';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import LinkIcon from '@/components/icons/LinkIcon';
 import { isValidUrl } from '@/logic/utils';
 import { useUploader } from '@/state/storage';
-import cn from 'classnames';
-import React, { useEffect, useState } from 'react';
-import { UseFormRegister, UseFormSetValue } from 'react-hook-form';
 
 interface ImageURLUploadFieldProps {
   formRegister: UseFormRegister<any>;

--- a/apps/tlon-web/src/components/InstallPrompt.tsx
+++ b/apps/tlon-web/src/components/InstallPrompt.tsx
@@ -1,7 +1,8 @@
-import api from '@/api';
-import { disableDefault } from '@/logic/utils';
 import * as Popover from '@radix-ui/react-popover';
 import usePWAInstall from 'use-pwa-install';
+
+import api from '@/api';
+import { disableDefault } from '@/logic/utils';
 
 export function enableVita() {
   return api.poke({

--- a/apps/tlon-web/src/components/Leap/Leap.tsx
+++ b/apps/tlon-web/src/components/Leap/Leap.tsx
@@ -1,6 +1,7 @@
-import keyMap from '@/keyMap';
 import React, { useRef } from 'react';
 import { useEventListener } from 'usehooks-ts';
+
+import keyMap from '@/keyMap';
 
 import Dialog from '../Dialog';
 import MobileHeader from '../MobileHeader';

--- a/apps/tlon-web/src/components/Leap/__fixtures__/LeapRow.fixture.tsx
+++ b/apps/tlon-web/src/components/Leap/__fixtures__/LeapRow.fixture.tsx
@@ -1,6 +1,7 @@
-import GlobeIcon from '@/components/icons/GlobeIcon';
 import { useValue } from 'react-cosmos/client';
 import { MemoryRouter } from 'react-router';
+
+import GlobeIcon from '@/components/icons/GlobeIcon';
 
 import LeapRow from '../LeapRow';
 

--- a/apps/tlon-web/src/components/Leap/useLeap.tsx
+++ b/apps/tlon-web/src/components/Leap/useLeap.tsx
@@ -1,3 +1,9 @@
+import { cite, deSig, preSig } from '@urbit/api';
+import fuzzy from 'fuzzy';
+import { uniqBy } from 'lodash';
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import {
   LEAP_DESCRIPTION_TRUNCATE_LENGTH,
   LEAP_RESULT_SCORE_THRESHOLD,
@@ -15,11 +21,6 @@ import { usePinnedChannels, usePinnedClubs } from '@/state/pins';
 import { Contact } from '@/types/contact';
 import { Club } from '@/types/dms';
 import { Group, GroupChannel } from '@/types/groups';
-import { cite, deSig, preSig } from '@urbit/api';
-import fuzzy from 'fuzzy';
-import { uniqBy } from 'lodash';
-import React, { useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 import useActiveTab from '../Sidebar/util';
 import BubbleIcon from '../icons/BubbleIcon';

--- a/apps/tlon-web/src/components/LightBox.tsx
+++ b/apps/tlon-web/src/components/LightBox.tsx
@@ -1,7 +1,8 @@
-import Dialog from '@/components/Dialog';
-import { useSafeAreaInsets } from '@/logic/native';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import React from 'react';
+
+import Dialog from '@/components/Dialog';
+import { useSafeAreaInsets } from '@/logic/native';
 
 import X16Icon from './icons/X16Icon';
 

--- a/apps/tlon-web/src/components/Mention/MentionPopup.tsx
+++ b/apps/tlon-web/src/components/Mention/MentionPopup.tsx
@@ -1,9 +1,3 @@
-import keyMap from '@/keyMap';
-import { isNativeApp } from '@/logic/native';
-import { preSig } from '@/logic/utils';
-import { useMultiDms } from '@/state/chat';
-import useContactState, { useContacts } from '@/state/contact';
-import { useGroup, useGroupFlag } from '@/state/groups';
 import { PluginKey } from '@tiptap/pm/state';
 import { ReactRenderer } from '@tiptap/react';
 import { SuggestionOptions, SuggestionProps } from '@tiptap/suggestion';
@@ -19,6 +13,13 @@ import React, {
 import { useMatch } from 'react-router';
 import tippy from 'tippy.js';
 import { clan, isValidPatp } from 'urbit-ob';
+
+import keyMap from '@/keyMap';
+import { isNativeApp } from '@/logic/native';
+import { preSig } from '@/logic/utils';
+import { useMultiDms } from '@/state/chat';
+import useContactState, { useContacts } from '@/state/contact';
+import { useGroup, useGroupFlag } from '@/state/groups';
 
 import Avatar from '../Avatar';
 import useLeap from '../Leap/useLeap';

--- a/apps/tlon-web/src/components/MessageEditor.tsx
+++ b/apps/tlon-web/src/components/MessageEditor.tsx
@@ -1,15 +1,3 @@
-import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
-import {
-  chatStoreLogger,
-  useChatBlocks,
-  useChatStore,
-} from '@/chat/useChatStore';
-import { PASTEABLE_MEDIA_TYPES } from '@/constants';
-import { Shortcuts, refPasteRule } from '@/logic/tiptap';
-import { useIsMobile } from '@/logic/useMedia';
-import { useCalm } from '@/state/settings';
-import { useFileStore } from '@/state/storage';
-import { Cite } from '@/types/channel';
 import Blockquote from '@tiptap/extension-blockquote';
 import Bold from '@tiptap/extension-bold';
 import Code from '@tiptap/extension-code';
@@ -29,6 +17,19 @@ import { EditorView } from '@tiptap/pm/view';
 import { Editor, EditorContent, JSONContent, useEditor } from '@tiptap/react';
 import cn from 'classnames';
 import React, { useCallback, useMemo } from 'react';
+
+import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
+import {
+  chatStoreLogger,
+  useChatBlocks,
+  useChatStore,
+} from '@/chat/useChatStore';
+import { PASTEABLE_MEDIA_TYPES } from '@/constants';
+import { Shortcuts, refPasteRule } from '@/logic/tiptap';
+import { useIsMobile } from '@/logic/useMedia';
+import { useCalm } from '@/state/settings';
+import { useFileStore } from '@/state/storage';
+import { Cite } from '@/types/channel';
 
 import getMentionPopup from './Mention/MentionPopup';
 

--- a/apps/tlon-web/src/components/MigrationTooltip.tsx
+++ b/apps/tlon-web/src/components/MigrationTooltip.tsx
@@ -1,7 +1,8 @@
-import useGroupPrivacy from '@/logic/useGroupPrivacy';
-import { useGroupLeaveMutation } from '@/state/groups';
 import * as Popover from '@radix-ui/react-popover';
 import React, { PropsWithChildren } from 'react';
+
+import useGroupPrivacy from '@/logic/useGroupPrivacy';
+import { useGroupLeaveMutation } from '@/state/groups';
 
 import ShipName from './ShipName';
 

--- a/apps/tlon-web/src/components/MobileHeader.tsx
+++ b/apps/tlon-web/src/components/MobileHeader.tsx
@@ -1,6 +1,7 @@
-import { useSafeAreaInsets } from '@/logic/native';
 import cn from 'classnames';
 import { Link } from 'react-router-dom';
+
+import { useSafeAreaInsets } from '@/logic/native';
 
 import CaretLeftIconMobileNav from './icons/CaretLeftIconMobileNav';
 

--- a/apps/tlon-web/src/components/PalIcon.tsx
+++ b/apps/tlon-web/src/components/PalIcon.tsx
@@ -1,7 +1,8 @@
-import { usePals } from '@/state/pals';
 import cn from 'classnames';
 import _ from 'lodash';
 import { useMemo } from 'react';
+
+import { usePals } from '@/state/pals';
 
 const outgoingSvg = (
   <svg

--- a/apps/tlon-web/src/components/QRWidget.tsx
+++ b/apps/tlon-web/src/components/QRWidget.tsx
@@ -1,9 +1,10 @@
-import CopyIcon from '@/components/icons/CopyIcon';
-import { useCopy } from '@/logic/utils';
-import { useCurrentTheme } from '@/state/local';
 import cn from 'classnames';
 import { useMemo } from 'react';
 import QRCode from 'react-qr-code';
+
+import CopyIcon from '@/components/icons/CopyIcon';
+import { useCopy } from '@/logic/utils';
+import { useCurrentTheme } from '@/state/local';
 
 import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
 import CheckIcon from './icons/CheckIcon';

--- a/apps/tlon-web/src/components/ReconnectingSpinner.tsx
+++ b/apps/tlon-web/src/components/ReconnectingSpinner.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useSubscriptionStatus } from '@/state/local';
-import React from 'react';
 
 type Props = {
   className?: string;

--- a/apps/tlon-web/src/components/References/AppReference.tsx
+++ b/apps/tlon-web/src/components/References/AppReference.tsx
@@ -1,10 +1,11 @@
+import React, { useEffect } from 'react';
+
 import ShipName from '@/components/ShipName';
 import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { useIsDark } from '@/logic/useMedia';
 import { getFlagParts } from '@/logic/utils';
 import useDocketState, { useTreaty } from '@/state/docket';
 import { useCalm } from '@/state/settings';
-import React, { useEffect } from 'react';
 
 interface AppReferenceProps {
   flag: string;

--- a/apps/tlon-web/src/components/References/ContentReference.tsx
+++ b/apps/tlon-web/src/components/References/ContentReference.tsx
@@ -1,7 +1,8 @@
-import { nestToFlag } from '@/logic/utils';
-import { Cite } from '@/types/channel';
 import { udToDec } from '@urbit/api';
 import React from 'react';
+
+import { nestToFlag } from '@/logic/utils';
+import { Cite } from '@/types/channel';
 
 // eslint-disable-next-line import/no-cycle
 import AppReference from './AppReference';

--- a/apps/tlon-web/src/components/References/CurioReference.tsx
+++ b/apps/tlon-web/src/components/References/CurioReference.tsx
@@ -1,3 +1,7 @@
+import bigInt from 'big-integer';
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import ShipName from '@/components/ShipName';
 import ShapesIcon from '@/components/icons/ShapesIcon';
 import useGroupJoin from '@/groups/useGroupJoin';
@@ -12,9 +16,6 @@ import getHeapContentType from '@/logic/useHeapContentType';
 import { useRemotePost } from '@/state/channel/channel';
 import { useChannelPreview, useGang } from '@/state/groups';
 import { imageUrlFromContent } from '@/types/channel';
-import bigInt from 'big-integer';
-import React, { useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 import ReferenceBar from './ReferenceBar';
 import ReferenceInHeap from './ReferenceInHeap';

--- a/apps/tlon-web/src/components/References/GroupReference.tsx
+++ b/apps/tlon-web/src/components/References/GroupReference.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import React from 'react';
+
 import ShipName from '@/components/ShipName';
 import ExclamationPoint from '@/components/icons/ExclamationPoint';
 import GroupAvatar from '@/groups/GroupAvatar';
@@ -11,8 +14,6 @@ import {
 } from '@/logic/utils';
 import { useGang, useGangPreview } from '@/state/groups';
 import { useCalm } from '@/state/settings';
-import cn from 'classnames';
-import React from 'react';
 
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 import ReferenceInHeap from './ReferenceInHeap';

--- a/apps/tlon-web/src/components/References/NoteReference.tsx
+++ b/apps/tlon-web/src/components/References/NoteReference.tsx
@@ -1,3 +1,7 @@
+import bigInt from 'big-integer';
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
 import Avatar from '@/components/Avatar';
 import { NOTE_REF_DISPLAY_LIMIT } from '@/constants';
 // eslint-disable-next-line import/no-cycle
@@ -13,9 +17,6 @@ import {
 } from '@/logic/utils';
 import { useRemotePost } from '@/state/channel/channel';
 import { useChannelPreview, useGang } from '@/state/groups';
-import bigInt from 'big-integer';
-import React, { useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import ShipName from '../ShipName';
 import NotebookIcon from '../icons/NotebookIcon';

--- a/apps/tlon-web/src/components/References/ReferenceBar.tsx
+++ b/apps/tlon-web/src/components/References/ReferenceBar.tsx
@@ -1,11 +1,12 @@
-import ChannelIcon from '@/channels/ChannelIcon';
-import Author from '@/chat/ChatMessage/Author';
-import GroupAvatar from '@/groups/GroupAvatar';
 import { daToUnix } from '@urbit/api';
 import { BigInteger } from 'big-integer';
 import cn from 'classnames';
 import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router';
+
+import ChannelIcon from '@/channels/ChannelIcon';
+import Author from '@/chat/ChatMessage/Author';
+import GroupAvatar from '@/groups/GroupAvatar';
 
 interface ReferenceBarProps {
   nest: string;

--- a/apps/tlon-web/src/components/References/UnavailableReference.tsx
+++ b/apps/tlon-web/src/components/References/UnavailableReference.tsx
@@ -1,6 +1,7 @@
-import { ChannelPreview } from '@/types/groups';
 import bigInt from 'big-integer';
 import React from 'react';
+
+import { ChannelPreview } from '@/types/groups';
 
 import ExclamationPoint from '../icons/ExclamationPoint';
 import ReferenceBar from './ReferenceBar';

--- a/apps/tlon-web/src/components/References/WritBaitReference.tsx
+++ b/apps/tlon-web/src/components/References/WritBaitReference.tsx
@@ -1,7 +1,8 @@
-import { useRemotePost } from '@/state/channel/channel';
 import { udToDec } from '@urbit/api';
 import bigInt from 'big-integer';
 import React from 'react';
+
+import { useRemotePost } from '@/state/channel/channel';
 
 import UnavailableReference from './UnavailableReference';
 // import { useWritByFlagAndGraphIndex } from '@/state/chat';

--- a/apps/tlon-web/src/components/References/WritBaseReference.tsx
+++ b/apps/tlon-web/src/components/References/WritBaseReference.tsx
@@ -1,3 +1,8 @@
+import bigInt from 'big-integer';
+import cn from 'classnames';
+import React, { useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
 // eslint-disable-next-line import/no-cycle
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import useGroupJoin from '@/groups/useGroupJoin';
@@ -6,10 +11,6 @@ import { useChannelFlag } from '@/logic/channel';
 import { isImageUrl, nestToFlag } from '@/logic/utils';
 import { useChannelPreview, useGang } from '@/state/groups';
 import { ReferenceResponse } from '@/types/channel';
-import bigInt from 'big-integer';
-import cn from 'classnames';
-import React, { useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 
 import ShipName from '../ShipName';
 import ReferenceBar from './ReferenceBar';

--- a/apps/tlon-web/src/components/References/WritChanReference.tsx
+++ b/apps/tlon-web/src/components/References/WritChanReference.tsx
@@ -1,6 +1,7 @@
-import { useRemotePost } from '@/state/channel/channel';
 import bigInt from 'big-integer';
 import React from 'react';
+
+import { useRemotePost } from '@/state/channel/channel';
 
 // eslint-disable-next-line import/no-cycle
 import UnavailableReference from './UnavailableReference';

--- a/apps/tlon-web/src/components/ReportContent.tsx
+++ b/apps/tlon-web/src/components/ReportContent.tsx
@@ -1,8 +1,9 @@
+import cn from 'classnames';
+import { useLocation } from 'react-router';
+
 import { useDismissNavigate } from '@/logic/routing';
 import { useIsMobile } from '@/logic/useMedia';
 import { useFlagContentMutation } from '@/state/groups';
-import cn from 'classnames';
-import { useLocation } from 'react-router';
 
 import Dialog from './Dialog';
 import WidgetDrawer from './WidgetDrawer';

--- a/apps/tlon-web/src/components/RoleBadges.tsx
+++ b/apps/tlon-web/src/components/RoleBadges.tsx
@@ -1,7 +1,8 @@
-import { getSectTitle } from '@/logic/utils';
-import { useGroup, useGroupFlag, useVessel } from '@/state/groups';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import _ from 'lodash';
+
+import { getSectTitle } from '@/logic/utils';
+import { useGroup, useGroupFlag, useVessel } from '@/state/groups';
 
 export default function RoleBadges(props: { ship: string; inList?: boolean }) {
   const { ship, inList } = props;

--- a/apps/tlon-web/src/components/Settings/BlockedUsers.tsx
+++ b/apps/tlon-web/src/components/Settings/BlockedUsers.tsx
@@ -1,3 +1,6 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Avatar from '@/components/Avatar';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
@@ -7,8 +10,6 @@ import SidebarItem from '@/components/Sidebar/SidebarItem';
 import { useIsMobile } from '@/logic/useMedia';
 import { useBlockedShips, useUnblockShipMutation } from '@/state/chat';
 import { useContact } from '@/state/contact';
-import React, { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 const BlockedUser = React.memo(({ ship: user }: { ship: string }) => {
   const navigate = useNavigate();

--- a/apps/tlon-web/src/components/Settings/BlockedUsersView.tsx
+++ b/apps/tlon-web/src/components/Settings/BlockedUsersView.tsx
@@ -1,6 +1,7 @@
-import { ViewProps } from '@/types/groups';
 import React from 'react';
 import { Helmet } from 'react-helmet';
+
+import { ViewProps } from '@/types/groups';
 
 import MobileHeader from '../MobileHeader';
 import BlockedUsers from './BlockedUsers';

--- a/apps/tlon-web/src/components/Settings/Setting.tsx
+++ b/apps/tlon-web/src/components/Settings/Setting.tsx
@@ -1,8 +1,9 @@
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import Toggle from '@/components/Toggle';
 import cn from 'classnames';
 import React, { HTMLAttributes } from 'react';
 import slugify from 'slugify';
+
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import Toggle from '@/components/Toggle';
 
 type SettingProps = {
   name: string;

--- a/apps/tlon-web/src/components/Settings/SettingDropdown.tsx
+++ b/apps/tlon-web/src/components/Settings/SettingDropdown.tsx
@@ -1,9 +1,10 @@
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import CaretDownIcon from '@/components/icons/CaretDownIcon';
-import CheckIcon from '@/components/icons/CheckIcon';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { HTMLAttributes } from 'react';
 import slugify from 'slugify';
+
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import CaretDownIcon from '@/components/icons/CaretDownIcon';
+import CheckIcon from '@/components/icons/CheckIcon';
 
 type SettingProps = {
   name: string;

--- a/apps/tlon-web/src/components/Settings/Settings.tsx
+++ b/apps/tlon-web/src/components/Settings/Settings.tsx
@@ -1,3 +1,5 @@
+import { Link, useLocation } from 'react-router-dom';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useIsMobile } from '@/logic/useMedia';
 import {
@@ -10,7 +12,6 @@ import {
   useTheme,
   useThemeMutation,
 } from '@/state/settings';
-import { Link, useLocation } from 'react-router-dom';
 
 import VolumeSetting from '../VolumeSetting';
 import Setting from './Setting';

--- a/apps/tlon-web/src/components/Settings/SettingsView.tsx
+++ b/apps/tlon-web/src/components/Settings/SettingsView.tsx
@@ -1,6 +1,7 @@
+import { Helmet } from 'react-helmet';
+
 import { useIsMobile } from '@/logic/useMedia';
 import { ViewProps } from '@/types/groups';
-import { Helmet } from 'react-helmet';
 
 import Layout from '../Layout/Layout';
 import MobileHeader from '../MobileHeader';

--- a/apps/tlon-web/src/components/ShipConnection.tsx
+++ b/apps/tlon-web/src/components/ShipConnection.tsx
@@ -1,5 +1,6 @@
-import { useNegotiate } from '@/state/negotiation';
 import cn from 'classnames';
+
+import { useNegotiate } from '@/state/negotiation';
 
 import {
   getCompletedText,

--- a/apps/tlon-web/src/components/ShipName.tsx
+++ b/apps/tlon-web/src/components/ShipName.tsx
@@ -1,6 +1,7 @@
-import { useCalm } from '@/state/settings';
 import { cite } from '@urbit/api';
 import React, { HTMLAttributes, useMemo } from 'react';
+
+import { useCalm } from '@/state/settings';
 
 import { useContact } from '../state/contact';
 

--- a/apps/tlon-web/src/components/ShipSelector.tsx
+++ b/apps/tlon-web/src/components/ShipSelector.tsx
@@ -1,12 +1,3 @@
-import Avatar from '@/components/Avatar';
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import ExclamationPoint from '@/components/icons/ExclamationPoint';
-import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
-import X16Icon from '@/components/icons/X16Icon';
-import { MAX_DISPLAYED_OPTIONS } from '@/constants';
-import { useIsMobile } from '@/logic/useMedia';
-import { preSig, whomIsFlag } from '@/logic/utils';
-import { useMemoizedContacts } from '@/state/contact';
 import { deSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import _, { includes } from 'lodash';
@@ -31,6 +22,16 @@ import {
 } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import ob from 'urbit-ob';
+
+import Avatar from '@/components/Avatar';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import ExclamationPoint from '@/components/icons/ExclamationPoint';
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
+import X16Icon from '@/components/icons/X16Icon';
+import { MAX_DISPLAYED_OPTIONS } from '@/constants';
+import { useIsMobile } from '@/logic/useMedia';
+import { preSig, whomIsFlag } from '@/logic/utils';
+import { useMemoizedContacts } from '@/state/contact';
 
 import ShipName from './ShipName';
 import UnknownAvatarIcon from './icons/UnknownAvatarIcon';

--- a/apps/tlon-web/src/components/Sidebar/ActivityIndicator.tsx
+++ b/apps/tlon-web/src/components/Sidebar/ActivityIndicator.tsx
@@ -1,5 +1,6 @@
-import { useNotifications } from '@/notifications/useNotifications';
 import cn from 'classnames';
+
+import { useNotifications } from '@/notifications/useNotifications';
 
 import BellIcon from '../icons/BellIcon';
 import BulletIcon from '../icons/BulletIcon';

--- a/apps/tlon-web/src/components/Sidebar/GangItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GangItem.tsx
@@ -1,3 +1,7 @@
+import * as Popover from '@radix-ui/react-popover';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
 import useLongPress from '@/logic/useLongPress';
@@ -11,9 +15,6 @@ import {
   useGroupLeaveMutation,
   useGroupRescindMutation,
 } from '@/state/groups';
-import * as Popover from '@radix-ui/react-popover';
-import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import LoadingSpinner from '../LoadingSpinner/LoadingSpinner';
 import X16Icon from '../icons/X16Icon';

--- a/apps/tlon-web/src/components/Sidebar/GroupList.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupList.tsx
@@ -1,7 +1,8 @@
-import { useIsMobile } from '@/logic/useMedia';
-import { Group } from '@/types/groups';
 import React, { ReactNode, useEffect, useMemo, useRef } from 'react';
 import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+
+import { useIsMobile } from '@/logic/useMedia';
+import { Group } from '@/types/groups';
 
 import GangItem from './GangItem';
 import GroupListPlaceholder from './GroupListPlaceholder';

--- a/apps/tlon-web/src/components/Sidebar/GroupListPlaceholder.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupListPlaceholder.tsx
@@ -1,6 +1,7 @@
-import { randomElement, randomIntInRange } from '@/logic/utils';
 import cn from 'classnames';
 import * as React from 'react';
+
+import { randomElement, randomIntInRange } from '@/logic/utils';
 
 function GroupItemPlaceholder() {
   const background = `bg-gray-${randomElement([100, 200, 400])}`;

--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -1,9 +1,10 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
 import GroupActions from '@/groups/GroupActions';
 import GroupAvatar from '@/groups/GroupAvatar';
 import useLongPress from '@/logic/useLongPress';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroups } from '@/state/groups';
-import React, { useEffect, useMemo, useState } from 'react';
 
 import { useGroupsScrolling } from './GroupsScrollingContext';
 import SidebarItem from './SidebarItem';

--- a/apps/tlon-web/src/components/Sidebar/MessagesSidebar.tsx
+++ b/apps/tlon-web/src/components/Sidebar/MessagesSidebar.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import { debounce } from 'lodash';
+import { useCallback, useRef, useState } from 'react';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Filter16Icon from '@/components/icons/Filter16Icon';
 import MessagesList from '@/dms/MessagesList';
@@ -11,9 +15,6 @@ import {
   useMessagesFilter,
   usePutEntryMutation,
 } from '@/state/settings';
-import cn from 'classnames';
-import { debounce } from 'lodash';
-import { useCallback, useRef, useState } from 'react';
 
 export default function MessagesSidebar({
   searchQuery,

--- a/apps/tlon-web/src/components/Sidebar/MessagesSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/MessagesSidebarItem.tsx
@@ -1,6 +1,7 @@
-import useMessagesUnreadCount from '@/logic/useMessagesUnreadCount';
 import cn from 'classnames';
 import { Link } from 'react-router-dom';
+
+import useMessagesUnreadCount from '@/logic/useMessagesUnreadCount';
 
 import AddIcon16 from '../icons/Add16Icon';
 import MessagesIcon from '../icons/MessagesIcon';

--- a/apps/tlon-web/src/components/Sidebar/MobileSidebar.tsx
+++ b/apps/tlon-web/src/components/Sidebar/MobileSidebar.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import { useContext, useEffect, useState } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router';
+
 import Asterisk16Icon from '@/components/icons/Asterisk16Icon';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { isNativeApp, useSafeAreaInsets } from '@/logic/native';
@@ -8,9 +12,6 @@ import { useNotifications } from '@/notifications/useNotifications';
 import { useHasUnreadMessages } from '@/state/chat';
 import { useCharge } from '@/state/docket';
 import { useLocalState } from '@/state/local';
-import cn from 'classnames';
-import { useContext, useEffect, useState } from 'react';
-import { Outlet, useLocation, useNavigate } from 'react-router';
 
 import Avatar from '../Avatar';
 import NavTab, { DoubleClickableNavTab } from '../NavTab';

--- a/apps/tlon-web/src/components/Sidebar/Sidebar.test.tsx
+++ b/apps/tlon-web/src/components/Sidebar/Sidebar.test.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { createMockGroup } from '@/mocks/groups';
-import { Group } from '@/types/groups';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
+
+import { createMockGroup } from '@/mocks/groups';
+import { Group } from '@/types/groups';
 
 import { render } from '../../../test/utils';
 import Sidebar from './Sidebar';

--- a/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
@@ -1,3 +1,13 @@
+import cn from 'classnames';
+import { debounce } from 'lodash';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
 import GroupList from '@/components/Sidebar/GroupList';
 import MobileSidebar from '@/components/Sidebar/MobileSidebar';
 import useGroupSort from '@/logic/useGroupSort';
@@ -10,15 +20,6 @@ import {
   usePendingGangsWithoutClaim,
   usePinnedGroups,
 } from '@/state/groups';
-import cn from 'classnames';
-import { debounce } from 'lodash';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
 
 import X16Icon from '../icons/X16Icon';
 import GangItem from './GangItem';

--- a/apps/tlon-web/src/components/Sidebar/SidebarHeader.tsx
+++ b/apps/tlon-web/src/components/Sidebar/SidebarHeader.tsx
@@ -1,10 +1,11 @@
-import SidebarItem from '@/components/Sidebar/SidebarItem';
-import useGroupJoin from '@/groups/useGroupJoin';
-import { useGang } from '@/state/groups';
 import cn from 'classnames';
 import React, { useState } from 'react';
 import { useLocation } from 'react-router';
 import { Link } from 'react-router-dom';
+
+import SidebarItem from '@/components/Sidebar/SidebarItem';
+import useGroupJoin from '@/groups/useGroupJoin';
+import { useGang } from '@/state/groups';
 
 import ActionMenu, { Action } from '../ActionMenu';
 import useLeap from '../Leap/useLeap';

--- a/apps/tlon-web/src/components/Sidebar/SidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/SidebarItem.tsx
@@ -1,6 +1,3 @@
-import { useIsMobile } from '@/logic/useMedia';
-import { isColor } from '@/logic/utils';
-import { useCurrentTheme } from '@/state/local';
 import cn from 'classnames';
 import { mix } from 'color2k';
 import React, {
@@ -11,6 +8,10 @@ import React, {
   useState,
 } from 'react';
 import { Link, LinkProps, useMatch } from 'react-router-dom';
+
+import { useIsMobile } from '@/logic/useMedia';
+import { isColor } from '@/logic/utils';
+import { useCurrentTheme } from '@/state/local';
 
 import CaretRightIcon from '../icons/CaretRightIcon';
 

--- a/apps/tlon-web/src/components/Sidebar/SidebarSorter.tsx
+++ b/apps/tlon-web/src/components/Sidebar/SidebarSorter.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'react';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import FilterIconMobileNav from '@/components/icons/FilterIconMobileNav';
 import SortIcon from '@/components/icons/SortIcon';
 import { useIsMobile } from '@/logic/useMedia';
 import useSidebarSort from '@/logic/useSidebarSort';
-import { useState } from 'react';
 
 type SidebarSorterProps = Omit<
   ReturnType<typeof useSidebarSort>,

--- a/apps/tlon-web/src/components/Sidebar/SidebarTopMenu.tsx
+++ b/apps/tlon-web/src/components/Sidebar/SidebarTopMenu.tsx
@@ -1,9 +1,10 @@
+import React, { useContext } from 'react';
+
 import Avatar, { useProfileColor } from '@/components/Avatar';
 import ShipName from '@/components/ShipName';
 import { ActivitySidebarItem } from '@/components/Sidebar/ActivityIndicator';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import { AppUpdateContext } from '@/logic/useAppUpdates';
-import React, { useContext } from 'react';
 
 import { DesktopUpdateButton } from '../UpdateNotices';
 import GroupsSidebarItem from './AddGroupSidebarItem';

--- a/apps/tlon-web/src/components/Sidebar/useSearchFilter.ts
+++ b/apps/tlon-web/src/components/Sidebar/useSearchFilter.ts
@@ -1,9 +1,10 @@
-import { useGangs, useGroups } from '@/state/groups';
-import { Gangs, Groups } from '@/types/groups';
 import { deSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import _ from 'lodash';
 import { useMemo } from 'react';
+
+import { useGangs, useGroups } from '@/state/groups';
+import { Gangs, Groups } from '@/types/groups';
 
 export interface GroupSearchRecord {
   flag: string;

--- a/apps/tlon-web/src/components/Sidebar/util.tsx
+++ b/apps/tlon-web/src/components/Sidebar/util.tsx
@@ -1,6 +1,7 @@
-import { useNavState, usePutEntryMutation } from '@/state/settings';
 import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+
+import { useNavState, usePutEntryMutation } from '@/state/settings';
 
 export type ActiveTab =
   | 'messages'

--- a/apps/tlon-web/src/components/VolumeSetting.tsx
+++ b/apps/tlon-web/src/components/VolumeSetting.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect, useState } from 'react';
+
 import {
   useBaseVolumeSetMutation,
   useGroupChannelVolumeSetMutation,
@@ -6,7 +8,6 @@ import {
   useVolume,
 } from '@/state/groups';
 import { LevelNames, Scope, VolumeValue } from '@/types/volume';
-import React, { useEffect, useState } from 'react';
 
 import RadioGroup, { RadioGroupOption } from './RadioGroup';
 

--- a/apps/tlon-web/src/components/WelcomeCard.tsx
+++ b/apps/tlon-web/src/components/WelcomeCard.tsx
@@ -1,8 +1,9 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
 import { getDmLink } from '@/logic/branch';
 import { useIsMobile } from '@/logic/useMedia';
 import { usePutEntryMutation, useSeenWelcomeCard } from '@/state/settings';
-import { useCallback, useEffect, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
 
 import X16Icon from './icons/X16Icon';
 

--- a/apps/tlon-web/src/components/WidgetDrawer.tsx
+++ b/apps/tlon-web/src/components/WidgetDrawer.tsx
@@ -1,6 +1,7 @@
-import { useSafeAreaInsets } from '@/logic/native';
 import cn from 'classnames';
 import { Drawer } from 'vaul';
+
+import { useSafeAreaInsets } from '@/logic/native';
 
 function Grabber() {
   return (

--- a/apps/tlon-web/src/components/__fixtures__/ActivityModal.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/ActivityModal.fixture.tsx
@@ -1,5 +1,6 @@
-import ActivityModal from '@/components/ActivityModal';
 import { MemoryRouter } from 'react-router';
+
+import ActivityModal from '@/components/ActivityModal';
 
 export default function ActivityModalFixture() {
   return (

--- a/apps/tlon-web/src/components/__fixtures__/ColorPicker.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/ColorPicker.fixture.tsx
@@ -1,5 +1,6 @@
-import ColorPicker from '@/components/ColorPicker';
 import { useState } from 'react';
+
+import ColorPicker from '@/components/ColorPicker';
 
 export default function ColorPickerFixture() {
   const [color, setColor] = useState('#F00');

--- a/apps/tlon-web/src/components/__fixtures__/CoverImageInput.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/CoverImageInput.fixture.tsx
@@ -1,6 +1,7 @@
-import CoverImageInput from '@/components/CoverImageInput';
 import { useSelect } from 'react-cosmos/client';
 import { FormProvider, useForm } from 'react-hook-form';
+
+import CoverImageInput from '@/components/CoverImageInput';
 
 export default function CoverImageInputFixture() {
   const form = useForm({});

--- a/apps/tlon-web/src/components/__fixtures__/Dialog.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/Dialog.fixture.tsx
@@ -1,5 +1,6 @@
-import Dialog from '@/components/Dialog';
 import { useSelect, useValue } from 'react-cosmos/client';
+
+import Dialog from '@/components/Dialog';
 
 export default function DialogFixture() {
   const [containerClass] = useValue('Container Class', {

--- a/apps/tlon-web/src/components/__fixtures__/Divider.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/Divider.fixture.tsx
@@ -1,5 +1,6 @@
-import Divider from '@/components/Divider';
 import { useValue } from 'react-cosmos/client';
+
+import Divider from '@/components/Divider';
 
 export default function DividerFixture() {
   const [isMobile] = useValue('Is mobile', { defaultValue: false });

--- a/apps/tlon-web/src/components/__fixtures__/ImageOrColorField.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/ImageOrColorField.fixture.tsx
@@ -1,6 +1,7 @@
-import ImageOrColorField from '@/components/ImageOrColorField';
 import { useSelect } from 'react-cosmos/client';
 import { FormProvider, useForm } from 'react-hook-form';
+
+import ImageOrColorField from '@/components/ImageOrColorField';
 
 export default function ImageOrColorFieldFixture() {
   const form = useForm({});

--- a/apps/tlon-web/src/components/__fixtures__/MessageEditor.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/MessageEditor.fixture.tsx
@@ -1,6 +1,7 @@
-import MessageEditor, { useMessageEditor } from '@/components/MessageEditor';
 import { useCallback } from 'react';
 import { MemoryRouter } from 'react-router';
+
+import MessageEditor, { useMessageEditor } from '@/components/MessageEditor';
 
 export default function MessageEditorFixture() {
   const messageEditor = useMessageEditor({

--- a/apps/tlon-web/src/components/__fixtures__/MigrationTooltip.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/MigrationTooltip.fixture.tsx
@@ -1,5 +1,6 @@
-import MigrationTooltip from '@/components/MigrationTooltip';
 import { useSelect } from 'react-cosmos/client';
+
+import MigrationTooltip from '@/components/MigrationTooltip';
 
 export default function MigrationTooltipFixture() {
   const [side] = useSelect('Side', {

--- a/apps/tlon-web/src/components/__fixtures__/NavTab.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/NavTab.fixture.tsx
@@ -1,6 +1,7 @@
+import { MemoryRouter } from 'react-router';
+
 import NavTab from '@/components/NavTab';
 import AppGroupsIcon from '@/components/icons/AppGroupsIcon';
-import { MemoryRouter } from 'react-router';
 
 export default function NavTabFixture() {
   return (

--- a/apps/tlon-web/src/components/__fixtures__/NavigationDots.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/NavigationDots.fixture.tsx
@@ -1,5 +1,6 @@
-import NavigationDots from '@/components/NavigationDots';
 import { useValue } from 'react-cosmos/client';
+
+import NavigationDots from '@/components/NavigationDots';
 
 export default function NavigationDotsFixture() {
   const [maxSteps] = useValue('maxSteps', { defaultValue: 3 });

--- a/apps/tlon-web/src/components/__fixtures__/Setting.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/Setting.fixture.tsx
@@ -1,6 +1,7 @@
-import Setting from '@/components/Settings/Setting';
 import { useCallback } from 'react';
 import { useSelect, useValue } from 'react-cosmos/client';
+
+import Setting from '@/components/Settings/Setting';
 
 export default function SettingFixture() {
   const [on, setOn] = useValue<boolean>('On', { defaultValue: false });

--- a/apps/tlon-web/src/components/__fixtures__/SettingDropdown.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/SettingDropdown.fixture.tsx
@@ -1,5 +1,6 @@
-import SettingDropdown from '@/components/Settings/SettingDropdown';
 import { useSelect, useValue } from 'react-cosmos/client';
+
+import SettingDropdown from '@/components/Settings/SettingDropdown';
 
 const options = [
   { label: 'First Option', value: 'first' },

--- a/apps/tlon-web/src/components/__fixtures__/SettingsDialog.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/SettingsDialog.fixture.tsx
@@ -1,5 +1,6 @@
-import SettingsDialog from '@/components/Settings/SettingsDialog';
 import { MemoryRouter } from 'react-router';
+
+import SettingsDialog from '@/components/Settings/SettingsDialog';
 
 export default function SettingsDialogFixture() {
   return (

--- a/apps/tlon-web/src/components/__fixtures__/ShipConnection.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/ShipConnection.fixture.tsx
@@ -1,6 +1,7 @@
+import { useSelect } from 'react-cosmos/client';
+
 import ShipConnection from '@/components/ShipConnection';
 import { ConnectionStatus } from '@/state/vitals';
-import { useSelect } from 'react-cosmos/client';
 
 export default function ShipConnectionFixture() {
   const [type] = useSelect('Type', {

--- a/apps/tlon-web/src/components/__fixtures__/system/Icons.fixture.tsx
+++ b/apps/tlon-web/src/components/__fixtures__/system/Icons.fixture.tsx
@@ -1,6 +1,7 @@
-import icons, { smallIcons } from '@/components/icons';
 import { Component, useEffect, useState } from 'react';
 import { useValue } from 'react-cosmos/client';
+
+import icons, { smallIcons } from '@/components/icons';
 
 export default function IconButtonFixture() {
   const [{ showTooltip, tooltipText }] = useValue('Tooltip', {

--- a/apps/tlon-web/src/components/icons/ColorBoxIcon.tsx
+++ b/apps/tlon-web/src/components/icons/ColorBoxIcon.tsx
@@ -1,7 +1,8 @@
-import { foregroundFromBackground } from '@/components/Avatar';
-import { IconProps } from '@/components/icons/icon';
 import classNames from 'classnames';
 import React from 'react';
+
+import { foregroundFromBackground } from '@/components/Avatar';
+import { IconProps } from '@/components/icons/icon';
 
 interface ColorBoxIconProps extends IconProps {
   color: string;

--- a/apps/tlon-web/src/components/icons/EmptyIconBox.tsx
+++ b/apps/tlon-web/src/components/icons/EmptyIconBox.tsx
@@ -1,5 +1,6 @@
-import { IconProps } from '@/components/icons/icon';
 import React from 'react';
+
+import { IconProps } from '@/components/icons/icon';
 
 export default function EmptyIconBox({ className }: IconProps) {
   return (

--- a/apps/tlon-web/src/components/icons/GlobeIcon.tsx
+++ b/apps/tlon-web/src/components/icons/GlobeIcon.tsx
@@ -1,5 +1,6 @@
-import { IconProps } from '@/components/icons/icon';
 import React from 'react';
+
+import { IconProps } from '@/components/icons/icon';
 
 export default function GlobeIcon({ className }: IconProps) {
   return (

--- a/apps/tlon-web/src/components/icons/LockIcon.tsx
+++ b/apps/tlon-web/src/components/icons/LockIcon.tsx
@@ -1,5 +1,6 @@
-import { IconProps } from '@/components/icons/icon';
 import React from 'react';
+
+import { IconProps } from '@/components/icons/icon';
 
 export default function LockIcon({ className }: IconProps) {
   return (

--- a/apps/tlon-web/src/components/icons/PrivateIcon.tsx
+++ b/apps/tlon-web/src/components/icons/PrivateIcon.tsx
@@ -1,5 +1,6 @@
-import { IconProps } from '@/components/icons/icon';
 import React from 'react';
+
+import { IconProps } from '@/components/icons/icon';
 
 export default function PrivateIcon({ className }: IconProps) {
   return (

--- a/apps/tlon-web/src/diary/DiaryChannel.tsx
+++ b/apps/tlon-web/src/diary/DiaryChannel.tsx
@@ -1,3 +1,9 @@
+import * as Toast from '@radix-ui/react-toast';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
+import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+
 import EmptyPlaceholder from '@/components/EmptyPlaceholder';
 import Layout from '@/components/Layout/Layout';
 import DiaryGridView from '@/diary/DiaryList/DiaryGridView';
@@ -17,11 +23,6 @@ import {
 } from '@/state/settings';
 import { PageTuple } from '@/types/channel';
 import { ViewProps } from '@/types/groups';
-import * as Toast from '@radix-ui/react-toast';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { Outlet, useLocation, useNavigate, useParams } from 'react-router';
-import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
 import DiaryChannelListPlaceholder from './DiaryChannelListPlaceholder';
 import DiaryHeader from './DiaryHeader';

--- a/apps/tlon-web/src/diary/DiaryChannelListPlaceholder.tsx
+++ b/apps/tlon-web/src/diary/DiaryChannelListPlaceholder.tsx
@@ -1,6 +1,7 @@
-import { randomElement } from '@/logic/utils';
 import cn from 'classnames';
 import * as React from 'react';
+
+import { randomElement } from '@/logic/utils';
 
 function DiaryChannelListItemPlaceholder() {
   const background = `bg-gray-${randomElement([100, 200, 400])}`;

--- a/apps/tlon-web/src/diary/DiaryCiteNode.tsx
+++ b/apps/tlon-web/src/diary/DiaryCiteNode.tsx
@@ -1,9 +1,10 @@
-import ContentReference from '@/components/References/ContentReference';
-import Sig16Icon from '@/components/icons/Sig16Icon';
-import { pathToCite } from '@/logic/utils';
 import { Node, NodeViewProps, mergeAttributes } from '@tiptap/core';
 import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
 import React from 'react';
+
+import ContentReference from '@/components/References/ContentReference';
+import Sig16Icon from '@/components/icons/Sig16Icon';
+import { pathToCite } from '@/logic/utils';
 
 import useDiaryNode from './useDiaryNode';
 

--- a/apps/tlon-web/src/diary/DiaryCommentField.tsx
+++ b/apps/tlon-web/src/diary/DiaryCommentField.tsx
@@ -1,3 +1,8 @@
+import { Editor } from '@tiptap/react';
+import cn from 'classnames';
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
 import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
 import {
   fetchChatBlocks,
@@ -21,10 +26,6 @@ import { pathToCite } from '@/logic/utils';
 import { useAddReplyMutation, useReply } from '@/state/channel/channel';
 import { Cite, Kind, Story } from '@/types/channel';
 import { Inline } from '@/types/content';
-import { Editor } from '@tiptap/react';
-import cn from 'classnames';
-import { useCallback, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 interface DiaryCommentFieldProps {
   flag: string;

--- a/apps/tlon-web/src/diary/DiaryCommenters.tsx
+++ b/apps/tlon-web/src/diary/DiaryCommenters.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
+
 import Avatar from '@/components/Avatar';
 import IconButton from '@/components/IconButton';
 import Bubble16Icon from '@/components/icons/Bubble16Icon';
 import BubbleIcon from '@/components/icons/BubbleIcon';
 import { pluralize } from '@/logic/utils';
-import React from 'react';
 
 interface DiaryCommentersProps {
   replyCount: number;

--- a/apps/tlon-web/src/diary/DiaryContent/DiaryContent.test.tsx
+++ b/apps/tlon-web/src/diary/DiaryContent/DiaryContent.test.tsx
@@ -1,5 +1,6 @@
-import { Inline } from '@/types/content';
 import { describe, expect, it } from 'vitest';
+
+import { Inline } from '@/types/content';
 
 import { groupByParagraph } from './DiaryContent';
 

--- a/apps/tlon-web/src/diary/DiaryContent/DiaryContent.tsx
+++ b/apps/tlon-web/src/diary/DiaryContent/DiaryContent.tsx
@@ -1,3 +1,10 @@
+import cn from 'classnames';
+import { toH } from 'hast-to-hyperscript';
+import _ from 'lodash';
+import React from 'react';
+import hoon from 'refractor/lang/hoon.js';
+import { refractor } from 'refractor/lib/common.js';
+
 // eslint-disable-next-line import/no-cycle
 import ContentReference from '@/components/References/ContentReference';
 import { useIsDark } from '@/logic/useMedia';
@@ -13,12 +20,6 @@ import {
   isLink,
   isStrikethrough,
 } from '@/types/content';
-import cn from 'classnames';
-import { toH } from 'hast-to-hyperscript';
-import _ from 'lodash';
-import React from 'react';
-import hoon from 'refractor/lang/hoon.js';
-import { refractor } from 'refractor/lib/common.js';
 
 import DiaryContentImage from './DiaryContentImage';
 

--- a/apps/tlon-web/src/diary/DiaryContent/DiaryContentImage.tsx
+++ b/apps/tlon-web/src/diary/DiaryContent/DiaryContentImage.tsx
@@ -1,5 +1,6 @@
-import { useCalm } from '@/state/settings';
 import React from 'react';
+
+import { useCalm } from '@/state/settings';
 
 interface DiaryContentImage {
   src: string;

--- a/apps/tlon-web/src/diary/DiaryHeader.tsx
+++ b/apps/tlon-web/src/diary/DiaryHeader.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
 import ChannelHeader from '@/channels/ChannelHeader';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
@@ -14,9 +18,6 @@ import {
   usePutEntryMutation,
 } from '@/state/settings';
 import { DisplayMode } from '@/types/channel';
-import cn from 'classnames';
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 
 interface DiaryHeaderProps {
   groupFlag: string;

--- a/apps/tlon-web/src/diary/DiaryImageNode.tsx
+++ b/apps/tlon-web/src/diary/DiaryImageNode.tsx
@@ -1,13 +1,14 @@
+import { Node, NodeViewProps } from '@tiptap/core';
+import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
+import cn from 'classnames';
+import React, { useEffect, useRef, useState } from 'react';
+
 import { UploadErrorPopover } from '@/chat/ChatInput/ChatInput';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import Asterisk16Icon from '@/components/icons/Asterisk16Icon';
 import LinkIcon from '@/components/icons/LinkIcon';
 import { useCalm } from '@/state/settings';
 import { useUploader } from '@/state/storage';
-import { Node, NodeViewProps } from '@tiptap/core';
-import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
-import cn from 'classnames';
-import React, { useEffect, useRef, useState } from 'react';
 
 import useDiaryNode from './useDiaryNode';
 

--- a/apps/tlon-web/src/diary/DiaryInlineEditor.tsx
+++ b/apps/tlon-web/src/diary/DiaryInlineEditor.tsx
@@ -1,10 +1,3 @@
-import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
-import IconButton from '@/components/IconButton';
-import getMentionPopup from '@/components/Mention/MentionPopup';
-import AddIcon16 from '@/components/icons/Add16Icon';
-import { Shortcuts } from '@/logic/tiptap';
-import { useIsMobile } from '@/logic/useMedia';
-import { useCalm } from '@/state/settings';
 import * as Popover from '@radix-ui/react-popover';
 import { EditorOptions, KeyboardShortcutCommand, Range } from '@tiptap/core';
 import Blockquote from '@tiptap/extension-blockquote';
@@ -38,6 +31,14 @@ import {
 } from '@tiptap/react';
 import cn from 'classnames';
 import { useState } from 'react';
+
+import ChatInputMenu from '@/chat/ChatInputMenu/ChatInputMenu';
+import IconButton from '@/components/IconButton';
+import getMentionPopup from '@/components/Mention/MentionPopup';
+import AddIcon16 from '@/components/icons/Add16Icon';
+import { Shortcuts } from '@/logic/tiptap';
+import { useIsMobile } from '@/logic/useMedia';
+import { useCalm } from '@/state/settings';
 
 import DiaryCiteNode from './DiaryCiteNode';
 import DiaryImageNode from './DiaryImageNode';

--- a/apps/tlon-web/src/diary/DiaryLinkNode.tsx
+++ b/apps/tlon-web/src/diary/DiaryLinkNode.tsx
@@ -1,4 +1,3 @@
-import LinkIcon from '@/components/icons/LinkIcon';
 import { Node, NodeViewProps } from '@tiptap/core';
 import {
   NodeViewContent,
@@ -6,6 +5,8 @@ import {
   ReactNodeViewRenderer,
 } from '@tiptap/react';
 import React from 'react';
+
+import LinkIcon from '@/components/icons/LinkIcon';
 
 import useDiaryNode from './useDiaryNode';
 

--- a/apps/tlon-web/src/diary/DiaryList/DiaryGridItem.tsx
+++ b/apps/tlon-web/src/diary/DiaryList/DiaryGridItem.tsx
@@ -1,9 +1,10 @@
+import cn from 'classnames';
+import { useNavigate } from 'react-router';
+
 import getKindDataFromEssay from '@/logic/getKindData';
 import { useIsPostUndelivered, usePostToggler } from '@/state/channel/channel';
 import { useCalm } from '@/state/settings';
 import { Post } from '@/types/channel';
-import cn from 'classnames';
-import { useNavigate } from 'react-router';
 
 import DiaryNoteHeadline from '../DiaryNoteHeadline';
 

--- a/apps/tlon-web/src/diary/DiaryList/DiaryGridView.tsx
+++ b/apps/tlon-web/src/diary/DiaryList/DiaryGridView.tsx
@@ -1,6 +1,3 @@
-import DiaryGridItem from '@/diary/DiaryList/DiaryGridItem';
-import { useIsMobile } from '@/logic/useMedia';
-import { PageTuple, Post } from '@/types/channel';
 import {
   RenderComponentProps,
   useInfiniteLoader,
@@ -9,6 +6,10 @@ import {
   useResizeObserver,
 } from 'masonic';
 import React, { useRef } from 'react';
+
+import DiaryGridItem from '@/diary/DiaryList/DiaryGridItem';
+import { useIsMobile } from '@/logic/useMedia';
+import { PageTuple, Post } from '@/types/channel';
 
 interface DiaryGridProps {
   outlines: PageTuple[];

--- a/apps/tlon-web/src/diary/DiaryList/DiaryListItem.tsx
+++ b/apps/tlon-web/src/diary/DiaryList/DiaryListItem.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { useNavigate } from 'react-router';
+
 import DiaryNoteHeadline from '@/diary/DiaryNoteHeadline';
 import {
   useIsPostPending,
@@ -5,8 +8,6 @@ import {
   usePostToggler,
 } from '@/state/channel/channel';
 import { Post } from '@/types/channel';
-import cn from 'classnames';
-import { useNavigate } from 'react-router';
 
 interface DiaryListItemProps {
   note: Post;

--- a/apps/tlon-web/src/diary/DiaryMarkdownEditor.tsx
+++ b/apps/tlon-web/src/diary/DiaryMarkdownEditor.tsx
@@ -1,5 +1,3 @@
-import { PATP_REGEX, REF_REGEX } from '@/logic/utils';
-import { JSONContent } from '@/types/content';
 // currently importing from tiptap, but this could be imported directly from
 // prosemirror when/if we ditch tiptap
 import { Node, DOMParser as PMDomParser, Schema } from '@tiptap/pm/model';
@@ -12,6 +10,9 @@ import {
 } from 'prosemirror-markdown';
 import { useEffect, useState } from 'react';
 import ob from 'urbit-ob';
+
+import { PATP_REGEX, REF_REGEX } from '@/logic/utils';
+import { JSONContent } from '@/types/content';
 
 import parserRules from './parserRules';
 import schema from './schema';

--- a/apps/tlon-web/src/diary/DiaryNote.tsx
+++ b/apps/tlon-web/src/diary/DiaryNote.tsx
@@ -1,3 +1,9 @@
+import { udToDec } from '@urbit/api';
+import bigInt from 'big-integer';
+import { useCallback, useEffect, useMemo } from 'react';
+import { Helmet } from 'react-helmet';
+import { useLocation, useNavigate, useParams } from 'react-router';
+
 import Divider from '@/components/Divider';
 import Layout from '@/components/Layout/Layout';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
@@ -31,11 +37,6 @@ import { useDiaryCommentSortMode } from '@/state/settings';
 import { useConnectivityCheck } from '@/state/vitals';
 import { Post, Posts } from '@/types/channel';
 import { ViewProps } from '@/types/groups';
-import { udToDec } from '@urbit/api';
-import bigInt from 'big-integer';
-import { useCallback, useEffect, useMemo } from 'react';
-import { Helmet } from 'react-helmet';
-import { useLocation, useNavigate, useParams } from 'react-router';
 
 import DiaryCommentField from './DiaryCommentField';
 import DiaryContent from './DiaryContent/DiaryContent';

--- a/apps/tlon-web/src/diary/DiaryNoteHeader.tsx
+++ b/apps/tlon-web/src/diary/DiaryNoteHeader.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { Link } from 'react-router-dom';
+
 import ChannelIcon from '@/channels/ChannelIcon';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
@@ -6,8 +9,6 @@ import { useChannelCompatibility } from '@/logic/channel';
 import { useIsMobile } from '@/logic/useMedia';
 import { getNestShip } from '@/logic/utils';
 import { useConnectivityCheck } from '@/state/vitals';
-import cn from 'classnames';
-import { Link } from 'react-router-dom';
 
 export interface DiaryNoteHeaderProps {
   title: string;

--- a/apps/tlon-web/src/diary/DiaryNoteHeadline.tsx
+++ b/apps/tlon-web/src/diary/DiaryNoteHeadline.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import { format } from 'date-fns';
+import { useNavigate } from 'react-router-dom';
+
 import Author from '@/chat/ChatMessage/Author';
 import IconButton from '@/components/IconButton';
 import CheckIcon from '@/components/icons/CheckIcon';
@@ -11,9 +15,6 @@ import { usePostToggler } from '@/state/channel/channel';
 import { useAmAdmin, useRouteGroup } from '@/state/groups/groups';
 import { useCalm } from '@/state/settings';
 import { PostEssay } from '@/types/channel';
-import cn from 'classnames';
-import { format } from 'date-fns';
-import { useNavigate } from 'react-router-dom';
 
 import useDiaryActions from './useDiaryActions';
 

--- a/apps/tlon-web/src/diary/DiaryNoteOptionsDropdown.tsx
+++ b/apps/tlon-web/src/diary/DiaryNoteOptionsDropdown.tsx
@@ -1,3 +1,7 @@
+import classNames from 'classnames';
+import React, { PropsWithChildren, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import { useChannelCompatibility } from '@/logic/channel';
@@ -8,9 +12,6 @@ import {
   usePostToggler,
 } from '@/state/channel/channel';
 import { useFlaggedData, useRouteGroup } from '@/state/groups';
-import classNames from 'classnames';
-import React, { PropsWithChildren, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import useDiaryActions from './useDiaryActions';
 

--- a/apps/tlon-web/src/diary/NoteReactions/NoteReaction.tsx
+++ b/apps/tlon-web/src/diary/NoteReactions/NoteReaction.tsx
@@ -1,3 +1,7 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+import cn from 'classnames';
+import React, { useCallback, useEffect } from 'react';
+
 import ShipName from '@/components/ShipName';
 import X16Icon from '@/components/icons/X16Icon';
 import {
@@ -5,9 +9,6 @@ import {
   useDeletePostReactMutation,
 } from '@/state/channel/channel';
 import useEmoji from '@/state/emoji';
-import * as Tooltip from '@radix-ui/react-tooltip';
-import cn from 'classnames';
-import React, { useCallback, useEffect } from 'react';
 
 interface NotReactionProps {
   whom: string;

--- a/apps/tlon-web/src/diary/NoteReactions/NoteReactions.tsx
+++ b/apps/tlon-web/src/diary/NoteReactions/NoteReactions.tsx
@@ -1,9 +1,10 @@
+import _ from 'lodash';
+import { useCallback, useState } from 'react';
+
 import EmojiPicker from '@/components/EmojiPicker';
 import AddReactIcon from '@/components/icons/AddReactIcon';
 import { useAddPostReactMutation } from '@/state/channel/channel';
 import { PostSeal } from '@/types/channel';
-import _ from 'lodash';
-import { useCallback, useState } from 'react';
 
 import NoteReaction from './NoteReaction';
 

--- a/apps/tlon-web/src/diary/PrismCodeBlock.tsx
+++ b/apps/tlon-web/src/diary/PrismCodeBlock.tsx
@@ -1,4 +1,3 @@
-import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { NodeViewProps, findChildren } from '@tiptap/core';
 import CodeBlock, { CodeBlockOptions } from '@tiptap/extension-code-block';
@@ -13,6 +12,8 @@ import {
 import React, { useState } from 'react';
 import hoon from 'refractor/lang/hoon.js';
 import { refractor } from 'refractor/lib/common.js';
+
+import CaretDown16Icon from '@/components/icons/CaretDown16Icon';
 
 import './PrismCodeBlock.css';
 

--- a/apps/tlon-web/src/diary/diary-add-note.tsx
+++ b/apps/tlon-web/src/diary/diary-add-note.tsx
@@ -1,3 +1,11 @@
+import cn from 'classnames';
+import { isFirstDayOfMonth } from 'date-fns';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+
 import CoverImageInput from '@/components/CoverImageInput';
 import Layout from '@/components/Layout/Layout';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
@@ -23,13 +31,6 @@ import { useGroup, useGroupChannel, useRouteGroup } from '@/state/groups';
 import { useMarkdownInDiaries, usePutEntryMutation } from '@/state/settings';
 import { constructStory } from '@/types/channel';
 import { JSONContent } from '@/types/content';
-import cn from 'classnames';
-import { isFirstDayOfMonth } from 'date-fns';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate, useParams } from 'react-router';
-import { Link } from 'react-router-dom';
 
 import DiaryInlineEditor, { useDiaryInlineEditor } from './DiaryInlineEditor';
 import DiaryMarkdownEditor from './DiaryMarkdownEditor';

--- a/apps/tlon-web/src/diary/plugins/actionmenu.tsx
+++ b/apps/tlon-web/src/diary/plugins/actionmenu.tsx
@@ -1,9 +1,3 @@
-import useLeap from '@/components/Leap/useLeap';
-import CheckIcon from '@/components/icons/CheckIcon';
-import CodeIcon from '@/components/icons/CodeIcon';
-import ShapesIcon from '@/components/icons/ShapesIcon';
-import Sig16Icon from '@/components/icons/Sig16Icon';
-import keyMap from '@/keyMap';
 import { Range } from '@tiptap/core';
 import { PluginKey } from '@tiptap/pm/state';
 import { Editor, Extension, ReactRenderer } from '@tiptap/react';
@@ -11,6 +5,13 @@ import Suggestion, { SuggestionOptions } from '@tiptap/suggestion';
 import cn from 'classnames';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import tippy from 'tippy.js';
+
+import useLeap from '@/components/Leap/useLeap';
+import CheckIcon from '@/components/icons/CheckIcon';
+import CodeIcon from '@/components/icons/CodeIcon';
+import ShapesIcon from '@/components/icons/ShapesIcon';
+import Sig16Icon from '@/components/icons/Sig16Icon';
+import keyMap from '@/keyMap';
 
 const ActionMenuPluginKey = new PluginKey('action-menu');
 

--- a/apps/tlon-web/src/diary/useDiaryActions.ts
+++ b/apps/tlon-web/src/diary/useDiaryActions.ts
@@ -1,12 +1,13 @@
+import { decToUd } from '@urbit/api';
+import { MouseEvent, useCallback, useState } from 'react';
+import { useNavigate } from 'react-router';
+
 import { citeToPath, useCopy } from '@/logic/utils';
 import {
   useArrangedPosts,
   useArrangedPostsMutation,
   useDeletePostMutation,
 } from '@/state/channel/channel';
-import { decToUd } from '@urbit/api';
-import { MouseEvent, useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
 
 interface useDiaryActionsParams {
   flag: string;

--- a/apps/tlon-web/src/dms/DMHero.tsx
+++ b/apps/tlon-web/src/dms/DMHero.tsx
@@ -1,7 +1,8 @@
-import { useModalNavigate } from '@/logic/routing';
-import { Contact } from '@/types/contact';
 import { Patp } from '@urbit/api';
 import { useLocation } from 'react-router';
+
+import { useModalNavigate } from '@/logic/routing';
+import { Contact } from '@/types/contact';
 
 import Avatar from '../components/Avatar';
 import ShipName from '../components/ShipName';

--- a/apps/tlon-web/src/dms/DMOptions.tsx
+++ b/apps/tlon-web/src/dms/DMOptions.tsx
@@ -1,3 +1,13 @@
+import cn from 'classnames';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
+
 import { useChatStore } from '@/chat/useChatStore';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Dialog from '@/components/Dialog';
@@ -19,15 +29,6 @@ import {
   useDeletePinMutation,
   usePinnedChats,
 } from '@/state/pins';
-import cn from 'classnames';
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
-import { useLocation, useNavigate } from 'react-router';
-import { Link } from 'react-router-dom';
 
 import DmInviteDialog from './DmInviteDialog';
 

--- a/apps/tlon-web/src/dms/DMThread.tsx
+++ b/apps/tlon-web/src/dms/DMThread.tsx
@@ -1,3 +1,18 @@
+import bigInt from 'big-integer';
+import cn from 'classnames';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+import { VirtuosoHandle } from 'react-virtuoso';
+import ob from 'urbit-ob';
+import { useEventListener } from 'usehooks-ts';
+
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
@@ -22,20 +37,6 @@ import {
   useWrit,
 } from '@/state/chat';
 import { ReplyTuple } from '@/types/channel';
-import bigInt from 'big-integer';
-import cn from 'classnames';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import { Link } from 'react-router-dom';
-import { VirtuosoHandle } from 'react-virtuoso';
-import ob from 'urbit-ob';
-import { useEventListener } from 'usehooks-ts';
 
 export default function DMThread() {
   const { chShip, ship, chName, idTime, idShip } = useParams<{

--- a/apps/tlon-web/src/dms/Dm.tsx
+++ b/apps/tlon-web/src/dms/Dm.tsx
@@ -1,3 +1,15 @@
+import cn from 'classnames';
+import React, { useCallback, useMemo, useRef } from 'react';
+import {
+  Outlet,
+  Route,
+  Routes,
+  useMatch,
+  useNavigate,
+  useParams,
+} from 'react-router';
+import { Link } from 'react-router-dom';
+
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import Avatar from '@/components/Avatar';
 import Layout from '@/components/Layout/Layout';
@@ -23,17 +35,6 @@ import { useContact } from '@/state/contact';
 import { useNegotiate } from '@/state/negotiation';
 import { useConnectivityCheck } from '@/state/vitals';
 import { Contact } from '@/types/contact';
-import cn from 'classnames';
-import React, { useCallback, useMemo, useRef } from 'react';
-import {
-  Outlet,
-  Route,
-  Routes,
-  useMatch,
-  useNavigate,
-  useParams,
-} from 'react-router';
-import { Link } from 'react-router-dom';
 
 import DmSearch from './DmSearch';
 import MessageSelector from './MessageSelector';

--- a/apps/tlon-web/src/dms/DmInvite.tsx
+++ b/apps/tlon-web/src/dms/DmInvite.tsx
@@ -1,6 +1,7 @@
-import { useDmRsvpMutation } from '@/state/chat';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
+
+import { useDmRsvpMutation } from '@/state/chat';
 
 import X16Icon from '../components/icons/X16Icon';
 import { useContact } from '../state/contact';

--- a/apps/tlon-web/src/dms/DmSearch.tsx
+++ b/apps/tlon-web/src/dms/DmSearch.tsx
@@ -1,6 +1,7 @@
+import { useParams } from 'react-router';
+
 import ChatSearch, { ChatSearchProps } from '@/chat/ChatSearch/ChatSearch';
 import { useInfiniteChatSearch } from '@/state/chat/search';
-import { useParams } from 'react-router';
 
 export default function DmSearch(
   props: Omit<ChatSearchProps, 'scan' | 'query' | 'isLoading' | 'endReached'>

--- a/apps/tlon-web/src/dms/DmWindow.tsx
+++ b/apps/tlon-web/src/dms/DmWindow.tsx
@@ -1,3 +1,9 @@
+import { udToDec } from '@urbit/api';
+import bigInt from 'big-integer';
+import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { VirtuosoHandle } from 'react-virtuoso';
+
 import ChatScroller from '@/chat/ChatScroller/ChatScroller';
 import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
 import DMUnreadAlerts from '@/chat/DMUnreadAlerts';
@@ -7,11 +13,6 @@ import { useIsScrolling } from '@/logic/scroll';
 import { getPatdaParts, log } from '@/logic/utils';
 import { useInfiniteDMs, useMarkDmReadMutation } from '@/state/chat';
 import { WritTuple } from '@/types/dms';
-import { udToDec } from '@urbit/api';
-import bigInt from 'big-integer';
-import { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { VirtuosoHandle } from 'react-virtuoso';
 
 interface DmWindowProps {
   whom: string;

--- a/apps/tlon-web/src/dms/MessageSelector.tsx
+++ b/apps/tlon-web/src/dms/MessageSelector.tsx
@@ -1,10 +1,11 @@
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 import ShipSelector from '@/components/ShipSelector';
 import { useSafeAreaInsets } from '@/logic/native';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
 import { dmListPath } from '@/logic/utils';
-import React, { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 export default function MessageSelector() {
   const { onEnter, setShips, ships } = useMessageSelector();

--- a/apps/tlon-web/src/dms/MessagesList.tsx
+++ b/apps/tlon-web/src/dms/MessagesList.tsx
@@ -1,3 +1,7 @@
+import { deSig } from '@urbit/api';
+import React, { PropsWithChildren, useEffect, useMemo, useRef } from 'react';
+import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+
 import { InlineEmptyPlaceholder } from '@/components/EmptyPlaceholder';
 import { canReadChannel } from '@/logic/channel';
 import { useIsMobile } from '@/logic/useMedia';
@@ -10,9 +14,6 @@ import { usePinnedChats } from '@/state/pins';
 import { SidebarFilter, filters } from '@/state/settings';
 import { Unread } from '@/types/channel';
 import { DMUnread } from '@/types/dms';
-import { deSig } from '@urbit/api';
-import React, { PropsWithChildren, useEffect, useMemo, useRef } from 'react';
-import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
 import {
   useDmUnreads,

--- a/apps/tlon-web/src/dms/MessagesSidebarItem.tsx
+++ b/apps/tlon-web/src/dms/MessagesSidebarItem.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect, useState } from 'react';
+
 import ClubName from '@/components/ClubName';
 import useLongPress from '@/logic/useLongPress';
-import React, { useEffect, useState } from 'react';
 
 import Avatar, { AvatarSizes } from '../components/Avatar';
 import ShipName from '../components/ShipName';

--- a/apps/tlon-web/src/dms/MobileDmSearch.tsx
+++ b/apps/tlon-web/src/dms/MobileDmSearch.tsx
@@ -1,3 +1,7 @@
+import { useRef, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { VirtuosoHandle } from 'react-virtuoso';
+
 import ChatSearchResults from '@/chat/ChatSearch/ChatSearchResults';
 import SearchBar from '@/chat/ChatSearch/SearchBar';
 import Layout from '@/components/Layout/Layout';
@@ -5,9 +9,6 @@ import { useSafeAreaInsets } from '@/logic/native';
 import useDebounce from '@/logic/useDebounce';
 import { useInfiniteChatSearch } from '@/state/chat/search';
 import { useSearchState } from '@/state/chat/search';
-import { useRef, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import { VirtuosoHandle } from 'react-virtuoso';
 
 export default function MobileDmSearch() {
   const params = useParams<{

--- a/apps/tlon-web/src/dms/MobileMessagesSidebar.tsx
+++ b/apps/tlon-web/src/dms/MobileMessagesSidebar.tsx
@@ -1,11 +1,12 @@
-import MobileHeader from '@/components/MobileHeader';
-import ReconnectingSpinner from '@/components/ReconnectingSpinner';
-import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
-import { usePinnedChats } from '@/state/pins';
 import cn from 'classnames';
 import { debounce } from 'lodash';
 import { useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+
+import MobileHeader from '@/components/MobileHeader';
+import ReconnectingSpinner from '@/components/ReconnectingSpinner';
+import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
+import { usePinnedChats } from '@/state/pins';
 
 import MessagesList from './MessagesList';
 import { MessagesScrollingContext } from './MessagesScrollingContext';

--- a/apps/tlon-web/src/dms/MultiDMEditModal.tsx
+++ b/apps/tlon-web/src/dms/MultiDMEditModal.tsx
@@ -1,3 +1,7 @@
+import React, { useCallback, useState } from 'react';
+import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+
 import Avatar from '@/components/Avatar';
 import ShipConnection from '@/components/ShipConnection';
 import ShipName from '@/components/ShipName';
@@ -6,9 +10,6 @@ import { useDismissNavigate } from '@/logic/routing';
 import { pluralize } from '@/logic/utils';
 import { useMultiDm } from '@/state/chat';
 import { useConnectivityCheck } from '@/state/vitals';
-import React, { useCallback, useState } from 'react';
-import { useParams } from 'react-router';
-import { Link } from 'react-router-dom';
 
 import Dialog from '../components/Dialog';
 import MultiDMInfoForm from './MultiDMInfoForm';

--- a/apps/tlon-web/src/dms/MultiDMInfoForm.tsx
+++ b/apps/tlon-web/src/dms/MultiDMInfoForm.tsx
@@ -1,3 +1,8 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import React, { useCallback, useEffect, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+
 import ImageOrColorField, {
   ImageOrColorFieldState,
 } from '@/components/ImageOrColorField';
@@ -9,10 +14,6 @@ import { Status } from '@/logic/status';
 import { isValidUrl } from '@/logic/utils';
 import { useEditMultiDm, useMultiDm } from '@/state/chat';
 import { GroupMeta } from '@/types/groups';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import React, { useCallback, useEffect, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
 
 interface MultiDMInfoFormProps {
   setEditing: (editing: boolean) => void;

--- a/apps/tlon-web/src/dms/MultiDMPendingIndicator.tsx
+++ b/apps/tlon-web/src/dms/MultiDMPendingIndicator.tsx
@@ -1,6 +1,7 @@
-import useShipNames from '@/logic/useShipNames';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import React from 'react';
+
+import useShipNames from '@/logic/useShipNames';
 
 export default function PendingIndicator({ hive }: { hive: string[] }) {
   const hiveNames = useShipNames({ ships: hive });

--- a/apps/tlon-web/src/dms/MultiDm.tsx
+++ b/apps/tlon-web/src/dms/MultiDm.tsx
@@ -1,3 +1,15 @@
+import cn from 'classnames';
+import React, { useCallback, useRef } from 'react';
+import {
+  Outlet,
+  Route,
+  Routes,
+  useMatch,
+  useNavigate,
+  useParams,
+} from 'react-router';
+import { Link } from 'react-router-dom';
+
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import ClubName from '@/components/ClubName';
 import Layout from '@/components/Layout/Layout';
@@ -15,17 +27,6 @@ import { dmListPath, pluralize } from '@/logic/utils';
 import { useMultiDm, useMultiDmIsPending, useSendMessage } from '@/state/chat';
 import { useNegotiateMulti } from '@/state/negotiation';
 import { Club } from '@/types/dms';
-import cn from 'classnames';
-import React, { useCallback, useRef } from 'react';
-import {
-  Outlet,
-  Route,
-  Routes,
-  useMatch,
-  useNavigate,
-  useParams,
-} from 'react-router';
-import { Link } from 'react-router-dom';
 
 import DmOptions from './DMOptions';
 import DmSearch from './DmSearch';

--- a/apps/tlon-web/src/dms/MultiDmAvatar.tsx
+++ b/apps/tlon-web/src/dms/MultiDmAvatar.tsx
@@ -1,8 +1,9 @@
+import cn from 'classnames';
+import React, { useState } from 'react';
+
 import GroupAvatar from '@/groups/GroupAvatar';
 import { isColor } from '@/logic/utils';
 import { useAvatar } from '@/state/avatar';
-import cn from 'classnames';
-import React, { useState } from 'react';
 
 import PeopleIcon from '../components/icons/PeopleIcon';
 

--- a/apps/tlon-web/src/dms/MultiDmHero.tsx
+++ b/apps/tlon-web/src/dms/MultiDmHero.tsx
@@ -1,6 +1,7 @@
-import ClubName from '@/components/ClubName';
 import cn from 'classnames';
 import React from 'react';
+
+import ClubName from '@/components/ClubName';
 
 import { pluralize } from '../logic/utils';
 import { Club } from '../types/dms';

--- a/apps/tlon-web/src/dms/NewDm.tsx
+++ b/apps/tlon-web/src/dms/NewDm.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import React, { useMemo, useRef } from 'react';
+
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import Layout from '@/components/Layout/Layout';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
@@ -8,8 +11,6 @@ import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
 import { dmListPath } from '@/logic/utils';
-import cn from 'classnames';
-import React, { useMemo, useRef } from 'react';
 
 import MessageSelector from './MessageSelector';
 

--- a/apps/tlon-web/src/dms/TalkHead.tsx
+++ b/apps/tlon-web/src/dms/TalkHead.tsx
@@ -1,11 +1,12 @@
+import _ from 'lodash';
+import { useMemo } from 'react';
+import { Helmet } from 'react-helmet';
+
 import { canReadChannel } from '@/logic/channel';
 import { useChannels, useUnreads } from '@/state/channel/channel';
 import { useDmUnreads, useMultiDms } from '@/state/chat';
 import { useGroups } from '@/state/groups';
 import { useMessagesFilter } from '@/state/settings';
-import _ from 'lodash';
-import { useMemo } from 'react';
-import { Helmet } from 'react-helmet';
 
 export default function TalkHead() {
   const messagesFilter = useMessagesFilter();

--- a/apps/tlon-web/src/eyrie/Eyrie.tsx
+++ b/apps/tlon-web/src/eyrie/Eyrie.tsx
@@ -1,7 +1,8 @@
-import { Fact, useEyreState } from '@/state/eyre';
 import * as Accordion from '@radix-ui/react-accordion';
 import cn from 'classnames';
 import React from 'react';
+
+import { Fact, useEyreState } from '@/state/eyre';
 
 import Subscription from './Subscription';
 

--- a/apps/tlon-web/src/eyrie/EyrieMenu.tsx
+++ b/apps/tlon-web/src/eyrie/EyrieMenu.tsx
@@ -1,6 +1,7 @@
-import { EyreState, useEyreState } from '@/state/eyre';
 import * as Popover from '@radix-ui/react-popover';
 import React from 'react';
+
+import { EyreState, useEyreState } from '@/state/eyre';
 
 import Eyrie from './Eyrie';
 

--- a/apps/tlon-web/src/eyrie/Subscription.tsx
+++ b/apps/tlon-web/src/eyrie/Subscription.tsx
@@ -1,7 +1,8 @@
-import { Fact, Subscription as SubscriptionType } from '@/state/eyre';
 import * as Accordion from '@radix-ui/react-accordion';
 import cn from 'classnames';
 import React, { useEffect, useRef, useState } from 'react';
+
+import { Fact, Subscription as SubscriptionType } from '@/state/eyre';
 
 interface SubscriptionProps {
   sub: SubscriptionType;

--- a/apps/tlon-web/src/groups/AddGroup/CreateGroup.tsx
+++ b/apps/tlon-web/src/groups/AddGroup/CreateGroup.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Dialog from '@/components/Dialog';
 import LargeTextInput from '@/components/FullsizeTextInput';
 import LargePrimaryButton from '@/components/LargePrimaryButton';
@@ -6,7 +8,6 @@ import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
 import { useDismissNavigate } from '@/logic/routing';
 import useCreateDefaultGroup from '@/logic/useCreateDefaultGroup';
 import { strToSym } from '@/logic/utils';
-import { useState } from 'react';
 
 export function CreateGroupSheetView(props: { back: () => void }) {
   return (

--- a/apps/tlon-web/src/groups/AddGroup/JoinGroup.tsx
+++ b/apps/tlon-web/src/groups/AddGroup/JoinGroup.tsx
@@ -1,3 +1,7 @@
+import { DialogTitle } from '@radix-ui/react-dialog';
+import cn from 'classnames';
+import { useRef, useState } from 'react';
+
 import Dialog from '@/components/Dialog';
 import LargeTextInput from '@/components/FullsizeTextInput';
 import ShipSelector, { ShipOption } from '@/components/ShipSelector';
@@ -5,9 +9,6 @@ import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
 import { useDismissNavigate } from '@/logic/routing';
 import { whomIsFlag } from '@/logic/utils';
 import { useGangs, useGroups } from '@/state/groups';
-import { DialogTitle } from '@radix-ui/react-dialog';
-import cn from 'classnames';
-import { useRef, useState } from 'react';
 
 import { MobileGroupPreview } from '../Join/GroupPreview';
 import InvitedGroupsDisplay from './InvitedGroupsDisplay';

--- a/apps/tlon-web/src/groups/AddGroup/SearchResults.tsx
+++ b/apps/tlon-web/src/groups/AddGroup/SearchResults.tsx
@@ -1,3 +1,5 @@
+import cn from 'classnames';
+
 import Avatar from '@/components/Avatar';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ShipName from '@/components/ShipName';
@@ -5,7 +7,6 @@ import SidebarItem from '@/components/Sidebar/SidebarItem';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { useGang, useGroup } from '@/state/groups';
 import { Gang } from '@/types/groups';
-import cn from 'classnames';
 
 import GroupAvatar from '../GroupAvatar';
 

--- a/apps/tlon-web/src/groups/AddGroup/useGroupSearch.ts
+++ b/apps/tlon-web/src/groups/AddGroup/useGroupSearch.ts
@@ -1,7 +1,8 @@
-import { useGroupIndex } from '@/state/groups';
-import { useConnectivityCheck } from '@/state/vitals';
 import { preSig } from '@urbit/api';
 import { isValidPatp } from 'urbit-ob';
+
+import { useGroupIndex } from '@/state/groups';
+import { useConnectivityCheck } from '@/state/vitals';
 
 export interface SearchResult {
   flags: string[];

--- a/apps/tlon-web/src/groups/AddGroup/useShipSearch.ts
+++ b/apps/tlon-web/src/groups/AddGroup/useShipSearch.ts
@@ -1,10 +1,11 @@
-import { MAX_DISPLAYED_OPTIONS } from '@/constants';
-import { useMemoizedContacts } from '@/state/contact';
 import { deSig, preSig } from '@urbit/api';
 import fuzzy from 'fuzzy';
 import _ from 'lodash';
 import { useMemo } from 'react';
 import { isValidPatp } from 'urbit-ob';
+
+import { MAX_DISPLAYED_OPTIONS } from '@/constants';
+import { useMemoizedContacts } from '@/state/contact';
 
 export default function useShipSearch(
   query: string

--- a/apps/tlon-web/src/groups/AddGroupSheet.tsx
+++ b/apps/tlon-web/src/groups/AddGroupSheet.tsx
@@ -1,9 +1,10 @@
+import cn from 'classnames';
+import { useState } from 'react';
+
 import WidgetDrawer from '@/components/WidgetDrawer';
 import HomeIconMobileNav from '@/components/icons/HomeIconMobileNav';
 import NewRaysIcon from '@/components/icons/NewRaysIcon';
 import { isNativeApp } from '@/logic/native';
-import cn from 'classnames';
-import { useState } from 'react';
 
 import { CreateGroupSheetView as CreateGroup } from './AddGroup/CreateGroup';
 import JoinGroupSheet from './AddGroup/JoinGroup';

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelJoinSelector.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelJoinSelector.tsx
@@ -1,7 +1,8 @@
-import CheckIcon from '@/components/icons/CheckIcon';
-import { ChannelFormSchema } from '@/types/groups';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+
+import CheckIcon from '@/components/icons/CheckIcon';
+import { ChannelFormSchema } from '@/types/groups';
 
 export default function ChannelJoinSelector() {
   const { register, watch } = useFormContext<ChannelFormSchema>();

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelManagerHeader.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelManagerHeader.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { Link, useLocation } from 'react-router-dom';
+
 import Tooltip from '@/components/Tooltip';
 import { useIsMobile } from '@/logic/useMedia';
 import {
@@ -5,8 +8,6 @@ import {
   useGroupCompatibility,
   useRouteGroup,
 } from '@/state/groups';
-import cn from 'classnames';
-import { Link, useLocation } from 'react-router-dom';
 
 import GroupHostConnection from '../GroupHostConnection';
 import ChannelsListSearch from './ChannelsListSearch';

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelPermsSelector.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelPermsSelector.tsx
@@ -1,12 +1,13 @@
-import CheckIcon from '@/components/icons/CheckIcon';
-import { useGroup, useRouteGroup } from '@/state/groups';
-import { ChannelFormSchema, ChannelPrivacyType } from '@/types/groups';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import cn from 'classnames';
 import { AnimatePresence, motion } from 'framer-motion';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+
+import CheckIcon from '@/components/icons/CheckIcon';
+import { useGroup, useRouteGroup } from '@/state/groups';
+import { ChannelFormSchema, ChannelPrivacyType } from '@/types/groups';
 
 interface ChannelPrivacySetting {
   title: string;

--- a/apps/tlon-web/src/groups/ChannelsList/Channels.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/Channels.tsx
@@ -1,11 +1,12 @@
+import React from 'react';
+import { Draggable, Droppable } from 'react-beautiful-dnd';
+
 import ChannelsListItem from '@/groups/ChannelsList/ChannelsListItem';
 import {
   useAmAdmin,
   useGroupCompatibility,
   useRouteGroup,
 } from '@/state/groups';
-import React from 'react';
-import { Draggable, Droppable } from 'react-beautiful-dnd';
 
 import EmptySectionTools from './EmptySectionTools';
 import { ChannelListItem } from './types';

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelsList.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelsList.tsx
@@ -1,6 +1,7 @@
+import React, { useCallback, useMemo } from 'react';
+
 import { canReadChannel } from '@/logic/channel';
 import { useGroup, useRouteGroup, useVessel } from '@/state/groups';
-import React, { useCallback, useMemo } from 'react';
 
 import ChannelsListDropContext from './ChannelsListDropContext';
 import { SectionMap } from './types';

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelsListDropContext.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelsListDropContext.tsx
@@ -1,10 +1,3 @@
-import {
-  useAddChannelMutation,
-  useAmAdmin,
-  useGroupMoveChannelMutation,
-  useGroupMoveZoneMutation,
-  useRouteGroup,
-} from '@/state/groups';
 import { formatUv } from '@urbit/aura';
 import bigInt from 'big-integer';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -13,6 +6,14 @@ import {
   DraggableLocation,
   DropResult,
 } from 'react-beautiful-dnd';
+
+import {
+  useAddChannelMutation,
+  useAmAdmin,
+  useGroupMoveChannelMutation,
+  useGroupMoveZoneMutation,
+  useRouteGroup,
+} from '@/state/groups';
 
 import ChannelManagerHeader from './ChannelManagerHeader';
 import ChannelsListSections from './ChannelsListSections';

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelsListItem.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelsListItem.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useCallback, useState } from 'react';
+import { DraggableProvided, DraggableStateSnapshot } from 'react-beautiful-dnd';
+
 import ChannelIcon from '@/channels/ChannelIcon';
 import Tooltip from '@/components/Tooltip';
 import SixDotIcon from '@/components/icons/SixDotIcon';
@@ -22,9 +26,6 @@ import {
   useRouteGroup,
 } from '@/state/groups';
 import { GroupChannel } from '@/types/groups';
-import cn from 'classnames';
-import React, { useCallback, useState } from 'react';
-import { DraggableProvided, DraggableStateSnapshot } from 'react-beautiful-dnd';
 
 interface ChannelsListItemProps {
   nest: string;

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelsListSearch.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelsListSearch.tsx
@@ -1,6 +1,7 @@
-import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
 import cn from 'classnames';
 import React, { ChangeEvent } from 'react';
+
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
 
 import useChannelListSearch from './useChannelListSearch';
 

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelsListSections.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelsListSections.tsx
@@ -1,6 +1,7 @@
-import { useAmAdmin, useRouteGroup } from '@/state/groups';
 import React from 'react';
 import { Droppable } from 'react-beautiful-dnd';
+
+import { useAmAdmin, useRouteGroup } from '@/state/groups';
 
 import Section from './Section';
 import { SectionMap } from './types';

--- a/apps/tlon-web/src/groups/ChannelsList/DeleteChannelModal.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/DeleteChannelModal.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
+
 import Dialog from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { Status } from '@/logic/status';
 import { GroupChannel } from '@/types/groups';
-import React from 'react';
 
 interface DeleteChannelModalProps {
   deleteChannelIsOpen: boolean;

--- a/apps/tlon-web/src/groups/ChannelsList/EditChannelModal.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/EditChannelModal.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
+
 import EditChannelForm from '@/channels/EditChannelForm';
 import Dialog from '@/components/Dialog';
 import { prettyChannelTypeName } from '@/logic/channel';
 import { GroupChannel } from '@/types/groups';
-import React from 'react';
 
 interface EditChannelModalProps {
   nest: string;

--- a/apps/tlon-web/src/groups/ChannelsList/EditSectionDropdown.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/EditSectionDropdown.tsx
@@ -1,9 +1,10 @@
+import cn from 'classnames';
+import { useState } from 'react';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import ElipsisIcon from '@/components/icons/EllipsisIcon';
 import { useGroupCompatibility, useRouteGroup } from '@/state/groups';
-import cn from 'classnames';
-import { useState } from 'react';
 
 interface EditSectionDropDownProps {
   handleEditClick: () => void;

--- a/apps/tlon-web/src/groups/ChannelsList/EmptySectionTools.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/EmptySectionTools.tsx
@@ -1,6 +1,7 @@
-import { useRouteGroup } from '@/state/groups';
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+
+import { useRouteGroup } from '@/state/groups';
 
 interface EmptySectionToolsProps {
   sectionKey: string;

--- a/apps/tlon-web/src/groups/ChannelsList/GroupChannelManager.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/GroupChannelManager.tsx
@@ -1,8 +1,9 @@
+import { Helmet } from 'react-helmet';
+
 import MobileHeader from '@/components/MobileHeader';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroup, useRouteGroup } from '@/state/groups/groups';
 import { ViewProps } from '@/types/groups';
-import { Helmet } from 'react-helmet';
 
 import GroupActions from '../GroupActions';
 import GroupAvatar from '../GroupAvatar';

--- a/apps/tlon-web/src/groups/ChannelsList/Section.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/Section.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Draggable } from 'react-beautiful-dnd';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import PinIcon16 from '@/components/icons/PinIcon16';
 import SixDotIcon from '@/components/icons/SixDotIcon';
@@ -13,9 +17,6 @@ import {
   useGroupDeleteZoneMutation,
   useRouteGroup,
 } from '@/state/groups';
-import cn from 'classnames';
-import React, { useCallback, useEffect, useState } from 'react';
-import { Draggable } from 'react-beautiful-dnd';
 
 interface SectionProps {
   sectionData: SectionListItem;

--- a/apps/tlon-web/src/groups/ChannelsList/SectionNameEditInput.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/SectionNameEditInput.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
 import { strToSym } from '@/logic/utils';
 import {
   useGroupCreateZoneMutation,
@@ -6,8 +9,6 @@ import {
   useRouteGroup,
 } from '@/state/groups';
 import { GroupMeta } from '@/types/groups';
-import React from 'react';
-import { useForm } from 'react-hook-form';
 
 interface HandleSectionNameEditInputProps {
   handleEditingChange: () => void;

--- a/apps/tlon-web/src/groups/FindGroups.tsx
+++ b/apps/tlon-web/src/groups/FindGroups.tsx
@@ -1,3 +1,9 @@
+import cn from 'classnames';
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import ob from 'urbit-ob';
+
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import ShipConnection from '@/components/ShipConnection';
@@ -12,11 +18,6 @@ import {
 } from '@/state/groups';
 import { useConnectivityCheck } from '@/state/vitals';
 import { Gangs, ViewProps } from '@/types/groups';
-import cn from 'classnames';
-import React, { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import ob from 'urbit-ob';
 
 import GroupJoinList, { GroupJoinItem } from './GroupJoinList';
 import GroupJoinListPlaceholder from './GroupJoinListPlaceholder';

--- a/apps/tlon-web/src/groups/GroupActions.tsx
+++ b/apps/tlon-web/src/groups/GroupActions.tsx
@@ -1,3 +1,12 @@
+import cn from 'classnames';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import UnreadIndicator from '@/components/Sidebar/UnreadIndicator';
 import VolumeSetting from '@/components/VolumeSetting';
@@ -13,14 +22,6 @@ import {
   usePinnedGroups,
 } from '@/state/groups';
 import { useAddPinMutation, useDeletePinMutation } from '@/state/pins';
-import cn from 'classnames';
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import GroupHostConnection from './GroupHostConnection';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupAdmin.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupAdmin.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
 import MobileHeader from '@/components/MobileHeader';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import AddPersonIcon from '@/components/icons/AddPersonIcon';
@@ -7,8 +10,6 @@ import PeopleIcon from '@/components/icons/PeopleIcon';
 import XIcon from '@/components/icons/XIcon';
 import { useIsMobile } from '@/logic/useMedia';
 import { useAmAdmin, useRouteGroup } from '@/state/groups/groups';
-import React from 'react';
-import { Outlet } from 'react-router-dom';
 
 export default function GroupAdmin() {
   const flag = useRouteGroup();

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupDelete.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupDelete.tsx
@@ -1,3 +1,6 @@
+import React, { ChangeEvent, useCallback, useState } from 'react';
+import { useNavigate } from 'react-router';
+
 import Dialog, { DialogClose } from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
@@ -9,8 +12,6 @@ import {
   useGroupCompatibility,
   useRouteGroup,
 } from '@/state/groups';
-import React, { ChangeEvent, useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
 
 const removeSpecialChars = (s: string) =>
   s.toLocaleLowerCase().replace(/[^\w\s]/gi, '');

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfo.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
 import Dialog from '@/components/Dialog';
 import { useDismissNavigate } from '@/logic/routing';
 import { ViewProps } from '@/types/groups';
-import React from 'react';
-import { Helmet } from 'react-helmet';
 
 import { useGroup, useRouteGroup } from '../../state/groups/groups';
 import GroupSummary from '../GroupSummary';

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfoEditor.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfoEditor.tsx
@@ -1,3 +1,7 @@
+import React, { useCallback } from 'react';
+import { Helmet } from 'react-helmet';
+import { FormProvider, useForm } from 'react-hook-form';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
 import Tooltip from '@/components/Tooltip';
@@ -18,9 +22,6 @@ import {
   PrivacyType,
   ViewProps,
 } from '@/types/groups';
-import React, { useCallback } from 'react';
-import { Helmet } from 'react-helmet';
-import { FormProvider, useForm } from 'react-hook-form';
 
 import GroupInfoFields from './GroupInfoFields';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInfoFields.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInfoFields.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
 import ImageOrColorField, {
   ImageOrColorFieldState,
 } from '@/components/ImageOrColorField';
@@ -6,9 +10,6 @@ import { useIsMobile } from '@/logic/useMedia';
 import { isValidUrl } from '@/logic/utils';
 import { useCalm } from '@/state/settings';
 import { GroupMeta } from '@/types/groups';
-import cn from 'classnames';
-import React, { useEffect, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
 
 export default function GroupInfoFields() {
   const {

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupInvitesPrivacy.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupInvitesPrivacy.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
 import MobileHeader from '@/components/MobileHeader';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroup, useRouteGroup } from '@/state/groups';
 import { ViewProps } from '@/types/groups';
-import React from 'react';
-import { Helmet } from 'react-helmet';
 
 import { GroupInviteBlock } from '../GroupInviteDialog';
 import LureInviteBlock from '../LureInviteBlock';

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupMemberItem.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupMemberItem.tsx
@@ -1,3 +1,9 @@
+import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import cn from 'classnames';
+import _ from 'lodash';
+import React, { useCallback, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import Avatar from '@/components/Avatar';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
@@ -22,11 +28,6 @@ import {
   useVessel,
 } from '@/state/groups';
 import { Vessel } from '@/types/groups';
-import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import cn from 'classnames';
-import _ from 'lodash';
-import React, { useCallback, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 interface GroupMemberItemProps {
   member: string;

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupMemberManager.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupMemberManager.tsx
@@ -1,5 +1,3 @@
-import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
-import { useGroup, useRouteGroup } from '@/state/groups/groups';
 import { deSig } from '@urbit/api';
 import cn from 'classnames';
 import fuzzy from 'fuzzy';
@@ -11,6 +9,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
+
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
+import { useGroup, useRouteGroup } from '@/state/groups/groups';
 
 import MemberScroller from './MemberScroller';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupMembers.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupMembers.tsx
@@ -1,9 +1,10 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
 import MobileHeader from '@/components/MobileHeader';
 import { useIsMobile } from '@/logic/useMedia';
 import { useGroup, useRouteGroup } from '@/state/groups/groups';
 import { ViewProps } from '@/types/groups';
-import React from 'react';
-import { Helmet } from 'react-helmet';
 
 import GroupMemberManager from './GroupMemberManager';
 import GroupPendingManager from './GroupPendingManager';

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupPendingManager.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupPendingManager.tsx
@@ -1,5 +1,3 @@
-import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
-import { useGroup, useRouteGroup } from '@/state/groups/groups';
 import { daToUnix, deSig } from '@urbit/api';
 import bigInt from 'big-integer';
 import cn from 'classnames';
@@ -12,6 +10,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
+
+import MagnifyingGlass16Icon from '@/components/icons/MagnifyingGlass16Icon';
+import { useGroup, useRouteGroup } from '@/state/groups/groups';
 
 import PendingScroller from './PendingScroller';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupRoleCreate.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupRoleCreate.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import Tooltip from '@/components/Tooltip';
 import { strToSym } from '@/logic/utils';
@@ -7,8 +10,6 @@ import {
   useGroupCompatibility,
   useRouteGroup,
 } from '@/state/groups';
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router';
 
 type Props = {
   onCreate: () => void;

--- a/apps/tlon-web/src/groups/GroupAdmin/GroupRoles.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/GroupRoles.tsx
@@ -1,3 +1,16 @@
+import fuzzy from 'fuzzy';
+import _, { debounce } from 'lodash';
+import {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Helmet } from 'react-helmet';
+import { Link, useLocation } from 'react-router-dom';
+
 import IconButton from '@/components/IconButton';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
@@ -18,18 +31,6 @@ import {
   useGroupEditRoleMutation,
   useRouteGroup,
 } from '@/state/groups';
-import fuzzy from 'fuzzy';
-import _, { debounce } from 'lodash';
-import {
-  ChangeEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { Helmet } from 'react-helmet';
-import { Link, useLocation } from 'react-router-dom';
 
 import RoleCreate from './GroupRoleCreate';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/MemberScroller.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/MemberScroller.tsx
@@ -1,6 +1,7 @@
-import { useIsMobile } from '@/logic/useMedia';
 import React, { ForwardedRef, forwardRef } from 'react';
 import { Virtuoso, Components as VirtuosoComponents } from 'react-virtuoso';
+
+import { useIsMobile } from '@/logic/useMedia';
 
 import GroupMemberItem from './GroupMemberItem';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/PendingMemberItem.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/PendingMemberItem.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useCallback } from 'react';
+import { useLocation } from 'react-router';
+
 import Avatar from '@/components/Avatar';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ShipName from '@/components/ShipName';
@@ -11,9 +15,6 @@ import {
   useGroupInviteMutation,
   useGroupRevokeMutation,
 } from '@/state/groups';
-import cn from 'classnames';
-import React, { useCallback } from 'react';
-import { useLocation } from 'react-router';
 
 interface PendingMemberItemProps {
   member: string;

--- a/apps/tlon-web/src/groups/GroupAdmin/PendingScroller.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/PendingScroller.tsx
@@ -1,6 +1,7 @@
-import { useIsMobile } from '@/logic/useMedia';
 import React, { forwardRef } from 'react';
 import { Virtuoso, Components as VirtuosoComponents } from 'react-virtuoso';
+
+import { useIsMobile } from '@/logic/useMedia';
 
 import PendingMemberItem from './PendingMemberItem';
 

--- a/apps/tlon-web/src/groups/GroupAdmin/PrivacySelector.tsx
+++ b/apps/tlon-web/src/groups/GroupAdmin/PrivacySelector.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useCallback } from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import Tooltip from '@/components/Tooltip';
 import GlobeIcon from '@/components/icons/GlobeIcon';
@@ -14,9 +18,6 @@ import {
 } from '@/state/groups';
 import { useLure } from '@/state/lure/lure';
 import { GroupFormSchema, GroupMeta, PrivacyType } from '@/types/groups';
-import cn from 'classnames';
-import React, { useCallback } from 'react';
-import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 
 interface PrivacySetting {
   title: string;

--- a/apps/tlon-web/src/groups/GroupAvatar.tsx
+++ b/apps/tlon-web/src/groups/GroupAvatar.tsx
@@ -1,10 +1,11 @@
+import cn from 'classnames';
+import React, { useMemo } from 'react';
+
 import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import { useIsDark } from '@/logic/useMedia';
 import { isColor } from '@/logic/utils';
 import { useAvatar } from '@/state/avatar';
 import { useCalm } from '@/state/settings';
-import cn from 'classnames';
-import React, { useMemo } from 'react';
 
 interface GroupAvatarProps {
   image?: string;

--- a/apps/tlon-web/src/groups/GroupChannel.tsx
+++ b/apps/tlon-web/src/groups/GroupChannel.tsx
@@ -1,7 +1,8 @@
+import { Outlet, useParams } from 'react-router';
+
 import type { AnalyticsChannelType } from '@/logic/analytics';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { useRouteGroup } from '@/state/groups';
-import { Outlet, useParams } from 'react-router';
 
 type Props = {
   type: AnalyticsChannelType;

--- a/apps/tlon-web/src/groups/GroupInviteDialog.tsx
+++ b/apps/tlon-web/src/groups/GroupInviteDialog.tsx
@@ -1,3 +1,8 @@
+import cn from 'classnames';
+import { useCallback, useState } from 'react';
+import { useMatch } from 'react-router-dom';
+import ob from 'urbit-ob';
+
 import Dialog, { DialogClose } from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ShipSelector, { ShipOption } from '@/components/ShipSelector';
@@ -12,10 +17,6 @@ import {
   useGroupInviteMutation,
   useRouteGroup,
 } from '@/state/groups/groups';
-import cn from 'classnames';
-import { useCallback, useState } from 'react';
-import { useMatch } from 'react-router-dom';
-import ob from 'urbit-ob';
 
 import GroupHostConnection from './GroupHostConnection';
 import LureInviteBlock from './LureInviteBlock';

--- a/apps/tlon-web/src/groups/GroupJoinList.tsx
+++ b/apps/tlon-web/src/groups/GroupJoinList.tsx
@@ -1,9 +1,10 @@
+import cn from 'classnames';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import { matchesBans } from '@/logic/utils';
 import { useGang } from '@/state/groups';
 import { Gang, Gangs } from '@/types/groups';
-import cn from 'classnames';
 
 import GroupAvatar from './GroupAvatar';
 import useGroupJoin from './useGroupJoin';

--- a/apps/tlon-web/src/groups/GroupLeaveDialog.tsx
+++ b/apps/tlon-web/src/groups/GroupLeaveDialog.tsx
@@ -1,3 +1,6 @@
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router';
+
 import Dialog, { DialogClose } from '@/components/Dialog';
 import { useDismissNavigate } from '@/logic/routing';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
@@ -6,8 +9,6 @@ import {
   useGroupLeaveMutation,
   useRouteGroup,
 } from '@/state/groups/groups';
-import React, { useCallback } from 'react';
-import { useNavigate } from 'react-router';
 
 export default function GroupInviteDialog() {
   const dismiss = useDismissNavigate();

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.test.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.test.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { createChannel, createMockGroup } from '@/mocks/groups';
-import { Group } from '@/types/groups';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
+
+import { createChannel, createMockGroup } from '@/mocks/groups';
+import { Group } from '@/types/groups';
 
 import { render } from '../../../test/utils';
 import ChannelList from './ChannelList';

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
@@ -1,3 +1,13 @@
+import cn from 'classnames';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
+
 import ChannelIcon from '@/channels/ChannelIcon';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Divider from '@/components/Divider';
@@ -25,15 +35,6 @@ import {
   useVessel,
 } from '@/state/groups';
 import { GroupChannel } from '@/types/groups';
-import cn from 'classnames';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { StateSnapshot, Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
 const UNZONED = 'default';
 

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -1,3 +1,8 @@
+import cn from 'classnames';
+import _ from 'lodash';
+import { useCallback, useContext, useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
 import { foregroundFromBackground } from '@/components/Avatar';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import AddIcon from '@/components/icons/AddIcon';
@@ -20,10 +25,6 @@ import {
   useGroupFlag,
 } from '@/state/groups/groups';
 import { useCalm } from '@/state/settings';
-import cn from 'classnames';
-import _ from 'lodash';
-import { useCallback, useContext, useMemo } from 'react';
-import { Link, useLocation } from 'react-router-dom';
 
 function GroupHeader() {
   const flag = useGroupFlag();

--- a/apps/tlon-web/src/groups/GroupSidebar/MobileGroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/MobileGroupSidebar.tsx
@@ -1,11 +1,12 @@
+import cn from 'classnames';
+import { Outlet, useLocation, useMatch } from 'react-router';
+
 import NavTab from '@/components/NavTab';
 import BellIcon from '@/components/icons/BellIcon';
 import HashIcon from '@/components/icons/HashIcon';
 import { useSafeAreaInsets } from '@/logic/native';
 import { useIsDark } from '@/logic/useMedia';
 import { useGroup, useGroupFlag } from '@/state/groups/groups';
-import cn from 'classnames';
-import { Outlet, useLocation, useMatch } from 'react-router';
 
 import GroupAvatar from '../GroupAvatar';
 

--- a/apps/tlon-web/src/groups/GroupVolumeDialog.tsx
+++ b/apps/tlon-web/src/groups/GroupVolumeDialog.tsx
@@ -1,9 +1,10 @@
+import { Helmet } from 'react-helmet';
+
 import Dialog from '@/components/Dialog';
 import VolumeSetting from '@/components/VolumeSetting';
 import { useDismissNavigate } from '@/logic/routing';
 import { useGroup, useRouteGroup } from '@/state/groups';
 import { ViewProps } from '@/types/groups';
-import { Helmet } from 'react-helmet';
 
 import GroupSummary from './GroupSummary';
 

--- a/apps/tlon-web/src/groups/Groups.tsx
+++ b/apps/tlon-web/src/groups/Groups.tsx
@@ -1,3 +1,8 @@
+import cookies from 'browser-cookies';
+import _ from 'lodash';
+import { useEffect } from 'react';
+import { Outlet, useMatch, useNavigate } from 'react-router';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { canReadChannel } from '@/logic/channel';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
@@ -16,10 +21,6 @@ import {
   useVessel,
 } from '@/state/groups/groups';
 import { useNewGroupFlags, usePutEntryMutation } from '@/state/settings';
-import cookies from 'browser-cookies';
-import _ from 'lodash';
-import { useEffect } from 'react';
-import { Outlet, useMatch, useNavigate } from 'react-router';
 
 function Groups() {
   const navigate = useNavigate();

--- a/apps/tlon-web/src/groups/Join/GroupPreview.tsx
+++ b/apps/tlon-web/src/groups/Join/GroupPreview.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+
 import Dialog from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ShipConnection from '@/components/ShipConnection';
@@ -25,9 +29,6 @@ import {
   useRouteGroup,
 } from '@/state/groups';
 import { useConnectivityCheck } from '@/state/vitals';
-import cn from 'classnames';
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
 
 import GroupAvatar from '../GroupAvatar';
 

--- a/apps/tlon-web/src/groups/Join/RejectConfirmModal.tsx
+++ b/apps/tlon-web/src/groups/Join/RejectConfirmModal.tsx
@@ -1,11 +1,12 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
+
 import Dialog from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useDismissNavigate } from '@/logic/routing';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { toTitleCase } from '@/logic/utils';
 import { useGang, useGroupRejectMutation, useRouteGroup } from '@/state/groups';
-import React, { useCallback, useEffect, useRef } from 'react';
-import { useLocalStorage } from 'usehooks-ts';
 
 const PRIVATE_COPY =
   "If you reject this invite, you'll need to send a membership request in order to join this group.";

--- a/apps/tlon-web/src/groups/LureAutojoiner.tsx
+++ b/apps/tlon-web/src/groups/LureAutojoiner.tsx
@@ -1,12 +1,13 @@
+import cookies from 'browser-cookies';
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
 import { getPrivacyFromGang } from '@/logic/utils';
 import {
   useGroupJoinMutation,
   usePendingGangsWithoutClaim,
 } from '@/state/groups';
 import { Gangs } from '@/types/groups';
-import cookies from 'browser-cookies';
-import { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router';
 
 export default function LureAutojoiner(): React.ReactElement {
   const { mutateAsync: joinMutation } = useGroupJoinMutation();

--- a/apps/tlon-web/src/groups/LureInviteBlock.tsx
+++ b/apps/tlon-web/src/groups/LureInviteBlock.tsx
@@ -1,10 +1,11 @@
+import cn from 'classnames';
+import { useEffect } from 'react';
+
 import QRWidget, { QRWidgetPlaceholder } from '@/components/QRWidget';
 import CheckIcon from '@/components/icons/CheckIcon';
 import { isGroupHost } from '@/logic/utils';
 import { useLureLinkStatus } from '@/state/lure/lure';
 import { Group } from '@/types/groups';
-import cn from 'classnames';
-import { useEffect } from 'react';
 
 interface LureInviteBlock {
   flag: string;

--- a/apps/tlon-web/src/groups/Members.tsx
+++ b/apps/tlon-web/src/groups/Members.tsx
@@ -1,3 +1,15 @@
+import { deSig } from '@urbit/api';
+import fuzzy from 'fuzzy';
+import { debounce } from 'lodash';
+import React, {
+  ChangeEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Avatar from '@/components/Avatar';
 import ConfirmationModal from '@/components/ConfirmationModal';
@@ -21,17 +33,6 @@ import {
   useRouteGroup,
   useSects,
 } from '@/state/groups';
-import { deSig } from '@urbit/api';
-import fuzzy from 'fuzzy';
-import { debounce } from 'lodash';
-import React, {
-  ChangeEvent,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 import RoleSelect from './RoleInput/RoleSelector';
 import SetRolesDialog from './RoleInput/SetRolesDialog';

--- a/apps/tlon-web/src/groups/MobileGroupChannelList.tsx
+++ b/apps/tlon-web/src/groups/MobileGroupChannelList.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { Link, useLocation } from 'react-router-dom';
+
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
@@ -7,8 +10,6 @@ import { useTextColor } from '@/logic/useTextColor';
 import { isColor } from '@/logic/utils';
 import { useAmAdmin, useGroup, useGroupFlag } from '@/state/groups';
 import { useCalm } from '@/state/settings';
-import cn from 'classnames';
-import { Link, useLocation } from 'react-router-dom';
 
 import GroupActions from './GroupActions';
 import GroupHostConnection from './GroupHostConnection';

--- a/apps/tlon-web/src/groups/NewGroup/GroupInfoPreview.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/GroupInfoPreview.tsx
@@ -1,9 +1,10 @@
+import cn from 'classnames';
+import React from 'react';
+
 import { ImageOrColorFieldState } from '@/components/ImageOrColorField';
 import EmptyIconBox from '@/components/icons/EmptyIconBox';
 import GroupAvatar from '@/groups/GroupAvatar';
 import { isValidUrl } from '@/logic/utils';
-import cn from 'classnames';
-import React from 'react';
 
 interface GroupInfoPreviewProps {
   iconType: ImageOrColorFieldState;

--- a/apps/tlon-web/src/groups/NewGroup/NewGroup.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/NewGroup.tsx
@@ -1,3 +1,7 @@
+import { ReactElement, useCallback, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+
 import NavigationDots from '@/components/NavigationDots';
 import NewGroupForm from '@/groups/NewGroup/NewGroupForm';
 import NewGroupInvite from '@/groups/NewGroup/NewGroupInvite';
@@ -5,9 +9,6 @@ import NewGroupPrivacy from '@/groups/NewGroup/NewGroupPrivacy';
 import { strToSym } from '@/logic/utils';
 import { useCreateGroupMutation } from '@/state/groups';
 import { Cordon, GroupFormSchema } from '@/types/groups';
-import { ReactElement, useCallback, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
 
 export type Role = 'Member' | 'Admin';
 

--- a/apps/tlon-web/src/groups/NewGroup/NewGroupDialog.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/NewGroupDialog.tsx
@@ -1,6 +1,7 @@
+import { useStep } from 'usehooks-ts';
+
 import Dialog from '@/components/Dialog';
 import { useDismissNavigate } from '@/logic/routing';
-import { useStep } from 'usehooks-ts';
 
 import NewGroup from './NewGroup';
 

--- a/apps/tlon-web/src/groups/NewGroup/NewGroupForm.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/NewGroupForm.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
+
 import GroupInfoFields from '@/groups/GroupAdmin/GroupInfoFields';
 import { useDismissNavigate } from '@/logic/routing';
 import { useIsMobile } from '@/logic/useMedia';
-import React from 'react';
 
 interface NewGroupFormProps {
   isValid: boolean;

--- a/apps/tlon-web/src/groups/NewGroup/NewGroupInvite.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/NewGroupInvite.tsx
@@ -1,3 +1,8 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import cn from 'classnames';
+import _ from 'lodash';
+import React, { useCallback, useState } from 'react';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Avatar from '@/components/Avatar';
 import IconButton from '@/components/IconButton';
@@ -9,10 +14,6 @@ import X16Icon from '@/components/icons/X16Icon';
 import XIcon from '@/components/icons/XIcon';
 import { Status } from '@/logic/status';
 import { PrivacyType } from '@/types/groups';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import cn from 'classnames';
-import _ from 'lodash';
-import React, { useCallback, useState } from 'react';
 
 interface NewGroupInviteProps {
   groupName: string;

--- a/apps/tlon-web/src/groups/NewGroup/NewGroupView.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/NewGroupView.tsx
@@ -1,5 +1,6 @@
-import MobileHeader from '@/components/MobileHeader';
 import { useStep } from 'usehooks-ts';
+
+import MobileHeader from '@/components/MobileHeader';
 
 import NewGroup from './NewGroup';
 

--- a/apps/tlon-web/src/groups/NewGroup/TemplateOrScratch.tsx
+++ b/apps/tlon-web/src/groups/NewGroup/TemplateOrScratch.tsx
@@ -1,5 +1,6 @@
-import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 import React from 'react';
+
+import ColorBoxIcon from '@/components/icons/ColorBoxIcon';
 
 interface TemplateOrScratchProps {
   next: (templateType?: string) => void;

--- a/apps/tlon-web/src/groups/PrivacyNotice.tsx
+++ b/apps/tlon-web/src/groups/PrivacyNotice.tsx
@@ -1,7 +1,8 @@
-import Dialog from '@/components/Dialog';
-import { useDismissNavigate } from '@/logic/routing';
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+
+import Dialog from '@/components/Dialog';
+import { useDismissNavigate } from '@/logic/routing';
 
 export function PrivacyContents({ className }: { className?: string }) {
   const { state } = useLocation();

--- a/apps/tlon-web/src/groups/RoleInput/RoleSelector.tsx
+++ b/apps/tlon-web/src/groups/RoleInput/RoleSelector.tsx
@@ -1,3 +1,5 @@
+import { MouseEvent, useCallback, useState } from 'react';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import CheckIcon from '@/components/icons/CheckIcon';
 import ExclamationPoint from '@/components/icons/ExclamationPoint';
@@ -9,7 +11,6 @@ import {
   useVessel,
 } from '@/state/groups';
 import { Vessel } from '@/types/groups';
-import { MouseEvent, useCallback, useState } from 'react';
 
 export default function RoleSelect({
   role,

--- a/apps/tlon-web/src/groups/useGroupJoin.ts
+++ b/apps/tlon-web/src/groups/useGroupJoin.ts
@@ -1,3 +1,6 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 import { useDismissNavigate, useModalNavigate } from '@/logic/routing';
 import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import {
@@ -11,8 +14,6 @@ import {
 import { useSawRopeMutation } from '@/state/hark';
 import { useNewGroupFlags, usePutEntryMutation } from '@/state/settings';
 import { Gang, Group, PrivacyType } from '@/types/groups';
-import { useCallback, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
 
 function getButtonText(
   privacy: PrivacyType,

--- a/apps/tlon-web/src/heap/AddCurioModal.tsx
+++ b/apps/tlon-web/src/heap/AddCurioModal.tsx
@@ -1,3 +1,6 @@
+import { JSONContent } from '@tiptap/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
 import Dialog from '@/components/Dialog';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { PASTEABLE_MEDIA_TYPES } from '@/constants';
@@ -8,8 +11,6 @@ import useGroupPrivacy from '@/logic/useGroupPrivacy';
 import { useIsMobile } from '@/logic/useMedia';
 import { useAddPostMutation } from '@/state/channel/channel';
 import { useFileStore, useUploader } from '@/state/storage';
-import { JSONContent } from '@tiptap/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import CurioPreview, { canPreview } from './CurioPreview';
 import NewCurioInput, { EditorUpdate } from './NewCurioInput';

--- a/apps/tlon-web/src/heap/CurioPreview.tsx
+++ b/apps/tlon-web/src/heap/CurioPreview.tsx
@@ -1,9 +1,10 @@
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
-import ContentReference from '@/components/References/ContentReference';
-import { isImageUrl, isRef, pathToCite } from '@/logic/utils';
 import cn from 'classnames';
 import { useEffect, useState } from 'react';
 import isURL from 'validator/lib/isURL';
+
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+import ContentReference from '@/components/References/ContentReference';
+import { isImageUrl, isRef, pathToCite } from '@/logic/utils';
 
 export function canPreview(text: string) {
   return (

--- a/apps/tlon-web/src/heap/EditCurioForm.tsx
+++ b/apps/tlon-web/src/heap/EditCurioForm.tsx
@@ -1,3 +1,9 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { JSONContent } from '@tiptap/core';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router';
+
 import ConfirmationModal from '@/components/ConfirmationModal';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useChannelFlag } from '@/logic/channel';
@@ -10,11 +16,6 @@ import { useEditPostMutation, usePost } from '@/state/channel/channel';
 import { useRouteGroup } from '@/state/groups';
 import { chatStoryFromStory, storyFromChatStory } from '@/types/channel';
 import { Inline } from '@/types/content';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { JSONContent } from '@tiptap/core';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useNavigate, useParams } from 'react-router';
 
 import HeapTextInput from './HeapTextInput';
 import useCurioActions from './useCurioActions';

--- a/apps/tlon-web/src/heap/HeapBlock.tsx
+++ b/apps/tlon-web/src/heap/HeapBlock.tsx
@@ -1,3 +1,8 @@
+import cn from 'classnames';
+import { formatDistanceToNow } from 'date-fns';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import Avatar from '@/components/Avatar';
 import ConfirmationModal from '@/components/ConfirmationModal';
@@ -30,10 +35,6 @@ import {
 } from '@/state/groups/groups';
 import { useCalm } from '@/state/settings';
 import { Post, Story, imageUrlFromContent, isCite } from '@/types/channel';
-import cn from 'classnames';
-import { formatDistanceToNow } from 'date-fns';
-import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
 
 import useCurioActions from './useCurioActions';
 

--- a/apps/tlon-web/src/heap/HeapChannel.tsx
+++ b/apps/tlon-web/src/heap/HeapChannel.tsx
@@ -1,3 +1,10 @@
+import * as Toast from '@radix-ui/react-toast';
+import bigInt from 'big-integer';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Outlet, useParams } from 'react-router';
+import { GridStateSnapshot, VirtuosoGrid } from 'react-virtuoso';
+
 import EmptyPlaceholder from '@/components/EmptyPlaceholder';
 import Layout from '@/components/Layout/Layout';
 import X16Icon from '@/components/icons/X16Icon';
@@ -15,12 +22,6 @@ import { useHeapDisplayMode, useHeapSortMode } from '@/state/settings';
 import { useUploader } from '@/state/storage';
 import { PageTuple, Post } from '@/types/channel';
 import { ViewProps } from '@/types/groups';
-import * as Toast from '@radix-ui/react-toast';
-import bigInt from 'big-integer';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { Outlet, useParams } from 'react-router';
-import { GridStateSnapshot, VirtuosoGrid } from 'react-virtuoso';
 
 import HeapHeader from './HeapHeader';
 import HeapPlaceholder from './HeapPlaceholder';

--- a/apps/tlon-web/src/heap/HeapDetail.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail.tsx
@@ -1,3 +1,9 @@
+import bigInt from 'big-integer';
+import cn from 'classnames';
+import { Helmet } from 'react-helmet';
+import { useParams } from 'react-router';
+import { Link, useLocation } from 'react-router-dom';
+
 import Layout from '@/components/Layout/Layout';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import CaretLeftIcon from '@/components/icons/CaretLeftIcon';
@@ -15,11 +21,6 @@ import {
 import { useRouteGroup } from '@/state/groups';
 import { Post, newReplyMap } from '@/types/channel';
 import { ViewProps } from '@/types/groups';
-import bigInt from 'big-integer';
-import cn from 'classnames';
-import { Helmet } from 'react-helmet';
-import { useParams } from 'react-router';
-import { Link, useLocation } from 'react-router-dom';
 
 import HeapDetailBody from './HeapDetail/HeapDetailBody';
 import HeapDetailHeader from './HeapDetail/HeapDetailHeader';

--- a/apps/tlon-web/src/heap/HeapDetail/EmbedFallback.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/EmbedFallback.tsx
@@ -1,5 +1,6 @@
-import LinkIcon from '@/components/icons/LinkIcon';
 import React from 'react';
+
+import LinkIcon from '@/components/icons/LinkIcon';
 
 export default function EmbedFallback({ url }: { url: string }) {
   return (

--- a/apps/tlon-web/src/heap/HeapDetail/HeapDetailBody.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/HeapDetailBody.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import ContentReference from '@/components/References/ContentReference';
 import HeapAudioPlayer from '@/heap/HeapAudioPlayer';
@@ -16,7 +18,6 @@ import {
   imageUrlFromContent,
   isCite,
 } from '@/types/channel';
-import { useEffect } from 'react';
 
 import HeapVideoPlayer from '../HeapVideoPlayer';
 import HeapVimeoPlayer from '../HeapVimeoPlayer';

--- a/apps/tlon-web/src/heap/HeapDetail/HeapDetailEmbed.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/HeapDetailEmbed.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /* eslint-disable react/no-danger */
-import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
 import cn from 'classnames';
 import DOMPurify from 'dompurify';
 import React from 'react';
 import EmbedContainer from 'react-oembed-container';
+
+import EmbedFallback from '@/heap/HeapDetail/EmbedFallback';
 
 interface HeapDetailEmbedProps {
   oembed: any;

--- a/apps/tlon-web/src/heap/HeapDetail/HeapDetailHeader.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/HeapDetailHeader.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { Link } from 'react-router-dom';
+
 import ChannelIcon from '@/channels/ChannelIcon';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
@@ -11,8 +14,6 @@ import { isImageUrl, makePrettyDayAndTime } from '@/logic/utils';
 import { useAmAdmin } from '@/state/groups';
 import { PostEssay, chatStoryFromStory } from '@/types/channel';
 import { isLink } from '@/types/content';
-import cn from 'classnames';
-import { Link } from 'react-router-dom';
 
 import useCurioActions from '../useCurioActions';
 

--- a/apps/tlon-web/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailCommentField.tsx
@@ -1,7 +1,8 @@
+import { useParams } from 'react-router';
+
 import DiaryCommentField from '@/diary/DiaryCommentField';
 import { useChannelFlag } from '@/logic/channel';
 import { useRouteGroup } from '@/state/groups';
-import { useParams } from 'react-router';
 
 export default function HeapDetailCommentField() {
   const { idTime } = useParams();

--- a/apps/tlon-web/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail/HeapDetailSidebar/HeapDetailComments.tsx
@@ -1,3 +1,7 @@
+import bigInt from 'big-integer';
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
 import ChatScrollerPlaceholder from '@/chat/ChatScroller/ChatScrollerPlaceholder';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { canWriteChannel, useChannelFlag } from '@/logic/channel';
@@ -7,9 +11,6 @@ import { usePerms, useUnread } from '@/state/channel/channel';
 import { useGroup, useRouteGroup, useVessel } from '@/state/groups/groups';
 import { useDiaryCommentSortMode } from '@/state/settings';
 import { ReplyTuple } from '@/types/channel';
-import bigInt from 'big-integer';
-import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import HeapDetailCommentField from './HeapDetailCommentField';
 

--- a/apps/tlon-web/src/heap/HeapHeader.tsx
+++ b/apps/tlon-web/src/heap/HeapHeader.tsx
@@ -1,3 +1,7 @@
+import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import cn from 'classnames';
+import React, { useEffect, useState } from 'react';
+
 import ChannelHeader from '@/channels/ChannelHeader';
 import DisplayDropdown from '@/channels/DisplayDropdown';
 import ActionMenu, { Action } from '@/components/ActionMenu';
@@ -16,9 +20,6 @@ import {
   usePutEntryMutation,
 } from '@/state/settings';
 import { DisplayMode, SortMode } from '@/types/channel';
-import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import cn from 'classnames';
-import React, { useEffect, useState } from 'react';
 
 import AddCurioModal from './AddCurioModal';
 

--- a/apps/tlon-web/src/heap/HeapLoadingBlock.tsx
+++ b/apps/tlon-web/src/heap/HeapLoadingBlock.tsx
@@ -1,5 +1,6 @@
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import React from 'react';
+
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 
 export default function HeapLoadingBlock({
   reference = false,

--- a/apps/tlon-web/src/heap/HeapLoadingRow.tsx
+++ b/apps/tlon-web/src/heap/HeapLoadingRow.tsx
@@ -1,5 +1,6 @@
-import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import React from 'react';
+
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 
 export default function HeapLoadingRow() {
   return (

--- a/apps/tlon-web/src/heap/HeapPlaceholder.tsx
+++ b/apps/tlon-web/src/heap/HeapPlaceholder.tsx
@@ -1,7 +1,8 @@
-import { useIsMobile } from '@/logic/useMedia';
-import { randomElement } from '@/logic/utils';
 import cn from 'classnames';
 import * as React from 'react';
+
+import { useIsMobile } from '@/logic/useMedia';
+import { randomElement } from '@/logic/utils';
 
 interface ChatScrollerPlaceholderProps {
   count: number;

--- a/apps/tlon-web/src/heap/HeapRow.tsx
+++ b/apps/tlon-web/src/heap/HeapRow.tsx
@@ -1,3 +1,11 @@
+import { daToUnix } from '@urbit/api';
+import bigInt from 'big-integer';
+import cn from 'classnames';
+import { formatDistanceToNow } from 'date-fns';
+import _ from 'lodash';
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+
 import Avatar from '@/components/Avatar';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import IconButton from '@/components/IconButton';
@@ -26,13 +34,6 @@ import {
 } from '@/state/groups/groups';
 import { useCalm } from '@/state/settings';
 import { Post, Story, VerseBlock, imageUrlFromContent } from '@/types/channel';
-import { daToUnix } from '@urbit/api';
-import bigInt from 'big-integer';
-import cn from 'classnames';
-import { formatDistanceToNow } from 'date-fns';
-import _ from 'lodash';
-import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
 
 import useCurioActions from './useCurioActions';
 

--- a/apps/tlon-web/src/heap/HeapTextInput.tsx
+++ b/apps/tlon-web/src/heap/HeapTextInput.tsx
@@ -1,3 +1,8 @@
+import { Editor, JSONContent } from '@tiptap/react';
+import cn from 'classnames';
+import { reduce } from 'lodash';
+import React, { useCallback, useEffect } from 'react';
+
 import {
   fetchChatBlocks,
   useChatInfo,
@@ -21,10 +26,6 @@ import {
 } from '@/state/channel/channel';
 import { PostEssay, constructStory } from '@/types/channel';
 import { Inline, InlineKey } from '@/types/content';
-import { Editor, JSONContent } from '@tiptap/react';
-import cn from 'classnames';
-import { reduce } from 'lodash';
-import React, { useCallback, useEffect } from 'react';
 
 interface HeapTextInputProps {
   flag: string;

--- a/apps/tlon-web/src/heap/NewCurioInput.tsx
+++ b/apps/tlon-web/src/heap/NewCurioInput.tsx
@@ -1,5 +1,3 @@
-import { Shortcuts } from '@/logic/tiptap';
-import { useCalm } from '@/state/settings';
 import Blockquote from '@tiptap/extension-blockquote';
 import Bold from '@tiptap/extension-bold';
 import Code from '@tiptap/extension-code';
@@ -17,6 +15,9 @@ import { Slice } from '@tiptap/pm/model';
 import { EditorView } from '@tiptap/pm/view';
 import { Editor, EditorContent, JSONContent, useEditor } from '@tiptap/react';
 import { useCallback, useMemo } from 'react';
+
+import { Shortcuts } from '@/logic/tiptap';
+import { useCalm } from '@/state/settings';
 
 interface NewCurioInput {
   placeholder: string;

--- a/apps/tlon-web/src/heap/useCurioActions.ts
+++ b/apps/tlon-web/src/heap/useCurioActions.ts
@@ -1,9 +1,10 @@
-import { citeToPath, nestToFlag, useCopy } from '@/logic/utils';
-import { useDeletePostMutation, usePostToggler } from '@/state/channel/channel';
-import { useGroupFlag } from '@/state/groups';
 import { decToUd } from '@urbit/api';
 import { useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+
+import { citeToPath, nestToFlag, useCopy } from '@/logic/utils';
+import { useDeletePostMutation, usePostToggler } from '@/state/channel/channel';
+import { useGroupFlag } from '@/state/groups';
 
 interface useCurioActionsProps {
   nest: string;

--- a/apps/tlon-web/src/logic/analytics.ts
+++ b/apps/tlon-web/src/logic/analytics.ts
@@ -1,5 +1,6 @@
-import { PrivacyType } from '@/types/groups';
 import posthog, { Properties } from 'posthog-js';
+
+import { PrivacyType } from '@/types/groups';
 
 import { isNativeApp } from './native';
 import { log } from './utils';

--- a/apps/tlon-web/src/logic/channel.ts
+++ b/apps/tlon-web/src/logic/channel.ts
@@ -1,3 +1,7 @@
+import _, { get, groupBy } from 'lodash';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+
 import { ChatStore, useChatStore } from '@/chat/useChatStore';
 import {
   ALPHABETICAL_SORT,
@@ -17,9 +21,6 @@ import { useNegotiate } from '@/state/negotiation';
 import { Perm, Story, Unreads } from '@/types/channel';
 import { isLink } from '@/types/content';
 import { Channels, Group, GroupChannel, Vessel, Zone } from '@/types/groups';
-import _, { get, groupBy } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
 
 import useRecentChannel from './useRecentChannel';
 import useSidebarSort, {

--- a/apps/tlon-web/src/logic/heap.ts
+++ b/apps/tlon-web/src/logic/heap.ts
@@ -1,11 +1,12 @@
 /* eslint-disable */
+import { JSONContent } from '@tiptap/core';
+import { reduce } from 'lodash';
+import isURL from 'validator/lib/isURL';
+
 import { JSONToInlines } from '@/logic/tiptap';
 import { PostEssay, storyFromChatStory } from '@/types/channel';
 import { ChatStory } from '@/types/channel';
 import { Inline, InlineKey } from '@/types/content';
-import { JSONContent } from '@tiptap/core';
-import { reduce } from 'lodash';
-import isURL from 'validator/lib/isURL';
 
 import { isRef, pathToCite } from './utils';
 import { isImageUrl } from './utils';

--- a/apps/tlon-web/src/logic/messageSender.ts
+++ b/apps/tlon-web/src/logic/messageSender.ts
@@ -1,3 +1,5 @@
+import { JSONContent } from '@tiptap/core';
+
 import { CacheId } from '@/state/channel/channel';
 import { SendMessageVariables, SendReplyVariables } from '@/state/chat';
 import { buildAddDelta, createMessage } from '@/state/chat/utils';
@@ -10,7 +12,6 @@ import {
   constructStory,
 } from '@/types/channel';
 import { WritDelta } from '@/types/dms';
-import { JSONContent } from '@tiptap/core';
 
 import { JSONToInlines } from './tiptap';
 import { isImageUrl } from './utils';

--- a/apps/tlon-web/src/logic/tiptap.test.ts
+++ b/apps/tlon-web/src/logic/tiptap.test.ts
@@ -1,8 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { Block } from '@/types/channel';
-import { Inline } from '@/types/content';
 import { JSONContent } from '@tiptap/react';
 import { describe, expect, it } from 'vitest';
+
+import { Block } from '@/types/channel';
+import { Inline } from '@/types/content';
 
 import {
   JSONToInlines,

--- a/apps/tlon-web/src/logic/tiptap.ts
+++ b/apps/tlon-web/src/logic/tiptap.ts
@@ -1,3 +1,13 @@
+import {
+  Editor,
+  Extension,
+  KeyboardShortcutCommand,
+  PasteRule,
+} from '@tiptap/core';
+import { JSONContent } from '@tiptap/react';
+import { deSig } from '@urbit/api';
+import { isEqual, reduce } from 'lodash';
+
 import { Block, Cite, HeaderLevel, Listing, Story } from '@/types/channel';
 import {
   Inline,
@@ -12,15 +22,6 @@ import {
   isShip,
   isStrikethrough,
 } from '@/types/content';
-import {
-  Editor,
-  Extension,
-  KeyboardShortcutCommand,
-  PasteRule,
-} from '@tiptap/core';
-import { JSONContent } from '@tiptap/react';
-import { deSig } from '@urbit/api';
-import { isEqual, reduce } from 'lodash';
 
 import { citeToPath, getFirstInline, pathToCite, preSig } from './utils';
 

--- a/apps/tlon-web/src/logic/useAppUpdates.ts
+++ b/apps/tlon-web/src/logic/useAppUpdates.ts
@@ -1,6 +1,7 @@
-import useKilnState, { usePike } from '@/state/kiln';
 import { createContext, useCallback, useEffect, useState } from 'react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
+
+import useKilnState, { usePike } from '@/state/kiln';
 
 const CHECK_FOR_UPDATES_INTERVAL = 10 * 60 * 1000; // 10 minutes
 

--- a/apps/tlon-web/src/logic/useCreateDefaultGroup.ts
+++ b/apps/tlon-web/src/logic/useCreateDefaultGroup.ts
@@ -1,6 +1,7 @@
+import { useNavigate } from 'react-router';
+
 import { useCreateMutation } from '@/state/channel/channel';
 import { useCreateGroupMutation } from '@/state/groups';
-import { useNavigate } from 'react-router';
 
 export default function useCreateDefaultGroup() {
   const { mutateAsync: createGroupMutation, isLoading } =

--- a/apps/tlon-web/src/logic/useDismissChannelNotifications.ts
+++ b/apps/tlon-web/src/logic/useDismissChannelNotifications.ts
@@ -1,8 +1,9 @@
+import { useEffect } from 'react';
+
 import { useIsChannelUnread } from '@/logic/channel';
 import { useNotifications } from '@/notifications/useNotifications';
 import { useRouteGroup } from '@/state/groups';
 import { useSawRopeMutation } from '@/state/hark';
-import { useEffect } from 'react';
 
 import { nestToFlag } from './utils';
 

--- a/apps/tlon-web/src/logic/useGroupSort.ts
+++ b/apps/tlon-web/src/logic/useGroupSort.ts
@@ -1,7 +1,8 @@
-import { ALPHABETICAL_SORT, RECENT_SORT } from '@/constants';
-import { Group, Groups } from '@/types/groups';
 import { get } from 'lodash';
 import { useCallback, useMemo } from 'react';
+
+import { ALPHABETICAL_SORT, RECENT_SORT } from '@/constants';
+import { Group, Groups } from '@/types/groups';
 
 import { useChannelSort } from './channel';
 import useSidebarSort, {

--- a/apps/tlon-web/src/logic/useIsGroupUnread.ts
+++ b/apps/tlon-web/src/logic/useIsGroupUnread.ts
@@ -1,5 +1,6 @@
-import { useGroups } from '@/state/groups';
 import { useCallback } from 'react';
+
+import { useGroups } from '@/state/groups';
 
 import { useCheckChannelUnread } from './channel';
 

--- a/apps/tlon-web/src/logic/useMessageSelector.ts
+++ b/apps/tlon-web/src/logic/useMessageSelector.ts
@@ -1,3 +1,9 @@
+import { difference } from 'lodash';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import ob from 'urbit-ob';
+import { useLocalStorage } from 'usehooks-ts';
+
 import { ShipOption } from '@/components/ShipSelector';
 import {
   SendMessageVariables,
@@ -10,11 +16,6 @@ import {
   useForceNegotiationUpdate,
   useNegotiateMulti,
 } from '@/state/negotiation';
-import { difference } from 'lodash';
-import { useCallback, useEffect, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router';
-import ob from 'urbit-ob';
-import { useLocalStorage } from 'usehooks-ts';
 
 import { createStorageKey, newUv } from './utils';
 

--- a/apps/tlon-web/src/logic/useMessagesUnreadCount.ts
+++ b/apps/tlon-web/src/logic/useMessagesUnreadCount.ts
@@ -1,9 +1,10 @@
+import { useMemo } from 'react';
+
 import { nestToFlag, whomIsDm, whomIsMultiDm, whomIsNest } from '@/logic/utils';
 import { useChatStoreChannelUnreads } from '@/state/channel/channel';
 import { useChatStoreDmUnreads } from '@/state/chat';
 import { usePinnedChats } from '@/state/pins';
 import { useMessagesFilter } from '@/state/settings';
-import { useMemo } from 'react';
 
 export default function useMessagesUnreadCount(): number {
   const dmUnreads = useChatStoreDmUnreads();

--- a/apps/tlon-web/src/logic/useReactQueryScry.ts
+++ b/apps/tlon-web/src/logic/useReactQueryScry.ts
@@ -1,7 +1,8 @@
-import api from '@/api';
-import useSchedulerStore from '@/state/scheduler';
 import { QueryKey, UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
+
+import api from '@/api';
+import useSchedulerStore from '@/state/scheduler';
 
 export default function useReactQueryScry<T>({
   queryKey,

--- a/apps/tlon-web/src/logic/useReactQuerySubscribeOnce.tsx
+++ b/apps/tlon-web/src/logic/useReactQuerySubscribeOnce.tsx
@@ -1,5 +1,6 @@
-import api from '@/api';
 import { QueryKey, UseQueryOptions, useQuery } from '@tanstack/react-query';
+
+import api from '@/api';
 
 export default function useReactQuerySubscribeOnce<T>({
   queryKey,

--- a/apps/tlon-web/src/logic/useReactQuerySubscription.tsx
+++ b/apps/tlon-web/src/logic/useReactQuerySubscription.tsx
@@ -1,5 +1,3 @@
-import api from '@/api';
-import useSchedulerStore from '@/state/scheduler';
 import {
   QueryKey,
   UseQueryOptions,
@@ -8,6 +6,9 @@ import {
 } from '@tanstack/react-query';
 import _ from 'lodash';
 import { useEffect, useRef } from 'react';
+
+import api from '@/api';
+import useSchedulerStore from '@/state/scheduler';
 
 export default function useReactQuerySubscription<T, Event = null>({
   queryKey,

--- a/apps/tlon-web/src/logic/useScrollerMessages.ts
+++ b/apps/tlon-web/src/logic/useScrollerMessages.ts
@@ -1,8 +1,9 @@
-import { Post, Reply } from '@/types/channel';
-import { Writ } from '@/types/dms';
 import { daToUnix } from '@urbit/api';
 import bigInt, { BigInteger } from 'big-integer';
 import { useMemo, useRef } from 'react';
+
+import { Post, Reply } from '@/types/channel';
+import { Writ } from '@/types/dms';
 
 import getKindDataFromEssay from './getKindData';
 

--- a/apps/tlon-web/src/logic/useShipNames.ts
+++ b/apps/tlon-web/src/logic/useShipNames.ts
@@ -1,5 +1,6 @@
-import { useContacts } from '@/state/contact';
 import { preSig } from '@urbit/aura';
+
+import { useContacts } from '@/state/contact';
 
 type Props = {
   ships: string[];

--- a/apps/tlon-web/src/logic/useSidebarSort.ts
+++ b/apps/tlon-web/src/logic/useSidebarSort.ts
@@ -1,3 +1,5 @@
+import { useCallback, useMemo } from 'react';
+
 import { DEFAULT_SORT, RECENT_SORT, SortMode } from '@/constants';
 import { useUnreads } from '@/state/channel/channel';
 import { useDmUnreads } from '@/state/chat';
@@ -6,7 +8,6 @@ import {
   usePutEntryMutation,
   useSideBarSortMode,
 } from '@/state/settings';
-import { useCallback, useMemo } from 'react';
 
 import { whomIsDm, whomIsMultiDm } from './utils';
 

--- a/apps/tlon-web/src/logic/utils.ts
+++ b/apps/tlon-web/src/logic/utils.ts
@@ -1,4 +1,25 @@
 import {
+  BigIntOrderedMap,
+  Docket,
+  DocketHref,
+  Treaty,
+  udToDec,
+  unixToDa,
+} from '@urbit/api';
+import { formatUv } from '@urbit/aura';
+import anyAscii from 'any-ascii';
+import bigInt, { BigInteger } from 'big-integer';
+import { hsla, parseToHsla, parseToRgba } from 'color2k';
+import { differenceInDays, endOfToday, format } from 'date-fns';
+import emojiRegex from 'emoji-regex';
+import _ from 'lodash';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router';
+import ob from 'urbit-ob';
+import { useCopyToClipboard } from 'usehooks-ts';
+import isURL from 'validator/es/lib/isURL';
+
+import {
   ChatStory,
   Cite,
   Listing,
@@ -20,26 +41,6 @@ import {
   Rank,
   Saga,
 } from '@/types/groups';
-import {
-  BigIntOrderedMap,
-  Docket,
-  DocketHref,
-  Treaty,
-  udToDec,
-  unixToDa,
-} from '@urbit/api';
-import { formatUv } from '@urbit/aura';
-import anyAscii from 'any-ascii';
-import bigInt, { BigInteger } from 'big-integer';
-import { hsla, parseToHsla, parseToRgba } from 'color2k';
-import { differenceInDays, endOfToday, format } from 'date-fns';
-import emojiRegex from 'emoji-regex';
-import _ from 'lodash';
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { useParams } from 'react-router';
-import ob from 'urbit-ob';
-import { useCopyToClipboard } from 'usehooks-ts';
-import isURL from 'validator/es/lib/isURL';
 
 import type {
   ConnectionCompleteStatus,

--- a/apps/tlon-web/src/mocks/chat.ts
+++ b/apps/tlon-web/src/mocks/chat.ts
@@ -1,11 +1,12 @@
 /* eslint-disable import/no-cycle */
-import { AUTHORS } from '@/constants';
-import { randomElement } from '@/logic/utils';
-import { Post, Posts, Story, storyFromChatStory } from '@/types/channel';
 import faker from '@faker-js/faker';
 import { decToUd, unixToDa } from '@urbit/api';
 import { subDays, subMinutes } from 'date-fns';
 import _ from 'lodash';
+
+import { AUTHORS } from '@/constants';
+import { randomElement } from '@/logic/utils';
+import { Post, Posts, Story, storyFromChatStory } from '@/types/channel';
 
 import { DMUnreads } from '../types/dms';
 

--- a/apps/tlon-web/src/mocks/groups.ts
+++ b/apps/tlon-web/src/mocks/groups.ts
@@ -1,7 +1,8 @@
 /* eslint-disable import/no-cycle */
+import faker from '@faker-js/faker';
+
 import { AUTHORS } from '@/constants';
 import { randomElement } from '@/logic/utils';
-import faker from '@faker-js/faker';
 
 import {
   Cordon,

--- a/apps/tlon-web/src/mocks/handlers.ts
+++ b/apps/tlon-web/src/mocks/handlers.ts
@@ -1,4 +1,18 @@
 /* eslint-disable import/no-cycle */
+import UrbitMock, {
+  Handler,
+  Message,
+  Poke,
+  PokeHandler,
+  ScryHandler,
+  SubscriptionHandler,
+  SubscriptionRequestInterface,
+  createResponse,
+} from '@tloncorp/mock-http-api';
+import { decToUd, udToDec, unixToDa } from '@urbit/api';
+import bigInt from 'big-integer';
+import _ from 'lodash';
+
 import {
   chatKeys,
   dmList,
@@ -23,19 +37,6 @@ import {
   WritDiff,
 } from '@/types/dms';
 import { GroupAction } from '@/types/groups';
-import UrbitMock, {
-  Handler,
-  Message,
-  Poke,
-  PokeHandler,
-  ScryHandler,
-  SubscriptionHandler,
-  SubscriptionRequestInterface,
-  createResponse,
-} from '@tloncorp/mock-http-api';
-import { decToUd, udToDec, unixToDa } from '@urbit/api';
-import bigInt from 'big-integer';
-import _ from 'lodash';
 
 const getNowUd = () => decToUd(unixToDa(Date.now() * 1000).toString());
 

--- a/apps/tlon-web/src/mocks/heaps.ts
+++ b/apps/tlon-web/src/mocks/heaps.ts
@@ -1,10 +1,11 @@
-import { Channels, Perm, Posts } from '@/types/channel';
 import {
   Handler,
   ScryHandler,
   SubscriptionHandler,
 } from '@tloncorp/mock-http-api';
 import { subMinutes } from 'date-fns';
+
+import { Channels, Perm, Posts } from '@/types/channel';
 
 const unixTime = subMinutes(new Date(), 1).getTime();
 

--- a/apps/tlon-web/src/nav/GroupsNav.tsx
+++ b/apps/tlon-web/src/nav/GroupsNav.tsx
@@ -1,3 +1,8 @@
+import cn from 'classnames';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import { Outlet, matchPath, useLocation, useMatch } from 'react-router';
+
 import Sidebar from '@/components/Sidebar/Sidebar';
 import useActiveTab, {
   ActiveTab,
@@ -5,10 +10,6 @@ import useActiveTab, {
 } from '@/components/Sidebar/util';
 import GroupSidebar from '@/groups/GroupSidebar/GroupSidebar';
 import { useIsMobile } from '@/logic/useMedia';
-import cn from 'classnames';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
-import { Outlet, matchPath, useLocation, useMatch } from 'react-router';
 
 export function DesktopNav() {
   const location = useLocation();

--- a/apps/tlon-web/src/nav/MobileRoot.tsx
+++ b/apps/tlon-web/src/nav/MobileRoot.tsx
@@ -1,3 +1,6 @@
+import { debounce } from 'lodash';
+import { useMemo, useRef, useState } from 'react';
+
 import Layout from '@/components/Layout/Layout';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
@@ -19,8 +22,6 @@ import {
   usePendingGangsWithoutClaim,
   usePinnedGroups,
 } from '@/state/groups';
-import { debounce } from 'lodash';
-import { useMemo, useRef, useState } from 'react';
 
 export default function MobileRoot() {
   const [isScrolling, setIsScrolling] = useState(false);

--- a/apps/tlon-web/src/notifications/DMNotification.tsx
+++ b/apps/tlon-web/src/notifications/DMNotification.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
+
 import Avatar from '@/components/Avatar';
 import { useMultiDm } from '@/state/chat';
 import { Skein, isYarnShip } from '@/types/hark';
-import React from 'react';
 
 import Notification from './Notification';
 

--- a/apps/tlon-web/src/notifications/Notification.tsx
+++ b/apps/tlon-web/src/notifications/Notification.tsx
@@ -1,3 +1,9 @@
+import cn from 'classnames';
+import _ from 'lodash';
+import { ReactNode, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import ob from 'urbit-ob';
+
 import ShipName from '@/components/ShipName';
 import Bullet16Icon from '@/components/icons/Bullet16Icon';
 import useGroupJoin from '@/groups/useGroupJoin';
@@ -9,11 +15,6 @@ import { usePost } from '@/state/channel/channel';
 import { useGang, useGroup } from '@/state/groups';
 import { useSawRopeMutation } from '@/state/hark';
 import { Skein, YarnContent } from '@/types/hark';
-import cn from 'classnames';
-import _ from 'lodash';
-import { ReactNode, useCallback } from 'react';
-import { Link } from 'react-router-dom';
-import ob from 'urbit-ob';
 
 import {
   isBlock,

--- a/apps/tlon-web/src/notifications/Notifications.tsx
+++ b/apps/tlon-web/src/notifications/Notifications.tsx
@@ -1,3 +1,8 @@
+import cn from 'classnames';
+import { ComponentType, PropsWithChildren, useCallback, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link, useLocation } from 'react-router-dom';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
@@ -10,10 +15,6 @@ import { useAmAdmin, useGroup, useRouteGroup } from '@/state/groups';
 import { useSawRopeMutation, useSawSeamMutation } from '@/state/hark';
 import { ViewProps } from '@/types/groups';
 import { Skein } from '@/types/hark';
-import cn from 'classnames';
-import { ComponentType, PropsWithChildren, useCallback, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { Link, useLocation } from 'react-router-dom';
 
 import { NotificationFilterType, useNotifications } from './useNotifications';
 

--- a/apps/tlon-web/src/notifications/useNotifications.tsx
+++ b/apps/tlon-web/src/notifications/useNotifications.tsx
@@ -1,8 +1,9 @@
+import _ from 'lodash';
+
 import { useIsMobile } from '@/logic/useMedia';
 import { makePrettyDay } from '@/logic/utils';
 import { useSkeins } from '@/state/hark';
 import { Flag, Rope, Skein, Yarn } from '@/types/hark';
-import _ from 'lodash';
 
 export interface DayGrouping {
   date: string;

--- a/apps/tlon-web/src/profiles/EditProfile/EditProfile.tsx
+++ b/apps/tlon-web/src/profiles/EditProfile/EditProfile.tsx
@@ -1,3 +1,8 @@
+import _ from 'lodash';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { FormProvider, useForm } from 'react-hook-form';
+
 import Avatar from '@/components/Avatar';
 import GroupSelector, { GroupOption } from '@/components/GroupSelector';
 import Layout from '@/components/Layout/Layout';
@@ -15,10 +20,6 @@ import {
   ContactEditField,
 } from '@/types/contact';
 import { ViewProps } from '@/types/groups';
-import _ from 'lodash';
-import React, { useCallback, useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { FormProvider, useForm } from 'react-hook-form';
 
 import ProfileCoverImage from '../ProfileCoverImage';
 import PublicProfileSelector from '../PublicProfileSelector';

--- a/apps/tlon-web/src/profiles/EditProfile/ProfileFields.tsx
+++ b/apps/tlon-web/src/profiles/EditProfile/ProfileFields.tsx
@@ -1,11 +1,12 @@
-import ColorPicker from '@/components/ColorPicker';
-import ImageURLUploadField from '@/components/ImageURLUploadField';
-import { normalizeUrbitColor } from '@/logic/utils';
-import { useCalm } from '@/state/settings';
 import { ContactEditField } from '@urbit/api';
 import { debounce } from 'lodash';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+
+import ColorPicker from '@/components/ColorPicker';
+import ImageURLUploadField from '@/components/ImageURLUploadField';
+import { normalizeUrbitColor } from '@/logic/utils';
+import { useCalm } from '@/state/settings';
 
 export default function ProfileFields() {
   const { register, watch, setValue, formState } =

--- a/apps/tlon-web/src/profiles/EditProfile/ProfileGroup.tsx
+++ b/apps/tlon-web/src/profiles/EditProfile/ProfileGroup.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import X16Icon from '@/components/icons/X16Icon';
 import { useGroup } from '@/state/groups';
-import React from 'react';
 
 interface ProfileGroupProps {
   groupFlag: string;

--- a/apps/tlon-web/src/profiles/EditPublicProfile.tsx
+++ b/apps/tlon-web/src/profiles/EditPublicProfile.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { useEffect, useState } from 'react';
+
 import Dialog from '@/components/Dialog';
 import SpinToggle from '@/components/SpinToggle';
 import WidgetDrawer from '@/components/WidgetDrawer';
@@ -9,8 +12,6 @@ import useWidgets, {
   useShowWidgetMutation,
 } from '@/state/profile/profile';
 import { Widget } from '@/state/profile/types';
-import cn from 'classnames';
-import { useEffect, useState } from 'react';
 
 export default function EditPublicProfile({
   open,

--- a/apps/tlon-web/src/profiles/FavoriteGroup.tsx
+++ b/apps/tlon-web/src/profiles/FavoriteGroup.tsx
@@ -1,9 +1,10 @@
-import GroupAvatar from '@/groups/GroupAvatar';
-import { useModalNavigate } from '@/logic/routing';
-import { useGang, useGangPreview, useGroup } from '@/state/groups';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import React from 'react';
 import { useLocation, useNavigate } from 'react-router';
+
+import GroupAvatar from '@/groups/GroupAvatar';
+import { useModalNavigate } from '@/logic/routing';
+import { useGang, useGangPreview, useGroup } from '@/state/groups';
 
 interface FavoriteGroupProps {
   groupFlag: string;

--- a/apps/tlon-web/src/profiles/Profile.tsx
+++ b/apps/tlon-web/src/profiles/Profile.tsx
@@ -1,3 +1,9 @@
+import cn from 'classnames';
+import { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import { Drawer } from 'vaul';
+
 import Avatar from '@/components/Avatar';
 import MobileHeader from '@/components/MobileHeader';
 import QRWidget, { QRWidgetPlaceholder } from '@/components/QRWidget';
@@ -25,11 +31,6 @@ import { useIsMobile } from '@/logic/useMedia';
 import { isHosted, useCopy, useIsHttps } from '@/logic/utils';
 import { useOurContact } from '@/state/contact';
 import { ViewProps } from '@/types/groups';
-import cn from 'classnames';
-import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet';
-import { Link } from 'react-router-dom';
-import { Drawer } from 'vaul';
 
 import ProfileCoverImage from './ProfileCoverImage';
 import PublicProfileSelector from './PublicProfileSelector';

--- a/apps/tlon-web/src/profiles/ProfileCoverImage.tsx
+++ b/apps/tlon-web/src/profiles/ProfileCoverImage.tsx
@@ -1,9 +1,10 @@
-import { useIsMobile } from '@/logic/useMedia';
-import { useContact } from '@/state/contact';
-import { useCalm } from '@/state/settings';
 import { Contact } from '@urbit/api';
 import classNames from 'classnames';
 import React, { PropsWithChildren } from 'react';
+
+import { useIsMobile } from '@/logic/useMedia';
+import { useContact } from '@/state/contact';
+import { useCalm } from '@/state/settings';
 
 type CoverProps = PropsWithChildren<{
   cover: string;

--- a/apps/tlon-web/src/profiles/ProfileModal.tsx
+++ b/apps/tlon-web/src/profiles/ProfileModal.tsx
@@ -1,3 +1,7 @@
+import cn from 'classnames';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+
 import Avatar from '@/components/Avatar';
 import ConfirmationModal from '@/components/ConfirmationModal';
 import Dialog from '@/components/Dialog';
@@ -18,9 +22,6 @@ import {
 import useContactState, { useContact } from '@/state/contact';
 import usePalsState from '@/state/pals';
 import { useConnectivityCheck } from '@/state/vitals';
-import cn from 'classnames';
-import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router';
 
 import FavoriteGroupGrid from './FavoriteGroupGrid';
 import ProfileBio from './ProfileBio';

--- a/apps/tlon-web/src/profiles/PublicProfileSelector.tsx
+++ b/apps/tlon-web/src/profiles/PublicProfileSelector.tsx
@@ -1,3 +1,6 @@
+import cn from 'classnames';
+import { useState } from 'react';
+
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import SidebarItem from '@/components/Sidebar/SidebarItem';
 import CheckIcon from '@/components/icons/CheckIcon';
@@ -10,8 +13,6 @@ import {
   useMakeProfilePublicMutation,
   useProfileIsPublic,
 } from '@/state/profile/profile';
-import cn from 'classnames';
-import { useState } from 'react';
 
 import EditPublicProfile from './EditPublicProfile';
 

--- a/apps/tlon-web/src/replies/ReplyMessage.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessage.tsx
@@ -1,5 +1,19 @@
 /* eslint-disable react/no-unused-prop-types */
 // eslint-disable-next-line import/no-cycle
+import { daToUnix } from '@urbit/api';
+import { BigInteger } from 'big-integer';
+import cn from 'classnames';
+import { format } from 'date-fns';
+import debounce from 'lodash/debounce';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useInView } from 'react-intersection-observer';
+
 import ChatContent from '@/chat/ChatContent/ChatContent';
 import Author from '@/chat/ChatMessage/Author';
 import DateDivider from '@/chat/ChatMessage/DateDivider';
@@ -26,19 +40,6 @@ import {
 } from '@/state/chat';
 import { Reply, Story, Unread, emptyReply } from '@/types/channel';
 import { DMUnread } from '@/types/dms';
-import { daToUnix } from '@urbit/api';
-import { BigInteger } from 'big-integer';
-import cn from 'classnames';
-import { format } from 'date-fns';
-import debounce from 'lodash/debounce';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { useInView } from 'react-intersection-observer';
 
 import ReplyMessageOptions from './ReplyMessageOptions';
 import ReplyReactions from './ReplyReactions/ReplyReactions';

--- a/apps/tlon-web/src/replies/ReplyMessageOptions.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessageOptions.tsx
@@ -1,3 +1,9 @@
+import { decToUd } from '@urbit/api';
+import cn from 'classnames';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
+
 import { useChatDialog } from '@/chat/useChatStore';
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import ConfirmationModal from '@/components/ConfirmationModal';
@@ -39,11 +45,6 @@ import {
   useVessel,
 } from '@/state/groups';
 import { Reply, emptyReply } from '@/types/channel';
-import { decToUd } from '@urbit/api';
-import cn from 'classnames';
-import { useCallback, useEffect, useMemo } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
-import { useSearchParams } from 'react-router-dom';
 
 export default function ReplyMessageOptions(props: {
   open: boolean;

--- a/apps/tlon-web/src/replies/ReplyReactions/ReplyReaction.tsx
+++ b/apps/tlon-web/src/replies/ReplyReactions/ReplyReaction.tsx
@@ -1,3 +1,7 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+import cn from 'classnames';
+import { useCallback, useEffect } from 'react';
+
 import ShipName from '@/components/ShipName';
 import X16Icon from '@/components/icons/X16Icon';
 import { useIsDmOrMultiDm, useThreadParentId } from '@/logic/utils';
@@ -12,9 +16,6 @@ import {
   useDeleteDMReplyReactMutation,
 } from '@/state/chat';
 import useEmoji from '@/state/emoji';
-import * as Tooltip from '@radix-ui/react-tooltip';
-import cn from 'classnames';
-import { useCallback, useEffect } from 'react';
 
 interface ReplyReactionProps {
   whom: string;

--- a/apps/tlon-web/src/replies/ReplyReactions/ReplyReactions.tsx
+++ b/apps/tlon-web/src/replies/ReplyReactions/ReplyReactions.tsx
@@ -1,3 +1,6 @@
+import _ from 'lodash';
+import { useCallback, useState } from 'react';
+
 import EmojiPicker from '@/components/EmojiPicker';
 import AddReactIcon from '@/components/icons/AddReactIcon';
 import { useIsMobile } from '@/logic/useMedia';
@@ -8,8 +11,6 @@ import {
 } from '@/state/channel/channel';
 import { useAddDMReplyReactMutation } from '@/state/chat';
 import { ReplySeal } from '@/types/channel';
-import _ from 'lodash';
-import { useCallback, useState } from 'react';
 
 import ReplyReaction from './ReplyReaction';
 

--- a/apps/tlon-web/src/replies/ReplyScroller/ReplyScrollerPlaceholder.tsx
+++ b/apps/tlon-web/src/replies/ReplyScroller/ReplyScrollerPlaceholder.tsx
@@ -1,6 +1,7 @@
-import { randomElement } from '@/logic/utils';
 import cn from 'classnames';
 import * as React from 'react';
+
+import { randomElement } from '@/logic/utils';
 
 function ChatItemPlaceholder() {
   const background = `bg-gray-${randomElement([100, 200, 400])}`;

--- a/apps/tlon-web/src/replies/replies.ts
+++ b/apps/tlon-web/src/replies/replies.ts
@@ -1,7 +1,8 @@
-import { Kind, Reply, ReplyTuple, Unread } from '@/types/channel';
 import { daToUnix } from '@urbit/aura';
 import bigInt, { BigInteger } from 'big-integer';
 import { isSameDay } from 'date-fns';
+
+import { Kind, Reply, ReplyTuple, Unread } from '@/types/channel';
 
 export interface ReplyProps {
   han: Kind;

--- a/apps/tlon-web/src/state/bootstrap.ts
+++ b/apps/tlon-web/src/state/bootstrap.ts
@@ -1,10 +1,11 @@
+import Urbit from '@urbit/http-api';
+import _ from 'lodash';
+
 import api from '@/api';
 import { useChatStore } from '@/chat/useChatStore';
 import { asyncWithDefault } from '@/logic/utils';
 import queryClient from '@/queryClient';
 import { GroupsInit } from '@/types/ui';
-import Urbit from '@urbit/http-api';
-import _ from 'lodash';
 
 import { ChannnelKeys } from './channel/keys';
 import { initializeChat } from './chat';

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -1,3 +1,11 @@
+import { QueryKey, useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { decToUd, udToDec, unixToDa } from '@urbit/api';
+import { Poke } from '@urbit/http-api';
+import bigInt from 'big-integer';
+import _ from 'lodash';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import create from 'zustand';
+
 import api from '@/api';
 import { useChatStore } from '@/chat/useChatStore';
 import {
@@ -43,13 +51,6 @@ import {
   newChatMap,
 } from '@/types/channel';
 import { Flag } from '@/types/hark';
-import { QueryKey, useInfiniteQuery, useMutation } from '@tanstack/react-query';
-import { decToUd, udToDec, unixToDa } from '@urbit/api';
-import { Poke } from '@urbit/http-api';
-import bigInt from 'big-integer';
-import _ from 'lodash';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import create from 'zustand';
 
 import { channelKey } from './keys';
 import shouldAddPostToCache from './util';

--- a/apps/tlon-web/src/state/chat/chat.ts
+++ b/apps/tlon-web/src/state/chat/chat.ts
@@ -1,3 +1,12 @@
+import { QueryKey, useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { decToUd, udToDec } from '@urbit/api';
+import { formatUd, unixToDa } from '@urbit/aura';
+import { Poke } from '@urbit/http-api';
+import bigInt, { BigInteger } from 'big-integer';
+import _ from 'lodash';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import create from 'zustand';
+
 import api from '@/api';
 import { ChatStore, useChatInfo, useChatStore } from '@/chat/useChatStore';
 import {
@@ -38,14 +47,6 @@ import {
   Writs,
 } from '@/types/dms';
 import { GroupMeta } from '@/types/groups';
-import { QueryKey, useInfiniteQuery, useMutation } from '@tanstack/react-query';
-import { decToUd, udToDec } from '@urbit/api';
-import { formatUd, unixToDa } from '@urbit/aura';
-import { Poke } from '@urbit/http-api';
-import bigInt, { BigInteger } from 'big-integer';
-import _ from 'lodash';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import create from 'zustand';
 
 import { CacheId, PostStatus, TrackedPost } from '../channel/channel';
 import ChatKeys from './keys';

--- a/apps/tlon-web/src/state/chat/search.ts
+++ b/apps/tlon-web/src/state/chat/search.ts
@@ -1,3 +1,10 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { decToUd } from '@urbit/api';
+import bigInt from 'big-integer';
+import { useMemo } from 'react';
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
 import api from '@/api';
 import { createStorageKey, whomIsDm, whomIsMultiDm } from '@/logic/utils';
 import { ChatMap, ReplyTuple, newChatMap } from '@/types/channel';
@@ -8,12 +15,6 @@ import {
   WritTuple,
   newWritMap,
 } from '@/types/dms';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { decToUd } from '@urbit/api';
-import bigInt from 'big-integer';
-import { useMemo } from 'react';
-import create from 'zustand';
-import { persist } from 'zustand/middleware';
 
 type Whom = string;
 type SearchResult = ChatMap;

--- a/apps/tlon-web/src/state/chat/utils.ts
+++ b/apps/tlon-web/src/state/chat/utils.ts
@@ -1,3 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
+import { udToDec } from '@urbit/api';
+import { formatUd, unixToDa } from '@urbit/aura';
+import bigInt from 'big-integer';
+import _ from 'lodash';
+
 import {
   PostEssay,
   Replies,
@@ -16,11 +22,6 @@ import {
   WritMemo,
   WritSeal,
 } from '@/types/dms';
-import { QueryClient } from '@tanstack/react-query';
-import { udToDec } from '@urbit/api';
-import { formatUd, unixToDa } from '@urbit/aura';
-import bigInt from 'big-integer';
-import _ from 'lodash';
 
 export default function emptyMultiDm(): Club {
   return {

--- a/apps/tlon-web/src/state/contact.ts
+++ b/apps/tlon-web/src/state/contact.ts
@@ -1,4 +1,9 @@
 /* eslint-disable no-param-reassign */
+import { Patp, preSig } from '@urbit/api';
+import produce from 'immer';
+import _ from 'lodash';
+import { useCallback, useMemo } from 'react';
+
 import api from '@/api';
 import { BaseState, createState } from '@/state/base';
 import {
@@ -9,10 +14,6 @@ import {
   ContactNews,
   ContactRolodex,
 } from '@/types/contact';
-import { Patp, preSig } from '@urbit/api';
-import produce from 'immer';
-import _ from 'lodash';
-import { useCallback, useMemo } from 'react';
 
 export interface BaseContactState {
   contacts: ContactRolodex;

--- a/apps/tlon-web/src/state/docket.ts
+++ b/apps/tlon-web/src/state/docket.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { normalizeUrbitColor } from '@/logic/utils';
 import {
   Allies,
   AllyUpdateIni,
@@ -25,6 +24,8 @@ import { omit, pick } from 'lodash';
 import React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import create, { SetState } from 'zustand';
+
+import { normalizeUrbitColor } from '@/logic/utils';
 
 import api from '../api';
 

--- a/apps/tlon-web/src/state/embed.ts
+++ b/apps/tlon-web/src/state/embed.ts
@@ -1,6 +1,7 @@
-import { isValidUrl, jsonFetch } from '@/logic/utils';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
+
+import { isValidUrl, jsonFetch } from '@/logic/utils';
 
 const OEMBED_PROVIDER = 'https://noembed.com/embed';
 

--- a/apps/tlon-web/src/state/groups/groups.ts
+++ b/apps/tlon-web/src/state/groups/groups.ts
@@ -1,3 +1,16 @@
+import {
+  MutationFunction,
+  UseMutationOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { decToUd } from '@urbit/api';
+import { Poke } from '@urbit/http-api';
+import _ from 'lodash';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useParams } from 'react-router';
+import create from 'zustand';
+
 import api from '@/api';
 import { captureGroupsAnalyticsEvent } from '@/logic/analytics';
 import useReactQueryScry from '@/logic/useReactQueryScry';
@@ -30,18 +43,6 @@ import {
   isGroup,
 } from '@/types/groups';
 import { Scope, VolumeValue } from '@/types/volume';
-import {
-  MutationFunction,
-  UseMutationOptions,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query';
-import { decToUd } from '@urbit/api';
-import { Poke } from '@urbit/http-api';
-import _ from 'lodash';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useParams } from 'react-router';
-import create from 'zustand';
 
 import { useGroupPins } from '../pins';
 import { useNewGroupFlags } from '../settings';

--- a/apps/tlon-web/src/state/groups/type.ts
+++ b/apps/tlon-web/src/state/groups/type.ts
@@ -1,6 +1,7 @@
+import { GroupMeta } from '@tloncorp/shared';
+
 import { BaitCite } from '@/types/channel';
 import { GroupsInit } from '@/types/ui';
-import { GroupMeta } from '@tloncorp/shared';
 
 import {
   ChannelPreview,

--- a/apps/tlon-web/src/state/hark.ts
+++ b/apps/tlon-web/src/state/hark.ts
@@ -1,3 +1,6 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { decToUd } from '@urbit/api';
+
 import api from '@/api';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import {
@@ -12,8 +15,6 @@ import {
   Skein,
   Yarn,
 } from '@/types/hark';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { decToUd } from '@urbit/api';
 
 function harkAction(action: HarkAction) {
   return {

--- a/apps/tlon-web/src/state/kiln.ts
+++ b/apps/tlon-web/src/state/kiln.ts
@@ -1,8 +1,9 @@
-import api from '@/api';
 import { Pike, Pikes, getPikes, scryLag } from '@urbit/api';
 import produce from 'immer';
 import { useCallback } from 'react';
 import create from 'zustand';
+
+import api from '@/api';
 
 interface KilnState {
   pikes: Pikes;

--- a/apps/tlon-web/src/state/lure/lure.ts
+++ b/apps/tlon-web/src/state/lure/lure.ts
@@ -1,3 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import produce from 'immer';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
 import api from '@/api';
 import { createDeepLink } from '@/logic/branch';
 import { getPreviewTracker } from '@/logic/subscriptionTracking';
@@ -10,11 +16,6 @@ import {
   storageVersion,
 } from '@/logic/utils';
 import { GroupMeta } from '@/types/groups';
-import { useQuery } from '@tanstack/react-query';
-import produce from 'immer';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import create from 'zustand';
-import { persist } from 'zustand/middleware';
 
 import { useLocalState } from '../local';
 

--- a/apps/tlon-web/src/state/negotiation.ts
+++ b/apps/tlon-web/src/state/negotiation.ts
@@ -1,9 +1,10 @@
-import api from '@/api';
-import queryClient from '@/queryClient';
-import { MatchingEvent, MatchingResponse } from '@/types/negotiation';
 import { useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import api from '@/api';
+import queryClient from '@/queryClient';
+import { MatchingEvent, MatchingResponse } from '@/types/negotiation';
 
 function negotiationUpdater(
   event: MatchingEvent | null,

--- a/apps/tlon-web/src/state/pals.ts
+++ b/apps/tlon-web/src/state/pals.ts
@@ -1,6 +1,7 @@
 // Special thanks @willbach of @uqbar-dao
-import api from '@/api';
 import create, { SetState } from 'zustand';
+
+import api from '@/api';
 
 interface Outgoing {
   lists: string[];

--- a/apps/tlon-web/src/state/pins.ts
+++ b/apps/tlon-web/src/state/pins.ts
@@ -1,11 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+import _ from 'lodash';
+import { useMemo } from 'react';
+
 import api from '@/api';
 import useReactQueryScry from '@/logic/useReactQueryScry';
 import { whomIsDm, whomIsFlag, whomIsMultiDm, whomIsNest } from '@/logic/utils';
 import queryClient from '@/queryClient';
 import { Nest } from '@/types/channel';
-import { useMutation } from '@tanstack/react-query';
-import _ from 'lodash';
-import { useMemo } from 'react';
 
 export const pinsKey = () => ['groups-ui', 'pins'];
 

--- a/apps/tlon-web/src/state/profile/profile.ts
+++ b/apps/tlon-web/src/state/profile/profile.ts
@@ -1,9 +1,10 @@
-import api from '@/api';
-import useReactQueryScry from '@/logic/useReactQueryScry';
-import queryClient from '@/queryClient';
 import { useMutation } from '@tanstack/react-query';
 import _ from 'lodash';
 import { useMemo } from 'react';
+
+import api from '@/api';
+import useReactQueryScry from '@/logic/useReactQueryScry';
+import queryClient from '@/queryClient';
 
 import ProfileKeys from './keys';
 import { ProfLayout, ProfWidgets, Widget, getWidgetIdParts } from './types';

--- a/apps/tlon-web/src/state/settings.ts
+++ b/apps/tlon-web/src/state/settings.ts
@@ -1,3 +1,11 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { DelBucket, DelEntry, PutBucket, Value } from '@urbit/api';
+import cookies from 'browser-cookies';
+import produce from 'immer';
+import _ from 'lodash';
+import { useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
 import api from '@/api';
 import {
   ALPHABETICAL_SORT,
@@ -10,13 +18,6 @@ import { isNativeApp } from '@/logic/native';
 import useReactQuerySubscription from '@/logic/useReactQuerySubscription';
 import { isHosted } from '@/logic/utils';
 import { DisplayMode, SortMode } from '@/types/channel';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { DelBucket, DelEntry, PutBucket, Value } from '@urbit/api';
-import cookies from 'browser-cookies';
-import produce from 'immer';
-import _ from 'lodash';
-import { useMemo } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 interface ChannelSetting {
   flag: string;

--- a/apps/tlon-web/src/state/storage/reducer.ts
+++ b/apps/tlon-web/src/state/storage/reducer.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
-import { hostingUploadURL } from '@/logic/utils';
 import _ from 'lodash';
+
+import { hostingUploadURL } from '@/logic/utils';
 
 import { BaseState } from '../base';
 import { BaseStorageState, StorageUpdate } from './type';

--- a/apps/tlon-web/src/state/storage/storage.ts
+++ b/apps/tlon-web/src/state/storage/storage.ts
@@ -1,6 +1,7 @@
-import { hostingUploadURL, isHosted } from '@/logic/utils';
 import { enableMapSet } from 'immer';
 import _ from 'lodash';
+
+import { hostingUploadURL, isHosted } from '@/logic/utils';
 
 import {
   BaseState,

--- a/apps/tlon-web/src/state/storage/type.ts
+++ b/apps/tlon-web/src/state/storage/type.ts
@@ -1,5 +1,6 @@
-import { Status } from '@/logic/status';
 import { S3Client } from '@aws-sdk/client-s3';
+
+import { Status } from '@/logic/status';
 
 export type StorageService = 'presigned-url' | 'credentials';
 

--- a/apps/tlon-web/src/state/storage/upload.ts
+++ b/apps/tlon-web/src/state/storage/upload.ts
@@ -1,6 +1,3 @@
-import api from '@/api';
-import { isIOSWebView, isSafari } from '@/logic/native';
-import { Status } from '@/logic/status';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { deSig, formatDa, unixToDa } from '@urbit/aura';
@@ -10,6 +7,10 @@ import _ from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 import { getImageSize } from 'react-image-size';
 import create from 'zustand';
+
+import api from '@/api';
+import { isIOSWebView, isSafari } from '@/logic/native';
+import { Status } from '@/logic/status';
 
 import { useStorage } from './storage';
 import {

--- a/apps/tlon-web/src/state/vere.ts
+++ b/apps/tlon-web/src/state/vere.ts
@@ -1,5 +1,6 @@
-import api from '@/api';
 import create, { SetState } from 'zustand';
+
+import api from '@/api';
 
 interface Vere {
   cur: VereState;

--- a/apps/tlon-web/src/state/vitals.ts
+++ b/apps/tlon-web/src/state/vitals.ts
@@ -1,6 +1,7 @@
-import api from '@/api';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
+
+import api from '@/api';
 
 interface Connected {
   complete: 'yes';

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v4.2hu8t.a0d9h.ft1sd.3mrls.tc0p7.glob' 0v4.2hu8t.a0d9h.ft1sd.3mrls.tc0p7]
+    glob-http+['https://bootstrap.urbit.org/glob-0v2.062f1.1dst2.4u2ni.deo3e.p7plb.glob' 0v2.062f1.1dst2.4u2ni.deo3e.p7plb]
     base+'groups'
     version+[5 5 1]
     website+'https://tlon.io'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "landscape-apps-mono",
+  "name": "homestead",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,9 +2,10 @@
   "name": "@tloncorp/shared",
   "version": "1.0.0",
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsup",
+    "build": "tsup src/index.ts --format esm --minify --dts --out-dir dist",
     "dev": "npm run build -- --watch"
   },
   "dependencies": {}


### PR DESCRIPTION
- adds the build step back in for the shared package. we're going to want `npm run dev` in there so we can update files in there while working in dev on either app, afaict. updates gh workflows appropriately.
- fixes the import sort order issue. prettier rc had been updated to use `@trivago/prettier-plugin-sort-imports` and wasn't configured with our `@/` root alias in mind. This made eslint mad every time you opened a file.