### PR TITLE
broadcaster: fix compile errors

### DIFF
--- a/desk/app/broadcaster.hoon
+++ b/desk/app/broadcaster.hoon
@@ -1,7 +1,7 @@
 ::  broadcaster: multi-target dms
 ::
-/-  c=chat, ch=channels
-/+  cj=channel-json, dm,
+/-  c=chat, c3=chat-3, c4=chat-4, ch=channels
+/+  sj=story-json, cc=chat-conv,
     dbug, verb
 ::
 |%
@@ -90,7 +90,7 @@
   ++  outward-0-to-1
     |=  outward=(list writ:c3)
     ^-  (list writ:c4)
-    (turn outward writ-7-to-8:dm)
+    (turn outward v4:writ:v3:cc)
   --
 ::
 ++  on-poke
@@ -207,7 +207,7 @@
     ?-  +<.r
       %add  a+(turn ~(tap in targets.r) |=(=@p s+(scot %p p)))
       %del  a+(turn ~(tap in targets.r) |=(=@p s+(scot %p p)))
-      %msg  (story:enjs:cj story.r)
+      %msg  (story:enjs:sj story.r)
       %err  s+err.r
     ==
   ?+  path  [~ ~]


### PR DESCRIPTION
## Summary

Chat and channels type changes accumulated over recent months have broken the compilation of the broadcaster agent. We fix this by referencing correct types.

## Changes

1. Fix compilation errors by referencing correct types and arms.

## How did I test?

Compiled broadcaster and run it.

## Risks and impact

- Safe to rollback without consulting PR author? No
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

No state update, can be rolled back, but it is going to stop any ship running broadcaster from upgrading groups desk.