### PR TITLE
pwa: fix the scope/url issue in the manifest

### DIFF
--- a/apps/tlon-web/src/manifest.ts
+++ b/apps/tlon-web/src/manifest.ts
@@ -3,8 +3,8 @@ export default {
   description:
     'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a peer-to-peer collaboration tool built on Urbit that provides a few simple basics that communities can shape into something unique to their needs.',
   short_name: 'Tlon',
-  start_url: '/apps/groups/',
-  scope: '/apps/groups/',
+  start_url: '/apps/groups',
+  scope: '/apps/groups',
   id: '/apps/groups/',
   icons: [
     {


### PR DESCRIPTION
This fixes the issue where navigating to `[your ship]/apps/groups` would appear to be outside the scope of the PWA (you'd see the gray bar at the top, indicating you're at an external link).

Fixes LAND-1631