### PR TITLE
backend: misc fixes

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1595,7 +1595,7 @@
   |=  [channels=@ud context=@ud]
   ^-  (map nest:c (unit posts:c))
   =/  =activity:v8:av
-    ?.  .^(? %gu (scry-path %activity /$))  
+    ?.  .^(? %gu (scry-path %activity /$))
       *activity:v8:av
     %-  ~(gas by *activity:v8:av)
     .^  (list [source:v8:av activity-summary:v8:av])  %gx

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1594,7 +1594,9 @@
 ++  init-posts
   |=  [channels=@ud context=@ud]
   ^-  (map nest:c (unit posts:c))
-  =/  activity
+  =/  =activity:v8:av
+    ?.  .^(? %gu (scry-path %activity /$))  
+      *activity:v8:av
     %-  ~(gas by *activity:v8:av)
     .^  (list [source:v8:av activity-summary:v8:av])  %gx
       (scry-path %activity /v4/activity/unreads/activity-summary-pairs-4)
@@ -1851,12 +1853,9 @@
       ::  and if we're the author of the post, mentioned, or in the replies.
       ::
       =/  thread=source  [%thread parent-key nest group.perm.channel]
-      =/  has-setting=?
-        ?.  running:ca-activity  |
-        =/  =path  (scry-path %activity /v4/volume-settings/noun)
-        =+  .^(settings=volume-settings %gx path)
-        (~(has by settings) thread)
-      ?.  ?&  !has-setting
+      =/  =path  (scry-path %activity /v4/volume-settings/noun)
+      =+  .^(settings=volume-settings %gx path)
+      ?.  ?&  !(~(has by settings) thread)
               ?|  mention
                   in-replies
                   =(parent-author our.bowl)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1838,8 +1838,6 @@
           |=  [=time reply=(may:c v-reply:c)]
           ?:  ?=(%| -.reply)  |
           =((get-author-ship:utils author.reply) our.bowl)
-      =/  =path  (scry-path %activity /v4/volume-settings/noun)
-      =+  .^(settings=volume-settings %gx path)
       =/  =action
         :*  %add  %reply
             [[reply-author id] id]
@@ -1850,9 +1848,15 @@
             mention
         ==
       ::  only follow thread if we haven't adjusted settings already
-      ::  and if we're the author of the post, mentioned, or in the replies
+      ::  and if we're the author of the post, mentioned, or in the replies.
+      ::
       =/  thread=source  [%thread parent-key nest group.perm.channel]
-      ?.  ?&  !(~(has by settings) thread)
+      =/  has-setting=?
+        ?.  running:ca-activity  |
+        =/  =path  (scry-path %activity /v4/volume-settings/noun)
+        =+  .^(settings=volume-settings %gx path)
+        (~(has by settings) thread)
+      ?.  ?&  !has-setting
               ?|  mention
                   in-replies
                   =(parent-author our.bowl)
@@ -3451,13 +3455,16 @@
     =/  =source:v8:av  [%channel nest flag]
     ?.  (can-read:ca-perms our.bowl)
       (send:ca-activity [%adjust source ~] ~)
-    =+  .^(=volume-settings:v8:av %gx (scry-path %activity /v4/volume-settings/noun))
+    =/  setting=(unit volume-map:v8:av)
+      ?.  running:ca-activity  ~
+      =+  .^(=volume-settings:v8:av %gx (scry-path %activity /v4/volume-settings/noun))
+      (~(get by volume-settings) source)
     =.  ca-core
       ::  if we don't have a setting, no-op
-      ?~  setting=(~(get by volume-settings) source)  ca-core
-      ::  if they have a setting that's not mute, retain it otherwise
+      ?~  setting  ca-core
+      ::  if they have a setting that's not mute, retain it. otherwise
       ::  delete setting if it's mute so it defaults
-      ?.  =(setting mute:v8:av)  ca-core
+      ?:  !=(u.setting mute:v8:av)  ca-core
       (send:ca-activity [%adjust source ~] ~)
     ::  if our read permissions restored, re-subscribe
     (ca-safe-sub |)

--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -3469,8 +3469,8 @@
   ::  leave the subscriptions only
   ::
   ++  ca-simple-leave
-    =.  ca-core
-      (unsubscribe (weld ca-area /checkpoint) [ship.nest server])
+    =.  ca-core  (unsubscribe (weld ca-area /backlog) [ship.nest server])
+    =.  ca-core  (unsubscribe (weld ca-area /checkpoint) [ship.nest server])
     (unsubscribe ca-sub-wire [ship.nest server])
   ::
   ::  leave the subscription, tell people about it, and delete our local


### PR DESCRIPTION
## Summary

We fix activity integration in a few places to prevent crashes on ships where the activity agent is not running. An 2 years old bug in activity was also found: due to incorrect comparison, a piece of logic that would reset the channel's volume to defaults if it was previously muted would never fire.

## Changes

1. Shield some activity scries with activity existence check.
2. Fix a bug in muted channels logic.

## How did I test?

Run the changes on a test moon.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.

