### PR TITLE
fix: test gateway-status helpers from api root export

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/api",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "files": [
     "dist",

--- a/packages/api/src/__tests__/gatewayStatusApi.test.ts
+++ b/packages/api/src/__tests__/gatewayStatusApi.test.ts
@@ -7,7 +7,7 @@ import {
   gatewayStart,
   gatewayStatusAction,
   gatewayStop,
-} from '../client/gatewayStatusApi';
+} from '../index';
 import { poke } from '../client/urbit';
 
 vi.mock('../client/urbit', () => ({

--- a/packages/api/src/__tests__/gatewayStatusApi.test.ts
+++ b/packages/api/src/__tests__/gatewayStatusApi.test.ts
@@ -1,6 +1,7 @@
 import { da, dr, render } from '@urbit/aura';
 import { expect, test, vi } from 'vitest';
 
+import { poke } from '../client/urbit';
 import {
   configureGatewayStatus,
   gatewayHeartbeat,
@@ -8,7 +9,6 @@ import {
   gatewayStatusAction,
   gatewayStop,
 } from '../index';
-import { poke } from '../client/urbit';
 
 vi.mock('../client/urbit', () => ({
   poke: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

Fixes a bad `@tloncorp/api@0.0.5` publish.

Bumps the package to `0.0.6` and makes the gateway-status API test verify the public root entrypoint, so these helpers are covered by the exported package surface rather than only by an internal client module.

## Changes

- bump `@tloncorp/api` version to `0.0.6`
- update the gateway-status API test to import from the package root entrypoint instead of the internal client module

## Testing

- `pnpm exec vitest run src/__tests__/gatewayStatusApi.test.ts`

During verification, I also manually checked the built package root export surface to confirm the gateway-status helpers were present before republishing.
