### PR TITLE
groupsApi: split channel meta image into URL vs color

### DIFF
--- a/packages/api/src/client/groupsApi.ts
+++ b/packages/api/src/client/groupsApi.ts
@@ -1890,13 +1890,16 @@ function toClientChannel({
   );
   const currentUserIsMember = isOpenChannel || userHasReadPermission;
 
+  const clientMeta = toClientMeta(channel.meta);
   return {
     id,
     groupId,
     type: getChannelType(id),
-    iconImage: omitEmpty(channel.meta.image),
+    iconImage: clientMeta.iconImage,
+    iconImageColor: clientMeta.iconImageColor,
+    coverImage: clientMeta.coverImage,
+    coverImageColor: clientMeta.coverImageColor,
     title: omitEmpty(channel.meta.title),
-    coverImage: omitEmpty(channel.meta.cover),
     description,
     contentConfiguration: channelContentConfiguration,
     currentUserIsHost: hostUserId === currentUserId,
@@ -1920,13 +1923,16 @@ function toClientChannelFromPreview({
   const currentUserId = getCurrentUserId();
   const { host: hostUserId } = parseGroupChannelId(id);
 
+  const clientMeta = toClientMeta(channel.meta);
   return {
     id,
     groupId,
     type: getChannelType(id),
-    iconImage: omitEmpty(channel.meta.image),
+    iconImage: clientMeta.iconImage,
+    iconImageColor: clientMeta.iconImageColor,
+    coverImage: clientMeta.coverImage,
+    coverImageColor: clientMeta.coverImageColor,
     title: omitEmpty(channel.meta.title),
-    coverImage: omitEmpty(channel.meta.cover),
     description,
     contentConfiguration: channelContentConfiguration,
     currentUserIsHost: hostUserId === currentUserId,


### PR DESCRIPTION
## Summary

Channels were storing any hex color (e.g. #RRGGBB) from meta.image into iconImage (the URL field), which caused <Image> loads to fail and the group-icon fallback to be bypassed — resulting in blank-looking channel avatars. Now routes hex into iconImageColor via toClientMeta, matching what groups already do.

## Changes

- used `toClientMeta` to transform incoming values into correct structure

## How did I test?

Manually through web

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<img width="606" height="567" alt="image" src="https://github.com/user-attachments/assets/1e1a4606-413a-4642-ae44-3d05230e7796" />

