### PR TITLE
edit: fix issue with editing replies in notebooks and galleries

### DIFF
--- a/apps/tlon-web/src/replies/ReplyMessage.tsx
+++ b/apps/tlon-web/src/replies/ReplyMessage.tsx
@@ -41,7 +41,7 @@ import DoubleCaretRightIcon from '@/components/icons/DoubleCaretRightIcon';
 import { JSONToInlines, diaryMixedToJSON } from '@/logic/tiptap';
 import useLongPress from '@/logic/useLongPress';
 import { useIsMobile } from '@/logic/useMedia';
-import { useIsDmOrMultiDm } from '@/logic/utils';
+import { nestToFlag, useIsDmOrMultiDm, whomIsNest } from '@/logic/utils';
 import {
   useEditReplyMutation,
   useIsEdited,
@@ -125,6 +125,9 @@ const ReplyMessage = React.memo<
       }: ReplyMessageProps,
       ref
     ) => {
+      // we pass `whom` as a channel flag for chat, nest for diary/heap
+      // because we use flags in unreads
+      const nest = whomIsNest(whom) ? whom : `chat/${whom}`;
       const [searchParms, setSearchParams] = useSearchParams();
       const isEditing = searchParms.get('editReply') === reply.seal.id;
       const isEdited = useIsEdited(reply);
@@ -285,7 +288,7 @@ const ReplyMessage = React.memo<
           }
 
           editReply({
-            nest: `chat/${whom}`,
+            nest,
             postId: seal['parent-id'],
             replyId: seal.id,
             memo: {
@@ -297,7 +300,7 @@ const ReplyMessage = React.memo<
 
           setSearchParams({}, { replace: true });
         },
-        [editReply, whom, seal, memo, setSearchParams]
+        [editReply, nest, seal, memo, setSearchParams]
       );
 
       const messageEditor = useMessageEditor({


### PR DESCRIPTION
Re-opened with a new branch based off of staging.

Fixes LAND-1731 by making sure we have a nest (we don't in the case of chat, we do in the case of diary/heap, previously we were just appending chat/ to whatever we had in whom).

