### PR TITLE
backend: fix PostHog 400 error

### DIFF
--- a/desk/ted/posthog.hoon
+++ b/desk/ted/posthog.hoon
@@ -52,7 +52,6 @@
   ?>(?=(%s -.u.event) u.event)
 =/  event=json
   %-  pairs:enjs:format
-  =/ distinct-id  
   =/  timestamp=@t
     %-  crip
     =+  (yore time.log-item)


### PR DESCRIPTION
## Summary

This was happening because their backend was updated to no longer accept numeric timestamps. Instead we need to send a standardized string representation.

## Changes

- use snippet for formatting `timestamp` value
- pull `distinct_id` up to top level, as described in PostHog docs

## How did I test?

Installed the desk and triggered a lib logs event.

## Risks and impact

- Safe to rollback without consulting PR author? yes
- Affects important code area: Telemetry

## Rollback plan

Revert and redeploy.
