### PR TITLE
edit: fix the space issue by using a ref for isEditing

### DIFF
--- a/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
+++ b/apps/tlon-web/src/chat/ChatScroller/ChatScroller.tsx
@@ -27,7 +27,6 @@ import {
   useInvertedScrollInteraction,
   useUserHasScrolled,
 } from '@/logic/scroll';
-import useIsEditingMessage from '@/logic/useIsEditingMessage';
 import { useIsMobile } from '@/logic/useMedia';
 import {
   ChatMessageListItemData,
@@ -215,7 +214,6 @@ export default function ChatScroller({
   const contentElementRef = useRef<HTMLDivElement>(null);
   const { userHasScrolled, resetUserHasScrolled } =
     useUserHasScrolled(scrollElementRef);
-  const isEditing = useIsEditingMessage();
 
   // Update the tracked load direction when loading state changes.
   useEffect(() => {
@@ -484,7 +482,7 @@ export default function ChatScroller({
   virtualizerRef.current = virtualizer;
 
   useFakeVirtuosoHandle(scrollerRef, virtualizer);
-  useInvertedScrollInteraction(scrollElementRef, isInverted, isEditing);
+  useInvertedScrollInteraction(scrollElementRef, isInverted);
 
   // Load more items when list reaches the top or bottom.
   useEffect(() => {

--- a/apps/tlon-web/src/logic/scroll.ts
+++ b/apps/tlon-web/src/logic/scroll.ts
@@ -55,20 +55,26 @@ export function useIsScrolling(
  */
 export function useInvertedScrollInteraction(
   scrollElementRef: RefObject<HTMLDivElement>,
-  isInverted: boolean,
-  // isEditing must be passed in rather than using useIsEditingMessage because
-  // it won't update if we use it here.
-  isEditing: boolean
+  isInverted: boolean
 ) {
+  const isEditing = useIsEditingMessage();
+  const isEditingRef = useRef(isEditing);
+
+  useEffect(() => {
+    isEditingRef.current = isEditing;
+  }, [isEditing]);
+
   useEffect(() => {
     const el = scrollElementRef.current;
-    if (!isInverted || !el || isEditing) return undefined;
+    if (!isInverted || !el) return undefined;
 
     const invertScrollWheel = (e: WheelEvent) => {
       el.scrollTop -= e.deltaY;
       e.preventDefault();
     };
     const invertSpaceAndArrows = (e: KeyboardEvent) => {
+      if (isEditingRef.current) return;
+
       if (e.key === 'ArrowUp') {
         e.preventDefault();
         el.scrollBy({ top: 30, behavior: e.repeat ? 'auto' : 'smooth' });


### PR DESCRIPTION
I'm not sure why the previous fix appeared to work. The event listeners weren't actually getting removed, so the issue persisted. Instead, we should keep isEditing in a ref and use that ref within the event listener, updating the ref when isEditing actually changes.

Fixes LAND-1681 (again).