### PR TITLE
fix list items in contacts screen not receiving presses

### DIFF
--- a/packages/app/ui/components/listItems/ContactListItem.tsx
+++ b/packages/app/ui/components/listItems/ContactListItem.tsx
@@ -21,6 +21,7 @@ export const ContactListItem = ({
   matchText,
   subtitle,
   size = '$2xl',
+  hoverStyle,
   ...props
 }: {
   contactId: string;
@@ -44,6 +45,7 @@ export const ContactListItem = ({
       borderRadius="$xl"
       onPress={handlePress}
       onLongPress={handleLongPress}
+      hoverStyle={hoverStyle}
     >
       <ListItem alignItems="center" justifyContent="flex-start" {...props}>
         {showIcon && <ListItem.ContactIcon size={size} contactId={contactId} />}


### PR DESCRIPTION
## Summary
fixes TLON-5707
Fix `ContactListItem` in contacts screen (rightmost tab) not responding to press events.

## Changes
We were forwarding all unbound props from `ContactListItem` to `ListItem` (which is a `styled` `XStack`), which included `hoverStyle` – apparently, `hoverStyle` opts the view into greedy pointer handling, which was stopping presses from bubbling to the parent `Pressable`.

## How did I test?
on iOS / Android / web: Opened contacts screen and pressed on contact to see navigation.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

git revert

## Screenshots / videos

https://github.com/user-attachments/assets/9c98cc10-f827-4fd3-9b8f-21a9ee93f23d


https://github.com/user-attachments/assets/19eaf136-264c-432f-839c-a2a87d7a5555


https://github.com/user-attachments/assets/528e63d0-7f8d-43ce-a33e-2e702502b94c

