### PR TITLE
DMs: fix issue where users needed to leave the DM and return to see u…

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3201,7 +3201,7 @@ export const deletePostReaction = createWriteQuery(
         )
       );
   },
-  ['postReactions']
+  ['posts', 'postReactions']
 );
 
 export const deletePosts = createWriteQuery(

--- a/packages/shared/src/store/sync.ts
+++ b/packages/shared/src/store/sync.ts
@@ -1231,7 +1231,7 @@ export const handleChatUpdate = async (
       await db.deletePosts({ ids: [update.postId] }, ctx);
       break;
     case 'addReaction':
-      db.insertPostReactions(
+      await db.insertPostReactions(
         {
           reactions: [
             {
@@ -1245,7 +1245,7 @@ export const handleChatUpdate = async (
       );
       break;
     case 'deleteReaction':
-      db.deletePostReaction(
+      await db.deletePostReaction(
         {
           postId: update.postId,
           contactId: update.userId,


### PR DESCRIPTION
## Summary

fixes tlon-4646.

After fixing the bug on Friday that had to do with emoji reactions in threads never persisting, I noticed that emoji reactions in DM threads were not live updating.

After stepping through the code path, I noticed that we're not awaiting the calls to `insertPostReactions` and `deletePostReaction` in `handleChatUpdate` in `sync.ts`. I also noticed we were missing a table dep on `deletePostReaction`. These should both be awaited. Awaiting them fixes the issue.

I'm still not certain why reactions on non-reply messages in DMs *were* live updating before this change, though. I thought it was maybe because of the `changeListener`, but it looks to me like the query keys we're using to refetch queries there are actually just wrong (the queries have nested query keys and the `['postReference', postId]` keys that we use there never resolve to a real query), so `changeListener` actually wasn't (and still isn't) doing anything for us for updating reactions.

I'm guessing that we were somehow getting updates because of `useChannelPosts`? Regardless, `awaiting` both `insertPostReactions` and `deletePostReaction` is the way this *should* work, and now we don't have to rely on however this might have been happening incidentally before.

Also, any objections to just removing the `post_reactions` related logic from `changeListener`?

## Changes

- awaited two functions that should have been awaited
- added a missing table dep to `deletePostReaction`

## How did I test?

desktop web

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Revert