### PR TITLE
MediaViewerScreen: fix hidden download/close buttons on web

### DIFF
--- a/packages/app/features/top/MediaViewerScreen.tsx
+++ b/packages/app/features/top/MediaViewerScreen.tsx
@@ -33,16 +33,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  AnimatePresence,
-  Spinner,
-  Stack,
-  View,
-  XStack,
-  YStack,
-  ZStack,
-  isWeb,
-} from 'tamagui';
+import { Spinner, Stack, View, XStack, YStack, ZStack, isWeb } from 'tamagui';
 
 import type { RootStackParamList } from '../../navigation/types';
 
@@ -641,40 +632,35 @@ function ImageViewer(props: {
             >
               <View flex={1}>{children}</View>
 
-              <AnimatePresence>
-                {showOverlay ? (
-                  <YStack
-                    key="overlay"
-                    animation="simple"
-                    enterStyle={{ opacity: 0 }}
-                    exitStyle={{ opacity: 0 }}
-                    position="absolute"
-                    width="100%"
-                    padding="$xl"
-                    paddingTop={isWeb ? 16 : top}
+              <YStack
+                animation="simple"
+                opacity={showOverlay ? 1 : 0}
+                pointerEvents={showOverlay ? 'auto' : 'none'}
+                position="absolute"
+                width="100%"
+                padding="$xl"
+                paddingTop={isWeb ? 16 : top}
+              >
+                <XStack
+                  justifyContent={isWeb ? 'flex-end' : 'space-between'}
+                  gap="$m"
+                >
+                  <TouchableOpacity
+                    onPress={handleDownloadImage}
+                    activeOpacity={0.8}
                   >
-                    <XStack
-                      justifyContent={isWeb ? 'flex-end' : 'space-between'}
-                      gap="$m"
-                    >
-                      <TouchableOpacity
-                        onPress={handleDownloadImage}
-                        activeOpacity={0.8}
-                      >
-                        <OverlayIconButton icon="ArrowDown" />
-                      </TouchableOpacity>
+                    <OverlayIconButton icon="ArrowDown" />
+                  </TouchableOpacity>
 
-                      <TouchableOpacity
-                        onPress={dismiss}
-                        activeOpacity={0.8}
-                        testID="MediaViewerCloseButton"
-                      >
-                        <OverlayIconButton icon="Close" />
-                      </TouchableOpacity>
-                    </XStack>
-                  </YStack>
-                ) : null}
-              </AnimatePresence>
+                  <TouchableOpacity
+                    onPress={dismiss}
+                    activeOpacity={0.8}
+                    testID="MediaViewerCloseButton"
+                  >
+                    <OverlayIconButton icon="Close" />
+                  </TouchableOpacity>
+                </XStack>
+              </YStack>
             </ZStack>
           </ImageViewerContainer>
         );


### PR DESCRIPTION
## Summary

(Hot) fixes TLON-5671 by removing AnimatePresence to show/hide the image lightbox controls. Tamagui's Moti animation driver behaves like a native driver on web, relying on Reanimated dev-only code to complete the enter animation. That code gets stripped in production, so the opacity: 0 enter state never transitions to 1. Driving opacity as a plain prop avoids the enter-style lifecycle entirely.                                                       
                                                                           
## Changes

Replaces `enterStyle` + `AnimatePresence` with `opacity={showOverlay ? 1 : 0}` on a persistently-mounted YStack.  

## How did I test?

Confirmed instance by building a production bundle locally and running. Applied fix, re-built production bundle, re-ran locally, fix confirmed.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: lightbox

## Rollback plan

git revert

## Screenshots / videos

Built to a production bundle, ran locally.

|before|after|
|------|-----|
|<img alt="Screenshot 2026-04-23 at 1 37 25 PM" src="https://github.com/user-attachments/assets/7b563f3f-0e2a-43bd-9552-3a93fa864a13" />|<img alt="Screenshot 2026-04-23 at 1 38 56 PM" src="https://github.com/user-attachments/assets/c01465fa-2360-4a1f-b2b9-4d412a35d100" />|





