### PR TITLE
tests: support loading custom vase in +do-load

### DIFF
--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -200,7 +200,7 @@
 ::
 ++  do-load
   =+  scry-warn=&
-  |=  =agent
+  |=  [=agent vase=(unit vase)]
   =/  m  (mare ,(list card))
   ^-  form:m
   ;<  old-scry=scry  bind:m  |=(s=state &+[scry.s s])
@@ -210,7 +210,8 @@
                                ['scrying during +on-load... careful!' p]
                              (old-scry p)
   ;<  c=(list card)  bind:m  %-  do  |=  s=state
-                             (~(on-load agent bowl.s) ~(on-save agent.s bowl.s))
+                             %-  ~(on-load agent bowl.s)
+                             (fall vase ~(on-save agent.s bowl.s))
   ;<  ~              bind:m  (set-scry-gate old-scry)
   (pure:m c)
 ::
@@ -300,7 +301,7 @@
 ::  bowl modification
 ::
 ++  jab-bowl
-  |=  f=$-(bowl:gall bowl)
+  |=  f=$-(bowl bowl)
   =/  m  (mare ,~)
   ^-  form:m
   |=  s=state
@@ -409,6 +410,7 @@
 ++  ex-arvo
   |=  [=wire note=note-arvo]
   (ex-card %pass wire %arvo note)
+::
 ++  ex-scry-result
   |=  [=path =vase]
   =/  m  (mare ,~)

--- a/desk/tests/lib/negotiate.hoon
+++ b/desk/tests/lib/negotiate.hoon
@@ -135,7 +135,7 @@
 ::
 ++  perform-upgrade
   |=  args=libargs
-  (do-load ((agent:libn args) dummy-agent))
+  (do-load ((agent:libn args) dummy-agent) ~)
 ::
 ++  perform-init-clean
   |=  args=libargs


### PR DESCRIPTION
Was using this library for my own purposes recently and found that it offered no built-in affordance for modifying state or injecting state wholesale. Since `+on-load` gets called with a `vase`, seems appropriate for `+do-load` to accept that as an argument.

This way, state migrations may be tested, and agent state may be created ex-nihilo instead of needing to come about strictly through the normal lifecycle.

We take a `(unit vase)` so that it remains easy to fall back to `+on-save`'s output.

(Includes some tiny stylistic touch-ups to the library as well.)