### PR TITLE
channels: ditch semi-redundant faces in $v-channel

### DIFF
--- a/desk/app/channels-server.hoon
+++ b/desk/app/channels-server.hoon
@@ -745,7 +745,7 @@
   =/  affected=(list nest:c)
     %+  murn  ~(tap by v-channels)
     |=  [=nest:c channel=v-channel:c]
-    ?.  =(flag.r-groups group.perm.perm.channel)  ~
+    ?.  =(flag.r-groups group.perm.channel)  ~
     `nest
   =*  r-group  r-group.r-groups
   ?+    r-group  cor
@@ -812,7 +812,7 @@
   ++  emit  |=(=card ca-core(cor (^emit card)))
   ++  emil  |=(caz=(list card) ca-core(cor (^emil caz)))
   ++  give  |=(=gift:agent:gall ca-core(cor (^give gift)))
-  ++  ca-perms  ~(. perms:utils our.bowl now.bowl nest group.perm.perm.channel)
+  ++  ca-perms  ~(. perms:utils our.bowl now.bowl nest group.perm.channel)
   ++  ca-abet
     %_  cor
         v-channels
@@ -827,7 +827,7 @@
   ++  ca-area  `path`/[kind.nest]/[name.nest]
   ++  ca-sub-path  `path`(weld ca-area /updates)
   ++  ca-watch-create
-    =/  =update:c  [now.bowl %create perm.perm.channel meta.meta.channel]
+    =/  =update:c  [now.bowl %create +.perm.channel +.meta.channel]
     =/  =path  /[kind.nest]/[name.nest]/create
     =/  =cage  [%channel-update !>(update)]
     (give %fact ~[path] cage)
@@ -878,7 +878,7 @@
         perm  [1 writers.new group.new]
       ==
     =.  ca-core
-      =/  =update:c  [now.bowl %create perm.perm.channel meta.meta.channel]
+      =/  =update:c  [now.bowl %create +.perm.channel +.meta.channel]
       =/  =cage  [%channel-update !>(update)]
       =/  =path  /[kind.nest]/[name.nest]/create
       =.  ca-core  (give %fact ~[path] cage)
@@ -939,17 +939,17 @@
     ::
         %add-writers
       ?>  (is-admin:ca-perms src.bowl)
-      =/  new-writers  (~(uni in writers.perm.perm.channel) sects.c-channel)
+      =/  new-writers  (~(uni in writers.perm.channel) sects.c-channel)
       =^  changed  perm.channel
-        (next-rev:c perm.channel new-writers group.perm.perm.channel)
+        (next-rev:c perm.channel new-writers group.perm.channel)
       ?.  changed  ca-core
       (ca-update %perm perm.channel)
     ::
         %del-writers
       ?>  (is-admin:ca-perms src.bowl)
-      =/  new-writers  (~(dif in writers.perm.perm.channel) sects.c-channel)
+      =/  new-writers  (~(dif in writers.perm.channel) sects.c-channel)
       =^  changed  perm.channel
-        (next-rev:c perm.channel new-writers group.perm.perm.channel)
+        (next-rev:c perm.channel new-writers group.perm.channel)
       ?.  changed  ca-core
       (ca-update %perm perm.channel)
     ::
@@ -963,7 +963,7 @@
   ++  ca-c-post
     |=  =c-post:c
     ^-  [(unit u-channel:c) _ca-core]
-    ?>  (can-write:ca-perms src.bowl writers.perm.perm.channel)
+    ?>  (can-write:ca-perms src.bowl writers.perm.channel)
     =*  no-op  `ca-core
     ?-    -.c-post
         %add
@@ -1295,7 +1295,7 @@
     ::  to remove any missing sects.
     ::
     =/  missing=(set sect:v0:gv)
-      (~(dif in writers.perm.perm.channel) sects)
+      (~(dif in writers.perm.channel) sects)
     =?  ca-core  !=(missing ~)
       =/  =c-channels:c  [%channel nest %del-writers missing]
       =/  =cage  [%channel-command !>(c-channels)]
@@ -1326,7 +1326,7 @@
   ^-  bowl:h
   =/  group=(unit group:v7:gv)
     ?~  channel  ~
-    =*  flag  group.perm.perm.+.u.channel
+    =*  flag  group.perm.u.channel
     %-  some
     ?.  .^(? %gu (scry-path %groups /$))  *group:v7:gv
     ?.  .^(? %gu (scry-path %groups /groups/(scot %p p.flag)/[q.flag]))

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1304,7 +1304,7 @@
   =/  affected=(list nest:c)
     %+  murn  ~(tap by v-channels)
     |=  [=nest:c channel=v-channel:c]
