### PR TITLE
channels-server: fix wrong logging wire

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -132,7 +132,7 @@
 ++  emit  |=(=card cor(cards [card cards]))
 ++  emil  |=(caz=(list card) cor(cards (welp (flop caz) cards)))
 ++  give  |=(=gift:agent:gall (emit %give gift))
-++  log   ~(. logs [our.bowl /channels-server])
+++  log   ~(. logs [our.bowl /logs])
 ++  safe-watch
   |=  [=wire =dock =path]
   ^+  cor


### PR DESCRIPTION
## Summary

As part of the sequence numbers changes, a wrong wire was mistakenly put in place of the usual `/logs` in the channels-server, causing a crash after each logging event.

## Changes

Fix the wire.

## How did I test?

Compiled.

## Risks and impact

- Safe to rollback without consulting PR author? No
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications

## Rollback plan

Should not be rolled back.
