### PR TITLE
contacts: call meet when viewing another user's profile

### DIFF
--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -1,10 +1,10 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import * as api from '@tloncorp/api';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import type * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import { useMemo, useState } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { View, isWeb, useTheme } from 'tamagui';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
@@ -39,6 +39,12 @@ export function UserProfileScreen({ route, navigation }: Props) {
   const { data: calmSettings } = store.useCalmSettings();
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
   const { resetToDm } = useRootNavigation();
+
+  useEffect(() => {
+    if (userId && userId !== currentUserId) {
+      api.syncUserProfiles([userId]);
+    }
+  }, [userId, currentUserId]);
 
   const handleGoToDm = useCallback(
     async (participants: string[]) => {


### PR DESCRIPTION
## Summary

Dispatches the `meet` poke to the contacts agent when viewing another user's profile, ensuring contact data is set up even if automatic meeting failed. Resolves TLON-5540.

## Changes

- Added a `useEffect` in `UserProfileScreen` that calls `api.syncUserProfiles([userId])` when the screen mounts for a non-self user profile.

## How did I test?

Manual review of the change logic. The `syncUserProfiles` API is already used elsewhere in the codebase (boot sequence, contact suggestions) and is a fire-and-forget poke.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit. No data migration or backend changes involved.

## Screenshots / videos

N/A