### PR TITLE
web scroller: stick to scroll start when scroll is <1px away from start

### DIFF
--- a/packages/app/ui/components/Channel/PostList/PostList.web.tsx
+++ b/packages/app/ui/components/Channel/PostList/PostList.web.tsx
@@ -1,5 +1,5 @@
 import { useMutableCallback } from '@tloncorp/shared';
-import { isEqual } from 'lodash';
+import { isEqual, memoize } from 'lodash';
 import * as React from 'react';
 import { View } from 'react-native';
 
@@ -136,7 +136,12 @@ const PostListSingleColumn: PostListComponent = React.forwardRef(
 
     const [insideScrolledToBottomBoundary] = useScrollBoundary(
       scrollerRef.current,
-      { boundaryRatio: onScrolledToBottomThreshold, side: 'bottom' }
+      {
+        isNearBoundary: withinViewportRatioOfBoundary(
+          onScrolledToBottomThreshold
+        ),
+        side: 'bottom',
+      }
     );
     React.useEffect(() => {
       if (insideScrolledToBottomBoundary) {
@@ -285,21 +290,21 @@ function PostListItem({
 
 function isElementScrolledNearTop(
   element: HTMLElement,
-  boundaryRatio: number
+  isNearBoundary: (distance: number, viewportHeight: number) => boolean
 ): boolean {
   const distanceFromTop = element.scrollTop;
   const viewportHeight = element.clientHeight;
-  const isNearTop = distanceFromTop / viewportHeight <= boundaryRatio;
+  const isNearTop = isNearBoundary(distanceFromTop, viewportHeight);
   return isNearTop;
 }
 function isElementScrolledNearBottom(
   element: HTMLElement,
-  boundaryRatio: number
+  isNearBoundary: (distance: number, viewportHeight: number) => boolean
 ): boolean {
   const distanceFromBottom =
     element.scrollHeight - (element.scrollTop + element.clientHeight);
   const viewportHeight = element.clientHeight;
-  const isNearBottom = distanceFromBottom / viewportHeight <= boundaryRatio;
+  const isNearBottom = isNearBoundary(distanceFromBottom, viewportHeight);
   return isNearBottom;
 }
 
@@ -337,14 +342,10 @@ function isElementScrolledNearBottom(
 function useScrollBoundary(
   element: HTMLElement | null,
   {
-    boundaryRatio,
+    isNearBoundary,
     side,
   }: {
-    /**
-     * Max ratio of (distance to boundary) / (viewport height) that will be considered "near boundary".
-     * e.g. `boundaryRatio: 0.5` means that `isNearTop` will be true once we're a half screen from the top of the scroll.
-     */
-    boundaryRatio: number;
+    isNearBoundary: (distance: number, viewportHeight: number) => boolean;
     side: 'top' | 'bottom';
   }
 ) {
@@ -354,8 +355,8 @@ function useScrollBoundary(
     }
     const check =
       side === 'top' ? isElementScrolledNearTop : isElementScrolledNearBottom;
-    return check(element, boundaryRatio);
-  }, [element, side, boundaryRatio]);
+    return check(element, isNearBoundary);
+  }, [element, side, isNearBoundary]);
 
   const [insideBoundary, setInsideBoundary] = React.useState(
     () => checkInsideBoundary() ?? false
@@ -372,7 +373,7 @@ function useScrollBoundary(
     return () => {
       element.removeEventListener('scroll', handleScroll);
     };
-  }, [element, boundaryRatio, checkInsideBoundary]);
+  }, [element, checkInsideBoundary]);
   return [insideBoundary, checkInsideBoundary] as const;
 }
 
@@ -556,7 +557,8 @@ function useStickToScrollStart({
   const shouldStickToStartRef = React.useRef(false);
 
   const [isAtStart] = useScrollBoundary(scrollerRef.current, {
-    boundaryRatio: 0,
+    // Avoid subpixel issues by allowing distances <1px
+    isNearBoundary: React.useCallback((distance: number) => distance < 1, []),
     side: inverted ? 'bottom' : 'top',
   });
 
@@ -651,7 +653,7 @@ function useBoundaryCallbacks({
     onStartReached ?? null
   );
   const [reachedStart, getReachedStart] = useScrollBoundary(element, {
-    boundaryRatio: onStartReachedThreshold,
+    isNearBoundary: withinViewportRatioOfBoundary(onStartReachedThreshold),
     side: inverted ? 'bottom' : 'top',
   });
   React.useEffect(() => {
@@ -690,7 +692,7 @@ function useBoundaryCallbacks({
     onEndReached ?? null
   );
   const [reachedEnd, getReachedEnd] = useScrollBoundary(element, {
-    boundaryRatio: onEndReachedThreshold,
+    isNearBoundary: withinViewportRatioOfBoundary(onEndReachedThreshold),
     side: inverted ? 'top' : 'bottom',
   });
   React.useEffect(() => {
@@ -803,3 +805,16 @@ function useIdentityHash(...deps: unknown[]): unknown {
   }, [deps]);
   return hash;
 }
+
+/**
+ * Returns a function for `useScrollBoundary`'s `isNearBoundary` that checks
+ * if the distance to the boundary is within `viewportRatio * viewportHeight`.
+ * Useful for matching the behavior of `VirtualizedList`'s
+ * `onStartReachedThreshold` and `onEndReachedThreshold`, which are expressed as
+ * ratios of the viewport height.
+ */
+const withinViewportRatioOfBoundary = memoize(
+  (viewportRatio: number) =>
+    (distance: number, viewportHeight: number): boolean =>
+      distance / viewportHeight <= viewportRatio
+);


### PR DESCRIPTION
## Summary
fixes TLON-4859
When sticking to scroll start, keep stuck if scrolled <1px away from start. (Previously, we had 0px of tolerance.)

## Changes
- Changes `useScrollBoundary`'s predicate arg for "is near boundary" to a function so we can support both "ratio of viewport" and "is within constant distance" checks
- Changes `useStickToScrollStart` to consider scroll to be "near start" if within 1px of scroll

I used 1px because, in the "repro" below, I found that the scroll was becoming unstuck because of the scroll reporting itself a varying distance from bottom, always less than 1 pixel. I don't know the true root cause - my guess right now is that the very first "scroll to most recent unread" has sub pixel inaccuracy.

## How did I test?
I don't have a great repro, but I found this on macOS Firefox:
1. set up a group with 2 chat channels
2. send message in first channel
3. switch to other, send message
4. switch back and forth, sending messages until bug is hit
bug happens randomly but generally within 10 tries

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
git revert

## Screenshots / videos

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ceee8bfd-e97c-4f2e-8c62-9a3fd3a7c7c7" /> | <video src="https://github.com/user-attachments/assets/5059a947-14ec-4e1c-a0e3-3404c287d98f" /> |