### PR TITLE
fix: close mention popup when sending without selecting a suggestion

### DIFF
--- a/apps/tlon-web/e2e/chat-core-functionality.spec.ts
+++ b/apps/tlon-web/e2e/chat-core-functionality.spec.ts
@@ -125,6 +125,24 @@ test('should test comprehensive chat functionality', async ({
     expectedMentionInline: { sect: 'admin' },
     postMentionTestId: 'PostMention-admin',
   });
+
+  // Send with the mention popup open but no suggestion selected (TLON-5709):
+  // outgoing payload should be the literal typed text and the popup should dismiss.
+  await helpers.sendUnselectedMentionMessage(zodPage, {
+    inputText: 'TLON-5709 unselected @all',
+    suggestionTestId: '-all--group',
+    expectedLiteralText: /TLON-5709 unselected @all/,
+  });
+
+  // Same case in a thread reply composer.
+  await helpers.startThread(zodPage, 'Hello, world!');
+  await helpers.sendUnselectedMentionMessage(zodPage, {
+    inputText: 'TLON-5709 thread unselected @all',
+    suggestionTestId: '-all--group',
+    expectedLiteralText: /TLON-5709 thread unselected @all/,
+    containerSelector: '#reply-container',
+  });
+  await helpers.navigateBack(zodPage);
 });
 
 test('should require confirmation before deleting a message (cancel prevents deletion)', async ({

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1484,16 +1484,24 @@ function getPostAddFromChannelAction(postData: string | null) {
       channel?: {
         action?: {
           post?: {
-            add?: {
-              content?: unknown;
+            add?: { content?: unknown };
+            reply?: {
+              action?: {
+                add?: { content?: unknown };
+              };
             };
           };
         };
       };
     };
   }[];
-  const postAdd = events.find((event) => event.json?.channel?.action?.post?.add)
-    ?.json?.channel?.action?.post?.add;
+  const event = events.find(
+    (event) =>
+      event.json?.channel?.action?.post?.add ||
+      event.json?.channel?.action?.post?.reply?.action?.add
+  );
+  const post = event?.json?.channel?.action?.post;
+  const postAdd = post?.add ?? post?.reply?.action?.add;
 
   expect(postAdd).toBeTruthy();
   return postAdd;

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1550,6 +1550,97 @@ export async function sendMentionMessage(
   await expectMessageInputReady(page);
 }
 
+function flattenInlineText(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(flattenInlineText).join('');
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    if ('inline' in obj) {
+      return flattenInlineText(obj.inline);
+    }
+    if (typeof obj.text === 'string') {
+      return obj.text;
+    }
+    return Object.values(obj).map(flattenInlineText).join('');
+  }
+  return '';
+}
+
+function containsRichMentionInline(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(containsRichMentionInline);
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    if ('ship' in obj || 'sect' in obj) {
+      return true;
+    }
+    return Object.values(obj).some(containsRichMentionInline);
+  }
+  return false;
+}
+
+/**
+ * Types an active mention query, clicks the send button without selecting
+ * the suggestion, and asserts that the message sends as literal text and
+ * the mention popup dismisses.
+ */
+export async function sendUnselectedMentionMessage(
+  page: Page,
+  {
+    inputText,
+    suggestionTestId,
+    expectedLiteralText,
+    containerSelector,
+  }: {
+    inputText: string;
+    suggestionTestId: string;
+    expectedLiteralText: string | RegExp;
+    containerSelector?: string;
+  }
+) {
+  await waitForSessionStability(page);
+
+  const root = containerSelector ? page.locator(containerSelector) : page;
+  const messageInput = root.getByTestId('MessageInput');
+  const sendButton = root.getByTestId('MessageInputSendButton');
+  const suggestion = root.getByTestId(suggestionTestId);
+
+  if (!containerSelector) {
+    await expectMessageInputReady(page);
+  }
+
+  await messageInput.click();
+  await messageInput.fill(inputText);
+  await expect(suggestion).toBeVisible();
+
+  const postResponse = waitForChannelPost(page);
+  await sendButton.click();
+  const response = await postResponse;
+  const postAdd = getPostAddFromChannelAction(response.request().postData());
+
+  const flattened = flattenInlineText(postAdd?.content);
+  expect(flattened).toMatch(expectedLiteralText);
+  expect(containsRichMentionInline(postAdd?.content)).toBe(false);
+
+  const post = page
+    .getByTestId('Post')
+    .filter({ hasText: expectedLiteralText })
+    .first();
+  await expect(post).toBeVisible({ timeout: 10000 });
+
+  await expect(suggestion).toBeHidden();
+  await expect(messageInput).toHaveValue('');
+
+  if (!containerSelector) {
+    await expectMessageInputReady(page);
+  }
+}
+
 /**
  * Long presses on a message to open the context menu
  */

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -297,6 +297,7 @@ function BareChatInput(
     handleMention,
     handleSelectMention,
     handleMentionEscape,
+    resetMentionMode,
   } = useMentions({ chatId: groupId ?? channelId, roleOptions });
   const maxInputHeight = useKeyboardHeight(maxInputHeightBasic);
   const inputRef = useRef<TextInput>(null);
@@ -453,6 +454,7 @@ function BareChatInput(
       bareChatInputLogger.log('resetting input height');
       setInputHeight(initialHeight);
       setEditingPost?.(undefined);
+      resetMentionMode();
 
       try {
         bareChatInputLogger.log('sending message');
@@ -486,6 +488,7 @@ function BareChatInput(
       channelId,
       setMentions,
       initialHeight,
+      resetMentionMode,
     ]
   );
 
@@ -807,7 +810,16 @@ function BareChatInput(
     clearDraft();
     clearAttachments();
     setInputHeight(initialHeight);
-  }, [setEditingPost, clearDraft, clearAttachments, initialHeight]);
+    resetMentionMode();
+    setMentions([]);
+  }, [
+    setEditingPost,
+    clearDraft,
+    clearAttachments,
+    initialHeight,
+    resetMentionMode,
+    setMentions,
+  ]);
 
   const theme = useTheme();
   const placeholderTextColor = {

--- a/packages/app/ui/components/BareChatInput/useMentions.tsx
+++ b/packages/app/ui/components/BareChatInput/useMentions.tsx
@@ -292,6 +292,14 @@ export const useMentions = ({
     setLastDismissedTriggerIndex(mentionStartIndex);
   };
 
+  const resetMentionMode = () => {
+    setIsMentionModeActive(false);
+    setMentionStartIndex(null);
+    setMentionSearchText('');
+    setWasDismissedByEscape(false);
+    setLastDismissedTriggerIndex(null);
+  };
+
   return {
     mentions,
     validOptions,
@@ -304,5 +312,6 @@ export const useMentions = ({
     setIsMentionModeActive,
     handleMentionEscape,
     hasMentionCandidates,
+    resetMentionMode,
   };
 };


### PR DESCRIPTION
## Summary

Fixes TLON-5709: on desktop/web, typing `hello @all` and then clicking the send button (instead of pressing Enter or selecting a suggestion) sent the message but left `InputMentionPopup` visible above the cleared composer.

Root cause: `useMentions` only updates its search state from `handleTextChange`. The send-button path clears the composer programmatically, bypassing the text-change handler and leaving `isMentionModeActive`, `mentionStartIndex`, `mentionSearchText`, `wasDismissedByEscape`, and `lastDismissedTriggerIndex` stale. The Enter path is unaffected because it routes through `handleSelectMention`, which already resets state.

Adds a `resetMentionMode` helper in `useMentions` and calls it from `sendMessage` (before the await, so selected rich mentions still serialize) and from `handleCancelEditing` (which also now clears `mentions`, fixing a separate case where canceling an edit left stale rich mentions on the next draft).

## Changes

- `packages/app/ui/components/BareChatInput/useMentions.tsx`: added `resetMentionMode` that clears the five mention-search setters (deliberately does not touch the selected `mentions` array, callers decide).
- `packages/app/ui/components/BareChatInput/index.tsx`: call `resetMentionMode()` in `sendMessage` after the composer-clear block and before the network await; call `resetMentionMode()` and `setMentions([])` in `handleCancelEditing`.
- `apps/tlon-web/e2e/helpers.ts`: new exported helper `sendUnselectedMentionMessage` with an optional `containerSelector` for thread scoping. Asserts popup is visible pre-send, the outgoing channel-action payload contains the literal typed text with no `ship`/`sect` inline keys, the rendered Post is visible, the popup is dismissed, and the input is empty.
- `apps/tlon-web/e2e/chat-core-functionality.spec.ts`: two new cases at the end of `should test comprehensive chat functionality` covering main-chat unselected `@all` send and thread-reply unselected `@all` send (bookended with `startThread('Hello, world!')` and `navigateBack`).

Other things to be aware of:

- Clicking send while a mention is active and a suggestion is highlighted still sends the literal text rather than auto-selecting the highlighted suggestion.
- `handleBlur` does not dismiss the popup either.

## How did I test?

- Manual testing on desktop web.
- Confirmed Enter-to-send and clicking a suggestion still work, and that rich mentions selected before sending still serialize into the outgoing post.
- Confirmed cancel-edit no longer leaves stale mentions on the next draft.
- Ran the updated chat-core-functionality.spec.ts e2e test.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: Message input.

## Rollback plan

Revert.