### PR TITLE
edit: fix issue with re-renders on editing reply message

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -156,15 +156,16 @@ const SuspendedDiaryAddNote = (
 );
 
 interface RoutesProps {
-  state: { backgroundLocation?: Location } | null;
-  location: Location;
   isMobile: boolean;
   isSmall: boolean;
 }
 
-function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
+const GroupsRoutes = React.memo(({ isMobile, isSmall }: RoutesProps) => {
   const groupsTitle = 'Tlon';
   const loaded = useSettingsLoaded();
+  const location = useLocation();
+
+  const state = location.state as { backgroundLocation?: Location } | null;
 
   useEffect(() => {
     if (loaded) {
@@ -558,7 +559,7 @@ function GroupsRoutes({ state, location, isMobile, isSmall }: RoutesProps) {
       ) : null}
     </>
   );
-}
+});
 
 function authRedirect() {
   document.location = `${document.location.protocol}//${document.location.host}`;
@@ -613,7 +614,6 @@ function App() {
   useNativeBridge();
   const navigate = useNavigate();
   const handleError = useErrorHandler();
-  const location = useLocation();
   const isMobile = useIsMobile();
   const isSmall = useMedia('(max-width: 1023px)');
 
@@ -637,20 +637,13 @@ function App() {
     })();
   }, [handleError]);
 
