### PR TITLE
Sidebar: reduce re-renders to further minimize jank

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -610,7 +610,7 @@ function Scheduler() {
   return null;
 }
 
-function App() {
+const App = React.memo(() => {
   useNativeBridge();
   const navigate = useNavigate();
   const handleError = useErrorHandler();
@@ -650,7 +650,7 @@ function App() {
       </LeapProvider>
     </div>
   );
-}
+});
 
 function RoutedApp() {
   const mode = import.meta.env.MODE;

--- a/apps/tlon-web/src/components/Sidebar/AddGroupSidebarItem.tsx
+++ b/apps/tlon-web/src/components/Sidebar/AddGroupSidebarItem.tsx
@@ -1,11 +1,11 @@
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import AddIcon16 from '../icons/Add16Icon';
 import SidebarItem from './SidebarItem';
 
-export default function GroupSidebarItem() {
+const AddGroupSidebarItem = React.memo(() => {
   const navigate = useNavigate();
   const location = useLocation();
   const [open, setOpen] = useState(false);
@@ -59,4 +59,6 @@ export default function GroupSidebarItem() {
       </Dropdown.Content>
     </Dropdown.Root>
   );
-}
+});
+
+export default AddGroupSidebarItem;

--- a/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
+++ b/apps/tlon-web/src/components/Sidebar/Sidebar.tsx
@@ -10,7 +10,6 @@ import React, {
 
 import GroupList from '@/components/Sidebar/GroupList';
 import useGroupSort from '@/logic/useGroupSort';
-import { useIsMobile } from '@/logic/useMedia';
 import {
   useGangsWithClaim,
   useGroupsWithQuery,
@@ -32,7 +31,7 @@ import SidebarSorter from './SidebarSorter';
 import useSearchFilter, { GroupSearchRecord } from './useSearchFilter';
 import useActiveTab from './util';
 
-export default function Sidebar() {
+const Sidebar = React.memo(() => {
   const [isScrolling, setIsScrolling] = useState(false);
   const [atTop, setAtTop] = useState(true);
   const { sortFn, setSortFn, sortOptions, sortGroups } = useGroupSort();
@@ -259,32 +258,36 @@ export default function Sidebar() {
       </div>
     </nav>
   );
-}
+});
 
-function SidebarTopSection({
-  title,
-  noBorder = false,
-  children,
-  empty,
-}: {
-  title?: string;
-  noBorder?: boolean;
-  children?: React.ReactNode;
-  empty: boolean;
-}) {
-  if (empty) return null;
+const SidebarTopSection = React.memo(
+  ({
+    title,
+    noBorder = false,
+    children,
+    empty,
+  }: {
+    title?: string;
+    noBorder?: boolean;
+    children?: React.ReactNode;
+    empty: boolean;
+  }) => {
+    if (empty) return null;
 
-  return (
-    <div
-      className={cn(
-        'mb-4 flex flex-col p-2 pb-1',
-        !noBorder && 'border-t-2 border-gray-50'
-      )}
-    >
-      {title && (
-        <h2 className="p-2 text-sm font-semibold text-gray-400">{title}</h2>
-      )}
-      {children}
-    </div>
-  );
-}
+    return (
+      <div
+        className={cn(
+          'mb-4 flex flex-col p-2 pb-1',
+          !noBorder && 'border-t-2 border-gray-50'
+        )}
+      >
+        {title && (
+          <h2 className="p-2 text-sm font-semibold text-gray-400">{title}</h2>
+        )}
+        {children}
+      </div>
+    );
+  }
+);
+
+export default Sidebar;

--- a/apps/tlon-web/src/components/Sidebar/SidebarSorter.tsx
+++ b/apps/tlon-web/src/components/Sidebar/SidebarSorter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import ActionMenu, { Action } from '@/components/ActionMenu';
 import FilterIconMobileNav from '@/components/icons/FilterIconMobileNav';
@@ -11,48 +11,52 @@ type SidebarSorterProps = Omit<
   'sortChannels' | 'sortGroups' | 'sortRecordsBy'
 >;
 
-export default function SidebarSorter({
-  sortOptions,
-  sortFn,
-  setSortFn,
-}: SidebarSorterProps) {
-  const isMobile = useIsMobile();
-  const [open, setOpen] = useState(false);
+const SidebarSorter = React.memo(
+  ({ sortOptions, sortFn, setSortFn }: SidebarSorterProps) => {
+    const isMobile = useIsMobile();
+    const [open, setOpen] = useState(false);
 
-  const actions: Action[] = [];
+    const renderIcon = useCallback(() => {
+      if (isMobile) {
+        return <FilterIconMobileNav className="h-8 w-8 text-gray-900" />;
+      }
 
-  if (!isMobile) {
-    actions.push({
-      key: 'ordering',
-      type: 'disabled',
-      content: 'Group Ordering',
+      return <SortIcon className="h-6 w-6 text-gray-400 sm:h-4 sm:w-4" />;
+    }, [isMobile]);
+
+    const actions: Action[] = [];
+
+    if (!isMobile) {
+      actions.push({
+        key: 'ordering',
+        type: 'disabled',
+        content: 'Group Ordering',
+      });
+    }
+
+    Object.keys(sortOptions).forEach((k) => {
+      actions.push({
+        key: k,
+        type: k === sortFn ? 'prominent' : 'default',
+        onClick: () => setSortFn(k),
+        content: k,
+      });
     });
+
+    return (
+      <ActionMenu
+        open={open}
+        onOpenChange={setOpen}
+        actions={actions}
+        asChild={false}
+        triggerClassName="default-focus flex items-center rounded text-base font-semibold hover:bg-gray-50 sm:p-1"
+        contentClassName="w-56"
+        ariaLabel="Groups Sort Options"
+      >
+        {renderIcon()}
+      </ActionMenu>
+    );
   }
+);
 
-  Object.keys(sortOptions).forEach((k) => {
-    actions.push({
-      key: k,
-      type: k === sortFn ? 'prominent' : 'default',
-      onClick: () => setSortFn(k),
-      content: k,
-    });
-  });
-
-  return (
-    <ActionMenu
-      open={open}
-      onOpenChange={setOpen}
-      actions={actions}
-      asChild={false}
-      triggerClassName="default-focus flex items-center rounded text-base font-semibold hover:bg-gray-50 sm:p-1"
-      contentClassName="w-56"
-      ariaLabel="Groups Sort Options"
-    >
-      {isMobile ? (
-        <FilterIconMobileNav className="h-8 w-8 text-gray-900" />
-      ) : (
-        <SortIcon className="h-6 w-6 text-gray-400 sm:h-4 sm:w-4" />
-      )}
-    </ActionMenu>
-  );
-}
+export default SidebarSorter;

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
@@ -124,7 +124,9 @@ const virtuosoStateByFlag: Record<string, StateSnapshot> = {};
 
 const ChannelList = React.memo(({ paddingTop }: { paddingTop?: number }) => {
   const flag = useGroupFlag();
-  const group = useGroup(flag);
+  const realGroup = useGroup(flag);
+  const lastGroupRef = useRef(realGroup);
+  const group = lastGroupRef.current;
   const connected = useGroupConnection(flag);
   const { sortFn, sortChannels } = useChannelSort();
   const isDefaultSort = sortFn === DEFAULT_SORT;

--- a/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/ChannelList.tsx
@@ -139,6 +139,12 @@ const ChannelList = React.memo(({ paddingTop }: { paddingTop?: number }) => {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
   useEffect(() => {
+    if (realGroup) {
+      lastGroupRef.current = realGroup;
+    }
+  }, [realGroup]);
+
+  useEffect(() => {
     const currentVirtuosoRef = virtuosoRef.current;
     return () => {
       currentVirtuosoRef?.getState((state) => {

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -1,6 +1,12 @@
 import cn from 'classnames';
 import _ from 'lodash';
-import React, { useCallback, useContext, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { foregroundFromBackground } from '@/components/Avatar';
@@ -129,6 +135,12 @@ const GroupSidebar = React.memo(() => {
     () => (group ? getPrivacyFromGroup(group) : undefined),
     [group]
   );
+
+  useEffect(() => {
+    if (realGroup) {
+      lastGroupRef.current = realGroup;
+    }
+  }, [realGroup]);
 
   return (
     <nav className="flex h-full min-w-64 flex-none flex-col bg-white">

--- a/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
+++ b/apps/tlon-web/src/groups/GroupSidebar/GroupSidebar.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames';
 import _ from 'lodash';
-import { useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { foregroundFromBackground } from '@/components/Avatar';
@@ -28,7 +28,9 @@ import { useCalm } from '@/state/settings';
 
 function GroupHeader() {
   const flag = useGroupFlag();
-  const group = useGroup(flag);
+  const realGroup = useGroup(flag);
+  const lastGroupRef = useRef(realGroup);
+  const group = lastGroupRef.current;
   const { needsUpdate } = useContext(AppUpdateContext);
   const { preview, claim } = useGang(flag);
   const defaultImportCover = useMemo(
@@ -115,9 +117,11 @@ function GroupHeader() {
   );
 }
 
-export default function GroupSidebar() {
+const GroupSidebar = React.memo(() => {
   const flag = useGroupFlag();
-  const group = useGroup(flag);
+  const realGroup = useGroup(flag);
+  const lastGroupRef = useRef(realGroup);
+  const group = lastGroupRef.current;
   const isDark = useIsDark();
   const location = useLocation();
   const isAdmin = useAmAdmin(flag);
@@ -183,4 +187,6 @@ export default function GroupSidebar() {
       </div>
     </nav>
   );
-}
+});
+
+export default GroupSidebar;


### PR DESCRIPTION
Just added more memoization to prevent "normal" re-renders and used refs to store the group from useGroup() in the relevant components to prevent the skeleton state from loading when we navigate out of a group.