### PR TITLE
streamline post filtering logic and fix deduplication

### DIFF
--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -28,10 +28,12 @@ describe('mergePendingPosts with hasNewest = true', () => {
     const mergedSentAts = mergePendingPosts({
       pendingPosts,
       existingPosts,
+      deletedPosts: {},
+      newPosts: [],
       hasNewest: true,
     }).map((p) => p.sentAt);
 
-    expect(mergedSentAts).toEqual([5, 4, 1]);
+    expect(mergedSentAts).toEqual([4, 5, 1]);
   });
 
   // Test Case: Pending posts are all newer than existing posts
@@ -42,6 +44,8 @@ describe('mergePendingPosts with hasNewest = true', () => {
     const mergedSentAts = mergePendingPosts({
       pendingPosts,
       existingPosts,
+      deletedPosts: {},
+      newPosts: [],
       hasNewest: true,
     }).map((p) => p.sentAt);
 
@@ -56,24 +60,12 @@ describe('mergePendingPosts with hasNewest = true', () => {
     const mergedSentAts = mergePendingPosts({
       pendingPosts,
       existingPosts,
+      deletedPosts: {},
+      newPosts: [],
       hasNewest: true,
     }).map((p) => p.sentAt);
 
     expect(mergedSentAts).toEqual([4, 3, 2]);
-  });
-
-  // Test Case: Pending posts older than the lowest existing post are filtered out
-  test('should filter out pending posts with sentAts equal to or less than the lowest existing', () => {
-    const existingPosts = [makePost(5), makePost(3)];
-    const pendingPosts = [makePost(6), makePost(2), makePost(1)]; // 2 and 1 should be filtered
-
-    const mergedSentAts = mergePendingPosts({
-      pendingPosts,
-      existingPosts,
-      hasNewest: true,
-    }).map((p) => p.sentAt);
-
-    expect(mergedSentAts).toEqual([6, 5, 3]);
   });
 });
 
@@ -86,10 +78,12 @@ describe('mergePendingPosts with hasNewest = false', () => {
     const mergedSentAts = mergePendingPosts({
       pendingPosts,
       existingPosts,
+      deletedPosts: {},
+      newPosts: [],
       hasNewest: false,
     }).map((p) => p.sentAt);
 
-    expect(mergedSentAts).toEqual([5, 4, 3, 2, 1]);
+    expect(mergedSentAts).toEqual([4, 2, 5, 3, 1]);
   });
 
   // Test Case: Only pending posts within the existing posts' range are inserted
@@ -100,10 +94,12 @@ describe('mergePendingPosts with hasNewest = false', () => {
     const mergedSentAts = mergePendingPosts({
       pendingPosts,
       existingPosts,
+      deletedPosts: {},
+      newPosts: [],
       hasNewest: false,
     }).map((p) => p.sentAt);
 
-    expect(mergedSentAts).toEqual([5, 4, 2, 1]);
+    expect(mergedSentAts).toEqual([4, 2, 5, 1]);
   });
 
   // Test Case: Pending post older than lowest existing should still be filtered out
