### PR TITLE
fix(ui): wayfinding invite screen layout

### DIFF
--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -470,8 +470,7 @@ export function InviteContactsContent(props: {
             keyExtractor={(item) => item.id}
             style={{ flex: 1 }}
             contentContainerStyle={{
-              paddingTop: 8,
-              paddingHorizontal: 14,
+              padding: getTokenValue('$l', 'size'),
               paddingBottom: getTokenValue('$4xl', 'size'),
             }}
             renderItem={({ item: contact }) => (

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -19,7 +19,6 @@ import { FlatList, Image, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
-  XStack,
   YStack,
   ZStack,
   getTokenValue,
@@ -449,30 +448,30 @@ export function InviteContactsContent(props: {
       ) : !isReady ? (
         <LoadingState />
       ) : (
-        <>
+        <View flex={1}>
           <SplashParagraph marginTop="$l" marginBottom="$xl">
             {INVITE_EXPLANATION_TEXT}
           </SplashParagraph>
-          <XStack paddingHorizontal="$xl">
-            <SearchBar
-              height="$4xl"
-              debounceTime={100}
-              onChangeQuery={handleSearch}
-              placeholder="Search contacts"
-              inputProps={{
-                spellCheck: false,
-                autoCapitalize: 'none',
-                autoComplete: 'off',
-                flex: 1,
-              }}
-            />
-          </XStack>
+          <SearchBar
+            paddingHorizontal="$xl"
+            flexGrow={0}
+            debounceTime={100}
+            onChangeQuery={handleSearch}
+            placeholder="Search contacts"
+            inputProps={{
+              spellCheck: false,
+              autoCapitalize: 'none',
+              autoComplete: 'off',
+              flex: 1,
+            }}
+          />
           <FlatList
             data={displayContacts}
             keyExtractor={(item) => item.id}
             style={{ flex: 1 }}
             contentContainerStyle={{
-              padding: getTokenValue('$l', 'size'),
+              paddingTop: 8,
+              paddingHorizontal: 14,
               paddingBottom: getTokenValue('$4xl', 'size'),
             }}
             renderItem={({ item: contact }) => (
@@ -483,7 +482,7 @@ export function InviteContactsContent(props: {
               />
             )}
           />
-        </>
+        </View>
       )}
     </YStack>
   );

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -448,7 +448,7 @@ export function InviteContactsContent(props: {
       ) : !isReady ? (
         <LoadingState />
       ) : (
-        <View flex={1}>
+        <>
           <SplashParagraph marginTop="$l" marginBottom="$xl">
             {INVITE_EXPLANATION_TEXT}
           </SplashParagraph>
@@ -481,7 +481,7 @@ export function InviteContactsContent(props: {
               />
             )}
           />
-        </View>
+        </>
       )}
     </YStack>
   );


### PR DESCRIPTION
## Summary

The "Invite your friends" pane in the onboarding splash sequence had a layout bug where the search bar's bottom border visually overlapped the first contact item. This PR fixes the SearchBar wrapper sizing so the input renders cleanly above the contact list.

Resolves [TLON-5566](https://linear.app/tlon/issue/TLON-5566/expo-54-layout-collision-on-contacts-search-screen-in-onboarding).

## Changes

- Drop `height="$4xl"` (48px) from the `SearchBar`. The underlying `TextInput` has a hard-coded height of 56px; with the wrapper's `alignItems: "center"`, the input was overflowing its wrapper by 4px on top and bottom, which is what caused the border to bleed into the first list row.
- Add `flexGrow={0}` to the `SearchBar`. Its internal `YStack` defaults to `flexGrow: 1`, so without this override the search bar was stretching vertically inside the parent column, pushing the list content down inconsistently.
- Remove the redundant `XStack` wrapper and set `paddingHorizontal="$xl"` directly on `SearchBar`.

## How did I test?

Tested on iOS simulator. Before: the first contact row's avatar/name were clipped a few pixels behind the search bar, and the search bar's bottom border appeared to be overlapped by the first list item. After: the search bar renders cleanly and items below it are unobstructed. Verified the empty-contacts and loading states still render correctly.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert this commit. The change is scoped to a single file (`packages/app/ui/components/Wayfinding/SplashSequence.tsx`) and only affects the onboarding "Invite your friends" pane.

## Screenshots / videos

<img width="380" height="788" alt="image" src="https://github.com/user-attachments/assets/0c2c8d9c-0aa6-4097-a6a0-274428c06acb" />