### PR TITLE
fix android group title sheet sizing

### DIFF
--- a/packages/app/features/groups/GroupTitleInputSheet.tsx
+++ b/packages/app/features/groups/GroupTitleInputSheet.tsx
@@ -65,12 +65,12 @@ export function GroupTitleInputSheet({
   );
 
   const content = isWindowNarrow ? (
-    <YStack flex={1} gap="$l">
+    <YStack gap="$l">
       {header}
       <YStack paddingHorizontal="$xl">{input}</YStack>
-      <YStack flex={1} />
       <YStack
         padding="$xl"
+        paddingTop="$2xl"
         paddingBottom={bottom + getTokenValue('$xl', 'size')}
       >
         {nextButton}
@@ -89,10 +89,7 @@ export function GroupTitleInputSheet({
   );
 
   const actionSheetProps = isWindowNarrow
-    ? {
-        snapPoints: [50],
-        snapPointsMode: 'percent' as const,
-      }
+    ? {}
     : {
         mode: 'dialog' as const,
         closeButton: true,


### PR DESCRIPTION
## Summary

Fix the Android basic group title sheet so the action button stays reachable after focusing the title input.

The sheet was fixed at 50% height with a flex spacer pushing the button to the bottom. On Android, keyboard resize could leave the button stuck below the visible area. This lets the sheet size to its content and keeps the button in normal flow.

Fixes TLON-5694

## Changes

- Removed the fixed mobile snap point from the group title sheet.
- Removed the mobile spacer between the title input and Next button.
- Added a little fixed top padding above the Next button.

## How did I test?

Tested on device