### PR TITLE
groups: fix role deletion DDOS

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -772,13 +772,6 @@
   ++  ca-safe-sub
     |=  delay=?
     ?:  ca-has-sub  ca-core
-    =/  =flag:g  group.perm.perm.channel
-    =/  =path
-      %+  weld
-        /(scot %p our.bowl)/groups/(scot %da now.bowl)
-      /groups/(scot %p p.flag)/[q.flag]/v1/group-ui
-    =+  .^(group=group-ui:g %gx path)
-    ?.  (~(has by channels.group) nest)  ca-core
     ?^  posts.channel  (ca-start-updates delay)
     =.  load.net.channel  |
     %.  delay
@@ -1871,6 +1864,17 @@
   ::
   ++  ca-recheck
     |=  sects=(set sect:g)
+    =/  =flag:g  group.perm.perm.channel
+    =/  groups-prefix  /(scot %p our.bowl)/groups/(scot %da now.bowl)
+    =/  exists-path  (weld groups-prefix /exists/(scot %p p.flag)/[q.flag])
+    =+  .^(exists=? %gx exists-path)
+    ?.  exists  ca-core
+    =/  =path
+      %+  weld
+        groups-prefix
+      /groups/(scot %p p.flag)/[q.flag]/v1/group-ui
+    =+  .^(group=group-ui:g %gx path)
+    ?.  (~(has by channels.group) nest)  ca-core
     ::  if our read permissions restored, re-subscribe
     ?:  (can-read:ca-perms our.bowl)  (ca-safe-sub |)
     ca-core

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -767,11 +767,18 @@
   ::
   ++  ca-has-sub
     ^-  ?
-    (~(has by wex.bowl) [ca-sub-wire ship.nest dap.bowl])
+    (~(has by wex.bowl) [ca-sub-wire ship.nest %channels-server])
   ::
   ++  ca-safe-sub
     |=  delay=?
     ?:  ca-has-sub  ca-core
+    =/  =flag:g  group.perm.perm.channel
+    =/  =path
+      %+  weld
+        /(scot %p our.bowl)/groups/(scot %da now.bowl)
+      /groups/(scot %p p.flag)/[q.flag]/v1/group-ui
+    =+  .^(group=group-ui:g %gx path)
+    ?.  (~(has by channels.group) nest)  ca-core
     ?^  posts.channel  (ca-start-updates delay)
     =.  load.net.channel  |
     %.  delay

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1459,50 +1459,38 @@
     ::
         %del
       =.  cabals.group  (~(del by cabals.group) sect)
-      go-repair-permissions
-    ==
-  ::
-  ++  go-repair-permissions
-    =/  current-sects  ~(key by cabals.group)
-    =.  go-core
-      ::  repair members as needed
-      ::
-      %-  go-fleet-del-sects
-      %+  roll
-        ~(tap by fleet.group)
-      |=  [[s=ship =vessel:fleet:g] [ships=(set ship) sects=(set sect:g)]]
-      ::  traverse through each member to collect all old sects and the
-      ::  ships which had them
-      =/  dif  (~(dif in sects.vessel) current-sects)
-      :-  ?:(=(~ dif) ships (~(put in ships) s))
-      (~(uni in sects) dif)
-    =^  core=_go-core  cor
-      %+  roll
-        ~(tap by channels.group)
-      |=  [[=nest:g =channel:g] [gc=_go-core cr=_cor]]
-      =.  gc
+      =/  old-sect=(set sect:g)  (sy sect ~)
+      =.  go-core
+        ::  remove from members as needed
+        ::
+        %-  go-fleet-del-sects
+        :_  old-sect
+        %+  roll
+          ~(tap by fleet.group)
+        |=  [[s=ship =vessel:fleet:g] ships=(set ship)]
+        ?.  (~(has in sects.vessel) sect)  ships
+        (~(put in ships) s)
+      =^  core=_go-core  cor
+        %+  roll
+          ~(tap by channels.group)
+        |=  [[=nest:g =channel:g] [gc=_go-core cr=_cor]]
         ::  repair readers as needed
         ::
