### PR TITLE
Raise shake thresholds for UX report popup

### DIFF
--- a/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx
+++ b/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx
@@ -20,10 +20,10 @@ import {
 
 const logger = createDevLogger('PoorUxReport', false);
 const SHAKE_UPDATE_INTERVAL_MS = 250;
-const SHAKE_DELTA_THRESHOLD = 1.1;
-const SHAKE_HITS_REQUIRED = 2;
-const SHAKE_HITS_WINDOW_MS = 700;
-const SHAKE_COOLDOWN_MS = 1500;
+const SHAKE_DELTA_THRESHOLD = 2.5;
+const SHAKE_HITS_REQUIRED = 3;
+const SHAKE_HITS_WINDOW_MS = 1000;
+const SHAKE_COOLDOWN_MS = 3000;
 const FOREGROUND_SHAKE_GRACE_MS = 1500;
 
 export function usePoorUxShakeReport() {


### PR DESCRIPTION
## Summary

Increases shake detection thresholds so the "Report Poor UX" popup no longer fires from normal walking motion. Closes TLON-5474.

100% LLM-assisted.

## Changes

- `SHAKE_DELTA_THRESHOLD`: 1.1 → 2.5 (walking produces ~0.5–1.5; intentional shakes produce 2.5+)
- `SHAKE_HITS_REQUIRED`: 2 → 3 (require 3 shake events, not 2)
- `SHAKE_HITS_WINDOW_MS`: 700 → 1000 (wider window to accommodate 3 required hits)
- `SHAKE_COOLDOWN_MS`: 1500 → 3000 (longer cooldown between consecutive triggers)

## How did I test?

Code review of accelerometer thresholds against known walking vs. intentional-shake acceleration ranges.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Shake-to-report UX feedback (mobile only)

## Rollback plan

Revert the single commit to restore previous threshold values.

## Screenshots / videos

N/A — constants-only change, no visual diff.