### PR TITLE
fix(mobile): work around RN border-radius bug on Android unread badge

### DIFF
--- a/packages/app/ui/components/ListItem/ListItem.tsx
+++ b/packages/app/ui/components/ListItem/ListItem.tsx
@@ -188,6 +188,12 @@ const ListItemCount = ({
     : '$secondaryBackground';
   return (
     <View
+      // Workaround for facebook/react-native#52415: on Android new
+      // arch, a View whose backgroundColor transitions from
+      // transparent to opaque loses its border-radius clipping.
+      // Keying on the visible state forces a fresh mount so the
+      // badge keeps its rounded shape.
+      key={count < 1 ? 'hidden' : notified ? 'notified' : 'normal'}
       opacity={opacity}
       paddingHorizontal={'$m'}
       backgroundColor={count < 1 ? undefined : backgroundColor}


### PR DESCRIPTION
## Summary

The chat list unread count badge renders as a square instead of a rounded pill on Android with the new architecture. Same root cause as the nav bar unread dot fix — facebook/react-native#52415, where a View whose `backgroundColor` transitions from transparent to opaque loses its `borderRadius` clipping.

## Changes

- Add a `key` prop to the `View` in `ListItemCount` (packages/app/ui/components/ListItem/ListItem.tsx) that changes whenever the badge's background goes from transparent to opaque (or between gray and blue). React remounts the View, so it never has to perform the broken transparent→opaque transition.

This mirrors the workaround already shipping in `NavBar/NavIcon.tsx` for the nav bar unread dot.

## How did I test?

- Manually verified on Android (new arch, full app restart — hot reload masks this RN bug). Unread badges with notifications render as rounded pills again.
- iOS unaffected; iOS rendering of the badge is unchanged.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display (chat list unread badge)
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the single commit on this branch.

## Screenshots / videos

Before (square blue badge on Android, screenshot from issue report):
- Blue "4" badge renders as a rectangle; gray badges happen to render correctly because they were mounted with their final color.

After: badge renders as a rounded pill regardless of which color it ends up with.
