### PR TITLE
e2e tests: avoid relying on urbit.org for runtime downloads

### DIFF
--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -88,10 +88,10 @@ const getUrbitBinaryUrlByPlatformAndArch = () => {
       switch (arch) {
         case 'x64':
           console.log('Downloading linux-x86_64');
-          return 'https://urbit.org/install/linux-x86_64/latest';
+          return 'https://github.com/urbit/vere/releases/latest/download/linux-x86_64.tgz';
         case 'arm64':
           console.log('Downloading linux-aarch64');
-          return 'https://urbit.org/install/linux-aarch64/latest';
+          return 'https://github.com/urbit/vere/releases/latest/download/linux-aarch64.tgz';
         default:
           throw new Error(`unsupported arch ${arch}`);
       }
@@ -99,10 +99,10 @@ const getUrbitBinaryUrlByPlatformAndArch = () => {
       switch (arch) {
         case 'x64':
           console.log('Downloading macos-x86_64');
-          return 'https://urbit.org/install/macos-x86_64/latest';
+          return 'https://github.com/urbit/vere/releases/latest/download/macos-x86_64.tgz';
         case 'arm64':
           console.log('Downloading macos-aarch64');
-          return 'https://urbit.org/install/macos-aarch64/latest';
+          return 'https://github.com/urbit/vere/releases/latest/download/macos-aarch64.tgz';
         default:
           throw new Error(`unsupported arch ${arch}`);
       }


### PR DESCRIPTION
OTT

Updates them to point directly at the vere GitHub release.

Fixes LAND-1658

PR Checklist
- [ ] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context