### PR TITLE
native: catch storage key not found when initializing debug

### DIFF
--- a/packages/app/lib/debug.ts
+++ b/packages/app/lib/debug.ts
@@ -10,6 +10,9 @@ storage
   })
   .then((enabled) => {
     useDebugStore.getState().toggle(enabled);
+  })
+  .catch(() => {
+    useDebugStore.getState().toggle(false);
   });
 
 export const setDebug = async (enabled: boolean) => {


### PR DESCRIPTION
Just adds a catch statement to prevent this warning I've been getting when the sim starts:

<img src="https://github.com/user-attachments/assets/f1afcf63-ccd0-4ab1-ad37-30fc9d43541c" height="600" />
