### PR TITLE
fix unread dot shape

### DIFF
--- a/packages/app/ui/components/UnreadDot.tsx
+++ b/packages/app/ui/components/UnreadDot.tsx
@@ -6,6 +6,7 @@ export function UnreadDot(
 ) {
   return (
     <Circle
+      key={props.color ?? 'primary'}
       size="$m"
       backgroundColor={
         props.color === 'neutral' ? '$neutralUnreadDot' : '$positiveActionText'


### PR DESCRIPTION
## Summary

This fixes blue unread dots sometimes rendering as squares on Android.

The dot now gets a new key when switching between neutral and primary unread states, matching the existing workaround for the nav unread dot. This avoids reused native view state losing its circle clipping.

Fixes TLON-5706

## Changes

- remount unread dots when their color state changes

## How did I test?

Tested on device