### PR TITLE
edit: use v1 sub paths for posts and channels updates

### DIFF
--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -394,6 +394,7 @@ export default function ChatInput({
         lastMessageIdRef.current &&
         !isEditing &&
         !editor.isDestroyed &&
+        editor.isEmpty &&
         // don't allow editing of DM/Group DM messages until we support it
         // on the backend.
         !isDmOrMultiDM

--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -864,7 +864,7 @@ export function useChannelsFirehose() {
   useEffect(() => {
     api.subscribe({
       app: 'channels',
-      path: '/',
+      path: '/v1',
       event: eventHandler,
     });
   }, [eventHandler]);
@@ -956,7 +956,7 @@ export function usePost(nest: Nest, postId: string, disabled = false) {
     [nest, postId]
   );
 
-  const subPath = useMemo(() => `/${nest}`, [nest]);
+  const subPath = useMemo(() => `/v1/${nest}`, [nest]);
 
   const enabled = useMemo(
     () => postId !== '0' && postId !== '' && nest !== '' && !disabled,


### PR DESCRIPTION
Fixes LAND-1683 ("Edited" not appearing next to posts until we scry again for posts)

Also fixes an annoying issue I found where if you pressed the up arrow key while composing a new message, you would jump to editing your last message and the text you typed into the chat input would disappear temporarily until you returned to the chat input. Instead, we just disable the up arrow key while you're composing a new message.