### PR TITLE
negotiate: add reset poke, re-announce on reload, debug peeks

### DIFF
--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -345,23 +345,22 @@
     ++  reset-heed
       |=  target=(unit gill:gall)
       ^-  (quip card _state)
-      =/  keys=(list [gill:gall protocol])
+      =/  keys=(list [=gill:gall =protocol])
+        ?~  target  ~(tap in ~(key by heed))
         %+  skim  ~(tap in ~(key by heed))
-        |=  [=gill:gall *]
-        ?~  target  &
-        =(gill u.target)
+        |=([=gill:gall *] =(gill u.target))
       =|  out=(list card)
       |-
       ?~  keys  [out state]
-      =*  entry  i.keys
-      =/  =wire
-        /~/negotiate/heed/(scot %p p.entry)/[q.entry]/[+.entry]
-      =.  out  (snoc out [%pass wire %agent -.entry %leave ~])
       =.  out
-        %+  snoc  out
-        (tell:log %dbug ~[>[%reset-heed entry]<] ~)
-      =.  heed  (~(del by heed) entry)
-      =^  caz  state  (negotiate entry)
+        :+  (tell:log %dbug ~[>[%reset-heed i.keys]<] ~)
+          =,  i.keys
+          :+  %pass
+            /~/negotiate/heed/(scot %p p.gill)/[q.gill]/[protocol]
+          [%agent gill %leave ~]
+        out
+      =.  heed  (~(del by heed) i.keys)
+      =^  caz  state  (negotiate i.keys)
       $(out (weld out caz), keys t.keys)
     ::
     ++  ours-changed
@@ -749,28 +748,29 @@
         =/  dat  (on-peek:og path)
         ?:  ?=(?(~ [~ ~]) dat)  ~
         (fall ((soft (list mass)) q.q.u.u.dat) ~)
-      ?:  =(/x/dbug/state path)
-        ``noun+!>((slop on-save:og !>(negotiate=state)))
-      ?:  =(/x/dbug/wex path)
-        ``noun+!>(wex.bowl)
-      ?:  =(/x/dbug/sup path)
-        ``noun+!>(sup.bowl)
-      ?:  =(/x/dbug/bowl path)
-        ``noun+!>(bowl)
-      ::  orphan diff: heed keys whose /~/negotiate/heed/... subscription
-      ::  is missing from wex.bowl. non-empty result means +inflate's
-      ::  orphan detector should have fired but didn't (or hasn't yet).
-      ::
-      ?:  =(/x/dbug/orphans path)
-        :^  ~  ~  %noun
-        !>  ^-  (list [gill:gall protocol])
-        %+  murn  ~(tap by heed)
-        |=  [[=gill:gall =protocol] *]
-        =/  =wire
-          :+  %~.~  %negotiate
-          [%heed (scot %p p.gill) q.gill protocol ~]
-        ?:  (~(has by wex.bowl) [wire gill])  ~
-        `[gill protocol]
+      ?:  ?=([%x %dbug *] path)
+        ?+  t.t.path  [~ ~]
+            [%wex ~]   ``noun+!>(wex.bowl)
+            [%sup ~]   ``noun+!>(sup.bowl)
+            [%bowl ~]  ``noun+!>(bowl)
+            [%state ~]
+          ``noun+!>((slop on-save:og !>(negotiate=state)))
+        ::
+        ::  orphan diff: heed keys whose /~/negotiate/heed/... subscription
+        ::  is missing from wex.bowl. non-empty result means +inflate's
+        ::  orphan detector should have fired but didn't (or hasn't yet).
+        ::
+            [%orphans ~]
+          :^  ~  ~  %noun
+          !>  ^-  (list [gill:gall protocol])
+          %+  murn  ~(tap by heed)
+          |=  [[=gill:gall =protocol] *]
+          =/  =wire
+            :+  %~.~  %negotiate
+            [%heed (scot %p p.gill) q.gill protocol ~]
+          ?:  (~(has by wex.bowl) [wire gill])  ~
+          `[gill protocol]
+        ==
       ?.  ?=([@ %~.~ %negotiate *] path)
         (on-peek:og path)
       !:

