### PR TITLE
Show thinking indicator in all 1:1 DMs

### DIFF
--- a/packages/app/ui/components/Channel/useShouldShowThinkingState.ts
+++ b/packages/app/ui/components/Channel/useShouldShowThinkingState.ts
@@ -1,4 +1,3 @@
-import { isBotDmChannel, p } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { useMemo } from 'react';
 
@@ -9,34 +8,9 @@ export function useShouldShowThinkingState(channel: db.Channel) {
   const currentUserId = useCurrentUserId();
   const canRead = useCanRead(channel, currentUserId);
 
-  const botDmNodeType = useMemo(() => {
-    if (channel.type !== 'dm') {
-      return null;
-    }
-
-    const dmShip = channel.contactId ?? channel.id;
-
-    try {
-      return p.kind(dmShip);
-    } catch {
-      return null;
-    }
-  }, [channel.contactId, channel.id, channel.type]);
-
-  const isBotDm = useMemo(
-    () =>
-      isBotDmChannel({ channel }) ||
-      // hack: bot detection cues off ~pinser-botter prefix, but that's incomplete in practice. Particularly
-      // in dev, where fake galaxies are used. For now, we'll be permissive about which DMs qualify and
-      // additionally cue off ship type
-      botDmNodeType === 'moon' ||
-      botDmNodeType === 'galaxy',
-    [botDmNodeType, channel]
-  );
-
   const shouldShowThinkingState = useMemo(
-    () => canRead && isBotDm,
-    [canRead, isBotDm]
+    () => canRead && channel.type === 'dm',
+    [canRead, channel.type]
   );
 
   return shouldShowThinkingState;


### PR DESCRIPTION
## Summary
- Drop the bot-only gate on the thinking indicator. The old check matched `~pinser-botter`-prefixed ships, moons, and galaxies via `isBotDmChannel` + `p.kind`. Now any 1:1 DM where you have read access can surface the indicator.
- `<ThinkingState>` still no-ops when no active `computing` presence status exists for the conversation, so this only broadens *where* the indicator can appear, not *when*.

## Test plan
- [ ] DM with a non-bot peer: when peer publishes a `computing` presence status, indicator appears.
- [ ] DM with a non-bot peer: no active status → no indicator (component returns null).
- [ ] Group channel / group DM: indicator does not appear.
- [ ] Channel you can't read: indicator does not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)