### PR TITLE
errors: send mail to support@tlon.io

### DIFF
--- a/apps/tlon-web/src/components/ErrorAlert.tsx
+++ b/apps/tlon-web/src/components/ErrorAlert.tsx
@@ -30,11 +30,11 @@ function SubmitIssue({ error }: { error: Error }) {
   return (
     <a
       className="button"
-      href={`https://github.com/tloncorp/homestead/issues/new?assignees=&labels=bug&template=bug_report.md&title=${title}&body=${body}`}
+      href={`mailto:support@tlon.io?subject=${title}&body=${body}`}
       target="_blank"
       rel="noreferrer"
     >
-      Submit Issue
+      Submit Issue via Email
     </a>
   );
 }


### PR DESCRIPTION
Adjusts the error boundary component to send an email to support@tlon.io rather than pre-filling a GitHub issue.

Fixes LAND-1452

PR Checklist
- [ ] Includes changes to desk files
- [x] Tested locally with Vite dev server proxied against livenet planet
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context