### PR TITLE
mobile: fix display of new groups in list

### DIFF
--- a/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/GroupsSidebarItem.tsx
@@ -63,6 +63,7 @@ const GroupsSidebarItem = React.memo(
             />
           )
         }
+        className={isNew ? 'pr-10' : undefined}
         to={`/groups/${flag}`}
         {...handlers}
       >

--- a/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
@@ -87,7 +87,7 @@ export default function Sidebar() {
     Object.keys(invitedGroups).forEach((flag) => {
       accum.set(flag, 'invited');
     });
-    Object.keys(newGroups).forEach((flag) => {
+    newGroups.forEach(([flag]) => {
       accum.set(flag, 'new');
     });
     return accum;

--- a/apps/tlon-web/src/nav/MobileRoot.tsx
+++ b/apps/tlon-web/src/nav/MobileRoot.tsx
@@ -45,14 +45,6 @@ export default function MobileRoot() {
     [pinnedGroups]
   );
 
-  const newGroupsOptions = useMemo(
-    () =>
-      Object.keys(newGroups).map(([flag]) => (
-        <GroupsSidebarItem key={flag} flag={flag} isNew />
-      )),
-    [newGroups]
-  );
-
   const hasPinnedGroups = !!pinnedGroupsOptions.length;
   const hasLoadingGroups = !!loadingGroups.length;
   const hasGangsWithClaims = !!gangsWithClaims.length;
@@ -132,7 +124,10 @@ export default function MobileRoot() {
                         <GangItem key={flag} flag={flag} />
                       ))}
 
-                    {hasNewGroups && newGroupsOptions}
+                    {hasNewGroups &&
+                      newGroups.map(([flag]) => (
+                        <GroupsSidebarItem key={flag} flag={flag} isNew />
+                      ))}
                   </div>
 
                   {hasPendingGangs && (


### PR DESCRIPTION
PR Checklist
- [ ] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context

Changes
- Fixes display of new groups in home tab of the mobile app
- Adds padding to display of new groups in desktop app sidebar

Tested using livenet ship

Mobile before & after
<img width="350" src="https://github.com/tloncorp/landscape-apps/assets/1013230/2ad2f086-d313-45ea-aeee-e4f0cf3146cd"> <img width="350" src="https://github.com/tloncorp/landscape-apps/assets/1013230/a69be090-2168-4a9d-9914-6f4390af41cd">

Desktop before & after
<img width="218" alt="Screenshot 2024-02-21 at 11 04 10 PM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/5f649ac4-6e30-4458-bb5e-a5deb4bd4d78"> <img width="221" alt="Screenshot 2024-02-21 at 11 04 23 PM" src="https://github.com/tloncorp/landscape-apps/assets/1013230/36ec1fee-80f4-4d80-a65e-55b019cd050e">
