### PR TITLE
embeds: better twitter behavior

### DIFF
--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -1,4 +1,4 @@
-import { isTrustedEmbed } from '@tloncorp/shared';
+import { isTrustedEmbed, trustedProviders } from '@tloncorp/shared';
 import { Icon, Image, Pressable, Text, useCopy } from '@tloncorp/ui';
 import { ImageLoadEventData } from 'expo-image';
 import React, {
@@ -244,7 +244,14 @@ export function LinkBlock({
     }
   }, [block.url]);
 
-  if (renderEmbed && isTrustedEmbed(block.url)) {
+  const embedProviders = useMemo(() => {
+    // for now, avoid showing twitter embeds on web
+    return Platform.OS === 'web'
+      ? trustedProviders.filter((tp) => tp.name !== 'Twitter')
+      : trustedProviders;
+  }, []);
+
+  if (renderEmbed && isTrustedEmbed(block.url, embedProviders)) {
     const embedBlock: cn.EmbedBlockData = {
       type: 'embed',
       url: block.url,


### PR DESCRIPTION
## Summary

Better default behavior for Twitter links.

## Changes

- `%metagrab` is insufficient for Twitter links. Instead, always prefer the fallback option for populating those
- Avoid trying to render embeds on Web, instead show the default rich `LinkBlock` visual.

## How did I test?

Paste a tweet link in chat and gallery.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Simple revert is fine.

## Screenshots / videos
Before
<img width="957" alt="image" src="https://github.com/user-attachments/assets/6a4fca0a-82f0-4eca-aa46-670ea61bcb1f" />

After
<img width="992" alt="image" src="https://github.com/user-attachments/assets/4b366559-fdd5-4313-9ee6-f77e1759521c" />

