### PR TITLE
metagrab: include accept-language header

### DIFF
--- a/desk/app/metagrab.hoon
+++ b/desk/app/metagrab.hoon
@@ -105,17 +105,14 @@
   ==
 ::
 ++  fetch
-  |=  [met=?(%head %get) url=@t uas=@t]
+  |=  [met=?(%head %get) url=@t hes=header-list:http]
   ^-  card
-  =/  =header-list:http
-    :~  ['user-agent' uas]
-        ['accept' '*/*']
-    ==
+  =.  hes  [['accept' '*/*'] hes]
   =/  =request:http
-    [?-(met %head %'HEAD', %get %'GET') url header-list ~]
+    [?-(met %head %'HEAD', %get %'GET') url hes ~]
   ::NOTE  outbound-config is actually meaningless,
   ::      iris doesn't do anything with it at present...
-  [%pass /fetch/(scot %t url)/(scot %t uas)/[met] %arvo %i %request request *outbound-config:iris]
+  [%pass /fetch/(scot %t url)/(crip ~(rend co %blob hes))/[met] %arvo %i %request request *outbound-config:iris]
 ::
 ++  extract-data
   |=  $:  url=@t
@@ -302,7 +299,7 @@
       %noun
     =+  url=!<(@t vase)
     ?>  ?=(^ (de-purl:html url))
-    [[(fetch %head url user-agent) ~] this]
+    [[(fetch %head url ['user-agent' user-agent]~) ~] this]
   ::
       %handle-http-request
     =+  !<(order:hutils vase)
@@ -345,14 +342,22 @@
         ::  no valid cache entry for this target, start a new fetch
         ::
         =.  await  (~(put ju await) u.target id)
-        =/  uas=@t
-          ::  pass on the user-agent string from the original request,
-          ::  in an attempt to evade some over-aggresive bot protections
+        =;  hes=(list (unit [@t @t]))
+          [[(fetch %head u.target (murn hes same)) ~] this]
+        =*  hl  header-list.request
+        :~  ::  pass on the user-agent string from the original request,
+            ::  in an attempt to evade some over-aggresive bot protections
+            ::
+            %-  some
+            :-  'user-agent'
+            (fall (get-header:http 'user-agent' hl) user-agent)
           ::
-          %+  fall
-            (get-header:http 'user-agent' header-list.request)
-          user-agent
-        [[(fetch %head u.target uas) ~] this]
+            ::  include the original accept-language header in case the
+            ::  target supports translations
+            ::
+            =-  (bind - (lead 'accept-language'))
+            (get-header:http 'accept-language' hl)
+        ==
       ::  we have a valid cache entry.
       ::  if it's a redirect where we know the next target,
       ::  and can make a request to that,
@@ -384,7 +389,11 @@
       [%fetch @ @ ?(%head %get) ~]
     =/  url=@t   (slav %t i.t.wire)
     =.  url.log  `url
-    =/  uas=@t   (fall (slaw %t i.t.t.wire) user-agent)
+    =/  hes=header-list:http
+      ?~  coin=(rush i.t.t.wire nuck:so)  ~
+      ?:  ?=([%$ %t @] u.coin)  ['user-agent' q.p.u.coin]~  ::  legacy
+      ?.  ?=(%blob -.u.coin)    ~
+      (fall ((soft header-list:http) p.u.coin) ~)
     =/  met      i.t.t.t.wire
     ?>  ?=([%iris %http-response *] sign)
     =*  res  client-response.sign
@@ -419,7 +428,7 @@
                 (get-header:http 'content-type' headers.response-header.res)
               (cury end 3^9)
           ==
-        [[(fetch %get url uas) ~] this]
+        [[(fetch %get url hes) ~] this]
       ::  otherwise, this is the most we'll fetch, now process the data
       ::
       =/  [report=? =result]
@@ -460,7 +469,7 @@
         ==
       ::  no valid cache entry, start a new fetch
       ::
-      [[(fetch %head u.nex uas)]~ this]
+      [[(fetch %head u.nex hes)]~ this]
     ::TODO  detect redirect loops
     ::  we have a valid cache entry.
     ::  if it's a redirect where we know the next target,


### PR DESCRIPTION

## Summary
If the request coming in to metagrab includes an `accept-language` header, pass that on to whatever resource we're trying to grab metadata from. This way, we are hopefully more likely to get results in the user's language.

## Changes

We restructure lightly to make request header tracking more generic and require smaller diffs if we want to include another header in the future. Instead of putting the `user-agent` header contents in the wire, we put a `%blob` `$coin` containing the whole `$header-list:http`. We unpack this carefully, making sure it fits the expected type, and falling back to not retrieving headers instead of crashing the processing entirely. (This is a stylistic/defensive choice. We will get out what we put in 100% of the time.)

## How did I test?

By hitting a local echo server and observing that the headers put in by my browser were passed on correctly.

## Risks and impact

- Technically safe to rollback without consulting PR author, worst you'll see is failing to process some in-flight-during-ota metagrab responses.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.

## Screenshots / videos
<img width="717" height="238" alt="image" src="https://github.com/user-attachments/assets/d3d84c72-3bc9-4a02-9d27-3d8a7cb7023c" />

Fixes TLON-4878
