### PR TITLE
James/land 1647 navmobile safe area inset missing on profile channel list

### DIFF
--- a/apps/tlon-web/src/chat/ChatSearch/MobileChatSearch.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/MobileChatSearch.tsx
@@ -7,8 +7,8 @@ import SearchBar from '@/chat/ChatSearch/SearchBar';
 import Layout from '@/components/Layout/Layout';
 import { CHANNEL_SEARCH_RESULT_SIZE } from '@/constants';
 import { useSafeAreaInsets } from '@/logic/native';
+import { useBottomPadding } from '@/logic/position';
 import useDebounce from '@/logic/useDebounce';
-import useShowTabBar from '@/logic/useShowTabBar';
 import { useChannelSearch } from '@/state/channel/channel';
 import { useSearchState } from '@/state/chat/search';
 
@@ -24,8 +24,7 @@ export default function MobileChatSearch() {
   const insets = useSafeAreaInsets();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const [searchInput, setSearchInput] = useState(params.query || '');
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
+  const { paddingBottom } = useBottomPadding();
 
   const whom =
     params.chShip && params.chName
@@ -76,7 +75,7 @@ export default function MobileChatSearch() {
   return (
     <Layout
       className="flex-1 bg-white px-4"
-      style={{ paddingBottom: shouldApplyPaddingBottom ? 50 : 0 }}
+      style={{ paddingBottom }}
       header={
         <div className="mt-2 flex" style={{ paddingTop: insets.top }}>
           <SearchBar
@@ -94,7 +93,7 @@ export default function MobileChatSearch() {
         </div>
       }
     >
-      <div className="pb-4 z-30 flex h-full w-full flex-col pt-4">
+      <div className="z-30 flex h-full w-full flex-col py-4">
         {showRecentQueries && (
           <div className="mb-4 flex flex-col items-start">
             <p className="mb-4 text-sm font-semibold text-gray-400">

--- a/apps/tlon-web/src/groups/MobileGroupChannelList.tsx
+++ b/apps/tlon-web/src/groups/MobileGroupChannelList.tsx
@@ -6,6 +6,7 @@ import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import AddIconMobileNav from '@/components/icons/AddIconMobileNav';
 import GroupAvatar from '@/groups/GroupAvatar';
 import ChannelList, { ChannelSorter } from '@/groups/GroupSidebar/ChannelList';
+import { useBottomPadding } from '@/logic/position';
 import { useTextColor } from '@/logic/useTextColor';
 import { isColor } from '@/logic/utils';
 import { useAmAdmin, useGroup, useGroupFlag } from '@/state/groups';
@@ -22,6 +23,7 @@ export default function MobileGroupChannelList() {
   const defaultImportCover = group?.meta.cover === '0x0';
   const calm = useCalm();
   const textColor = useTextColor(group?.meta.cover || '');
+  const { paddingBottom } = useBottomPadding();
 
   const bgStyle = () => {
     if (
@@ -85,7 +87,12 @@ export default function MobileGroupChannelList() {
         pathBack="/"
         // TODO: here is where we will wire up the back button once the native groups list is ready
       />
-      <div className="relative z-10 mt-2 h-full rounded-t-3xl bg-white pb-4 drop-shadow-[0_-2px_4px_rgba(0,0,0,0.125)]">
+      <div
+        className="relative z-10 mt-2 h-full rounded-t-3xl bg-white pb-4 drop-shadow-[0_-2px_4px_rgba(0,0,0,0.125)]"
+        style={{
+          paddingBottom,
+        }}
+      >
         <ChannelList paddingTop={6} />
       </div>
       <div

--- a/apps/tlon-web/src/notifications/Notifications.tsx
+++ b/apps/tlon-web/src/notifications/Notifications.tsx
@@ -11,8 +11,8 @@ import ReconnectingSpinner from '@/components/ReconnectingSpinner';
 import ToggleGroup from '@/components/ToggleGroup';
 import WelcomeCard from '@/components/WelcomeCard';
 import GroupSummary from '@/groups/GroupSummary';
+import { useBottomPadding } from '@/logic/position';
 import { useIsMobile } from '@/logic/useMedia';
-import useShowTabBar from '@/logic/useShowTabBar';
 import { randomElement, randomIntInRange } from '@/logic/utils';
 import { useAmAdmin, useGroup, useRouteGroup } from '@/state/groups';
 import { useSawRopeMutation, useSawSeamMutation } from '@/state/hark';
@@ -71,6 +71,7 @@ export default function Notifications({
   const flag = useRouteGroup();
   const group = useGroup(flag);
   const isMobile = useIsMobile();
+  const { paddingBottom } = useBottomPadding();
   const isAdmin = useAmAdmin(flag);
   const location = useLocation();
   const [notificationFilter, setNotificationFilter] =
@@ -147,9 +148,6 @@ export default function Notifications({
     </button>
   );
 
-  const showTabBar = useShowTabBar();
-  const shouldApplyPaddingBottom = showTabBar;
-
   return (
     <>
       {isMobile && (
@@ -166,7 +164,7 @@ export default function Notifications({
       <section
         className="relative flex h-full w-full flex-col space-y-6 overflow-y-scroll bg-white p-2 sm:bg-gray-50 sm:p-6"
         style={{
-          paddingBottom: shouldApplyPaddingBottom ? 50 : 24,
+          paddingBottom,
         }}
         data-testid="notifications-screen"
       >

--- a/apps/tlon-web/src/profiles/Profile.tsx
+++ b/apps/tlon-web/src/profiles/Profile.tsx
@@ -34,9 +34,9 @@ export default function Profile({ title }: ViewProps) {
       </Helmet>
 
       {isMobile ? <MobileHeader title="Profile" /> : null}
-      <div className="flex h-full w-full">
+      <div className="flex h-full w-full overflow-auto md:overflow-hidden">
         <nav
-          className="flex grow flex-col gap-1 overflow-auto p-4 md:w-64 md:shrink-0 md:border-r-2 md:border-r-gray-50 md:px-1 md:py-2"
+          className="flex grow flex-col gap-1 p-4 md:w-64 md:shrink-0 md:overflow-auto md:border-r-2 md:border-r-gray-50 md:px-1 md:py-2"
           style={{
             paddingBottom,
           }}


### PR DESCRIPTION
Fixes LAND-1647.

- Applies the new useBottomPadding hook to the MobileChatSearch, MobileGroupChannelList, and Notifications views
- Redresses the Profile root menu scrolling once again

PR Checklist
- [ ] Includes changes to desk files
- [x] Tested on-device using the Vite dev server proxied to a livenet planet
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context