### PR TITLE
e2e: fix e2e by fixing state transitions in %notify

### DIFF
--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -1224,7 +1224,7 @@ export function useJoinMutation() {
       channelAction(chan, {
         join: group,
       }),
-      { app: 'channels', path: '/' },
+      { app: 'channels', path: '/v1' },
       (event) => event.nest === chan && 'create' in event.response
     );
   };
@@ -1390,7 +1390,7 @@ export function useAddPostMutation(nest: string) {
               channelPostAction(nest, {
                 add: variables.essay,
               }),
-              { app: 'channels', path: `/${nest}` },
+              { app: 'channels', path: `/v1/${nest}` },
               ({ response }) => {
                 if ('post' in response) {
                   const { id, 'r-post': postResponse } = response.post;
@@ -1615,7 +1615,7 @@ export function useDeletePostMutation() {
       channelPostAction(variables.nest, { del: variables.time }),
       {
         app: 'channels',
-        path: `/${variables.nest}`,
+        path: `/v1/${variables.nest}`,
       },
       (event) => {
         if ('post' in event.response) {
@@ -1709,7 +1709,7 @@ export function useCreateMutation() {
           create: variables,
         },
       },
-      { app: 'channels', path: '/' },
+      { app: 'channels', path: '/v1' },
       (event) => {
         const { response, nest } = event;
         return (

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -25,11 +25,21 @@
       =client-state
   ==
 +$  base-state-2
-  $:  notifications=(map uid notification)
+::  We set notifications to * because we had an issue with the notification type
+::  definition being wrong and this wrong state made its way onto some ships.
+  $:  notifications=*
       base-state-0
   ==
 ::
 +$  base-state-3
+::  We set notifications to * because we had an issue with the notification type
+::  definition being wrong and this wrong state made its way onto some ships.
+  $:  last-timer=time
+      notifications=*
+      base-state-0
+  ==
+::
++$  base-state-4
   $:  last-timer=time
       notifications=(map uid notification)
       base-state-0
@@ -49,15 +59,19 @@
 +$  state-4
   [%4 base-state-3]
 ::
++$  state-5
+  [%5 base-state-4]
+::
 +$  versioned-state
   $%  state-0
       state-1
       state-2
       state-3
       state-4
+      state-5
   ==
 ::
-+$  current-state  state-4
++$  current-state  state-5
 ::
 ++  migrate-state
   |=  old=versioned-state
@@ -67,7 +81,8 @@
     %1  $(old (migrate-1-to-2 old))
     %2  $(old (migrate-2-to-3 old))
     %3  $(old (migrate-3-to-4 old))
-    %4  old
+    %4  $(old (migrate-4-to-5 old))
+    %5  old
   ==
 ::
 ++  migrate-0-to-1
@@ -89,6 +104,11 @@
   |=  old=state-3
   ^-  state-4
   [%4 `@da`0 [+.old]]
+::
+++  migrate-4-to-5
+  |=  old=state-4
+  ^-  state-5
+  old(- %5, notifications ~)
 ::
 --
 ::

--- a/desk/sur/notify.hoon
+++ b/desk/sur/notify.hoon
@@ -30,7 +30,7 @@
   +$  bin      [=path =place]
   +$  place    [=desk =path]
   +$  body     [title=content =content =time binned=path link=path]
-  +$  content  (list $%([%ship =ship] [%cord =cord]))
+  +$  content  (list $%([%ship =ship] [%text =cord]))
   --
 ::
 +$  whitelist


### PR DESCRIPTION
Fixes LAND-1682 by fixing an issue in the state types in %notify.

At one point, the `notification` type changed and was subtly wrong. This went unnoticed because we used to drop old state anytime it didn't match the current state type.

This began to fail when we introduced changes to the %notify agent that included state transitions and there were ships that had not yet had that old state dropped.

This particularly effected the fake ships we use for e2e tests, because they boot with an old version of %groups. This would have also effected any ships that had not yet dropped their old state %3 and replaced it with the "new" state %3 with the bad notification type.

We get around this issue by just accepting any noun for the `notifications` type for base-state-2 and base-state-3, and creating a new base-state-4 with the correct type. Ships on either version of state %3 or already on state %4 should transition without issue now.
