### PR TITLE
Add Cosmos fixtures for bot onboarding splash panes

### DIFF
--- a/packages/app/fixtures/SplashSequence.fixture.tsx
+++ b/packages/app/fixtures/SplashSequence.fixture.tsx
@@ -1,14 +1,21 @@
 import * as db from '@tloncorp/shared/db';
+import { PersonalityType } from '@tloncorp/shared/domain';
 import React, { useEffect } from 'react';
 import { useValue } from 'react-cosmos/client';
 
 import { SplashModal } from '../ui/components/Wayfinding/SplashModal';
 import {
+  BotLaunchLoadingPane,
+  BotLaunchPane,
+  BotModelPane,
+  BotNamePane,
+  BotPersonalityPane,
   ChannelsPane,
   GroupsPane,
   InviteContactsContent,
   InvitePane,
   PrivacyPane,
+  ShareGroupPane,
   SplashSequence,
   TlonBotPane,
   WelcomePane,
@@ -146,6 +153,118 @@ function InvitePaneFixture() {
   );
 }
 
+function BotNamePaneFixture() {
+  const [name, setName] = useValue('Bot Name', { defaultValue: '' });
+  const [emoji, setEmoji] = useValue('Bot Emoji', { defaultValue: '🌱' });
+  const handleAction = React.useCallback(() => {
+    console.log('BotName pane action pressed');
+  }, []);
+
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <BotNamePane
+        name={name}
+        emoji={emoji}
+        onNameChange={setName}
+        onEmojiChange={setEmoji}
+        onActionPress={handleAction}
+      />
+    </FixtureWrapper>
+  );
+}
+
+function BotPersonalityPaneFixture() {
+  const [personality, setPersonality] = useValue<PersonalityType>(
+    'Personality',
+    {
+      defaultValue: 'assistant',
+    }
+  );
+  const handleAction = React.useCallback(() => {
+    console.log('BotPersonality pane action pressed');
+  }, []);
+
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <BotPersonalityPane
+        personality={personality}
+        onPersonalityChange={setPersonality}
+        onActionPress={handleAction}
+      />
+    </FixtureWrapper>
+  );
+}
+
+function BotModelPaneFixture() {
+  const [model, setModel] = useValue('Model', { defaultValue: 'minimax' });
+  const [apiKey, setApiKey] = useValue('API Key', { defaultValue: '' });
+  const handleAction = React.useCallback(() => {
+    console.log('BotModel pane action pressed');
+  }, []);
+
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <BotModelPane
+        model={model}
+        apiKey={apiKey}
+        onModelChange={setModel}
+        onApiKeyChange={setApiKey}
+        onActionPress={handleAction}
+      />
+    </FixtureWrapper>
+  );
+}
+
+function BotLaunchPaneFixture() {
+  const [showError] = useValue('Show Error', { defaultValue: false });
+  const handleCreateGroup = React.useCallback(() => {
+    console.log('Create group pressed');
+  }, []);
+  const handleSkip = React.useCallback(() => {
+    console.log('Skip pressed');
+  }, []);
+
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <BotLaunchPane
+        botName="Tlonbot"
+        botEmoji="🌱"
+        onCreateGroup={handleCreateGroup}
+        onSkip={handleSkip}
+        error={showError ? 'Something went wrong. Try again or skip.' : null}
+      />
+    </FixtureWrapper>
+  );
+}
+
+function BotLaunchLoadingPaneFixture() {
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <BotLaunchLoadingPane botEmoji="🌱" />
+    </FixtureWrapper>
+  );
+}
+
+function ShareGroupPaneFixture() {
+  const [hasInviteLink] = useValue('Has Invite Link', { defaultValue: true });
+  const handleAction = React.useCallback(() => {
+    console.log('ShareGroup pane action pressed');
+  }, []);
+
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <ShareGroupPane
+        botName="Tlonbot"
+        botEmoji="🌱"
+        inviteLink={
+          hasInviteLink ? 'https://join.tlon.io/example-invite-link' : null
+        }
+        onActionPress={handleAction}
+      />
+    </FixtureWrapper>
+  );
+}
+
 function SplashModalFixture() {
   const [open, setOpen] = React.useState(true);
 
@@ -164,6 +283,12 @@ export default {
   'Channels Pane': <ChannelsPaneFixture />,
   'Privacy Pane': <PrivacyPaneFixture />,
   'TlonBot Pane': <TlonBotPaneFixture />,
+  'Bot Name Pane': <BotNamePaneFixture />,
+  'Bot Personality Pane': <BotPersonalityPaneFixture />,
+  'Bot Model Pane': <BotModelPaneFixture />,
+  'Bot Launch Pane': <BotLaunchPaneFixture />,
+  'Bot Launch Loading Pane': <BotLaunchLoadingPaneFixture />,
+  'Share Group Pane': <ShareGroupPaneFixture />,
   'Invite Pane': <InvitePaneFixture />,
   'Splash Modal': <SplashModalFixture />,
 };

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -416,7 +416,7 @@ export function TlonBotPane(props: {
   );
 }
 
-function BotNamePane(props: {
+export function BotNamePane(props: {
   name: string;
   emoji: string;
   onNameChange: (name: string) => void;
@@ -510,7 +510,7 @@ function BotNamePane(props: {
   );
 }
 
-function BotPersonalityPane(props: {
+export function BotPersonalityPane(props: {
   personality: PersonalityType;
   onPersonalityChange: (p: PersonalityType) => void;
   onActionPress: () => void;
@@ -558,7 +558,7 @@ function BotPersonalityPane(props: {
   );
 }
 
-function BotModelPane(props: {
+export function BotModelPane(props: {
   model: string;
   apiKey: string;
   onModelChange: (model: string) => void;
@@ -639,7 +639,7 @@ function BotModelPane(props: {
   );
 }
 
-function BotLaunchPane(props: {
+export function BotLaunchPane(props: {
   botName: string;
   botEmoji: string;
   onCreateGroup: () => void;
@@ -702,7 +702,7 @@ function BotLaunchPane(props: {
   );
 }
 
-function BotLaunchLoadingPane(props: { botEmoji: string }) {
+export function BotLaunchLoadingPane(props: { botEmoji: string }) {
   const insets = useSafeAreaInsets();
 
   return (
@@ -728,7 +728,7 @@ function BotLaunchLoadingPane(props: { botEmoji: string }) {
   );
 }
 
-function ShareGroupPane(props: {
+export function ShareGroupPane(props: {
   botName: string;
   botEmoji: string;
   inviteLink?: string | null;


### PR DESCRIPTION
## Summary

Export and add individual Cosmos fixtures for the 6 bot onboarding panes in SplashSequence, enabling isolated visual development and review of each step.

## Changes

- Export `BotNamePane`, `BotPersonalityPane`, `BotModelPane`, `BotLaunchPane`, `BotLaunchLoadingPane`, and `ShareGroupPane` from `SplashSequence.tsx`
- Add Cosmos fixtures for each with interactive `useValue` controls (name, emoji, personality type, model, API key, error state, invite link toggle)

## How did I test?

TypeScript compilation passes cleanly (`npx tsc --noEmit`).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit. The only functional change is adding `export` to 6 pane components.

## Screenshots / videos

N/A — fixtures viewable in Cosmos.