### PR TITLE
onboarding: fix nickname handling

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -33,6 +33,25 @@ type FormData = {
 };
 
 const logger = createDevLogger('SetNicknameScreen', false);
+const NICKNAME_SETUP_STARTING_DELAY_MS = 1000;
+const NICKNAME_SETUP_MAX_DELAY_MS = 4000;
+const NICKNAME_SETUP_NUM_ATTEMPTS = 6;
+
+function getRetryDelayMs(attemptNumber: number) {
+  return Math.min(
+    NICKNAME_SETUP_STARTING_DELAY_MS *
+      Math.pow(2, Math.max(attemptNumber - 1, 0)),
+    NICKNAME_SETUP_MAX_DELAY_MS
+  );
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getAttemptsUsed(retryCount: number) {
+  return Math.min(retryCount + 1, NICKNAME_SETUP_NUM_ATTEMPTS);
+}
 
 export const SetNicknameScreen = ({ navigation }: Props) => {
   const theme = useTheme();
@@ -55,6 +74,8 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
   const signupContext = useSignupContext();
 
   const onSubmit = handleSubmit(({ nickname }) => {
+    let retryCount = 0;
+
     signupContext.setOnboardingValues({
       nickname,
       userWasReadyAt: Date.now(),
@@ -73,33 +94,63 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
           throw new Error('No nickname provided during nickname setup');
         }
 
-        await store.updateCurrentUserProfile({ nickname });
+        await store.updateCurrentUserProfile(
+          { nickname },
+          { shouldThrow: true }
+        );
 
         const isBotEnabled = await db.hostingBotEnabled.getValue();
         if (isBotEnabled) {
           const botNickname = `${nickname}'s TlonBot 🌱`;
           await api.setTlawnNickname(userId, botNickname);
-
-          const botHomeGroup = await db.getBotHomeGroup();
-          if (!botHomeGroup) {
-            throw new Error('No Bot Home Group found during nickname setup');
-          }
-
-          await store.updateGroupMeta({
-            ...botHomeGroup,
-            title: `${nickname}'s Group`,
-          });
         }
       },
-      { startingDelay: 0, numOfAttempts: 4, maxDelay: 4000 }
-    ).catch((err) => {
-      logger.trackError(
-        'Failed to set nickname on bot ship or update Home Group',
-        {
-          error: err instanceof Error ? err.message : String(err),
+      {
+        startingDelay: NICKNAME_SETUP_STARTING_DELAY_MS,
+        numOfAttempts: NICKNAME_SETUP_NUM_ATTEMPTS,
+        maxDelay: NICKNAME_SETUP_MAX_DELAY_MS,
+        retry: (error, retryNumber) => {
+          retryCount = retryNumber;
+          const willRetry = retryNumber < NICKNAME_SETUP_NUM_ATTEMPTS;
+
+          logger.trackEvent(
+            willRetry
+              ? 'Set nickname retry scheduled'
+              : 'Set nickname retries exhausted',
+            {
+              attemptsUsed: willRetry
+                ? retryNumber
+                : NICKNAME_SETUP_NUM_ATTEMPTS,
+              error: getErrorMessage(error),
+              maxAttempts: NICKNAME_SETUP_NUM_ATTEMPTS,
+              nextDelayMs: willRetry ? getRetryDelayMs(retryNumber) : null,
+              retryNumber,
+            }
+          );
+
+          return willRetry;
+        },
+      }
+    )
+      .then(() => {
+        if (retryCount > 0) {
+          logger.trackEvent('Set nickname retry recovered', {
+            attemptsUsed: getAttemptsUsed(retryCount),
+            maxAttempts: NICKNAME_SETUP_NUM_ATTEMPTS,
+            retryCount,
+          });
         }
-      );
-    });
+      })
+      .catch((err) => {
+        logger.trackError(
+          'Failed to set nickname on bot ship or update Home Group',
+          {
+            attemptsUsed: getAttemptsUsed(retryCount),
+            error: getErrorMessage(err),
+            retryCount,
+          }
+        );
+      });
 
     navigation.push('SetNotifications');
   });

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -60,6 +60,8 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
       userWasReadyAt: Date.now(),
     });
 
+    db.splashNickname.setValue(nickname ?? '');
+
     // once they've decided on a nickname, we need to re-title their bot
     // and update the name of their home group
     withRetry(
@@ -77,12 +79,6 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
           { nickname },
           { shouldThrow: true }
         );
