### PR TITLE
filteredchatlist: make sure we use flashlist correctly

### DIFF
--- a/packages/app/features/chat-list/FilteredChatList.tsx
+++ b/packages/app/features/chat-list/FilteredChatList.tsx
@@ -223,6 +223,7 @@ export const FilteredChatList = React.memo(
             getItemType={getItemType}
             estimatedItemSize={sizeRefs.current.chatListItem}
             overrideItemLayout={handleOverrideLayout}
+            extraData={selectedIndex}
             {...listProps}
           />
         )}


### PR DESCRIPTION
## Summary

I think something changed with FlashList and this was required for it to actually re-render when `selectedIndex` changed, been bothering me because I couldn't actually see the selection when using the leap bar.

## Changes

- added extra data for FlashList to know to re-render

## How did I test?

Manually

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
