### PR TITLE
web/nav: restore safe area inset for mobile nav in native app

### DIFF
--- a/apps/tlon-web/e2e/004-navigate-between-sections.spec.ts
+++ b/apps/tlon-web/e2e/004-navigate-between-sections.spec.ts
@@ -28,7 +28,7 @@ test('Render AppNav correctly in different screen sizes', async ({ page }) => {
   const mobileBoundingBox = await mobileNav.boundingBox();
   if (mobileBoundingBox) {
     expect(mobileBoundingBox.x).toBeCloseTo(0);
-    expect(mobileBoundingBox.y).toBeCloseTo(790);
+    expect(mobileBoundingBox.y).toBeCloseTo(794);
   } else {
     throw new Error('Mobile navigation bounding box is null');
   }

--- a/apps/tlon-web/src/chat/ChatChannel.tsx
+++ b/apps/tlon-web/src/chat/ChatChannel.tsx
@@ -17,10 +17,9 @@ import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobi
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useFullChannel } from '@/logic/channel';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 import {
   useAddPostMutation,
   useLeaveMutation,
@@ -65,14 +64,10 @@ function ChatChannel({ title }: ViewProps) {
   const replyingWrit = useReplyPost(nest, chatReplyId);
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const isScrolling = useIsScrolling(scrollElementRef);
-  const showTabBar = useShowTabBar();
   const root = `${
     activeTab === 'messages' ? '/dm' : ''
   }/groups/${groupFlag}/channels/${nest}`;
-  // We only inset the bottom for groups, since DMs display the navbar
-  // underneath this view
-  const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
 
   const {
     group,
@@ -88,7 +83,7 @@ function ChatChannel({ title }: ViewProps) {
     <>
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+          paddingBottom,
         }}
         className="padding-bottom-transition flex-1 bg-white"
         header={

--- a/apps/tlon-web/src/chat/ChatChannel.tsx
+++ b/apps/tlon-web/src/chat/ChatChannel.tsx
@@ -17,6 +17,7 @@ import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobi
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useFullChannel } from '@/logic/channel';
+import { isNativeApp } from '@/logic/native';
 import { useIsScrolling } from '@/logic/scroll';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
@@ -71,6 +72,7 @@ function ChatChannel({ title }: ViewProps) {
   // We only inset the bottom for groups, since DMs display the navbar
   // underneath this view
   const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
 
   const {
     group,
@@ -86,7 +88,7 @@ function ChatChannel({ title }: ViewProps) {
     <>
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
         }}
         className="padding-bottom-transition flex-1 bg-white"
         header={

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -19,6 +19,7 @@ import keyMap from '@/keyMap';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useChannelCompatibility, useChannelFlag } from '@/logic/channel';
+import { isNativeApp } from '@/logic/native';
 import { useIsScrolling } from '@/logic/scroll';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
@@ -107,6 +108,7 @@ export default function ChatThread() {
     _.intersection(perms.writers, vessel.sects).length !== 0;
   const { compatible, text } = useChannelCompatibility(`chat/${flag}`);
   const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const readTimeout = useChatInfo(flag).unread?.readTimeout;
   const isSmall = useMedia('(max-width: 1023px)');
   const clearOnNavRef = useRef({ isSmall, readTimeout, nest, flag, markRead });
@@ -149,8 +151,8 @@ export default function ChatThread() {
     clearOnNavRef.current = { isSmall, readTimeout, nest, flag, markRead };
   }, [readTimeout, nest, flag, isSmall, markRead]);
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       const curr = clearOnNavRef.current;
       if (
         curr.isSmall &&
@@ -161,8 +163,9 @@ export default function ChatThread() {
         useChatStore.getState().read(curr.flag);
         curr.markRead({ nest: curr.nest });
       }
-    };
-  }, []);
+    },
+    []
+  );
 
   useEffect(() => {
     if (!idTimeIsNumber) {
@@ -177,7 +180,7 @@ export default function ChatThread() {
       className="padding-bottom-transition relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
     >
       {isMobile ? (

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -19,7 +19,7 @@ import keyMap from '@/keyMap';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useChannelCompatibility, useChannelFlag } from '@/logic/channel';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
@@ -107,8 +107,7 @@ export default function ChatThread() {
     perms.writers.length === 0 ||
     _.intersection(perms.writers, vessel.sects).length !== 0;
   const { compatible, text } = useChannelCompatibility(`chat/${flag}`);
-  const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const readTimeout = useChatInfo(flag).unread?.readTimeout;
   const isSmall = useMedia('(max-width: 1023px)');
   const clearOnNavRef = useRef({ isSmall, readTimeout, nest, flag, markRead });
@@ -180,7 +179,7 @@ export default function ChatThread() {
       className="padding-bottom-transition relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
     >
       {isMobile ? (

--- a/apps/tlon-web/src/components/About/AboutView.tsx
+++ b/apps/tlon-web/src/components/About/AboutView.tsx
@@ -1,9 +1,8 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import { Helmet } from 'react-helmet';
 
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 
 import Layout from '../Layout/Layout';
 import MobileHeader from '../MobileHeader';
@@ -11,10 +10,7 @@ import About from './About';
 
 export default function AboutView({ title }: ViewProps) {
   const isMobile = useIsMobile();
-
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
-  const paddingBottom = isNativeApp() ? 64 : 50;
+  const { paddingBottom } = useBottomPadding();
 
   return (
     <Layout
@@ -31,7 +27,7 @@ export default function AboutView({ title }: ViewProps) {
       <div
         className="flex flex-col space-y-4 px-4 pt-4"
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+          paddingBottom,
         }}
       >
         {!isMobile && (

--- a/apps/tlon-web/src/components/About/AboutView.tsx
+++ b/apps/tlon-web/src/components/About/AboutView.tsx
@@ -1,6 +1,7 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import { Helmet } from 'react-helmet';
 
+import { isNativeApp } from '@/logic/native';
 import { useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
 
@@ -13,6 +14,7 @@ export default function AboutView({ title }: ViewProps) {
 
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar;
+  const paddingBottom = isNativeApp() ? 64 : 50;
 
   return (
     <Layout
@@ -29,7 +31,7 @@ export default function AboutView({ title }: ViewProps) {
       <div
         className="flex flex-col space-y-4 px-4 pt-4"
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 64 : 0,
+          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
         }}
       >
         {!isMobile && (

--- a/apps/tlon-web/src/components/Settings/SettingsView.tsx
+++ b/apps/tlon-web/src/components/Settings/SettingsView.tsx
@@ -1,9 +1,8 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import { Helmet } from 'react-helmet';
 
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 
 import Layout from '../Layout/Layout';
 import MobileHeader from '../MobileHeader';
@@ -11,10 +10,7 @@ import Settings from './Settings';
 
 export default function SettingsView({ title }: ViewProps) {
   const isMobile = useIsMobile();
-
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
-  const paddingBottom = isNativeApp() ? 64 : 50;
+  const { paddingBottom } = useBottomPadding();
 
   return (
     <Layout
@@ -31,7 +27,7 @@ export default function SettingsView({ title }: ViewProps) {
       <div
         className="flex flex-col space-y-4 px-4 pt-4"
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+          paddingBottom,
         }}
       >
         {!isMobile && (

--- a/apps/tlon-web/src/components/Settings/SettingsView.tsx
+++ b/apps/tlon-web/src/components/Settings/SettingsView.tsx
@@ -1,6 +1,7 @@
 import { ViewProps } from '@tloncorp/shared/dist/urbit/groups';
 import { Helmet } from 'react-helmet';
 
+import { isNativeApp } from '@/logic/native';
 import { useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
 
@@ -13,6 +14,7 @@ export default function SettingsView({ title }: ViewProps) {
 
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar;
+  const paddingBottom = isNativeApp() ? 64 : 50;
 
   return (
     <Layout
@@ -29,7 +31,7 @@ export default function SettingsView({ title }: ViewProps) {
       <div
         className="flex flex-col space-y-4 px-4 pt-4"
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 64 : 0,
+          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
         }}
       >
         {!isMobile && (

--- a/apps/tlon-web/src/components/Sidebar/AppNav.tsx
+++ b/apps/tlon-web/src/components/Sidebar/AppNav.tsx
@@ -418,10 +418,12 @@ export default function AppNav() {
         <footer
           data-testid="app-nav"
           className={cn(
-            'navbar-transition z-50 flex-none border-t-2 border-gray-50 bg-white fixed bottom-0 w-full',
-            isChatInputFocused && 'translate-y-[200%] opacity-0 h-0',
-            !isNativeApp() && 'pb-1'
+            'navbar-transition z-50 flex-none border-t-2 border-gray-50 bg-white fixed w-full bottom-0',
+            isChatInputFocused && 'translate-y-[200%] opacity-0 h-0'
           )}
+          style={{
+            paddingBottom: isNativeApp() ? safeAreaInsets.bottom : 0,
+          }}
         >
           <nav>
             <ul className="flex h-12">

--- a/apps/tlon-web/src/diary/DiaryNote.tsx
+++ b/apps/tlon-web/src/diary/DiaryNote.tsx
@@ -8,16 +8,14 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 
 import Divider from '@/components/Divider';
 import Layout from '@/components/Layout/Layout';
-import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import {
   canWriteChannel,
   useChannelCompatibility,
   useChannelIsJoined,
 } from '@/logic/channel';
 import getKindDataFromEssay from '@/logic/getKindData';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
-import { useIsMobile } from '@/logic/useMedia';
 import { getFlagParts, pluralize } from '@/logic/utils';
 import ReplyMessage from '@/replies/ReplyMessage';
 import { groupReplies, setNewDaysForReplies } from '@/replies/replies';
@@ -70,10 +68,7 @@ export default function DiaryNote({ title }: ViewProps) {
   const unread = useUnread(nest);
   const sort = useDiaryCommentSortMode(chFlag);
   const perms = usePerms(nest);
-  const isMobile = useIsMobile();
-  const { isChatInputFocused } = useChatInputFocus();
-  const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 64 : 50;
+  const { paddingBottom } = useBottomPadding();
   const { compatible } = useChannelCompatibility(nest);
   const { mutateAsync: joinDiary } = useJoinMutation();
   const joinChannel = useCallback(async () => {
@@ -138,7 +133,7 @@ export default function DiaryNote({ title }: ViewProps) {
     return (
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+          paddingBottom,
         }}
         className="h-full flex-1 bg-white"
         header={

--- a/apps/tlon-web/src/diary/DiaryNote.tsx
+++ b/apps/tlon-web/src/diary/DiaryNote.tsx
@@ -15,6 +15,7 @@ import {
   useChannelIsJoined,
 } from '@/logic/channel';
 import getKindDataFromEssay from '@/logic/getKindData';
+import { isNativeApp } from '@/logic/native';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { useIsMobile } from '@/logic/useMedia';
 import { getFlagParts, pluralize } from '@/logic/utils';
@@ -72,6 +73,7 @@ export default function DiaryNote({ title }: ViewProps) {
   const isMobile = useIsMobile();
   const { isChatInputFocused } = useChatInputFocus();
   const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 64 : 50;
   const { compatible } = useChannelCompatibility(nest);
   const { mutateAsync: joinDiary } = useJoinMutation();
   const joinChannel = useCallback(async () => {
@@ -136,7 +138,7 @@ export default function DiaryNote({ title }: ViewProps) {
     return (
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
         }}
         className="h-full flex-1 bg-white"
         header={

--- a/apps/tlon-web/src/dms/DMThread.tsx
+++ b/apps/tlon-web/src/dms/DMThread.tsx
@@ -27,9 +27,8 @@ import MobileHeader from '@/components/MobileHeader';
 import BranchIcon from '@/components/icons/BranchIcon';
 import X16Icon from '@/components/icons/X16Icon';
 import keyMap from '@/keyMap';
-import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
@@ -67,9 +66,7 @@ export default function DMThread() {
   const threadRef = useRef<HTMLDivElement | null>(null);
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const isScrolling = useIsScrolling(scrollElementRef);
-  const { isChatInputFocused } = useChatInputFocus();
-  const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const readTimeout = useChatInfo(whom).unread?.readTimeout;
   const { mutate: markDmRead } = useMarkDmReadMutation();
   const isSmall = useMedia('(max-width: 1023px)');
@@ -154,7 +151,7 @@ export default function DMThread() {
       className="relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
     >
       {isMobile ? (

--- a/apps/tlon-web/src/dms/DMThread.tsx
+++ b/apps/tlon-web/src/dms/DMThread.tsx
@@ -29,6 +29,7 @@ import X16Icon from '@/components/icons/X16Icon';
 import keyMap from '@/keyMap';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
+import { isNativeApp } from '@/logic/native';
 import { useIsScrolling } from '@/logic/scroll';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
@@ -68,6 +69,7 @@ export default function DMThread() {
   const isScrolling = useIsScrolling(scrollElementRef);
   const { isChatInputFocused } = useChatInputFocus();
   const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const readTimeout = useChatInfo(whom).unread?.readTimeout;
   const { mutate: markDmRead } = useMarkDmReadMutation();
   const isSmall = useMedia('(max-width: 1023px)');
@@ -127,8 +129,8 @@ export default function DMThread() {
     clearOnNavRef.current = { isSmall, readTimeout, whom, markDmRead };
   }, [readTimeout, whom, isSmall, markDmRead]);
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       const curr = clearOnNavRef.current;
       if (
         curr.isSmall &&
@@ -139,8 +141,9 @@ export default function DMThread() {
         useChatStore.getState().read(curr.whom);
         curr.markDmRead({ whom: curr.whom });
       }
-    };
-  }, []);
+    },
+    []
+  );
 
   if (!writ || isLoading) return null;
 
@@ -151,7 +154,7 @@ export default function DMThread() {
       className="relative flex h-full w-full flex-col overflow-y-auto bg-white lg:w-96 lg:border-l-2 lg:border-gray-50"
       ref={threadRef}
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
     >
       {isMobile ? (

--- a/apps/tlon-web/src/dms/Dm.tsx
+++ b/apps/tlon-web/src/dms/Dm.tsx
@@ -27,6 +27,7 @@ import DmInvite from '@/dms/DmInvite';
 import DmWindow from '@/dms/DmWindow';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
+import { isNativeApp } from '@/logic/native';
 import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
@@ -123,6 +124,7 @@ export default function Dm() {
   const canStart = ship && !!unread;
   const root = `/dm/${ship}`;
   const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const { matchedOrPending, isLoading: negotiationLoading } = useNegotiate(
     ship,
     'chat',
@@ -155,7 +157,7 @@ export default function Dm() {
     <>
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
         }}
         className="padding-bottom-transition flex-1"
         header={

--- a/apps/tlon-web/src/dms/Dm.tsx
+++ b/apps/tlon-web/src/dms/Dm.tsx
@@ -27,11 +27,10 @@ import DmInvite from '@/dms/DmInvite';
 import DmWindow from '@/dms/DmWindow';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
-import useShowTabBar from '@/logic/useShowTabBar';
 import { dmListPath } from '@/logic/utils';
 import { useDmIsPending, useDmUnread, useSendMessage } from '@/state/chat';
 import { useContact } from '@/state/contact';
@@ -120,11 +119,9 @@ export default function Dm() {
   const unread = useDmUnread(ship);
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const isScrolling = useIsScrolling(scrollElementRef);
-  const showTabBar = useShowTabBar();
   const canStart = ship && !!unread;
   const root = `/dm/${ship}`;
-  const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const { matchedOrPending, isLoading: negotiationLoading } = useNegotiate(
     ship,
     'chat',
@@ -157,7 +154,7 @@ export default function Dm() {
     <>
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+          paddingBottom,
         }}
         className="padding-bottom-transition flex-1"
         header={

--- a/apps/tlon-web/src/dms/MobileDmSearch.tsx
+++ b/apps/tlon-web/src/dms/MobileDmSearch.tsx
@@ -7,8 +7,8 @@ import SearchBar from '@/chat/ChatSearch/SearchBar';
 import Layout from '@/components/Layout/Layout';
 import { CHANNEL_SEARCH_RESULT_SIZE } from '@/constants';
 import { useSafeAreaInsets } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import useDebounce from '@/logic/useDebounce';
-import useShowTabBar from '@/logic/useShowTabBar';
 import { useInfiniteChatSearch, useSearchState } from '@/state/chat/search';
 
 export default function MobileDmSearch() {
@@ -23,8 +23,7 @@ export default function MobileDmSearch() {
   const insets = useSafeAreaInsets();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const [searchInput, setSearchInput] = useState(params.query || '');
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
+  const { paddingBottom } = useBottomPadding();
 
   const whom =
     params.chShip && params.chName
@@ -75,7 +74,7 @@ export default function MobileDmSearch() {
   return (
     <Layout
       className="mb-4 flex-1 bg-white px-4"
-      style={{ paddingBottom: shouldApplyPaddingBottom ? 64 : 0 }}
+      style={{ paddingBottom }}
       header={
         <div className="mt-2 flex" style={{ paddingTop: insets.top }}>
           <SearchBar

--- a/apps/tlon-web/src/dms/MobileMessagesSidebar.tsx
+++ b/apps/tlon-web/src/dms/MobileMessagesSidebar.tsx
@@ -6,8 +6,7 @@ import { Link } from 'react-router-dom';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
-import { isNativeApp } from '@/logic/native';
-import useShowTabBar from '@/logic/useShowTabBar';
+import { useBottomPadding } from '@/logic/position';
 import { usePinnedChats } from '@/state/pins';
 
 import MessagesList from './MessagesList';
@@ -15,9 +14,7 @@ import { MessagesScrollingContext } from './MessagesScrollingContext';
 import MessagesSidebarItem from './MessagesSidebarItem';
 
 export default function MobileMessagesSidebar() {
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const [isScrolling, setIsScrolling] = useState(false);
   const pinned = usePinnedChats(true);
 
@@ -29,7 +26,7 @@ export default function MobileMessagesSidebar() {
     <div
       className="flex h-full w-full flex-col"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
       data-testid="messages-menu"
     >

--- a/apps/tlon-web/src/dms/MobileMessagesSidebar.tsx
+++ b/apps/tlon-web/src/dms/MobileMessagesSidebar.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import MobileHeader from '@/components/MobileHeader';
 import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
+import { isNativeApp } from '@/logic/native';
 import useShowTabBar from '@/logic/useShowTabBar';
 import { usePinnedChats } from '@/state/pins';
 
@@ -16,6 +17,7 @@ import MessagesSidebarItem from './MessagesSidebarItem';
 export default function MobileMessagesSidebar() {
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const [isScrolling, setIsScrolling] = useState(false);
   const pinned = usePinnedChats(true);
 
@@ -27,7 +29,7 @@ export default function MobileMessagesSidebar() {
     <div
       className="flex h-full w-full flex-col"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
       data-testid="messages-menu"
     >

--- a/apps/tlon-web/src/dms/MultiDm.tsx
+++ b/apps/tlon-web/src/dms/MultiDm.tsx
@@ -21,6 +21,7 @@ import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobi
 import DmWindow from '@/dms/DmWindow';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
+import { isNativeApp } from '@/logic/native';
 import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
@@ -88,6 +89,7 @@ export default function MultiDm() {
   const isScrolling = useIsScrolling(scrollElementRef);
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const dmParticipants = [...(club?.team ?? []), ...(club?.hive ?? [])];
   const { match: negotiationMatch, isLoading: negotiationLoading } =
     useNegotiateMulti(dmParticipants, 'chat', 'chat');
@@ -114,7 +116,7 @@ export default function MultiDm() {
     <>
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
         }}
         className="padding-bottom-transition flex-1"
         header={

--- a/apps/tlon-web/src/dms/MultiDm.tsx
+++ b/apps/tlon-web/src/dms/MultiDm.tsx
@@ -21,11 +21,10 @@ import MagnifyingGlassMobileNavIcon from '@/components/icons/MagnifyingGlassMobi
 import DmWindow from '@/dms/DmWindow';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
-import useShowTabBar from '@/logic/useShowTabBar';
 import { dmListPath, pluralize } from '@/logic/utils';
 import { useMultiDm, useMultiDmIsPending, useSendMessage } from '@/state/chat';
 import { useNegotiateMulti } from '@/state/negotiation';
@@ -87,9 +86,7 @@ export default function MultiDm() {
   const root = `/dm/${clubId}`;
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const isScrolling = useIsScrolling(scrollElementRef);
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const dmParticipants = [...(club?.team ?? []), ...(club?.hive ?? [])];
   const { match: negotiationMatch, isLoading: negotiationLoading } =
     useNegotiateMulti(dmParticipants, 'chat', 'chat');
@@ -116,7 +113,7 @@ export default function MultiDm() {
     <>
       <Layout
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+          paddingBottom,
         }}
         className="padding-bottom-transition flex-1"
         header={

--- a/apps/tlon-web/src/dms/NewDm.tsx
+++ b/apps/tlon-web/src/dms/NewDm.tsx
@@ -1,13 +1,12 @@
 import cn from 'classnames';
-import React, { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 
 import ChatInput from '@/chat/ChatInput/ChatInput';
 import Layout from '@/components/Layout/Layout';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
-import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
@@ -30,9 +29,7 @@ export default function NewDM() {
   const isMobile = useIsMobile();
   const scrollElementRef = useRef<HTMLDivElement>(null);
   const isScrolling = useIsScrolling(scrollElementRef);
-  const { isChatInputFocused } = useChatInputFocus();
-  const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const shouldBlockInput =
     isMultiDm && !existingMultiDm && multiDmVersionMismatch;
 
@@ -40,7 +37,7 @@ export default function NewDM() {
     <Layout
       className="flex-1"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
       header={
         isMobile && <MobileHeader title="New Message" pathBack={dmListPath} />

--- a/apps/tlon-web/src/dms/NewDm.tsx
+++ b/apps/tlon-web/src/dms/NewDm.tsx
@@ -7,6 +7,7 @@ import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 import MobileHeader from '@/components/MobileHeader';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useDragAndDrop } from '@/logic/DragAndDropContext';
+import { isNativeApp } from '@/logic/native';
 import { useIsScrolling } from '@/logic/scroll';
 import { useIsMobile } from '@/logic/useMedia';
 import useMessageSelector from '@/logic/useMessageSelector';
@@ -31,6 +32,7 @@ export default function NewDM() {
   const isScrolling = useIsScrolling(scrollElementRef);
   const { isChatInputFocused } = useChatInputFocus();
   const shouldApplyPaddingBottom = isMobile && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const shouldBlockInput =
     isMultiDm && !existingMultiDm && multiDmVersionMismatch;
 
@@ -38,7 +40,7 @@ export default function NewDM() {
     <Layout
       className="flex-1"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
       header={
         isMobile && <MobileHeader title="New Message" pathBack={dmListPath} />

--- a/apps/tlon-web/src/heap/HeapDetail.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail.tsx
@@ -14,6 +14,7 @@ import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useFullChannel } from '@/logic/channel';
 import getKindDataFromEssay from '@/logic/getKindData';
 import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
@@ -46,10 +47,7 @@ export default function HeapDetail({ title }: ViewProps) {
   const isMobile = useIsMobile();
   const { post: note, isLoading } = usePost(nest, idTime || '');
   const { title: curioTitle } = getKindDataFromEssay(note.essay);
-  const { isChatInputFocused } = useChatInputFocus();
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const { nextPost: nextNote, prevPost: prevNote } = useOrderedPosts(
     nest,
     idTime || ''
@@ -86,7 +84,7 @@ export default function HeapDetail({ title }: ViewProps) {
   return (
     <Layout
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
       className="padding-bottom-transition flex-1 bg-white"
       header={

--- a/apps/tlon-web/src/heap/HeapDetail.tsx
+++ b/apps/tlon-web/src/heap/HeapDetail.tsx
@@ -13,6 +13,7 @@ import CaretRightIcon from '@/components/icons/CaretRightIcon';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { useFullChannel } from '@/logic/channel';
 import getKindDataFromEssay from '@/logic/getKindData';
+import { isNativeApp } from '@/logic/native';
 import { useGroupsAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
@@ -48,6 +49,7 @@ export default function HeapDetail({ title }: ViewProps) {
   const { isChatInputFocused } = useChatInputFocus();
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar && !isChatInputFocused;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const { nextPost: nextNote, prevPost: prevNote } = useOrderedPosts(
     nest,
     idTime || ''
@@ -84,7 +86,7 @@ export default function HeapDetail({ title }: ViewProps) {
   return (
     <Layout
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
       className="padding-bottom-transition flex-1 bg-white"
       header={

--- a/apps/tlon-web/src/logic/position.ts
+++ b/apps/tlon-web/src/logic/position.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+import { useChatInputFocus } from './ChatInputFocusContext';
+import { useSafeAreaInsets } from './native';
+import useShowTabBar from './useShowTabBar';
+
+export const BOTTOM_WEB_NAV_OFFSET = 50;
+
+export function useBottomPadding() {
+  const safeAreaInsets = useSafeAreaInsets();
+  const { isChatInputFocused } = useChatInputFocus();
+  const showTabBar = useShowTabBar();
+  const shouldApplyBottomPadding = useMemo(
+    () => showTabBar && !isChatInputFocused,
+    [showTabBar, isChatInputFocused]
+  );
+
+  return {
+    shouldApplyBottomPadding,
+    paddingBottom: shouldApplyBottomPadding
+      ? safeAreaInsets.bottom + BOTTOM_WEB_NAV_OFFSET
+      : 0,
+  };
+}

--- a/apps/tlon-web/src/nav/MobileRoot.tsx
+++ b/apps/tlon-web/src/nav/MobileRoot.tsx
@@ -13,6 +13,7 @@ import WelcomeCard from '@/components/WelcomeCard';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
 import AddGroupSheet from '@/groups/AddGroupSheet';
 import GroupJoinList from '@/groups/GroupJoinList';
+import { isNativeApp } from '@/logic/native';
 import useGroupSort from '@/logic/useGroupSort';
 import useShowTabBar from '@/logic/useShowTabBar';
 import {
@@ -27,6 +28,7 @@ import {
 export default function MobileRoot() {
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar;
+  const paddingBottom = isNativeApp() ? 86 : 50;
   const [isScrolling, setIsScrolling] = useState(false);
   const [addGroupOpen, setAddGroupOpen] = useState(false);
   const scroll = useRef(
@@ -74,7 +76,7 @@ export default function MobileRoot() {
     <Layout
       className="flex-1 bg-white"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
       header={
         <MobileHeader

--- a/apps/tlon-web/src/nav/MobileRoot.tsx
+++ b/apps/tlon-web/src/nav/MobileRoot.tsx
@@ -13,9 +13,8 @@ import WelcomeCard from '@/components/WelcomeCard';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
 import AddGroupSheet from '@/groups/AddGroupSheet';
 import GroupJoinList from '@/groups/GroupJoinList';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import useGroupSort from '@/logic/useGroupSort';
-import useShowTabBar from '@/logic/useShowTabBar';
 import {
   useGangsWithClaim,
   useGroupsWithQuery,
@@ -26,9 +25,7 @@ import {
 } from '@/state/groups';
 
 export default function MobileRoot() {
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
   const [isScrolling, setIsScrolling] = useState(false);
   const [addGroupOpen, setAddGroupOpen] = useState(false);
   const scroll = useRef(
@@ -76,7 +73,7 @@ export default function MobileRoot() {
     <Layout
       className="flex-1 bg-white"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
       header={
         <MobileHeader

--- a/apps/tlon-web/src/profiles/EditProfile/EditProfile.tsx
+++ b/apps/tlon-web/src/profiles/EditProfile/EditProfile.tsx
@@ -16,10 +16,9 @@ import GroupSelector, { GroupOption } from '@/components/GroupSelector';
 import Layout from '@/components/Layout/Layout';
 import MobileHeader from '@/components/MobileHeader';
 import ShipName from '@/components/ShipName';
-import { isNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 import useContactState, { useOurContact } from '@/state/contact';
 import { useGroups } from '@/state/groups';
 import { useProfileIsPublic } from '@/state/profile/profile';
@@ -59,7 +58,6 @@ const onFormSubmit = (values: ProfileFormSchema, contact: Contact) => {
 
 function EditProfileContent() {
   const profileIsPublic = useProfileIsPublic();
-  const isMobile = useIsMobile();
   const [allGroups, setAllGroups] = useState<GroupOption[]>([]);
   const groupData = useGroups();
   const groupFlags = Object.keys(groupData);
@@ -144,16 +142,13 @@ function EditProfileContent() {
   };
 
   const watchCover = form.watch('cover');
-
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
-  const paddingBottom = isNativeApp() ? 86 : 50;
+  const { paddingBottom } = useBottomPadding();
 
   return (
     <div
       className="w-full p-4"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
+        paddingBottom,
       }}
     >
       <FormProvider {...form}>

--- a/apps/tlon-web/src/profiles/EditProfile/EditProfile.tsx
+++ b/apps/tlon-web/src/profiles/EditProfile/EditProfile.tsx
@@ -16,6 +16,7 @@ import GroupSelector, { GroupOption } from '@/components/GroupSelector';
 import Layout from '@/components/Layout/Layout';
 import MobileHeader from '@/components/MobileHeader';
 import ShipName from '@/components/ShipName';
+import { isNativeApp } from '@/logic/native';
 import { useAnalyticsEvent } from '@/logic/useAnalyticsEvent';
 import { useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
@@ -146,12 +147,13 @@ function EditProfileContent() {
 
   const showTabBar = useShowTabBar();
   const shouldApplyPaddingBottom = showTabBar;
+  const paddingBottom = isNativeApp() ? 86 : 50;
 
   return (
     <div
       className="w-full p-4"
       style={{
-        paddingBottom: shouldApplyPaddingBottom ? 50 : 0,
+        paddingBottom: shouldApplyPaddingBottom ? paddingBottom : 0,
       }}
     >
       <FormProvider {...form}>

--- a/apps/tlon-web/src/profiles/Profile.tsx
+++ b/apps/tlon-web/src/profiles/Profile.tsx
@@ -15,8 +15,8 @@ import PersonIcon from '@/components/icons/PersonIcon';
 import ShareIcon from '@/components/icons/ShareIcon';
 import TlonIcon from '@/components/icons/TlonIcon';
 import { isNativeApp, postActionToNativeApp } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 import { isHosted } from '@/logic/utils';
 import { useOurContact } from '@/state/contact';
 
@@ -25,9 +25,7 @@ import ProfileCoverImage from './ProfileCoverImage';
 export default function Profile({ title }: ViewProps) {
   const isMobile = useIsMobile();
   const contact = useOurContact();
-
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
+  const { paddingBottom } = useBottomPadding();
 
   return (
     <>
@@ -40,7 +38,7 @@ export default function Profile({ title }: ViewProps) {
         <nav
           className="flex grow flex-col gap-1 overflow-auto p-4 md:w-64 md:shrink-0 md:border-r-2 md:border-r-gray-50 md:px-1 md:py-2"
           style={{
-            marginBottom: shouldApplyPaddingBottom ? 148 : 0,
+            paddingBottom,
           }}
           data-testid="profile-menu"
         >

--- a/apps/tlon-web/src/profiles/Profile.tsx
+++ b/apps/tlon-web/src/profiles/Profile.tsx
@@ -40,7 +40,7 @@ export default function Profile({ title }: ViewProps) {
         <nav
           className="flex grow flex-col gap-1 overflow-auto p-4 md:w-64 md:shrink-0 md:border-r-2 md:border-r-gray-50 md:px-1 md:py-2"
           style={{
-            marginBottom: shouldApplyPaddingBottom ? 96 : 0,
+            marginBottom: shouldApplyPaddingBottom ? 148 : 0,
           }}
           data-testid="profile-menu"
         >

--- a/apps/tlon-web/src/profiles/ShareDMLure.tsx
+++ b/apps/tlon-web/src/profiles/ShareDMLure.tsx
@@ -6,14 +6,12 @@ import Layout from '@/components/Layout/Layout';
 import MobileHeader from '@/components/MobileHeader';
 import QRWidget, { QRWidgetPlaceholder } from '@/components/QRWidget';
 import { getDmLink } from '@/logic/branch';
+import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 
 export default function ShareDMLure({ title }: ViewProps) {
   const isMobile = useIsMobile();
-
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
+  const { paddingBottom } = useBottomPadding();
 
   const [dmLink, setDmLink] = useState('');
 
@@ -41,7 +39,7 @@ export default function ShareDMLure({ title }: ViewProps) {
       <div
         className="flex flex-col space-y-4 px-4 pt-4"
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 64 : 0,
+          paddingBottom,
         }}
       >
         {!isMobile && (


### PR DESCRIPTION
Restores the safe area inset for the horizontal (mobile) orientation and compensates for it in each shouldAddPadding check. Has the nice effect of providing two different padding values: one for the native app, one for the mobile PWA.

PR Checklist
- [ ] Includes changes to desk files
- [x] Tested on-device pointed at Vite dev server, proxied against livenet planet
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context