### PR TITLE
fix note paste crash

### DIFF
--- a/packages/app/ui/components/MessageInput/index.tsx
+++ b/packages/app/ui/components/MessageInput/index.tsx
@@ -55,6 +55,12 @@ export const DEFAULT_MESSAGE_INPUT_HEIGHT = Platform.OS === 'web' ? 38 : 44;
 
 const messageInputLogger = createDevLogger('MessageInput', false);
 
+const isEmptyEditorJson = (json?: JSONContent) =>
+  !json?.content?.length ||
+  (json.content.length === 1 &&
+    json.content[0].type === 'paragraph' &&
+    !json.content[0].content);
+
 type MessageEditorMessage = {
   type: 'contentHeight';
   payload: number;
@@ -215,14 +221,19 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     }, [editorContent]);
 
     const webviewRef = editor.webviewRef;
+    const reloadContentRef = useRef<JSONContent>();
+    const editorWithJsonContent = editor as EditorBridge & {
+      setContent: (content: string | JSONContent | null) => void;
+    };
 
     const reloadWebview = useCallback(
       (reason: string) => {
+        reloadContentRef.current = editorContent as JSONContent | undefined;
         webviewRef.current?.reload();
         messageInputLogger.log('[webview] Reloading webview, reason:', reason);
         setEditorCrashed(undefined);
       },
-      [webviewRef]
+      [editorContent, webviewRef]
     );
 
     const lastEditingPost = useRef<db.Post | undefined>(editingPost);
