### PR TITLE
mobile: fix local image imports

### DIFF
--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -78,7 +78,7 @@ function isValidImageSource(source: any) {
     }
 
     if (typeof uri === 'number') {
-      // this is the case for imports of bundled files (require returns a numeric module ID)
+      // this is the case for imports of bundled files (require() returns a numeric metro module ID)
       return true;
     }
 


### PR DESCRIPTION
The image fix from this morning (https://github.com/tloncorp/tlon-apps/pull/4810) was overly restrictive when screening for valid image `source` values. When requiring images locally on mobile, metro returns a module identifier for the image which is just a number.

We expand what's a valid source to include numbers. Note, this will still prevent the hex code issue that the URL checks were meant to defend against. 

Fixes TLON-4301