### PR TITLE
chat: fix re-render on chat input

### DIFF
--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -395,37 +395,39 @@ export default function ChatInput({
     placeholder: 'Message',
     allowMentions: true,
     onEnter: useCallback(
-      ({ editor }) => {
+      ({ editor }: HandlerParams) => {
         onSubmit(editor);
         return true;
       },
       [onSubmit]
     ),
     onUpdate: onUpdate.current,
-    onUpArrow: useCallback(
-      ({ editor }: HandlerParams) => {
-        if (
-          lastMessageId &&
-          !isEditing &&
-          !editor.isDestroyed &&
-          // don't allow editing of DM/Group DM messages until we support it
-          // on the backend.
-          // TODO: remove this check when backend supports it
-          !isDmOrMultiDM
-        ) {
-          setSearchParams(
-            {
-              edit: lastMessageId,
-            },
-            { replace: true }
-          );
-          editor.commands.blur();
-          return true;
-        }
-        return false;
-      },
-      [lastMessageId, setSearchParams, isEditing, isDmOrMultiDM]
-    ),
+    // this is causing a re-render
+    // TODO: investigate why and re-implement
+    // onUpArrow: useCallback(
+    // ({ editor }: HandlerParams) => {
+    // if (
+    // lastMessageId &&
+    // !isEditing &&
+    // !editor.isDestroyed &&
+    // // don't allow editing of DM/Group DM messages until we support it
+    // // on the backend.
+    // // TODO: remove this check when backend supports it
+    // !isDmOrMultiDM
+    // ) {
+    // setSearchParams(
+    // {
+    // edit: lastMessageId,
+    // },
+    // { replace: true }
+    // );
+    // editor.commands.blur();
+    // return true;
+    // }
+    // return false;
+    // },
+    // [lastMessageId, setSearchParams, isEditing, isDmOrMultiDM]
+    // ),
   });
 
   useEffect(() => {

--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -54,7 +54,6 @@ import {
   createStorageKey,
   pathToCite,
   useIsDmOrMultiDm,
-  useObjectChangeLogging,
   useThreadParentId,
 } from '@/logic/utils';
 import { CacheId, useMyLastMessage } from '@/state/channel/channel';
@@ -381,14 +380,6 @@ export default function ChatInput({
       mostRecentFile?.url,
     ]
   );
-
-  useObjectChangeLogging({
-    lastMessageId,
-    setSearchParams,
-    isEditing,
-    isDmOrMultiDM,
-    isMobile,
-  });
 
   const onUpArrow = useCallback(
     ({ editor }: HandlerParams) => {


### PR DESCRIPTION
~The onUpArrow function being passed into the useMessageEditor hook was causing the chat input to re-render after send.~

~I'm disabling it for now so that it doesn't block getting the edit feature out. We should investigate why it's happening and re-implement later if possible.~

It turns out the re-render is only happening on mobile when `lastMessageId` changes. Not clear why this isn't effecting desktop, but we can effectively fix the issue (and disable onUpArrow) on mobile by setting lastMessageId to always be `''` on mobile.
 
Fixes LAND-1674

tested locally on livenet moons

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context