### PR TITLE
onboarding: handle auto navigation when system permissions resolve

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
@@ -4,13 +4,7 @@ import {
   requestNotificationToken,
   useNotificationPermissions,
 } from '@tloncorp/app/lib/notifications';
-import {
-  Button,
-  ScreenHeader,
-  TlonText,
-  View,
-  YStack,
-} from '@tloncorp/app/ui';
+import { Button, ScreenHeader, TlonText, View, YStack } from '@tloncorp/app/ui';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { useCallback, useEffect, useRef } from 'react';

--- a/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
@@ -1,18 +1,19 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
-import { requestNotificationToken } from '@tloncorp/app/lib/notifications';
+import {
+  requestNotificationToken,
+  useNotificationPermissions,
+} from '@tloncorp/app/lib/notifications';
 import {
   Button,
-  Icon,
   ScreenHeader,
   TlonText,
   View,
-  XStack,
   YStack,
 } from '@tloncorp/app/ui';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { ImageBackground, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -30,6 +31,8 @@ export const AllowNotificationsScreen = ({ navigation }: Props) => {
   const signupContext = useSignupContext();
   const insets = useSafeAreaInsets();
   const isDarkMode = useIsDarkMode();
+  const notifPerms = useNotificationPermissions();
+  const hasContinued = useRef(false);
 
   // Select background image based on platform and theme
   const getBackgroundImage = () => {
@@ -44,6 +47,29 @@ export const AllowNotificationsScreen = ({ navigation }: Props) => {
     }
   };
 
+  const continueOnboarding = useCallback(
+    async (notificationToken?: string) => {
+      if (hasContinued.current) {
+        return;
+      }
+
+      hasContinued.current = true;
+
+      // Save the notification token to signup context
+      signupContext.setOnboardingValues({
+        notificationToken,
+      });
+
+      if (signupContext.isGuidedLogin) {
+        signupContext.handlePostSignup();
+        await db.hostedAccountIsInitialized.setValue(true);
+      } else {
+        navigation.push('ReserveShip');
+      }
+    },
+    [signupContext, navigation]
+  );
+
   const handleNext = useCallback(async () => {
     let notificationToken: string | undefined;
 
@@ -57,18 +83,36 @@ export const AllowNotificationsScreen = ({ navigation }: Props) => {
       }
     }
 
-    // Save the notification token to signup context
-    signupContext.setOnboardingValues({
-      notificationToken,
-    });
+    await continueOnboarding(notificationToken);
+  }, [continueOnboarding]);
 
-    if (signupContext.isGuidedLogin) {
-      signupContext.handlePostSignup();
-      await db.hostedAccountIsInitialized.setValue(true);
-    } else {
-      navigation.push('ReserveShip');
+  useEffect(() => {
+    if (!notifPerms.initialized || hasContinued.current) {
+      return;
     }
-  }, [signupContext, navigation]);
+
+    if (notifPerms.hasPermission) {
+      requestNotificationToken()
+        .then((notificationToken) => continueOnboarding(notificationToken))
+        .catch((err) => {
+          console.error('Error getting notification token:', err);
+          if (err instanceof Error) {
+            logger.trackError('Error getting notification token', err);
+          }
+          continueOnboarding();
+        });
+      return;
+    }
+
+    if (!notifPerms.canAskPermission) {
+      continueOnboarding();
+    }
+  }, [
+    continueOnboarding,
+    notifPerms.canAskPermission,
+    notifPerms.hasPermission,
+    notifPerms.initialized,
+  ]);
 
   useEffect(
     () =>

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -161,6 +161,7 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
                 onBlur={onBlur}
                 onChangeText={onChange}
                 onSubmitEditing={onSubmit}
+                autoFocus
                 autoCapitalize="words"
                 autoComplete="name"
                 returnKeyType="send"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1503,8 +1503,8 @@ export function GroupsPane(props: {
           testID="got-it"
           onPress={props.onActionPress}
           label="Got it"
-          preset="secondary"
-          fill="text"
+          preset={props.hostingBotEnabled ? 'secondary' : 'hero'}
+          fill={props.hostingBotEnabled ? 'text' : undefined}
         />
       </YStack>
     </View>
@@ -1839,6 +1839,12 @@ export function InvitePane(props: {
   const hasAutoProcessed = useRef(false);
   const perms = useContactPermissions();
 
+  const advanceToInviteContacts = useCallback(() => {
+    hasAutoProcessed.current = true;
+    setSysContacts([]);
+    setShowInviteContacts(true);
+  }, []);
+
   const processContacts = useCallback(async () => {
     try {
       setIsProcessing(true);
@@ -1860,16 +1866,26 @@ export function InvitePane(props: {
   }, [storeContext]);
 
   useEffect(() => {
-    if (
-      !isWeb &&
-      perms.hasPermission &&
-      !perms.isLoading &&
-      !hasAutoProcessed.current
-    ) {
+    if (isWeb || perms.isLoading || hasAutoProcessed.current) {
+      return;
+    }
+
+    if (perms.hasPermission) {
       hasAutoProcessed.current = true;
       processContacts();
+      return;
     }
-  }, [perms.hasPermission, perms.isLoading, processContacts]);
+
+    if (perms.permissionDenied) {
+      advanceToInviteContacts();
+    }
+  }, [
+    advanceToInviteContacts,
+    perms.hasPermission,
+    perms.isLoading,
+    perms.permissionDenied,
+    processContacts,
+  ]);
 
   const handleConnectContacts = async () => {
     try {
@@ -1877,7 +1893,17 @@ export function InvitePane(props: {
         const status = await perms.requestPermissions();
         if (status === 'granted') {
           await processContacts();
+          return;
         }
+
+        if (status === 'denied') {
+          advanceToInviteContacts();
+        }
+        return;
+      }
+
+      if (perms.permissionDenied) {
+        advanceToInviteContacts();
       }
     } catch (e) {
       logger.trackEvent(AnalyticsEvent.ErrorSystemContacts, {

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1892,6 +1892,7 @@ export function InvitePane(props: {
       if (perms.canAskPermission) {
         const status = await perms.requestPermissions();
         if (status === 'granted') {
+          hasAutoProcessed.current = true;
           await processContacts();
           return;
         }

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1504,7 +1504,7 @@ export function GroupsPane(props: {
           onPress={props.onActionPress}
           label="Got it"
           preset={props.hostingBotEnabled ? 'secondary' : 'hero'}
-          fill={props.hostingBotEnabled ? 'text' : undefined}
+          backgroundColor={props.hostingBotEnabled ? '$transparent' : undefined}
         />
       </YStack>
     </View>


### PR DESCRIPTION
## Summary

Handles navigation automatically on `SplashSequence` contacts pane and `AllowNotificationsScreen` once the system permission is confirmed granted/denied.

It will also auto-navigate if you land on the screen with your permission already set, whereas previously you'd still have to tap a button before we'd detect that perms were configured. We could pull that logic a screen forward and prevent ever showing the permission prompt screen/pane, but I think introducing that at this stage would be riskier and no new user should ever encounter it during an actual signup.

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

Onboarded with/without perms pre-configured in iOS Simulator

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding

Fixes TLON-5670