### PR TITLE
broadcaster: fix chat types

### DIFF
--- a/desk/app/broadcaster.hoon
+++ b/desk/app/broadcaster.hoon
@@ -13,7 +13,8 @@
 +$  cohort
   $:  targets=(set ship)
       logging=(list relive)
-      outward=(list writ:c4)  ::NOTE  invented-here fake seal?
+      :: TODO: outward is unused, remove?
+      outward=(list writ:c4)
   ==
 +$  relive
   $:  wen=@da


### PR DESCRIPTION
## Summary

We missed some types when adding chat sequence numbers. This is preventing the ship that uses %broadcaster from upgrading.

## Changes

- changed chat type to chat-4

## How did I test?

Compiled

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
