### PR TITLE
personal invite logic removed from chat list screen; tooltip text upd…

### DIFF
--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -66,20 +66,7 @@ export function ChatListScreenView({
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [personalInviteOpen, setPersonalInviteOpen] = useState(false);
   const personalInvite = db.personalInviteLink.useValue();
-  const viewedPersonalInvite = db.hasViewedPersonalInvite.useValue();
   const { isOpen, setIsOpen } = useGlobalSearch();
-  const theme = useTheme();
-  const inviteButtonColor = useMemo(
-    () =>
-      (viewedPersonalInvite
-        ? theme?.primaryText?.val
-        : theme?.positiveActionText?.val) as ColorTokens,
-    [
-      theme?.positiveActionText?.val,
-      theme?.primaryText?.val,
-      viewedPersonalInvite,
-    ]
-  );
 
   const [activeTab, setActiveTab] = useState<TabName>('home');
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
@@ -314,7 +301,6 @@ export function ChatListScreenView({
                 personalInvite ? (
                   <ScreenHeader.IconButton
                     type="AddPerson"
-                    color={inviteButtonColor}
                     onPress={handlePersonalInvitePress}
                   />
                 ) : undefined
@@ -331,10 +317,16 @@ export function ChatListScreenView({
                         type="Add"
                         onPress={handlePressAddChat}
                         testID="CreateChatSheetTrigger"
-                        backgroundColor="$positiveActionText"
-                        color="$white"
-                        borderRadius="$6xl"
-                        customSize={['$2xl', '$xl']}
+                        color={
+                          isWindowNarrow && showHomeAddTooltip
+                            ? '$positiveActionText'
+                            : '$primaryText'
+                        }
+                        backgroundColor={
+                          isWindowNarrow && showHomeAddTooltip
+                            ? '$positiveBackground'
+                            : 'transparent'
+                        }
                       />
                       {isWindowNarrow && showHomeAddTooltip && (
                         <WayfindingNotice.HomeAddTooltip />

--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -1,3 +1,4 @@
+import { getCurrentUserIsHosted } from '@tloncorp/api';
 import * as db from '@tloncorp/shared/db';
 import { Text } from '@tloncorp/ui';
 import { useMemo } from 'react';
@@ -154,6 +155,10 @@ function CustomizeGroup() {
 }
 
 export function HomeAddTooltip() {
+  const hostingBotEnabled = db.hostingBotEnabled.useValue();
+  const isHostedUser = getCurrentUserIsHosted();
+  const botEnabled = isHostedUser && hostingBotEnabled;
+
   return (
     <View pointerEvents="none" position="absolute" top={36} right={18}>
       <YStack alignItems="flex-end">
@@ -165,7 +170,9 @@ export function HomeAddTooltip() {
           borderRadius="$l"
         >
           <Text size="$label/l" color="$white">
-            Tap here to create a new group
+            {botEnabled
+              ? 'Tap here to create a new group and invite your Tlonbot.'
+              : 'Tap here to create a new group.'}
           </Text>
         </View>
       </YStack>


### PR DESCRIPTION
Removes blue highlighting from the personal invite button, moves it to the + button. Uses positiveActionText and positiveBackground for highlighting the button itself. Checks the user's Tlonbot-enabled status and displays two different bubble messages.