### PR TITLE
mobile reactions: fix hidden emoji picker

### DIFF
--- a/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
+++ b/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+import shipManifest from './shipManifest.json';
+
+const groupHostUrl = `${shipManifest['~naldeg-mardev'].webUrl}/apps/groups/`;
+const groupHost = 'mardev';
+const testGroupName = 'mardev Club';
+const testChannelName = 'mardev chat';
+const testMessageText = `hi, it's me, ~naldeg-mardev`;
+const defaultVisibleEmoji = '😇';
+
+test('Add reaction', async ({ browser }) => {
+  // authenticate as test group host
+  const hostContext = await browser.newContext({
+    storageState: shipManifest['~naldeg-mardev'].authFile,
+  });
+  const page = await hostContext.newPage();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(groupHostUrl);
+
+  // navigate to test channel
+  await page.getByRole('link', { name: testGroupName }).waitFor();
+  await page.getByRole('link', { name: testGroupName }).click();
+  await page.getByRole('link', { name: testChannelName }).waitFor();
+  await page.getByRole('link', { name: testChannelName }).click();
+
+  // open longpress menu
+  await page.getByText(testMessageText).click({ delay: 300 });
+  await page.getByTestId('chat-message-options').waitFor();
+  await expect(page.getByTestId('chat-message-options')).toBeVisible();
+
+  // open picker and add reaction
+  await page.getByTestId('react').click();
+  await page.getByTestId('emoji-picker').waitFor();
+  await expect(page.getByTestId('emoji-picker')).toBeVisible();
+  await page.getByText(defaultVisibleEmoji).waitFor();
+  await page.getByText(defaultVisibleEmoji).click();
+
+  // verify reaction
+  await page.getByTestId('emoji-picker').waitFor({ state: 'detached' });
+  await page.getByText(defaultVisibleEmoji).waitFor();
+  await expect(page.getByText(defaultVisibleEmoji)).toBeVisible();
+});

