### PR TITLE
Fix OTP input duplicate digits on Android (Expo 54)

### DIFF
--- a/packages/app/ui/components/Form/OTPInput.tsx
+++ b/packages/app/ui/components/Form/OTPInput.tsx
@@ -84,7 +84,10 @@ export function OTPInput({
             right: 0,
             bottom: 0,
             opacity: 1,
-            color: 'transparent',
+            // Use #ffffff00 instead of 'transparent' to work around
+            // https://github.com/facebook/react-native/issues/53343
+            // (fixed upstream by https://github.com/facebook/react-native/pull/55380, not yet merged).
+            color: '#ffffff00',
             fontSize: 48,
             letterSpacing: 35,
             paddingLeft: 18,


### PR DESCRIPTION
## Summary

Works around a React Native 0.81 Android regression where `color: 'transparent'` on a `TextInput` is no longer honored, causing the `OTPInput` component to render duplicated/ghosted digits in the confirmation-code screen. Closes [TLON-5658](https://linear.app/tlon/issue/TLON-5658/expo-54-android-duplicate-numbers-in-confirmation-code-input).

## Changes

`packages/app/ui/components/Form/OTPInput.tsx`: swap `color: 'transparent'` for `color: '#ffffff00'` on the hidden `TextInput` that sits over the digit cells. Everything else about the component is unchanged.

The upstream fix is [facebook/react-native#55380](https://github.com/facebook/react-native/pull/55380), which is open but not yet merged. Using an explicit `#ffffff00` (zero-alpha) color sidesteps the `transparent` keyword and renders correctly on both the current and the patched RN.

## How did I test?

- Reproduced the ghosted digits on Android with Expo 54 before the change.
- After the change, entered a code on Android: only the cell digits are visible, no ghosting.
- Verified on iOS that the input still behaves the same (focus, paste, single-tap anywhere in the row).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

Scoped to one style property in one component used only in the phone/email confirmation-code screens. Web/iOS rendering of the same color is equivalent.

## Rollback plan

Revert this commit.

## Screenshots / videos

<img width="391" height="331" alt="image" src="https://github.com/user-attachments/assets/020f15c7-f99e-45ab-b261-1beaf30038fa" />

<img width="388" height="210" alt="image" src="https://github.com/user-attachments/assets/924d5d21-5d81-4c2d-bad2-bf8300b51a9f" />
