### PR TITLE
broadcaster: update for latest chat types

### DIFF
--- a/desk/app/broadcaster.hoon
+++ b/desk/app/broadcaster.hoon
@@ -157,7 +157,7 @@
       :-  who
       :-  [our now]:bowl
       [%add essay ~]
-    [%pass wire %agent [our.bowl %chat] %poke %chat-dm-action !>(action)]
+    [%pass wire %agent [our.bowl %chat] %poke %chat-dm-action-1 !>(action)]
   ::
       %delete
     =/  =cohort
@@ -175,7 +175,7 @@
       /delete/(scot %t cohort.action)/(scot %da time-id.action)/(scot %p who)
     =/  =id:c         [our.bowl time-id.action]
     =/  =action:dm:c  [who id %del ~]
-    [%pass wire %agent [our.bowl %chat] %poke %chat-dm-action !>(action)]
+    [%pass wire %agent [our.bowl %chat] %poke %chat-dm-action-1 !>(action)]
   ==
 ::
 ++  on-agent


### PR DESCRIPTION
## Summary

Update the broadcaster agent for the latest chat/dm api.

## Changes

Broadcaster agent doesn't run by default, so it had slipped through the cracks of our upgrade process.

Here we update it to work with the latest chat types. Since we stored some of those types in our state, we must do a small state migration.

## How did I test?

Started broadcaster on a ship with previous groups, then updated to latest without this change. Didn't work. Applied these changes. It worked.

## Risks and impact

- Safe to rollback without consulting PR author, yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

I wouldn't worry about it.

## Screenshots / videos

You wish.
