### PR TITLE
desk: 408 compatibility (part 2, da boogaloo)

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -2138,7 +2138,7 @@
     ?.  =(our.bowl ship.nest)
       =/  count  ?:(=(%diary kind.nest) '20' '100')
       /[kind.nest]/[name.nest]/checkpoint/before/[count]
-    /[kind.nest]/[name.nest]/checkpoint/time-range/(scot %da *@da)
+    /[kind.nest]/[name.nest]/checkpoint/time-range/(scot:h136 %da *@da)
   ::
   ++  ca-start-updates
     |=  delay=?
@@ -2148,7 +2148,7 @@
       (bind (ram:on-v-posts:c posts.channel) head)
     %.  delay
     %^  safe-watch  ca-sub-wire  [ship.nest server]
-    /[kind.nest]/[name.nest]/updates/(scot %da (fall tim *@da))
+    /[kind.nest]/[name.nest]/updates/(scot:h136 %da (fall tim *@da))
   ::
   ++  ca-agent
     |=  [=wire =sign:agent:gall]
@@ -2323,7 +2323,7 @@
     %+  welp
       /[kind.nest]/[name.nest]/checkpoint/time-range
     ~|  `*`key.u.checkpoint-start
-    /(scot %da *@da)/(scot %da key.u.checkpoint-start)
+    /(scot:h136 %da *@da)/(scot:h136 %da key.u.checkpoint-start)
   ::
   ++  ca-ingest-backlog
     |=  chk=u-checkpoint:c

--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -417,7 +417,7 @@
         ::  already subscribed
         ?:  ?=(%want sag)
           si-cor
-        =/  pat  [%v1 %contact ?~(for / /at/(scot %da wen.for))]
+        =/  pat  [%v1 %contact ?~(for / /at/(scot:h136 %da wen.for))]
         %_  si-cor
           cor  (pass /contact %agent [who dap.bowl] %watch pat)
           sag  %want
@@ -646,7 +646,7 @@
         :_  (~(put by peers) who fir %want)
         ?:  (~(has by wex.bowl) [/contact who dap.bowl])
           caz
-        =/  =path  [%v1 %contact ?~(fir / /at/(scot %da wen.fir))]
+        =/  =path  [%v1 %contact ?~(fir / /at/(scot:h136 %da wen.fir))]
         :_  caz
         [%pass /contact %agent [who dap.bowl] %watch path]
       [caz state-1]
@@ -661,7 +661,7 @@
         ?:  ?&  =(%want sag)
                 !(~(has by wex.bowl) [/contact who dap.bowl])
             ==
-          =/  =path  [%v1 %contact ?~(for / /at/(scot %da wen.for))]
+          =/  =path  [%v1 %contact ?~(for / /at/(scot:h136 %da wen.for))]
           :_  caz
           [%pass /contact %agent [who dap.bowl] %watch path]
         caz

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1491,7 +1491,7 @@
       %fact
     ::  we use the same subscription path for client and agent subscriptions.
     ::  here we only process the most recent mark coming from the
-    ::  channel host. 
+    ::  channel host.
     ::
     ?.  =(p.cage.sign %channel-preview-1)  cor
     =+  !<(=channel-preview:v7:gv q.cage.sign)
@@ -3499,7 +3499,7 @@
       ?:  ?=(%pub -.net)  *@da
       time.net
     =/  sub-path=path
-      (weld go-server-path /updates/(scot %p our.bowl)/(scot %da sub-time))
+      (weld go-server-path /updates/(scot %p our.bowl)/(scot:h136 %da sub-time))
     =.  cor
       %.  delay
       (safe-watch go-sub-wire [p.flag server] sub-path)

--- a/desk/lib/test-agent.hoon
+++ b/desk/lib/test-agent.hoon
@@ -263,7 +263,7 @@
     =/  =duct  [%test-sub (scot %p src.bowl.s) path]~
     ~_  leaf+"sub on {(spud path)} not yet made by {(scow %p src.bowl.s)}"
     ?>  (~(has by sup.bowl.s) duct)
-    (~(del by sup.bowl.s) duct [src.bowl.s path])
+    (~(del by sup.bowl.s) duct)
   %.  s  %-  do
   |=  s=state
   (~(on-leave agent.s bowl.s) path)

--- a/desk/lib/test-negotiate-agent.hoon
+++ b/desk/lib/test-negotiate-agent.hoon
@@ -140,7 +140,7 @@
     =/  =duct  [%test-sub (scot %p src.bowl.s) path]~
     ~_  leaf+"sub on {(spud path)} not yet made by {(scow %p src.bowl.s)}"
     ?>  (~(has by sup.bowl.s) duct)
-    (~(del by sup.bowl.s) duct [src.bowl.s path])
+    (~(del by sup.bowl.s) duct)
   %.  s  %-  do
   |=  s=state
   (~(on-leave agent.s bowl.s) path)

