### PR TITLE
Improve channel/group settings discoverability and header UX

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -401,8 +401,8 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - libavif/core (0.11.1)
-  - libavif/libdav1d (0.11.1):
+  - libavif/core (1.0.0)
+  - libavif/libdav1d (1.0.0):
     - libavif/core
     - libdav1d (>= 0.6.0)
   - libdav1d (1.2.0)
@@ -446,7 +446,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - PostHog (3.31.0)
+  - PostHog (3.49.1)
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
@@ -2453,12 +2453,12 @@ PODS:
   - SDWebImage (5.19.7):
     - SDWebImage/Core (= 5.19.7)
   - SDWebImage/Core (5.19.7)
-  - SDWebImageAVIFCoder (0.11.0):
+  - SDWebImageAVIFCoder (0.11.1):
     - libavif/core (>= 0.11.0)
     - SDWebImage (~> 5.10)
   - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
-  - SDWebImageWebPCoder (0.14.6):
+  - SDWebImageWebPCoder (0.15.0):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.57.2)
@@ -2992,12 +2992,12 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
+  libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   op-sqlite: 833d4789d2953bf0df4363d9294016c26a0f1b48
-  PostHog: fcb0bc4425a69a2b0ee0ff5782b298a23aedcc83
+  PostHog: 83ac10c7713958b0cd75e4a977884362407172d4
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
@@ -3082,9 +3082,9 @@ SPEC CHECKSUMS:
   RNSentry: 974b21b0345c073586c22a3aaf77d69b3e47f63e
   RNSVG: d332ea2a8540218eadc5c8f31c2b58dfba6b14b5
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
-  SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
+  SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
-  SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
+  SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
   Sentry: 83a3814c3ca042874b39c5c5bdffb6570d4d760e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   sqlite3: 73513155ec6979715d3904ef53a8d68892d4032b

--- a/apps/tlon-web/e2e/channel-details.spec.ts
+++ b/apps/tlon-web/e2e/channel-details.spec.ts
@@ -268,7 +268,10 @@ test('channel header title navigates to channel details with sidebar context', a
   });
 
   // Click the channel title to navigate to channel details
-  await page.getByTestId('ScreenHeaderTitle').click();
+  await page
+    .getByTestId('ChannelHeaderTitle')
+    .getByTestId('ScreenHeaderTitle')
+    .click();
 
   // Verify we're on channel details
   await expect(page.getByText('Channel info')).toBeVisible({

--- a/apps/tlon-web/e2e/channel-details.spec.ts
+++ b/apps/tlon-web/e2e/channel-details.spec.ts
@@ -251,7 +251,7 @@ test('channel edit meta back button returns to channel details with sidebar cont
   });
 });
 
