### PR TITLE
perf: speed up sidebar sorter

### DIFF
--- a/apps/tlon-web/src/logic/useSidebarSort.ts
+++ b/apps/tlon-web/src/logic/useSidebarSort.ts
@@ -106,7 +106,7 @@ export default function useSidebarSort({
       records: Record<string, T>,
       accessor: (k: string, v: T) => string,
       reverse = false
-    ) => {
+    ): [string, T][] => {
       // pre-compute values for comparison
       const entries = Object.entries(records).map(([key, obj]) => ({
         key,

--- a/apps/tlon-web/src/logic/useSidebarSort.ts
+++ b/apps/tlon-web/src/logic/useSidebarSort.ts
@@ -107,16 +107,23 @@ export default function useSidebarSort({
       accessor: (k: string, v: T) => string,
       reverse = false
     ) => {
-      const entries = Object.entries(records);
-      entries.sort(([aKey, aObj], [bKey, bObj]) => {
-        const aVal = accessor(aKey, aObj);
-        const bVal = accessor(bKey, bObj);
+      // pre-compute values for comparison
+      const entries = Object.entries(records).map(([key, obj]) => ({
+        key,
+        obj,
+        value: accessor(key, obj),
+      }));
 
+      // integrate reverse sorting logic into the comparison
+      const directionMultiplier = reverse ? -1 : 1;
+
+      entries.sort((a, b) => {
         const sorter = sortOptions[sortFn] ?? sortOptions[RECENT_SORT];
-        return sorter(aVal, bVal);
+        return directionMultiplier * sorter(a.value, b.value);
       });
 
-      return reverse ? entries.reverse() : entries;
+      // map back to the original format
+      return entries.map(({ key, obj }) => [key, obj]);
     },
     [sortFn, sortOptions]
   );


### PR DESCRIPTION
I was getting annoyed with how slow the sidebar can be, so I did a performance profile and root caused that this particular function was pretty heavy.

Saw a marked improvement in performance for this function by just pre-computing the values for comparison before running the comparison and eliminating the use of .reverse().

Note that this isn't a cure-all, I just decided to take a weed wacker to the tallest weed on a cursory look.

tested locally by running the dev server against my livenet planet.

No idea if there's a linear ticket for sidebar perf.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context