### PR TITLE
channels: make sure channel data is up to date when we have unreads

### DIFF
--- a/apps/tlon-web/src/state/bootstrap.ts
+++ b/apps/tlon-web/src/state/bootstrap.ts
@@ -3,13 +3,14 @@ import _ from 'lodash';
 
 import api from '@/api';
 import { useChatStore } from '@/chat/useChatStore';
-import { asyncWithDefault } from '@/logic/utils';
+import { asyncWithDefault, whomIsDm } from '@/logic/utils';
 import queryClient from '@/queryClient';
 import { GroupsInit } from '@/types/ui';
 
 import { infinitePostQueryFn } from './channel/channel';
 import { ChannnelKeys } from './channel/keys';
-import { initializeChat } from './chat';
+import { infiniteDMsQueryFn, initializeChat } from './chat';
+import ChatQueryKeys from './chat/keys';
 import useContactState from './contact';
 import useDocketState from './docket';
 import useKilnState from './kiln';
@@ -52,6 +53,7 @@ async function startGroups() {
   queryClient.setQueryData(['unreads'], unreads);
   queryClient.setQueryData(pinsKey(), pins);
   initializeChat(chat);
+  const { unreads: chatUnreads } = chat;
 
   // if we have unreads fetch them in advance
   Object.keys(unreads || {}).forEach(async (nest) => {
@@ -66,6 +68,27 @@ async function startGroups() {
         await queryClient.fetchInfiniteQuery(
           queryKey,
           infinitePostQueryFn(nest)
+        );
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    }
+  });
+
+  Object.keys(chatUnreads).forEach(async (whom) => {
+    const unread = chatUnreads[whom];
+    const isDM = whomIsDm(whom);
+    const type = isDM ? 'dm' : 'club';
+    const queryKey = ChatQueryKeys.infiniteDmsKey(whom);
+
+    if (unread.count) {
+      try {
+        // we don't care about the result, just that it's fetched
+        // we do this because we may not have cached data for the chat
+        await queryClient.fetchInfiniteQuery(
+          queryKey,
+          infiniteDMsQueryFn(whom, type)
         );
       } catch (e) {
         // eslint-disable-next-line no-console

--- a/apps/tlon-web/src/state/channel/keys.ts
+++ b/apps/tlon-web/src/state/channel/keys.ts
@@ -1,6 +1,6 @@
 import { nestToFlag } from '@/logic/utils';
 
-export const channelKey = (...parts: string[]) => ['channel', ...parts];
+export const channelKey = (...parts: string[]) => ['channels', ...parts];
 
 export const infinitePostsKey = (nest: string) => {
   const [han, flag] = nestToFlag(nest);

--- a/apps/tlon-web/src/state/chat/keys.ts
+++ b/apps/tlon-web/src/state/chat/keys.ts
@@ -1,9 +1,12 @@
 const pending = () => ['dms', 'pending'];
 const unreads = () => ['dms', 'unreads'];
 
+const infiniteDmsKey = (whom: string) => ['dms', whom, 'infinite'];
+
 const ChatQueryKeys = {
   pending,
   unreads,
+  infiniteDmsKey,
 };
 
 export default ChatQueryKeys;


### PR DESCRIPTION
Fixes LAND-1556.

getQueryData was always returning undefined in my testing locally, so rather than only refetching if we have cached data for a query, we just fetch the query if we have an unread for the channel (since we know we *will* use that data later).

I also noticed that channelKey in state/channel/keys.ts was using 'channel' rather than 'channels'. 'channel' isn't used as a queryKey anywhere afaict, I assumed this was supposed to be 'channels', so I changed that.

Tested locally with livenet moons.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context