### PR TITLE
nav/desktop: wire up update button

### DIFF
--- a/apps/tlon-web/src/components/Sidebar/AppNav.tsx
+++ b/apps/tlon-web/src/components/Sidebar/AppNav.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import Asterisk16Icon from '@/components/icons/Asterisk16Icon';
 import { useChatInputFocus } from '@/logic/ChatInputFocusContext';
 import { isNativeApp, useSafeAreaInsets } from '@/logic/native';
-import { AppUpdateContext } from '@/logic/useAppUpdates';
+import useAppUpdates, { AppUpdateContext } from '@/logic/useAppUpdates';
 import { useIsAnyGroupUnread } from '@/logic/useIsGroupUnread';
 import { useIsDark, useIsMobile } from '@/logic/useMedia';
 import useShowTabBar from '@/logic/useShowTabBar';
@@ -227,6 +227,7 @@ function ActivityTab(props: { isInactive: boolean; isDarkMode: boolean }) {
 function UpdateTab() {
   const isMobile = useIsMobile();
   const location = useLocation();
+  const { triggerUpdate } = useAppUpdates();
 
   if (isMobile) {
     return (
@@ -248,16 +249,15 @@ function UpdateTab() {
   }
 
   return (
-    <Link
+    <button
       className="relative m-auto flex h-10 w-10 items-center justify-center rounded-lg"
-      to="/update-needed"
-      state={{ backgroundLocation: location }}
+      onClick={() => triggerUpdate(true)}
       aria-label="Update Needed"
     >
       <div className="flex h-[40px] w-[40px] items-center justify-center rounded-md bg-yellow">
         <Asterisk16Icon className="h-6 w-6 text-black dark:text-white" />
       </div>
-    </Link>
+    </button>
   );
 }
 

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -101,10 +101,9 @@ function GroupHeader() {
       </GroupActions>
       <Link
         to=".."
-        className={cn(
-          'h-6-w-6 absolute left-2 top-2.5 z-40 flex items-center justify-center rounded bg-transparent bg-white p-1 text-gray-400',
-          needsUpdate ? 'bg-yellow' : 'bg-transparent'
-        )}
+        className={
+          'h-6-w-6 absolute left-2 top-2.5 z-40 flex items-center justify-center rounded bg-transparent bg-white p-1 text-gray-400'
+        }
       >
         {needsUpdate ? (
           <AsteriskIcon className="h-4 w-4 text-black dark:text-white" />


### PR DESCRIPTION
Restores the functionality of the update button on desktop. I was routing to /update-needed, which doesn't exist on mobile and only throws a sheet dialog with _another_ update button.

PR Checklist
- [ ] Includes changes to desk files
- [x] Tested locally with the Vite dev server proxied against a livenet planet
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context