### PR TITLE
fix image validation

### DIFF
--- a/packages/app/ui/components/EditProfileScreenView.tsx
+++ b/packages/app/ui/components/EditProfileScreenView.tsx
@@ -238,7 +238,7 @@ export function EditProfileScreenView(props: Props) {
               }}
               rules={{
                 pattern: {
-                  value: /^(?!file).+/,
+                  value: /^(?!file|data).+/,
                   message: 'Image has not finished uploading',
                 },
               }}

--- a/packages/app/ui/components/MetaEditorScreenView.tsx
+++ b/packages/app/ui/components/MetaEditorScreenView.tsx
@@ -121,7 +121,7 @@ export function MetaEditorScreenView({
               }}
               rules={{
                 pattern: {
-                  value: /^(?!file).+/,
+                  value: /^(?!file|data).+/,
                   message: 'Image has not finished uploading',
                 },
               }}


### PR DESCRIPTION
## Summary

The regex we were using to determine whether the image url was valid only worked on mobile. This PR updates it to work for desktop and web.

## Changes

Updates valid image regex in profile and group info editors.