### PR TITLE
fix(ios): preserve fallback content when NSE rich render fails

### DIFF
--- a/apps/tlon-mobile/ios/Notifications/NotificationService.swift
+++ b/apps/tlon-mobile/ios/Notifications/NotificationService.swift
@@ -23,6 +23,14 @@ class NotificationService: UNNotificationServiceExtension {
                 .error(err),
                 .delivery(["uid": .string(uid), "message": .string("Fallback notification delivered successfully")])
             ])
+
+            // iOS suppresses the banner if both title and body are empty, so
+            // ensure there is at least a generic placeholder when rich
+            // rendering fails and the server did not provide any fallback
+            // text in the APS payload.
+            if notification.title.isEmpty && notification.body.isEmpty {
+                notification.body = "You received a notification"
+            }
             return notification
         }
     }
@@ -34,12 +42,14 @@ class NotificationService: UNNotificationServiceExtension {
         // Store the JSON string in notification userInfo
         notification.userInfo["activityEventJsonString"] = activityEventJsonString
 
-        // If we have a preview, make sure to fully replace server-provided title / body.
-        notification.title = ""
-        notification.body = ""
-
         let renderer = NotificationPreviewContentNodeRenderer()
         let preview = try getPreview(rawActivityEvent: rawActivityEvent, uid: uid, activityEventJsonString: activityEventJsonString)
+
+        // Now that we have a preview, fully replace server-provided title / body.
+        // Clearing here (rather than before the throwing render call) preserves
+        // the server's fallback text if rendering fails.
+        notification.title = ""
+        notification.body = ""
         if let title = preview.notification.title {
             notification.title = await renderer.render(title)
         }


### PR DESCRIPTION
## Summary

iOS notification banners stopped showing for at least one tester after the Expo 54 upgrade, even though the badge updated correctly and silent dismissal pushes (`[dismisser]` log path) processed normally. That combination — badge moves but no visible banner — pointed at the Notification Service Extension running, getting through to the badge-set step, then failing during rich content rendering and emitting a notification with empty title and body. iOS suppresses the banner when both fields are empty.

## Changes

`processRichNotification` clears `notification.title` and `notification.body` and then calls `getPreview()`, which can throw if `bundle.js` resource loading, `JSContext` evaluation, the `tlon.renderActivityEventPreview` call, or `NotificationPreviewPayload` decoding fails. When it throws, the catch block in `applyNotif` returns the now-empty notification.

This PR moves the title/body clear so it only runs *after* the preview renders successfully. If `getPreview()` throws, whatever fallback content the server placed in the APS alert is preserved on the way out. As a defense-in-depth, the catch path now sets `notification.body = "You received a notification"` when both fields would otherwise be empty so a banner displays even if the server provided no fallback text.

This does not identify or fix the underlying reason `getPreview()` is throwing for the affected user — that needs NSE-process logs from `Console.app` to pin down (the script load, the `JSContext` exception handler, or the `NotificationPreviewPayload` decode are all candidates). The change here only ensures that path no longer silently swallows the banner.

## How did I test?

Static analysis only so far — the affected user has not retested with this build. The diff is small enough that I want to land it as a defensive fix and have someone install a build from this branch to confirm banners reappear (either with the real preview content if rendering succeeds, or with the fallback string if rendering still throws — in which case we still need the NSE logs to find the root cause).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

Revert the single commit. Behavior returns to the prior state where notifications can deliver with empty title/body if rich rendering throws.

## Screenshots / videos

N/A (native code change). Tester reported badge incrementing without any banner appearing on lock screen or in Notification Center; that's the case this fix addresses.
