### PR TITLE
native: fix "scroll to latest" button styling

### DIFF
--- a/packages/ui/src/components/Channel/Scroller.tsx
+++ b/packages/ui/src/components/Channel/Scroller.tsx
@@ -13,7 +13,6 @@ import React, {
   useState,
 } from 'react';
 import {
-  Dimensions,
   FlatList,
   ListRenderItem,
   View as RNView,
@@ -22,7 +21,6 @@ import {
 } from 'react-native';
 import { useStyle } from 'tamagui';
 
-import { ArrowDown } from '../../assets/icons';
 import { Modal, View, XStack } from '../../core';
 import { Button } from '../Button';
 import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component';
@@ -281,7 +279,7 @@ const UnreadsButton = ({ onPress }: { onPress: () => void }) => {
   return (
     <XStack position="absolute" zIndex={50} bottom="5%" width="40%" left="30%">
       <Button
-        backgroundColor="$blueSoft"
+        backgroundColor="$positiveBackground"
         paddingVertical="$s"
         paddingHorizontal="$m"
         borderRadius="$l"
@@ -292,8 +290,14 @@ const UnreadsButton = ({ onPress }: { onPress: () => void }) => {
         onPress={onPress}
         size="$s"
       >
-        <Button.Text color="$blue">Scroll to latest</Button.Text>
-        <Icon type="ArrowDown" color="$blue" width="$s" height="$s" size="$l" />
+        <Button.Text color="$positiveActionText">Scroll to latest</Button.Text>
+        <Icon
+          type="ArrowDown"
+          color="$positiveActionText"
+          width="$s"
+          height="$s"
+          size="$l"
+        />
       </Button>
     </XStack>
   );


### PR DESCRIPTION
Fixes for "Scroll to latest" button:
- Dark mode styling
- Truly centered
- Icon shows properly

I was having issues with `Button.Icon` and opted not to use it - we may want to revisit that component and align it with the shared `Icon` component?

Before
<img width="337" alt="Screenshot 2024-05-06 at 9 57 06 PM" src="https://github.com/tloncorp/tlon-apps/assets/1013230/3eb4eeb8-5891-4103-9ba5-81e9bc181461">

After
<img width="345" alt="Screenshot 2024-05-06 at 9 56 36 PM" src="https://github.com/tloncorp/tlon-apps/assets/1013230/391a8ab6-0d8f-49d8-9bb0-20c8f5d7175e">
