### PR TITLE
desk: update egg-any version

### DIFF
--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -334,7 +334,7 @@
       %egg-any
     =+  !<(=egg-any:gall vase)
     ?-  -.egg-any
-        ?(%15 %16)
+        ?(%15 %16 %17)
       ?.  ?=(%live +<.egg-any)
         ~&  [dap.bowl %egg-any-not-live]
         cor

--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -408,7 +408,7 @@
   |=  =egg-any:gall
   =.  pimp  ~
   ?-  -.egg-any
-      ?(%15 %16)
+      ?(%15 %16 %17)
     ?.  ?=(%live +<.egg-any)
       ~&  [dap.bowl %egg-any-not-live]
       cor

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -664,7 +664,7 @@
   ^+  cor
   =.  pimp  ~
   ?-  -.egg-any
-      ?(%15 %16)
+      ?(%15 %16 %17)
     ?.  ?=(%live +<.egg-any)
       ~&  [dap.bowl %egg-any-not-live]
       cor

--- a/desk/app/chat.hoon
+++ b/desk/app/chat.hoon
@@ -570,7 +570,7 @@
       %egg-any
     =+  !<(=egg-any:gall vase)
     ?-  -.egg-any
-        ?(%15 %16)
+        ?(%15 %16 %17)
       ?.  ?=(%live +<.egg-any)
         ~&  [dap.bowl %egg-any-not-live]
         cor

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -291,7 +291,7 @@
   ^+  cor
   =.  pimp  ~
   ?-  -.egg-any
-      ?(%15 %16)
+      ?(%15 %16 %17)
     ?.  ?=(%live +<.egg-any)
       ~&  [dap.bowl %egg-any-not-live]
       cor

--- a/desk/app/profile.hoon
+++ b/desk/app/profile.hoon
@@ -357,7 +357,7 @@
       %egg-any
     =+  !<(=egg-any:gall vase)
     ?-  -.egg-any
-        ?(%15 %16)
+        ?(%15 %16 %17)
       ?.  ?=(%live +<.egg-any)
         ~&  [dap.bowl %egg-any-not-live]
         [~ this]


### PR DESCRIPTION
urbit/urbit#7181 was recently merged to fix a long-standing Gall bug. In the PR we wrote a Gall migration that did not change the type of the state but modified the `blocked` queue somewhat. We decided to increment the `egg-any` version also to keep it in sync with the Gall state version number, even though in this case it isn't strictly necessary. The state of Gall %16 and %17 is exactly the same.

All `egg-any` version bumps are technically breaking changes so in an ideal world that Gall PR should go out with a kelvin release. In practice I think that the amount of desks using the `egg-any` backup-and-restore feature is so small that we can get away with releasing the Gall fix in a 410 bugfix release, synchronizing it in such a way that this groups PR has been released beforehand. This allows us to release a fix for Gall bug as soon as possible.