### PR TITLE
fix(mobile): Poor UX report modal buttons overflow card

### DIFF
--- a/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx
+++ b/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx
@@ -156,8 +156,7 @@ export function usePoorUxShakeReport() {
                 Report Poor UX
               </Text>
               <TextArea
-                height={120}
-                flexShrink={0}
+                numberOfLines={5}
                 backgroundColor="$background"
                 borderColor="$secondaryBorder"
                 borderWidth={1}

--- a/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx
+++ b/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx
@@ -156,7 +156,8 @@ export function usePoorUxShakeReport() {
                 Report Poor UX
               </Text>
               <TextArea
-                minHeight={120}
+                height={120}
+                flexShrink={0}
                 backgroundColor="$background"
                 borderColor="$secondaryBorder"
                 borderWidth={1}


### PR DESCRIPTION
## Summary

The Report Poor UX modal (shake-to-report) rendered its Cancel and Submit buttons outside the card's rounded background, sitting on the dark overlay — but only after the Tamagui v2 upgrade.

## Changes

`TextArea` in [usePoorUxShakeReport.tsx](https://github.com/tloncorp/tlon-apps/blob/f3aea67fcb85e770ed2239c47d534b34fb72d74d/apps/tlon-mobile/src/hooks/usePoorUxShakeReport.tsx#L156-L160): `minHeight={120}` → `numberOfLines={5}`.

## Root cause

In Tamagui v1 (`develop`), the TextArea wrapper forced a default `numberOfLines: 4` on the native RN TextInput via a render-time prop, and v1's styled pipeline did not propagate our `minHeight={120}` down to the native input. The input stayed compact (~4 lines) and the card's natural height always contained the button row.

In Tamagui v2 + RN 0.81, the default changed to `rows: 3` set in the size variant. RN 0.81 maps `rows` → `numberOfLines` in its TextInput shim ([TextInput.js#L696](https://github.com/facebook/react-native/blob/main/Libraries/Components/TextInput/TextInput.js#L696)), so the prop does land. But the variant also computes an explicit `height` from `rows × lineHeight`, and our `minHeight={120}` now interacts with the variant's height in a way that leaves the input taller than the card layout expects — in some contexts the native UITextView ends up much taller than 120px, in others it's exactly 120 but the card still doesn't include it. Either way, the button row spills past the card's rounded bottom.

`numberOfLines={5}` gives around the height that we want without overflow.

## Other TextArea usages in the app

Checked `packages/app/ui/components/EditableNotePostContent.tsx`, `packages/app/ui/components/MarkdownEditor.tsx`, and `packages/app/fixtures/ChannelConfigurationBar.fixture.tsx`. All three put the TextArea inside a dedicated editor screen where "grow to fill parent" is the intended behavior — they don't rely on `minHeight` and don't composit with a card/button row, so they aren't affected by this regression.

## How did I test?

Reproduced on iPhone 16 Pro simulator (iOS 18.6) with the Expo 54 dev build. Auto-opened the Poor UX modal on home-screen mount. Compared against a second checkout built from `develop` (Tamagui v1) installed side-by-side as `io.tlon.groups.preview`.

<img width="380" height="779" alt="image" src="https://github.com/user-attachments/assets/f79a5f4d-979a-4471-92b9-65d0ebaa1684" />

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: dev-only shake-to-report modal

## Rollback plan

Revert the commit; no migrations or data changes.

## Screenshots / videos

See validation screenshot above.