### PR TITLE
fix sharing into the preview app

### DIFF
--- a/apps/tlon-mobile/ios/Landscape/Info-preview.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info-preview.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppGroupIdentifier</key>
+	<string>group.io.tlon.groups.preview</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.expo.modules.backgroundtask.processing</string>


### PR DESCRIPTION
## Summary
This fixes sharing into the preview app.

The preview app was missing the app group id that the share flow reads from, so the app could open without finding the shared data.

## Changes
- add `AppGroupIdentifier` to the preview app plist

## How did I test?
- Tested on device