-    ?.  =(flag group.perm.perm.channel)  ~
+    ?.  =(flag group.perm.channel)  ~
     `nest
   =*  r-group  r-group.r-groups
   ?+    r-group  cor
@@ -1440,7 +1440,7 @@
     %-  uv-posts-3:utils
     %+  gas:on-v-posts:c  ~
     =/  around=(unit id-post:c)
-      ?~  act=(~(get by activity) [%channel nest group.perm.perm.chan])  ~
+      ?~  act=(~(get by activity) [%channel nest group.perm.chan])  ~
       ?~(unread.u.act ~ `time.u.unread.u.act)
     ?~  around
       ::NOTE  equivalent of /newest scry
@@ -1605,7 +1605,7 @@
   ++  emit  |=(=card ca-core(cor (^emit card)))
   ++  emil  |=(caz=(list card) ca-core(cor (^emil caz)))
   ++  give  |=(=gift:agent:gall ca-core(cor (^give gift)))
-  ++  ca-perms  ~(. perms:utils our.bowl now.bowl nest group.perm.perm.channel)
+  ++  ca-perms  ~(. perms:utils our.bowl now.bowl nest group.perm.channel)
   ++  safe-watch
     |=  [=wire =dock =path]
     |=  delay=?
@@ -1637,12 +1637,12 @@
       ?.  .^(? %gu (scry-path %activity /$))
         ca-core
       ?:  =(author-ship our.bowl)
-        =/  =source  [%channel nest group.perm.perm.channel]
+        =/  =source  [%channel nest group.perm.channel]
         (send [%read source [%all `now.bowl |]] ~)
-      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.perm.channel our.bowl)
+      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.channel our.bowl)
       =/  mention=?  (was-mentioned:utils content our.bowl seat)
       =/  action
-        [%add %post [[author-ship id] id] nest group.perm.perm.channel content mention]
+        [%add %post [[author-ship id] id] nest group.perm.channel content mention]
       (send ~[action])
     ::
     ++  on-post-delete
@@ -1650,12 +1650,12 @@
       ^+  ca-core
       ::  remove any activity that might've happened under this post
       ::
-      =*  group  group.perm.perm.channel
+      =*  group  group.perm.channel
       =/  chan=source  [%channel nest group]
       =/  key=message-key
         [[(get-author-ship:utils author) id] id]
       =/  thread=source  [%thread key nest group]
-      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.perm.channel our.bowl)
+      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.channel our.bowl)
       =/  mention  (was-mentioned:utils content our.bowl seat)
       =/  =incoming-event  [%post key nest group content mention]
       (send [%del thread] [%del-event chan incoming-event] ~)
@@ -1670,9 +1670,9 @@
       =/  parent-key=message-key
         [[parent-author id.parent] id.parent]
       ?:  =(reply-author our.bowl)
-        =/  =source  [%thread parent-key nest group.perm.perm.channel]
+        =/  =source  [%thread parent-key nest group.perm.channel]
         (send [%read source [%all `now.bowl |]] ~)
-      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.perm.channel our.bowl)
+      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.channel our.bowl)
       =/  mention=?  (was-mentioned:utils content our.bowl seat)
       =/  in-replies
           %+  lien  (tap:on-v-replies:c replies.parent)
@@ -1686,13 +1686,13 @@
             [[reply-author id] id]
             parent-key
             nest
-            group.perm.perm.channel
+            group.perm.channel
             content
             mention
         ==
       ::  only follow thread if we haven't adjusted settings already
       ::  and if we're the author of the post, mentioned, or in the replies
-      =/  thread=source  [%thread parent-key nest group.perm.perm.channel]
+      =/  thread=source  [%thread parent-key nest group.perm.channel]
       ?.  ?&  !(~(has by settings) thread)
               ?|  mention
                   in-replies
@@ -1709,13 +1709,13 @@
       =*  reply-author   (get-author-ship:utils author.reply)
       ::  remove any activity that might've happened under this post
       ::
-      =*  group  group.perm.perm.channel
+      =*  group  group.perm.channel
       =/  key=message-key
         [[reply-author id.reply] id.reply]
       =/  top=message-key
         [[parent-author id.parent] id.parent]
       =/  thread=source  [%thread top nest group]
-      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.perm.channel our.bowl)
+      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.channel our.bowl)
       =/  mention  (was-mentioned:utils content.reply our.bowl seat)
       =/  =incoming-event  [%reply key top nest group content.reply mention]
       (send [%del-event thread incoming-event] ~)
@@ -1740,7 +1740,7 @@
     =.  nest  [kind.create our.bowl name.create]
     ?<  (~(has by v-channels) nest)
     =.  channel  *v-channel:c
-    =.  group.perm.perm.channel  group.create
+    =.  group.perm.channel  group.create
     =.  meta.channel  [0 meta.create]
     =.  last-read.remark.channel  now.bowl
     =.  ca-core  (send:ca-activity [%add %chan-init nest group.create] ~)
