### PR TITLE
groups: better data loading flow

### DIFF
--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tlon-web",
-  "version": "5.5.0",
+  "version": "5.7.0",
   "private": true,
   "scripts": {
     "rube": "tsc ./rube/index.ts --outDir ./rube/dist && node ./rube/dist/index.js",

--- a/apps/tlon-web/src/state/groups/groups.ts
+++ b/apps/tlon-web/src/state/groups/groups.ts
@@ -170,11 +170,8 @@ export function useGroup(flag: string, updating = false): Group | undefined {
     path: `/groups/${flag}/v1`,
     options: {
       enabled: !!flag && flag !== '' && updating && connection,
-      placeholderData: group,
       refetchOnMount: updating,
       retry: true,
-      // prevents skeleton from flashing on unmount when we have cached data
-      keepPreviousData: true,
     },
   });
 
@@ -185,10 +182,10 @@ export function useGroup(flag: string, updating = false): Group | undefined {
   }, [flag, updating, subscribe]);
 
   if (rest.isLoading || rest.isError || data === undefined) {
-    return undefined;
+    return group;
   }
 
-  return data;
+  return data || group;
 }
 
 export function useGroupIsLoading(flag: string) {

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -4,7 +4,7 @@
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
     glob-http+['https://bootstrap.urbit.org/glob-0vfhst0.i8lv2.as4pf.709s3.1q1qv.glob' 0vfhst0.i8lv2.as4pf.709s3.1q1qv]
     base+'groups'
-    version+[5 5 1]
+    version+[5 7 0]
     website+'https://tlon.io'
     license+'MIT'
 ==


### PR DESCRIPTION
This needs to be tested more thoroughly because it might have far reaching implications. Fixes LAND-1639.

`keepPreviousData` was biting us because if you were coming from another group that would be the data in the query, but then we'd check `canRead` and it would be false because we were comparing against a different group. This caused a redirect to occur to the group home. Then from the group home we try to do the channel redirect and wouldn't find a good candidate so we'd redirect to `${group}/channels`.

Similarly, `placeholderData` didn't seem to be updating every time the flag changed, so I removed entirely in favor of just defaulting to existing data in `useGroups`.

Tested by running locally on both desktop and mobile, navigating to different channels in messages tab and also random groups pages to make sure we weren't missing data or seeing anything weird.

PR Checklist
- [ ] Includes changes to desk files
- [X] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context