### PR TITLE
e2e: fix commit hash diff issue

### DIFF
--- a/apps/tlon-web/e2e/shipManifest.json
+++ b/apps/tlon-web/e2e/shipManifest.json
@@ -1,7 +1,7 @@
 {
   "~zod": {
     "authFile": "e2e/.auth/zod.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-zod6.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-zod7.tgz",
     "url": "http://localhost:35453",
     "ship": "zod",
     "code": "lidlut-tabwed-pillex-ridrup",
@@ -11,7 +11,7 @@
   },
   "~bus": {
     "authFile": "e2e/.auth/bus.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-bus6.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-bus7.tgz",
     "url": "http://localhost:36963",
     "ship": "bus",
     "code": "riddec-bicrym-ridlev-pocsef",
@@ -21,7 +21,7 @@
   },
   "~habduc-patbud": {
     "authFile": "e2e/.auth/habduc-patbud.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-habduc-patbud6.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-habduc-patbud7.tgz",
     "url": "http://localhost:35553",
     "ship": "habduc-patbud",
     "code": "bisrym-lomwep-binbyr-tidwed",
@@ -31,7 +31,7 @@
   },
   "~naldeg-mardev": {
     "authFile": "e2e/.auth/naldeg-mardev.json",
-    "downloadUrl": "https://bootstrap.urbit.org/rube-naldeg-mardev6.tgz",
+    "downloadUrl": "https://bootstrap.urbit.org/rube-naldeg-mardev7.tgz",
     "url": "http://localhost:36663",
     "ship": "naldeg-mardev",
     "code": "hadbyn-savfel-lanlur-ronped",


### PR DESCRIPTION
Tests were failing because the %groups hash didn't change after we ran commit, attempting to ~fix by updating fake ships to vere 3 (the old fake ships would first update themselves to vere 3 before doing anything else, because we were downloading the latest vere before running the ships).~

Opening this PR is testing the hypothesis, do not merge yet.

Fixes LAND-1682