@@ -114,6 +110,8 @@ describe('mergePendingPosts with hasNewest = false', () => {
     const mergedSentAts = mergePendingPosts({
       pendingPosts,
       existingPosts,
+      deletedPosts: {},
+      newPosts: [],
       hasNewest: false,
     }).map((p) => p.sentAt);
 
@@ -128,9 +126,11 @@ describe('mergePendingPosts Edge Cases', () => {
     const pendingPosts = [makePost(5), makePost(3)];
 
     const mergedSentAts = mergePendingPosts({
+      newPosts: [],
       pendingPosts,
       existingPosts,
-      hasNewest: true,
+      deletedPosts: {},
+      hasNewest: false,
     }).map((p) => p.sentAt);
 
     expect(mergedSentAts).toEqual([5, 3]);
@@ -142,9 +142,11 @@ describe('mergePendingPosts Edge Cases', () => {
     const pendingPosts: Post[] = [];
 
     const mergedSentAts = mergePendingPosts({
+      newPosts: [],
       pendingPosts,
       existingPosts,
-      hasNewest: true,
+      deletedPosts: {},
+      hasNewest: false,
     }).map((p) => p.sentAt);
 
     expect(mergedSentAts).toEqual([5, 3]);
@@ -156,9 +158,11 @@ describe('mergePendingPosts Edge Cases', () => {
     const pendingPosts: Post[] = [];
 
     const mergedSentAts = mergePendingPosts({
+      newPosts: [],
       pendingPosts,
       existingPosts,
-      hasNewest: true,
+      deletedPosts: {},
+      hasNewest: false,
     }).map((p) => p.sentAt);
 
     expect(mergedSentAts).toEqual([]);
@@ -167,12 +171,14 @@ describe('mergePendingPosts Edge Cases', () => {
   // Test Case: No pending posts are relevant to the window after filtering
   test('should return only existing posts when all pending posts are filtered out', () => {
     const existingPosts = [makePost(5), makePost(3)];
-    const pendingPosts = [makePost(1), makePost(0)]; // Both are filtered out
+    const pendingPosts = [makePost(5), makePost(3)];
 
     const mergedSentAts = mergePendingPosts({
+      newPosts: [],
       pendingPosts,
       existingPosts,
-      hasNewest: true,
+      deletedPosts: {},
+      hasNewest: false,
     }).map((p) => p.sentAt);
 
     expect(mergedSentAts).toEqual([5, 3]);

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -4,91 +4,60 @@ import * as db from '../db';
  * Pending posts aren't assigned sequence numbers, so we need to weave them into the existing posts
  * we want to display based on what we do have (sentAt)
  *
+ * @param newPosts An array of posts that have come in since we started querying
  * @param pendingPosts An array of all pending posts for the channel, sorted newest first.
  * @param existingPosts A contiguous sequence of confirmed posts, sorted newest first.
+ * @param deletedPosts A map of post IDs to a boolean indicating if the post has been deleted.
  * @param hasNewest A boolean indicating if existingPosts represents the newest available messages.
+ * @param filterDeleted A boolean indicating if deleted posts should be filtered out.
  * @returns A single array of posts, sorted newest first, with relevant pending posts woven in.
  */
 export const mergePendingPosts = ({
+  newPosts,
   pendingPosts,
   existingPosts,
+  deletedPosts,
   hasNewest,
+  filterDeleted = false,
 }: {
+  newPosts: db.Post[];
   pendingPosts: db.Post[];
   existingPosts: db.Post[];
+  deletedPosts: Record<string, boolean>;
   hasNewest: boolean;
+  filterDeleted?: boolean;
 }): db.Post[] => {
-  // --- Step 1: Handle Initial Edge Cases ---
-  if (!existingPosts.length) {
-    // If no existing posts, the list is just the pending posts.
-    return pendingPosts;
-  }
-
-  if (!pendingPosts.length) {
-    // If there are no pending posts, the list is just the existing posts.
-    return existingPosts;
-  }
+  const sentAtMap = new Map<number, db.Post>();
+  [...newPosts, ...pendingPosts].forEach((post) => {
+    if (!sentAtMap.has(post.sentAt)) {
+      sentAtMap.set(post.sentAt, post);
+    }
+  });
+  const newAndPendingPosts = Array.from(sentAtMap.values()).sort((a, b) => {
+    const aUnconfirmed = a.sequenceNum === 0;
+    const bUnconfirmed = b.sequenceNum === 0;
+    if (aUnconfirmed !== bUnconfirmed) return aUnconfirmed ? -1 : 1;
+    return aUnconfirmed ? b.sentAt - a.sentAt : b.receivedAt - a.receivedAt;
+  });
+  if (!existingPosts.length) return newAndPendingPosts;
 
   // --- Step 2: Establish the Filtering Window for pendingPosts ---
-  const lowestBound = existingPosts[existingPosts.length - 1].sentAt;
-  const highestBound = hasNewest ? Infinity : existingPosts[0].sentAt;
+  const lowerPaginationBound = existingPosts[existingPosts.length - 1].sentAt;
+  const upperPaginationBound = hasNewest ? Infinity : existingPosts[0].sentAt;
 
-  // Filter out pending posts outside the chronological window.
-  const relevantPendingPosts = pendingPosts.filter(
-    (p) => p.sentAt > lowestBound && p.sentAt <= highestBound
-  );
+  const filteredNewPosts = newAndPendingPosts.filter((p) => {
+    return (
+      p.sentAt > lowerPaginationBound &&
+      p.sentAt < upperPaginationBound &&
+      !existingPosts.some((existing) => existing.sentAt === p.sentAt)
+    );
+  });
+  const finalPosts = [...filteredNewPosts, ...existingPosts];
 
-  // If no pending posts are relevant to this specific window, just return the existing posts.
-  if (!relevantPendingPosts.length) {
-    return existingPosts;
-  }
-
-  // --- Step 3: Perform a Two-Pointer Merge ---
-  const mergedPosts: db.Post[] = [];
-  let pendingPointer = 0;
-  let existingPointer = 0;
-
-  while (
-    pendingPointer < relevantPendingPosts.length ||
-    existingPointer < existingPosts.length
-  ) {
-    const currentPending = relevantPendingPosts[pendingPointer];
-    const currentExisting = existingPosts[existingPointer];
-
-    // Case A: Only pending posts remain
-    if (!currentExisting) {
-      mergedPosts.push(currentPending);
-      pendingPointer++;
-      continue;
-    }
-
-    // Case B: Only existing posts remain
-    if (!currentPending) {
-      mergedPosts.push(currentExisting);
-      existingPointer++;
-      continue;
-    }
-
-    // Case C: Deduplication (sentAt matches)
-    // Assume if sentAt is identical, the pending post has become an existing post.
-    // Prioritize the existing post as it is the "official" version.
-    if (currentPending.sentAt === currentExisting.sentAt) {
-      mergedPosts.push(currentExisting);
-      pendingPointer++;
-      existingPointer++;
-      continue;
-    }
-
-    // Case D: Standard Merge (compare sentAt)
-    // Push the chronologically newer post into the merged list.
-    if (currentPending.sentAt > currentExisting.sentAt) {
-      mergedPosts.push(currentPending);
-      pendingPointer++;
-    } else {
-      mergedPosts.push(currentExisting);
-      existingPointer++;
-    }
-  }
-
-  return mergedPosts;
+  return finalPosts.filter((p) => {
+    return (
+      !p.isSequenceStub &&
+      (!filterDeleted || (!p.isDeleted && !deletedPosts[p.id]))
+    );
+  });
 };


### PR DESCRIPTION
## Summary

This PR simplifies post filtering and ensures that posts are not duplicated across `newPosts`, `pendingPosts`, and `existingPosts`

## Changes

- Moved all filtering logic to `useMergePendingPosts`
- Added deduplication between `addedPosts` and `pendingPosts`
- Modified sorting to sort unconfirmed message in front of confirmed ones, regardless of sent times.
- Updated tests.

## How did I test?

Tested rapid sending of messages on web.