### PR TITLE
Fix desktop sidebar pinned chat scroll anchoring

### DIFF
--- a/apps/tlon-web/e2e/helpers/scrollers.ts
+++ b/apps/tlon-web/e2e/helpers/scrollers.ts
@@ -1,0 +1,57 @@
+import type { Page } from '@playwright/test';
+
+export type ScrollOffset = {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+};
+
+/**
+ * Resolve the scroll offset of the actually-scrollable descendant under a
+ * `data-testid` anchor. Used to verify FlashList anchoring behavior on web.
+ *
+ * Fail-closed: throws if no scrollable descendant (overflowY auto/scroll AND
+ * scrollHeight > clientHeight) is found, so a non-scrollable wrapper with
+ * `overflow: hidden` and `scrollTop === 0` cannot cause a false pass.
+ */
+export async function resolveScrollOffset(
+  page: Page,
+  testId: string
+): Promise<ScrollOffset> {
+  const handle = await page.getByTestId(testId).elementHandle();
+  if (!handle) {
+    throw new Error(`Scroller testID not found: ${testId}`);
+  }
+  return handle.evaluate((root): ScrollOffset => {
+    function isScrollable(el: Element): boolean {
+      const cs = getComputedStyle(el);
+      const overflowY = cs.overflowY;
+      const html = el as HTMLElement;
+      return (
+        (overflowY === 'auto' || overflowY === 'scroll') &&
+        html.scrollHeight > html.clientHeight
+      );
+    }
+    const measure = (el: HTMLElement): ScrollOffset => ({
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    });
+    if (isScrollable(root)) {
+      return measure(root as HTMLElement);
+    }
+    const stack: Element[] = [root];
+    while (stack.length) {
+      const node = stack.shift()!;
+      for (const child of Array.from(node.children)) {
+        if (isScrollable(child)) {
+          return measure(child as HTMLElement);
+        }
+        stack.push(child);
+      }
+    }
+    throw new Error(
+      'No scrollable descendant found under scrollerTestID. Setup must produce a list that overflows the viewport.'
+    );
+  });
+}