-
-        const isBotEnabled = await db.hostingBotEnabled.getValue();
-        if (isBotEnabled) {
-          const botNickname = `${nickname}'s TlonBot 🌱`;
-          await api.setTlawnNickname(userId, botNickname);
-        }
       },
       {
         startingDelay: 1000,

--- a/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SetNicknameScreen.tsx
@@ -33,25 +33,6 @@ type FormData = {
 };
 
 const logger = createDevLogger('SetNicknameScreen', false);
-const NICKNAME_SETUP_STARTING_DELAY_MS = 1000;
-const NICKNAME_SETUP_MAX_DELAY_MS = 4000;
-const NICKNAME_SETUP_NUM_ATTEMPTS = 6;
-
-function getRetryDelayMs(attemptNumber: number) {
-  return Math.min(
-    NICKNAME_SETUP_STARTING_DELAY_MS *
-      Math.pow(2, Math.max(attemptNumber - 1, 0)),
-    NICKNAME_SETUP_MAX_DELAY_MS
-  );
-}
-
-function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function getAttemptsUsed(retryCount: number) {
-  return Math.min(retryCount + 1, NICKNAME_SETUP_NUM_ATTEMPTS);
-}
 
 export const SetNicknameScreen = ({ navigation }: Props) => {
   const theme = useTheme();
@@ -74,8 +55,6 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
   const signupContext = useSignupContext();
 
   const onSubmit = handleSubmit(({ nickname }) => {
-    let retryCount = 0;
-
     signupContext.setOnboardingValues({
       nickname,
       userWasReadyAt: Date.now(),
@@ -106,51 +85,28 @@ export const SetNicknameScreen = ({ navigation }: Props) => {
         }
       },
       {
-        startingDelay: NICKNAME_SETUP_STARTING_DELAY_MS,
-        numOfAttempts: NICKNAME_SETUP_NUM_ATTEMPTS,
-        maxDelay: NICKNAME_SETUP_MAX_DELAY_MS,
+        startingDelay: 1000,
+        numOfAttempts: 4,
+        maxDelay: 4000,
         retry: (error, retryNumber) => {
-          retryCount = retryNumber;
-          const willRetry = retryNumber < NICKNAME_SETUP_NUM_ATTEMPTS;
+          if (retryNumber < 4) {
+            logger.trackEvent('Set nickname failed, retrying', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return true;
+          }
 
-          logger.trackEvent(
-            willRetry
-              ? 'Set nickname retry scheduled'
-              : 'Set nickname retries exhausted',
-            {
-              attemptsUsed: willRetry
-                ? retryNumber
-                : NICKNAME_SETUP_NUM_ATTEMPTS,
-              error: getErrorMessage(error),
-              maxAttempts: NICKNAME_SETUP_NUM_ATTEMPTS,
-              nextDelayMs: willRetry ? getRetryDelayMs(retryNumber) : null,
-              retryNumber,
-            }
-          );
-
-          return willRetry;
+          return false;
         },
       }
-    )
-      .then(() => {
-        if (retryCount > 0) {
-          logger.trackEvent('Set nickname retry recovered', {
-            attemptsUsed: getAttemptsUsed(retryCount),
-            maxAttempts: NICKNAME_SETUP_NUM_ATTEMPTS,
-            retryCount,
-          });
+    ).catch((err) => {
+      logger.trackError(
+        'Failed to set nickname on bot ship or update Home Group',
+        {
+          error: err instanceof Error ? err.message : String(err),
         }
-      })
-      .catch((err) => {
-        logger.trackError(
-          'Failed to set nickname on bot ship or update Home Group',
-          {
-            attemptsUsed: getAttemptsUsed(retryCount),
-            error: getErrorMessage(err),
-            retryCount,
-          }
-        );
-      });
+      );
+    });
 
     navigation.push('SetNotifications');
   });

--- a/packages/api/src/client/wayfinding.ts
+++ b/packages/api/src/client/wayfinding.ts
@@ -105,7 +105,26 @@ export function personalGroupHasDefaultTitle(group?: db.Group | null) {
   return group.title?.toLowerCase().includes('group');
 }
 
+export function botHomeGroupHasDefaultTitle(group?: db.Group | null) {
+  if (!group) {
+    return false;
+  }
+
+  return (
+    group.title?.toLowerCase().includes('group') ||
+    group.title?.toLowerCase().includes('home')
+  );
+}
+
 export function generatePersonalGroupTitle(contact: {
+  id: string;
+  nickname?: string | null;
+}) {
+  const displayName = contact.nickname || contact.id;
+  return `${displayName}'s Group`;
+}
+
+export function generateBotHomeGroupTitle(contact: {
   id: string;
   nickname?: string | null;
 }) {

--- a/packages/api/src/lib/utils.ts
+++ b/packages/api/src/lib/utils.ts
@@ -254,16 +254,29 @@ export function convertToAscii(str: string): string {
 
 export type RetryConfig = Pick<
   BackoffOptions,
-  'startingDelay' | 'numOfAttempts' | 'maxDelay'
+  'startingDelay' | 'numOfAttempts' | 'maxDelay' | 'timeMultiple' | 'retry'
 >;
 
 export const withRetry = <T>(fn: () => Promise<T>, config?: RetryConfig) => {
-  return backOff(fn, {
+  const options: BackoffOptions = {
     delayFirstAttempt: false,
     startingDelay: config?.startingDelay ?? 1000,
     numOfAttempts: config?.numOfAttempts ?? 4,
-    maxDelay: config?.maxDelay,
-  });
+  };
+
+  if (typeof config?.maxDelay === 'number') {
+    options.maxDelay = config.maxDelay;
+  }
+
+  if (typeof config?.timeMultiple === 'number') {
+    options.timeMultiple = config.timeMultiple;
+  }
+
+  if (config?.retry) {
+    options.retry = config.retry;
+  }
+
+  return backOff(fn, options);
 };
 
 /**

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -90,6 +90,15 @@ enum SplashPane {
 
 type CustomBotSetupStatus = 'idle' | 'pending' | 'ready' | 'failed';
 
+function getPreviewBotName(userNickname?: string | null) {
+  const trimmedNickname = userNickname?.trim();
+  if (!trimmedNickname) {
+    return 'Tlonbot';
+  }
+
+  return `${trimmedNickname}'s TlonBot 🌱`;
+}
+
 function SplashSequenceComponent(props: {
   onCompleted: () => void;
   inviteSystemContacts?: InviteSystemContactsFn;
@@ -146,14 +155,20 @@ function SplashSequenceComponent(props: {
         const userId = await db.hostingUserId.getValue();
         if (shipId) {
           setUserShipId(`~${shipId}`);
-          const [botInfo, providerConfig, userContact] = await Promise.all([
-            api.getTlawnBotInfo(shipId).catch(() => null),
-            userId ? api.getTlawnProviderKeys(userId).catch(() => null) : null,
-            db.getContact({ id: `~${shipId}` }).catch(() => null),
-          ]);
+          const [botInfo, providerConfig, userContact, savedSignup] =
+            await Promise.all([
+              api.getTlawnBotInfo(shipId).catch(() => null),
+              userId
+                ? api.getTlawnProviderKeys(userId).catch(() => null)
+                : null,
+              db.getContact({ id: `~${shipId}` }).catch(() => null),
+              db.signupData.getValue().catch(() => null),
+            ]);
           if (!cancelled) {
-            if (userContact?.nickname) {
-              setUserNickname(userContact.nickname);
+            const resolvedUserNickname =
+              userContact?.nickname?.trim() || savedSignup?.nickname?.trim();
+            if (resolvedUserNickname) {
+              setUserNickname(resolvedUserNickname);
             }
             if (botInfo?.moon) {
               // Hosting returns the moon prefix (e.g., `pinser-botter`); the
@@ -893,8 +908,8 @@ export function BotNamePane(props: {
                 autoFocus
                 placeholder={
                   props.userNickname
-                    ? `${props.userNickname}'s Tlonbot`
-                    : 'Tlonbot'
+                    ? getPreviewBotName(props.userNickname)
+                    : 'TlonBot'
                 }
                 frameStyle={{ height: 72 }}
                 style={{ fontSize: 24, lineHeight: 30 }}

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -96,7 +96,7 @@ function getPreviewBotName(userNickname?: string | null) {
     return 'Tlonbot';
   }
 
-  return `${trimmedNickname}'s TlonBot 🌱`;
+  return `${trimmedNickname}'s Tlonbot 🌱`;
 }
 
 function SplashSequenceComponent(props: {
@@ -155,18 +155,18 @@ function SplashSequenceComponent(props: {
         const userId = await db.hostingUserId.getValue();
         if (shipId) {
           setUserShipId(`~${shipId}`);
-          const [botInfo, providerConfig, userContact, savedSignup] =
+          const [botInfo, providerConfig, userContact, cachedNickname] =
             await Promise.all([
               api.getTlawnBotInfo(shipId).catch(() => null),
               userId
                 ? api.getTlawnProviderKeys(userId).catch(() => null)
                 : null,
               db.getContact({ id: `~${shipId}` }).catch(() => null),
-              db.signupData.getValue().catch(() => null),
+              db.splashNickname.getValue().catch(() => null),
             ]);
           if (!cancelled) {
             const resolvedUserNickname =
-              userContact?.nickname?.trim() || savedSignup?.nickname?.trim();
+              userContact?.nickname?.trim() || cachedNickname?.trim();
             if (resolvedUserNickname) {
               setUserNickname(resolvedUserNickname);
             }
@@ -909,7 +909,7 @@ export function BotNamePane(props: {
                 placeholder={
                   props.userNickname
                     ? getPreviewBotName(props.userNickname)
-                    : 'TlonBot'
+                    : 'Tlonbot'
                 }
                 frameStyle={{ height: 72 }}
                 style={{ fontSize: 24, lineHeight: 30 }}

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -319,6 +319,11 @@ export const userHasPersonalGroup = createStorageItem<boolean>({
   defaultValue: false,
 });
 
+export const splashNickname = createStorageItem<string>({
+  key: 'splashNickname',
+  defaultValue: '',
+});
+
 export const wayfindingProgress = createStorageItem<WayfindingProgress>({
   key: 'wayfindingProgress',
   defaultValue: {

--- a/packages/shared/src/store/contactActions.ts
+++ b/packages/shared/src/store/contactActions.ts
@@ -288,7 +288,10 @@ export async function updateContactMetadata(
   }
 }
 
-export async function updateCurrentUserProfile(update: api.ProfileUpdate) {
+export async function updateCurrentUserProfile(
+  update: api.ProfileUpdate,
+  config?: { shouldThrow?: boolean }
+) {
   const currentUserId = api.getCurrentUserId();
   const currentUserContact = await db.getContact({ id: currentUserId });
 
@@ -332,16 +335,44 @@ export async function updateCurrentUserProfile(update: api.ProfileUpdate) {
           id: currentUserId,
           nickname: update.nickname,
         });
-        await GroupActions.updateGroupMeta({
-          ...personalGroup,
-          title: newTitle,
+        await GroupActions.updateGroupMeta(
+          {
+            ...personalGroup,
+            title: newTitle,
+          },
+          config
+        );
+      }
+    }
+
+    // handle updating the home group title if user sets their nickname
+    const homeGroup = await db.getBotHomeGroup();
+    if (homeGroup) {
+      const hasDefaultTitle = logic.botHomeGroupHasDefaultTitle(homeGroup);
+      const changedNickname =
+        currentUserContact?.peerNickname !== update.nickname;
+
+      if (hasDefaultTitle && changedNickname) {
+        const newTitle = logic.generateBotHomeGroupTitle({
+          id: currentUserId,
+          nickname: update.nickname,
         });
+        await GroupActions.updateGroupMeta(
+          {
+            ...homeGroup,
+            title: newTitle,
+          },
+          config
+        );
       }
     }
   } catch (e) {
     console.error('Error updating profile', e);
     // Rollback the update
     await db.updateContact({ id: currentUserId, ...startFields });
+    if (config?.shouldThrow) {
+      throw e;
+    }
   }
 }
 

--- a/packages/shared/src/store/groupActions.ts
+++ b/packages/shared/src/store/groupActions.ts
@@ -444,7 +444,10 @@ export async function updateGroupPrivacy(
   }
 }
 
-export async function updateGroupMeta(group: db.Group) {
+export async function updateGroupMeta(
+  group: db.Group,
+  config?: { shouldThrow?: boolean }
+) {
   logger.log('updating group', group.id);
   logger.trackEvent(AnalyticsEvent.ActionCustomizedGroup, {
     ...logic.getModelAnalytics({ group }),
@@ -474,6 +477,9 @@ export async function updateGroupMeta(group: db.Group) {
     // rollback optimistic update
     if (existingGroup) {
       await db.updateGroup(existingGroup);
+    }
+    if (config?.shouldThrow) {
+      throw e;
     }
   }
 }


### PR DESCRIPTION
- fix the bug where retries would fire immediately instead of delaying as expected
- set home group title whenever user nickname is updated if still has default title (same as old style personal group)
- check signup context for nickname in addition to pulling from local db contact