### PR TITLE
usernames: show full patp except for comets

### DIFF
--- a/packages/app/ui/utils/user.test.ts
+++ b/packages/app/ui/utils/user.test.ts
@@ -47,9 +47,7 @@ test('format star moon', () => {
   const formatted = formatUserId(starMoon);
 
   expect(formatted?.display).toBe('~sampel-sampel-dozzod-bacwyd');
-  expect(formatted?.ariaLabel).toBe(
-    'sampel - sampel - dozzod - bacwyd'
-  );
+  expect(formatted?.ariaLabel).toBe('sampel - sampel - dozzod - bacwyd');
 });
 
 test('format galaxy moon', () => {

--- a/packages/app/ui/utils/user.test.ts
+++ b/packages/app/ui/utils/user.test.ts
@@ -30,8 +30,8 @@ test('format moon', () => {
   const moon = '~livnex-tarlup-pondus-watbel';
   const formatted = formatUserId(moon);
 
-  expect(formatted?.display).toBe('~pondus^watbel');
-  expect(formatted?.ariaLabel).toBe('pondus ^ watbel');
+  expect(formatted?.display).toBe('~livnex-tarlup-pondus-watbel');
+  expect(formatted?.ariaLabel).toBe('livnex - tarlup - pondus - watbel');
 });
 
 test('format moon (full)', () => {
@@ -40,6 +40,24 @@ test('format moon (full)', () => {
 
   expect(formatted?.display).toBe('~livnex-tarlup-pondus-watbel');
   expect(formatted?.ariaLabel).toBe('livnex - tarlup - pondus - watbel');
+});
+
+test('format star moon', () => {
+  const starMoon = '~sampel-sampel-dozzod-bacwyd';
+  const formatted = formatUserId(starMoon);
+
+  expect(formatted?.display).toBe('~sampel-sampel-dozzod-bacwyd');
+  expect(formatted?.ariaLabel).toBe(
+    'sampel - sampel - dozzod - bacwyd'
+  );
+});
+
+test('format galaxy moon', () => {
+  const galaxyMoon = '~sampel-sampel-dozzod-dozzod';
+  const formatted = formatUserId(galaxyMoon);
+
+  expect(formatted?.display).toBe('~sampel-sampel-dozzod-dozzod');
+  expect(formatted?.ariaLabel).toBe('sampel - sampel - dozzod - dozzod');
 });
 
 test('format comet', () => {

--- a/packages/app/ui/utils/user.ts
+++ b/packages/app/ui/utils/user.ts
@@ -4,6 +4,20 @@ import { p } from '@urbit/aura';
 
 const USER_ID_SEPARATORS = /([_^-])/;
 
+// p.cite shortens moons in ways that lose information: star/galaxy moons get
+// rendered as just their parent (impersonating it), and planet moons drop the
+// parent-planet prefix. Only shorten comets — everything else shows in full.
+function citeShip(userId: string): string | null {
+  try {
+    if (p.kind(userId) === 'comet') {
+      return p.cite(userId);
+    }
+    return userId;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Format a user ID for display with proper aria label.
  * @param userId - The user ID to format (e.g., '~sampel-palnet')
@@ -14,7 +28,7 @@ export function formatUserId(
   userId: string,
   full = false
 ): { display: string; ariaLabel: string } | null {
-  const shortenedName = full ? userId : p.cite(userId);
+  const shortenedName = full ? userId : citeShip(userId);
   if (!shortenedName) return null;
 
   const ariaLabel = desig(shortenedName).split(USER_ID_SEPARATORS).join(' ');


### PR DESCRIPTION
## Summary

Fixes TLON-5254

## Changes

- render all patp's fully except for comets

## How did I test?

Manual

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [X] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
