### PR TITLE
chat input: fix rerendering issue on last message delivered

### DIFF
--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -183,7 +183,7 @@ export default function ChatInput({
   const { mutate: unblockShip } = useUnblockShipMutation();
   const isDmOrMultiDM = useIsDmOrMultiDm(whom);
   const myLastMessage = useMyLastMessage(whom, replying);
-  const lastMessageId = !isMobile && myLastMessage ? myLastMessage.seal.id : '';
+  const lastMessageId = myLastMessage ? myLastMessage.seal.id : '';
 
   const handleUnblockClick = useCallback(() => {
     unblockShip({
@@ -381,29 +381,26 @@ export default function ChatInput({
     ]
   );
 
-  const onUpArrow = useCallback(
-    ({ editor }: HandlerParams) => {
-      if (
-        lastMessageId !== '' &&
-        !isEditing &&
-        !editor.isDestroyed &&
-        // don't allow editing of DM/Group DM messages until we support it
-        // on the backend.
-        !isDmOrMultiDM
-      ) {
-        setSearchParams(
-          {
-            edit: lastMessageId,
-          },
-          { replace: true }
-        );
-        editor.commands.blur();
-        return true;
-      }
-      return false;
-    },
-    [lastMessageId, setSearchParams, isEditing, isDmOrMultiDM]
-  );
+  const onUpArrow = useRef(({ editor }: HandlerParams) => {
+    if (
+      lastMessageId &&
+      !isEditing &&
+      !editor.isDestroyed &&
+      // don't allow editing of DM/Group DM messages until we support it
+      // on the backend.
+      !isDmOrMultiDM
+    ) {
+      setSearchParams(
+        {
+          edit: lastMessageId,
+        },
+        { replace: true }
+      );
+      editor.commands.blur();
+      return true;
+    }
+    return false;
+  });
 
   /**
    * !!! CAUTION !!!
@@ -419,14 +416,14 @@ export default function ChatInput({
     placeholder: 'Message',
     allowMentions: true,
     onEnter: useCallback(
-      ({ editor }: HandlerParams) => {
+      ({ editor }) => {
         onSubmit(editor);
         return true;
       },
       [onSubmit]
     ),
     onUpdate: onUpdate.current,
-    onUpArrow,
+    onUpArrow: onUpArrow.current,
   });
 
   useEffect(() => {

--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -184,6 +184,13 @@ export default function ChatInput({
   const isDmOrMultiDM = useIsDmOrMultiDm(whom);
   const myLastMessage = useMyLastMessage(whom, replying);
   const lastMessageId = myLastMessage ? myLastMessage.seal.id : '';
+  const lastMessageIdRef = useRef(lastMessageId);
+
+  useEffect(() => {
+    if (lastMessageId && lastMessageId !== lastMessageIdRef.current) {
+      lastMessageIdRef.current = lastMessageId;
+    }
+  }, [lastMessageId]);
 
   const handleUnblockClick = useCallback(() => {
     unblockShip({
@@ -381,26 +388,29 @@ export default function ChatInput({
     ]
   );
 
-  const onUpArrow = useRef(({ editor }: HandlerParams) => {
-    if (
-      lastMessageId &&
-      !isEditing &&
-      !editor.isDestroyed &&
-      // don't allow editing of DM/Group DM messages until we support it
-      // on the backend.
-      !isDmOrMultiDM
-    ) {
-      setSearchParams(
-        {
-          edit: lastMessageId,
-        },
-        { replace: true }
-      );
-      editor.commands.blur();
-      return true;
-    }
-    return false;
-  });
+  const onUpArrow = useCallback(
+    ({ editor }: HandlerParams) => {
+      if (
+        lastMessageIdRef.current &&
+        !isEditing &&
+        !editor.isDestroyed &&
+        // don't allow editing of DM/Group DM messages until we support it
+        // on the backend.
+        !isDmOrMultiDM
+      ) {
+        setSearchParams(
+          {
+            edit: lastMessageIdRef.current,
+          },
+          { replace: true }
+        );
+        editor.commands.blur();
+        return true;
+      }
+      return false;
+    },
+    [isEditing, isDmOrMultiDM, setSearchParams]
+  );
 
   /**
    * !!! CAUTION !!!
@@ -423,7 +433,7 @@ export default function ChatInput({
       [onSubmit]
     ),
     onUpdate: onUpdate.current,
-    onUpArrow: onUpArrow.current,
+    onUpArrow,
   });
 
   useEffect(() => {


### PR DESCRIPTION
This fixes LAND-1678 by moving lastMessageId into a ref, preventing onUpArrow from changing and thus causing the message editor to re-render.

Tested locally on a livenet moon.

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [ ] Comments added anywhere logic may be confusing without context