### PR TITLE
splash: keep model list order stable on select (TLON-5653)

### DIFF
--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1068,14 +1068,12 @@ export function BotModelPane(props: {
 
   const visibleModels = useMemo(() => {
     const normalizedQuery = modelSearchQuery.trim().toLowerCase();
-    const sortedModels = [...models].sort((a, b) => {
-      if (a.id === selectedModel) return -1;
-      if (b.id === selectedModel) return 1;
-      return a.id.localeCompare(b.id, undefined, {
+    const sortedModels = [...models].sort((a, b) =>
+      a.id.localeCompare(b.id, undefined, {
         numeric: true,
         sensitivity: 'base',
-      });
-    });
+      })
+    );
 
     if (!normalizedQuery) {
       return sortedModels;
@@ -1084,7 +1082,7 @@ export function BotModelPane(props: {
     return sortedModels.filter((model) =>
       model.id.toLowerCase().includes(normalizedQuery)
     );
-  }, [modelSearchQuery, models, selectedModel]);
+  }, [modelSearchQuery, models]);
 
   const handleModelListScrollBeginDrag = useCallback(() => {
     Keyboard.dismiss();


### PR DESCRIPTION
## Summary

Fixes TLON-5653. In the splash/onboarding bot model picker, selecting a model (from 350+ options) was moving it to the top of the list, costing the user their scroll position and visual confirmation.

## Changes

- `packages/app/ui/components/Wayfinding/SplashSequence.tsx`: Removed the selected-model priority branches from the sort comparator in `BotModelPane` (and dropped `selectedModel` from the `useMemo` dependency array). The list is now sorted purely alphanumerically by model id and stays stable across selections. Selection state is already communicated in place by `ModelOptionCard` via its checkmark + highlight, so no additional UI changes are needed.

## How did I test?

- Typechecked `packages/app` (`npx tsc --noEmit`) — passes.
- Verified `ModelOptionCard` already renders a checkmark and positive background/border when `selected` is true, so in-place visual confirmation is preserved.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding

## Rollback plan

Revert this commit; the prior sort behavior returns.

## Screenshots / videos

N/A