### PR TITLE
version tracking improvements

### DIFF
--- a/.github/workflows/build-and-glob.yml
+++ b/.github/workflows/build-and-glob.yml
@@ -29,6 +29,9 @@ jobs:
           run_install: |
             - recursive: true
               args: [--frozen-lockfile]
+      - name: Extract git hash
+        id: gitHash
+        run: echo "gitHash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Build packages
         run: pnpm build:all
       - working-directory: ./apps/tlon-web
@@ -44,6 +47,7 @@ jobs:
       VITE_BRANCH_KEY_TEST: ${{ secrets.VITE_BRANCH_KEY_TEST}}
       VITE_INVITE_SERVICE_ENDPOINT: ${{ secrets.VITE_INVITE_SERVICE_ENDPOINT}}
       VITE_POST_HOG_API_KEY: ${{ secrets.VITE_POST_HOG_API_KEY}}
+      VITE_GIT_HASH: ${{ steps.gitHash.outputs.gitHash }}
   glob:
     runs-on: ubuntu-latest
     name: "Make a glob"

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -33,6 +33,8 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Setup PNPM
         uses: pnpm/action-setup@v3
+      - name: Setup jq
+        uses: dcarbone/install-jq-action@v3
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create build vars
@@ -53,3 +55,28 @@ jobs:
           NOTIFY_SERVICE:
             "${{ steps.vars.outputs.profile == 'preview' &&
             'tlon-preview-release' || 'groups-native' }}"
+      - name: Extract version and build numbers
+        id: version_info
+        working-directory: ./apps/tlon-mobile
+        run: |
+          CONFIG=$(eas build:version:get --profile preview --json --non-interactive --platform all)
+          ANDROID_BUILD=$(echo "$CONFIG" | jq -r '.versionCode')
+          IOS_BUILD=$(echo "$CONFIG" | jq -r '.buildNumber')
+          echo "android_build=$ANDROID_BUILD" >> $GITHUB_OUTPUT
+          echo "ios_build=$IOS_BUILD" >> $GITHUB_OUTPUT
+      - name: Create git tags
+        run: |
+          PROFILE=${{ steps.vars.outputs.profile }}
+          PLATFORM="${{ inputs.platform || 'all' }}"
+
+          if [ "$PLATFORM" = "all" ] || [ "$PLATFORM" = "android" ]; then
+            ANDROID_BUILD=${{ steps.version_info.outputs.android_build }}
+            git tag -f "android-${PROFILE}-${ANDROID_BUILD}"
+          fi
+
+          if [ "$PLATFORM" = "all" ] || [ "$PLATFORM" = "ios" ]; then
+            IOS_BUILD=${{ steps.version_info.outputs.ios_build }}
+            git tag -f "ios-${PROFILE}-${IOS_BUILD}"
+          fi
+
+          git push origin --tags --force

