### PR TITLE
fix(app): remove useLivePost setState chain that doubles re-renders

### DIFF
--- a/packages/app/ui/contexts/requests.tsx
+++ b/packages/app/ui/contexts/requests.tsx
@@ -5,16 +5,7 @@ import {
   usePostWithRelations,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { isEqual } from 'lodash';
-import {
-  PropsWithChildren,
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { PropsWithChildren, createContext, useContext, useMemo } from 'react';
 
 type State = {
   usePost: typeof usePostWithRelations;
@@ -68,22 +59,7 @@ export const RequestsProvider = ({
 };
 
 export const useLivePost = (initialPost: db.Post): db.Post => {
-  const [post, setPost] = useState(initialPost);
   const { usePost } = useRequests();
   const { data: updatedPost } = usePost({ id: initialPost.id }, initialPost);
-
-  const prevInitialPostRef = useRef(initialPost);
-  const prevUpdatedPostRef = useRef(updatedPost);
-
-  useEffect(() => {
-    if (updatedPost && !isEqual(updatedPost, prevUpdatedPostRef.current)) {
-      setPost(updatedPost);
-      prevUpdatedPostRef.current = updatedPost;
-    } else if (!isEqual(initialPost, prevInitialPostRef.current)) {
-      setPost(initialPost);
-      prevInitialPostRef.current = initialPost;
-    }
-  }, [updatedPost, initialPost]);
-
-  return post;
+  return updatedPost ?? initialPost;
 };


### PR DESCRIPTION
## Summary

Simplifies \`useLivePost\` in \`packages/app/ui/contexts/requests.tsx\`. The hook previously kept a local \`useState\` copy of the post and used a deep-equality check inside a \`useEffect\` to decide whether to call \`setPost\` — a pattern intended to *reduce* re-renders but which actually *adds* a setState-in-effect pass after every data update. On \`develop\` this is a latent perf issue; on the Expo 54 upgrade branch it is a reliable crash.

## Background

Started investigating a \`Maximum update depth exceeded\` crash on the Expo 54 upgrade branch (\`janic/expo-54\`). Repro: scroll a chat while new messages are syncing from the ship.

The upgrade bumps React 18.3.1 → 19.1.0 and React Native to a Fabric-based renderer. React's internal \`nestedUpdateCount\` check — which exists in both versions and aborts with \"Maximum update depth exceeded\" if the same root commits too many times in a row with pending sync lanes — trips now where it didn't before. The useLivePost pattern described below has been producing 2 commits per data change for a long time; under React 18's scheduling those commits mostly collapsed into a single batched pass, so the counter stayed low. Under React 19 + Fabric, consecutive commit-with-pending-sync-lanes boundaries are more aggressive, and during a sync-driven mass invalidation (10+ visible \`BaseScrollerItem\`s, each calling \`useLivePost\` twice) the chain walks the counter past its 50-commit limit and throws.

Instrumenting React's \`getRootForUpdatedFiber\` with a ring buffer of recent \`scheduleUpdateOnFiber\` calls confirmed the chain source. Every cycle on \`BaseScrollerItem\` looked like:

\`\`\`
#N+0 src=uSES fiber=BaseScrollerItem count@schedule=K     ← query observer notifies
#N+1 src=hook fiber=BaseScrollerItem count@schedule=K     ← setPost (useLivePost for item)
#N+2 src=hook fiber=BaseScrollerItem count@schedule=K     ← setPost (useLivePost for previousPost)
[scroll-debug] commit finished with pending sync lanes; nestedUpdateCount=K+1
\`\`\`

Count climbs 1 → 2 → … → 11 → crash.

## Why the old code caused extra renders

\`\`\`ts
const [post, setPost] = useState(initialPost);
const { data: updatedPost } = usePost({ id: initialPost.id }, initialPost);
const prevInitialPostRef = useRef(initialPost);
const prevUpdatedPostRef = useRef(updatedPost);

useEffect(() => {
  if (updatedPost && !isEqual(updatedPost, prevUpdatedPostRef.current)) {
    setPost(updatedPost);
    prevUpdatedPostRef.current = updatedPost;
  } else if (!isEqual(initialPost, prevInitialPostRef.current)) {
    setPost(initialPost);
    prevInitialPostRef.current = initialPost;
  }
}, [updatedPost, initialPost]);
return post;
\`\`\`

Per data update, this produces two commits:

1. React Query observer fires → component re-renders with new \`updatedPost\`, but local \`post\` state is still the old value.
2. Effect runs after commit, \`isEqual\` is false (because \`db.Post\` contains fields that churn per sync, e.g. timestamps, so structural sharing doesn't preserve identity), \`setPost(updatedPost)\` fires.
3. Second commit re-renders with \`post === updatedPost\`.

So the deep-equal check was meant to *skip* unnecessary renders but in practice it almost always returns \`false\` and just delays the real render by one commit. React Query's own \`replaceEqualDeep\` structural sharing already handles true no-ops for free; the extra state machine is net negative.

## The fix

Return the query data directly:

\`\`\`ts
export const useLivePost = (initialPost: db.Post): db.Post => {
  const { usePost } = useRequests();
  const { data: updatedPost } = usePost({ id: initialPost.id }, initialPost);
  return updatedPost ?? initialPost;
};
\`\`\`

- One commit per data change, not two.
- Semantically equivalent: \`usePost\` is already invoked with \`initialData: initialPost\`, so data is \`initialPost\` on first render and fresh data thereafter. The \`?? initialPost\` fallback handles the narrow case where the DB-backed query returns \`null\` (e.g. \`EMPTY_POST\` passed for a non-existent previous post) and keeps the return type as \`db.Post\`.
- Confirmed by per-hook ref-churn logging: old code produced two log lines per data update (one where \`updated=NEW result=same fallback=yes\`, then another where \`updated=same result=NEW fallback=no\`); new code produces one (\`updated=NEW result=NEW\`).

## How did I test?

- Reproduced the crash on Expo 54 dev build by scrolling a channel while another ship posted messages. To tighten the repro I temporarily lowered \`NESTED_UPDATE_LIMIT\` in \`ReactFabric-dev.js\` from 50 → 10 so the counter tripped within seconds. Without the fix: reliably crashes within 10–15s of sustained scroll. With the fix: no crash across extended tests, counter never climbs past 1–2.
- \`pnpm -F @tloncorp/app tsc --noEmit\` on the changed file is clean. (Other TS errors exist on \`develop\` unrelated to this change.)

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — single-file revert, no data or schema implications.
- Affects important code area:
  - [x] State / providers
  - [x] Message sync
  - [ ] Onboarding
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other

Behavior note: the old code had one theoretical advantage — if React Query ever returned a new-reference but deep-equal \`data\`, lodash's \`isEqual\` would skip the \`setPost\`. In the new code that case would cause one extra re-render. RQ's \`replaceEqualDeep\` already handles this for plain-JSON-like data, so it's rare in practice. If a specific post query later turns out to churn identity for trivial reasons, the right fix is a \`select\` that normalizes/strips the churning field — not to re-introduce the setState dance.

## Rollback plan

Revert this commit. No migrations, no external deps.