### PR TITLE
remove unused media playback permission

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" tools:node="remove"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" tools:node="remove"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -73,6 +73,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   android: {
     runtimeVersion: '4.0.2',
+    blockedPermissions: [
+      'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+    ],
   },
   plugins: [
     'expo-asset',


### PR DESCRIPTION
## Summary

This removes the Android media playback foreground service permission from the app build.

`expo-video` adds this permission in our current version, but we do not use media playback as a foreground service. Keeping it out should avoid the Play Console warning for that permission.

## Changes

- block `android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK` in Expo config
- remove the same permission from the checked-in Android manifest during manifest merge

## How did I test?

- Ran `./gradlew :app:processProductionReleaseManifestForPackage :app:processPreviewReleaseManifestForPackage`
- Checked the production and preview packaged manifests for `FOREGROUND_SERVICE_MEDIA_PLAYBACK`