### PR TITLE
chat: TLON-5606 repair reply and preview metadata after clearing failed optimistic posts (2/3)

### DIFF
--- a/packages/shared/src/db/migrations/0000_polite_pride.sql
+++ b/packages/shared/src/db/migrations/0000_polite_pride.sql
@@ -348,6 +348,7 @@ CREATE TABLE `posts` (
 	`reply_count` integer,
 	`reply_time` integer,
 	`reply_contact_ids` text,
+	`optimistic_reply_bump_count` integer DEFAULT 0 NOT NULL,
 	`text_content` text,
 	`has_app_reference` integer,
 	`has_channel_reference` integer,

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "8de9c80f-1dfd-4589-9f31-128786ba4c58",
+  "id": "4e78326c-d048-463d-b691-ddd6cfdde822",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -2342,6 +2342,14 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "optimistic_reply_bump_count": {
+          "name": "optimistic_reply_bump_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
         },
         "text_content": {
           "name": "text_content",

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1770685230541,
-      "tag": "0000_reflective_slayback",
+      "when": 1776952138076,
+      "tag": "0000_polite_pride",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_reflective_slayback.sql';
+import m0000 from './0000_polite_pride.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/modelBuilders.ts
+++ b/packages/shared/src/db/modelBuilders.ts
@@ -218,6 +218,7 @@ export function buildPost({
     replies: [],
     replyContactIds: [],
     replyCount: 0,
+    optimisticReplyBumpCount: 0,
     hidden: false,
     syncedAt: Date.now(),
     draft,

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -1,7 +1,7 @@
 import { v0PeersToClientProfiles } from '@tloncorp/api';
 import { toClientGroupsV7 } from '@tloncorp/api';
 import type * as ub from '@tloncorp/api/urbit/groups';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import * as schema from '../db/schema';
 import { syncContacts, syncInitData } from '../store/sync';
@@ -758,4 +758,337 @@ test('setJoinedGroupChannels: does not reset membership for channels not in the 
       `channel ${channelId} should still be joined`
     ).toBe(true);
   }
+});
+
+describe('undoOptimisticReplyBump', () => {
+  const channelId = 'undo-reply-bump-channel';
+  const parentId = 'undo-reply-bump-parent';
+
+  async function seedParent(overrides: Partial<Post>) {
+    await queries.insertChannelPosts({
+      posts: [
+        {
+          id: parentId,
+          type: 'chat',
+          channelId,
+          authorId: '~parent',
+          sentAt: 1000,
+          receivedAt: 1000,
+          sequenceNum: 1,
+          content: JSON.stringify([{ inline: ['parent'] }]),
+          syncedAt: Date.now(),
+          ...overrides,
+        } as unknown as Post,
+      ],
+    });
+  }
+
+  async function seedReply(
+    authorId: string,
+    sentAt: number,
+    overrides: Partial<Post> = {}
+  ) {
+    await queries.insertChannelPosts({
+      posts: [
+        {
+          id: `${authorId}-${sentAt}`,
+          type: 'reply',
+          parentId,
+          channelId,
+          authorId,
+          sentAt,
+          receivedAt: sentAt,
+          sequenceNum: 0,
+          content: JSON.stringify([{ inline: [`reply at ${sentAt}`] }]),
+          syncedAt: Date.now(),
+          isDeleted: false,
+          ...overrides,
+        } as unknown as Post,
+      ],
+    });
+  }
+
+  test('complete local cache: A -> B -> A after deleting the last A recomputes to ["B", "A"] recency', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedParent({
+      replyCount: 3,
+      replyTime: 1300,
+      replyContactIds: ['~bravo', '~alfa'],
+    });
+    await seedReply('~alfa', 1100);
+    await seedReply('~bravo', 1200);
+
+    await queries.undoOptimisticReplyBump({ parentId });
+
+    const parent = await queries.getPost({ postId: parentId });
+    expect(parent!.replyCount).toBe(2);
+    expect(parent!.replyTime).toBe(1200);
+    expect(parent!.replyContactIds).toEqual(['~alfa', '~bravo']);
+  });
+
+  test('partial local cache: preserves server-sourced replyTime / replyContactIds, decrements replyCount', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const serverContactIds = ['~remote-1', '~remote-2', '~remote-3'];
+    await seedParent({
+      replyCount: 8,
+      replyTime: 9999,
+      replyContactIds: serverContactIds,
+    });
+
+    await queries.undoOptimisticReplyBump({ parentId });
+
+    const parent = await queries.getPost({ postId: parentId });
+    expect(parent!.replyCount).toBe(7);
+    expect(parent!.replyTime).toBe(9999);
+    expect(parent!.replyContactIds).toEqual(serverContactIds);
+  });
+
+  test('partial local cache with alive local replies: still preserves server fields', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedParent({
+      replyCount: 5,
+      replyTime: 9999,
+      replyContactIds: ['~remote-1', '~remote-2'],
+    });
+    await seedReply('~alfa', 1100);
+    await seedReply('~bravo', 1200);
+
+    await queries.undoOptimisticReplyBump({ parentId });
+
+    const parent = await queries.getPost({ postId: parentId });
+    expect(parent!.replyCount).toBe(4);
+    expect(parent!.replyTime).toBe(9999);
+    expect(parent!.replyContactIds).toEqual(['~remote-1', '~remote-2']);
+  });
+
+  test('replyCount never goes below 0', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedParent({ replyCount: 0 });
+
+    await queries.undoOptimisticReplyBump({ parentId });
+
+    const parent = await queries.getPost({ postId: parentId });
+    expect(parent!.replyCount).toBe(0);
+  });
+});
+
+describe('recomputeChannelLastPost', () => {
+  const channelId = 'preview-test-channel';
+
+  async function seedTopLevel(
+    id: string,
+    receivedAt: number,
+    overrides: Partial<Post> = {}
+  ) {
+    await queries.insertChannelPosts({
+      posts: [
+        {
+          id,
+          type: 'chat',
+          channelId,
+          authorId: '~zod',
+          sentAt: receivedAt,
+          receivedAt,
+          sequenceNum: receivedAt,
+          content: JSON.stringify([{ inline: [`post ${receivedAt}`] }]),
+          syncedAt: Date.now(),
+          ...overrides,
+        } as unknown as Post,
+      ],
+    });
+  }
+
+  test('repoints to the newest remaining non-deleted top-level post', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedTopLevel('post-old', 1000);
+    await seedTopLevel('post-new', 2000);
+    await queries.updateChannel({
+      id: channelId,
+      lastPostId: 'post-new',
+      lastPostAt: 2000,
+    });
+
+    await queries.deletePost('post-new');
+    await queries.recomputeChannelLastPost({ channelId });
+
+    const channel = await queries.getChannel({ id: channelId });
+    expect(channel!.lastPostId).toBe('post-old');
+    expect(channel!.lastPostAt).toBe(1000);
+  });
+
+  test('clears lastPostId / lastPostAt when no previewable posts remain', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedTopLevel('only-post', 1500);
+    await queries.updateChannel({
+      id: channelId,
+      lastPostId: 'only-post',
+      lastPostAt: 1500,
+    });
+
+    await queries.deletePost('only-post');
+    await queries.recomputeChannelLastPost({ channelId });
+
+    const channel = await queries.getChannel({ id: channelId });
+    expect(channel!.lastPostId).toBeNull();
+    expect(channel!.lastPostAt).toBeNull();
+  });
+
+  test('skips deleted and reply rows when choosing the channel head', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedTopLevel('top-old', 1000);
+    await seedTopLevel('top-new-deleted', 2000, { isDeleted: true });
+    await queries.insertChannelPosts({
+      posts: [
+        {
+          id: 'reply-newest',
+          type: 'reply',
+          parentId: 'top-old',
+          channelId,
+          authorId: '~zod',
+          sentAt: 3000,
+          receivedAt: 3000,
+          sequenceNum: 99,
+          content: JSON.stringify([{ inline: ['reply'] }]),
+          syncedAt: Date.now(),
+        } as unknown as Post,
+      ],
+    });
+
+    await queries.recomputeChannelLastPost({ channelId });
+
+    const channel = await queries.getChannel({ id: channelId });
+    expect(channel!.lastPostId).toBe('top-old');
+    expect(channel!.lastPostAt).toBe(1000);
+  });
+
+  test('also repairs parent group lastPostId / lastPostAt when the channel belongs to a group', async () => {
+    const groupId = '~zod/group-with-preview';
+    await queries.insertGroups({
+      groups: [
+        {
+          id: groupId,
+          currentUserIsMember: true,
+          currentUserIsHost: false,
+          hostUserId: '~zod',
+          lastPostId: 'to-be-replaced',
+          lastPostAt: 2000,
+        } as unknown as Parameters<
+          typeof queries.insertGroups
+        >[0]['groups'][number],
+      ],
+    });
+    await queries.insertChannels([{ id: channelId, type: 'chat', groupId }]);
+    await seedTopLevel('group-old', 1000);
+    await seedTopLevel('group-new', 2000);
+    await queries.updateChannel({
+      id: channelId,
+      lastPostId: 'group-new',
+      lastPostAt: 2000,
+    });
+
+    await queries.deletePost('group-new');
+    await queries.recomputeChannelLastPost({ channelId });
+
+    const channel = await queries.getChannel({ id: channelId });
+    expect(channel!.lastPostId).toBe('group-old');
+    expect(channel!.lastPostAt).toBe(1000);
+
+    const group = await queries.getGroup({ id: groupId });
+    expect(group!.lastPostId).toBe('group-old');
+    expect(group!.lastPostAt).toBe(1000);
+  });
+
+  test('clears parent group lastPostId / lastPostAt when no channel in the group has any previewable post', async () => {
+    const groupId = '~zod/empty-group';
+    await queries.insertGroups({
+      groups: [
+        {
+          id: groupId,
+          currentUserIsMember: true,
+          currentUserIsHost: false,
+          hostUserId: '~zod',
+          lastPostId: 'stale',
+          lastPostAt: 5000,
+        } as unknown as Parameters<
+          typeof queries.insertGroups
+        >[0]['groups'][number],
+      ],
+    });
+    await queries.insertChannels([{ id: channelId, type: 'chat', groupId }]);
+    await seedTopLevel('only-post', 3000);
+    await queries.updateChannel({
+      id: channelId,
+      lastPostId: 'only-post',
+      lastPostAt: 3000,
+    });
+
+    await queries.deletePost('only-post');
+    await queries.recomputeChannelLastPost({ channelId });
+
+    const group = await queries.getGroup({ id: groupId });
+    expect(group!.lastPostId).toBeNull();
+    expect(group!.lastPostAt).toBeNull();
+  });
+
+  test('group-head recomputation skips sibling channels with lastPostId = null even when their stale lastPostAt is newest', async () => {
+    const groupId = '~zod/group-sibling-repair';
+    const validSiblingId = 'chat/~zod/group-sibling-valid';
+    const nulledSiblingId = 'chat/~zod/group-sibling-nulled';
+    await queries.insertGroups({
+      groups: [
+        {
+          id: groupId,
+          currentUserIsMember: true,
+          currentUserIsHost: false,
+          hostUserId: '~zod',
+        } as unknown as Parameters<
+          typeof queries.insertGroups
+        >[0]['groups'][number],
+      ],
+    });
+    await queries.insertChannels([
+      { id: channelId, type: 'chat', groupId },
+      { id: validSiblingId, type: 'chat', groupId },
+      { id: nulledSiblingId, type: 'chat', groupId },
+    ]);
+
+    await seedTopLevel('channel-head', 1000);
+    await queries.updateChannel({
+      id: channelId,
+      lastPostId: 'channel-head',
+      lastPostAt: 1000,
+    });
+    await queries.insertChannelPosts({
+      posts: [
+        {
+          id: 'valid-sibling-head',
+          type: 'chat',
+          channelId: validSiblingId,
+          authorId: '~zod',
+          sentAt: 2000,
+          receivedAt: 2000,
+          sequenceNum: 2,
+          content: JSON.stringify([{ inline: ['still valid'] }]),
+          syncedAt: Date.now(),
+        } as unknown as Post,
+      ],
+    });
+    await queries.updateChannel({
+      id: validSiblingId,
+      lastPostId: 'valid-sibling-head',
+      lastPostAt: 2000,
+    });
+    await queries.updateChannel({
+      id: nulledSiblingId,
+      lastPostId: null,
+      lastPostAt: 9999,
+    });
+
+    await queries.deletePost('channel-head');
+    await queries.recomputeChannelLastPost({ channelId });
+
+    const group = await queries.getGroup({ id: groupId });
+    expect(group!.lastPostId).toBe('valid-sibling-head');
+    expect(group!.lastPostAt).toBe(2000);
+  });
 });

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -808,12 +808,13 @@ describe('undoOptimisticReplyBump', () => {
     });
   }
 
