### PR TITLE
Fix duplicate shortcode reaction chips

### DIFF
--- a/packages/app/ui/utils/postUtils.test.ts
+++ b/packages/app/ui/utils/postUtils.test.ts
@@ -1,7 +1,11 @@
 import * as db from '@tloncorp/shared/db';
 import { describe, expect, test } from 'vitest';
 
-import { computeReactionDetails } from './postUtils';
+import {
+  computeReactionDetails,
+  groupReactionsByValue,
+  normalizeReactionValue,
+} from './postUtils';
 
 describe('computeReactionDetails', () => {
   describe('contact name resolution', () => {
@@ -243,6 +247,59 @@ describe('computeReactionDetails', () => {
   });
 
   describe('reaction aggregation', () => {
+    test('should normalize shortcode reactions before aggregating', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: ':heart:',
+          contact: null,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~bus',
+          value: '❤️',
+          contact: null,
+        },
+      ];
+
+      const result = computeReactionDetails(reactions, '~zod');
+
+      expect(result.list).toHaveLength(1);
+      expect(result.list[0].value).toBe('❤️');
+      expect(result.list[0].count).toBe(2);
+      expect(result.self.value).toBe('❤️');
+    });
+
+    test('should leave unknown shortcode-like reactions unchanged', () => {
+      expect(normalizeReactionValue(':not-a-real-emoji:')).toBe(
+        ':not-a-real-emoji:'
+      );
+    });
+
+    test('should group shortcode and native reactions together', () => {
+      const reactions: db.Reaction[] = [
+        {
+          postId: 'post-1',
+          contactId: '~zod',
+          value: ':+1:',
+          contact: null,
+        },
+        {
+          postId: 'post-1',
+          contactId: '~bus',
+          value: '👍',
+          contact: null,
+        },
+      ];
+
+      const result = groupReactionsByValue(reactions);
+
+      expect(Object.keys(result)).toEqual(['👍']);
+      expect(result['👍']).toHaveLength(2);
+      expect(result['👍'][0].value).toBe('👍');
+    });
+
     test('should aggregate reactions by value', () => {
       const reactions: db.Reaction[] = [
         {

--- a/packages/app/ui/utils/postUtils.tsx
+++ b/packages/app/ui/utils/postUtils.tsx
@@ -1,3 +1,4 @@
+import EmojiData, { type EmojiMartData } from '@emoji-mart/data';
 import * as db from '@tloncorp/shared/db';
 import { useMemo } from 'react';
 
@@ -17,6 +18,24 @@ export interface ReactionDetails {
   };
   aggregate: Record<string, ReactionListItem>;
   list: ReactionListItem[];
+}
+
+const SHORTCODE_REACTION_REGEX = /^:?([a-zA-Z0-9_+-]+):?$/;
+const NATIVE_EMOJI_BY_SHORTCODE = Object.freeze(
+  Object.entries((EmojiData as EmojiMartData).emojis).reduce(
+    (acc, [key, emoji]) => {
+      acc[key] = emoji.skins[0]?.native;
+      return acc;
+    },
+    {} as Record<string, string | undefined>
+  )
+);
+
+export function normalizeReactionValue(value: string): string {
+  const shortcode = value.match(SHORTCODE_REACTION_REGEX)?.[1];
+  return (
+    (shortcode ? NATIVE_EMOJI_BY_SHORTCODE[shortcode] : undefined) ?? value
+  );
 }
 
 function resolveContactName(
@@ -48,15 +67,17 @@ export function computeReactionDetails(
   } as ReactionDetails;
 
   reactions.forEach((reaction) => {
-    if (details.aggregate[reaction.value]) {
-      details.aggregate[reaction.value].count++;
-      details.aggregate[reaction.value].users.push({
+    const reactionValue = normalizeReactionValue(reaction.value);
+
+    if (details.aggregate[reactionValue]) {
+      details.aggregate[reactionValue].count++;
+      details.aggregate[reactionValue].users.push({
         id: reaction.contactId,
         name: resolveContactName(reaction.contact, reaction.contactId),
       });
     } else {
-      details.aggregate[reaction.value] = {
-        value: reaction.value,
+      details.aggregate[reactionValue] = {
+        value: reactionValue,
         count: 1,
         users: [
           {
@@ -68,7 +89,7 @@ export function computeReactionDetails(
     }
     if (reaction.contactId === ourId) {
       details.self.didReact = true;
-      details.self.value = reaction.value;
+      details.self.value = reactionValue;
     }
     details.list = Object.values(details.aggregate);
   });
@@ -91,22 +112,28 @@ export type GroupedReactions = Record<
   { value: string; userId: string }[]
 >;
 
+export function groupReactionsByValue(
+  reactions: db.Reaction[]
+): GroupedReactions {
+  const groupedReactions: GroupedReactions = {};
+
+  reactions.forEach((reaction) => {
+    const reactionValue = normalizeReactionValue(reaction.value);
+
+    if (!groupedReactions[reactionValue]) {
+      groupedReactions[reactionValue] = [];
+    }
+    groupedReactions[reactionValue].push({
+      value: reactionValue,
+      userId: reaction.contactId,
+    });
+  });
+
+  return groupedReactions;
+}
+
 export function useGroupedReactions(
   reactions: db.Reaction[]
 ): GroupedReactions {
-  return useMemo(() => {
-    const groupedReactions: GroupedReactions = {};
-
-    reactions.forEach((reaction) => {
-      if (!groupedReactions[reaction.value]) {
-        groupedReactions[reaction.value] = [];
-      }
-      groupedReactions[reaction.value].push({
-        value: reaction.value,
-        userId: reaction.contactId,
-      });
-    });
-
-    return groupedReactions;
-  }, [reactions]);
+  return useMemo(() => groupReactionsByValue(reactions), [reactions]);
 }


### PR DESCRIPTION
## Summary
- Normalize legacy shortcode reactions (for example `:heart:` and `:+1:`) before aggregating reaction chips.
- Reuse normalized reaction values for the reactions detail pane so shortcode/native variants are grouped together.
- Add unit coverage for shortcode/native aggregation and unknown shortcode fallback.

## Tests
- `pnpm --filter @tloncorp/app exec eslint ui/utils/postUtils.tsx ui/utils/postUtils.test.ts`
- `pnpm --filter @tloncorp/app exec vitest run ui/utils/postUtils.test.ts`
- `pnpm --filter @tloncorp/editor build` (needed to generate editorHtml before app typecheck)
- `pnpm --filter @tloncorp/app tsc`