### PR TITLE
upload: preserve gif format on web paste

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -130,6 +130,8 @@ function usePasteHandler(addAttachment: (attachment: Attachment) => void) {
               uri,
               height: img.height,
               width: img.width,
+              mimeType: file.type || undefined,
+              fileSize: file.size,
             },
           });
         };

--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -200,8 +200,15 @@ async function uploadImageAsset(
       logger.log('resizing asset', asset.uri);
       let resizedAsset = asset;
       const originalMimeType = asset.mimeType;
-      // avoid resizing gifs
-      if (!asset.mimeType?.includes('gif')) {
+      // Only resize when we know it's a non-gif image. If mimeType is missing
+      // or non-image, upload the original bytes — re-encoding through the
+      // canvas-backed manipulator would clobber the format (e.g. animated
+      // gifs flattened to a single PNG/JPEG frame).
+      const canResize =
+        !!asset.mimeType &&
+        asset.mimeType.startsWith('image/') &&
+        !asset.mimeType.includes('gif');
+      if (canResize) {
         const format = getSaveFormat(asset.mimeType);
         resizedAsset = await manipulateAsync(
           asset.uri,


### PR DESCRIPTION
## Summary

Pasted GIFs on web were being clobbered into static images during upload. The web paste handler dropped the source `File`'s `type` and `size`, so the upload pipeline saw an `undefined` mimeType and re-encoded the GIF through `expo-image-manipulator`'s canvas-backed web shim — flattening the animation.

## Changes

- `packages/app/ui/components/BareChatInput/index.tsx` — paste handler now forwards `mimeType: file.type` and `fileSize: file.size` to the image attachment, matching what `FileDrop.tsx` already does for drag-and-drop.
- `packages/shared/src/store/storage/storageActions.ts` — flipped the resize guard from "skip GIFs" to "only resize known non-GIF images." When mimeType is missing or non-image, the original bytes are uploaded unchanged instead of being round-tripped through `manipulateAsync` (which on web uses a canvas and silently re-encodes).

## How did I test?

- `pnpm -r tsc` clean across `@tloncorp/shared` and `@tloncorp/app`.
- Existing `imagePickerAsset.web.test.ts` suite still passes.
- Manual: pasted an animated GIF into a chat on web — uploaded URL retains `.gif` extension and animates after sending.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: image upload pipeline (web paste path + shared resize guard)

The resize guard is now stricter (only known non-GIF images get resized). Side effect: assets that arrive without a mimeType — previously silently re-encoded as JPEG — will now upload at their original byte size. This is the correct behavior, but if any upstream caller was relying on the old auto-resize for an unknown asset, those uploads will be larger.

## Rollback plan

Revert the commit. Both edits are localized; no migrations or schema changes.

## Screenshots / videos

_TODO: attach before/after of an animated GIF paste on web._