### PR TITLE
Search: Don't focus ChatInput for /dm/groups/... routes

### DIFF
--- a/apps/tlon-web/src/chat/ChatChannel.tsx
+++ b/apps/tlon-web/src/chat/ChatChannel.tsx
@@ -49,6 +49,9 @@ function ChatChannel({ title }: ViewProps) {
   const isSmall = useMedia('(max-width: 1023px)');
   const inThread = !!idTime;
   const inSearch = useMatch(`/groups/${groupFlag}/channels/${nest}/search/*`);
+  const inDmSearch = useMatch(
+    `/dm/groups/${groupFlag}/channels/${nest}/search/*`
+  );
   const { mutateAsync: leaveChat } = useLeaveMutation();
   const { mutate: sendMessage } = useAddPostMutation(nest);
   const dropZoneId = `chat-input-dropzone-${chFlag}`;
@@ -156,7 +159,7 @@ function ChatChannel({ title }: ViewProps) {
                 whom={chFlag}
                 sendChatMessage={sendMessage}
                 showReply
-                autoFocus={!inThread && !inSearch}
+                autoFocus={!inThread && !inSearch && !inDmSearch}
                 dropZoneId={dropZoneId}
                 replyingWrit={replyingWrit || undefined}
                 isScrolling={isScrolling}


### PR DESCRIPTION
Since the nav bars of groups and talk were combined, when viewing a Group Chat using the Messages tab on desktop, the ChatChannel view does't recognize the search route if  the Search button is clicked. In this case, the URL has a "/dm/groups" portion (instead of "/groups" as when in the Groups nav tab). Chat input should not be focused in those cases to allow the search input to be used.

Fixes LAND-1577

Tested locally with livenet ship

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context