### PR TITLE
fix: pop to existing tab screens on NavBar taps

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -163,6 +163,35 @@ module.exports = {
         message:
           'Please use the useTypedReset() hook instead of importing reset from @react-navigation/native for type safety.',
       },
+      {
+        // `navigation.navigate('ChatList' | 'Activity' | 'Contacts' | 'Settings', …)`.
+        // Also matches TS casts like `navigate('ChatList' as never)`, which
+        // wrap the literal in a TSAsExpression.
+        // The escape hatch is a `pop: true` property anywhere in the call's
+        // subtree (accepts both the top-level `{ pop: true }` options arg
+        // and nested-param forms like `getDesktopChannelRoute`).
+        selector:
+          'CallExpression[callee.property.name="navigate"]' +
+          ':matches(' +
+          '[arguments.0.value=/^(ChatList|Activity|Contacts|Settings)$/],' +
+          '[arguments.0.expression.value=/^(ChatList|Activity|Contacts|Settings)$/]' +
+          ')' +
+          ':not(:has(Property[key.name="pop"][value.value=true]))',
+        message:
+          "navigate() to a top-level tab route must pass { pop: true } as the third argument. React Navigation 7's navigate() pushes a new screen by default — without pop:true this causes duplicate screen mounts and perceived input delay on Android. See TLON-5598.",
+      },
+      {
+        // Destructured `navigate('ChatList' | ...)` (e.g. `const { navigate } = props.navigation`).
+        selector:
+          'CallExpression[callee.name="navigate"]' +
+          ':matches(' +
+          '[arguments.0.value=/^(ChatList|Activity|Contacts|Settings)$/],' +
+          '[arguments.0.expression.value=/^(ChatList|Activity|Contacts|Settings)$/]' +
+          ')' +
+          ':not(:has(Property[key.name="pop"][value.value=true]))',
+        message:
+          "navigate() to a top-level tab route must pass { pop: true } as the third argument. React Navigation 7's navigate() pushes a new screen by default — without pop:true this causes duplicate screen mounts and perceived input delay on Android. See TLON-5598.",
+      },
     ],
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -167,28 +167,35 @@ module.exports = {
         // `navigation.navigate('ChatList' | 'Activity' | 'Contacts' | 'Settings', …)`.
         // Also matches TS casts like `navigate('ChatList' as never)`, which
         // wrap the literal in a TSAsExpression.
-        // The escape hatch is a `pop: true` property anywhere in the call's
-        // subtree (accepts both the top-level `{ pop: true }` options arg
-        // and nested-param forms like `getDesktopChannelRoute`).
+        // The escape hatch requires an ObjectExpression third argument
+        // containing `pop: true` (including quoted `"pop"` keys).
         selector:
           'CallExpression[callee.property.name="navigate"]' +
           ':matches(' +
           '[arguments.0.value=/^(ChatList|Activity|Contacts|Settings)$/],' +
           '[arguments.0.expression.value=/^(ChatList|Activity|Contacts|Settings)$/]' +
           ')' +
-          ':not(:has(Property[key.name="pop"][value.value=true]))',
+          ':not(:matches(' +
+          '[arguments.2.type="ObjectExpression"]:has(Property[key.name="pop"][value.value=true]),' +
+          '[arguments.2.type="ObjectExpression"]:has(Property[key.value="pop"][value.value=true])' +
+          '))',
         message:
           "navigate() to a top-level tab route must pass { pop: true } as the third argument. React Navigation 7's navigate() pushes a new screen by default — without pop:true this causes duplicate screen mounts and perceived input delay on Android. See TLON-5598.",
       },
       {
         // Destructured `navigate('ChatList' | ...)` (e.g. `const { navigate } = props.navigation`).
+        // Requires an ObjectExpression third argument containing
+        // `pop: true` (including quoted `"pop"` keys).
         selector:
           'CallExpression[callee.name="navigate"]' +
           ':matches(' +
           '[arguments.0.value=/^(ChatList|Activity|Contacts|Settings)$/],' +
           '[arguments.0.expression.value=/^(ChatList|Activity|Contacts|Settings)$/]' +
           ')' +
-          ':not(:has(Property[key.name="pop"][value.value=true]))',
+          ':not(:matches(' +
+          '[arguments.2.type="ObjectExpression"]:has(Property[key.name="pop"][value.value=true]),' +
+          '[arguments.2.type="ObjectExpression"]:has(Property[key.value="pop"][value.value=true])' +
+          '))',
         message:
           "navigate() to a top-level tab route must pass { pop: true } as the third argument. React Navigation 7's navigate() pushes a new screen by default — without pop:true this causes duplicate screen mounts and perceived input delay on Android. See TLON-5598.",
       },

