### PR TITLE
lure: ensure metadata gaps are filled when generating links

### DIFF
--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -117,6 +117,19 @@
     |*  [caz=(list card) etc=*]
     [[cad caz] etc]
   --
+::  +group-og-title: render the open-graph title for a group invite.
+::  empty group title falls back to "a Groupchat".
+::
+++  group-og-title
+  |=  [nickname=(unit @t) group-title=@t]
+  ^-  @t
+  =/  gt=@t
+    ?:  =('' group-title)  'a Groupchat'
+    group-title
+  %-  crip
+  ?:  |(?=(~ nickname) =('' u.nickname))
+    "Tlon Messenger: You're Invited to {(trip gt)}"
+  "Tlon Messenger: {(trip u.nickname)} invited you to {(trip gt)}"
 --
 |_  =bowl:gall
 +*  this  .
@@ -445,16 +458,9 @@
         ::
         =+  type=(~(get by fields.meta) %'inviteType')
         ?:  |(?=(~ type) =('group' u.type))
-          =/  group-title=@t
-            =+  til=(~(get by fields.meta) %'invitedGroupTitle')
-            ?:  |(?=(~ til) =('' u.til))
-              'a Groupchat'
-            u.til
           =/  title=@t
-            %-  crip
-            ?:  |(?=(~ nickname) =('' u.nickname))
-              "Tlon Messenger: You're Invited to {(trip group-title)}"
-            "Tlon Messenger: {(trip u.nickname)} invited you to {(trip group-title)}"
+            %+  group-og-title  nickname
+            (fall (~(get by fields.meta) %'invitedGroupTitle') '')
           =.  fields.update
             (~(put by fields.update) %'$og_title' title)
           =.  fields.update
@@ -499,15 +505,9 @@
         ?+    -.r-group.r-groups  ~
             %meta
           =*  meta  meta.r-group.r-groups
-          =+  nickname=(~(get cy:t our-profile) %nickname %text)
-          =/  group-title=@t
-            ?:  =('' title.meta)  'a Groupchat'
-            title.meta
           =/  title=@t
-            %-  crip
-            ?:  |(?=(~ nickname) =('' u.nickname))
-              "Tlon Messenger: You're Invited to {(trip group-title)}"
-            "Tlon Messenger: {(trip u.nickname)} invited you to {(trip group-title)}"
+            %-  group-og-title
+            [(~(get cy:t our-profile) %nickname %text) title.meta]
           %-  ~(gas by *(map field:reel cord))
           :~  %'invitedGroupTitle'^title.meta
               %'invitedGroupDescription'^description.meta

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -230,6 +230,57 @@
           [%'inviterUserId' (scot %p src.bowl)]
           [%'invitedGroupId' id]
       ==
+    ::  gap-fill open-graph metadata from server state when the caller
+    ::  didn't provide it: title / description / image from %groups,
+    ::  and nickname / avatar from our cached profile. Caller-provided
+    ::  values always win; scry failures are tolerated.
+    ::
+    =/  type=(unit @t)  (~(get by fields.metadata) %'inviteType')
+    =?  fields.metadata  |(?=(~ type) =('group' u.type))
+      =/  fld  fields.metadata
+      ::  inviter fields from our-profile
+      ::
+      =/  nickname=(unit @t)  (~(get cy:t our-profile) %nickname %text)
+      =/  avatar=(unit @t)    (~(get cy:t our-profile) %avatar %look)
+      =?  fld
+          ?&  ?=(^ nickname)
+              !=('' u.nickname)
+              =(~ (~(get by fld) %'inviterNickname'))
+          ==
+        (~(put by fld) %'inviterNickname' u.nickname)
+      =?  fld
+          ?&  ?=(^ avatar)
+              !=('' u.avatar)
+              =(~ (~(get by fld) %'inviterAvatarImage'))
+          ==
+        (~(put by fld) %'inviterAvatarImage' u.avatar)
+      ::  group meta from %groups; only attempt when id parses as a flag
+      ::
+      =/  parsed=(unit flag:v0:groups-ver)  (rush id flag)
+      ?~  parsed  fld
+      =/  grp=(unit group:v9:groups-ver)
+        %-  mole  |.
+        .^  group:v9:groups-ver  %gx
+          /(scot %p our.bowl)/groups/(scot %da now.bowl)/v2/groups/(scot %p p.u.parsed)/[q.u.parsed]/group-2
+        ==
+      ?~  grp  fld
+      =*  gmeta  meta.u.grp
+      =?  fld
+          ?&  !=('' title.gmeta)
+              =(~ (~(get by fld) %'invitedGroupTitle'))
+          ==
+        (~(put by fld) %'invitedGroupTitle' title.gmeta)
+      =?  fld
+          ?&  !=('' description.gmeta)
+              =(~ (~(get by fld) %'invitedGroupDescription'))
+          ==
+        (~(put by fld) %'invitedGroupDescription' description.gmeta)
+      =?  fld
+          ?&  !=('' image.gmeta)
+              =(~ (~(get by fld) %'invitedGroupIconImageUrl'))
+          ==
+        (~(put by fld) %'invitedGroupIconImageUrl' image.gmeta)
+      fld
     ::  the nonce here is a temporary identifier for the metadata.
     ::  a new one will be assigned by the bait provider and returned to us.
     ::
