### PR TITLE
Expo 54: fix nav issue in group settings

### DIFF
--- a/packages/app/features/groups/GroupMetaScreen.tsx
+++ b/packages/app/features/groups/GroupMetaScreen.tsx
@@ -16,6 +16,7 @@ import {
   MetaEditorScreenView,
   YStack,
   useGroupTitle,
+  useIsWindowNarrow,
 } from '../../ui';
 
 type Props = NativeStackScreenProps<GroupSettingsStackParamList, 'GroupMeta'>;
@@ -30,6 +31,7 @@ export function GroupMetaScreen(props: Props) {
   const canUpload = useCanUpload();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const currentUserId = useCurrentUserId();
+  const isWindowNarrow = useIsWindowNarrow();
 
   const navigateToHome = useCallback(() => {
     navigation.getParent()?.navigate('ChatList', undefined, { pop: true });
@@ -48,10 +50,19 @@ export function GroupMetaScreen(props: Props) {
       if (fromBlankChannel) {
         navigation.goBack();
       } else if (fromChatDetails) {
-        navigation.getParent()?.navigate('ChatDetails', {
-          chatType: 'group',
-          chatId: groupId,
-        });
+        // Same RN7 issue as the back path in useHandleGoBack: on narrow,
+        // the old navigate('ChatDetails', ...) pushed a duplicate route
+        // instead of popping to the existing one, so pop the GroupSettings
+        // stack with goBack() to return to the sibling ChatDetails. Wide
+        // keeps the pre-existing cross-navigator navigate, which already
+        // worked correctly for this flow.
+        if (isWindowNarrow) {
+          navigation.goBack();
+        } else {
+          navigation
+            .getParent()
+            ?.navigate('ChatDetails', { chatType: 'group', chatId: groupId });
+        }
       } else {
         onPressChatDetails({ type: 'group', id: groupId });
       }
@@ -62,6 +73,7 @@ export function GroupMetaScreen(props: Props) {
       onPressChatDetails,
       fromBlankChannel,
       fromChatDetails,
+      isWindowNarrow,
       navigation,
     ]
   );

--- a/packages/app/hooks/useChatSettingsNavigation.ts
+++ b/packages/app/hooks/useChatSettingsNavigation.ts
@@ -21,19 +21,31 @@ export const useHandleGoBack = (
   }
 ) => {
   const { groupId, fromChatDetails, fromBlankChannel } = params;
+  const isWindowNarrow = useIsWindowNarrow();
 
   return useCallback(() => {
     if (fromBlankChannel) {
       navigation.goBack();
     } else if (fromChatDetails) {
-      navigation.getParent()?.navigate('ChatDetails', {
-        chatType: 'group',
-        chatId: groupId,
-      });
+      // On narrow (mobile) under React Navigation v7, the old
+      // navigate('ChatDetails', ...) call pushed a duplicate ChatDetails
+      // route instead of popping to the existing one, which caused the
+      // TLON-5647 back-navigation loop. Popping the GroupSettings stack
+      // with goBack() returns to the sibling ChatDetails directly.
+      // Wide (desktop) keeps the pre-existing cross-navigator navigate,
+      // which already worked correctly for the same flow.
+      if (isWindowNarrow) {
+        navigation.goBack();
+      } else {
+        navigation.getParent()?.navigate('ChatDetails', {
+          chatType: 'group',
+          chatId: groupId,
+        });
+      }
     } else {
       navigation.goBack();
     }
-  }, [navigation, fromChatDetails, fromBlankChannel, groupId]);
+  }, [navigation, fromChatDetails, fromBlankChannel, groupId, isWindowNarrow]);
 };
 
 export const useChatSettingsNavigation = () => {


### PR DESCRIPTION
## Summary

Fixes the infinite back-navigation loop on mobile when exiting the group members list (and sibling screens reached from Group info & settings) under Expo 54 / React Navigation v7. Closes TLON-5647.

## Changes

- `packages/app/hooks/useChatSettingsNavigation.ts`: in the `fromChatDetails` branch of `useHandleGoBack`, narrow/mobile now calls `navigation.goBack()` to pop the `GroupSettings` stack back to the existing sibling `ChatDetails` route. Wide/desktop keeps the pre-existing `navigation.getParent()?.navigate('ChatDetails', ...)` behavior, which already worked on desktop.
- `packages/app/features/groups/GroupMetaScreen.tsx`: same narrow/wide split applied to the `handleSubmit` save path (Edit group info → Save), which is a sibling call site with the same RN7 issue.

Consumers of `useHandleGoBack` — `GroupMembersScreen`, `ManageChannelsScreen`, `GroupPrivacyScreen`, `GroupRolesScreen`, and the back path of `GroupMetaScreen` — inherit the fix automatically.

Context: under RN7 the old cross-navigator `navigate('ChatDetails', ...)` pushes a fresh route instead of popping to the existing one, so each back tap alternated between a new `ChatDetails` and the members screen.

## How did I test?

- Narrow/mobile: group channel → Group info & settings → Members → back → back. Lands on `ChatDetails`, then the channel, with no loop.
- Narrow/mobile: group channel → Group info & settings → Edit group info → Save. Lands on the existing `ChatDetails` without an extra back press.
- Narrow/mobile sibling back paths spot-checked: `ManageChannels`, `GroupPrivacy`, `GroupRoles`, and the `GroupMeta` header back.
- Wide/desktop regression spot-check of both flows (code path unchanged on wide, verified still working).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A

## Rollback plan

Revert.

## Screenshots / videos

N/A