--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -3874,9 +3874,9 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   BranchSDK: cb046c2714b03e573484ce9e349e2ddbad7016e8
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   EXApplication: 1e98d4b1dccdf30627f92917f4b2c5a53c330e5f
   EXAV: b60fcf142fae6684d295bc28cd7cfcb3335570ea
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
@@ -3935,8 +3935,8 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSessions: b9a92c1c51bbb81e78fc3142cda6d925d700f8e7
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172

--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -18,12 +18,7 @@ import {
   useGroupTitle,
 } from '../../ui';
 
-type Props = NativeStackScreenProps<
-  GroupSettingsStackParamList,
-  'GroupMeta'
-> & {
-  navigateToHome: () => void;
-};
+type Props = NativeStackScreenProps<GroupSettingsStackParamList, 'GroupMeta'>;
 
 export function GroupMetaScreen(props: Props) {
   const { groupId, fromBlankChannel, fromChatDetails } = props.route.params;

--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -37,7 +37,7 @@ export function GroupMetaScreen(props: Props) {
   const currentUserId = useCurrentUserId();
 
   const navigateToHome = useCallback(() => {
-    navigation.getParent()?.navigate('ChatList');
+    navigation.getParent()?.navigate('ChatList', undefined, { pop: true });
   }, [navigation]);
 
   const handleGoBack = useHandleGoBack(navigation, {

--- a/packages/app/features/top/ActivityScreen.tsx
+++ b/packages/app/features/top/ActivityScreen.tsx
@@ -90,7 +90,7 @@ export function ActivityScreen(props: Props) {
   );
 
   const handleNavigateToContacts = useCallback(() => {
-    props.navigation.navigate('Contacts');
+    props.navigation.navigate('Contacts', undefined, { pop: true });
   }, [props.navigation]);
 
   const handleInviteFriends = useCallback(() => {
@@ -115,9 +115,15 @@ export function ActivityScreen(props: Props) {
           onInviteFriends={handleInviteFriends}
         />
         <NavBarView
-          navigateToContacts={() => props.navigation.navigate('Contacts')}
-          navigateToHome={() => props.navigation.navigate('ChatList')}
-          navigateToNotifications={() => props.navigation.navigate('Activity')}
+          navigateToContacts={() =>
+            props.navigation.navigate('Contacts', undefined, { pop: true })
+          }
+          navigateToHome={() =>
+            props.navigation.navigate('ChatList', undefined, { pop: true })
+          }
+          navigateToNotifications={() =>
+            props.navigation.navigate('Activity', undefined, { pop: true })
+          }
           currentRoute="Activity"
           currentUserId={currentUserId}
           showContactsTab={contactsTabEnabled}

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -373,13 +373,13 @@ export function ChatListScreenView({
         {displayData && <SystemNotices.NotificationsPrompt />}
         <NavBarView
           navigateToContacts={() => {
-            navigation.navigate('Contacts');
+            navigation.navigate('Contacts', undefined, { pop: true });
           }}
           navigateToHome={() => {
-            navigation.navigate('ChatList');
+            navigation.navigate('ChatList', undefined, { pop: true });
           }}
           navigateToNotifications={() => {
-            navigation.navigate('Activity');
+            navigation.navigate('Activity', undefined, { pop: true });
           }}
           currentRoute="ChatList"
           currentUserId={currentUser}

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -106,7 +106,7 @@ export default function ContactsScreen(props: Props) {
                 type="Settings"
                 testID="ContactsSettingsButton"
                 onPress={() => {
-                  navigate('Settings');
+                  navigate('Settings', undefined, { pop: true });
                 }}
               />
             }
@@ -128,13 +128,13 @@ export default function ContactsScreen(props: Props) {
           />
           <NavBarView
             navigateToContacts={() => {
-              navigate('Contacts');
+              navigate('Contacts', undefined, { pop: true });
             }}
             navigateToHome={() => {
-              navigate('ChatList');
+              navigate('ChatList', undefined, { pop: true });
             }}
             navigateToNotifications={() => {
-              navigate('Activity');
+              navigate('Activity', undefined, { pop: true });
             }}
             currentRoute="Contacts"
             currentUserId={currentUser}

--- a/packages/app/features/top/GroupChannelsScreen.tsx
+++ b/packages/app/features/top/GroupChannelsScreen.tsx
@@ -64,7 +64,7 @@ export function GroupChannelsScreenContent({
 
   const handleGoBackPressed = useCallback(() => {
     if (isWindowNarrow) {
-      navigation.navigate('ChatList');
+      navigation.navigate('ChatList', undefined, { pop: true });
     } else {
       // Reset is necessary on desktop to ensure that the ChannelStack is cleared
       navigation.reset({

--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -201,7 +201,7 @@ export const useChatSettingsNavigation = () => {
 
   const onLeaveGroup = useCallback(() => {
     if (isWindowNarrow) {
-      navigationRef.current.navigate('ChatList');
+      navigationRef.current.navigate('ChatList', undefined, { pop: true });
     } else {
       // Desktop: Reset navigation stack to clean Home state
       reset([{ name: 'Home' }]);

--- a/packages/app/hooks/useGroupNavigation.ts
+++ b/packages/app/hooks/useGroupNavigation.ts
@@ -44,7 +44,7 @@ export const useGroupNavigation = () => {
   );
 
   const goToHome = useCallback(() => {
-    navigationRef.current.navigate('ChatList');
+    navigationRef.current.navigate('ChatList', undefined, { pop: true });
   }, [navigationRef]);
 
   return {

--- a/packages/app/navigation/GroupSettingsStack.tsx
+++ b/packages/app/navigation/GroupSettingsStack.tsx
@@ -1,8 +1,5 @@
 import { NavigationProp } from '@react-navigation/native';
-import {
-  NativeStackNavigationProp,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { ChannelInfoScreen } from '../features/groups/ChannelInfoScreen';
 import { CreateChannelPermissionsScreen } from '../features/groups/CreateChannelPermissionsScreen';
@@ -21,37 +18,14 @@ import { GroupSettingsStackParamList } from './types';
 
 const GroupSettings = createNativeStackNavigator<GroupSettingsStackParamList>();
 
-type GroupMetaProps = {
-  navigation: NativeStackNavigationProp<
-    GroupSettingsStackParamList,
-    'GroupMeta'
-  >;
-  route: {
-    key: string;
-    name: 'GroupMeta';
-    params: {
-      groupId: string;
-      fromBlankChannel?: boolean;
-    };
-  };
-};
-
 export function GroupSettingsStack({
   navigation,
 }: {
   navigation: NavigationProp<GroupSettingsStackParamList>;
 }) {
-  const navigateToHome = () => {
-    (navigation as any).navigate('ChatList', undefined, { pop: true });
-  };
-
   return (
     <GroupSettings.Navigator screenOptions={{ headerShown: false }}>
-      <GroupSettings.Screen name="GroupMeta">
-        {(props: GroupMetaProps) => (
-          <GroupMetaScreen {...props} navigateToHome={navigateToHome} />
-        )}
-      </GroupSettings.Screen>
+      <GroupSettings.Screen name="GroupMeta" component={GroupMetaScreen} />
       <GroupSettings.Screen name="ChannelInfo" component={ChannelInfoScreen} />
       <GroupSettings.Screen
         name="GroupMembers"

--- a/packages/app/navigation/GroupSettingsStack.tsx
+++ b/packages/app/navigation/GroupSettingsStack.tsx
@@ -42,7 +42,7 @@ export function GroupSettingsStack({
   navigation: NavigationProp<GroupSettingsStackParamList>;
 }) {
   const navigateToHome = () => {
-    navigation.getParent()?.navigate('ChatList', undefined, { pop: true });
+    (navigation as any).navigate('ChatList', undefined, { pop: true });
   };
 
   return (

--- a/packages/app/navigation/GroupSettingsStack.tsx
+++ b/packages/app/navigation/GroupSettingsStack.tsx
@@ -42,7 +42,7 @@ export function GroupSettingsStack({
   navigation: NavigationProp<GroupSettingsStackParamList>;
 }) {
   const navigateToHome = () => {
-    navigation.navigate('ChatList' as never);
+    navigation.getParent()?.navigate('ChatList', undefined, { pop: true });
   };
 
   return (


### PR DESCRIPTION
## Summary

Fixes TLON-5598 by passing `{ pop: true }` to every `navigate()` call that targets a top-level tab route (`ChatList`, `Activity`, `Contacts`, `Settings`).

Also fixes TLON-5608.

React Navigation 7 silently changed the semantics of `navigate(name)`: in RN 6, calling `navigation.navigate('ChatList')` popped back to an existing `ChatList` instance already in the stack. In RN 7, the same call **pushes a new screen** with a fresh key, so `react-native-screens` mounts a brand-new instance with all its queries, subscriptions, and effects. Users saw the press ripple immediately but the new screen took 100–500 ms to mount and paint on Android, which felt like a missed tap. Passing `{ pop: true }` as the third argument restores the RN 6 behavior — RN 7's router re-uses the existing route in the stack instead of pushing a new one.

The `{ pop: true }` convention was already established on the Expo 54 branch in earlier cleanup commits (`378ea8196`, `b80321e60`); this PR covers the sites those passes missed. It also adds an ESLint rule so the convention stays enforced going forward.

## Changes

**Runtime fixes — direct response to the bug report**

Three mobile NavBar tap handlers, one set per top-level screen:

-   `packages/app/features/top/ChatListScreen.tsx` — 3× `NavBarView` handlers (`navigateToContacts`, `navigateToHome`, `navigateToNotifications`)
-   `packages/app/features/top/ActivityScreen.tsx` — 3× `NavBarView` handlers
-   `packages/app/features/top/ContactsScreen.tsx` — 3× `NavBarView` handlers

**Additional sites surfaced by the new lint rule**

Same bug class, same fix, different entry points. The lint rule caught these on its first run across `packages/app`:

-   `packages/app/features/top/ActivityScreen.tsx` — `handleNavigateToContacts`
-   `packages/app/features/top/ContactsScreen.tsx` — Settings header icon (`onPress={() => navigate('Settings')}`)
-   `packages/app/features/top/GroupChannelsScreen.tsx` — `handleGoBackPressed` (narrow-window branch)
-   `packages/app/features/groups/GroupMetaScreen.tsx` — `navigateToHome` after group delete
-   `packages/app/hooks/useChatSettingsNavigation.ts` — `onLeaveGroup` (narrow-window branch)
-   `packages/app/hooks/useGroupNavigation.ts` — `goToHome`
-   `packages/app/navigation/GroupSettingsStack.tsx` — `navigateToHome`, surfaced after tightening the selector to handle `TSAsExpression` wrappers in follow-up review. Rewritten to use `getParent()?.navigate('ChatList', undefined, { pop: true })` in place of the triple-`as never` cast — behaviorally equivalent, since when the inner stack can't handle a `NAVIGATE` action to `ChatList`, RN's router bubbles it to the parent anyway (verified in `@react-navigation/core`'s `useOnAction`).

**Lint rule — `.eslintrc.cjs` (29 additions, no modifications to existing rules)**

Two `no-restricted-syntax` entries flag any `navigate()` call whose first argument is the string literal `'ChatList' | 'Activity' | 'Contacts' | 'Settings'` and whose subtree does not contain `pop: true`. Notes:

-   The selector uses `:matches([arguments.0.value=…], [arguments.0.expression.value=…])` so TS-cast forms like `navigate('ChatList' as never)` are also caught (the `TSAsExpression` wrapper otherwise hides the literal from the `arguments.0.value` path).
-   The escape hatch is `[value.value=true]`, not just `:has(Property[key.name="pop"])`, so `{ pop: false }` does not bypass the rule.
-   Two variants: one for `someObj.navigate(...)` (`callee.property.name`) and one for destructured `const { navigate } = ...; navigate(...)` (`callee.name`).
-   Known non-blocking false negatives: `navigate('ChatList', { pop: true })` with `pop:true` in the wrong position (already a TS error in typed call sites), deeply nested `pop: true` buried under an unrelated property, and the dynamic-variable case `const r = 'ChatList' as const; navigate(r)` (general `no-restricted-syntax` limitation). A `useTabNavigate()` helper or a custom ESLint plugin would close these gaps if we want stronger guarantees later.

**Tradeoffs to be aware of**

`{ pop: true }` tells RN 7's stack router to pop back to an existing instance of the target route if one exists — which is what we want for tab-like behavior on a stack navigator — but it is not free:

-   It drops any intermediate stack entries between the current screen and the target. If a user is three screens deep in `ChatList → Channel → Post` and taps the Home tab, they land on `ChatList` with the intermediate screens unmounted. This matches the RN 6 behavior the app was built around and matches user expectations for a bottom tab bar, but it is not identical to a true `BottomTabs` navigator, which would preserve per-tab sub-stacks.
-   Per-tab state (scroll position, transient UI state in sub-screens) is not preserved across tab switches the way it would be with `BottomTabs`. In practice this is already how the mobile app behaves on the current `develop` branch — we are restoring that behavior, not regressing from it.
-   A proper longer-term fix would be to migrate the mobile top-level navigator to `BottomTabs`, which would preserve per-tab sub-stacks natively. That's out of scope here — this PR is the smallest change that gets Expo 54 to feel right on Android.

## How did I test?

-   `pnpm -r tsc --noEmit` clean in `packages/app`
-   `pnpm lint:all` passes with zero TLON-5598 errors across the monorepo, and re-running the new rule against the working tree flags the adjacent sites it was designed to catch (confirmed by reverting each fix locally)
-   Manually tested the bottom nav bar on a physical Android device on the Expo 54 branch before and after the fix. Taps feel responsive again — no more duplicate-mount pause.
-   Spot-checked each of the non-NavBar call sites (`useChatSettingsNavigation`, `useGroupNavigation`, `GroupMetaScreen`, `GroupChannelsScreen`, `GroupSettingsStack`) on a dev build to confirm the return-to-ChatList flows land on the existing screen instead of pushing a fresh one.
-   Audited desktop navigation: `packages/app/navigation/desktop/TopLevelDrawer.tsx` uses `reset(...)` for section switching, not `navigate()`, so there is no desktop equivalent of this bug and no desktop-side change is needed.

## Risks and impact

-   Safe to rollback without consulting PR author? **Yes**
-   Affects important code area: Navigation.

## Rollback plan

Revert.