### PR TITLE
settings: disable options menu on group/channel list items in push notification settings

### DIFF
--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -188,6 +188,7 @@ export function ExceptionsDisplay({
                 />
               }
               paddingVertical="$s"
+              disableOptions
             />
           );
         })}
@@ -210,6 +211,7 @@ export function ExceptionsDisplay({
                 />
               }
               paddingVertical="$s"
+              disableOptions
             />
           );
         })}


### PR DESCRIPTION
## Summary

We use GroupListItem and ChannelListItem to display groups or channels that follow a different push notification rule than the rule the user has set at the top level. Both of these components show an options menu by default unless we pass in `disableOptions`. Since that prop wasn't passed in, the options menu button was displayed on top of the "close" icon.

fixes tlon-4293

## Changes

We pass the `disableOptions` prop on both of those components.

## How did I test?

Tested on web, the only place this problem appears.

## Risks and impact

- Safe to rollback without consulting PR author? Yes, but the bug will come back.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert the merge commit.

## Screenshots / videos

![image](https://github.com/user-attachments/assets/758812b4-789a-42f9-90b4-a4a4f5fe3fab)