@@ -1767,7 +1767,7 @@
       =.  channel  (~(got by v-channels) nest)
       (ca-safe-sub |)
     =.  channel  *v-channel:c
-    =.  group.perm.perm.channel  group
+    =.  group.perm.channel  group
     =.  last-read.remark.channel  now.bowl
     =.  ca-core  ca-give-unread
     =.  ca-core  (ca-response %join group)
@@ -1801,13 +1801,13 @@
         (~(put ju debounce) nest sent.essay.c-post.a-channel)
       =/  source=(unit source:activity)
         ?.  ?=(%reply -.c-post.a-channel)
-          `[%channel nest group.perm.perm.channel]
+          `[%channel nest group.perm.channel]
         =/  id  id.c-post.a-channel
         =/  post  (got:on-v-posts:c posts.channel id)
         ?:  ?=(%| -.post)  ~
         =/  =message-key:activity
           [[(get-author-ship:utils author.post) id] id]
-        `[%thread [message-key nest group.perm.perm.channel]]
+        `[%thread [message-key nest group.perm.channel]]
       =?  ca-core  ?=(^ source)  (send:ca-activity [%bump u.source] ~)
       (ca-send-command [%channel nest a-channel])
     ==
@@ -2124,15 +2124,15 @@
   ++  ca-apply-checkpoint
     |=  [chk=u-checkpoint:c send=?]
     =^  changed  order.channel  (apply-rev:c order.channel order.chk)
-    =?  ca-core  &(changed send)  (ca-response %order order.order.channel)
+    =?  ca-core  &(changed send)  (ca-response %order +.order.channel)
     =^  changed  view.channel  (apply-rev:c view.channel view.chk)
-    =?  ca-core  &(changed send)  (ca-response %view view.view.channel)
+    =?  ca-core  &(changed send)  (ca-response %view +.view.channel)
     =^  changed  sort.channel  (apply-rev:c sort.channel sort.chk)
-    =?  ca-core  &(changed send)  (ca-response %sort sort.sort.channel)
+    =?  ca-core  &(changed send)  (ca-response %sort +.sort.channel)
     =^  changed  perm.channel  (apply-rev:c perm.channel perm.chk)
-    =?  ca-core  &(changed send)  (ca-response %perm perm.perm.channel)
+    =?  ca-core  &(changed send)  (ca-response %perm +.perm.channel)
     =^  changed  meta.channel  (apply-rev:c meta.channel meta.chk)
-    =?  ca-core  &(changed send)  (ca-response %meta meta.meta.channel)
+    =?  ca-core  &(changed send)  (ca-response %meta +.meta.channel)
     =/  old  posts.channel
     =.  posts.channel
       ((uno:mo-v-posts:c posts.channel posts.chk) ca-apply-may-post)
@@ -2198,33 +2198,33 @@
     ?-    -.u-channel
         %create
       ?.  =(0 rev.perm.channel)  ca-core
-      =.  perm.perm.channel  perm.u-channel
+      =.  +.perm.channel  perm.u-channel
       (ca-response %create perm.u-channel)
     ::
         %order
       =^  changed  order.channel  (apply-rev:c order.channel +.u-channel)
       ?.  changed  ca-core
-      (ca-response %order order.order.channel)
+      (ca-response %order +.order.channel)
     ::
         %view
       =^  changed  view.channel  (apply-rev:c view.channel +.u-channel)
       ?.  changed  ca-core
-      (ca-response %view view.view.channel)
+      (ca-response %view +.view.channel)
     ::
         %sort
       =^  changed  sort.channel  (apply-rev:c sort.channel +.u-channel)
       ?.  changed  ca-core
-      (ca-response %sort sort.sort.channel)
+      (ca-response %sort +.sort.channel)
     ::
         %perm
       =^  changed  perm.channel  (apply-rev:c perm.channel +.u-channel)
       ?.  changed  ca-core
-      (ca-response %perm perm.perm.channel)
+      (ca-response %perm +.perm.channel)
     ::
         %meta
       =^  changed  meta.channel  (apply-rev:c meta.channel +.u-channel)
       ?.  changed  ca-core
-      (ca-response %meta meta.meta.channel)
+      (ca-response %meta +.meta.channel)
     ::
         %post
       =/  old  posts.channel
@@ -2448,7 +2448,7 @@
       ::
       ?.  ?=(kind:c -.kind.post)  ca-core
       =/  =rope:ha  (ca-rope -.kind.post id-post ~)
-      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.perm.channel our.bowl)
+      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.channel our.bowl)
       ?:  (was-mentioned:utils content.post our.bowl seat)
         ?.  (want-hark %mention)
           ca-core
@@ -2513,7 +2513,7 @@
         ==
       ::  notify because we were mentioned in the reply
       ::
