### PR TITLE
chat editing: fix issue with inability to add spaces

### DIFF
--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -27,6 +27,7 @@ import {
   useInvertedScrollInteraction,
   useUserHasScrolled,
 } from '@/logic/scroll';
+import useIsEditingMessage from '@/logic/useIsEditingMessage';
 import { useIsMobile } from '@/logic/useMedia';
 import {
   ChatMessageListItemData,
@@ -214,6 +215,7 @@ export default function ChatScroller({
   const contentElementRef = useRef<HTMLDivElement>(null);
   const { userHasScrolled, resetUserHasScrolled } =
     useUserHasScrolled(scrollElementRef);
+  const isEditing = useIsEditingMessage();
 
   // Update the tracked load direction when loading state changes.
   useEffect(() => {
@@ -482,7 +484,7 @@ export default function ChatScroller({
   virtualizerRef.current = virtualizer;
 
   useFakeVirtuosoHandle(scrollerRef, virtualizer);
-  useInvertedScrollInteraction(scrollElementRef, isInverted);
+  useInvertedScrollInteraction(scrollElementRef, isInverted, isEditing);
 
   // Load more items when list reaches the top or bottom.
   useEffect(() => {

--- a/apps/tlon-web/src/logic/scroll.ts
+++ b/apps/tlon-web/src/logic/scroll.ts
@@ -55,13 +55,15 @@ export function useIsScrolling(
  */
 export function useInvertedScrollInteraction(
   scrollElementRef: RefObject<HTMLDivElement>,
-  isInverted: boolean
+  isInverted: boolean,
+  // isEditing must be passed in rather than using useIsEditingMessage because
+  // it won't update if we use it here.
+  isEditing: boolean
 ) {
-  const isEditing = useIsEditingMessage();
-
   useEffect(() => {
     const el = scrollElementRef.current;
     if (!isInverted || !el || isEditing) return undefined;
+
     const invertScrollWheel = (e: WheelEvent) => {
       el.scrollTop -= e.deltaY;
       e.preventDefault();


### PR DESCRIPTION
Fixes LAND-1681.

This was introduced by yesterday's fix in #3325. If we use `useIsEditingMessage` within `useInvertedScrollInteraction`, the `isEditing` value never updates and those listeners are still active.

So the space keydown was getting captured in `useInvertedScrollInteraction` when it shouldn't have been.