### PR TITLE
channels: fix post refs path

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1124,7 +1124,7 @@
   |=  =(pole knot)
   ~>  %spin.['watch']
   ^+  cor
-  =?  pole  !?=([?(%v0 %v1 %v2 %v3 %v4) *] pole)
+  =?  pole  !?=([?(%v0 %v1 %v2 %v3 %v4 %v5) *] pole)
     [%v0 pole]
   ?+  pole  ~|(bad-watch-path+`path`pole !!)
     [?(%v0 %v1 %v2 %v3 %v4) ~]  ?>(from-self cor)


### PR DESCRIPTION
## Summary

OTT this was failing on the frontend because we were prefixing it with `v0` since it wasn't in the union

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
