### PR TITLE
native: add tamagui

### DIFF
--- a/apps/tlon-mobile/metro.config.js
+++ b/apps/tlon-mobile/metro.config.js
@@ -28,6 +28,10 @@ module.exports = mergeConfig(config, {
     nodeModulesPaths: [
       path.resolve(projectRoot, 'node_modules'),
       path.resolve(workspaceRoot, 'node_modules'),
+      // Tamagui packages expect to be able to require anything under the
+      // tamagui umbrella node_modules folder. Some modules fail to resolve
+      // without this.
+      path.resolve(workspaceRoot, 'node_modules/tamagui/node_modules'),
     ],
   },
 });

--- a/apps/tlon-mobile/src/App.tsx
+++ b/apps/tlon-mobile/src/App.tsx
@@ -7,6 +7,7 @@ import {
   useNavigation,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { TamaguiProvider } from '@tloncorp/ui';
 import { PostHogProvider } from 'posthog-react-native';
 import { useEffect, useState } from 'react';
 import { Alert, StatusBar, Text, View } from 'react-native';
@@ -249,12 +250,14 @@ const App = ({ wer: initialWer }: Props) => {
 export default function AnalyticsApp(props: Props) {
   const isDarkMode = useIsDarkMode();
   return (
-    <ShipProvider>
-      <NavigationContainer theme={isDarkMode ? DarkTheme : DefaultTheme}>
-        <PostHogProvider client={posthogAsync} autocapture>
-          <App {...props} />
-        </PostHogProvider>
-      </NavigationContainer>
-    </ShipProvider>
+    <TamaguiProvider>
+      <ShipProvider>
+        <NavigationContainer theme={isDarkMode ? DarkTheme : DefaultTheme}>
+          <PostHogProvider client={posthogAsync} autocapture>
+            <App {...props} />
+          </PostHogProvider>
+        </NavigationContainer>
+      </ShipProvider>
+    </TamaguiProvider>
   );
 }

--- a/apps/tlon-mobile/src/tamagui.d.ts
+++ b/apps/tlon-mobile/src/tamagui.d.ts
@@ -1,0 +1,8 @@
+import type { config } from '@tloncorp/ui';
+
+export type Conf = typeof config;
+
+// Sets up typing for tamagui so that theme variables autocomplete
+declare module 'tamagui' {
+  interface TamaguiCustomConfig extends Conf {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,72 +21,6 @@
         "npm": "^10.2.4"
       }
     },
-    "apps/spill": {
-      "name": "Whatever",
-      "version": "0.0.1",
-      "extraneous": true,
-      "dependencies": {
-        "@react-native-cookies/cookies": "^6.2.1",
-        "@react-navigation/bottom-tabs": "^6.5.11",
-        "@react-navigation/native": "^6.1.9",
-        "@react-navigation/native-stack": "^6.9.17",
-        "@realm/react": "^0.6.2",
-        "@tamagui/animations-moti": "1.88.11",
-        "@tamagui/babel-plugin": "1.88.11",
-        "@tamagui/config": "1.88.11",
-        "@tamagui/linear-gradient": "^1.88.11",
-        "@tloncorp/shared": "*",
-        "@urbit/aura": "^1.0.0",
-        "babel-plugin-transform-inline-environment-variables": "^0.4.4",
-        "big-integer": "^1.6.52",
-        "date-fns": "^2.30.0",
-        "events": "^3.3.0",
-        "expo": "^50.0.0",
-        "expo-clipboard": "^5.0.1",
-        "expo-linear-gradient": "^12.7.0",
-        "jotai": "^2.6.0",
-        "lodash": "^4.17.21",
-        "react": "18.2.0",
-        "react-hook-form": "^7.49.2",
-        "react-native": "0.73.3",
-        "react-native-fast-image": "^8.6.3",
-        "react-native-ios-modal": "^0.1.8",
-        "react-native-reanimated": "^3.6.1",
-        "react-native-safe-area-context": "^4.8.2",
-        "react-native-screens": "^3.29.0",
-        "react-native-sse": "^1.2.0",
-        "react-native-svg": "^14.1.0",
-        "react-native-webview": "^13.6.4",
-        "realm": "^12.6.0",
-        "sorted-btree": "^1.8.1",
-        "tamagui": "1.88.11"
-      },
-      "devDependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/preset-env": "^7.20.0",
-        "@babel/runtime": "^7.20.0",
-        "@react-native/babel-preset": "^0.73.18",
-        "@react-native/eslint-config": "^0.73.1",
-        "@react-native/gradle-plugin": "^0.73.4",
-        "@react-native/metro-config": "^0.73.2",
-        "@react-native/typescript-config": "^0.73.1",
-        "@tsconfig/react-native": "^3.0.0",
-        "@types/lodash": "^4.14.202",
-        "@types/react": "^18.2.6",
-        "@types/react-test-renderer": "^18.0.0",
-        "babel-jest": "^29.6.3",
-        "babel-plugin-module-resolver": "^5.0.0",
-        "eslint": "^8.19.0",
-        "jest": "^29.6.3",
-        "metro-react-native-babel-preset": "0.76.8",
-        "prettier": "2.8.8",
-        "react-cosmos": "^6.0.0-beta.10",
-        "react-cosmos-native": "^6.0.0-beta.10",
-        "react-native-svg-transformer": "^1.3.0",
-        "react-test-renderer": "18.2.0",
-        "typescript": "5.3.2"
-      }
-    },
     "apps/tlon-mobile": {
       "version": "3.1.3",
       "hasInstallScript": true,
@@ -4794,6 +4728,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -4809,6 +4744,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4824,6 +4760,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4839,6 +4776,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4852,6 +4790,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4868,6 +4807,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4883,6 +4823,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4898,6 +4839,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4913,6 +4855,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4928,6 +4871,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4943,6 +4887,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4958,6 +4903,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4973,6 +4919,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4988,6 +4935,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5003,6 +4951,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5018,6 +4967,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5033,6 +4983,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5048,6 +4999,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -5063,6 +5015,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -5078,6 +5031,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -5093,6 +5047,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5108,6 +5063,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5123,6 +5079,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -13186,36 +13143,6 @@
         "@tamagui/web": "1.89.26"
       }
     },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -13235,15 +13162,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -13257,39 +13175,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
     "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/polyfill-dev": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
       "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -13315,16 +13204,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-constant": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
@@ -13344,36 +13223,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-presence": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
@@ -13383,24 +13232,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/animate": {
@@ -13423,88 +13254,10 @@
         "@tamagui/web": "1.89.26"
       }
     },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/animate/node_modules/@tamagui/use-constant": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
       "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
       "peerDependencies": {
         "react": "*"
       }
@@ -13520,24 +13273,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/animate/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/@tamagui/animations-moti": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/animations-moti/-/animations-moti-1.89.26.tgz",
@@ -13549,84 +13284,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-presence": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
@@ -13636,24 +13293,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/aria-hidden": {
@@ -13683,36 +13322,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/avatar/node_modules/@tamagui/get-font-sized": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
@@ -13722,15 +13331,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
       }
     },
     "node_modules/@tamagui/avatar/node_modules/@tamagui/helpers-tamagui": {
@@ -13746,30 +13346,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/avatar/node_modules/@tamagui/shapes": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/shapes/-/shapes-1.89.26.tgz",
@@ -13781,11 +13357,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/avatar/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -13811,64 +13382,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/avatar/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/@tamagui/card": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/card/-/card-1.89.26.tgz",
@@ -13884,36 +13397,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/card/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/card/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -13921,44 +13404,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/card/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -13969,64 +13414,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/card/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/checkbox-headless": {
@@ -14042,36 +13429,6 @@
         "@tamagui/label": "1.89.26",
         "@tamagui/use-controllable-state": "1.89.26",
         "@tamagui/use-previous": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
       },
       "peerDependencies": {
         "react": "*"
@@ -14120,15 +13477,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -14161,35 +13509,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/text": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
@@ -14203,16 +13522,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-controllable-state": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
@@ -14224,57 +13533,39 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-previous": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
       "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
     },
-    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/web": {
+    "node_modules/@tamagui/compose-refs": {
       "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
       "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
         "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/@tamagui/dialog": {
@@ -14328,36 +13619,6 @@
         "@tamagui/web": "1.89.26"
       }
     },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/dialog/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -14377,15 +13638,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/@tamagui/dialog/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -14399,39 +13651,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
     "node_modules/@tamagui/dialog/node_modules/@tamagui/polyfill-dev": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
       "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/dialog/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -14457,16 +13680,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/dialog/node_modules/@tamagui/use-constant": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
@@ -14486,36 +13699,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/dialog/node_modules/@tamagui/use-presence": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
@@ -14525,24 +13708,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dialog/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/dismissable": {
@@ -14560,132 +13725,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/dismissable/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/@tamagui/elements": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/elements/-/elements-1.89.26.tgz",
@@ -14696,132 +13735,6 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/elements/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/floating": {
@@ -14883,33 +13796,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/focus-scope/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/focus-scope/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/focus-scope/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/get-token": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/get-token/-/get-token-1.89.26.tgz",
@@ -14922,100 +13808,13 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/helpers": {
+    "node_modules/@tamagui/helpers": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
       "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
       "dependencies": {
         "@tamagui/constants": "1.89.26",
         "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/get-token/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/image": {
@@ -15031,132 +13830,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/image/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/image/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/@tamagui/linear-gradient": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/linear-gradient/-/linear-gradient-1.89.26.tgz",
@@ -15169,74 +13842,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
@@ -15248,62 +13853,12 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/timer": {
+    "node_modules/@tamagui/normalize-css-color": {
       "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
       "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "@react-native/normalize-color": "^2.1.0"
       }
     },
     "node_modules/@tamagui/popover": {
@@ -15347,73 +13902,10 @@
         "@tamagui/helpers": "1.89.26"
       }
     },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
     "node_modules/@tamagui/popover/node_modules/@tamagui/polyfill-dev": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
       "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
     },
     "node_modules/@tamagui/popover/node_modules/@tamagui/scroll-view": {
       "version": "1.89.26",
@@ -15427,11 +13919,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/popover/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
@@ -15443,16 +13930,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/popover/node_modules/@tamagui/use-controllable-state": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
@@ -15462,54 +13939,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popover/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/popper": {
@@ -15530,74 +13959,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/popper/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
@@ -15609,16 +13970,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/popper/node_modules/@tamagui/use-controllable-state": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
@@ -15628,54 +13979,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/popper/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/portal": {
@@ -15693,74 +13996,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/portal/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
@@ -15770,64 +14005,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/portal/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/progress": {
@@ -15847,36 +14024,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/progress/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -15884,44 +14031,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/progress/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -15934,68 +14043,21 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/timer": {
+    "node_modules/@tamagui/react-native-use-pressable": {
       "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
       "peerDependencies": {
         "react": "*"
       }
     },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/use-event": {
+    "node_modules/@tamagui/react-native-use-responder-events": {
       "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/progress/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/@tamagui/react-native-svg": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-svg/-/react-native-svg-1.89.26.tgz",
-      "integrity": "sha512-QunyPS4oNQZ8+p1XVq5z+QGDlSrnkf9gHG/RwuPTa5ZKvxfBo6LEv9NCGzEbnj4HYHoqW6/ZmnKvXZJgTj6hpA=="
     },
     "node_modules/@tamagui/remove-scroll": {
       "version": "1.89.26",
@@ -16100,36 +14162,6 @@
         "@tamagui/web": "1.89.26"
       }
     },
-    "node_modules/@tamagui/select/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/select/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -16158,15 +14190,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
       }
     },
     "node_modules/@tamagui/select/node_modules/@tamagui/helpers-tamagui": {
@@ -16200,30 +14223,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/select/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/select/node_modules/@tamagui/separator": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/separator/-/separator-1.89.26.tgz",
@@ -16235,11 +14234,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/select/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -16264,16 +14258,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
     },
     "node_modules/@tamagui/select/node_modules/@tamagui/use-constant": {
       "version": "1.89.26",
@@ -16302,36 +14286,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/select/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/select/node_modules/@tamagui/use-presence": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
@@ -16347,24 +14301,6 @@
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
       "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
-    },
-    "node_modules/@tamagui/select/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
     },
     "node_modules/@tamagui/sheet": {
       "version": "1.89.26",
@@ -16417,73 +14353,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/sheet/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
       "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
       "peerDependencies": {
         "react": "*"
       }
@@ -16500,11 +14373,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/sheet/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
@@ -16515,16 +14383,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
     },
     "node_modules/@tamagui/sheet/node_modules/@tamagui/use-constant": {
       "version": "1.89.26",
@@ -16545,36 +14403,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/sheet/node_modules/@tamagui/use-presence": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
@@ -16586,23 +14414,10 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/sheet/node_modules/@tamagui/web": {
+    "node_modules/@tamagui/simple-hash": {
       "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/slider": {
       "version": "1.89.26",
@@ -16624,36 +14439,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/slider/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -16661,44 +14446,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/slider/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -16711,16 +14458,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/slider/node_modules/@tamagui/use-controllable-state": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
@@ -16732,60 +14469,12 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/slider/node_modules/@tamagui/use-direction": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-direction/-/use-direction-1.89.26.tgz",
       "integrity": "sha512-usyYMSMjB2AnCGtJ5ImQBZa8Ka8WAXuAgiBXJlECiv5LxnowfxqROu0+2lnwTc6h/fMAWEs++ydK+XbVapGgGg==",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/slider/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@tamagui/switch": {
@@ -16824,36 +14513,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/@tamagui/switch-headless/node_modules/@tamagui/create-context": {
@@ -16899,15 +14558,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/@tamagui/switch-headless/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -16940,35 +14590,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/switch-headless/node_modules/@tamagui/text": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
@@ -16982,98 +14603,10 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-previous": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
       "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
-    },
-    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
     },
     "node_modules/@tamagui/switch/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
@@ -17118,15 +14651,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/@tamagui/switch/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -17159,35 +14683,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
     "node_modules/@tamagui/switch/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
@@ -17212,16 +14707,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/switch/node_modules/@tamagui/use-controllable-state": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
@@ -17233,58 +14718,15 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/switch/node_modules/@tamagui/use-previous": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
       "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
     },
