### PR TITLE
avatar: match sigil inner size parity to outer size

### DIFF
--- a/packages/app/ui/components/Avatar.tsx
+++ b/packages/app/ui/components/Avatar.tsx
@@ -305,17 +305,21 @@ export const TextAvatar = React.memo(function TextAvatarComponent({
 
 // Hardcoded integer sizes for the inner sigil SVG. Fractional sizes render
 // blurry and can shift the sigil off the pixel grid, especially for tiny
-// avatars where the desktop tokens (14, 22) don't divide evenly.
-// Keyed off the numeric sigil size so this works for both mobile (16/24/…) and
-// desktop (14/22/…) token scales.
+// avatars where the desktop tokens (14, 22) don't divide evenly. Inner size
+// must also match the outer size's parity so the leftover margin splits evenly
+// on both sides — otherwise the sigil shifts by a subpixel on non-retina.
+function matchParity(value: number, base: number): number {
+  const rounded = Math.floor(value);
+  return rounded % 2 === base % 2 ? rounded : rounded + 1;
+}
 function getDefaultInnerSigilSize(sigilSize: number): number {
   // small sizes need a larger ratio to be recognizable
-  if (sigilSize <= 16) return Math.floor(sigilSize * 0.75);
-  if (sigilSize <= 24) return Math.floor(sigilSize * 0.625);
+  if (sigilSize <= 16) return matchParity(sigilSize * 0.75, sigilSize);
+  if (sigilSize <= 24) return matchParity(sigilSize * 0.625, sigilSize);
   // $3xl/$3.5xl: simplified sigils read better with a little color frame.
-  if (sigilSize < 44) return Math.floor(sigilSize * 0.55);
+  if (sigilSize < 44) return matchParity(sigilSize * 0.55, sigilSize);
   // $4xl and up render with detail, so give the linework a bit more room.
-  return Math.floor(sigilSize * 0.625);
+  return matchParity(sigilSize * 0.625, sigilSize);
 }
 
 export const SigilAvatar = React.memo(function SigilAvatarComponent({


### PR DESCRIPTION
## Summary

Inner sigil dimension must share parity with the outer avatar so the leftover margin splits evenly on both sides. Otherwise the sigil shifts by a subpixel and appears to jitter on non-retina displays.

(one more sorry y'all didn't think about retina vs non-retina)

## Changes

- Made sigil dimension match even/odd sizing around it

## How did I test?

Manually on web

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [X] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<img width="855" height="608" alt="Screenshot 2026-04-17 at 11 17 33 AM" src="https://github.com/user-attachments/assets/6c97205e-1102-43af-b468-8ebaabafb07d" />