@@ -231,14 +242,23 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       if (!hasSetInitialContent && editorState.isReady) {
         messageInputLogger.log('Setting initial content');
         try {
+          if (reloadContentRef.current) {
+            editorWithJsonContent.setContent(reloadContentRef.current);
+            setEditorIsEmpty(
+              isEmptyEditorJson(reloadContentRef.current) &&
+                attachments.length === 0
+            );
+            reloadContentRef.current = undefined;
+            setHasSetInitialContent(true);
+            return;
+          }
           getDraft(draftType).then((draft) => {
             if (!editingPost && draft) {
               messageInputLogger.log(
                 'Not editing and we have draft content',
                 draft
               );
-              // @ts-expect-error setContent does accept JSONContent
-              editor.setContent(draft);
+              editorWithJsonContent.setContent(draft);
               setEditorIsEmpty(false);
               messageInputLogger.log(
                 'set has set initial content, not editing'
@@ -272,8 +292,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
                 'Setting content with edit post content',
                 tiptapContent
               );
-              // @ts-expect-error setContent does accept JSONContent
-              editor.setContent(tiptapContent);
+              editorWithJsonContent.setContent(tiptapContent);
               setEditorIsEmpty(false);
               messageInputLogger.log('set has set initial content, editing');
               setHasSetInitialContent(true);
@@ -386,11 +405,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
         const json = (await editor.getJSON()) as JSONContent;
         messageInputLogger.log('Storing draft', json);
 
-        if (
-          json.content?.length === 1 &&
-          json.content[0].type === 'paragraph' &&
-          !json.content[0].content
-        ) {
+        if (isEmptyEditorJson(json)) {
           clearDraft(draftType);
           return; // Don't store empty draft after clearing!
         }
@@ -570,6 +585,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             : (JSON.parse(data) as MessageEditorMessage);
 
         if (type === 'editor-ready') {
+          if (reloadContentRef.current) {
+            setHasSetInitialContent(false);
+          }
           webviewRef.current?.injectJavaScript(
             `
               function updateContentHeight() {

--- a/patches/@10play__tentap-editor@0.5.21.patch
+++ b/patches/@10play__tentap-editor@0.5.21.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/commonjs/assets/index.js b/lib/commonjs/assets/index.js
-index 7f1d49228a8540b3797daee2bcbfc4c88f5b7cbb..c15aca1052f351c1f72bb2e2fc4d5a3871142524 100644
+index 7f1d49228a..c15aca1052 100644
 --- a/lib/commonjs/assets/index.js
 +++ b/lib/commonjs/assets/index.js
 @@ -5,29 +5,6 @@ Object.defineProperty(exports, "__esModule", {
@@ -35,7 +35,7 @@ index 7f1d49228a8540b3797daee2bcbfc4c88f5b7cbb..c15aca1052f351c1f72bb2e2fc4d5a38
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/lib/commonjs/index.js b/lib/commonjs/index.js
-index 071b63d05bf746fa4ad0bb4d7996e73e764351aa..ef24460a9788922a7b2a6084643ba39f97e1d1bd 100644
+index 071b63d05b..ef24460a97 100644
 --- a/lib/commonjs/index.js
 +++ b/lib/commonjs/index.js
 @@ -22,12 +22,7 @@ Object.defineProperty(exports, "EditorHelper", {
@@ -61,7 +61,7 @@ index 071b63d05bf746fa4ad0bb4d7996e73e764351aa..ef24460a9788922a7b2a6084643ba39f
  var _editorHtml = require("./simpleWebEditor/build/editorHtml");
  function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 diff --git a/lib/module/assets/index.js b/lib/module/assets/index.js
-index da8a084ff551d9d3e391f4c8e8b6e376130a4904..152ab2aff5d48645fa67ceb8373bae2645c5b6a6 100644
+index da8a084ff5..152ab2aff5 100644
 --- a/lib/module/assets/index.js
 +++ b/lib/module/assets/index.js
 @@ -1,27 +1,4 @@
@@ -95,7 +95,7 @@ index da8a084ff551d9d3e391f4c8e8b6e376130a4904..152ab2aff5d48645fa67ceb8373bae26
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/lib/module/index.js b/lib/module/index.js
-index e23219ce2ee83e8ff94d291e2a9c49aa7deb0d3a..9b66fc508c41c61b55bfd371b26c634b7557bf08 100644
+index e23219ce2e..9b66fc508c 100644
 --- a/lib/module/index.js
 +++ b/lib/module/index.js
 @@ -25,7 +25,6 @@ export * from './bridges/core';
@@ -108,7 +108,7 @@ index e23219ce2ee83e8ff94d291e2a9c49aa7deb0d3a..9b66fc508c41c61b55bfd371b26c634b
  //# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/src/assets/index.ts b/src/assets/index.ts
-index 858dd108b0e4643b46a94447f37f3a564c2435f4..f94d342bf997c1fb4b78c3eae15fa43319aef497 100644
+index 858dd108b0..f94d342bf9 100644
 --- a/src/assets/index.ts
 +++ b/src/assets/index.ts
 @@ -1,26 +1,3 @@
@@ -139,3 +139,31 @@ index 858dd108b0e4643b46a94447f37f3a564c2435f4..f94d342bf997c1fb4b78c3eae15fa433
 -  close: require('./close.png'),
 +
  };
+diff --git a/lib-web/index.mjs b/lib-web/index.mjs
+index 8c3dae2c12..bd99f3dcb5 100644
+--- a/lib-web/index.mjs
++++ b/lib-web/index.mjs
+@@ -13937,21 +13937,8 @@ const eg = se.create({
+   addPasteRules() {
+     return [
+       _e({
+-        find: (n, e) => {
+-          var t;
+-          const r = (t = e == null ? void 0 : e.clipboardData) === null || t === void 0 ? void 0 : t.getData("text/html"), i = [];
+-          if (r) {
+-            const s = new DOMParser().parseFromString(r, "text/html"), o = s.querySelectorAll("a");
+-            o.length && [...o].forEach((l) => i.push({
+-              text: l.innerText,
+-              data: {
+-                href: l.getAttribute("href")
+-              },
+-              // get the index of the anchor inside the text
+-              // and add the length of the anchor text
+-              index: s.body.innerText.indexOf(l.innerText) + l.innerText.length
+-            }));
+-          }
++        find: (n) => {
++          const i = [];
+           if (n) {
+             const s = ls(n).filter((o) => o.isLink);
+             s.length && s.forEach((o) => i.push({

--- a/patches/README.md
+++ b/patches/README.md
@@ -32,3 +32,34 @@ Removal:
 Remove this patch once we upgrade to a compatible `react-native-screens`
 version that already includes the upstream fix. `4.24.0+` has the behavior
 enabled by default.
+
+## @10play/tentap-editor@0.5.21
+
+Why:
+- Strips the package's bundled `Images` export, which was causing import errors in prod
+- Removes the web bundle's legacy HTML hyperlink paste fallback, which can
+  crash the Firefox note editor when pasting rich hyperlinks and make existing
+  text appear deleted.
+
+Local patch:
+`patches/@10play__tentap-editor@0.5.21.patch`
+
+Upstream:
+- TipTap removed the same HTML-anchor paste path in
+  `ueberdosis/tiptap@e8cfe043b753ee2a26cc595e95fd5e6e901285bf`
+- Later `@10play/tentap-editor` versions also appear to have dropped this
+  behavior. As of upstream `1.0.1`, the package is on TipTap 3 and
+  `src/bridges/link.ts` is just a thin wrapper around
+  `@tiptap/extension-link`, without the old HTML `text/html` anchor fallback.
+
+Validation:
+- Build the editor package and verify the patch still applies cleanly.
+- In Firefox, paste a rich hyperlink into notes and confirm the editor does not
+  crash or reload.
+- Confirm the app still builds in production without reintroducing the original
+  `@10play/tentap-editor` import error.
+
+Removal:
+Remove this patch once we upgrade off the old `0.5.x` web bundle and confirm
+the replacement no longer vendors the legacy HTML link paste fallback or needs
+the local asset export stripping.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ patchedDependencies:
     hash: xjpmkpcw463yvoqvocxrxq7ici
     path: patches/@10play__tentap-editor@0.4.55.patch
   '@10play/tentap-editor@0.5.21':
-    hash: eb6lqjeso4iwimtyxzymqd6yd4
+    hash: l63pvelugwthlyotjpntaskl3a
     path: patches/@10play__tentap-editor@0.5.21.patch
   '@likashefqet/react-native-image-zoom@4.2.0':
     hash: roe32gwh34j3bcmaenpx3xgtly
@@ -187,7 +187,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: 0.5.21
-        version: 0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@aws-sdk/client-s3':
         specifier: ^3.190.0
         version: 3.190.0
@@ -578,7 +578,7 @@ importers:
         version: 0.0.3(react-dom@18.3.1(react@18.3.1))(react-native-web@0.19.12(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@10play/tentap-editor':
         specifier: 0.5.21
-        version: 0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@aws-sdk/client-s3':
         specifier: ^3.190.0
         version: 3.190.0
@@ -1032,7 +1032,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: 0.5.21
-        version: 0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@emoji-mart/data':
         specifier: ^1.1.2
         version: 1.1.2
@@ -1129,7 +1129,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: 0.5.21
-        version: 0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@tiptap/core':
         specifier: ^2.6.6
         version: 2.6.6(@tiptap/pm@2.6.6)
@@ -1297,7 +1297,7 @@ importers:
     dependencies:
       '@10play/tentap-editor':
         specifier: 0.5.21
-        version: 0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@emoji-mart/data':
         specifier: ^1.1.2
         version: 1.1.2
@@ -14680,7 +14680,7 @@ snapshots:
       react-native: 0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1)
       react-native-web: 0.19.12(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@10play/tentap-editor@0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@10play/tentap-editor@0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.25.2)(@babel/preset-env@7.28.3(@babel/core@7.25.2))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tiptap/extension-blockquote': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
       '@tiptap/extension-bold': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
@@ -14717,7 +14717,7 @@ snapshots:
     transitivePeerDependencies:
       - '@tiptap/core'
 
-  '@10play/tentap-editor@0.5.21(patch_hash=eb6lqjeso4iwimtyxzymqd6yd4)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@10play/tentap-editor@0.5.21(patch_hash=l63pvelugwthlyotjpntaskl3a)(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))(react-native-webview@13.12.5(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.28.4)(@babel/preset-env@7.28.3(@babel/core@7.28.4))(@react-native-community/cli@13.6.9(encoding@0.1.13))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tiptap/extension-blockquote': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))
       '@tiptap/extension-bold': 2.6.6(@tiptap/core@2.6.6(@tiptap/pm@2.6.6))


### PR DESCRIPTION
## Summary

This fixes a note editor crash when pasting rich links.

It also restores the current note content if the editor webview reloads after a crash so the user doesn't lose data if the webview crashes.

Fixes TLON-5552

## Changes

- patch `@10play/tentap-editor@0.5.21` to remove the old HTML link paste fallback that was crashing
- restore content after editor crashes

## How did I test?

Tested on web. 