### PR TITLE
changes: fallback to full sync if stamp is old & more telemetry

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -7,7 +7,6 @@ import { useFindSuggestedContacts } from '@tloncorp/app/hooks/useFindSuggestedCo
 import { useNetworkLogger } from '@tloncorp/app/hooks/useNetworkLogger';
 import { useTelemetry } from '@tloncorp/app/hooks/useTelemetry';
 import { useUpdatePresentedNotifications } from '@tloncorp/app/lib/notifications';
-import { hapticPerfSignal } from '@tloncorp/app/lib/platformHelpers';
 import { RootStack } from '@tloncorp/app/navigation/RootStack';
 import { AppDataProvider } from '@tloncorp/app/provider/AppDataProvider';
 import {

--- a/packages/shared/src/api/changesApi.ts
+++ b/packages/shared/src/api/changesApi.ts
@@ -6,11 +6,14 @@ import { toClientUnreads } from './activityApi';
 import { v1PeerToClientProfile } from './contactsApi';
 import { toClientGroups } from './groupsApi';
 import { toPostsData } from './postsApi';
-import { scry } from './urbit';
+import { checkIsNodeBusy, scry } from './urbit';
 
 export async function fetchChangesSince(
   timestamp: number
-): Promise<db.ChangesResult> {
+): Promise<
+  db.ChangesResult & { nodeBusyStatus: 'available' | 'busy' | 'unknown' }
+> {
+  const nodeIsBusy = checkIsNodeBusy();
   const encodedTimestamp = formatDa(unixToDa(timestamp));
   const response = await scry<ub.Changes>({
     app: 'groups-ui',
@@ -33,5 +36,13 @@ export async function fetchChangesSince(
 
   const unreads = toClientUnreads(response.activity);
 
-  return { groups, posts, contacts, unreads };
+  const nodeBusyStatus = await Promise.race([nodeIsBusy, timedOutDefault(500)]);
+
+  return { groups, posts, contacts, unreads, nodeBusyStatus };
+}
+
+// We want to avoid the UX of waiting too long for the busy check to return. It's served by the runtime,
+// so should in theory always be quicker. But adding a timeout race to be safe.
+async function timedOutDefault(ms: number): Promise<'unknown'> {
+  return new Promise((resolve) => setTimeout(() => resolve('unknown'), ms));
 }

--- a/packages/shared/src/api/urbit.ts
+++ b/packages/shared/src/api/urbit.ts
@@ -556,6 +556,10 @@ async function track<R>(
   });
 }
 
+export async function checkIsNodeBusy() {
+  return config.client?.checkIsNodeBusy() || Promise.resolve('unknown');
+}
+
 export async function scry<T>({
   app,
   path,

--- a/packages/shared/src/http-api/Urbit.ts
+++ b/packages/shared/src/http-api/Urbit.ts
@@ -868,6 +868,27 @@ export class Urbit {
     }
   }
 
+  async checkIsNodeBusy(): Promise<'available' | 'busy' | 'unknown'> {
+    try {
+      const response = await this.fetchFn(`${this.url}/~_~/healthz`, {
+        method: 'GET',
+      });
+      if (response.status === 204) {
+        return 'available';
+      }
+      if (response.status === 429) {
+        return 'busy';
+      }
+      logger.trackEvent('Unexpected node busy response', {
+        status: response.status,
+      });
+      return 'unknown';
+    } catch (e) {
+      logger.trackEvent('Failed to check if node is busy', { error: e });
+      return 'unknown';
+    }
+  }
+
   /**
    * Scry into an gall agent at a path
    *


### PR DESCRIPTION
## Summary

- if our `/changes` stamp is more than 3 days old, fall back to a normal "full sync" on app open (i.e. `syncStart`)
- include breakdown of time to fetch vs time to write + a new check for whether your node was busy in `/changes` telemetry

## Changes
- modify `syncLatestChanges` accordingly
- new `http-api` method for using the `/~_~/healthz` endpoint (ty @Fang- )

## How did I test?

Faked an old stamp, confirmed it falls back.

Ran multiple times until I got both `busy` and `available` results from the busy check.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - Message sync
