### PR TITLE
TLON-5655 fix tlonbot settings url

### DIFF
--- a/packages/app/features/settings/BotSettingsScreen.tsx
+++ b/packages/app/features/settings/BotSettingsScreen.tsx
@@ -10,7 +10,7 @@ import { useWebView } from '../../hooks/useWebview';
 import { RootStackParamList } from '../../navigation/types';
 import { LoadingSpinner, ScreenHeader, View, YStack, isWeb } from '../../ui';
 
-const BOT_SETTINGS_URL = 'https://tlon.network/tlawnbot';
+const BOT_SETTINGS_URL = 'https://tlon.network/tlonbot';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'BotSettings'>;
 

--- a/packages/app/navigation/desktop/SettingsNavigator.tsx
+++ b/packages/app/navigation/desktop/SettingsNavigator.tsx
@@ -54,7 +54,7 @@ function DrawerContent(props: DrawerContentComponentProps) {
   }, [navigate]);
 
   const onBotSettingsPressed = useCallback(() => {
-    Linking.openURL('https://tlon.network/tlawnbot');
+    Linking.openURL('https://tlon.network/tlonbot');
   }, []);
 
   const onExperimentalFeaturesPressed = useCallback(() => {


### PR DESCRIPTION
## Summary

Fixes old/bad tlonbot settings url

## Changes

`/tlawnbot` -> `/tlonbot`

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