--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -7,6 +7,7 @@ declare const process: {
 
 const projectId = '617bb643-5bf6-4c40-8af6-c6e9dd7e3bd0';
 const isPreview = process.env.APP_VARIANT === 'preview';
+const buildGitHash = process.env.EAS_BUILD_GIT_COMMIT_HASH || 'development';
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
@@ -49,6 +50,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     branchDomain: process.env.BRANCH_DOMAIN_PROD,
     inviteServiceEndpoint: process.env.INVITE_SERVICE_ENDPOINT,
     inviteServiceIsDev: process.env.INVITE_SERVICE_IS_DEV,
+    gitHash: buildGitHash ? buildGitHash.substring(0, 7) : 'dev',
   },
   ios: {
     runtimeVersion: '4.0.2',

--- a/apps/tlon-web/src/env.d.ts
+++ b/apps/tlon-web/src/env.d.ts
@@ -30,6 +30,7 @@ interface ImportMetaEnv
   readonly VITE_SHIP_URL: string;
   readonly VITE_INVITE_SERVICE_ENDPOINT: string;
   readonly VITE_INVITE_SERVICE_IS_DEV: 'true' | 'false' | undefined;
+  readonly VITE_GIT_HASH: string | undefined;
 }
 
 interface ImportMeta {

--- a/packages/app/lib/envVars.native.ts
+++ b/packages/app/lib/envVars.native.ts
@@ -45,6 +45,7 @@ export const BRANCH_DOMAIN = envVars.branchDomain ?? '';
 export const INVITE_SERVICE_ENDPOINT = envVars.inviteServiceEndpoint ?? '';
 export const INVITE_SERVICE_IS_DEV =
   envVars.inviteServiceIsDev === 'true' ? true : undefined;
+export const GIT_HASH = envVars.gitHash ?? 'unknown';
 
 export const ENV_VARS = {
   DEV_SHIP_URL,
@@ -74,4 +75,5 @@ export const ENV_VARS = {
   BRANCH_DOMAIN,
   INVITE_SERVICE_ENDPOINT,
   INVITE_SERVICE_IS_DEV,
+  GIT_HASH,
 };

--- a/packages/app/lib/envVars.ts
+++ b/packages/app/lib/envVars.ts
@@ -30,6 +30,7 @@ const envVars = {
   branchDomain: env.VITE_BRANCH_DOMAIN_PROD,
   inviteServiceEndpoint: env.VITE_INVITE_SERVICE_ENDPOINT,
   inviteServiceIsDev: env.VITE_INVITE_SERVICE_IS_DEV,
+  gitHash: env.VITE_GIT_HASH,
 } as Record<string, string | undefined>;
 
 export const DEV_SHIP_URL = envVars.devShipUrl ?? '';
@@ -69,6 +70,7 @@ export const BRANCH_DOMAIN = envVars.branchDomain ?? 'join.tlon.io';
 export const INVITE_SERVICE_ENDPOINT = envVars.inviteServiceEndpoint ?? '';
 export const INVITE_SERVICE_IS_DEV =
   envVars.inviteServiceIsDev === 'true' ? true : undefined;
+export const GIT_HASH = envVars.gitHash ?? 'unknown';
 
 export const ENV_VARS = {
   DEV_SHIP_URL,
@@ -99,4 +101,5 @@ export const ENV_VARS = {
   BRANCH_DOMAIN,
   INVITE_SERVICE_ENDPOINT,
   INVITE_SERVICE_IS_DEV,
+  GIT_HASH,
 };

--- a/packages/app/utils/posthog.ts
+++ b/packages/app/utils/posthog.ts
@@ -3,7 +3,7 @@ import { useDebugStore } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import PostHog from 'posthog-react-native';
 
-import { POST_HOG_API_KEY } from '../constants';
+import { GIT_HASH, POST_HOG_API_KEY } from '../constants';
 
 export type OnboardingProperties = {
   actionName: string;
@@ -34,6 +34,9 @@ posthogAsync?.then((client) => {
   posthog = client;
   crashlytics().setAttribute('analyticsId', client.getDistinctId());
   useDebugStore.getState().initializeErrorLogger(client);
+  posthog?.register({
+    gitHash: GIT_HASH,
+  });
 });
 
 const capture = (event: string, properties?: { [key: string]: any }) => {

--- a/packages/shared/src/domain/constants.ts
+++ b/packages/shared/src/domain/constants.ts
@@ -28,6 +28,7 @@ interface Constants {
   BRANCH_DOMAIN: string;
   INVITE_SERVICE_ENDPOINT: string;
   INVITE_SERVICE_IS_DEV: boolean;
+  GIT_HASH: string;
 }
 
 export function getConstants(): Constants {


### PR DESCRIPTION
## Summary

Adds git hash to posthog events and automatically adds build number tag to git repo (eg `android-preview-462`).

## Changes

- Adds git tag step to mobile build workflow
- Modifies `app.config.ts` to pass current git hash in eas environment
- Modifies glob and build workflow to pass git hash

## How did I test?

- Ran mobile workflow to test 
- Ran web + mobile locally to ensure nothing broken

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: Build system