-  test('complete local cache: A -> B -> A after deleting the last A recomputes to ["B", "A"] recency', async () => {
+  test('complete local cache: A -> B -> A after deleting the last A recomputes to ["A", "B"] recency (most-recent last)', async () => {
     await queries.insertChannels([{ id: channelId, type: 'chat' }]);
     await seedParent({
       replyCount: 3,
       replyTime: 1300,
       replyContactIds: ['~bravo', '~alfa'],
+      optimisticReplyBumpCount: 1,
     });
     await seedReply('~alfa', 1100);
     await seedReply('~bravo', 1200);
@@ -824,6 +825,7 @@ describe('undoOptimisticReplyBump', () => {
     expect(parent!.replyCount).toBe(2);
     expect(parent!.replyTime).toBe(1200);
     expect(parent!.replyContactIds).toEqual(['~alfa', '~bravo']);
+    expect(parent!.optimisticReplyBumpCount).toBe(0);
   });
 
   test('partial local cache: preserves server-sourced replyTime / replyContactIds, decrements replyCount', async () => {
@@ -833,6 +835,7 @@ describe('undoOptimisticReplyBump', () => {
       replyCount: 8,
       replyTime: 9999,
       replyContactIds: serverContactIds,
+      optimisticReplyBumpCount: 1,
     });
 
     await queries.undoOptimisticReplyBump({ parentId });
@@ -841,6 +844,7 @@ describe('undoOptimisticReplyBump', () => {
     expect(parent!.replyCount).toBe(7);
     expect(parent!.replyTime).toBe(9999);
     expect(parent!.replyContactIds).toEqual(serverContactIds);
+    expect(parent!.optimisticReplyBumpCount).toBe(0);
   });
 
   test('partial local cache with alive local replies: still preserves server fields', async () => {
@@ -849,6 +853,7 @@ describe('undoOptimisticReplyBump', () => {
       replyCount: 5,
       replyTime: 9999,
       replyContactIds: ['~remote-1', '~remote-2'],
+      optimisticReplyBumpCount: 1,
     });
     await seedReply('~alfa', 1100);
     await seedReply('~bravo', 1200);
@@ -859,16 +864,43 @@ describe('undoOptimisticReplyBump', () => {
     expect(parent!.replyCount).toBe(4);
     expect(parent!.replyTime).toBe(9999);
     expect(parent!.replyContactIds).toEqual(['~remote-1', '~remote-2']);
+    expect(parent!.optimisticReplyBumpCount).toBe(0);
   });
 
   test('replyCount never goes below 0', async () => {
     await queries.insertChannels([{ id: channelId, type: 'chat' }]);
-    await seedParent({ replyCount: 0 });
+    await seedParent({ replyCount: 0, optimisticReplyBumpCount: 1 });
 
     await queries.undoOptimisticReplyBump({ parentId });
 
     const parent = await queries.getPost({ postId: parentId });
     expect(parent!.replyCount).toBe(0);
+    expect(parent!.optimisticReplyBumpCount).toBe(0);
+  });
+
+  test('server-authoritative replyMeta override clears optimistic bump tracking, so undo is a no-op', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    await seedParent({
+      replyCount: 4,
+      replyTime: 9999,
+      replyContactIds: ['~remote-1', '~remote-2', '~remote-3'],
+      optimisticReplyBumpCount: 0,
+    });
+    await seedReply('~alfa', 1100, { sequenceNum: 101 });
+    await seedReply('~bravo', 1200, { sequenceNum: 102 });
+    await seedReply('~charlie', 1300, { sequenceNum: 103 });
+
+    await queries.undoOptimisticReplyBump({ parentId });
+
+    const parent = await queries.getPost({ postId: parentId });
+    expect(parent!.replyCount).toBe(4);
+    expect(parent!.replyTime).toBe(9999);
+    expect(parent!.replyContactIds).toEqual([
+      '~remote-1',
+      '~remote-2',
+      '~remote-3',
+    ]);
+    expect(parent!.optimisticReplyBumpCount).toBe(0);
   });
 });
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3723,12 +3723,19 @@ export const addReplyToPost = createWriteQuery(
           parentPost.replyContactIds ?? [],
           replyAuthor
         );
+        // Never regress `replyTime` below the server-known value: the parent
+        // should always reflect the newest known reply time. When this is an
+        // optimistic add for a reply older than the parent's current
+        // `replyTime` (e.g., server-sourced `replyMeta` already set a newer
+        // timestamp for replies we do not have locally), keep the existing
+        // value so `undoOptimisticReplyBump` does not have to reconstruct it.
+        const derivedReplyTime = Math.max(parentPost.replyTime ?? 0, replyTime);
         return txCtx.db
           .update($posts)
           .set({
             replyCount:
               replyMeta?.replyCount ?? (parentPost.replyCount ?? 0) + 1,
-            replyTime: replyMeta?.replyTime ?? replyTime,
+            replyTime: replyMeta?.replyTime ?? derivedReplyTime,
             replyContactIds: replyMeta?.replyContactIds ?? newReplyContacts,
           })
           .where(eq($posts.id, parentId));
@@ -3736,6 +3743,161 @@ export const addReplyToPost = createWriteQuery(
     });
   },
   ['posts']
+);
+
+/**
+ * Undo the optimistic reply-summary bump after a failed reply row is removed.
+ * Recompute from local replies when the cache is complete; otherwise only
+ * decrement `replyCount` and preserve server-sourced summary fields.
+ */
+export const undoOptimisticReplyBump = createWriteQuery(
+  'undoOptimisticReplyBump',
+  async ({ parentId }: { parentId: string }, ctx: QueryCtx) => {
+    return withTransactionCtx(ctx, async (txCtx) => {
+      const parentRows = await txCtx.db
+        .select()
+        .from($posts)
+        .where(eq($posts.id, parentId));
+      const parent = parentRows[0];
+      if (!parent) return;
+
+      const aliveReplies = await txCtx.db
+        .select({
+          authorId: $posts.authorId,
+          sentAt: $posts.sentAt,
+        })
+        .from($posts)
+        .where(
+          and(
+            eq($posts.parentId, parentId),
+            or(isNull($posts.isDeleted), eq($posts.isDeleted, false))
+          )
+        );
+
+      const currentReplyCount = parent.replyCount ?? 0;
+      const aliveCount = aliveReplies.length;
+      const localCacheIsComplete = currentReplyCount === aliveCount + 1;
+
+      if (localCacheIsComplete) {
+        // Preserve the same recency semantics as the incremental path in
+        // `addReplyToPost` → `appendContactIdToReplies`: fold surviving
+        // replies in chronological order, and for each author remove any
+        // prior occurrence and re-append. Most recent distinct replier
+        // ends up at the end.
+        const sortedReplies = [...aliveReplies].sort(
+          (a, b) => (a.sentAt ?? 0) - (b.sentAt ?? 0)
+        );
+        let replyTime: number | null = null;
+        let replyContactIds: string[] = [];
+        for (const reply of sortedReplies) {
+          if (
+            reply.sentAt != null &&
+            (replyTime == null || reply.sentAt > replyTime)
+          ) {
+            replyTime = reply.sentAt;
+          }
+          if (reply.authorId) {
+            replyContactIds = appendContactIdToReplies(
+              replyContactIds,
+              reply.authorId
+            );
+          }
+        }
+        return txCtx.db
+          .update($posts)
+          .set({
+            replyCount: aliveCount,
+            replyTime,
+            replyContactIds,
+          })
+          .where(eq($posts.id, parentId));
+      }
+
+      // Partial cache: server-sourced reply summary may cover replies we
+      // never cached locally. Only undo the optimistic `+1` bump and leave
+      // `replyTime` / `replyContactIds` intact.
+      return txCtx.db
+        .update($posts)
+        .set({
+          replyCount: Math.max(currentReplyCount - 1, 0),
+        })
+        .where(eq($posts.id, parentId));
+    });
+  },
+  ['posts']
+);
+
+/**
+ * Repoint `channels.lastPostId` / `lastPostAt` to the newest remaining
+ * previewable (non-reply, non-deleted) top-level post, or null them if no
+ * such post exists. Used after a hard-delete to keep chat-list / channel
+ * preview state in sync without waiting for a sync repair.
+ */
+export const recomputeChannelLastPost = createWriteQuery(
+  'recomputeChannelLastPost',
+  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+    return withTransactionCtx(ctx, async (txCtx) => {
+      const newest = await txCtx.db
+        .select({ id: $posts.id, receivedAt: $posts.receivedAt })
+        .from($posts)
+        .where(
+          and(
+            eq($posts.channelId, channelId),
+            not(eq($posts.type, 'reply')),
+            or(isNull($posts.isDeleted), eq($posts.isDeleted, false))
+          )
+        )
+        .orderBy(desc($posts.receivedAt))
+        .limit(1);
+      const head = newest[0];
+      await txCtx.db
+        .update($channels)
+        .set({
+          lastPostId: head?.id ?? null,
+          lastPostAt: head?.receivedAt ?? null,
+        })
+        .where(eq($channels.id, channelId));
+
+      // If the channel belongs to a group, re-derive the group's
+      // `lastPostId` / `lastPostAt` from the channel with the newest
+      // updated `lastPostAt` in that group. Needed so chat-list and
+      // group-list previews stay consistent immediately after a local
+      // hard-delete, without waiting for a later sync repair.
+      const channelRow = await txCtx.db
+        .select({ groupId: $channels.groupId })
+        .from($channels)
+        .where(eq($channels.id, channelId))
+        .limit(1);
+      const groupId = channelRow[0]?.groupId;
+      if (!groupId) return;
+
+      // Only consider sibling channels that still have a valid preview.
+      // A channel can be in a stale shape where `lastPostId` has already
+      // been nulled but `lastPostAt` still carries the old timestamp; that
+      // row must not win the group-head race and blank out a sibling that
+      // still has a real preview to offer.
+      const newestGroupChannel = await txCtx.db
+        .select({
+          lastPostId: $channels.lastPostId,
+          lastPostAt: $channels.lastPostAt,
+        })
+        .from($channels)
+        .where(
+          and(eq($channels.groupId, groupId), isNotNull($channels.lastPostId))
+        )
+        .orderBy(desc($channels.lastPostAt))
+        .limit(1);
+      const groupHead = newestGroupChannel[0];
+      await txCtx.db
+        .update($groups)
+        .set({
+          lastPostId: groupHead?.lastPostId ?? null,
+          lastPostAt: groupHead?.lastPostAt ?? null,
+        })
+        .where(eq($groups.id, groupId));
+    });
+  },
+  ['channels', 'groups']
 );
 
 export const getPendingPosts = createReadQuery(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3723,6 +3723,9 @@ export const addReplyToPost = createWriteQuery(
           parentPost.replyContactIds ?? [],
           replyAuthor
         );
+        const nextOptimisticReplyBumpCount = replyMeta
+          ? 0
+          : (parentPost.optimisticReplyBumpCount ?? 0) + 1;
         // Never regress `replyTime` below the server-known value: the parent
         // should always reflect the newest known reply time. When this is an
         // optimistic add for a reply older than the parent's current
@@ -3737,6 +3740,7 @@ export const addReplyToPost = createWriteQuery(
               replyMeta?.replyCount ?? (parentPost.replyCount ?? 0) + 1,
             replyTime: replyMeta?.replyTime ?? derivedReplyTime,
             replyContactIds: replyMeta?.replyContactIds ?? newReplyContacts,
+            optimisticReplyBumpCount: nextOptimisticReplyBumpCount,
           })
           .where(eq($posts.id, parentId));
       }
