### PR TITLE
negotiate: detect and repair orphaned heed entries in +inflate

### DIFF
--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -195,6 +195,25 @@
         =?  kill  !=(u.hail `v.i.need)
           (~(put in kill) [wire gill])
         $(need t.need)
+      ::  re-negotiate orphaned heed entries whose subscriptions were lost.
+      ::  without this, a stale version in heed persists indefinitely
+      ::  because +negotiate-missing skips protocols already in heed.
+      ::
+      =^  init  heed
+        =/  entries=(list [[=gill:gall =protocol] ver=(unit version)])
+          ~(tap by heed)
+        |-
+        ?~  entries  [init heed]
+        =/  =wire
+          :+  %~.~  %negotiate
+          [%heed (scot %p p.gill.i.entries) q.gill.i.entries protocol.i.entries ~]
+        ?:  (~(has by boat) [wire gill.i.entries])
+          $(entries t.entries)
+        ::  subscription missing: clear heed and queue for re-negotiation
+        ::
+        =.  heed  (~(del by heed) [gill.i.entries protocol.i.entries])
+        =.  init  (~(put in init) [gill.i.entries protocol.i.entries])
+        $(entries t.entries)
       ::
       =^  inis  state
         =|  caz=(list card)

--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -198,8 +198,11 @@
       ::  re-negotiate orphaned heed entries whose subscriptions were lost.
       ::  without this, a stale version in heed persists indefinitely
       ::  because +negotiate-missing skips protocols already in heed.
+      ::  only run during +on-load (knew is non-null) to avoid defeating
+      ::  the ~m30 backoff timers used by the nack/kick retry path.
       ::
       =^  init  heed
+        ?.  ?=(^ knew)  [init heed]
         =/  entries=(list [[=gill:gall =protocol] ver=(unit version)])
           ~(tap by heed)
         |-


### PR DESCRIPTION
## Summary

Fixes a bug in `lib/negotiate.hoon` where a lost negotiate subscription leaves a stale version in the `heed` map with no recovery path, causing a permanent `%clash` status for affected gills. This was the root cause of TLON-5587, where `~malmur-halmex` could not invite `~somfyl-paclev` due to a `%groups` negotiation clash.

## Changes

- Added orphaned heed entry detection to `+inflate` in `desk/lib/negotiate.hoon`. After the existing `wex.bowl` iteration, the new code iterates all `heed` entries, checks if the corresponding negotiate/heed subscription still exists in `wex.bowl`, and if missing, clears the stale entry and queues it for fresh re-negotiation.

## How did I test?

- `debug-build` succeeds on local zod
- All 17 existing negotiate unit tests pass (`/tests/lib/negotiate`)
- Code review of the negotiate subscription lifecycle confirms the fix addresses the gap: `+negotiate-missing` and `+initiate` both skip protocols already in `heed`, so without this fix there is no recovery when a subscription is lost but the `heed` entry persists

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: `lib/negotiate` (protocol version negotiation between ships)

## Rollback plan

Revert the single commit. Affected ships would retain stale heed entries but no new damage is introduced — the bug existed before this fix.

## Screenshots / videos

N/A — backend-only Hoon change.