### PR TITLE
scroller: fix inverted scroll direction issue

### DIFF
--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -27,7 +27,6 @@ import {
   useInvertedScrollInteraction,
   useUserHasScrolled,
 } from '@/logic/scroll';
-import useIsEditingMessage from '@/logic/useIsEditingMessage';
 import { useIsMobile } from '@/logic/useMedia';
 import {
   ChatMessageListItemData,
@@ -207,7 +206,6 @@ export default function ChatScroller({
   const isMobile = useIsMobile();
   const scrollTo = useBigInt(rawScrollTo);
   const showDevTools = useShowDevTools();
-  const isEditing = useIsEditingMessage();
   const [loadDirection, setLoadDirection] = useState<'newer' | 'older'>(
     'older'
   );
@@ -484,7 +482,7 @@ export default function ChatScroller({
   virtualizerRef.current = virtualizer;
 
   useFakeVirtuosoHandle(scrollerRef, virtualizer);
-  useInvertedScrollInteraction(scrollElementRef, isInverted, !!isEditing);
+  useInvertedScrollInteraction(scrollElementRef, isInverted);
 
   // Load more items when list reaches the top or bottom.
   useEffect(() => {

--- a/apps/tlon-web/src/logic/scroll.ts
+++ b/apps/tlon-web/src/logic/scroll.ts
@@ -1,6 +1,8 @@
 import { throttle } from 'lodash';
 import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
+import useIsEditingMessage from './useIsEditingMessage';
+
 /**
  * Utility for tracking scrolling state. Caller should call `didScroll` whenever
  * a scroll event occurs.
@@ -53,9 +55,10 @@ export function useIsScrolling(
  */
 export function useInvertedScrollInteraction(
   scrollElementRef: RefObject<HTMLDivElement>,
-  isInverted: boolean,
-  isEditing: boolean
+  isInverted: boolean
 ) {
+  const isEditing = useIsEditingMessage();
+
   useEffect(() => {
     const el = scrollElementRef.current;
     if (!isInverted || !el || isEditing) return undefined;
@@ -79,6 +82,10 @@ export function useInvertedScrollInteraction(
         });
       }
     };
+
+    el.addEventListener('wheel', invertScrollWheel, false);
+    el.addEventListener('keydown', invertSpaceAndArrows, true);
+
     return () => {
       el.removeEventListener('wheel', invertScrollWheel);
       el.removeEventListener('keydown', invertSpaceAndArrows);


### PR DESCRIPTION
Two event listeners were accidentally removed in #3288, this PR adds them back in.

This also moves the use of the `useIsEditingMessage` hook into the `useInvertedScrollInteraction` hook, rather than using it in the scroller directly (since we only use it in `useInvertedScrollInteraction` hook anyway).

Fixes LAND-1675.

Tested locally on livenet moon.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context