### PR TITLE
 fix chat list swipe actions disappearing after release

### DIFF
--- a/packages/app/ui/components/listItems/InteractableChatListItem.tsx
+++ b/packages/app/ui/components/listItems/InteractableChatListItem.tsx
@@ -33,9 +33,6 @@ function BaseInteractableChatRow({
   ...props
 }: ListItemProps<db.Chat> & { onLayout?: (e: any) => void }) {
   const swipeableRef = useRef<SwipeableMethods>(null);
-  const [currentSwipeDirection, setCurrentSwipeDirection] = useState<
-    'left' | 'right' | null
-  >(null);
 
   const isMuted = useMemo(() => {
     return logic.isMuted(model.volumeSettings?.level, model.type);
@@ -78,19 +75,11 @@ function BaseInteractableChatRow({
     }
   );
 
-  const onSwipeableWillOpen = useCallback((direction: 'left' | 'right') => {
-    setCurrentSwipeDirection(direction);
-  }, []);
-
-  const onSwipeableClose = useCallback(() => {
-    setCurrentSwipeDirection(null);
-  }, []);
-
   const renderLeftActions = useCallback(
     (progress: SharedValue<number>, drag: SharedValue<number>) => {
       const hasUnread = model.unreadCount > 0;
 
-      if (currentSwipeDirection === 'right' || !hasUnread) {
+      if (!hasUnread) {
         return <View />;
       }
 
@@ -102,15 +91,11 @@ function BaseInteractableChatRow({
         />
       );
     },
-    [model.unreadCount, currentSwipeDirection, handleAction]
+    [model.unreadCount, handleAction]
   );
 
   const renderRightActions = useCallback(
     (progress: SharedValue<number>, drag: SharedValue<number>) => {
-      if (currentSwipeDirection === 'left') {
-        return <View />;
-      }
-
       return (
         <RightActions
           progress={progress}
@@ -120,7 +105,7 @@ function BaseInteractableChatRow({
         />
       );
     },
-    [handleAction, mutedState, currentSwipeDirection]
+    [handleAction, mutedState]
   );
 
   if (!isWeb) {
@@ -129,8 +114,6 @@ function BaseInteractableChatRow({
         ref={swipeableRef}
         renderLeftActions={renderLeftActions}
         renderRightActions={renderRightActions}
-        onSwipeableWillOpen={onSwipeableWillOpen}
-        onSwipeableClose={onSwipeableClose}
         leftThreshold={1}
         rightThreshold={1}
         friction={1.5}


### PR DESCRIPTION
## Summary

Fixes TLON-5672: on native (iOS and Android), swipe actions on the chat list rows become unusable once the row settles open. Removes an app-level swipe-direction guard in `InteractableChatListItem` that was hiding the action panel the user had just revealed.

Same defect as TLON-5491 on the Expo-54 branch; this mirrors the fix in `adba45ea3` on `origin/janic/expo-54`.

## Changes

Single file: `packages/app/ui/components/listItems/InteractableChatListItem.tsx` (+3 / −20).

- Removed `currentSwipeDirection` state and its setters.
- Removed `onSwipeableWillOpen` / `onSwipeableClose` callbacks and their props on `<Swipeable>`.
- `renderLeftActions`: dropped the `currentSwipeDirection === 'right'` branch; kept the `!hasUnread` branch (unrelated).
- `renderRightActions`: dropped the `currentSwipeDirection === 'left'` branch.

### Why

`InteractableChatListItem` stored `onSwipeableWillOpen(direction)` in state and used it to suppress one side's action renderer. In `react-native-gesture-handler` 2.24.0 (`ReanimatedSwipeable.tsx:342-345`), that `direction` is the **gesture direction**, not the side being opened. So a right swipe opens `LeftActions` and simultaneously sets the flag that blanks `LeftActions` — the component was removing the panel it had just revealed. Symmetric on the other side.

The guard was added in `22c5d3d27` against an older RNGH contract where the callback reported which side was opening. It became user-visible when RNGH was pinned to 2.24.0 in `95eb41014` (mobile lightbox work). Removing it is the minimum change that restores correct behavior.

## How did I test?

Tested on the iOS Simulator and Android Emulator.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: ChatList

## Rollback plan

Revert

## Screenshots / videos

[android emulator 4-23-2026 .webm](https://github.com/user-attachments/assets/42224aca-a799-474f-b60b-9ae812b6833c)

https://github.com/user-attachments/assets/68503481-72bb-429c-8f8a-f7f58eb983a2


