### PR TITLE
Fix notification bell unread dot rendering as square on Android

### DIFF
--- a/packages/app/ui/components/NavBar/NavIcon.tsx
+++ b/packages/app/ui/components/NavBar/NavIcon.tsx
@@ -3,7 +3,7 @@ import { Icon, IconType } from '@tloncorp/ui';
 import { Pressable } from '@tloncorp/ui';
 import { View } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
-import { Circle, ColorTokens, isWeb } from 'tamagui';
+import { ColorTokens, isWeb } from 'tamagui';
 
 import { ContactAvatar } from '../Avatar';
 
@@ -99,8 +99,10 @@ export default function NavIcon({
           justifyContent="center"
           alignItems="center"
         >
-          <Circle
-            size="$s"
+          <View
+            width="$s"
+            height="$s"
+            borderRadius="$s"
             backgroundColor={hasUnreads ? '$blue' : 'transparent'}
           />
         </View>

--- a/packages/app/ui/components/NavBar/NavIcon.tsx
+++ b/packages/app/ui/components/NavBar/NavIcon.tsx
@@ -3,7 +3,7 @@ import { Icon, IconType } from '@tloncorp/ui';
 import { Pressable } from '@tloncorp/ui';
 import { View } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
-import { ColorTokens, isWeb } from 'tamagui';
+import { Circle, ColorTokens, isWeb } from 'tamagui';
 
 import { ContactAvatar } from '../Avatar';
 
@@ -99,10 +99,14 @@ export default function NavIcon({
           justifyContent="center"
           alignItems="center"
         >
-          <View
-            width="$s"
-            height="$s"
-            borderRadius="$s"
+          <Circle
+            // Workaround for facebook/react-native#52415: on Android new
+            // arch, a View whose backgroundColor transitions from
+            // transparent to opaque loses its border-radius clipping.
+            // Keying on hasUnreads forces a fresh mount so the dot is
+            // rendered as a circle.
+            key={hasUnreads ? 'unread' : 'read'}
+            size="$s"
             backgroundColor={hasUnreads ? '$blue' : 'transparent'}
           />
         </View>


### PR DESCRIPTION
## Summary

On Android, the unread indicator dot under the Activity (bell) tab icon renders as a square instead of a circle.

Fixes TLON-5662

## Root cause

[facebook/react-native#52415](https://github.com/facebook/react-native/issues/52415): on Android with the new architecture, a View whose `backgroundColor` transitions from `transparent` to an opaque color loses its `border-radius` clipping. The nav bar dot in `NavIcon` starts with `backgroundColor: 'transparent'` (no unreads) and transitions to `$blue` when unreads arrive, so the rendered View keeps the rectangular shape it had when it was transparent. iOS is unaffected. Hot reload masks the bug because it re-mounts the view with the new background color; a full app launch reproduces it reliably.

## Changes

- `packages/app/ui/components/NavBar/NavIcon.tsx`: key the unread dot `Circle` on `hasUnreads`, so each transition triggers a fresh mount with the final background color already applied and `border-radius` is honored.

## How did I test?

- Android: cold-launched the app (not hot reload — hot reload hides the bug) and confirmed the dot renders as a circle when unreads are present.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other: bottom nav bar visuals only

## Rollback plan

Revert the commits on this branch. The change is isolated to the nav bar unread indicator.

## Screenshots / videos

_To be added once a build is ready._