### PR TITLE
meta: add "Next Release" label to corresponding issue from PR

### DIFF
--- a/.github/workflows/update-version-label.yml
+++ b/.github/workflows/update-version-label.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           label_uuid="5f815077-796f-43e2-9572-73d488ae2e73"
           curl -X POST \
-            -H "Authorization: ${{ secrets.LINEAR_ACCESS_TOKEN }}" \
+            -H "Authorization: ${{ secrets.LINEAR_APIKEY }}" \
             -H "Content-Type: application/json" \
             -d "{\"query\": \"mutation { issueAddLabel(id: \\\"${{ steps.get_issue_id.outputs.ISSUE_ID }}\\\", labelId: \\\"$label_uuid\\\") { success issue { id title state { id name } } } }\"}" \
             https://api.linear.app/graphql

--- a/.github/workflows/update-version-label.yml
+++ b/.github/workflows/update-version-label.yml
@@ -1,0 +1,29 @@
+name: PR merge to "Next Release" label
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get Linear issue ID from PR comments
+        id: get_issue_id
+        run: |
+          echo "::set-output name=ISSUE_ID::$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments | jq -r '.[] | select(.user.login == "linear[bot]") | .body' | grep -oP 'LAND-\d+')"
+
+      - name: Set Linear issue label
+        run: |
+          label_uuid="5f815077-796f-43e2-9572-73d488ae2e73"
+          curl -X POST \
+            -H "Authorization: ${{ secrets.LINEAR_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { issueAddLabel(id: \\\"${{ steps.get_issue_id.outputs.ISSUE_ID }}\\\", labelId: \\\"$label_uuid\\\") { success issue { id title state { id name } } } }\"}" \
+            https://api.linear.app/graphql


### PR DESCRIPTION
Adds a GitHub workflow (action) to update issues in Linear when their corresponding PRs are merged.

The workflow is:
- Open a PR and associate it with a Linear issue
- Wait for the Linear bot to comment with the linkage
- Merge the PR
- Observe the corresponding issue update with "Done" status (handled by Linear)
- Observe the "Next Release" issue label being added by the action

I have hardcoded the LAND- issue prefix and the "Next Release" label UUID, which are specific to our Linear workspace. Ideally these come from secrets or some other environment variable but I figured this will do.

This does not write back to the GitHub PR itself (yet).

Tested with a public repository and my own Linear workspace - see the screen recording below. I used a dummy label ("Improvement") to demonstrate that the issue labelling works. 

https://github.com/tloncorp/landscape-apps/assets/748181/edd707fd-09c9-49b4-a4fc-79a1622df2e3

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context