-  const state = location.state as { backgroundLocation?: Location } | null;
-
   return (
     <div className="flex h-full w-full flex-col">
       <DisconnectNotice />
       <LeapProvider>
         <ChatInputFocusProvider>
           <DragAndDropProvider>
-            <GroupsRoutes
-              state={state}
-              location={location}
-              isMobile={isMobile}
-              isSmall={isSmall}
-            />
+            <GroupsRoutes isMobile={isMobile} isSmall={isSmall} />
           </DragAndDropProvider>
         </ChatInputFocusProvider>
         <Leap />

--- a/apps/tlon-web/src/chat/ChatChannel.tsx
+++ b/apps/tlon-web/src/chat/ChatChannel.tsx
@@ -30,7 +30,7 @@ import { useRouteGroup } from '@/state/groups/groups';
 
 import ChatThread from './ChatThread/ChatThread';
 
-function ChatChannel({ title }: ViewProps) {
+const ChatChannel = React.memo(({ title }: ViewProps) => {
   const { isChatInputFocused } = useChatInputFocus();
   // TODO: We need to reroute users who can't read the channel
   // const navigate = useNavigate();
@@ -195,6 +195,6 @@ function ChatChannel({ title }: ViewProps) {
       </Routes>
     </>
   );
-}
+});
 
 export default ChatChannel;

--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -185,12 +185,20 @@ export default function ChatInput({
   const myLastMessage = useMyLastMessage(whom, replying);
   const lastMessageId = myLastMessage ? myLastMessage.seal.id : '';
   const lastMessageIdRef = useRef(lastMessageId);
+  const isReplyingRef = useRef(!!replying);
 
   useEffect(() => {
     if (lastMessageId && lastMessageId !== lastMessageIdRef.current) {
       lastMessageIdRef.current = lastMessageId;
     }
   }, [lastMessageId]);
+
+  useEffect(() => {
+    if (isReplyingRef.current && !replying) {
+      isReplyingRef.current = false;
+    }
+    isReplyingRef.current = !!replying;
+  }, [replying]);
 
   const handleUnblockClick = useCallback(() => {
     unblockShip({
@@ -400,9 +408,11 @@ export default function ChatInput({
         !isDmOrMultiDM
       ) {
         setSearchParams(
-          {
-            edit: lastMessageIdRef.current,
-          },
+          isReplyingRef.current
+            ? { editReply: lastMessageIdRef.current }
+            : {
+                edit: lastMessageIdRef.current,
+              },
           { replace: true }
         );
         editor.commands.blur();

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -21,6 +21,7 @@ import { useDragAndDrop } from '@/logic/DragAndDropContext';
 import { useChannelCompatibility, useChannelFlag } from '@/logic/channel';
 import { useBottomPadding } from '@/logic/position';
 import { useIsScrolling } from '@/logic/scroll';
+import useIsEditingMessage from '@/logic/useIsEditingMessage';
 import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
   useAddReplyMutation,
@@ -48,6 +49,7 @@ export default function ChatThread() {
   }>();
   const isMobile = useIsMobile();
   const { isChatInputFocused } = useChatInputFocus();
+  const isEditing = useIsEditingMessage();
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const flag = useChannelFlag()!;
   const nest = `chat/${flag}`;
@@ -259,7 +261,7 @@ export default function ChatThread() {
       </div>
       <div
         className={cn(
-          isDragging || isOver || !canWrite
+          isDragging || isOver || !canWrite || (isEditing && isMobile)
             ? ''
             : 'sticky bottom-0 border-t-2 border-gray-50 bg-white p-3 sm:p-4'
         )}

--- a/apps/tlon-web/src/chat/ChatWindow.tsx
+++ b/apps/tlon-web/src/chat/ChatWindow.tsx
@@ -5,7 +5,6 @@ import React, {
   useEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { VirtuosoHandle } from 'react-virtuoso';
@@ -29,207 +28,212 @@ interface ChatWindowProps {
   isScrolling: boolean;
 }
 
-export default function ChatWindow({
-  whom,
-  root,
-  prefixedElement,
-  scrollElementRef,
-  isScrolling,
-}: ChatWindowProps) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const { idTime } = useParams();
-  const scrollToId = useMemo(
-    () => searchParams.get('msg') || searchParams.get('edit') || idTime,
-    [searchParams, idTime]
-  );
-  const nest = `chat/${whom}`;
-  const {
-    posts: messages,
-    hasNextPage,
-    hasPreviousPage,
-    fetchPreviousPage,
-    refetch,
-    remove,
-    fetchNextPage,
-    isLoading,
-    isFetching,
-    isFetchingNextPage,
-    isFetchingPreviousPage,
-  } = useInfinitePosts(nest, scrollToId);
-  const { mutate: markRead } = useMarkReadMutation();
-  const scrollerRef = useRef<VirtuosoHandle>(null);
-  const readTimeout = useChatInfo(whom).unread?.readTimeout;
-  const clearOnNavRef = useRef({ readTimeout, nest, whom, markRead });
-  const { compatible } = useChannelCompatibility(nest);
-  const navigate = useNavigate();
-  const latestMessageIndex = messages.length - 1;
-  const scrollToIndex = useMemo(
-    () =>
-      scrollToId
-        ? messages.findIndex((m) => m[0].toString() === scrollToId)
-        : latestMessageIndex,
-    [scrollToId, messages, latestMessageIndex]
-  );
-  const msgIdTimeInMessages = useMemo(
-    () =>
-      scrollToId
-        ? messages.findIndex((m) => m[0].toString() === scrollToId) !== -1
-        : false,
-    [scrollToId, messages]
-  );
-  const latestIsMoreThan30NewerThanScrollTo = useMemo(
-    () =>
-      scrollToIndex !== latestMessageIndex &&
-      latestMessageIndex - scrollToIndex > 30,
-    [scrollToIndex, latestMessageIndex]
-  );
-
-  const goToLatest = useCallback(async () => {
-    if (idTime) {
-      navigate(root);
-    } else {
-      setSearchParams({});
-    }
-    if (hasPreviousPage) {
-      // wait until next tick to avoid the race condition where refetch
-      // happens before navigation completes and clears scrollToId
-      // TODO: is there a better way to handle this?
-      setTimeout(() => {
-        remove();
-        refetch();
-      }, 0);
-    } else {
-      scrollerRef.current?.scrollToIndex({ index: 'LAST', align: 'end' });
-    }
-  }, [
-    setSearchParams,
-    remove,
-    refetch,
-    hasPreviousPage,
-    scrollerRef,
-    idTime,
-    navigate,
+const ChatWindow = React.memo(
+  ({
+    whom,
     root,
-  ]);
+    prefixedElement,
+    scrollElementRef,
+    isScrolling,
+  }: ChatWindowProps) => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const { idTime } = useParams();
+    const scrollToId = useMemo(
+      () => searchParams.get('msg') || searchParams.get('edit') || idTime,
+      [searchParams, idTime]
+    );
+    const nest = `chat/${whom}`;
+    const {
+      posts: messages,
+      hasNextPage,
+      hasPreviousPage,
+      fetchPreviousPage,
+      refetch,
+      remove,
+      fetchNextPage,
+      isLoading,
+      isFetching,
+      isFetchingNextPage,
+      isFetchingPreviousPage,
+    } = useInfinitePosts(nest, scrollToId);
+    const { mutate: markRead } = useMarkReadMutation();
+    const scrollerRef = useRef<VirtuosoHandle>(null);
+    const readTimeout = useChatInfo(whom).unread?.readTimeout;
+    const clearOnNavRef = useRef({ readTimeout, nest, whom, markRead });
+    const { compatible } = useChannelCompatibility(nest);
+    const navigate = useNavigate();
+    const latestMessageIndex = messages.length - 1;
+    const scrollToIndex = useMemo(
+      () =>
+        scrollToId
+          ? messages.findIndex((m) => m[0].toString() === scrollToId)
+          : latestMessageIndex,
+      [scrollToId, messages, latestMessageIndex]
+    );
+    const msgIdTimeInMessages = useMemo(
+      () =>
+        scrollToId
+          ? messages.findIndex((m) => m[0].toString() === scrollToId) !== -1
+          : false,
+      [scrollToId, messages]
+    );
+    const latestIsMoreThan30NewerThanScrollTo = useMemo(
+      () =>
+        scrollToIndex !== latestMessageIndex &&
+        latestMessageIndex - scrollToIndex > 30,
+      [scrollToIndex, latestMessageIndex]
+    );
 
-  useEffect(() => {
-    useChatStore.getState().setCurrent(whom);
-
-    return () => {
-      useChatStore.getState().setCurrent('');
-    };
-  }, [whom]);
-
-  const onAtBottom = useCallback(() => {
-    const { bottom, delayedRead } = useChatStore.getState();
-    bottom(true);
-    delayedRead(whom, () => markRead({ nest }));
-    if (hasPreviousPage && !isFetching) {
-      log('fetching previous page');
-      fetchPreviousPage();
-    }
-  }, [nest, whom, markRead, fetchPreviousPage, hasPreviousPage, isFetching]);
-
-  const onAtTop = useCallback(() => {
-    if (hasNextPage && !isFetching) {
-      log('fetching next page');
-      fetchNextPage();
-    }
-  }, [fetchNextPage, hasNextPage, isFetching]);
-
-  // read the messages once navigated away
-  useEffect(() => {
-    clearOnNavRef.current = { readTimeout, nest, whom, markRead };
-  }, [readTimeout, nest, whom, markRead]);
-
-  useEffect(
-    () => () => {
-      const curr = clearOnNavRef.current;
-      if (curr.readTimeout !== undefined && curr.readTimeout !== 0) {
-        useChatStore.getState().read(curr.whom);
-        curr.markRead({ nest: curr.nest });
+    const goToLatest = useCallback(async () => {
+      if (idTime) {
+        navigate(root);
+      } else {
+        setSearchParams({});
       }
-    },
-    []
-  );
+      if (hasPreviousPage) {
+        // wait until next tick to avoid the race condition where refetch
+        // happens before navigation completes and clears scrollToId
+        // TODO: is there a better way to handle this?
+        setTimeout(() => {
+          remove();
+          refetch();
+        }, 0);
+      } else {
+        scrollerRef.current?.scrollToIndex({ index: 'LAST', align: 'end' });
+      }
+    }, [
+      setSearchParams,
+      remove,
+      refetch,
+      hasPreviousPage,
+      scrollerRef,
+      idTime,
+      navigate,
+      root,
+    ]);
 
-  useEffect(() => {
-    const doRefetch = async () => {
-      remove();
-      await refetch();
-    };
+    useEffect(() => {
+      useChatStore.getState().setCurrent(whom);
 
-    // If we have a scrollTo, we have a next page, and the scrollTo message is
-    // not in our current set of messages, that means we're scrolling to a
-    // message that's not yet cached. So, we need to refetch (which would fetch
-    // messages around the scrollTo time), then scroll to the message.
-    if (scrollToId && hasNextPage && !msgIdTimeInMessages) {
-      doRefetch();
-    }
-  }, [scrollToId, hasNextPage, remove, refetch, msgIdTimeInMessages]);
+      return () => {
+        useChatStore.getState().setCurrent('');
+      };
+    }, [whom]);
 
-  if (isLoading) {
-    return (
-      <div className="h-full overflow-hidden">
-        <ChatScrollerPlaceholder count={30} />
-      </div>
+    const onAtBottom = useCallback(() => {
+      const { bottom, delayedRead } = useChatStore.getState();
+      bottom(true);
+      delayedRead(whom, () => markRead({ nest }));
+      if (hasPreviousPage && !isFetching) {
+        log('fetching previous page');
+        fetchPreviousPage();
+      }
+    }, [nest, whom, markRead, fetchPreviousPage, hasPreviousPage, isFetching]);
+
+    const onAtTop = useCallback(() => {
+      if (hasNextPage && !isFetching) {
+        log('fetching next page');
+        fetchNextPage();
+      }
+    }, [fetchNextPage, hasNextPage, isFetching]);
+
+    // read the messages once navigated away
+    useEffect(() => {
+      clearOnNavRef.current = { readTimeout, nest, whom, markRead };
+    }, [readTimeout, nest, whom, markRead]);
+
+    useEffect(
+      () => () => {
+        const curr = clearOnNavRef.current;
+        if (curr.readTimeout !== undefined && curr.readTimeout !== 0) {
+          useChatStore.getState().read(curr.whom);
+          curr.markRead({ nest: curr.nest });
+        }
+      },
+      []
     );
-  }
 
-  if (!compatible && messages.length === 0) {
-    return (
-      <div className="h-full w-full overflow-hidden">
-        <EmptyPlaceholder>
-          <p>
-            There may be content in this channel, but it is inaccessible because
-            the host is using an older, incompatible version of the app.
-          </p>
-          <p>Please try again later.</p>
-        </EmptyPlaceholder>
-      </div>
-    );
-  }
+    useEffect(() => {
+      const doRefetch = async () => {
+        remove();
+        await refetch();
+      };
 
-  return (
-    <div className="relative h-full">
-      <ChatUnreadAlerts nest={nest} root={root} />
-      <div className="flex h-full w-full flex-col overflow-hidden">
-        <ChatScroller
-          /**
-           * key=whom forces a remount for each channel switch
-           * This resets the scroll position when switching channels;
-           * previously, when switching between channels, the virtuoso
-           * internal scroll index would remain the same. So, if one scrolled
-           * far back in a long channel, then switched to a less active one,
-           * the channel would be scrolled to the top.
-           */
-          key={whom}
-          messages={messages}
-          isLoadingOlder={isFetchingNextPage}
-          isLoadingNewer={isFetchingPreviousPage}
-          whom={whom}
-          topLoadEndMarker={prefixedElement}
-          scrollTo={scrollToId ? bigInt(scrollToId) : undefined}
-          scrollerRef={scrollerRef}
-          onAtTop={onAtTop}
-          onAtBottom={onAtBottom}
-          scrollElementRef={scrollElementRef}
-          isScrolling={isScrolling}
-          hasLoadedOldest={!hasNextPage}
-          hasLoadedNewest={!hasPreviousPage}
-        />
-      </div>
-      {scrollToId &&
-      (hasPreviousPage || latestIsMoreThan30NewerThanScrollTo) ? (
-        <div className="absolute bottom-2 left-1/2 z-20 flex w-full -translate-x-1/2 flex-wrap items-center justify-center gap-2">
-          <button
-            className="button bg-blue-soft text-sm text-blue dark:bg-blue-900 lg:text-base"
-            onClick={goToLatest}
-          >
-            Go to Latest <ArrowS16Icon className="ml-2 h-4 w-4" />
-          </button>
+      // If we have a scrollTo, we have a next page, and the scrollTo message is
+      // not in our current set of messages, that means we're scrolling to a
+      // message that's not yet cached. So, we need to refetch (which would fetch
+      // messages around the scrollTo time), then scroll to the message.
+      if (scrollToId && hasNextPage && !msgIdTimeInMessages) {
+        doRefetch();
+      }
+    }, [scrollToId, hasNextPage, remove, refetch, msgIdTimeInMessages]);
+
+    if (isLoading) {
+      return (
+        <div className="h-full overflow-hidden">
+          <ChatScrollerPlaceholder count={30} />
         </div>
-      ) : null}
-    </div>
-  );
-}
+      );
+    }
+
+    if (!compatible && messages.length === 0) {
+      return (
+        <div className="h-full w-full overflow-hidden">
+          <EmptyPlaceholder>
+            <p>
+              There may be content in this channel, but it is inaccessible
+              because the host is using an older, incompatible version of the
+              app.
+            </p>
+            <p>Please try again later.</p>
+          </EmptyPlaceholder>
+        </div>
+      );
+    }
+
+    return (
+      <div className="relative h-full">
+        <ChatUnreadAlerts nest={nest} root={root} />
+        <div className="flex h-full w-full flex-col overflow-hidden">
+          <ChatScroller
+            /**
+             * key=whom forces a remount for each channel switch
+             * This resets the scroll position when switching channels;
+             * previously, when switching between channels, the virtuoso
+             * internal scroll index would remain the same. So, if one scrolled
+             * far back in a long channel, then switched to a less active one,
+             * the channel would be scrolled to the top.
+             */
+            key={whom}
+            messages={messages}
+            isLoadingOlder={isFetchingNextPage}
+            isLoadingNewer={isFetchingPreviousPage}
+            whom={whom}
+            topLoadEndMarker={prefixedElement}
+            scrollTo={scrollToId ? bigInt(scrollToId) : undefined}
+            scrollerRef={scrollerRef}
+            onAtTop={onAtTop}
+            onAtBottom={onAtBottom}
+            scrollElementRef={scrollElementRef}
+            isScrolling={isScrolling}
+            hasLoadedOldest={!hasNextPage}
+            hasLoadedNewest={!hasPreviousPage}
+          />
+        </div>
+        {scrollToId &&
+        (hasPreviousPage || latestIsMoreThan30NewerThanScrollTo) ? (
+          <div className="absolute bottom-2 left-1/2 z-20 flex w-full -translate-x-1/2 flex-wrap items-center justify-center gap-2">
+            <button
+              className="button bg-blue-soft text-sm text-blue dark:bg-blue-900 lg:text-base"
+              onClick={goToLatest}
+            >
+              Go to Latest <ArrowS16Icon className="ml-2 h-4 w-4" />
+            </button>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+export default ChatWindow;

--- a/apps/tlon-web/src/logic/useIsEditingMessage.tsx
+++ b/apps/tlon-web/src/logic/useIsEditingMessage.tsx
@@ -3,7 +3,10 @@ import { useSearchParams } from 'react-router-dom';
 
 export default function useIsEditingMessage() {
   const [searchParams] = useSearchParams();
-  const isEditing = useMemo(() => !!searchParams.get('edit'), [searchParams]);
+  const isEditing = useMemo(
+    () => !!searchParams.get('edit') || !!searchParams.get('editReply'),
+    [searchParams]
+  );
 
   return isEditing;
 }

--- a/apps/tlon-web/src/replies/ReplyMessage.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessage.tsx
@@ -126,7 +126,7 @@ const ReplyMessage = React.memo<
       ref
     ) => {
       const [searchParms, setSearchParams] = useSearchParams();
-      const isEditing = searchParms.get('edit') === reply.seal.id;
+      const isEditing = searchParms.get('editReply') === reply.seal.id;
       const isEdited = useIsEdited(reply);
       const { seal, memo } = reply.seal.id ? reply : emptyReply;
       const container = useRef<HTMLDivElement>(null);

--- a/apps/tlon-web/src/replies/ReplyMessageOptions.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessageOptions.tsx
@@ -173,7 +173,7 @@ export default function ReplyMessageOptions(props: {
   }, [doCopy, isMobile, onOpenChange]);
 
   const edit = useCallback(() => {
-    setSearchParams({ edit: seal.id }, { replace: true });
+    setSearchParams({ editReply: seal.id }, { replace: true });
   }, [seal, setSearchParams]);
 
   const setReplyParam = useCallback(() => {

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v6vejo.ambet.2v7qd.muvf7.d92qm.glob' 0v6vejo.ambet.2v7qd.muvf7.d92qm]
+    glob-http+['https://bootstrap.urbit.org/glob-0v5.dvi7n.9bcsc.hid09.mhlbr.jr4l5.glob' 0v5.dvi7n.9bcsc.hid09.mhlbr.jr4l5]
     base+'groups'
     version+[5 7 0]
     website+'https://tlon.io'

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0vcdj6c.jc8nr.avuag.uhh4v.vqc33.glob' 0vcdj6c.jc8nr.avuag.uhh4v.vqc33]
+    glob-http+['https://bootstrap.urbit.org/glob-0v6vejo.ambet.2v7qd.muvf7.d92qm.glob' 0v6vejo.ambet.2v7qd.muvf7.d92qm]
     base+'groups'
     version+[5 7 0]
     website+'https://tlon.io'

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v3.7j179.0p4cu.tm5tf.eghif.esdei.glob' 0v3.7j179.0p4cu.tm5tf.eghif.esdei]
+    glob-http+['https://bootstrap.urbit.org/glob-0vcdj6c.jc8nr.avuag.uhh4v.vqc33.glob' 0vcdj6c.jc8nr.avuag.uhh4v.vqc33]
     base+'groups'
     version+[5 7 0]
     website+'https://tlon.io'


### PR DESCRIPTION
We were setting the scrollToId in the ChatWindow using the `edit` url param, which could include an ID for a reply message. The message would never be found and we'd end up in a re-render. We needed a different url param for editing a reply, `editReply`.

I also used wydr to try to root cause this originally, and found that we were seeing some unnecessary re-renders that could be fixed by moving the useLocation() hook call into the GroupsRoutes component and that we ought to memoize ChatChannel and ChatWindow.

fixes LAND-1701