### PR TITLE
fix thread unreads while viewing threads

### DIFF
--- a/apps/tlon-web/e2e/dm-thread-unread-clearing.spec.ts
+++ b/apps/tlon-web/e2e/dm-thread-unread-clearing.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from '@playwright/test';
+
+import * as helpers from './helpers';
+import { test } from './test-fixtures';
+
+test('should clear DM thread unreads while user is viewing the thread', async ({
+  zodPage,
+  tenPage,
+}) => {
+  test.setTimeout(120000); // 2 minutes for cross-ship DM operations
+
+  // Assert that we're on the Home page for both ships
+  await expect(zodPage.getByText('Home')).toBeVisible();
+  await expect(tenPage.getByText('Home')).toBeVisible();
+
+  // ~zod creates a DM with ~ten
+  await helpers.createDirectMessage(zodPage, '~ten');
+  await helpers.sendMessage(zodPage, 'DM thread unread test parent message');
+
+  if (await helpers.isMobileViewport(zodPage)) {
+    await helpers.navigateBack(zodPage);
+  }
+
+  // ~ten receives and accepts the DM
+  await tenPage.reload();
+  await expect(tenPage.getByTestId('ChannelListItem-~zod')).toBeVisible({
+    timeout: 15000,
+  });
+  await tenPage.getByTestId('ChannelListItem-~zod').click();
+  await expect(
+    tenPage.getByText('DM thread unread test parent message').first()
+  ).toBeVisible({ timeout: 10000 });
+  await expect(tenPage.getByText('Accept')).toBeVisible({ timeout: 5000 });
+  await tenPage.getByText('Accept').click();
+  await expect(tenPage.getByTestId('MessageInput')).toBeVisible({
+    timeout: 10000,
+  });
+
+  // ~zod starts a thread on the message
+  await zodPage.getByTestId('ChannelListItem-~ten').click();
+  await expect(
+    zodPage.getByText('DM thread unread test parent message').first()
+  ).toBeVisible({ timeout: 10000 });
+  await helpers.startThread(zodPage, 'DM thread unread test parent message');
+  await helpers.sendThreadReply(zodPage, 'Initial DM thread reply from zod');
+
+  // ~zod stays in the thread — this is the key setup for the bug fix test
+  await expect(
+    zodPage.getByText('Initial DM thread reply from zod').first()
+  ).toBeVisible();
+
+  // ~ten sees the thread indicator
+  await expect(tenPage.getByText('1 reply')).toBeVisible({ timeout: 20000 });
+
+  // ~ten enters the thread and sends a reply WHILE ~zod is still viewing it
+  await tenPage.getByText('1 reply').click();
+  await expect(
+    tenPage.getByText('Initial DM thread reply from zod').first()
+  ).toBeVisible({ timeout: 5000 });
+  await helpers.sendThreadReply(tenPage, 'DM reply while zod views thread');
+
+  // ~zod should see the new reply arrive in the thread they're viewing
+  await expect(
+    zodPage.getByText('DM reply while zod views thread').first()
+  ).toBeVisible({ timeout: 15000 });
+
+  // ~zod navigates back to the DM view
+  await helpers.navigateBack(zodPage);
+
+  // The critical assertion: the parent message should NOT show a thread unread dot.
+  // Before the fix, the unread dot would persist because useMarkThreadAsReadEffect
+  // never re-fired while the user was already viewing the thread.
+  const parentMessage = zodPage
+    .getByTestId('Post')
+    .filter({ hasText: 'DM thread unread test parent message' });
+  await expect(parentMessage).toBeVisible({ timeout: 10000 });
+  await expect(parentMessage.getByTestId('ThreadUnreadDot')).not.toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/apps/tlon-web/e2e/thread-unread-clearing.spec.ts
+++ b/apps/tlon-web/e2e/thread-unread-clearing.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from '@playwright/test';
+
+import * as helpers from './helpers';
+import { test } from './test-fixtures';
+
+test('should clear thread unreads while user is viewing the thread', async ({
+  zodSetup,
+  tenSetup,
+}) => {
+  const zodPage = zodSetup.page;
+  const tenPage = tenSetup.page;
+
+  // Assert that we're on the Home page for both ships
+  await expect(zodPage.getByText('Home')).toBeVisible();
+  await expect(tenPage.getByText('Home')).toBeVisible();
+
+  // Create a new group as ~zod
+  await helpers.createGroup(zodPage);
+  const groupName = '~ten, ~zod';
+
+  // Invite ~ten to the group
+  await helpers.inviteMembersToGroup(zodPage, ['ten']);
+
+  // Navigate back to Home and into the group
+  await helpers.navigateBack(zodPage);
+  if (await zodPage.getByText('Home').isVisible()) {
+    await expect(
+      zodPage.getByTestId('GroupListItem-Untitled group-unpinned')
+    ).toBeVisible({ timeout: 5000 });
+    await zodPage.getByTestId('GroupListItem-Untitled group-unpinned').click();
+    await expect(zodPage.getByText(groupName).first()).toBeVisible();
+  }
+
+  // Send initial message as ~zod with distinctive text for selector scoping
+  await helpers.sendMessage(zodPage, 'Thread unread test parent message');
+
+  // Accept the group invitation as ~ten
+  await helpers.acceptGroupInvite(tenPage, groupName);
+  await helpers.navigateToChannel(tenPage, 'General');
+
+  // Verify ~ten can see the message from ~zod
+  await expect(
+    tenPage
+      .getByTestId('Post')
+      .getByText('Thread unread test parent message', { exact: true })
+  ).toBeVisible({ timeout: 10000 });
+
+  // ~zod starts a thread on the message
+  await helpers.startThread(zodPage, 'Thread unread test parent message');
+  await helpers.sendThreadReply(zodPage, 'Initial thread reply from zod');
+
+  // ~zod stays in the thread — this is the key setup for the bug fix test
+  // Verify ~zod is in the thread view
+  await expect(
+    zodPage.getByText('Initial thread reply from zod').first()
+  ).toBeVisible();
+
+  // ~ten sees the thread indicator and enters the thread
+  await expect(tenPage.getByText('1 reply')).toBeVisible({ timeout: 15000 });
+
+  // ~ten sends a reply WHILE ~zod is still viewing the thread
+  // This is the exact scenario that triggered the bug: the new reply should
+  // be auto-marked as read because ~zod is actively viewing the thread.
+  await tenPage.getByText('1 reply').click();
+  await expect(
+    tenPage.getByText('Initial thread reply from zod').first()
+  ).toBeVisible({ timeout: 5000 });
+  await helpers.sendThreadReply(tenPage, 'New reply while zod views thread');
+
+  // ~zod should see the new reply arrive in the thread they're viewing
+  await expect(
+    zodPage.getByText('New reply while zod views thread').first()
+  ).toBeVisible({ timeout: 15000 });
+
+  // ~zod navigates back to the channel view
+  await helpers.navigateBack(zodPage);
+
+  // The critical assertion: the parent message should NOT show a thread unread dot.
+  // Before the fix, the unread dot would persist because useMarkThreadAsReadEffect
+  // never re-fired while the user was already viewing the thread.
+  const parentMessage = zodPage
+    .getByTestId('Post')
+    .filter({ hasText: 'Thread unread test parent message' });
+  await expect(parentMessage).toBeVisible({ timeout: 10000 });
+  await expect(parentMessage.getByTestId('ThreadUnreadDot')).not.toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/apps/tlon-web/e2e/thread-unread-clearing.spec.ts
+++ b/apps/tlon-web/e2e/thread-unread-clearing.spec.ts
@@ -7,6 +7,8 @@ test('should clear thread unreads while user is viewing the thread', async ({
   zodSetup,
   tenSetup,
 }) => {
+  test.setTimeout(120000); // 2 minutes for cross-ship group operations
+
   const zodPage = zodSetup.page;
   const tenPage = tenSetup.page;
 

--- a/packages/app/ui/components/ChatMessage/ChatMessageReplySummary.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageReplySummary.tsx
@@ -141,7 +141,12 @@ function ThreadUnreadDot({
   isNotify: boolean;
 }) {
   if (unreadCount) {
-    return <UnreadDot color={isNotify ? 'primary' : 'neutral'} />;
+    return (
+      <UnreadDot
+        testID="ThreadUnreadDot"
+        color={isNotify ? 'primary' : 'neutral'}
+      />
+    );
   }
 
   return null;

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -482,32 +482,44 @@ function useMarkThreadAsReadEffect(
     channel: db.Channel;
     parent: db.Post;
     mostRecentlyReceivedReply: db.Post;
+    hasThreadUnreads: boolean;
   } | null
 ) {
   const store = useStore();
-  const markRead = useCallback(() => {
-    if (opts == null) {
-      return;
-    }
+  const shouldMarkRead = opts?.shouldMarkRead ?? false;
+  const latestReplyId = opts?.mostRecentlyReceivedReply?.id ?? null;
+  const hasThreadUnreads = opts?.hasThreadUnreads ?? false;
 
-    const { channel, parent, mostRecentlyReceivedReply } = opts;
-    if (channel && parent && mostRecentlyReceivedReply) {
+  // Ref captures the latest opts so the effect can read current values
+  // without depending on the unstable inline object identity.
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  // Single effect with two trigger signals:
+  //   - hasThreadUnreads: authoritative signal (SSE pushed unread count > 0).
+  //   - latestReplyId: secondary signal (thread sync delivered a new post,
+  //     allowing immediate mark-read if hasThreadUnreads is already true).
+  //
+  // Guard: only acts when hasThreadUnreads is true.
+  //   - false -> true: guard passes, marks read.
+  //   - true -> false (unread state cleared): guard returns early, no poke sent.
+  // This directly mirrors Channel/index.tsx:292-301's `if (hasUnreads && ...)`.
+  useEffect(() => {
+    if (!shouldMarkRead || !hasThreadUnreads) return;
+    const current = optsRef.current;
+    if (current == null) return;
+    const { channel, parent, mostRecentlyReceivedReply } = current;
+    if (!channel || !parent || !mostRecentlyReceivedReply) return;
+
+    const timeoutId = setTimeout(() => {
       store.markThreadRead({
         channel,
         parentPost: parent,
         post: mostRecentlyReceivedReply,
       });
-    }
-  }, [opts, store]);
-
-  const shouldMarkRead = opts?.shouldMarkRead ?? false;
-  useEffect(() => {
-    if (shouldMarkRead) {
-      markRead();
-    }
-    // Only want to trigger once per set of params
-    // eslint-disable-next-line
-  }, [shouldMarkRead]);
+    }, 150);
+    return () => clearTimeout(timeoutId);
+  }, [shouldMarkRead, hasThreadUnreads, latestReplyId, store]);
 }
 
 function SinglePostView({
@@ -575,6 +587,13 @@ function SinglePostView({
     }
     initializeChannelUnread();
   }, [parentPost.id]);
+
+  const { data: liveThreadUnread } = store.useLiveThreadUnreadByParentId(
+    parentPost.id
+  );
+  const hasThreadUnreads = !!(
+    liveThreadUnread?.count && liveThreadUnread.count > 0
+  );
 
   const { data: threadPosts } = store.useThreadPosts({
     postId: parentPost.id,
@@ -699,6 +718,7 @@ function SinglePostView({
           mostRecentlyReceivedReply: threadPosts[0],
           parent: parentPost,
           shouldMarkRead: isFocusedPost && hasLoadedReplies && isUserActive,
+          hasThreadUnreads,
         }
   );
 

--- a/packages/app/ui/contexts/storeContext.tsx
+++ b/packages/app/ui/contexts/storeContext.tsx
@@ -18,6 +18,9 @@ const HOOK_MOCKS: Record<string, unknown> = {
   useThreadPosts: {
     data: [],
   },
+  useLiveThreadUnreadByParentId: {
+    data: null,
+  },
   useChannel: {
     data: null,
   },

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -248,6 +248,30 @@ export const useLiveThreadUnread = (unread: db.ThreadUnreadState | null) => {
   });
 };
 
+/**
+ * Reactively tracks the unread state for a thread, keyed by the parent post's
+ * ID. Unlike `useLiveThreadUnread` (which requires a `ThreadUnreadState` seed
+ * and goes dormant when the seed is null), this hook always tracks reactively
+ * as long as `parentPostId` is non-null — even when the thread starts with no
+ * unread row.
+ */
+export const useLiveThreadUnreadByParentId = (parentPostId: string | null) => {
+  const depsKey = useMemo(
+    () => (parentPostId ? keyFromQueryDeps(db.getThreadUnreadState) : null),
+    [parentPostId]
+  );
+
+  return useQuery({
+    queryKey: ['liveUnreadCount', depsKey, 'thread', parentPostId],
+    queryFn: async () => {
+      if (parentPostId) {
+        return db.getThreadUnreadState({ parentId: parentPostId });
+      }
+      return null;
+    },
+  });
+};
+
 export const useLiveChannelUnread = (unread: db.ChannelUnread | null) => {
   const depsKey = useMemo(
     () => (unread ? keyFromQueryDeps(db.getChannelUnread) : null),


### PR DESCRIPTION
## Summary

Fixes TLON-5336: thread unreads now clear in real time while the user is already viewing the thread, matching main-channel behavior. Previously, `useMarkThreadAsReadEffect` only re-fired on the initial `shouldMarkRead` transition, so replies that arrived while a user was inside a chat or DM thread left a stale unread.

## Changes

- Added `useLiveThreadUnreadByParentId` in `packages/shared/src/store/dbHooks.ts`, a `useQuery`-backed hook that reactively tracks a thread's unread state keyed by `parentPostId`, using the same table-level invalidation pattern as the adjacent `useLiveThreadUnread`.
- Updated `SinglePostView` in `packages/app/ui/components/PostScreenView.tsx` to consume the new hook and derive a `hasThreadUnreads` boolean that is passed into `useMarkThreadAsReadEffect`.
- Rewrote `useMarkThreadAsReadEffect` in the same file as a single guarded effect depending on `[shouldMarkRead, hasThreadUnreads, latestReplyId, store]`. The effect guards on `!shouldMarkRead || !hasThreadUnreads`, reads current opts through an `optsRef` for stable identity, and schedules `markThreadRead` after 150ms with a cleanup. This mirrors the channel unread-trigger pattern in `Channel/index.tsx`.
- Added `testID="ThreadUnreadDot"` to the `UnreadDot` rendered by `ThreadUnreadDot` in `packages/app/ui/components/ChatMessage/ChatMessageReplySummary.tsx` for E2E selector stability.
- Added regression coverage:
  - `apps/tlon-web/e2e/thread-unread-clearing.spec.ts` for the chat thread scenario.
  - `apps/tlon-web/e2e/dm-thread-unread-clearing.spec.ts` for the DM thread scenario.

  Both specs exercise the exact failing scenario: ~zod opens a thread, ~ten sends a reply while ~zod is viewing the thread, ~zod navigates back, and the parent message's `ThreadUnreadDot` is asserted absent.

## How did I test?

- Local E2E:
  - `thread-unread-clearing.spec.ts` passes.
  - `dm-thread-unread-clearing.spec.ts` passes.
  - `dm-thread-interactions.spec.ts` passes.
  - `thread-cross-ship.spec.ts` passes.
- Manually tested locally on web

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [  ] Message sync
  - [x] Channel display
  - [ ] Notifications

## Rollback plan

Revert.

