### PR TITLE
fix(ContactBook): swap height 100% for auto to fix Create group button on Android (TLON-5660)

### DIFF
--- a/packages/app/ui/components/ContactBook.tsx
+++ b/packages/app/ui/components/ContactBook.tsx
@@ -196,7 +196,7 @@ export function ContactBook({
   return (
     <View
       flex={1}
-      height={height || '100%'}
+      height={height || 'auto'}
       width={width || '100%'}
       display={'flex'}
       minHeight={minHeight}


### PR DESCRIPTION
## Summary

Fixes [TLON-5660](https://linear.app/tlon/issue/TLON-5660/expo-54-android-new-group-sheet-layout-issue) — on Android (Expo 54 / new arch), opening the New group sheet showed the contact list but the "Create group" button was pushed off the bottom of the sheet and was unreachable.

## Changes

Swap `height: '100%'` for `height: 'auto'` on the outer `View` of `ContactBook`. The combination of `flex: 1` + `height: '100%'` was making Yoga resolve the wrapper against the parent's full content box before distributing flex space, so when ContactBook sat next to a sibling in a flex column (the Create group button in `CreateChatSheet`) it claimed the full height and pushed the sibling out of view. Dropping to `auto` lets `flex: 1` drive sizing on its own; callers that need a fixed height still pass it via the `height` prop.

iOS was previously masking the bug — it tolerated the conflicting constraints — so this also restores correct sizing on Android without regressing iOS.

## How did I test?

- Android emulator (Pixel medium, API 35): opened Home → + → New group, confirmed "Create group" button is visible at the bottom of the sheet and the contact list scrolls.
- iOS: contact list + button still render correctly inside the sheet.
- Also exercised the join-by-code and direct-message flows in the same sheet.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: shared `ContactBook` component (used in New group / New DM sheets, Invite sheet, Add Contacts screen, Invite users screen)

## Rollback plan

Revert the single-line change in `packages/app/ui/components/ContactBook.tsx` (`height: 'auto'` → `height: '100%'`).

## Screenshots / videos

<!-- Android before/after screenshots if useful -->