### PR TITLE
images: make sure files uploaded to memex or downloaded to device have a file extension

### DIFF
--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -12,6 +12,7 @@ import { createDevLogger, escapeLog } from '../../debug';
 import { setUploadState } from './storageUploadState';
 import {
   fetchFileFromUri,
+  getExtensionFromMimeType,
   getMemexUpload,
   hasCustomS3Creds,
   hasHostingUploadCreds,
@@ -20,23 +21,6 @@ import {
 const logger = createDevLogger('storageActions', false);
 
 export const PLACEHOLDER_ASSET_URI = 'placeholder-asset-id';
-
-function getExtensionFromMimeType(mimeType?: string): string {
-  if (!mimeType) {
-    return '.jpg';
-  }
-
-  const mimeToExt: Record<string, string> = {
-    'image/jpeg': '.jpg',
-    'image/jpg': '.jpg',
-    'image/png': '.png',
-    'image/gif': '.gif',
-    'image/webp': '.webp',
-    'image/heic': '.heic',
-    'image/heif': '.heif',
-  };
-  return mimeToExt[mimeType.toLowerCase()] || '.jpg';
-}
 
 function getSaveFormat(mimeType?: string): SaveFormat {
   if (!mimeType) {


### PR DESCRIPTION
fixes tlon-4593

## Summary

Users were seeing an alert saying "Failed to save image to photos. Please check your device storage and try again" when they attempted to download some images from the ImageViewerScreenView via the download button.

I was able to repro this by attempting to download any image with a filename that *didn't* include a filetype extension. 

That specific error language about checking device storage is just what we show anytime we see any errors with saving. The console showed this:

```
Save error: Error: This file type is not supported yet
    at construct (native)
    at apply (native)
    at _construct (http://192.168.0.46:8081/apps/tlon-mobile/index.bundle//&platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:3623:67)
    at Wrapper (http://192.168.0.46:8081/apps/tlon-mobile/index.bundle//&platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:3595:25)
    at construct (native)
    at _callSuper (http://192.168.0.46:8081/apps/tlon-mobile/index.bundle//&platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:110001:170)
    at CodedError (http://192.168.0.46:8081/apps/tlon-mobile/index.bundle//&platform=ios&dev=true&hot=false&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable:110012:25)
```

I added a function to take on a filetype extension to the URLs, and the images save just fine.

So, we actually had two problems:

1) Some images are uploaded to memex without a filtype extension.
2) Expo's MediaLibrary won't allow a user to attempt to download a file without an extension.

And a third problem if you count the fact that you *could* download these files on web, but without an extension your OS wouldn't know how to open them.
  

## Changes

- add `ensureFileExtension` to `ImageViewerScreenView` to catch any instance of a previously uploaded image without an extension (there are surely many of these floating around).
- add `getExtensionFromMimeType` to `storageActions` so we can add an appropriate filetype extension to any uploaded file before upload.

Both default to `.jpg` if we can't infer the appropriate extension from the MIME type.

## How did I test?

Tested on iOS, Android, and Web. Made sure image uploads/downloads still work where they should.

If you'd like to test yourself, a known-bad image is the latest image uploaded by Galen to the Tlon Studio groups's 2025 Studio gallery (it's a picture of a red flower). Try it on develop vs this branch.

Try uploading images via memex and make sure they have a file extension.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: image uploads.

## Rollback plan

Revert

## Screenshots / videos

N/A
