### PR TITLE
Don't focus ChatInput for /dm/groups/... routes [LAND-1577]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "homestead",
+  "name": "landscape-apps-mono",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Since the nav bars of groups and talk were combined, when viewing a Group Chat using the Messages tab on desktop, the ChatChannel view does't recognize the search route if  the Search button is clicked. In this case, the URL has a "/dm/groups" portion (instead of "/groups" as when in the Groups nav tab). Chat input should not be focused in those cases to allow the search input to be used.

Tested using hosted ship running on local vite dev build

Fixes LAND-1577

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context