### PR TITLE
feat: integrate bot config with hosting API, consolidate UI, add desktop nav

### DIFF
--- a/apps/tlon-mobile/.env.sample
+++ b/apps/tlon-mobile/.env.sample
@@ -34,6 +34,8 @@ RECAPTCHA_SITE_KEY_ANDROID=
 RECAPTCHA_SITE_KEY_IOS=
 ENABLED_LOGGERS=query,sync
 IGNORE_COSMOS=false
+# Force the bot config splash sequence to show regardless of normal gating
+FORCE_SPLASH_SEQUENCE=false
 TLON_EMPLOYEE_GROUP=
 BRANCH_KEY=
 BRANCH_DOMAIN=

--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -56,6 +56,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     inviteServiceIsDev: process.env.INVITE_SERVICE_IS_DEV,
     gitHash: buildGitHash ? buildGitHash.substring(0, 7) : 'dev',
     automatedTest: process.env.AUTOMATED_TEST,
+    forceSplashSequence: process.env.FORCE_SPLASH_SEQUENCE,
   },
   ios: {
     runtimeVersion: '4.0.2',

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -12,6 +12,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import ErrorBoundary from '@tloncorp/app/ErrorBoundary';
 import { BranchProvider } from '@tloncorp/app/contexts/branch';
+import { FORCE_SPLASH_SEQUENCE } from '@tloncorp/app/constants';
 import { useShip } from '@tloncorp/app/contexts/ship';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import { useMigrations } from '@tloncorp/app/lib/nativeDb';
@@ -142,7 +143,7 @@ const App = () => {
   ]);
 
   const showSplashSequence = useMemo(() => {
-    return showAuthenticatedApp && needsSplashSequence;
+    return showAuthenticatedApp && (FORCE_SPLASH_SEQUENCE || needsSplashSequence);
   }, [showAuthenticatedApp, needsSplashSequence]);
 
   return (

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -97,9 +97,7 @@ const App = () => {
   const haveHostedLogin = db.haveHostedLogin.useValue();
   const hostedAccountInitialized = db.hostedAccountIsInitialized.useValue();
   const hostedNodeRunning = db.hostedNodeIsRunning.useValue();
-  // TODO: remove __DEV__ override before merging
-  const _hostingBotEnabled = db.hostingBotEnabled.useValue();
-  const hostingBotEnabled = __DEV__ || _hostingBotEnabled;
+  const hostingBotEnabled = db.hostingBotEnabled.useValue();
 
   const currentlyOnboarding = useMemo(() => {
     return signupContext.email || signupContext.phoneNumber;
@@ -143,9 +141,8 @@ const App = () => {
     isAuthenticated,
   ]);
 
-  // TODO: remove __DEV__ override before merging — forces splash for testing
   const showSplashSequence = useMemo(() => {
-    return showAuthenticatedApp && (__DEV__ || needsSplashSequence);
+    return showAuthenticatedApp && needsSplashSequence;
   }, [showAuthenticatedApp, needsSplashSequence]);
 
   return (

--- a/packages/api/src/client/hostedBotApi.ts
+++ b/packages/api/src/client/hostedBotApi.ts
@@ -1,0 +1,297 @@
+import { createDevLogger } from './logger';
+
+const logger = createDevLogger('hostedBotApi', false);
+
+// Re-use the hosting fetch infrastructure from hostingApi.
+// These imports are internal to the api package so we import directly.
+import { HostingError } from './hostingApi';
+import { getConstants } from '../types';
+
+// --- Types ---
+
+export interface HostedBotProviderConfigInfo {
+  keys: Record<string, string>;
+  models: HostedBotModelEntry[];
+  defaultKeys: Record<string, { key: string; id?: string }>;
+}
+
+export interface HostedBotModelEntry {
+  provider: string;
+  model: string;
+}
+
+export interface HostedBotPrimaryModelUpdate {
+  provider: string;
+  model: string;
+  fallbacks?: HostedBotModelEntry[];
+}
+
+export interface HostedBotProviderKeysUpdate {
+  keys?: Record<string, string>;
+  models?: HostedBotModelEntry[];
+}
+
+export interface HostedBotBotInfo {
+  enabled: boolean;
+  provider?: string;
+  model?: string;
+  moon?: string;
+}
+
+export interface HostedBotConfig {
+  dmAllowlist: string[];
+  defaultAuthorizedShips: string[];
+  channelRules: Record<string, { mode: string; allowedShips: string[] }>;
+  groupChannels: string[];
+  groupInviteAllowlist: string[];
+  autoAcceptDmInvites: boolean;
+  autoDiscoverChannels: boolean;
+}
+
+// --- Fetch helper ---
+// Follows the same pattern as hostingApi but scoped to hosted bot endpoints.
+// Requires the caller to pass userId/shipId since this module doesn't own
+// the session store.
+
+interface HostedBotFetchInit extends RequestInit {
+  json?: unknown;
+}
+
+async function hostedBotFetch<T>(
+  path: string,
+  authCookie: string,
+  init?: HostedBotFetchInit
+): Promise<T> {
+  const env = getConstants();
+  const modifiedCookie = authCookie.replace(' HttpOnly;', '');
+  const { json, ...fetchInit } = init ?? {};
+
+  const headers: Record<string, string> = {
+    ...(fetchInit.headers as Record<string, string>),
+    Cookie: modifiedCookie,
+  };
+  if (json !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15_000);
+
+  let response: Response;
+  try {
+    response = await fetch(`${env.API_URL}${path}`, {
+      ...fetchInit,
+      credentials: 'include',
+      signal: controller.signal,
+      headers,
+      body: json !== undefined ? JSON.stringify(json) : fetchInit.body,
+    });
+  } catch (e) {
+    throw new HostingError(
+      e.name === 'AbortError' ? 'Request timed out' : 'Unknown error occurred',
+      { method: fetchInit.method ?? 'GET', path, status: null }
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  const responseText = await response.text();
+  let result: T;
+  try {
+    result = JSON.parse(responseText) as T;
+  } catch {
+    throw new HostingError('Failed to parse response', {
+      method: fetchInit.method ?? 'GET',
+      path,
+      status: response.status,
+      responseText,
+    });
+  }
+
+  if (!response.ok) {
+    throw new HostingError(
+      (result as any)?.message ?? 'An unknown error has occurred.',
+      { method: fetchInit.method ?? 'GET', path, status: response.status }
+    );
+  }
+
+  return result;
+}
+
+// --- User-level endpoints ---
+
+export async function getProviderKeys(
+  userId: string,
+  authCookie: string
+): Promise<HostedBotProviderConfigInfo> {
+  return hostedBotFetch<HostedBotProviderConfigInfo>(
+    `/v1/tlawn/users/${userId}/provider-keys`,
+    authCookie
+  );
+}
+
+export async function updateProviderKeys(
+  userId: string,
+  authCookie: string,
+  update: HostedBotProviderKeysUpdate
+): Promise<HostedBotProviderConfigInfo> {
+  return hostedBotFetch<HostedBotProviderConfigInfo>(
+    `/v1/tlawn/users/${userId}/provider-keys`,
+    authCookie,
+    { method: 'PUT', json: update }
+  );
+}
+
+export async function setProviderKey(
+  userId: string,
+  authCookie: string,
+  provider: string,
+  key: string
+): Promise<HostedBotProviderConfigInfo> {
+  return hostedBotFetch<HostedBotProviderConfigInfo>(
+    `/v1/tlawn/users/${userId}/provider-keys/${provider}`,
+    authCookie,
+    { method: 'PUT', json: { key } }
+  );
+}
+
+export async function deleteProviderKey(
+  userId: string,
+  authCookie: string,
+  provider: string
+): Promise<HostedBotProviderConfigInfo> {
+  return hostedBotFetch<HostedBotProviderConfigInfo>(
+    `/v1/tlawn/users/${userId}/provider-keys/${provider}`,
+    authCookie,
+    { method: 'DELETE' }
+  );
+}
+
+export async function setPrimaryModel(
+  userId: string,
+  authCookie: string,
+  update: HostedBotPrimaryModelUpdate
+): Promise<HostedBotProviderConfigInfo> {
+  return hostedBotFetch<HostedBotProviderConfigInfo>(
+    `/v1/tlawn/users/${userId}/primary-model`,
+    authCookie,
+    { method: 'PUT', json: update }
+  );
+}
+
+// --- Ship-level endpoints ---
+
+export async function getBotInfo(
+  ship: string,
+  authCookie: string
+): Promise<HostedBotBotInfo> {
+  return hostedBotFetch<HostedBotBotInfo>(
+    `/v1/tlawn/ships/${ship}`,
+    authCookie
+  );
+}
+
+export async function setBotEnabled(
+  ship: string,
+  authCookie: string,
+  enabled: boolean,
+  moon?: string
+): Promise<string | null> {
+  return hostedBotFetch<string | null>(
+    `/v1/tlawn/ships/${ship}/enabled`,
+    authCookie,
+    { method: 'PUT', json: { enabled, moon } }
+  );
+}
+
+export async function getBotNickname(
+  ship: string,
+  authCookie: string
+): Promise<string | null> {
+  return hostedBotFetch<string | null>(
+    `/v1/tlawn/ships/${ship}/nickname`,
+    authCookie
+  );
+}
+
+export async function setBotNickname(
+  ship: string,
+  authCookie: string,
+  nickname: string
+): Promise<string | null> {
+  return hostedBotFetch<string | null>(
+    `/v1/tlawn/ships/${ship}/nickname`,
+    authCookie,
+    { method: 'PUT', json: { nickname } }
+  );
+}
+
+export async function getBotConfig(
+  ship: string,
+  authCookie: string
+): Promise<HostedBotConfig> {
+  return hostedBotFetch<HostedBotConfig>(
+    `/v1/tlawn/ships/${ship}/config`,
+    authCookie
+  );
+}
+
+export async function updateBotConfig(
+  ship: string,
+  authCookie: string,
+  config: Partial<HostedBotConfig>
+): Promise<HostedBotConfig> {
+  return hostedBotFetch<HostedBotConfig>(
+    `/v1/tlawn/ships/${ship}/config`,
+    authCookie,
+    { method: 'PUT', json: config }
+  );
+}
+
+export async function addBotToGroup(
+  ship: string,
+  authCookie: string,
+  group: string,
+  moon?: string
+): Promise<void> {
+  await hostedBotFetch<void>(
+    `/v1/tlawn/ships/${ship}/join?group=${encodeURIComponent(group)}${moon ? `&moon=${encodeURIComponent(moon)}` : ''}`,
+    authCookie,
+    { method: 'POST' }
+  );
+}
+
+export async function addBotToCordon(
+  ship: string,
+  authCookie: string,
+  group: string,
+  moon?: string
+): Promise<void> {
+  await hostedBotFetch<void>(
+    `/v1/tlawn/ships/${ship}/add-to-cordon?group=${encodeURIComponent(group)}${moon ? `&moon=${encodeURIComponent(moon)}` : ''}`,
+    authCookie,
+    { method: 'POST' }
+  );
+}
+
+export async function reloadBot(
+  ship: string,
+  authCookie: string
+): Promise<void> {
+  await hostedBotFetch<void>(
+    `/v1/tlawn/ships/${ship}/reload`,
+    authCookie,
+    { method: 'POST' }
+  );
+}
+
+export async function isBotRunning(
+  ship: string,
+  authCookie: string
+): Promise<boolean> {
+  const result = await hostedBotFetch<{ running: boolean }>(
+    `/v1/tlawn/ships/${ship}/running`,
+    authCookie
+  );
+  return result.running;
+}

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -51,3 +51,4 @@ export type { HostingHeartBeatCode } from './hostingApi';
 export * from './apiUtils';
 export * from './metagrabApi';
 export * from './changesApi';
+export * from './hostedBotApi';

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -45,6 +45,7 @@ function getBucket(key: string): string {
     case 'completedWayfindingTutorial':
     case 'disableTlonInfraEnhancement':
     case 'enableTelemetry':
+    case 'tlonbotConfig':
       return 'groups';
     case 'disableAvatars':
     case 'disableNicknames':
@@ -76,6 +77,16 @@ export const setSetting = async (key: string, val: any) => {
       },
     },
   });
+};
+
+export const getSettingValue = async (key: string): Promise<unknown> => {
+  const bucket = getBucket(key);
+  const results = await scry<ub.GroupsDeskSettings>({
+    app: 'settings',
+    path: '/desk/groups',
+  });
+  const desk = results as Record<string, Record<string, unknown>> | undefined;
+  return desk?.[bucket]?.[key] ?? null;
 };
 
 export const getSettings = async (): Promise<{

--- a/packages/app/lib/envVars.native.ts
+++ b/packages/app/lib/envVars.native.ts
@@ -66,6 +66,7 @@ export const INVITE_SERVICE_ENDPOINT = envVars.inviteServiceEndpoint ?? '';
 export const INVITE_SERVICE_IS_DEV =
   envVars.inviteServiceIsDev === 'true' ? true : undefined;
 export const GIT_HASH = envVars.gitHash ?? 'unknown';
+export const FORCE_SPLASH_SEQUENCE = envVars.forceSplashSequence === 'true';
 
 export const ENV_VARS = {
   DEV_SHIP_URL,
@@ -100,4 +101,5 @@ export const ENV_VARS = {
   INVITE_SERVICE_IS_DEV,
   GIT_HASH,
   AUTOMATED_TEST,
+  FORCE_SPLASH_SEQUENCE,
 };

--- a/packages/app/lib/envVars.ts
+++ b/packages/app/lib/envVars.ts
@@ -33,6 +33,7 @@ const envVars = {
   inviteServiceIsDev: env.VITE_INVITE_SERVICE_IS_DEV,
   gitHash: env.VITE_GIT_HASH,
   disableSplashModal: env.VITE_DISABLE_SPLASH_MODAL,
+  forceSplashSequence: env.VITE_FORCE_SPLASH_SEQUENCE,
   automatedTest: env.VITE_AUTOMATED_TEST,
   sentryDsn: env.VITE_SENTRY_DSN,
 } as Record<string, string | undefined>;
@@ -78,6 +79,7 @@ export const INVITE_SERVICE_IS_DEV =
   envVars.inviteServiceIsDev === 'true' ? true : undefined;
 export const GIT_HASH = envVars.gitHash ?? 'unknown';
 export const DISABLE_SPLASH_MODAL = envVars.disableSplashModal === 'true';
+export const FORCE_SPLASH_SEQUENCE = envVars.forceSplashSequence === 'true';
 export const SENTRY_DSN = envVars.sentryDsn ?? '';
 
 export const ENV_VARS = {
@@ -112,5 +114,6 @@ export const ENV_VARS = {
   INVITE_SERVICE_IS_DEV,
   GIT_HASH,
   DISABLE_SPLASH_MODAL,
+  FORCE_SPLASH_SEQUENCE,
   SENTRY_DSN,
 };

--- a/packages/app/navigation/desktop/SettingsNavigator.tsx
+++ b/packages/app/navigation/desktop/SettingsNavigator.tsx
@@ -6,8 +6,10 @@ import { getVariableValue, useTheme } from '@tamagui/core';
 import { getCurrentUserIsHosted } from '@tloncorp/api';
 import * as db from '@tloncorp/shared/db';
 import { useCallback, useEffect, useState } from 'react';
-import { Linking, Platform } from 'react-native';
+import { Platform } from 'react-native';
 
+import { BotBehaviorScreen } from '../../features/bot/BotBehaviorScreen';
+import { BotIdentityScreen } from '../../features/bot/BotIdentityScreen';
 import { AppInfoScreen } from '../../features/settings/AppInfoScreen';
 import { BlockedUsersScreen } from '../../features/settings/BlockedUsersScreen';
 import { FeatureFlagScreen } from '../../features/settings/FeatureFlagScreen';
@@ -54,8 +56,8 @@ function DrawerContent(props: DrawerContentComponentProps) {
   }, [navigate]);
 
   const onBotSettingsPressed = useCallback(() => {
-    Linking.openURL('https://tlon.network/tlawnbot');
-  }, []);
+    navigate('BotIdentity');
+  }, [navigate]);
 
   const onExperimentalFeaturesPressed = useCallback(() => {
     navigate('FeatureFlags');
@@ -136,6 +138,14 @@ export const SettingsNavigator = () => {
         component={PrivacySettingsScreen}
       />
       <SettingsDrawer.Screen name="WompWomp" component={UserBugReportScreen} />
+      <SettingsDrawer.Screen
+        name="BotIdentity"
+        component={BotIdentityScreen}
+      />
+      <SettingsDrawer.Screen
+        name="BotBehavior"
+        component={BotBehaviorScreen}
+      />
     </SettingsDrawer.Navigator>
   );
 };

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -163,6 +163,8 @@ export type SettingsDrawerParamList = Pick<
   | 'PushNotificationSettings'
   | 'WompWomp'
   | 'PrivacySettings'
+  | 'BotIdentity'
+  | 'BotBehavior'
 >;
 
 export type ChannelStackParamList = {

--- a/packages/app/ui/components/BotBehaviorScreenView.tsx
+++ b/packages/app/ui/components/BotBehaviorScreenView.tsx
@@ -6,7 +6,6 @@ import {
 } from '@tloncorp/shared/domain';
 import {
   DEFAULT_BOTTOM_PADDING,
-  Icon,
   KEYBOARD_EXTRA_PADDING,
   KeyboardAvoidingView,
   Pressable,
@@ -22,6 +21,7 @@ import {
   Field,
   FormFrame,
 } from './Form';
+import { ModelOptionCard } from './ModelOptionCard';
 import { ScreenHeader } from './ScreenHeader';
 
 export interface BotBehaviorFormData {
@@ -113,60 +113,16 @@ export function BotBehaviorScreenView({
             {/* Model Picker */}
             <Field label="Model provider">
               <YStack gap="$s">
-                {MODEL_OPTIONS.map((option) => {
-                  const isSelected = currentModel === option.value;
-                  return (
-                    <Pressable
-                      key={option.value}
-                      onPress={() =>
-                        setValue('model', option.value, { shouldDirty: true })
-                      }
-                    >
-                      <XStack
-                        padding="$l"
-                        borderRadius="$xl"
-                        borderWidth={2}
-                        borderColor={
-                          isSelected ? '$positiveActionText' : '$border'
-                        }
-                        backgroundColor={
-                          isSelected
-                            ? '$positiveBackground'
-                            : '$secondaryBackground'
-                        }
-                        justifyContent="space-between"
-                        alignItems="center"
-                      >
-                        <YStack>
-                          <Text
-                            fontSize={16}
-                            fontWeight="500"
-                            color={
-                              isSelected
-                                ? '$positiveActionText'
-                                : '$primaryText'
-                            }
-                          >
-                            {option.label}
-                          </Text>
-                          <Text
-                            fontSize={12}
-                            color={
-                              isSelected
-                                ? '$positiveActionText'
-                                : '$secondaryText'
-                            }
-                          >
-                            {option.description}
-                          </Text>
-                        </YStack>
-                        {isSelected && (
-                          <Icon type="Checkmark" color="$positiveActionText" />
-                        )}
-                      </XStack>
-                    </Pressable>
-                  );
-                })}
+                {MODEL_OPTIONS.map((option) => (
+                  <ModelOptionCard
+                    key={option.value}
+                    option={option}
+                    selected={currentModel === option.value}
+                    onPress={() =>
+                      setValue('model', option.value, { shouldDirty: true })
+                    }
+                  />
+                ))}
               </YStack>
             </Field>
 

--- a/packages/app/ui/components/BotIdentityScreenView.tsx
+++ b/packages/app/ui/components/BotIdentityScreenView.tsx
@@ -15,7 +15,7 @@ import { ScrollView, Text, View, XStack, YStack, useTheme } from 'tamagui';
 
 import { useKeyboardAwareScroll } from '../hooks/useKeyboardAwareScroll';
 import { EmojiPicker } from './EmojiPicker';
-import { ControlledTextField, FormFrame } from './Form';
+import { ControlledTextField, Field, FormFrame } from './Form';
 import { NameSuggestions } from './NameSuggestions';
 import { PersonalityCard } from './PersonalityCard';
 import { ScreenHeader } from './ScreenHeader';
@@ -176,7 +176,9 @@ export function BotIdentityScreenView({
             </YStack>
 
             {/* Emoji Picker */}
-            <EmojiPicker value={currentEmoji} onSelect={handleEmojiSelect} />
+            <Field label="Emoji">
+              <EmojiPicker value={currentEmoji} onSelect={handleEmojiSelect} />
+            </Field>
 
             {/* Personality Type */}
             <YStack gap="$m">

--- a/packages/app/ui/components/EmojiPicker.tsx
+++ b/packages/app/ui/components/EmojiPicker.tsx
@@ -1,8 +1,6 @@
 import { SUGGESTED_EMOJIS } from '@tloncorp/shared/domain';
 import { Pressable } from '@tloncorp/ui';
-import { Text, View, XStack, YStack } from 'tamagui';
-
-import { Field } from './Form';
+import { Text, View } from 'tamagui';
 
 interface Props {
   value: string;
@@ -11,39 +9,25 @@ interface Props {
 
 export function EmojiPicker({ value, onSelect }: Props) {
   return (
-    <Field label="Emoji">
-      <YStack gap="$m">
-        <View
-          flexDirection="row"
-          flexWrap="wrap"
-          gap="$s"
-        >
-          {SUGGESTED_EMOJIS.map((emoji) => (
-            <Pressable key={emoji} onPress={() => onSelect(emoji)}>
-              <View
-                width={48}
-                height={48}
-                borderRadius="$m"
-                borderWidth={2}
-                borderColor={value === emoji ? '$positiveActionText' : '$border'}
-                backgroundColor={
-                  value === emoji ? '$positiveBackground' : '$secondaryBackground'
-                }
-                alignItems="center"
-                justifyContent="center"
-              >
-                <Text fontSize={24}>{emoji}</Text>
-              </View>
-            </Pressable>
-          ))}
-        </View>
-        <XStack gap="$s" alignItems="center">
-          <Text fontSize={14} color="$secondaryText">
-            Selected:
-          </Text>
-          <Text fontSize={24}>{value}</Text>
-        </XStack>
-      </YStack>
-    </Field>
+    <View flexDirection="row" flexWrap="wrap" gap="$s">
+      {SUGGESTED_EMOJIS.map((emoji) => (
+        <Pressable key={emoji} onPress={() => onSelect(emoji)}>
+          <View
+            width={48}
+            height={48}
+            borderRadius="$m"
+            borderWidth={2}
+            borderColor={value === emoji ? '$positiveActionText' : '$border'}
+            backgroundColor={
+              value === emoji ? '$positiveBackground' : '$secondaryBackground'
+            }
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Text fontSize={24}>{emoji}</Text>
+          </View>
+        </Pressable>
+      ))}
+    </View>
   );
 }

--- a/packages/app/ui/components/ModelOptionCard.tsx
+++ b/packages/app/ui/components/ModelOptionCard.tsx
@@ -1,0 +1,44 @@
+import type { ModelOption } from '@tloncorp/shared/domain';
+import { Icon, Pressable } from '@tloncorp/ui';
+import { Text, XStack, YStack } from 'tamagui';
+
+interface Props {
+  option: ModelOption;
+  selected: boolean;
+  onPress: () => void;
+}
+
+export function ModelOptionCard({ option, selected, onPress }: Props) {
+  return (
+    <Pressable onPress={onPress}>
+      <XStack
+        padding="$l"
+        borderRadius="$xl"
+        borderWidth={2}
+        borderColor={selected ? '$positiveActionText' : '$border'}
+        backgroundColor={
+          selected ? '$positiveBackground' : '$secondaryBackground'
+        }
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <YStack>
+          <Text
+            fontSize={16}
+            fontWeight="500"
+            color={selected ? '$positiveActionText' : '$primaryText'}
+          >
+            {option.label}
+          </Text>
+          <Text
+            fontSize={12}
+            color={selected ? '$positiveActionText' : '$secondaryText'}
+          >
+            {option.description}
+          </Text>
+        </YStack>
+        {selected && <Icon type="Checkmark" color="$positiveActionText" />}
+      </XStack>
+    </Pressable>
+  );
+}

--- a/packages/app/ui/components/SettingsScreenView.tsx
+++ b/packages/app/ui/components/SettingsScreenView.tsx
@@ -115,15 +115,16 @@ export function SettingsScreenView(props: Props) {
               isFocused={props.focusedRouteName === 'BotSettings'}
             />
           )}
-          {/* TODO: restore props.botEnabled gate before merging */}
-          <SettingsAction
-            title="Bot Config"
-            leftIcon="Settings"
-            rightIcon={'ChevronRight'}
-            onPress={props.onBotConfigPressed}
-            subtitle="Identity & behavior"
-            isFocused={props.focusedRouteName === 'BotIdentity'}
-          />
+          {props.botEnabled && (
+            <SettingsAction
+              title="Bot Config"
+              leftIcon="Settings"
+              rightIcon={'ChevronRight'}
+              onPress={props.onBotConfigPressed}
+              subtitle="Identity & behavior"
+              isFocused={props.focusedRouteName === 'BotIdentity'}
+            />
+          )}
           <SettingsAction
             title="Theme"
             leftIcon="ChannelGalleries"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -6,7 +6,7 @@ import {
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { Button, Icon, LoadingSpinner, Pressable, Text } from '@tloncorp/ui';
+import { Button, LoadingSpinner, Text } from '@tloncorp/ui';
 import React, {
   ComponentProps,
   useCallback,
@@ -42,12 +42,11 @@ import {
   DEFAULT_BOT_CONFIG,
   MODEL_OPTIONS,
   PERSONALITY_TYPES,
-  SUGGESTED_EMOJIS,
-  SUGGESTED_NAMES,
   type BotConfig,
   type PersonalityType,
 } from '@tloncorp/shared/domain';
 import { EmojiPicker } from '../EmojiPicker';
+import { ModelOptionCard } from '../ModelOptionCard';
 import { NameSuggestions } from '../NameSuggestions';
 import { PersonalityCard } from '../PersonalityCard';
 import { PersonalInviteButton } from '../PersonalInviteButton';
@@ -454,30 +453,7 @@ function BotNamePane(props: {
           <SplashParagraph marginHorizontal={0} marginBottom="$s" color="$tertiaryText">
             Choose an emoji
           </SplashParagraph>
-          <View flexDirection="row" flexWrap="wrap" gap="$s">
-            {SUGGESTED_EMOJIS.map((emoji) => (
-              <Pressable key={emoji} onPress={() => props.onEmojiChange(emoji)}>
-                <View
-                  width={48}
-                  height={48}
-                  borderRadius="$m"
-                  borderWidth={2}
-                  borderColor={
-                    props.emoji === emoji ? '$positiveActionText' : '$border'
-                  }
-                  backgroundColor={
-                    props.emoji === emoji
-                      ? '$positiveBackground'
-                      : '$secondaryBackground'
-                  }
-                  alignItems="center"
-                  justifyContent="center"
-                >
-                  <Text fontSize={24}>{emoji}</Text>
-                </View>
-              </Pressable>
-            ))}
-          </View>
+          <EmojiPicker value={props.emoji} onSelect={props.onEmojiChange} />
         </ScrollView>
       </YStack>
       <Button
@@ -574,50 +550,14 @@ function BotModelPane(props: {
           <SplashParagraph marginHorizontal={0} marginBottom="$m">
             MiniMax is free. Bring your own API key to use a different provider.
           </SplashParagraph>
-          {MODEL_OPTIONS.map((option) => {
-            const isSelected = props.model === option.value;
-            return (
-              <Pressable
-                key={option.value}
-                onPress={() => props.onModelChange(option.value)}
-              >
-                <XStack
-                  padding="$l"
-                  borderRadius="$xl"
-                  borderWidth={2}
-                  borderColor={isSelected ? '$positiveActionText' : '$border'}
-                  backgroundColor={
-                    isSelected ? '$positiveBackground' : '$secondaryBackground'
-                  }
-                  justifyContent="space-between"
-                  alignItems="center"
-                >
-                  <YStack>
-                    <Text
-                      fontSize={16}
-                      fontWeight="500"
-                      color={
-                        isSelected ? '$positiveActionText' : '$primaryText'
-                      }
-                    >
-                      {option.label}
-                    </Text>
-                    <Text
-                      fontSize={12}
-                      color={
-                        isSelected ? '$positiveActionText' : '$secondaryText'
-                      }
-                    >
-                      {option.description}
-                    </Text>
-                  </YStack>
-                  {isSelected && (
-                    <Icon type="Checkmark" color="$positiveActionText" />
-                  )}
-                </XStack>
-              </Pressable>
-            );
-          })}
+          {MODEL_OPTIONS.map((option) => (
+            <ModelOptionCard
+              key={option.value}
+              option={option}
+              selected={props.model === option.value}
+              onPress={() => props.onModelChange(option.value)}
+            />
+          ))}
           {needsApiKey && (
             <View
               borderRadius="$xl"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -37,6 +37,7 @@ import { useActiveTheme } from '../../../provider';
 import { useStore } from '../../contexts';
 import { useSystemContactSearch } from '../../hooks/systemContactSorters';
 import { ListItem, SystemContactListItem } from '../ListItem';
+import * as api from '@tloncorp/api';
 import { saveBotConfig } from '@tloncorp/shared/api';
 import {
   DEFAULT_BOT_CONFIG,
@@ -74,7 +75,7 @@ function SplashSequenceComponent(props: {
   inviteSystemContacts?: InviteSystemContactsFn;
   hostingBotEnabled?: boolean;
 }) {
-  const store = useStore();
+  const appStore = useStore();
   const [currentPane, setCurrentPane] = React.useState<SplashPane>(
     SplashPane.Welcome
   );
@@ -86,11 +87,14 @@ function SplashSequenceComponent(props: {
   );
   const [botModel, setBotModel] = React.useState(DEFAULT_BOT_CONFIG.model);
   const [botApiKey, setBotApiKey] = React.useState('');
+  const [createdGroupId, setCreatedGroupId] = React.useState<string | null>(null);
+  const [groupInviteLink, setGroupInviteLink] = React.useState<string | null>(null);
+  const [launchError, setLaunchError] = React.useState<string | null>(null);
 
   const handleSplashCompleted = useCallback(() => {
-    store.completeWayfindingSplash();
+    appStore.completeWayfindingSplash();
     props.onCompleted();
-  }, [props, store]);
+  }, [props, appStore]);
 
   return (
     <View flex={1}>
@@ -157,15 +161,52 @@ function SplashSequenceComponent(props: {
         <BotLaunchPane
           botName={botName || 'Tlonbot'}
           botEmoji={botEmoji}
-          onCreateGroup={() => {
+          onCreateGroup={async () => {
             setCurrentPane(SplashPane.BotLaunchLoading);
-            // TODO: wire up actual group creation + bot invite + branch link
-            // For now, simulate the loading period then show share screen
-            setTimeout(() => {
+            setLaunchError(null);
+            try {
+              // Create the group
+              const group = await store.createDefaultGroup({
+                title: `${botName || 'Tlonbot'}'s Group`,
+              });
+              setCreatedGroupId(group.id);
+
+              // Add bot to the group (best-effort)
+              const shipId = await db.hostedUserNodeId.getValue();
+              const authCookie = await db.hostingAuthToken.getValue();
+              if (shipId && authCookie) {
+                try {
+                  await api.addBotToCordon(shipId, authCookie, group.id);
+                  await api.addBotToGroup(shipId, authCookie, group.id);
+                } catch (e) {
+                  console.warn('Failed to add bot to group:', e);
+                }
+              }
+
+              // Generate invite link (best-effort)
+              try {
+                await store.createGroupInviteLink(group.id);
+                const lureState = store.useLureState.getState();
+                await lureState.fetchLure(group.id, '', false);
+                const lure = lureState.lures[group.id];
+                if (lure?.deepLinkUrl) {
+                  setGroupInviteLink(lure.deepLinkUrl);
+                } else if (lure?.url) {
+                  setGroupInviteLink(lure.url);
+                }
+              } catch (e) {
+                console.warn('Failed to generate invite link:', e);
+              }
+
               setCurrentPane(SplashPane.ShareGroup);
-            }, 3000);
+            } catch (e) {
+              console.error('Failed to create group:', e);
+              setLaunchError('Something went wrong. Try again or skip.');
+              setCurrentPane(SplashPane.BotLaunch);
+            }
           }}
           onSkip={() => setCurrentPane(SplashPane.Group)}
+          error={launchError}
         />
       )}
       {currentPane === 'BotLaunchLoading' && (
@@ -175,6 +216,7 @@ function SplashSequenceComponent(props: {
         <ShareGroupPane
           botName={botName || 'Tlonbot'}
           botEmoji={botEmoji}
+          inviteLink={groupInviteLink}
           onActionPress={handleSplashCompleted}
         />
       )}
@@ -602,6 +644,7 @@ function BotLaunchPane(props: {
   botEmoji: string;
   onCreateGroup: () => void;
   onSkip: () => void;
+  error?: string | null;
 }) {
   const insets = useSafeAreaInsets();
 
@@ -629,6 +672,11 @@ function BotLaunchPane(props: {
         paddingBottom={insets.bottom}
         gap="$l"
       >
+        {props.error && (
+          <Text fontSize={14} color="$negativeActionText" textAlign="center">
+            {props.error}
+          </Text>
+        )}
         <Button
           onPress={props.onCreateGroup}
           label="Create a group"
@@ -683,14 +731,14 @@ function BotLaunchLoadingPane(props: { botEmoji: string }) {
 function ShareGroupPane(props: {
   botName: string;
   botEmoji: string;
+  inviteLink?: string | null;
   onActionPress: () => void;
 }) {
   const insets = useSafeAreaInsets();
-  const [copied, setCopied] = useState(false);
-  // TODO: replace with actual invite link from group creation
-  const inviteLink = 'https://join.tlon.io/example-invite-link';
+  const inviteLink = props.inviteLink ?? null;
 
-  const handleCopy = useCallback(async () => {
+  const handleShare = useCallback(async () => {
+    if (!inviteLink) return;
     try {
       await Share.share({
         message: `Join my group on Tlon! ${inviteLink}`,
@@ -709,34 +757,38 @@ function ShareGroupPane(props: {
           <Text color="$positiveActionText">set.</Text>
         </SplashTitle>
         <SplashParagraph textAlign="center">
-          Your group is ready and {props.botName} is in it. Share the link
-          below to invite your friends.
+          Your group is ready and {props.botName} is in it.
+          {inviteLink
+            ? ' Share the link below to invite your friends.'
+            : ' You can invite friends later from the group settings.'}
         </SplashParagraph>
 
-        <YStack
-          marginHorizontal="$xl"
-          width="100%"
-          paddingHorizontal="$xl"
-          gap="$m"
-        >
-          <View
-            borderRadius="$xl"
-            borderWidth={1}
-            borderColor="$border"
-            backgroundColor="$secondaryBackground"
-            paddingHorizontal="$l"
-            paddingVertical="$m"
+        {inviteLink && (
+          <YStack
+            marginHorizontal="$xl"
+            width="100%"
+            paddingHorizontal="$xl"
+            gap="$m"
           >
-            <Text
-              fontSize={14}
-              color="$secondaryText"
-              numberOfLines={1}
-              textAlign="center"
+            <View
+              borderRadius="$xl"
+              borderWidth={1}
+              borderColor="$border"
+              backgroundColor="$secondaryBackground"
+              paddingHorizontal="$l"
+              paddingVertical="$m"
             >
-              {inviteLink}
-            </Text>
-          </View>
-        </YStack>
+              <Text
+                fontSize={14}
+                color="$secondaryText"
+                numberOfLines={1}
+                textAlign="center"
+              >
+                {inviteLink}
+              </Text>
+            </View>
+          </YStack>
+        )}
       </YStack>
 
       <YStack
@@ -744,17 +796,20 @@ function ShareGroupPane(props: {
         paddingBottom={insets.bottom}
         gap="$l"
       >
-        <Button
-          onPress={handleCopy}
-          label="Share invite link"
-          preset="hero"
-          shadow
-        />
+        {inviteLink && (
+          <Button
+            onPress={handleShare}
+            label="Share invite link"
+            preset="hero"
+            shadow
+          />
+        )}
         <Button
           onPress={props.onActionPress}
           label="Continue"
-          preset="secondary"
-          fill="text"
+          preset={inviteLink ? 'secondary' : 'hero'}
+          fill={inviteLink ? 'text' : undefined}
+          shadow={!inviteLink}
         />
       </YStack>
     </View>

--- a/packages/shared/src/api/botConfigApi.ts
+++ b/packages/shared/src/api/botConfigApi.ts
@@ -1,9 +1,95 @@
 import * as api from '@tloncorp/api';
 
+import * as db from '../db';
 import type { BotConfig } from '../domain/botConfig';
+import { DEFAULT_BOT_CONFIG } from '../domain/botConfig';
 
-const BOT_CONFIG_KEY = 'tlonbotConfig';
+const LOCAL_CONFIG_KEY = 'tlonbotConfig';
 
+// Provider name used by the hosted bot API for each model option
+const MODEL_TO_PROVIDER: Record<string, string> = {
+  minimax: 'basic',
+  anthropic: 'anthropic',
+  openai: 'openai',
+  openrouter: 'openrouter',
+};
+
+// Default model identifiers per provider on the hosted bot API
+const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
+  basic: 'minimax/minimax-m2.5',
+  anthropic: 'anthropic/claude-haiku-4-5-20251001',
+  openai: 'openai/gpt-4o-mini',
+  openrouter: 'openrouter/auto',
+};
+
+async function getAuthCookie(): Promise<string> {
+  const token = await db.hostingAuthToken.getValue();
+  if (!token) {
+    throw new Error('Not authenticated with hosting');
+  }
+  return token;
+}
+
+/**
+ * Save bot config. Sends provider keys, primary model, and nickname to the
+ * hosted bot hosting API, then persists the full config locally for fields that
+ * have no remote endpoint (emoji, personality, response style, active hours).
+ */
 export async function saveBotConfig(config: BotConfig): Promise<void> {
-  await api.setSetting(BOT_CONFIG_KEY, JSON.stringify(config));
+  // Always persist full config locally so the UI can reload it
+  await api.setSetting(LOCAL_CONFIG_KEY, JSON.stringify(config));
+
+  // Attempt to sync remote-backed fields to the hosting API
+  const userId = await db.hostingUserId.getValue();
+  const shipId = await db.hostedUserNodeId.getValue();
+  if (!userId || !shipId) {
+    return;
+  }
+
+  let authCookie: string;
+  try {
+    authCookie = await getAuthCookie();
+  } catch {
+    return;
+  }
+
+  const provider = MODEL_TO_PROVIDER[config.model] ?? 'basic';
+  const model = PROVIDER_DEFAULT_MODEL[provider] ?? PROVIDER_DEFAULT_MODEL.basic;
+
+  const results = await Promise.allSettled([
+    // Set provider key if user provided one
+    config.apiKey
+      ? api.setProviderKey(userId, authCookie, provider, config.apiKey)
+      : Promise.resolve(),
+
+    // Set primary model
+    api.setPrimaryModel(userId, authCookie, { provider, model }),
+
+    // Set bot nickname
+    config.name
+      ? api.setBotNickname(shipId, authCookie, config.name)
+      : Promise.resolve(),
+  ]);
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.warn('hosted bot API call failed during bot config save:', result.reason);
+    }
+  }
+}
+
+/**
+ * Load bot config from local settings.
+ */
+export async function loadBotConfig(): Promise<BotConfig> {
+  try {
+    const raw = await api.getSettingValue(LOCAL_CONFIG_KEY);
+    if (raw) {
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      return { ...DEFAULT_BOT_CONFIG, ...parsed };
+    }
+  } catch {
+    // Fall through to default
+  }
+  return { ...DEFAULT_BOT_CONFIG };
 }


### PR DESCRIPTION
## Summary

Cleans up and properly integrates the auto-generated bot configuration splash flow. Wires bot config to the hosted bot (tlawn) API, consolidates duplicated UI components, registers bot screens in desktop navigation, removes dev overrides, and gates bot settings behind the `botEnabled` flag.

## Changes

- **New `hostedBotApi` client** (`packages/api/src/client/hostedBotApi.ts`): Typed client for all ylem tlawn endpoints — provider keys, primary model, bot nickname, bot config, group join/cordon, enable/disable, reload, running status.
- **`botConfigApi` rewrite** (`packages/shared/src/api/botConfigApi.ts`): `saveBotConfig` now persists locally via Urbit settings AND syncs provider key, primary model, and nickname to the hosting API (best-effort, parallel). Added `loadBotConfig` to read config back.
- **`getSettingValue`** added to `settingsApi.ts` for reading individual setting keys; `tlonbotConfig` mapped to `groups` bucket.
- **UI consolidation**: Extracted shared `ModelOptionCard` and simplified `EmojiPicker` into reusable components used by both `SplashSequence` and the standalone bot settings screens (`BotBehaviorScreenView`, `BotIdentityScreenView`).
- **Real group creation in bot launch flow** (`SplashSequence.tsx`): Replaced `setTimeout` stub with actual `createDefaultGroup` + `addBotToCordon`/`addBotToGroup` + invite link generation via lure. Error state displayed on failure.
- **Desktop/web navigation**: Registered `BotIdentity` and `BotBehavior` screens in `SettingsNavigator`; replaced external URL link with in-app navigation.
- **Dev overrides removed**: Stripped `__DEV__` overrides from `App.main.tsx`; added `FORCE_SPLASH_SEQUENCE` env var for both mobile (Expo) and web (Vite) to force splash during testing.
- **Bot config gated**: "Bot Config" settings entry only shown when `botEnabled` is true (hosted user + hosting flag).

## How did I test?

Typecheck passes (`npx tsc --noEmit`). Visual review of diff. FORCE_SPLASH_SEQUENCE env var wired for manual testing.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Bot config settings, hosted bot API integration

## Rollback plan

Revert the merge commit. No migrations or irreversible state changes.

## Screenshots / videos

N/A — splash flow is gated behind `hostingBotEnabled` flag + `FORCE_SPLASH_SEQUENCE` env var.