### PR TITLE
wayfinding: make home add tooltip dismissible

### DIFF
--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -1,7 +1,7 @@
 import { getCurrentUserIsHosted } from '@tloncorp/api';
 import * as db from '@tloncorp/shared/db';
-import { Text } from '@tloncorp/ui';
-import { useMemo } from 'react';
+import { Icon, Pressable, Text } from '@tloncorp/ui';
+import { useCallback, useMemo } from 'react';
 import { Circle, View, XStack, YStack, isWeb, styled } from 'tamagui';
 
 import { useStore } from '../../contexts/storeContext';
@@ -159,12 +159,22 @@ export function HomeAddTooltip() {
   const isHostedUser = getCurrentUserIsHosted();
   const botEnabled = isHostedUser && hostingBotEnabled;
 
+  const handleDismiss = useCallback(() => {
+    db.wayfindingProgress.setValue((prev) => ({
+      ...prev,
+      tappedHomeAdd: true,
+    }));
+  }, []);
+
   return (
-    <View pointerEvents="none" position="absolute" top={36} right={18}>
+    <View position="absolute" top={36} right={18}>
       <YStack alignItems="flex-end">
-        <View
+        <Pressable
           testID="HomeAddWayfindingTooltip"
-          padding={20}
+          onPress={handleDismiss}
+          paddingVertical={20}
+          paddingLeft={20}
+          paddingRight={44}
           width={220}
           backgroundColor="$positiveActionText"
           borderRadius="$l"
@@ -174,7 +184,15 @@ export function HomeAddTooltip() {
               ? 'Tap here to create a new group and invite your Tlonbot.'
               : 'Tap here to create a new group.'}
           </Text>
-        </View>
+          <View position="absolute" top={8} right={8} padding={4}>
+            <Icon
+              type="Close"
+              size="$s"
+              color="$white"
+              testID="HomeAddWayfindingTooltipDismiss"
+            />
+          </View>
+        </Pressable>
       </YStack>
     </View>
   );


### PR DESCRIPTION
## Summary

Adds a visible close button and tap-to-dismiss behavior to the "Create a group" onboarding tooltip. Fixes [TLON-5654](https://linear.app/tlon/issue/TLON-5654): the tooltip previously had `pointerEvents="none"` and no discoverable way to dismiss.

## Changes

- In `packages/app/ui/components/Wayfinding/Notices.tsx`, `HomeAddTooltip` now renders as a `Pressable` with an `onPress` that sets `wayfindingProgress.tappedHomeAdd` to `true`.
- Adds a white `Close` icon in the top-right corner of the tooltip for discoverability.
- Removes `pointerEvents="none"` from the outer container so taps register.

## How did I test?

Ran the web dev server at 375x812 viewport, forced the tooltip to show by setting `wayfindingProgress.tappedHomeAdd = false` in localStorage, and verified three dismiss paths: tapping the tooltip body, tapping the X icon, and tapping the `+` button (which still opens the CreateChatSheet). Typecheck passes (`pnpm -r tsc`).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding

## Rollback plan

Revert the single commit on this branch; no schema, state, or migration changes.

## Screenshots / videos

Shown here on web.

<img width="498" height="170" alt="Screenshot 2026-04-22 at 12 38 58 PM" src="https://github.com/user-attachments/assets/232fac35-ad79-45a8-b70e-f1b4a1e869cf" />
