### PR TITLE
notify: support generic notifications

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/TalkMessagingService.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/TalkMessagingService.kt
@@ -23,6 +23,7 @@ import io.tlon.landscape.notifications.TalkNotificationManager
 import io.tlon.landscape.notifications.NotificationMessagesCache
 import io.tlon.landscape.notifications.buildMessagingTappable
 import io.tlon.landscape.notifications.processNotificationBlocking
+import io.tlon.landscape.notifications.showGenericNotification
 import io.tlon.landscape.notifications.toBasicBundle
 import android.service.notification.StatusBarNotification
 import io.tlon.landscape.utils.UvParser
@@ -99,6 +100,22 @@ class TalkMessagingService : FirebaseMessagingService() {
                     } catch (e: NotificationException) {
                         NotificationLogger.logError(e)
                         showFallbackNotification(this, e, remoteMessage)
+                    }
+                }
+
+                if (data["action"] == "message") {
+                    data["uid"]?.let { uid ->
+                        val bundle = remoteMessage.toBasicBundle()
+                        val message = data["message"] ?: bundle.getString("body")
+                        if (message != null) {
+                            showGenericNotification(
+                                this,
+                                uid,
+                                bundle.getString("title") ?: getString(R.string.app_name),
+                                message,
+                                bundle
+                            )
+                        }
                     }
                 }
 

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -201,12 +201,53 @@ private fun showRichNotification(context: Context, uid: String, preview: Activit
     NotificationManagerCompat.from(context).notify(preview.groupingKey?.hashCode() ?: id, builder.build())
 }
 
+fun showGenericNotification(
+    context: Context,
+    uid: String,
+    title: String,
+    message: String,
+    extras: Bundle
+) {
+    val id = UvParser.getIntCompatibleFromUv(uid)
+    if (ActivityCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) != PackageManager.PERMISSION_GRANTED
+    ) {
+        NotificationLogger.logError(
+            NotificationException(
+                message = "Lacking notification permissions",
+                uid = uid
+            )
+        )
+        Log.w(NOTIFICATION_MANAGER, "Cannot show notification - no permission")
+        return
+    }
+
+    if (!extras.containsKey("id")) {
+        extras.putString("id", uid)
+    }
+    extras.putString("genericMessage", message)
+
+    val builder = NotificationCompat.Builder(context, TalkNotificationManager.CHANNEL_ID)
+        .buildMessagingTappable(context, id, extras)
+        .setContentTitle(title)
+        .setContentText(message)
+        .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+
+    NotificationManagerCompat.from(context).notify(id, builder.build())
+    NotificationLogger.logDelivery(mapOf(
+        "uid" to uid,
+        "message" to "Generic notification delivered successfully"
+    ))
+}
+
 fun RemoteMessage.toBasicBundle(): Bundle {
     val bundle = Bundle()
 
     // Prioritize notification fields, fall back to data fields
     val title = notification?.title ?: data["title"]
-    val body = notification?.body ?: data["body"]
+    val body = notification?.body ?: data["body"] ?: data["message"]
 
     title?.let { bundle.putString("title", it) }
     body?.let { bundle.putString("body", it) }

--- a/apps/tlon-mobile/ios/Notifications/NotificationService.swift
+++ b/apps/tlon-mobile/ios/Notifications/NotificationService.swift
@@ -132,6 +132,18 @@ class NotificationService: UNNotificationServiceExtension {
         return preview
     }
 
+    private func applyGenericMessage(_ message: String, uid: String, notification: UNMutableNotificationContent) -> UNNotificationContent {
+        if notification.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            notification.title = "Tlon"
+        }
+        notification.body = message
+        notification.sound = UNNotificationSound.default
+        notification.interruptionLevel = .active
+        notification.userInfo["uid"] = uid
+        notification.userInfo["genericMessage"] = message
+        return notification
+    }
+
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
@@ -171,6 +183,18 @@ class NotificationService: UNNotificationServiceExtension {
               contentHandler(notifContent)
               return
 
+          case .message(let uid, let message):
+              let notifContent = bestAttemptContent ?? UNMutableNotificationContent()
+              let notification = notifContent.mutableCopy() as! UNMutableNotificationContent
+              let renderedNotification = applyGenericMessage(
+                message,
+                uid: uid,
+                notification: notification
+              )
+              await NotificationLogger.logDelivery(properties: ["uid": .string(uid), "message": .string("Generic notification delivered successfully")])
+              contentHandler(renderedNotification)
+              return
+
           case .dismiss:
               // Should not be hit, but set up fallback notification just in case.
               // We can't prevent this alert from being shown, so at least make it truthful.
@@ -202,10 +226,6 @@ class NotificationService: UNNotificationServiceExtension {
               }
 
               await NotificationLogger.logDelivery(properties: ["message": .string("Fallback notification delivered successfully")])
-              contentHandler(bestAttemptContent!)
-              return
-
-            case .dismiss:
               contentHandler(bestAttemptContent!)
               return
             }