--- a/apps/tlon-web/e2e/home-sidebar-pinned-scroll.spec.ts
+++ b/apps/tlon-web/e2e/home-sidebar-pinned-scroll.spec.ts
@@ -176,7 +176,7 @@ test('home sidebar mounts at the top with the Pinned section visible', async ({
 
     await assertPinnedAboveAllAndAtTop(page);
   } finally {
-    // Cleanup every title actually created, in reverse order so PinnedScroll-Pin
+    // Cleanup every title actually created, in reverse order so PScroll-Target
     // (the only pinned row) is unpinned before its filler neighbors are
     // touched. cleanupNamedGroup is best-effort and re-routes to Home before
     // each delete, so a mid-test failure can't strand fixtures.

--- a/apps/tlon-web/e2e/home-sidebar-pinned-scroll.spec.ts
+++ b/apps/tlon-web/e2e/home-sidebar-pinned-scroll.spec.ts
@@ -1,0 +1,216 @@
+import { Page, expect } from '@playwright/test';
+
+import * as helpers from './helpers';
+import { resolveScrollOffset } from './helpers/scrollers';
+import { test } from './test-fixtures';
+
+const FILLER_COUNT = 4;
+// IMPORTANT: do not put the substrings "Pin"/"Unpin" in any of these titles.
+// helpers.toggleChatPin uses getByText('Pin')/getByText('Unpin'), and any row
+// or header text containing those substrings on the chat-details screen will
+// trigger a Playwright strict-mode violation.
+const PIN_TITLE = 'PScroll-Target';
+const fillerTitle = (i: number) =>
+  `PScroll-Filler-${String(i).padStart(2, '0')}`;
+const fillerTitles = Array.from({ length: FILLER_COUNT }, (_, i) =>
+  fillerTitle(i)
+);
+
+async function createNamedGroup(
+  page: Page,
+  title: string,
+  registerForCleanup: (title: string) => void
+) {
+  await helpers.createGroup(page);
+  await helpers.openGroupCustomization(page);
+  await helpers.changeGroupName(page, title);
+  // The rename has been saved; the group exists under the unique title even if
+  // a later step (back-nav, HomeNavIcon, visibility wait) times out. Register
+  // for cleanup immediately so the finally-block sweep can find and delete it.
+  registerForCleanup(title);
+  // back out of edit-group-info, then back to Home
+  await helpers.navigateBack(page);
+  await page.getByTestId('HomeNavIcon').click();
+  await expect(page.getByTestId('HomeSidebarHeader')).toBeVisible({
+    timeout: 5000,
+  });
+  await expect(page.getByText(title, { exact: true })).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+async function returnToHome(page: Page) {
+  // Cleanup may run while the page is mid-flow (e.g. inside group settings,
+  // an open sheet, or a modal). Try a few standard exits before giving up; a
+  // failed attempt should never throw because we still want subsequent
+  // cleanups to run.
+  for (let i = 0; i < 4; i++) {
+    if (
+      await page
+        .getByTestId('HomeSidebarHeader')
+        .isVisible({ timeout: 500 })
+        .catch(() => false)
+    ) {
+      return;
+    }
+    // Dismiss any open modal/sheet that traps navigation.
+    const cancel = page.getByText('Cancel');
+    if (await cancel.isVisible({ timeout: 200 }).catch(() => false)) {
+      await cancel.click().catch(() => {});
+      await page.waitForTimeout(200);
+      continue;
+    }
+    // HomeNavIcon is the most reliable jump-to-Home control.
+    const homeIcon = page.getByTestId('HomeNavIcon');
+    if (await homeIcon.isVisible({ timeout: 500 }).catch(() => false)) {
+      await homeIcon.click().catch(() => {});
+      await page.waitForTimeout(300);
+      continue;
+    }
+    // Last resort: peel back stack frames.
+    await helpers.navigateBack(page).catch(() => {});
+    await page.waitForTimeout(300);
+  }
+}
+
+async function cleanupNamedGroup(page: Page, title: string) {
+  try {
+    await returnToHome(page);
+    const row = page.getByText(title, { exact: true }).first();
+    if (!(await row.isVisible({ timeout: 1000 }).catch(() => false))) {
+      return;
+    }
+    await row.click();
+    await helpers.openGroupSettings(page);
+    // Unpin first if pinned (toggleChatPin's "Unpin" branch is idempotent).
+    if (
+      await page
+        .getByText('Unpin')
+        .isVisible({ timeout: 1000 })
+        .catch(() => false)
+    ) {
+      await page.getByText('Unpin').click();
+      await page.getByText('Pin').waitFor({ state: 'visible', timeout: 5000 });
+    }
+    await helpers.deleteGroup(page, title);
+  } catch (error) {
+    // Cleanup is best-effort. Surface failures without aborting the rest of
+    // the cleanup sweep so other titles still get removed.
+    console.warn(
+      `cleanupNamedGroup failed for "${title}":`,
+      (error as Error).message
+    );
+  }
+}
+
+test('home sidebar mounts at the top with the Pinned section visible', async ({
+  zodPage,
+}) => {
+  // Creating multiple groups, navigating, asserting, then cleaning up all of
+  // them serially exceeds the 60s default. Bump to 5 minutes.
+  test.setTimeout(300_000);
+  const page = zodPage;
+  const createdTitles: string[] = [];
+  const registerForCleanup = (title: string) => {
+    createdTitles.push(title);
+  };
+
+  try {
+    // Smaller viewport keeps the filler count modest while still guaranteeing
+    // the sidebar overflows.
+    await page.setViewportSize({ width: 1024, height: 480 });
+
+    await expect(page.getByText('Home')).toBeVisible();
+
+    // Setup: uniquely-named filler groups so we can assert on / clean up by
+    // exact title without colliding on duplicate "Untitled group" rows.
+    for (const title of fillerTitles) {
+      await createNamedGroup(page, title, registerForCleanup);
+    }
+
+    // Pinned group: create, rename, then pin via group settings.
+    await createNamedGroup(page, PIN_TITLE, registerForCleanup);
+    await page.getByText(PIN_TITLE, { exact: true }).first().click();
+    await expect(page.getByTestId('ChannelListItem-General')).toBeVisible({
+      timeout: 10000,
+    });
+    await helpers.openGroupSettings(page);
+    // The Group info header must be present before toggleChatPin queries for
+    // Pin/Unpin — without this wait, isVisible races against the screen mount
+    // and reports false.
+    await expect(page.getByText('Group info')).toBeVisible({ timeout: 10000 });
+    const pinStatus = await helpers.toggleChatPin(page);
+    expect(pinStatus).toBe('pinned');
+    await helpers.navigateBack(page);
+    await page.getByTestId('HomeNavIcon').click();
+    await expect(page.getByTestId('HomeSidebarHeader')).toBeVisible({
+      timeout: 5000,
+    });
+    // Confirm the pin landed before forcing a fresh mount; otherwise reload may
+    // beat the pin-write to the cache and the [Pinned, All] transition we want
+    // to assert against won't happen.
+    await expect(page.getByText('Pinned', { exact: true })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Force a fresh Home mount — closest equivalent to the originally reported
+    // bug, where the cold render briefly has [All] before pinned hydrates.
+    await page.reload();
+    await page.waitForSelector('text=Home', { state: 'visible' });
+    await expect(page.getByTestId('HomeSidebarHeader')).toBeVisible({
+      timeout: 10000,
+    });
+
+    await assertPinnedAboveAllAndAtTop(page);
+
+    // Originally reported repro path: navigate into a group, then back via
+    // HomeNavIcon. List should still mount at scrollTop 0 with Pinned above.
+    await page.getByText(PIN_TITLE, { exact: true }).first().click();
+    await expect(page.getByTestId('ChannelListItem-General')).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByTestId('HomeNavIcon').click();
+    await expect(page.getByTestId('HomeSidebarHeader')).toBeVisible({
+      timeout: 5000,
+    });
+
+    await assertPinnedAboveAllAndAtTop(page);
+  } finally {
+    // Cleanup every title actually created, in reverse order so PinnedScroll-Pin
+    // (the only pinned row) is unpinned before its filler neighbors are
+    // touched. cleanupNamedGroup is best-effort and re-routes to Home before
+    // each delete, so a mid-test failure can't strand fixtures.
+    for (const title of [...createdTitles].reverse()) {
+      await cleanupNamedGroup(page, title);
+    }
+  }
+});
+
+async function assertPinnedAboveAllAndAtTop(page: Page) {
+  // Wait for the Pinned section to appear before measuring offset.
+  await expect(page.getByText('Pinned', { exact: true })).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Real-offset assertion: the sidebar must be scrollable AND mounted at the
+  // top. resolveScrollOffset throws if no scrollable descendant exists, so
+  // setup must produce overflow before this point.
+  const offset = await resolveScrollOffset(page, 'HomeSidebarChatScroller');
+  expect(offset.scrollHeight).toBeGreaterThan(offset.clientHeight);
+  expect(offset.scrollTop).toBe(0);
+
+  // Rendered-order assertion: inside the resolved scroller, "Pinned" must
+  // precede "All". Comparing bounding-box top edges is robust against any
+  // layout container differences and is what the user actually sees.
+  const scroller = page.getByTestId('HomeSidebarChatScroller');
+  const pinnedHeader = scroller.getByText('Pinned', { exact: true }).first();
+  const allHeader = scroller.getByText('All', { exact: true }).first();
+  await expect(pinnedHeader).toBeVisible();
+  await expect(allHeader).toBeAttached();
+
+  const pinnedBox = await pinnedHeader.boundingBox();
+  const allBox = await allHeader.boundingBox();
+  expect(pinnedBox).not.toBeNull();
+  expect(allBox).not.toBeNull();
+  expect(pinnedBox!.y).toBeLessThan(allBox!.y);
+}

--- a/packages/app/features/chat-list/ChatList.helpers.test.ts
+++ b/packages/app/features/chat-list/ChatList.helpers.test.ts
@@ -1,7 +1,7 @@
 import * as db from '@tloncorp/shared/db';
 import { describe, expect, it } from 'vitest';
 
-import { SectionedChatData } from '../../hooks/useFilteredChats';
+import type { SectionedChatData } from '../../hooks/useFilteredChats';
 import {
   buildChatListFlashListProps,
   buildChatListItems,

--- a/packages/app/features/chat-list/ChatList.helpers.test.ts
+++ b/packages/app/features/chat-list/ChatList.helpers.test.ts
@@ -1,0 +1,119 @@
+import * as db from '@tloncorp/shared/db';
+import { describe, expect, it } from 'vitest';
+
+import { SectionedChatData } from '../../hooks/useFilteredChats';
+import {
+  buildChatListFlashListProps,
+  buildChatListItems,
+  getChatKey,
+  isSectionHeader,
+} from './ChatList.helpers';
+
+function makeUnpinnedGroup(id: string): db.Chat {
+  return {
+    id,
+    type: 'group',
+    pin: null,
+    volumeSettings: null,
+    timestamp: 0,
+    isPending: false,
+    unreadCount: 0,
+    group: { id, title: id } as unknown as db.Group,
+  } as db.Chat;
+}
+
+function makePinnedGroup(id: string, index: number): db.Chat {
+  return {
+    id,
+    type: 'group',
+    pin: { type: 'group', index, itemId: id } as db.Pin,
+    volumeSettings: null,
+    timestamp: 0,
+    isPending: false,
+    unreadCount: 0,
+    group: { id, title: id } as unknown as db.Group,
+  } as db.Chat;
+}
+
+const unpinned: db.Chat[] = [
+  makeUnpinnedGroup('group-a'),
+  makeUnpinnedGroup('group-b'),
+  makeUnpinnedGroup('group-c'),
+];
+
+const pinned: db.Chat[] = [
+  makePinnedGroup('group-pin-1', 0),
+  makePinnedGroup('group-pin-2', 1),
+];
+
+const initial: SectionedChatData = [{ title: 'All', data: unpinned }];
+const afterPinHydrates: SectionedChatData = [
+  { title: 'Pinned', data: pinned },
+  { title: 'All', data: unpinned },
+];
+
+describe('buildChatListFlashListProps', () => {
+  it('omits maintainVisibleContentPosition by default', () => {
+    const props = buildChatListFlashListProps({ data: initial });
+    expect(props).not.toHaveProperty('maintainVisibleContentPosition');
+  });
+
+  it('omits maintainVisibleContentPosition when explicitly false', () => {
+    const props = buildChatListFlashListProps({
+      data: initial,
+      disableScrollAnchoring: false,
+    });
+    expect(props).not.toHaveProperty('maintainVisibleContentPosition');
+  });
+
+  it('disables maintainVisibleContentPosition when opted in', () => {
+    const props = buildChatListFlashListProps({
+      data: initial,
+      disableScrollAnchoring: true,
+    });
+    expect(props.maintainVisibleContentPosition).toEqual({ disabled: true });
+  });
+
+  it('flattens [All] -> [Pinned, ...pinned, All, ...unpinned] in order', () => {
+    const before = buildChatListFlashListProps({
+      data: initial,
+      disableScrollAnchoring: true,
+    });
+    const beforeKeys = before.data.map(getChatKey);
+    expect(beforeKeys[0]).toBe('All');
+
+    const after = buildChatListFlashListProps({
+      data: afterPinHydrates,
+      disableScrollAnchoring: true,
+    });
+    const keys = after.data.map(getChatKey);
+    expect(keys[0]).toBe('Pinned');
+
+    const allIndex = keys.indexOf('All');
+    expect(allIndex).toBeGreaterThan(0);
+    for (const chat of pinned) {
+      const expectedKey = `${chat.id}-${chat.pin?.itemId ?? ''}`;
+      const idx = keys.indexOf(expectedKey);
+      expect(idx).toBeGreaterThan(0);
+      expect(idx).toBeLessThan(allIndex);
+    }
+
+    for (const chat of unpinned) {
+      const expectedKey = `${chat.id}-${chat.pin?.itemId ?? ''}`;
+      expect(keys.indexOf(expectedKey)).toBeGreaterThan(allIndex);
+    }
+  });
+});
+
+describe('buildChatListItems', () => {
+  it('inlines a sectionHeader entry before each section', () => {
+    const items = buildChatListItems(afterPinHydrates);
+    expect(items).toHaveLength(2 + pinned.length + unpinned.length);
+    expect(isSectionHeader(items[0])).toBe(true);
+    expect(items[0]).toEqual({ type: 'sectionHeader', title: 'Pinned' });
+    const allHeaderIndex = items.findIndex(
+      (item) => isSectionHeader(item) && item.title === 'All'
+    );
+    expect(allHeaderIndex).toBe(1 + pinned.length);
+  });
+});

--- a/packages/app/features/chat-list/ChatList.helpers.ts
+++ b/packages/app/features/chat-list/ChatList.helpers.ts
@@ -1,0 +1,57 @@
+import * as db from '@tloncorp/shared/db';
+
+import { SectionedChatData } from '../../hooks/useFilteredChats';
+
+export type SectionHeaderData = { type: 'sectionHeader'; title: string };
+export type ChatListItemData = db.Chat | SectionHeaderData;
+
+export function buildChatListItems(
+  data: SectionedChatData
+): ChatListItemData[] {
+  return data.flatMap((section) => [
+    { title: section.title, type: 'sectionHeader' },
+    ...section.data,
+  ]);
+}
+
+export function isSectionHeader(
+  data: ChatListItemData
+): data is SectionHeaderData {
+  return 'type' in data && data.type === 'sectionHeader';
+}
+
+export function getItemType(item: ChatListItemData): string {
+  return isSectionHeader(item) ? 'sectionHeader' : item.type;
+}
+
+export function getChatKey(chatItem: ChatListItemData): string {
+  if (!chatItem || typeof chatItem !== 'object') {
+    return 'invalid-item';
+  }
+
+  if (isSectionHeader(chatItem)) {
+    return chatItem.title;
+  }
+
+  return `${chatItem.id}-${chatItem.pin?.itemId ?? ''}`;
+}
+
+export function buildChatListFlashListProps({
+  data,
+  disableScrollAnchoring,
+}: {
+  data: SectionedChatData;
+  disableScrollAnchoring?: boolean;
+}): {
+  data: ChatListItemData[];
+  maintainVisibleContentPosition?: { disabled: true };
+} {
+  const items = buildChatListItems(data);
+  if (disableScrollAnchoring) {
+    return {
+      data: items,
+      maintainVisibleContentPosition: { disabled: true },
+    };
+  }
+  return { data: items };
+}

--- a/packages/app/features/chat-list/ChatList.helpers.ts
+++ b/packages/app/features/chat-list/ChatList.helpers.ts
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 
-import { SectionedChatData } from '../../hooks/useFilteredChats';
+import type { SectionedChatData } from '../../hooks/useFilteredChats';
 
 export type SectionHeaderData = { type: 'sectionHeader'; title: string };
 export type ChatListItemData = db.Chat | SectionHeaderData;

--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -119,12 +119,9 @@ export const ChatList = React.memo(function ChatListComponent({
       getItemType={getItemType}
       onLoad={onLoad ? () => onLoad() : undefined}
       testID={scrollerTestID}
-      {...(flashListProps.maintainVisibleContentPosition
-        ? {
-            maintainVisibleContentPosition:
-              flashListProps.maintainVisibleContentPosition,
-          }
-        : null)}
+      maintainVisibleContentPosition={
+        flashListProps.maintainVisibleContentPosition
+      }
     />
   );
 }, isEqual);

--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -12,29 +12,35 @@ import {
   SectionListHeader,
   useChatOptions,
 } from '../../ui';
+import {
+  ChatListItemData,
+  buildChatListFlashListProps,
+  getChatKey,
+  getItemType,
+  isSectionHeader,
+} from './ChatList.helpers';
 
-type SectionHeaderData = { type: 'sectionHeader'; title: string };
-export type ChatListItemData = db.Chat | SectionHeaderData;
+export type { ChatListItemData } from './ChatList.helpers';
+export { getChatKey, getItemType, isSectionHeader } from './ChatList.helpers';
 
 export const ChatList = React.memo(function ChatListComponent({
   data,
   onPressItem,
   onLoad,
+  disableScrollAnchoring,
+  scrollerTestID,
 }: {
   data: SectionedChatData;
   onPressItem?: (chat: db.Chat) => void;
   onLoad?: () => void;
+  disableScrollAnchoring?: boolean;
+  scrollerTestID?: string;
 }) {
-  const listItems: ChatListItemData[] = useMemo(
-    () =>
-      data.flatMap((section) => {
-        return [
-          { title: section.title, type: 'sectionHeader' },
-          ...section.data,
-        ];
-      }),
-    [data]
+  const flashListProps = useMemo(
+    () => buildChatListFlashListProps({ data, disableScrollAnchoring }),
+    [data, disableScrollAnchoring]
   );
+  const listItems: ChatListItemData[] = flashListProps.data;
 
   const { open } = useChatOptions();
   const handleLongPress = useCallback(
@@ -112,28 +118,13 @@ export const ChatList = React.memo(function ChatListComponent({
       renderItem={renderItem}
       getItemType={getItemType}
       onLoad={onLoad ? () => onLoad() : undefined}
+      testID={scrollerTestID}
+      {...(flashListProps.maintainVisibleContentPosition
+        ? {
+            maintainVisibleContentPosition:
+              flashListProps.maintainVisibleContentPosition,
+          }
+        : null)}
     />
   );
 }, isEqual);
-
-export function getItemType(item: ChatListItemData) {
-  return isSectionHeader(item) ? 'sectionHeader' : item.type;
-}
-
-export function isSectionHeader(
-  data: ChatListItemData
-): data is SectionHeaderData {
-  return 'type' in data && data.type === 'sectionHeader';
-}
-
-export function getChatKey(chatItem: ChatListItemData) {
-  if (!chatItem || typeof chatItem !== 'object') {
-    return 'invalid-item';
-  }
-
-  if (isSectionHeader(chatItem)) {
-    return chatItem.title;
-  }
-
-  return `${chatItem.id}-${chatItem.pin?.itemId ?? ''}`;
-}

--- a/packages/app/navigation/desktop/HomeSidebar.tsx
+++ b/packages/app/navigation/desktop/HomeSidebar.tsx
@@ -259,7 +259,12 @@ export const HomeSidebar = memo(
                     </Text>
                   </View>
                 ) : (
-                  <ChatList data={displayData} onPressItem={onPressChat} />
+                  <ChatList
+                    data={displayData}
+                    onPressItem={onPressChat}
+                    disableScrollAnchoring
+                    scrollerTestID="HomeSidebarChatScroller"
+                  />
                 )}
               </View>
               <MobileAppPromoBanner />

--- a/packages/app/navigation/desktop/MessagesSidebar.tsx
+++ b/packages/app/navigation/desktop/MessagesSidebar.tsx
@@ -203,7 +203,12 @@ export const MessagesSidebar = memo(
                 }
               />
               {chats && chats.unpinned.length ? (
-                <ChatList data={displayData} onPressItem={onPressChat} />
+                <ChatList
+                  data={displayData}
+                  onPressItem={onPressChat}
+                  disableScrollAnchoring
+                  scrollerTestID="MessagesSidebarChatScroller"
+                />
               ) : null}
               <GroupPreviewSheet
                 open={!!selectedGroup}


### PR DESCRIPTION
## Summary

Fixes TLON-5729: pinned items being scrolled out of view when the desktop Home sidebar mounts. FlashList v2 (pulled in by the Expo 54 upgrade) defaults `maintainVisibleContentPosition` to enabled, and the chat list keys section headers by their bare title, so inserting a `Pinned` section above an already-rendered `All` header anchored scroll to `All` and pushed the offset down by the height of the inserted rows. This PR opts the desktop `HomeSidebar` and `MessagesSidebar` out of FlashList's anchoring; mobile keeps the v2 default.

## Changes

- Added `disableScrollAnchoring` and `scrollerTestID` props to `ChatList` (`packages/app/features/chat-list/ChatList.tsx`). Default behavior is unchanged; opting in passes `maintainVisibleContentPosition={{ disabled: true }}` through to FlashList.
- Extracted pure helpers (`buildChatListItems`, `getChatKey`, `getItemType`, `isSectionHeader`, `buildChatListFlashListProps`) into a new `packages/app/features/chat-list/ChatList.helpers.ts` so the regression test does not need the React/FlashList/Tamagui graph at runtime. `ChatList.tsx` re-exports the existing helpers to keep the public surface stable.
- Opted in on desktop only:
  - `packages/app/navigation/desktop/HomeSidebar.tsx` (`scrollerTestID="HomeSidebarChatScroller"`).
  - `packages/app/navigation/desktop/MessagesSidebar.tsx` (`scrollerTestID="MessagesSidebarChatScroller"`); the existing `chats.unpinned.length` render guard is preserved as-is.
- Added a Vitest regression at `packages/app/features/chat-list/ChatList.helpers.test.ts` (5 cases) covering opt-in gating, the `maintainVisibleContentPosition: { disabled: true }` payload shape, and the `[All] -> [Pinned, ...pinned, All, ...unpinned]` flatten order.
- Added an e2e helper `apps/tlon-web/e2e/helpers/scrollers.ts` with a fail-closed `resolveScrollOffset` that walks descendants of a `data-testid` anchor and only returns metrics for a node that is actually scrollable (`overflowY` of `auto`/`scroll` and `scrollHeight > clientHeight`); throws otherwise so a non-scrollable wrapper at the testID anchor cannot produce a false pass.
- Added `apps/tlon-web/e2e/home-sidebar-pinned-scroll.spec.ts`: 1024x480 viewport, creates four uniquely-named filler groups (`PScroll-Filler-NN`) plus a `PScroll-Target` group, pins it, reloads, and asserts `scrollTop === 0` and that the rendered `Pinned` header precedes `All` against `HomeSidebarChatScroller`. Repeats the assertion after `Home -> group -> HomeNavIcon`. Cleanup is keyed on titles registered immediately after `helpers.changeGroupName` succeeds, wrapped in `try/finally`. Filler/target titles intentionally avoid the substrings `Pin`/`Unpin` so they don't strict-mode-conflict with `helpers.toggleChatPin`'s `getByText('Pin')` / `getByText('Unpin')` lookups.

## How did I test?

- `pnpm -r tsc` — clean across all 9 workspace projects.
- `cd packages/app && pnpm test` — full Vitest suite passed (118 passed, 3 skipped, 0 failed); `ChatList.helpers.test.ts` is 5/5.
- ESLint clean over all changed files.
- `cd apps/tlon-web && pnpm e2e:test home-sidebar-pinned-scroll.spec.ts` — passed in 49.4s on the rube harness.
- Manual desktop verification on the web dev server with both pinned and unpinned items: the original symptom no longer reproduces on a fresh Home load or via `Home -> group -> HomeNavIcon` back-navigation.

### Test plan checklist

- [x] Helper Vitest (`packages/app/features/chat-list/ChatList.helpers.test.ts`) passes.
- [x] Playwright spec `home-sidebar-pinned-scroll.spec.ts` passes via `pnpm e2e:test`.
- [x] Manual desktop pass: cold mount of Home sidebar shows pinned section at top with `scrollTop === 0`.
- [x] Manual desktop pass: `Home -> group -> HomeNavIcon` back-navigation shows pinned section at top.
- [x] Mobile chat list scroll behavior unchanged (mobile `ChatListScreen` does not pass `disableScrollAnchoring`, so FlashList v2's default anchoring stays on).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: ChatList

The behavior change is gated behind two new optional props that only the desktop sidebars set. Mobile and any other `ChatList` consumer keep the existing FlashList v2 default. The helper extraction is a refactor with no runtime change — `ChatList.tsx` re-exports the previously co-located helpers so the import surface is preserved.

## Rollback plan

Revert