### PR TITLE
upload: handle no publicUrlBase

### DIFF
--- a/apps/tlon-web/src/state/storage/upload.ts
+++ b/apps/tlon-web/src/state/storage/upload.ts
@@ -255,7 +255,21 @@ export const useFileStore = create<FileStore>((set, get) => ({
       });
 
       const { isSecureContext } = window;
-      const s3Url = new URL(config.publicUrlBase);
+
+      let s3Url: URL;
+
+      if (config.publicUrlBase) {
+        s3Url = new URL(config.publicUrlBase);
+      } else {
+        s3Url = new URL(
+          await getSignedUrl(client, command)
+            .then((res) => res.split('?')[0])
+            .catch((e) => {
+              console.log('failed to get signed url', { e });
+              return '';
+            })
+        );
+      }
 
       const url = config.publicUrlBase
         ? s3Url.toString()


### PR DESCRIPTION
Fixes a TypeError in upload.ts when uploading to a S3 bucket without a publicUrlBase set in the %storage config. 

Uploading an image was throwing a `Uncaught (in promise) TypeError: Failed to construct 'URL': Invalid URL` error. I interpret this to mean that we were failing to instantiate a variable with a URL type because the `new URL()` function takes a single argument (which cannot be null). Open to other, cleaner fixes.

Tested locally with the Vite dev server proxied against my livenet planet.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context