-    "node_modules/@tamagui/switch/node_modules/@tamagui/web": {
+    "node_modules/@tamagui/timer": {
       "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
     },
     "node_modules/@tamagui/tooltip": {
       "version": "1.89.26",
@@ -17310,36 +14752,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@tamagui/tooltip/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -17359,15 +14771,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/@tamagui/tooltip/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -17381,39 +14784,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
     "node_modules/@tamagui/tooltip/node_modules/@tamagui/polyfill-dev": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
       "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/@tamagui/tooltip/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -17439,16 +14813,6 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
     "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-controllable-state": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
@@ -17460,7 +14824,17 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-did-finish-ssr": {
+    "node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/use-callback-ref": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-callback-ref/-/use-callback-ref-1.89.26.tgz",
+      "integrity": "sha512-CZEw+GKLtuO7oXf25iS0enJVyOov++CUQ8W7Ca3G7J2/UJCVC+60Nd5lo8FCo81yxNpwpUO3uDwfWV0lcFfm9g=="
+    },
+    "node_modules/@tamagui/use-did-finish-ssr": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
       "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
@@ -17471,7 +14845,15 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-event": {
+    "node_modules/@tamagui/use-escape-keydown": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-escape-keydown/-/use-escape-keydown-1.89.26.tgz",
+      "integrity": "sha512-2yVXjR7/HCxyNX5JpQc6aqxMYoDodFKl7pol0ywdpEkWc1clGFxdRtTeDQQQGScC+xEnsxUodL+gozgMhHfzjg==",
+      "dependencies": {
+        "@tamagui/use-callback-ref": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/use-event": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
       "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
@@ -17482,43 +14864,12 @@
         "react": "*"
       }
     },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-force-update": {
+    "node_modules/@tamagui/use-force-update": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
       "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@tamagui/tooltip/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/@tamagui/use-callback-ref": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-callback-ref/-/use-callback-ref-1.89.26.tgz",
-      "integrity": "sha512-CZEw+GKLtuO7oXf25iS0enJVyOov++CUQ8W7Ca3G7J2/UJCVC+60Nd5lo8FCo81yxNpwpUO3uDwfWV0lcFfm9g=="
-    },
-    "node_modules/@tamagui/use-escape-keydown": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-escape-keydown/-/use-escape-keydown-1.89.26.tgz",
-      "integrity": "sha512-2yVXjR7/HCxyNX5JpQc6aqxMYoDodFKl7pol0ywdpEkWc1clGFxdRtTeDQQQGScC+xEnsxUodL+gozgMhHfzjg==",
-      "dependencies": {
-        "@tamagui/use-callback-ref": "1.89.26"
       }
     },
     "node_modules/@tamagui/use-keyboard-visible": {
@@ -17542,272 +14893,7 @@
         "react-native": "*"
       }
     },
-    "node_modules/@tamagui/use-window-dimensions/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/vite-plugin/-/vite-plugin-1.89.26.tgz",
-      "integrity": "sha512-WwkLCpBMScs3i7ZOVJfKAASXq4W2CdlUJDxNN0tG8zCtc8fn0NrE4mU9AXr4KJbuMvl2mEb6XnQs/xiT+wAypw==",
-      "dependencies": {
-        "@tamagui/fake-react-native": "1.89.26",
-        "@tamagui/proxy-worm": "1.89.26",
-        "@tamagui/react-native-svg": "1.89.26",
-        "@tamagui/static": "1.89.26",
-        "esm-resolve": "^1.0.8",
-        "fs-extra": "^11.2.0",
-        "outdent": "^0.8.0"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/build": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/build/-/build-1.89.26.tgz",
-      "integrity": "sha512-4Sou1dSy/M92fwqSLEgfDrOH3FxOUbVyS9tHyOq5CP6Ab1qFuxJc7dXU1ULyjjeu8scLQmcKGqPCCAxJRKd70g==",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@types/fs-extra": "^9.0.13",
-        "babel-plugin-fully-specified": "*",
-        "chokidar": "^3.5.2",
-        "esbuild": "^0.19.11",
-        "execa": "^5.0.0",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.2.0",
-        "get-tsconfig": "^4.5.0",
-        "lodash.debounce": "^4.0.8"
-      },
-      "bin": {
-        "tamagui-build": "tamagui-build.js"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/cli-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/cli-color/-/cli-color-1.89.26.tgz",
-      "integrity": "sha512-2r+j+42XRxRBHqFNTL4tfsD1PY8Irxnh70gKqkqvI6C4FYUCGRsA//X1SBRFfSUGU1VJv1IAStUvP/b+NJT8gA=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/config-default": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/config-default/-/config-default-1.89.26.tgz",
-      "integrity": "sha512-UThNHhzFQOWiCcf+nrzduPDOayeDMznRJQ0INDwBGXMdvBxWfMy1z4Pdr78ByxfQqwHFP++mC6g2bHW0JpZRKg==",
-      "dependencies": {
-        "@tamagui/core": "1.89.26",
-        "@tamagui/shorthands": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/create-theme": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/create-theme/-/create-theme-1.89.26.tgz",
-      "integrity": "sha512-rgm4T6E8S2DOchptysaXCgZInvV8GE46vRGEb9iT+8Nvc75ywooVYVdnpkk5MVR8w3E4ZFhEbMRJyklMrWMkhw==",
-      "dependencies": {
-        "@tamagui/web": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/fake-react-native": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/fake-react-native/-/fake-react-native-1.89.26.tgz",
-      "integrity": "sha512-JDsjFQrIgJSvpLNsWnY/X1pEVRNCZGsslFx1GBIPXeUSHiCcg05mvS3QOPdOkNnAi/dzizv5OOaK4pgCfXLbqA=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/generate-themes": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/generate-themes/-/generate-themes-1.89.26.tgz",
-      "integrity": "sha512-KhfigT9oYeaY6Ijg2Q8vUmyHf2Pe6g8Q1uYQXK0WyXipqYmCGqW3D4jjr0XWCPYT1Qcemy4svM4h3gwolhbGBg==",
-      "dependencies": {
-        "@tamagui/create-theme": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "esbuild-register": "^3.4.2",
-        "fs-extra": "^11.2.0"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/helpers-node": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers-node/-/helpers-node-1.89.26.tgz",
-      "integrity": "sha512-2QI9pkEL9j3hIAq6btq1WdXNrJ5qwJp+x5TSE7YAJjeoHZNF5JqUynHji2yUXlgHxuL+7uRqYtsKd0HW11BSHw==",
-      "dependencies": {
-        "@tamagui/types": "1.89.26"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/proxy-worm": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/proxy-worm/-/proxy-worm-1.89.26.tgz",
-      "integrity": "sha512-TVCBDwQKHxq1CFrutz1lh9wxpNdhhJyx0RFoGOc6Nmz6qq1CiNHAOrGRlWstPQXGXp9id8pxFQ4bqNW1PdrPdw=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/shorthands": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/shorthands/-/shorthands-1.89.26.tgz",
-      "integrity": "sha512-A0P4tkAMaMtAT/j7BSbQxa8T1Vl68PShQf+c8sb6FxhzPO1PNzhUjAL0m6pMPlfXrlmtQpQiqt7Zlw+YfiYw9Q=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/static": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/static/-/static-1.89.26.tgz",
-      "integrity": "sha512-8xcOLeEW1p6FiRL2iDQ90eQO+OgHYHbhSc3c/2rsAx2wPq4w1pNTBM6CeRZ7gUAY8xGlBJYfWKS2IgdLoxOR7g==",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "@babel/parser": "^7.23.3",
-        "@babel/plugin-transform-react-jsx": "^7.22.15",
-        "@babel/runtime": "^7.23.2",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
-        "@tamagui/build": "1.89.26",
-        "@tamagui/cli-color": "1.89.26",
-        "@tamagui/config-default": "1.89.26",
-        "@tamagui/core": "1.89.26",
-        "@tamagui/fake-react-native": "1.89.26",
-        "@tamagui/generate-themes": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/helpers-node": "1.89.26",
-        "@tamagui/proxy-worm": "1.89.26",
-        "@tamagui/shorthands": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "babel-literal-to-ast": "^2.1.0",
-        "browserslist": "^4.22.2",
-        "esbuild": "^0.19.11",
-        "esbuild-register": "^3.4.2",
-        "find-cache-dir": "^3.3.2",
-        "find-root": "^1.1.0",
-        "fs-extra": "^11.2.0",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "react-native-web": "^0.19.10",
-        "react-native-web-internals": "1.89.26",
-        "react-native-web-lite": "1.89.26"
-      },
-      "optionalDependencies": {
-        "lightningcss": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/web": {
+    "node_modules/@tamagui/web": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
       "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
@@ -17823,139 +14909,6 @@
         "@tamagui/use-force-update": "1.89.26",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/@types/fs-extra": {
-      "version": "9.0.13",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/esbuild": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
-      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.19.12",
-        "@esbuild/android-arm": "0.19.12",
-        "@esbuild/android-arm64": "0.19.12",
-        "@esbuild/android-x64": "0.19.12",
-        "@esbuild/darwin-arm64": "0.19.12",
-        "@esbuild/darwin-x64": "0.19.12",
-        "@esbuild/freebsd-arm64": "0.19.12",
-        "@esbuild/freebsd-x64": "0.19.12",
-        "@esbuild/linux-arm": "0.19.12",
-        "@esbuild/linux-arm64": "0.19.12",
-        "@esbuild/linux-ia32": "0.19.12",
-        "@esbuild/linux-loong64": "0.19.12",
-        "@esbuild/linux-mips64el": "0.19.12",
-        "@esbuild/linux-ppc64": "0.19.12",
-        "@esbuild/linux-riscv64": "0.19.12",
-        "@esbuild/linux-s390x": "0.19.12",
-        "@esbuild/linux-x64": "0.19.12",
-        "@esbuild/netbsd-x64": "0.19.12",
-        "@esbuild/openbsd-x64": "0.19.12",
-        "@esbuild/sunos-x64": "0.19.12",
-        "@esbuild/win32-arm64": "0.19.12",
-        "@esbuild/win32-ia32": "0.19.12",
-        "@esbuild/win32-x64": "0.19.12"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/react-native-web-internals": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/react-native-web-internals/-/react-native-web-internals-1.89.26.tgz",
-      "integrity": "sha512-lLoRB1716Hc4VjAz8XArf8FExu7a+j6hsVa0vTjh/mv5Z1vZsGg8E7A2X649aS/8l8h6jb7iDMrEW72wRWzmRw==",
-      "dependencies": {
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26",
-        "react": "^18.2.0",
-        "styleq": "^0.1.3"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/react-native-web-lite": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/react-native-web-lite/-/react-native-web-lite-1.89.26.tgz",
-      "integrity": "sha512-MnzWa2kAUfXyoBGC2ZixNmNz+ILd25ryuXidKw0vr16eqsf53h0s9k/6ZNKHEC9UTFGERbrecqyLMEuIiqwtZw==",
-      "dependencies": {
-        "@tamagui/normalize-css-color": "1.89.26",
-        "invariant": "^2.2.4",
-        "react-native-web-internals": "1.89.26",
-        "styleq": "^0.1.3"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@tamagui/vite-plugin/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@tanstack/match-sorter-utils": {
@@ -20638,19 +17591,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-literal-to-ast": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/babel-literal-to-ast/-/babel-literal-to-ast-2.1.0.tgz",
-      "integrity": "sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==",
-      "dependencies": {
-        "@babel/parser": "^7.1.6",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.1.2"
-      }
-    },
     "node_modules/babel-merge": {
       "version": "3.0.0",
       "license": "MIT",
@@ -20667,14 +17607,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-plugin-fully-specified": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-fully-specified/-/babel-plugin-fully-specified-1.3.0.tgz",
-      "integrity": "sha512-STW+rXLxwCB839gmwBizuipaDBb/iGZ5Vg0bmfynYLyXRTWgofXDrePuW5VvBJq2x8yB6xvT+3J7Z0U79uQYNw==",
-      "peerDependencies": {
-        "@babel/core": "*"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -22280,6 +19212,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
       "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "peer": true,
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
       }
@@ -23242,6 +20175,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.14.54",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -23282,6 +20216,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -23298,6 +20233,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -23314,6 +20250,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -23328,6 +20265,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23345,6 +20283,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -23361,6 +20300,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -23377,6 +20317,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23393,6 +20334,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23409,6 +20351,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23425,6 +20368,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23441,6 +20385,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23457,6 +20402,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23473,6 +20419,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23489,6 +20436,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -23505,6 +20453,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -23521,6 +20470,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -23530,17 +20480,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-register": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.5.0.tgz",
-      "integrity": "sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
-      }
-    },
     "node_modules/esbuild-sunos-64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
@@ -23548,6 +20487,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -23564,6 +20504,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -23580,6 +20521,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -23596,6 +20538,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -23612,6 +20555,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -24186,11 +21130,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/esm-resolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.8.tgz",
-      "integrity": "sha512-pzYHY8bf7uLpDuefGsI6JtHVS1J3N1uOkIEC36ejvvWhiiMr/xKBX4PrxCtsxeISJbCEMBLkPZvRwZNHgdwn5A=="
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -25068,7 +22007,8 @@
     "node_modules/fast-loops": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
-      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==",
+      "peer": true
     },
     "node_modules/fast-xml-parser": {
       "version": "4.0.11",
@@ -25264,22 +22204,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-      }
     },
     "node_modules/find-root": {
       "version": "1.1.0",
@@ -25492,6 +22416,7 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -25678,6 +22603,7 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
       "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -26151,7 +23077,8 @@
     "node_modules/hyphenate-style-name": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
+      "peer": true
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -26287,6 +23214,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
       "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "peer": true,
       "dependencies": {
         "css-in-js-utils": "^3.1.0",
         "fast-loops": "^1.1.3"
@@ -28125,6 +25053,7 @@
     },
     "node_modules/less": {
       "version": "4.1.3",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -28151,6 +25080,7 @@
     },
     "node_modules/less/node_modules/copy-anything": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -28163,6 +25093,7 @@
     },
     "node_modules/less/node_modules/is-what": {
       "version": "3.14.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -28236,7 +25167,9 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.23.0.tgz",
       "integrity": "sha512-SEArWKMHhqn/0QzOtclIwH5pXIYQOUEkF8DgICd/105O+GCgd7jxjNod/QPnBCSWvpRHQBGVz5fQ9uScby03zA==",
+      "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -29105,20 +26038,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
-    },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -31201,11 +28120,6 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "node_modules/outdent": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
-      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
-    },
     "node_modules/outvariant": {
       "version": "1.3.0",
       "dev": true,
@@ -31295,6 +28209,7 @@
     },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -31699,65 +28614,6 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pkg-types": {
@@ -33157,6 +30013,7 @@
       "version": "0.19.10",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.19.10.tgz",
       "integrity": "sha512-IQoHiTQq8egBCVVwmTrYcFLgEFyb4LMZYEktHn4k22JMk9+QTCEz5WTfvr+jdNoeqj/7rtE81xgowKbfGO74qg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-color": "^2.1.0",
@@ -33175,7 +30032,8 @@
     "node_modules/react-native-web/node_modules/memoize-one": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "peer": true
     },
     "node_modules/react-native-webview": {
       "version": "13.6.4",
@@ -34077,6 +30935,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -35104,7 +31963,8 @@
     "node_modules/styleq": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.3.tgz",
-      "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA=="
+      "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==",
+      "peer": true
     },
     "node_modules/stylis": {
       "version": "4.0.13",
@@ -35646,36 +32506,6 @@
         "react": "*"
       }
     },