--- a/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
+++ b/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
@@ -30,6 +30,7 @@ test('Add reaction', async ({ browser }) => {
   await expect(page.getByTestId('chat-message-options')).toBeVisible();
 
   // open picker and add reaction
+  await page.getByTestId('react').waitFor();
   await page.getByTestId('react').click();
   await page.getByTestId('emoji-picker').waitFor();
   await expect(page.getByTestId('emoji-picker')).toBeVisible();

--- a/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
+++ b/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
@@ -31,7 +31,7 @@ test('Add reaction', async ({ browser }) => {
 
   // open picker and add reaction
   await page.getByTestId('react').waitFor();
-  await page.getByTestId('react').click();
+  await page.getByTestId('react').dispatchEvent('click'); // workaround for vaul intercepting the click event
   await page.getByTestId('emoji-picker').waitFor();
   await expect(page.getByTestId('emoji-picker')).toBeVisible();
   await page.getByText(defaultVisibleEmoji).waitFor();

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -405,7 +405,12 @@ function ChatMessageOptions(props: {
   return (
     <>
       {isMobile ? (
-        <ActionMenu open={open} onOpenChange={onOpenChange} actions={actions} />
+        <ActionMenu
+          testId="chat-message-options"
+          open={open}
+          onOpenChange={onOpenChange}
+          actions={actions}
+        />
       ) : (
         <div
           className="absolute -top-5 right-2 z-10 min-h-fit"

--- a/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
+++ b/apps/tlon-web/src/chat/ChatMessage/ChatMessageOptions.tsx
@@ -431,7 +431,6 @@ function ChatMessageOptions(props: {
                   icon={<FaceIcon className="h-6 w-6 text-gray-400" />}
                   label="React"
                   showTooltip
-                  aria-label="React"
                   action={openPicker}
                 />
               </EmojiPicker>

--- a/apps/tlon-web/src/components/ActionMenu.tsx
+++ b/apps/tlon-web/src/components/ActionMenu.tsx
@@ -32,6 +32,7 @@ type ActionMenuProps = PropsWithChildren<{
   className?: string;
   triggerClassName?: string;
   contentClassName?: string;
+  testId?: string;
 }>;
 
 function classNameForType(type?: ActionType) {
@@ -58,6 +59,7 @@ const ActionMenu = React.memo(
     disabled,
     align,
     ariaLabel,
+    testId,
     className,
     triggerClassName,
     contentClassName,
@@ -81,9 +83,13 @@ const ActionMenu = React.memo(
             )}
             <Drawer.Portal>
               <Drawer.Overlay className="fixed inset-0 z-[49] bg-black/20" />
-              <Drawer.Content className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pb-8 pt-4 outline-none after:!bg-transparent">
+              <Drawer.Content
+                data-testid={testId}
+                className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pb-8 pt-4 outline-none after:!bg-transparent"
+              >
                 {actions.map((action) => (
                   <button
+                    data-testid={action.key}
                     key={action.key}
                     onClick={
                       action.keepOpenOnClick

--- a/apps/tlon-web/src/components/ActionMenu.tsx
+++ b/apps/tlon-web/src/components/ActionMenu.tsx
@@ -85,7 +85,7 @@ const ActionMenu = React.memo(
               <Drawer.Overlay className="fixed inset-0 z-[49] bg-black/20" />
               <Drawer.Content
                 data-testid={testId}
-                className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pb-8 pt-4 outline-none after:!bg-transparent"
+                className="fixed bottom-0 z-[99999] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pb-8 pt-4 outline-none after:!bg-transparent"
               >
                 {actions.map((action) => (
                   <button

--- a/apps/tlon-web/src/components/ActionMenu.tsx
+++ b/apps/tlon-web/src/components/ActionMenu.tsx
@@ -85,7 +85,7 @@ const ActionMenu = React.memo(
               <Drawer.Overlay className="fixed inset-0 z-[49] bg-black/20" />
               <Drawer.Content
                 data-testid={testId}
-                className="fixed bottom-0 z-[99999] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pb-8 pt-4 outline-none after:!bg-transparent"
+                className="fixed bottom-0 z-[49] flex w-full flex-col rounded-t-[32px] bg-white px-[24px] pb-8 pt-4 outline-none after:!bg-transparent"
               >
                 {actions.map((action) => (
                   <button

--- a/apps/tlon-web/src/components/EmojiPicker.tsx
+++ b/apps/tlon-web/src/components/EmojiPicker.tsx
@@ -147,8 +147,9 @@ export default function EmojiPicker({
           collisionPadding={15}
           onInteractOutside={isMobile ? () => dismss() : undefined}
           data-testid="emoji-picker"
+          className="z-50"
         >
-          <div className="z-50 mx-10 flex h-96 w-72 items-center justify-center">
+          <div className="mx-10 flex h-96 w-72 items-center justify-center">
             {data ? (
               <Picker
                 data={data}

--- a/apps/tlon-web/src/components/IconButton.tsx
+++ b/apps/tlon-web/src/components/IconButton.tsx
@@ -1,6 +1,6 @@
 import * as Tooltip from '@radix-ui/react-tooltip';
 import cn from 'classnames';
-import React, { MouseEventHandler } from 'react';
+import React, { MouseEventHandler, useMemo } from 'react';
 
 interface IconButtonProps {
   icon: React.ReactElement;
@@ -21,6 +21,11 @@ export default function IconButton({
   small = false,
   disabled = false,
 }: IconButtonProps) {
+  const testId = useMemo(
+    () => label.toLowerCase().split(' ').join('-'),
+    [label]
+  );
+
   return (
     <div className={cn('group-two cursor-pointer', className)}>
       <Tooltip.Root delayDuration={800} disableHoverableContent>
@@ -64,6 +69,7 @@ export default function IconButton({
             )}
             onClick={action}
             aria-label={label}
+            data-testid={testId}
             disabled={disabled}
           >
             {icon}


### PR DESCRIPTION
The new nav introduced a z-index issue where the emoji picker wasn't visible on mobile. This simply shuffles where the picker z-index is set ensuring it's again visible.

Also adds a test to make sure we'll catch issues with adding reactions next time.

Tested against a local ship.

Fixes LAND-1641

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [x] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context