### PR TITLE
groups: don't crash during "can read" on-peek

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1049,11 +1049,12 @@
       ::
         [%channel app=@ ship=@ name=@ rest=*]
       =/  nes=nest:g  [app.pole (slav %p ship.pole) name.pole]
-      =/  =channel:g  (~(got by channels.group) nes)
       ?+    rest.pole  ~
           [%can-read member=@ ~]
+        ?~  channel=(~(get by channels.group) nes)
+          `loob+!>(`?`|)
         =/  member  (slav %p member.rest.pole)
-        `loob+!>((go-can-read member channel))
+        `loob+!>((go-can-read member u.channel))
         ::
           [%can-write member=@ ~]
         =/  member  (slav %p member.rest.pole)


### PR DESCRIPTION
The scry endpoints for a group's channels' permission checks would crash if the channel did not exist in that group. In cases where the channel was deleted, other agents might still know about the channel, and so still try to ask the group about relevant permissions, but the scry handling would crash.

Here we update the scry logic to not crash, and instead produce a "not allowed to read" flag in cases where the asked-about channel doesn't exist in the group.

~~We suspect this will ameliorate at least some of the problems seen around role modifications and permission rechecks, as this crashing scry was causing group fact handling to crash, causing locally-originating kicks, causing resubscribes.~~ Don't get your hopes up.
