### PR TITLE
fix pinned group channels in chat lists

### DIFF
--- a/packages/app/hooks/useFilteredChats.ts
+++ b/packages/app/hooks/useFilteredChats.ts
@@ -1,4 +1,4 @@
-import { TalkSidebarFilter } from '@tloncorp/api/urbit';
+import type { TalkSidebarFilter } from '@tloncorp/api/urbit';
 import { useMessagesFilter } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { useMemo } from 'react';
@@ -132,6 +132,10 @@ function filterChats(
         return true;
       }
 
+      if (chat.channel.type === 'chat' && !!chat.pin) {
+        return true;
+      }
+
       if (filter === 'Direct Messages') {
         return chat.channel.type === 'dm' || chat.channel.type === 'groupDm';
       }
@@ -151,7 +155,8 @@ function filterChats(
       return (
         chat.type === 'group' ||
         (chat.type === 'channel' && chat.channel.type === 'dm') ||
-        (chat.type === 'channel' && chat.channel.type === 'groupDm')
+        (chat.type === 'channel' && chat.channel.type === 'groupDm') ||
+        (chat.type === 'channel' && chat.channel.type === 'chat' && !!chat.pin)
       );
     }
 


### PR DESCRIPTION
## Summary

Fix pinned group channels so they show up in the pinned list on Home and in the Messages pane.

The pin state was saved, but the chat list filter still hid pinned group channels anywhere that normally only shows groups and direct messages.

Fixes TLON-5697

## Changes

- Allow pinned group channels through the Home filter.
- Allow pinned group channels through the Messages/Talk filter.
- Keep unpinned group channels hidden from those views.

## How did I test?

Tested on device