### PR TITLE
restore preview share extension target

### DIFF
--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		0C9C9CAB2F2BD797004BFACB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9C9CAA2F2BD797004BFACB /* AppDelegate.swift */; };
 		0C9C9CAC2F2BD797004BFACB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9C9CAA2F2BD797004BFACB /* AppDelegate.swift */; };
+		1A74C9DBAC9D4949A040EA55 /* ShareExtensionPreview.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3507AE1D048346668887E8DE /* ShareExtensionPreview.appex */; };
+		24E7CA9B2CC448F48B8737F0 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1E325AC599214F3CA5B91BA4 /* PrivacyInfo.xcprivacy */; };
+		2B491A3280B249B4A1A337DC /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4AAB945CECE149D893E29730 /* MainInterface.storyboard */; };
 		3DC46BC1B669DF8F5F059CA8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACB38DC4FF4D6377774BF5F /* ExpoModulesProvider.swift */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		4ACCD7281520ED84DDC2759A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 74D2BEF1344CF71A07C17F5E /* PrivacyInfo.xcprivacy */; };
@@ -190,10 +193,17 @@
 		70F99AAA2B2D337600D77256 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700B635F2A71E0810017F40F /* SettingsStore.swift */; };
 		70F99AAB2B2D337600D77256 /* UserDefaultsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7036E3532ACD0FC90020A9FB /* UserDefaultsStore.swift */; };
 		70F99AAC2B2D338E00D77256 /* UrbitModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EAEAB42A57A99100FE96E4 /* UrbitModule.swift */; };
+		777768A4CBBC4BD7A6339A5F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1E325AC599214F3CA5B91BA4 /* PrivacyInfo.xcprivacy */; };
+		7AB4EBEC93184CA4A56FCEF8 /* ShareExtensionPreprocessor.js in Resources */ = {isa = PBXBuildFile; fileRef = 7921BAA51C1F4AB0927D16A9 /* ShareExtensionPreprocessor.js */; };
+		7F6063AC57974E4287785178 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3E46F6CF2FCE4FBDA5B598CE /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		855125DEE814E6B0DFE6229D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 9D6B23EFDEDD5888235A22BB /* PrivacyInfo.xcprivacy */; };
+		9800D0CF75B94AF4B4F91344 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9042C1EE9669440FB104FA17 /* ShareViewController.swift */; };
+		9F3F596CE47E4B2AAFE7F156 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4AAB945CECE149D893E29730 /* MainInterface.storyboard */; };
 		AA0FE320B86E4AD5A2E68DE9 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 6354B01B2DA4510400A00356 /* bundle.js */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		AC9B29734DA146748D2BEDC9 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9042C1EE9669440FB104FA17 /* ShareViewController.swift */; };
 		C184662C2ABBDFF1008EA8C0 /* GoogleService-Info-io.tlon.groups.plist in Resources */ = {isa = PBXBuildFile; fileRef = C184662B2ABBDFF1008EA8C0 /* GoogleService-Info-io.tlon.groups.plist */; };
+		C4DCBC2505E8483F971EF4DE /* ShareExtensionPreprocessor.js in Resources */ = {isa = PBXBuildFile; fileRef = 7921BAA51C1F4AB0927D16A9 /* ShareExtensionPreprocessor.js */; };
 		C5AA2DA09E0243819EFF88B6 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 6354B01B2DA4510400A00356 /* bundle.js */; };
 		C83014822C7BA74C00D9A5CA /* UIFont+SystemDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = C83014812C7BA74C00D9A5CA /* UIFont+SystemDesign.m */; };
 		C83014832C7BA74C00D9A5CA /* UIFont+SystemDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = C83014812C7BA74C00D9A5CA /* UIFont+SystemDesign.m */; };
@@ -232,6 +242,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		31F895BCB80F4806A5F6C2C2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 64210DE667CC422A9D8996CA;
+			remoteInfo = ShareExtension;
+		};
 		630DE0E82C51AA0D0053603B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
@@ -245,6 +262,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 630DE0BD2C51A8780053603B;
 			remoteInfo = "Notifications-preview";
