### PR TITLE
fix secure storage bug

### DIFF
--- a/packages/shared/src/db/getStorageMethods.native.ts
+++ b/packages/shared/src/db/getStorageMethods.native.ts
@@ -5,7 +5,19 @@ export function getStorageMethods(isSecure: boolean) {
   if (isSecure) {
     return {
       getItem: SecureStore.getItemAsync,
-      setItem: SecureStore.setItemAsync,
+      setItem: async (key: string, value: string) => {
+        // This deletion should be temporary -- we just want to be sure that all
+        // keys are initially set with the correct `keychainAccessible` option.
+        // see issue here: https://github.com/expo/expo/issues/23924
+        try {
+          await SecureStore.deleteItemAsync(key);
+        } catch (e) {
+          // ignore error -- we don't care if it can't be deleted because it doesn't exist
+        }
+        return SecureStore.setItemAsync(key, value, {
+          keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+        });
+      },
       removeItem: SecureStore.deleteItemAsync,
     };
   }


### PR DESCRIPTION
## Summary

This applies a fix to our native `AsyncStorage` suggested in an issue on the `expo-secure-storage` module. I was not able to reproduce the original issue, so I can't verify absolutely that it works, but I did test that it didn't cause any other issues. Should fix TLON-4307.

## Changes

- Adds `keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK` to newly set `SecureStore` keys.
- Deletes existing keys before updating values to ensure that the option is applied properly.

## How did I test?

Tested login flow on iOS and Android.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
