### PR TITLE
feat: add gateway-status agent for tlon bot availability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Key rules:
 -   **`verb` takes 3 arguments**: `%^  verb  |  %warn` (loud flag, log volume, agent). Not `%+  verb  |`.
 -   **State types belong in the app file**, not in `sur/`. Only shared protocol types (actions, updates, type aliases used by marks) belong in `sur/`.
 -   **Application logic helpers** (liveness checks, predicates) belong in the app helper core, not in `sur/`.
+-   **New agents require a spec doc** in `docs/<agent-name>.md`. The doc should cover purpose, poke/watch/scry surface, state model, and any important lifecycle or invariants.
 -   **Register new agents** in `desk/desk.bill`.
 
 #### Type Naming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,15 @@ Key rules:
 -   **`=|  versioned-state` must NOT have a face** (not `=|  state=versioned-state`). The bare `=|` makes state fields directly accessible in the helper core. Adding a face wraps the fields and breaks `=.  field  value` access.
 -   **No extra arms in the agent door.** The `^-  agent:gall` cast requires exactly the 10 standard arms. Put all helpers in the lower core via `=<`.
 -   **`verb` takes 3 arguments**: `%^  verb  |  %warn` (loud flag, log volume, agent). Not `%+  verb  |`.
+-   **State types belong in the app file**, not in `sur/`. Only shared protocol types (actions, updates, type aliases used by marks) belong in `sur/`.
+-   **Application logic helpers** (liveness checks, predicates) belong in the app helper core, not in `sur/`.
 -   **Register new agents** in `desk/desk.bill`.
