### PR TITLE
various: tree deletion correctness

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2432,7 +2432,9 @@
             %|  seq.post.u-post
           ==
         =?  pending.channel  ?=(%& -.post.u-post)
-          =/  client-id  [author sent]:post.u-post
+          =/  =client-id:c
+            :_  sent.post.u-post
+            (get-author-ship:utils author.post.u-post)
           pending.channel(posts (~(del by posts.pending.channel) client-id))
         (ca-response %post id-post %set post)
       ::
@@ -2508,7 +2510,9 @@
           (on-reply:ca-activity post +.reply.u-reply)
         =?  pending.channel  ?=(%& -.reply.u-reply)
           =/  reply-essay  +>+.reply.u-reply
-          =/  client-id  [author sent]:reply-essay
+          =/  =client-id:c
+            :_  sent.reply-essay
+            (get-author-ship:utils author.reply-essay)
           =/  new-replies  (~(del by replies.pending.channel) [id-post client-id])
           pending.channel(replies new-replies)
         (put-reply reply.u-reply %set reply)

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2660,9 +2660,15 @@
           ==
       ::  clean up ask and pending record
       ::
-      =.  pending.ad   (~(del by pending.ad) ship)
+      =.  pending.ad
+        %-  ~(rep in ships)
+        |=  [=ship =_pending.ad]
+        (~(del by pending) ship)
       ::TODO kick from /ask  sub
-      =.  requests.ad  (~(del by requests.ad) ship)
+      =.  requests.ad
+        %-  ~(rep in ships)
+        |=  [=ship =_requests.ad]
+        (~(del by requests) ship)
       ::TODO if any of the ships was pending and invited,
       ::     cancel their tokens.
       ::

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -474,7 +474,7 @@
         [(tell:log %dbug ~['context sub ack ok' >src.bowl< >context<] ~)]~
       ::  nacked, can't do anything, drop desire
       ::
-      :_  this(want (~(del by want) src.bowl context))
+      :_  this(want (~(del in want) src.bowl context))
       =-  [(tell:log %warn - ~)]~
       :*  'context sub nacked, dropping desire'
           >[src=src.bowl context=context]<
@@ -591,7 +591,7 @@
 ++  on-fail
   |=  [=term =tang]
   ^-  (quip card _this)
-  ::TODO  want to ~(del by want) if ?=(%fact term) but don't know the wire...
+  ::TODO  want to ~(del in want) if ?=(%fact term) but don't know the wire...
   %.  [~ this]
   (slog (rap 3 dap.bowl ': +on-fail: ' term ~) tang)
 ::


### PR DESCRIPTION
## Summary

Starting in 408, the compiler will catch these easy-to-make mistakes. This applies the cases found by that early. Twin commit to the one in #5648.

## Changes

Correct map-vs-set and deletion key in the following:
- Post and reply deletion.
- Group membership deletion.
- Presence interest dropping.

## How did I test?

Compiles in 408!

## Risks and impact

- Yes, safe to rollback without consulting PR author.

## Rollback plan

Revert.