--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -338,14 +338,10 @@
       ?<  (~(has by heed) for)
       :-  [(watch-version for)]~
       state(heed (~(put by heed) for ~))
-    ::  +reset-heed: operator-invoked repair for stuck heed entries
+    ::  +reset-heed: renegotiate targeted heed entries
     ::
     ::    for each matching heed key, emit %leave on the heed subscription
-    ::    wire, clear the entry, and call +negotiate to re-subscribe. this
-    ::    forces the publisher to re-answer via +on-watch with its current
-    ::    version, healing zombie/desynced subscription state that the
-    ::    orphan detector cannot see (both sides' wex/sup agree, but the
-    ::    version we heard is stale).
+    ::    wire, clear the entry, and call +negotiate to re-subscribe.
     ::
     ++  reset-heed
       |=  target=(unit gill:gall)
@@ -380,18 +376,15 @@
         %+  turn  old
         |=  [=protocol =version]
         [%give %kick [/~/negotiate/version/[protocol]]~ ~]
-      ::  re-announce current version for every protocol we expose.
-      ::  idempotent on subscribers (+heed-changed short-circuits on
-      ::  same version), but heals cases where a prior %fact was
-      ::  missed (breach-adjacent flow reset, upgrade path that
-      ::  skipped this arm, etc). called unconditionally from on-load
-      ::  so every reload acts as a safety-net re-announce.
+      ::  give updates for protocols whose supported version changed
       ::
       ^-  (list card)
       %-  zing
-      %+  turn  ~(tap by neu)
+      %+  murn  ~(tap by neu)
       |=  [=protocol =version]
-      ^-  (list card)
+      ^-  (unit (list card))
+      ?:  =(`version (~(get by ole) protocol))  ~
+      %-  some
       :~  (tell:log %dbug ~[>[%ours-changed 'giving version' version 'for protocol' protocol]<] ~)
           [%give %fact [/~/negotiate/version/[protocol]]~ %noun !>(version)]
       ==
@@ -614,13 +607,9 @@
             $(cards (weld cards caz), suz t.suz)
           ?>  ?=(%1 -.old)
           =.  state  old
-          ::  always re-announce current versions on reload as a safety
-          ::  net. +ours-changed handles both the kick path (for removed
-          ::  protocols) and the fact emission (for current protocols);
-          ::  facts are no-ops on subscribers whose heed is already
-          ::  in sync via +heed-changed's early return.
-          ::
-          =/  caz1  (ours-changed:up ours our-versions)
+          =/  caz1
+            ?:  =(ours our-versions)  ~
+            (ours-changed:up ours our-versions)
           =.  ours   our-versions
           =/  knew   know
           =.  know   our-config
@@ -763,10 +752,6 @@
         (fall ((soft (list mass)) q.q.u.u.dat) ~)
       ?:  =(/x/dbug/state path)
         ``noun+!>((slop on-save:og !>(negotiate=state)))
-      ::  raw outer-bowl peeks: these bypass +inner-boat/+inner-bitt so
-      ::  operators can see library-internal wires that would otherwise
-      ::  be filtered out of any inner-agent (e.g. +dbug) scry.
-      ::
       ?:  =(/x/dbug/wex path)
         ``noun+!>(wex.bowl)
       ?:  =(/x/dbug/sup path)
@@ -885,10 +870,6 @@
     ++  on-poke
       |=  [=mark =vase]
       ^-  (quip card _this)
-      ::  library-level repair poke: clear targeted heed entries and
-      ::  re-negotiate, healing stuck subscriptions without waiting
-      ::  for the next reload.
-      ::
       ?:  ?=(%negotiate-reset mark)
         =+  !<(target=(unit gill:gall) vase)
         =^  cards  state  (reset-heed:up target)

--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -871,6 +871,7 @@
       |=  [=mark =vase]
       ^-  (quip card _this)
       ?:  ?=(%negotiate-reset mark)
+        ?>  =(our src):bowl
         =+  !<(target=(unit gill:gall) vase)
         =^  cards  state  (reset-heed:up target)
         [cards this]

--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -338,6 +338,36 @@
       ?<  (~(has by heed) for)
       :-  [(watch-version for)]~
       state(heed (~(put by heed) for ~))
+    ::  +reset-heed: operator-invoked repair for stuck heed entries
+    ::
+    ::    for each matching heed key, emit %leave on the heed subscription
+    ::    wire, clear the entry, and call +negotiate to re-subscribe. this
+    ::    forces the publisher to re-answer via +on-watch with its current
+    ::    version, healing zombie/desynced subscription state that the
+    ::    orphan detector cannot see (both sides' wex/sup agree, but the
+    ::    version we heard is stale).
+    ::
+    ++  reset-heed
+      |=  target=(unit gill:gall)
+      ^-  (quip card _state)
+      =/  keys=(list [gill:gall protocol])
+        %+  skim  ~(tap in ~(key by heed))
+        |=  [=gill:gall *]
+        ?~  target  &
+        =(gill u.target)
+      =|  out=(list card)
+      |-
+      ?~  keys  [out state]
+      =*  entry  i.keys
+      =/  =wire
+        /~/negotiate/heed/(scot %p p.entry)/[q.entry]/[+.entry]
+      =.  out  (snoc out [%pass wire %agent -.entry %leave ~])
+      =.  out
+        %+  snoc  out
+        (tell:log %dbug ~[>[%reset-heed entry]<] ~)
+      =.  heed  (~(del by heed) entry)
+      =^  caz  state  (negotiate entry)
+      $(out (weld out caz), keys t.keys)
     ::
     ++  ours-changed
       |=  [ole=(map protocol version) neu=(map protocol version)]
@@ -350,15 +380,18 @@
         %+  turn  old
         |=  [=protocol =version]
         [%give %kick [/~/negotiate/version/[protocol]]~ ~]
-      ::  give updates for protocols whose supported version changed
+      ::  re-announce current version for every protocol we expose.
+      ::  idempotent on subscribers (+heed-changed short-circuits on
+      ::  same version), but heals cases where a prior %fact was
+      ::  missed (breach-adjacent flow reset, upgrade path that
+      ::  skipped this arm, etc). called unconditionally from on-load
+      ::  so every reload acts as a safety-net re-announce.
       ::
       ^-  (list card)
       %-  zing
-      %+  murn  ~(tap by neu)
+      %+  turn  ~(tap by neu)
       |=  [=protocol =version]
-      ^-  (unit (list card))
-      ?:  =(`version (~(get by ole) protocol))  ~
-      %-  some
+      ^-  (list card)
       :~  (tell:log %dbug ~[>[%ours-changed 'giving version' version 'for protocol' protocol]<] ~)
           [%give %fact [/~/negotiate/version/[protocol]]~ %noun !>(version)]
       ==
