### PR TITLE
reel: v6 migration to update links profile metadata

### DIFF
--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -188,7 +188,7 @@
   =^  caz=(list card)  old
     ?.  ?=(%5 -.old)  `old
     :_  old(- %6)
-    =+  wait=(mul ~s1 (~(rad og eny.bowl) 3.600))
+    =+  wait=(~(rad og eny.bowl) ~h1)
     [%pass /load/profile %arvo %b %wait (add now.bowl wait)]~
   ?>  ?=(%6 -.old)
   =.  state  old


### PR DESCRIPTION
## Summary

The recently deployed lure sync feature only updates invite links on received events from either contacts or groups. Ships which will not update their profile data will not be able to take advantage of this and have their links updated to match their most recent profile information. To address this, we perform a v6 migration that automatically triggers a refresh of _all_ locally generated links using latest profile information retrieved from `%contacts`.

Fixes TLON-4849

## Changes

1. Perform v6 migration which schedules a timer with a random jitter to offload the bait provider. When the timer fires, reel agent injects a synthetic profile update, which triggers the update of all local links. If invite links were already up to date at the time of the migration no update will be performed.

## How did I test?

A ship was setup with an out-of-date personal link, while the subscription to contacts of the reel agent was cut off. I then updated the profile, and verified that the link metadata were not updated. The subscription was then restored, and migration was performed. After migration, the link appeared updated with new profile information.

Backend unit tests pass ✅
## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Can't be exactly rolled back because this is a state migration. However, the link update can be simply removed to restore original functionality.
