### PR TITLE
make sqlite exec async

### DIFF
--- a/packages/app/lib/betterSqlite3Connection.ts
+++ b/packages/app/lib/betterSqlite3Connection.ts
@@ -10,7 +10,7 @@ import type { SQLiteConnection } from './sqliteConnection';
 export class BetterSqlite3$SQLiteConnection implements SQLiteConnection {
   constructor(private connection: Database) {}
 
-  execute(query: string): void {
+  async execute(query: string): Promise<void> {
     this.connection.exec(query);
   }
 
@@ -47,12 +47,11 @@ export class BetterSqlite3$SQLiteConnection implements SQLiteConnection {
   }
 
   async migrateClient(_client: AnySqliteDatabase): Promise<void> {
-    Object.entries(migrations.migrations)
-      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-      .forEach(([_key, migration]) => {
-        this.execute(migration);
-      });
-    return;
+    await Promise.all(
+      Object.entries(migrations.migrations)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+        .map(([_key, migration]) => this.execute(migration))
+    );
   }
 
   createClient(opts: DrizzleConfig<Schema>): AnySqliteDatabase {

--- a/packages/app/lib/opsqliteConnection.ts
+++ b/packages/app/lib/opsqliteConnection.ts
@@ -13,8 +13,8 @@ export class OPSQLite$SQLiteConnection
 {
   constructor(private connection: DB) {}
 
-  execute(query: string): void {
-    this.connection.execute(query);
+  async execute(query: string): Promise<void> {
+    await this.connection.execute(query);
   }
 
   updateHook(

--- a/packages/app/lib/sqliteConnection.ts
+++ b/packages/app/lib/sqliteConnection.ts
@@ -10,7 +10,7 @@ import type { DrizzleConfig } from 'drizzle-orm/utils';
 export interface SQLiteConnection<
   Client extends AnySqliteDatabase = AnySqliteDatabase,
 > {
-  execute(query: string): void;
+  execute(query: string): Promise<void>;
   updateHook(
     callback:
       | ((params: {


### PR DESCRIPTION
## Summary

Make sqlite connection `exec` method async and await calls. Fixes TLON-4234.

## How did I test?

Tested on web, iOS + Android.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Revert