+		};
+		6950718DD30D4243B6890527 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BF7A2FBCE4AC4111B1F79BF6;
+			remoteInfo = ShareExtensionPreview;
 		};
 		70F99A922B2D2B5700D77256 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -263,6 +287,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				630DE0E72C51AA0C0053603B /* Notifications.appex in Embed Foundation Extensions */,
+				7F6063AC57974E4287785178 /* ShareExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -274,6 +299,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				630DE0E62C51A9D30053603B /* Notifications-preview.appex in Embed Foundation Extensions */,
+				1A74C9DBAC9D4949A040EA55 /* ShareExtensionPreview.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -281,11 +307,16 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0F80B9E935DB48E096A2A289 /* ShareExtension-Info.plist */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = "ShareExtension-Info.plist"; path = "ShareExtension-Info.plist"; sourceTree = "<group>"; };
 		0C9C9CAA2F2BD797004BFACB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Landscape/AppDelegate.swift; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* Landscape.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Landscape.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Landscape/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Landscape/Info.plist; sourceTree = "<group>"; };
+		1E325AC599214F3CA5B91BA4 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = PrivacyInfo.xcprivacy; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3507AE1D048346668887E8DE /* ShareExtensionPreview.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = undefined; name = ShareExtensionPreview.appex; path = ShareExtensionPreview.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B0B210E999A7E0E1A345468 /* Pods-Landscape-preview.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape-preview.release.xcconfig"; path = "Target Support Files/Pods-Landscape-preview/Pods-Landscape-preview.release.xcconfig"; sourceTree = "<group>"; };
+		3E46F6CF2FCE4FBDA5B598CE /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = undefined; name = ShareExtension.appex; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AAB945CECE149D893E29730 /* MainInterface.storyboard */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = MainInterface.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
 		5A1EB9522CAC451A00029EDC /* GroupStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupStore.swift; sourceTree = "<group>"; };
 		5A277C472E8B35F80030DB0E /* NotificationPreviewPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationPreviewPayload.swift; sourceTree = "<group>"; };
 		5A277C4D2E8B36AA0030DB0E /* NotificationDismissHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NotificationDismissHandler.swift; path = Landscape/NotificationDismissHandler.swift; sourceTree = "<group>"; };
@@ -342,9 +373,11 @@
 		70F99A972B2D2B6E00D77256 /* YarnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YarnTests.swift; sourceTree = "<group>"; };
 		74633B6584F10A6AA2FEE339 /* Pods-Landscape.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.release.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.release.xcconfig"; sourceTree = "<group>"; };
 		74D2BEF1344CF71A07C17F5E /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Landscape/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		7921BAA51C1F4AB0927D16A9 /* ShareExtensionPreprocessor.js */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = ShareExtensionPreprocessor.js; path = ShareExtensionPreprocessor.js; sourceTree = "<group>"; };
 		79BDD5DCE15A385BB361AED1 /* Pods_Landscape.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Landscape.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A4D352CD337FB3A3BF06240 /* Pods-Landscape.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.release.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.release.xcconfig"; sourceTree = "<group>"; };
 		8ACB38DC4FF4D6377774BF5F /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-Landscape-preview/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		9042C1EE9669440FB104FA17 /* ShareViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ShareViewController.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		9D6B23EFDEDD5888235A22BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Landscape/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = Landscape/SplashScreen.storyboard; sourceTree = "<group>"; };
 		B35AC6CF758CAFC9D112A69F /* Pods-Landscape.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Landscape.debug.xcconfig"; path = "Target Support Files/Pods-Landscape/Pods-Landscape.debug.xcconfig"; sourceTree = "<group>"; };
@@ -415,6 +448,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0EBA8C1D226D456F88691850 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				0F80B9E935DB48E096A2A289 /* ShareExtension-Info.plist */,
+				9042C1EE9669440FB104FA17 /* ShareViewController.swift */,
+				7921BAA51C1F4AB0927D16A9 /* ShareExtensionPreprocessor.js */,
+				4AAB945CECE149D893E29730 /* MainInterface.storyboard */,
+				1E325AC599214F3CA5B91BA4 /* PrivacyInfo.xcprivacy */,
+			);
+			name = ShareExtension;
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
 		13B07FAE1A68108700A75B9A /* Landscape */ = {
 			isa = PBXGroup;
 			children = (
@@ -598,6 +644,7 @@
 				63E7040B2C540F30006CF214 /* Shared */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				6374ACE02C49DA9600E637C0 /* Notifications */,
+				0EBA8C1D226D456F88691850 /* ShareExtension */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				D65327D7A22EEC0BE12398D9 /* Pods */,
@@ -617,6 +664,8 @@
 				70DBC0152B7C60B50021EA96 /* Landscape-preview.app */,
 				6374ACDF2C49DA9600E637C0 /* Notifications.appex */,
 				630DE0E22C51A8790053603B /* Notifications-preview.appex */,
+				3E46F6CF2FCE4FBDA5B598CE /* ShareExtension.appex */,
+				3507AE1D048346668887E8DE /* ShareExtensionPreview.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -687,6 +736,7 @@
 			);
 			dependencies = (
 				630DE0E92C51AA0D0053603B /* PBXTargetDependency */,
+				BE42D6D0E9294943B42A3E87 /* PBXTargetDependency */,
 			);
 			name = Landscape;
 			packageProductDependencies = (
@@ -741,6 +791,22 @@
 			productReference = 6374ACDF2C49DA9600E637C0 /* Notifications.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		64210DE667CC422A9D8996CA /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D4C53DF303DE449CBD4EC41F /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				5105048CFBEB4946844A50EC /* Sources */,
+				A7CC6DE65D8A4FBFBC95C823 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtension;
+			productName = ShareExtension;
+			productReference = 3E46F6CF2FCE4FBDA5B598CE /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		70DBBFDF2B7C60B50021EA96 /* Landscape-preview */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 70DBC0122B7C60B50021EA96 /* Build configuration list for PBXNativeTarget "Landscape-preview" */;
@@ -763,6 +829,7 @@
 			);
 			dependencies = (
 				63A26F822C5C49530049EC5A /* PBXTargetDependency */,
+				864D5DD36F8F4AB9B5B84988 /* PBXTargetDependency */,
 			);
 			name = "Landscape-preview";
 			packageProductDependencies = (
@@ -791,6 +858,22 @@
 			productReference = 70F99A8E2B2D2B5700D77256 /* LandscapeTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		BF7A2FBCE4AC4111B1F79BF6 /* ShareExtensionPreview */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC9B8C45996F4C28AD09C50D /* Build configuration list for PBXNativeTarget "ShareExtensionPreview" */;
+			buildPhases = (
+				0604CDC8DADE4C65B8B3AD39 /* Sources */,
+				575E0A654767488F93B59B64 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtensionPreview;
+			productName = ShareExtensionPreview;
+			productReference = 3507AE1D048346668887E8DE /* ShareExtensionPreview.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -810,10 +893,18 @@
 						CreatedOnToolsVersion = 15.0;
 						LastSwiftMigration = 1620;
 					};
+					64210DE667CC422A9D8996CA = {
+						DevelopmentTeam = XU9PR2N722;
+						ProvisioningStyle = Automatic;
+					};
 					70F99A8D2B2D2B5700D77256 = {
 						CreatedOnToolsVersion = 15.0.1;
 						LastSwiftMigration = 1620;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
+					BF7A2FBCE4AC4111B1F79BF6 = {
+						DevelopmentTeam = XU9PR2N722;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -840,6 +931,8 @@
 				70F99A8D2B2D2B5700D77256 /* LandscapeTests */,
 				6374ACDE2C49DA9600E637C0 /* Notifications */,
 				630DE0BD2C51A8780053603B /* Notifications-preview */,
+				64210DE667CC422A9D8996CA /* ShareExtension */,
+				BF7A2FBCE4AC4111B1F79BF6 /* ShareExtensionPreview */,
 			);
 		};
 /* End PBXProject section */
@@ -855,6 +948,16 @@
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
 				C5AA2DA09E0243819EFF88B6 /* bundle.js in Resources */,
 				4ACCD7281520ED84DDC2759A /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		575E0A654767488F93B59B64 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C4DCBC2505E8483F971EF4DE /* ShareExtensionPreprocessor.js in Resources */,
+				9F3F596CE47E4B2AAFE7F156 /* MainInterface.storyboard in Resources */,
+				777768A4CBBC4BD7A6339A5F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -891,6 +994,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7CC6DE65D8A4FBFBC95C823 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7AB4EBEC93184CA4A56FCEF8 /* ShareExtensionPreprocessor.js in Resources */,
+				2B491A3280B249B4A1A337DC /* MainInterface.storyboard in Resources */,
+				24E7CA9B2CC448F48B8737F0 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1383,6 +1496,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0604CDC8DADE4C65B8B3AD39 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9800D0CF75B94AF4B4F91344 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		13B07F871A680F5B00A75B9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1434,6 +1555,14 @@
 				D3715FF82E5B6FCB00570A4C /* ChangesAPI.swift in Sources */,
 				5AA9810E2E68C91600FBE023 /* NotificationLogger.swift in Sources */,
 				D0A57BA86BAF5327C2EECEE4 /* ExpoModulesProvider.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5105048CFBEB4946844A50EC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC9B29734DA146748D2BEDC9 /* ShareViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1631,6 +1760,16 @@
 			isa = PBXTargetDependency;
 			target = 13B07F861A680F5B00A75B9A /* Landscape */;
 			targetProxy = 70F99A922B2D2B5700D77256 /* PBXContainerItemProxy */;
+		};
+		864D5DD36F8F4AB9B5B84988 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BF7A2FBCE4AC4111B1F79BF6 /* ShareExtensionPreview */;
+			targetProxy = 6950718DD30D4243B6890527 /* PBXContainerItemProxy */;
+		};
+		BE42D6D0E9294943B42A3E87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 64210DE667CC422A9D8996CA /* ShareExtension */;
+			targetProxy = 31F895BCB80F4806A5F6C2C2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2066,6 +2205,33 @@
 			};
 			name = Release;
 		};
