### PR TITLE
leap: fix crash on open

### DIFF
--- a/apps/tlon-web/src/components/Leap/MenuOptions.tsx
+++ b/apps/tlon-web/src/components/Leap/MenuOptions.tsx
@@ -68,7 +68,7 @@ export const menuOptions: IMenuOption[] = [
     title: 'Profile & Settings',
     subtitle: '',
     to: '/profile',
-    icon: <Avatar ship={window.our} size="xs" />,
+    icon: () => <Avatar ship={window.our} size="xs" />,
     modal: false,
   },
 ];


### PR DESCRIPTION
Fixes LAND-1640, a new bug that was introduced on develop yesterday.

Just needed to pass an anonymous function here that returns the component, rather than the component itself.

Tested locally on livenet moons.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context