@@ -402,7 +453,7 @@
           =/  title=@t
             %-  crip
             ?:  |(?=(~ nickname) =('' u.nickname))
-              "Tlon Messenger: You're Invited to a Groupchat"
+              "Tlon Messenger: You're Invited to {(trip group-title)}"
             "Tlon Messenger: {(trip u.nickname)} invited you to {(trip group-title)}"
           =.  fields.update
             (~(put by fields.update) %'$og_title' title)
@@ -455,7 +506,7 @@
           =/  title=@t
             %-  crip
             ?:  |(?=(~ nickname) =('' u.nickname))
-              "Tlon Messenger: You're Invited to a Groupchat"
+              "Tlon Messenger: You're Invited to {(trip group-title)}"
             "Tlon Messenger: {(trip u.nickname)} invited you to {(trip group-title)}"
           %-  ~(gas by *(map field:reel cord))
           :~  %'invitedGroupTitle'^title.meta

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -246,11 +246,18 @@
     ::  gap-fill open-graph metadata from server state when the caller
     ::  didn't provide it: title / description / image from %groups,
     ::  and nickname / avatar from our cached profile. Caller-provided
-    ::  values always win; scry failures are tolerated.
+    ::  values always win.
     ::
     =/  type=(unit @t)  (~(get by fields.metadata) %'inviteType')
     =?  fields.metadata  |(?=(~ type) =('group' u.type))
       =/  fld  fields.metadata
+      ::  treat absent or empty-string fields as gap-fillable.
+      ::
+      =/  blank
+        |=  [m=(map cord cord) k=cord]
+        ^-  ?
+        =/  v  (~(get by m) k)
+        ?|(?=(~ v) =('' u.v))
       ::  inviter fields from our-profile
       ::
       =/  nickname=(unit @t)  (~(get cy:t our-profile) %nickname %text)
@@ -258,39 +265,41 @@
       =?  fld
           ?&  ?=(^ nickname)
               !=('' u.nickname)
-              =(~ (~(get by fld) %'inviterNickname'))
+              (blank fld %'inviterNickname')
           ==
         (~(put by fld) %'inviterNickname' u.nickname)
       =?  fld
           ?&  ?=(^ avatar)
               !=('' u.avatar)
-              =(~ (~(get by fld) %'inviterAvatarImage'))
+              (blank fld %'inviterAvatarImage')
           ==
         (~(put by fld) %'inviterAvatarImage' u.avatar)
       ::  group meta from %groups; only attempt when id parses as a flag
+      ::  and the group exists locally.
       ::
       =/  parsed=(unit flag:v0:groups-ver)  (rush id flag)
       ?~  parsed  fld
-      =/  grp=(unit group:v9:groups-ver)
-        %-  mole  |.
+      =/  base  /(scot %p our.bowl)/groups/(scot %da now.bowl)
+      ?.  .^(? %gu (weld base /groups/(scot %p p.u.parsed)/[q.u.parsed]))
+        fld
+      =/  grp=group:v9:groups-ver
         .^  group:v9:groups-ver  %gx
-          /(scot %p our.bowl)/groups/(scot %da now.bowl)/v2/groups/(scot %p p.u.parsed)/[q.u.parsed]/group-2
+          (weld base /v2/groups/(scot %p p.u.parsed)/[q.u.parsed]/group-2)
         ==
-      ?~  grp  fld
-      =*  gmeta  meta.u.grp
+      =*  gmeta  meta.grp
       =?  fld
           ?&  !=('' title.gmeta)
