### PR TITLE
fix(ios): drop lineHeight on single-line TextInput

### DIFF
--- a/packages/app/ui/components/Form/inputs.tsx
+++ b/packages/app/ui/components/Form/inputs.tsx
@@ -49,18 +49,25 @@ import {
   getBorderVariantStyle as getBackgroundTypeVariantStyle,
 } from './formUtils';
 
+// lineHeight on single-line TextInput is buggy on iOS; restore it for
+// multiline inputs below where line spacing matters.
+const { lineHeight: mobileInputLineHeight, ...mobileInputTypeStyles } =
+  mobileTypeStyles['$label/xl'];
+const { lineHeight: desktopInputLineHeight, ...desktopInputTypeStyles } =
+  desktopTypeStyles['$label/xl'];
+
 // Common text input styling configuration
 // Only contains style properties and Tamagui-specific config (name, variants, media queries)
 const textInputStyleConfig = {
   name: 'RawTextInput',
-  ...mobileTypeStyles['$label/xl'],
+  ...mobileInputTypeStyles,
   context: FieldContext,
   color: '$primaryText',
   fontFamily: '$body',
   textAlignVertical: 'top' as const,
   paddingVertical: '$l',
-  '$platform-web': { outlineStyle: 'none', lineHeight: 'unset' },
-  $gtSm: desktopTypeStyles['$label/xl'],
+  '$platform-web': { outlineStyle: 'none' },
+  $gtSm: desktopInputTypeStyles,
   variants: {
     accent: {
       negative: {
@@ -153,21 +160,29 @@ const TextInputComponent = RawTextInput.styleable<{
     const shouldUseBottomSheetInput =
       actionSheetContext?.isInsideSheet && Platform.OS !== 'web';
 
+    const isMultiline =
+      !!props.multiline ||
+      (props.numberOfLines != null && props.numberOfLines !== 1);
+
     // Shared props for both input components
     // Type cast needed because Tamagui's styled() wrapper adds broader types (like boxShadow: array)
     // that don't exactly match TextInput's narrower prop types (boxShadow: string only)
     const sharedInputProps = {
       flex: 1,
       ...textInputDefaultProps,
+      ...(isMultiline
+        ? {
+            lineHeight: mobileInputLineHeight,
+            $gtSm: { lineHeight: desktopInputLineHeight },
+          }
+        : {}),
       ...props,
     } as GetProps<typeof RawTextInput>;
 
     return (
       <InputFrame
         accent={accent ?? fieldContext.accent}
-        {...(props.numberOfLines && props.numberOfLines !== 1
-          ? { height: 'unset' }
-          : {})}
+        {...(isMultiline ? { height: 'unset' } : {})}
         backgroundType={backgroundType ?? fieldContext.backgroundType}
         {...frameStyle}
       >


### PR DESCRIPTION
Fixes [TLON-5563](https://linear.app/tlon/issue/TLON-5563/expo-54-text-not-vertically-centered-in-inputs).

## Description

On iOS with the new architecture (Fabric), typed text inside a single-line `TextInput` sits too low whenever `lineHeight` is greater than `fontSize`. The placeholder stays centered, but as soon as the user types, the glyphs anchor to the bottom of the attributed-string line box, leaving an asymmetric gap above the text.

We hit this on the Expo 54 / RN 0.81 upgrade branch — for example in the Add Contacts search input, which uses the shared `$label/xl` text style (`fontSize: 17`, `lineHeight: 24`). The regression tracks the 0.76 → 0.77+ window and matches upstream issue [facebook/react-native#39145](https://github.com/facebook/react-native/issues/39145).

## Solution

Strip `lineHeight` from the base style applied to our shared `RawTextInput`. Single-line inputs sit inside an `InputFrame` with a fixed 56 px height and `alignItems: 'center'`, so the text node is already vertically centered by its parent; the attributed `lineHeight` buys nothing on the vertical axis and only triggers the iOS baseline bug.

Multiline inputs are different — line-to-line spacing still matters — so `TextInputComponent` restores `lineHeight` (mobile + `$gtSm` desktop) when `multiline` is set or `numberOfLines > 1`. The same flag now drives the `InputFrame` `height: 'unset'` override, so `multiline={true}` alone (without `numberOfLines`) correctly expands the frame.

Also working on an upstream fix to the underlying bug: https://github.com/facebook/react-native/pull/56487

But I think this is a lot simpler and safer for now.

## Test plan
- Open **Add Contacts** → tap the search input → type a character. Expected: the typed character is vertically centered in the input, matching the placeholder position.
- Verify Android looks ok too

<img width="396" height="253" alt="image" src="https://github.com/user-attachments/assets/136dcdf0-cecc-4f7e-b69d-3ec84f5c4772" />

<img width="391" height="310" alt="image" src="https://github.com/user-attachments/assets/50b1f357-f039-4b02-9e86-da8d8693fd0c" />
