### PR TITLE
onboarding: visual tweaks

### DIFF
--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1034,6 +1034,7 @@ export function BotAvatarPane(props: {
               onPress={openSheet}
               label="Change photo"
               preset="secondary"
+              backgroundColor="transparent"
               disabled={!canUpload || isUploading}
             />
             <Button
@@ -1058,7 +1059,7 @@ export function BotAvatarPane(props: {
               onPress={props.onActionPress}
               label="Skip"
               preset="secondary"
-              fill="text"
+              backgroundColor="transparent"
             />
           </>
         )}
@@ -1475,7 +1476,7 @@ export function GroupsPane(props: {
           )}
         </ScrollView>
       </YStack>
-      <YStack paddingHorizontal="$xl" gap="$2xl" marginTop="$xl">
+      <YStack paddingHorizontal="$xl" gap="$l" marginTop="$xl">
         {props.hostingBotEnabled ? (
           <Button
             onPress={
@@ -1504,7 +1505,7 @@ export function GroupsPane(props: {
           onPress={props.onActionPress}
           label="Got it"
           preset="secondary"
-          fill="text"
+          backgroundColor="transparent"
         />
       </YStack>
     </View>
@@ -1818,7 +1819,7 @@ function ConnectContactBookContent(props: {
             onPress={props.onSkip}
             label="Skip"
             preset="secondary"
-            fill="text"
+            backgroundColor="transparent"
             disabled={props.isProcessing || props.isCompleting}
           />
         )}

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1051,7 +1051,7 @@ export function BotAvatarPane(props: {
               onPress={props.onActionPress}
               label={isUploading ? 'Uploading…' : 'Continue'}
               preset="hero"
-              shadow
+              shadow={!isUploading}
               loading={isUploading}
               disabled={isUploading}
             />

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1501,12 +1501,12 @@ export function GroupsPane(props: {
                   ? 'Preparing invite link'
                   : 'Invite link unavailable'
             }
-            intent="positive"
+            intent={groupInviteIsReady ? 'positive' : undefined}
             size="large"
             leadingIcon={groupInviteIsLoading ? undefined : 'Link'}
             loading={groupInviteIsLoading}
             disabled={!groupInviteIsReady}
-            glow
+            glow={groupInviteIsReady}
           />
         ) : null}
         <Button
@@ -1809,7 +1809,7 @@ function ConnectContactBookContent(props: {
           </YStack>
         )}
       </YStack>
-      <YStack paddingHorizontal="$xl" gap="$2xl">
+      <YStack paddingHorizontal="$xl" gap="$l">
         <Button
           data-testid="connect-contact-book"
           onPress={handleAction}

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -891,6 +891,11 @@ export function BotNamePane(props: {
                 onSubmitEditing={handlePress}
                 enablesReturnKeyAutomatically
                 autoFocus
+                placeholder={
+                  props.userNickname
+                    ? `${props.userNickname}'s Tlonbot`
+                    : 'Tlonbot'
+                }
                 frameStyle={{ height: 72 }}
                 style={{ fontSize: 24, lineHeight: 30 }}
               />
@@ -901,7 +906,12 @@ export function BotNamePane(props: {
           onPress={handlePress}
           label="Next"
           preset="hero"
-          shadow
+          disabled={
+            props.name.trim().length === 0 || props.name.trim().length > 50
+          }
+          shadow={
+            props.name.trim().length > 0 && props.name.trim().length <= 50
+          }
           marginHorizontal="$xl"
           marginTop="$xl"
         />


### PR DESCRIPTION
## Summary

Fixes TLON-5665 and fixes TLON-5675 by avoiding `fill="text"` on `Button` components, instead opting for a combination of `preset="secondary" and backgroundColor="$transparent` to achieve the same purpose without the layout-collapsing side effects.

Fixes TLON-5661 by adding placeholder text using the user's nickname + " Tlonbot" so the suggestion reads "Alice's Tlonbot." This also disables the "Next" button until the user types a nickname that meets validation (trimmed string <50ch).

Also removes the positive action treatment and glow on the bot group invite button while the invite is still processing or in a failed state.

|screen|change|
|------|------|
|<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-23 at 12 12 49" src="https://github.com/user-attachments/assets/dc057526-6e93-4458-8229-ad90b84b52f7" />|Placeholder text, disabled button w/ no shadow|
|<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-23 at 12 16 51" src="https://github.com/user-attachments/assets/2418c169-b920-4af5-b257-1eb9d3de24ab" />|Button enabled once text entered|
|<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-23 at 12 12 56" src="https://github.com/user-attachments/assets/ffef193e-80d7-4e70-82e0-661b6b6c5dd6" />|Correct button spacing|
|<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-23 at 12 19 39" src="https://github.com/user-attachments/assets/95290087-7fa4-4151-bc5f-94f2ab52b373" />|Correct button spacing, no shadow while processing|
|<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-23 at 12 13 21" src="https://github.com/user-attachments/assets/01f87394-e9e3-4b20-b0ef-20da92b15b57" />|Correct button spacing, glow disabled in bad state|
|<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-23 at 12 13 47" src="https://github.com/user-attachments/assets/3752fdad-e93d-48e8-b813-75752810200e" />|Correct button spacing|