-        =/  invalid-readers  (~(dif in readers.channel) ~(key by cabals.group))
-        ?~  invalid-readers  gc
-        (go-channel-del-sects:gc nest invalid-readers)
-      ::  repair writers as needed
-      ::
-      =+  .^(has=? %gu (channel-scry nest))
-      ?.  has  [gc cr]
-      =+  .^([writers=(set sect:g) *] %gx (welp (channel-scry nest) /perm/noun))
-      =/  diff=(set sect:g)  (~(dif in writers) ~(key by cabals.group))
-      :: unsupported channel
-      ?.  ?=(?(%chat %heap %diary) p.nest)  [gc cr]
-      :: no writers to remove
-      ?:  =(diff ~)  [gc cr]
-      :: not host
-      ?:  !=(our.bowl p.q.nest)  [gc cr]
-      =/  cmd=c-channels:d  [%channel nest %del-writers diff]
-      =/  cage  [%channel-command !>(cmd)]
-      :-  gc
-      cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
-    core
+        =.  gc  (go-channel-del-sects:gc nest old-sect)
+        ::  repair writers as needed
+        ::
+        =+  .^(has=? %gu (channel-scry nest))
+        ?.  has  [gc cr]
+        :: unsupported channel
+        ?.  ?=(?(%chat %heap %diary) p.nest)  [gc cr]
+        :: not host
+        ?:  !=(our.bowl p.q.nest)  [gc cr]
+        =/  cmd=c-channels:d  [%channel nest %del-writers old-sect]
+        =/  cage  [%channel-command !>(cmd)]
+        :-  gc
+        cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
+      core
+    ==
   ::
   ++  go-fleet-update
     |=  [ships=(set ship) =diff:fleet:g]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1460,36 +1460,33 @@
         %del
       =.  cabals.group  (~(del by cabals.group) sect)
       =/  old-sect=(set sect:g)  (sy sect ~)
-      =.  go-core
+      =.  fleet.group
         ::  remove from members as needed
         ::
-        %-  go-fleet-del-sects
-        :_  old-sect
-        %+  roll
-          ~(tap by fleet.group)
-        |=  [[s=ship =vessel:fleet:g] ships=(set ship)]
-        ?.  (~(has in sects.vessel) sect)  ships
-        (~(put in ships) s)
-      =^  core=_go-core  cor
-        %+  roll
-          ~(tap by channels.group)
-        |=  [[=nest:g =channel:g] [gc=_go-core cr=_cor]]
-        ::  repair readers as needed
-        ::
-        =.  gc  (go-channel-del-sects:gc nest old-sect)
-        ::  repair writers as needed
-        ::
-        =+  .^(has=? %gu (channel-scry nest))
-        ?.  has  [gc cr]
-        :: unsupported channel
-        ?.  ?=(?(%chat %heap %diary) p.nest)  [gc cr]
-        :: not host
-        ?:  !=(our.bowl p.q.nest)  [gc cr]
-        =/  cmd=c-channels:d  [%channel nest %del-writers old-sect]
-        =/  cage  [%channel-command !>(cmd)]
-        :-  gc
-        cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
-      core
+        %-  ~(urn by fleet.group)
+        |=  [* =vessel:fleet:g]
+        vessel(sects (~(dif in sects.vessel) sects))
+      =/  channels  ~(tap by channels.group)
+      |-
+      ?~  channels  go-core
+      =/  [=nest:g =channel:g]  i.channels
+      ::  repair readers as needed
+      ::
+      =.  go-core  (go-channel-del-sects nest old-sect)
+      ::  repair writers as needed
+      ::
+      =+  .^(has=? %gu (channel-scry nest))
+      ::  missing channel
+      ?.  has  $(channels t.channels)
+      ::  unsupported channel
+      ?.  ?=(?(%chat %heap %diary) p.nest)  $(channels t.channels)
+      ::  not host
+      ?:  !=(our.bowl p.q.nest)  $(channels t.channels)
+      =/  cmd=c-channels:d  [%channel nest %del-writers old-sect]
+      =/  cage  [%channel-command !>(cmd)]
+      =/  dock  [p.q.nest %channels-server]
+      =.  cor  (emit %pass /groups/role %agent dock %poke cage)
+      $(channels t.channels)
     ==
   ::
   ++  go-fleet-update
@@ -1630,16 +1627,13 @@
         %del-sects
       ?>  go-is-bloc
       ?:  &(has-host (~(has in sects.diff) 'admin'))  go-core
