### PR TITLE
fix disabled posthog

### DIFF
--- a/packages/app/lib/envVars.native.ts
+++ b/packages/app/lib/envVars.native.ts
@@ -28,6 +28,7 @@ export const INVITE_PROVIDER =
 export const NOTIFY_PROVIDER = envVars.notifyProvider ?? 'rivfur-livmet';
 export const NOTIFY_SERVICE = envVars.notifyService ?? 'groups-native';
 export const POST_HOG_API_KEY = envVars.postHogApiKey ?? '';
+export const POST_HOG_IN_DEV = envVars.postHogInDev === 'true';
 export const SENTRY_DSN = envVars.sentryDsn ?? '';
 export const APP_VARIANT = envVars.appVariant ?? 'production';
 const configuredScheme = Constants.expoConfig?.scheme;

--- a/packages/app/lib/envVars.ts
+++ b/packages/app/lib/envVars.ts
@@ -43,7 +43,7 @@ export const INVITE_PROVIDER =
 export const NOTIFY_PROVIDER = envVars.notifyProvider ?? 'rivfur-livmet';
 export const NOTIFY_SERVICE = envVars.notifyService ?? 'groups-native';
 export const POST_HOG_API_KEY = envVars.postHogApiKey ?? '';
-export const POST_HOG_IN_DEV = Boolean(envVars.postHogInDev);
+export const POST_HOG_IN_DEV = envVars.postHogInDev === 'true';
 export const APP_SCHEME = 'io.tlon.groups';
 export const API_URL = envVars.apiUrl ?? 'https://tlon.network';
 export const API_AUTH_USERNAME = envVars.apiAuthUsername;

--- a/packages/app/provider/TelemetryProvider.native.tsx
+++ b/packages/app/provider/TelemetryProvider.native.tsx
@@ -7,10 +7,6 @@ export function TelemetryProvider({ children }: PropsWithChildren) {
   return (
     <PostHogProvider
       client={posthog}
-      options={{
-        disabled:
-          process.env.NODE_ENV === 'test' && !process.env.POST_HOG_IN_DEV,
-      }}
       autocapture={{
         captureTouches: false,
         captureScreens: false,

--- a/packages/app/utils/posthog.ts
+++ b/packages/app/utils/posthog.ts
@@ -5,7 +5,7 @@ import * as db from '@tloncorp/shared/db';
 import PostHog from 'posthog-react-native';
 import { Platform, TurboModuleRegistry } from 'react-native';
 
-import { GIT_HASH, POST_HOG_API_KEY } from '../constants';
+import { GIT_HASH, POST_HOG_API_KEY, POST_HOG_IN_DEV } from '../constants';
 import { createSentryErrorLogger } from './sentry';
 import { UrbitModuleSpec } from './urbitModule';
 
@@ -24,12 +24,28 @@ export type OnboardingProperties = {
   inviteType?: 'user' | 'group';
 };
 
-export const posthog: PostHog | undefined =
-  process.env.NODE_ENV === 'test' && !process.env.POST_HOG_IN_DEV
-    ? undefined
-    : new PostHog(POST_HOG_API_KEY, {
-        host: 'https://data-bridge-v1.vercel.app/ingest',
-      });
+export const posthogEnabled = (() => {
+  if (process.env.NODE_ENV === 'test') return false;
+  if (process.env.NODE_ENV === 'development') {
+    return POST_HOG_IN_DEV;
+  }
+  return true;
+})();
+
+export const posthog: PostHog = new PostHog(
+  // PostHog complains on passing an empty string. Allow omitting PostHog key
+  // when PostHog is disabled by passing a dummy key and then disabling the client.
+  // (If PostHog is enabled, pass the empty string to get a nice error message.)
+  POST_HOG_API_KEY !== ''
+    ? POST_HOG_API_KEY
+    : posthogEnabled
+      ? ''
+      : 'dummy-key',
+  {
+    host: 'https://data-bridge-v1.vercel.app/ingest',
+    disabled: !posthogEnabled,
+  }
+);
 
 if (posthog) {
   const distinctId = posthog.getDistinctId();


### PR DESCRIPTION
## Summary
Avoids PostHog error when running in dev mode without a PostHog key.

## Changes

- `envVars.native.ts` did not have a binding for `POST_HOG_IN_DEV` - added that and use it instead of directly accessing the string `process.env.POST_HOG_IN_DEV`
- `Boolean(process.env.POST_HOG_IN_DEV)` would evaluate to true with `POST_HOG_IN_DEV=false` - changed to check `=== 'true'`
- Optionally disable PostHog client when constructing (instead of further down in provider)

## How did I test?
On iOS:
- Ran development build without a PostHog API key – got past launch.
- Run release non-preview build with a real PostHog key, poked around in app and saw that PostHog events were being received in real-time in online dashboard

## Risks and impact
**This could break sending all analytics** so I'd appreciate a close review.

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Analytics

## Rollback plan
git revert
