### PR TITLE
e2e: remove specs interdependency

### DIFF
--- a/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
+++ b/apps/tlon-web/e2e/005-mobile-chat-options.spec.ts
@@ -2,31 +2,51 @@ import { expect, test } from '@playwright/test';
 
 import shipManifest from './shipManifest.json';
 
-const groupHostUrl = `${shipManifest['~naldeg-mardev'].webUrl}/apps/groups/`;
 const groupHost = 'mardev';
-const testGroupName = 'mardev Club';
-const testChannelName = 'mardev chat';
-const testMessageText = `hi, it's me, ~naldeg-mardev`;
+const hostShip = '~naldeg-mardev';
+const groupHostUrl = `${shipManifest[hostShip].webUrl}/apps/groups/`;
+const testGroupName = `${groupHost} test group`;
+const testChannelId = `sidebar-item-text-${groupHost} chat`;
+const guestShip = '~naldeg-mardev';
+const testMessageText = `hi there`;
 const defaultVisibleEmoji = '😇';
 
-test('Add reaction', async ({ browser }) => {
+test('Post chat message as group guest', async ({ browser }) => {
+  // Authenticate as guestShip
+  const guestContext = await browser.newContext({
+    storageState: shipManifest[guestShip].authFile,
+  });
+  const page = await guestContext.newPage();
+  await page.goto(groupHostUrl);
+  await page.getByRole('link', { name: testGroupName }).waitFor();
+  await page.getByRole('link', { name: testGroupName }).click();
+  await page.getByTestId(testChannelId).waitFor();
+  await page.getByTestId(testChannelId).click();
+  await page.locator('.ProseMirror').click();
+  await page.locator('.ProseMirror').fill(testMessageText);
+  await page.locator('.ProseMirror').press('Enter');
+  await expect(page.getByText(testMessageText)).toBeVisible();
+});
+
+test('Add reaction as group host', async ({ browser }) => {
   // authenticate as test group host
   const hostContext = await browser.newContext({
-    storageState: shipManifest['~naldeg-mardev'].authFile,
+    storageState: shipManifest[hostShip].authFile,
   });
   const page = await hostContext.newPage();
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto(groupHostUrl);
 
   // navigate to test channel
+  await page.goto(groupHostUrl);
   await page.getByRole('link', { name: testGroupName }).waitFor();
   await page.getByRole('link', { name: testGroupName }).click();
-  await page.getByRole('link', { name: testChannelName }).waitFor();
-  await page.getByRole('link', { name: testChannelName }).click();
+  await page.getByTestId(testChannelId).waitFor();
+  await page.getByTestId(testChannelId).click();
 
   // open longpress menu
   await page.getByText(testMessageText).click({ delay: 300 });
-  await page.getByTestId('chat-message-options').waitFor();
+  // await page.getByTestId('chat-message-options').waitFor();
   await expect(page.getByTestId('chat-message-options')).toBeVisible();
 
   // open picker and add reaction


### PR DESCRIPTION
005-mobile-chat-options.spec.ts expects that a chat message from spec 001 is present. This can cause random failures if spec 001 has not finished before 005 starts. Also, specs should be independent so that they can be run individualy.

This change consists in adding one step to spec 005 where the chat message is created. The test then continues from the 2nd ship by reacting to that message.

Tested locally by running `npm run e2e:debug`
We should wait for CI to run off of this branch to confirm.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context