### PR TITLE
cleanup: consistent formatting for shared packages

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,36 @@
+module.exports = {
+  bracketSpacing: true,
+  printWidth: 80,
+  proseWrap: 'always',
+  singleQuote: true,
+  tabWidth: 2,
+  useTabs: false,
+  trailingComma: 'es5',
+  semi: true,
+  overrides: [
+    {
+      files: ['*.html'],
+      htmlWhitespaceSensitivity: 'ignore',
+      // https://github.com/prettier/prettier-vscode/issues/646#issuecomment-514776589
+    },
+    {
+      files: ['*.md'],
+      options: {
+        tabWidth: 4,
+        printWidth: 1000,
+      },
+    },
+    {
+      files: ['package*.json'],
+      options: {
+        printWidth: 1000,
+      },
+    },
+    {
+      files: ['*.yml'],
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
+};

--- a/apps/tlon-mobile/.prettierrc.js
+++ b/apps/tlon-mobile/.prettierrc.js
@@ -1,45 +1,10 @@
 module.exports = {
-  bracketSpacing: true,
-  printWidth: 80,
-  proseWrap: 'always',
-  singleQuote: true,
-  tabWidth: 2,
-  useTabs: false,
-  trailingComma: 'es5',
   plugins: [
-    'prettier-plugin-tailwindcss',
-    '@trivago/prettier-plugin-sort-imports',
+    "prettier-plugin-tailwindcss",
+    "@trivago/prettier-plugin-sort-imports",
   ],
-  overrides: [
-    {
-      files: ['*.html'],
-      htmlWhitespaceSensitivity: 'ignore',
-      // https://github.com/prettier/prettier-vscode/issues/646#issuecomment-514776589
-    },
-    {
-      files: ['*.md'],
-      options: {
-        tabWidth: 4,
-        printWidth: 1000,
-      },
-    },
-    {
-      files: ['package*.json'],
-      options: {
-        printWidth: 1000,
-      },
-    },
-    {
-      files: ['*.yml'],
-      options: {
-        singleQuote: false,
-      },
-    },
-  ],
-  tailwindConfig: './tailwind.config.js',
-  semi: true,
-  trailingComma: 'es5',
-  importOrder: ['<THIRD_PARTY_MODULES>', '^[./]'],
+  tailwindConfig: "./tailwind.config.js",
+  importOrder: ["<THIRD_PARTY_MODULES>", "^[./]"],
   importOrderSeparation: true,
   importOrderSortSpecifiers: true,
 };

--- a/apps/tlon-web/.prettierrc.js
+++ b/apps/tlon-web/.prettierrc.js
@@ -1,45 +1,10 @@
 module.exports = {
-  bracketSpacing: true,
-  printWidth: 80,
-  proseWrap: 'always',
-  singleQuote: true,
-  tabWidth: 2,
-  useTabs: false,
-  trailingComma: 'es5',
   plugins: [
-    'prettier-plugin-tailwindcss',
-    '@trivago/prettier-plugin-sort-imports',
+    "prettier-plugin-tailwindcss",
+    "@trivago/prettier-plugin-sort-imports",
   ],
-  overrides: [
-    {
-      files: ['*.html'],
-      htmlWhitespaceSensitivity: 'ignore',
-      // https://github.com/prettier/prettier-vscode/issues/646#issuecomment-514776589
-    },
-    {
-      files: ['*.md'],
-      options: {
-        tabWidth: 4,
-        printWidth: 1000,
-      },
-    },
-    {
-      files: ['package*.json'],
-      options: {
-        printWidth: 1000,
-      },
-    },
-    {
-      files: ['*.yml'],
-      options: {
-        singleQuote: false,
-      },
-    },
-  ],
-  tailwindConfig: './tailwind.config.js',
-  semi: true,
-  trailingComma: 'es5',
-  importOrder: ['<THIRD_PARTY_MODULES>', '^@/(.*)', '^[./]'],
+  tailwindConfig: "./tailwind.config.js",
+  importOrder: ["<THIRD_PARTY_MODULES>", "^@/(.*)", "^[./]"],
   importOrderSeparation: true,
   importOrderSortSpecifiers: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "concurrently": "^8.2.2",
         "husky": "^9.0.10",
         "patch-package": "^6.4.7",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postinstall": "npx patch-package"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "concurrently": "^8.2.2",
     "husky": "^9.0.10",
     "patch-package": "^6.4.7",

--- a/packages/shared/prettierrc.js
+++ b/packages/shared/prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ['@trivago/prettier-plugin-sort-imports'],
+  importOrder: ['<THIRD_PARTY_MODULES>', '^@/(.*)', '^[./]'],
+  importOrderSeparation: true,
+  importOrderSortSpecifiers: true,
+};

--- a/packages/ui/prettierrc.js
+++ b/packages/ui/prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ['@trivago/prettier-plugin-sort-imports'],
+  importOrder: ['<THIRD_PARTY_MODULES>', '^@/(.*)', '^[./]'],
+  importOrderSeparation: true,
+  importOrderSortSpecifiers: true,
+};


### PR DESCRIPTION
This PR creates a root `.prettierrc.js` for common formatting settings. I also added new `.prettierrc.js` files for the `shared` and `ui` packages, which were missing them before.

One small future improvement would be to also hoist the import order plugin config -- I didn't do that here because I started seeing import/module format issues when I did.