### PR TITLE
fix: drop ContentContext subscription on ContentImage (TLON-5570)

### DIFF
--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -592,7 +592,6 @@ export function ImageBlock({
 
 const ContentImage = styled(Image, {
   name: 'ContentImage',
-  context: ContentContext,
   width: '100%',
 });
 


### PR DESCRIPTION
Fixes [TLON-5570](https://linear.app/tlon/issue/TLON-5570).

## Summary

Tapping a post image in a chat/channel no longer opened the lightbox after the Expo 54 upgrade. Long-press still worked.

## Root cause

The Expo 54 upgrade pulled in a newer Tamagui rc. In this version, Tamagui's `styled()` machinery installs an RNGH-backed press gesture on **any** styled component that receives a press-shaped prop (`onPress`, `onLongPress`, `onPressIn`, `onPressOut`, or even `pressStyle`). Every such gesture participates in Tamagui's shared global press-ownership state (`@tamagui/native/src/gestureState.ts`). On each touch, the innermost gesture overwrites the shared owner, and only the current owner's `onPress` fires.

`ContentImage` in `BlockRenderer.tsx` subscribed to `ContentContext`, which carries `onLongPress` (among other fields) so that `ImageBlock` can long-press-to-open-the-action-sheet. Tamagui's context merging spreads every context field onto the subscribing component as a prop — silently turning every rendered image into a press boundary. On release, the image stole ownership from the surrounding `Pressable`, then dropped the tap because no `onPress` was defined on the image itself. Long-press still fired because the image actually had an `onLongPress` handler.

## Fix

Remove `context: ContentContext` from `ContentImage`. Safe because `ContentImage` doesn't actually use any context values: it has no variants (nothing to key styling off of), and both call sites pass all props explicitly. The consumers that need the context (`ImageBlock`, `LineText`, `BlockWrapper`) already read it via `useContentContext()` or their own variants. Dropping the subscription keeps press-shaped props off the image and restores normal tap arbitration.

## Test plan
- [x] Open a chat with image posts. Tap an image — lightbox opens.