### PR TITLE
settings: use %landscape, not %garden

### DIFF
--- a/apps/tlon-web/e2e/001-create-group-channels-invite.spec.ts
+++ b/apps/tlon-web/e2e/001-create-group-channels-invite.spec.ts
@@ -24,7 +24,7 @@ test('Create a group', async ({ browser }) => {
   await page.getByTestId('create-group-dropdown-button').click();
   await page.getByTestId('create-group-name-input').fill('mardev Club');
   await page.getByTestId('create-group-submit-button').click();
-  await page.getByText('New Channel').waitFor();
+  await page.getByTestId('new-channel-button').waitFor();
 });
 
 test('Create a chat channel', async ({ browser }) => {
@@ -36,8 +36,8 @@ test('Create a chat channel', async ({ browser }) => {
   await page.goto(ownerUrl);
   await page.getByRole('link', { name: 'mardev Club' }).waitFor();
   await page.getByRole('link', { name: 'mardev Club' }).click();
-  await page.getByRole('link', { name: 'New Channel' }).waitFor();
-  await page.getByRole('link', { name: 'New Channel' }).click();
+  await page.getByTestId('new-channel-button').waitFor();
+  await page.getByTestId('new-channel-button').click();
   await page
     .locator('label')
     .filter({ hasText: 'ChatA simple, standard text chat' })
@@ -68,7 +68,7 @@ test('Create a notebook channel and post to it.', async ({ browser }) => {
   await page.getByRole('link', { name: 'mardev Club' }).waitFor();
   await page.getByRole('link', { name: 'mardev Club' }).click();
   await page.getByRole('link', { name: 'All Channels' }).click();
-  await page.getByRole('link', { name: 'New Channel' }).click();
+  await page.getByTestId('new-channel-button').click();
   await page
     .locator('label')
     .filter({ hasText: 'NotebookLongform publishing and discussion' })

--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -596,7 +596,7 @@ const runPlaywrightTests = async () => {
       const playwrightArgs = ['playwright', 'test', '--workers=2', ''];
 
       if (process.env.DEBUG_PLAYWRIGHT) {
-        playwrightArgs.push('--debug');
+        playwrightArgs.push('--ui');
       }
 
       const testProcess = childProcess.spawn('npx', playwrightArgs, {

--- a/apps/tlon-web/src/constants.ts
+++ b/apps/tlon-web/src/constants.ts
@@ -39,7 +39,7 @@ export const AUTHORS = [
   '~mister-dister-dozzod-dozzod',
 ];
 
-export const lsDesk = 'garden';
+export const lsDesk = 'landscape';
 
 export const ALPHABETICAL_SORT = 'A → Z';
 export const DEFAULT_SORT = 'Arranged';

--- a/apps/tlon-web/src/groups/ChannelsList/ChannelManagerHeader.tsx
+++ b/apps/tlon-web/src/groups/ChannelsList/ChannelManagerHeader.tsx
@@ -48,6 +48,7 @@ export default function ChannelManagerHeader({
               'bg-blue-soft text-center text-blue',
               isMobile ? 'small-button' : 'button'
             )}
+            data-testid="new-channel-button"
           >
             New Channel
           </Link>


### PR DESCRIPTION
We still had this value hardcoded to `garden`. It's used in `state/settings.ts` (ultimately used by useMergedSettings, which many other hooks rely on).