--- a/desk/tests/app/channels-server.hoon
+++ b/desk/tests/app/channels-server.hoon
@@ -43,14 +43,13 @@
         [kind=/chat meta=~ blob=~]
     ==
   ::  edit carefully to work around lib negotiate state.
-  ::  yes, the inner state is double-vased!
   ::
   ;<  save=vase  bind:m  get-save
   =.  save
     ;:  slop
       (slot 2 save)  ::  lib discipline
       (slot 6 save)  ::  lib negotiate
-      !>(!>(state))  ::  negotiate's double-vasing
+      !>(state)
     ==
   ;<  *  bind:m  (do-load agent `save)
   ;<  caz=(list card)  bind:m
@@ -273,14 +272,13 @@
       (~(put by *v-channels:c) *nest:c chan)
     ;<  *  bind:m  (do-init dap agent)
     ::  edit carefully to work around lib negotiate state.
-    ::  yes, the inner state is double-vased!
     ::
     ;<  save=vase  bind:m  get-save
     =.  save
       ;:  slop
         (slot 2 save)      ::  lib discipline
         (slot 6 save)      ::  lib negotiate
-        !>(!>(bad-state))  :: negotiate's double-vasing
+        !>(bad-state)
       ==
     ;<  caz=(list card:agent:gall)  bind:m  (do-load agent `save)
     ::
@@ -294,8 +292,8 @@
       (~(put by *v-channels:c) *nest:c chan)
     ::  again, carefully work around lib negotiate state.
     ::
-    =.  save  (slot 3 save)           ::  lib discipline
-    =.  save  !<(vase (slot 3 save))  ::  lib negotiate
+    =.  save  (slot 3 save)  ::  lib discipline
+    =.  save  (slot 3 save)  ::  lib negotiate
     (ex-equal save !>(fixed-state))
   --
 --

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -74,7 +74,7 @@
   =/  backlog-wire  (weld negotiate-wire /backlog)
   =/  backlog-path
     %+  welp  /chat/test/checkpoint/time-range
-    /(scot %da *@da)/(scot %da last-post-time)
+    /(scot:h136 %da *@da)/(scot:h136 %da last-post-time)
   =/  backlog-retry  (weld /~/retry (weld sub-wire /backlog))
   ;<  *  bind:m  (do-agent backlog-wire the-dock %watch-ack ~)
   (check-subscription-loop backlog-wire backlog-wire the-dock backlog-path backlog-retry)

--- a/desk/tests/app/channels.hoon
+++ b/desk/tests/app/channels.hoon
@@ -257,7 +257,7 @@
       (~(put by *v-channels:c) *nest:c chan)
     ::
     =.  save  (slot 3 save)  ::  move "through" discipline state
-    =.  save  !<(vase (slot 3 save))  ::  move "through" negotiate state & shenanigans
+    =.  save  (slot 3 save)  ::  move "through" negotiate state
     (ex-equal save !>(fixed-state))
   --
 ::
@@ -369,8 +369,8 @@
         tombstone-fix-test-channel
       (~(put by *v-channels:c) *nest:c chan)
     ::
-    =.  save  (slot 3 save)           ::  lib discipline
-    =.  save  !<(vase (slot 3 save))  ::  lib negotiate
+    =.  save  (slot 3 save)  ::  lib discipline
+    =.  save  (slot 3 save)  ::  lib negotiate
     (ex-equal save !>(fixed-state))
   --
 ::

--- a/desk/tests/app/contacts.hoon
+++ b/desk/tests/app/contacts.hoon
@@ -798,7 +798,7 @@
   ::  update is sent
   ::
   ;<  ~  b  (set-src ~sun)
-  ;<  caz=(list card)  b  (do-watch /v1/contact/at/(scot %da now.bowl))
+  ;<  caz=(list card)  b  (do-watch /v1/contact/at/(scot:h136 %da now.bowl))
   ;<  ~  b
     %+  ex-cards  caz
     :~  (ex-fact ~ contact-update-1+!>([%full now con]))
@@ -807,7 +807,7 @@
   ::  no update is sent - already at latest
   ::
   ;<  ~  b  (set-src ~sun)
-  ;<  caz=(list card)  b  (do-watch /v1/contact/at/(scot %da now))
+  ;<  caz=(list card)  b  (do-watch /v1/contact/at/(scot:h136 %da now))
   (ex-cards caz ~)
 ::
 ::  +test-sub-profile
@@ -872,7 +872,7 @@
   %+  ex-cards  caz
   :~  %^  ex-task  /contact
           [~sun %contacts]
-          [%watch /v1/contact/at/(scot %da (add now.bowl tick))]
+          [%watch /v1/contact/at/(scot:h136 %da (add now.bowl tick))]
   ==
 ::
 ++  test-peek-0-all

--- a/desk/tests/app/groups-server.hoon
+++ b/desk/tests/app/groups-server.hoon
@@ -64,7 +64,7 @@
   ::  self-join the group
   ::
   ;<  *  bind:m  (do-poke group-command+!>([%join my-flag ~]))