-      (go-fleet-del-sects ships sects.diff)
-    ==
-  ++  go-fleet-del-sects
-    |=  [ships=(set ship) sects=(set sect:g)]
-    =.  fleet.group
+      =.  fleet.group
         %-  ~(urn by fleet.group)
         |=  [=ship =vessel:fleet:g]
         ?.  (~(has in ships) ship)  vessel
-        vessel(sects (~(dif in sects.vessel) sects))
+        vessel(sects (~(dif in sects.vessel) sects.diff))
       go-core
+    ==
   ::
   ++  go-channel-update
     |=  [ch=nest:g =diff:channel:g]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1465,10 +1465,11 @@
         ::
         %-  ~(urn by fleet.group)
         |=  [* =vessel:fleet:g]
-        vessel(sects (~(dif in sects.vessel) sects))
+        vessel(sects (~(dif in sects.vessel) old-sect))
       =/  channels  ~(tap by channels.group)
       |-
       ?~  channels  go-core
+      =*  next  $(channels t.channels)
       =/  [=nest:g =channel:g]  i.channels
       ::  repair readers as needed
       ::
@@ -1477,16 +1478,16 @@
       ::
       =+  .^(has=? %gu (channel-scry nest))
       ::  missing channel
-      ?.  has  $(channels t.channels)
+      ?.  has  next
       ::  unsupported channel
-      ?.  ?=(?(%chat %heap %diary) p.nest)  $(channels t.channels)
+      ?.  ?=(?(%chat %heap %diary) p.nest)  next
       ::  not host
-      ?:  !=(our.bowl p.q.nest)  $(channels t.channels)
+      ?:  !=(our.bowl p.q.nest)  next
       =/  cmd=c-channels:d  [%channel nest %del-writers old-sect]
       =/  cage  [%channel-command !>(cmd)]
       =/  dock  [p.q.nest %channels-server]
       =.  cor  (emit %pass /groups/role %agent dock %poke cage)
-      $(channels t.channels)
+      next
     ==
   ::
   ++  go-fleet-update

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -253,16 +253,21 @@
 ++  verify-cabals  (roll ~(tap by groups) verify-group-cabals)
 ++  verify-group-cabals
   |=  [[=flag:g [* =group:g]] core=_cor]
+  =/  current-sects  ~(key by cabals.group)
   =.  core
     ::  repair members as needed
     ::
-    %+  roll
-      ~(tap by fleet.group)
-    |=  [[s=ship =vessel:fleet:g] cre=_core]
-    =/  diff  (~(dif in sects.vessel) ~(key by cabals.group))
-    ?:  =(~(wyt in diff) 0)  cre
-    =/  action  [flag now.bowl %fleet (~(gas in *(set ship)) ~[s]) %del-sects diff]
-    cre(cards [[%pass /groups/role %agent [our.bowl dap.bowl] %poke [act:mar:g !>(action)]] cards.cre])
+    =/  [affected=(set ship) old-sects=(set sect:g)]
+      %+  roll
+        ~(tap by fleet.group)
+      |=  [[s=ship =vessel:fleet:g] [ships=(set ship) sects=(set sect:g)]]
+      ::  traverse through each member to collect all old sects and the
+      ::  ships which had them
+      =/  dif  (~(dif in sects.vessel) current-sects)
+      :-  ?:(=(~(wyt in dif) 0) ships (~(put in ships) s))
+      (~(uni in sects) dif)
+    =/  action  [flag now.bowl %fleet affected %del-sects old-sects]
+    (emit %pass /groups/role %agent [our.bowl dap.bowl] %poke [act:mar:g !>(action)])
   %+  roll
     ~(tap by channels.group)
   |=  [[=nest:g =channel:g] cr=_core]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1476,33 +1476,33 @@
       =/  dif  (~(dif in sects.vessel) current-sects)
       :-  ?:(=(~ dif) ships (~(put in ships) s))
       (~(uni in sects) dif)