-              =(~ (~(get by fld) %'invitedGroupTitle'))
+              (blank fld %'invitedGroupTitle')
           ==
         (~(put by fld) %'invitedGroupTitle' title.gmeta)
       =?  fld
           ?&  !=('' description.gmeta)
-              =(~ (~(get by fld) %'invitedGroupDescription'))
+              (blank fld %'invitedGroupDescription')
           ==
         (~(put by fld) %'invitedGroupDescription' description.gmeta)
       =?  fld
           ?&  !=('' image.gmeta)
-              =(~ (~(get by fld) %'invitedGroupIconImageUrl'))
+              (blank fld %'invitedGroupIconImageUrl')
           ==
         (~(put by fld) %'invitedGroupIconImageUrl' image.gmeta)
       fld

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -123,13 +123,13 @@
 ++  group-og-title
   |=  [nickname=(unit @t) group-title=@t]
   ^-  @t
-  =/  gt=@t
+  =/  title=@t
     ?:  =('' group-title)  'a Groupchat'
     group-title
   %-  crip
   ?:  |(?=(~ nickname) =('' u.nickname))
-    "Tlon Messenger: You're Invited to {(trip gt)}"
-  "Tlon Messenger: {(trip u.nickname)} invited you to {(trip gt)}"
+    "Tlon Messenger: You're Invited to {(trip title)}"
+  "Tlon Messenger: {(trip u.nickname)} invited you to {(trip title)}"
 --
 |_  =bowl:gall
 +*  this  .
@@ -245,64 +245,63 @@
       ==
     ::  gap-fill open-graph metadata from server state when the caller
     ::  didn't provide it: title / description / image from %groups,
-    ::  and nickname / avatar from our cached profile. Caller-provided
-    ::  values always win.
+    ::  and nickname / avatar from our cached profile. caller-provided
+    ::  values take priority.
     ::
     =/  type=(unit @t)  (~(get by fields.metadata) %'inviteType')
     =?  fields.metadata  |(?=(~ type) =('group' u.type))
-      =/  fld  fields.metadata
-      ::  treat absent or empty-string fields as gap-fillable.
+      =*  fields  fields.metadata
+      ::  treat absent or empty-string fields as gap-fillable
       ::
-      =/  blank
-        |=  [m=(map cord cord) k=cord]
+      =*  is-blank
+        |=  k=field:reel
         ^-  ?
-        =/  v  (~(get by m) k)
+        =/  v  (~(get by fields) k)
         ?|(?=(~ v) =('' u.v))
       ::  inviter fields from our-profile
       ::
       =/  nickname=(unit @t)  (~(get cy:t our-profile) %nickname %text)
       =/  avatar=(unit @t)    (~(get cy:t our-profile) %avatar %look)
-      =?  fld
+      =?  fields
           ?&  ?=(^ nickname)
               !=('' u.nickname)
-              (blank fld %'inviterNickname')
+              (is-blank %'inviterNickname')
           ==
-        (~(put by fld) %'inviterNickname' u.nickname)
-      =?  fld
+        (~(put by fields) %'inviterNickname' u.nickname)
+      =?  fields
           ?&  ?=(^ avatar)
               !=('' u.avatar)
-              (blank fld %'inviterAvatarImage')
+              (is-blank %'inviterAvatarImage')
           ==
-        (~(put by fld) %'inviterAvatarImage' u.avatar)
+        (~(put by fields) %'inviterAvatarImage' u.avatar)
       ::  group meta from %groups; only attempt when id parses as a flag
       ::  and the group exists locally.
       ::
-      =/  parsed=(unit flag:v0:groups-ver)  (rush id flag)
-      ?~  parsed  fld
+      ?~  parsed=(rush id flag)  fields
       =/  base  /(scot %p our.bowl)/groups/(scot %da now.bowl)
-      ?.  .^(? %gu (weld base /groups/(scot %p p.u.parsed)/[q.u.parsed]))
-        fld
+      ?.  .^(? %gu (weld base /groups/(scot %p -.u.parsed)/[+.u.parsed]))
+        fields
       =/  grp=group:v9:groups-ver
         .^  group:v9:groups-ver  %gx
-          (weld base /v2/groups/(scot %p p.u.parsed)/[q.u.parsed]/group-2)
+          (weld base /v2/groups/(scot %p -.u.parsed)/[+.u.parsed]/group-2)
         ==
