### PR TITLE
improve forward sheet behavior

### DIFF
--- a/packages/app/hooks/chatSearchRanking.ts
+++ b/packages/app/hooks/chatSearchRanking.ts
@@ -41,7 +41,7 @@ export function hasAllChatSearchTokens(
   );
 }
 
-function tokenPresenceScore(
+export function tokenPresenceScore(
   value: string,
   token: string,
   weights: {

--- a/packages/app/hooks/useChatSearch.ts
+++ b/packages/app/hooks/useChatSearch.ts
@@ -1,0 +1,280 @@
+import { configurationFromChannel } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import Fuse from 'fuse.js';
+import { debounce } from 'lodash';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import { getChannelTitle, getGroupTitle } from '../ui';
+import {
+  ChatSearchCandidate,
+  ChatSearchFuzzyScore,
+  hasAllChatSearchTokens,
+  normalizeChatSearchString,
+  rankChatSearchCandidates,
+  tokenPresenceScore,
+  tokenizeChatSearchQuery,
+} from './chatSearchRanking';
+
+type ChatSearchDoc = ChatSearchCandidate & {
+  chat: db.Chat;
+};
+
+type ChatSearchSource = {
+  key: string;
+  docs: ChatSearchDoc[];
+  fuse: Fuse<ChatSearchDoc>;
+  allChats: db.Chat[];
+};
+
+type ChatSearchResult = {
+  sourceKey: string;
+  query: string;
+  chats: db.Chat[];
+};
+
+function buildChatSearchDoc(
+  chat: db.Chat,
+  disableNicknames: boolean
+): ChatSearchDoc {
+  const title = normalizeChatSearchString(
+    getChatTitle(chat, disableNicknames)
+  );
+  const groupTitle = normalizeChatSearchString(
+    chat.type === 'channel' && chat.channel.group
+      ? getGroupTitle(chat.channel.group, disableNicknames)
+      : ''
+  );
+  const id = normalizeChatSearchString(chat.id);
+  return {
+    chat,
+    id,
+    title,
+    groupTitle,
+    combined: `${title} ${groupTitle} ${id}`.trim(),
+    timestamp: chat.timestamp,
+  };
+}
+
+function getChatTitle(chat: db.Chat, disableNicknames: boolean): string {
+  if (chat.type === 'channel') {
+    return getChannelTitle({
+      ...configurationFromChannel(chat.channel),
+      channelTitle: chat.channel.title,
+      members: chat.channel.members,
+      disableNicknames,
+    });
+  }
+
+  return getGroupTitle(chat.group, disableNicknames);
+}
+
+function scoreSubstringMatch(
+  candidate: ChatSearchCandidate,
+  normalizedQuery: string
+) {
+  return (
+    tokenPresenceScore(candidate.title, normalizedQuery, {
+      exact: 120,
+      prefix: 90,
+      contains: 48,
+    }) +
+    tokenPresenceScore(candidate.groupTitle, normalizedQuery, {
+      exact: 70,
+      prefix: 50,
+      contains: 20,
+    }) +
+    tokenPresenceScore(candidate.id, normalizedQuery, {
+      exact: 28,
+      prefix: 20,
+      contains: 10,
+    })
+  );
+}
+
+function searchChatDocs(
+  docs: ChatSearchDoc[],
+  fuse: Fuse<ChatSearchDoc>,
+  query: string
+): db.Chat[] {
+  const normalizedQuery = normalizeChatSearchString(query);
+  if (!normalizedQuery) {
+    return [];
+  }
+
+  const directMatches = docs.filter((candidate) =>
+    candidate.combined.includes(normalizedQuery)
+  );
+
+  if (directMatches.length > 0) {
+    directMatches.sort((a, b) => {
+      const scoreDiff =
+        scoreSubstringMatch(b, normalizedQuery) -
+        scoreSubstringMatch(a, normalizedQuery);
+
+      return scoreDiff !== 0 ? scoreDiff : b.timestamp - a.timestamp;
+    });
+
+    return directMatches.map((candidate) => candidate.chat);
+  }
+
+  const tokens = tokenizeChatSearchQuery(query);
+  const fuzzyResults = fuse.search(normalizedQuery);
+
+  if (tokens.length <= 1) {
+    return fuzzyResults.map((result) => result.item.chat);
+  }
+
+  const tokenMatchedCandidates = docs.filter((candidate) =>
+    hasAllChatSearchTokens(candidate, tokens)
+  );
+
+  if (!tokenMatchedCandidates.length) {
+    return fuzzyResults.map((result) => result.item.chat);
+  }
+
+  const fuzzyScores = new Map<string, ChatSearchFuzzyScore>(
+    fuzzyResults.map((result, rank) => [
+      result.item.id,
+      {
+        rank,
+        score: result.score ?? Number.POSITIVE_INFINITY,
+      },
+    ])
+  );
+
+  return rankChatSearchCandidates(
+    tokenMatchedCandidates,
+    tokens,
+    normalizedQuery,
+    fuzzyScores
+  ).map((candidate) => candidate.chat);
+}
+
+function createChatSearchSource(
+  chats: db.Chat[],
+  disableNicknames: boolean,
+  key: string
+): ChatSearchSource {
+  const docs = chats.map((chat) => buildChatSearchDoc(chat, disableNicknames));
+
+  return {
+    key,
+    docs,
+    allChats: docs.map((doc) => doc.chat),
+    fuse: new Fuse(docs, {
+      includeScore: true,
+      ignoreLocation: true,
+      threshold: 0.45,
+      keys: [
+        { name: 'combined', weight: 0.75 },
+        { name: 'title', weight: 0.15 },
+        { name: 'groupTitle', weight: 0.08 },
+        { name: 'id', weight: 0.02 },
+      ],
+    }),
+  };
+}
+
+function useDebouncedValue<T>(input: T, delay: number) {
+  const [value, setValue] = useState<T>(input);
+  const debouncedSetValue = useMemo(
+    () => debounce(setValue, delay, { leading: true }),
+    [delay]
+  );
+
+  useLayoutEffect(() => {
+    if (delay <= 0) {
+      debouncedSetValue.cancel();
+      setValue(input);
+      return;
+    }
+
+    debouncedSetValue(input);
+    return () => debouncedSetValue.cancel();
+  }, [debouncedSetValue, delay, input]);
+
+  return delay <= 0 ? input : value;
+}
+
+export function useChatSearch({
+  chats,
+  searchQuery,
+  debounceMs,
+  disableNicknames,
+  semanticCacheKey,
+}: {
+  chats: db.Chat[];
+  searchQuery: string;
+  debounceMs: number;
+  disableNicknames: boolean;
+  semanticCacheKey?: string;
+}) {
+  const sourceCacheRef = useRef<ChatSearchSource | null>(null);
+  const resultCacheRef = useRef<ChatSearchResult | null>(null);
+  const searchSource = useMemo(() => {
+    if (!semanticCacheKey) {
+      return createChatSearchSource(chats, disableNicknames, '');
+    }
+
+    const cachedSource = sourceCacheRef.current;
+    if (cachedSource?.key === semanticCacheKey) {
+      return cachedSource;
+    }
+
+    const nextSource = createChatSearchSource(
+      chats,
+      disableNicknames,
+      semanticCacheKey
+    );
+    sourceCacheRef.current = nextSource;
+    return nextSource;
+  }, [chats, disableNicknames, semanticCacheKey]);
+  const searchDocsList = searchSource.docs;
+  const searchFuse = searchSource.fuse;
+  const allChats = searchSource.allChats;
+
+  const debouncedQuery = useDebouncedValue(searchQuery, debounceMs);
+  const trimmedQuery = debouncedQuery.trim();
+  const isSearching = trimmedQuery !== '';
+
+  const results = useMemo(() => {
+    if (!isSearching) {
+      return [];
+    }
+
+    if (semanticCacheKey) {
+      const cachedResult = resultCacheRef.current;
+      if (
+        cachedResult?.sourceKey === searchSource.key &&
+        cachedResult.query === trimmedQuery
+      ) {
+        return cachedResult.chats;
+      }
+    }
+
+    const nextChats = searchChatDocs(searchDocsList, searchFuse, trimmedQuery);
+
+    if (semanticCacheKey) {
+      resultCacheRef.current = {
+        sourceKey: searchSource.key,
+        query: trimmedQuery,
+        chats: nextChats,
+      };
+    }
+
+    return nextChats;
+  }, [
+    isSearching,
+    searchDocsList,
+    searchFuse,
+    searchSource.key,
+    semanticCacheKey,
+    trimmedQuery,
+  ]);
+
+  return {
+    isSearching,
+    results,
+    allChats,
+  };
+}

--- a/packages/app/hooks/useChatSearch.ts
+++ b/packages/app/hooks/useChatSearch.ts
@@ -2,7 +2,7 @@ import { configurationFromChannel } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import Fuse from 'fuse.js';
 import { debounce } from 'lodash';
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { getChannelTitle, getGroupTitle } from '../ui';
 import {
@@ -188,8 +188,11 @@ function useDebouncedValue<T>(input: T, delay: number) {
     }
 
     debouncedSetValue(input);
-    return () => debouncedSetValue.cancel();
   }, [debouncedSetValue, delay, input]);
+
+  useEffect(() => {
+    return () => debouncedSetValue.cancel();
+  }, [debouncedSetValue]);
 
   return delay <= 0 ? input : value;
 }

--- a/packages/app/hooks/useChatSearch.ts
+++ b/packages/app/hooks/useChatSearch.ts
@@ -15,27 +15,27 @@ import {
   tokenizeChatSearchQuery,
 } from './chatSearchRanking';
 
-type ChatSearchDoc = ChatSearchCandidate & {
-  chat: db.Chat;
+type ChatSearchDoc<TChat extends db.Chat> = ChatSearchCandidate & {
+  chat: TChat;
 };
 
-type ChatSearchSource = {
+type ChatSearchSource<TChat extends db.Chat> = {
   key: string;
-  docs: ChatSearchDoc[];
-  fuse: Fuse<ChatSearchDoc>;
-  allChats: db.Chat[];
+  docs: ChatSearchDoc<TChat>[];
+  fuse: Fuse<ChatSearchDoc<TChat>>;
+  allChats: TChat[];
 };
 
-type ChatSearchResult = {
+type ChatSearchResult<TChat extends db.Chat> = {
   sourceKey: string;
   query: string;
-  chats: db.Chat[];
+  chats: TChat[];
 };
 
-function buildChatSearchDoc(
-  chat: db.Chat,
+function buildChatSearchDoc<TChat extends db.Chat>(
+  chat: TChat,
   disableNicknames: boolean
-): ChatSearchDoc {
+): ChatSearchDoc<TChat> {
   const title = normalizeChatSearchString(getChatTitle(chat, disableNicknames));
   const groupTitle = normalizeChatSearchString(
     chat.type === 'channel' && chat.channel.group
@@ -89,11 +89,11 @@ function scoreSubstringMatch(
   );
 }
 
-function searchChatDocs(
-  docs: ChatSearchDoc[],
-  fuse: Fuse<ChatSearchDoc>,
+function searchChatDocs<TChat extends db.Chat>(
+  docs: ChatSearchDoc<TChat>[],
+  fuse: Fuse<ChatSearchDoc<TChat>>,
   query: string
-): db.Chat[] {
+): TChat[] {
   const normalizedQuery = normalizeChatSearchString(query);
   if (!normalizedQuery) {
     return [];
@@ -148,17 +148,17 @@ function searchChatDocs(
   ).map((candidate) => candidate.chat);
 }
 
-function createChatSearchSource(
-  chats: db.Chat[],
+function createChatSearchSource<TChat extends db.Chat>(
+  chats: TChat[],
   disableNicknames: boolean,
   key: string
-): ChatSearchSource {
+): ChatSearchSource<TChat> {
   const docs = chats.map((chat) => buildChatSearchDoc(chat, disableNicknames));
 
   return {
     key,
     docs,
-    allChats: docs.map((doc) => doc.chat),
+    allChats: chats,
     fuse: new Fuse(docs, {
       includeScore: true,
       ignoreLocation: true,
@@ -197,21 +197,21 @@ function useDebouncedValue<T>(input: T, delay: number) {
   return delay <= 0 ? input : value;
 }
 
-export function useChatSearch({
+export function useChatSearch<TChat extends db.Chat>({
   chats,
   searchQuery,
   debounceMs,
   disableNicknames,
   semanticCacheKey,
 }: {
-  chats: db.Chat[];
+  chats: TChat[];
   searchQuery: string;
   debounceMs: number;
   disableNicknames: boolean;
   semanticCacheKey?: string;
 }) {
-  const sourceCacheRef = useRef<ChatSearchSource | null>(null);
-  const resultCacheRef = useRef<ChatSearchResult | null>(null);
+  const sourceCacheRef = useRef<ChatSearchSource<TChat> | null>(null);
+  const resultCacheRef = useRef<ChatSearchResult<TChat> | null>(null);
   const searchSource = useMemo(() => {
     if (!semanticCacheKey) {
       return createChatSearchSource(chats, disableNicknames, '');

--- a/packages/app/hooks/useChatSearch.ts
+++ b/packages/app/hooks/useChatSearch.ts
@@ -36,9 +36,7 @@ function buildChatSearchDoc(
   chat: db.Chat,
   disableNicknames: boolean
 ): ChatSearchDoc {
-  const title = normalizeChatSearchString(
-    getChatTitle(chat, disableNicknames)
-  );
+  const title = normalizeChatSearchString(getChatTitle(chat, disableNicknames));
   const groupTitle = normalizeChatSearchString(
     chat.type === 'channel' && chat.channel.group
       ? getGroupTitle(chat.channel.group, disableNicknames)

--- a/packages/app/hooks/useFilteredChannelChats.ts
+++ b/packages/app/hooks/useFilteredChannelChats.ts
@@ -72,13 +72,8 @@ export function useFilteredChannelChats({
     semanticCacheKey,
   });
 
-  const visibleChannelChats = useMemo(
-    () => (isSearching ? searchResults : allChats).filter(isChannelChat),
-    [allChats, isSearching, searchResults]
-  );
-
   return {
-    channelChats: visibleChannelChats,
+    channelChats: isSearching ? searchResults : allChats,
     isSearching,
   };
 }

--- a/packages/app/hooks/useFilteredChannelChats.ts
+++ b/packages/app/hooks/useFilteredChannelChats.ts
@@ -60,7 +60,11 @@ export function useFilteredChannelChats({
     [channelChats, disableNicknames]
   );
 
-  const { isSearching, results: searchResults, allChats } = useChatSearch({
+  const {
+    isSearching,
+    results: searchResults,
+    allChats,
+  } = useChatSearch({
     chats: channelChats,
     searchQuery,
     debounceMs: 0,

--- a/packages/app/hooks/useFilteredChannelChats.ts
+++ b/packages/app/hooks/useFilteredChannelChats.ts
@@ -1,0 +1,80 @@
+import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
+import { useMemo } from 'react';
+
+import { useCalm } from '../ui';
+import { useChatSearch } from './useChatSearch';
+import { useResolvedChats } from './useResolvedChats';
+
+type ChannelChat = db.Chat & { type: 'channel' };
+
+function isChannelChat(chat: db.Chat): chat is ChannelChat {
+  return chat.type === 'channel';
+}
+
+function buildChannelChatSearchKey(
+  channelChats: ChannelChat[],
+  disableNicknames: boolean
+) {
+  return `${disableNicknames ? 'nicknames-off' : 'nicknames-on'}:${channelChats
+    .map((chat) =>
+      [
+        chat.id,
+        chat.channel.title ?? '',
+        chat.channel.members?.length ?? 0,
+        chat.channel.group?.id ?? '',
+        chat.channel.group?.title ?? '',
+        chat.channel.group?.members?.length ?? 0,
+        chat.channel.group?.privacy ?? '',
+        chat.channel.group?.joinStatus ?? '',
+        chat.channel.group?.haveInvite ? '1' : '0',
+        chat.channel.group?.currentUserIsMember === false ? '0' : '1',
+        chat.timestamp,
+      ].join('\u0001')
+    )
+    .join('\u0002')}`;
+}
+
+export function useFilteredChannelChats({
+  searchQuery,
+  channelFilter,
+}: {
+  searchQuery: string;
+  channelFilter?: (channel: db.Channel) => boolean;
+}) {
+  const { disableNicknames } = useCalm();
+  const { data: chats } = store.useCurrentChats();
+  const resolvedChats = useResolvedChats(chats);
+
+  const channelChats = useMemo(() => {
+    const all = [...resolvedChats.pinned, ...resolvedChats.unpinned].filter(
+      isChannelChat
+    );
+
+    return channelFilter
+      ? all.filter((chat) => channelFilter(chat.channel))
+      : all;
+  }, [channelFilter, resolvedChats.pinned, resolvedChats.unpinned]);
+  const semanticCacheKey = useMemo(
+    () => buildChannelChatSearchKey(channelChats, disableNicknames),
+    [channelChats, disableNicknames]
+  );
+
+  const { isSearching, results: searchResults, allChats } = useChatSearch({
+    chats: channelChats,
+    searchQuery,
+    debounceMs: 0,
+    disableNicknames,
+    semanticCacheKey,
+  });
+
+  const visibleChannelChats = useMemo(
+    () => (isSearching ? searchResults : allChats).filter(isChannelChat),
+    [allChats, isSearching, searchResults]
+  );
+
+  return {
+    channelChats: visibleChannelChats,
+    isSearching,
+  };
+}

--- a/packages/app/hooks/useFilteredChats.ts
+++ b/packages/app/hooks/useFilteredChats.ts
@@ -99,7 +99,14 @@ export function useFilteredChats({
         data: searchResults,
       },
     ];
-  }, [activeTab, allChats, pinnedChats, searchQuery, searchResults, talkFilter]);
+  }, [
+    activeTab,
+    allChats,
+    pinnedChats,
+    searchQuery,
+    searchResults,
+    talkFilter,
+  ]);
 }
 
 function filterChats(

--- a/packages/app/hooks/useFilteredChats.ts
+++ b/packages/app/hooks/useFilteredChats.ts
@@ -1,20 +1,10 @@
 import { TalkSidebarFilter } from '@tloncorp/api/urbit';
-import { configurationFromChannel, useMessagesFilter } from '@tloncorp/shared';
+import { useMessagesFilter } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import Fuse from 'fuse.js';
-import { debounce } from 'lodash';
-import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { useCalm } from '../ui';
-import { getChannelTitle, getGroupTitle } from '../ui';
-import {
-  ChatSearchCandidate,
-  ChatSearchFuzzyScore,
-  hasAllChatSearchTokens,
-  normalizeChatSearchString,
-  rankChatSearchCandidates,
-  tokenizeChatSearchQuery,
-} from './chatSearchRanking';
+import { useChatSearch } from './useChatSearch';
 
 export type TabName =
   | 'all'
@@ -28,10 +18,6 @@ export type SectionedChatData = {
   title: string;
   data: db.Chat[];
 }[];
-
-type ChatSearchDoc = ChatSearchCandidate & {
-  chat: db.Chat;
-};
 
 function getAllSectionHeader(
   activeTab: TabName,
@@ -74,49 +60,21 @@ export function useFilteredChats({
   );
   const searchableChats = useMemo(
     () => filterChats(chats, activeTab, talkFilter),
-    [chats, activeTab, talkFilter]
+    [activeTab, chats, talkFilter]
   );
-  const getSearchTitle = useCallback(
-    (chat: db.Chat) => getChatTitle(chat, disableNicknames),
-    [disableNicknames]
+  const { results: searchResults } = useChatSearch({
+    chats: searchableChats,
+    searchQuery,
+    debounceMs: 200,
+    disableNicknames,
+  });
+  const pinnedChats = useMemo(
+    () => filterChats(pinned, activeTab, talkFilter),
+    [activeTab, pinned, talkFilter]
   );
-  const getSearchGroupTitle = useCallback(
-    (chat: db.Chat) => {
-      if (chat.type !== 'channel' || !chat.channel.group) {
-        return '';
-      }
-
-      return getGroupTitle(chat.channel.group, disableNicknames);
-    },
-    [disableNicknames]
-  );
-  const searchDocs = useMemo(
-    () =>
-      buildChatSearchDocs({
-        chats: searchableChats,
-        getChatTitle: getSearchTitle,
-        getGroupTitleForChat: getSearchGroupTitle,
-      }),
-    [searchableChats, getSearchTitle, getSearchGroupTitle]
-  );
-  const searchFuse = useMemo(
-    () => createChatSearchFuse(searchDocs),
-    [searchDocs]
-  );
-  const performSearch = useCallback(
-    (query: string) => {
-      return searchChatDocs({
-        docs: searchDocs,
-        fuse: searchFuse,
-        query,
-      });
-    },
-    [searchDocs, searchFuse]
-  );
-  const debouncedQuery = useDebouncedValue(searchQuery, 200);
-  const searchResults = useMemo(
-    () => performSearch(debouncedQuery),
-    [debouncedQuery, performSearch]
+  const allChats = useMemo(
+    () => filterChats([...pending, ...unpinned], activeTab, talkFilter),
+    [activeTab, pending, talkFilter, unpinned]
   );
 
   return useMemo(() => {
@@ -124,118 +82,24 @@ export function useFilteredChats({
     if (!isSearching) {
       const pinnedSection = {
         title: 'Pinned',
-        data: filterChats(pinned, activeTab, talkFilter),
+        data: pinnedChats,
       };
       const allSection = {
         title: getAllSectionHeader(activeTab, talkFilter),
-        data: filterChats([...pending, ...unpinned], activeTab, talkFilter),
+        data: allChats,
       };
       return pinnedSection.data.length
         ? [pinnedSection, allSection]
         : [allSection];
-    } else {
-      return [
-        {
-          title: 'Search results',
-          data: searchResults,
-        },
-      ];
     }
-  }, [
-    activeTab,
-    pending,
-    searchQuery,
-    searchResults,
-    unpinned,
-    pinned,
-    talkFilter,
-  ]);
-}
 
-function buildChatSearchDocs({
-  chats,
-  getChatTitle,
-  getGroupTitleForChat,
-}: {
-  chats: db.Chat[];
-  getChatTitle: (chat: db.Chat) => string;
-  getGroupTitleForChat: (chat: db.Chat) => string;
-}): ChatSearchDoc[] {
-  return chats.map((chat) => {
-    const title = normalizeChatSearchString(getChatTitle(chat));
-    const groupTitle = normalizeChatSearchString(getGroupTitleForChat(chat));
-    const id = normalizeChatSearchString(chat.id);
-
-    return {
-      chat,
-      id,
-      title,
-      groupTitle,
-      combined: `${title} ${groupTitle} ${id}`.trim(),
-      timestamp: chat.timestamp,
-    };
-  });
-}
-
-function createChatSearchFuse(docs: ChatSearchDoc[]) {
-  return new Fuse(docs, {
-    includeScore: true,
-    ignoreLocation: true,
-    threshold: 0.45,
-    keys: [
-      { name: 'combined', weight: 0.75 },
-      { name: 'title', weight: 0.15 },
-      { name: 'groupTitle', weight: 0.08 },
-      { name: 'id', weight: 0.02 },
-    ],
-  });
-}
-
-function searchChatDocs({
-  docs,
-  fuse,
-  query,
-}: {
-  docs: ChatSearchDoc[];
-  fuse: Fuse<ChatSearchDoc>;
-  query: string;
-}): db.Chat[] {
-  const normalizedQuery = normalizeChatSearchString(query);
-  if (!normalizedQuery) {
-    return [];
-  }
-
-  const tokens = tokenizeChatSearchQuery(query);
-  const fuzzyResults = fuse.search(normalizedQuery);
-
-  if (!tokens.length) {
-    return fuzzyResults.map((result) => result.item.chat);
-  }
-
-  const tokenMatchedCandidates = docs.filter((candidate) =>
-    hasAllChatSearchTokens(candidate, tokens)
-  );
-
-  if (!tokenMatchedCandidates.length) {
-    return fuzzyResults.map((result) => result.item.chat);
-  }
-
-  const fuzzyScores = new Map<string, ChatSearchFuzzyScore>(
-    fuzzyResults.map((result, rank) => [
-      result.item.id,
+    return [
       {
-        rank,
-        score: result.score ?? Number.POSITIVE_INFINITY,
+        title: 'Search results',
+        data: searchResults,
       },
-    ])
-  );
-
-  return rankChatSearchCandidates(
-    tokenMatchedCandidates,
-    tokens,
-    normalizedQuery,
-    fuzzyScores
-  ).map((candidate) => candidate.chat);
+    ];
+  }, [activeTab, allChats, pinnedChats, searchQuery, searchResults, talkFilter]);
 }
 
 function filterChats(
@@ -286,30 +150,4 @@ function filterChats(
 
     return true;
   });
-}
-
-function getChatTitle(chat: db.Chat, disableNicknames: boolean): string {
-  if (chat.type === 'channel') {
-    return getChannelTitle({
-      disableNicknames,
-      channelTitle: chat.channel.title,
-      members: chat.channel.members,
-      usesMemberListAsFallbackTitle: configurationFromChannel(chat.channel)
-        .usesMemberListAsFallbackTitle,
-    });
-  } else {
-    return getGroupTitle(chat.group, disableNicknames);
-  }
-}
-
-function useDebouncedValue<T>(input: T, delay: number) {
-  const [value, setValue] = useState<T>(input);
-  const debouncedSetValue = useMemo(
-    () => debounce(setValue, delay, { leading: true }),
-    [delay]
-  );
-  useLayoutEffect(() => {
-    debouncedSetValue(input);
-  }, [debouncedSetValue, input]);
-  return value;
 }

--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -154,7 +154,9 @@ const ActionSheetComponent = ({
     SheetProps &
     Pick<
       BottomSheetWrapperProps,
-      'enableContentPanningGesture' | 'hasScrollableContent'
+      | 'enableContentPanningGesture'
+      | 'hasScrollableContent'
+      | 'keyboardBehavior'
     >
 >) => {
   const mode = useAdaptiveMode(forcedMode);
@@ -362,6 +364,7 @@ const ActionSheetComponent = ({
       showOverlay={true}
       enablePanDownToClose={true}
       enableContentPanningGesture={props.enableContentPanningGesture}
+      keyboardBehavior={props.keyboardBehavior}
       footerComponent={footerComponent}
       hasScrollableContent={hasScrollableContent}
       frameStyle={{}}

--- a/packages/app/ui/components/BottomSheetWrapper.native.tsx
+++ b/packages/app/ui/components/BottomSheetWrapper.native.tsx
@@ -377,9 +377,10 @@ export const BottomSheetWrapper = forwardRef<
     const nonModalProps = useMemo(
       () => ({
         ...commonProps,
+        ...commonOverrides,
         index: open ? 0 : -1, // Control visibility via index instead of conditional rendering
       }),
-      [commonProps, open]
+      [commonOverrides, commonProps, open]
     );
 
     const isNested = useContext(ActionSheetContext).isInsideSheet;

--- a/packages/app/ui/components/BottomSheetWrapper.native.tsx
+++ b/packages/app/ui/components/BottomSheetWrapper.native.tsx
@@ -1,5 +1,7 @@
 import BottomSheet, {
   BottomSheetBackdrop,
+  BottomSheetFooter,
+  BottomSheetFooterProps,
   BottomSheetModal,
   BottomSheetView,
   BottomSheetScrollView as GorhomBottomSheetScrollView,
@@ -179,6 +181,21 @@ export const BottomSheetWrapper = forwardRef<
       [backgroundColor]
     );
 
+    const wrappedFooterComponent = useMemo(
+      () =>
+        footerComponent
+          ? (props: BottomSheetFooterProps) => {
+              const content = footerComponent(props);
+              return content ? (
+                <BottomSheetFooter {...props}>
+                  <View backgroundColor={backgroundColor}>{content}</View>
+                </BottomSheetFooter>
+              ) : null;
+            }
+          : undefined,
+      [backgroundColor, footerComponent]
+    );
+
     // Transform snapPoints based on snapPointsMode for compatibility with Tamagui Sheet API
     const transformedSnapPoints = useMemo(() => {
       if (!snapPoints) return snapPoints;
@@ -321,7 +338,7 @@ export const BottomSheetWrapper = forwardRef<
         backdropComponent: renderBackdrop,
         handleComponent: renderHandle,
         backgroundComponent: renderBackground,
-        footerComponent,
+        footerComponent: wrappedFooterComponent,
         style: frameStyle,
         snapPointsMode,
         snapPoints: transformedSnapPoints,
@@ -343,7 +360,7 @@ export const BottomSheetWrapper = forwardRef<
         renderBackdrop,
         renderHandle,
         renderBackground,
-        footerComponent,
+        wrappedFooterComponent,
         frameStyle,
         snapPointsMode,
         transformedSnapPoints,

--- a/packages/app/ui/components/ForwardChannelSelector.tsx
+++ b/packages/app/ui/components/ForwardChannelSelector.tsx
@@ -35,7 +35,6 @@ export function ForwardChannelSelector({
     searchQuery: query,
     channelFilter,
   });
-
   const handleQueryChanged = useCallback((newQuery: string) => {
     setQuery(newQuery);
     // Reset any explicit row selection when the result set changes.
@@ -97,7 +96,7 @@ export function ForwardChannelSelector({
       </XStack>
 
       {isOpen ? (
-        <View flex={1}>
+        <View flex={1} minHeight={200}>
           {isSearching && channelChats.length === 0 ? (
             <Text color="$tertiaryText" textAlign="center" fontFamily="$body">
               No results found
@@ -117,6 +116,7 @@ export function ForwardChannelSelector({
                   >)}
                 />
               )}
+              keyboardShouldPersistTaps="always"
             />
           )}
         </View>

--- a/packages/app/ui/components/ForwardChannelSelector.tsx
+++ b/packages/app/ui/components/ForwardChannelSelector.tsx
@@ -1,6 +1,5 @@
 import { FlashList, type ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
-import * as store from '@tloncorp/shared/store';
 import {
   ComponentProps,
   useCallback,
@@ -10,8 +9,7 @@ import {
 } from 'react';
 import { Text, View, XStack, getTokenValue } from 'tamagui';
 
-import { useFilteredChats } from '../../hooks/useFilteredChats';
-import { useResolvedChats } from '../../hooks/useResolvedChats';
+import { useFilteredChannelChats } from '../../hooks/useFilteredChannelChats';
 import { ActionSheet } from './ActionSheet';
 import { ForwardChannelListItem } from './ForwardChannelListItem';
 import { SearchBar } from './SearchBar';
@@ -22,6 +20,8 @@ type ForwardChannelSelectorProps = {
   channelFilter?: (channel: db.Channel) => boolean;
 };
 
+type ChannelChat = db.Chat & { type: 'channel' };
+
 export function ForwardChannelSelector({
   isOpen,
   onChannelSelected,
@@ -31,30 +31,14 @@ export function ForwardChannelSelector({
   const [selectedChannelId, setSelectedChannelId] = useState<string | null>(
     null
   );
-  const { data: chats } = store.useCurrentChats();
-  const resolvedChats = useResolvedChats(chats);
-  const filteredChatsConfig = useMemo(
-    () => ({
-      ...resolvedChats,
-      pending: [],
-      searchQuery: query,
-      activeTab: 'channels' as const,
-    }),
-    [resolvedChats, query]
-  );
-  const displayData = useFilteredChats(filteredChatsConfig);
-
-  const channels = useMemo(() => {
-    const allChats = displayData.flatMap((section) => section.data);
-
-    return allChats
-      .flatMap((chat) => (chat.type === 'channel' ? [chat.channel] : []))
-      .filter((channel) => (channelFilter ? channelFilter(channel) : true));
-  }, [channelFilter, displayData]);
+  const { channelChats, isSearching } = useFilteredChannelChats({
+    searchQuery: query,
+    channelFilter,
+  });
 
   const handleQueryChanged = useCallback((newQuery: string) => {
     setQuery(newQuery);
-    // Reset explicit row selection on a new query so top result is highlighted.
+    // Reset any explicit row selection when the result set changes.
     setSelectedChannelId(null);
   }, []);
 
@@ -66,14 +50,14 @@ export function ForwardChannelSelector({
   }, [isOpen]);
 
   const highlightedChannelId = useMemo(() => {
-    if (!channels.length) {
+    if (!selectedChannelId) {
       return null;
     }
-    if (selectedChannelId && channels.some((c) => c.id === selectedChannelId)) {
-      return selectedChannelId;
-    }
-    return channels[0].id;
-  }, [channels, selectedChannelId]);
+
+    return channelChats.some((chat) => chat.channel.id === selectedChannelId)
+      ? selectedChannelId
+      : null;
+  }, [channelChats, selectedChannelId]);
 
   const handleChannelSelected = useCallback(
     (channel: db.Channel) => {
@@ -83,11 +67,11 @@ export function ForwardChannelSelector({
     [onChannelSelected]
   );
 
-  const renderItem: ListRenderItem<db.Channel> = useCallback(
-    ({ item }: { item: db.Channel }) => (
+  const renderItem: ListRenderItem<ChannelChat> = useCallback(
+    ({ item }: { item: ChannelChat }) => (
       <ForwardChannelListItem
-        channel={item}
-        selected={highlightedChannelId === item.id}
+        channel={item.channel}
+        selected={highlightedChannelId === item.channel.id}
         onPress={handleChannelSelected}
       />
     ),
@@ -102,28 +86,28 @@ export function ForwardChannelSelector({
     []
   );
 
-  const isSearching = query.trim() !== '';
-
   return (
     <>
       <XStack paddingHorizontal="$xl">
         <SearchBar
           placeholder="Search channels"
           onChangeQuery={handleQueryChanged}
+          debounceTime={0}
         ></SearchBar>
       </XStack>
 
       {isOpen ? (
         <View flex={1}>
-          {isSearching && channels.length === 0 ? (
+          {isSearching && channelChats.length === 0 ? (
             <Text color="$tertiaryText" textAlign="center" fontFamily="$body">
               No results found
             </Text>
           ) : (
-            <FlashList<db.Channel>
-              data={channels}
+            <FlashList<ChannelChat>
+              data={channelChats}
+              extraData={highlightedChannelId}
               contentContainerStyle={contentContainerStyle}
-              keyExtractor={(channel) => channel.id}
+              keyExtractor={(chat) => chat.channel.id}
               renderItem={renderItem}
               estimatedItemSize={72}
               renderScrollComponent={(props) => (

--- a/packages/app/ui/components/ForwardToChannelSheet.tsx
+++ b/packages/app/ui/components/ForwardToChannelSheet.tsx
@@ -30,6 +30,9 @@ export function ForwardToChannelSheet({
       onOpenChange={onOpenChange}
       snapPointsMode="percent"
       snapPoints={FORWARD_SHEET_SNAP_POINTS}
+      keyboardBehavior="extend"
+      enableContentPanningGesture={false}
+      hasScrollableContent
       footerComponent={footerComponent}
     >
       <ActionSheet.Content flex={1} paddingBottom="$s">

--- a/packages/app/ui/components/SearchBar.tsx
+++ b/packages/app/ui/components/SearchBar.tsx
@@ -41,11 +41,16 @@ export function SearchBar({
         // if value was cleared, update immediately
         debouncedOnChangeQuery.cancel();
         onChangeQuery('');
+      } else if (debounceTime <= 0) {
+        // Some callers, like the forward sheet picker, want truly immediate
+        // search updates rather than going through the debounce wrapper.
+        debouncedOnChangeQuery.cancel();
+        onChangeQuery(newValue);
       } else {
         debouncedOnChangeQuery(newValue);
       }
     },
-    [debouncedOnChangeQuery, onChangeQuery]
+    [debounceTime, debouncedOnChangeQuery, onChangeQuery]
   );
 
   return (


### PR DESCRIPTION
## Summary

This builds on #5582 and makes the "Send to channel" sheet feel better.

Search updates right away, channel results are more direct, and tapping a result with the keyboard open is more reliable.

## Changes

- make search bar updates immediate when debounce is `0`
- refactor and simplify search sheets
- improve bottom sheet keyboard, footer, and tap behavior for the forward sheet

## How did I test?

- Tested on iOS, android, and web