-    "node_modules/tamagui/node_modules/@tamagui/compose-refs": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
-      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/constants": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
-      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/core": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
-      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
-      "dependencies": {
-        "@tamagui/react-native-use-pressable": "1.89.26",
-        "@tamagui/react-native-use-responder-events": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/web": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/tamagui/node_modules/@tamagui/create-context": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
@@ -35769,15 +32599,6 @@
         "react": "*"
       }
     },
-    "node_modules/tamagui/node_modules/@tamagui/helpers": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
-      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/simple-hash": "1.89.26"
-      }
-    },
     "node_modules/tamagui/node_modules/@tamagui/helpers-tamagui": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
@@ -35828,14 +32649,6 @@
         "react": "*"
       }
     },
-    "node_modules/tamagui/node_modules/@tamagui/normalize-css-color": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
-      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
-      "dependencies": {
-        "@react-native/normalize-color": "^2.1.0"
-      }
-    },
     "node_modules/tamagui/node_modules/@tamagui/polyfill-dev": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
@@ -35872,22 +32685,6 @@
       },
       "peerDependencies": {
         "react-native": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/react-native-use-pressable": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
-      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/react-native-use-responder-events": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
-      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/tamagui/node_modules/@tamagui/roving-focus": {
@@ -35944,11 +32741,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/simple-hash": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
-      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
     },
     "node_modules/tamagui/node_modules/@tamagui/stacks": {
       "version": "1.89.26",
@@ -36008,11 +32800,6 @@
         "react": "*"
       }
     },
-    "node_modules/tamagui/node_modules/@tamagui/timer": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
-      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
-    },
     "node_modules/tamagui/node_modules/@tamagui/toggle-group": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/toggle-group/-/toggle-group-1.89.26.tgz",
@@ -36035,11 +32822,6 @@
       "peerDependencies": {
         "react": "*"
       }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/types": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
-      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
     },
     "node_modules/tamagui/node_modules/@tamagui/use-constant": {
       "version": "1.89.26",
@@ -36068,40 +32850,10 @@
         "react": "*"
       }
     },
-    "node_modules/tamagui/node_modules/@tamagui/use-did-finish-ssr": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
-      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/tamagui/node_modules/@tamagui/use-direction": {
       "version": "1.89.26",
       "resolved": "https://registry.npmjs.org/@tamagui/use-direction/-/use-direction-1.89.26.tgz",
       "integrity": "sha512-usyYMSMjB2AnCGtJ5ImQBZa8Ka8WAXuAgiBXJlECiv5LxnowfxqROu0+2lnwTc6h/fMAWEs++ydK+XbVapGgGg==",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/use-event": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
-      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
-      "dependencies": {
-        "@tamagui/constants": "1.89.26"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/use-force-update": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
-      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
       "peerDependencies": {
         "react": "*"
       }
@@ -36131,24 +32883,6 @@
       },
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/tamagui/node_modules/@tamagui/web": {
-      "version": "1.89.26",
-      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
-      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
-      "dependencies": {
-        "@tamagui/compose-refs": "1.89.26",
-        "@tamagui/constants": "1.89.26",
-        "@tamagui/helpers": "1.89.26",
-        "@tamagui/normalize-css-color": "1.89.26",
-        "@tamagui/timer": "1.89.26",
-        "@tamagui/types": "1.89.26",
-        "@tamagui/use-did-finish-ssr": "1.89.26",
-        "@tamagui/use-event": "1.89.26",
-        "@tamagui/use-force-update": "1.89.26",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
       }
     },
     "node_modules/tapable": {
@@ -36953,6 +33687,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -37349,6 +34084,7 @@
     },
     "node_modules/vite": {
       "version": "4.4.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -37632,6 +34368,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -37647,6 +34384,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -37662,6 +34400,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -37677,6 +34416,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -37692,6 +34432,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -37707,6 +34448,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -37722,6 +34464,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37737,6 +34480,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37752,6 +34496,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37767,6 +34512,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37782,6 +34528,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37797,6 +34544,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37812,6 +34560,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37827,6 +34576,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37842,6 +34592,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -37857,6 +34608,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -37872,6 +34624,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -37887,6 +34640,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -37902,6 +34656,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -37917,6 +34672,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -37932,6 +34688,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -37942,6 +34699,7 @@
     },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.18.20",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -37977,6 +34735,7 @@
     },
     "node_modules/vite/node_modules/rollup": {
       "version": "3.28.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -39029,9 +35788,7 @@
       "dependencies": {
         "@tamagui/animations-moti": "^1.89.26",
         "@tamagui/get-token": "^1.89.26",
-        "@tamagui/vite-plugin": "^1.89.26",
-        "tamagui": "^1.89.26",
-        "vite": "^4.4.3"
+        "tamagui": "^1.89.26"
       }
     },
     "ui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "landscape-apps-mono",
+  "name": "landscape-apps",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -4794,7 +4794,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -4810,7 +4809,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4826,7 +4824,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4842,7 +4839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -4856,7 +4852,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4873,7 +4868,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -4889,7 +4883,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4905,7 +4898,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -4921,7 +4913,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4937,7 +4928,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4953,7 +4943,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4969,7 +4958,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4985,7 +4973,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5001,7 +4988,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5017,7 +5003,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5033,7 +5018,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5049,7 +5033,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5065,7 +5048,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -5081,7 +5063,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -5097,7 +5078,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -5113,7 +5093,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5129,7 +5108,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -5145,7 +5123,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7384,6 +7361,20 @@
         "@floating-ui/core": "^0.7.3"
       }
     },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.9.tgz",
+      "integrity": "sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.8",
+        "@floating-ui/utils": "^0.2.1",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@floating-ui/react-dom": {
       "version": "0.7.2",
       "license": "MIT",
