### PR TITLE
channels, chat: faster search ux

### DIFF
--- a/apps/tlon-web/src/channels/ChannelSearch.tsx
+++ b/apps/tlon-web/src/channels/ChannelSearch.tsx
@@ -1,16 +1,30 @@
+import { useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import ChatSearch, { ChatSearchProps } from '@/chat/ChatSearch/ChatSearch';
+import { CHANNEL_SEARCH_RESULT_SIZE } from '@/constants';
 import { useChannelSearch } from '@/state/channel/channel';
 
 export default function ChannelSearch(
   props: Omit<ChatSearchProps, 'scan' | 'query' | 'isLoading' | 'endReached'>
 ) {
   const { query } = useParams<{ query: string }>();
-  const { scan, isLoading, fetchNextPage } = useChannelSearch(
-    props.whom,
-    query || ''
-  );
+  const {
+    scan,
+    isLoading,
+    fetchNextPage,
+    depth,
+    oldestMessageSearched,
+    hasNextPage,
+  } = useChannelSearch(props.whom, query || '');
+
+  useEffect(() => {
+    const numResults = scan.toArray().length;
+    if (!isLoading && numResults < CHANNEL_SEARCH_RESULT_SIZE) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, isLoading, scan, depth]);
+
   return (
     <ChatSearch
       {...props}
@@ -18,6 +32,12 @@ export default function ChannelSearch(
       scan={scan}
       isLoading={isLoading}
       endReached={fetchNextPage}
+      searchDetails={{
+        numResults: scan.toArray().length,
+        depth,
+        oldestMessageSearched,
+        searchComplete: !hasNextPage,
+      }}
     >
       {props.children}
     </ChatSearch>

--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearch.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearch.tsx
@@ -20,6 +20,12 @@ export type ChatSearchProps = PropsWithChildren<{
   root: string;
   query?: string;
   scan: ChatMap;
+  searchDetails?: {
+    numResults: number;
+    depth: number;
+    oldestMessageSearched: Date | null;
+    searchComplete: boolean;
+  };
   isLoading: boolean;
   placeholder: string;
   endReached: () => void;
@@ -30,6 +36,7 @@ export default function ChatSearch({
   root,
   query,
   scan,
+  searchDetails,
   isLoading,
   placeholder,
   endReached,
@@ -130,6 +137,7 @@ export default function ChatSearch({
                   whom={whom}
                   root={root}
                   scan={scan}
+                  searchDetails={searchDetails}
                   isLoading={isLoading}
                   query={query}
                   selected={selected.index}

--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearchResults.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearchResults.tsx
@@ -1,18 +1,24 @@
 import { ChatMap, Post, Reply } from '@tloncorp/shared/dist/urbit/channel';
 import { Writ } from '@tloncorp/shared/dist/urbit/dms';
 import { BigInteger } from 'big-integer';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useIsMobile } from '@/logic/useMedia';
 
-import ChatScrollerPlaceholder from '../ChatScroller/ChatScrollerPlaceholder';
 import ChatSearchResult from './ChatSearchResult';
 
 interface ChatSearchResultsProps {
   whom: string;
   root: string;
   scan: ChatMap;
+  searchDetails?: {
+    numResults: number;
+    depth: number;
+    oldestMessageSearched: Date | null;
+    searchComplete: boolean;
+  };
   isLoading: boolean;
   query?: string;
   selected?: number;
@@ -45,6 +51,7 @@ const ChatSearchResults = React.forwardRef<
       whom,
       root,
       scan,
+      searchDetails,
       isLoading,
       selected,
       endReached,
@@ -53,8 +60,6 @@ const ChatSearchResults = React.forwardRef<
     },
     scrollerRef
   ) => {
-    const [delayedLoading, setDelayedLoading] = useState(false);
-    const reallyLoading = isLoading && query && query !== '';
     const isMobile = useIsMobile();
     const thresholds = {
       atBottomThreshold: 125,
@@ -83,27 +88,10 @@ const ChatSearchResults = React.forwardRef<
       [scan, whom, root, selected]
     );
 
-    useEffect(() => {
-      let timeout = 0;
-
-      if (reallyLoading) {
-        timeout = setTimeout(() => {
-          setDelayedLoading(true);
-        }, 150) as unknown as number;
-      } else {
-        clearTimeout(timeout);
-        setDelayedLoading(false);
-      }
-
-      return () => {
-        clearTimeout(timeout);
-      };
-    }, [reallyLoading]);
-
     return (
       <div className="flex flex-1 flex-col overflow-hidden">
         {withHeader && (
-          <div className="mb-6 flex items-center justify-between text-sm text-gray-400">
+          <div className="mb-4 flex items-center justify-between text-sm text-gray-400">
             {query && (
               <strong>
                 Search Results for &ldquo;
@@ -117,15 +105,17 @@ const ChatSearchResults = React.forwardRef<
             )}
           </div>
         )}
-        {delayedLoading ? (
-          <div className="-mx-4 flex-1">
-            <ChatScrollerPlaceholder count={30} />
-          </div>
-        ) : entries.length === 0 ? (
+        {entries.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center">
             <div className="font-semibold text-gray-600">
               {query ? 'No results found' : 'Enter a search to get started'}
             </div>
+            {query && searchDetails && (
+              <SearchDetails
+                searchDetails={searchDetails}
+                loading={isLoading}
+              />
+            )}
           </div>
         ) : (
           <Virtuoso
@@ -137,6 +127,17 @@ const ChatSearchResults = React.forwardRef<
             computeItemKey={(i, item) => item.time.toString()}
             endReached={endReached}
             className="h-full w-full list-none overflow-x-hidden overflow-y-scroll"
+            components={{
+              Footer: () =>
+                query && searchDetails ? (
+                  <SearchDetails
+                    searchDetails={searchDetails}
+                    loading={isLoading}
+                  />
+                ) : (
+                  <span />
+                ),
+            }}
           />
         )}
       </div>
@@ -145,3 +146,49 @@ const ChatSearchResults = React.forwardRef<
 );
 
 export default ChatSearchResults;
+
+function SearchDetails({
+  searchDetails,
+  loading,
+}: {
+  loading: boolean;
+  searchDetails: {
+    numResults: number;
+    depth: number;
+    oldestMessageSearched: Date | null;
+    searchComplete: boolean;
+  };
+}) {
+  return (
+    <div className="mt-2 flex w-full items-center justify-center text-gray-400">
+      {(loading || !searchDetails.searchComplete) && (
+        <LoadingSpinner className="mr-2 h-3 w-3 text-black" />
+      )}
+      {searchDetails.numResults !== 0 && (
+        <>
+          <strong className="text-gray-800">{searchDetails.numResults}</strong>
+          &nbsp;results found&nbsp;{'·'}&nbsp;
+        </>
+      )}
+      {searchDetails.oldestMessageSearched ? (
+        <span className="">
+          Searched&nbsp;
+          {searchDetails.searchComplete ? (
+            'all channel history'
+          ) : (
+            <>
+              through&nbsp;
+              <span className="text-gray-800">
+                {new Date(
+                  searchDetails?.oldestMessageSearched
+                ).toLocaleDateString()}
+              </span>
+            </>
+          )}
+        </span>
+      ) : (
+        'Searching...'
+      )}
+    </div>
+  );
+}

--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearchResults.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearchResults.tsx
@@ -6,6 +6,7 @@ import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import { useIsMobile } from '@/logic/useMedia';
+import { makePrettyShortDate } from '@/logic/utils';
 
 import ChatSearchResult from './ChatSearchResult';
 
@@ -179,9 +180,9 @@ function SearchDetails({
             <>
               through&nbsp;
               <span className="text-gray-800">
-                {new Date(
-                  searchDetails?.oldestMessageSearched
-                ).toLocaleDateString()}
+                {makePrettyShortDate(
+                  new Date(searchDetails?.oldestMessageSearched)
+                )}
               </span>
             </>
           )}

--- a/apps/tlon-web/src/chat/ChatSearch/MobileChatSearch.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/MobileChatSearch.tsx
@@ -48,7 +48,7 @@ export default function MobileChatSearch() {
       return;
     }
 
-    navigate(`${root}/search/${input}`);
+    navigate(`${root}/search/${encodeURIComponent(input)}`);
   }, 500);
 
   useEffect(() => {
@@ -65,7 +65,7 @@ export default function MobileChatSearch() {
 
   const repeatRecentSearch = (query: string) => {
     setSearchInput(query);
-    navigate(`${root}/search/${query}`);
+    navigate(`${root}/search/${encodeURIComponent(query)}`);
   };
 
   const showRecentQueries =

--- a/apps/tlon-web/src/chat/ChatSearch/useChatSearchInput.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/useChatSearchInput.tsx
@@ -39,7 +39,7 @@ export function useChatSearchInput({
       return;
     }
 
-    navigate(`${root}/search/${input}`);
+    navigate(`${root}/search/${encodeURIComponent(input)}`);
   }, 500);
 
   const onChange = useCallback(

--- a/apps/tlon-web/src/constants.ts
+++ b/apps/tlon-web/src/constants.ts
@@ -8,6 +8,7 @@ export const LEAP_DESCRIPTION_TRUNCATE_LENGTH = 48;
 export const LEAP_RESULT_TRUNCATE_SIZE = 5;
 export const LEAP_RESULT_SCORE_THRESHOLD = 10;
 export const CURIO_PAGE_SIZE = 250;
+export const CHANNEL_SEARCH_RESULT_SIZE = 20;
 
 export const PASTEABLE_MEDIA_TYPES = [
   'image/gif',

--- a/apps/tlon-web/src/dms/DmSearch.tsx
+++ b/apps/tlon-web/src/dms/DmSearch.tsx
@@ -7,10 +7,14 @@ export default function DmSearch(
   props: Omit<ChatSearchProps, 'scan' | 'query' | 'isLoading' | 'endReached'>
 ) {
   const { query } = useParams<{ query: string }>();
-  const { scan, isLoading, fetchNextPage } = useInfiniteChatSearch(
-    props.whom,
-    query || ''
-  );
+  const {
+    scan,
+    isLoading,
+    fetchNextPage,
+    depth,
+    oldestMessageSearched,
+    hasNextPage,
+  } = useInfiniteChatSearch(props.whom, query || '');
   return (
     <ChatSearch
       {...props}
@@ -18,6 +22,12 @@ export default function DmSearch(
       scan={scan}
       isLoading={isLoading}
       endReached={fetchNextPage}
+      searchDetails={{
+        depth,
+        oldestMessageSearched,
+        numResults: scan.toArray().length,
+        searchComplete: !hasNextPage,
+      }}
     >
       {props.children}
     </ChatSearch>

--- a/apps/tlon-web/src/dms/DmSearch.tsx
+++ b/apps/tlon-web/src/dms/DmSearch.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import { useParams } from 'react-router';
 
 import ChatSearch, { ChatSearchProps } from '@/chat/ChatSearch/ChatSearch';
+import { CHANNEL_SEARCH_RESULT_SIZE } from '@/constants';
 import { useInfiniteChatSearch } from '@/state/chat/search';
 
 export default function DmSearch(
@@ -15,6 +17,14 @@ export default function DmSearch(
     oldestMessageSearched,
     hasNextPage,
   } = useInfiniteChatSearch(props.whom, query || '');
+
+  useEffect(() => {
+    const numResults = scan.toArray().length;
+    if (!isLoading && numResults < CHANNEL_SEARCH_RESULT_SIZE) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, isLoading, scan, depth]);
+
   return (
     <ChatSearch
       {...props}

--- a/apps/tlon-web/src/dms/MobileDmSearch.tsx
+++ b/apps/tlon-web/src/dms/MobileDmSearch.tsx
@@ -1,15 +1,15 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { VirtuosoHandle } from 'react-virtuoso';
 
 import ChatSearchResults from '@/chat/ChatSearch/ChatSearchResults';
 import SearchBar from '@/chat/ChatSearch/SearchBar';
 import Layout from '@/components/Layout/Layout';
+import { CHANNEL_SEARCH_RESULT_SIZE } from '@/constants';
 import { useSafeAreaInsets } from '@/logic/native';
 import useDebounce from '@/logic/useDebounce';
 import useShowTabBar from '@/logic/useShowTabBar';
-import { useInfiniteChatSearch } from '@/state/chat/search';
-import { useSearchState } from '@/state/chat/search';
+import { useInfiniteChatSearch, useSearchState } from '@/state/chat/search';
 
 export default function MobileDmSearch() {
   const params = useParams<{
@@ -39,6 +39,13 @@ export default function MobileDmSearch() {
     hasNextPage,
   } = useInfiniteChatSearch(whom, params.query || '');
   const history = useSearchState.getState().history[whom];
+
+  useEffect(() => {
+    const numResults = scan.toArray().length;
+    if (!isLoading && numResults < CHANNEL_SEARCH_RESULT_SIZE) {
+      fetchNextPage();
+    }
+  }, [fetchNextPage, isLoading, scan, depth]);
 
   const root = location.pathname.split('/search')[0];
   const debouncedSearch = useDebounce((input: string) => {

--- a/apps/tlon-web/src/dms/MobileDmSearch.tsx
+++ b/apps/tlon-web/src/dms/MobileDmSearch.tsx
@@ -7,6 +7,7 @@ import SearchBar from '@/chat/ChatSearch/SearchBar';
 import Layout from '@/components/Layout/Layout';
 import { useSafeAreaInsets } from '@/logic/native';
 import useDebounce from '@/logic/useDebounce';
+import useShowTabBar from '@/logic/useShowTabBar';
 import { useInfiniteChatSearch } from '@/state/chat/search';
 import { useSearchState } from '@/state/chat/search';
 
@@ -22,15 +23,21 @@ export default function MobileDmSearch() {
   const insets = useSafeAreaInsets();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const [searchInput, setSearchInput] = useState(params.query || '');
+  const showTabBar = useShowTabBar();
+  const shouldApplyPaddingBottom = showTabBar;
 
   const whom =
     params.chShip && params.chName
       ? `${params.chShip}/${params.chName}`
       : params.ship!;
-  const { scan, isLoading, fetchNextPage } = useInfiniteChatSearch(
-    whom,
-    params.query || ''
-  );
+  const {
+    scan,
+    isLoading,
+    fetchNextPage,
+    depth,
+    oldestMessageSearched,
+    hasNextPage,
+  } = useInfiniteChatSearch(whom, params.query || '');
   const history = useSearchState.getState().history[whom];
 
   const root = location.pathname.split('/search')[0];
@@ -60,7 +67,8 @@ export default function MobileDmSearch() {
 
   return (
     <Layout
-      className="flex-1 bg-white px-4"
+      className="mb-4 flex-1 bg-white px-4"
+      style={{ paddingBottom: shouldApplyPaddingBottom ? 64 : 0 }}
       header={
         <div className="mt-2 flex" style={{ paddingTop: insets.top }}>
           <SearchBar
@@ -110,6 +118,16 @@ export default function MobileDmSearch() {
           isLoading={!showRecentResults && isLoading}
           query={
             showRecentResults ? history.lastQuery.query : params.query || ''
+          }
+          searchDetails={
+            showRecentResults
+              ? undefined
+              : {
+                  depth,
+                  oldestMessageSearched,
+                  numResults: scan.size,
+                  searchComplete: !hasNextPage,
+                }
           }
           selected={-1}
           withHeader={!showRecentResults}

--- a/apps/tlon-web/src/dms/MobileDmSearch.tsx
+++ b/apps/tlon-web/src/dms/MobileDmSearch.tsx
@@ -54,7 +54,7 @@ export default function MobileDmSearch() {
       return;
     }
 
-    navigate(`${root}/search/${input}`);
+    navigate(`${root}/search/${encodeURIComponent(input)}`);
   }, 500);
 
   const setValue = (newValue: string) => {
@@ -64,7 +64,7 @@ export default function MobileDmSearch() {
 
   const repeatRecentSearch = (query: string) => {
     setSearchInput(query);
-    navigate(`${root}/search/${query}`);
+    navigate(`${root}/search/${encodeURIComponent(query)}`);
   };
 
   const showRecentQueries =

--- a/apps/tlon-web/src/logic/utils.ts
+++ b/apps/tlon-web/src/logic/utils.ts
@@ -221,6 +221,10 @@ export function makePrettyDate(date: Date) {
   return `${format(date, 'PPP')}`;
 }
 
+export function makePrettyShortDate(date: Date) {
+  return format(date, 'MMM dd, yyyy');
+}
+
 export interface DayTimeDisplay {
   original: Date;
   diff: number;

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -2452,7 +2452,7 @@ export function useChannelSearch(nest: string, query: string) {
       newChatMap(
         (data?.pages || [])
           .reduce(
-            (a: ChannelScan, b: ChannelScam): ChannelScan => [...a, ...b.scan],
+            (a: ChannelScan, b: ChannelScam): ChannelScan => a.concat(b.scan),
             []
           )
           .map((scItem: ChannelScanItem) =>

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -2436,7 +2436,7 @@ export function useChannelSearch(nest: string, query: string) {
       const res = await api.scry<ChannelScam>({
         app: 'channels',
         path: `/${nest}/search/bounded/text/${
-          pageParam ? decToUd(pageParam.toString()) : '~' // TODO  proxy bug?
+          pageParam ? decToUd(pageParam.toString()) : '~' // TODO  vite proxy bug
         }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
       });
       return res;

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -2436,7 +2436,7 @@ export function useChannelSearch(nest: string, query: string) {
       const res = await api.scry<ChannelScam>({
         app: 'channels',
         path: `/${nest}/search/bounded/text/${
-          pageParam ? decToUd(pageParam.toString()) : '~' // TODO  vite proxy bug
+          pageParam ? decToUd(pageParam.toString()) : ''
         }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
       });
       return res;

--- a/apps/tlon-web/src/state/chat/search.ts
+++ b/apps/tlon-web/src/state/chat/search.ts
@@ -152,7 +152,7 @@ export function useInfiniteChatSearch(whom: string, query: string) {
     () =>
       newChatMap(
         (data?.pages || [])
-          .reduce((a: ChatScan, b: ChatScam): ChatScan => [...a, ...b.scan], [])
+          .reduce((a: ChatScan, b: ChatScam): ChatScan => a.concat(b.scan), [])
           .flat()
           .map((scItem: ChatScanItem) =>
             scItem && 'writ' in scItem

--- a/apps/tlon-web/src/state/chat/search.ts
+++ b/apps/tlon-web/src/state/chat/search.ts
@@ -137,7 +137,7 @@ export function useInfiniteChatSearch(whom: string, query: string) {
       const res = await api.scry<ChatScam>({
         app: 'chat',
         path: `/${type}/${whom}/search/bounded/text/${
-          pageParam ? decToUd(pageParam.toString()) : '~' // TODO  vite proxy bug
+          pageParam ? decToUd(pageParam.toString()) : ''
         }/${SINGLE_PAGE_SEARCH_DEPTH}/${encodedQuery}`,
       });
       return res;

--- a/apps/tlon-web/src/state/chat/search.ts
+++ b/apps/tlon-web/src/state/chat/search.ts
@@ -1,11 +1,11 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import {
-  ChanScam,
   ChatMap,
   ReplyTuple,
   newChatMap,
 } from '@tloncorp/shared/dist/urbit/channel';
 import {
+  ChatScam,
   ChatScan,
   ChatScanItem,
   Writ,

--- a/apps/tlon-web/src/state/chat/search.ts
+++ b/apps/tlon-web/src/state/chat/search.ts
@@ -13,7 +13,9 @@ import {
   newWritMap,
 } from '@tloncorp/shared/dist/urbit/dms';
 import { decToUd } from '@urbit/api';
+import { daToUnix } from '@urbit/aura';
 import bigInt from 'big-integer';
+import _ from 'lodash';
 import { useMemo } from 'react';
 import create from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -169,8 +171,24 @@ export function useInfiniteChatSearch(whom: string, query: string) {
     updateSearchHistory(whom, query, scan);
   }
 
+  const depth = useMemo(
+    () => (data?.pages.length ?? 0) * SINGLE_PAGE_SEARCH_DEPTH,
+    [data]
+  );
+
+  const oldestMessageSearched = useMemo(() => {
+    const params = data?.pages ?? [];
+    const lastValidParam = _.findLast(
+      params,
+      (page) => page.last !== null
+    )?.last;
+    return lastValidParam ? new Date(daToUnix(bigInt(lastValidParam))) : null;
+  }, [data]);
+
   return {
     scan,
+    depth,
+    oldestMessageSearched,
     ...rest,
   };
 }

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1354,10 +1354,7 @@
               %text     text:tries-bound:ca-search
               %mention  mention:tries-bound:ca-search
             ==
-          ?:  =(%$ from.pole)
-            ~
-          ?:  =(%'~' from.pole)  ::TODO  vite proxy bug workaround
-            ~
+          ?:  =(%$ from.pole)  ~
           `(slav %ud from.pole)
         (slav %ud tries.pole)
       ?-  kind.pole

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1356,7 +1356,7 @@
             ==
           ?:  =(%$ from.pole)
             ~
-          ?:  =(%'~' from.pole)  ::TODO  proxy bug(?) workaround
+          ?:  =(%'~' from.pole)  ::TODO  vite proxy bug workaround
             ~
           `(slav %ud from.pole)
         (slav %ud tries.pole)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1346,16 +1346,37 @@
       ?~  u.post  ~
       ?.  (has:on-v-replies:c replies.u.u.post reply-id)  ~
       `(ca-rope kind.nest post-id `reply-id)
+    ::
+        [%search %bounded kind=?(%text %mention) from=@ tries=@ nedl=@ ~]
+      :^  ~  ~  %channel-scam
+      !>  ^-  scam:c
+      %^    ?-  kind.pole
+              %text     text:tries-bound:ca-search
+              %mention  mention:tries-bound:ca-search
+            ==
+          ?:  =(%$ from.pole)
+            ~
+          ?:  =(%'~' from.pole)  ::TODO  proxy bug(?) workaround
+            ~
+          `(slav %ud from.pole)
+        (slav %ud tries.pole)
+      ?-  kind.pole
+        %text     (fall (slaw %t nedl.pole) nedl.pole)
+        %mention  (slav %p nedl.pole)
+      ==
+    ::
         [%search %text skip=@ count=@ nedl=@ ~]
-      :^  ~  ~  %channel-scan  !>
-      %^    text:ca-search
+      :^  ~  ~  %channel-scan
+      !>  ^-  scan:c
+      %^    text:hits-bound:ca-search
           (slav %ud skip.pole)
         (slav %ud count.pole)
       (fall (slaw %t nedl.pole) nedl.pole)
     ::
         [%search %mention skip=@ count=@ nedl=@ ~]
-      :^  ~  ~  %channel-scan  !>
-      %^    mention:ca-search
+      :^  ~  ~  %channel-scan
+      !>  ^-  scan:c
+      %^    mention:hits-bound:ca-search
           (slav %ud skip.pole)
         (slav %ud count.pole)
       (slav %p nedl.pole)
@@ -1461,15 +1482,33 @@
   ::
   ++  ca-search
     |^  |%
-        ++  mention
-          |=  [sip=@ud len=@ud nedl=ship]
-          ^-  scan:c
-          (scour sip len %mention nedl)
+        ::NOTE  largely considered deprecated in favor of +tries-bound,
+        ::      which (when used sanely) delivers better performance and ux.
+        ++  hits-bound  ::  searches until len results
+          |%
+          ++  mention
+            |=  [sip=@ud len=@ud nedl=ship]
+            ^-  scan:c
+            (scour-count sip len %mention nedl)
+          ::
+          ++  text
+            |=  [sip=@ud len=@ud nedl=@t]
+            ^-  scan:c
+            (scour-count sip len %text nedl)
+          --
         ::
-        ++  text
-          |=  [sip=@ud len=@ud nedl=@t]
-          ^-  scan:c
-          (scour sip len %text nedl)
+        ++  tries-bound  ::  searches until sum messages searched
+          |%
+          ++  mention
+            |=  [fro=(unit id-post:c) sum=@ud nedl=ship]
+            ^-  [(unit id-post:c) scan:c]
+            (scour-tries fro sum %mention nedl)
+          ::
+          ++  text
+            |=  [fro=(unit id-post:c) sum=@ud nedl=@t]
+            ^-  [(unit id-post:c) scan:c]
+            (scour-tries fro sum %text nedl)
+          --
         --
     ::
     +$  match-type
@@ -1477,12 +1516,53 @@
           [%text nedl=@t]
       ==
     ::
-    ++  scour
+    ++  scour-tries
+      |=  [from=(unit id-post:c) tries=@ud =match-type]
+      =*  posts  posts.channel
+      =.  posts  (lot:on-v-posts:c posts ~ from)  ::  verified correct
+      =|  s=[tries=_tries last=(unit id-post:c) =scan:c]
+      =<  [last scan]
+      |-  ^+  s
+      ?~  posts  s
+      ?:  =(0 tries.s)  s
+      =.  s  $(posts r.posts)  ::  process latest first
+      ?:  =(0 tries.s)  s
+      ::
+      =.  scan.s
+        ?~  val.n.posts  scan.s
+        ?.  (match u.val.n.posts match-type)  scan.s
+        :_  scan.s
+        [%post (uv-post-without-replies:utils u.val.n.posts)]
+      ::
+      =.  scan.s
+        ?~  val.n.posts  scan.s
+        =*  id-post  id.u.val.n.posts
+        =*  replies  replies.u.val.n.posts
+        |-  ^+  scan.s
+        ?~  replies  scan.s
+        =.  scan.s  $(replies r.replies)
+        ::
+        =.  scan.s
+          ?~  val.n.replies  scan.s
+          ?.  (match-reply u.val.n.replies match-type)  scan.s
+          :_  scan.s
+          [%reply id-post (uv-reply:utils id-post u.val.n.replies)]
+        ::
+        $(replies l.replies)
+      ::
+      =.  last.s  `key.n.posts
+      =.  tries.s  (dec tries.s)
+      $(posts l.posts)
+    ::
+    ++  scour-count
       |=  [skip=@ud len=@ud =match-type]
       =*  posts  posts.channel
       ?>  (gth len 0)
       =+  s=[skip=skip len=len *=scan:c]
       =-  (flop scan)
+      ::NOTE  yes, walking the tree manually is faster than using built-ins.
+      ::      +dop:mo gets closest, but is still slower.
+      ::      should re-evaluate the implementation here is mops ever get jets.
       |-  ^+  s
       ?~  posts  s
       ?:  =(0 len.s)  s
@@ -1605,6 +1685,8 @@
         &
       $(pos +(pos))
     ::
+    ::NOTE  :(cork trip ^cass crip) may be _very slightly_ faster,
+    ::      but not enough to matter
     ++  cass
       |=  text=@t
       ^-  @t

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1658,8 +1658,16 @@
       |=  =inline:c
       ?@  inline
         (find nedl inline |)
-      ?.  ?=(?(%bold %italics %strike %blockquote) -.inline)  |
-      ^$(p.verse p.inline)
+      ?+  -.inline  |
+        ?(%bold %italics %strike %blockquote)  ^$(p.verse p.inline)
+        ?(%code %inline-code)                  $(inline p.inline)
+      ::
+          %link
+        ?|  $(inline p.inline)
+        ?&  !=(p.inline q.inline)
+            $(inline q.inline)
+        ==  ==
+      ==
     ::
     ++  find
       |=  [nedl=@t hay=@t case=?]

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1338,10 +1338,7 @@
               %text     text:tries-bound:search:cu-pact
               %mention  mention:tries-bound:search:cu-pact
             ==
-          ?:  =(%$ from.pole)
-            ~
-          ?:  =(%'~' from.pole)  ::TODO  removeme, workaround for vite bug
-            ~
+          ?:  =(%$ from.pole)  ~
           `(slav %ud from.pole)
         (slav %ud tries.pole)
       ?-  kind.pole
@@ -1729,10 +1726,7 @@
               %text     text:tries-bound:search:di-pact
               %mention  mention:tries-bound:search:di-pact
             ==
-          ?:  =(%$ from.pole)
-            ~
-          ?:  =(%'~' from.pole)  ::TODO  removeme, workaround for vite bug
-            ~
+          ?:  =(%$ from.pole)  ~
           `(slav %ud from.pole)
         (slav %ud tries.pole)
       ?-  kind.pole

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -1331,12 +1331,30 @@
       [%writs rest=*]  (peek:cu-pact care rest.pole)
       [%crew ~]   ``chat-club-crew+!>(crew.club)
     ::
+        [%search %bounded kind=?(%text %mention) from=@ tries=@ nedl=@ ~]
+      :^  ~  ~  %chat-scam
+      !>  ^-  scam:c
+      %^    ?-  kind.pole
+              %text     text:tries-bound:search:cu-pact
+              %mention  mention:tries-bound:search:cu-pact
+            ==
+          ?:  =(%$ from.pole)
+            ~
+          ?:  =(%'~' from.pole)  ::TODO  removeme, workaround for vite bug
+            ~
+          `(slav %ud from.pole)
+        (slav %ud tries.pole)
+      ?-  kind.pole
+        %text     (fall (slaw %t nedl.pole) nedl.pole)
+        %mention  (slav %p nedl.pole)
+      ==
+    ::
         [%search %text skip=@ count=@ nedl=@ ~]
       %-  some
       %-  some
       :-  %chat-scan
-      !>
-      %^    text:search:cu-pact
+      !>  ^-  scan:c
+      %^    text:hits-bound:search:cu-pact
           (slav %ud skip.pole)
         (slav %ud count.pole)
       (fall (slaw %t nedl.pole) nedl.pole)
@@ -1345,8 +1363,8 @@
       %-  some
       %-  some
       :-  %chat-scan
-      !>
-      %^    mention:search:cu-pact
+      !>  ^-  scan:c
+      %^    mention:hits-bound:search:cu-pact
           (slav %ud skip.pole)
         (slav %ud count.pole)
       (slav %p nedl.pole)
@@ -1704,12 +1722,30 @@
         [%writs rest=*]
       (peek:di-pact care rest.pole)
     ::
+        [%search %bounded kind=?(%text %mention) from=@ tries=@ nedl=@ ~]
+      :^  ~  ~  %chat-scam
+      !>  ^-  scam:c
+      %^    ?-  kind.pole
+              %text     text:tries-bound:search:di-pact
+              %mention  mention:tries-bound:search:di-pact
+            ==
+          ?:  =(%$ from.pole)
+            ~
+          ?:  =(%'~' from.pole)  ::TODO  removeme, workaround for vite bug
+            ~
+          `(slav %ud from.pole)
+        (slav %ud tries.pole)
+      ?-  kind.pole
+        %text     (fall (slaw %t nedl.pole) nedl.pole)
+        %mention  (slav %p nedl.pole)
+      ==
+    ::
         [%search %text skip=@ count=@ nedl=@ ~]
       %-  some
       %-  some
       :-  %chat-scan
-      !>
-      %^    text:search:di-pact
+      !>  ^-  scan:c
+      %^    text:hits-bound:search:di-pact
           (slav %ud skip.pole)
         (slav %ud count.pole)
       (fall (slaw %t nedl.pole) nedl.pole)
@@ -1718,8 +1754,8 @@
       %-  some
       %-  some
       :-  %chat-scan
-      !>
-      %^    mention:search:di-pact
+      !>  ^-  scan:c
+      %^    mention:hits-bound:search:di-pact
           (slav %ud skip.pole)
         (slav %ud count.pole)
       (slav %p nedl.pole)

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -410,8 +410,16 @@
     |=  =inline:d
     ?@  inline
       (find nedl inline |)
-    ?.  ?=(?(%bold %italics %strike %blockquote) -.inline)  |
-    ^$(p.verse p.inline)
+    ?+  -.inline  |
+      ?(%bold %italics %strike %blockquote)  ^$(p.verse p.inline)
+      ?(%code %inline-code)                  $(inline p.inline)
+      ::
+          %link
+        ?|  $(inline p.inline)
+        ?&  !=(p.inline q.inline)
+            $(inline q.inline)
+        ==  ==
+    ==
   ::
   ++  find
     |=  [nedl=@t hay=@t case=?]

--- a/desk/lib/dm.hoon
+++ b/desk/lib/dm.hoon
@@ -258,15 +258,33 @@
 ::
 ++  search
   |^  |%
-      ++  mention
-        |=  [sip=@ud len=@ud nedl=^ship]
-        ^-  scan:c
-        (scour sip len %mention nedl)
+      ::NOTE  largely considered deprecated in favor of +tries-bound,
+      ::      which (when used sanely) delivers better performance and ux.
+      ++  hits-bound  ::  searches until len results
+        |%
+        ++  mention
+          |=  [sip=@ud len=@ud nedl=^ship]
+          ^-  scan:c
+          (scour-count sip len %mention nedl)
+        ::
+        ++  text
+          |=  [sip=@ud len=@ud nedl=@t]
+          ^-  scan:c
+          (scour-count sip len %text nedl)
+        --
       ::
-      ++  text
-        |=  [sip=@ud len=@ud nedl=@t]
-        ^-  scan:c
-        (scour sip len %text nedl)
+      ++  tries-bound  ::  searches until sum messages searched
+        |%
+        ++  mention
+          |=  [fro=(unit time) sum=@ud nedl=ship]
+          ^-  [(unit time) scan:c]
+          (scour-tries fro sum %mention nedl)
+        ::
+        ++  text
+          |=  [fro=(unit time) sum=@ud nedl=@t]
+          ^-  [(unit time) scan:c]
+          (scour-tries fro sum %text nedl)
+        --
       --
   ::
   +$  match-type
@@ -274,7 +292,40 @@
         [%text nedl=@t]
     ==
   ::
-  ++  scour
+  ++  scour-tries
+    |=  [from=(unit time) tries=@ud =match-type]
+    =*  posts  wit.pac
+    =.  posts  (lot:on:writs:c posts ~ from)  ::  verified correct
+    =|  s=[tries=_tries last=(unit time) =scan:c]
+    =<  [last scan]
+    |-  ^+  s
+    ?~  posts  s
+    ?:  =(0 tries.s)  s
+    =.  s  $(posts r.posts)  ::  process latest first
+    ?:  =(0 tries.s)  s
+    ::
+    =.  scan.s
+      ?.  (match val.n.posts match-type)  scan.s
+      [[%writ val.n.posts] scan.s]
+    ::
+    =.  scan.s
+      =*  id-post  id.val.n.posts
+      =*  replies  replies.val.n.posts
+      |-  ^+  scan.s
+      ?~  replies  scan.s
+      =.  scan.s  $(replies r.replies)
+      ::
+      =.  scan.s
+        ?.  (match-reply val.n.replies match-type)  scan.s
+        [[%reply id-post val.n.replies] scan.s]
+      ::
+      $(replies l.replies)
+    ::
+    =.  last.s  `key.n.posts
+    =.  tries.s  (dec tries.s)
+    $(posts l.posts)
+  ::
+  ++  scour-count
     |=  [sip=@ud len=@ud =match-type]
     ?>  (gth len 0)
     ^-  scan:c

--- a/desk/mar/channel/scam.hoon
+++ b/desk/mar/channel/scam.hoon
@@ -1,0 +1,19 @@
+/-  d=channels
+/+  j=channel-json
+|_  =scam:d
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  scam
+  ++  json
+    =,  enjs:format
+    %-  pairs
+    :~  'last'^?~(last.scam ~ (id:enjs:j u.last.scam))
+        'scan'^a+(turn scan.scam reference:enjs:j)
+    ==
+  --
+++  grab
+  |%
+  +$  noun  scam:d
+  --
+--

--- a/desk/mar/chat/scam.hoon
+++ b/desk/mar/chat/scam.hoon
@@ -1,0 +1,19 @@
+/-  c=chat
+/+  j=chat-json
+|_  =scam:c
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  scam
+  ++  json
+    =,  enjs:format
+    %-  pairs
+    :~  'last'^?~(last.scam ~ (time-id:enjs:j u.last.scam))
+        'scan'^a+(turn scan.scam reference:enjs:j)
+    ==
+  --
+++  grab
+  |%
+  +$  noun  scam:c
+  --
+--

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -198,6 +198,11 @@
 ::  $react: either an emoji identifier like :diff or a URL for custom
 +$  react     @ta
 +$  v-reacts  (map ship (rev (unit react)))
+::  $scam: bounded search results
++$  scam
+  $:  last=(unit id-post)  ::  last (top-level) message that was searched
+      =scan                ::  search results
+  ==
 ::  $scan: search results
 +$  scan  (list reference)
 +$  reference

--- a/desk/sur/chat.hoon
+++ b/desk/sur/chat.hoon
@@ -10,6 +10,11 @@
 +$  reply   [reply-seal memo:d]
 ::  $react: either an emoji identifier like :wave: or a URL for custom
 +$  react   @ta
+::  $scam: bounded search results
++$  scam
+  $:  last=(unit time)  ::  last (top-level) msg (local) id that was searched
+      =scan             ::  search results
+  ==
 ::  $scan: search results
 +$  scan  (list reference)
 ::  $blocked: a set of ships that the user has blocked

--- a/package-lock.json
+++ b/package-lock.json
@@ -32099,7 +32099,8 @@
     },
     "node_modules/sorted-btree": {
       "version": "1.8.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/sorted-btree/-/sorted-btree-1.8.1.tgz",
+      "integrity": "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -36470,7 +36471,11 @@
     },
     "packages/shared": {
       "name": "@tloncorp/shared",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "big-integer": "^1.6.52",
+        "sorted-btree": "^1.8.1"
+      }
     },
     "packages/ui": {
       "name": "@tloncorp/ui",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,5 +8,8 @@
     "build": "tsup src/index.ts src/urbit/* --format esm --minify --dts --out-dir dist",
     "dev": "npm run build -- --watch"
   },
-  "dependencies": {}
+  "dependencies": {
+    "big-integer": "^1.6.52",
+    "sorted-btree": "^1.8.1"
+  }
 }

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -641,6 +641,8 @@ export type ChannelScanItem = { post: Post } | ReplyReferenceResponse;
 
 export type ChannelScan = ChannelScanItem[];
 
+export type ChannelScam = { last: string | null, scan: ChannelScan }
+
 export type TogglePost = { hide: string } | { show: string };
 
 export type HiddenPosts = string[];

--- a/packages/shared/src/urbit/channel.ts
+++ b/packages/shared/src/urbit/channel.ts
@@ -641,7 +641,7 @@ export type ChannelScanItem = { post: Post } | ReplyReferenceResponse;
 
 export type ChannelScan = ChannelScanItem[];
 
-export type ChannelScam = { last: string | null, scan: ChannelScan }
+export type ChannelScam = { last: string | null; scan: ChannelScan };
 
 export type TogglePost = { hide: string } | { show: string };
 

--- a/packages/shared/src/urbit/dms.ts
+++ b/packages/shared/src/urbit/dms.ts
@@ -312,6 +312,8 @@ export type ChatScanItem = { writ: Writ } | WritReplyReferenceResponse;
 
 export type ChatScan = ChatScanItem[];
 
+export type ChatScam = { last: string | null; scan: ChatScan };
+
 interface WritSealInCache extends PostSealDataResponse {
   time: number;
 }


### PR DESCRIPTION
Primarily, we give channels and chat a new search api endpoint, which bounds its requests by messages _searched_, rather than the amount of search results _found_.

The existing search api is bounded by the amount of results returned. This makes searching for something with few results a pathological case: we will continue searching _all_ messages in a channel until we've hit the desired amount of results, or exhausted the entire backlog. This results in search being slow in unpredictable ways.

We add a new search api (that is, a new scry endpoint) where the search is bounded (and paginated) by the total amount of messages searched, rather than the subset that gives results. This way, we can bound the amount of computation that happens for any given "page" of search, making for more predictable ux. It also explicates the distance to which the backlog has been searched by including a "last-searched" identifier (accurately: the `time` key in our `mop`s). We use this to make search progress legible to the user, even in cases where no results have been found yet.

![image](https://github.com/tloncorp/landscape-apps/assets/3829764/7eb5b73d-f15b-45c6-86df-b74bc013caa5)

To maintain a simple api, we bound by the number of top-level messages, rather than messages plus replies. In contexts where replies are expected to make up the bulk of content, the search bounds/window should be adjusted downwardly to compensate.

Note that we leave the old search api in place, as outside clients like the mobile app might still be using it.

The current configuration, which searches 500 messages at a time, takes 1-2 seconds per request. This feels like a fine balance between request overhead and speed of results/search status. Tweaking this number is trivial, if we so desire.

I am also open to different names for the search "scam", the new search result structure encapsulating the previous "scan". (But don't get carried away bikeshedding: ultimately, the names don't matter.)

Remaining work:
- [x] Apply the frontend improvements for channel search to dm search as well.
- [x] Fix (or work around) a behavior in our dev server: it turns urls of the shape `/abc//def` into `/adc/def`, even though empty path segments are valid (and not entirely uncommon in urbit apis).
  - Right now, the backend api has to do something dumb and non-standard to support use through the dev server.

Closes LAND-1612.