### PR TITLE
profile: make sure text in the bio gets escaped

### DIFF
--- a/desk/app/profile/widgets.hoon
+++ b/desk/app/profile/widgets.hoon
@@ -170,7 +170,7 @@
             %+  join  `manx`;br;
             %+  turn  (to-wain:format bio.u.ours)
             |=  p=@t  ^-  manx
-            [[%$ $+[p ~] ~] ~]
+            [[%$ [%$ (trip p)] ~] ~]
       ==
     ==
   ==


### PR DESCRIPTION
While injecting the bio text as raw html isn't against the spirit of profiles, it is inconsistent with the way the bio text gets rendered in groups.

(Yes, this diff is sufficient for escaping the bio text. Normally, it gets handled by the sail->html conversion, but we are manually constructing sail elements here (to get text-only nodes). In doing so, we made the mistake of adding a string (`$tape`) of "one" "character" (the whole `@t`), rather than something sane.)