### PR TITLE
fix(ios): always forward didReceiveRemoteNotification to ExpoAppDelegate

### DIFF
--- a/apps/tlon-mobile/ios/Landscape/AppDelegate.swift
+++ b/apps/tlon-mobile/ios/Landscape/AppDelegate.swift
@@ -113,12 +113,10 @@ class AppDelegate: ExpoAppDelegate {
     // Handle notification dismiss actions
     NotificationDismissHandler.shared.handleNotificationDismiss(userInfo: userInfo)
 
-    // Call super to maintain existing functionality
-    if super.responds(to: #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))) {
-      super.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
-    } else {
-      completionHandler(.noData)
-    }
+    // Forward to ExpoAppDelegate so expo-notifications and other subscribers
+    // can process the push (including the silent `content-available` payload
+    // the notify-provider uses to wake the NSE).
+    super.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
   }
 }
 


### PR DESCRIPTION
## Summary

Cleanup. The `super.responds(to:)` guard around the super call is effectively dead code — `respondsToSelector:` walks the receiver's class hierarchy (which includes the override), so the check always returns true and the `else` branch never runs. Notifications work fine in practice; this just simplifies the method.

## Changes

Drop the conditional and always call super.

## How did I test?

Static reasoning only. No behavior change expected.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

Revert the single commit.

## Screenshots / videos

N/A.