+
+#### Type Naming
+
+-   Types in `sur/` use bare names (`action`, `update`, `status`) with `v1`/`v2` version arms for indirection. Mark files are versioned separately (`action-1.hoon`). Don't carry mark-version numbers into type names.
+-   Callers reference shared types through the version arm: `action:v1:gs`, `update:v1:gs`.
+-   Keep field names short. Drop redundant suffixes like `-at` on timestamp fields — the aura (`@da`, `@dr`) communicates the type.
 
 #### State Narrowing in Helper Cores
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,50 +70,125 @@ This is a monorepo for Tlon Messenger containing multiple applications and share
 -   **desk/**: Urbit backend applications written in Hoon
     -   Core agents: %groups, %channels, %chat, %contacts, %activity, %profile
 
+### Hoon Agent Development
+
+#### Agent Structure
+
+Agents use the `=<` + helper core pattern. The agent door (with the 10 standard `agent:gall` arms) sits above a helper core that contains all business logic:
+
+```hoon
+=|  versioned-state        ::  bare type, NO face
+=*  state  -               ::  alias state to subject head
+%-  agent:dbug
+%^  verb  |  %warn         ::  verb takes 3 args: loud flag, volume, agent
+^-  agent:gall
+=<
+  |_  =bowl:gall           ::  agent door (standard arms only)
+  +*  this  .
+      def   ~(. (default-agent this %.n) bowl)
+      cor   ~(. +> [bowl ~])
+  ++  on-poke  ...          ::  delegates to helper core via cor
+  --
+|_  [=bowl:gall cards=(list card)]   ::  helper core
+++  cor   .
+++  abet  [(flop cards) state]
+++  emit  |=(=card cor(cards [card cards]))
+++  give  |=(=gift:agent:gall (emit %give gift))
+...
+--
+```
+
+Key rules:
+
+-   **`=|  versioned-state` must NOT have a face** (not `=|  state=versioned-state`). The bare `=|` makes state fields directly accessible in the helper core. Adding a face wraps the fields and breaks `=.  field  value` access.
+-   **No extra arms in the agent door.** The `^-  agent:gall` cast requires exactly the 10 standard arms. Put all helpers in the lower core via `=<`.
+-   **`verb` takes 3 arguments**: `%^  verb  |  %warn` (loud flag, log volume, agent). Not `%+  verb  |`.
+-   **Register new agents** in `desk/desk.bill`.
+
+#### State Mutation Rules
+
+Inside the helper core, state fields (from `=*  state  -`) and the card accumulator (`cards` in the door sample) interact via the `cor` pattern. Follow these rules:
+
+-   **Never type-narrow state fields.** `?>  ?=(^ owner)` or `?~  lease-until  cor` narrows the field's type, which changes the core type and breaks `^+  cor`. Instead:
+    -   Use `=(status %up)` (equality) instead of `?=(%up status)` (type narrowing)
+    -   Use `(need owner)` or `=/  own  owner  ?~  own  cor` (local var) instead of `?>  ?=(^ owner)`
+    -   Use `=/  lut  lease-until  ?~  lut  cor` to unwrap units into locals
+-   **When assigning narrowed locals to state fields**, re-wrap to preserve the full type: `=.  last-id  \`u.mkey`(not`=. last-id mkey`where`mkey`was narrowed by`?~`)
+
+#### Activity Event Access
+
+When processing `%activity-update-4` facts:
+
+-   `time-event` in `[%add =source time-event]` is inlined without a face (`+$  time-event  [=time =event]`). Access via `event.upd`, not `event.time-event.upd`.
+-   `$%` variant payloads (like `dm-post-event` inside `incoming-event`) are also inlined without faces. Access the `key` face directly: `key.event`, not `key.dm-post-event.incoming-event.event`.
+-   Use positional addressing for the tag: `-<.event` to get the `incoming-event` tag.
+
+#### Mark Conventions
+
+-   **Versioned marks**: `action-1.hoon`, `update-1.hoon` in `desk/mar/<agent-name>/`
+-   **Mark naming**: `%gateway-status-action-1` (agent name + mark name + version)
+-   **JSON serialization for `@da`/`@dr`/`@p`**: Use `scot`/`se` pairs, not `numb`/`ni`:
+    -   Grow: `s+(scot %da lease-until)`, `s+(scot %dr active-window)`, `s+(scot %p owner)`
+    -   Grab: `(se %da)`, `(se %dr)`, `(se %p)`
+-   **Tagged union JSON**: Use `of` for the outer dispatch + `ot` for each variant's fields
+-   **Single-key objects**: Use `frond` instead of `pairs` with a one-element list
+
+#### Testing
+
+-   Agent tests use `/+  *test-agent` harness in `desk/tests/app/<agent>.hoon`
+-   Monadic `;<` style with `eval-mare`, `do-init`, `do-poke`, `do-agent`, `do-arvo`
+-   **Set bowl before `do-init`** so that `our.bowl` is correct when `on-init` subscribes to other agents
+-   Mock scries via `set-scry-gate` — at minimum return `&` for `[%gu @ %activity @ %$ ~]` if subscribing to `%activity`
+
 ## Platform-Specific Navigation Architecture
 
 **CRITICAL**: The app has completely different navigation implementations for mobile vs desktop/web. When making UI changes or adding testIDs for E2E tests, you MUST modify the correct platform-specific component.
 
 ### Navigation Entry Points
-- **Mobile**: Uses `packages/app/navigation/RootStack.tsx`
-- **Desktop/Web**: Uses `packages/app/navigation/desktop/TopLevelDrawer.tsx`
+
+-   **Mobile**: Uses `packages/app/navigation/RootStack.tsx`
+-   **Desktop/Web**: Uses `packages/app/navigation/desktop/TopLevelDrawer.tsx`
 
 The platform is determined by `BasePathNavigator` using the `isMobile` prop:
-- `isMobile={true}` → Renders `RootStack` (mobile navigation)
-- `isMobile={false}` → Renders `TopLevelDrawer` (desktop navigation)
+
+-   `isMobile={true}` → Renders `RootStack` (mobile navigation)
+-   `isMobile={false}` → Renders `TopLevelDrawer` (desktop navigation)
 
 ### Main Navigation Components
 
-| Screen | Mobile Component | Desktop Component |
-|---|---|---|
-| **Contacts** | `features/top/ContactsScreen.tsx` | `navigation/desktop/ProfileNavigator.tsx` |
+| Screen       | Mobile Component                       | Desktop Component                          |
+| ------------ | -------------------------------------- | ------------------------------------------ |
+| **Contacts** | `features/top/ContactsScreen.tsx`      | `navigation/desktop/ProfileNavigator.tsx`  |
 | **Settings** | `features/settings/SettingsScreen.tsx` | `navigation/desktop/SettingsNavigator.tsx` |
-| **Activity** | `features/top/ActivityScreen.tsx` | `navigation/desktop/ActivityNavigator.tsx` |
-| **Messages** | `features/top/ChatListScreen.tsx` | `navigation/desktop/MessagesNavigator.tsx` |
-| **Home** | N/A (uses bottom tabs) | `navigation/desktop/HomeNavigator.tsx` |
+| **Activity** | `features/top/ActivityScreen.tsx`      | `navigation/desktop/ActivityNavigator.tsx` |
+| **Messages** | `features/top/ChatListScreen.tsx`      | `navigation/desktop/MessagesNavigator.tsx` |
+| **Home**     | N/A (uses bottom tabs)                 | `navigation/desktop/HomeNavigator.tsx`     |
 
 ### E2E Testing Guidelines
 
 **Web E2E tests ALWAYS use desktop navigation components!**
 
 When adding testIDs for web E2E tests:
+
 1. Identify which main navigation component handles your screen (see table above)
 2. Add testID to the desktop component in `packages/app/navigation/desktop/`
 3. DO NOT modify the mobile component in `packages/app/features/`
 
 Example: To add a testID for the "Add Contact" button:
-- ❌ WRONG: Modify `packages/app/features/top/ContactsScreen.tsx`
-- ✅ CORRECT: Modify `packages/app/navigation/desktop/ProfileNavigator.tsx`
+
+-   ❌ WRONG: Modify `packages/app/features/top/ContactsScreen.tsx`
+-   ✅ CORRECT: Modify `packages/app/navigation/desktop/ProfileNavigator.tsx`
 
 ### Debugging Platform-Specific Issues
 
 To identify which component to modify:
+
 1. **Check the file path pattern**:
-   - `/features/` = Mobile component
-   - `/navigation/desktop/` = Desktop component
+    - `/features/` = Mobile component
+    - `/navigation/desktop/` = Desktop component
 2. **Find screen mappings**:
-   - Mobile: Check `packages/app/navigation/RootStack.tsx` for `<Root.Screen>` definitions
-   - Desktop: Check `packages/app/navigation/desktop/TopLevelDrawer.tsx` for `<Drawer.Screen>` definitions
+    - Mobile: Check `packages/app/navigation/RootStack.tsx` for `<Root.Screen>` definitions
+    - Desktop: Check `packages/app/navigation/desktop/TopLevelDrawer.tsx` for `<Drawer.Screen>` definitions
 3. **For testID issues**: Web builds render `testID` as `data-testid` in the DOM
 
 ## Key Technologies
@@ -151,6 +226,7 @@ To identify which component to modify:
 ### Shell Script Compatibility
 
 When writing or modifying bash scripts, ensure compatibility with both macOS and Linux:
+
 -   Use `#!/bin/bash` shebang (not `#!/bin/sh`) for consistent behavior
 -   Avoid bash-specific features that vary by version (e.g., associative arrays with `declare -A`)
 -   Handle differences between BSD (macOS) and GNU (Linux) tools, especially `tar`, `sed`, `grep`
@@ -291,10 +367,10 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 2. **If it passes, find the polluting test** - run subsets of tests alphabetically before the failing test
 3. **Check for missing cleanup** - look for tests that create contacts, profiles, or other persistent state
 4. **Common pollution sources**:
-   -   `invite-service.spec.ts` - creates contacts via invite links
-   -   Tests with profile editing - may leave custom nicknames
-   -   Tests creating DMs - both ships must clean up
-   -   Tests with group invites - may leave pending invitations
+    - `invite-service.spec.ts` - creates contacts via invite links
+    - Tests with profile editing - may leave custom nicknames
+    - Tests creating DMs - both ships must clean up
+    - Tests with group invites - may leave pending invitations
 
 **E2E Helper Function Design Principles:**
 
@@ -308,6 +384,7 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 ### E2E Test Infrastructure
 
 **Understanding the rube script:**
+
 -   `pnpm rube` or `pnpm e2e` runs the core test infrastructure
 -   Rube performs critical setup: nukes ship state, sets ~mug as reel provider, configures S3 storage (if env vars set), applies desk updates
 -   Ships are considered ready when rube outputs "SHIP_SETUP_COMPLETE" signal
@@ -315,6 +392,7 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 -   Default timeout is 30 seconds (can be extended with FORCE_EXTRACTION=true environment variable)
 
 **S3 Storage Configuration for E2E Tests:**
+
 -   Optional: Image upload tests will be skipped if not configured
 -   Set these environment variables to enable image uploads in e2e tests:
     -   `E2E_S3_ENDPOINT` - S3 endpoint URL (e.g., `https://s3.amazonaws.com`)
@@ -326,6 +404,7 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 -   Each test ship gets the same S3 configuration
 
 **Pier Archiving and Updates:**
+
 -   Test piers are pre-configured Urbit ships stored as archives in GCS
 -   Archives are referenced in `apps/tlon-web/e2e/shipManifest.json`
 -   To update pier archives: `./apps/tlon-web/rube/archive-piers.sh`
@@ -334,6 +413,7 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 -   Archive naming convention: `rube-{ship}{version}.tgz` (e.g., `rube-zod15.tgz`)
 
 **Important Scripts:**
+
 -   `./start-playwright-dev.sh` - Starts ships in background, returns when ready
 -   `./stop-playwright-dev.sh` - Comprehensive cleanup of all e2e processes
 -   `./apps/tlon-web/rube-cleanup.sh` - Emergency cleanup when processes are stuck
@@ -342,17 +422,20 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 -   `pnpm e2e` - Full test suite (now properly handles Ctrl+C interruption)
 
 **Process Cleanup Improvements:**
+
 -   **Automatic cleanup**: Ctrl+C now properly cleans up all processes including Urbit serf sub-processes
 -   **Emergency cleanup**: Run `./apps/tlon-web/rube-cleanup.sh` if processes get stuck
 -   **Pattern-based killing**: Infrastructure uses pattern matching to find and kill all related processes
 
 **Common E2E Testing Pitfalls:**
+
 -   **Ship readiness**: Checking for `.http.ports` files doesn't mean ships are ready - wait for SHIP_SETUP_COMPLETE
 -   **Desk updates**: Applying desk updates can take 5-10 minutes, default timeouts may be too short
 -   **Process cleanup**: Now handled automatically, but use `rube-cleanup.sh` for emergency recovery
 -   **Manifest changes**: Always backup `shipManifest.json` before modifying - it's critical for e2e tests
 
 **GCP Integration for E2E Archives:**
+
 -   E2E test piers are stored in GCS: `gs://bootstrap.urbit.org/`
 -   GCP project: `tlon-groups-mobile` (hardcoded for security)
 -   Archives are publicly readable once uploaded
@@ -360,6 +443,7 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 -   Verify access: `gsutil ls gs://bootstrap.urbit.org/`
 
 **Investigating CI E2E Failures:**
+
 -   The parallel E2E CI job runs tests in Docker containers across 4 shards. The main job log only shows container status polling and a summary (e.g., "Total tests: 71, Total failures: 1") — it does NOT contain the specific test failure details.
 -   To find the actual failing test, download the `e2e-test-results` artifact: `gh run download <run-id> --name e2e-test-results --dir /tmp/e2e-results`
 -   The artifact contains:
@@ -369,6 +453,7 @@ When using Claude Code with the Playwright MCP server for e2e testing:
 -   Common false positives: Cross-ship sync timeouts (e.g., waiting for reply counts to sync between ships) are a frequent source of flaky failures unrelated to code changes
 
 **Test State Persistence Issues:**
+
 -   Ship state is nuked between full test runs, but NOT between individual tests in the same run
 -   Contact relationships persist across tests within a run
 -   Profile modifications (nicknames, status, bio) persist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,23 +105,13 @@ Key rules:
 -   **`verb` takes 3 arguments**: `%^  verb  |  %warn` (loud flag, log volume, agent). Not `%+  verb  |`.
 -   **Register new agents** in `desk/desk.bill`.
 
-#### State Mutation Rules
+#### State Narrowing in Helper Cores
 
-Inside the helper core, state fields (from `=*  state  -`) and the card accumulator (`cards` in the door sample) interact via the `cor` pattern. Follow these rules:
+When using the `=<` + helper core pattern with `^+  cor`, be aware that type-narrowing a state field (e.g., `?>  ?=(^ owner)` or `?~  lease-until  cor`) changes the core type. This can break `^+  cor` if the narrowed branch continues to modify state or emit cards.
 
--   **Never type-narrow state fields.** `?>  ?=(^ owner)` or `?~  lease-until  cor` narrows the field's type, which changes the core type and breaks `^+  cor`. Instead:
-    -   Use `=(status %up)` (equality) instead of `?=(%up status)` (type narrowing)
-    -   Use `(need owner)` or `=/  own  owner  ?~  own  cor` (local var) instead of `?>  ?=(^ owner)`
-    -   Use `=/  lut  lease-until  ?~  lut  cor` to unwrap units into locals
--   **When assigning narrowed locals to state fields**, re-wrap to preserve the full type: `=.  last-id  \`u.mkey`(not`=. last-id mkey`where`mkey`was narrowed by`?~`)
-
-#### Activity Event Access
-
-When processing `%activity-update-4` facts:
-
--   `time-event` in `[%add =source time-event]` is inlined without a face (`+$  time-event  [=time =event]`). Access via `event.upd`, not `event.time-event.upd`.
--   `$%` variant payloads (like `dm-post-event` inside `incoming-event`) are also inlined without faces. Access the `key` face directly: `key.event`, not `key.dm-post-event.incoming-event.event`.
--   Use positional addressing for the tag: `-<.event` to get the `incoming-event` tag.
+-   Prefer locals when narrowing would fight `^+  cor`: `=/  own  owner  ?~  own  cor`
+-   Simple narrowing that leads directly to a return (no further state mutation) is fine: `?~  lease-until  cor  ?.  (lte u.lease-until now.bowl)  cor`
+-   When assigning a narrowed local back to a state field, re-wrap to preserve the declared type: `=.  last-id  \`u.mkey`
 
 #### Mark Conventions
 

--- a/desk/app/gateway-status.hoon
+++ b/desk/app/gateway-status.hoon
@@ -1,6 +1,6 @@
 ::  gateway-status: offline-reply and liveness agent for openclaw gateway
 ::
-/-  gs=gateway-status, a=activity, c=chat, s=story
+/-  gs=gateway-status, a=activity, cv=chat-ver, s=story
 /+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
@@ -32,7 +32,7 @@
   ++  on-agent
     |=  [=wire =sign:agent:gall]
     ^-  (quip card _this)
-    =^  cards  state  abet:(agnt:cor wire sign)
+    =^  cards  state  abet:(agent:cor wire sign)
     [cards this]
   ++  on-arvo
     |=  [=wire sign=sign-arvo]
@@ -42,7 +42,7 @@
   ++  on-watch
     |=  =path
     ^-  (quip card _this)
-    ?>  =(src.bowl our.bowl)
+    ?>  =(src our):bowl
     ?+  path  (on-watch:def path)
         [%v1 ~]
       :_  this
@@ -73,20 +73,24 @@
   ^+  cor
   (emit %pass /activity %agent [our.bowl %activity] %watch /v4)
 ::
+++  poke
+  |=  [=mark =vase]
+  ^+  cor
+  ?>  =(src our):bowl
+  ?>  ?=(%gateway-status-action-1 mark)
+  =/  act  !<(action-1:gs vase)
+  ?-  -.act
+    %configure          (handle-configure +.act)
+    %gateway-start      (handle-gateway-start +.act)
+    %gateway-heartbeat  (handle-gateway-heartbeat +.act)
+    %gateway-stop       (handle-gateway-stop +.act)
+  ==
+::
 ++  cancel-lease-timer
   ^+  cor
   =/  lut  lease-until
   ?~  lut  cor
   (emit %pass /lease-check %arvo %b %rest u.lut)
-::
-++  send-dm
-  |=  text=@t
-  ^+  cor
-  =/  content=story:s  ~[[%inline ~[text]]]
-  =/  =essay:c  [[content our.bowl now.bowl] chat+/ ~ ~]
-  =/  =diff:dm:c  [[our.bowl now.bowl] %add essay `now.bowl]
-  =/  =action:dm:c  [(need owner) diff]
-  (emit %pass /dm/send %agent [our.bowl %chat] %poke %chat-dm-action-2 !>(action))
 ::
 ++  status-update
   |=  [sts=?(%unknown %up %down) lut=(unit @da)]
@@ -100,28 +104,14 @@
       (lth (sub now last-owner-message-at) active-window)
   ==
 ::
-++  should-auto-reply
-  |=  current-key=message-key:a
-  ^-  ?
-  ?:  (is-gateway-live:gs status lease-until now.bowl)  %.n
-  =/  lrt  last-offline-auto-reply-to
-  ?:  ?&(?=(^ lrt) =(u.lrt current-key))  %.n
-  =/  lra  last-offline-auto-reply-at
-  ?:  ?&(?=(^ lra) (lth (sub now.bowl u.lra) offline-reply-cooldown))  %.n
-  %.y
-::
-++  poke
-  |=  [=mark =vase]
+++  send-dm
+  |=  text=@t
   ^+  cor
-  ?>  =(src.bowl our.bowl)
-  ?>  ?=(%gateway-status-action-1 mark)
-  =/  act  !<(action-1:gs vase)
-  ?-  -.act
-    %configure          (handle-configure +.act)
-    %gateway-start      (handle-gateway-start +.act)
-    %gateway-heartbeat  (handle-gateway-heartbeat +.act)
-    %gateway-stop       (handle-gateway-stop +.act)
-  ==
+  =/  content=story:s  ~[[%inline ~[text]]]
+  =/  =essay:v7:cv  [[content our.bowl now.bowl] chat+/ ~ ~]
+  =/  =diff:dm:v7:cv  [[our.bowl now.bowl] %add essay `now.bowl]
+  =/  =action:dm:v7:cv  [(need owner) diff]
+  (emit %pass /dm/send %agent [our.bowl %chat] %poke %chat-dm-action-2 !>(action))
 ::
 ++  handle-configure
   |=  [who=ship aw=@dr orc=@dr]
@@ -175,7 +165,7 @@
     (send-dm 'Your Tlon bot is restarting. I should be back shortly. 🔧')
   (status-update status lease-until)
 ::
-++  agnt
+++  agent
   |=  [=wire =sign:agent:gall]
   ^+  cor
   ?+  wire  cor
@@ -201,6 +191,16 @@
       ((slog 'gateway-status: dm send failed' u.p.sign) cor)
     ==
   ==
+::
+++  should-auto-reply
+  |=  current-key=message-key:a
+  ^-  ?
+  ?:  (is-gateway-live:gs status lease-until now.bowl)  %.n
+  =/  lrt  last-offline-auto-reply-to
+  ?:  ?&(?=(^ lrt) =(u.lrt current-key))  %.n
+  =/  lra  last-offline-auto-reply-at
+  ?:  ?&(?=(^ lra) (lth (sub now.bowl u.lra) offline-reply-cooldown))  %.n
+  %.y
 ::
 ++  handle-activity-add
   |=  [who=ship =source:a =event:a]
@@ -231,9 +231,8 @@
       [%lease-check ~]
     ?>  ?=([%behn %wake *] sign)
     ?.  =(status %up)  cor
-    =/  lut  lease-until
-    ?~  lut  cor
-    ?.  (lte u.lut now.bowl)  cor
+    ?~  lease-until  cor
+    ?.  (lte u.lease-until now.bowl)  cor
     %-  (slog leaf+"gateway-status: lease expired, transitioning to down" ~)
     =.  status  %down
     =.  pending-restart-notice  %.y

--- a/desk/app/gateway-status.hoon
+++ b/desk/app/gateway-status.hoon
@@ -4,9 +4,42 @@
 /+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
-+$  versioned-state  state-0:gs
+::  $state-0: agent state
+::
+::    .owner: ship whose DMs trigger offline replies (~ = unconfigured/inert)
+::    .last-owner-msg: timestamp of most recent owner DM
+::    .last-owner-msg-id: key of most recent owner DM
+::    .status: gateway liveness as seen by the ship
+::    .boot-id: identifies the current gateway process (~ after graceful stop)
+::    .lease-until: when the current heartbeat lease expires
+::    .last-heartbeat: timestamp of most recent accepted heartbeat
+::    .last-stop: timestamp of most recent graceful stop
+::    .last-start: timestamp of most recent gateway start
+::    .pending-restart: whether to send a back-online DM on next start
+::    .last-auto-reply: when the last offline auto-reply was sent
+::    .last-auto-reply-to: key of DM that last triggered an auto-reply (deduplication)
+::    .reply-cooldown: minimum interval between offline auto-replies
+::    .active-window: how recently owner must have messaged to get notices
+::
++$  state-0
+  $:  %0
+      owner=(unit ship)
+      last-owner-msg=@da
+      last-owner-msg-id=(unit message-key:a)
+      =status:gs
+      boot-id=(unit @t)
+      lease-until=(unit @da)
+      last-heartbeat=(unit @da)
+      last-stop=(unit @da)
+      last-start=(unit @da)
+      pending-restart=?
+      last-auto-reply=(unit @da)
+      last-auto-reply-to=(unit message-key:a)
+      reply-cooldown=@dr
+      active-window=@dr
+  ==
 --
-=|  versioned-state
+=|  state-0
 =*  state  -
 %-  agent:dbug
 %^  verb  |  %warn
@@ -23,7 +56,7 @@
   ++  on-load
     |=  ole=vase
     ^-  (quip card _this)
-    [~ this(state !<(versioned-state ole))]
+    [~ this(state !<(state-0 ole))]
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
@@ -46,7 +79,7 @@
     ?+  path  (on-watch:def path)
         [%v1 ~]
       :_  this
-      [%give %fact ~ %gateway-status-update-1 !>(`update-1:gs`[%status status lease-until])]~
+      [%give %fact ~ %gateway-status-update-1 !>(`update:v1:gs`[%status status lease-until])]~
     ==
   ++  on-leave  |=(path `this)
   ++  on-peek
@@ -54,7 +87,7 @@
     ^-  (unit (unit cage))
     ?+  path  [~ ~]
         [%x %status ~]       ``noun+!>([status lease-until])
-        [%x %owner-activity ~]  ``noun+!>(last-owner-message-at)
+        [%x %owner-activity ~]  ``noun+!>(last-owner-msg)
         [%x %state ~]        ``noun+!>(state)
     ==
   ++  on-fail
@@ -78,7 +111,7 @@
   ^+  cor
   ?>  =(src our):bowl
   ?>  ?=(%gateway-status-action-1 mark)
-  =/  act  !<(action-1:gs vase)
+  =/  act  !<(action:v1:gs vase)
   ?-  -.act
     %configure          (handle-configure +.act)
     %gateway-start      (handle-gateway-start +.act)
@@ -93,15 +126,22 @@
   (emit %pass /lease-check %arvo %b %rest u.lut)
 ::
 ++  status-update
-  |=  [sts=?(%unknown %up %down) lut=(unit @da)]
+  |=  [sts=status:gs lut=(unit @da)]
   ^+  cor
-  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%status sts lut]))
+  (give %fact ~[/v1] %gateway-status-update-1 !>(`update:v1:gs`[%status sts lut]))
 ::
 ++  is-owner-recently-active
   |=  now=@da
   ^-  ?
-  ?&  (gth last-owner-message-at *@da)
-      (lth (sub now last-owner-message-at) active-window)
+  ?&  (gth last-owner-msg *@da)
+      (lth (sub now last-owner-msg) active-window)
+  ==
+::
+++  is-gateway-live
+  ^-  ?
+  ?&  ?=(%up status)
+      ?=(^ lease-until)
+      (gth u.lease-until now.bowl)
   ==
 ::
 ++  send-dm
@@ -118,20 +158,20 @@
   ^+  cor
   =.  owner  `who
   =.  active-window  aw
-  =.  offline-reply-cooldown  orc
+  =.  reply-cooldown  orc
   (status-update status lease-until)
 ::
 ++  handle-gateway-start
   |=  [bid=@t lut=@da]
   ^+  cor
   =/  owner-guard  (need owner)  ::  crash if owner not configured
-  =/  should-notify  ?&(pending-restart-notice (is-owner-recently-active now.bowl))
+  =/  should-notify  ?&(pending-restart (is-owner-recently-active now.bowl))
   =.  cor  cancel-lease-timer
   =.  status  %up
   =.  boot-id  `bid
   =.  lease-until  `lut
-  =.  last-start-at  `now.bowl
-  =.  pending-restart-notice  %.n
+  =.  last-start  `now.bowl
+  =.  pending-restart  |
   =.  cor  (emit %pass /lease-check %arvo %b %wait lut)
   =?  cor  should-notify
     (send-dm 'Your Tlon bot is back online and ready to chat again. ✅')
@@ -144,9 +184,9 @@
   ?.  =(boot-id `bid)  cor
   =.  cor  cancel-lease-timer
   =.  status  %up
-  =.  pending-restart-notice  %.n
+  =.  pending-restart  |
   =.  lease-until  `lut
-  =.  last-heartbeat-at  `now.bowl
+  =.  last-heartbeat  `now.bowl
   =.  cor  (emit %pass /lease-check %arvo %b %wait lut)
   (status-update status lease-until)
 ::
@@ -159,8 +199,8 @@
   =.  cor  cancel-lease-timer
   =.  status  %down
   =.  boot-id  ~
-  =.  last-stop-at  `now.bowl
-  =.  pending-restart-notice  %.y
+  =.  last-stop  `now.bowl
+  =.  pending-restart  &
   =?  cor  should-notify
     (send-dm 'Your Tlon bot is restarting. I should be back shortly. 🔧')
   (status-update status lease-until)
@@ -195,12 +235,12 @@
 ++  should-auto-reply
   |=  current-key=message-key:a
   ^-  ?
-  ?:  (is-gateway-live:gs status lease-until now.bowl)  %.n
-  =/  lrt  last-offline-auto-reply-to
-  ?:  ?&(?=(^ lrt) =(u.lrt current-key))  %.n
-  =/  lra  last-offline-auto-reply-at
-  ?:  ?&(?=(^ lra) (lth (sub now.bowl u.lra) offline-reply-cooldown))  %.n
-  %.y
+  ?:  is-gateway-live  |
+  =/  lrt  last-auto-reply-to
+  ?:  ?&(?=(^ lrt) =(u.lrt current-key))  |
+  =/  lra  last-auto-reply
+  ?:  ?&(?=(^ lra) (lth (sub now.bowl u.lra) reply-cooldown))  |
+  &
 ::
 ++  handle-activity-add
   |=  [who=ship =source:a =event:a]
@@ -215,14 +255,14 @@
   ?.  =(sender who)  cor
   ?:  =(sender our.bowl)  cor
   =/  should-reply  (should-auto-reply u.mkey)
-  =.  last-owner-message-at  now.bowl
-  =.  last-owner-message-id  `u.mkey
-  =?  last-offline-auto-reply-at  should-reply  `now.bowl
-  =?  last-offline-auto-reply-to  should-reply  `u.mkey
-  =.  cor  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%owner-activity now.bowl]))
+  =.  last-owner-msg  now.bowl
+  =.  last-owner-msg-id  `u.mkey
+  =?  last-auto-reply  should-reply  `now.bowl
+  =?  last-auto-reply-to  should-reply  `u.mkey
+  =.  cor  (give %fact ~[/v1] %gateway-status-update-1 !>(`update:v1:gs`[%owner-activity now.bowl]))
   ?.  should-reply  cor
   =.  cor  (send-dm 'Your Tlon bot is offline right now, so replies are paused. I\'ll let you know when I\'m back. 🛰️')
-  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%auto-reply who now.bowl]))
+  (give %fact ~[/v1] %gateway-status-update-1 !>(`update:v1:gs`[%auto-reply who now.bowl]))
 ::
 ++  arvo
   |=  [=wire sign=sign-arvo]
@@ -235,7 +275,7 @@
     ?.  (lte u.lease-until now.bowl)  cor
     %-  (slog leaf+"gateway-status: lease expired, transitioning to down" ~)
     =.  status  %down
-    =.  pending-restart-notice  %.y
+    =.  pending-restart  &
     (status-update %down lease-until)
   ==
 --

--- a/desk/app/gateway-status.hoon
+++ b/desk/app/gateway-status.hoon
@@ -1,0 +1,236 @@
+/-  gs=gateway-status, a=activity, c=chat, s=story
+/+  default-agent, verb, dbug
+|%
++$  card  card:agent:gall
++$  versioned-state  state-0:gs
+--
+=|  versioned-state
+=*  state  -
+%-  agent:dbug
+%^  verb  |  %warn
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this  .
+      def   ~(. (default-agent this %.n) bowl)
+      cor   ~(. +> [bowl ~])
+  ++  on-init
+    =^  cards  state  abet:init:cor
+    [cards this]
+  ++  on-save  !>(state)
+  ++  on-load
+    |=  ole=vase
+    ^-  (quip card _this)
+    [~ this(state !<(versioned-state ole))]
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(poke:cor mark vase)
+    [cards this]
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(agnt:cor wire sign)
+    [cards this]
+  ++  on-arvo
+    |=  [=wire sign=sign-arvo]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(arvo:cor wire sign)
+    [cards this]
+  ++  on-watch
+    |=  =path
+    ^-  (quip card _this)
+    ?>  =(src.bowl our.bowl)
+    ?+  path  (on-watch:def path)
+        [%v1 ~]
+      :_  this
+      [%give %fact ~ %gateway-status-update-1 !>(`update-1:gs`[%status status lease-until])]~
+    ==
+  ++  on-leave  |=(path `this)
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?+  path  [~ ~]
+        [%x %status ~]       ``noun+!>([status lease-until])
+        [%x %owner-activity ~]  ``noun+!>(last-owner-message-at)
+        [%x %state ~]        ``noun+!>(state)
+    ==
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    %-  (slog 'gateway-status: on-fail' >term< tang)
+    [~ this]
+  --
+|_  [=bowl:gall cards=(list card)]
+++  cor   .
+++  abet  [(flop cards) state]
+++  emit  |=(=card cor(cards [card cards]))
+++  give  |=(=gift:agent:gall (emit %give gift))
+::
+++  init
+  ^+  cor
+  (emit %pass /activity %agent [our.bowl %activity] %watch /v4)
+::
+++  cancel-lease-timer
+  ^+  cor
+  =/  lut  lease-until
+  ?~  lut  cor
+  (emit %pass /lease-check %arvo %b %rest u.lut)
+::
+++  send-dm
+  |=  text=@t
+  ^+  cor
+  =/  content=story:s  ~[[%inline ~[text]]]
+  =/  =essay:c  [[content our.bowl now.bowl] chat+/ ~ ~]
+  =/  =diff:dm:c  [[our.bowl now.bowl] %add essay `now.bowl]
+  =/  =action:dm:c  [(need owner) diff]
+  (emit %pass /dm/send %agent [our.bowl %chat] %poke %chat-dm-action-2 !>(action))
+::
+++  status-update
+  |=  [sts=?(%unknown %up %stopping %down) lut=(unit @da)]
+  ^+  cor
+  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%status sts lut]))
+::
+++  is-owner-recently-active
+  |=  now=@da
+  ^-  ?
+  ?&  (gth last-owner-message-at *@da)
+      (lth (sub now last-owner-message-at) active-window)
+  ==
+::
+++  should-auto-reply
+  |=  current-key=message-key:a
+  ^-  ?
+  ?:  (is-gateway-live:gs status lease-until now.bowl)  %.n
+  =/  lrt  last-offline-auto-reply-to
+  ?:  ?&(?=(^ lrt) =(u.lrt current-key))  %.n
+  =/  lra  last-offline-auto-reply-at
+  ?:  ?&(?=(^ lra) (lth (sub now.bowl u.lra) offline-reply-cooldown))  %.n
+  %.y
+::
+++  poke
+  |=  [=mark =vase]
+  ^+  cor
+  ?>  =(src.bowl our.bowl)
+  ?>  ?=(%gateway-status-action-1 mark)
+  =/  act  !<(action-1:gs vase)
+  ?-  -.act
+    %configure          (handle-configure +.act)
+    %gateway-start      (handle-gateway-start +.act)
+    %gateway-heartbeat  (handle-gateway-heartbeat +.act)
+    %gateway-stop       (handle-gateway-stop +.act)
+  ==
+::
+++  handle-configure
+  |=  [who=ship aw=@dr orc=@dr]
+  ^+  cor
+  =.  owner  `who
+  =.  active-window  aw
+  =.  offline-reply-cooldown  orc
+  (status-update status lease-until)
+::
+++  handle-gateway-start
+  |=  [bid=@t lut=@da]
+  ^+  cor
+  =/  who  (need owner)
+  =/  should-notify  ?&(pending-restart-notice (is-owner-recently-active now.bowl))
+  =.  cor  cancel-lease-timer
+  =.  status  %up
+  =.  boot-id  `bid
+  =.  lease-until  `lut
+  =.  last-start-at  `now.bowl
+  =.  pending-restart-notice  %.n
+  =.  cor  (emit %pass /lease-check %arvo %b %wait lut)
+  =?  cor  should-notify
+    (send-dm 'Your Tlon bot is back online.')
+  (status-update status lease-until)
+::
+++  handle-gateway-heartbeat
+  |=  [bid=@t lut=@da]
+  ^+  cor
+  =/  who  (need owner)
+  ?.  =(boot-id `bid)  cor
+  =.  cor  cancel-lease-timer
+  =.  lease-until  `lut
+  =.  last-heartbeat-at  `now.bowl
+  =.  cor  (emit %pass /lease-check %arvo %b %wait lut)
+  (status-update status lease-until)
+::
+++  handle-gateway-stop
+  |=  reason=@t
+  ^+  cor
+  =/  who  (need owner)
+  =/  should-notify  (is-owner-recently-active now.bowl)
+  =.  cor  cancel-lease-timer
+  =.  status  %down
+  =.  last-stop-at  `now.bowl
+  =.  pending-restart-notice  %.y
+  =?  cor  should-notify
+    (send-dm 'Your Tlon bot is restarting on this ship. Replies may pause briefly.')
+  (status-update status lease-until)
+::
+++  agnt
+  |=  [=wire =sign:agent:gall]
+  ^+  cor
+  ?+  wire  cor
+      [%activity ~]
+    ?+  -.sign  cor
+        %fact
+      ?.  ?=(%activity-update-4 p.cage.sign)  cor
+      =/  own  owner
+      ?~  own  cor
+      =/  upd  !<(update:a q.cage.sign)
+      ?.  ?=(%add -.upd)  cor
+      (handle-activity-add u.own source.upd event.upd)
+        %kick
+      (emit %pass /activity %agent [our.bowl %activity] %watch /v4)
+        %watch-ack
+      ?~  p.sign  cor
+      ((slog 'gateway-status: activity watch nacked' u.p.sign) cor)
+    ==
+      [%dm %send ~]
+    ?+  -.sign  cor
+        %poke-ack
+      ?~  p.sign  cor
+      ((slog 'gateway-status: dm send failed' u.p.sign) cor)
+    ==
+  ==
+::
+++  handle-activity-add
+  |=  [who=ship =source:a =event:a]
+  ^+  cor
+  =/  mkey=(unit message-key:a)
+    ?+  -<.event  ~
+      %dm-post   `key.event
+      %dm-reply  `key.event
+    ==
+  ?~  mkey  cor
+  =/  sender=ship  p.id.u.mkey
+  ?.  =(sender who)  cor
+  ?:  =(sender our.bowl)  cor
+  =/  should-reply  (should-auto-reply u.mkey)
+  =.  last-owner-message-at  now.bowl
+  =.  last-owner-message-id  `u.mkey
+  =?  last-offline-auto-reply-at  should-reply  `now.bowl
+  =?  last-offline-auto-reply-to  should-reply  `u.mkey
+  =.  cor  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%owner-activity now.bowl]))
+  ?.  should-reply  cor
+  =.  cor  (send-dm 'Your Tlon bot is temporarily unavailable on this ship right now. It should come back shortly.')
+  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%auto-reply who now.bowl]))
+::
+++  arvo
+  |=  [=wire sign=sign-arvo]
+  ^+  cor
+  ?+  wire  cor
+      [%lease-check ~]
+    ?>  ?=([%behn %wake *] sign)
+    ?.  =(status %up)  cor
+    =/  lut  lease-until
+    ?~  lut  cor
+    ?.  (lte u.lut now.bowl)  cor
+    %-  (slog leaf+"gateway-status: lease expired, transitioning to down" ~)
+    =.  status  %down
+    =.  pending-restart-notice  %.y
+    (status-update %down lease-until)
+  ==
+--

--- a/desk/app/gateway-status.hoon
+++ b/desk/app/gateway-status.hoon
@@ -87,7 +87,7 @@
   (emit %pass /dm/send %agent [our.bowl %chat] %poke %chat-dm-action-2 !>(action))
 ::
 ++  status-update
-  |=  [sts=?(%unknown %up %stopping %down) lut=(unit @da)]
+  |=  [sts=?(%unknown %up %down) lut=(unit @da)]
   ^+  cor
   (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%status sts lut]))
 ::
@@ -132,7 +132,7 @@
 ++  handle-gateway-start
   |=  [bid=@t lut=@da]
   ^+  cor
-  =/  who  (need owner)
+  =/  owner-guard  (need owner)  ::  crash if owner not configured
   =/  should-notify  ?&(pending-restart-notice (is-owner-recently-active now.bowl))
   =.  cor  cancel-lease-timer
   =.  status  %up
@@ -148,21 +148,25 @@
 ++  handle-gateway-heartbeat
   |=  [bid=@t lut=@da]
   ^+  cor
-  =/  who  (need owner)
+  =/  owner-guard  (need owner)  ::  crash if owner not configured
   ?.  =(boot-id `bid)  cor
   =.  cor  cancel-lease-timer
+  =.  status  %up
+  =.  pending-restart-notice  %.n
   =.  lease-until  `lut
   =.  last-heartbeat-at  `now.bowl
   =.  cor  (emit %pass /lease-check %arvo %b %wait lut)
   (status-update status lease-until)
 ::
 ++  handle-gateway-stop
-  |=  reason=@t
+  |=  [bid=@t reason=@t]
   ^+  cor
-  =/  who  (need owner)
+  =/  owner-guard  (need owner)  ::  crash if owner not configured
+  ?.  =(boot-id `bid)  cor
   =/  should-notify  (is-owner-recently-active now.bowl)
   =.  cor  cancel-lease-timer
   =.  status  %down
+  =.  boot-id  ~
   =.  last-stop-at  `now.bowl
   =.  pending-restart-notice  %.y
   =?  cor  should-notify

--- a/desk/app/gateway-status.hoon
+++ b/desk/app/gateway-status.hoon
@@ -142,7 +142,7 @@
   =.  pending-restart-notice  %.n
   =.  cor  (emit %pass /lease-check %arvo %b %wait lut)
   =?  cor  should-notify
-    (send-dm 'Your Tlon bot is back online.')
+    (send-dm 'Your Tlon bot is back online and ready to chat again. ✅')
   (status-update status lease-until)
 ::
 ++  handle-gateway-heartbeat
@@ -170,7 +170,7 @@
   =.  last-stop-at  `now.bowl
   =.  pending-restart-notice  %.y
   =?  cor  should-notify
-    (send-dm 'Your Tlon bot is restarting on this ship. Replies may pause briefly.')
+    (send-dm 'Your Tlon bot is restarting. I should be back shortly. 🔧')
   (status-update status lease-until)
 ::
 ++  agnt
@@ -219,7 +219,7 @@
   =?  last-offline-auto-reply-to  should-reply  `u.mkey
   =.  cor  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%owner-activity now.bowl]))
   ?.  should-reply  cor
-  =.  cor  (send-dm 'Your Tlon bot is temporarily unavailable on this ship right now. It should come back shortly.')
+  =.  cor  (send-dm (rap 3 'Your Tlon bot is offline right now, so replies are paused. I' '\'' 'll let you know when I' '\'' 'm back. 🛰️' ~))
   (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%auto-reply who now.bowl]))
 ::
 ++  arvo

--- a/desk/app/gateway-status.hoon
+++ b/desk/app/gateway-status.hoon
@@ -1,3 +1,5 @@
+::  gateway-status: offline-reply and liveness agent for openclaw gateway
+::
 /-  gs=gateway-status, a=activity, c=chat, s=story
 /+  default-agent, verb, dbug
 |%
@@ -219,7 +221,7 @@
   =?  last-offline-auto-reply-to  should-reply  `u.mkey
   =.  cor  (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%owner-activity now.bowl]))
   ?.  should-reply  cor
-  =.  cor  (send-dm (rap 3 'Your Tlon bot is offline right now, so replies are paused. I' '\'' 'll let you know when I' '\'' 'm back. 🛰️' ~))
+  =.  cor  (send-dm 'Your Tlon bot is offline right now, so replies are paused. I\'ll let you know when I\'m back. 🛰️')
   (give %fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%auto-reply who now.bowl]))
 ::
 ++  arvo

--- a/desk/desk.bill
+++ b/desk/desk.bill
@@ -18,4 +18,5 @@
     %dumb-proxy
     %expose
     %metagrab
+    %gateway-status
 ==

--- a/desk/mar/gateway-status/action-1.hoon
+++ b/desk/mar/gateway-status/action-1.hoon
@@ -1,0 +1,50 @@
+/-  gs=gateway-status
+|_  =action-1:gs
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  action-1
+  ++  json
+    =,  enjs:format
+    ^-  ^json
+    ?-  -.action-1
+        %configure
+      %-  frond  :-  'configure'
+      %-  pairs
+      :~  ['owner' s+(scot %p owner.action-1)]
+          ['active-window' s+(scot %dr active-window.action-1)]
+          ['offline-reply-cooldown' s+(scot %dr offline-reply-cooldown.action-1)]
+      ==
+        %gateway-start
+      %-  frond  :-  'gateway-start'
+      %-  pairs
+      :~  ['boot-id' s+boot-id.action-1]
+          ['lease-until' s+(scot %da lease-until.action-1)]
+      ==
+        %gateway-heartbeat
+      %-  frond  :-  'gateway-heartbeat'
+      %-  pairs
+      :~  ['boot-id' s+boot-id.action-1]
+          ['lease-until' s+(scot %da lease-until.action-1)]
+      ==
+        %gateway-stop
+      %-  frond  :-  'gateway-stop'
+      (pairs ~[['reason' s+reason.action-1]])
+    ==
+  --
+++  grab
+  |%
+  ++  noun  action-1:gs
+  ++  json
+    |=  jon=^json
+    ^-  action-1:gs
+    =,  dejs:format
+    %.  jon
+    %-  of
+    :~  [%gateway-stop (ot ~[reason+so])]
+        [%gateway-start (ot ~[boot-id+so lease-until+(se %da)])]
+        [%gateway-heartbeat (ot ~[boot-id+so lease-until+(se %da)])]
+        [%configure (ot ~[owner+(se %p) active-window+(se %dr) offline-reply-cooldown+(se %dr)])]
+    ==
+  --
+--

--- a/desk/mar/gateway-status/action-1.hoon
+++ b/desk/mar/gateway-status/action-1.hoon
@@ -1,45 +1,45 @@
 ::  gateway-status-action-1: mark for gateway-status inbound actions
 ::
 /-  gs=gateway-status
-|_  =action-1:gs
+|_  =action:v1:gs
 ++  grad  %noun
 ++  grow
   |%
-  ++  noun  action-1
+  ++  noun  action
   ++  json
     =,  enjs:format
     ^-  ^json
-    ?-  -.action-1
+    ?-  -.action
         %configure
       %-  frond  :-  'configure'
       %-  pairs
-      :~  ['owner' s+(scot %p owner.action-1)]
-          ['active-window' s+(scot %dr active-window.action-1)]
-          ['offline-reply-cooldown' s+(scot %dr offline-reply-cooldown.action-1)]
+      :~  ['owner' s+(scot %p owner.action)]
+          ['active-window' s+(scot %dr active-window.action)]
+          ['offline-reply-cooldown' s+(scot %dr reply-cooldown.action)]
       ==
         %gateway-start
       %-  frond  :-  'gateway-start'
       %-  pairs
-      :~  ['boot-id' s+boot-id.action-1]
-          ['lease-until' s+(scot %da lease-until.action-1)]
+      :~  ['boot-id' s+boot-id.action]
+          ['lease-until' s+(scot %da lease-until.action)]
       ==
         %gateway-heartbeat
       %-  frond  :-  'gateway-heartbeat'
       %-  pairs
-      :~  ['boot-id' s+boot-id.action-1]
-          ['lease-until' s+(scot %da lease-until.action-1)]
+      :~  ['boot-id' s+boot-id.action]
+          ['lease-until' s+(scot %da lease-until.action)]
       ==
         %gateway-stop
       %-  frond  :-  'gateway-stop'
-      (pairs ~[['boot-id' s+boot-id.action-1] ['reason' s+reason.action-1]])
+      (pairs ~[['boot-id' s+boot-id.action] ['reason' s+reason.action]])
     ==
   --
 ++  grab
   |%
-  ++  noun  action-1:gs
+  ++  noun  action:v1:gs
   ++  json
     |=  jon=^json
-    ^-  action-1:gs
+    ^-  action:v1:gs
     =,  dejs:format
     %.  jon
     %-  of

--- a/desk/mar/gateway-status/action-1.hoon
+++ b/desk/mar/gateway-status/action-1.hoon
@@ -1,3 +1,5 @@
+::  gateway-status-action-1: mark for gateway-status inbound actions
+::
 /-  gs=gateway-status
 |_  =action-1:gs
 ++  grad  %noun

--- a/desk/mar/gateway-status/action-1.hoon
+++ b/desk/mar/gateway-status/action-1.hoon
@@ -29,7 +29,7 @@
       ==
         %gateway-stop
       %-  frond  :-  'gateway-stop'
-      (pairs ~[['reason' s+reason.action-1]])
+      (pairs ~[['boot-id' s+boot-id.action-1] ['reason' s+reason.action-1]])
     ==
   --
 ++  grab
@@ -41,7 +41,7 @@
     =,  dejs:format
     %.  jon
     %-  of
-    :~  [%gateway-stop (ot ~[reason+so])]
+    :~  [%gateway-stop (ot ~[boot-id+so reason+so])]
         [%gateway-start (ot ~[boot-id+so lease-until+(se %da)])]
         [%gateway-heartbeat (ot ~[boot-id+so lease-until+(se %da)])]
         [%configure (ot ~[owner+(se %p) active-window+(se %dr) offline-reply-cooldown+(se %dr)])]

--- a/desk/mar/gateway-status/update-1.hoon
+++ b/desk/mar/gateway-status/update-1.hoon
@@ -1,0 +1,12 @@
+/-  gs=gateway-status
+|_  =update-1:gs
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  update-1
+  --
+++  grab
+  |%
+  ++  noun  update-1:gs
+  --
+--

--- a/desk/mar/gateway-status/update-1.hoon
+++ b/desk/mar/gateway-status/update-1.hoon
@@ -1,12 +1,14 @@
+::  gateway-status-update-1: mark for gateway-status outbound updates
+::
 /-  gs=gateway-status
-|_  =update-1:gs
+|_  =update:v1:gs
 ++  grad  %noun
 ++  grow
   |%
-  ++  noun  update-1
+  ++  noun  update
   --
 ++  grab
   |%
-  ++  noun  update-1:gs
+  ++  noun  update:v1:gs
   --
 --

--- a/desk/sur/gateway-status.hoon
+++ b/desk/sur/gateway-status.hoon
@@ -1,6 +1,18 @@
+::  gateway-status: types for the gateway liveness and offline-reply agent
+::
 /-  a=activity
 |%
 ::  $state-0: agent state
+::
+::    .owner: ship whose DMs trigger offline replies (~ = unconfigured/inert)
+::    .status: gateway liveness as seen by the ship
+::    .boot-id: identifies the current gateway process (~ after graceful stop)
+::    .lease-until: when the current heartbeat lease expires
+::    .pending-restart-notice: whether to send a back-online DM on next start
+::    .last-owner-message-id: last owner DM key, used for reply deduplication
+::    .last-offline-auto-reply-to: key of the DM that last triggered an auto-reply
+::    .active-window: how recently owner must have messaged to get notices
+::    .offline-reply-cooldown: minimum interval between offline auto-replies
 ::
 +$  state-0
   $:  %0
@@ -19,7 +31,7 @@
       offline-reply-cooldown=@dr
       active-window=@dr
   ==
-::  $action-1: inbound poke protocol
+::  $action-1: inbound poke protocol from openclaw-tlon
 ::
 +$  action-1
   $%  [%configure owner=ship active-window=@dr offline-reply-cooldown=@dr]
@@ -27,7 +39,7 @@
       [%gateway-heartbeat boot-id=@t lease-until=@da]
       [%gateway-stop boot-id=@t reason=@t]
   ==
-::  $update-1: outbound subscription facts
+::  $update-1: outbound subscription facts for status observers
 ::
 +$  update-1
   $%  [%status status=?(%unknown %up %down) lease-until=(unit @da)]

--- a/desk/sur/gateway-status.hoon
+++ b/desk/sur/gateway-status.hoon
@@ -7,7 +7,7 @@
       owner=(unit ship)
       last-owner-message-at=@da
       last-owner-message-id=(unit message-key:a)
-      status=$~(%unknown ?(%unknown %up %stopping %down))
+      status=$~(%unknown ?(%unknown %up %down))
       boot-id=(unit @t)
       lease-until=(unit @da)
       last-heartbeat-at=(unit @da)
@@ -25,19 +25,19 @@
   $%  [%configure owner=ship active-window=@dr offline-reply-cooldown=@dr]
       [%gateway-start boot-id=@t lease-until=@da]
       [%gateway-heartbeat boot-id=@t lease-until=@da]
-      [%gateway-stop reason=@t]
+      [%gateway-stop boot-id=@t reason=@t]
   ==
 ::  $update-1: outbound subscription facts
 ::
 +$  update-1
-  $%  [%status status=?(%unknown %up %stopping %down) lease-until=(unit @da)]
+  $%  [%status status=?(%unknown %up %down) lease-until=(unit @da)]
       [%owner-activity last-owner-message-at=@da]
       [%auto-reply =ship at=@da]
   ==
 ::  +is-gateway-live: check if the gateway is currently available
 ::
 ++  is-gateway-live
-  |=  [status=?(%unknown %up %stopping %down) lease-until=(unit @da) now=@da]
+  |=  [status=?(%unknown %up %down) lease-until=(unit @da) now=@da]
   ^-  ?
   ?&  ?=(%up status)
       ?=(^ lease-until)

--- a/desk/sur/gateway-status.hoon
+++ b/desk/sur/gateway-status.hoon
@@ -1,0 +1,46 @@
+/-  a=activity
+|%
+::  $state-0: agent state
+::
++$  state-0
+  $:  %0
+      owner=(unit ship)
+      last-owner-message-at=@da
+      last-owner-message-id=(unit message-key:a)
+      status=$~(%unknown ?(%unknown %up %stopping %down))
+      boot-id=(unit @t)
+      lease-until=(unit @da)
+      last-heartbeat-at=(unit @da)
+      last-stop-at=(unit @da)
+      last-start-at=(unit @da)
+      pending-restart-notice=?
+      last-offline-auto-reply-at=(unit @da)
+      last-offline-auto-reply-to=(unit message-key:a)
+      offline-reply-cooldown=@dr
+      active-window=@dr
+  ==
+::  $action-1: inbound poke protocol
+::
++$  action-1
+  $%  [%configure owner=ship active-window=@dr offline-reply-cooldown=@dr]
+      [%gateway-start boot-id=@t lease-until=@da]
+      [%gateway-heartbeat boot-id=@t lease-until=@da]
+      [%gateway-stop reason=@t]
+  ==
+::  $update-1: outbound subscription facts
+::
++$  update-1
+  $%  [%status status=?(%unknown %up %stopping %down) lease-until=(unit @da)]
+      [%owner-activity last-owner-message-at=@da]
+      [%auto-reply =ship at=@da]
+  ==
+::  +is-gateway-live: check if the gateway is currently available
+::
+++  is-gateway-live
+  |=  [status=?(%unknown %up %stopping %down) lease-until=(unit @da) now=@da]
+  ^-  ?
+  ?&  ?=(%up status)
+      ?=(^ lease-until)
+      (gth u.lease-until now)
+  ==
+--

--- a/desk/sur/gateway-status.hoon
+++ b/desk/sur/gateway-status.hoon
@@ -1,58 +1,24 @@
-::  gateway-status: types for the gateway liveness and offline-reply agent
+::  gateway-status: shared types for the gateway liveness agent
 ::
-/-  a=activity
 |%
-::  $state-0: agent state
+::  $status: gateway liveness as seen by the ship
 ::
-::    .owner: ship whose DMs trigger offline replies (~ = unconfigured/inert)
-::    .status: gateway liveness as seen by the ship
-::    .boot-id: identifies the current gateway process (~ after graceful stop)
-::    .lease-until: when the current heartbeat lease expires
-::    .pending-restart-notice: whether to send a back-online DM on next start
-::    .last-owner-message-id: last owner DM key, used for reply deduplication
-::    .last-offline-auto-reply-to: key of the DM that last triggered an auto-reply
-::    .active-window: how recently owner must have messaged to get notices
-::    .offline-reply-cooldown: minimum interval between offline auto-replies
++$  status  $~(%unknown ?(%unknown %up %down))
+::  $action: inbound poke protocol from openclaw-tlon
 ::
-+$  state-0
-  $:  %0
-      owner=(unit ship)
-      last-owner-message-at=@da
-      last-owner-message-id=(unit message-key:a)
-      status=$~(%unknown ?(%unknown %up %down))
-      boot-id=(unit @t)
-      lease-until=(unit @da)
-      last-heartbeat-at=(unit @da)
-      last-stop-at=(unit @da)
-      last-start-at=(unit @da)
-      pending-restart-notice=?
-      last-offline-auto-reply-at=(unit @da)
-      last-offline-auto-reply-to=(unit message-key:a)
-      offline-reply-cooldown=@dr
-      active-window=@dr
-  ==
-::  $action-1: inbound poke protocol from openclaw-tlon
-::
-+$  action-1
-  $%  [%configure owner=ship active-window=@dr offline-reply-cooldown=@dr]
++$  action
+  $%  [%configure owner=ship active-window=@dr reply-cooldown=@dr]
       [%gateway-start boot-id=@t lease-until=@da]
       [%gateway-heartbeat boot-id=@t lease-until=@da]
       [%gateway-stop boot-id=@t reason=@t]
   ==
-::  $update-1: outbound subscription facts for status observers
+::  $update: outbound subscription facts for status observers
 ::
-+$  update-1
-  $%  [%status status=?(%unknown %up %down) lease-until=(unit @da)]
-      [%owner-activity last-owner-message-at=@da]
++$  update
+  $%  [%status =status lease-until=(unit @da)]
+      [%owner-activity last-owner-msg=@da]
       [%auto-reply =ship at=@da]
   ==
-::  +is-gateway-live: check if the gateway is currently available
 ::
-++  is-gateway-live
-  |=  [status=?(%unknown %up %down) lease-until=(unit @da) now=@da]
-  ^-  ?
-  ?&  ?=(%up status)
-      ?=(^ lease-until)
-      (gth u.lease-until now)
-  ==
+++  v1  .
 --

--- a/desk/tests/app/gateway-status.hoon
+++ b/desk/tests/app/gateway-status.hoon
@@ -1,0 +1,226 @@
+/-  gs=gateway-status, a=activity
+/+  *test-agent
+/=  agent  /app/gateway-status
+|%
+++  dap  %gateway-status
+++  scries
+  |=  =path
+  ^-  (unit vase)
+  ?+  path  ~
+    [%gu @ %activity @ %$ ~]  `!>(&)
+  ==
+::
+++  setup
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m  (set-scry-gate scries)
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev, now ~2024.1.1)))
+  ;<  *  bind:m  (do-init dap agent)
+  (pure:m ~)
+::
+++  configure
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%configure ~bus ~m5 ~m5]))
+  (pure:m ~)
+::
+++  make-dm-fact
+  |=  [sender=ship t=@da]
+  ^-  [wire gill:gall sign:agent:gall]
+  =/  =message-key:a  [[sender t] t]
+  =/  =source:a  [%dm %ship sender]
+  =/  =event:a  [[%dm-post message-key [%ship sender] ~[[%inline ~['hello']]] %.n] %.n %.n]
+  =/  =update:a  [%add source t event]
+  [/activity [~dev %activity] [%fact %activity-update-4 !>(update)]]
+::
+::  tests
+::
+++  test-init-subscribes-to-activity
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m  (set-scry-gate scries)
+  ;<  *  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  caz=(list card)  bind:m  (do-init dap agent)
+  %+  ex-cards  caz
+  :~  (ex-task /activity [~dev %activity] %watch /v4)
+  ==
+::
+++  test-configure-sets-owner
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%configure ~bus ~m5 ~m5]))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  (ex-fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%status %unknown ~]))
+    ==
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(owner.st) !>(`~bus))
+  (ex-equal !>(active-window.st) !>(~m5))
+::
+++  test-unconfigured-ignores-everything
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
+  (ex-cards caz ~)
+::
+++  test-lifecycle-poke-crashes-without-owner
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  (ex-fail (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' (add ~2024.1.1 ~m2)])))
+::
+++  test-owner-dm-while-down-sends-reply
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
+  %+  ex-cards  caz
+  :~  (ex-fact-paths ~[/v1])
+      (ex-poke-wire /dm/send)
+      (ex-fact-paths ~[/v1])
+  ==
+::
+++  test-owner-dm-while-healthy-no-reply
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~m2)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
+  %+  ex-cards  caz
+  :~  (ex-fact-paths ~[/v1])
+  ==
+::
+++  test-non-owner-dm-ignored
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~zod ~2024.1.1))
+  (ex-cards caz ~)
+::
+++  test-self-message-ignored
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%configure ~dev ~m5 ~m5]))
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~dev ~2024.1.1))
+  (ex-cards caz ~)
+::
+++  test-cooldown-suppresses-second-reply
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  (ex-fact-paths ~[/v1])
+        (ex-poke-wire /dm/send)
+        (ex-fact-paths ~[/v1])
+    ==
+  ;<  ~  bind:m  (wait ~s1)
+  =/  t2  (add ~2024.1.1 ~s1)
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus t2))
+  %+  ex-cards  caz
+  :~  (ex-fact-paths ~[/v1])
+  ==
+::
+++  test-dedupe-same-message-key
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  (ex-fact-paths ~[/v1])
+        (ex-poke-wire /dm/send)
+        (ex-fact-paths ~[/v1])
+    ==
+  ;<  ~  bind:m  (wait ~m6)
+  ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
+  %+  ex-cards  caz
+  :~  (ex-fact-paths ~[/v1])
+  ==
+::
+++  test-gateway-stop-sets-state
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~m2)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'test']))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%down))
+  (ex-equal !>(pending-restart-notice.st) !>(%.y))
+::
+++  test-gateway-start-clears-pending-notice
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~m2)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'test']))
+  ::  verify pending-restart-notice was set by stop
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(pending-restart-notice.st) !>(%.y))
+  ::  restart clears pending-restart-notice
+  =/  lease-time-2  (add ~2024.1.1 ~m4)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-2' lease-time-2]))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
+  (ex-equal !>(pending-restart-notice.st) !>(%.n))
+::
+++  test-gateway-start-sets-status-up
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~s90)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
+  (ex-equal !>(lease-until.st) !>(`lease-time))
+::
+++  test-lease-expiry-precondition
+  ::  verifies gateway-start leaves pending-restart-notice as %.n,
+  ::  confirming that a subsequent lease-expiry transition would be
+  ::  the only path that sets it to %.y in the crash scenario.
+  ::  the actual post-wake state change is verified on the live ship.
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~s90)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
+  (ex-equal !>(pending-restart-notice.st) !>(%.n))
+--

--- a/desk/tests/app/gateway-status.hoon
+++ b/desk/tests/app/gateway-status.hoon
@@ -5,13 +5,29 @@
 /=  agent  /app/gateway-status
 |%
 ++  dap  %gateway-status
++$  state-0
+  $:  %0
+      owner=(unit ship)
+      last-owner-msg=@da
+      last-owner-msg-id=(unit message-key:a)
+      =status:gs
+      boot-id=(unit @t)
+      lease-until=(unit @da)
+      last-heartbeat=(unit @da)
+      last-stop=(unit @da)
+      last-start=(unit @da)
+      pending-restart=?
+      last-auto-reply=(unit @da)
+      last-auto-reply-to=(unit message-key:a)
+      reply-cooldown=@dr
+      active-window=@dr
+  ==
 ++  scries
   |=  =path
   ^-  (unit vase)
   ?+  path  ~
     [%gu @ %activity @ %$ ~]  `!>(&)
   ==
-::
 ++  setup
   =/  m  (mare ,~)
   ^-  form:m
@@ -19,13 +35,11 @@
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev, now ~2024.1.1)))
   ;<  *  bind:m  (do-init dap agent)
   (pure:m ~)
-::
 ++  configure
   =/  m  (mare ,~)
   ^-  form:m
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%configure ~bus ~m5 ~m5]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%configure ~bus ~m5 ~m5]))
   (pure:m ~)
-::
 ++  make-dm-fact
   |=  [sender=ship t=@da]
   ^-  [wire gill:gall sign:agent:gall]
@@ -34,9 +48,6 @@
   =/  =event:a  [[%dm-post message-key [%ship sender] ~[[%inline ~['hello']]] %.n] %.n %.n]
   =/  =update:a  [%add source t event]
   [/activity [~dev %activity] [%fact %activity-update-4 !>(update)]]
-::
-::  tests
-::
 ++  test-init-subscribes-to-activity
   %-  eval-mare
   =/  m  (mare ,~)
@@ -47,22 +58,20 @@
   %+  ex-cards  caz
   :~  (ex-task /activity [~dev %activity] %watch /v4)
   ==
-::
 ++  test-configure-sets-owner
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
-  ;<  caz=(list card)  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%configure ~bus ~m5 ~m5]))
+  ;<  caz=(list card)  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%configure ~bus ~m5 ~m5]))
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-fact ~[/v1] %gateway-status-update-1 !>(`update-1:gs`[%status %unknown ~]))
+    :~  (ex-fact ~[/v1] %gateway-status-update-1 !>(`update:v1:gs`[%status %unknown ~]))
     ==
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(owner.st) !>(`~bus))
   (ex-equal !>(active-window.st) !>(~m5))
-::
 ++  test-unconfigured-ignores-everything
   %-  eval-mare
   =/  m  (mare ,~)
@@ -70,14 +79,12 @@
   ;<  ~  bind:m  setup
   ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
   (ex-cards caz ~)
-::
 ++  test-lifecycle-poke-crashes-without-owner
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
-  (ex-fail (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' (add ~2024.1.1 ~m2)])))
-::
+  (ex-fail (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' (add ~2024.1.1 ~m2)])))
 ++  test-owner-dm-while-down-sends-reply
   %-  eval-mare
   =/  m  (mare ,~)
@@ -90,7 +97,6 @@
       (ex-poke-wire /dm/send)
       (ex-fact-paths ~[/v1])
   ==
-::
 ++  test-owner-dm-while-healthy-no-reply
   %-  eval-mare
   =/  m  (mare ,~)
@@ -98,12 +104,11 @@
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
   ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~bus ~2024.1.1))
   %+  ex-cards  caz
   :~  (ex-fact-paths ~[/v1])
   ==
-::
 ++  test-non-owner-dm-ignored
   %-  eval-mare
   =/  m  (mare ,~)
@@ -112,16 +117,14 @@
   ;<  ~  bind:m  configure
   ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~zod ~2024.1.1))
   (ex-cards caz ~)
-::
 ++  test-self-message-ignored
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%configure ~dev ~m5 ~m5]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%configure ~dev ~m5 ~m5]))
   ;<  caz=(list card)  bind:m  (do-agent (make-dm-fact ~dev ~2024.1.1))
   (ex-cards caz ~)
-::
 ++  test-cooldown-suppresses-second-reply
   %-  eval-mare
   =/  m  (mare ,~)
@@ -141,7 +144,6 @@
   %+  ex-cards  caz
   :~  (ex-fact-paths ~[/v1])
   ==
-::
 ++  test-dedupe-same-message-key
   %-  eval-mare
   =/  m  (mare ,~)
@@ -160,7 +162,6 @@
   %+  ex-cards  caz
   :~  (ex-fact-paths ~[/v1])
   ==
-::
 ++  test-gateway-stop-sets-state
   %-  eval-mare
   =/  m  (mare ,~)
@@ -168,13 +169,12 @@
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-1' 'test']))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%down))
-  (ex-equal !>(pending-restart-notice.st) !>(%.y))
-::
+  (ex-equal !>(pending-restart.st) !>(&))
 ++  test-gateway-start-clears-pending-notice
   %-  eval-mare
   =/  m  (mare ,~)
@@ -182,20 +182,17 @@
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-1' 'test']))
-  ::  verify pending-restart-notice was set by stop
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
-  ;<  ~  bind:m  (ex-equal !>(pending-restart-notice.st) !>(%.y))
-  ::  restart clears pending-restart-notice
+  =/  st  !<(state-0 q.res)
+  ;<  ~  bind:m  (ex-equal !>(pending-restart.st) !>(&))
   =/  lease-time-2  (add ~2024.1.1 ~m4)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-2' lease-time-2]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-2' lease-time-2]))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
-  (ex-equal !>(pending-restart-notice.st) !>(%.n))
-::
+  (ex-equal !>(pending-restart.st) !>(|))
 ++  test-gateway-start-sets-status-up
   %-  eval-mare
   =/  m  (mare ,~)
@@ -203,84 +200,68 @@
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~s90)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
   (ex-equal !>(lease-until.st) !>(`lease-time))
-::
 ++  test-lease-expiry-precondition
-  ::  verifies gateway-start leaves pending-restart-notice as %.n,
-  ::  confirming that a subsequent lease-expiry transition would be
-  ::  the only path that sets it to %.y in the crash scenario.
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~s90)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
-  (ex-equal !>(pending-restart-notice.st) !>(%.n))
-::
+  (ex-equal !>(pending-restart.st) !>(|))
 ++  test-heartbeat-restores-up-after-expiry
-  ::  after lease expiry (crash path), a valid heartbeat restores %up
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~s90)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ::  advance past lease and fire wake
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
   ;<  ~  bind:m  (wait ~s91)
   ;<  *  bind:m  (do-arvo /lease-check [%behn %wake ~])
-  ::  deliver valid heartbeat with new lease
   =/  new-lease  (add ~2024.1.1 ~m5)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-heartbeat 'boot-1' new-lease]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-heartbeat 'boot-1' new-lease]))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
-  ;<  ~  bind:m  (ex-equal !>(pending-restart-notice.st) !>(%.n))
+  ;<  ~  bind:m  (ex-equal !>(pending-restart.st) !>(|))
   (ex-equal !>(lease-until.st) !>(`new-lease))
-::
 ++  test-stale-stop-ignored
-  ::  stop with wrong boot-id is ignored
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ::  stop with wrong boot-id
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-old' 'stale']))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-stop 'boot-old' 'stale']))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
   ;<  ~  bind:m  (ex-equal !>(boot-id.st) !>(`'boot-1'))
-  (ex-equal !>(pending-restart-notice.st) !>(%.n))
-::
+  (ex-equal !>(pending-restart.st) !>(|))
 ++  test-delayed-heartbeat-after-stop-ignored
-  ::  after graceful stop, delayed heartbeat from same instance cannot
-  ::  revive the agent because stop clears boot-id
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ::  graceful stop (clears boot-id)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-1' 'shutdown']))
-  ::  delayed heartbeat from same instance
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-start 'boot-1' lease-time]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-stop 'boot-1' 'shutdown']))
   =/  new-lease  (add ~2024.1.1 ~m5)
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-heartbeat 'boot-1' new-lease]))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action:v1:gs`[%gateway-heartbeat 'boot-1' new-lease]))
   ;<  res=cage  bind:m  (got-peek /x/state)
-  =/  st  !<(state-0:gs q.res)
+  =/  st  !<(state-0 q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%down))
   ;<  ~  bind:m  (ex-equal !>(boot-id.st) !>(~))
-  (ex-equal !>(pending-restart-notice.st) !>(%.y))
+  (ex-equal !>(pending-restart.st) !>(&))
 --

--- a/desk/tests/app/gateway-status.hoon
+++ b/desk/tests/app/gateway-status.hoon
@@ -1,3 +1,5 @@
+::  tests for %gateway-status agent
+::
 /-  gs=gateway-status, a=activity
 /+  *test-agent
 /=  agent  /app/gateway-status

--- a/desk/tests/app/gateway-status.hoon
+++ b/desk/tests/app/gateway-status.hoon
@@ -167,7 +167,7 @@
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
   ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'test']))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/state)
   =/  st  !<(state-0:gs q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%down))
@@ -181,7 +181,7 @@
   ;<  ~  bind:m  configure
   =/  lease-time  (add ~2024.1.1 ~m2)
   ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
-  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'test']))
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-1' 'test']))
   ::  verify pending-restart-notice was set by stop
   ;<  res=cage  bind:m  (got-peek /x/state)
   =/  st  !<(state-0:gs q.res)
@@ -211,7 +211,6 @@
   ::  verifies gateway-start leaves pending-restart-notice as %.n,
   ::  confirming that a subsequent lease-expiry transition would be
   ::  the only path that sets it to %.y in the crash scenario.
-  ::  the actual post-wake state change is verified on the live ship.
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
@@ -223,4 +222,63 @@
   =/  st  !<(state-0:gs q.res)
   ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
   (ex-equal !>(pending-restart-notice.st) !>(%.n))
+::
+++  test-heartbeat-restores-up-after-expiry
+  ::  after lease expiry (crash path), a valid heartbeat restores %up
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~s90)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ::  advance past lease and fire wake
+  ;<  ~  bind:m  (wait ~s91)
+  ;<  *  bind:m  (do-arvo /lease-check [%behn %wake ~])
+  ::  deliver valid heartbeat with new lease
+  =/  new-lease  (add ~2024.1.1 ~m5)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-heartbeat 'boot-1' new-lease]))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
+  ;<  ~  bind:m  (ex-equal !>(pending-restart-notice.st) !>(%.n))
+  (ex-equal !>(lease-until.st) !>(`new-lease))
+::
+++  test-stale-stop-ignored
+  ::  stop with wrong boot-id is ignored
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~m2)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ::  stop with wrong boot-id
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-old' 'stale']))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%up))
+  ;<  ~  bind:m  (ex-equal !>(boot-id.st) !>(`'boot-1'))
+  (ex-equal !>(pending-restart-notice.st) !>(%.n))
+::
+++  test-delayed-heartbeat-after-stop-ignored
+  ::  after graceful stop, delayed heartbeat from same instance cannot
+  ::  revive the agent because stop clears boot-id
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  configure
+  =/  lease-time  (add ~2024.1.1 ~m2)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-start 'boot-1' lease-time]))
+  ::  graceful stop (clears boot-id)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-stop 'boot-1' 'shutdown']))
+  ::  delayed heartbeat from same instance
+  =/  new-lease  (add ~2024.1.1 ~m5)
+  ;<  *  bind:m  (do-poke %gateway-status-action-1 !>(`action-1:gs`[%gateway-heartbeat 'boot-1' new-lease]))
+  ;<  res=cage  bind:m  (got-peek /x/state)
+  =/  st  !<(state-0:gs q.res)
+  ;<  ~  bind:m  (ex-equal !>(status.st) !>(%down))
+  ;<  ~  bind:m  (ex-equal !>(boot-id.st) !>(~))
+  (ex-equal !>(pending-restart-notice.st) !>(%.y))
 --

--- a/docs/gateway-status.md
+++ b/docs/gateway-status.md
@@ -1,0 +1,298 @@
+# %gateway-status
+
+Ship-native agent for offline DM auto-replies and gateway liveness tracking. Runs on a bot ship and works with an external gateway process (e.g., the `openclaw-tlon` plugin) that reports its lifecycle via pokes.
+
+This document describes the agent's behavior as implemented. It is not a replacement for reading the source, but it covers the protocol, state model, and lifecycle semantics needed to integrate with or modify the agent.
+
+## overview
+
+`%gateway-status` solves a problem that the gateway process itself cannot: responding to the owner's DMs while the gateway is down. Because no plugin code runs during downtime, the fallback responder must live on the ship.
+
+The agent:
+
+-   subscribes to `%activity /v4` for inbound owner DM events
+-   tracks gateway liveness using a lease/heartbeat model
+-   sends canned offline auto-reply DMs when the owner messages during downtime
+-   sends optional restart and recovery notices around shutdown/startup transitions
+
+The gateway process is responsible for:
+
+-   configuring the agent on startup (`%configure`)
+-   signaling start (`%gateway-start`) and stop (`%gateway-stop`)
+-   sending periodic heartbeats (`%gateway-heartbeat`) to extend its lease
+
+## state model
+
+The agent state is `state-0`:
+
+```
+owner              (unit ship)            owner ship; ~ = unconfigured/inert
+status             ?(%unknown %up %down)  gateway liveness (default %unknown)
+boot-id            (unit @t)              current gateway process id (~ after graceful stop)
+lease-until        (unit @da)             when the heartbeat lease expires
+pending-restart-notice  ?                 whether to send back-online DM on next start
+last-owner-message-at   @da               timestamp of most recent owner DM
+last-owner-message-id   (unit message-key)  key of most recent owner DM
+last-heartbeat-at       (unit @da)        timestamp of most recent accepted heartbeat
+last-stop-at            (unit @da)        timestamp of most recent graceful stop
+last-start-at           (unit @da)        timestamp of most recent gateway start
+last-offline-auto-reply-at   (unit @da)   when the last auto-reply was sent
+last-offline-auto-reply-to   (unit message-key)  key of DM that last triggered an auto-reply (deduplication)
+active-window      @dr                    how recently owner must have messaged for notices
+offline-reply-cooldown  @dr               minimum interval between offline auto-replies
+```
+
+While `owner` is `~`, the agent is inert: it subscribes to `%activity` but ignores all DM events. `%configure` is always accepted (it is how the agent leaves the inert state), but `%gateway-start`, `%gateway-heartbeat`, and `%gateway-stop` crash if owner is not set.
+
+### boot-id lifecycle
+
+-   Set to a new value on `%gateway-start`
+-   Retained in state after crash/lease-expiry (no `%gateway-stop` was received)
+-   Cleared to `~` on `%gateway-stop` (prevents delayed heartbeats from reviving the agent)
+
+This distinction is what separates graceful-stop recovery from crash recovery.
+
+### liveness check
+
+The agent considers the gateway live when all three conditions hold:
+
+-   `status` is `%up`
+-   `lease-until` is set
+-   `lease-until` is in the future
+
+This is computed by `++is-gateway-live` in the structure file.
+
+## poke protocol
+
+All pokes use mark `%gateway-status-action-1`. All pokes must come from self (`src.bowl == our.bowl`).
+
+### %configure
+
+Sets the owner ship and timing parameters. Idempotent. Safe to resend on every startup.
+
+| Field                    | Type  | Description                             |
+| ------------------------ | ----- | --------------------------------------- |
+| `owner`                  | `@p`  | Ship whose DMs trigger offline replies  |
+| `active-window`          | `@dr` | Time window for "recently active" owner |
+| `offline-reply-cooldown` | `@dr` | Minimum interval between auto-replies   |
+
+JSON:
+
+```json
+{ "configure": { "owner": "~zod", "active-window": "~m5", "offline-reply-cooldown": "~m5" } }
+```
+
+### %gateway-start
+
+Signals that a gateway instance has started. Requires owner to be configured (crashes otherwise).
+
+| Field         | Type  | Description                                |
+| ------------- | ----- | ------------------------------------------ |
+| `boot-id`     | `@t`  | Opaque identifier for this gateway process |
+| `lease-until` | `@da` | When this lease expires if not renewed     |
+
+Effects:
+
+-   Cancels any existing lease timer
+-   Sets `status` to `%up`, stores `boot-id` and `lease-until`
+-   Schedules a behn timer at `lease-until`
+-   If `pending-restart-notice` is set and owner was recently active, sends the back-online DM
+-   Clears `pending-restart-notice`
+
+JSON:
+
+```json
+{ "gateway-start": { "boot-id": "abc-123", "lease-until": "~2025.4.2..23.45.06" } }
+```
+
+### %gateway-heartbeat
+
+Extends the lease for an active gateway instance. Requires owner configured, and the `boot-id` must match the current boot-id in state. Heartbeats with a mismatched boot-id are silently ignored.
+
+| Field         | Type  | Description                |
+| ------------- | ----- | -------------------------- |
+| `boot-id`     | `@t`  | Must match current boot-id |
+| `lease-until` | `@da` | New lease expiry           |
+
+Effects:
+
+-   Cancels existing timer, schedules new timer at new `lease-until`
+-   Restores `status` to `%up` (relevant after lease-expiry recovery)
+-   Clears `pending-restart-notice`
+-   Updates `last-heartbeat-at`
+
+JSON:
+
+```json
+{ "gateway-heartbeat": { "boot-id": "abc-123", "lease-until": "~2025.4.2..23.46.36" } }
+```
+
+### %gateway-stop
+
+Signals graceful shutdown. Requires owner configured, and the `boot-id` must match. Stale stops with a mismatched boot-id are silently ignored.
+
+| Field     | Type | Description                                                                            |
+| --------- | ---- | -------------------------------------------------------------------------------------- |
+| `boot-id` | `@t` | Must match current boot-id                                                             |
+| `reason`  | `@t` | Human-readable reason; carried in the API but does not currently affect agent behavior |
+
+Effects:
+
+-   Cancels lease timer
+-   Sets `status` to `%down`
+-   Clears `boot-id` from state (prevents delayed heartbeats from reviving the agent)
+-   Sets `pending-restart-notice` to true
+-   If owner was recently active, sends the restarting DM
+
+JSON:
+
+```json
+{ "gateway-stop": { "boot-id": "abc-123", "reason": "shutdown" } }
+```
+
+## lifecycle semantics
+
+### normal operation
+
+```
+configure → gateway-start → heartbeat (every ~s30) → gateway-stop
+```
+
+### graceful shutdown
+
+`%gateway-stop` arrives before the process exits. The agent:
+
+1. Transitions to `%down`
+2. Clears `boot-id` (so delayed in-flight heartbeats are ignored)
+3. Arms `pending-restart-notice`
+4. Optionally sends the restarting DM if the owner was recently active
+
+### crash / lease expiry
+
+No `%gateway-stop` arrives. The behn timer fires at `lease-until`:
+
+1. If `status` is still `%up` and the lease has expired, transitions to `%down`
+2. Arms `pending-restart-notice`
+3. `boot-id` remains in state (enabling heartbeat recovery)
+
+### heartbeat recovery after lease expiry
+
+If the gateway is still alive but its heartbeat was delayed (network, load), a valid heartbeat with the matching `boot-id` can restore `%up`. This only works after crash/lease-expiry (where `boot-id` is retained), not after graceful stop (where `boot-id` was cleared).
+
+On heartbeat recovery:
+
+-   `status` is restored to `%up`
+-   `pending-restart-notice` is cleared (the gateway never actually went down)
+
+### restart after downtime
+
+When `%gateway-start` arrives with a new `boot-id`:
+
+-   If `pending-restart-notice` is set and the owner was recently active, sends the back-online DM
+-   Clears `pending-restart-notice`
+
+## offline auto-reply
+
+When the configured owner sends a DM (observed via `%activity /v4`) and the gateway is unavailable, the agent sends a canned reply. The reply is sent as a poke to `%chat` with mark `%chat-dm-action-2`.
+
+Three conditions must all be true for the reply to fire:
+
+1. **Gateway is unavailable**: `is-gateway-live` returns false
+2. **Not a duplicate**: the inbound message-key differs from `last-offline-auto-reply-to`
+3. **Cooldown elapsed**: time since `last-offline-auto-reply-at` exceeds `offline-reply-cooldown`
+
+The agent ignores:
+
+-   DMs from ships other than `owner`
+-   DMs from the bot ship itself (its own outbound messages)
+-   All DM events while `owner` is `~`
+
+### canned message text
+
+> Your Tlon bot is offline right now, so replies are paused. I'll let you know when I'm back. 🛰️
+
+## restart and shutdown notices
+
+### restarting notice
+
+Sent during `%gateway-stop` if the owner was recently active:
+
+> Your Tlon bot is restarting. I should be back shortly. 🔧
+
+### back-online notice
+
+Sent during `%gateway-start` if `pending-restart-notice` was armed and the owner was recently active:
+
+> Your Tlon bot is back online and ready to chat again. ✅
+
+### "recently active" definition
+
+The owner is considered recently active when:
+
+-   `last-owner-message-at` is non-zero
+-   `now - last-owner-message-at` is less than `active-window`
+
+## stale event protection
+
+Both `%gateway-heartbeat` and `%gateway-stop` check the inbound `boot-id` against the current `boot-id` in state. Mismatches are silently ignored.
+
+The key asymmetry:
+
+-   **Graceful stop** clears `boot-id` → later heartbeats from the old instance fail the check → agent stays `%down`
+-   **Crash/lease-expiry** retains `boot-id` → a late heartbeat from the same instance can restore `%up`
+
+## subscriptions and scries
+
+### watch surface
+
+| Path  | Access                              | Description            |
+| ----- | ----------------------------------- | ---------------------- |
+| `/v1` | Local only (`src.bowl == our.bowl`) | Gateway status updates |
+
+Initial fact on subscribe: `[%status status lease-until]`
+
+Ongoing facts use the `update-1` type:
+
+| Variant           | Fields                  | When emitted                             |
+| ----------------- | ----------------------- | ---------------------------------------- |
+| `%status`         | `status`, `lease-until` | After any lifecycle poke or lease expiry |
+| `%owner-activity` | `last-owner-message-at` | When the owner sends a DM                |
+| `%auto-reply`     | `ship`, `at`            | When an offline auto-reply is sent       |
+
+### scry surface
+
+All scries return `%noun` (no JSON conversion).
+
+| Path                | Returns                 | Description              |
+| ------------------- | ----------------------- | ------------------------ |
+| `/x/status`         | `[status lease-until]`  | Current status and lease |
+| `/x/owner-activity` | `last-owner-message-at` | Last owner DM timestamp  |
+| `/x/state`          | full `state-0`          | Debugging                |
+
+## integration with openclaw-tlon
+
+The gateway process is expected to call the agent in this order:
+
+1. **`configureGatewayStatus`** — on startup, before signaling start
+2. **`gatewayStart`** — after the gateway process is ready
+3. **`gatewayHeartbeat`** — on an interval (recommended: every 30 seconds) with a lease duration (recommended: 90 seconds)
+4. **`gatewayStop`** — on graceful shutdown, with the same `boot-id`
+
+The TypeScript helpers in `@tloncorp/api` handle temporal conversions:
+
+-   `configureGatewayStatus` converts seconds → `@dr` strings
+-   `gatewayStart` / `gatewayHeartbeat` convert Unix milliseconds → `@da` strings
+-   `gatewayStop` passes `bootId` and `reason` as strings
+
+The `boot-id` should be a unique identifier per gateway process (e.g., a UUID generated on startup).
+
+## timing defaults
+
+| Parameter                | Default    | Set by                              |
+| ------------------------ | ---------- | ----------------------------------- |
+| `active-window`          | 5 minutes  | Ship agent (via `%configure`)       |
+| `offline-reply-cooldown` | 5 minutes  | Ship agent (via `%configure`)       |
+| Heartbeat interval       | 30 seconds | Gateway process                     |
+| Lease duration           | 90 seconds | Gateway process (via `lease-until`) |
+
+The ship agent stores `active-window` and `offline-reply-cooldown`. The heartbeat interval and lease duration are computed by the gateway process and are not stored in agent state.

--- a/docs/gateway-status.md
+++ b/docs/gateway-status.md
@@ -27,20 +27,22 @@ The agent state is `state-0`:
 
 ```
 owner              (unit ship)            owner ship; ~ = unconfigured/inert
-status             ?(%unknown %up %down)  gateway liveness (default %unknown)
+last-owner-msg     @da                    timestamp of most recent owner DM
+last-owner-msg-id  (unit message-key)     key of most recent owner DM
+status             status:gs              gateway liveness (default %unknown)
 boot-id            (unit @t)              current gateway process id (~ after graceful stop)
 lease-until        (unit @da)             when the heartbeat lease expires
-pending-restart-notice  ?                 whether to send back-online DM on next start
-last-owner-message-at   @da               timestamp of most recent owner DM
-last-owner-message-id   (unit message-key)  key of most recent owner DM
-last-heartbeat-at       (unit @da)        timestamp of most recent accepted heartbeat
-last-stop-at            (unit @da)        timestamp of most recent graceful stop
-last-start-at           (unit @da)        timestamp of most recent gateway start
-last-offline-auto-reply-at   (unit @da)   when the last auto-reply was sent
-last-offline-auto-reply-to   (unit message-key)  key of DM that last triggered an auto-reply (deduplication)
+last-heartbeat     (unit @da)             timestamp of most recent accepted heartbeat
+last-stop          (unit @da)             timestamp of most recent graceful stop
+last-start         (unit @da)             timestamp of most recent gateway start
+pending-restart    ?                      whether to send back-online DM on next start
+last-auto-reply    (unit @da)             when the last offline auto-reply was sent
+last-auto-reply-to (unit message-key)     key of DM that last triggered an auto-reply (deduplication)
+reply-cooldown     @dr                    minimum interval between offline auto-replies
 active-window      @dr                    how recently owner must have messaged for notices
-offline-reply-cooldown  @dr               minimum interval between offline auto-replies
 ```
+
+State is defined in the app file (`desk/app/gateway-status.hoon`), not in `sur/`. The `status` type and shared protocol types (`action`, `update`) live in `desk/sur/gateway-status.hoon`.
 
 While `owner` is `~`, the agent is inert: it subscribes to `%activity` but ignores all DM events. `%configure` is always accepted (it is how the agent leaves the inert state), but `%gateway-start`, `%gateway-heartbeat`, and `%gateway-stop` crash if owner is not set.
 
@@ -60,7 +62,7 @@ The agent considers the gateway live when all three conditions hold:
 -   `lease-until` is set
 -   `lease-until` is in the future
 
-This is computed by `++is-gateway-live` in the structure file.
+This is computed by `++is-gateway-live` in the app helper core.
 
 ## poke protocol
 
@@ -96,8 +98,8 @@ Effects:
 -   Cancels any existing lease timer
 -   Sets `status` to `%up`, stores `boot-id` and `lease-until`
 -   Schedules a behn timer at `lease-until`
--   If `pending-restart-notice` is set and owner was recently active, sends the back-online DM
--   Clears `pending-restart-notice`
+-   If `pending-restart` is set and owner was recently active, sends the back-online DM
+-   Clears `pending-restart`
 
 JSON:
 
@@ -118,8 +120,8 @@ Effects:
 
 -   Cancels existing timer, schedules new timer at new `lease-until`
 -   Restores `status` to `%up` (relevant after lease-expiry recovery)
--   Clears `pending-restart-notice`
--   Updates `last-heartbeat-at`
+-   Clears `pending-restart`
+-   Updates `last-heartbeat`
 
 JSON:
 
@@ -141,7 +143,7 @@ Effects:
 -   Cancels lease timer
 -   Sets `status` to `%down`
 -   Clears `boot-id` from state (prevents delayed heartbeats from reviving the agent)
--   Sets `pending-restart-notice` to true
+-   Sets `pending-restart` to true
 -   If owner was recently active, sends the restarting DM
 
 JSON:
@@ -164,7 +166,7 @@ configure → gateway-start → heartbeat (every ~s30) → gateway-stop
 
 1. Transitions to `%down`
 2. Clears `boot-id` (so delayed in-flight heartbeats are ignored)
-3. Arms `pending-restart-notice`
+3. Arms `pending-restart`
 4. Optionally sends the restarting DM if the owner was recently active
 
 ### crash / lease expiry
@@ -172,7 +174,7 @@ configure → gateway-start → heartbeat (every ~s30) → gateway-stop
 No `%gateway-stop` arrives. The behn timer fires at `lease-until`:
 
 1. If `status` is still `%up` and the lease has expired, transitions to `%down`
-2. Arms `pending-restart-notice`
+2. Arms `pending-restart`
 3. `boot-id` remains in state (enabling heartbeat recovery)
 
 ### heartbeat recovery after lease expiry
@@ -182,14 +184,14 @@ If the gateway is still alive but its heartbeat was delayed (network, load), a v
 On heartbeat recovery:
 
 -   `status` is restored to `%up`
--   `pending-restart-notice` is cleared (the gateway never actually went down)
+-   `pending-restart` is cleared (the gateway never actually went down)
 
 ### restart after downtime
 
 When `%gateway-start` arrives with a new `boot-id`:
 
--   If `pending-restart-notice` is set and the owner was recently active, sends the back-online DM
--   Clears `pending-restart-notice`
+-   If `pending-restart` is set and the owner was recently active, sends the back-online DM
+-   Clears `pending-restart`
 
 ## offline auto-reply
 
@@ -198,8 +200,8 @@ When the configured owner sends a DM (observed via `%activity /v4`) and the gate
 Three conditions must all be true for the reply to fire:
 
 1. **Gateway is unavailable**: `is-gateway-live` returns false
-2. **Not a duplicate**: the inbound message-key differs from `last-offline-auto-reply-to`
-3. **Cooldown elapsed**: time since `last-offline-auto-reply-at` exceeds `offline-reply-cooldown`
+2. **Not a duplicate**: the inbound message-key differs from `last-auto-reply-to`
+3. **Cooldown elapsed**: time since `last-auto-reply` exceeds `reply-cooldown`
 
 The agent ignores:
 
@@ -221,7 +223,7 @@ Sent during `%gateway-stop` if the owner was recently active:
 
 ### back-online notice
 
-Sent during `%gateway-start` if `pending-restart-notice` was armed and the owner was recently active:
+Sent during `%gateway-start` if `pending-restart` was armed and the owner was recently active:
 
 > Your Tlon bot is back online and ready to chat again. ✅
 
@@ -229,8 +231,8 @@ Sent during `%gateway-start` if `pending-restart-notice` was armed and the owner
 
 The owner is considered recently active when:
 
--   `last-owner-message-at` is non-zero
--   `now - last-owner-message-at` is less than `active-window`
+-   `last-owner-msg` is non-zero
+-   `now - last-owner-msg` is less than `active-window`
 
 ## stale event protection
 
@@ -251,23 +253,23 @@ The key asymmetry:
 
 Initial fact on subscribe: `[%status status lease-until]`
 
-Ongoing facts use the `update-1` type:
+Ongoing facts use the `update:v1:gs` type:
 
 | Variant           | Fields                  | When emitted                             |
 | ----------------- | ----------------------- | ---------------------------------------- |
 | `%status`         | `status`, `lease-until` | After any lifecycle poke or lease expiry |
-| `%owner-activity` | `last-owner-message-at` | When the owner sends a DM                |
+| `%owner-activity` | `last-owner-msg`        | When the owner sends a DM                |
 | `%auto-reply`     | `ship`, `at`            | When an offline auto-reply is sent       |
 
 ### scry surface
 
 All scries return `%noun` (no JSON conversion).
 
-| Path                | Returns                 | Description              |
-| ------------------- | ----------------------- | ------------------------ |
-| `/x/status`         | `[status lease-until]`  | Current status and lease |
-| `/x/owner-activity` | `last-owner-message-at` | Last owner DM timestamp  |
-| `/x/state`          | full `state-0`          | Debugging                |
+| Path                | Returns                | Description              |
+| ------------------- | ---------------------- | ------------------------ |
+| `/x/status`         | `[status lease-until]` | Current status and lease |
+| `/x/owner-activity` | `last-owner-msg`       | Last owner DM timestamp  |
+| `/x/state`          | full `state-0`         | Debugging                |
 
 ## integration with openclaw-tlon
 
@@ -288,11 +290,11 @@ The `boot-id` should be a unique identifier per gateway process (e.g., a UUID ge
 
 ## timing defaults
 
-| Parameter                | Default    | Set by                              |
-| ------------------------ | ---------- | ----------------------------------- |
-| `active-window`          | 5 minutes  | Ship agent (via `%configure`)       |
-| `offline-reply-cooldown` | 5 minutes  | Ship agent (via `%configure`)       |
-| Heartbeat interval       | 30 seconds | Gateway process                     |
-| Lease duration           | 90 seconds | Gateway process (via `lease-until`) |
+| Parameter          | Default    | Set by                              |
+| ------------------ | ---------- | ----------------------------------- |
+| `active-window`    | 5 minutes  | Ship agent (via `%configure`)       |
+| `reply-cooldown`   | 5 minutes  | Ship agent (via `%configure`)       |
+| Heartbeat interval | 30 seconds | Gateway process                     |
+| Lease duration     | 90 seconds | Gateway process (via `lease-until`) |
 
-The ship agent stores `active-window` and `offline-reply-cooldown`. The heartbeat interval and lease duration are computed by the gateway process and are not stored in agent state.
+The ship agent stores `active-window` and `reply-cooldown`. The heartbeat interval and lease duration are computed by the gateway process and are not stored in agent state.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/api",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "files": [
     "dist",

--- a/packages/api/src/__tests__/gatewayStatusApi.test.ts
+++ b/packages/api/src/__tests__/gatewayStatusApi.test.ts
@@ -1,0 +1,117 @@
+import { da, dr, render } from '@urbit/aura';
+import { expect, test, vi } from 'vitest';
+
+import {
+  configureGatewayStatus,
+  gatewayHeartbeat,
+  gatewayStart,
+  gatewayStatusAction,
+  gatewayStop,
+} from '../client/gatewayStatusApi';
+import { poke } from '../client/urbit';
+
+vi.mock('../client/urbit', () => ({
+  poke: vi.fn().mockResolvedValue(undefined),
+}));
+
+test('gatewayStatusAction wraps configure action', () => {
+  const result = gatewayStatusAction({
+    configure: {
+      owner: '~zod',
+      'active-window': '~h1',
+      'offline-reply-cooldown': '~d1',
+    },
+  });
+  expect(result).toStrictEqual({
+    app: 'gateway-status',
+    mark: 'gateway-status-action-1',
+    json: {
+      configure: {
+        owner: '~zod',
+        'active-window': '~h1',
+        'offline-reply-cooldown': '~d1',
+      },
+    },
+  });
+});
+
+test('gatewayStatusAction wraps gateway-start action', () => {
+  const result = gatewayStatusAction({
+    'gateway-start': {
+      'boot-id': 'abc123',
+      'lease-until': '~2026.4.3..12.00.00',
+    },
+  });
+  expect(result.app).toBe('gateway-status');
+  expect(result.mark).toBe('gateway-status-action-1');
+  expect(result.json).toHaveProperty('gateway-start');
+});
+
+test('gatewayStatusAction wraps gateway-stop action', () => {
+  const result = gatewayStatusAction({
+    'gateway-stop': { reason: 'shutting down' },
+  });
+  expect(result.json).toStrictEqual({
+    'gateway-stop': { reason: 'shutting down' },
+  });
+});
+
+test('configureGatewayStatus converts seconds to @dr and pokes', async () => {
+  await configureGatewayStatus({
+    owner: '~sampel-palnet',
+    activeWindowSecs: 3600,
+    offlineReplyCooldownSecs: 86400,
+  });
+  expect(poke).toHaveBeenCalledWith({
+    app: 'gateway-status',
+    mark: 'gateway-status-action-1',
+    json: {
+      configure: {
+        owner: '~sampel-palnet',
+        'active-window': render('dr', dr.fromSeconds(BigInt(3600))),
+        'offline-reply-cooldown': render('dr', dr.fromSeconds(BigInt(86400))),
+      },
+    },
+  });
+});
+
+test('gatewayStart converts Unix millis to @da and pokes', async () => {
+  const leaseUntil = 1743638400000;
+  await gatewayStart({ bootId: 'boot-xyz', leaseUntil });
+  expect(poke).toHaveBeenCalledWith({
+    app: 'gateway-status',
+    mark: 'gateway-status-action-1',
+    json: {
+      'gateway-start': {
+        'boot-id': 'boot-xyz',
+        'lease-until': render('da', da.fromUnix(leaseUntil)),
+      },
+    },
+  });
+});
+
+test('gatewayHeartbeat converts Unix millis to @da and pokes', async () => {
+  const leaseUntil = 1743638400000;
+  await gatewayHeartbeat({ bootId: 'boot-xyz', leaseUntil });
+  expect(poke).toHaveBeenCalledWith({
+    app: 'gateway-status',
+    mark: 'gateway-status-action-1',
+    json: {
+      'gateway-heartbeat': {
+        'boot-id': 'boot-xyz',
+        'lease-until': render('da', da.fromUnix(leaseUntil)),
+      },
+    },
+  });
+});
+
+test('gatewayStop pokes with reason string', async () => {
+  await gatewayStop('maintenance window');
+  expect(poke).toHaveBeenCalledWith({
+    app: 'gateway-status',
+    mark: 'gateway-status-action-1',
+    json: {
+      'gateway-stop': { reason: 'maintenance window' },
+    },
+  });
+});

--- a/packages/api/src/__tests__/gatewayStatusApi.test.ts
+++ b/packages/api/src/__tests__/gatewayStatusApi.test.ts
@@ -49,10 +49,10 @@ test('gatewayStatusAction wraps gateway-start action', () => {
 
 test('gatewayStatusAction wraps gateway-stop action', () => {
   const result = gatewayStatusAction({
-    'gateway-stop': { reason: 'shutting down' },
+    'gateway-stop': { 'boot-id': 'boot-xyz', reason: 'shutting down' },
   });
   expect(result.json).toStrictEqual({
-    'gateway-stop': { reason: 'shutting down' },
+    'gateway-stop': { 'boot-id': 'boot-xyz', reason: 'shutting down' },
   });
 });
 
@@ -105,13 +105,13 @@ test('gatewayHeartbeat converts Unix millis to @da and pokes', async () => {
   });
 });
 
-test('gatewayStop pokes with reason string', async () => {
-  await gatewayStop('maintenance window');
+test('gatewayStop pokes with boot-id and reason', async () => {
+  await gatewayStop({ bootId: 'boot-abc', reason: 'maintenance window' });
   expect(poke).toHaveBeenCalledWith({
     app: 'gateway-status',
     mark: 'gateway-status-action-1',
     json: {
-      'gateway-stop': { reason: 'maintenance window' },
+      'gateway-stop': { 'boot-id': 'boot-abc', reason: 'maintenance window' },
     },
   });
 });

--- a/packages/api/src/client/gatewayStatusApi.ts
+++ b/packages/api/src/client/gatewayStatusApi.ts
@@ -1,10 +1,8 @@
 import { da, dr, render } from '@urbit/aura';
 
 import type * as ub from '../urbit';
-import { createDevLogger } from './logger';
 import { poke } from './urbit';
 
-const logger = createDevLogger('gatewayStatusApi', false);
 
 /**
  * Build a raw poke payload for the %gateway-status agent.
@@ -42,7 +40,6 @@ export async function configureGatewayStatus(params: {
       ),
     },
   });
-  logger.log('configuring gateway status', action);
   return poke(action);
 }
 
@@ -61,7 +58,6 @@ export async function gatewayStart(params: {
       'lease-until': render('da', da.fromUnix(params.leaseUntil)),
     },
   });
-  logger.log('gateway start', action);
   return poke(action);
 }
 
@@ -80,7 +76,6 @@ export async function gatewayHeartbeat(params: {
       'lease-until': render('da', da.fromUnix(params.leaseUntil)),
     },
   });
-  logger.log('gateway heartbeat', action);
   return poke(action);
 }
 
@@ -92,6 +87,5 @@ export async function gatewayStop(reason: string) {
   const action = gatewayStatusAction({
     'gateway-stop': { reason },
   });
-  logger.log('gateway stop', action);
   return poke(action);
 }

--- a/packages/api/src/client/gatewayStatusApi.ts
+++ b/packages/api/src/client/gatewayStatusApi.ts
@@ -80,11 +80,12 @@ export async function gatewayHeartbeat(params: {
 
 /**
  * Signal that a gateway instance has stopped.
- * @param reason - human-readable reason for stopping
+ * @param params.bootId - must match the current boot-id; stale stops are ignored
+ * @param params.reason - human-readable reason for stopping
  */