@@ -581,9 +614,13 @@
             $(cards (weld cards caz), suz t.suz)
           ?>  ?=(%1 -.old)
           =.  state  old
-          =/  caz1
-            ?:  =(ours our-versions)  ~
-            (ours-changed:up ours our-versions)
+          ::  always re-announce current versions on reload as a safety
+          ::  net. +ours-changed handles both the kick path (for removed
+          ::  protocols) and the fact emission (for current protocols);
+          ::  facts are no-ops on subscribers whose heed is already
+          ::  in sync via +heed-changed's early return.
+          ::
+          =/  caz1  (ours-changed:up ours our-versions)
           =.  ours   our-versions
           =/  knew   know
           =.  know   our-config
@@ -726,6 +763,30 @@
         (fall ((soft (list mass)) q.q.u.u.dat) ~)
       ?:  =(/x/dbug/state path)
         ``noun+!>((slop on-save:og !>(negotiate=state)))
+      ::  raw outer-bowl peeks: these bypass +inner-boat/+inner-bitt so
+      ::  operators can see library-internal wires that would otherwise
+      ::  be filtered out of any inner-agent (e.g. +dbug) scry.
+      ::
+      ?:  =(/x/dbug/wex path)
+        ``noun+!>(wex.bowl)
+      ?:  =(/x/dbug/sup path)
+        ``noun+!>(sup.bowl)
+      ?:  =(/x/dbug/bowl path)
+        ``noun+!>(bowl)
+      ::  orphan diff: heed keys whose /~/negotiate/heed/... subscription
+      ::  is missing from wex.bowl. non-empty result means +inflate's
+      ::  orphan detector should have fired but didn't (or hasn't yet).
+      ::
+      ?:  =(/x/dbug/orphans path)
+        :^  ~  ~  %noun
+        !>  ^-  (list [gill:gall protocol])
+        %+  murn  ~(tap by heed)
+        |=  [[=gill:gall =protocol] *]
+        =/  =wire
+          :+  %~.~  %negotiate
+          [%heed (scot %p p.gill) q.gill protocol ~]
+        ?:  (~(has by wex.bowl) [wire gill])  ~
+        `[gill protocol]
       ?.  ?=([@ %~.~ %negotiate *] path)
         (on-peek:og path)
       !:
@@ -824,6 +885,14 @@
     ++  on-poke
       |=  [=mark =vase]
       ^-  (quip card _this)
+      ::  library-level repair poke: clear targeted heed entries and
+      ::  re-negotiate, healing stuck subscriptions without waiting
+      ::  for the next reload.
+      ::
+      ?:  ?=(%negotiate-reset mark)
+        =+  !<(target=(unit gill:gall) vase)
+        =^  cards  state  (reset-heed:up target)
+        [cards this]
       ?.  ?&  ?=(%egg-any mark)
             !:
               =+  !<(=egg-any:gall vase)

--- a/desk/lib/negotiate.hoon
+++ b/desk/lib/negotiate.hoon
@@ -71,6 +71,13 @@
 +$  version   *
 +$  config    (map dude:gall (map protocol version))
 +$  status    ?(%match %clash %await %unmet)
++$  state-1
+  $:  %1
+      ours=(map protocol version)
+      know=config
+      heed=(map [gill:gall protocol] (unit version))
+      want=(map gill:gall (map wire path))  ::  un-packed wires
+  ==
 ::
 ++  initiate
   |=  =gill:gall
@@ -92,14 +99,6 @@
   |=  [notify=? our-versions=(map protocol version) =our=config]
   ^-  $-(agent:gall agent:gall)
   |^  agent
-  ::
-  +$  state-1
-    $:  %1
-        ours=(map protocol version)
-        know=config
-        heed=(map [gill:gall protocol] (unit version))
-        want=(map gill:gall (map wire path))  ::  un-packed wires
-    ==
   ::
   +$  card  card:agent:gall
   ::

--- a/desk/mar/negotiate/reset.hoon
+++ b/desk/mar/negotiate/reset.hoon
@@ -1,0 +1,17 @@
+::  negotiate-reset: operator poke to clear heed entries and re-negotiate
+::
+::    target is (unit gill:gall):
+::      ~         reset every heed entry (noisy — every peer re-negotiates)
+::      [~ gill]  reset all heed entries for that gill
+::
+|_  target=(unit gill:gall)
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  target
+  --
+++  grab
+  |%
+  ++  noun  (unit gill:gall)
+  --
+--


### PR DESCRIPTION
Addresses a class of stuck-version bugs where a subscriber's `heed` entry gets pinned at an old version with no recovery path, even when both sides' wex/sup agree the subscription is live. Observed with malmur/somfyl stuck at groups v1 after somfyl upgraded to v2, likely due to a dropped fact during a post-breach Ames flow reset window.

Three pieces:

1. `%negotiate-reset` poke (operator-invoked repair). Accepts `(unit gill:gall)`. For each matching heed key, emits `%leave` on the heed subscription wire, clears the entry, and calls `+negotiate` to re-subscribe. Forces the publisher to re-answer via `+on-watch` with its current version, healing stuck state immediately without waiting for a reload.

2. `+ours-changed` now always emits a `%fact` for every protocol in current `ours`, and the `+on-load` state-1 guard that gated it on `!=(ours our-versions)` has been removed. Every reload acts as a safety-net re-announce to all existing subscribers. `+heed-changed` short-circuits on same-version facts, so healthy subs pay nothing.

3. Debug peeks on the outer agent door: `/x/dbug/wex`, `/x/dbug/sup`, `/x/dbug/bowl`, `/x/dbug/orphans`. These bypass `+inner-boat` / `+inner-bitt` so operators can see library-internal wires that would otherwise be filtered from any `+dbug`-based scry.

## Summary

<!-- Briefly describe what this pull request does in 1-3 sentences. -->

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