-    go-core
-    :: =^  core=_go-core  cor
-    ::   %+  roll
-    ::     ~(tap by channels.group)
-    ::   |=  [[=nest:g =channel:g] [gc=_go-core cr=_cor]]
-    ::   =.  gc
-    ::     ::  repair readers as needed
-    ::     ::
-    ::     =/  invalid-readers  (~(dif in readers.channel) ~(key by cabals.group))
-    ::     ?~  readers  gc
-    ::     (go-channel-del-sects:gc nest invalid-readers)
-    ::   ::  repair writers as needed
-    ::   ::
-    ::   =+  .^(has=? %gu (channel-scry nest))
-    ::   ?.  has  [gc cr]
-    ::   =+  .^([writers=(set sect:g) *] %gx (welp (channel-scry nest) /perm/noun))
-    ::   =/  diff  (~(dif in writers) ~(key by cabals.group))
-    ::   ?:  ?|  =(diff ~)                          :: no writers to remove
-    ::           !=(our.bowl p.q.nest)              :: not host
-    ::           !(?=(?(%chat %heap %diary) p.nest))  :: unsupported channel
-    ::       ==
-    ::     [gc cr]
-    ::   =/  cmd=c-channels:d  [%channel nest %del-writers diff]
-    ::   =/  cage  [%channel-command !>(cmd)]
-    ::   :-  gc
-    ::   cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
-    :: core
+    =^  core=_go-core  cor
+      %+  roll
+        ~(tap by channels.group)
+      |=  [[=nest:g =channel:g] [gc=_go-core cr=_cor]]
+      =.  gc
+        ::  repair readers as needed
+        ::
+        =/  invalid-readers  (~(dif in readers.channel) ~(key by cabals.group))
+        ?~  invalid-readers  gc
+        (go-channel-del-sects:gc nest invalid-readers)
+      ::  repair writers as needed
+      ::
+      =+  .^(has=? %gu (channel-scry nest))
+      ?.  has  [gc cr]
+      =+  .^([writers=(set sect:g) *] %gx (welp (channel-scry nest) /perm/noun))
+      =/  diff=(set sect:g)  (~(dif in writers) ~(key by cabals.group))
+      :: unsupported channel
+      ?.  ?=(?(%chat %heap %diary) p.nest)  [gc cr]
+      :: no writers to remove
+      ?:  =(diff ~)  [gc cr]
+      :: not host
+      ?:  !=(our.bowl p.q.nest)  [gc cr]
+      =/  cmd=c-channels:d  [%channel nest %del-writers diff]
+      =/  cage  [%channel-command !>(cmd)]
+      :-  gc
+      cr(cards [[%pass /groups/role %agent [p.q.nest %channels-server] %poke cage] cards.cr])
+    core
   ::
   ++  go-fleet-update
     |=  [ships=(set ship) =diff:fleet:g]

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v3.7j179.0p4cu.tm5tf.eghif.esdei.glob' 0v3.7j179.0p4cu.tm5tf.eghif.esdei]
+    glob-http+['https://bootstrap.urbit.org/glob-0vcdj6c.jc8nr.avuag.uhh4v.vqc33.glob' 0vcdj6c.jc8nr.avuag.uhh4v.vqc33]
     base+'groups'
     version+[5 7 0]
     website+'https://tlon.io'


### PR DESCRIPTION
This PR should fix LAND-1698 by doing all our role removals in one event rather than an event for each member of the group. It also prevents channels from attempting to resubscribe to channels that are no longer associated with the group. This is untested, but should fix the issues we've been seeing.

**todos:**
- follow-up PR with proper tests
- follow-up PR to rip out old agent logic (heap/diary) that isn't involved in migration

As far as we understand the issue with role deletion was as follows:
**host**
delete role in UI (1 event) -> verify group cabal(role) data -> check every member's roles for old roles -> poke self for each member that needs a role change (5k events) -> disseminate events -> each event goes to 5k subscribers ... eventually receive resubscribes for channels 

**subscribers**
receive role change event for each member (5k events) -> recheck permissions of each channel -> for each channel that we can read, try to resubscribe if subscription is missing (5-10 events)

So we can calculate these by multiplying for each step. Also some of these events were ran multiple times:
5 tries * 5000 role change events * 5000 ships to distribute each event to = 125 million facts needing to be sent from nibset

meanwhile each time a ship hears any of those events it sends back 5 more events trying to resubscribe to deleted channels so 125m * 5 = 625 million

so in total facts/messages:
- distributed: 125m + 625 m (watch-acks/nacks) = 750m
- heard: 625m

which means nibset has been chewing through 1.375 b events. This makes me think we should have diagrams for each event flow to make sure we never cascade like this.

PR Checklist
- [X] Includes changes to desk files
- [ ] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [X] Comments added anywhere logic may be confusing without context