### PR TITLE
native: add monochrome android icon

### DIFF
--- a/apps/tlon-mobile/README.md
+++ b/apps/tlon-mobile/README.md
@@ -72,14 +72,14 @@ npm run ios
 
 #### Run Preview Scheme
 
-Run the Preview version of the app by specifying `scheme` or `variant` in the run command:
+Run the Preview version of the app by specifying different commands:
 
 ```sh
-npm run ios -- --scheme=Landscape-preview
+npm run ios:preview
 ```
 
 ```sh
-npm run android -- --variant=preview
+npm run android:preview
 ```
 
 ## Debugging

--- a/apps/tlon-mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/apps/tlon-mobile/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "concurrently \"tailwindcss --input input.css --output tailwind.css --no-autoprefixer --watch\" \"tailwind-rn --watch\"",
-    "android": "expo run:android",
+    "android": "expo run:android --variant=productionDebug",
+    "android:preview": "expo run:android --variant=previewDebug",
     "bundler": "expo start",
     "clearcache": "expo start -c",
     "ios": "expo run:ios",
+    "ios:preview": "expo run:ios --scheme=Landscape-preview",
     "generate": "npm run generate:tailwind && npm run generate:ios",
     "generate:ios": "react-native bundle --entry-file='index.js' --bundle-output='./ios/main.jsbundle' --dev=false --platform='ios' --assets-dest='./ios'",
     "generate:tailwind": "tailwindcss --input input.css --output tailwind.css --no-autoprefixer && tailwind-rn",


### PR DESCRIPTION
- Fixes Android run command
- Adds preview run commands
- Updates Android icon to allow for icon theming

Before
![Screenshot_20240328_211612_One UI Home](https://github.com/tloncorp/tlon-apps/assets/1013230/6ad440b6-9e9a-4c1e-bafc-f15d34f774be)

After
![Screenshot_20240328_211801_One UI Home](https://github.com/tloncorp/tlon-apps/assets/1013230/a46350a9-d0d1-4288-bae8-b716286cc2d5)
