### PR TITLE
[draft] initial idea for how to structure ephemeral deployment moons

### DIFF
--- a/.github/helpers/create_moon.sh
+++ b/.github/helpers/create_moon.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# this script creates a moon for an ephemeral deployment on a ship.
+# assumes gcloud credentials are loaded and gcloud installed.
+
+ship=$1
+zone=$2
+project=$3
+
+echo "Creating a moon under $ship in $zone of $project"
+set -e
+set -o pipefail
+cmdfile=$(mktemp "${TMPDIR:-/tmp/}moonspawn.XXXXXXXXX")
+moondir=$(mktemp "${TMPDIR:-/urbit/}moondir.XXXXXXXXX")
+# mktemp only used for generating a random folder name below
+cmds='
+click -kp /urbit/natmud-mogzod \
+(our hoon thread to make a moon here) > $moondir/details ## need to provide actual hoon thread to extract moon name and keys + write to file
+moon_name =$(cat $moondir/details | grep "some pattern for getting moon name")
+moon_key =$(cat $moondir/details | grep "some pattern for getting moon key")
+mkdir $moondir/$moon_name
+urbit -w $moondir/$moon_name -k $moon_key ## we need to run this in a detached way
+curl ... #some check to see if the moon is up
+'
+echo "$cmds"
+echo "$cmds" >> "$cmdfile"
+sshpriv=$(mktemp "${TMPDIR:-/tmp/}ssh.XXXXXXXXX")
+sshpub=$sshpriv.pub
+echo "$SSH_PUB_KEY" >> "$sshpub"
+echo "$SSH_SEC_KEY" >> "$sshpriv"
+chmod 600 $sshpub
+chmod 600 $sshpriv
+
+gcloud compute \
+  --project "$project" \
+  ssh \
+  --tunnel-through-iap \
+  --ssh-key-file "$sshpriv" \
+  --ssh-flag="-T" \
+  --zone "$zone" --verbosity info \
+  urb@"$ship" < "$cmdfile"
+
+echo "moon created"

--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -1,0 +1,107 @@
+name: Deploy Groups (ephemeral)
+on:
+  push:
+    branches:
+      - 'do/ephemeral-moons'
+
+  #pull_request:
+
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    name: 'Build Frontend'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+  
+      - name: Install Dependencies
+        run: npm ci
+  
+      - working-directory: ./apps/tlon-web
+        run:
+          npm run build
+  
+      - uses: actions/upload-artifact@v4
+        with:
+          name: 'ui-dist'
+          path:  apps/tlon-web/dist
+
+  glob:
+    runs-on: ubuntu-latest
+    name: 'Make a glob'
+    needs: build-frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: 'ui-dist'
+          path: apps/tlon-web/dist
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: 'glob'
+        uses: ./.github/actions/glob
+        with:
+          folder: 'apps/tlon-web/dist/*'
+          docket: 'desk/desk.docket-0'
+      - name: Commit and Push Glob
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email github-actions@github.com
+          git add desk/desk.docket-0
+          git commit -n -m "update glob: ${{ steps.glob.outputs.hash }} [skip actions]" || echo "No changes to commit"
+          INPUT=${{ env.tag }}
+          BRANCH=${INPUT:-"staging"}
+          git pull origin $BRANCH --rebase --autostash
+          git push
+
+  create_moon:
+    runs-on: ubuntu-latest
+    name: "Create Moon"
+    needs: glob
+    steps:
+      - uses: actions/checkout@v4
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: create_moon
+        name: Create Moon
+        run: |
+          ./.github/helpers/create_moon.sh ephemeral-landscape-apps-moon-host us-central1-a mainnet-tlon-other-2d
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+
+
+  deploy:
+    needs: create_moon
+    runs-on: ubuntu-latest
+    name: "Release to ~binnec-dozzod-marnus (canary)"
+    steps:
+      - uses: actions/checkout@v4
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SERVICE_KEY }}'
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - id: deploy
+        name: Deploy
+        run:
+          ./.github/helpers/deploy.sh tloncorp/landscape-apps groups ${{ needs.build_test_images.outputs.moon_name }} us-central1-a mainnet-tlon-other-2d
+        env:
+          SSH_SEC_KEY: ${{ secrets.GCP_SSH_SEC_KEY }}
+          SSH_PUB_KEY: ${{ secrets.GCP_SSH_PUB_KEY }}
+          URBIT_REPO_TAG: ${{ vars.URBIT_REPO_TAG }}

--- a/desk/ted/moon.hoon
+++ b/desk/ted/moon.hoon
@@ -1,0 +1,30 @@
+/-  spider
+/+  strandio
+=,  strand=strand:spider
+^-  thread:spider
+|=  arg=vase
+=/  m  (strand ,vase)
+^-  form:m
+=+  !<(arg=?(~ [~ ?(mon=@p [mon=@p =pass])]) arg)
+;<  =bowl:spider  bind:m  get-bowl:strandio
+=/  mon=ship
+  ?^  arg
+    ?@(+.arg mon.arg mon.arg)
+  (add our.bowl (lsh 5 (end 5 (shaz eny.bowl))))
+=/  seg=ship  (sein:title our.bowl now.bowl mon)
+?.  =(our.bowl seg)
+  %+  strand-fail:strand  %not-our-moon
+  :_  ~
+  :-  %leaf
+  "can't create keys for {(scow %p mon)}, which belongs to {(scow %p seg)}"
+=/  [seed=(unit seed:jael) =pass]
+  ~!  arg
+  ?:  ?=([~ @ @] arg)
+    [~ pass.arg]
+  =/  cub  (pit:nu:crub:crypto 512 (shaz (jam mon life=1 eny.bowl)))
+  :-  `[mon 1 sec:ex:cub ~]
+  pub:ex:cub
+;<  ~  bind:m
+  %-  send-raw-card:strandio
+  [%pass /ted/moon %arvo %j %moon mon *id:block:jael %keys [1 1 pass] %.n]
+(pure:m !>([mon `(unit @uw)`(bind seed jam)]))


### PR DESCRIPTION
Just trying to structure out how we could potentially start up ephemeral moons for development branches. 

To make this work we need a hoon thread to run through click to generate a moon. We then need to write that output to a file, then extract the moon name and key, and then use that to boot the one-off moon. One problem I see with the current approach is that the bash script copied/ran on the VM host is very much a "one shot" type thing where the script is just ran one time, similar to how our current `deploy.sh` script is ran. Need to determine how we can actually see if the moon is successfully booted before moving forward with the deployment script itself.