@@ -7395,6 +7386,65 @@
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
+    },
+    "node_modules/@floating-ui/react-native": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-native/-/react-native-0.10.4.tgz",
+      "integrity": "sha512-R0RiZ+XiC+S2Xw11i+HjXj8/ik006edp2SDGKELOlkP55SNE1UMfxackchi/rJfnv+qL9YHQRNySte967+kyVA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-native": ">=0.64.0"
+      }
+    },
+    "node_modules/@floating-ui/react-native/node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/react-native/node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@floating-ui/react/node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/react/node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react/node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.1.1",
@@ -13096,6 +13146,4818 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/@tamagui/alert-dialog": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/alert-dialog/-/alert-dialog-1.89.26.tgz",
+      "integrity": "sha512-UMMA0n4UnAeQQlXqg5u/j4tRQm3efUrkXlkyRrQeVllhiKM/xfSykMQMSsdtdpHxoXYjaKNwmRr9pg2z26fvTQ==",
+      "dependencies": {
+        "@tamagui/animate-presence": "1.89.26",
+        "@tamagui/aria-hidden": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/dialog": "1.89.26",
+        "@tamagui/dismissable": "1.89.26",
+        "@tamagui/focus-scope": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/popper": "1.89.26",
+        "@tamagui/portal": "1.89.26",
+        "@tamagui/remove-scroll": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/animate-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate-presence/-/animate-presence-1.89.26.tgz",
+      "integrity": "sha512-eO5gSv99Vxg+vqrjKSKJhU1XaxpZEk2F3Ha7cNzxZPHcg5fHkOhwLaiNZ6xGiiCq22fJ1ky/tgMEylb+emDx4g==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/polyfill-dev": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
+      "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-constant": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
+      "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/alert-dialog/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/animate": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate/-/animate-1.89.26.tgz",
+      "integrity": "sha512-yFF4cQZhi+29eBUi/wtQwlZWGCUaej7kZqbIZTzFHd5r6/96LSlBMi3YKh2ZZ+qsIPB+oqne8kIZd7tAxTTiLA==",
+      "dependencies": {
+        "@tamagui/animate-presence": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/animate-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate-presence/-/animate-presence-1.89.26.tgz",
+      "integrity": "sha512-eO5gSv99Vxg+vqrjKSKJhU1XaxpZEk2F3Ha7cNzxZPHcg5fHkOhwLaiNZ6xGiiCq22fJ1ky/tgMEylb+emDx4g==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/use-constant": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
+      "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animate/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/animations-moti": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animations-moti/-/animations-moti-1.89.26.tgz",
+      "integrity": "sha512-LkvggusE4YXcJESlRhNJecWkZo1fm8LnRiXQ8Bw43tOz9DuW1GvTgEmnV74i4AextxnZ+xKIVMa4F813q6g5Zg==",
+      "dependencies": {
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26",
+        "moti": "^0.27.2",
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/animations-moti/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/aria-hidden": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/aria-hidden/-/aria-hidden-1.89.26.tgz",
+      "integrity": "sha512-LU7UZlA26Pbbh6WCXLWNvWeKRofbVcW1NGuZCiZX0GzBZFM9EONEBnK2ywRlQLYFBjntf/GQcVLqbogl6RacUg==",
+      "dependencies": {
+        "aria-hidden": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/avatar/-/avatar-1.89.26.tgz",
+      "integrity": "sha512-vCyluWeRuPky09yVWlMH6eI7K2iBILIzFmL3axRAid2oY74tAomeMpC7bCsFe8dOTIYvkBLbVrGgz7QOhzJXPQ==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/image": "1.89.26",
+        "@tamagui/shapes": "1.89.26",
+        "@tamagui/text": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/shapes": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/shapes/-/shapes-1.89.26.tgz",
+      "integrity": "sha512-UF8DVGE6lAp3kV2Z2xDS7mFg5Eb5Z2OjqASTjLik32ol9RbYN2fnV8a26o1/f6oRDq11IeeVWeBXaMiqFllMbQ==",
+      "dependencies": {
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/avatar/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/card": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/card/-/card-1.89.26.tgz",
+      "integrity": "sha512-PZso5aVwrifQXi2Sj/m/Hh4QwRa9EwdC1EvpnZv1yQLyQ41r4+5v5xZygbfWqWnQb2pL1n5Kt3rAUSDCfybh7w==",
+      "dependencies": {
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/card/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/checkbox-headless/-/checkbox-headless-1.89.26.tgz",
+      "integrity": "sha512-N1do+pPWd+5yckw+EULh70S+M+A4m5lKRxryLdFFtO4IIo/DdNGZfHonhYi2A05MM+kderuIsvb7H9c1QyiIBA==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/label": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-previous": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/focusable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/focusable/-/focusable-1.89.26.tgz",
+      "integrity": "sha512-gC7qq+ikahAcM3olNtQ1KXuic82PGKJK1aTPNEz85P0l5uMrtheMPQJVRTZcMgiN9ZcNy1/ExUSZ0vjqfvnLEw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-button-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-button-sized/-/get-button-sized-1.89.26.tgz",
+      "integrity": "sha512-s2nuHV4BD4DNbX0V5TrmC1sL2wmQGmnTmMUO3nyNGRnapkNyGlxnE3qTtbhsu6x6ou9Cx+O9YMbb5cVSPAbGaA==",
+      "dependencies": {
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/label": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/label/-/label-1.89.26.tgz",
+      "integrity": "sha512-OmNQmbn/idrzop6h5akcJAwmFY7EEOaithpmihqClOHYRVOwHRTtGxTZLlaAciBP+IHg+oQFzwyqjmMYrGiMgQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-previous": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
+      "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/dialog": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/dialog/-/dialog-1.89.26.tgz",
+      "integrity": "sha512-WeER9KR2XVgjAC+lbYKRHU7bbFYabAPqSU6oUpYLeGrrHOV2rqqrN0qb/jMmyan3CjrMWQQY2h3JYB4XUsNX7Q==",
+      "dependencies": {
+        "@tamagui/adapt": "1.89.26",
+        "@tamagui/animate-presence": "1.89.26",
+        "@tamagui/aria-hidden": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/dismissable": "1.89.26",
+        "@tamagui/focus-scope": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/popper": "1.89.26",
+        "@tamagui/portal": "1.89.26",
+        "@tamagui/remove-scroll": "1.89.26",
+        "@tamagui/sheet": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/adapt": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/adapt/-/adapt-1.89.26.tgz",
+      "integrity": "sha512-tP6+yLEh08d081R3wlBTAqKD2ynPCNhKcAz+KmaqkFxSA0X9QKI2xr7AmA9GYpS0tWDU+bnNT8/83GiCmb4UqA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/helpers": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/animate-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate-presence/-/animate-presence-1.89.26.tgz",
+      "integrity": "sha512-eO5gSv99Vxg+vqrjKSKJhU1XaxpZEk2F3Ha7cNzxZPHcg5fHkOhwLaiNZ6xGiiCq22fJ1ky/tgMEylb+emDx4g==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/polyfill-dev": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
+      "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-constant": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
+      "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dialog/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/dismissable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/dismissable/-/dismissable-1.89.26.tgz",
+      "integrity": "sha512-0neBp3aDHasOQzSn2+SGBG4qbkpOa6BaYoLCJdMxEuB5SGRZdlGHA6NYAf2tHsYND8d3XzYN1pHj7+Zjxt9Y3A==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-escape-keydown": "1.89.26",
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/dismissable/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/elements": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/elements/-/elements-1.89.26.tgz",
+      "integrity": "sha512-Vh6JdQJBM2wpkSZpQgx7NgD9B7CHgYVpjjj0iIiLcRf2cT9RPgquhVcjPq/baYU1sgWJ6xNccKV5sEi4Ctndeg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/elements/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/floating": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/floating/-/floating-1.89.26.tgz",
+      "integrity": "sha512-8+0E4tpswAI2zjOb+S5iTrrXF3QO9bY3hxYX2Dn/QGgTQ4NXYiN/i49R1nwP31IXaYTh4OrG2Mo3wBN8+/0Umw==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.6",
+        "@floating-ui/react-native": "^0.10.3",
+        "react-dom": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/floating/node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@tamagui/floating/node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@tamagui/floating/node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@tamagui/floating/node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@tamagui/focus-scope": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/focus-scope/-/focus-scope-1.89.26.tgz",
+      "integrity": "sha512-fnP2Of6L4KPfDPGvQJ40RBI4kTgKGg3fHX+lAvFNH4v33iofLaJYoyZxYhTxuqNsOtiqoREU2X+HDaNpFVgpHw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/focus-scope/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/focus-scope/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/focus-scope/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-token/-/get-token-1.89.26.tgz",
+      "integrity": "sha512-O2bL7XfJlhOKCtETdvAg48qWJbIj8h0Srle/QOxc2QlwqS7aLUgZKWnBG7niYxNNtOznX4sZR39vpvuhOLKC4g==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/get-token/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/image": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/image/-/image-1.89.26.tgz",
+      "integrity": "sha512-gjNVvixgobul4xUsmfSkuJzGh2gcZn4hILyztlaFtrrYk/EgoW9wSa3o3nr4SUj91OzRNzCtBrb+wJiw9tiLIA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/image/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/linear-gradient/-/linear-gradient-1.89.26.tgz",
+      "integrity": "sha512-HXORz2J+nkn6gLQpU8t5nGp0ouvzW6mP5UHAWvcO6NxtrsWRMJXspFiZv2NtrpY6zYW1DaoWmkA2FxcBiPm50g==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26",
+        "@tamagui/stacks": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/linear-gradient/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/popover": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/popover/-/popover-1.89.26.tgz",
+      "integrity": "sha512-thRNqZB0P0hRcw5o8IF0VFJDVFrim3bRnZBEgWDEE9C+/eb8o7n70w0yjd/frReG5XvlDW9RqXW+M8WCc8FaSg==",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.6",
+        "@tamagui/adapt": "1.89.26",
+        "@tamagui/animate": "1.89.26",
+        "@tamagui/aria-hidden": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/dismissable": "1.89.26",
+        "@tamagui/floating": "1.89.26",
+        "@tamagui/focus-scope": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/popper": "1.89.26",
+        "@tamagui/portal": "1.89.26",
+        "@tamagui/remove-scroll": "1.89.26",
+        "@tamagui/scroll-view": "1.89.26",
+        "@tamagui/sheet": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "react-freeze": "^1.0.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/adapt": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/adapt/-/adapt-1.89.26.tgz",
+      "integrity": "sha512-tP6+yLEh08d081R3wlBTAqKD2ynPCNhKcAz+KmaqkFxSA0X9QKI2xr7AmA9GYpS0tWDU+bnNT8/83GiCmb4UqA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/helpers": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/polyfill-dev": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
+      "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/scroll-view": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/scroll-view/-/scroll-view-1.89.26.tgz",
+      "integrity": "sha512-wS3cDnz/YpmLSfy3Ya/Uv508ZYXQKuajUYbccasPsJ4FTvSBpssG/mIYZVXGMZxD0VugiWgCC9HDLR/7sTX85A==",
+      "dependencies": {
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popover/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/popper": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/popper/-/popper-1.89.26.tgz",
+      "integrity": "sha512-aEOdohgeH+VLr7nqGN96p0l4aTuueWGtkmDe6HREp/Yq/MCmfPZtsoPRxJBhJjnfOV1/kyAqKWEhizhDuO5cvw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/floating": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/popper/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/portal": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/portal/-/portal-1.89.26.tgz",
+      "integrity": "sha512-CMbsgI66znGUqkDAgei2dpE2xYcPDZjw9M8Ldf3gKBBvb1pxmgbWaCXEiyicab9ka83H6IdCeb+4iGO6vesYsg==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/portal/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/progress": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/progress/-/progress-1.89.26.tgz",
+      "integrity": "sha512-PZufiNb+N0yJZD8bNL0mtDdc9qsnfnwimus4RgpculwDOgyfkVBHnLOXIJjiBw0222wtbhT/XHjoiLmg6Z5KNA==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/stacks": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/progress/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/react-native-svg": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-svg/-/react-native-svg-1.89.26.tgz",
+      "integrity": "sha512-QunyPS4oNQZ8+p1XVq5z+QGDlSrnkf9gHG/RwuPTa5ZKvxfBo6LEv9NCGzEbnj4HYHoqW6/ZmnKvXZJgTj6hpA=="
+    },
+    "node_modules/@tamagui/remove-scroll": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/remove-scroll/-/remove-scroll-1.89.26.tgz",
+      "integrity": "sha512-JbwIELrtQAVdIxD6g2XFLQ6hqsGMwayVfFvlG0SOUfzHQRQn9RhEaO7yb+BV/I2DaxHIl0kcXYi9jTxEAWn6nA==",
+      "dependencies": {
+        "react-remove-scroll": "^2.5.5"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/select/-/select-1.89.26.tgz",
+      "integrity": "sha512-+gtiWVMTWIQbYnLLDgwxJRnr6rfXEWf1kki/BtgbAxIaJKeBJgBsBVI3VpfIJL53ZAtZ97fCt/AK/t4xgtving==",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.6",
+        "@floating-ui/react-dom": "^2.0.6",
+        "@floating-ui/react-native": "^0.10.3",
+        "@tamagui/adapt": "1.89.26",
+        "@tamagui/animate-presence": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/dismissable": "1.89.26",
+        "@tamagui/focus-scope": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/list-item": "1.89.26",
+        "@tamagui/portal": "1.89.26",
+        "@tamagui/remove-scroll": "1.89.26",
+        "@tamagui/separator": "1.89.26",
+        "@tamagui/sheet": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-debounce": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-previous": "1.89.26",
+        "react-dom": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/adapt": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/adapt/-/adapt-1.89.26.tgz",
+      "integrity": "sha512-tP6+yLEh08d081R3wlBTAqKD2ynPCNhKcAz+KmaqkFxSA0X9QKI2xr7AmA9GYpS0tWDU+bnNT8/83GiCmb4UqA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/helpers": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/animate-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate-presence/-/animate-presence-1.89.26.tgz",
+      "integrity": "sha512-eO5gSv99Vxg+vqrjKSKJhU1XaxpZEk2F3Ha7cNzxZPHcg5fHkOhwLaiNZ6xGiiCq22fJ1ky/tgMEylb+emDx4g==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/font-size": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/font-size/-/font-size-1.89.26.tgz",
+      "integrity": "sha512-P6A4ml6Z0ScbDxCE2puPOBXbsxcEKd9fe4bsBm7Xqdfdto1kwaJ7HFXAsOAIa0+WgNEszuKMW6r3eMdihOHRiw==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/list-item": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/list-item/-/list-item-1.89.26.tgz",
+      "integrity": "sha512-tE5k2lZOwGkWWVDjoMyGleGQCRfLo3oCODha6GJDgnlLvEmIuf1hQiYOBaeb97S/SdoKn2Vqv7oddJswVHaung==",
+      "dependencies": {
+        "@tamagui/font-size": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/separator": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/separator/-/separator-1.89.26.tgz",
+      "integrity": "sha512-VyEJrqN9BH/9cNUmdjwo5GdV4IMFq6KXmaWSzNL8iEeW2RDLOl+EHw0YnrY4JUOi8EF1D3CZnTVrWk3f3kqPjA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-constant": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
+      "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-debounce": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-debounce/-/use-debounce-1.89.26.tgz",
+      "integrity": "sha512-l37uHmt6QHL6a7RbNvGESw9G7pR9uw2CMCB/moWgLsdidxLsTmKXheJ1yTTXPyygPsh0h8PXe9HC+ztlr+RlpA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/use-previous": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
+      "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
+    },
+    "node_modules/@tamagui/select/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/sheet": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/sheet/-/sheet-1.89.26.tgz",
+      "integrity": "sha512-XlTfissHG5Ekl3vbZ+Zmk2FuNqbzXDnK4lPUp4bgO2sgLVaJOJa8rtH0VLfRKm44FOVcxprgmmhqqt6Z1K/xDQ==",
+      "dependencies": {
+        "@tamagui/animate-presence": "1.89.26",
+        "@tamagui/animations-react-native": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/portal": "1.89.26",
+        "@tamagui/remove-scroll": "1.89.26",
+        "@tamagui/scroll-view": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-keyboard-visible": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/animate-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate-presence/-/animate-presence-1.89.26.tgz",
+      "integrity": "sha512-eO5gSv99Vxg+vqrjKSKJhU1XaxpZEk2F3Ha7cNzxZPHcg5fHkOhwLaiNZ6xGiiCq22fJ1ky/tgMEylb+emDx4g==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/animations-react-native": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animations-react-native/-/animations-react-native-1.89.26.tgz",
+      "integrity": "sha512-i+uztNUaNDQvf2HbTMQAZoMNaLKaSjOvzPr+q3bChBxQ6IX5sMqKKYxpr/BcD3ljrPGHt7rIEtIt1Kq0RihATQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/scroll-view": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/scroll-view/-/scroll-view-1.89.26.tgz",
+      "integrity": "sha512-wS3cDnz/YpmLSfy3Ya/Uv508ZYXQKuajUYbccasPsJ4FTvSBpssG/mIYZVXGMZxD0VugiWgCC9HDLR/7sTX85A==",
+      "dependencies": {
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-constant": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
+      "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/sheet/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/slider": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/slider/-/slider-1.89.26.tgz",
+      "integrity": "sha512-Qx4UbsoX4bG+ytmOaUGtHTd2R5z2WLbPy+QeVf9f//dLeAMarxAeG2L1vQIjvTBB2IKqAbNX3ay1lV7Ney6vuw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-direction": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/use-direction": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-direction/-/use-direction-1.89.26.tgz",
+      "integrity": "sha512-usyYMSMjB2AnCGtJ5ImQBZa8Ka8WAXuAgiBXJlECiv5LxnowfxqROu0+2lnwTc6h/fMAWEs++ydK+XbVapGgGg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/slider/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/switch": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/switch/-/switch-1.89.26.tgz",
+      "integrity": "sha512-6sHidbwBsWs65nyakCLmd0iYiAZFENBcUkGQ8zYE0INwwO8ybxYh6UyFCYQhKtbWyrHitSDtFoDP4lxFTAzTZg==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/label": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/switch-headless": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-previous": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/switch-headless/-/switch-headless-1.89.26.tgz",
+      "integrity": "sha512-+bWl2G/iy6jc7KNx8QUR9ri2vC6d/nYa9juRDcZ1stjNNm5TkMKg/9O9surHBB5e41BHx4P9iYw/VqdQNxa+Hw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/label": "1.89.26",
+        "@tamagui/use-previous": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/focusable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/focusable/-/focusable-1.89.26.tgz",
+      "integrity": "sha512-gC7qq+ikahAcM3olNtQ1KXuic82PGKJK1aTPNEz85P0l5uMrtheMPQJVRTZcMgiN9ZcNy1/ExUSZ0vjqfvnLEw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/get-button-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-button-sized/-/get-button-sized-1.89.26.tgz",
+      "integrity": "sha512-s2nuHV4BD4DNbX0V5TrmC1sL2wmQGmnTmMUO3nyNGRnapkNyGlxnE3qTtbhsu6x6ou9Cx+O9YMbb5cVSPAbGaA==",
+      "dependencies": {
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/label": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/label/-/label-1.89.26.tgz",
+      "integrity": "sha512-OmNQmbn/idrzop6h5akcJAwmFY7EEOaithpmihqClOHYRVOwHRTtGxTZLlaAciBP+IHg+oQFzwyqjmMYrGiMgQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/use-previous": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
+      "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
+    },
+    "node_modules/@tamagui/switch-headless/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/focusable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/focusable/-/focusable-1.89.26.tgz",
+      "integrity": "sha512-gC7qq+ikahAcM3olNtQ1KXuic82PGKJK1aTPNEz85P0l5uMrtheMPQJVRTZcMgiN9ZcNy1/ExUSZ0vjqfvnLEw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/get-button-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-button-sized/-/get-button-sized-1.89.26.tgz",
+      "integrity": "sha512-s2nuHV4BD4DNbX0V5TrmC1sL2wmQGmnTmMUO3nyNGRnapkNyGlxnE3qTtbhsu6x6ou9Cx+O9YMbb5cVSPAbGaA==",
+      "dependencies": {
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/label": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/label/-/label-1.89.26.tgz",
+      "integrity": "sha512-OmNQmbn/idrzop6h5akcJAwmFY7EEOaithpmihqClOHYRVOwHRTtGxTZLlaAciBP+IHg+oQFzwyqjmMYrGiMgQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/use-previous": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
+      "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
+    },
+    "node_modules/@tamagui/switch/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/tooltip": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/tooltip/-/tooltip-1.89.26.tgz",
+      "integrity": "sha512-tRJOmr2fQyAdJBa+qTYn0fYtHw9Gw+sJ6+YlpO4pfpmUyv3WObP9MqOZ3SxynK+UakseOyZb8wcmu0K9xNLYaw==",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.6",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/floating": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/popover": "1.89.26",
+        "@tamagui/popper": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/polyfill-dev": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
+      "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/tooltip/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/use-callback-ref": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-callback-ref/-/use-callback-ref-1.89.26.tgz",
+      "integrity": "sha512-CZEw+GKLtuO7oXf25iS0enJVyOov++CUQ8W7Ca3G7J2/UJCVC+60Nd5lo8FCo81yxNpwpUO3uDwfWV0lcFfm9g=="
+    },
+    "node_modules/@tamagui/use-escape-keydown": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-escape-keydown/-/use-escape-keydown-1.89.26.tgz",
+      "integrity": "sha512-2yVXjR7/HCxyNX5JpQc6aqxMYoDodFKl7pol0ywdpEkWc1clGFxdRtTeDQQQGScC+xEnsxUodL+gozgMhHfzjg==",
+      "dependencies": {
+        "@tamagui/use-callback-ref": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/use-keyboard-visible": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-keyboard-visible/-/use-keyboard-visible-1.89.26.tgz",
+      "integrity": "sha512-/vw9o9NvCXMU3oxtcQqPevM4RaSEZ6EcPJe+Kd3rhkS/28h73fwvKZNY8zMm5Cl0B/cZX2Ua7RYbZbYlYUzPfQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/use-window-dimensions": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-window-dimensions/-/use-window-dimensions-1.89.26.tgz",
+      "integrity": "sha512-aw8BlZOWXFIt4AmzefQWxMbihB98oioQSecgejiQ9+7qJOQ8MTb3cIMYX+ABppcXWBDq6RAo7+UXuvKo7ItW2g==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/use-window-dimensions/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/vite-plugin/-/vite-plugin-1.89.26.tgz",
+      "integrity": "sha512-WwkLCpBMScs3i7ZOVJfKAASXq4W2CdlUJDxNN0tG8zCtc8fn0NrE4mU9AXr4KJbuMvl2mEb6XnQs/xiT+wAypw==",
+      "dependencies": {
+        "@tamagui/fake-react-native": "1.89.26",
+        "@tamagui/proxy-worm": "1.89.26",
+        "@tamagui/react-native-svg": "1.89.26",
+        "@tamagui/static": "1.89.26",
+        "esm-resolve": "^1.0.8",
+        "fs-extra": "^11.2.0",
+        "outdent": "^0.8.0"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/build": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/build/-/build-1.89.26.tgz",
+      "integrity": "sha512-4Sou1dSy/M92fwqSLEgfDrOH3FxOUbVyS9tHyOq5CP6Ab1qFuxJc7dXU1ULyjjeu8scLQmcKGqPCCAxJRKd70g==",
+      "dependencies": {
+        "@babel/core": "^7.23.3",
+        "@types/fs-extra": "^9.0.13",
+        "babel-plugin-fully-specified": "*",
+        "chokidar": "^3.5.2",
+        "esbuild": "^0.19.11",
+        "execa": "^5.0.0",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.2.0",
+        "get-tsconfig": "^4.5.0",
+        "lodash.debounce": "^4.0.8"
+      },
+      "bin": {
+        "tamagui-build": "tamagui-build.js"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/cli-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/cli-color/-/cli-color-1.89.26.tgz",
+      "integrity": "sha512-2r+j+42XRxRBHqFNTL4tfsD1PY8Irxnh70gKqkqvI6C4FYUCGRsA//X1SBRFfSUGU1VJv1IAStUvP/b+NJT8gA=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/config-default": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/config-default/-/config-default-1.89.26.tgz",
+      "integrity": "sha512-UThNHhzFQOWiCcf+nrzduPDOayeDMznRJQ0INDwBGXMdvBxWfMy1z4Pdr78ByxfQqwHFP++mC6g2bHW0JpZRKg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26",
+        "@tamagui/shorthands": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/create-theme": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-theme/-/create-theme-1.89.26.tgz",
+      "integrity": "sha512-rgm4T6E8S2DOchptysaXCgZInvV8GE46vRGEb9iT+8Nvc75ywooVYVdnpkk5MVR8w3E4ZFhEbMRJyklMrWMkhw==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/fake-react-native": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/fake-react-native/-/fake-react-native-1.89.26.tgz",
+      "integrity": "sha512-JDsjFQrIgJSvpLNsWnY/X1pEVRNCZGsslFx1GBIPXeUSHiCcg05mvS3QOPdOkNnAi/dzizv5OOaK4pgCfXLbqA=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/generate-themes": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/generate-themes/-/generate-themes-1.89.26.tgz",
+      "integrity": "sha512-KhfigT9oYeaY6Ijg2Q8vUmyHf2Pe6g8Q1uYQXK0WyXipqYmCGqW3D4jjr0XWCPYT1Qcemy4svM4h3gwolhbGBg==",
+      "dependencies": {
+        "@tamagui/create-theme": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "esbuild-register": "^3.4.2",
+        "fs-extra": "^11.2.0"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/helpers-node": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-node/-/helpers-node-1.89.26.tgz",
+      "integrity": "sha512-2QI9pkEL9j3hIAq6btq1WdXNrJ5qwJp+x5TSE7YAJjeoHZNF5JqUynHji2yUXlgHxuL+7uRqYtsKd0HW11BSHw==",
+      "dependencies": {
+        "@tamagui/types": "1.89.26"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/proxy-worm": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/proxy-worm/-/proxy-worm-1.89.26.tgz",
+      "integrity": "sha512-TVCBDwQKHxq1CFrutz1lh9wxpNdhhJyx0RFoGOc6Nmz6qq1CiNHAOrGRlWstPQXGXp9id8pxFQ4bqNW1PdrPdw=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/shorthands": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/shorthands/-/shorthands-1.89.26.tgz",
+      "integrity": "sha512-A0P4tkAMaMtAT/j7BSbQxa8T1Vl68PShQf+c8sb6FxhzPO1PNzhUjAL0m6pMPlfXrlmtQpQiqt7Zlw+YfiYw9Q=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/static": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/static/-/static-1.89.26.tgz",
+      "integrity": "sha512-8xcOLeEW1p6FiRL2iDQ90eQO+OgHYHbhSc3c/2rsAx2wPq4w1pNTBM6CeRZ7gUAY8xGlBJYfWKS2IgdLoxOR7g==",
+      "dependencies": {
+        "@babel/core": "^7.23.3",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/parser": "^7.23.3",
+        "@babel/plugin-transform-react-jsx": "^7.22.15",
+        "@babel/runtime": "^7.23.2",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
+        "@tamagui/build": "1.89.26",
+        "@tamagui/cli-color": "1.89.26",
+        "@tamagui/config-default": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/fake-react-native": "1.89.26",
+        "@tamagui/generate-themes": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/helpers-node": "1.89.26",
+        "@tamagui/proxy-worm": "1.89.26",
+        "@tamagui/shorthands": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "babel-literal-to-ast": "^2.1.0",
+        "browserslist": "^4.22.2",
+        "esbuild": "^0.19.11",
+        "esbuild-register": "^3.4.2",
+        "find-cache-dir": "^3.3.2",
+        "find-root": "^1.1.0",
+        "fs-extra": "^11.2.0",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "react-native-web": "^0.19.10",
+        "react-native-web-internals": "1.89.26",
+        "react-native-web-lite": "1.89.26"
+      },
+      "optionalDependencies": {
+        "lightningcss": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/react-native-web-internals": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/react-native-web-internals/-/react-native-web-internals-1.89.26.tgz",
+      "integrity": "sha512-lLoRB1716Hc4VjAz8XArf8FExu7a+j6hsVa0vTjh/mv5Z1vZsGg8E7A2X649aS/8l8h6jb7iDMrEW72wRWzmRw==",
+      "dependencies": {
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26",
+        "react": "^18.2.0",
+        "styleq": "^0.1.3"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/react-native-web-lite": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/react-native-web-lite/-/react-native-web-lite-1.89.26.tgz",
+      "integrity": "sha512-MnzWa2kAUfXyoBGC2ZixNmNz+ILd25ryuXidKw0vr16eqsf53h0s9k/6ZNKHEC9UTFGERbrecqyLMEuIiqwtZw==",
+      "dependencies": {
+        "@tamagui/normalize-css-color": "1.89.26",
+        "invariant": "^2.2.4",
+        "react-native-web-internals": "1.89.26",
+        "styleq": "^0.1.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/vite-plugin/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@tanstack/match-sorter-utils": {
       "version": "8.8.4",
       "license": "MIT",
@@ -13878,6 +18740,10 @@
     },
     "node_modules/@tloncorp/shared": {
       "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@tloncorp/ui": {
+      "resolved": "packages/ui",
       "link": true
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -15772,6 +20638,19 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/babel-literal-to-ast": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/babel-literal-to-ast/-/babel-literal-to-ast-2.1.0.tgz",
+      "integrity": "sha512-CxfpQ0ysQ0bZOhlaPgcWjl79Em16Rhqc6++UAFn0A3duiXmuyhhj8yyl9PYbj0I0CyjrHovdDbp2QEKT7uIMxw==",
+      "dependencies": {
+        "@babel/parser": "^7.1.6",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.1.6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.1.2"
+      }
+    },
     "node_modules/babel-merge": {
       "version": "3.0.0",
       "license": "MIT",
@@ -15788,6 +20667,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-plugin-fully-specified": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-fully-specified/-/babel-plugin-fully-specified-1.3.0.tgz",
+      "integrity": "sha512-STW+rXLxwCB839gmwBizuipaDBb/iGZ5Vg0bmfynYLyXRTWgofXDrePuW5VvBJq2x8yB6xvT+3J7Z0U79uQYNw==",
+      "peerDependencies": {
+        "@babel/core": "*"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -17389,6 +22276,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
     "node_modules/css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
@@ -18347,7 +23242,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.14.54",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -18388,7 +23282,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -18405,7 +23298,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -18422,7 +23314,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -18437,7 +23328,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18455,7 +23345,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -18472,7 +23361,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -18489,7 +23377,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18506,7 +23393,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18523,7 +23409,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18540,7 +23425,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18557,7 +23441,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18574,7 +23457,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18591,7 +23473,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18608,7 +23489,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -18625,7 +23505,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -18642,7 +23521,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -18652,6 +23530,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/esbuild-register": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.5.0.tgz",
+      "integrity": "sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.12 <1"
+      }
+    },
     "node_modules/esbuild-sunos-64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
@@ -18659,7 +23548,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -18676,7 +23564,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -18693,7 +23580,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -18710,7 +23596,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -18727,7 +23612,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -19302,6 +24186,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/esm-resolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/esm-resolve/-/esm-resolve-1.0.8.tgz",
+      "integrity": "sha512-pzYHY8bf7uLpDuefGsI6JtHVS1J3N1uOkIEC36ejvvWhiiMr/xKBX4PrxCtsxeISJbCEMBLkPZvRwZNHgdwn5A=="
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -20176,6 +25065,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.0.11",
       "license": "MIT",
@@ -20370,6 +25264,22 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
     },
     "node_modules/find-root": {
       "version": "1.1.0",
@@ -20579,9 +25489,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.1.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -20768,7 +25678,6 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
       "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
-      "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -21239,6 +26148,11 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "license": "MIT",
@@ -21368,6 +26282,15 @@
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
       "license": "MIT"
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
+      }
     },
     "node_modules/inquirer": {
       "version": "8.2.4",
@@ -23202,7 +28125,6 @@
     },
     "node_modules/less": {
       "version": "4.1.3",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -23229,7 +28151,6 @@
     },
     "node_modules/less/node_modules/copy-anything": {
       "version": "2.0.6",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -23242,7 +28163,6 @@
     },
     "node_modules/less/node_modules/is-what": {
       "version": "3.14.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -23316,9 +28236,7 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.23.0.tgz",
       "integrity": "sha512-SEArWKMHhqn/0QzOtclIwH5pXIYQOUEkF8DgICd/105O+GCgd7jxjNod/QPnBCSWvpRHQBGVz5fQ9uScby03zA==",
-      "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -24187,6 +29105,20 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -25198,6 +30130,17 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/moti": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/moti/-/moti-0.27.2.tgz",
+      "integrity": "sha512-QYH9Id14Zdjx9L75iMPyvxUN+GvHZ4lk6QhUyA63kWgXyqPT2yMnEIbk7hIeQ0WQDW2eLAXEi2/6FJkS7TEwsw==",
+      "dependencies": {
+        "framer-motion": "^6.5.1"
+      },
+      "peerDependencies": {
+        "react-native-reanimated": "*"
       }
     },
     "node_modules/ms": {
@@ -26258,6 +31201,11 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "node_modules/outdent": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
+    },
     "node_modules/outvariant": {
       "version": "1.3.0",
       "dev": true,
@@ -26347,7 +31295,6 @@
     },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -26689,6 +31636,11 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/performant-array-to-tree": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.11.0.tgz",
+      "integrity": "sha512-YwCqIDvnaebXaKuKQhI5yJD6ryDc3FxvoeX/5ougXTKDUWb7s5S2BuBgIyftCa4sBe1+ZU5Kmi4RJy+pjjjrpw=="
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "license": "ISC"
@@ -26747,6 +31699,65 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pkg-types": {
@@ -28142,6 +33153,30 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/react-native-web": {
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.19.10.tgz",
+      "integrity": "sha512-IQoHiTQq8egBCVVwmTrYcFLgEFyb4LMZYEktHn4k22JMk9+QTCEz5WTfvr+jdNoeqj/7rtE81xgowKbfGO74qg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@react-native/normalize-color": "^2.1.0",
+        "fbjs": "^3.0.4",
+        "inline-style-prefixer": "^6.0.1",
+        "memoize-one": "^6.0.0",
+        "nullthrows": "^1.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "styleq": "^0.1.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-native-web/node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/react-native-webview": {
       "version": "13.6.4",
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.6.4.tgz",
@@ -28729,6 +33764,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/reforest": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/reforest/-/reforest-0.13.0.tgz",
+      "integrity": "sha512-f0It/s51f1UWCCCni0viULALDBhxWBPFnLmZRYtKcz4zYeNWqeNTdcnU/OpBry9tk+jyMQcH3MLK8UdzsAvA5w==",
+      "dependencies": {
+        "performant-array-to-tree": "^1.11.0",
+        "zustand": "^4.3.8"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/reforest/node_modules/zustand": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.0.tgz",
+      "integrity": "sha512-zlVFqS5TQ21nwijjhJlx4f9iGrXSL0o/+Dpy4txAP22miJ8Ti6c1Ol1RLNN98BMib83lmDH/2KmLwaNXpjrO1A==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/refractor": {
       "version": "4.8.0",
       "license": "MIT",
@@ -29003,7 +34077,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -30028,6 +35101,11 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/styleq": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.3.tgz",
+      "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA=="
+    },
     "node_modules/stylis": {
       "version": "4.0.13",
       "license": "MIT"
@@ -30266,6 +35344,11 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "node_modules/tailwind-rn": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tailwind-rn/-/tailwind-rn-4.2.0.tgz",
@@ -30380,6 +35463,692 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/tamagui/-/tamagui-1.89.26.tgz",
+      "integrity": "sha512-g8QxnI4N+Cq8naDNee/6RSGsvjmD6tZfYsEdyQrg81iwnuy7jCaUyH4o57Ibxfu2H1vrwuMCYPvupsZyFir/+Q==",
+      "dependencies": {
+        "@tamagui/accordion": "1.89.26",
+        "@tamagui/adapt": "1.89.26",
+        "@tamagui/alert-dialog": "1.89.26",
+        "@tamagui/animate-presence": "1.89.26",
+        "@tamagui/avatar": "1.89.26",
+        "@tamagui/button": "1.89.26",
+        "@tamagui/card": "1.89.26",
+        "@tamagui/checkbox": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/dialog": "1.89.26",
+        "@tamagui/elements": "1.89.26",
+        "@tamagui/fake-react-native": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/font-size": "1.89.26",
+        "@tamagui/form": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/group": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/image": "1.89.26",
+        "@tamagui/label": "1.89.26",
+        "@tamagui/linear-gradient": "1.89.26",
+        "@tamagui/list-item": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/popover": "1.89.26",
+        "@tamagui/popper": "1.89.26",
+        "@tamagui/portal": "1.89.26",
+        "@tamagui/progress": "1.89.26",
+        "@tamagui/radio-group": "1.89.26",
+        "@tamagui/react-native-media-driver": "1.89.26",
+        "@tamagui/scroll-view": "1.89.26",
+        "@tamagui/select": "1.89.26",
+        "@tamagui/separator": "1.89.26",
+        "@tamagui/shapes": "1.89.26",
+        "@tamagui/sheet": "1.89.26",
+        "@tamagui/slider": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/switch": "1.89.26",
+        "@tamagui/tabs": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/theme": "1.89.26",
+        "@tamagui/toggle-group": "1.89.26",
+        "@tamagui/tooltip": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-debounce": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-window-dimensions": "1.89.26",
+        "@tamagui/visually-hidden": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/accordion": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/accordion/-/accordion-1.89.26.tgz",
+      "integrity": "sha512-Bt48YqTtahmnvACkcxRq1BDnxCO3xGV1Me+Ab9884g+lwQUmQwnn7QGVxoSrRaHvyOS1LejvSZ1yDpj3dcDVLA==",
+      "dependencies": {
+        "@tamagui/collapsible": "1.89.26",
+        "@tamagui/collection": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/adapt": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/adapt/-/adapt-1.89.26.tgz",
+      "integrity": "sha512-tP6+yLEh08d081R3wlBTAqKD2ynPCNhKcAz+KmaqkFxSA0X9QKI2xr7AmA9GYpS0tWDU+bnNT8/83GiCmb4UqA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/helpers": "1.89.26"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/animate-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/animate-presence/-/animate-presence-1.89.26.tgz",
+      "integrity": "sha512-eO5gSv99Vxg+vqrjKSKJhU1XaxpZEk2F3Ha7cNzxZPHcg5fHkOhwLaiNZ6xGiiCq22fJ1ky/tgMEylb+emDx4g==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-constant": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "@tamagui/use-presence": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/button": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/button/-/button-1.89.26.tgz",
+      "integrity": "sha512-YF4tUERZTtyOXntlFvyef3NpaJBUgUU7lfp29Y6MpGvuQI6odwfvPNgX1Z2tx/3gZJjq9TpWx9u1Bx8IEiuKZw==",
+      "dependencies": {
+        "@tamagui/font-size": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/checkbox": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/checkbox/-/checkbox-1.89.26.tgz",
+      "integrity": "sha512-UDmQTcWqLI//3B15CHR5Mz8AdCPiR1rLRDjqX0dPp/SFR+qCs97IcMtvr/WTzrLwkIPgqfJPNmrQJaVNZOOKuA==",
+      "dependencies": {
+        "@tamagui/checkbox-headless": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/font-size": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/label": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-previous": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/collapsible": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/collapsible/-/collapsible-1.89.26.tgz",
+      "integrity": "sha512-2Osw4Sq+hhcKnF6xMTzaV9CQzQOH5N/l+082HLDcD51JOUsILMvlAmiE42+o/s4bx36XF9zL0Y7GFTzdSd0L3Q==",
+      "dependencies": {
+        "@tamagui/animate-presence": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/collection": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/collection/-/collection-1.89.26.tgz",
+      "integrity": "sha512-93Sylr22Iq+Xc14jzT853vxmo7jMOyFtSqGvP47QArdejb5CGHHNbWW9Rc80ze57qE5VIK1RmoYd+IDCimrgZA==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/polyfill-dev": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/compose-refs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.89.26.tgz",
+      "integrity": "sha512-VR0FB1HwPAmmpImivPjsxmIEhOPB/x5kS+79+BleOCs/LBGOYXl2L471jKHzlVN8jtfa8JvR3wQ8bm3+3fj8qQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/constants": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.89.26.tgz",
+      "integrity": "sha512-sgmMdVYApBi20vjT06iVUyT6U8vHY7UtjNRFJO8qivOdV6pIHiXzpbAWlkvLs4bUNBUZFYoqtCgQsy7fE/C/FQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/core": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.89.26.tgz",
+      "integrity": "sha512-4O9mm2byAMqCB8cXPMIJVrCLg36ojsNc3WjwAJApihsFlybwe3CoAYoUFiml8K9j9C2TuG2ejPnd8EcCu+u60A==",
+      "dependencies": {
+        "@tamagui/react-native-use-pressable": "1.89.26",
+        "@tamagui/react-native-use-responder-events": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/create-context": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.89.26.tgz",
+      "integrity": "sha512-Rv5RQq+F9WBcKHJjY4vvYBlsKAU+Ja2eDu73jxSV00rexIUiq/s7xlj9ZEpTR8pgGXzWrp+ikC0J5M3xZGpj1A==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/fake-react-native": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/fake-react-native/-/fake-react-native-1.89.26.tgz",
+      "integrity": "sha512-JDsjFQrIgJSvpLNsWnY/X1pEVRNCZGsslFx1GBIPXeUSHiCcg05mvS3QOPdOkNnAi/dzizv5OOaK4pgCfXLbqA=="
+    },
+    "node_modules/tamagui/node_modules/@tamagui/focusable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/focusable/-/focusable-1.89.26.tgz",
+      "integrity": "sha512-gC7qq+ikahAcM3olNtQ1KXuic82PGKJK1aTPNEz85P0l5uMrtheMPQJVRTZcMgiN9ZcNy1/ExUSZ0vjqfvnLEw==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/font-size": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/font-size/-/font-size-1.89.26.tgz",
+      "integrity": "sha512-P6A4ml6Z0ScbDxCE2puPOBXbsxcEKd9fe4bsBm7Xqdfdto1kwaJ7HFXAsOAIa0+WgNEszuKMW6r3eMdihOHRiw==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/form": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/form/-/form-1.89.26.tgz",
+      "integrity": "sha512-X1nifRpzqjBlaR2EOfIb8RBEE6dIGwWr78kGz2tgax62H4U+3JrT9tGAHxNeyUZ1y/8uupQIyaS1/+pWGkCVOg==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/text": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/get-button-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-button-sized/-/get-button-sized-1.89.26.tgz",
+      "integrity": "sha512-s2nuHV4BD4DNbX0V5TrmC1sL2wmQGmnTmMUO3nyNGRnapkNyGlxnE3qTtbhsu6x6ou9Cx+O9YMbb5cVSPAbGaA==",
+      "dependencies": {
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/get-font-sized": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.89.26.tgz",
+      "integrity": "sha512-v3IzsNQTZOt31LEMg8h71pSycXlgupvvgWWgp1tnpzCLlYwgyVcl/fNdoN3ddC0YGDLwagBN9i9BCwakeCsHSg==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/group": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/group/-/group-1.89.26.tgz",
+      "integrity": "sha512-pUTu/1aP2LZFIYwDqUjNYHS6WN6sd4NsFd2+eQKUutWq6tfpi4J7VDILsP/xBVHx5Q4+kFvdgOqQ81u4kOnXdA==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "reforest": "^0.13.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/helpers": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.89.26.tgz",
+      "integrity": "sha512-IRU0BX+142yhpwi1/9XrpFIP+9/p2VimzV3UuJNBNlwgS8/2ZU8A7MA4Fm4woXgixlzseD5cU4JVS2J0vA/5Yw==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/simple-hash": "1.89.26"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.89.26.tgz",
+      "integrity": "sha512-ZD2m3dGUvSKxgHVnp6JP2pasThMptNXc2U9HGhbBFtIT0JpyasaWhf04q/nBTkHJk7TWk/4XFBLRK695kyzOHA==",
+      "dependencies": {
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/label": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/label/-/label-1.89.26.tgz",
+      "integrity": "sha512-OmNQmbn/idrzop6h5akcJAwmFY7EEOaithpmihqClOHYRVOwHRTtGxTZLlaAciBP+IHg+oQFzwyqjmMYrGiMgQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/list-item": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/list-item/-/list-item-1.89.26.tgz",
+      "integrity": "sha512-tE5k2lZOwGkWWVDjoMyGleGQCRfLo3oCODha6GJDgnlLvEmIuf1hQiYOBaeb97S/SdoKn2Vqv7oddJswVHaung==",
+      "dependencies": {
+        "@tamagui/font-size": "1.89.26",
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/text": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.89.26.tgz",
+      "integrity": "sha512-UYbu36OYjxCtEG9d+163tQGklBvb4Tx0lcke0+67oxR8ZmafSz26hiE5w+33oTY6moJ8wYWX5LYSTnwFvNpqew==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/polyfill-dev": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/polyfill-dev/-/polyfill-dev-1.89.26.tgz",
+      "integrity": "sha512-mbaYH3/jxwTyg8Vww4lro0oKdWR1lZxPDTjuRc5JjG2LS1xxnUkq2EW7e20iNcanYY+n/1k0+qEJLZTk/rXXUw=="
+    },
+    "node_modules/tamagui/node_modules/@tamagui/radio-group": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/radio-group/-/radio-group-1.89.26.tgz",
+      "integrity": "sha512-Vg13c3jtshKXqzLjWl46ywgm21v9EFDd10GwISl725DSQYV0QyRyETB7jBfJiJ3vTATOYZQpMuq7Eq/wtpp8Ew==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/label": "1.89.26",
+        "@tamagui/roving-focus": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-previous": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/react-native-media-driver": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-media-driver/-/react-native-media-driver-1.89.26.tgz",
+      "integrity": "sha512-WsT8lxtGLP9cf2PlsxXdSzAbrEKeDo0BhM+l66FNfxI3NH4coMSOEkXQEvED2WmalvMK+DgMSijC9F+Z/LjLpg==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.89.26.tgz",
+      "integrity": "sha512-QlphU9ppLbXCwndmTkZaKRT3T005zOex9/DmBSmcKjJ/XyOb2NVSl5IokW7sG+r8eVwsq5IhHJiram9lFUj+vQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.89.26.tgz",
+      "integrity": "sha512-WTduIBNRXotxOzK+DIPgK5RE+IT/obAyt65kyFxub3zan747Jo/Q9kI4CVGfA9UuDIEBcXPFq1Ndjgmsaj2juw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/roving-focus": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/roving-focus/-/roving-focus-1.89.26.tgz",
+      "integrity": "sha512-sAP4aELDpMxPBgMONSMLzX33ksdT8EzTlOk3+82Mb5EPJisCt+ueuICqJnE1D4B1fGp5jB4ku/STSgUIiDoduw==",
+      "dependencies": {
+        "@tamagui/collection": "1.89.26",
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-direction": "1.89.26",
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/scroll-view": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/scroll-view/-/scroll-view-1.89.26.tgz",
+      "integrity": "sha512-wS3cDnz/YpmLSfy3Ya/Uv508ZYXQKuajUYbccasPsJ4FTvSBpssG/mIYZVXGMZxD0VugiWgCC9HDLR/7sTX85A==",
+      "dependencies": {
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/separator": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/separator/-/separator-1.89.26.tgz",
+      "integrity": "sha512-VyEJrqN9BH/9cNUmdjwo5GdV4IMFq6KXmaWSzNL8iEeW2RDLOl+EHw0YnrY4JUOi8EF1D3CZnTVrWk3f3kqPjA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/shapes": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/shapes/-/shapes-1.89.26.tgz",
+      "integrity": "sha512-UF8DVGE6lAp3kV2Z2xDS7mFg5Eb5Z2OjqASTjLik32ol9RbYN2fnV8a26o1/f6oRDq11IeeVWeBXaMiqFllMbQ==",
+      "dependencies": {
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/simple-hash": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.89.26.tgz",
+      "integrity": "sha512-KTUKSj6o9MY6NVeUa6OeAPak4zc22Q74GVOlKSZvdzJcH/X/SO6eqVcW+RM7R7JinqUiCae+mdFIUkvJnVCN4A=="
+    },
+    "node_modules/tamagui/node_modules/@tamagui/stacks": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.89.26.tgz",
+      "integrity": "sha512-S3O+Mz4Ugyx1i8rM7S6GdxGaWO7+2FSxHqlz1iyjwrkYi56z5j8OJK9sO5V7APBiw2zWRxQ6huvtK/ltXrpt2w==",
+      "dependencies": {
+        "@tamagui/core": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/tabs": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/tabs/-/tabs-1.89.26.tgz",
+      "integrity": "sha512-W3SYzbk8t1Pi9pgDvcg12CEyQVdCcEMjBtc3dKgJN8EkHatCVRsKnl7EGHESIUxOIwBL6TLmrMaVeT//Ek8ryQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/get-button-sized": "1.89.26",
+        "@tamagui/group": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/roving-focus": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-direction": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/text": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.89.26.tgz",
+      "integrity": "sha512-/m6BXxkwwn34BwUBIzJhWkw3Ks4w35AAcmG11szZWUrkQxlaz2wpbrx+LbbWw7KwScVKY92RCZcvYsuaHvfztA==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/theme": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/theme/-/theme-1.89.26.tgz",
+      "integrity": "sha512-VkCkjlEnhhiXp1zkMcDWH2cuZgfc1j9RkxG3p+SPlODUFAa48hToNnd/9eiwwwucLBHVliwWUU+Fch8JnH8GTQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/timer": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.89.26.tgz",
+      "integrity": "sha512-SlZdGh6O0mZ5GZ7F5f6C8XP7zocrKsMPoDJhsvvc1JMJVRFQC0J3ku5Lu6fEO29g1TJaKrHD5C4mY1vDaXUKXw=="
+    },
+    "node_modules/tamagui/node_modules/@tamagui/toggle-group": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/toggle-group/-/toggle-group-1.89.26.tgz",
+      "integrity": "sha512-V2tcIrY53j0eC3HlEGwMoLkKVMcwD1l32ZLA0Esc/tOWOhZ0DjAkwwC6mr1fUsWbHT8kpEk6He0gXZS1NG/M6A==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/create-context": "1.89.26",
+        "@tamagui/focusable": "1.89.26",
+        "@tamagui/font-size": "1.89.26",
+        "@tamagui/get-token": "1.89.26",
+        "@tamagui/group": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/helpers-tamagui": "1.89.26",
+        "@tamagui/roving-focus": "1.89.26",
+        "@tamagui/stacks": "1.89.26",
+        "@tamagui/use-controllable-state": "1.89.26",
+        "@tamagui/use-direction": "1.89.26",
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/types": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.89.26.tgz",
+      "integrity": "sha512-7ARzVQSFwDwJTF1mE0Whe9woyCQIJcNq7v94+xCR4VzxiQf17z8OFOQhm78QS7PsJX2WyAuCiehn/Jq6bzxx0Q=="
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-constant": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-constant/-/use-constant-1.89.26.tgz",
+      "integrity": "sha512-LFjqIvMnr32k6dNGj86cAkwneXtivucCAIh04PoOmwTkz3LjLubbC6SqX6mJifUiYkz5pZRrTOyiTi4iTWoTxg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.89.26.tgz",
+      "integrity": "sha512-16SU6uhCF/3njIJwoT1orv0Y9hKA5hnY4VbafSeUjyx/b4FIMvLikCEIMjnDd2NoPxecIIqkebLH2WIYy0Xocw==",
+      "dependencies": {
+        "@tamagui/use-event": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-debounce": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-debounce/-/use-debounce-1.89.26.tgz",
+      "integrity": "sha512-l37uHmt6QHL6a7RbNvGESw9G7pR9uw2CMCB/moWgLsdidxLsTmKXheJ1yTTXPyygPsh0h8PXe9HC+ztlr+RlpA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.89.26.tgz",
+      "integrity": "sha512-AcvdWmgDJwUwGzhTe2B+J9P/kQcmHMq7Oa6VOojnLLSZIoFEtwnjRPzp9nIvGYpziRAB4ttoADVUi/pay4jSKA==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-direction": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-direction/-/use-direction-1.89.26.tgz",
+      "integrity": "sha512-usyYMSMjB2AnCGtJ5ImQBZa8Ka8WAXuAgiBXJlECiv5LxnowfxqROu0+2lnwTc6h/fMAWEs++ydK+XbVapGgGg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-event": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.89.26.tgz",
+      "integrity": "sha512-aA4I5j9QZryC1aRp3eOqoGEhKDPpv+1J2OnkJ7UTbc3mJkUVhX/Z6myNhWNrQ4ywJsSqIXUFQxVRe79CcV59KQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-force-update": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.89.26.tgz",
+      "integrity": "sha512-TwXQUeOLm2WwKXY0iIzBqjfpqiUcQczuMyz459zj/OAxeBRhdiF0TKErJeR5AWdFjrSo1xKRSyAS5YhPSs8VvA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-presence": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-presence/-/use-presence-1.89.26.tgz",
+      "integrity": "sha512-6XN58dtmjAOvKIDZdb1cYrPn+Hu/1jGYJHKfm4GxBt6c6tUVWT1Fchoz7ePChnjbWNLRZLxj78NcfF232zd6pA==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/use-previous": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.89.26.tgz",
+      "integrity": "sha512-Sg4ZXWtVy1+6eTPVyQDy+8Tqj1oTuIrsGUbP0qKvCiKjXikCfeySdpdgKQACnvFRyx18ZDB7mJFUvVZ4THesmA=="
+    },
+    "node_modules/tamagui/node_modules/@tamagui/visually-hidden": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/visually-hidden/-/visually-hidden-1.89.26.tgz",
+      "integrity": "sha512-Edu1lMluiDozCb0Dl0Bx3iNt/2euw0WLBf2Ss7cGjCQNPxTytW5tz4PHkL1GkWQcKK+tnOXv/nQ/WiS+zidA5A==",
+      "dependencies": {
+        "@tamagui/web": "1.89.26"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/web": {
+      "version": "1.89.26",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.89.26.tgz",
+      "integrity": "sha512-XAKCBLjvZTWjYbis5H6z21rLucU473LUF95NbmxIBc7nmcOr03VAZ5uk/eETx3EDE0x1bbaSmoTidHQXCmJXwQ==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.89.26",
+        "@tamagui/constants": "1.89.26",
+        "@tamagui/helpers": "1.89.26",
+        "@tamagui/normalize-css-color": "1.89.26",
+        "@tamagui/timer": "1.89.26",
+        "@tamagui/types": "1.89.26",
+        "@tamagui/use-did-finish-ssr": "1.89.26",
+        "@tamagui/use-event": "1.89.26",
+        "@tamagui/use-force-update": "1.89.26",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/tapable": {
@@ -31184,7 +36953,6 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -31581,7 +37349,6 @@
     },
     "node_modules/vite": {
       "version": "4.4.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -31865,7 +37632,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -31881,7 +37647,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -31897,7 +37662,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -31913,7 +37677,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31929,7 +37692,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -31945,7 +37707,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -31961,7 +37722,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31977,7 +37737,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -31993,7 +37752,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32009,7 +37767,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32025,7 +37782,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32041,7 +37797,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32057,7 +37812,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32073,7 +37827,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32089,7 +37842,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -32105,7 +37857,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -32121,7 +37872,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -32137,7 +37887,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -32153,7 +37902,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -32169,7 +37917,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -32185,7 +37932,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -32196,7 +37942,6 @@
     },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.18.20",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -32232,7 +37977,6 @@
     },
     "node_modules/vite/node_modules/rollup": {
       "version": "3.28.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -33279,6 +39023,16 @@
     "packages/shared": {
       "name": "@tloncorp/shared",
       "version": "1.0.0"
+    },
+    "packages/ui": {
+      "name": "@tloncorp/ui",
+      "dependencies": {
+        "@tamagui/animations-moti": "^1.89.26",
+        "@tamagui/get-token": "^1.89.26",
+        "@tamagui/vite-plugin": "^1.89.26",
+        "tamagui": "^1.89.26",
+        "vite": "^4.4.3"
+      }
     },
     "ui": {
       "name": "landscape-apps",

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,3 @@
+# @tloncorp/ui
+
+This package contains UI components which can be used in both web and mobile environments.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,8 +10,6 @@
   "dependencies": {
     "@tamagui/animations-moti": "^1.89.26",
     "@tamagui/get-token": "^1.89.26",
-    "@tamagui/vite-plugin": "^1.89.26",
-    "tamagui": "^1.89.26",
-    "vite": "^4.4.3"
+    "tamagui": "^1.89.26"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@tloncorp/ui",
+  "types": "./src",
+  "main": "src/index.ts",
+  "module:jsx": "src",
+  "files": [
+    "types",
+    "dist"
+  ],
+  "dependencies": {
+    "@tamagui/animations-moti": "^1.89.26",
+    "@tamagui/get-token": "^1.89.26",
+    "@tamagui/vite-plugin": "^1.89.26",
+    "tamagui": "^1.89.26",
+    "vite": "^4.4.3"
+  }
+}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,64 @@
+import { getSize } from "@tamagui/get-token";
+import {
+  SizeTokens,
+  Stack,
+  Text,
+  createStyledContext,
+  styled,
+  useTheme,
+  withStaticProperties,
+} from "tamagui";
+import { cloneElement, useContext } from "react";
+
+export const ButtonContext = createStyledContext<{ size: SizeTokens }>({
+  size: "$m",
+});
+
+export const ButtonFrame = styled(Stack, {
+  name: "Button",
+  context: ButtonContext,
+  backgroundColor: "$background",
+  alignItems: "center",
+  flexDirection: "row",
+  pressStyle: {
+    backgroundColor: "$positiveBackground",
+  },
+  borderColor: "$border",
+  borderWidth: 1,
+  borderRadius: "$m",
+  paddingVertical: "$s",
+  paddingHorizontal: "$l",
+});
+
+export const ButtonText = styled(Text, {
+  name: "ButtonText",
+  context: ButtonContext,
+  color: "$primaryText",
+  userSelect: "none",
+
+  variants: {
+    size: {
+      "...fontSize": (name, { font }) => ({
+        fontSize: font?.size[name],
+      }),
+    },
+  } as const,
+});
+
+const ButtonIcon = (props: { children: any }) => {
+  const { size } = useContext(ButtonContext.context);
+  const smaller = getSize(size, {
+    shift: -2,
+  });
+  const theme = useTheme();
+  return cloneElement(props.children, {
+    size: smaller.val * 0.5,
+    color: theme.primaryText.get(),
+  });
+};
+
+export const Button = withStaticProperties(ButtonFrame, {
+  Props: ButtonContext.Provider,
+  Text: ButtonText,
+  Icon: ButtonIcon,
+});

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,14 +1,14 @@
 import { getSize } from "@tamagui/get-token";
+import { cloneElement, useContext } from "react";
 import {
+  createStyledContext,
   SizeTokens,
   Stack,
-  Text,
-  createStyledContext,
   styled,
+  Text,
   useTheme,
   withStaticProperties,
 } from "tamagui";
-import { cloneElement, useContext } from "react";
 
 export const ButtonContext = createStyledContext<{ size: SizeTokens }>({
   size: "$m",
@@ -38,8 +38,8 @@ export const ButtonText = styled(Text, {
 
   variants: {
     size: {
-      "...fontSize": (name, { font }) => ({
-        fontSize: font?.size[name],
+      "...fontSize": (name) => ({
+        fontSize: name,
       }),
     },
   } as const,

--- a/packages/ui/src/components/TamaguiProvider.tsx
+++ b/packages/ui/src/components/TamaguiProvider.tsx
@@ -1,0 +1,10 @@
+import { TamaguiProvider as BaseTamaguiProvider } from "tamagui";
+import { config } from "../tamagui.config";
+
+export function TamaguiProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <BaseTamaguiProvider config={config} defaultTheme="light">
+      {children}
+    </BaseTamaguiProvider>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./components/Button";
+export * from "./components/TamaguiProvider";
+export * from "./tamagui.config";

--- a/packages/ui/src/tamagui.config.ts
+++ b/packages/ui/src/tamagui.config.ts
@@ -1,0 +1,179 @@
+import { createAnimations } from "@tamagui/animations-moti";
+import { createFont, createTamagui, createTokens } from "tamagui";
+
+export const animations = createAnimations({
+  simple: {
+    type: "timing",
+    duration: 100,
+  },
+  quick: {
+    type: "spring",
+    damping: 30,
+    mass: 1,
+    stiffness: 250,
+  },
+});
+
+export const tokens = createTokens({
+  color: {
+    translucentBlack: "rgba(0, 0, 0, 0.2)",
+    black: "#000000",
+    gray900: "#1A1A1A",
+    gray800: "#333333",
+    gray700: "#4C4C4C",
+    gray600: "#666666",
+    gray500: "#808080",
+    gray400: "#999999",
+    gray300: "#B3B3B3",
+    gray200: "#CCCCCC",
+    gray100: "#E5E5E5",
+    gray50: "#F5F5F5",
+    white: "#FFFFFF",
+    red: "#FF6240",
+    orange: "#FF9040",
+    yellow: "#FADE7A",
+    green: "#2AD546",
+    blue: "#008EFF",
+    indigo: "#615FD3",
+    redSoft: "#FFEFEC",
+    orangeSoft: "#FFF4EC",
+    yellowSoft: "#FAF5D9",
+    greenSoft: "#EAFBEC",
+    blueSoft: "#E5F4FF",
+    indigoSoft: "#EFEFFB",
+  },
+  space: {
+    "2xs": 2,
+    xs: 4,
+    s: 6,
+    m: 8,
+    l: 12,
+    xl: 16,
+    true: 16,
+    "2xl": 24,
+    "3xl": 32,
+    "4xl": 48,
+  },
+  size: {
+    "2xs": 2,
+    xs: 4,
+    s: 6,
+    m: 8,
+    l: 12,
+    xl: 16,
+    true: 16,
+    "2xl": 24,
+    "3xl": 32,
+    "4xl": 48,
+  },
+  radius: {
+    "2xs": 2,
+    xs: 4,
+    s: 6,
+    m: 8,
+    l: 12,
+    xl: 16,
+    true: 16,
+    "2xl": 24,
+    "3xl": 32,
+    "4xl": 48,
+  },
+  zIndex: {
+    s: 0,
+    true: 0,
+    m: 1,
+    l: 10,
+    xl: 9999,
+  },
+});
+
+export const themes = {
+  dark: {
+    primaryText: "#FFFFFF",
+    secondaryText: "#B3B3B3",
+    background: "#1A1818",
+    secondaryBackground: "#322E2E",
+    tertiaryText: "#808080",
+    border: "#333333",
+    activeBorder: "#4C4C4C",
+    positiveActionText: "#4E91F5",
+    positiveBackground: "#143A5E",
+    positiveBorder: "#3D567C",
+    negativeActionText: "#E96A6A",
+    negativeBackground: "#4B2525",
+    negativeBorder: "#814444",
+  },
+  light: {
+    primaryText: "#1A1818",
+    secondaryText: "#666666",
+    background: "#FFFFFF",
+    secondaryBackground: "#F5F5F5",
+    tertiaryText: "#999999",
+    border: "#E5E5E5",
+    activeBorder: "#CCCCCC",
+    positiveActionText: "#3B80E8",
+    positiveBackground: "#F5FAFF",
+    positiveBorder: "#CCDCF3",
+    negativeActionText: "#E22A2A",
+    negativeBackground: "#FEF5F5",
+    negativeBorder: "#FCD0D0",
+  },
+};
+
+export const sfFont = createFont({
+  family: "System",
+  size: {
+    s: 14,
+    m: 17,
+    true: 17,
+    l: 17,
+    xl: 17,
+  },
+  lineHeight: {
+    s: 22,
+  },
+  weight: {
+    s: "400",
+  },
+  letterSpacing: {
+    s: 0,
+  },
+});
+
+export const monoFont = createFont({
+  family: "Menlo-Regular",
+  size: {
+    s: 14,
+    m: 14,
+    true: 15,
+    l: 15,
+    xl: 15,
+  },
+  lineHeight: {
+    l: 19,
+  },
+  weight: {
+    l: "200",
+  },
+  letterSpacing: {
+    l: 0,
+  },
+});
+
+export const fonts = {
+  // === Tamagui components require fonts for these properties
+  heading: sfFont,
+  body: sfFont,
+  mono: monoFont,
+  // ===
+};
+
+export const config = createTamagui({
+  tokens,
+  fonts,
+  themes,
+  settings: {
+    allowedStyleValues: "somewhat-strict",
+  },
+  animations,
+});

--- a/packages/ui/src/tamagui.d.ts
+++ b/packages/ui/src/tamagui.d.ts
@@ -1,0 +1,8 @@
+import { config } from "./tamagui.config";
+
+export type Conf = typeof config;
+
+// Sets up typing for tamagui so that theme variables autocomplete
+declare module "tamagui" {
+  interface TamaguiCustomConfig extends Conf {}
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,45 @@
+{
+  "compilerOptions": {
+    "importHelpers": true,
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "preserveSymlinks": true,
+    "incremental": true,
+    "jsx": "react-jsx",
+    "module": "system",
+    "moduleResolution": "node",
+    "noEmitOnError": false,
+    "noImplicitAny": false,
+    "noImplicitReturns": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "useUnknownInCatchVariables": false,
+    "preserveConstEnums": true,
+    // DONT DO THIS so jsdoc will remain
+    "removeComments": false,
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "strictNullChecks": true,
+    "target": "es2020",
+    "types": [
+      "node",
+      "react"
+    ],
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+  ],
+  "exclude": [
+    "node_modules/**/*"
+  ],
+  "typeAcquisition": {
+    "enable": true
+  }
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -11,7 +11,6 @@
     "module": "system",
     "moduleResolution": "node",
     "noEmitOnError": false,
-    "noImplicitAny": false,
     "noImplicitReturns": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
This PR performs initial setup of tamagui in the native mobile app. Tamagui components are kept in a separate package (`ui`) to help keep it encapsulated, since the longer term goal is to use it in both the web and native apps.

How to test:
- Build the mobile app
- Try using `Button` from `@tloncorp/ui`