### PR TITLE
chat: fix missing reply meta on posts in outline requests

### DIFF
--- a/desk/lib/channel-utils.hoon
+++ b/desk/lib/channel-utils.hoon
@@ -91,8 +91,12 @@
 ++  uv-post-without-replies
   |=  post=v-post:c
   ^-  post:c
-  =.  replies.post  ~
-  (uv-post post)
+  :_  +.post
+  :*  id.post
+      (uv-reacts reacts.post)
+      *replies:c
+      (get-reply-meta post)
+  ==
 ::
 ++  suv-post-without-replies
   |=  post=v-post:c


### PR DESCRIPTION
We were attempting to re-use the `uv-post` arm for `uv-post-without-replies`, but in order to do that we were setting replies to null before calling `uv-post`. This meant that the get-reply-meta arm, when being called from `uv-post`, would show no reply-meta for the post, even if there were replies.

Fixes LAND-1673

Tested locally with livenet moons.

PR Checklist
- [x] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context