### PR TITLE
implement bot mention tooltip and related wayfinding logic

### DIFF
--- a/apps/tlon-web/e2e/chat-core-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-core-functionality.spec.ts
@@ -1,10 +1,113 @@
-import { expect } from '@playwright/test';
+import { type Page, expect } from '@playwright/test';
 
 import * as helpers from './helpers';
 import { test } from './test-fixtures';
 
 // Increase timeout for these comprehensive tests
 test.setTimeout(90000);
+
+async function expectMentionSelected(
+  page: Page,
+  expectedText: RegExp,
+  selectedMentionTestId: string
+) {
+  const messageInput = page.getByTestId('MessageInput');
+  await expect
+    .poll(async () => (await messageInput.inputValue()).trim())
+    .toMatch(expectedText);
+  await expect(page.getByTestId(selectedMentionTestId)).toBeVisible();
+}
+
+async function expectMessageInputReady(page: Page) {
+  const messageInput = page.getByTestId('MessageInput');
+  const selectedMentions = page.locator('[data-testid^="SelectedMention-"]');
+  let readySince = 0;
+
+  await expect
+    .poll(
+      async () => {
+        const [value, selectedMentionCount] = await Promise.all([
+          messageInput.inputValue(),
+          selectedMentions.count(),
+        ]);
+
+        if (value.trim() !== '' || selectedMentionCount > 0) {
+          readySince = 0;
+          return 'busy';
+        }
+
+        readySince ||= Date.now();
+        return Date.now() - readySince >= 250 ? 'ready' : 'settling';
+      },
+      { timeout: 10000, intervals: [50, 100, 100, 250] }
+    )
+    .toBe('ready');
+}
+
+function waitForChannelPost(page: Page) {
+  return page.waitForResponse(
+    (response) => {
+      const request = response.request();
+      const postData = request.postData();
+
+      return (
+        request.method() === 'PUT' &&
+        response.status() === 204 &&
+        response.url().includes('/~/channel/') &&
+        (!postData ||
+          (postData.includes('"post"') && postData.includes('"add"')))
+      );
+    },
+    { timeout: 10000 }
+  );
+}
+
+function getPostAddFromChannelAction(postData: string | null) {
+  expect(postData).toBeTruthy();
+
+  const events = JSON.parse(postData ?? '[]') as {
+    json?: {
+      channel?: {
+        action?: {
+          post?: {
+            add?: {
+              content?: unknown;
+            };
+          };
+        };
+      };
+    };
+  }[];
+  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
+    ?.json?.channel?.action?.post?.add;
+
+  expect(postAdd).toBeTruthy();
+  return postAdd;
+}
+
+async function sendCurrentMessage(
+  page: Page,
+  expectedText: string | RegExp,
+  expectedInline: string,
+  postMentionTestId: string
+) {
+  const postResponse = waitForChannelPost(page);
+  await page.getByTestId('MessageInputSendButton').click({ force: true });
+  const response = await postResponse;
+  const postAdd = getPostAddFromChannelAction(response.request().postData());
+  expect(JSON.stringify(postAdd?.content)).toContain(expectedInline);
+
+  const post = page
+    .getByTestId('Post')
+    .filter({
+      has: page.getByTestId(postMentionTestId),
+      hasText: expectedText,
+    })
+    .first();
+  await expect(post).toBeVisible({ timeout: 10000 });
+  await expect(post.getByTestId(postMentionTestId)).toBeVisible();
+  await expectMessageInputReady(page);
+}
 
 test('should test comprehensive chat functionality', async ({
   zodSetup,
@@ -47,7 +150,7 @@ test('should test comprehensive chat functionality', async ({
 
   // Navigate back to the channel and verify thread reply count
   await helpers.navigateBack(zodPage);
-  await expect(zodPage.getByText('1 reply')).toBeVisible();
+  await expect(zodPage.getByText('1 reply')).toBeVisible({ timeout: 10000 });
 
   // React to the original message with thumb emoji
   await helpers.reactToMessage(zodPage, 'Hello, world!', 'thumb');
@@ -94,37 +197,56 @@ test('should test comprehensive chat functionality', async ({
   await helpers.editMessage(zodPage, 'Edit this message', 'Edited message');
 
   // Mention a user in a message
+  await expectMessageInputReady(zodPage);
   await zodPage.getByTestId('MessageInput').click();
   await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @ten');
   await expect(zodPage.getByTestId('~ten-contact')).toBeVisible();
   await zodPage.getByTestId('~ten-contact').click();
-  await zodPage.getByTestId('MessageInputSendButton').click();
-  // Wait for message to appear
-  await expect(
-    zodPage.getByTestId('Post').getByText('mentioning ~ten')
-  ).toBeVisible();
+  await expectMentionSelected(
+    zodPage,
+    /^mentioning [@~]ten$/,
+    'SelectedMention-~ten'
+  );
+  await sendCurrentMessage(
+    zodPage,
+    /mentioning\s+~ten/i,
+    '{"ship":"~ten"}',
+    'PostMention-~ten'
+  );
 
   // Mention all in a message
   await zodPage.getByTestId('MessageInput').click();
   await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @all');
   await expect(zodPage.getByTestId('-all--group')).toBeVisible();
   await zodPage.getByTestId('-all--group').click();
-  await zodPage.getByTestId('MessageInputSendButton').click();
-  // Wait for message to appear
-  await expect(
-    zodPage.getByTestId('Post').getByText('mentioning @all')
-  ).toBeVisible();
+  await expectMentionSelected(
+    zodPage,
+    /^mentioning @all$/i,
+    'SelectedMention--all-'
+  );
+  await sendCurrentMessage(
+    zodPage,
+    /mentioning\s+@all/i,
+    '{"sect":null}',
+    'PostMention--all-'
+  );
 
   // Mention a role in a message
   await zodPage.getByTestId('MessageInput').click();
   await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @admin');
   await expect(zodPage.getByTestId('admin-group')).toBeVisible();
   await zodPage.getByTestId('admin-group').click();
-  await zodPage.getByTestId('MessageInputSendButton').click();
-  // Wait for message to appear
-  await expect(
-    zodPage.getByTestId('Post').getByText('mentioning @admin')
-  ).toBeVisible();
+  await expectMentionSelected(
+    zodPage,
+    /^mentioning @admin$/i,
+    'SelectedMention-admin'
+  );
+  await sendCurrentMessage(
+    zodPage,
+    /mentioning\s+@admin/i,
+    '{"sect":"admin"}',
+    'PostMention-admin'
+  );
 });
 
 test('should require confirmation before deleting a message (cancel prevents deletion)', async ({

--- a/apps/tlon-web/e2e/chat-core-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-core-functionality.spec.ts
@@ -1,113 +1,10 @@
-import { type Page, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import * as helpers from './helpers';
 import { test } from './test-fixtures';
 
 // Increase timeout for these comprehensive tests
 test.setTimeout(90000);
-
-async function expectMentionSelected(
-  page: Page,
-  expectedText: RegExp,
-  selectedMentionTestId: string
-) {
-  const messageInput = page.getByTestId('MessageInput');
-  await expect
-    .poll(async () => (await messageInput.inputValue()).trim())
-    .toMatch(expectedText);
-  await expect(page.getByTestId(selectedMentionTestId)).toBeVisible();
-}
-
-async function expectMessageInputReady(page: Page) {
-  const messageInput = page.getByTestId('MessageInput');
-  const selectedMentions = page.locator('[data-testid^="SelectedMention-"]');
-  let readySince = 0;
-
-  await expect
-    .poll(
-      async () => {
-        const [value, selectedMentionCount] = await Promise.all([
-          messageInput.inputValue(),
-          selectedMentions.count(),
-        ]);
-
-        if (value.trim() !== '' || selectedMentionCount > 0) {
-          readySince = 0;
-          return 'busy';
-        }
-
-        readySince ||= Date.now();
-        return Date.now() - readySince >= 250 ? 'ready' : 'settling';
-      },
-      { timeout: 10000, intervals: [50, 100, 100, 250] }
-    )
-    .toBe('ready');
-}
-
-function waitForChannelPost(page: Page) {
-  return page.waitForResponse(
-    (response) => {
-      const request = response.request();
-      const postData = request.postData();
-
-      return (
-        request.method() === 'PUT' &&
-        response.status() === 204 &&
-        response.url().includes('/~/channel/') &&
-        (!postData ||
-          (postData.includes('"post"') && postData.includes('"add"')))
-      );
-    },
-    { timeout: 10000 }
-  );
-}
-
-function getPostAddFromChannelAction(postData: string | null) {
-  expect(postData).toBeTruthy();
-
-  const events = JSON.parse(postData ?? '[]') as {
-    json?: {
-      channel?: {
-        action?: {
-          post?: {
-            add?: {
-              content?: unknown;
-            };
-          };
-        };
-      };
-    };
-  }[];
-  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
-    ?.json?.channel?.action?.post?.add;
-
-  expect(postAdd).toBeTruthy();
-  return postAdd;
-}
-
-async function sendCurrentMessage(
-  page: Page,
-  expectedText: string | RegExp,
-  expectedInline: string,
-  postMentionTestId: string
-) {
-  const postResponse = waitForChannelPost(page);
-  await page.getByTestId('MessageInputSendButton').click({ force: true });
-  const response = await postResponse;
-  const postAdd = getPostAddFromChannelAction(response.request().postData());
-  expect(JSON.stringify(postAdd?.content)).toContain(expectedInline);
-
-  const post = page
-    .getByTestId('Post')
-    .filter({
-      has: page.getByTestId(postMentionTestId),
-      hasText: expectedText,
-    })
-    .first();
-  await expect(post).toBeVisible({ timeout: 10000 });
-  await expect(post.getByTestId(postMentionTestId)).toBeVisible();
-  await expectMessageInputReady(page);
-}
 
 test('should test comprehensive chat functionality', async ({
   zodSetup,
@@ -197,56 +94,37 @@ test('should test comprehensive chat functionality', async ({
   await helpers.editMessage(zodPage, 'Edit this message', 'Edited message');
 
   // Mention a user in a message
-  await expectMessageInputReady(zodPage);
-  await zodPage.getByTestId('MessageInput').click();
-  await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @ten');
-  await expect(zodPage.getByTestId('~ten-contact')).toBeVisible();
-  await zodPage.getByTestId('~ten-contact').click();
-  await expectMentionSelected(
-    zodPage,
-    /^mentioning [@~]ten$/,
-    'SelectedMention-~ten'
-  );
-  await sendCurrentMessage(
-    zodPage,
-    /mentioning\s+~ten/i,
-    '{"ship":"~ten"}',
-    'PostMention-~ten'
-  );
+  await helpers.sendMentionMessage(zodPage, {
+    inputText: 'mentioning @ten',
+    suggestionTestId: '~ten-contact',
+    selectedMentionTestId: 'SelectedMention-~ten',
+    expectedInputText: /^mentioning [@~]ten$/,
+    expectedPostText: /mentioning\s+~ten/i,
+    expectedMentionInline: { ship: '~ten' },
+    postMentionTestId: 'PostMention-~ten',
+  });
 
   // Mention all in a message
-  await zodPage.getByTestId('MessageInput').click();
-  await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @all');
-  await expect(zodPage.getByTestId('-all--group')).toBeVisible();
-  await zodPage.getByTestId('-all--group').click();
-  await expectMentionSelected(
-    zodPage,
-    /^mentioning @all$/i,
-    'SelectedMention--all-'
-  );
-  await sendCurrentMessage(
-    zodPage,
-    /mentioning\s+@all/i,
-    '{"sect":null}',
-    'PostMention--all-'
-  );
+  await helpers.sendMentionMessage(zodPage, {
+    inputText: 'mentioning @all',
+    suggestionTestId: '-all--group',
+    selectedMentionTestId: 'SelectedMention--all-',
+    expectedInputText: /^mentioning @all$/i,
+    expectedPostText: /mentioning\s+@all/i,
+    expectedMentionInline: { sect: null },
+    postMentionTestId: 'PostMention--all-',
+  });
 
   // Mention a role in a message
-  await zodPage.getByTestId('MessageInput').click();
-  await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @admin');
-  await expect(zodPage.getByTestId('admin-group')).toBeVisible();
-  await zodPage.getByTestId('admin-group').click();
-  await expectMentionSelected(
-    zodPage,
-    /^mentioning @admin$/i,
-    'SelectedMention-admin'
-  );
-  await sendCurrentMessage(
-    zodPage,
-    /mentioning\s+@admin/i,
-    '{"sect":"admin"}',
-    'PostMention-admin'
-  );
+  await helpers.sendMentionMessage(zodPage, {
+    inputText: 'mentioning @admin',
+    suggestionTestId: 'admin-group',
+    selectedMentionTestId: 'SelectedMention-admin',
+    expectedInputText: /^mentioning @admin$/i,
+    expectedPostText: /mentioning\s+@admin/i,
+    expectedMentionInline: { sect: 'admin' },
+    postMentionTestId: 'PostMention-admin',
+  });
 });
 
 test('should require confirmation before deleting a message (cancel prevents deletion)', async ({

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1401,6 +1401,148 @@ export async function sendMessage(page: Page, message: string) {
   }).toPass({ timeout: 5000, intervals: [100, 200, 500] });
 }
 
+type ExpectedMentionInline = { ship: string } | { sect: string | null };
+
+type SendMentionMessageOptions = {
+  inputText: string;
+  suggestionTestId: string;
+  selectedMentionTestId: string;
+  expectedInputText: RegExp;
+  expectedPostText: string | RegExp;
+  expectedMentionInline: ExpectedMentionInline;
+  postMentionTestId: string;
+};
+
+async function expectMentionSelected(
+  page: Page,
+  expectedText: RegExp,
+  selectedMentionTestId: string
+) {
+  const messageInput = page.getByTestId('MessageInput');
+  await expect
+    .poll(async () => (await messageInput.inputValue()).trim())
+    .toMatch(expectedText);
+  await expect(page.getByTestId(selectedMentionTestId)).toBeVisible();
+}
+
+async function expectMessageInputReady(page: Page) {
+  const messageInput = page.getByTestId('MessageInput');
+  const selectedMentions = page.locator('[data-testid^="SelectedMention-"]');
+  let readySince = 0;
+
+  await expect
+    .poll(
+      async () => {
+        const [value, selectedMentionCount] = await Promise.all([
+          messageInput.inputValue(),
+          selectedMentions.count(),
+        ]);
+
+        if (value.trim() !== '' || selectedMentionCount > 0) {
+          readySince = 0;
+          return 'busy';
+        }
+
+        readySince ||= Date.now();
+        return Date.now() - readySince >= 250 ? 'ready' : 'settling';
+      },
+      { timeout: 10000, intervals: [50, 100, 100, 250] }
+    )
+    .toBe('ready');
+}
+
+function waitForChannelPost(page: Page) {
+  return page.waitForResponse(
+    (response) => {
+      const request = response.request();
+      const postData = request.postData();
+
+      return (
+        request.method() === 'PUT' &&
+        response.status() === 204 &&
+        response.url().includes('/~/channel/') &&
+        (!postData ||
+          (postData.includes('"post"') && postData.includes('"add"')))
+      );
+    },
+    { timeout: 10000 }
+  );
+}
+
+function getPostAddFromChannelAction(postData: string | null) {
+  expect(postData).toBeTruthy();
+
+  const events = JSON.parse(postData ?? '[]') as {
+    json?: {
+      channel?: {
+        action?: {
+          post?: {
+            add?: {
+              content?: unknown;
+            };
+          };
+        };
+      };
+    };
+  }[];
+  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
+    ?.json?.channel?.action?.post?.add;
+
+  expect(postAdd).toBeTruthy();
+  return postAdd;
+}
+
+/**
+ * Sends a message containing a rich mention and verifies the selected,
+ * serialized, and rendered mention state.
+ */
+export async function sendMentionMessage(
+  page: Page,
+  {
+    inputText,
+    suggestionTestId,
+    selectedMentionTestId,
+    expectedInputText,
+    expectedPostText,
+    expectedMentionInline,
+    postMentionTestId,
+  }: SendMentionMessageOptions
+) {
+  await waitForSessionStability(page);
+  await expectMessageInputReady(page);
+
+  await page.getByTestId('MessageInput').click();
+  await page.fill('[data-testid="MessageInput"]', inputText);
+  await expect(page.getByTestId(suggestionTestId)).toBeVisible();
+  await page.getByTestId(suggestionTestId).click();
+  await expectMentionSelected(page, expectedInputText, selectedMentionTestId);
+
+  const postResponse = waitForChannelPost(page);
+  await page.getByTestId('MessageInputSendButton').click({ force: true });
+  const response = await postResponse;
+  const postAdd = getPostAddFromChannelAction(response.request().postData());
+  expect(postAdd?.content).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        inline: expect.arrayContaining([
+          expect.objectContaining(expectedMentionInline),
+        ]),
+      }),
+    ])
+  );
+
+  const post = page
+    .getByTestId('Post')
+    .filter({
+      has: page.getByTestId(postMentionTestId),
+      hasText: expectedPostText,
+    })
+    .first();
+  await expect(post).toBeVisible({ timeout: 10000 });
+  await expect(post.getByTestId(postMentionTestId)).toBeVisible();
+  await expectMessageInputReady(page);
+}
+
 /**
  * Long presses on a message to open the context menu
  */

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1518,7 +1518,7 @@ export async function sendMentionMessage(
   await expectMentionSelected(page, expectedInputText, selectedMentionTestId);
 
   const postResponse = waitForChannelPost(page);
-  await page.getByTestId('MessageInputSendButton').click({ force: true });
+  await page.getByTestId('MessageInputSendButton').click();
   const response = await postResponse;
   const postAdd = getPostAddFromChannelAction(response.request().postData());
   expect(postAdd?.content).toEqual(

--- a/packages/api/src/client/wayfinding.ts
+++ b/packages/api/src/client/wayfinding.ts
@@ -1,5 +1,9 @@
 import type * as db from '../types/models';
-import { PersonalGroupNames, PersonalGroupSlugs } from '../types/wayfinding';
+import {
+  BotHomeGroupSlugs,
+  PersonalGroupNames,
+  PersonalGroupSlugs,
+} from '../types/wayfinding';
 import { getChannelKindFromType } from '../urbit';
 
 export function getPersonalGroupKeys(currentUserId: string) {
@@ -79,6 +83,10 @@ export function isPersonalGroup(
 
 export function isPersonalChatChannel(channelId: string): boolean {
   return channelId.includes(PersonalGroupSlugs.chatSlug);
+}
+
+export function isBotHomeGroupChatChannel(channelId: string): boolean {
+  return channelId.includes(BotHomeGroupSlugs.chatSlug);
 }
 
 export function isPersonalCollectionChannel(channelId: string): boolean {

--- a/packages/api/src/types/wayfinding.ts
+++ b/packages/api/src/types/wayfinding.ts
@@ -26,4 +26,5 @@ export interface WayfindingProgress {
   tappedAddNote: boolean;
   tappedAddCollection: boolean;
   tappedChatInput: boolean;
+  tappedBotMention: boolean;
 }

--- a/packages/app/fixtures/WayfindingNotices.fixture.tsx
+++ b/packages/app/fixtures/WayfindingNotices.fixture.tsx
@@ -4,6 +4,7 @@ import { View, XStack, YStack } from 'tamagui';
 
 import { ScreenHeader } from '../ui';
 import WayfindingNotice, {
+  BotMentionTooltip,
   ChatInputTooltip,
   CollectionInputTooltip,
   HomeAddTooltip,
@@ -110,6 +111,39 @@ function ChatInputTooltipFixture() {
           />
         </XStack>
         <ChatInputTooltip />
+      </YStack>
+    </FixtureWrapper>
+  );
+}
+
+function BotMentionTooltipFixture() {
+  return (
+    <FixtureWrapper fillWidth fillHeight safeArea>
+      <YStack flex={1} position="relative">
+        <View flex={1} />
+        <XStack
+          height={60}
+          backgroundColor="$secondaryBackground"
+          alignItems="center"
+          paddingHorizontal="$l"
+          borderTopWidth={1}
+          borderColor="$border"
+        >
+          <View
+            flex={1}
+            height={40}
+            backgroundColor="$background"
+            borderRadius="$l"
+            marginRight="$m"
+          />
+          <View
+            width={40}
+            height={40}
+            backgroundColor="$primaryText"
+            borderRadius="$l"
+          />
+        </XStack>
+        <BotMentionTooltip />
       </YStack>
     </FixtureWrapper>
   );
@@ -242,6 +276,21 @@ function AllTooltipsFixture() {
 
         <YStack gap="$xl">
           <Text size="$label/l" color="$secondaryText">
+            Bot Mention Tooltip
+          </Text>
+          <YStack
+            height={150}
+            position="relative"
+            backgroundColor="$secondaryBackground"
+            borderRadius="$l"
+          >
+            <View flex={1} />
+            <BotMentionTooltip />
+          </YStack>
+        </YStack>
+
+        <YStack gap="$xl">
+          <Text size="$label/l" color="$secondaryText">
             Collection Input Tooltip
           </Text>
           <YStack
@@ -280,6 +329,7 @@ export default {
   'Customize Group Notice': <CustomizeGroupNoticeFixture />,
   'Home Add Tooltip': <HomeAddTooltipFixture />,
   'Chat Input Tooltip': <ChatInputTooltipFixture />,
+  'Bot Mention Tooltip': <BotMentionTooltipFixture />,
   'Collection Input Tooltip': <CollectionInputTooltipFixture />,
   'Notebook Input Tooltip': <NotebookInputTooltipFixture />,
   'All Tooltips': <AllTooltipsFixture />,

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -189,6 +189,7 @@ function TextWithMentions({
     textParts.push(
       <Text
         key={`mention-${mention.id}-${index}`}
+        testID={`SelectedMention-${mention.id}`}
         color="$positiveActionText"
         backgroundColor="$positiveBackground"
       >

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -251,6 +251,7 @@ function BareChatInput(
     goBack,
     shouldAutoFocus,
     showWayfindingTooltip,
+    showBotMentionTooltip,
     sendPostFromDraft,
   }: MessageInputProps,
   ref: ForwardedRef<DraftInputHandle>
@@ -838,6 +839,12 @@ function BareChatInput(
         tappedChatInput: true,
       }));
     }
+    if (logic.isBotHomeGroupChatChannel(channelId)) {
+      db.wayfindingProgress.setValue((prev) => ({
+        ...prev,
+        tappedBotMention: true,
+      }));
+    }
   }, [channelId]);
 
   const handleKeyPress = useCallback(
@@ -901,6 +908,7 @@ function BareChatInput(
       disableSend={disableSend}
       sendError={sendError}
       showWayfindingTooltip={showWayfindingTooltip}
+      showBotMentionTooltip={showBotMentionTooltip}
       isMentionModeActive={isMentionModeActive}
       mentionText={mentionSearchText}
       mentionOptions={validOptions}

--- a/packages/app/ui/components/MessageInput/MessageInputBase.tsx
+++ b/packages/app/ui/components/MessageInput/MessageInputBase.tsx
@@ -43,6 +43,7 @@ export interface MessageInputProps {
   setShowBigInput?: (showBigInput: boolean) => void;
   showAttachmentButton?: boolean;
   showWayfindingTooltip?: boolean;
+  showBotMentionTooltip?: boolean;
   floatingActionButton?: boolean;
   paddingHorizontal?: SpaceTokens;
   backgroundColor?: ThemeTokens;
@@ -86,6 +87,7 @@ export const MessageInputContainer = memo(
     showAttachmentButton = true,
     floatingActionButton = false,
     showWayfindingTooltip = false,
+    showBotMentionTooltip = false,
     disableSend = false,
     isSending = false,
     mentionText,
@@ -106,6 +108,7 @@ export const MessageInputContainer = memo(
     showAttachmentButton?: boolean;
     floatingActionButton?: boolean;
     showWayfindingTooltip?: boolean;
+    showBotMentionTooltip?: boolean;
     disableSend?: boolean;
     isSending?: boolean;
     mentionText?: string;
@@ -194,6 +197,7 @@ export const MessageInputContainer = memo(
             ) : (
               <View marginBottom="$xs">
                 {showWayfindingTooltip && <Notices.ChatInputTooltip />}
+                {showBotMentionTooltip && <Notices.BotMentionTooltip />}
                 <Button
                   preset="secondary"
                   disabled={disableSend}

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -95,6 +95,8 @@ export function InlineGroupMention({
   const handlePress = useCallback(() => {
     onGoToGroupSettings?.();
   }, [onGoToGroupSettings]);
+  // All mentions serialize as `{ sect: null }` and render back as group "all",
+  // while newly selected composer mentions use ALL_MENTION_ID.
   const isAllMention =
     inline.group === ALL_MENTION_ID || inline.group === 'all';
   const testIdGroup = isAllMention ? ALL_MENTION_ID : inline.group;

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -73,7 +73,11 @@ export function InlineMention({
     onGoToUserProfile?.(inline.contactId);
   }, [onGoToUserProfile, inline.contactId]);
   return (
-    <MentionText onPress={handlePress} color={'$positiveActionText'}>
+    <MentionText
+      testID={`PostMention-${inline.contactId}`}
+      onPress={handlePress}
+      color={'$positiveActionText'}
+    >
       {contactName}
     </MentionText>
   );
@@ -91,16 +95,23 @@ export function InlineGroupMention({
   const handlePress = useCallback(() => {
     onGoToGroupSettings?.();
   }, [onGoToGroupSettings]);
+  const isAllMention =
+    inline.group === ALL_MENTION_ID || inline.group === 'all';
+  const testIdGroup = isAllMention ? ALL_MENTION_ID : inline.group;
 
   const prettyRole = useMemo(() => {
     const roles = group?.roles ?? [];
-    return inline.group === ALL_MENTION_ID
+    return isAllMention
       ? 'all'
       : roles.find((role) => role.id === inline.group)?.title || inline.group;
-  }, [group, inline.group]);
+  }, [group, inline.group, isAllMention]);
 
   return (
-    <MentionText onPress={handlePress} color={'$positiveActionText'}>
+    <MentionText
+      testID={`PostMention-${testIdGroup}`}
+      onPress={handlePress}
+      color={'$positiveActionText'}
+    >
       @{prettyRole}
     </MentionText>
   );

--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -24,6 +24,7 @@ const WayfindingNotice = {
   CustomizeGroup,
   HomeAddTooltip,
   ChatInputTooltip,
+  BotMentionTooltip,
   CollectionInputTooltip,
   NotebookInputTooltip,
 };
@@ -210,6 +211,29 @@ export function ChatInputTooltip() {
         >
           <Text size="$label/l" color="$white">
             Send a message here.
+          </Text>
+        </View>
+        <XStack width="100%" justifyContent="flex-end">
+          <Circle backgroundColor="$positiveActionText" size="$2xl" />
+        </XStack>
+      </YStack>
+    </View>
+  );
+}
+
+export function BotMentionTooltip() {
+  return (
+    <View position="absolute" bottom={35} right={50}>
+      <YStack gap="$l">
+        <View
+          padding={20}
+          width={240}
+          backgroundColor="$positiveActionText"
+          borderRadius="$l"
+          testID="BotMentionWayfindingTooltip"
+        >
+          <Text size="$label/l" color="$white">
+            @-mention your bot here to use it in this group.
           </Text>
         </View>
         <XStack width="100%" justifyContent="flex-end">

--- a/packages/app/ui/components/draftInputs/ChatInput.tsx
+++ b/packages/app/ui/components/draftInputs/ChatInput.tsx
@@ -29,6 +29,7 @@ export function ChatInput({
 
   const isWindowNarrow = useIsWindowNarrow();
   const showWayfindingTooltip = store.useShowChatInputWayfinding(channel.id);
+  const showBotMentionTooltip = store.useShowBotMentionWayfinding(channel.id);
 
   return (
     <SafeAreaView edges={['right', 'left', 'bottom']}>
@@ -52,6 +53,7 @@ export function ChatInput({
           showInlineAttachments
           showAttachmentButton
           showWayfindingTooltip={showWayfindingTooltip}
+          showBotMentionTooltip={showBotMentionTooltip}
         />
       </ParentAgnosticKeyboardAvoidingView>
     </SafeAreaView>

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -335,6 +335,7 @@ export const wayfindingProgress = createStorageItem<WayfindingProgress>({
     tappedAddNote: true,
     tappedAddCollection: true,
     tappedChatInput: true,
+    tappedBotMention: true,
   },
 });
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -678,6 +678,18 @@ export const useShowChatInputWayfinding = (channelId: string) => {
   return isCorrectChan && !wayfindingProgress.tappedChatInput;
 };
 
+export const useShowBotMentionWayfinding = (channelId: string) => {
+  const wayfindingProgress = db.wayfindingProgress.useValue();
+  const hostingBotEnabled = db.hostingBotEnabled.useValue();
+  const isCorrectChan = useMemo(() => {
+    return logic.isBotHomeGroupChatChannel(channelId);
+  }, [channelId]);
+
+  return (
+    isCorrectChan && !!hostingBotEnabled && !wayfindingProgress.tappedBotMention
+  );
+};
+
 export const useShowHomeAddTooltip = () => {
   const wayfindingProgress = db.wayfindingProgress.useValue();
   return wayfindingProgress.tappedHomeAdd === false;

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -680,14 +680,11 @@ export const useShowChatInputWayfinding = (channelId: string) => {
 
 export const useShowBotMentionWayfinding = (channelId: string) => {
   const wayfindingProgress = db.wayfindingProgress.useValue();
-  const hostingBotEnabled = db.hostingBotEnabled.useValue();
   const isCorrectChan = useMemo(() => {
     return logic.isBotHomeGroupChatChannel(channelId);
   }, [channelId]);
 
-  return (
-    isCorrectChan && !!hostingBotEnabled && !wayfindingProgress.tappedBotMention
-  );
+  return isCorrectChan && !wayfindingProgress.tappedBotMention;
 };
 
 export const useShowHomeAddTooltip = () => {

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -63,6 +63,7 @@ export async function completeWayfindingSplash() {
     tappedAddNote: false,
     tappedAddCollection: false,
     tappedChatInput: false,
+    tappedBotMention: false,
   }));
 
   // optimistic update


### PR DESCRIPTION
# Summary

Adds a tooltip flow for Tlonbot hosted users. When a user opens the bot home group's chat channel for the first time and has a hosting bot, they see a tooltip prompting them to @-mention their bot.

Fixes TLON-5691

# Changes
                                                                                                                                                                                                                                      
- packages/api/src/types/wayfinding.ts — added tappedBotMention to WayfindingProgress
- packages/api/src/client/wayfinding.ts:84-86 — added isBotHomeGroupChatChannel helper                                     
- packages/shared/src/db/keyValue.ts:338 — default tappedBotMention: true (off, matching existing convention)            
- packages/shared/src/store/settingsActions.ts:67 — reset to false in completeWayfindingSplash so new signups see it       
- packages/shared/src/store/dbHooks.ts — added useShowBotMentionWayfinding, gated on hostingBotEnabled                     
- packages/app/ui/components/Wayfinding/Notices.tsx — added BotMentionTooltip component                                    
- packages/app/ui/components/MessageInput/MessageInputBase.tsx — wired showBotMentionTooltip prop                          
- packages/app/ui/components/BareChatInput/index.tsx — wired prop + dismiss in handleFocus for bot home group chat         
- packages/app/ui/components/draftInputs/ChatInput.tsx — wired the new hook                                                
- packages/app/fixtures/WayfindingNotices.fixture.tsx — added cosmos fixtures  

# Testing

- Sign up with new Tlonbot account
- Tap into group
- Confirm the tooltip appears

# Media

<img width="681" height="1310" alt="image" src="https://github.com/user-attachments/assets/a52fbab8-619f-455a-a160-6e550f7db9a0" />
