### PR TITLE
web: fix search bar closing on click

### DIFF
--- a/apps/tlon-web/src/chat/ChatSearch/ChatSearch.tsx
+++ b/apps/tlon-web/src/chat/ChatSearch/ChatSearch.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { ChatMap } from '@tloncorp/shared/dist/urbit/channel';
 import cn from 'classnames';
-import React, { PropsWithChildren, useCallback } from 'react';
+import React, { PropsWithChildren, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { Link } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
@@ -86,6 +86,15 @@ export default function ChatSearch({
     [navigate, root]
   );
 
+  // This is a hack to prevent the bug where nested @radix-ui components cause
+  // pointerEvents to get set to none on body which trips up our prevent close
+  // detection
+  useEffect(() => {
+    setTimeout(() => {
+      document.body.style.pointerEvents = '';
+    }, 0);
+  });
+
   return (
     <div
       className="border-b-2 border-gray-50 bg-white"
@@ -112,11 +121,7 @@ export default function ChatSearch({
               isSmall={isSmall}
             />
           </label>
-          <Dialog.Root
-            open
-            modal={activeTab === 'messages' ? true : false}
-            onOpenChange={onOpenChange}
-          >
+          <Dialog.Root open onOpenChange={onOpenChange}>
             <Dialog.Content
               onInteractOutside={preventClose}
               onOpenAutoFocus={disableDefault}


### PR DESCRIPTION
OTT. 

Was another nested `@radix-ui` issue. Wasn't able to shake it by updating deps, so added a workaround to prevent the bad behavior.

Tested locally against a hosted ship.

Fixes LAND-1577

PR Checklist
- [ ] Includes changes to desk files
- [x] Describes how you tested the PR locally (test ship vs livenet)
- [ ] If a new feature, includes automated tests
- [x] Comments added anywhere logic may be confusing without context