### PR TITLE
contacts: expose unified /v1/directory scry

### DIFF
--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -804,7 +804,7 @@
         (~(get by book) id+u.id)
       ``contact-page-0+!>(`^page`(fall page *^page))
       ::
-        [%x %v1 %all ~]
+        [%x %v1 %directory ~]
       =|  dir=directory
       ::  export self
       ::

--- a/desk/app/contacts.hoon
+++ b/desk/app/contacts.hoon
@@ -806,22 +806,25 @@
       ::
         [%x %v1 %all ~]
       =|  dir=directory
+      ::  export self
+      ::
+      =.  dir  (~(put by dir) our.bowl [& con.rof ~])
       ::  export all ship contacts
       ::
       =.  dir
         %-  ~(rep by book)
         |=  [[=kip =page] =_dir]
-        ?^  kip
-          dir
-        (~(put by dir) kip (contact-uni page))
-      ::  export all peers
+        ?^  kip  dir
+        =*  who  kip
+        (~(put by dir) who [& page])
+      ::  export all peers skipping contacts
       ::
       =.  dir
         %-  ~(rep by peers)
         |=  [[who=ship far=foreign] =_dir]
         ?~  for.far  dir
         ?:  (~(has by dir) who)  dir
-        (~(put by dir) who con.for.far)
+        (~(put by dir) who [| con.for.far ~])
       ``contact-directory-0+!>(dir)
       ::
         [%x %v1 %changes since=@ ~]

--- a/desk/lib/contacts/json-1.hoon
+++ b/desk/lib/contacts/json-1.hoon
@@ -61,10 +61,10 @@
     |=  =directory:c
     %-  pairs
     %+  turn  ~(tap by directory)
-    |=  [who=@p =marked-page:c]
+    |=  [who=@p =leaf:c]
     :-  (scot %p who)
     %-   pairs
-    =,  marked-page
+    =,  leaf
     :~  'isContact'^b+contact
         contact+(^contact con)
         mod+(^contact mod)

--- a/desk/lib/contacts/json-1.hoon
+++ b/desk/lib/contacts/json-1.hoon
@@ -59,12 +59,16 @@
   ::
   ++  directory
     |=  =directory:c
-    ^-  json
-    =|  dir=(map @ta json)
-    :-  %o
-    %-  ~(rep by directory)
-    |=  [[who=@p con=contact:c] acc=_dir]
-    (~(put by acc) (scot %p who) (contact con))
+    %-  pairs
+    %+  turn  ~(tap by directory)
+    |=  [who=@p =marked-page:c]
+    :-  (scot %p who)
+    %-   pairs
+    =,  marked-page
+    :~  'isContact'^b+contact
+        contact+(^contact con)
+        mod+(^contact mod)
+    ==
   ::
   ++  response
     |=  n=response:c

--- a/desk/sur/contacts.hoon
+++ b/desk/sur/contacts.hoon
@@ -82,9 +82,12 @@
 ::  $book: contact book
 ::
 +$  book  (map kip page)
-::  $directory: merged contacts
+::  $marked-page: standalone contact page
 ::
-+$  directory  (map ship contact)
++$  marked-page  [contact=? page]
+::  $directory: peers and contacts directory
+::
++$  directory  (map ship marked-page)
 ::  $peers: network peers
 ::
 +$  peers  (map ship foreign)

--- a/desk/sur/contacts.hoon
+++ b/desk/sur/contacts.hoon
@@ -82,12 +82,12 @@
 ::  $book: contact book
 ::
 +$  book  (map kip page)
-::  $marked-page: standalone contact page
+::  $leaf: standalone contact page
 ::
-+$  marked-page  [contact=? page]
++$  leaf  [contact=? page]
 ::  $directory: peers and contacts directory
 ::
-+$  directory  (map ship marked-page)
++$  directory  (map ship leaf)
 ::  $peers: network peers
 ::
 +$  peers  (map ship foreign)

--- a/desk/tests/app/contacts.hoon
+++ b/desk/tests/app/contacts.hoon
@@ -1036,17 +1036,17 @@
     (do-agent /contact [~mur %contacts] %fact contact-update-1+!>([%full now.bowl con-mur]))
   ::  peek all: two contacts are found
   ::
-  ;<  peek=(unit (unit cage))  b  (get-peek /x/v1/all)
+  ;<  peek=(unit (unit cage))  b  (get-peek /x/v1/directory)
   =/  cag=cage  (need (need peek))
   ?>  ?=(%contact-directory-0 p.cag)
   =/  dir  !<(directory q.cag)
   ;<  ~  b
     %+  ex-equal
     !>  (~(got by dir) ~sun)
-    !>  (contact-uni:c con-sun con-mod)
+    !>  `marked-page`[& con-sun con-mod]
   %+  ex-equal
   !>  (~(got by dir) ~mur)
-  !>  con-mur
+  !>  `marked-page`[| con-mur ~]
 ::  +test-retry: test resubscription logic
 ::
 ::    scenario

--- a/desk/tests/app/contacts.hoon
+++ b/desk/tests/app/contacts.hoon
@@ -1043,10 +1043,10 @@
   ;<  ~  b
     %+  ex-equal
     !>  (~(got by dir) ~sun)
-    !>  `marked-page`[& con-sun con-mod]
+    !>  `leaf`[& con-sun con-mod]
   %+  ex-equal
   !>  (~(got by dir) ~mur)
-  !>  `marked-page`[| con-mur ~]
+  !>  `leaf`[| con-mur ~]
 ::  +test-retry: test resubscription logic
 ::
 ::    scenario


### PR DESCRIPTION
## Summary

The new directory scry exposes all known contacts and peers, including user's own profile. This is the API desired by the client, which otherwise would have assemble data obtained from other scries.

 The `isContact` flag indicates whether the entry was derived from contact or peer data. User's profile is considered a contact.

Closes TLON-3879

This is an improved version of the PR originally targeted at landscape: https://github.com/tloncorp/landscape/pull/314

## Changes

1. Remove `/v1/all` scry (unused by the client), and repurpose it into `/v1/directory` which returns a map of `$marked-page`s

## How did I test?

Queried the endpoint.

## Risks and impact

- Safe to rollback without consulting PR author? Yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.