### PR TITLE
groups: respect protocol mismatch when joining

### DIFF
--- a/packages/app/ui/components/GroupPreviewSheet.tsx
+++ b/packages/app/ui/components/GroupPreviewSheet.tsx
@@ -2,7 +2,6 @@ import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import { useNegotiate } from '@tloncorp/shared/store';
 import { Button, LoadingSpinner, Text, useIsWindowNarrow } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { XStack, YStack } from 'tamagui';
@@ -100,7 +99,7 @@ export function GroupPreviewPane({
 }) {
   const [isJoining, setIsJoining] = useState(group?.joinStatus === 'joining');
 
-  const { status: negotiationStatus } = useNegotiate(
+  const { status: negotiationStatus } = store.useNegotiate(
     group?.hostUserId ?? '',
     'groups',
     'groups'
@@ -469,8 +468,14 @@ export function getActionGroups(
     return [
       {
         title: 'Request invite',
-        accent: 'hero',
-        onPress: actions.requestInvite,
+        accent: status.isProtocolMismatch ? 'disabled' : 'hero',
+        disabled: status.isProtocolMismatch,
+        onPress: status.isProtocolMismatch
+          ? undefined
+          : actions.requestInvite,
+        description: status.isProtocolMismatch
+          ? MISMATCH_DESCRIPTION
+          : undefined,
       },
     ];
   }

--- a/packages/app/ui/components/GroupPreviewSheet.tsx
+++ b/packages/app/ui/components/GroupPreviewSheet.tsx
@@ -470,9 +470,7 @@ export function getActionGroups(
         title: 'Request invite',
         accent: status.isProtocolMismatch ? 'disabled' : 'hero',
         disabled: status.isProtocolMismatch,
-        onPress: status.isProtocolMismatch
-          ? undefined
-          : actions.requestInvite,
+        onPress: status.isProtocolMismatch ? undefined : actions.requestInvite,
         description: status.isProtocolMismatch
           ? MISMATCH_DESCRIPTION
           : undefined,

--- a/packages/app/ui/components/GroupPreviewSheet.tsx
+++ b/packages/app/ui/components/GroupPreviewSheet.tsx
@@ -2,6 +2,7 @@ import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
+import { useNegotiate } from '@tloncorp/shared/store';
 import { Button, LoadingSpinner, Text, useIsWindowNarrow } from '@tloncorp/ui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { XStack, YStack } from 'tamagui';
@@ -30,6 +31,7 @@ interface JoinStatus {
   needsInvite: boolean;
   hasInvite: boolean;
   requestedInvite: boolean;
+  isProtocolMismatch: boolean;
 }
 
 export type GroupPreviewAction = 'goTo' | 'joined' | 'other';
@@ -98,6 +100,13 @@ export function GroupPreviewPane({
 }) {
   const [isJoining, setIsJoining] = useState(group?.joinStatus === 'joining');
 
+  const { status: negotiationStatus } = useNegotiate(
+    group?.hostUserId ?? '',
+    'groups',
+    'groups'
+  );
+  const isProtocolMismatch = negotiationStatus === 'clash';
+
   const status: JoinStatus = useMemo(
     () => ({
       isMember: group?.currentUserIsMember ?? false,
@@ -107,6 +116,7 @@ export function GroupPreviewPane({
       needsInvite: group?.privacy !== 'public',
       hasInvite: group?.haveInvite ?? false,
       requestedInvite: group?.haveRequestedInvite ?? false,
+      isProtocolMismatch,
     }),
     [
       group?.currentUserIsMember,
@@ -115,6 +125,7 @@ export function GroupPreviewPane({
       group?.joinStatus,
       group?.privacy,
       isJoining,
+      isProtocolMismatch,
     ]
   );
 
@@ -166,7 +177,11 @@ export function GroupPreviewPane({
       // In lieu of a reactive update to the `group` prop, poll the database
       const interval = setInterval(async () => {
         const nextGroup = await db.getGroup({ id: group.id });
-        // TODO: handle case whare joinStatus === 'errored'
+        if (nextGroup?.joinStatus === 'errored') {
+          setIsJoining(false);
+          clearInterval(interval);
+          return;
+        }
         if (nextGroup?.currentUserIsMember === true) {
           setIsJoining(false);
           store
@@ -266,6 +281,9 @@ export function GroupPreviewPane({
                 <Badge text={privacyLabel} type="neutral" />
               </XStack>
             ) : null}
+            {isProtocolMismatch ? (
+              <Badge text="Incompatible" type="warning" />
+            ) : null}
             <ConnectionStatus contactId={group.hostUserId} type="badge" />
           </XStack>
         </YStack>
@@ -347,6 +365,23 @@ export function GroupPreviewPane({
 
 export const GroupPreviewSheet = React.memo(GroupPreviewSheetComponent);
 
+const MISMATCH_DESCRIPTION =
+  "The group host is running an incompatible version of the app. You won't be able to join until one of you updates.";
+
+const cancelJoinButton = (onPress: () => void): GroupActionButton => ({
+  title: 'Cancel join',
+  accent: 'negative',
+  onPress,
+});
+
+const rejectInviteButton = (
+  onPress: (accepted: boolean) => void
+): GroupActionButton => ({
+  title: 'Reject invite',
+  accent: 'secondary',
+  onPress: () => onPress(false),
+});
+
 export function getActionGroups(
   status: JoinStatus,
   actions: {
@@ -374,34 +409,36 @@ export function getActionGroups(
         accent: 'minimal',
         disabled: true,
       },
-      {
-        title: 'Cancel join',
-        accent: 'negative',
-        onPress: actions.cancelJoin,
-      },
+      cancelJoinButton(actions.cancelJoin),
     ];
   }
   if (status.isErrored) {
     return [
       {
-        title: 'Cancel join',
-        accent: 'negative',
-        onPress: actions.cancelJoin,
+        title: 'Joining failed',
+        accent: 'disabled',
+        disabled: true,
+        description: status.isProtocolMismatch
+          ? MISMATCH_DESCRIPTION
+          : 'Something went wrong while trying to join this group.',
       },
+      cancelJoinButton(actions.cancelJoin),
     ];
   }
   if (status.hasInvite) {
     return [
       {
         title: 'Accept invite',
-        accent: 'hero',
-        onPress: () => actions.respondToInvite(true),
+        accent: status.isProtocolMismatch ? 'disabled' : 'hero',
+        disabled: status.isProtocolMismatch,
+        onPress: status.isProtocolMismatch
+          ? undefined
+          : () => actions.respondToInvite(true),
+        description: status.isProtocolMismatch
+          ? MISMATCH_DESCRIPTION
+          : undefined,
       },
-      {
-        title: 'Reject invite',
-        accent: 'secondary',
-        onPress: () => actions.respondToInvite(false),
-      },
+      rejectInviteButton(actions.respondToInvite),
     ];
   }
   if (status.isSecret && !status.hasInvite) {
@@ -440,8 +477,10 @@ export function getActionGroups(
   return [
     {
       title: 'Join group',
-      accent: 'heroPositive',
-      onPress: actions.joinGroup,
+      accent: status.isProtocolMismatch ? 'disabled' : 'heroPositive',
+      disabled: status.isProtocolMismatch,
+      onPress: status.isProtocolMismatch ? undefined : actions.joinGroup,
+      description: status.isProtocolMismatch ? MISMATCH_DESCRIPTION : undefined,
     },
   ];
 }


### PR DESCRIPTION
## Summary

Adds client-side handling for the protocol mismatch error emitted by the `%groups` backend (added in #5464 / TLON-5251). The join and accept-invite buttons are now disabled when the group host is running an incompatible protocol version, and a failed join no longer hangs indefinitely.

Fixes TLON-5292

## Changes

- Check negotiation status of group host via `useNegotiate` in `GroupPreviewPane`
- Disable "Join group" / "Accept invite" buttons and show explanation when protocol clash detected
- Show an "Incompatible" warning badge on the group preview header
- Improve errored join state: show "Joining failed" with contextual message instead of only "Cancel join"
- Fix join polling loop to stop when `joinStatus` becomes `'errored'` (was looping forever)
- Extract shared button helpers (`cancelJoinButton`, `rejectInviteButton`) and `MISMATCH_DESCRIPTION` constant

## How did I test?

Typechecked with `tsc --noEmit`.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Group join flow

## Rollback plan

Revert the commit.

## Screenshots / videos

<!-- Attach any relevant media. -->