-export async function gatewayStop(reason: string) {
+export async function gatewayStop(params: { bootId: string; reason: string }) {
   const action = gatewayStatusAction({
-    'gateway-stop': { reason },
+    'gateway-stop': { 'boot-id': params.bootId, reason: params.reason },
   });
   return poke(action);
 }

--- a/packages/api/src/client/gatewayStatusApi.ts
+++ b/packages/api/src/client/gatewayStatusApi.ts
@@ -1,0 +1,97 @@
+import { da, dr, render } from '@urbit/aura';
+
+import type * as ub from '../urbit';
+import { createDevLogger } from './logger';
+import { poke } from './urbit';
+
+const logger = createDevLogger('gatewayStatusApi', false);
+
+/**
+ * Build a raw poke payload for the %gateway-status agent.
+ * Temporal fields must already be in @da/@dr string format.
+ */
+export function gatewayStatusAction(action: ub.GatewayStatusAction) {
+  return {
+    app: 'gateway-status',
+    mark: 'gateway-status-action-1',
+    json: action,
+  };
+}
+
+/**
+ * Configure the gateway-status agent.
+ * @param owner - @p string of the owner ship, e.g. "~zod"
+ * @param activeWindowSecs - owner activity window in seconds
+ * @param offlineReplyCooldownSecs - minimum seconds between auto-replies
+ */
+export async function configureGatewayStatus(params: {
+  owner: string;
+  activeWindowSecs: number;
+  offlineReplyCooldownSecs: number;
+}) {
+  const action = gatewayStatusAction({
+    configure: {
+      owner: params.owner,
+      'active-window': render(
+        'dr',
+        dr.fromSeconds(BigInt(params.activeWindowSecs))
+      ),
+      'offline-reply-cooldown': render(
+        'dr',
+        dr.fromSeconds(BigInt(params.offlineReplyCooldownSecs))
+      ),
+    },
+  });
+  logger.log('configuring gateway status', action);
+  return poke(action);
+}
+
+/**
+ * Signal that a gateway instance has started.
+ * @param bootId - opaque boot identifier
+ * @param leaseUntil - lease expiry as Unix milliseconds
+ */
+export async function gatewayStart(params: {
+  bootId: string;
+  leaseUntil: number;
+}) {
+  const action = gatewayStatusAction({
+    'gateway-start': {
+      'boot-id': params.bootId,
+      'lease-until': render('da', da.fromUnix(params.leaseUntil)),
+    },
+  });
+  logger.log('gateway start', action);
+  return poke(action);
+}
+
+/**
+ * Extend the lease for an active gateway instance.
+ * @param bootId - must match the current boot-id
+ * @param leaseUntil - new lease expiry as Unix milliseconds
+ */
+export async function gatewayHeartbeat(params: {
+  bootId: string;
+  leaseUntil: number;
+}) {
+  const action = gatewayStatusAction({
+    'gateway-heartbeat': {
+      'boot-id': params.bootId,
+      'lease-until': render('da', da.fromUnix(params.leaseUntil)),
+    },
+  });
+  logger.log('gateway heartbeat', action);
+  return poke(action);
+}
+
+/**
+ * Signal that a gateway instance has stopped.
+ * @param reason - human-readable reason for stopping
+ */
+export async function gatewayStop(reason: string) {
+  const action = gatewayStatusAction({
+    'gateway-stop': { reason },
+  });
+  logger.log('gateway stop', action);
+  return poke(action);
+}

--- a/packages/api/src/client/gatewayStatusApi.ts
+++ b/packages/api/src/client/gatewayStatusApi.ts
@@ -3,7 +3,6 @@ import { da, dr, render } from '@urbit/aura';
 import type * as ub from '../urbit';
 import { poke } from './urbit';
 
-
 /**
  * Build a raw poke payload for the %gateway-status agent.
  * Temporal fields must already be in @da/@dr string format.

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -51,3 +51,4 @@ export type { HostingHeartBeatCode } from './hostingApi';
 export * from './apiUtils';
 export * from './metagrabApi';
 export * from './changesApi';
+export * from './gatewayStatusApi';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -51,6 +51,7 @@ export {
   type WritResponseDelta,
   type WritDelta,
   type WritDiff,
+  type GatewayStatusAction,
 } from './urbit';
 export {
   appendFileUploadToPostBlob,

--- a/packages/api/src/urbit/gatewayStatus.ts
+++ b/packages/api/src/urbit/gatewayStatus.ts
@@ -1,0 +1,33 @@
+export interface GatewayStatusConfigure {
+  configure: {
+    owner: string;
+    'active-window': string;
+    'offline-reply-cooldown': string;
+  };
+}
+
+export interface GatewayStatusStart {
+  'gateway-start': {
+    'boot-id': string;
+    'lease-until': string;
+  };
+}
+
+export interface GatewayStatusHeartbeat {
+  'gateway-heartbeat': {
+    'boot-id': string;
+    'lease-until': string;
+  };
+}
+
+export interface GatewayStatusStop {
+  'gateway-stop': {
+    reason: string;
+  };
+}
+
+export type GatewayStatusAction =
+  | GatewayStatusConfigure
+  | GatewayStatusStart
+  | GatewayStatusHeartbeat
+  | GatewayStatusStop;

--- a/packages/api/src/urbit/gatewayStatus.ts
+++ b/packages/api/src/urbit/gatewayStatus.ts
@@ -22,6 +22,7 @@ export interface GatewayStatusHeartbeat {
 
 export interface GatewayStatusStop {
   'gateway-stop': {
+    'boot-id': string;
     reason: string;
   };
 }

--- a/packages/api/src/urbit/index.ts
+++ b/packages/api/src/urbit/index.ts
@@ -32,3 +32,4 @@ export * from './vitals';
 export * from './lanyard';
 export * from './metagrab';
 export * from './meta';
+export * from './gatewayStatus';


### PR DESCRIPTION
## Summary

Resolves TLON-5534

Adds a new `%gateway-status` Gall agent plus `@tloncorp/api` helpers to support lease-based gateway liveness for the Tlon bot. The agent tracks owner DM recency, sends offline auto-replies while the gateway is down, sends a back-online notice after restart when the owner was recently active, and uses a heartbeat lease so it can distinguish graceful shutdowns from hard crashes.

The final implementation also follows local Hoon conventions more closely: shared protocol types live in `sur/`, while agent state and app-local helper logic live in the app file.

## Changes

- Added `desk/app/gateway-status.hoon` with the new Gall agent, including the app-local `state-0`, liveness helper, `%activity /v4` subscription, lease/timer handling, and `%chat` DM notices
- Added `desk/sur/gateway-status.hoon` with the shared `status`, `action`, and `update` types plus `v1` indirection
- Added `desk/mar/gateway-status/action-1.hoon` for the inbound JSON action protocol (`%configure`, `%gateway-start`, `%gateway-heartbeat`, `%gateway-stop`)
- Added `desk/mar/gateway-status/update-1.hoon` for outbound `%noun` subscription updates (`%status`, `%owner-activity`, `%auto-reply`)
- Added `desk/tests/app/gateway-status.hoon` with 17 agent-level tests covering init, configure, lifecycle state transitions, owner DM auto-reply, cooldown suppression, deduplication, stale stop/heartbeat protection, and lease-expiry recovery
- Registered `%gateway-status` in `desk/desk.bill`
- Added `packages/api/src/urbit/gatewayStatus.ts` and `packages/api/src/client/gatewayStatusApi.ts` for the `%gateway-status` poke surface (`configureGatewayStatus`, `gatewayStart`, `gatewayHeartbeat`, `gatewayStop`)
- Added `packages/api/src/__tests__/gatewayStatusApi.test.ts` and re-exported the new API helpers from the package entrypoints
- Added `docs/gateway-status.md` as an implementation-facing spec for the new agent
- Updated `CLAUDE.md` with repo-specific Hoon guidance around agent structure, `sur/` responsibilities, type naming, mark conventions, and testing
- Bumped `packages/api/package.json` to `0.0.5`

## How did I test?

- Ran the 17 Hoon agent tests via the `test-agent` harness
- Ran the TypeScript unit tests for the new `@tloncorp/api` helpers
- Built the updated Hoon files directly on fake ships while iterating on the agent shape and mark surface
- Manually verified the full lifecycle with local fake ships (`~zod` bot, `~ten` owner) and the `openclaw-tlon` dev environment:
  - startup transitions `%gateway-status` to `%up`
  - heartbeat extends `lease-until`
  - graceful gateway shutdown transitions status to `%down`
  - owner DMs while down receive the offline auto-reply
  - cooldown suppresses repeated offline auto-replies within 5 minutes
  - restart after graceful shutdown sends the back-online notice and clears the pending restart flag
  - ungraceful gateway kill leaves status `%up` until the lease expires, then transitions to `%down`
  - owner DMs after crash-driven lease expiry also receive the offline auto-reply
  - restart after crash-driven lease expiry also sends the back-online notice

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: backend agent surface and `@tloncorp/api` integration

## Rollback plan

Revert.