### PR TITLE
ops: fix failing E2E on develop/staging

### DIFF
--- a/apps/tlon-web/e2e/chat-core-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-core-functionality.spec.ts
@@ -1,10 +1,113 @@
-import { expect } from '@playwright/test';
+import { type Page, expect } from '@playwright/test';
 
 import * as helpers from './helpers';
 import { test } from './test-fixtures';
 
 // Increase timeout for these comprehensive tests
 test.setTimeout(90000);
+
+async function expectMentionSelected(
+  page: Page,
+  expectedText: RegExp,
+  selectedMentionTestId: string
+) {
+  const messageInput = page.getByTestId('MessageInput');
+  await expect
+    .poll(async () => (await messageInput.inputValue()).trim())
+    .toMatch(expectedText);
+  await expect(page.getByTestId(selectedMentionTestId)).toBeVisible();
+}
+
+async function expectMessageInputReady(page: Page) {
+  const messageInput = page.getByTestId('MessageInput');
+  const selectedMentions = page.locator('[data-testid^="SelectedMention-"]');
+  let readySince = 0;
+
+  await expect
+    .poll(
+      async () => {
+        const [value, selectedMentionCount] = await Promise.all([
+          messageInput.inputValue(),
+          selectedMentions.count(),
+        ]);
+
+        if (value.trim() !== '' || selectedMentionCount > 0) {
+          readySince = 0;
+          return 'busy';
+        }
+
+        readySince ||= Date.now();
+        return Date.now() - readySince >= 250 ? 'ready' : 'settling';
+      },
+      { timeout: 10000, intervals: [50, 100, 100, 250] }
+    )
+    .toBe('ready');
+}
+
+function waitForChannelPost(page: Page) {
+  return page.waitForResponse(
+    (response) => {
+      const request = response.request();
+      const postData = request.postData();
+
+      return (
+        request.method() === 'PUT' &&
+        response.status() === 204 &&
+        response.url().includes('/~/channel/') &&
+        (!postData ||
+          (postData.includes('"post"') && postData.includes('"add"')))
+      );
+    },
+    { timeout: 10000 }
+  );
+}
+
+function getPostAddFromChannelAction(postData: string | null) {
+  expect(postData).toBeTruthy();
+
+  const events = JSON.parse(postData ?? '[]') as {
+    json?: {
+      channel?: {
+        action?: {
+          post?: {
+            add?: {
+              content?: unknown;
+            };
+          };
+        };
+      };
+    };
+  }[];
+  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
+    ?.json?.channel?.action?.post?.add;
+
+  expect(postAdd).toBeTruthy();
+  return postAdd;
+}
+
+async function sendCurrentMessage(
+  page: Page,
+  expectedText: string | RegExp,
+  expectedInline: string,
+  postMentionTestId: string
+) {
+  const postResponse = waitForChannelPost(page);
+  await page.getByTestId('MessageInputSendButton').click({ force: true });
+  const response = await postResponse;
+  const postAdd = getPostAddFromChannelAction(response.request().postData());
+  expect(JSON.stringify(postAdd?.content)).toContain(expectedInline);
+
+  const post = page
+    .getByTestId('Post')
+    .filter({
+      has: page.getByTestId(postMentionTestId),
+      hasText: expectedText,
+    })
+    .first();
+  await expect(post).toBeVisible({ timeout: 10000 });
+  await expect(post.getByTestId(postMentionTestId)).toBeVisible();
+  await expectMessageInputReady(page);
+}
 
 test('should test comprehensive chat functionality', async ({
   zodSetup,
@@ -94,37 +197,56 @@ test('should test comprehensive chat functionality', async ({
   await helpers.editMessage(zodPage, 'Edit this message', 'Edited message');
 
   // Mention a user in a message
+  await expectMessageInputReady(zodPage);
   await zodPage.getByTestId('MessageInput').click();
   await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @ten');
   await expect(zodPage.getByTestId('~ten-contact')).toBeVisible();
   await zodPage.getByTestId('~ten-contact').click();
-  await zodPage.getByTestId('MessageInputSendButton').click();
-  // Wait for message to appear
-  await expect(
-    zodPage.getByTestId('Post').getByText('mentioning ~ten')
-  ).toBeVisible({ timeout: 10000 });
+  await expectMentionSelected(
+    zodPage,
+    /^mentioning [@~]ten$/,
+    'SelectedMention-~ten'
+  );
+  await sendCurrentMessage(
+    zodPage,
+    /mentioning\s+~ten/i,
+    '{"ship":"~ten"}',
+    'PostMention-~ten'
+  );
 
   // Mention all in a message
   await zodPage.getByTestId('MessageInput').click();
   await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @all');
   await expect(zodPage.getByTestId('-all--group')).toBeVisible();
   await zodPage.getByTestId('-all--group').click();
-  await zodPage.getByTestId('MessageInputSendButton').click();
-  // Wait for message to appear
-  await expect(
-    zodPage.getByTestId('Post').getByText('mentioning @all')
-  ).toBeVisible({ timeout: 10000 });
+  await expectMentionSelected(
+    zodPage,
+    /^mentioning @all$/i,
+    'SelectedMention--all-'
+  );
+  await sendCurrentMessage(
+    zodPage,
+    /mentioning\s+@all/i,
+    '{"sect":null}',
+    'PostMention--all-'
+  );
 
   // Mention a role in a message
   await zodPage.getByTestId('MessageInput').click();
   await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @admin');
   await expect(zodPage.getByTestId('admin-group')).toBeVisible();
   await zodPage.getByTestId('admin-group').click();
-  await zodPage.getByTestId('MessageInputSendButton').click();
-  // Wait for message to appear
-  await expect(
-    zodPage.getByTestId('Post').getByText('mentioning @admin')
-  ).toBeVisible({ timeout: 10000 });
+  await expectMentionSelected(
+    zodPage,
+    /^mentioning @admin$/i,
+    'SelectedMention-admin'
+  );
+  await sendCurrentMessage(
+    zodPage,
+    /mentioning\s+@admin/i,
+    '{"sect":"admin"}',
+    'PostMention-admin'
+  );
 });
 
 test('should require confirmation before deleting a message (cancel prevents deletion)', async ({

--- a/apps/tlon-web/e2e/chat-core-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-core-functionality.spec.ts
@@ -1,113 +1,10 @@
-import { type Page, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import * as helpers from './helpers';
 import { test } from './test-fixtures';
 
 // Increase timeout for these comprehensive tests
 test.setTimeout(90000);
-
-async function expectMentionSelected(
-  page: Page,
-  expectedText: RegExp,
-  selectedMentionTestId: string
-) {
-  const messageInput = page.getByTestId('MessageInput');
-  await expect
-    .poll(async () => (await messageInput.inputValue()).trim())
-    .toMatch(expectedText);
-  await expect(page.getByTestId(selectedMentionTestId)).toBeVisible();
-}
-
-async function expectMessageInputReady(page: Page) {
-  const messageInput = page.getByTestId('MessageInput');
-  const selectedMentions = page.locator('[data-testid^="SelectedMention-"]');
-  let readySince = 0;
-
-  await expect
-    .poll(
-      async () => {
-        const [value, selectedMentionCount] = await Promise.all([
-          messageInput.inputValue(),
-          selectedMentions.count(),
-        ]);
-
-        if (value.trim() !== '' || selectedMentionCount > 0) {
-          readySince = 0;
-          return 'busy';
-        }
-
-        readySince ||= Date.now();
-        return Date.now() - readySince >= 250 ? 'ready' : 'settling';
-      },
-      { timeout: 10000, intervals: [50, 100, 100, 250] }
-    )
-    .toBe('ready');
-}
-
-function waitForChannelPost(page: Page) {
-  return page.waitForResponse(
-    (response) => {
-      const request = response.request();
-      const postData = request.postData();
-
-      return (
-        request.method() === 'PUT' &&
-        response.status() === 204 &&
-        response.url().includes('/~/channel/') &&
-        (!postData ||
-          (postData.includes('"post"') && postData.includes('"add"')))
-      );
-    },
-    { timeout: 10000 }
-  );
-}
-
-function getPostAddFromChannelAction(postData: string | null) {
-  expect(postData).toBeTruthy();
-
-  const events = JSON.parse(postData ?? '[]') as {
-    json?: {
-      channel?: {
-        action?: {
-          post?: {
-            add?: {
-              content?: unknown;
-            };
-          };
-        };
-      };
-    };
-  }[];
-  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
-    ?.json?.channel?.action?.post?.add;
-
-  expect(postAdd).toBeTruthy();
-  return postAdd;
-}
-
-async function sendCurrentMessage(
-  page: Page,
-  expectedText: string | RegExp,
-  expectedInline: string,
-  postMentionTestId: string
-) {
-  const postResponse = waitForChannelPost(page);
-  await page.getByTestId('MessageInputSendButton').click({ force: true });
-  const response = await postResponse;
-  const postAdd = getPostAddFromChannelAction(response.request().postData());
-  expect(JSON.stringify(postAdd?.content)).toContain(expectedInline);
-
-  const post = page
-    .getByTestId('Post')
-    .filter({
-      has: page.getByTestId(postMentionTestId),
-      hasText: expectedText,
-    })
-    .first();
-  await expect(post).toBeVisible({ timeout: 10000 });
-  await expect(post.getByTestId(postMentionTestId)).toBeVisible();
-  await expectMessageInputReady(page);
-}
 
 test('should test comprehensive chat functionality', async ({
   zodSetup,
@@ -197,56 +94,37 @@ test('should test comprehensive chat functionality', async ({
   await helpers.editMessage(zodPage, 'Edit this message', 'Edited message');
 
   // Mention a user in a message
-  await expectMessageInputReady(zodPage);
-  await zodPage.getByTestId('MessageInput').click();
-  await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @ten');
-  await expect(zodPage.getByTestId('~ten-contact')).toBeVisible();
-  await zodPage.getByTestId('~ten-contact').click();
-  await expectMentionSelected(
-    zodPage,
-    /^mentioning [@~]ten$/,
-    'SelectedMention-~ten'
-  );
-  await sendCurrentMessage(
-    zodPage,
-    /mentioning\s+~ten/i,
-    '{"ship":"~ten"}',
-    'PostMention-~ten'
-  );
+  await helpers.sendMentionMessage(zodPage, {
+    inputText: 'mentioning @ten',
+    suggestionTestId: '~ten-contact',
+    selectedMentionTestId: 'SelectedMention-~ten',
+    expectedInputText: /^mentioning [@~]ten$/,
+    expectedPostText: /mentioning\s+~ten/i,
+    expectedMentionInline: { ship: '~ten' },
+    postMentionTestId: 'PostMention-~ten',
+  });
 
   // Mention all in a message
-  await zodPage.getByTestId('MessageInput').click();
-  await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @all');
-  await expect(zodPage.getByTestId('-all--group')).toBeVisible();
-  await zodPage.getByTestId('-all--group').click();
-  await expectMentionSelected(
-    zodPage,
-    /^mentioning @all$/i,
-    'SelectedMention--all-'
-  );
-  await sendCurrentMessage(
-    zodPage,
-    /mentioning\s+@all/i,
-    '{"sect":null}',
-    'PostMention--all-'
-  );
+  await helpers.sendMentionMessage(zodPage, {
+    inputText: 'mentioning @all',
+    suggestionTestId: '-all--group',
+    selectedMentionTestId: 'SelectedMention--all-',
+    expectedInputText: /^mentioning @all$/i,
+    expectedPostText: /mentioning\s+@all/i,
+    expectedMentionInline: { sect: null },
+    postMentionTestId: 'PostMention--all-',
+  });
 
   // Mention a role in a message
-  await zodPage.getByTestId('MessageInput').click();
-  await zodPage.fill('[data-testid="MessageInput"]', 'mentioning @admin');
-  await expect(zodPage.getByTestId('admin-group')).toBeVisible();
-  await zodPage.getByTestId('admin-group').click();
-  await expectMentionSelected(
-    zodPage,
-    /^mentioning @admin$/i,
-    'SelectedMention-admin'
-  );
-  await sendCurrentMessage(
-    zodPage,
-    /mentioning\s+@admin/i,
-    '{"sect":"admin"}',
-    'PostMention-admin'
-  );
+  await helpers.sendMentionMessage(zodPage, {
+    inputText: 'mentioning @admin',
+    suggestionTestId: 'admin-group',
+    selectedMentionTestId: 'SelectedMention-admin',
+    expectedInputText: /^mentioning @admin$/i,
+    expectedPostText: /mentioning\s+@admin/i,
+    expectedMentionInline: { sect: 'admin' },
+    postMentionTestId: 'PostMention-admin',
+  });
 });
 
 test('should require confirmation before deleting a message (cancel prevents deletion)', async ({

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1401,6 +1401,148 @@ export async function sendMessage(page: Page, message: string) {
   }).toPass({ timeout: 5000, intervals: [100, 200, 500] });
 }
 
+type ExpectedMentionInline = { ship: string } | { sect: string | null };
+
+type SendMentionMessageOptions = {
+  inputText: string;
+  suggestionTestId: string;
+  selectedMentionTestId: string;
+  expectedInputText: RegExp;
+  expectedPostText: string | RegExp;
+  expectedMentionInline: ExpectedMentionInline;
+  postMentionTestId: string;
+};
+
+async function expectMentionSelected(
+  page: Page,
+  expectedText: RegExp,
+  selectedMentionTestId: string
+) {
+  const messageInput = page.getByTestId('MessageInput');
+  await expect
+    .poll(async () => (await messageInput.inputValue()).trim())
+    .toMatch(expectedText);
+  await expect(page.getByTestId(selectedMentionTestId)).toBeVisible();
+}
+
+async function expectMessageInputReady(page: Page) {
+  const messageInput = page.getByTestId('MessageInput');
+  const selectedMentions = page.locator('[data-testid^="SelectedMention-"]');
+  let readySince = 0;
+
+  await expect
+    .poll(
+      async () => {
+        const [value, selectedMentionCount] = await Promise.all([
+          messageInput.inputValue(),
+          selectedMentions.count(),
+        ]);
+
+        if (value.trim() !== '' || selectedMentionCount > 0) {
+          readySince = 0;
+          return 'busy';
+        }
+
+        readySince ||= Date.now();
+        return Date.now() - readySince >= 250 ? 'ready' : 'settling';
+      },
+      { timeout: 10000, intervals: [50, 100, 100, 250] }
+    )
+    .toBe('ready');
+}
+
+function waitForChannelPost(page: Page) {
+  return page.waitForResponse(
+    (response) => {
+      const request = response.request();
+      const postData = request.postData();
+
+      return (
+        request.method() === 'PUT' &&
+        response.status() === 204 &&
+        response.url().includes('/~/channel/') &&
+        (!postData ||
+          (postData.includes('"post"') && postData.includes('"add"')))
+      );
+    },
+    { timeout: 10000 }
+  );
+}
+
+function getPostAddFromChannelAction(postData: string | null) {
+  expect(postData).toBeTruthy();
+
+  const events = JSON.parse(postData ?? '[]') as {
+    json?: {
+      channel?: {
+        action?: {
+          post?: {
+            add?: {
+              content?: unknown;
+            };
+          };
+        };
+      };
+    };
+  }[];
+  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
+    ?.json?.channel?.action?.post?.add;
+
+  expect(postAdd).toBeTruthy();
+  return postAdd;
+}
+
+/**
+ * Sends a message containing a rich mention and verifies the selected,
+ * serialized, and rendered mention state.
+ */
+export async function sendMentionMessage(
+  page: Page,
+  {
+    inputText,
+    suggestionTestId,
+    selectedMentionTestId,
+    expectedInputText,
+    expectedPostText,
+    expectedMentionInline,
+    postMentionTestId,
+  }: SendMentionMessageOptions
+) {
+  await waitForSessionStability(page);
+  await expectMessageInputReady(page);
+
+  await page.getByTestId('MessageInput').click();
+  await page.fill('[data-testid="MessageInput"]', inputText);
+  await expect(page.getByTestId(suggestionTestId)).toBeVisible();
+  await page.getByTestId(suggestionTestId).click();
+  await expectMentionSelected(page, expectedInputText, selectedMentionTestId);
+
+  const postResponse = waitForChannelPost(page);
+  await page.getByTestId('MessageInputSendButton').click({ force: true });
+  const response = await postResponse;
+  const postAdd = getPostAddFromChannelAction(response.request().postData());
+  expect(postAdd?.content).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        inline: expect.arrayContaining([
+          expect.objectContaining(expectedMentionInline),
+        ]),
+      }),
+    ])
+  );
+
+  const post = page
+    .getByTestId('Post')
+    .filter({
+      has: page.getByTestId(postMentionTestId),
+      hasText: expectedPostText,
+    })
+    .first();
+  await expect(post).toBeVisible({ timeout: 10000 });
+  await expect(post.getByTestId(postMentionTestId)).toBeVisible();
+  await expectMessageInputReady(page);
+}
+
 /**
  * Long presses on a message to open the context menu
  */

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1518,7 +1518,7 @@ export async function sendMentionMessage(
   await expectMentionSelected(page, expectedInputText, selectedMentionTestId);
 
   const postResponse = waitForChannelPost(page);
-  await page.getByTestId('MessageInputSendButton').click({ force: true });
+  await page.getByTestId('MessageInputSendButton').click();
   const response = await postResponse;
   const postAdd = getPostAddFromChannelAction(response.request().postData());
   expect(postAdd?.content).toEqual(

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -189,6 +189,7 @@ function TextWithMentions({
     textParts.push(
       <Text
         key={`mention-${mention.id}-${index}`}
+        testID={`SelectedMention-${mention.id}`}
         color="$positiveActionText"
         backgroundColor="$positiveBackground"
       >

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -95,6 +95,8 @@ export function InlineGroupMention({
   const handlePress = useCallback(() => {
     onGoToGroupSettings?.();
   }, [onGoToGroupSettings]);
+  // All mentions serialize as `{ sect: null }` and render back as group "all",
+  // while newly selected composer mentions use ALL_MENTION_ID.
   const isAllMention =
     inline.group === ALL_MENTION_ID || inline.group === 'all';
   const testIdGroup = isAllMention ? ALL_MENTION_ID : inline.group;

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -73,7 +73,11 @@ export function InlineMention({
     onGoToUserProfile?.(inline.contactId);
   }, [onGoToUserProfile, inline.contactId]);
   return (
-    <MentionText onPress={handlePress} color={'$positiveActionText'}>
+    <MentionText
+      testID={`PostMention-${inline.contactId}`}
+      onPress={handlePress}
+      color={'$positiveActionText'}
+    >
       {contactName}
     </MentionText>
   );
@@ -91,16 +95,23 @@ export function InlineGroupMention({
   const handlePress = useCallback(() => {
     onGoToGroupSettings?.();
   }, [onGoToGroupSettings]);
+  const isAllMention =
+    inline.group === ALL_MENTION_ID || inline.group === 'all';
+  const testIdGroup = isAllMention ? ALL_MENTION_ID : inline.group;
 
   const prettyRole = useMemo(() => {
     const roles = group?.roles ?? [];
-    return inline.group === ALL_MENTION_ID
+    return isAllMention
       ? 'all'
       : roles.find((role) => role.id === inline.group)?.title || inline.group;
-  }, [group, inline.group]);
+  }, [group, inline.group, isAllMention]);
 
   return (
-    <MentionText onPress={handlePress} color={'$positiveActionText'}>
+    <MentionText
+      testID={`PostMention-${testIdGroup}`}
+      onPress={handlePress}
+      color={'$positiveActionText'}
+    >
       @{prettyRole}
     </MentionText>
   );


### PR DESCRIPTION
The `chat-core-functionality.spec.ts` e2e test has been consistently failing on the mention message. I haven't figured out where it broke, but we hastily merged a few failing CI PRs last week.

It seemed like there was a race where the post was being sent before the rich mention state settled. The result was the plain text *mentioning @ten* got sent.

This adds explicit checks for mention specific posts:
- input has the selected mention token before sending
- post payload includes the structured mention data
- resulting post renders a real mention (test ID based)