### PR TITLE
edit: make useMyLastMessage more performant

### DIFF
--- a/apps/tlon-web/src/chat/ChatChannel.tsx
+++ b/apps/tlon-web/src/chat/ChatChannel.tsx
@@ -24,6 +24,7 @@ import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
   useAddPostMutation,
   useLeaveMutation,
+  useMyLastMessage,
   useReplyPost,
 } from '@/state/channel/channel';
 import { useRouteGroup } from '@/state/groups/groups';
@@ -46,6 +47,7 @@ const ChatChannel = React.memo(({ title }: ViewProps) => {
   const groupFlag = useRouteGroup();
   const chFlag = `${chShip}/${chName}`;
   const nest = `chat/${chFlag}`;
+  const myLastMessage = useMyLastMessage(nest);
   const isMobile = useIsMobile();
   const isSmall = useMedia('(max-width: 1023px)');
   const inThread = !!idTime;
@@ -162,6 +164,7 @@ const ChatChannel = React.memo(({ title }: ViewProps) => {
                 dropZoneId={dropZoneId}
                 replyingWrit={replyingWrit || undefined}
                 isScrolling={isScrolling}
+                myLastMessage={myLastMessage}
               />
             ) : !canWrite && compatible ? null : (
               <div className="rounded-lg border-2 border-transparent bg-gray-50 px-2 py-1 leading-5 text-gray-600">

--- a/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
+++ b/apps/tlon-web/src/chat/ChatInput/ChatInput.tsx
@@ -4,9 +4,12 @@ import {
   Cite,
   Memo,
   Nest,
+  Post,
   PostEssay,
   PostTuple,
+  Reply,
   ReplyTuple,
+  Writ,
 } from '@tloncorp/shared/dist/urbit/channel';
 import { WritTuple } from '@tloncorp/shared/dist/urbit/dms';
 import cn from 'classnames';
@@ -73,6 +76,7 @@ interface ChatInputProps {
   autoFocus?: boolean;
   showReply?: boolean;
   className?: string;
+  myLastMessage?: Post | Writ | Reply | null;
   sendDisabled?: boolean;
   sendDm?: (variables: SendMessageVariables) => void;
   sendDmReply?: (variables: SendReplyVariables) => void;
@@ -136,6 +140,7 @@ export default function ChatInput({
   className = '',
   showReply = false,
   sendDisabled = false,
+  myLastMessage,
   sendDm,
   sendDmReply,
   sendChatMessage,
@@ -182,7 +187,6 @@ export default function ChatInput({
   const shipHasBlockedUs = useShipHasBlockedUs(whom);
   const { mutate: unblockShip } = useUnblockShipMutation();
   const isDmOrMultiDM = useIsDmOrMultiDm(whom);
-  const myLastMessage = useMyLastMessage(whom, replying);
   const lastMessageId = myLastMessage ? myLastMessage.seal.id : '';
   const lastMessageIdRef = useRef(lastMessageId);
   const isReplyingRef = useRef(!!replying);

--- a/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
+++ b/apps/tlon-web/src/chat/ChatThread/ChatThread.tsx
@@ -26,6 +26,7 @@ import useMedia, { useIsMobile } from '@/logic/useMedia';
 import {
   useAddReplyMutation,
   useMarkReadMutation,
+  useMyLastReply,
   usePerms,
   usePost,
   useReply,
@@ -53,6 +54,7 @@ export default function ChatThread() {
   const scrollerRef = useRef<VirtuosoHandle>(null);
   const flag = useChannelFlag()!;
   const nest = `chat/${flag}`;
+  const lastReply = useMyLastReply(nest);
   const groupFlag = useRouteGroup();
   const { mutate: sendMessage } = useAddReplyMutation();
   const location = useLocation();
@@ -272,6 +274,7 @@ export default function ChatThread() {
             replying={idTime}
             replyingWrit={replyingWrit}
             sendReply={sendMessage}
+            myLastMessage={lastReply}
             showReply
             autoFocus
             dropZoneId={dropZoneId}


### PR DESCRIPTION
Rewrote useMyLastMessage to be used only for chat channels, added useMyLastReply to be used only for replies in channels. Made `myLastMessage` a prop for chatInput, we now call the hook from whatever the parent of ChatInput is.

Noticed/remembered this while looking into perf via the profiler elsewhere.