### PR TITLE
activity: drop trailing slashes from scry paths

### DIFF
--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -42,9 +42,9 @@ export async function getThreadUnreadsByChannel(channel: db.Channel) {
       channelParts.host,
       channelParts.name,
     ].join('/');
-    scryPath = `/${pathParts}/`;
+    scryPath = `/${pathParts}`;
   } else {
-    scryPath = `/v4/activity/dm-threads/${channel.id}/`;
+    scryPath = `/v4/activity/dm-threads/${channel.id}`;
   }
   const activity = await scry<ub.Activity>({
     app: 'activity',
@@ -105,7 +105,7 @@ export async function getPagedActivityByBucket({
     cursor
   );
   const urbitCursor = formatUd(da.fromUnix(cursor).toString());
-  const path = `/v5/feed/${bucket}/${ACTIVITY_SOURCE_PAGESIZE}/${urbitCursor}/`;
+  const path = `/v5/feed/${bucket}/${ACTIVITY_SOURCE_PAGESIZE}/${urbitCursor}`;
   const { feed, summaries } = await scry<ub.ActivityFeed>({
     app: 'activity',
     path,


### PR DESCRIPTION
## Summary

- The `getThreadUnreadsByChannel`, DM thread-unreads, and paginated `getPagedActivityByBucket` scry paths in `packages/api/src/client/activityApi.ts` all ended with a trailing `/`.
- Eyre parses that trailing `/` into an empty `%$` knot before the terminator, so the `%activity` agent's peek arms — which require the path to terminate right after the last parameter — never matched. These three scries have been silently failing since they were introduced (Jul 2024, `d035793e7`).
- Fix is just dropping the trailing `/` on all three paths. Nothing in our `urbit.ts` wrapper or `@urbit/http-api` has ever normalized trailing slashes, so there was no prior behavior relying on it.

Fixes TLON-5679

## Test plan

- [ ] Verify per-channel thread unreads now populate in the activity feed
- [ ] Verify DM thread unreads now populate
- [ ] Verify paginating the activity feed (scrolling past the initial page) returns results instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)