### PR TITLE
fix gallery sheet backdrop

### DIFF
--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -811,17 +811,19 @@ export const SimpleActionSheet = ({
   icon,
   actions,
   accent,
+  modal,
 }: {
   title?: string;
   subtitle?: string;
   icon?: ReactElement;
   actions: Action[];
   accent?: Accent;
+  modal?: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
   return (
-    <ActionSheet open={open} onOpenChange={onOpenChange}>
+    <ActionSheet open={open} onOpenChange={onOpenChange} modal={modal}>
       {title || subtitle ? (
         <SimpleActionSheetHeader
           title={title}

--- a/packages/app/ui/components/AddGalleryPost.tsx
+++ b/packages/app/ui/components/AddGalleryPost.tsx
@@ -79,6 +79,7 @@ export default function AddGalleryPost({
         open={route === 'add-post'}
         onOpenChange={onClose}
         actions={actions}
+        modal
       />
       {/* On web, "Media or File" opens the system file picker directly,
           so AttachmentSheet is only needed on mobile. */}


### PR DESCRIPTION
## Summary

Fix the Android gallery new-post sheet so its backdrop covers the channel header, matching the other modal sheets.

The gallery new-post menu was using the non-modal sheet path, so on Android its backdrop was mounted below the header.

Fixes TLON-5702

## Changes

- Let `SimpleActionSheet` forward the existing `modal` prop to `ActionSheet`.
- Open the gallery new-post sheet as a modal sheet.

## Testing

Tested on device
