### PR TITLE
chatlist: add tooltip and styles for "Add Chat" button

### DIFF
--- a/packages/api/src/types/wayfinding.ts
+++ b/packages/api/src/types/wayfinding.ts
@@ -17,6 +17,7 @@ export interface WayfindingProgress {
   viewedChatChannel: boolean;
   viewedCollectionChannel: boolean;
   viewedNotebookChannel: boolean;
+  tappedHomeAdd: boolean;
   tappedAddNote: boolean;
   tappedAddCollection: boolean;
   tappedChatInput: boolean;

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -66,20 +66,7 @@ export function ChatListScreenView({
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [personalInviteOpen, setPersonalInviteOpen] = useState(false);
   const personalInvite = db.personalInviteLink.useValue();
-  const viewedPersonalInvite = db.hasViewedPersonalInvite.useValue();
   const { isOpen, setIsOpen } = useGlobalSearch();
-  const theme = useTheme();
-  const inviteButtonColor = useMemo(
-    () =>
-      (viewedPersonalInvite
-        ? theme?.primaryText?.val
-        : theme?.positiveActionText?.val) as ColorTokens,
-    [
-      theme?.positiveActionText?.val,
-      theme?.primaryText?.val,
-      viewedPersonalInvite,
-    ]
-  );
 
   const [activeTab, setActiveTab] = useState<TabName>('home');
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
@@ -314,7 +301,6 @@ export function ChatListScreenView({
                 personalInvite ? (
                   <ScreenHeader.IconButton
                     type="AddPerson"
-                    color={inviteButtonColor}
                     onPress={handlePersonalInvitePress}
                   />
                 ) : undefined
@@ -331,10 +317,16 @@ export function ChatListScreenView({
                         type="Add"
                         onPress={handlePressAddChat}
                         testID="CreateChatSheetTrigger"
-                        backgroundColor="$positiveActionText"
-                        color="$white"
-                        borderRadius="$6xl"
-                        customSize={['$2xl', '$xl']}
+                        color={
+                          isWindowNarrow && showHomeAddTooltip
+                            ? '$positiveActionText'
+                            : '$primaryText'
+                        }
+                        backgroundColor={
+                          isWindowNarrow && showHomeAddTooltip
+                            ? '$positiveBackground'
+                            : 'transparent'
+                        }
                       />
                       {isWindowNarrow && showHomeAddTooltip && (
                         <WayfindingNotice.HomeAddTooltip />

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -40,6 +40,7 @@ import {
   useIsWindowNarrow,
 } from '../../ui';
 import SystemNotices from '../../ui/components/SystemNotices';
+import WayfindingNotice from '../../ui/components/Wayfinding/Notices';
 import { identifyTlonEmployee } from '../../utils/posthog';
 import { ChatList } from '../chat-list/ChatList';
 import { ChatListSearch } from '../chat-list/ChatListSearch';
@@ -194,6 +195,10 @@ export function ChatListScreenView({
   );
 
   const handlePressAddChat = useCallback(() => {
+    db.wayfindingProgress.setValue((prev) => ({
+      ...prev,
+      tappedHomeAdd: true,
+    }));
     createChatSheetRef.current?.open();
   }, []);
 
@@ -235,6 +240,7 @@ export function ChatListScreenView({
   const [searchQuery, setSearchQuery] = useState('');
 
   const isWindowNarrow = useIsWindowNarrow();
+  const showHomeAddTooltip = store.useShowHomeAddTooltip();
 
   const handleSearchInputToggled = useCallback(() => {
     if (isWindowNarrow) {
@@ -320,11 +326,20 @@ export function ChatListScreenView({
                     onPress={handleSearchInputToggled}
                   />
                   {isWindowNarrow ? (
-                    <ScreenHeader.IconButton
-                      type="Add"
-                      onPress={handlePressAddChat}
-                      testID="CreateChatSheetTrigger"
-                    />
+                    <View position="relative" alignItems="flex-end">
+                      <ScreenHeader.IconButton
+                        type="Add"
+                        onPress={handlePressAddChat}
+                        testID="CreateChatSheetTrigger"
+                        backgroundColor="$positiveActionText"
+                        color="$white"
+                        borderRadius="$6xl"
+                        customSize={['$2xl', '$xl']}
+                      />
+                      {isWindowNarrow && showHomeAddTooltip && (
+                        <WayfindingNotice.HomeAddTooltip />
+                      )}
+                    </View>
                   ) : (
                     <CreateChatSheet
                       ref={createChatSheetRef}

--- a/packages/app/fixtures/WayfindingNotices.fixture.tsx
+++ b/packages/app/fixtures/WayfindingNotices.fixture.tsx
@@ -2,9 +2,11 @@ import * as db from '@tloncorp/shared/db';
 import { Text } from '@tloncorp/ui';
 import { View, XStack, YStack } from 'tamagui';
 
+import { ScreenHeader } from '../ui';
 import WayfindingNotice, {
   ChatInputTooltip,
   CollectionInputTooltip,
+  HomeAddTooltip,
   NotebookInputTooltip,
 } from '../ui/components/Wayfinding/Notices';
 import { FixtureWrapper } from './FixtureWrapper';
@@ -113,6 +115,42 @@ function ChatInputTooltipFixture() {
   );
 }
 
+function HomeAddTooltipFixture() {
+  return (
+    <FixtureWrapper fillWidth fillHeight safeArea>
+      <YStack flex={1} position="relative">
+        <ScreenHeader
+          title="Home"
+          rightControls={
+            <>
+              <ScreenHeader.IconButton type="Search" />
+              <View position="relative" alignItems="flex-end">
+                <ScreenHeader.IconButton
+                  type="Add"
+                  backgroundColor="$positiveActionText"
+                  color="$white"
+                  borderRadius="$6xl"
+                  customSize={['$2xl', '$xl']}
+                />
+                <View
+                  pointerEvents="none"
+                  position="absolute"
+                  top="100%"
+                  right={0}
+                  marginTop="$s"
+                >
+                  <HomeAddTooltip />
+                </View>
+              </View>
+            </>
+          }
+        />
+        <View flex={1} />
+      </YStack>
+    </FixtureWrapper>
+  );
+}
+
 function CollectionInputTooltipFixture() {
   return (
     <FixtureWrapper fillWidth fillHeight safeArea>
@@ -175,6 +213,20 @@ function AllTooltipsFixture() {
 
         <YStack gap="$xl">
           <Text size="$label/l" color="$secondaryText">
+            Home Add Tooltip
+          </Text>
+          <YStack
+            height={170}
+            position="relative"
+            backgroundColor="$secondaryBackground"
+            borderRadius="$l"
+          >
+            <HomeAddTooltip />
+          </YStack>
+        </YStack>
+
+        <YStack gap="$xl">
+          <Text size="$label/l" color="$secondaryText">
             Chat Input Tooltip
           </Text>
           <YStack
@@ -226,6 +278,7 @@ export default {
   'Empty Channel - Notebook': <EmptyChannelNotebookFixture />,
   'Group Channels Notice': <GroupChannelsNoticeFixture />,
   'Customize Group Notice': <CustomizeGroupNoticeFixture />,
+  'Home Add Tooltip': <HomeAddTooltipFixture />,
   'Chat Input Tooltip': <ChatInputTooltipFixture />,
   'Collection Input Tooltip': <CollectionInputTooltipFixture />,
   'Notebook Input Tooltip': <NotebookInputTooltipFixture />,

--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -1,3 +1,4 @@
+import { getCurrentUserIsHosted } from '@tloncorp/api';
 import * as db from '@tloncorp/shared/db';
 import { Text } from '@tloncorp/ui';
 import { useMemo } from 'react';
@@ -154,6 +155,10 @@ function CustomizeGroup() {
 }
 
 export function HomeAddTooltip() {
+  const hostingBotEnabled = db.hostingBotEnabled.useValue();
+  const isHostedUser = getCurrentUserIsHosted();
+  const botEnabled = isHostedUser && hostingBotEnabled;
+
   return (
     <View pointerEvents="none" position="absolute" top={36} right={18}>
       <YStack alignItems="flex-end">
@@ -165,7 +170,9 @@ export function HomeAddTooltip() {
           borderRadius="$l"
         >
           <Text size="$label/l" color="$white">
-            Tap here to create a new group
+            {botEnabled
+              ? 'Tap here to create a new group and invite your Tlonbot.'
+              : 'Tap here to create a new group.'}
           </Text>
         </View>
       </YStack>

--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -21,6 +21,7 @@ const WayfindingNotice = {
   EmptyChannel,
   GroupChannels,
   CustomizeGroup,
+  HomeAddTooltip,
   ChatInputTooltip,
   CollectionInputTooltip,
   NotebookInputTooltip,
@@ -148,6 +149,26 @@ function CustomizeGroup() {
           your friends.
         </NoticeText>
       </NoticeContainer>
+    </View>
+  );
+}
+
+export function HomeAddTooltip() {
+  return (
+    <View pointerEvents="none" position="absolute" top={36} right={18}>
+      <YStack alignItems="flex-end">
+        <View
+          testID="HomeAddWayfindingTooltip"
+          padding={20}
+          width={220}
+          backgroundColor="$positiveActionText"
+          borderRadius="$l"
+        >
+          <Text size="$label/l" color="$white">
+            Tap here to create a new group
+          </Text>
+        </View>
+      </YStack>
     </View>
   );
 }

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -321,6 +321,7 @@ export const wayfindingProgress = createStorageItem<WayfindingProgress>({
     viewedChatChannel: false,
     viewedCollectionChannel: false,
     viewedNotebookChannel: false,
+    tappedHomeAdd: true,
     tappedAddNote: true,
     tappedAddCollection: true,
     tappedChatInput: true,

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -678,6 +678,11 @@ export const useShowChatInputWayfinding = (channelId: string) => {
   return isCorrectChan && !wayfindingProgress.tappedChatInput;
 };
 
+export const useShowHomeAddTooltip = () => {
+  const wayfindingProgress = db.wayfindingProgress.useValue();
+  return wayfindingProgress.tappedHomeAdd === false;
+};
+
 export const useShowCollectionAddTooltip = (channelId: string) => {
   const wayfindingProgress = db.wayfindingProgress.useValue();
   const isCorrectChan = useMemo(() => {

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -53,6 +53,18 @@ export async function updateCalmSetting(
 }
 
 export async function completeWayfindingSplash() {
+  await db.wayfindingProgress.setValue((prev) => ({
+    ...prev,
+    viewedPersonalGroup: false,
+    viewedChatChannel: false,
+    viewedCollectionChannel: false,
+    viewedNotebookChannel: false,
+    tappedHomeAdd: false,
+    tappedAddNote: false,
+    tappedAddCollection: false,
+    tappedChatInput: false,
+  }));
+
   // optimistic update
   await db.insertSettings({ completedWayfindingSplash: true });
   try {


### PR DESCRIPTION
## Summary

Adds heavier styling to emphasize the *Add chat* button and a coach mark for new signups.

## Changes
- new field in `wayfindingProgress` and corresponding DB hook
- new `/Wayfinding/Notices` component
- wire up the tooltip and adjust style for *Add chat* on the `ChatList`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding

## Screenshots / videos

<img height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-20 at 17 27 44" src="https://github.com/user-attachments/assets/5387b6fe-b028-4717-988f-9e161d21deca" />
