### PR TITLE
activity: show contact alias for ship name in notification content

### DIFF
--- a/apps/tlon-web/src/notifications/Notification.tsx
+++ b/apps/tlon-web/src/notifications/Notification.tsx
@@ -62,7 +62,10 @@ function NotificationContent({
                 key={`${s}-${index}`}
                 className="mr-1 inline-block rounded bg-blue-soft px-1.5 py-0 text-blue mix-blend-multiply dark:mix-blend-normal"
               >
-                <ShipName name={s.replaceAll(PUNCTUATION_REGEX, '')} />
+                <ShipName
+                  name={s.replaceAll(PUNCTUATION_REGEX, '')}
+                  showAlias
+                />
               </span>
             ) : (
               <span key={`${s}-${index}`}>{s} </span>


### PR DESCRIPTION
Fixes LAND-1544 by ensuring that we show the alias for a ship name (if we have it) in the notification content in the activity view.

Tested on local livenet dev moon.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context