### PR TITLE
discipline: remove own state from %egg-any imports

### DIFF
--- a/desk/lib/discipline.hoon
+++ b/desk/lib/discipline.hoon
@@ -268,9 +268,29 @@
     res
   ::
   ++  on-poke
-    |=  =cage
+    |=  [=mark =vase]
     ^-  (quip card _this)
-    =^  cards  inner  (on-poke:og cage)
+    ?.  ?&  ?=(%egg-any mark)
+            !:
+              =+  !<(=egg-any:gall vase)
+          ?&  ?=(%live +<.egg-any)
+              ?=([[%discipline *] *] q.old-state.egg-any)
+          ==  ==
+      =^  cards  inner  (on-poke:og mark vase)
+      =.  cards  (check-cards:help ~ cards)
+      [cards this]
+    ::  strip the negotiate state out of the egg,
+    ::  and pass it on to the inner agent
+    ::
+    =/  =cage  !:
+      :-  mark
+      !>  ^-  egg-any:gall
+      =+  !<(=egg-any:gall vase)
+      ?>  ?=(%live +<.egg-any)
+      %_  egg-any
+        +.old-state  (slot 3 +.old-state.egg-any)
+      ==
+    =^  cards  inner  (on-poke:og cage)  !:
     =.  cards  (check-cards:help ~ cards)
     [cards this]
   ::


### PR DESCRIPTION
## Summary

@pkova caught this yesterday while trying to run imports on dalwes. Discipline, just like other wrapper libraries (see: lib negotiate) needs to remove its own state before passing an import into the inner agent, otherwise the inner agent can't work with it.

## Changes

Agent exports obtained directly from gall will have the full state, including that of wrapper agents. /lib/discipline is no exception, and so needs to take care that when an agent gets an older egg imported into it, that it remove the library state before passing the egg into the inner agent.

## How did I test?

It compiles. We ran this same change manually yesterday.

## Risks and impact

- Safe to rollback without consulting PR author, yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Just revert.

## Screenshots / videos

Nay.
