### PR TITLE
presence: include nack tangs in logs as-is

### DIFF
--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -408,7 +408,7 @@
       ?~  p.sign  :_(this [(tell:log %dbug ~['local sub ack ok' >wire<] ~)]~)
       %-  (slog (rap 3 dap.bowl ' rejected by local for ' (spat wire) ~) u.p.sign)
       :_  this
-      [(tell:log %warn ~['local sub nacked' >wire< >u.p.sign<] ~)]~
+      [(tell:log %warn ['local sub nacked' >wire=wire< u.p.sign] ~)]~
     ::
         %fact
       ?.  ?=(%activity-update-4 p.cage.sign)
@@ -454,7 +454,11 @@
         [(tell:log %dbug ~['context poke acked' >src.bowl< >context<] ~)]~
       %-  (slog (rap 3 dap.bowl ': poke-nacked by ' (scot %p src.bowl) ~) u.p.sign)
       :_  this
-      [(tell:log %warn ~['context poke nacked' >src.bowl< >context< >u.p.sign<] ~)]~
+      =-  [(tell:log %warn - ~)]~
+      :*  'context poke nacked'
+          >[src=src.bowl context=context]<
+          u.p.sign
+      ==
     ::
         %kick
       ::  resubscribe after brief wait, prevent hot-looping
@@ -471,7 +475,11 @@
       ::  nacked, can't do anything, drop desire
       ::
       :_  this(want (~(del by want) src.bowl context))
-      [(tell:log %warn ~['context sub nacked, dropping desire' >src.bowl< >context< >u.p.sign<] ~)]~
+      =-  [(tell:log %warn - ~)]~
+      :*  'context sub nacked, dropping desire'
+          >[src=src.bowl context=context]<
+          u.p.sign
+      ==
     ::
         %fact
       ?.  ?=(%presence-update-1 p.cage.sign)


### PR DESCRIPTION
## Changes

Instead of tanking the tangs, include them as-is in the log tang.

## How did I test?

Compiles!

## Risks and impact

- Yes, safe to rollback without consulting PR author.

## Rollback plan

Revert.