-      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.perm.channel our.bowl)
+      =/  seat=(unit seat:v7:gv)  (get-seat group.perm.channel our.bowl)
       ?:  (was-mentioned:utils content.reply our.bowl seat)
         ?.  (want-hark %mention)  ~
         `~[[%ship reply-author] ' mentioned you: ' (flatten:utils content.reply)]
@@ -2576,7 +2576,7 @@
     =/  rest
       ?~  id-reply  path
       (snoc path (rsh 4 (scot %ui u.id-reply)))
-    =*  group  group.perm.perm.channel
+    =*  group  group.perm.channel
     =/  gn=nest:g  nest
     =/  thread  (welp /[kind.nest]/(scot %p ship.nest)/[name.nest] rest)
     [`group `gn q.byk.bowl thread]
@@ -2586,7 +2586,7 @@
   ++  ca-spin
     |=  [=rope:ha con=(list content:ha) but=(unit button:ha)]
     ^-  new-yarn:ha
-    =*  group  group.perm.perm.channel
+    =*  group  group.perm.channel
     =/  link  (welp /groups/(scot %p p.group)/[q.group]/channels ted.rope)
     [& & rope con link but]
   ::
@@ -2725,7 +2725,7 @@
       ?:  ?=(%v0 ver)  (ca-peek-posts-0 rest.pole)
       (ca-peek-posts rest.pole ver)
     ::
-        [%perm ~]        ``channel-perm+!>(perm.perm.channel)
+        [%perm ~]        ``channel-perm+!>(+.perm.channel)
     ::
         [%hark %rope post=@ ~]
       =/  id  (slav %ud post.pole)
@@ -3389,7 +3389,7 @@
   ::
   ++  ca-recheck
     |=  sects=(set sect:v0:gv)
-    =/  =flag:g  group.perm.perm.channel
+    =/  =flag:g  group.perm.channel
     =/  exists-path
       (scry-path %groups /groups/(scot %p p.flag)/[q.flag])
     =+  .^(exists=? %gu exists-path)
@@ -3416,7 +3416,7 @@
   ::
   ::  assorted helpers
   ::
-  ++  ca-from-host  |(=(ship.nest src.bowl) =(p.group.perm.perm.channel src.bowl))
+  ++  ca-from-host  |(=(ship.nest src.bowl) =(p.group.perm.channel src.bowl))
   ::
   ::  leave the subscription only
   ::
@@ -3429,7 +3429,7 @@
   ++  ca-leave
     =.  ca-core  ca-simple-leave
     =.  ca-core  (ca-response %leave ~)
-    =.  ca-core  (send:ca-activity [%del %channel nest group.perm.perm.channel] ~)
+    =.  ca-core  (send:ca-activity [%del %channel nest group.perm.channel] ~)
     =.  gone  &
     ca-core
   --

--- a/desk/lib/channel-json.hoon
+++ b/desk/lib/channel-json.hoon
@@ -338,10 +338,10 @@
   ++  v-channel
     |=  ca=v-channel:c
     %-  pairs
-    :~  order+(order order.order.ca)
-        perms+(perm perm.perm.ca)
-        view+s+view.view.ca
-        sort+s+sort.sort.ca
+    :~  order+(order +.order.ca)
+        perms+(perm +.perm.ca)
+        view+s++.view.ca
+        sort+s++.sort.ca
         pending+(pending-msgs pending.ca)
     ==
   ::

--- a/desk/sur/channels.hoon
+++ b/desk/sur/channels.hoon
@@ -40,11 +40,11 @@
     $:  posts=v-posts
         ::  .count: number of posts, for sequence nr generation
         count=@ud
-        order=(rev order=arranged-posts)
-        view=(rev =view)
-        sort=(rev =sort)
-        perm=(rev =perm)
-        meta=(rev meta=(unit @t))
+        order=(rev arranged-posts)
+        view=(rev view)
+        sort=(rev sort)
+        perm=(rev perm)
+        meta=(rev (unit @t))
     ==
   ::  $window: sparse set of time ranges
   ::


### PR DESCRIPTION
## Summary

Proposal for dropping semi-redundant faces on revisioned parts of `$v-channel`.

## Changes

`$v-channel`'s `$global` type `+rev`isions most of its child nouns. As written, they get two faces: one on the outer [revision value] pair, and one on the value itself.

The way that's written makes it easier to skip past the revision and get just the value out, at the cost of making usage of the stuff _inside_ the value more verbose.

This commit makes the opposite tradeoff and removes the additional face. This way, skipping past the revision to the raw value requires raw tree addressing, but working with the stuff inside the value takes one less face.

Presented as RFC. Made a note of this a while ago and wanted to try it the other way, I'd be fine with either merging or closing. Argument in favor of this is that usage happens spread out all over the place, but stripping the revision off happens in more or less the same place for all these types, limiting the cognitive drawback of looking at the lark.

## How did I test?

Compiles, should be equivalent.

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.