### PR TITLE
fix group edit nav loop

### DIFF
--- a/packages/app/ui/components/Channel/EmptyChannelNotice.tsx
+++ b/packages/app/ui/components/Channel/EmptyChannelNotice.tsx
@@ -151,7 +151,7 @@ export function EmptyChannelNotice({
             }
             onPress={
               isSingleChannelGroup
-                ? () => onPressGroupMeta()
+                ? () => onPressGroupMeta(true)
                 : onPressChannelMeta
             }
           />


### PR DESCRIPTION
## Summary

This fixes the back button loop after tapping "Edit group" from the welcome message in a fresh group.

The welcome message now opens group info as coming from a blank channel, so the back button returns to the channel instead of jumping into group settings.

Fixes TLON-5641

## Changes

- pass the blank-channel flag from the welcome "Edit group" button

## How did I test?

- Tested on device