### PR TITLE
Fix home-group wayfinding tooltip

### DIFF
--- a/packages/api/src/client/wayfinding.ts
+++ b/packages/api/src/client/wayfinding.ts
@@ -85,8 +85,11 @@ export function isPersonalChatChannel(channelId: string): boolean {
   return channelId.includes(PersonalGroupSlugs.chatSlug);
 }
 
-export function isBotHomeGroupChatChannel(channelId: string): boolean {
-  return channelId.includes(BotHomeGroupSlugs.chatSlug);
+export function isBotHomeGroupChatChannel(
+  currentUserId: string,
+  channelId: string
+): boolean {
+  return channelId.endsWith(`${currentUserId}/${BotHomeGroupSlugs.chatSlug}`);
 }
 
 export function isPersonalCollectionChannel(channelId: string): boolean {

--- a/packages/api/src/types/wayfinding.ts
+++ b/packages/api/src/types/wayfinding.ts
@@ -26,5 +26,5 @@ export interface WayfindingProgress {
   tappedAddNote: boolean;
   tappedAddCollection: boolean;
   tappedChatInput: boolean;
-  tappedBotMention: boolean;
+  tappedHomeGroupHint: boolean;
 }

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -843,7 +843,7 @@ function BareChatInput(
     if (logic.isBotHomeGroupChatChannel(getCurrentUserId(), channelId)) {
       db.wayfindingProgress.setValue((prev) => ({
         ...prev,
-        tappedBotMention: true,
+        tappedHomeGroupHint: true,
       }));
     }
   }, [channelId]);

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -1,4 +1,4 @@
-import { toContentReference } from '@tloncorp/api';
+import { getCurrentUserId, toContentReference } from '@tloncorp/api';
 import { JSONContent, Story, pathToCite } from '@tloncorp/api/urbit';
 import {
   Attachment,
@@ -840,7 +840,7 @@ function BareChatInput(
         tappedChatInput: true,
       }));
     }
-    if (logic.isBotHomeGroupChatChannel(channelId)) {
+    if (logic.isBotHomeGroupChatChannel(getCurrentUserId(), channelId)) {
       db.wayfindingProgress.setValue((prev) => ({
         ...prev,
         tappedBotMention: true,

--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -233,7 +233,8 @@ export function BotMentionTooltip() {
           testID="BotMentionWayfindingTooltip"
         >
           <Text size="$label/l" color="$white">
-            @-mention your bot here to use it in this group.
+            Since you own this group, your Tlonbot will automatically respond to
+            your messages. Others can @-mention your bot to interact with it.
           </Text>
         </View>
         <XStack width="100%" justifyContent="flex-end">

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -394,7 +394,7 @@ export const wayfindingProgress = createStorageItem<WayfindingProgress>({
     tappedAddNote: true,
     tappedAddCollection: true,
     tappedChatInput: true,
-    tappedBotMention: true,
+    tappedHomeGroupHint: true,
   },
 });
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -685,7 +685,7 @@ export const useShowBotMentionWayfinding = (channelId: string) => {
     return logic.isBotHomeGroupChatChannel(currentUserId, channelId);
   }, [channelId, currentUserId]);
 
-  return isCorrectChan && !wayfindingProgress.tappedBotMention;
+  return isCorrectChan && !wayfindingProgress.tappedHomeGroupHint;
 };
 
 export const useShowHomeAddTooltip = () => {

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -680,9 +680,10 @@ export const useShowChatInputWayfinding = (channelId: string) => {
 
 export const useShowBotMentionWayfinding = (channelId: string) => {
   const wayfindingProgress = db.wayfindingProgress.useValue();
+  const currentUserId = api.getCurrentUserId();
   const isCorrectChan = useMemo(() => {
-    return logic.isBotHomeGroupChatChannel(channelId);
-  }, [channelId]);
+    return logic.isBotHomeGroupChatChannel(currentUserId, channelId);
+  }, [channelId, currentUserId]);
 
   return isCorrectChan && !wayfindingProgress.tappedBotMention;
 };

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -63,7 +63,7 @@ export async function completeWayfindingSplash() {
     tappedAddNote: false,
     tappedAddCollection: false,
     tappedChatInput: false,
-    tappedBotMention: false,
+    tappedHomeGroupHint: false,
   }));
 
   // optimistic update
@@ -88,7 +88,7 @@ export async function completeRevivalSplash() {
   await db.wayfindingProgress.setValue((prev) => ({
     ...prev,
     tappedHomeAdd: false,
-    tappedBotMention: false,
+    tappedHomeGroupHint: false,
   }));
 
   // Marking the splash complete keeps other clients from showing the modal again.

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -83,11 +83,12 @@ export async function completeWayfindingSplash() {
 }
 
 export async function completeRevivalSplash() {
-  // Revived users should only get the home add tooltip, not the full first-run
-  // coach mark sequence.
+  // Revived users should get the home add and Tlonbot chat tooltips, not the
+  // full first-run coach mark sequence.
   await db.wayfindingProgress.setValue((prev) => ({
     ...prev,
     tappedHomeAdd: false,
+    tappedBotMention: false,
   }));
 
   // Marking the splash complete keeps other clients from showing the modal again.


### PR DESCRIPTION
## Summary

Changes the language of and fixes the rules for showing the home-group tooltip. This tooltip was appearing for users in other users' home-groups they were invited to.

## Changes

- Label change
- Passes the user's current ID in to the `isBotHomeGroupChatChannel` check; returns false if the channel ID doesn't match.
