### PR TITLE
groups: fix foreign insertion

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -4009,6 +4009,9 @@
       =.  foreigns
         %+  roll  ~(tap by previews)
         |=  [[=flag:gv =preview:v7:gv] =_foreigns]
+        ?.  (~(has by foreigns) flag)
+          =|  =foreign:v7:gv
+          (~(put by foreigns) flag foreign(preview `preview))
         %+  ~(jab by foreigns)  flag
         |=  far=foreign:v7:gv
         far(preview `preview)


### PR DESCRIPTION
## Summary

We were crashing here because the foreigns didn't exist yet (jab crashes on key not existing)

## Changes

- added case for when we don't have the foreign in state

## How did I test?

Ship A creates a private group (that ship B has never seen). Ship B then clicks "Join group" from the plus menu, and pastes shortcode from ship A the clicks go. Should see a non-empty state.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
