### PR TITLE
channel: represent "cannot read" state for a currently viewed channel

### DIFF
--- a/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
+++ b/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
@@ -5,11 +5,18 @@ import { SizableText, View, YStack } from 'tamagui';
 export function ReadOnlyNotice({
   type,
 }: {
-  type: 'read-only' | 'dm-mismatch' | 'group-dm-mismatch' | 'channel-mismatch';
+  type:
+    | 'read-only'
+    | 'dm-mismatch'
+    | 'group-dm-mismatch'
+    | 'channel-mismatch'
+    | 'no-longer-read';
 }) {
   const Message =
     type === 'read-only' ? (
       <>'This channel is read-only for you.'</>
+    ) : type === 'no-longer-read' ? (
+      <>You no longer have permission to read this channel.</>
     ) : (
       <>
         Your node&apos;s version of the Tlon app doesn&apos;t match the{' '}

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -165,6 +165,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const groups = useMemo(() => (group ? [group] : null), [group]);
     const currentUserId = useCurrentUserId();
     const canWrite = utils.useCanWrite(channel, currentUserId);
+    const canRead = utils.useCanRead(channel, currentUserId);
     const collectionRef = useRef<PostCollectionHandle>(null);
 
     const isChatChannel = channel ? getIsChatChannel(channel) : true;
@@ -426,16 +427,18 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                             )}
                           </AnimatePresence>
 
-                          {!canWrite || !negotiationMatch ? (
+                          {!canRead || !canWrite || !negotiationMatch ? (
                             <ReadOnlyNotice
                               type={
-                                !canWrite
-                                  ? 'read-only'
-                                  : isDM
-                                    ? 'dm-mismatch'
-                                    : isGroupDm
-                                      ? 'group-dm-mismatch'
-                                      : 'channel-mismatch'
+                                !canRead
+                                  ? 'no-longer-read'
+                                  : !canWrite
+                                    ? 'read-only'
+                                    : isDM
+                                      ? 'dm-mismatch'
+                                      : isGroupDm
+                                        ? 'group-dm-mismatch'
+                                        : 'channel-mismatch'
                               }
                             />
                           ) : channel.contentConfiguration == null ? (

--- a/packages/app/ui/utils/channelUtils.tsx
+++ b/packages/app/ui/utils/channelUtils.tsx
@@ -172,6 +172,21 @@ export function useCanWrite(channel: db.Channel, userId: string): boolean {
   return canWrite;
 }
 
+export function useCanRead(channel: db.Channel, userId: string): boolean {
+  const readers = useMemo(
+    () => channel.readerRoles?.map((role) => role.roleId) ?? [],
+    [channel.readerRoles]
+  );
+  const memberRoles = useMemberRoles(channel.groupId ?? '', userId);
+  const canRead = useMemo(
+    () =>
+      readers.length === 0 ||
+      memberRoles.some((role) => readers.includes(role)),
+    [readers, memberRoles]
+  );
+  return canRead;
+}
+
 export function getChannelTypeIcon(type: db.Channel['type']): IconType {
   switch (type) {
     case 'dm':


### PR DESCRIPTION
## Summary

fixes tlon-4608. 

Users can get into a weird state if they're actively viewing a channel while the admin for the group changes the channel permissions in such a way to prevent that user from viewing it.

The UI wouldn't update to show this new state, so the user wouldn't know that they can't read it (or post to it).

Normally it would be impossible to get into this state since you can't navigate to channels you're not allowed to read, this can only happen if you're actively viewing the channel.

This PR adds a new type to `ReadOnlyNotice`, `no-longer-read`, that lets the user know they can no longer read the channel. It also adds a new hook, `useCanRead`, that we call in the channel component to determine if the user is in this state.

## How did I test?

Tested on web and iOS simulator.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

revert

## Screenshots / videos

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-28 at 11 27 37" src="https://github.com/user-attachments/assets/99430046-94d3-4b93-b854-cae88ed68078" />

