### PR TITLE
telemetry: log instances of protocol mismatch notice seen

### DIFF
--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -111,6 +111,7 @@ export enum AnalyticsEvent {
   ActionPinChat = 'Pinned Chat',
   ActionUnpinChat = 'Unpinned Chat',
   ActionVisitedChannel = 'Viewed Channel',
+  ProtocolMismatchNoticeSeen = 'Protocol mismatch notice seen',
   ActionTappedChat = 'Tapped Chatlist Item',
   ActionJoinChannel = 'Joined Channel',
   ActionMoveChannel = 'Moved Channel',

--- a/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
+++ b/packages/app/ui/components/Channel/ReadOnlyNotice.tsx
@@ -1,6 +1,14 @@
+import {
+  AnalyticsEvent,
+  createDevLogger,
+  useConnectionStatus,
+} from '@tloncorp/shared';
 import { Icon } from '@tloncorp/ui';
+import { useEffect, useRef } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SizableText, View, YStack } from 'tamagui';
+
+const logger = createDevLogger('ReadOnlyNotice', false);
 
 export function ReadOnlyNotice({
   type,
@@ -14,6 +22,26 @@ export function ReadOnlyNotice({
     | 'channel-deleted'
     | 'group-deleted';
 }) {
+  const connectionStatus = useConnectionStatus();
+  const hasTrackedProtocolMismatchNotice = useRef(false);
+  const isProtocolMismatch =
+    type === 'dm-mismatch' ||
+    type === 'group-dm-mismatch' ||
+    type === 'channel-mismatch';
+
+  useEffect(() => {
+    if (!isProtocolMismatch || hasTrackedProtocolMismatchNotice.current) {
+      return;
+    }
+
+    hasTrackedProtocolMismatchNotice.current = true;
+    logger.trackEvent(AnalyticsEvent.ProtocolMismatchNoticeSeen, {
+      noticeType: type,
+      connectionStatus,
+      isShipConnectionStatusConnected: connectionStatus === 'Connected',
+    });
+  }, [connectionStatus, isProtocolMismatch, type]);
+
   const Message =
     type === 'read-only' ? (
       <>This channel is read-only for you.</>


### PR DESCRIPTION
## Summary

Adds a PostHog event for when a user sees the protocol mismatch message. Also logs their connection state to disambiguate between real clashes vs. trying to interact with an offline / left-behind ship, which both have interesting stories.

## Changes

- Adds a ProtocolMismatchNoticeSeen type to analytics
- Creates a logger in the ReadOnlyNotice component
- When the ReadOnlyNotice component mounts, create a ref to track its "seen" status. If there's a valid protocol mismatch, we log it and grab the connection status. We don't log for any of the ReadOnlyNotice conditions.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: analytics

## Rollback plan

git revert

## Screenshots / videos

n/a