### PR TITLE
hidden message: fix issue with react query key

### DIFF
--- a/apps/tlon-web/src/state/channel/channel.ts
+++ b/apps/tlon-web/src/state/channel/channel.ts
@@ -2588,7 +2588,7 @@ export function useTogglePostMutation() {
   return useMutation(mutationFn, {
     onMutate: ({ toggle }) => {
       const hiding = 'hide' in toggle;
-      queryClient.setQueryData<HiddenPosts>(['diary', 'hidden'], (prev) => {
+      queryClient.setQueryData<HiddenPosts>(['channels', 'hidden'], (prev) => {
         if (!prev) {
           return hiding ? [udToDec(toggle.hide)] : [];
         }
@@ -2599,7 +2599,7 @@ export function useTogglePostMutation() {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(['diary', 'hidden']);
+      queryClient.invalidateQueries(['channels', 'hidden']);
     },
   });
 }


### PR DESCRIPTION
found this while working on another bug. we were using both ['diary', 'hidden'] and ['channels', 'hidden'] as query keys, this caused an issue where you sometimes were unable to unhide a message.

fixes LAND-1703