### PR TITLE
onboarding: prefill existing nickname on revival

### DIFF
--- a/apps/tlon-mobile/src/hooks/useOnboardingHelpers.ts
+++ b/apps/tlon-mobile/src/hooks/useOnboardingHelpers.ts
@@ -96,13 +96,25 @@ export function useOnboardingHelpers() {
         signupContext.setOnboardingValues({
           onboardingFlow,
         });
-        navigation.navigate('SetNickname');
 
         // we won't have set up the connection yet, so do that first
         const shipInfoToUse = inputShipInfo
           ? { shipName: inputShipInfo.ship, shipUrl: inputShipInfo.shipUrl }
           : { shipName: ship, shipUrl }; // default to existing if none passed in
         configureUrbitClient(shipInfoToUse);
+
+        // Pull fresh contacts from the ship so SetNickname's revival prefill
+        // reads an up-to-date nickname rather than a stale local cache.
+        try {
+          await store.syncContacts();
+        } catch (e) {
+          logger.trackEvent(AnalyticsEvent.WayfindingDebug, {
+            context: 'revival onboarding: contact pre-sync failed',
+            error: e,
+          });
+        }
+
+        navigation.navigate('SetNickname');
         store.syncStart();
 
         // Clear the Hosting revival flag only after the user completes revival


### PR DESCRIPTION
## Summary
- `handleGuidedLogin` configures the urbit client and `await store.syncContacts()` before navigating to `SetNickname`, so the local DB has fresh contact data when the screen mounts.
- `SetNicknameScreen` reads `db.getContact({ id: '~<hostedUserNodeId>' })` on mount and `reset({ nickname })` the form when an existing nickname is found. Guarded by `!isDirty` so any input the user has already typed is preserved.

## Why
Revival users (existing accounts going through the guided login flow) were hitting `SetNickname` with an empty input and a `required` validator — typing *anything* to satisfy the form silently overwrote their existing nickname via `updateCurrentUserProfile`. Prefilling makes the prompt an obvious review/edit rather than a clobber.

## Behavior

| user state | what they see |
|---|---|
| New signup, no nickname | Empty input (or `DEFAULT_ONBOARDING_NICKNAME` env default) |
| Revival, no nickname on ship | Empty input |
| Revival, has nickname on ship | Input prefilled, "Next" already enabled |
| Sync/lookup fails | Empty input, error tracked via `WayfindingDebug` / dev logger |

## Test plan
- [ ] Sign up a fresh account → confirm `SetNickname` still appears empty
- [ ] Trigger the revival flow on an account with a nickname → confirm the nickname is prefilled and editable
- [ ] Edit the prefilled value and submit → confirm the new value is saved
- [ ] Submit without editing → confirm the original nickname is preserved on the ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)