### PR TITLE
fix group avatars disappearing

### DIFF
--- a/packages/app/ui/components/Avatar.tsx
+++ b/packages/app/ui/components/Avatar.tsx
@@ -186,6 +186,7 @@ export const GroupAvatar = React.memo(function GroupAvatarComponent({
 
   return (
     <ImageAvatar
+      key={model.iconImage ?? 'fallback'}
       imageUrl={model.iconImage ?? undefined}
       fallback={fallback}
       isGroupIcon={true}


### PR DESCRIPTION
## Summary

This fixes group avatars sometimes turning into member face piles after scrolling away and back.

FlashList can reuse rows as you scroll. Group avatar images now get a key from the group icon, so recycled rows do not keep stale image load state from another group.

Fixes TLON-5632

## Changes

- key group image avatars by their icon image

## How did I test?

Tested on device.