### PR TITLE
avatar: make sigil ratios a little better

### DIFF
--- a/packages/app/ui/components/Avatar.tsx
+++ b/packages/app/ui/components/Avatar.tsx
@@ -309,8 +309,9 @@ export const TextAvatar = React.memo(function TextAvatarComponent({
 // Keyed off the numeric sigil size so this works for both mobile (16/24/…) and
 // desktop (14/22/…) token scales.
 function getDefaultInnerSigilSize(sigilSize: number): number {
-  if (sigilSize <= 16) return 12;
-  if (sigilSize <= 24) return 14;
+  // small sizes need a larger ratio to be recognizable
+  if (sigilSize <= 16) return Math.floor(sigilSize * 0.75);
+  if (sigilSize <= 24) return Math.floor(sigilSize * 0.625);
   // $3xl/$3.5xl: simplified sigils read better with a little color frame.
   if (sigilSize < 44) return Math.floor(sigilSize * 0.55);
   // $4xl and up render with detail, so give the linework a bit more room.


### PR DESCRIPTION
## Summary

The smallest sigils were too large, needed to be adjusted down. Made everything floored ratios

## Changes

- tweaked `getDefaultInnerSigilSize`

## How did I test?

Checked in browser manually

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [X] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos
check the reply line and quoted message below

<img width="966" height="516" alt="image" src="https://github.com/user-attachments/assets/c83d205b-7815-486b-bc08-d7b08bddd911" />