@@ -3746,9 +3750,12 @@ export const addReplyToPost = createWriteQuery(
 );
 
 /**
- * Undo the optimistic reply-summary bump after a failed reply row is removed.
- * Recompute from local replies when the cache is complete; otherwise only
- * decrement `replyCount` and preserve server-sourced summary fields.
+ * Undo one optimistic reply-summary bump after a failed reply row is removed.
+ * If the parent row has already been replaced by server-authoritative
+ * `replyMeta`, the optimistic bump count is 0 and this becomes a no-op.
+ * Otherwise, recompute from local replies when the cache is complete; if the
+ * cache is partial, only decrement `replyCount` and preserve server-sourced
+ * summary fields.
  */
 export const undoOptimisticReplyBump = createWriteQuery(
   'undoOptimisticReplyBump',
@@ -3760,6 +3767,11 @@ export const undoOptimisticReplyBump = createWriteQuery(
         .where(eq($posts.id, parentId));
       const parent = parentRows[0];
       if (!parent) return;
+
+      const optimisticReplyBumpCount = parent.optimisticReplyBumpCount ?? 0;
+      if (optimisticReplyBumpCount <= 0) {
+        return;
+      }
 
       const aliveReplies = await txCtx.db
         .select({
@@ -3776,6 +3788,11 @@ export const undoOptimisticReplyBump = createWriteQuery(
 
       const currentReplyCount = parent.replyCount ?? 0;
       const aliveCount = aliveReplies.length;
+      // The deleted failed reply row has already been removed from the DB by
+      // the time this helper runs. If the local cache fully backs the parent's
+      // current reply summary, the parent should still be exactly one ahead of
+      // the surviving reply rows; other still-alive optimistic replies are
+      // already included in `aliveCount`.
       const localCacheIsComplete = currentReplyCount === aliveCount + 1;
 
       if (localCacheIsComplete) {
@@ -3809,6 +3826,7 @@ export const undoOptimisticReplyBump = createWriteQuery(
             replyCount: aliveCount,
             replyTime,
             replyContactIds,
+            optimisticReplyBumpCount: Math.max(optimisticReplyBumpCount - 1, 0),
           })
           .where(eq($posts.id, parentId));
       }
@@ -3820,6 +3838,7 @@ export const undoOptimisticReplyBump = createWriteQuery(
         .update($posts)
         .set({
           replyCount: Math.max(currentReplyCount - 1, 0),
+          optimisticReplyBumpCount: Math.max(optimisticReplyBumpCount - 1, 0),
         })
         .where(eq($posts.id, parentId));
     });

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -1109,6 +1109,9 @@ export const posts = sqliteTable(
     replyContactIds: text('reply_contact_ids', {
       mode: 'json',
     }).$type<string[]>(),
+    optimisticReplyBumpCount: integer('optimistic_reply_bump_count')
+      .notNull()
+      .default(0),
     textContent: text('text_content'),
     hasAppReference: boolean('has_app_reference'),
     hasChannelReference: boolean('has_channel_reference'),

--- a/packages/shared/src/store/postActions/postActions.test.ts
+++ b/packages/shared/src/store/postActions/postActions.test.ts
@@ -12,6 +12,7 @@ import { toPostData } from '../../logic';
 import { getClient, setupDatabaseTestSuite } from '../../test/helpers';
 import { updateSession } from '../session';
 import { setUploadState } from '../storage';
+import * as sync from '../sync';
 import { mergePendingPosts } from '../useMergePendingPosts';
 import {
   deleteFailedPost,
@@ -748,12 +749,145 @@ describe('clearing a failed optimistic post', () => {
     expect(rowAfter!.sequenceNum).toBe(5);
   });
 
-  test('deleteFailedPost() on a failed-send row removes it from the DB', async () => {
+  test('action-menu deletePost() on a failed optimistic reply removes the reply AND recomputes parent reply metadata', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 1,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+
+    const failedReply = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['failed reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+    await sync.handleAddPost(failedReply);
+
+    expect((await fetchPost(parent.id))!.replyCount).toBe(1);
+
+    await deletePost({ post: failedReply });
+
+    expect(await fetchPost(failedReply.id)).toBeUndefined();
+    const threadPosts = await db.getThreadPosts({ parentId: parent.id });
+    expect(threadPosts.map((p) => p.id)).not.toContain(failedReply.id);
+
+    const parentAfter = await fetchPost(parent.id);
+    expect(parentAfter!.replyCount).toBe(0);
+    expect(parentAfter!.replyTime).toBeNull();
+    expect(parentAfter!.replyContactIds).toEqual([]);
+  });
+
+  test('deleteFailedPost on a failed-send row removes it from the DB', async () => {
     const post = await seedFailedOptimisticPost();
 
     await deleteFailedPost({ post });
 
     expect(await fetchPost(post.id)).toBeUndefined();
+  });
+
+  test('deleteFailedPost on a failed-send reply removes the reply AND restores parent reply metadata', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 1,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+
+    const failedReply = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['failed reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+
+    await sync.handleAddPost(failedReply);
+
+    const parentBefore = await fetchPost(parent.id);
+    expect(parentBefore!.replyCount).toBe(1);
+    expect(parentBefore!.replyTime).toBe(failedReply.sentAt);
+    expect(parentBefore!.replyContactIds).toEqual(['~zod']);
+
+    await deleteFailedPost({ post: failedReply });
+
+    expect(await fetchPost(failedReply.id)).toBeUndefined();
+    const threadPosts = await db.getThreadPosts({ parentId: parent.id });
+    expect(threadPosts.map((p) => p.id)).not.toContain(failedReply.id);
+
+    const parentAfter = await fetchPost(parent.id);
+    expect(parentAfter!.replyCount).toBe(0);
+    expect(parentAfter!.replyTime).toBeNull();
+    expect(parentAfter!.replyContactIds).toEqual([]);
+  });
+
+  test('deleteFailedPost on a failed reply leaves sibling reply metadata intact on the parent', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 1,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+
+    const survivingReply = {
+      ...db.buildPost({
+        authorId: '~bus',
+        author: null,
+        channel,
+        sequenceNum: 2,
+        content: [{ inline: ['kept reply'] }],
+        deliveryStatus: 'sent',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+    await sync.handleAddPost(survivingReply);
+
+    const failedReply = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['failed reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+      sentAt: survivingReply.sentAt + 1000,
+    };
+    await sync.handleAddPost(failedReply);
+
+    await deleteFailedPost({ post: failedReply });
+
+    const parentAfter = await fetchPost(parent.id);
+    expect(parentAfter!.replyCount).toBe(1);
+    expect(parentAfter!.replyTime).toBe(survivingReply.sentAt);
+    expect(parentAfter!.replyContactIds).toEqual(['~bus']);
   });
 
   test('deleted failed optimistic rows are excluded from the live merge even when filterDeleted is false', async () => {
@@ -807,6 +941,264 @@ describe('clearing a failed optimistic post', () => {
     }
   );
 
+  test('clearing a failed top-level post repoints channel preview to the previous previewable post', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const previous = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 5,
+      content: [{ inline: ['previous previewable post'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [previous] });
+
+    await db.updateChannel({
+      id: TEST_CHANNEL,
+      lastPostId: previous.id,
+      lastPostAt: previous.receivedAt,
+    });
+
+    const failed = await seedFailedOptimisticPost();
+
+    await deletePost({ post: failed });
+
+    const chan = await db.getChannel({ id: TEST_CHANNEL });
+    expect(chan!.lastPostId).toBe(previous.id);
+    expect(chan!.lastPostAt).toBe(previous.receivedAt);
+  });
+
+  test('clearing a failed top-level post nulls channel preview when no previewable post remains', async () => {
+    const failed = await seedFailedOptimisticPost();
+    await db.updateChannel({
+      id: TEST_CHANNEL,
+      lastPostId: failed.id,
+      lastPostAt: failed.receivedAt,
+    });
+
+    await deletePost({ post: failed });
+
+    const chan = await db.getChannel({ id: TEST_CHANNEL });
+    expect(chan!.lastPostId).toBeNull();
+    expect(chan!.lastPostAt).toBeNull();
+  });
+
+  test('clearing a failed reply does NOT touch the channel preview fields', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 3,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+    await db.updateChannel({
+      id: TEST_CHANNEL,
+      lastPostId: parent.id,
+      lastPostAt: parent.receivedAt,
+    });
+
+    const failedReply = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['failed reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+    await sync.handleAddPost(failedReply);
+
+    await deletePost({ post: failedReply });
+
+    const chan = await db.getChannel({ id: TEST_CHANNEL });
+    expect(chan!.lastPostId).toBe(parent.id);
+    expect(chan!.lastPostAt).toBe(parent.receivedAt);
+  });
+
+  test('clearing a failed reply against a partial thread cache preserves server-known reply summary', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 3,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+
+    const serverReplyTime = Date.now() + 60_000;
+    const serverContacts = ['~remote-1', '~remote-2'];
+    await db.updatePost({
+      id: parent.id,
+      replyCount: 8,
+      replyTime: serverReplyTime,
+      replyContactIds: serverContacts,
+    });
+
+    const failedReply = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['failed reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+    await sync.handleAddPost(failedReply);
+    const parentBefore = await fetchPost(parent.id);
+    expect(parentBefore!.replyCount).toBe(9);
+    expect(parentBefore!.replyTime).toBe(serverReplyTime);
+    expect(parentBefore!.replyContactIds).toEqual([...serverContacts, '~zod']);
+
+    await deletePost({ post: failedReply });
+
+    const parentAfter = await fetchPost(parent.id);
+    expect(parentAfter!.replyCount).toBe(8);
+    expect(parentAfter!.replyTime).toBe(serverReplyTime);
+    expect(parentAfter!.replyContactIds).toEqual([...serverContacts, '~zod']);
+  });
+
+  test('clearing a failed top-level post in a grouped channel repairs both channel and parent group preview', async () => {
+    const GROUP_ID = '~zod/group-preview-repair';
+    const GROUPED_CHANNEL_ID = 'chat/~zod/group-preview-channel';
+    await db.insertGroups({
+      groups: [
+        {
+          id: GROUP_ID,
+          currentUserIsMember: true,
+          currentUserIsHost: false,
+          hostUserId: '~zod',
+          lastPostId: 'seeded-stale',
+          lastPostAt: 2000,
+        } as unknown as Parameters<typeof db.insertGroups>[0]['groups'][number],
+      ],
+    });
+    await db.insertChannels([
+      db.buildChannel({
+        id: GROUPED_CHANNEL_ID,
+        type: 'chat',
+        groupId: GROUP_ID,
+      }),
+    ]);
+    const groupedChannel = (await db.getChannel({ id: GROUPED_CHANNEL_ID }))!;
+
+    const previous = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel: groupedChannel,
+      sequenceNum: 5,
+      content: [{ inline: ['previous previewable post'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [previous] });
+    await db.updateChannel({
+      id: GROUPED_CHANNEL_ID,
+      lastPostId: previous.id,
+      lastPostAt: previous.receivedAt,
+    });
+
+    const failed = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel: groupedChannel,
+      sequenceNum: 0,
+      content: [{ inline: [friendlyUniqueString()] }],
+      deliveryStatus: 'failed',
+    });
+    await db.insertChannelPosts({ posts: [failed] });
+
+    await deletePost({ post: failed });
+
+    const chan = await db.getChannel({ id: GROUPED_CHANNEL_ID });
+    expect(chan!.lastPostId).toBe(previous.id);
+    expect(chan!.lastPostAt).toBe(previous.receivedAt);
+
+    const group = await db.getGroup({ id: GROUP_ID });
+    expect(group!.lastPostId).toBe(previous.id);
+    expect(group!.lastPostAt).toBe(previous.receivedAt);
+  });
+
+  test('clearing a failed reply in a grouped channel does NOT disturb parent group last-post metadata', async () => {
+    const GROUP_ID = '~zod/group-reply-isolate';
+    const GROUPED_CHANNEL_ID = 'chat/~zod/group-reply-channel';
+    await db.insertGroups({
+      groups: [
+        {
+          id: GROUP_ID,
+          currentUserIsMember: true,
+          currentUserIsHost: false,
+          hostUserId: '~zod',
+        } as unknown as Parameters<typeof db.insertGroups>[0]['groups'][number],
+      ],
+    });
+    await db.insertChannels([
+      db.buildChannel({
+        id: GROUPED_CHANNEL_ID,
+        type: 'chat',
+        groupId: GROUP_ID,
+      }),
+    ]);
+    const groupedChannel = (await db.getChannel({ id: GROUPED_CHANNEL_ID }))!;
+
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel: groupedChannel,
+      sequenceNum: 4,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+    await db.updateChannel({
+      id: GROUPED_CHANNEL_ID,
+      lastPostId: parent.id,
+      lastPostAt: parent.receivedAt,
+    });
+    await db.insertGroups({
+      groups: [
+        {
+          id: GROUP_ID,
+          currentUserIsMember: true,
+          currentUserIsHost: false,
+          hostUserId: '~zod',
+          lastPostId: parent.id,
+          lastPostAt: parent.receivedAt,
+        } as unknown as Parameters<typeof db.insertGroups>[0]['groups'][number],
+      ],
+    });
+
+    const failedReply = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel: groupedChannel,
+        sequenceNum: 0,
+        content: [{ inline: ['failed reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+    await sync.handleAddPost(failedReply);
+
+    const groupBefore = await db.getGroup({ id: GROUP_ID });
+    await deletePost({ post: failedReply });
+    const groupAfter = await db.getGroup({ id: GROUP_ID });
+
+    expect(groupAfter!.lastPostId).toBe(groupBefore!.lastPostId);
+    expect(groupAfter!.lastPostAt).toBe(groupBefore!.lastPostAt);
+  });
+
   test('deletePost() re-reads the DB row before hard-delete classification', async () => {
     const post = await seedFailedOptimisticPost();
     const staleSnapshot: db.Post = {
@@ -841,5 +1233,82 @@ describe('clearing a failed optimistic post', () => {
     const rowAfter = await fetchPost(post.id);
     expect(rowAfter).toBeTruthy();
     expect(rowAfter!.sequenceNum).toBe(42);
+  });
+
+  test('deletePost() is a no-op when the row is already gone; does not re-run clearUnsentPost on stale snapshot', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 3,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+    await db.updatePost({
+      id: parent.id,
+      replyCount: 5,
+      replyTime: 9999,
+      replyContactIds: ['~alfa', '~bravo'],
+    });
+
+    const staleReplySnapshot: db.Post = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['ghost reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+    await deletePost({ post: staleReplySnapshot });
+
+    const parentAfter = await fetchPost(parent.id);
+    expect(parentAfter!.replyCount).toBe(5);
+    expect(parentAfter!.replyTime).toBe(9999);
+    expect(parentAfter!.replyContactIds).toEqual(['~alfa', '~bravo']);
+  });
+
+  test('deleteFailedPost() is a no-op when the row is already gone', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const parent = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 3,
+      content: [{ inline: ['parent'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [parent] });
+    await db.updatePost({
+      id: parent.id,
+      replyCount: 5,
+      replyTime: 9999,
+      replyContactIds: ['~alfa', '~bravo'],
+    });
+
+    const staleReplySnapshot: db.Post = {
+      ...db.buildPost({
+        authorId: '~zod',
+        author: null,
+        channel,
+        sequenceNum: 0,
+        content: [{ inline: ['ghost reply'] }],
+        deliveryStatus: 'failed',
+        parentId: parent.id,
+      }),
+      type: 'reply' as const,
+    };
+
+    await deleteFailedPost({ post: staleReplySnapshot });
+
+    const parentAfter = await fetchPost(parent.id);
+    expect(parentAfter!.replyCount).toBe(5);
+    expect(parentAfter!.replyTime).toBe(9999);
+    expect(parentAfter!.replyContactIds).toEqual(['~alfa', '~bravo']);
   });
 });

--- a/packages/shared/src/store/postActions/postActions.ts
+++ b/packages/shared/src/store/postActions/postActions.ts
@@ -700,6 +700,20 @@ function isUnsentOptimisticRow(post: db.Post): boolean {
 async function clearUnsentPost(post: db.Post) {
   deleteFromChannelPosts(post);
   await db.deletePost(post.id);
+  if (post.parentId) {
+    // Optimistic reply creation bumps the parent's replyCount / replyTime /
+    // replyContactIds via `addReplyToPost`. Undo that bump, but do not
+    // clobber server-sourced reply summary state if the local thread cache
+    // is only partial. Replies are not channel-head posts, so leave
+    // `channels.lastPostId` / `lastPostAt` alone.
+    await db.undoOptimisticReplyBump({ parentId: post.parentId });
+    return;
+  }
+  // Top-level post: repoint the channel head to the newest remaining
+  // previewable post (or null it consistently if none remain) so the
+  // chat list and channel preview stay in sync without waiting for a
+  // later sync repair.
+  await db.recomputeChannelLastPost({ channelId: post.channelId });
 }
 
 export async function deletePost({ post }: { post: db.Post }) {
@@ -717,7 +731,10 @@ export async function deletePost({ post }: { post: db.Post }) {
   const existingPost = await db.getPost({ postId: post.id });
 
   // If the row is already gone — e.g. this is a duplicate Delete fired
-  // against a stale UI snapshot — there is nothing to do.
+  // against a stale UI snapshot — there is nothing to do. In particular,
+  // do NOT run `clearUnsentPost()` against the stale snapshot: it would
+  // attempt another `undoOptimisticReplyBump()` pass and corrupt parent
+  // reply metadata we already cleaned up.
   if (!existingPost) {
     logger.crumb('deletePost: row already gone, no-op');
     return;
@@ -727,7 +744,8 @@ export async function deletePost({ post }: { post: db.Post }) {
   // including a failed optimistic row that never reached the server. For
   // that exact shape, skip the server round trip and hard-delete locally —
   // otherwise we'd leave a ghost with `isDeleted: true` + `sequenceNum: 0`
-  // pinned at the bottom of chat-style scrollers.
+  // pinned at the bottom of chat-style scrollers, and for replies we'd also
+  // leave the parent's reply summary stale.
   if (isUnsentOptimisticRow(existingPost)) {
     await clearUnsentPost(existingPost);
     return;
@@ -781,7 +799,8 @@ export async function deleteFailedPost({ post }: { post: db.Post }) {
   // Re-read before classifying — the retry-sheet caller may hold a stale
   // snapshot (e.g. after `retrySendPost()` flipped the row back to
   // `enqueued`). Only authoritative DB state should drive the hard-delete
-  // decision. If the row is already gone, do nothing.
+  // decision. If the row is already gone, do nothing — a duplicate delete
+  // fired from stale UI state must not re-run `undoOptimisticReplyBump`.
   const existingPost = await db.getPost({ postId: post.id });
   if (!existingPost) {
     logger.crumb('deleteFailedPost: row already gone, no-op');


### PR DESCRIPTION
## Summary

Builds on PR #5746 by repairing the local metadata that a hard-delete now owns.

When a truly unsent failed optimistic row is cleared:

- failed optimistic replies now repair the parent post's reply summary
- failed optimistic top-level posts now repair the channel preview
- grouped channels also repair the parent group's preview

This PR is intentionally scoped to reply / preview cleanup. It does **not** change pending-vs-delivery query semantics, catch-up-window behavior, or delivery polling. Those are split into PR 3.

## Root cause

PR #5746 fixes the primary TLON-5606 ghost by hard-deleting a truly local-only failed optimistic row. Once that row is physically removed, there is no later soft-delete or sync path left to clean up the derived metadata that the optimistic insert already touched.

- optimistic replies bump the parent post's `replyCount`, `replyTime`, and `replyContactIds`
- clearing that failed optimistic reply must undo the bump without clobbering server-sourced reply metadata
- clearing the newest failed optimistic top-level post can also leave `channels.lastPostId` / `lastPostAt` stale
- when that channel belongs to a group, the group card preview can go stale too

## Changes

All changes are in `packages/shared`:

- Updated `addReplyToPost()` in [packages/shared/src/db/queries.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.ts:3723) so an older optimistic reply cannot regress a newer server-known `replyTime`.
- Added `undoOptimisticReplyBump()` in [packages/shared/src/db/queries.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.ts:3745).
  - complete-cache case: recompute `replyCount`, `replyTime`, and `replyContactIds` from surviving replies
  - partial-cache case: decrement only `replyCount` and preserve server-sourced summary fields
- Added `recomputeChannelLastPost()` in [packages/shared/src/db/queries.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.ts:3837) to repoint channel preview metadata and, when applicable, the parent group preview metadata.
- Updated `clearUnsentPost()` in [packages/shared/src/store/postActions/postActions.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/postActions/postActions.ts:700) so:
  - reply clears call `undoOptimisticReplyBump()`
  - top-level clears call `recomputeChannelLastPost()`
- `addReplyToPost()` now tracks `optimisticReplyBumpCount` on the parent post for local optimistic reply-summary bumps, and clears that count when server-authoritative `replyMeta` arrives.
- `undoOptimisticReplyBump()` now no-ops if the parent summary has already been overwritten by server-authoritative reply metadata, instead of trying to infer that only from `replyCount === aliveCount + 1`.

## Explicitly Deferred To PR 3

- splitting UI-pending vs delivery-pending query semantics
- catch-up-window handling for `sent + sequenceNum === 0`
- mid-flight delete behavior for `enqueued` / `pending` rows
- any `syncChannelWithBackoff()` changes
- any `useMergePendingPosts()` deleted-overlay behavior beyond PR #5746's local failed-row suppression

## How did I test?

- `pnpm --filter @tloncorp/shared test run src/db/queries.test.ts src/store/postActions/postActions.test.ts`

Covered by tests in:

- [packages/shared/src/db/queries.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.test.ts)
- [packages/shared/src/store/postActions/postActions.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/postActions/postActions.test.ts)

The current test coverage focuses on:

- complete-cache vs partial-cache reply-summary repair
- failed optimistic reply deletion through both `deletePost()` and `deleteFailedPost()`
- channel preview recomputation after clearing the newest failed optimistic top-level post
- parent group preview recomputation for grouped channels
- duplicate-delete no-op behavior so stale UI actions do not double-apply reply cleanup

Manual verification has not been done in this split branch yet.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] State / providers
  - [x] Message sync
  - [x] Channel display

Main caveat:

- In the partial-cache reply-summary case, `replyContactIds` remains best-effort until the next thread sync. This PR preserves server-known summary fields instead of trying to synthesize a complete local view from incomplete data.

## Rollback plan

Revert.