-  ;<  *  bind:m  (do-watch (weld se-area /updates/~zod/(scot %da *@da)))
+  ;<  *  bind:m  (do-watch (weld se-area /updates/~zod/(scot:h136 %da *@da)))
   ;<  =bowl:gall  bind:m  get-bowl
   (pure:m caz)
 ::
@@ -85,7 +85,7 @@
   ::  self-join the group
   ::
   ;<  *  bind:m  (do-poke group-command+!>([%join my-flag ~]))
-  ;<  *  bind:m  (do-watch (weld se-area /updates/~zod/(scot %da *@da)))
+  ;<  *  bind:m  (do-watch (weld se-area /updates/~zod/(scot:h136 %da *@da)))
   ;<  =bowl:gall  bind:m  get-bowl
   (pure:m caz)
 ::
@@ -131,7 +131,7 @@
 ++  ex-update
   |=  [=time =u-group:v9:gv]
   %+  ex-fact
-    ~[/server/groups/~zod/my-test-group/updates/~zod/(scot %da *@da)]
+    ~[/server/groups/~zod/my-test-group/updates/~zod/(scot:h136 %da *@da)]
   group-update+!>(`update:g`[time u-group])
 ::
 ++  ex-arvo-token-expire

--- a/desk/tests/app/groups.hoon
+++ b/desk/tests/app/groups.hoon
@@ -62,7 +62,7 @@
     [%gu ship=@ %activity now=@ rest=*]         `!>(|)
     [%gx ship=@ %chat now=@ %blocked %ships ~]  `!>(~)
   ::
-      [%gx ship=@ %groups now=@ %~.~ %negotiate %status ship=@ agent=@ %noun ~]  
+      [%gx ship=@ %groups now=@ %~.~ %negotiate %status ship=@ agent=@ %noun ~]
     `!>(%match)
   ==
 ++  do-groups-init
@@ -82,7 +82,7 @@
 :: ++  ex-update
 ::   |=  [=time =u-group:v7:gv]
 ::   %+  ex-fact
-::     ~[/server/groups/~zod/my-test-group/updates/~zod/(scot %da *@da)]
+::     ~[/server/groups/~zod/my-test-group/updates/~zod/(scot:h136 %da *@da)]
 ::   group-update+!>(`update:g`[time u-group])
 ++  go-area  /groups/(scot %p p:my-flag)/[q:my-flag]
 ++  fi-area  /foreigns/(scot %p p:my-flag)/[q:my-flag]
@@ -232,7 +232,7 @@
     =/  =wire  (weld go-area /updates)
     =/  sub=path
       %+  weld  `path`[%server go-area]
-      /updates/~dev/(scot %da *@da)
+      /updates/~dev/(scot:h136 %da *@da)
     %+  ex-cards  caz
     :~  (ex-task wire [~zod my-agent] %watch sub)
         (ex-foreign-response %*(. *foreign:g progress `%watch))

--- a/desk/tests/lib/negotiate.hoon
+++ b/desk/tests/lib/negotiate.hoon
@@ -11,7 +11,7 @@
   ==
 ::
 +$  libstate
-  $:  %1
+  $:  %2
       ours=(map protocol:libn version:libn)
       know=config:libn
       heed=(map [gill:gall protocol:libn] (unit version:libn))
@@ -118,7 +118,7 @@
   =/  m  (mare ,libstate)
   ^-  form:m
   ;<  state=vase  bind:m  get-save
-  (pure:m o:!<([[%negotiate o=libstate] vase] state))
+  (pure:m o:!<([%negotiate o=libstate] (slot 2 state)))
 ::
 ++  perform-hear-version
   |=  [=gill:gall =protocol:libn =version:libn]


### PR DESCRIPTION
## Summary

Zuse 408K brings along Hoon 135K. With that, the behavior of `@da` rendering changes to pad month and day segments to be two digits consistently. 135K parsing accepts both the new and old format, but older ships (136K and older) will still only accept the old format.

Here, we update subscription path construction to always use old-style `@da` rendering. This way ships on 408 will be able to (re)open their usual subscriptions to ships running 409.

## Changes

22676b7 updates the tests to pass on 408, accounting for the breaking changes and the ones from #5648.

784f3d3 updates all the places where we serialize timestamps into wires. Found these by looking over all instances of `%da`. In practice, it's always a `+scot` call.

We probably don't want to do this forever. We don't even strictly need to do it right now! But changing the subscription paths constitutes a protocol change, and backcompat here is trivial, so we'll save cleanup here for another day.

We notably don't touch anything that's local only (like wires) or treated opaquely once serialized (like reel nonces).

## How did I test?

Ran a 409 migration and ran the tests. ~Presently awaiting on-the-ground report from mopfel-winrux, who encountered problems caused by this through running pre-release.~ Fix confirmed on an affected ship!

## Risks and impact

- Yes, safe to rollback without consulting PR author, but this is required for 408 compatibility.
- Affects important code area:
  - Message sync

## Rollback plan

Revert.