### PR TITLE
stop voice memo recording on app background

### DIFF
--- a/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
@@ -8,7 +8,6 @@ import {
   getRecordingPermissionsAsync,
   requestRecordingPermissionsAsync,
 } from 'expo-audio';
-import { useAppStatusChange } from 'packages/app/hooks/useAppStatusChange';
 import {
   ComponentProps,
   forwardRef,
@@ -23,6 +22,7 @@ import {
 import { Alert, StyleSheet } from 'react-native';
 import { useTheme } from 'tamagui';
 
+import { useAppStatusChange } from '../../../hooks/useAppStatusChange';
 import {
   FinishMode,
   IWaveformRef,

--- a/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
@@ -351,13 +351,17 @@ export const AudioRecorder = forwardRef<
   useAppStatusChange(
     useCallback(
       (status) => {
-        if (status === 'background') {
+        if (
+          status === 'background' &&
+          state.live &&
+          state.recorderState === RecorderState.recording
+        ) {
           refApi.stopRecording().catch((error) => {
             console.error('Failed to stop recording on app background', error);
           });
         }
       },
-      [refApi]
+      [refApi, state]
     )
   );
 

--- a/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
@@ -8,6 +8,7 @@ import {
   getRecordingPermissionsAsync,
   requestRecordingPermissionsAsync,
 } from 'expo-audio';
+import { useAppStatusChange } from 'packages/app/hooks/useAppStatusChange';
 import {
   ComponentProps,
   forwardRef,
@@ -345,6 +346,19 @@ export const AudioRecorder = forwardRef<
   const progressLabel = useMemo(
     () => makePrettyTimeFromMs(elapsedMs ?? 0),
     [elapsedMs]
+  );
+
+  useAppStatusChange(
+    useCallback(
+      (status) => {
+        if (status === 'background') {
+          refApi.stopRecording().catch((error) => {
+            console.error('Failed to stop recording on app background', error);
+          });
+        }
+      },
+      [refApi]
+    )
   );
 
   return (


### PR DESCRIPTION
## Summary
fixes TLON-5683
Stops audio recording from voice memo recorder when app is backgrounded.

## How did I test?
On iOS / Android simulators, started recording, then backgrounded app; on return, voice memo had been stopped at the time of backgrounding; sending the post worked.

Backgrounding app while previewing a recorded voice memo does not crash the app.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
git revert

## Screenshots / videos

https://github.com/user-attachments/assets/96691a24-3d67-45cf-a9d3-fb8afd5c1198

https://github.com/user-attachments/assets/fad41dfe-7cd7-4fea-a9f9-291aeef751c5



