### PR TITLE
SplashSequence: retitle and pin home group with bot nickname

### DIFF
--- a/apps/tlon-mobile/src/hooks/analytics.ts
+++ b/apps/tlon-mobile/src/hooks/analytics.ts
@@ -2,6 +2,7 @@ import * as api from '@tloncorp/api';
 import { useLureMetadata } from '@tloncorp/app/contexts/branch';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
+import { getHomeGroupId } from '@tloncorp/shared/logic';
 import * as Contacts from 'expo-contacts';
 import * as Notifications from 'expo-notifications';
 import { useEffect } from 'react';
@@ -9,7 +10,6 @@ import { useEffect } from 'react';
 import { checkLatestVersion } from '../lib/lifecycleEvents';
 
 const logger = createDevLogger('analytics hooks', true);
-const HOME_GROUP_SLUG = 'home-group';
 
 export function useCheckAppInstalled() {
   const lureMeta = useLureMetadata();
@@ -57,9 +57,9 @@ export async function checkAnalyticsDigest() {
   ) {
     try {
       const digest = await db.getAnalyticsDigest();
-      const homeGroup = await db.getGroup({
-        id: `${currentUserId}/${HOME_GROUP_SLUG}`,
-      });
+      const homeGroupId =
+        (await db.homeGroupId.getValue()) ?? getHomeGroupId(currentUserId);
+      const homeGroup = await db.getGroup({ id: homeGroupId });
       const homeGroupMemberCount =
         homeGroup?.memberCount ?? homeGroup?.members?.length ?? null;
 

--- a/apps/tlon-mobile/src/hooks/analytics.ts
+++ b/apps/tlon-mobile/src/hooks/analytics.ts
@@ -2,7 +2,7 @@ import * as api from '@tloncorp/api';
 import { useLureMetadata } from '@tloncorp/app/contexts/branch';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { getHomeGroupId } from '@tloncorp/shared/logic';
+import { getFallbackHomeGroupId } from '@tloncorp/shared/logic';
 import * as Contacts from 'expo-contacts';
 import * as Notifications from 'expo-notifications';
 import { useEffect } from 'react';
@@ -58,7 +58,8 @@ export async function checkAnalyticsDigest() {
     try {
       const digest = await db.getAnalyticsDigest();
       const homeGroupId =
-        (await db.homeGroupId.getValue()) ?? getHomeGroupId(currentUserId);
+        (await db.homeGroupId.getValue()) ??
+        getFallbackHomeGroupId(currentUserId);
       const homeGroup = await db.getGroup({ id: homeGroupId });
       const homeGroupMemberCount =
         homeGroup?.memberCount ?? homeGroup?.members?.length ?? null;

--- a/packages/api/src/client/wayfinding.ts
+++ b/packages/api/src/client/wayfinding.ts
@@ -113,10 +113,13 @@ export function generatePersonalGroupTitle(contact: {
   return `${displayName}'s Group`;
 }
 
-export const HOME_GROUP_SLUG = 'home-group';
+// Fallback only. The authoritative home group ID is resolved from the hosting
+// lure token metadata and cached in `db.homeGroupId`; callers should prefer
+// that value and fall back to this constant only when the cache is empty.
+export const FALLBACK_HOME_GROUP_SLUG = 'home-group';
 
-export function getHomeGroupId(currentUserId: string) {
-  return `${currentUserId}/${HOME_GROUP_SLUG}`;
+export function getFallbackHomeGroupId(currentUserId: string) {
+  return `${currentUserId}/${FALLBACK_HOME_GROUP_SLUG}`;
 }
 
 export function generateHomeGroupTitle(botNickname: string) {

--- a/packages/api/src/client/wayfinding.ts
+++ b/packages/api/src/client/wayfinding.ts
@@ -112,3 +112,15 @@ export function generatePersonalGroupTitle(contact: {
   const displayName = contact.nickname || contact.id;
   return `${displayName}'s Group`;
 }
+
+export const HOME_GROUP_SLUG = 'home-group';
+
+export function getHomeGroupId(currentUserId: string) {
+  return `${currentUserId}/${HOME_GROUP_SLUG}`;
+}
+
+export function generateHomeGroupTitle(botNickname: string) {
+  const trimmed = botNickname.trim();
+  const name = trimmed || 'Tlonbot';
+  return `${name}'s Group`;
+}

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -4,6 +4,7 @@ import {
   AnalyticsEvent,
   createDevLogger,
   extractNormalizedInviteLink,
+  getMetadataFromInviteToken,
   withRetry,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
@@ -121,6 +122,21 @@ export function useBootSequence() {
           `https://${env.BRANCH_DOMAIN}/${reservedNode.homeGroupInviteToken}`
         );
         await db.homeGroupInviteLink.setValue(inviteLink);
+
+        // Resolve the home group ID from the lure token so downstream
+        // wayfinding logic doesn't rely on a hardcoded slug.
+        try {
+          const metadata = await getMetadataFromInviteToken(
+            reservedNode.homeGroupInviteToken
+          );
+          if (metadata?.invitedGroupId) {
+            await db.homeGroupId.setValue(metadata.invitedGroupId);
+          }
+        } catch (e) {
+          logger.trackError('failed to resolve home group id from token', {
+            errorMessage: e instanceof Error ? e.message : String(e),
+          });
+        }
       } else {
         logger.trackError('Signup missing home group invite token', {
           nodeId: reservedNode.id,

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -11,7 +11,7 @@ import { DEFAULT_BOT_CONFIG } from '@tloncorp/shared/domain';
 import {
   extractTokenFromInviteLink,
   generateHomeGroupTitle,
-  getHomeGroupId,
+  getFallbackHomeGroupId,
   getMetadataFromInviteToken,
   withRetry,
 } from '@tloncorp/shared/logic';
@@ -680,7 +680,7 @@ async function resolveHomeGroupId(currentUserId: string): Promise<string> {
     }
   }
 
-  return getHomeGroupId(currentUserId);
+  return getFallbackHomeGroupId(currentUserId);
 }
 
 // Hosting provisions the home group generic and unpinned; once the user

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -8,7 +8,11 @@ import {
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { DEFAULT_BOT_CONFIG } from '@tloncorp/shared/domain';
-import { withRetry } from '@tloncorp/shared/logic';
+import {
+  generateHomeGroupTitle,
+  getHomeGroupId,
+  withRetry,
+} from '@tloncorp/shared/logic';
 import { uploadAsset, useCanUpload } from '@tloncorp/shared/store';
 import {
   Button,
@@ -285,10 +289,20 @@ function SplashSequenceComponent(props: {
           }
         }
 
+        try {
+          await applyHomeGroupBotIdentity(store, name);
+          logger.trackEvent('Wayfinding Home Group Sync Succeeded', meta);
+        } catch (error) {
+          logger.trackError('Wayfinding Home Group Sync Failed', {
+            ...meta,
+            error,
+          });
+        }
+
         logger.trackEvent('Wayfinding Bot Identity Sync Completed', meta);
       })();
     },
-    []
+    [store]
   );
 
   const handleBotAvatarCompleted = useCallback(() => {
@@ -638,6 +652,40 @@ function SplashSequenceComponent(props: {
 export const SplashSequence = React.memo(SplashSequenceComponent);
 
 const BASIC_PROVIDER_ID = 'basic';
+
+// Hosting provisions the home group generic and unpinned; once the user
+// picks a bot nickname we retitle and pin it client-side.
+async function applyHomeGroupBotIdentity(
+  store: {
+    updateGroupMeta: (group: db.Group) => Promise<void>;
+    pinGroup: (group: db.Group) => Promise<unknown>;
+  },
+  botNickname: string
+) {
+  const currentUserId = api.getCurrentUserId();
+  const homeGroupId = getHomeGroupId(currentUserId);
+  const newTitle = generateHomeGroupTitle(botNickname);
+
+  await withRetry(
+    async () => {
+      const homeGroup = await db.getGroup({ id: homeGroupId });
+      if (!homeGroup) {
+        throw new Error('Home group not yet available');
+      }
+      if (homeGroup.title !== newTitle) {
+        await store.updateGroupMeta({ ...homeGroup, title: newTitle });
+      }
+      if (!homeGroup.pin) {
+        await store.pinGroup(homeGroup);
+      }
+    },
+    {
+      startingDelay: 1000,
+      numOfAttempts: 5,
+      maxDelay: 4000,
+    }
+  );
+}
 
 async function shareTlonbotGroupInvite(homeGroupInviteLink: string) {
   if (isWeb) {

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -9,8 +9,10 @@ import {
 import * as db from '@tloncorp/shared/db';
 import { DEFAULT_BOT_CONFIG } from '@tloncorp/shared/domain';
 import {
+  extractTokenFromInviteLink,
   generateHomeGroupTitle,
   getHomeGroupId,
+  getMetadataFromInviteToken,
   withRetry,
 } from '@tloncorp/shared/logic';
 import { uploadAsset, useCanUpload } from '@tloncorp/shared/store';
@@ -290,7 +292,7 @@ function SplashSequenceComponent(props: {
         }
 
         try {
-          await applyHomeGroupBotIdentity(store, name);
+          await applyHomeGroupBotIdentity(name);
           logger.trackEvent('Wayfinding Home Group Sync Succeeded', meta);
         } catch (error) {
           logger.trackError('Wayfinding Home Group Sync Failed', {
@@ -653,17 +655,44 @@ export const SplashSequence = React.memo(SplashSequenceComponent);
 
 const BASIC_PROVIDER_ID = 'basic';
 
+// Resolve the home group ID from the cached lure token metadata so we don't
+// rely on the hardcoded slug. Falls back to the conventional slug if the
+// token metadata hasn't been cached or fails to resolve.
+async function resolveHomeGroupId(currentUserId: string): Promise<string> {
+  const cached = await db.homeGroupId.getValue();
+  if (cached) {
+    return cached;
+  }
+
+  const inviteLink = await db.homeGroupInviteLink.getValue();
+  const token = inviteLink ? extractTokenFromInviteLink(inviteLink) : null;
+  if (token) {
+    try {
+      const metadata = await getMetadataFromInviteToken(token);
+      if (metadata?.invitedGroupId) {
+        await db.homeGroupId.setValue(metadata.invitedGroupId);
+        return metadata.invitedGroupId;
+      }
+    } catch (e) {
+      logger.trackError('failed to resolve home group id from invite token', {
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return getHomeGroupId(currentUserId);
+}
+
 // Hosting provisions the home group generic and unpinned; once the user
 // picks a bot nickname we retitle and pin it client-side.
-async function applyHomeGroupBotIdentity(
-  store: {
-    updateGroupMeta: (group: db.Group) => Promise<void>;
-    pinGroup: (group: db.Group) => Promise<unknown>;
-  },
-  botNickname: string
-) {
+//
+// Goes through `api` directly (rather than the `store.updateGroupMeta` /
+// `store.pinGroup` helpers) because those swallow poke failures and roll back
+// optimistically. We want errors to propagate here so `withRetry` actually
+// retries transient failures and the Wayfinding analytics reflect server state.
+async function applyHomeGroupBotIdentity(botNickname: string) {
   const currentUserId = api.getCurrentUserId();
-  const homeGroupId = getHomeGroupId(currentUserId);
+  const homeGroupId = await resolveHomeGroupId(currentUserId);
   const newTitle = generateHomeGroupTitle(botNickname);
 
   await withRetry(
@@ -673,10 +702,18 @@ async function applyHomeGroupBotIdentity(
         throw new Error('Home group not yet available');
       }
       if (homeGroup.title !== newTitle) {
-        await store.updateGroupMeta({ ...homeGroup, title: newTitle });
+        await api.updateGroupMeta({
+          groupId: homeGroup.id,
+          meta: {
+            title: newTitle,
+            description: homeGroup.description ?? '',
+            cover: homeGroup.coverImage ?? homeGroup.coverImageColor ?? '',
+            image: homeGroup.iconImage ?? homeGroup.iconImageColor ?? '',
+          },
+        });
       }
       if (!homeGroup.pin) {
-        await store.pinGroup(homeGroup);
+        await api.pinItem(homeGroup.id);
       }
     },
     {

--- a/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
+++ b/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
@@ -1,5 +1,6 @@
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
+import { getHomeGroupId } from '@tloncorp/shared/logic';
 import { enableGroupLinks, useGroup, useLure } from '@tloncorp/shared/store';
 import { useEffect, useMemo, useRef } from 'react';
 
@@ -9,25 +10,20 @@ import {
 } from '../../contexts/appDataContext';
 
 const logger = createDevLogger('useHomeGroupInviteLink', true);
-const HOME_GROUP_SLUG = 'home-group';
 
 type HomeGroupInviteState = 'ready' | 'loading' | 'unavailable';
-
-function getHomeGroupId(currentUserId: string) {
-  return `${currentUserId}/${HOME_GROUP_SLUG}`;
-}
 
 export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
   const currentUserId = useCurrentUserId();
   const inviteService = useInviteService();
   const cachedInviteLink = db.homeGroupInviteLink.useValue();
+  const cachedHomeGroupId = db.homeGroupId.useValue();
   const enabledGroupLinksRef = useRef<string | null>(null);
 
-  const homeGroupId = useMemo(
-    () =>
-      enabled && currentUserId ? getHomeGroupId(currentUserId) : undefined,
-    [currentUserId, enabled]
-  );
+  const homeGroupId = useMemo(() => {
+    if (!enabled || !currentUserId) return undefined;
+    return cachedHomeGroupId ?? getHomeGroupId(currentUserId);
+  }, [cachedHomeGroupId, currentUserId, enabled]);
   const { data: homeGroup, isLoading: homeGroupIsLoading } = useGroup({
     id: homeGroupId,
   });

--- a/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
+++ b/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
@@ -1,6 +1,6 @@
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { getHomeGroupId } from '@tloncorp/shared/logic';
+import { getFallbackHomeGroupId } from '@tloncorp/shared/logic';
 import { enableGroupLinks, useGroup, useLure } from '@tloncorp/shared/store';
 import { useEffect, useMemo, useRef } from 'react';
 
@@ -22,7 +22,7 @@ export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
 
   const homeGroupId = useMemo(() => {
     if (!enabled || !currentUserId) return undefined;
-    return cachedHomeGroupId ?? getHomeGroupId(currentUserId);
+    return cachedHomeGroupId ?? getFallbackHomeGroupId(currentUserId);
   }, [cachedHomeGroupId, currentUserId, enabled]);
   const { data: homeGroup, isLoading: homeGroupIsLoading } = useGroup({
     id: homeGroupId,

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -163,6 +163,11 @@ export const homeGroupInviteLink = createStorageItem<string | null>({
   defaultValue: null,
 });
 
+export const homeGroupId = createStorageItem<string | null>({
+  key: 'homeGroupId',
+  defaultValue: null,
+});
+
 export const hasViewedPersonalInvite = createStorageItem<boolean>({
   key: 'hasViewedPersonalInvite',
   defaultValue: false,


### PR DESCRIPTION
## Summary

Once the user sets a bot nickname in the splash sequence, the home group provisioned by hosting is retitled to `{botName}'s Group` and pinned client-side. This makes the bot nickname flow through to the group the same way it already does for the bot DM, and lets the bot-related group sit alongside the bot DM in the pinned section of the chat list.

## Changes

- `packages/api/src/client/wayfinding.ts`: added `HOME_GROUP_SLUG`, `getHomeGroupId`, and `generateHomeGroupTitle` helpers next to the existing `generatePersonalGroupTitle` convention.
- `packages/shared/src/db/keyValue.ts`: added `homeGroupId` storage item for caching the resolved home group ID.
- `packages/app/hooks/useBootSequence.ts`: during the `RESERVING` phase, after caching the invite link, resolve the lure token metadata via `getMetadataFromInviteToken` and cache `invitedGroupId` as `db.homeGroupId` so downstream wayfinding code doesn't depend on the hardcoded slug. Failure is logged but non-fatal.
- `packages/app/ui/components/Wayfinding/SplashSequence.tsx`: after `setTlawnNickname` (and the optional avatar sync) in `persistBotIdentityInBackground`, call a new `applyHomeGroupBotIdentity` helper that loads the home group from the local db and pokes `%groups` via `api.updateGroupMeta` to update the title and `api.pinItem` to pin it. Uses a new `resolveHomeGroupId` helper that reads `db.homeGroupId` (with a lazy re-resolve from the cached invite link, falling back to `getHomeGroupId`). Goes through `api` directly rather than `store.updateGroupMeta` / `store.pinGroup` because those swallow poke failures and roll back optimistically; we want errors to propagate so `withRetry` actually retries transient failures and the Wayfinding analytics reflect real server state. Wrapped in `withRetry` to cover the window where the home group hasn't synced into the local db yet, and logs `Wayfinding Home Group Sync Succeeded/Failed` analytics events.
- `packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts`: use the cached `db.homeGroupId` via the hook variant with fallback to `getHomeGroupId`; dropped the locally-duplicated `HOME_GROUP_SLUG` constant and `getHomeGroupId` function in favor of the canonical import from `@tloncorp/shared/logic`.
- `apps/tlon-mobile/src/hooks/analytics.ts`: read the cached `db.homeGroupId` with fallback to `getHomeGroupId(currentUserId)` when looking up the home group for the analytics digest; dropped the locally-duplicated `HOME_GROUP_SLUG` constant in favor of the canonical import.

## How did I test?

- `pnpm --filter @tloncorp/app tsc --noEmit`, `pnpm --filter @tloncorp/api tsc --noEmit`, `pnpm --filter @tloncorp/shared tsc --noEmit`, and `pnpm --filter tlon-mobile tsc --noEmit` all pass.
- Have not exercised the splash sequence end-to-end against a freshly provisioned hosted ship.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert this commit. The splash sequence will go back to leaving the home group with its hosting-provisioned title and unpinned.

## Screenshots / videos

<!-- Attach any relevant media. -->