### PR TITLE
leap: change default menu items, icon type

### DIFF
--- a/apps/tlon-web/src/components/Leap/LeapRow.tsx
+++ b/apps/tlon-web/src/components/Leap/LeapRow.tsx
@@ -4,7 +4,7 @@ import { IconProps } from '../icons/icon';
 
 export interface LeapOption {
   onSelect: () => void;
-  icon: (props: IconProps) => JSX.Element;
+  icon: React.ReactElement | ((props: IconProps) => React.ReactElement);
   input?: string | undefined;
   title: string;
   subtitle: string;
@@ -55,7 +55,9 @@ export default function LeapRow({
       } flex cursor-pointer items-center justify-between whitespace-nowrap p-3 text-base text-gray-700 hover:bg-gray-100`}
     >
       <div className="flex w-full items-center">
-        <div className="mr-2 shrink-0">{icon({ className: 'w-6 h-6' })}</div>
+        <div className="mr-2 shrink-0">
+          {typeof icon === 'function' ? icon({ className: 'w-6 h-6' }) : icon}
+        </div>
         <LeapRowTitle title={title} input={input} />
         <span className="shrink-1 ml-2 truncate text-base font-semibold text-gray-400">
           {subtitle}

--- a/apps/tlon-web/src/components/Leap/MenuOptions.tsx
+++ b/apps/tlon-web/src/components/Leap/MenuOptions.tsx
@@ -1,7 +1,7 @@
+import Avatar from '../Avatar';
 import AddIcon16 from '../icons/Add16Icon';
 import ArrowEIcon16 from '../icons/ArrowEIcon16';
 import GridIcon from '../icons/GridIcon';
-import TlonIcon from '../icons/TlonIcon';
 import { IconProps } from '../icons/icon';
 
 function CommandBadge() {
@@ -21,7 +21,7 @@ function PlusBadge() {
 }
 
 export interface IMenuOption {
-  icon: (props: IconProps) => JSX.Element;
+  icon: React.ReactElement | ((props: IconProps) => React.ReactElement);
   title: string;
   subtitle: string;
   to: string;
@@ -51,38 +51,24 @@ export const menuOptions: IMenuOption[] = [
     modal: false,
   },
   {
-    title: 'Find Groups',
+    title: 'Create a new Group',
     subtitle: '',
-    to: '/find',
-    icon: CommandBadge,
-    modal: false,
-  },
-  {
-    title: 'Create New Group',
-    subtitle: '',
-    to: '/groups/new',
+    to: '/add-group/create',
     icon: PlusBadge,
     modal: true,
   },
   {
-    title: 'Profile',
+    title: 'Join a Group',
     subtitle: '',
-    to: '/profile/edit',
-    icon: CommandBadge,
-    modal: false,
-  },
-  {
-    title: 'Tlon Settings',
-    subtitle: '',
-    to: '/settings',
-    icon: CommandBadge,
+    to: '/add-group/join',
+    icon: PlusBadge,
     modal: true,
   },
   {
-    title: 'Tlon',
+    title: 'Profile & Settings',
     subtitle: '',
-    to: '/',
-    icon: TlonIcon,
+    to: '/profile',
+    icon: <Avatar ship={window.our} size="xs" />,
     modal: false,
   },
 ];


### PR DESCRIPTION
Changes a few of the default Leap menu items to reflect our current reality:
- Adds "Join a Group"
- Redirects "Create a new Group" to the new, name-only group creation route
- Combines "Profile" and "Tlon Settings" into a single item, "Profile & Settings," which uses the current ship avatar as the icon
- Removes "Find Groups"
- Removes "Tlon"

Also changes the `icon` type to accept a React element (the Avatar component) and handles appropriately in the render of LeapRow.

![Screenshot 2024-02-29 at 11 58 30 AM](https://github.com/tloncorp/landscape-apps/assets/748181/2a31d1c3-5615-4550-a7f9-1c326d91a41d)

Fixes LAND-1635

PR Checklist
- [ ] Includes changes to desk files
- [x] Tested locally using the Vite dev server proxied against a livenet planet
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context