### PR TITLE
reel: fix mark conversion

### DIFF
--- a/desk/lib/reel.hoon
+++ b/desk/lib/reel.hoon
@@ -13,11 +13,36 @@
   :~  ['tag' s+tag.metadata]
       ['fields' (pairs:enjs:format fields)]
   ==
-++  dejs-metadata
-  %-  ot:dejs:format
-  :~  tag+so:dejs:format
-      fields+(om so):dejs:format
-  ==
+++  dejs
+  =,  dejs:format
+  |%
+  ++  metadata
+    ^-  $-(json metadata:v1:^reel)
+    %-  ot
+    :~  tag+so
+        fields+(op field so)
+    ==
+  ++  field
+    %-  perk
+    :~  %'bite-type'
+      ::
+        %'inviteType'
+      ::
+        %'inviterUserId'
+        %'inviterNickname'
+        %'inviterAvatarImage'
+        %'inviterColor'
+      ::
+        %'invitedGroupId'
+        %'invitedGroupTitle'
+        %'invitedGroupDescription'
+        %'invitedGroupIconImageUrl'
+        %'invitedGroupDeleted'
+      ::
+        %'$og_title'
+        %'$twitter_title'
+    ==
+  --
 ++  conv
   |%
   ++  v0
@@ -25,7 +50,7 @@
     ++  metadata
       |%
       ++  v1
-        |^  
+        |^
         |=  meta=metadata:v0:reel
         ^-  metadata:v1:reel
         =*  fields  fields.meta

--- a/desk/mar/reel/describe.hoon
+++ b/desk/mar/reel/describe.hoon
@@ -5,7 +5,7 @@
 ++  grab
   |%
   ++  noun  ,[token:reel metadata:v1:reel]
-  ++  json  (ot:dejs:format ~[token+so:dejs:format metadata+dejs-metadata])
+  ++  json  (ot:dejs:format ~[token+so:dejs:format metadata+metadata:dejs])
   --
 ++  grow
   |%

--- a/desk/mar/reel/metadata.hoon
+++ b/desk/mar/reel/metadata.hoon
@@ -5,7 +5,7 @@
 ++  grab
   |%
   ++  noun  metadata
-  ++  json  dejs-metadata
+  ++  json  metadata:dejs
   --
 ++  grow
   |%


### PR DESCRIPTION
## Summary

This PR https://github.com/tloncorp/tlon-apps/pull/5692 introduced a bug with converting reel describes from JSON. It likely passed in aqua because it was being poked as a noun which is not affected.

## Changes

- limit field type conversion so it actually nests

## How did I test?

Create a new group see invite link generate immediately

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
