### PR TITLE
fix: show bot tags on thread replies

### DIFF
--- a/packages/api/src/client/postsApi.ts
+++ b/packages/api/src/client/postsApi.ts
@@ -1407,6 +1407,7 @@ export function toPostReplyData(
   reply: ub.Reply | ub.WritReply | ub.PostTombstone
 ): db.Post {
   if (isPostTombstone(reply)) {
+    reply.author = normalizeAuthor(reply.author);
     return {
       id: getCanonicalPostId(reply.id),
       parentId: getCanonicalPostId(postId),
@@ -1415,6 +1416,7 @@ export function toPostReplyData(
       type: 'reply',
       sentAt: getReceivedAtFromId(reply.id),
       isDeleted: true,
+      isBot: isBotProfile(reply.author),
       deletedAt: reply['deleted-at'],
       receivedAt: getReceivedAtFromId(reply.id),
       sequenceNum: null,
@@ -1433,6 +1435,8 @@ export function toPostReplyData(
           ).memo,
           blob: null,
         };
+  replyEssay.author = normalizeAuthor(replyEssay.author);
+  const isBot = isBotProfile(replyEssay.author);
   const [content, flags] = toPostContent(replyEssay.content);
   const id = getCanonicalPostId(reply.seal.id);
   const backendTime =
@@ -1445,6 +1449,7 @@ export function toPostReplyData(
     type: 'reply',
     authorId: getAuthorId(replyEssay.author),
     isEdited: !!reply.revision && reply.revision !== '0',
+    isBot,
     parentId: getCanonicalPostId(postId),
     reactions: toReactionsData(reply.seal.reacts, id),
     content: JSON.stringify(content),

--- a/packages/app/ui/components/DetailPostUsingContentConfiguration/DetailPostUsingContentConfiguration.tsx
+++ b/packages/app/ui/components/DetailPostUsingContentConfiguration/DetailPostUsingContentConfiguration.tsx
@@ -96,23 +96,31 @@ export function DetailPostView({
         <FlatList
           ref={listRef}
           data={listData}
-          renderItem={({ item }) => (
-            <ContextGestureListener
-              presentationCandidate={{
-                post: item.post,
-                postActionIds: ['delete', 'edit'],
-              }}
-              menuApi={postContextMenu}
-            >
-              {({ present }) => (
-                <PostView
-                  post={item.post}
-                  showReplies={item.type !== 'op'}
-                  onLongPress={present}
-                />
-              )}
-            </ContextGestureListener>
-          )}
+          renderItem={({ item, index }) => {
+            const previousItem = index > 0 ? listData[index - 1] : undefined;
+            const showAuthor =
+              !previousItem ||
+              previousItem.post.authorId !== item.post.authorId;
+            return (
+              <ContextGestureListener
+                presentationCandidate={{
+                  post: item.post,
+                  postActionIds: ['delete', 'edit'],
+                }}
+                menuApi={postContextMenu}
+              >
+                {({ present }) => (
+                  <PostView
+                    post={item.post}
+                    showAuthor={showAuthor}
+                    showReplies={item.type !== 'op'}
+                    onLongPress={present}
+                  />
+                )}
+              </ContextGestureListener>
+            );
+          }}
+          keyExtractor={(item) => item.post.id}
           contentInsetAdjustmentBehavior="scrollableAxes"
         />
 

--- a/packages/app/ui/components/DetailPostUsingContentConfiguration/DetailPostUsingContentConfiguration.tsx
+++ b/packages/app/ui/components/DetailPostUsingContentConfiguration/DetailPostUsingContentConfiguration.tsx
@@ -100,6 +100,8 @@ export function DetailPostView({
             const previousItem = index > 0 ? listData[index - 1] : undefined;
             const showAuthor =
               !previousItem ||
+              previousItem.post.isDeleted ||
+              previousItem.type === 'op' ||
               previousItem.post.authorId !== item.post.authorId;
             return (
               <ContextGestureListener

--- a/packages/app/ui/components/postCollectionViews/shared.tsx
+++ b/packages/app/ui/components/postCollectionViews/shared.tsx
@@ -60,8 +60,7 @@ export function ConnectedPostView({
 
       ...overrides,
 
-      showAuthor: standardConfig?.showAuthor,
-      showReplies: standardConfig?.showReplies,
+      ...(standardConfig ?? {}),
     }),
     [ctx, livePost, overrides, standardConfig, editPost]
   );


### PR DESCRIPTION
## Summary

Fixes a bug where bot badges/tags were not displayed on replies in thread views, even though they appeared on top-level messages. Closes TLON-5322.

## Changes

- **`DetailPostUsingContentConfiguration.tsx`**: Compute `showAuthor` based on consecutive author grouping and pass it to `PostView`, so `AuthorRow` (which renders the bot badge) is rendered for thread replies. Added `keyExtractor` for proper list keying.
- **`postsApi.ts`**: Add `normalizeAuthor()` and `isBot` detection to `toPostReplyData()` for both tombstone and normal reply paths, matching the existing behavior in `toPostData()`.

## How did I test?

TypeScript type-check passes across all packages (`pnpm -r tsc`).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit; bot tags will revert to not showing in threads (pre-existing behavior).

## Screenshots / videos

| After | Before |
|-------|--------|
| <img alt="Screenshot 2026-04-06 at 2 23 26 PM" src="https://github.com/user-attachments/assets/7b1c2aa4-c10d-4f0c-a97c-ebce2a43c21c" /> | <img alt="Screenshot 2026-04-06 at 2 23 43 PM" src="https://github.com/user-attachments/assets/410707f2-7abb-4d3a-926b-98973ad027ab" /> |