-      =*  gmeta  meta.grp
-      =?  fld
-          ?&  !=('' title.gmeta)
-              (blank fld %'invitedGroupTitle')
+      =*  meta  meta.grp
+      =?  fields
+          ?&  !=('' title.meta)
+              (is-blank %'invitedGroupTitle')
           ==
-        (~(put by fld) %'invitedGroupTitle' title.gmeta)
-      =?  fld
-          ?&  !=('' description.gmeta)
-              (blank fld %'invitedGroupDescription')
+        (~(put by fields) %'invitedGroupTitle' title.meta)
+      =?  fields
+          ?&  !=('' description.meta)
+              (is-blank %'invitedGroupDescription')
           ==
-        (~(put by fld) %'invitedGroupDescription' description.gmeta)
-      =?  fld
-          ?&  !=('' image.gmeta)
-              (blank fld %'invitedGroupIconImageUrl')
+        (~(put by fields) %'invitedGroupDescription' description.meta)
+      =?  fields
+          ?&  !=('' image.meta)
+              (is-blank %'invitedGroupIconImageUrl')
           ==
-        (~(put by fld) %'invitedGroupIconImageUrl' image.gmeta)
-      fld
+        (~(put by fields) %'invitedGroupIconImageUrl' image.meta)
+      fields
     ::  the nonce here is a temporary identifier for the metadata.
     ::  a new one will be assigned by the bait provider and returned to us.
     ::

--- a/desk/tests/app/reel.hoon
+++ b/desk/tests/app/reel.hoon
@@ -46,13 +46,17 @@
   %-  ~(gas by *contact:t)
   :~  %nickname^text+'Sampel Palnet'
   ==
-::  scry mock for the gap-fill path in %reel-describe. returns an empty
-::  group so the agent's gap-fill checks (!=('' title.gmeta) etc.) all
-::  fall through and no fields are added.
+::  scry mock for the gap-fill path in %reel-describe. the %gu check
+::  reports the group as present so the %gx fetch proceeds; the %gx
+::  returns an empty group so the agent's gap-fill checks
+::  (!=('' title.gmeta) etc.) all fall through and no fields are added.
 ::
 ++  scry
   |=  =(pole knot)
   ?+  pole  ~|(`path`pole !!)
+    [%gu @ %groups @ %groups host=@ term=@ ~]
+      `!>(&)
+  ::
     [%gx @ %groups @ %v2 %groups host=@ term=@ %group-2 ~]
       `!>(*group:v9:gv)
   ==

--- a/desk/tests/app/reel.hoon
+++ b/desk/tests/app/reel.hoon
@@ -46,6 +46,16 @@
   %-  ~(gas by *contact:t)
   :~  %nickname^text+'Sampel Palnet'
   ==
