### PR TITLE
native: fix urbit color normalization

### DIFF
--- a/packages/shared/src/api/contactsApi.test.ts
+++ b/packages/shared/src/api/contactsApi.test.ts
@@ -28,7 +28,7 @@ const outputContact = {
   bio: 'happy to chat, send a dm any time',
   nickname: 'galen',
   status: 'listening to music',
-  color: '#ffffff',
+  color: '#FFFFFF',
   pinnedGroups: [
     { groupId: '~ravmel-ropdyl/audio-video-images', contactId: 'test' },
     { groupId: '~nibset-napwyn/tlon', contactId: 'test' },

--- a/packages/shared/src/api/contactsApi.ts
+++ b/packages/shared/src/api/contactsApi.ts
@@ -1,6 +1,5 @@
-import { parseUx } from '@urbit/aura';
-
 import * as db from '../db';
+import { normalizeUrbitColor } from '../logic';
 import * as ub from '../urbit';
 import { scry } from './urbit';
 
@@ -29,7 +28,7 @@ export const toClientContact = (
     nickname: contact?.nickname ?? null,
     bio: contact?.bio ?? null,
     status: contact?.status ?? null,
-    color: parseUrbitColor(contact?.color),
+    color: contact?.color ? normalizeUrbitColor(contact.color) : null,
     coverImage: contact?.cover ?? null,
     avatarImage: contact?.avatar ?? null,
     pinnedGroups:
@@ -39,14 +38,3 @@ export const toClientContact = (
       })) ?? [],
   };
 };
-
-function parseUrbitColor(color?: string) {
-  let result = color ? parseUx(color) : null;
-  if (!result) {
-    return null;
-  }
-  while (result.length < 6) {
-    result = result + '0';
-  }
-  return '#' + result;
-}

--- a/packages/shared/src/logic/utils.test.ts
+++ b/packages/shared/src/logic/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeUrbitColor } from './utils';
+
+describe('normalizeUrbitColor', () => {
+  describe('the user submits a color hex value with one or more leading zeroes', () => {
+    it('normalizes @ux values of color hexes for all zeroes', () => {
+      expect(normalizeUrbitColor('0x0')).toEqual('#000000');
+    });
+
+    it('normalizes @ux values of color hexes with 5 leading zeros', () => {
+      expect(normalizeUrbitColor('0xf')).toEqual('#00000F');
+    });
+
+    it('normalizes @ux values of color hexes with 4 leading zeros', () => {
+      expect(normalizeUrbitColor('0xff')).toEqual('#0000FF');
+    });
+
+    it('normalizes @ux values of color hexes with 3 leading zeros', () => {
+      expect(normalizeUrbitColor('0xfff')).toEqual('#000FFF');
+    });
+
+    it('normalizes @ux values of color hexes with 2 leading zeros', () => {
+      expect(normalizeUrbitColor('0xffff')).toEqual('#00FFFF');
+    });
+
+    it('normalizes @ux values of color hexes with 1 leading zero', () => {
+      expect(normalizeUrbitColor('0xf.ffff')).toEqual('#0FFFFF');
+    });
+  });
+
+  it('normalizes colors with a leading alpha char', () => {
+    expect(normalizeUrbitColor('0xff.ffff')).toEqual('#FFFFFF');
+  });
+
+  it('normalizes colors with a leading 0', () => {
+    expect(normalizeUrbitColor('0x00.0000')).toEqual('#000000');
+  });
+
+  it('passes through color hexes', () => {
+    expect(normalizeUrbitColor('#ffffff')).toEqual('#ffffff');
+  });
+});

--- a/packages/shared/src/logic/utils.ts
+++ b/packages/shared/src/logic/utils.ts
@@ -1,6 +1,5 @@
 import { differenceInDays, endOfToday, format } from 'date-fns';
 import emojiRegex from 'emoji-regex';
-import _ from 'lodash';
 
 export const IMAGE_REGEX =
   /(\.jpg|\.img|\.png|\.gif|\.tiff|\.jpeg|\.webp|\.svg)(?:\?.*)?$/i;
@@ -111,7 +110,7 @@ export function isSingleEmoji(input: string): boolean {
   return (
     (matches &&
       matches.length === 1 &&
-      matches.length === _.split(input, '').length) ??
+      matches.length === input.split('').length) ??
     false
   );
 }
@@ -122,6 +121,6 @@ export function normalizeUrbitColor(color: string): string {
   }
 
   const colorString = color.slice(2).replace('.', '').toUpperCase();
-  const lengthAdjustedColor = _.padStart(colorString, 6, '0');
+  const lengthAdjustedColor = colorString.padStart(6, '0');
   return `#${lengthAdjustedColor}`;
 }


### PR DESCRIPTION
- Updates contacts sync to use shared `normalizeUrbitColor` utility instead of local `parseUrbitColor` utility which padded the wrong side of the color value
- Pulls in `normalizeUrbitColor` tests from the web repo
- Removes unneeded lodash dependencies

Before
<img width="120" alt="Screenshot 2024-04-26 at 1 17 17 PM" src="https://github.com/tloncorp/tlon-apps/assets/1013230/cdbcfd4b-6c23-4016-9da0-014ce189e9e5">

After
<img width="123" alt="Screenshot 2024-04-26 at 1 16 21 PM" src="https://github.com/tloncorp/tlon-apps/assets/1013230/1107b110-e776-42c1-b853-b50300eff23a">
