### PR TITLE
mobile: fix backwards compatibility with native options

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -638,7 +638,8 @@ function RoutedApp() {
   const analyticsId = useAnalyticsId();
   const { needsUpdate, triggerUpdate } = useAppUpdates();
   const body = document.querySelector('body');
-  const colorSchemeFromNative = window.nativeOptions?.colorScheme;
+  const colorSchemeFromNative =
+    window.nativeOptions?.colorScheme ?? window.colorscheme;
 
   const appUpdateContextValue = useMemo(
     () => ({ needsUpdate, triggerUpdate }),

--- a/apps/tlon-web/src/logic/SafeAreaContext.tsx
+++ b/apps/tlon-web/src/logic/SafeAreaContext.tsx
@@ -7,12 +7,13 @@ import {
   useState,
 } from 'react';
 
-const defaultSafeAreaInsets = window.nativeOptions?.safeAreaInsets ?? {
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
-};
+const defaultSafeAreaInsets = window.nativeOptions?.safeAreaInsets ??
+  window.safeAreaInsets ?? {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
 
 const SafeAreaContext = createContext({
   safeAreaInsets: defaultSafeAreaInsets,

--- a/apps/tlon-web/src/window.ts
+++ b/apps/tlon-web/src/window.ts
@@ -16,6 +16,14 @@ declare global {
       postMessage: (message: string) => void;
     };
     nativeOptions?: NativeWebViewOptions;
+    // old values for backwards compatibility with Tlon Mobile v3
+    colorscheme: any;
+    safeAreaInsets?: {
+      top: number;
+      bottom: number;
+      left: number;
+      right: number;
+    };
   }
 }
 


### PR DESCRIPTION
PR Checklist
- [ ] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context

Re-introduces the `window.colorscheme` and `window.safeAreaInsets` values to fix backwards compatibility with Tlon Mobile v3 (existing production versions). Tested locally with mobile build pointed to web dev server.