+		71339CEBB1904FA89E169B9C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = XU9PR2N722;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShareExtension/ShareExtension-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 4.0.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.tlon.groups.share-extension";
+				PRODUCT_NAME = ShareExtension;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2271,6 +2437,95 @@
 			};
 			name = Release;
 		};
+		CB0AF7EA01584941BD78A541 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "ShareExtension/ShareExtension-preview.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = XU9PR2N722;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShareExtension/ShareExtension-Info-preview.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 4.0.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.tlon.groups.preview.share-extension";
+				PRODUCT_NAME = ShareExtensionPreview;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D82951F58569420EA8BF110D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "ShareExtension/ShareExtension-preview.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = XU9PR2N722;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShareExtension/ShareExtension-Info-preview.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 4.0.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.tlon.groups.preview.share-extension";
+				PRODUCT_NAME = ShareExtensionPreview;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FC0723E804914A66ACD13F74 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = XU9PR2N722;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShareExtension/ShareExtension-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 4.0.0;
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.tlon.groups.share-extension";
+				PRODUCT_NAME = ShareExtension;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2324,6 +2579,24 @@
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,
 				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AC9B8C45996F4C28AD09C50D /* Build configuration list for PBXNativeTarget "ShareExtensionPreview" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D82951F58569420EA8BF110D /* Debug */,
+				CB0AF7EA01584941BD78A541 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D4C53DF303DE449CBD4EC41F /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC0723E804914A66ACD13F74 /* Debug */,
+				71339CEBB1904FA89E169B9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
## Summary

This restores the preview iOS share extension target that was missing from the Expo 54 branch.

The native share extension files were still present, but the Xcode project no longer built or embedded `ShareExtensionPreview.appex`, so the preview app could not show up as a share target.

Fixes TLON-5725

## Changes

- add the production and preview share extension targets back to the Xcode project
- embed the share extension appex in the production and preview app targets
- wire the share extension source and resource files into those targets

## How did I test?

- Tested on device