### PR TITLE
chore: add npm run build:shared to postinstall on root package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build Shared Packages
-        run: npm run build:shared
-
       - name: Run Lint
         run: npm run lint --workspaces --if-present
 

--- a/.github/workflows/deploy-talk.yml
+++ b/.github/workflows/deploy-talk.yml
@@ -20,8 +20,6 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Dependencies
         run: npm ci
-      - name: Build Shared Packages
-        run: npm run build:shared
       - working-directory: ./apps/tlon-web
         run: npm run build:chat
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,6 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Dependencies
         run: npm ci
-      - name: Build Shared Packages
-        run: npm run build:shared
       - working-directory: ./apps/tlon-web
         run: npm run build
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/glob-and-deploy-kernel.yml
+++ b/.github/workflows/glob-and-deploy-kernel.yml
@@ -20,8 +20,6 @@ jobs:
           node-version-file: .nvmrc
       - name: Install Dependencies
         run: npm ci
-      - name: Build Shared Packages
-        run: npm run build:shared
       - working-directory: ./apps/tlon-web
         run: npm run build
       - uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:web": "concurrently \"npm run dev:shared\" \"npm run dev-no-ssl --prefix ./apps/tlon-web\"",
     "test": "npm run test --workspaces --if-present -- run -u",
     "prepare": "husky",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package && npm run build:shared"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
Without this you could run into eslint/ts errors on importing the package (until you manually build the package or run the dev script for it).