### PR TITLE
fix(mobile): voice message send on Android (Expo 54)

### DIFF
--- a/packages/app/ui/components/AttachmentSheet.tsx
+++ b/packages/app/ui/components/AttachmentSheet.tsx
@@ -248,20 +248,21 @@ export default function AttachmentSheet({
   const draftInputContext = useDraftInputContext();
   const audioRecorder = useAudioRecorderController({
     async onSubmit({ audioFilePath, waveformPreview }) {
+      const audioFileUri = filePathToFileUri(audioFilePath);
       const duration = await (async () => {
         try {
-          return await getAudioFileDurationSeconds(audioFilePath);
+          return await getAudioFileDurationSeconds(audioFileUri);
         } catch {
           return undefined;
         }
       })();
       const attachment: VoiceMemoAttachment = {
         type: 'voicememo',
-        localUri: filePathToFileUri(audioFilePath),
-        size: getFileSize(audioFilePath) ?? -1,
+        localUri: audioFileUri,
+        size: getFileSize(audioFileUri) ?? -1,
         waveformPreview,
         duration: duration ?? undefined,
-        mimeType: getMimeType(audioFilePath) ?? undefined,
+        mimeType: getMimeType(audioFileUri) ?? undefined,
       };
       audioRecorder.dismiss();
 

--- a/packages/app/utils/files.ts
+++ b/packages/app/utils/files.ts
@@ -1,22 +1,12 @@
 import { createAudioPlayer } from 'expo-audio';
 import { File } from 'expo-file-system';
 
-// expo-file-system V2 requires an absolute URI (e.g. `file:///...`). Accept
-// either a raw path or a URI and normalize to a URI.
-function toFileUri(pathOrUri: string): string {
-  try {
-    return new URL(pathOrUri).toString();
-  } catch {
-    return new URL(`file://${pathOrUri}`).toString();
-  }
-}
-
 export function getMimeType(uri: string): string | null {
-  return new File(toFileUri(uri)).type;
+  return new File(uri).type;
 }
 
 export function getFileSize(uri: string): number | null {
-  return new File(toFileUri(uri)).size;
+  return new File(uri).size;
 }
 
 export async function getAudioFileDurationSeconds(

--- a/packages/app/utils/files.ts
+++ b/packages/app/utils/files.ts
@@ -1,12 +1,22 @@
 import { createAudioPlayer } from 'expo-audio';
 import { File } from 'expo-file-system';
 
+// expo-file-system V2 requires an absolute URI (e.g. `file:///...`). Accept
+// either a raw path or a URI and normalize to a URI.
+function toFileUri(pathOrUri: string): string {
+  try {
+    return new URL(pathOrUri).toString();
+  } catch {
+    return new URL(`file://${pathOrUri}`).toString();
+  }
+}
+
 export function getMimeType(uri: string): string | null {
-  return new File(uri).type;
+  return new File(toFileUri(uri)).type;
 }
 
 export function getFileSize(uri: string): number | null {
-  return new File(uri).size;
+  return new File(toFileUri(uri)).size;
 }
 
 export async function getAudioFileDurationSeconds(


### PR DESCRIPTION
## Summary

Voice messages silently fail to send on Android after the Expo 54 upgrade. The send button visually reacts but nothing happens — no error surfaces in LogBox.

Closes [TLON-5595](https://linear.app/tlon/issue/TLON-5595/expo-54-android-cant-send-a-voice-message).

## Changes

The root cause: expo-file-system V2 (shipped with Expo 54) requires an absolute URI for the `File` constructor. On Android the audio recorder returns a raw path like `/data/user/0/io.tlon.groups/cache/...m4a`. Passing that to `new File(uri)` throws `IllegalArgumentException: URI is not absolute`. The caller (`AttachmentSheet.onSubmit`) is async and the throw became an unhandled promise rejection that Hermes does not currently surface to LogBox, so the UI just went quiet.

In `AttachmentSheet.onSubmit` for the voice recorder, convert the raw recording path to a `file://` URI once and reuse it for `getFileSize`, `getMimeType`, `getAudioFileDurationSeconds`, and `localUri`.

## How did I test?

Tested on both iOS and Android

- Recorded a voice memo in a DM, tapped send.
- Before: button showed press feedback, nothing sent, no visible error.
- After: voice memo attaches and the post sends normally.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert this PR. The change is isolated to the voice-memo submit path.

## Screenshots / videos

N/A