### PR TITLE
chat: TLON-5606 split UI-pending and delivery-pending message handling (3/3)

### DIFF
--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -232,8 +232,10 @@ export default function ChannelScreen(props: Props) {
 
   const filteredPosts = useMemo(
     () =>
-      channel?.type !== 'chat' ? posts?.filter((p) => !p.isDeleted) : posts,
-    [posts, channel]
+      channelConfiguration?.includeDeletedPosts
+        ? posts
+        : posts?.filter((p) => !p.isDeleted),
+    [posts, channelConfiguration?.includeDeletedPosts]
   );
   usePushNotifTapTelemetry({
     channelId: currentChannelId,

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -760,6 +760,148 @@ test('setJoinedGroupChannels: does not reset membership for channels not in the 
   }
 });
 
+// TLON-5606: `getPendingPosts` feeds the main-channel pending-merge layer.
+// Once a failed optimistic row is marked deleted, it must not come back as a
+// "pending" row and ghost the bottom of the chat scroller.
+describe('getPendingPosts', () => {
+  const channelId = 'pending-test-channel';
+  const authorId = '~zod';
+
+  async function seedPost(overrides: Partial<Post>): Promise<Post> {
+    const base: Post = {
+      id: `post-${overrides.sentAt ?? Date.now()}-${Math.random()}`,
+      type: 'chat',
+      channelId,
+      authorId,
+      sentAt: Date.now(),
+      receivedAt: Date.now(),
+      sequenceNum: 0,
+      content: JSON.stringify([{ inline: ['seed'] }]),
+      syncedAt: Date.now(),
+      ...overrides,
+    } as Post;
+    await queries.insertChannelPosts({ posts: [base] });
+    return base;
+  }
+
+  test('includes optimistic enqueued and pending rows', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const enqueued = await seedPost({
+      id: 'enq',
+      deliveryStatus: 'enqueued',
+      isDeleted: false,
+    });
+    const pending = await seedPost({
+      id: 'pend',
+      deliveryStatus: 'pending',
+      isDeleted: false,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).toEqual(expect.arrayContaining([enqueued.id, pending.id]));
+  });
+
+  test('includes failed rows that have not been cleared (Retry sheet must surface these)', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const failed = await seedPost({
+      id: 'failed',
+      deliveryStatus: 'failed',
+      isDeleted: false,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).toContain(failed.id);
+  });
+
+  test('excludes truly local-only deleted failed sends (TLON-5606 ghost-row fix)', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const failedCleared = await seedPost({
+      id: 'failed-cleared',
+      deliveryStatus: 'failed',
+      isDeleted: true,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).not.toContain(failedCleared.id);
+  });
+
+  test('includes deleted markPostSent / needs_verification rows so the remount path still has a tombstone source', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    // `markPostSent` catch-up: server already acknowledged, sequenced
+    // `addPost` hasn't arrived yet, and the user deleted in the gap.
+    const sentCatchUp = await seedPost({
+      id: 'sent-catchup',
+      deliveryStatus: 'sent',
+      sequenceNum: 0,
+      isDeleted: true,
+    });
+    // `needs_verification` may also have reached the server.
+    const verifyCleared = await seedPost({
+      id: 'verify-cleared',
+      deliveryStatus: 'needs_verification',
+      sequenceNum: 0,
+      isDeleted: true,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([sentCatchUp.id, verifyCleared.id])
+    );
+  });
+
+  test('includes deleted in-flight rows (enqueued / pending) so the tombstone stays visible while delivery polling resolves', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const enqueuedCleared = await seedPost({
+      id: 'enqueued-cleared',
+      deliveryStatus: 'enqueued',
+      sequenceNum: 0,
+      isDeleted: true,
+    });
+    const pendingCleared = await seedPost({
+      id: 'pending-cleared',
+      deliveryStatus: 'pending',
+      sequenceNum: 0,
+      isDeleted: true,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([enqueuedCleared.id, pendingCleared.id])
+    );
+  });
+
+  test('excludes confirmed rows (null deliveryStatus) regardless of isDeleted', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const confirmed = await seedPost({
+      id: 'confirmed',
+      sequenceNum: 5,
+      deliveryStatus: null,
+      isDeleted: false,
+    });
+    const confirmedTombstone = await seedPost({
+      id: 'confirmed-tombstone',
+      sequenceNum: 6,
+      deliveryStatus: null,
+      isDeleted: true,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).not.toContain(confirmed.id);
+    expect(ids).not.toContain(confirmedTombstone.id);
+  });
+
+  test('excludes replies regardless of isDeleted', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const reply = await seedPost({
+      id: 'reply',
+      type: 'reply',
+      parentId: 'some-parent',
+      deliveryStatus: 'pending',
+      isDeleted: false,
+    });
+    const ids = (await queries.getPendingPosts(channelId)).map((p) => p.id);
+    expect(ids).not.toContain(reply.id);
+  });
+});
+
+// TLON-5606: `undoOptimisticReplyBump` must undo a single optimistic reply
+// add without clobbering server-sourced reply summary state. Two regimes:
+// complete local cache → full recompute; partial local cache → decrement
+// only.
 describe('undoOptimisticReplyBump', () => {
   const channelId = 'undo-reply-bump-channel';
   const parentId = 'undo-reply-bump-parent';
@@ -810,6 +952,10 @@ describe('undoOptimisticReplyBump', () => {
 
   test('complete local cache: A -> B -> A after deleting the last A recomputes to ["A", "B"] recency (most-recent last)', async () => {
     await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    // The third A has already been hard-deleted by the caller. At this
+    // point the parent still reflects the pre-delete count (3) because
+    // `addReplyToPost` incremented it. `aliveCount + 1 === replyCount`
+    // means we are in the complete-cache regime.
     await seedParent({
       replyCount: 3,
       replyTime: 1300,
@@ -824,12 +970,40 @@ describe('undoOptimisticReplyBump', () => {
     const parent = await queries.getPost({ postId: parentId });
     expect(parent!.replyCount).toBe(2);
     expect(parent!.replyTime).toBe(1200);
+    // Surviving A@1100, B@1200 → appendContactIdToReplies semantics yield
+    // ['~alfa', '~bravo'] (most recent at the end, not the clobbered
+    // pre-delete ordering).
+    expect(parent!.replyContactIds).toEqual(['~alfa', '~bravo']);
+  });
+
+  test('complete local cache: recompute preserves recency semantics after undo', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    // Parent's replyCount = aliveCount + 1 → complete regime.
+    await seedParent({
+      replyCount: 3,
+      replyTime: 1300,
+      replyContactIds: ['~alfa', '~bravo'],
+      optimisticReplyBumpCount: 1,
+    });
+    // Surviving replies after the failed-optimistic delete, in chronological
+    // order: alfa @1100, bravo @1200. Recompute must yield ['~alfa', '~bravo'].
+    await seedReply('~alfa', 1100);
+    await seedReply('~bravo', 1200);
+
+    await queries.undoOptimisticReplyBump({ parentId });
+
+    const parent = await queries.getPost({ postId: parentId });
+    expect(parent!.replyCount).toBe(2);
+    expect(parent!.replyTime).toBe(1200);
     expect(parent!.replyContactIds).toEqual(['~alfa', '~bravo']);
     expect(parent!.optimisticReplyBumpCount).toBe(0);
   });
 
   test('partial local cache: preserves server-sourced replyTime / replyContactIds, decrements replyCount', async () => {
     await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    // Server says 8 replies. Only 1 is locally cached — the one we are
+    // about to pretend we just hard-deleted. After delete, aliveCount === 0.
+    // The parent still carries server-known replyTime / replyContactIds.
     const serverContactIds = ['~remote-1', '~remote-2', '~remote-3'];
     await seedParent({
       replyCount: 8,
@@ -837,11 +1011,15 @@ describe('undoOptimisticReplyBump', () => {
       replyContactIds: serverContactIds,
       optimisticReplyBumpCount: 1,
     });
+    // No local replies — simulating the one local reply having just been
+    // hard-deleted by `clearUnsentPost`.
 
     await queries.undoOptimisticReplyBump({ parentId });
 
     const parent = await queries.getPost({ postId: parentId });
+    // Count decremented by 1 (undoes the optimistic +1 from addReplyToPost).
     expect(parent!.replyCount).toBe(7);
+    // Server-sourced fields left intact.
     expect(parent!.replyTime).toBe(9999);
     expect(parent!.replyContactIds).toEqual(serverContactIds);
     expect(parent!.optimisticReplyBumpCount).toBe(0);
@@ -855,6 +1033,9 @@ describe('undoOptimisticReplyBump', () => {
       replyContactIds: ['~remote-1', '~remote-2'],
       optimisticReplyBumpCount: 1,
     });
+    // 2 local undeleted replies. The parent's replyCount (5) is greater
+    // than aliveCount (2) + 1 (the deleted one) = 3, so we're still in the
+    // partial regime.
     await seedReply('~alfa', 1100);
     await seedReply('~bravo', 1200);
 
@@ -904,6 +1085,8 @@ describe('undoOptimisticReplyBump', () => {
   });
 });
 
+// TLON-5606: `recomputeChannelLastPost` must repoint `lastPostId` and
+// `lastPostAt` to the newest previewable top-level post after a hard delete.
 describe('recomputeChannelLastPost', () => {
   const channelId = 'preview-test-channel';
 
@@ -940,6 +1123,7 @@ describe('recomputeChannelLastPost', () => {
       lastPostAt: 2000,
     });
 
+    // Simulate the hard-delete of post-new (caller removed the row first).
     await queries.deletePost('post-new');
     await queries.recomputeChannelLastPost({ channelId });
 
@@ -989,6 +1173,7 @@ describe('recomputeChannelLastPost', () => {
     await queries.recomputeChannelLastPost({ channelId });
 
     const channel = await queries.getChannel({ id: channelId });
+    // Skips reply-newest (reply) and top-new-deleted (isDeleted=true).
     expect(channel!.lastPostId).toBe('top-old');
     expect(channel!.lastPostAt).toBe(1000);
   });
@@ -1018,6 +1203,7 @@ describe('recomputeChannelLastPost', () => {
       lastPostAt: 2000,
     });
 
+    // Hard-delete the newest post, then recompute.
     await queries.deletePost('group-new');
     await queries.recomputeChannelLastPost({ channelId });
 
@@ -1026,6 +1212,7 @@ describe('recomputeChannelLastPost', () => {
     expect(channel!.lastPostAt).toBe(1000);
 
     const group = await queries.getGroup({ id: groupId });
+    // Group last-post metadata must follow the channel head back down.
     expect(group!.lastPostId).toBe('group-old');
     expect(group!.lastPostAt).toBe(1000);
   });
@@ -1084,12 +1271,14 @@ describe('recomputeChannelLastPost', () => {
       { id: nulledSiblingId, type: 'chat', groupId },
     ]);
 
+    // Seed the channel we're about to delete from.
     await seedTopLevel('channel-head', 1000);
     await queries.updateChannel({
       id: channelId,
       lastPostId: 'channel-head',
       lastPostAt: 1000,
     });
+    // Valid sibling still has a real preview.
     await queries.insertChannelPosts({
       posts: [
         {
@@ -1110,17 +1299,155 @@ describe('recomputeChannelLastPost', () => {
       lastPostId: 'valid-sibling-head',
       lastPostAt: 2000,
     });
+    // Nulled sibling still carries a stale newer `lastPostAt` but its
+    // `lastPostId` is already null. This is the exact shape prior delete
+    // paths can leave behind.
     await queries.updateChannel({
       id: nulledSiblingId,
       lastPostId: null,
       lastPostAt: 9999,
     });
 
+    // Delete the head on `channelId`, then recompute.
     await queries.deletePost('channel-head');
     await queries.recomputeChannelLastPost({ channelId });
 
     const group = await queries.getGroup({ id: groupId });
+    // Must pick the valid sibling's preview, NOT the stale
+    // `{ lastPostId: null, lastPostAt: 9999 }` from the nulled sibling.
     expect(group!.lastPostId).toBe('valid-sibling-head');
     expect(group!.lastPostAt).toBe(2000);
+  });
+});
+
+// TLON-5606: the delivery-polling query must keep in-flight rows visible
+// even when the user has locally cleared them, so the backoff can still
+// reconcile against the server. `failed` and `needs_verification` are
+// handled separately and should not drive the delivery loop.
+describe('getDeliveryPendingPosts', () => {
+  const channelId = 'delivery-test-channel';
+
+  async function seedPost(overrides: Partial<Post>) {
+    const base: Post = {
+      id: `d-${overrides.id ?? Math.random()}`,
+      type: 'chat',
+      channelId,
+      authorId: '~zod',
+      sentAt: Date.now(),
+      receivedAt: Date.now(),
+      sequenceNum: 0,
+      content: JSON.stringify([{ inline: ['seed'] }]),
+      syncedAt: Date.now(),
+      ...overrides,
+    } as Post;
+    await queries.insertChannelPosts({ posts: [base] });
+    return base;
+  }
+
+  test('includes enqueued and pending rows regardless of isDeleted', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const enqueuedLive = await seedPost({
+      id: 'enq-live',
+      deliveryStatus: 'enqueued',
+      isDeleted: false,
+    });
+    const enqueuedCleared = await seedPost({
+      id: 'enq-cleared',
+      deliveryStatus: 'enqueued',
+      isDeleted: true,
+    });
+    const pendingLive = await seedPost({
+      id: 'pend-live',
+      deliveryStatus: 'pending',
+      isDeleted: false,
+    });
+    const pendingCleared = await seedPost({
+      id: 'pend-cleared',
+      deliveryStatus: 'pending',
+      isDeleted: true,
+    });
+
+    const ids = (await queries.getDeliveryPendingPosts(channelId)).map(
+      (p) => p.id
+    );
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        enqueuedLive.id,
+        enqueuedCleared.id,
+        pendingLive.id,
+        pendingCleared.id,
+      ])
+    );
+  });
+
+  test('excludes failed and needs_verification rows', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const failedRow = await seedPost({
+      id: 'failed-row',
+      deliveryStatus: 'failed',
+      isDeleted: false,
+    });
+    const verifyRow = await seedPost({
+      id: 'verify-row',
+      deliveryStatus: 'needs_verification',
+      isDeleted: false,
+    });
+
+    const ids = (await queries.getDeliveryPendingPosts(channelId)).map(
+      (p) => p.id
+    );
+    expect(ids).not.toContain(failedRow.id);
+    expect(ids).not.toContain(verifyRow.id);
+  });
+
+  test('excludes replies and confirmed rows', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const reply = await seedPost({
+      id: 'reply',
+      type: 'reply',
+      parentId: 'parent',
+      deliveryStatus: 'pending',
+      isDeleted: false,
+    });
+    const confirmed = await seedPost({
+      id: 'confirmed',
+      sequenceNum: 5,
+      deliveryStatus: null,
+      isDeleted: false,
+    });
+
+    const ids = (await queries.getDeliveryPendingPosts(channelId)).map(
+      (p) => p.id
+    );
+    expect(ids).not.toContain(reply.id);
+    expect(ids).not.toContain(confirmed.id);
+  });
+
+  test('includes markPostSent catch-up rows (sent + sequenceNum === 0) so the backoff keeps polling', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const catchUp = await seedPost({
+      id: 'sent-catchup',
+      deliveryStatus: 'sent',
+      sequenceNum: 0,
+      isDeleted: false,
+    });
+    const ids = (await queries.getDeliveryPendingPosts(channelId)).map(
+      (p) => p.id
+    );
+    expect(ids).toContain(catchUp.id);
+  });
+
+  test('excludes sequenced sent rows (the sequenced addPost has already reconciled the row)', async () => {
+    await queries.insertChannels([{ id: channelId, type: 'chat' }]);
+    const reconciled = await seedPost({
+      id: 'sent-reconciled',
+      deliveryStatus: 'sent',
+      sequenceNum: 42,
+      isDeleted: false,
+    });
+    const ids = (await queries.getDeliveryPendingPosts(channelId)).map(
+      (p) => p.id
+    );
+    expect(ids).not.toContain(reconciled.id);
   });
 });

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -3750,12 +3750,36 @@ export const addReplyToPost = createWriteQuery(
 );
 
 /**
- * Undo one optimistic reply-summary bump after a failed reply row is removed.
- * If the parent row has already been replaced by server-authoritative
- * `replyMeta`, the optimistic bump count is 0 and this becomes a no-op.
- * Otherwise, recompute from local replies when the cache is complete; if the
- * cache is partial, only decrement `replyCount` and preserve server-sourced
- * summary fields.
+ * Undo a single optimistic reply bump on a parent post after the optimistic
+ * reply row has been hard-deleted.
+ *
+ * This is the inverse of the optimistic side of `addReplyToPost` (which
+ * increments `replyCount`, sets `replyTime`, and appends to
+ * `replyContactIds` when the caller does not provide server-sourced
+ * `replyMeta`).
+ *
+ * Server-authoritative `replyMeta` updates reset `optimisticReplyBumpCount`
+ * to 0. When that has already happened, this helper becomes a no-op: the
+ * parent's reply summary no longer includes the failed local reply.
+ *
+ * Otherwise there are two regimes:
+ *
+ * 1. **Local cache is complete** — the parent's `replyCount` equals the
+ *    number of local undeleted replies + 1 (the one we just deleted). In
+ *    that case the local rows are authoritative and we can recompute all
+ *    three fields from them, using `appendContactIdToReplies` so ordering
+ *    matches the incremental path.
+ *
+ * 2. **Local cache is partial** — the parent's `replyCount` is larger than
+ *    (local undeleted replies + 1). That means the parent carries
+ *    server-sourced `replyMeta` for replies we have not cached locally.
+ *    We decrement `replyCount` by 1 (the optimistic +1 we applied at send
+ *    time) and leave `replyTime` / `replyContactIds` untouched so we do
+ *    not collapse server-known thread summary to a partial local view.
+ *
+ * Caller must have already removed the deleted reply row from the `posts`
+ * table before invoking this helper; the "alive replies" count is taken
+ * from the current DB state.
  */
 export const undoOptimisticReplyBump = createWriteQuery(
   'undoOptimisticReplyBump',
@@ -3926,7 +3950,59 @@ export const getPendingPosts = createReadQuery(
       where: and(
         eq($posts.channelId, channelId),
         isNotNull($posts.deliveryStatus),
-        not(eq($posts.type, 'reply'))
+        not(eq($posts.type, 'reply')),
+        // Exclude only truly local-only deleted sends. Deleted rows whose
+        // `deliveryStatus` is `'sent'` or `'needs_verification'` may still
+        // be server-backed but not yet sequenced; keep them as a DB-backed
+        // tombstone source so the channel remount path still renders them
+        // before the sequenced `addPost` arrives. Enqueued / pending rows
+        // are still in-flight and also remain visible — they either reach
+        // `'sent'` (stay as tombstone) or `'failed'` (vanish on next tick).
+        //
+        // SQL NULL handling: `isDeleted` is a nullable boolean. A bare
+        // `not(and(eq(isDeleted, true), ...))` would evaluate to NULL for
+        // rows where `isDeleted IS NULL`, which SQL treats as filter-out.
+        // Enumerate the keep condition explicitly instead.
+        or(
+          isNull($posts.isDeleted),
+          eq($posts.isDeleted, false),
+          not(eq($posts.deliveryStatus, 'failed'))
+        )
+      ),
+    });
+  },
+  ['posts']
+);
+
+/**
+ * Rows that are still in-flight from the sender's perspective, used by
+ * `syncChannelWithBackoff` to decide whether delivery polling should
+ * continue. Unlike `getPendingPosts` (UI merge input), this does NOT
+ * exclude `isDeleted` rows — a user can delete a post mid-flight, and the
+ * server still needs to acknowledge the original send before anything is
+ * truly settled. `failed` and `needs_verification` are handled by dedicated
+ * retry / verification flows, so they are not treated as "still delivering".
+ *
+ * Server-acknowledged but unsequenced rows (`deliveryStatus: 'sent'` while
+ * still `sequenceNum === 0`) are also included: `markPostSent` sets the
+ * status before the sequenced `addPost` event arrives with a real sequence
+ * number, and if that follow-up event is delayed or lost the delivery loop
+ * must keep polling `syncPosts` until the row reconciles. Once the
+ * sequenced `addPost` lands (`sequenceNum > 0`), the row drops out of this
+ * query and the backoff can settle.
+ */
+export const getDeliveryPendingPosts = createReadQuery(
+  'getDeliveryPendingPosts',
+  (channelId: string, ctx: QueryCtx) => {
+    return ctx.db.query.posts.findMany({
+      where: and(
+        eq($posts.channelId, channelId),
+        not(eq($posts.type, 'reply')),
+        or(
+          eq($posts.deliveryStatus, 'enqueued'),
+          eq($posts.deliveryStatus, 'pending'),
+          and(eq($posts.deliveryStatus, 'sent'), eq($posts.sequenceNum, 0))
+        )
       ),
     });
   },

--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -448,6 +448,33 @@ describe('mergePendingPosts locally-cleared optimistic rows', () => {
 // tombstone immediately, without waiting for the paginated query to catch
 // up with the DB write from `markPostAsDeleted`.
 describe('mergePendingPosts deleted-overlay synthesis', () => {
+  test('confirmed echo in newPosts inherits deleted state from an optimistic row with the same sentAt', () => {
+    const optimistic = {
+      ...makePost(10),
+      id: 'optimistic-1',
+      sequenceNum: 0,
+      deliveryStatus: 'pending' as const,
+    };
+    const confirmedEcho = {
+      ...makePost(10),
+      id: 'confirmed-echo-1',
+      sequenceNum: 42,
+      deliveryStatus: null,
+      content: JSON.stringify([{ inline: ['real message body'] }]),
+    };
+    const [merged] = mergePendingPosts({
+      newPosts: [confirmedEcho],
+      pendingPosts: [optimistic],
+      existingPosts: [],
+      deletedPosts: { [optimistic.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged.id).toBe(confirmedEcho.id);
+    expect(merged.isDeleted).toBe(true);
+  });
+
   test('confirmed echo in newPosts with deletedPosts[id] surfaces as isDeleted:true', () => {
     const confirmedEcho = {
       ...makePost(10),

--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -517,10 +517,10 @@ describe('mergePendingPosts deleted-overlay synthesis', () => {
       sequenceNum: 0,
       deliveryStatus: 'sent' as const,
       isDeleted: true,
-      // `markPostAsDeleted` clears authorId, so this path must not rely
-      // solely on an author-qualified merge key.
+      // `markPostAsDeleted` clears authorId at runtime, so this path must
+      // not rely solely on an author-qualified merge key.
       authorId: null,
-    } as Post;
+    } as unknown as Post;
 
     const [merged] = mergePendingPosts({
       newPosts: [],

--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -504,6 +504,64 @@ describe('mergePendingPosts deleted-overlay synthesis', () => {
     expect(merged.isDeleted).toBe(true);
   });
 
+  test('deleted pending tombstone overlays a stale existing row with the same sentAt', () => {
+    const existing = {
+      ...makePost(10),
+      id: 'existing-row',
+      sequenceNum: 5,
+      deliveryStatus: null,
+    };
+    const pendingTombstone = {
+      ...makePost(10),
+      id: 'pending-tombstone',
+      sequenceNum: 0,
+      deliveryStatus: 'sent' as const,
+      isDeleted: true,
+      // `markPostAsDeleted` clears authorId, so this path must not rely
+      // solely on an author-qualified merge key.
+      authorId: null,
+    } as Post;
+
+    const [merged] = mergePendingPosts({
+      newPosts: [],
+      pendingPosts: [pendingTombstone],
+      existingPosts: [existing],
+      deletedPosts: {},
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged.id).toBe(existing.id);
+    expect(merged.isDeleted).toBe(true);
+  });
+
+  test('deleted overlay on a sibling pending row applies to the surviving existing row', () => {
+    const existing = {
+      ...makePost(10),
+      id: 'existing-row',
+      sequenceNum: 5,
+      deliveryStatus: null,
+    };
+    const pendingSibling = {
+      ...makePost(10),
+      id: 'pending-sibling',
+      sequenceNum: 0,
+      deliveryStatus: 'sent' as const,
+    };
+
+    const [merged] = mergePendingPosts({
+      newPosts: [],
+      pendingPosts: [pendingSibling],
+      existingPosts: [existing],
+      deletedPosts: { [pendingSibling.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged.id).toBe(existing.id);
+    expect(merged.isDeleted).toBe(true);
+  });
+
   test('rows not in deletedPosts are passed through untouched', () => {
     const liveRow = {
       ...makePost(10),

--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -448,33 +448,6 @@ describe('mergePendingPosts locally-cleared optimistic rows', () => {
 // tombstone immediately, without waiting for the paginated query to catch
 // up with the DB write from `markPostAsDeleted`.
 describe('mergePendingPosts deleted-overlay synthesis', () => {
-  test('confirmed echo in newPosts inherits deleted state from an optimistic row with the same sentAt', () => {
-    const optimistic = {
-      ...makePost(10),
-      id: 'optimistic-1',
-      sequenceNum: 0,
-      deliveryStatus: 'pending' as const,
-    };
-    const confirmedEcho = {
-      ...makePost(10),
-      id: 'confirmed-echo-1',
-      sequenceNum: 42,
-      deliveryStatus: null,
-      content: JSON.stringify([{ inline: ['real message body'] }]),
-    };
-    const [merged] = mergePendingPosts({
-      newPosts: [confirmedEcho],
-      pendingPosts: [optimistic],
-      existingPosts: [],
-      deletedPosts: { [optimistic.id]: true },
-      hasNewest: true,
-      filterDeleted: false,
-    });
-
-    expect(merged.id).toBe(confirmedEcho.id);
-    expect(merged.isDeleted).toBe(true);
-  });
-
   test('confirmed echo in newPosts with deletedPosts[id] surfaces as isDeleted:true', () => {
     const confirmedEcho = {
       ...makePost(10),

--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -296,6 +296,11 @@ describe('mergePendingPosts Edge Cases', () => {
   });
 });
 
+// TLON-5606 consumer contract: optimistic rows explicitly cleared by the user
+// (via `deleteFromChannelPosts` → `deletedPosts[postId] = true`) must not
+// re-enter the merged output from `newPosts` or `pendingPosts`, even in
+// chat-style views where `filterDeleted` is false. Confirmed-row tombstones
+// from `existingPosts` are unaffected.
 describe('mergePendingPosts locally-cleared optimistic rows', () => {
   test('drops a deleted optimistic row from newPosts even when filterDeleted is false', () => {
     const optimistic = {
@@ -335,5 +340,239 @@ describe('mergePendingPosts locally-cleared optimistic rows', () => {
     }).map((p) => p.id);
 
     expect(mergedIds).not.toContain(optimistic.id);
+  });
+
+  test('leaves confirmed existingPosts rows in place even if they share an id with deletedPosts', () => {
+    // Confirmed tombstones are meant to keep rendering in chat-like views.
+    // `deletedPosts` is the session-local signal for optimistic clears, so we
+    // only filter the live merge inputs, not `existingPosts`.
+    const confirmed = {
+      ...makePost(10),
+      id: 'confirmed-1',
+      sequenceNum: 5,
+    };
+    const mergedIds = mergePendingPosts({
+      newPosts: [],
+      pendingPosts: [],
+      existingPosts: [confirmed],
+      deletedPosts: { [confirmed.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    }).map((p) => p.id);
+
+    expect(mergedIds).toContain(confirmed.id);
+  });
+
+  test('keeps a confirmed server-echo row in newPosts during the catch-up window even when deletedPosts[id] is true', () => {
+    // `newPosts` transiently holds confirmed echoes before the main query
+    // catches up. Deleting one of those mid-session should not make the row
+    // disappear entirely — chat / DM views still want to render it as a
+    // tombstone. Only the unconfirmed (`sequenceNum === 0`) rows should be
+    // filtered out by the session-local `deletedPosts` overlay.
+    const confirmedEcho = {
+      ...makePost(10),
+      id: 'confirmed-echo-1',
+      sequenceNum: 42,
+    };
+    const optimistic = {
+      ...makePost(20),
+      id: 'optimistic-1',
+      sequenceNum: 0,
+      deliveryStatus: 'failed' as const,
+    };
+    const mergedIds = mergePendingPosts({
+      newPosts: [optimistic, confirmedEcho],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: {
+        [confirmedEcho.id]: true,
+        [optimistic.id]: true,
+      },
+      hasNewest: true,
+      filterDeleted: false,
+    }).map((p) => p.id);
+
+    expect(mergedIds).toContain(confirmedEcho.id);
+    expect(mergedIds).not.toContain(optimistic.id);
+  });
+
+  test('filterDeleted=true still removes confirmed tombstones, including newPosts echoes', () => {
+    // Notebook / gallery keep the original semantics: `isDeleted || deletedPosts[id]`
+    // both filter out rows. The narrowed live-merge check must not affect this.
+    // A non-empty existingPosts is required because mergePendingPosts short-
+    // circuits the final filter pass when existingPosts is empty.
+    const confirmedEcho = {
+      ...makePost(10),
+      id: 'confirmed-echo-1',
+      sequenceNum: 42,
+    };
+    const anchor = {
+      ...makePost(1),
+      id: 'anchor-1',
+      sequenceNum: 1,
+    };
+    const mergedIds = mergePendingPosts({
+      newPosts: [confirmedEcho],
+      pendingPosts: [],
+      existingPosts: [anchor],
+      deletedPosts: { [confirmedEcho.id]: true },
+      hasNewest: true,
+      filterDeleted: true,
+    }).map((p) => p.id);
+
+    expect(mergedIds).not.toContain(confirmedEcho.id);
+    expect(mergedIds).toContain(anchor.id);
+  });
+});
+
+// TLON-5606 / post-review 6: chat-style rendering keys off `post.isDeleted`
+// to decide whether to show a tombstone. When a confirmed echo is kept in
+// `newPosts` under `deletedPosts[id]`, mergePendingPosts must synthesize
+// `isDeleted: true` on the returned object so the row renders as a
+// tombstone immediately, without waiting for the paginated query to catch
+// up with the DB write from `markPostAsDeleted`.
+describe('mergePendingPosts deleted-overlay synthesis', () => {
+  test('confirmed echo in newPosts with deletedPosts[id] surfaces as isDeleted:true', () => {
+    const confirmedEcho = {
+      ...makePost(10),
+      id: 'confirmed-echo-1',
+      sequenceNum: 42,
+      content: JSON.stringify([{ inline: ['real message body'] }]),
+    };
+    const [merged] = mergePendingPosts({
+      newPosts: [confirmedEcho],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: { [confirmedEcho.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged.id).toBe(confirmedEcho.id);
+    expect(merged.isDeleted).toBe(true);
+  });
+
+  test('does not mutate the input post object', () => {
+    const confirmedEcho = {
+      ...makePost(10),
+      id: 'confirmed-echo-1',
+      sequenceNum: 42,
+    };
+    const before = { ...confirmedEcho };
+    mergePendingPosts({
+      newPosts: [confirmedEcho],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: { [confirmedEcho.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+    expect(confirmedEcho.isDeleted).toBe(before.isDeleted);
+  });
+
+  test('confirmed existingPosts row with deletedPosts[id] also gets overlayed', () => {
+    const confirmed = {
+      ...makePost(10),
+      id: 'confirmed-1',
+      sequenceNum: 5,
+    };
+    const [merged] = mergePendingPosts({
+      newPosts: [],
+      pendingPosts: [],
+      existingPosts: [confirmed],
+      deletedPosts: { [confirmed.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+    expect(merged.id).toBe(confirmed.id);
+    expect(merged.isDeleted).toBe(true);
+  });
+
+  test('rows not in deletedPosts are passed through untouched', () => {
+    const liveRow = {
+      ...makePost(10),
+      id: 'live-1',
+      sequenceNum: 5,
+      isDeleted: false,
+    };
+    const [merged] = mergePendingPosts({
+      newPosts: [],
+      pendingPosts: [],
+      existingPosts: [liveRow],
+      deletedPosts: {},
+      hasNewest: true,
+      filterDeleted: false,
+    });
+    expect(merged).toBe(liveRow);
+  });
+});
+
+// TLON-5606 / post-review 7: in the `markPostSent` catch-up window a row
+// is already server-acknowledged (`deliveryStatus: 'sent'`) but still
+// temporarily has `sequenceNum === 0` until the sequenced `addPost` event
+// arrives. Deleting in that window must not drop the row from the merged
+// output — the server has it, so the tombstone slot must stay visible.
+describe('mergePendingPosts markPostSent catch-up window', () => {
+  test('keeps a sent-but-unsequenced row visible as a tombstone when deletedPosts[id] is true', () => {
+    const sentCatchUp = {
+      ...makePost(10),
+      id: 'marked-sent-1',
+      sequenceNum: 0,
+      deliveryStatus: 'sent' as const,
+    };
+    const merged = mergePendingPosts({
+      newPosts: [sentCatchUp],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: { [sentCatchUp.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe(sentCatchUp.id);
+    expect(merged[0].isDeleted).toBe(true);
+  });
+
+  test('keeps a needs_verification row visible as a tombstone when deletedPosts[id] is true', () => {
+    // `needs_verification` rows may have reached the server too; same
+    // rationale as the markPostSent case.
+    const nv = {
+      ...makePost(10),
+      id: 'needs-verify-1',
+      sequenceNum: 0,
+      deliveryStatus: 'needs_verification' as const,
+    };
+    const merged = mergePendingPosts({
+      newPosts: [nv],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: { [nv.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe(nv.id);
+    expect(merged[0].isDeleted).toBe(true);
+  });
+
+  test('still drops a failed, locally-cleared optimistic row (TLON-5606 regression guard)', () => {
+    const failed = {
+      ...makePost(10),
+      id: 'failed-1',
+      sequenceNum: 0,
+      deliveryStatus: 'failed' as const,
+    };
+    const merged = mergePendingPosts({
+      newPosts: [failed],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: { [failed.id]: true },
+      hasNewest: true,
+      filterDeleted: false,
+    });
+
+    expect(merged.map((p) => p.id)).not.toContain(failed.id);
   });
 });

--- a/packages/shared/src/store/mergePendingPosts.test.ts
+++ b/packages/shared/src/store/mergePendingPosts.test.ts
@@ -399,8 +399,6 @@ describe('mergePendingPosts locally-cleared optimistic rows', () => {
   test('filterDeleted=true still removes confirmed tombstones, including newPosts echoes', () => {
     // Notebook / gallery keep the original semantics: `isDeleted || deletedPosts[id]`
     // both filter out rows. The narrowed live-merge check must not affect this.
-    // A non-empty existingPosts is required because mergePendingPosts short-
-    // circuits the final filter pass when existingPosts is empty.
     const confirmedEcho = {
       ...makePost(10),
       id: 'confirmed-echo-1',
@@ -422,6 +420,24 @@ describe('mergePendingPosts locally-cleared optimistic rows', () => {
 
     expect(mergedIds).not.toContain(confirmedEcho.id);
     expect(mergedIds).toContain(anchor.id);
+  });
+
+  test('filterDeleted=true also removes deleted overlays when existingPosts is empty', () => {
+    const confirmedEcho = {
+      ...makePost(10),
+      id: 'confirmed-echo-empty-1',
+      sequenceNum: 42,
+    };
+    const mergedIds = mergePendingPosts({
+      newPosts: [confirmedEcho],
+      pendingPosts: [],
+      existingPosts: [],
+      deletedPosts: { [confirmedEcho.id]: true },
+      hasNewest: true,
+      filterDeleted: true,
+    }).map((p) => p.id);
+
+    expect(mergedIds).not.toContain(confirmedEcho.id);
   });
 });
 

--- a/packages/shared/src/store/postActions/postActions.test.ts
+++ b/packages/shared/src/store/postActions/postActions.test.ts
@@ -683,11 +683,14 @@ function unsafe_extractUploadKey(att: Attachment): Attachment.UploadIntent.Key {
   return Attachment.UploadIntent.extractKey(uploadIntent);
 }
 
+// TLON-5606: lifecycle of a failed optimistic row when the user clears it.
 describe('clearing a failed optimistic post', () => {
   beforeEach(async () => {
     await db.insertChannels([
       db.buildChannel({ id: TEST_CHANNEL, type: 'chat' }),
     ]);
+    // `deletePost` dispatches an API call through `sessionActionQueue`, which
+    // hangs indefinitely without an active session.
     vi.mocked(poke).mockResolvedValue(0);
     updateSession({ startTime: Date.now(), channelStatus: 'active' });
   });
@@ -714,22 +717,44 @@ describe('clearing a failed optimistic post', () => {
     return merged;
   }
 
-  test('action-menu deletePost() on a failed optimistic row hard-deletes the row', async () => {
+  test('mainline repro: action-menu deletePost() on a failed optimistic row hard-deletes the row and clears the pending layer', async () => {
     const post = await seedFailedOptimisticPost();
 
+    // confirm preconditions: the row is in both the DB and the pending layer
+    expect(await fetchPost(post.id)).toMatchObject({
+      isDeleted: null,
+      deliveryStatus: 'failed',
+      sequenceNum: 0,
+    });
     expect((await db.getPendingPosts(TEST_CHANNEL)).map((p) => p.id)).toContain(
       post.id
     );
 
+    // The normal chat / thread action menu routes here. For a failed
+    // optimistic row, `deletePost()` now short-circuits through the
+    // `clearUnsentPost` branch instead of calling the server.
     await deletePost({ post });
 
+    // Row is removed from the DB entirely — no ghost tombstone left over,
+    // and no server round trip was attempted.
     expect(await fetchPost(post.id)).toBeUndefined();
-    expect(
-      (await db.getPendingPosts(TEST_CHANNEL)).map((p) => p.id)
-    ).not.toContain(post.id);
+
+    // Pending merge layer is clean.
+    const pending = await db.getPendingPosts(TEST_CHANNEL);
+    expect(pending.map((p) => p.id)).not.toContain(post.id);
+    const merged = mergePendingPosts({
+      newPosts: [],
+      pendingPosts: pending,
+      existingPosts: [],
+      deletedPosts: {},
+      hasNewest: true,
+    });
+    expect(merged.map((p) => p.id)).not.toContain(post.id);
   });
 
-  test('action-menu deletePost() on a confirmed post still marks deleted locally', async () => {
+  test('action-menu deletePost() on a confirmed post still marks deleted locally and does NOT hard-delete', async () => {
+    // Regression guard: we must not accidentally hard-delete confirmed
+    // server-backed rows through the new short-circuit.
     const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
     const post = db.buildPost({
       authorId: '~zod',
@@ -777,6 +802,9 @@ describe('clearing a failed optimistic post', () => {
 
     expect((await fetchPost(parent.id))!.replyCount).toBe(1);
 
+    // Thread-level action menu also routes to deletePost(). For a failed
+    // reply, the failed-optimistic short-circuit runs instead of the normal
+    // mark-deleted + server call path.
     await deletePost({ post: failedReply });
 
     expect(await fetchPost(failedReply.id)).toBeUndefined();
@@ -791,10 +819,12 @@ describe('clearing a failed optimistic post', () => {
 
   test('deleteFailedPost on a failed-send row removes it from the DB', async () => {
     const post = await seedFailedOptimisticPost();
-
     await deleteFailedPost({ post });
 
     expect(await fetchPost(post.id)).toBeUndefined();
+    expect(
+      (await db.getPendingPosts(TEST_CHANNEL)).map((p) => p.id)
+    ).not.toContain(post.id);
   });
 
   test('deleteFailedPost on a failed-send reply removes the reply AND restores parent reply metadata', async () => {
@@ -822,6 +852,8 @@ describe('clearing a failed optimistic post', () => {
       type: 'reply' as const,
     };
 
+    // Go through the real optimistic reply path so the parent's reply
+    // summary is mutated exactly the way a send would mutate it.
     await sync.handleAddPost(failedReply);
 
     const parentBefore = await fetchPost(parent.id);
@@ -835,6 +867,7 @@ describe('clearing a failed optimistic post', () => {
     const threadPosts = await db.getThreadPosts({ parentId: parent.id });
     expect(threadPosts.map((p) => p.id)).not.toContain(failedReply.id);
 
+    // Parent reply summary restored (no stale count/time/contacts).
     const parentAfter = await fetchPost(parent.id);
     expect(parentAfter!.replyCount).toBe(0);
     expect(parentAfter!.replyTime).toBeNull();
@@ -867,6 +900,7 @@ describe('clearing a failed optimistic post', () => {
     };
     await sync.handleAddPost(survivingReply);
 
+    // small delay so failed reply has a larger sentAt than the surviving one
     const failedReply = {
       ...db.buildPost({
         authorId: '~zod',
@@ -890,56 +924,105 @@ describe('clearing a failed optimistic post', () => {
     expect(parentAfter!.replyContactIds).toEqual(['~bus']);
   });
 
-  test('deleted failed optimistic rows are excluded from the live merge even when filterDeleted is false', async () => {
+  test('newPosts path: an optimistic failed row that is deleted on-screen is excluded from mergePendingPosts even when filterDeleted is false', async () => {
+    // Simulate what `useChannelPosts` sees: the optimistic failed row is
+    // cached in `newPosts` and also lives in the DB-backed `pendingPosts`.
     const post = await seedFailedOptimisticPost();
 
-    const merged = mergePendingPosts({
+    // Pre-delete: row is in both inputs and shows in the merged output.
+    let pending = await db.getPendingPosts(TEST_CHANNEL);
+    let merged = mergePendingPosts({
       newPosts: [post],
-      pendingPosts: await db.getPendingPosts(TEST_CHANNEL),
+      pendingPosts: pending,
+      existingPosts: [],
+      deletedPosts: {},
+      hasNewest: true,
+      filterDeleted: false,
+    });
+    expect(merged.map((p) => p.id)).toContain(post.id);
+
+    // Long-press Delete via the confirmed repro path.
+    await deletePost({ post });
+
+    // The DB-backed pending layer is cleaned up by the `getPendingPosts`
+    // narrowing. The session-local overlay is populated by
+    // `deleteFromChannelPosts(post)` — we simulate the same overlay state a
+    // live `useChannelPosts` hook would hold onto.
+    pending = await db.getPendingPosts(TEST_CHANNEL);
+    merged = mergePendingPosts({
+      newPosts: [post],
+      pendingPosts: pending,
       existingPosts: [],
       deletedPosts: { [post.id]: true },
       hasNewest: true,
       filterDeleted: false,
     });
-
     expect(merged.map((p) => p.id)).not.toContain(post.id);
   });
 
-  test.each([
-    {
-      label: 'needs_verification row',
-      postOverrides: { deliveryStatus: 'needs_verification' as const },
-      seedExistingPost: undefined,
-      expectedSequenceNum: 0,
-    },
-    {
-      label: 'failed-edit confirmed row',
-      postOverrides: { deliveryStatus: 'sent' as const, sequenceNum: 5 },
-      seedExistingPost: async (id: string) =>
-        db.updatePost({ id, editStatus: 'failed' }),
-      expectedSequenceNum: 5,
-    },
-    {
-      label: 'failed-delete confirmed row',
-      postOverrides: { deliveryStatus: 'sent' as const, sequenceNum: 7 },
-      seedExistingPost: async (id: string) =>
-        db.updatePost({ id, deleteStatus: 'failed' }),
-      expectedSequenceNum: 7,
-    },
-  ])(
-    'deleteFailedPost() on a $label does not hard-delete',
-    async ({ postOverrides, seedExistingPost, expectedSequenceNum }) => {
-      const post = await seedFailedOptimisticPost(postOverrides);
-      await seedExistingPost?.(post.id);
+  test('deleteFailedPost on a needs_verification row does NOT hard-delete (row may live on server)', async () => {
+    const post = await seedFailedOptimisticPost({
+      deliveryStatus: 'needs_verification',
+    });
+    await deleteFailedPost({ post });
 
-      await deleteFailedPost({ post: { ...post, ...postOverrides } });
+    const rowAfter = await fetchPost(post.id);
+    expect(rowAfter).toBeTruthy();
+    expect(rowAfter!.isDeleted).toBe(true);
+    expect(rowAfter!.deliveryStatus).toBe('needs_verification');
+    expect(rowAfter!.sequenceNum).toBe(0);
 
-      const rowAfter = await fetchPost(post.id);
-      expect(rowAfter).toBeTruthy();
-      expect(rowAfter!.isDeleted).toBe(true);
-      expect(rowAfter!.sequenceNum).toBe(expectedSequenceNum);
-    }
-  );
+    // Under the narrowed `getPendingPosts` contract, deleted rows that may
+    // still be server-backed (`needs_verification`, `sent`) are retained
+    // as a DB-backed tombstone source so the remount path can still
+    // surface them before the sequenced `addPost` arrives. Only truly
+    // local-only deleted failed sends are excluded.
+    expect((await db.getPendingPosts(TEST_CHANNEL)).map((p) => p.id)).toContain(
+      post.id
+    );
+  });
+
+  test('deleteFailedPost on a failed-edit (confirmed row) does NOT hard-delete', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const post = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 5,
+      content: [{ inline: ['original confirmed post'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [post] });
+    await db.updatePost({ id: post.id, editStatus: 'failed' });
+
+    await deleteFailedPost({ post: { ...post, editStatus: 'failed' } });
+
+    const rowAfter = await fetchPost(post.id);
+    expect(rowAfter).toBeTruthy();
+    expect(rowAfter!.isDeleted).toBe(true);
+    expect(rowAfter!.sequenceNum).toBe(5);
+  });
+
+  test('deleteFailedPost on a failed-delete (confirmed row) does NOT hard-delete', async () => {
+    const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
+    const post = db.buildPost({
+      authorId: '~zod',
+      author: null,
+      channel,
+      sequenceNum: 7,
+      content: [{ inline: ['original confirmed post'] }],
+      deliveryStatus: 'sent',
+    });
+    await db.insertChannelPosts({ posts: [post] });
+    await db.updatePost({ id: post.id, deleteStatus: 'failed' });
+
+    await deleteFailedPost({ post: { ...post, deleteStatus: 'failed' } });
+
+    const rowAfter = await fetchPost(post.id);
+    expect(rowAfter).toBeTruthy();
+    expect(rowAfter!.isDeleted).toBe(true);
+    expect(rowAfter!.sequenceNum).toBe(7);
+  });
 
   test('clearing a failed top-level post repoints channel preview to the previous previewable post', async () => {
     const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
@@ -953,6 +1036,7 @@ describe('clearing a failed optimistic post', () => {
     });
     await db.insertChannelPosts({ posts: [previous] });
 
+    // Seed the channel head to the previous post before the failed send.
     await db.updateChannel({
       id: TEST_CHANNEL,
       lastPostId: previous.id,
@@ -1017,11 +1101,19 @@ describe('clearing a failed optimistic post', () => {
     await deletePost({ post: failedReply });
 
     const chan = await db.getChannel({ id: TEST_CHANNEL });
+    // Reply path must not repoint or null the channel head.
     expect(chan!.lastPostId).toBe(parent.id);
     expect(chan!.lastPostAt).toBe(parent.receivedAt);
   });
 
   test('clearing a failed reply against a partial thread cache preserves server-known reply summary', async () => {
+    // Simulates the scenario where the parent carries server-sourced
+    // `replyMeta` (e.g., 8 replies) but only a subset is locally cached —
+    // here just the one failed optimistic reply we are about to clear. The
+    // `addReplyToPost` path bumped replyCount to 9 when the optimistic
+    // reply landed; clearing it must bring it back to 8 without collapsing
+    // `replyCount` to 0 and without regressing server-known `replyTime` /
+    // `replyContactIds`.
     const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
     const parent = db.buildPost({
       authorId: '~zod',
@@ -1033,6 +1125,9 @@ describe('clearing a failed optimistic post', () => {
     });
     await db.insertChannelPosts({ posts: [parent] });
 
+    // Seed server-sourced reply summary. The server's newest reply time is
+    // in the future (server has replies newer than anything we're about to
+    // send locally) so the optimistic add must not regress it.
     const serverReplyTime = Date.now() + 60_000;
     const serverContacts = ['~remote-1', '~remote-2'];
     await db.updatePost({
@@ -1055,6 +1150,9 @@ describe('clearing a failed optimistic post', () => {
       type: 'reply' as const,
     };
     await sync.handleAddPost(failedReply);
+    // handleAddPost → addReplyToPost bumped replyCount by 1 (no replyMeta
+    // was supplied for the optimistic insert). It did NOT regress the
+    // server-known replyTime because the local reply's sentAt is older.
     const parentBefore = await fetchPost(parent.id);
     expect(parentBefore!.replyCount).toBe(9);
     expect(parentBefore!.replyTime).toBe(serverReplyTime);
@@ -1063,8 +1161,13 @@ describe('clearing a failed optimistic post', () => {
     await deletePost({ post: failedReply });
 
     const parentAfter = await fetchPost(parent.id);
+    // Partial-cache regime: only the +1 optimistic bump is undone. Server-
+    // known summary fields stay intact.
     expect(parentAfter!.replyCount).toBe(8);
     expect(parentAfter!.replyTime).toBe(serverReplyTime);
+    // The ~zod append stays (partial regime leaves replyContactIds alone).
+    // That is acceptable and will reconcile on next thread sync — the
+    // critical invariant here is `replyCount` not collapsing.
     expect(parentAfter!.replyContactIds).toEqual([...serverContacts, '~zod']);
   });
 
@@ -1107,6 +1210,7 @@ describe('clearing a failed optimistic post', () => {
       lastPostAt: previous.receivedAt,
     });
 
+    // Seed the failed optimistic top-level post on the same grouped channel.
     const failed = db.buildPost({
       authorId: '~zod',
       author: null,
@@ -1124,6 +1228,7 @@ describe('clearing a failed optimistic post', () => {
     expect(chan!.lastPostAt).toBe(previous.receivedAt);
 
     const group = await db.getGroup({ id: GROUP_ID });
+    // Parent group preview must follow the channel head back down.
     expect(group!.lastPostId).toBe(previous.id);
     expect(group!.lastPostAt).toBe(previous.receivedAt);
   });
@@ -1164,6 +1269,8 @@ describe('clearing a failed optimistic post', () => {
       lastPostId: parent.id,
       lastPostAt: parent.receivedAt,
     });
+    // Seed a deliberate, distinct group preview so we can catch accidental
+    // writes.
     await db.insertGroups({
       groups: [
         {
@@ -1195,27 +1302,39 @@ describe('clearing a failed optimistic post', () => {
     await deletePost({ post: failedReply });
     const groupAfter = await db.getGroup({ id: GROUP_ID });
 
+    // Reply path must not mutate the group preview.
     expect(groupAfter!.lastPostId).toBe(groupBefore!.lastPostId);
     expect(groupAfter!.lastPostAt).toBe(groupBefore!.lastPostAt);
   });
 
-  test('deletePost() re-reads the DB row before hard-delete classification', async () => {
+  test('deletePost() re-reads the DB row before picking the hard-delete path; stale failed snapshot does NOT hard-delete a row that has since moved to enqueued', async () => {
+    // Simulate a race: the UI holds a failed snapshot (e.g. the retry sheet
+    // captured the post state at the moment it opened), but by the time
+    // Delete fires the row has already been advanced back to 'enqueued' by
+    // `retrySendPost()` or similar. The hard-delete branch must NOT fire.
     const post = await seedFailedOptimisticPost();
     const staleSnapshot: db.Post = {
       ...post,
       deliveryStatus: 'failed',
       sequenceNum: 0,
     };
+    // Advance the authoritative DB row past the "never sent" shape.
     await db.updatePost({ id: post.id, deliveryStatus: 'enqueued' });
 
     await deletePost({ post: staleSnapshot });
 
+    // Row must NOT have been hard-deleted — it still exists, and it went
+    // through the normal `markPostAsDeleted` optimistic update path.
     const rowAfter = await fetchPost(post.id);
     expect(rowAfter).toBeTruthy();
     expect(rowAfter!.isDeleted).toBe(true);
   });
 
-  test('deleteFailedPost() re-reads the DB row before hard-delete classification', async () => {
+  test('deleteFailedPost() re-reads the DB row; stale failed snapshot does NOT hard-delete a delivered row', async () => {
+    // The retry-sheet caller's `post` snapshot still says failed, but the
+    // authoritative row has been reconciled into a delivered server-backed
+    // state (`sequenceNum > 0`, `deliveryStatus: 'sent'`). We must not
+    // hard-delete such a row.
     const post = await seedFailedOptimisticPost();
     const staleSnapshot: db.Post = {
       ...post,
@@ -1232,10 +1351,16 @@ describe('clearing a failed optimistic post', () => {
 
     const rowAfter = await fetchPost(post.id);
     expect(rowAfter).toBeTruthy();
+    expect(rowAfter!.isDeleted).toBe(true);
     expect(rowAfter!.sequenceNum).toBe(42);
   });
 
   test('deletePost() is a no-op when the row is already gone; does not re-run clearUnsentPost on stale snapshot', async () => {
+    // Simulates a duplicate Delete fired from stale UI state after the
+    // failed reply row has already been removed (e.g. the user tapped
+    // Delete twice, or a retry-sheet action raced a long-press). The first
+    // cleanup already called `undoOptimisticReplyBump` on the parent; the
+    // second call must not decrement parent metadata a second time.
     const channel = (await db.getChannel({ id: TEST_CHANNEL }))!;
     const parent = db.buildPost({
       authorId: '~zod',
@@ -1246,6 +1371,8 @@ describe('clearing a failed optimistic post', () => {
       deliveryStatus: 'sent',
     });
     await db.insertChannelPosts({ posts: [parent] });
+    // Seed a parent reply summary as it would look after the first cleanup
+    // has already run (one reply removed, one sibling remaining).
     await db.updatePost({
       id: parent.id,
       replyCount: 5,
@@ -1265,8 +1392,11 @@ describe('clearing a failed optimistic post', () => {
       }),
       type: 'reply' as const,
     };
+    // Row is NOT in the DB — this is the stale-duplicate-delete scenario.
+
     await deletePost({ post: staleReplySnapshot });
 
+    // Parent reply summary must be untouched.
     const parentAfter = await fetchPost(parent.id);
     expect(parentAfter!.replyCount).toBe(5);
     expect(parentAfter!.replyTime).toBe(9999);

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -40,6 +40,7 @@ import {
 } from '../../test/helpers';
 import rawGroupsInit2 from '../../test/init.json';
 import {
+  syncChannelWithBackoff,
   syncDms,
   syncGroups,
   syncInitData,
@@ -104,6 +105,166 @@ test('syncs pins', async () => {
     (a, b) => a.index - b.index
   );
   expect(savedItems).toEqual(outputData);
+});
+
+// TLON-5606: after a user clears a failed send, `syncChannelWithBackoff`
+// must not treat the deleted optimistic row as a still-pending message.
+// The invariant the backoff relies on is
+// `getDeliveryPendingPosts(channelId).length` going to zero once the only
+// failed row has `isDeleted: true`.
+test('syncChannelWithBackoff resolves when the only failed post was locally cleared', async () => {
+  const channelId = 'backoff-test-channel';
+  await db.insertChannels([{ id: channelId, type: 'chat' }]);
+
+  // Seed a row that would have ghosted the backoff loop before the fix.
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'cleared-failed',
+        type: 'chat',
+        channelId,
+        authorId: '~zod',
+        sentAt: Date.now(),
+        receivedAt: Date.now(),
+        sequenceNum: 0,
+        content: JSON.stringify([{ inline: ['will be cleared'] }]),
+        deliveryStatus: 'failed',
+        isDeleted: true,
+        syncedAt: Date.now(),
+      } as unknown as db.Post,
+    ],
+  });
+
+  // Delivery polling explicitly excludes `failed` rows (they are handled
+  // by the retry/delete flow), so the backoff's `isStillPending` short-
+  // circuits on the first tick.
+  expect((await db.getDeliveryPendingPosts(channelId)).length).toBe(0);
+
+  // `backOff` uses setTimeout, so fake timers let the test resolve without
+  // waiting for the 3s startingDelay.
+  vi.useFakeTimers();
+  try {
+    const promise = syncChannelWithBackoff({ channelId });
+    await vi.advanceTimersByTimeAsync(3_100);
+    await expect(promise).resolves.toBe(true);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+// TLON-5606 / post-review 5: a user can delete an optimistic post while its
+// original send is still in flight (`enqueued` or `pending`). Those rows
+// must stay visible to the delivery-polling path so the server round trip
+// still reconciles — otherwise the delete silently strands the in-flight
+// message until some unrelated sync repairs it. Under the post-review 8
+// contract, they also surface from `getPendingPosts` as a DB-backed
+// tombstone source (only `failed + isDeleted` is excluded from the UI).
+test('syncChannelWithBackoff keeps polling when a deleted row is still in flight', async () => {
+  const channelId = 'backoff-inflight-channel';
+  await db.insertChannels([{ id: channelId, type: 'chat' }]);
+
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'deleted-but-still-pending',
+        type: 'chat',
+        channelId,
+        authorId: '~zod',
+        sentAt: Date.now(),
+        receivedAt: Date.now(),
+        sequenceNum: 0,
+        content: JSON.stringify([{ inline: ['in flight'] }]),
+        deliveryStatus: 'pending',
+        // User deleted the optimistic post mid-flight.
+        isDeleted: true,
+        syncedAt: Date.now(),
+      } as unknown as db.Post,
+    ],
+  });
+
+  // Delivery polling query keeps the row visible — still in flight.
+  expect((await db.getDeliveryPendingPosts(channelId)).length).toBe(1);
+  // UI query also surfaces it as a tombstone source so remount renders a
+  // "Message deleted" row instead of a gap while the send reconciles.
+  expect((await db.getPendingPosts(channelId)).length).toBe(1);
+});
+
+// TLON-5606 regression guard: deleted rows with the final local-only shape
+// (`failed + isDeleted`) must stay out of BOTH the UI pending source AND
+// the delivery-polling source — failed sends do not re-poll, and leaving
+// them in the UI would re-introduce the original ghost-at-bottom bug.
+test('deleted failed rows are excluded from both UI and delivery queries', async () => {
+  const channelId = 'backoff-failed-channel';
+  await db.insertChannels([{ id: channelId, type: 'chat' }]);
+
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: 'deleted-failed',
+        type: 'chat',
+        channelId,
+        authorId: '~zod',
+        sentAt: Date.now(),
+        receivedAt: Date.now(),
+        sequenceNum: 0,
+        content: JSON.stringify([{ inline: ['failed'] }]),
+        deliveryStatus: 'failed',
+        isDeleted: true,
+        syncedAt: Date.now(),
+      } as unknown as db.Post,
+    ],
+  });
+
+  expect((await db.getPendingPosts(channelId)).length).toBe(0);
+  expect((await db.getDeliveryPendingPosts(channelId)).length).toBe(0);
+});
+
+// TLON-5606 / post-review 9: after `markPostSent` flips a row to
+// `deliveryStatus: 'sent'` the sequenced `addPost` event carries the real
+// sequence number. If that follow-up event is delayed or missed, the row
+// can strand as `sent + sequenceNum:0`. The delivery loop must keep
+// polling across that catch-up window and only settle once the row is
+// reconciled with a real `sequenceNum`.
+test('syncChannelWithBackoff keeps polling across the markPostSent catch-up window', async () => {
+  const channelId = 'backoff-catchup-channel';
+  await db.insertChannels([{ id: channelId, type: 'chat' }]);
+
+  const catchUpId = 'sent-catchup';
+  await db.insertChannelPosts({
+    posts: [
+      {
+        id: catchUpId,
+        type: 'chat',
+        channelId,
+        authorId: '~zod',
+        sentAt: Date.now(),
+        receivedAt: Date.now(),
+        sequenceNum: 0,
+        content: JSON.stringify([{ inline: ['server acked, no seq yet'] }]),
+        deliveryStatus: 'sent',
+        syncedAt: Date.now(),
+      } as unknown as db.Post,
+    ],
+  });
+
+  // Precondition: the row is still visible to the delivery-polling path.
+  expect(
+    (await db.getDeliveryPendingPosts(channelId)).map((p) => p.id)
+  ).toContain(catchUpId);
+
+  // Simulate the sequenced `addPost` finally arriving: the row is
+  // reconciled in place with a real `sequenceNum` and the deliveryStatus
+  // transition that normally follows.
+  await db.updatePost({
+    id: catchUpId,
+    sequenceNum: 42,
+    deliveryStatus: null,
+  });
+
+  // The polling query must now drop the row — nothing left to reconcile.
+  expect(
+    (await db.getDeliveryPendingPosts(channelId)).map((p) => p.id)
+  ).not.toContain(catchUpId);
 });
 
 test('syncs contacts', async () => {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -1766,7 +1766,11 @@ export async function syncChannelWithBackoff({
   channelId: string;
 }): Promise<boolean> {
   async function isStillPending() {
-    return (await db.getPendingPosts(channelId)).length > 0;
+    // Delivery polling uses the dedicated `getDeliveryPendingPosts` query:
+    // it keeps in-flight `enqueued` / `pending` rows visible even when the
+    // user has locally cleared them, so mid-flight deletes still reconcile
+    // against the server. UI ghost-row filtering lives in `getPendingPosts`.
+    return (await db.getDeliveryPendingPosts(channelId)).length > 0;
   }
 
   const checkDelivered = async () => {

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -43,10 +43,6 @@ export const mergePendingPosts = ({
     post.sequenceNum === 0 &&
     deletedPosts[post.id] &&
     post.deliveryStatus === 'failed';
-  // Track `sentAt` slots that already carry deleted state somewhere in the
-  // optimistic/confirmed handoff. This lets a confirmed echo inherit the
-  // local tombstone overlay from the optimistic row it replaced.
-  const deletedSentAts = new Set<number>();
   // Stamp `isDeleted: true` on any surviving row the user has locally
   // cleared. This keeps confirmed echoes visible in the list (so the
   // tombstone slot is preserved) but flips them to the deleted-rendering
@@ -54,9 +50,7 @@ export const mergePendingPosts = ({
   // to the DB write from `markPostAsDeleted`.
   const applyDeletedOverlay = (posts: db.Post[]) =>
     posts.map((p) =>
-      !p.isDeleted && (deletedPosts[p.id] || deletedSentAts.has(p.sentAt))
-        ? { ...p, isDeleted: true }
-        : p
+      !p.isDeleted && deletedPosts[p.id] ? { ...p, isDeleted: true } : p
     );
   const finalizePosts = (posts: db.Post[]) =>
     posts.filter((p) => {
@@ -66,9 +60,6 @@ export const mergePendingPosts = ({
   [...newPosts, ...pendingPosts]
     .filter((post) => !isLocallyClearedOptimistic(post))
     .forEach((post) => {
-      if (post.isDeleted || deletedPosts[post.id]) {
-        deletedSentAts.add(post.sentAt);
-      }
       if (!sentAtMap.has(post.sentAt)) {
         sentAtMap.set(post.sentAt, post);
       }

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -27,10 +27,31 @@ export const mergePendingPosts = ({
   hasNewest: boolean;
   filterDeleted?: boolean;
 }): db.Post[] => {
+  // Drop **truly local-only** rows the user has locally cleared. The send
+  // either failed outright or was never acknowledged by the server, so the
+  // row can vanish immediately. Rows that are already server-acknowledged
+  // (`deliveryStatus: 'sent'`) but still waiting on their sequenced
+  // `addPost` event (`sequenceNum === 0`) — i.e., the `markPostSent`
+  // catch-up window — must NOT be dropped; they fall through and get an
+  // isDeleted tombstone overlay synthesized below. `needs_verification`
+  // rows also may have reached the server, so keep them visible too.
+  //
+  // `sequenceNum === 0` alone is not enough to conclude "safe to drop":
+  // the field only flips to a real value when the sequenced addPost
+  // arrives, which is strictly after the server-acknowledgement.
   const isLocallyClearedOptimistic = (post: db.Post) =>
     post.sequenceNum === 0 &&
     deletedPosts[post.id] &&
     post.deliveryStatus === 'failed';
+  // Stamp `isDeleted: true` on any surviving row the user has locally
+  // cleared. This keeps confirmed echoes visible in the list (so the
+  // tombstone slot is preserved) but flips them to the deleted-rendering
+  // path immediately, without waiting for the paginated query to catch up
+  // to the DB write from `markPostAsDeleted`.
+  const applyDeletedOverlay = (posts: db.Post[]) =>
+    posts.map((p) =>
+      !p.isDeleted && deletedPosts[p.id] ? { ...p, isDeleted: true } : p
+    );
   const sentAtMap = new Map<number, db.Post>();
   [...newPosts, ...pendingPosts]
     .filter((post) => !isLocallyClearedOptimistic(post))
@@ -45,7 +66,7 @@ export const mergePendingPosts = ({
     if (aUnconfirmed !== bUnconfirmed) return aUnconfirmed ? -1 : 1;
     return aUnconfirmed ? b.sentAt - a.sentAt : b.receivedAt - a.receivedAt;
   });
-  if (!existingPosts.length) return newAndPendingPosts;
+  if (!existingPosts.length) return applyDeletedOverlay(newAndPendingPosts);
 
   // --- Step 2: Establish the Filtering Window for pendingPosts ---
   const lowerPaginationBound = existingPosts[existingPosts.length - 1].sentAt;
@@ -58,12 +79,12 @@ export const mergePendingPosts = ({
       !existingPosts.some((existing) => existing.sentAt === p.sentAt)
     );
   });
-  const finalPosts = [...filteredNewPosts, ...existingPosts];
+  const finalPosts = applyDeletedOverlay([
+    ...filteredNewPosts,
+    ...existingPosts,
+  ]);
 
   return finalPosts.filter((p) => {
-    return (
-      !p.isSequenceStub &&
-      (!filterDeleted || (!p.isDeleted && !deletedPosts[p.id]))
-    );
+    return !p.isSequenceStub && (!filterDeleted || !p.isDeleted);
   });
 };

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -27,6 +27,28 @@ export const mergePendingPosts = ({
   hasNewest: boolean;
   filterDeleted?: boolean;
 }): db.Post[] => {
+  const postMergeKeys = (post: db.Post) => {
+    const keys = [`${post.channelId}:${post.sentAt}`];
+    if (post.authorId) {
+      keys.push(`${post.channelId}:${post.authorId}:${post.sentAt}`);
+    }
+    return keys;
+  };
+  const deletedPostKeys = new Set<string>();
+  [...newPosts, ...pendingPosts, ...existingPosts].forEach((post) => {
+    if (!post.isDeleted && !deletedPosts[post.id]) {
+      return;
+    }
+    postMergeKeys(post).forEach((key) => deletedPostKeys.add(key));
+  });
+  const hasDeletedOverlay = (post: db.Post) => {
+    return (
+      post.isDeleted ||
+      deletedPosts[post.id] ||
+      postMergeKeys(post).some((key) => deletedPostKeys.has(key))
+    );
+  };
+
   // Drop **truly local-only** rows the user has locally cleared. The send
   // either failed outright or was never acknowledged by the server, so the
   // row can vanish immediately. Rows that are already server-acknowledged
@@ -41,16 +63,17 @@ export const mergePendingPosts = ({
   // arrives, which is strictly after the server-acknowledgement.
   const isLocallyClearedOptimistic = (post: db.Post) =>
     post.sequenceNum === 0 &&
-    deletedPosts[post.id] &&
+    hasDeletedOverlay(post) &&
     post.deliveryStatus === 'failed';
   // Stamp `isDeleted: true` on any surviving row the user has locally
   // cleared. This keeps confirmed echoes visible in the list (so the
-  // tombstone slot is preserved) but flips them to the deleted-rendering
-  // path immediately, without waiting for the paginated query to catch up
-  // to the DB write from `markPostAsDeleted`.
+  // tombstone slot is preserved) but flips them to the deleted-rendering path
+  // immediately. A deleted DB-backed pending row may be filtered out by a
+  // same-sentAt existing post below, so carry deletion by merge key as well as
+  // exact id.
   const applyDeletedOverlay = (posts: db.Post[]) =>
     posts.map((p) =>
-      !p.isDeleted && deletedPosts[p.id] ? { ...p, isDeleted: true } : p
+      !p.isDeleted && hasDeletedOverlay(p) ? { ...p, isDeleted: true } : p
     );
   const finalizePosts = (posts: db.Post[]) =>
     posts.filter((p) => {

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -52,6 +52,10 @@ export const mergePendingPosts = ({
     posts.map((p) =>
       !p.isDeleted && deletedPosts[p.id] ? { ...p, isDeleted: true } : p
     );
+  const finalizePosts = (posts: db.Post[]) =>
+    posts.filter((p) => {
+      return !p.isSequenceStub && (!filterDeleted || !p.isDeleted);
+    });
   const sentAtMap = new Map<number, db.Post>();
   [...newPosts, ...pendingPosts]
     .filter((post) => !isLocallyClearedOptimistic(post))
@@ -66,7 +70,9 @@ export const mergePendingPosts = ({
     if (aUnconfirmed !== bUnconfirmed) return aUnconfirmed ? -1 : 1;
     return aUnconfirmed ? b.sentAt - a.sentAt : b.receivedAt - a.receivedAt;
   });
-  if (!existingPosts.length) return applyDeletedOverlay(newAndPendingPosts);
+  if (!existingPosts.length) {
+    return finalizePosts(applyDeletedOverlay(newAndPendingPosts));
+  }
 
   // --- Step 2: Establish the Filtering Window for pendingPosts ---
   const lowerPaginationBound = existingPosts[existingPosts.length - 1].sentAt;
@@ -84,7 +90,5 @@ export const mergePendingPosts = ({
     ...existingPosts,
   ]);
 
-  return finalPosts.filter((p) => {
-    return !p.isSequenceStub && (!filterDeleted || !p.isDeleted);
-  });
+  return finalizePosts(finalPosts);
 };

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -43,6 +43,10 @@ export const mergePendingPosts = ({
     post.sequenceNum === 0 &&
     deletedPosts[post.id] &&
     post.deliveryStatus === 'failed';
+  // Track `sentAt` slots that already carry deleted state somewhere in the
+  // optimistic/confirmed handoff. This lets a confirmed echo inherit the
+  // local tombstone overlay from the optimistic row it replaced.
+  const deletedSentAts = new Set<number>();
   // Stamp `isDeleted: true` on any surviving row the user has locally
   // cleared. This keeps confirmed echoes visible in the list (so the
   // tombstone slot is preserved) but flips them to the deleted-rendering
@@ -50,7 +54,9 @@ export const mergePendingPosts = ({
   // to the DB write from `markPostAsDeleted`.
   const applyDeletedOverlay = (posts: db.Post[]) =>
     posts.map((p) =>
-      !p.isDeleted && deletedPosts[p.id] ? { ...p, isDeleted: true } : p
+      !p.isDeleted && (deletedPosts[p.id] || deletedSentAts.has(p.sentAt))
+        ? { ...p, isDeleted: true }
+        : p
     );
   const finalizePosts = (posts: db.Post[]) =>
     posts.filter((p) => {
@@ -60,6 +66,9 @@ export const mergePendingPosts = ({
   [...newPosts, ...pendingPosts]
     .filter((post) => !isLocallyClearedOptimistic(post))
     .forEach((post) => {
+      if (post.isDeleted || deletedPosts[post.id]) {
+        deletedSentAts.add(post.sentAt);
+      }
       if (!sentAtMap.has(post.sentAt)) {
         sentAtMap.set(post.sentAt, post);
       }

--- a/packages/shared/src/store/useMergePendingPosts.ts
+++ b/packages/shared/src/store/useMergePendingPosts.ts
@@ -36,10 +36,9 @@ export const mergePendingPosts = ({
   };
   const deletedPostKeys = new Set<string>();
   [...newPosts, ...pendingPosts, ...existingPosts].forEach((post) => {
-    if (!post.isDeleted && !deletedPosts[post.id]) {
-      return;
+    if (post.isDeleted || deletedPosts[post.id]) {
+      postMergeKeys(post).forEach((key) => deletedPostKeys.add(key));
     }
-    postMergeKeys(post).forEach((key) => deletedPostKeys.add(key));
   });
   const hasDeletedOverlay = (post: db.Post) => {
     return (


### PR DESCRIPTION


## Summary

Builds on the TLON-5606 core fix (PR #5746) and the PR #5747 cleanup by separating UI-pending semantics from delivery-pending semantics.

This PR is the query / merge / sync follow-up:

- chat-style views should stop resurfacing a cleared local-only failed row as a ghost
- delivery polling should still continue for rows that are deleted locally but are still in flight
- catch-up-window rows that are already server-backed should remain representable as tombstones until reconciliation finishes

This PR is intended to be reviewed stacked on PR #5747. The main review focus here is the pending-query, merge, and sync behavior. It does **not** introduce additional reply-summary repair or channel/group preview repair logic beyond the already-stacked PR #5747 base.

## Root cause

A single `getPendingPosts()` contract was trying to serve two different consumers:

- the UI merge layer, which decides what can still be rendered as a pending/tombstone row
- the delivery backoff loop, which decides whether the client still needs to poll for reconciliation

Those consumers do not want the same rows.

- a deleted `failed + sequenceNum === 0` row is a local-only terminal state and should disappear from the UI pending layer
- a deleted `enqueued` / `pending` row is still in flight and should keep delivery polling alive
- a deleted `sent + sequenceNum === 0` row is already server-backed but still waiting for the sequenced `addPost`, so it should remain representable as a tombstone during the catch-up window
- `needs_verification` rows may also be server-backed and cannot be treated like a purely local failed send

Without splitting those contracts, fixing one side risks regressing the other.

## Changes

All changes are in `packages/shared`:

- Narrowed `getPendingPosts()` in [packages/shared/src/db/queries.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.ts) so only truly local-only deleted failed sends drop out of the UI pending layer.
- Added `getDeliveryPendingPosts()` in [packages/shared/src/db/queries.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.ts) for `syncChannelWithBackoff()`.
  - includes `enqueued` / `pending` rows regardless of `isDeleted`
  - includes the `sent + sequenceNum === 0` catch-up window
  - excludes terminal-failed rows
- Updated `mergePendingPosts()` in [packages/shared/src/store/useMergePendingPosts.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/useMergePendingPosts.ts) so:
  - locally-cleared failed optimistic rows are still dropped
  - surviving rows flagged in `deletedPosts` get an `isDeleted` overlay for immediate tombstone rendering
  - confirmed tombstones and catch-up-window rows remain visible
- Updated `syncChannelWithBackoff()` in [packages/shared/src/store/sync/sync.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/sync/sync.ts) to use `getDeliveryPendingPosts()` instead of `getPendingPosts()`
- Added supporting regression coverage in [packages/shared/src/store/postActions/postActions.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/postActions/postActions.test.ts) for how the new pending/query semantics interact with `deletePost()` / `deleteFailedPost()`

## Explicitly Not In Scope

- hard-delete classification for truly unsent failed optimistic rows
- reply parent metadata repair
- channel / group preview recomputation
- changing the current `needs_verification` delete posture beyond pending/query behavior

## How did I test?

Ran:

- `pnpm --filter @tloncorp/shared test run src/db/queries.test.ts src/store/mergePendingPosts.test.ts src/store/sync/sync.test.ts src/store/postActions/postActions.test.ts`

Coverage for this area lives in:

- [packages/shared/src/db/queries.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/db/queries.test.ts)
- [packages/shared/src/store/mergePendingPosts.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/mergePendingPosts.test.ts)
- [packages/shared/src/store/sync/sync.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/sync/sync.test.ts)
- [packages/shared/src/store/postActions/postActions.test.ts](/Users/patrick/workspace/homestead/packages/shared/src/store/postActions/postActions.test.ts)

The current test coverage focuses on:

- deleted failed rows stay out of both the UI-pending and delivery-pending paths
- deleted in-flight rows still keep delivery polling alive
- catch-up-window rows remain visible until reconciliation
- overlayed deleted rows render as tombstones without mutating the input objects
- delete entrypoints still behave correctly around `needs_verification`, failed-edit, and failed-delete rows under the narrowed query contract

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] State / providers
  - [x] Message sync
  - [x] Channel display

Main caveat:

- This PR still preserves the current `needs_verification` posture. It improves the pending/query behavior around those rows, but it does not add verify-before-delete or a server delete handoff.

## Rollback plan

Revert.
