### PR TITLE
channels: send sequence numbers in json as numbers

### DIFF
--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -247,7 +247,7 @@
     |=  =seal:c
     %-  pairs
     :~  id+(id id.seal)
-        seq+(seq seq.seal)
+        seq+(numb seq.seal)
         mod-at+(mod-at mod-at.seal)
         reacts+(reacts reacts.seal)
         replies+(replies replies.seal)
@@ -330,10 +330,6 @@
   ++  id
     |=  =@da
     s+`@t`(rsh 4 (scot %ui da))
-  ::
-  ++  seq
-    |=  =@ud
-    s+`@t`(rsh 4 (scot %ui ud))
   ::
   ++  mod-at
     |=  =@da


### PR DESCRIPTION


## Summary

Send `number`s instead of `string`s for the `seq` field.

## Changes

Makes channel-json produce `number`s for sequence numbers, as opposed to `string`s. This should have slightly better client-side ergonomics.

We can go up to 2^53 sequential messages with this, should be enough for anyone.

We push this change straight in instead of doing a full API bump because integration of this data is still pending (in #4925).

## How did I test?

Looked at the resulting json.

## Risks and impact

- Safe to rollback without consulting PR author, sure.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [x] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert.

## Screenshots / videos

Zilch.
