### PR TITLE
Remove duplicate query provider from the App provider

### DIFF
--- a/packages/app/provider/index.tsx
+++ b/packages/app/provider/index.tsx
@@ -1,6 +1,6 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { syncSettings, updateTheme, useThemeSettings } from '@tloncorp/shared';
 import { subscribeToSettings } from '@tloncorp/shared/api';
+import { queryClient } from '@tloncorp/shared/api';
 import { themeSettings } from '@tloncorp/shared/db';
 import React, { useEffect, useState } from 'react';
 import { TamaguiProvider, TamaguiProviderProps } from 'tamagui';
@@ -15,25 +15,12 @@ export const ThemeContext = React.createContext<{
   activeTheme: AppTheme;
 }>({ setActiveTheme: () => {}, activeTheme: 'light' });
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: false,
-    },
-  },
-});
-
 export function Provider({
   children,
   ...rest
 }: Omit<TamaguiProviderProps, 'config'>) {
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProviderContent tamaguiProps={rest}>
-        {children}
-      </ThemeProviderContent>
-    </QueryClientProvider>
+    <ThemeProviderContent tamaguiProps={rest}>{children}</ThemeProviderContent>
   );
 }
 


### PR DESCRIPTION
It turns out this was caused by adding a duplicate query provider to the tree (in the app provider. there's already one in main.tsx for web and App.main.tsx on mobile). The db would get updated but the react query queries would never re-run. Removing the duplicate provider fixes the issue.

To test: run the web app locally, send a message to the ship you have it pointed at (while you're looking at the home screen), see that the sidebar updates.