### PR TITLE
api: harden getCanonicalPostId parsing

### DIFF
--- a/packages/api/src/client/apiUtils.ts
+++ b/packages/api/src/client/apiUtils.ts
@@ -140,15 +140,26 @@ export async function with404Handler<T>(
   }
 }
 export function getCanonicalPostId(inputId: string) {
-  let id = inputId;
-  // Dm and club posts come prefixed with the author, so we strip it
+  let id = inputId.trim();
+
+  // DM and club posts can be prefixed with author/path; keep only trailing id segment.
   if (id[0] === '~') {
-    id = id.split('/').pop()!;
+    const tail = id.split('/').pop();
+    if (tail) id = tail.trim();
   }
-  // The id in group post ids doesn't come dot separated, so we format it
-  if (id[3] !== '.') {
-    id = render('ud', BigInt(id)); //REVIEW  weird, and dot check is not ideal
+
+  // Already canonical dotted @ud (e.g. 1.234, 12.345, 123.456, 1.234.567)
+  if (/^\d{1,3}(?:\.\d{3})*$/.test(id)) {
+    return id;
   }
+
+  // Raw undotted digits -> canonical dotted @ud
+  if (/^\d+$/.test(id)) {
+    return render('ud', BigInt(id));
+  }
+
+  // Unknown/non-numeric shape: don't crash parser pipeline.
+  // Return as-is; caller can log/track malformed IDs upstream.
   return id;
 }
 

--- a/packages/api/src/client/apiUtils.ts
+++ b/packages/api/src/client/apiUtils.ts
@@ -139,6 +139,12 @@ export async function with404Handler<T>(
     throw e;
   }
 }
+const CANONICAL_UD_ID = /^\d{1,3}(?:\.\d{3})*$/;
+
+export function isCanonicalPostId(id: string): boolean {
+  return CANONICAL_UD_ID.test(id);
+}
+
 export function getCanonicalPostId(inputId: string) {
   let id = inputId.trim();
 
@@ -149,7 +155,7 @@ export function getCanonicalPostId(inputId: string) {
   }
 
   // Already canonical dotted @ud (e.g. 1.234, 12.345, 123.456, 1.234.567)
-  if (/^\d{1,3}(?:\.\d{3})*$/.test(id)) {
+  if (CANONICAL_UD_ID.test(id)) {
     return id;
   }
 

--- a/packages/api/src/client/harkApi.ts
+++ b/packages/api/src/client/harkApi.ts
@@ -1,7 +1,12 @@
 import { createDevLogger } from '../lib/logger';
-import { getCanonicalPostId } from './apiUtils';
+import { getCanonicalPostId, isCanonicalPostId } from './apiUtils';
 
 const logger = createDevLogger('harkApi', true);
+
+const toCanonicalOrNull = (raw: string): string | null => {
+  const id = getCanonicalPostId(raw);
+  return isCanonicalPostId(id) ? id : null;
+};
 
 export const getPostInfoFromWer = (
   wer: string
@@ -17,19 +22,15 @@ export const getPostInfoFromWer = (
     }
 
     if (isDm && parts[5]) {
-      return {
-        id: getCanonicalPostId(parts[5]),
-        authorId: parts[4],
-        isDm,
-      };
+      const id = toCanonicalOrNull(parts[5]);
+      if (!id) return null;
+      return { id, authorId: parts[4], isDm };
     }
 
     if (isChannelPost && isGroupChannelReply && parts[9]) {
-      return {
-        id: getCanonicalPostId(parts[9]),
-        authorId: '',
-        isDm,
-      };
+      const id = toCanonicalOrNull(parts[9]);
+      if (!id) return null;
+      return { id, authorId: '', isDm };
     }
 
     return null;


### PR DESCRIPTION
## Summary
Fixes TLON-5597

- fix unsafe canonicalization check in `getCanonicalPostId` that used `id[3] !== '.'`
- accept already-canonical dotted `@ud` IDs without reparsing
- only parse with `BigInt` for undotted numeric IDs
- preserve unknown/malformed shapes instead of throwing in parser pipeline

## Why
The old `id[3]` heuristic is incorrect for valid dotted IDs like `12.345` (dot index 2), which could trigger `BigInt('12.345')` and throw during DM/event parsing.

## Testing
- not run (small targeted parser change)