-test('channel header edit button navigates to channel details with sidebar context', async ({
+test('channel header title navigates to channel details with sidebar context', async ({
   zodPage,
 }) => {
   const page = zodPage;
@@ -267,9 +267,8 @@ test('channel header edit button navigates to channel details with sidebar conte
     timeout: 5000,
   });
 
-  // Click the edit button (pen icon) in the channel header
-  // This button is visible for admins in multi-channel groups
-  await page.getByTestId('ChannelHeaderEditButton').click();
+  // Click the channel title to navigate to channel details
+  await page.getByTestId('ScreenHeaderTitle').click();
 
   // Verify we're on channel details
   await expect(page.getByText('Channel info')).toBeVisible({

--- a/packages/app/features/chat-list/ChatListSearch.tsx
+++ b/packages/app/features/chat-list/ChatListSearch.tsx
@@ -67,7 +67,7 @@ export const ChatListSearch = React.memo(function ChatListSearchComponent({
       >
         <View paddingHorizontal="$l" paddingTop="$xl">
           <TextInput
-            icon="Filter"
+            icon="Search"
             placeholder="Filter by name"
             value={query}
             onChangeText={onQueryChange}

--- a/packages/app/features/chat-list/ChatListSearch.tsx
+++ b/packages/app/features/chat-list/ChatListSearch.tsx
@@ -67,8 +67,8 @@ export const ChatListSearch = React.memo(function ChatListSearchComponent({
       >
         <View paddingHorizontal="$l" paddingTop="$xl">
           <TextInput
-            icon="Search"
-            placeholder="Find by name"
+            icon="Filter"
+            placeholder="Filter by name"
             value={query}
             onChangeText={onQueryChange}
             spellCheck={false}

--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -218,7 +218,7 @@ function ChatDetailsScreenView() {
             <ScreenHeader.TextButton
               onPress={!actionsEnabled ? undefined : handlePressEdit}
               disabled={!actionsEnabled}
-              color="$positiveActionText"
+              color={actionsEnabled ? '$positiveActionText' : undefined}
               testID="DetailsEditButton"
             >
               Rename

--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -218,7 +218,7 @@ function ChatDetailsScreenView() {
             <ScreenHeader.TextButton
               onPress={!actionsEnabled ? undefined : handlePressEdit}
               disabled={!actionsEnabled}
-              color={actionsEnabled ? '$positiveActionText' : undefined}
+              color="$primaryText"
               testID="DetailsEditButton"
             >
               Rename

--- a/packages/app/features/top/ChatDetailsScreen.tsx
+++ b/packages/app/features/top/ChatDetailsScreen.tsx
@@ -215,13 +215,14 @@ function ChatDetailsScreenView() {
         title={getTitle()}
         rightControls={
           currentUserIsAdmin ? (
-            <ScreenHeader.IconButton
-              aria-label="Edit"
+            <ScreenHeader.TextButton
               onPress={!actionsEnabled ? undefined : handlePressEdit}
               disabled={!actionsEnabled}
-              type="Draw"
+              color="$positiveActionText"
               testID="DetailsEditButton"
-            />
+            >
+              Rename
+            </ScreenHeader.TextButton>
           ) : null
         }
       />

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -316,7 +316,7 @@ export function ChatListScreenView({
               rightControls={
                 <>
                   <ScreenHeader.IconButton
-                    type="Filter"
+                    type="Search"
                     onPress={handleSearchInputToggled}
                   />
                   {isWindowNarrow ? (

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -316,7 +316,7 @@ export function ChatListScreenView({
               rightControls={
                 <>
                   <ScreenHeader.IconButton
-                    type="Search"
+                    type="Filter"
                     onPress={handleSearchInputToggled}
                   />
                   {isWindowNarrow ? (

--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -344,7 +344,11 @@ export function ChannelHeader({
             <ScreenHeader.TextButton
               onPress={goToEdit}
               testID="ChannelHeaderEditButton"
-              color="$positiveActionText"
+              color={
+                post?.authorId && post.authorId !== currentUserId
+                  ? '$positiveActionText'
+                  : '$primaryText'
+              }
             >
               Edit
             </ScreenHeader.TextButton>

--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -315,7 +315,14 @@ export function ChannelHeader({
   return (
     <ScreenHeader
       title={displayTitle}
-      titleIcon={avatarElement || titleIcon}
+      titleIcon={
+        <>
+          {avatarElement || titleIcon}
+          {channelHost && !isWindowNarrow && (
+            <ConnectionStatus contactId={channelHost} type="indicator" />
+          )}
+        </>
+      }
       subtitle={displaySubtitle}
       testID="ChannelHeaderTitle"
       showSubtitle
@@ -326,12 +333,6 @@ export function ChannelHeader({
       leftControls={goBack && <ScreenHeader.BackButton onPress={goBack} />}
       rightControls={
         <>
-          {channelHost && !isWindowNarrow && (
-            <ConnectionStatus
-              contactId={channelHost}
-              type="indicator-with-text"
-            />
-          )}
           {showSearchButton && (
             <ScreenHeader.IconButton type="Search" onPress={goToSearch} />
           )}
@@ -340,11 +341,13 @@ export function ChannelHeader({
             <Fragment key={index}>{item}</Fragment>
           ))}
           {showEditButton && (
-            <ScreenHeader.IconButton
+            <ScreenHeader.TextButton
               onPress={goToEdit}
               testID="ChannelHeaderEditButton"
-              type="Settings"
-            />
+              color="$positiveActionText"
+            >
+              Edit
+            </ScreenHeader.TextButton>
           )}
         </>
       }

--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -344,11 +344,7 @@ export function ChannelHeader({
             <ScreenHeader.TextButton
               onPress={goToEdit}
               testID="ChannelHeaderEditButton"
-              color={
-                post?.authorId && post.authorId !== currentUserId
-                  ? '$positiveActionText'
-                  : '$primaryText'
-              }
+              color="$primaryText"
             >
               Edit
             </ScreenHeader.TextButton>

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -194,8 +194,6 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const isNotebookOrGallery =
       channel.type === 'notebook' || channel.type === 'gallery';
     const pinnedPostId = logic.getPinnedPostId(channel);
-    const isSingleChannelGroup = group?.channels?.length === 1;
-
     // For DMs, get the other participant's ID
     const dmRecipientId = useMemo(() => {
       if (isDM && channel.members) {
@@ -224,23 +222,6 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
       },
       [onGroupAction]
     );
-
-    const handleGoToChannelDetails = useCallback(() => {
-      if (!channel.groupId) return;
-
-      if (isSingleChannelGroup) {
-        return;
-      } else {
-        if (goToChannelDetails) {
-          goToChannelDetails(channel.groupId, channel.id);
-        }
-      }
-    }, [
-      goToChannelDetails,
-      channel.groupId,
-      channel.id,
-      group?.channels?.length,
-    ]);
 
     const { attachAssets } = useAttachmentContext();
 

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -241,6 +241,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
       channel.id,
       group?.channels?.length,
     ]);
+
     const { attachAssets } = useAttachmentContext();
 
     const inView = useIsFocused();
@@ -539,16 +540,6 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
                             channel.type === 'dm' ||
                             channel.type === 'groupDm'
                           }
-                          showEditButton={
-                            isGroupAdmin &&
-                            !isSingleChannelGroup &&
-                            !!channel.groupId &&
-                            (channel.type === 'chat' ||
-                              channel.type === 'notebook' ||
-                              channel.type === 'gallery') &&
-                            draftInputPresentationMode !== 'fullscreen'
-                          }
-                          goToEdit={handleGoToChannelDetails}
                         />
                         {shouldShowPinnedPostBanner && (
                           <PinnedPostBanner

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -294,6 +294,7 @@ export const GroupChannelsScreenView = React.memo(
             group && isGroupAdmin ? (
               <ScreenHeader.IconButton
                 type="EditList"
+                color="$positiveActionText"
                 onPress={() => onPressManageChannels(group.id, false)}
                 disabled={!canEdit}
                 aria-label="Edit channels"

--- a/packages/app/ui/components/GroupChannelsScreenView.tsx
+++ b/packages/app/ui/components/GroupChannelsScreenView.tsx
@@ -13,7 +13,6 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { LayoutChangeEvent } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-  Popover,
   View,
   YStack,
   getTokenValue,
@@ -29,7 +28,6 @@ import { useGroupTitle, useIsAdmin } from '../utils/channelUtils';
 import { GroupAvatar } from './Avatar';
 import { Badge } from './Badge';
 import { ChatOptionsSheet } from './ChatOptionsSheet';
-import ConnectionStatus from './ConnectionStatus';
 import { ChannelListItem } from './ListItem/ChannelListItem';
 import { CreateChannelSheet } from './ManageChannels/CreateChannelSheet';
 import { ScreenHeader } from './ScreenHeader';
@@ -293,22 +291,14 @@ export const GroupChannelsScreenView = React.memo(
           backAction={onBackPressed}
           onTitlePress={handleTitlePress}
           rightControls={
-            <>
-              {group && isGroupAdmin && (
-                <Popover hoverable allowFlip placement="bottom-end">
-                  <Popover.Trigger>
-                    <ScreenHeader.IconButton
-                      type="Settings"
-                      aria-label="Edit channels"
-                      onPress={() =>
-                        group && onPressManageChannels(group.id, false)
-                      }
-                      disabled={!canEdit}
-                    />
-                  </Popover.Trigger>
-                </Popover>
-              )}
-            </>
+            group && isGroupAdmin ? (
+              <ScreenHeader.IconButton
+                type="EditList"
+                onPress={() => onPressManageChannels(group.id, false)}
+                disabled={!canEdit}
+                aria-label="Edit channels"
+              />
+            ) : null
           }
         />
         {isPersonalGroup && group && (

--- a/packages/app/ui/components/ScreenHeader.tsx
+++ b/packages/app/ui/components/ScreenHeader.tsx
@@ -128,7 +128,6 @@ export const ScreenHeaderComponent = ({
       color="$secondaryText"
       size="$label/s"
       numberOfLines={1}
-      paddingTop={5}
       testID="ScreenHeaderSubtitle"
     >
       {resolvedSubtitle}
@@ -512,7 +511,9 @@ const HeaderTitleText = styled(Text, {
 
 const HeaderControls = styled(XStack, {
   position: 'absolute',
-  bottom: '$m',
+  bottom: 0,
+  height: '$4xl',
+  alignItems: 'center',
   gap: '$l',
   zIndex: 1,
   variants: {

--- a/packages/app/ui/components/draftInputs/GalleryInput.tsx
+++ b/packages/app/ui/components/draftInputs/GalleryInput.tsx
@@ -284,12 +284,13 @@ export function GalleryInput({
       () =>
         route !== 'gallery' && route !== 'add-post' ? null : (
           <>
-            <ScreenHeader.IconButton
+            <ScreenHeader.TextButton
               key="gallery"
-              type="Add"
               onPress={handleAdd}
               testID="AddGalleryPost"
-            />
+            >
+              New
+            </ScreenHeader.TextButton>
             <Notices.CollectionInputTooltip channelId={channel.id} />
           </>
         ),

--- a/packages/app/ui/components/draftInputs/NotebookInput.tsx
+++ b/packages/app/ui/components/draftInputs/NotebookInput.tsx
@@ -52,12 +52,13 @@ export function NotebookInput({
       () =>
         showBigInput ? null : (
           <>
-            <ScreenHeader.IconButton
+            <ScreenHeader.TextButton
               key="notebook"
-              type="Add"
               onPress={handleAdd}
               testID="AddNotebookPost"
-            />
+            >
+              New
+            </ScreenHeader.TextButton>
             <WayfindingNotices.NotebookInputTooltip
               channelId={draftInputContext.channel.id}
             />

--- a/packages/ui/src/assets/icons/EditList.svg
+++ b/packages/ui/src/assets/icons/EditList.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 7H20" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M4 12H18" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M4 17H12" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M16.5 16L20.5 12L22 13.5L18 17.5L16 18L16.5 16Z" stroke="#1A1818" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/ui/src/assets/icons/EditList.svg
+++ b/packages/ui/src/assets/icons/EditList.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M4 7H20" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
-<path d="M4 12H18" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M4 12H16" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
 <path d="M4 17H12" stroke="#1A1818" stroke-width="1.6" stroke-linecap="round"/>
 <path d="M16.5 16L20.5 12L22 13.5L18 17.5L16 18L16.5 16Z" stroke="#1A1818" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/ui/src/assets/icons/index.ts
+++ b/packages/ui/src/assets/icons/index.ts
@@ -31,6 +31,7 @@ export { default as Copy } from './Copy.svg';
 export { default as Discover } from './Discover.svg';
 export { default as Dragger } from './Dragger.svg';
 export { default as Draw } from './Draw.svg';
+export { default as EditList } from './EditList.svg';
 export { default as Face } from './Face.svg';
 export { default as Filter } from './Filter.svg';
 export { default as FontSize } from './FontSize.svg';


### PR DESCRIPTION
## Summary

In #5289 we drastically overcorrected for header uniformity by using too many pictorial icons vs clear text labels. This PR rectifies by replacing confusing cog/pen icons with explicit labels, removing redundant navigation entry points, and improving the header UX across channel, group, and notebook views.

Fixes TLON-5439
Fixes TLON-5545
Fixes TLON-5544
Fixes TLON-5466
Fixes TLON-4529
Fixes TLON-5496

## Changes

- **Admin actions:** Any admin action within a group, channel, or post header uses the alternate positive action text color (blue in the default themes). Other run-of-the-mill actions use the primary text color. This makes it easy to see what actions you're taking as an administrator.
- **Channel header**: Removed redundant "Edit" button (available via channel info screen instead, via "Rename"). Moved connectivity indicator dot from right controls to immediately left of channel name.
- **Group sidebar header**: Replaced cog icon/popover with new `EditList` icon (list + pencil) for "Edit channels" action.
- **Notebook/gallery post detail header**: Changed cog icon to "Edit" text button for editing posts (TLON-5466).
  - Edit button uses `$primaryText` when editing your own post.
  - Edit button uses `$positiveActionText` (green) when an admin is editing another user's post.
- **Chat details screen**: Replaced hidden pen icon with "Rename" text button for editing group/channel metadata.
- **Notebook/gallery "+" button**: Changed `Add` icon button to "New" text button.
- **Home screen**: Changed magnifying glass to filter icon, updated placeholder from "Find by name" to "Filter by name".
- **New icon**: Added `EditList.svg` — a list-with-pencil icon for the group channel management action.

## How did I test?

Visual verification in browser and iOS simulator. TypeScript typecheck passes.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit. All changes are UI-only (icons, labels, layout) with no data or state implications.

## Screenshots / videos

| Screen | Description | Image |
|--------|-------------|-------|
| Home | Changes the magnifying glass (implying 'search') to a filter, which is what the control actually does - filters the list by name. | <img alt="home-filter" src="https://github.com/user-attachments/assets/84496787-4005-41c1-8955-db56129c5b47" /> |
| Group | Introduces the EditList icon, which is a middle-ground between using a text label ("Edit Channels," which takes up too much room) and the all-too-ambiguous "Draw" icon. Note the blue color, since this is an admin action. | <img alt="group-channels" src="https://github.com/user-attachments/assets/69f7ff5d-9c3e-4f71-a9a0-b9a436dcacf7" /> |
| Chat channel | Removes the redundant and confusing cog/settings icon, which pointed to editing the channel name/description, in favor of the plainly obvious dropdown caret. | <img alt="in-channel" src="https://github.com/user-attachments/assets/90d01580-6568-4555-8b0b-09e008d87e55" /> |
| Channel details | Once the user taps the down-caret / channel title, they are now presented with a smack-dab obvious "Rename" action. Note the blue color, since this is an admin action. | <img alt="channel-info-rename" src="https://github.com/user-attachments/assets/523a2168-d124-450c-b74b-dc5a98a2e2fb" /> |
| Non-chat channels (Gallery, Notebook) | Switches from the somewhat-ambiguous + button to an explicit "New" text button. We might consider the same on the Home screen, open to that discussion. | <img alt="notebook-new" src="https://github.com/user-attachments/assets/31857abd-f173-422e-9d34-ac8e77fd9191" /> <img alt="gallery-new" src="https://github.com/user-attachments/assets/0db1591a-6ab9-44e6-a609-1df4e34b35b7" /> |
| Editing your own post | If the user is editing their own post, regardless if they're an admin or not, they will see an explicit "Edit" button, rather than the ambiguous "Draw" icon. Note the black color here, since any user can edit their own post and this is not unique to admins. | <img alt="gallery-edit-yours" src="https://github.com/user-attachments/assets/c0a29e0b-1e99-4c4e-8ee3-59bec6b3476c" /> |
| Editing others' posts | Similar to the above. Switches the "Draw" icon to an explicit "Edit" text action for others' posts; visible only to admins. Note the blue color as a result. | <img alt="notebook-edit-others" src="https://github.com/user-attachments/assets/c78bb332-e8e7-4f99-b727-a6a6d0e76165" /> |

