### PR TITLE
group info: add pending members list back to group info screen

### DIFF
--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -447,7 +447,8 @@ function ChatMembersList({
   canInvite: boolean;
   canManage: boolean;
 }) {
-  const memberCount = members?.length ?? 0;
+  const joinedMembers = members?.filter((m) => m.status === 'joined');
+  const memberCount = joinedMembers?.length ?? 0;
   const { onPressGroupMembers, onPressChannelMembers, onPressInvite } =
     useChatOptions();
 
@@ -488,18 +489,20 @@ function ChatMembersList({
             </XStack>
           </Pressable>
         ) : null}
-        {members?.slice(0, maxMembersToDisplay).map((member: db.ChatMember) => {
-          return (
-            <ContactListItem
-              size="$3xl"
-              height="auto"
-              padding={0}
-              showNickname
-              key={member.contactId}
-              contactId={member.contactId}
-            />
-          );
-        })}
+        {joinedMembers
+          ?.slice(0, maxMembersToDisplay)
+          .map((member: db.ChatMember) => {
+            return (
+              <ContactListItem
+                size="$3xl"
+                height="auto"
+                padding={0}
+                showNickname
+                key={member.contactId}
+                contactId={member.contactId}
+              />
+            );
+          })}
         {(memberCount > maxMembersToDisplay || canInvite) && (
           <Pressable onPress={handlePressSeeAllMembers}>
             <XStack

--- a/packages/app/ui/components/GroupMembersScreenView.tsx
+++ b/packages/app/ui/components/GroupMembersScreenView.tsx
@@ -76,9 +76,11 @@ export function GroupMembersScreenView({
     [members]
   );
 
-  const membersWithoutRoles = members.filter(
-    (m) => m.roles?.length === 0 || m.roles === null
-  );
+  const membersWithoutRoles = members
+    .filter((m) => m.status !== 'invited')
+    .filter((m) => m.roles?.length === 0 || m.roles === null);
+
+  const invitedMembers = members.filter((m) => m.status === 'invited');
 
   const bannedUserData: db.ChatMember[] = useMemo(
     () =>
@@ -123,6 +125,16 @@ export function GroupMembersScreenView({
             : []
         )
         .concat(
+          invitedMembers.length > 0
+            ? [
+                {
+                  title: 'Invited',
+                  data: invitedMembers,
+                },
+              ]
+            : []
+        )
+        .concat(
           bannedUserData.length > 0 && currentUserIsAdmin
             ? [
                 {
@@ -147,6 +159,7 @@ export function GroupMembersScreenView({
       joinRequestData,
       bannedUserData,
       membersWithoutRoles,
+      invitedMembers,
       currentUserIsAdmin,
     ]
   );
@@ -213,6 +226,9 @@ export function GroupMembersScreenView({
           groupHostId={groupHostId}
           userIsBanned={bannedUsers.some(
             (b) => b.contactId === selectedContact
+          )}
+          userIsInvited={invitedMembers.some(
+            (m) => m.contactId === selectedContact
           )}
           onOpenChange={(open) => {
             if (!open) {

--- a/packages/app/ui/components/ProfileSheet.tsx
+++ b/packages/app/ui/components/ProfileSheet.tsx
@@ -78,6 +78,7 @@ export function ProfileSheet({
   groupHostId,
   groupIsOpen,
   userIsBanned,
+  userIsInvited,
   onPressBan,
   onPressUnban,
   onPressKick,
@@ -95,6 +96,7 @@ export function ProfileSheet({
   groupHostId?: string;
   groupIsOpen?: boolean;
   userIsBanned?: boolean;
+  userIsInvited?: boolean;
   onPressKick?: () => void;
   onPressBan?: () => void;
   onPressUnban?: () => void;
@@ -160,14 +162,15 @@ export function ProfileSheet({
             />
           ),
         },
-        currentUserId !== contactId && {
-          title: 'Kick User',
-          action: () => {
-            onPressKick?.();
-            onOpenChange(false);
+        currentUserId !== contactId &&
+          !userIsInvited && {
+            title: 'Kick User',
+            action: () => {
+              onPressKick?.();
+              onOpenChange(false);
+            },
           },
-        },
-        groupIsOpen && currentUserId !== contactId
+        groupIsOpen && currentUserId !== contactId && !userIsInvited
           ? userIsBanned
             ? {
                 title: 'Unban User',

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1388,6 +1388,7 @@ export const addChatMembers = createWriteQuery(
       chatId: string;
       contactIds: string[];
       type: 'group' | 'channel';
+      status: 'invited' | 'joined';
     },
     ctx: QueryCtx
   ) => {
@@ -1399,6 +1400,7 @@ export const addChatMembers = createWriteQuery(
             chatId,
             contactId,
             membershipType: type,
+            status: 'invited' as 'invited' | 'joined',
           }))
         )
         .onConflictDoNothing();

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -283,6 +283,7 @@ export async function inviteGroupMembers({
     chatId: groupId,
     type: 'group',
     contactIds,
+    status: 'invited',
   });
 
   logger.trackEvent(AnalyticsEvent.OnNetworkInvite, {
@@ -1024,6 +1025,7 @@ export async function kickUserFromGroup({
       chatId: groupId,
       type: 'group',
       contactIds: [contactId],
+      status: 'joined',
     });
   }
 }
@@ -1088,6 +1090,7 @@ export async function banUserFromGroup({
       chatId: groupId,
       type: 'group',
       contactIds: [contactId],
+      status: 'joined',
     });
 
     await db.deleteGroupMemberBans({
@@ -1197,6 +1200,7 @@ export async function acceptUserJoin({
     chatId: groupId,
     type: 'group',
     contactIds: [contactId],
+    status: 'joined',
   });
 
   await db.deleteGroupJoinRequests({

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -791,6 +791,7 @@ async function handleGroupUpdate(update: api.GroupUpdate, ctx: QueryCtx) {
           chatId: update.groupId,
           contactIds: update.ships,
           type: 'group',
+          status: 'joined',
         },
         ctx
       );


### PR DESCRIPTION
## Summary
fixes tlon-4386

This PR adds the pending members list back to the group members screen by properly handling invited members and displaying them in a separate "Invited" section.

The linear ticket suggested putting the "Invited" list after the "Everyone else" list, but the "Everyone else" list can be very long, so I opted to place it after the role sections and before the banned users and "everyone else" sections.

I would have added a "rescind invite" action to the ProfileSheet, but the %groups agent doesn't currently allow group admins to rescind and invitation once sent (the %group-rescind poke in %groups is unrelated, it's actually a way for a user to cancel an invite request to a private group).

## Changes

- **ChatDetailsScreen.tsx**: Modified member list to only show joined members (excluding invited members from count and display)
- **GroupMembersScreenView.tsx**: Added separate "Invited" section for invited members and updated member filtering to exclude invited members from the main member list
- **ProfileSheet.tsx**: Added `userIsInvited` prop and disabled kick/ban actions for invited users
- **groupsApi.ts**: Enhanced member processing to extract invited members from pending list and added `status` field to distinguish between invited and joined members
- **queries.ts**: Added `status` parameter to `addChatMembers` function to track member status
- **groupActions.ts**: Updated member management functions to properly set member status when adding/managing members

## How did I test?

Tested on web

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert the merge commit

## Screenshots / videos

<img width="930" height="913" alt="image" src="https://github.com/user-attachments/assets/859e7cda-05a4-4f8a-b313-c4b8e20c1b2e" />

