### PR TITLE
pending posts: don't show pending replies in main chat

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -897,7 +897,7 @@ export const getChats = createReadQuery(
       id: g.id,
       type: 'group',
       pin: g.pin,
-      timestamp: g.haveInvite 
+      timestamp: g.haveInvite
         ? g.unread?.updatedAt ?? 0
         : g.lastPostAt ?? g.unread?.updatedAt ?? 0,
       volumeSettings: g.volumeSettings,
@@ -3605,7 +3605,8 @@ export const getPendingPosts = createReadQuery(
     return ctx.db.query.posts.findMany({
       where: and(
         eq($posts.channelId, channelId),
-        isNotNull($posts.deliveryStatus)
+        isNotNull($posts.deliveryStatus),
+        not(eq($posts.type, 'reply'))
       ),
     });
   },


### PR DESCRIPTION
## Summary

OTT, fixes tlon-4884.

`usePendingPostsInChannel` uses our `getPendingPosts` db query. This query wasn't filtering out replies. Now it does, and pending replies appear where they should.

## How did I test?

Tested on web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert

## Screenshots / videos

N/A