+::  scry mock for the gap-fill path in %reel-describe. returns an empty
+::  group so the agent's gap-fill checks (!=('' title.gmeta) etc.) all
+::  fall through and no fields are added.
+::
+++  scry
+  |=  =(pole knot)
+  ?+  pole  ~|(`path`pole !!)
+    [%gx @ %groups @ %v2 %groups host=@ term=@ %group-2 ~]
+      `!>(*group:v9:gv)
+  ==
 ++  do-register-invite
   |=  [=token:reel =metadata:reel]
   =/  m  (mare ,(list card))
@@ -134,6 +144,7 @@
   ^-  form:m
   ;<  *  bind:m  (do-init dap reel-agent)
   ;<  ~  bind:m  (jab-bowl |=(=bowl bowl(now ~2025.9.3, our ~sampel-palnet)))
+  ;<  ~  bind:m  (set-scry-gate scry)
   ::  a group invite can be requested from reel
   ::
   =/  =nonce:reel  (scot %da ~2025.9.3)
@@ -186,6 +197,7 @@
   ^-  form:m
   ;<  ~  bind:m  (jab-bowl |=(=bowl bowl(our ~sampel-palnet)))
   ;<  caz=(list card)  bind:m  (do-init dap reel-agent)
+  ;<  ~  bind:m  (set-scry-gate scry)
   ;<  *  bind:m  (do-agent /contacts [~sampel-palnet %contacts] %watch-ack ~)
   ;<  *  bind:m  (do-agent /groups [~sampel-palnet %groups] %watch-ack ~)
   ;<  *  bind:m  (do-register-invite ~.0v1 group-invite-meta)
@@ -214,8 +226,8 @@
     :~  %'invitedGroupTitle'^'Early Sunrise'
         %'invitedGroupDescription'^'Sunrise, sunset.'
         %'invitedGroupIconImageUrl'^'https://sampel-palnet.arvo.network/early-sunrise.jpg'
-        %'$og_title'^'Tlon Messenger: You\'re Invited to a Groupchat'
-        %'$twitter_title'^'Tlon Messenger: You\'re Invited to a Groupchat'
+        %'$og_title'^'Tlon Messenger: You\'re Invited to Early Sunrise'
+        %'$twitter_title'^'Tlon Messenger: You\'re Invited to Early Sunrise'
     ==
   ;<  ~  bind:m
     %+  ex-cards  caz
@@ -294,6 +306,7 @@
   ^-  form:m
   ;<  ~  bind:m  (jab-bowl |=(=bowl bowl(our ~sampel-palnet)))
   ;<  caz=(list card)  bind:m  (do-init dap reel-agent)
+  ;<  ~  bind:m  (set-scry-gate scry)
   ;<  *  bind:m  (do-agent /contacts [~sampel-palnet %contacts] %watch-ack ~)
   ;<  *  bind:m  (do-register-invite ~.0v1 group-invite-meta)
   ;<  *  bind:m  (do-register-invite ~.0v2 personal-invite-meta)

--- a/desk/tests/app/reel.hoon
+++ b/desk/tests/app/reel.hoon
@@ -46,10 +46,6 @@
   %-  ~(gas by *contact:t)
   :~  %nickname^text+'Sampel Palnet'
   ==
-::  scry mock for the gap-fill path in %reel-describe. the %gu check
-::  reports the group as present so the %gx fetch proceeds; the %gx
-::  returns an empty group so the agent's gap-fill checks
-::  (!=('' title.gmeta) etc.) all fall through and no fields are added.
 ::
 ++  scry
   |=  =(pole knot)


### PR DESCRIPTION
## Summary

%reel had a bug whereby empty nicknames wouldn't fill with any existing group title, minor but still good to fix. The other piece here is making sure we always fill in any gaps in the metadata. %reel has drifted into being more heavily integrated into groups/contacts and this just furthers that by making sure any kind of reel describe calls actually fill in gaps in the metadata from what we have on the backend. This was present in https://github.com/tloncorp/ylem/blob/8af770c82083f1031c84b72a877a7b8ad226c56f/pkg/runtime/pioneer/src/Pioneer/Command/Click.hs#L1537 where we're only giving `userId`, `type`, and `groupId`.

Fixes TLON-5790

## Changes

- **`%reel-describe` gap-filling** (`desk/app/reel.hoon`): when a caller's describe is sparse, backfill missing open-graph fields from server state — `invitedGroupTitle` / `invitedGroupDescription` / `invitedGroupIconImageUrl` scried from `%groups`, and `inviterNickname` / `inviterAvatarImage` read from reel's cached `our-profile`. Caller-provided values always win; the group scry is wrapped in `mole` so a missing group doesn't crash the poke.
- **"a Groupchat" fallback fix**: the no-nickname branch of the OG-title formula was hard-coding "You're Invited to a Groupchat" even when the group had a real title. It now uses `group-title` (which itself still falls back to "a Groupchat" when the title is empty).
- **`group-og-title` helper**: extracted the formula shared by the `/contacts` and `/groups` subscription handlers into a single helper in the upper `|%` core. No behavior change.
- **Tests** (`desk/tests/app/reel.hoon`): added a scry mock returning an empty `group:v9:gv` for the gap-fill path, wired it into the three tests that exercise `%reel-describe` (`test-reel-describe`, `test-groups-update`, `test-contacts-update`). Updated the `test-groups-update` `$og_title` expectation to reflect the corrected fallback (`"You're Invited to Early Sunrise"` instead of `"…a Groupchat"`).

## How did I test?

Ran `./backend/run-tests.sh` locally against a moon— all three reel tests pass (`test-reel-describe`, `test-groups-update`, `test-contacts-update`). No e2e or client changes

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: lure / invite-link metadata (`%reel` agent)

## Rollback plan

Revert the merge commit. The agent state-version is unchanged, so no migration concerns. Any lures registered while this is live keep their backfilled metadata fields, which is forward-compatible with the prior code path (extra fields are just ignored downstream if reverted).

## Screenshots / videos

N/A — backend / Hoon only. The user-visible effect is open-graph previews on shared invite links: titles like *"Tlon Messenger: You're Invited to &lt;Group Title&gt;"* instead of *"…to a Groupchat"* when the inviter has no nickname yet.
