### PR TITLE
native: fix missing nav bar in onboarding stack

### DIFF
--- a/apps/tlon-mobile/src/hooks/useScreenOptions.ts
+++ b/apps/tlon-mobile/src/hooks/useScreenOptions.ts
@@ -2,10 +2,15 @@ import type { NativeStackNavigationOptions } from '@react-navigation/native-stac
 
 import { useIsDarkMode } from './useIsDarkMode';
 
-export const useScreenOptions = (): NativeStackNavigationOptions => {
+type Props = {
+  overrides?: NativeStackNavigationOptions;
+};
+
+export const useScreenOptions = (
+  props?: Props
+): NativeStackNavigationOptions => {
   const isDarkMode = useIsDarkMode();
   return {
-    headerShown: false,
     headerTitle: '',
     headerBackTitleVisible: false,
     headerShadowVisible: false,
@@ -13,5 +18,6 @@ export const useScreenOptions = (): NativeStackNavigationOptions => {
       backgroundColor: isDarkMode ? '#000' : '#fff',
     },
     headerTintColor: isDarkMode ? '#fff' : '#333',
+    ...props?.overrides,
   };
 };

--- a/apps/tlon-mobile/src/navigation/HomeStack.tsx
+++ b/apps/tlon-mobile/src/navigation/HomeStack.tsx
@@ -14,7 +14,11 @@ const Stack = createNativeStackNavigator<HomeStackParamList>();
 
 export const HomeStack = ({ navigation }: Props) => {
   const { setVisibility } = useWebviewPositionContext();
-  const screenOptions = useScreenOptions();
+  const screenOptions = useScreenOptions({
+    overrides: {
+      headerShown: false,
+    },
+  });
 
   useEffect(() => {
     navigation.setOptions({


### PR DESCRIPTION
[This change](https://github.com/tloncorp/tlon-apps/commit/f743da3188a429909e976971f1753807e4909275#diff-ef1a11e46f5301a808634240cd96b8fdf05898ebcf1f4efdfd255da71a56ce8c) for the `HomeStack` ended up removing the top nav bar for the `OnboardingStack` as well. I've updated the `useScreenOptioins` hook to accept overrides to the default values to support the `HomeStack`.