--- a/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
+++ b/apps/tlon-mobile/ios/Shared/Notifications/PushNotificationManager.swift
@@ -12,6 +12,7 @@ import NotificationCenter
 @objc final class PushNotificationManager: NSObject {
     enum ParseNotificationResult {
         case notify(uid: String, event: Any)
+        case message(uid: String, message: String)
         case dismiss
         case invalid
         case failedFetchContents(Error)
@@ -34,6 +35,11 @@ import NotificationCenter
             } catch {
                 return .failedFetchContents(error)
             }
+        case "message":
+            guard let message = userInfo["message"] as? String else {
+                return .invalid
+            }
+            return .message(uid: uid, message: message)
         case "dismiss":
             return .dismiss
 

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -771,9 +771,8 @@
         id+(scot %ud uid.update)
         notify-count+(scot %ud notify-count.update)
         dismiss-source+?.(?=(%dismiss -.action.update) '' source.action.update)
+        message+?.(?=(%message -.action.update) '' message.action.update)
     ==
-  =?  params  ?=(%message -.action.update)
-    [message+message.action.update params]
   %:  post-form
       /send-notification/(scot %uv (sham eny.bowl))
       notify-endpoint.entry

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -756,9 +756,8 @@
   |=  [[p=@t q=@t] out=@t]
   =/  key  (crip (en-urlt:html (trip p)))
   =/  val  (crip (en-urlt:html (trip q)))
-  ?:  =(out '')
-    (rap 3 key '=' val ~)
-  (rap 3 out '&' key '=' val ~)
+  =/  pam  ?:(=(out '') '' '&')
+  (rap 3 out pam key '=' val ~)
 ::
 ++  send-notification
   |=  [entry=provider-entry who=@p =update]

--- a/desk/app/notify.hoon
+++ b/desk/app/notify.hoon
@@ -346,6 +346,22 @@
         =/  pact=provider-action  [%client-leave service.act]
         :_  state
         [(poke:pass [who.act %notify] %notify-provider-action !>(pact))]~
+      ::
+          %send-message
+        =+  .^(=activity:v8:av %gx (scry:io %activity /v4/activity/activity-summary-4))
+        =/  notify-count=@ud
+          notify-count:(~(gut by activity) [%base ~] *activity-summary:a)
+        =/  v1-paths
+          %+  murn  ~(tap by sup.bowl)
+          |=  [duct ship =path]
+          ?:  ?=([%notify *] path)  ~
+          `path
+        ?~  v1-paths
+          [~ state]
+        =/  =update:v1
+          [notify-count `@`(sham eny.bowl) %message message.act]
+        :_  state
+        ~[(fact:io notify-update-1+!>(update) v1-paths)]
       ==
     ::
     ++  handle-http-request
@@ -738,9 +754,11 @@
   ^-  @t
   %+  roll  data
   |=  [[p=@t q=@t] out=@t]
+  =/  key  (crip (en-urlt:html (trip p)))
+  =/  val  (crip (en-urlt:html (trip q)))
   ?:  =(out '')
-    (rap 3 p '=' q ~)
-  (rap 3 out '&' p '=' q ~)
+    (rap 3 key '=' val ~)
+  (rap 3 out '&' key '=' val ~)
 ::
 ++  send-notification
   |=  [entry=provider-entry who=@p =update]
@@ -755,6 +773,8 @@
         notify-count+(scot %ud notify-count.update)
         dismiss-source+?.(?=(%dismiss -.action.update) '' source.action.update)
     ==
+  =?  params  ?=(%message -.action.update)
+    [message+message.action.update params]
   %:  post-form
       /send-notification/(scot %uv (sham eny.bowl))
       notify-endpoint.entry

--- a/desk/mar/notify/client-action.hoon
+++ b/desk/mar/notify/client-action.hoon
@@ -18,6 +18,7 @@
     :~  connect-provider+connect-provider
         remove-provider+remove-provider
         connect-provider-with-binding+connect-provider-with-binding
+        send-message+send-message
     ==
     ++  connect-provider
       %-  ot
@@ -36,6 +37,10 @@
       %-  ot
       :~  who+(su fed:ag)
           service+so
+      ==
+    ++  send-message
+      %-  ot
+      :~  message+so
       ==
     --
   --

--- a/desk/sur/notify.hoon
+++ b/desk/sur/notify.hoon
@@ -19,6 +19,7 @@
   $%  [%connect-provider who=@p service=term address=@t]
       [%connect-provider-with-binding who=@p service=term address=@t binding=@t]
       [%remove-provider who=@p service=term]
+      [%send-message message=@t]
   ==
 ::
 +$  uid  @uvH
@@ -43,6 +44,7 @@
 +$  action
   $%  [%notify ~]
       [%dismiss source=@t]
+      [%message message=@t]
   ==
 ::
 +$  update


### PR DESCRIPTION
## Summary

Adds a notification type for sending generic messages. For use in dispatching timely messages from Hosting.

Model generated, feel free to discard if unfit or insufficiently idiomatic.

## Changes
- Added `%send-message` to `%notify` client actions, with JSON mark support
- Added `%message` notify update action carrying a generic text payload
- Sends generic notification messages to connected providers without changing activity or badge counts
- Added URL encoding for notify provider form payloads before posting to Twilio
- Included message form field only for generic `%message` notifications

## How did I test?

`|commit`'ed locally

## Risks and impact

- Safe to rollback without consulting PR author? Yes

Fixes TLON-5713