### PR TITLE
revival: harden deferred actions (e.g. set nickname)

### DIFF
--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -18,7 +18,7 @@ import {
   markPushNotifTapMeasurementAbandoned,
   markPushNotifTapSyncSinceComplete,
 } from '@tloncorp/app/lib/pushNotifTapTelemetry';
-import { recoverTlonbotRevivalNotificationLevel } from '@tloncorp/app/lib/tlonbotRevivalNotifications';
+import { recoverTlonbotRevivalDeferredConfig } from '@tloncorp/app/lib/tlonbotRevivalDeferredConfig';
 import { RootStack } from '@tloncorp/app/navigation/RootStack';
 import { AppDataProvider } from '@tloncorp/app/provider/AppDataProvider';
 import {
@@ -89,7 +89,7 @@ function AuthenticatedApp() {
       // app opened or returned from background
       if (status === 'opened' || status === 'active') {
         startChatListSettleMeasurement(status);
-        recoverTlonbotRevivalNotificationLevel(status);
+        recoverTlonbotRevivalDeferredConfig(status).catch(() => {});
         await checkForCachedChanges();
         telemetry.captureAppActive();
         const nodeCheck = await checkNodeStopped();

--- a/apps/tlon-mobile/src/hooks/useOnboardingHelpers.ts
+++ b/apps/tlon-mobile/src/hooks/useOnboardingHelpers.ts
@@ -78,8 +78,6 @@ export function useOnboardingHelpers() {
           onboardingFlow,
         });
 
-        const shipId =
-          inputShipInfo?.ship ?? (await db.hostedUserNodeId.getValue());
         logger.trackEvent(AnalyticsEvent.InitiatedTlonbotRevival, {
           source: 'post_login',
         });
@@ -89,7 +87,6 @@ export function useOnboardingHelpers() {
           applied: false,
           provisioningStarted: current.provisioningStarted ?? false,
           stage: current.stage ?? 'collecting',
-          shipId: shipId ?? undefined,
         }));
 
         await db.hostedAccountIsInitialized.setValue(false);

--- a/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/AllowNotificationsScreen.tsx
@@ -56,12 +56,10 @@ export const AllowNotificationsScreen = ({ navigation }: Props) => {
       });
 
       if (signupContext.onboardingFlow === 'tlonbotRevival') {
-        const shipId = await db.hostedUserNodeId.getValue();
         await db.tlonbotRevivalSetup.setValue((current) => ({
           ...current,
           pending: true,
           applied: false,
-          shipId: shipId ?? current.shipId,
           nickname: signupContext.nickname,
           notificationLevel: signupContext.notificationLevel,
           notificationToken,

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -18,7 +18,7 @@ import { setAndConfirmTlonbotRevivalNotificationLevel } from './tlonbotRevivalNo
 const logger = createDevLogger('tlonbotRevivalDeferredConfig', false);
 
 const BASIC_PROVIDER_ID = 'basic';
-const RECOVERY_RETRY_DELAY_MS = 30_000;
+const RECOVERY_RETRY_DELAYS_MS = [2_000, 5_000, 10_000, 30_000];
 const RECOVERY_RETRY_CONFIG = {
   startingDelay: 1000,
   numOfAttempts: 6,
@@ -38,6 +38,7 @@ type DeferredField = keyof db.TlonbotRevivalDeferredConfig;
 let recoveryPromise: Promise<boolean> | null = null;
 let recoveryTimer: ReturnType<typeof setTimeout> | null = null;
 let connectionUnsubscribe: (() => void) | null = null;
+let recoveryRetryIndex = 0;
 
 function hasBotModelConfig(config: db.TlonbotRevivalDeferredConfig) {
   return !!(
@@ -80,6 +81,19 @@ function runScheduledRecovery(source: string) {
   });
 }
 
+function nextRecoveryRetryDelay() {
+  const delay =
+    RECOVERY_RETRY_DELAYS_MS[
+      Math.min(recoveryRetryIndex, RECOVERY_RETRY_DELAYS_MS.length - 1)
+    ];
+  recoveryRetryIndex += 1;
+  return delay;
+}
+
+function resetRecoveryRetryDelay() {
+  recoveryRetryIndex = 0;
+}
+
 function clearRecoverySchedule() {
   if (recoveryTimer) {
     clearTimeout(recoveryTimer);
@@ -97,10 +111,11 @@ function scheduleTimedRecovery() {
     return;
   }
 
+  const delay = nextRecoveryRetryDelay();
   recoveryTimer = setTimeout(() => {
     recoveryTimer = null;
     runScheduledRecovery('scheduled_retry');
-  }, RECOVERY_RETRY_DELAY_MS);
+  }, delay);
 }
 
 function scheduleConnectionRecovery() {
@@ -203,6 +218,7 @@ export async function stageTlonbotRevivalDeferredConfig(
     botProvider: shouldSetBotModel ? setup.botProvider : undefined,
     botModel: shouldSetBotModel ? setup.botModel : undefined,
   }));
+  resetRecoveryRetryDelay();
 }
 
 export async function recoverTlonbotRevivalDeferredConfig(
@@ -219,6 +235,7 @@ export async function recoverTlonbotRevivalDeferredConfig(
       if (Object.keys(config).length > 0) {
         await db.tlonbotRevivalDeferredConfig.resetValue();
       }
+      resetRecoveryRetryDelay();
       return false;
     }
     if (!hasActiveConnection()) {
@@ -324,6 +341,7 @@ export async function recoverTlonbotRevivalDeferredConfig(
     const remaining = await db.tlonbotRevivalDeferredConfig.getValue(true);
     if (!hasPendingConfig(remaining)) {
       await db.tlonbotRevivalDeferredConfig.resetValue();
+      resetRecoveryRetryDelay();
       return true;
     }
 

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -12,8 +12,8 @@ import {
   getSession,
   subscribeToSession,
   syncGroups,
-  updateGroupMeta,
   updateCurrentUserProfile,
+  updateGroupMeta,
   uploadAsset,
   waitForUploads,
 } from '@tloncorp/shared/store';
@@ -309,10 +309,7 @@ export async function recoverTlonbotRevivalDeferredConfig(
         async () => {
           const nickname = config.profileNickname!;
           await syncGroups();
-          await updateCurrentUserProfile(
-            { nickname },
-            { shouldThrow: true }
-          );
+          await updateCurrentUserProfile({ nickname }, { shouldThrow: true });
           await ensureBotHomeGroupTitleForNickname(nickname);
         }
       );

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -3,11 +3,16 @@ import { desig } from '@tloncorp/api/lib/urbit';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Attachment } from '@tloncorp/shared/domain';
-import { withRetry } from '@tloncorp/shared/logic';
+import {
+  botHomeGroupHasDefaultTitle,
+  generateBotHomeGroupTitle,
+  withRetry,
+} from '@tloncorp/shared/logic';
 import {
   getSession,
   subscribeToSession,
   syncGroups,
+  updateGroupMeta,
   updateCurrentUserProfile,
   uploadAsset,
   waitForUploads,
@@ -66,6 +71,30 @@ function requireString(value: string | null | undefined, message: string) {
     throw new Error(message);
   }
   return value;
+}
+
+async function ensureBotHomeGroupTitleForNickname(nickname: string) {
+  const homeGroup = await db.getBotHomeGroup();
+  if (!homeGroup || !botHomeGroupHasDefaultTitle(homeGroup)) {
+    return;
+  }
+
+  const title = generateBotHomeGroupTitle({
+    id: api.getCurrentUserId(),
+    nickname,
+  });
+
+  if (homeGroup.title === title) {
+    return;
+  }
+
+  await updateGroupMeta(
+    {
+      ...homeGroup,
+      title,
+    },
+    { shouldThrow: true }
+  );
 }
 
 function hasActiveConnection() {
@@ -278,11 +307,13 @@ export async function recoverTlonbotRevivalDeferredConfig(
         source,
         ['profileNickname'],
         async () => {
+          const nickname = config.profileNickname!;
           await syncGroups();
           await updateCurrentUserProfile(
-            { nickname: config.profileNickname! },
+            { nickname },
             { shouldThrow: true }
           );
+          await ensureBotHomeGroupTitleForNickname(nickname);
         }
       );
     }

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -152,6 +152,18 @@ async function clearDeferredFields(fields: DeferredField[]) {
   });
 }
 
+function isRemoteAvatarUrl(url: string) {
+  return /^(?!file|data).+/.test(url);
+}
+
+function hasUnrecoverableBotAvatar(config: db.TlonbotRevivalDeferredConfig) {
+  return !!(
+    config.botAvatarUrl &&
+    !config.botAvatarUploadIntent &&
+    !isRemoteAvatarUrl(config.botAvatarUrl)
+  );
+}
+
 async function resolveDeferredBotAvatarUrl(
   config: db.TlonbotRevivalDeferredConfig
 ) {
@@ -169,7 +181,7 @@ async function resolveDeferredBotAvatarUrl(
     return uploadState.remoteUri;
   }
 
-  if (config.botAvatarUrl && /^(?!file|data).+/.test(config.botAvatarUrl)) {
+  if (config.botAvatarUrl && isRemoteAvatarUrl(config.botAvatarUrl)) {
     return config.botAvatarUrl;
   }
 
@@ -280,7 +292,13 @@ export async function recoverTlonbotRevivalDeferredConfig(
       });
     }
 
-    if (config.botAvatarUploadIntent || config.botAvatarUrl) {
+    if (hasUnrecoverableBotAvatar(config)) {
+      logger.trackError('TlonBot revival bot avatar update skipped', {
+        source,
+        step: 'missing_upload_intent',
+      });
+      await clearDeferredFields(['botAvatarUrl', 'botAvatarUploadIntent']);
+    } else if (config.botAvatarUploadIntent || config.botAvatarUrl) {
       await runAction(
         'botAvatar',
         source,

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -7,6 +7,7 @@ import { withRetry } from '@tloncorp/shared/logic';
 import {
   getSession,
   subscribeToSession,
+  syncGroups,
   updateCurrentUserProfile,
   uploadAsset,
   waitForUploads,
@@ -272,11 +273,17 @@ export async function recoverTlonbotRevivalDeferredConfig(
     }
 
     if (config.profileNickname) {
-      await runAction('profileNickname', source, ['profileNickname'], () =>
-        updateCurrentUserProfile(
-          { nickname: config.profileNickname! },
-          { shouldThrow: true }
-        )
+      await runAction(
+        'profileNickname',
+        source,
+        ['profileNickname'],
+        async () => {
+          await syncGroups();
+          await updateCurrentUserProfile(
+            { nickname: config.profileNickname! },
+            { shouldThrow: true }
+          );
+        }
       );
     }
 

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -1,0 +1,337 @@
+import * as api from '@tloncorp/api';
+import { desig } from '@tloncorp/api/lib/urbit';
+import { createDevLogger } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { Attachment } from '@tloncorp/shared/domain';
+import { withRetry } from '@tloncorp/shared/logic';
+import {
+  getSession,
+  subscribeToSession,
+  updateCurrentUserProfile,
+  uploadAsset,
+  waitForUploads,
+} from '@tloncorp/shared/store';
+
+import { connectNotifyProvider } from './notificationsApi';
+import { setAndConfirmTlonbotRevivalNotificationLevel } from './tlonbotRevivalNotifications';
+
+const logger = createDevLogger('tlonbotRevivalDeferredConfig', false);
+
+const BASIC_PROVIDER_ID = 'basic';
+const RECOVERY_RETRY_DELAY_MS = 30_000;
+const RECOVERY_RETRY_CONFIG = {
+  startingDelay: 1000,
+  numOfAttempts: 6,
+  maxDelay: 15_000,
+};
+
+type DeferredAction =
+  | 'profileNickname'
+  | 'notificationToken'
+  | 'notificationLevel'
+  | 'botNickname'
+  | 'botAvatar'
+  | 'botModel';
+
+type DeferredField = keyof db.TlonbotRevivalDeferredConfig;
+
+let recoveryPromise: Promise<boolean> | null = null;
+let recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+let connectionUnsubscribe: (() => void) | null = null;
+
+function hasBotModelConfig(config: db.TlonbotRevivalDeferredConfig) {
+  return !!(
+    config.botProvider &&
+    config.botProvider !== BASIC_PROVIDER_ID &&
+    config.botModel
+  );
+}
+
+function hasPendingConfig(config: db.TlonbotRevivalDeferredConfig) {
+  return !!(
+    config.profileNickname ||
+    config.notificationToken ||
+    config.notificationLevel ||
+    config.botName ||
+    config.botAvatarUploadIntent ||
+    config.botAvatarUrl ||
+    hasBotModelConfig(config)
+  );
+}
+
+function requireString(value: string | null | undefined, message: string) {
+  if (!value) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function hasActiveConnection() {
+  const status = getSession()?.channelStatus;
+  return status === 'active' || status === 'reconnected';
+}
+
+function runScheduledRecovery(source: string) {
+  recoverTlonbotRevivalDeferredConfig(source).catch((error) => {
+    logger.trackError('TlonBot revival deferred config recovery failed', {
+      error,
+      source,
+    });
+  });
+}
+
+function clearRecoverySchedule() {
+  if (recoveryTimer) {
+    clearTimeout(recoveryTimer);
+    recoveryTimer = null;
+  }
+
+  if (connectionUnsubscribe) {
+    connectionUnsubscribe();
+    connectionUnsubscribe = null;
+  }
+}
+
+function scheduleTimedRecovery() {
+  if (recoveryTimer) {
+    return;
+  }
+
+  recoveryTimer = setTimeout(() => {
+    recoveryTimer = null;
+    runScheduledRecovery('scheduled_retry');
+  }, RECOVERY_RETRY_DELAY_MS);
+}
+
+function scheduleConnectionRecovery() {
+  if (connectionUnsubscribe) {
+    return;
+  }
+
+  connectionUnsubscribe = subscribeToSession((session) => {
+    const connected =
+      session?.channelStatus === 'active' ||
+      session?.channelStatus === 'reconnected';
+    if (!connected) {
+      return;
+    }
+
+    connectionUnsubscribe?.();
+    connectionUnsubscribe = null;
+    runScheduledRecovery('connection_active');
+  });
+}
+
+function scheduleRecovery() {
+  scheduleTimedRecovery();
+  scheduleConnectionRecovery();
+}
+
+async function clearDeferredFields(fields: DeferredField[]) {
+  await db.tlonbotRevivalDeferredConfig.setValue((current) => {
+    const next = { ...current };
+    for (const field of fields) {
+      delete next[field];
+    }
+    return next;
+  });
+}
+
+async function resolveDeferredBotAvatarUrl(
+  config: db.TlonbotRevivalDeferredConfig
+) {
+  if (config.botAvatarUploadIntent) {
+    const uploadIntent = config.botAvatarUploadIntent;
+    const uploadKey = Attachment.UploadIntent.extractKey(uploadIntent);
+    await uploadAsset(uploadIntent);
+    const uploadStates = await waitForUploads([uploadKey]);
+    const uploadState = uploadStates[uploadKey];
+
+    if (uploadState?.status !== 'success') {
+      throw new Error('Deferred avatar upload did not finish successfully');
+    }
+
+    return uploadState.remoteUri;
+  }
+
+  if (config.botAvatarUrl && /^(?!file|data).+/.test(config.botAvatarUrl)) {
+    return config.botAvatarUrl;
+  }
+
+  throw new Error('Deferred bot avatar is not uploadable');
+}
+
+async function runAction(
+  action: DeferredAction,
+  source: string,
+  fields: DeferredField[],
+  fn: () => Promise<void>
+) {
+  try {
+    await withRetry(fn, RECOVERY_RETRY_CONFIG);
+    await clearDeferredFields(fields);
+    logger.trackEvent('TlonBot revival deferred config action succeeded', {
+      action,
+      source,
+    });
+  } catch (error) {
+    logger.trackError('TlonBot revival deferred config action failed', {
+      action,
+      error,
+      source,
+    });
+  }
+}
+
+export async function stageTlonbotRevivalDeferredConfig(
+  setup: db.TlonbotRevivalSetup
+) {
+  const shouldSetBotModel = !!(
+    setup.botProvider &&
+    setup.botProvider !== BASIC_PROVIDER_ID &&
+    setup.botModel
+  );
+
+  await db.tlonbotRevivalDeferredConfig.setValue((current) => ({
+    ...current,
+    profileNickname: setup.nickname,
+    notificationToken: setup.notificationToken,
+    notificationLevel: setup.notificationLevel ?? current.notificationLevel,
+    botName: setup.botName,
+    botAvatarUrl: setup.botAvatarUrl,
+    botAvatarUploadIntent: setup.botAvatarUploadIntent,
+    botProvider: shouldSetBotModel ? setup.botProvider : undefined,
+    botModel: shouldSetBotModel ? setup.botModel : undefined,
+  }));
+}
+
+export async function recoverTlonbotRevivalDeferredConfig(
+  source: string
+): Promise<boolean> {
+  if (recoveryPromise) {
+    return recoveryPromise;
+  }
+  clearRecoverySchedule();
+
+  recoveryPromise = (async () => {
+    const config = await db.tlonbotRevivalDeferredConfig.getValue(true);
+    if (!hasPendingConfig(config)) {
+      if (Object.keys(config).length > 0) {
+        await db.tlonbotRevivalDeferredConfig.resetValue();
+      }
+      return false;
+    }
+    if (!hasActiveConnection()) {
+      scheduleRecovery();
+      return false;
+    }
+
+    const hostedShipId = await db.hostedUserNodeId.getValue().catch(() => '');
+    const shipId = hostedShipId ? desig(hostedShipId) : '';
+    const userId = await db.hostingUserId.getValue().catch(() => '');
+
+    if (config.notificationLevel) {
+      await runAction('notificationLevel', source, ['notificationLevel'], () =>
+        setAndConfirmTlonbotRevivalNotificationLevel(config.notificationLevel!)
+      );
+    }
+
+    if (config.notificationToken) {
+      await runAction('notificationToken', source, ['notificationToken'], () =>
+        connectNotifyProvider(config.notificationToken!)
+      );
+    }
+
+    if (config.profileNickname) {
+      await runAction('profileNickname', source, ['profileNickname'], () =>
+        updateCurrentUserProfile(
+          { nickname: config.profileNickname! },
+          { shouldThrow: true }
+        )
+      );
+    }
+
+    if (config.botName) {
+      await runAction('botNickname', source, ['botName'], async () => {
+        await api.setTlawnNickname(
+          requireString(
+            shipId,
+            'Missing ship for deferred bot nickname update'
+          ),
+          config.botName!
+        );
+      });
+    }
+
+    if (config.botAvatarUploadIntent || config.botAvatarUrl) {
+      await runAction(
+        'botAvatar',
+        source,
+        ['botAvatarUrl', 'botAvatarUploadIntent'],
+        async () => {
+          await api.setTlawnAvatar(
+            requireString(
+              shipId,
+              'Missing ship for deferred bot avatar update'
+            ),
+            await resolveDeferredBotAvatarUrl(config)
+          );
+        }
+      );
+    }
+
+    if (hasBotModelConfig(config)) {
+      await runAction(
+        'botModel',
+        source,
+        ['botProvider', 'botModel'],
+        async () => {
+          await api.setTlawnPrimaryModel(
+            requireString(
+              userId,
+              'Missing user ID for deferred bot model update'
+            ),
+            {
+              provider: config.botProvider!,
+              model: config.botModel!,
+            }
+          );
+
+          const running = await api.awaitBotRunning(
+            requireString(
+              shipId,
+              'Missing ship for deferred bot model readiness check'
+            ),
+            {
+              timeoutMs: 30_000,
+              pollIntervalMs: 1500,
+            }
+          );
+          if (!running) {
+            logger.trackError(
+              'TlonBot revival model update readiness timed out',
+              {
+                provider: config.botProvider,
+                model: config.botModel,
+                source,
+              }
+            );
+          }
+        }
+      );
+    }
+
+    const remaining = await db.tlonbotRevivalDeferredConfig.getValue(true);
+    if (!hasPendingConfig(remaining)) {
+      await db.tlonbotRevivalDeferredConfig.resetValue();
+      return true;
+    }
+
+    scheduleRecovery();
+    return false;
+  })().finally(() => {
+    recoveryPromise = null;
+  });
+
+  return recoveryPromise;
+}

--- a/packages/app/lib/tlonbotRevivalDeferredConfig.ts
+++ b/packages/app/lib/tlonbotRevivalDeferredConfig.ts
@@ -342,6 +342,9 @@ export async function recoverTlonbotRevivalDeferredConfig(
     if (!hasPendingConfig(remaining)) {
       await db.tlonbotRevivalDeferredConfig.resetValue();
       resetRecoveryRetryDelay();
+      logger.trackEvent('TlonBot revival deferred config completed', {
+        source,
+      });
       return true;
     }
 

--- a/packages/app/lib/tlonbotRevivalNotifications.ts
+++ b/packages/app/lib/tlonbotRevivalNotifications.ts
@@ -11,8 +11,6 @@ const logger = createDevLogger('tlonbotRevivalNotifications', true);
 const TEMPORARY_PROVISIONING_NOTIFICATION_LEVEL: NotificationLevel = 'hush';
 const DEFAULT_RESTORE_NOTIFICATION_LEVEL: NotificationLevel = 'medium';
 
-let recoveryPromise: Promise<boolean> | null = null;
-
 function normalizeBaseVolumeLevel(level: NotificationLevel): NotificationLevel {
   return level === 'default' ? 'medium' : level;
 }
@@ -25,7 +23,9 @@ async function getRemoteBaseVolumeLevel(): Promise<NotificationLevel | null> {
     : null;
 }
 
-async function setAndConfirmBaseVolumeLevel(level: NotificationLevel) {
+export async function setAndConfirmTlonbotRevivalNotificationLevel(
+  level: NotificationLevel
+) {
   await setBaseVolumeLevel({ level });
 
   const expectedLevel = normalizeBaseVolumeLevel(level);
@@ -56,25 +56,23 @@ async function registerNotificationToken(notificationToken?: string) {
   });
 }
 
-async function markNotificationRestorePending(desiredLevel: NotificationLevel) {
-  await db.tlonbotRevivalNotificationRestore.setValue((current) => ({
+async function stageNotificationRestore(desiredLevel: NotificationLevel) {
+  await db.tlonbotRevivalDeferredConfig.setValue((current) => ({
     ...current,
-    pending: true,
-    desiredLevel,
-    createdAt: current.createdAt ?? Date.now(),
-    lastErrorAt: undefined,
-    lastErrorMessage: undefined,
+    notificationLevel: desiredLevel,
   }));
 }
 
 async function temporarilyMuteNodeNotifications(
   restoreLevel: NotificationLevel
 ) {
-  await markNotificationRestorePending(restoreLevel);
+  await stageNotificationRestore(restoreLevel);
 
   await withRetry(
     () =>
-      setAndConfirmBaseVolumeLevel(TEMPORARY_PROVISIONING_NOTIFICATION_LEVEL),
+      setAndConfirmTlonbotRevivalNotificationLevel(
+        TEMPORARY_PROVISIONING_NOTIFICATION_LEVEL
+      ),
     {
       startingDelay: 750,
       numOfAttempts: 4,
@@ -102,11 +100,11 @@ export async function prepareTlonbotRevivalNotifications(
 }
 
 async function getFallbackRestoreNotificationLevel(): Promise<NotificationLevel> {
-  const pendingRestore = await db.tlonbotRevivalNotificationRestore
+  const pendingConfig = await db.tlonbotRevivalDeferredConfig
     .getValue(true)
     .catch(() => null);
-  if (pendingRestore?.desiredLevel) {
-    return pendingRestore.desiredLevel;
+  if (pendingConfig?.notificationLevel) {
+    return pendingConfig.notificationLevel;
   }
 
   return DEFAULT_RESTORE_NOTIFICATION_LEVEL;
@@ -127,77 +125,4 @@ export async function prepareTlonbotRevivalNotificationsForProvisioning(
     setup.notificationToken,
     restoreLevel
   );
-}
-
-export function getTlonbotRevivalRestoreNotificationLevel(
-  setup: Pick<db.TlonbotRevivalSetup, 'notificationLevel'>
-): NotificationLevel {
-  return setup.notificationLevel ?? DEFAULT_RESTORE_NOTIFICATION_LEVEL;
-}
-
-export async function restoreTlonbotRevivalNotificationLevel(
-  restoreLevel: NotificationLevel,
-  source: string
-): Promise<boolean> {
-  await db.tlonbotRevivalNotificationRestore.setValue((current) => ({
-    ...current,
-    pending: true,
-    desiredLevel: restoreLevel,
-    lastAttemptAt: Date.now(),
-  }));
-
-  try {
-    await withRetry(() => setAndConfirmBaseVolumeLevel(restoreLevel), {
-      startingDelay: 1000,
-      numOfAttempts: 4,
-      maxDelay: 4000,
-    });
-
-    await db.tlonbotRevivalNotificationRestore.resetValue();
-    logger.trackEvent('Tlonbot revival notifications restored', {
-      restoreNotificationLevel: restoreLevel,
-      source,
-    });
-    return true;
-  } catch (error) {
-    await db.tlonbotRevivalNotificationRestore.setValue((current) => ({
-      ...current,
-      pending: true,
-      desiredLevel: restoreLevel,
-      lastErrorAt: Date.now(),
-      lastErrorMessage: error instanceof Error ? error.message : String(error),
-    }));
-    logger.trackError('TlonBot revival notification level restore failed', {
-      error,
-      restoreNotificationLevel: restoreLevel,
-      source,
-    });
-    return false;
-  }
-}
-
-export async function recoverTlonbotRevivalNotificationLevel(
-  source: string
-): Promise<boolean> {
-  if (recoveryPromise) {
-    return recoveryPromise;
-  }
-
-  recoveryPromise = (async () => {
-    const pendingRestore =
-      await db.tlonbotRevivalNotificationRestore.getValue(true);
-
-    if (!pendingRestore.pending || !pendingRestore.desiredLevel) {
-      return false;
-    }
-
-    return restoreTlonbotRevivalNotificationLevel(
-      pendingRestore.desiredLevel,
-      source
-    );
-  })().finally(() => {
-    recoveryPromise = null;
-  });
-
-  return recoveryPromise;
 }

--- a/packages/app/ui/components/ContactNameV2.tsx
+++ b/packages/app/ui/components/ContactNameV2.tsx
@@ -100,6 +100,11 @@ const BaseContactName = RawText.styleable<{
     const formattedId = useMemo(() => {
       return showContactId ? formatUserId(contactId, expandLongIds) : null;
     }, [contactId, expandLongIds, showContactId]);
+    const contactNameProps = useContactNameProps({
+      contactId,
+      expandLongIds,
+      mode,
+    });
 
     if (showContactId && !formattedId) {
       console.error('unable to display invalid id', contactId);
@@ -108,7 +113,7 @@ const BaseContactName = RawText.styleable<{
 
     return (
       <RawText
-        {...useContactNameProps({ contactId, expandLongIds, mode })}
+        {...contactNameProps}
         {...props}
         style={props.style ?? { whiteSpace: 'nowrap' }}
       ></RawText>

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -16,6 +16,7 @@ import {
   syncStart,
   uploadAsset,
   useCanUpload,
+  useLureState,
 } from '@tloncorp/shared/store';
 import {
   Button,
@@ -653,6 +654,15 @@ function SplashSequenceComponent(props: {
   }, [botModel, providerOptions, handleValidateProvider]);
 
   const handleTlonbotSetupComplete = useCallback(async () => {
+    useLureState
+      .getState()
+      .start()
+      .catch((error) => {
+        logger.trackError('Wayfinding Home Group Invite Bait Warmup Failed', {
+          error,
+        });
+      });
+
     await db.tlonbotRevivalSetup.setValue((current) => ({
       ...current,
       pending: true,

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -14,10 +14,8 @@ import {
   clearShipRevivalStatus,
   markCurrentUserTlonbotEnabled,
   syncStart,
-  updateCurrentUserProfile,
   uploadAsset,
   useCanUpload,
-  waitForUploads,
 } from '@tloncorp/shared/store';
 import {
   Button,
@@ -60,12 +58,11 @@ import {
   InviteSystemContactsFn,
   useInviteSystemContactHandler,
 } from '../../../hooks/useInviteSystemContactHandler';
-import { connectNotifyProvider } from '../../../lib/notificationsApi';
 import {
-  getTlonbotRevivalRestoreNotificationLevel,
-  prepareTlonbotRevivalNotificationsForProvisioning,
-  restoreTlonbotRevivalNotificationLevel,
-} from '../../../lib/tlonbotRevivalNotifications';
+  recoverTlonbotRevivalDeferredConfig,
+  stageTlonbotRevivalDeferredConfig,
+} from '../../../lib/tlonbotRevivalDeferredConfig';
+import { prepareTlonbotRevivalNotificationsForProvisioning } from '../../../lib/tlonbotRevivalNotifications';
 import { useActiveTheme } from '../../../provider';
 import {
   AttachmentProvider,
@@ -945,161 +942,6 @@ function prejoinTlonbotRevivalGroups() {
   });
 }
 
-async function applyProfileAndNotificationPreferences(
-  setup: db.TlonbotRevivalSetup
-) {
-  if (setup.nickname) {
-    await withRetry(
-      () =>
-        updateCurrentUserProfile(
-          { nickname: setup.nickname },
-          { shouldThrow: true }
-        ),
-      {
-        startingDelay: 1000,
-        numOfAttempts: 4,
-        maxDelay: 4000,
-      }
-    ).catch((error) => {
-      logger.trackError('TlonBot revival profile update failed', { error });
-    });
-  }
-
-  if (setup.notificationToken) {
-    await withRetry(() => connectNotifyProvider(setup.notificationToken!), {
-      startingDelay: 1000,
-      numOfAttempts: 4,
-      maxDelay: 4000,
-    }).catch((error) => {
-      logger.trackError('TlonBot revival notification token update failed', {
-        error,
-      });
-    });
-  }
-
-  const restoreNotificationLevel =
-    getTlonbotRevivalRestoreNotificationLevel(setup);
-  await restoreTlonbotRevivalNotificationLevel(
-    restoreNotificationLevel,
-    'post_wait_setup'
-  );
-}
-
-async function applyBotPreferences(
-  shipId: string,
-  setup: db.TlonbotRevivalSetup
-) {
-  if (setup.botName) {
-    await withRetry(() => api.setTlawnNickname(shipId, setup.botName!), {
-      startingDelay: 750,
-      numOfAttempts: 4,
-      maxDelay: 4000,
-    }).catch((error) => {
-      logger.trackError('TlonBot revival bot nickname update failed', {
-        error,
-      });
-    });
-  }
-
-  const botAvatarUrl = await resolveDeferredBotAvatarUrl(setup);
-  if (botAvatarUrl) {
-    await withRetry(() => api.setTlawnAvatar(shipId, botAvatarUrl), {
-      startingDelay: 750,
-      numOfAttempts: 4,
-      maxDelay: 4000,
-    }).catch((error) => {
-      logger.trackError('TlonBot revival bot avatar update failed', { error });
-    });
-  }
-
-  if (
-    setup.botProvider &&
-    setup.botProvider !== BASIC_PROVIDER_ID &&
-    setup.botModel
-  ) {
-    const userId = await db.hostingUserId.getValue();
-    if (!userId) {
-      logger.trackError('TlonBot revival model update failed', {
-        step: 'missing_user_id',
-      });
-      return;
-    }
-
-    await withRetry(
-      () =>
-        api.setTlawnPrimaryModel(userId, {
-          provider: setup.botProvider!,
-          model: setup.botModel!,
-        }),
-      {
-        startingDelay: 750,
-        numOfAttempts: 4,
-        maxDelay: 4000,
-      }
-    )
-      .then(async () => {
-        const running = await api.awaitBotRunning(shipId, {
-          timeoutMs: 30_000,
-          pollIntervalMs: 1500,
-        });
-        if (!running) {
-          logger.trackError(
-            'TlonBot revival model update readiness timed out',
-            {
-              provider: setup.botProvider,
-              model: setup.botModel,
-            }
-          );
-        }
-      })
-      .catch((error) => {
-        logger.trackError('TlonBot revival model update failed', { error });
-      });
-  }
-}
-
-async function resolveDeferredBotAvatarUrl(setup: db.TlonbotRevivalSetup) {
-  if (setup.botAvatarUploadIntent) {
-    return withRetry(
-      async () => {
-        const uploadIntent = setup.botAvatarUploadIntent!;
-        const uploadKey = Attachment.UploadIntent.extractKey(uploadIntent);
-        await uploadAsset(uploadIntent);
-        const uploadStates = await waitForUploads([uploadKey]);
-        const uploadState = uploadStates[uploadKey];
-
-        if (uploadState?.status !== 'success') {
-          throw new Error('Deferred avatar upload did not finish successfully');
-        }
-
-        return uploadState.remoteUri;
-      },
-      {
-        startingDelay: 1000,
-        numOfAttempts: 3,
-        maxDelay: 4000,
-      }
-    ).catch((error) => {
-      logger.trackError('TlonBot revival deferred avatar upload failed', {
-        error,
-      });
-      return null;
-    });
-  }
-
-  if (setup.botAvatarUrl && /^(?!file|data).+/.test(setup.botAvatarUrl)) {
-    return setup.botAvatarUrl;
-  }
-
-  if (setup.botAvatarUrl) {
-    logger.trackError('TlonBot revival bot avatar update failed', {
-      step: 'missing_upload_intent',
-    });
-  }
-
-  return null;
-}
-
 async function shareTlonbotGroupInvite(homeGroupInviteLink: string) {
   if (isWeb) {
     try {
@@ -1844,44 +1686,43 @@ function TlonBotSetupPane(props: {
     await onLogout();
   }, [onLogout]);
 
-  const applyDeferredSetup = useCallback(
-    async (shipId: string) => {
-      if (applyingRef.current) {
-        return;
-      }
+  const applyDeferredSetup = useCallback(async () => {
+    if (applyingRef.current) {
+      return;
+    }
 
-      applyingRef.current = true;
+    applyingRef.current = true;
 
-      try {
-        const setup = await db.tlonbotRevivalSetup.getValue(true);
+    try {
+      const setup = await db.tlonbotRevivalSetup.getValue(true);
 
-        if (!setup.applied) {
-          await syncStart(true).catch((error) => {
-            logger.trackError(
-              'TlonBot revival sync failed before setup apply',
-              {
-                error,
-              }
-            );
+      if (!setup.applied) {
+        await stageTlonbotRevivalDeferredConfig(setup);
+        syncStart(true).catch((error) => {
+          logger.trackError('TlonBot revival sync failed after setup apply', {
+            error,
           });
+        });
 
-          await applyProfileAndNotificationPreferences(setup);
-          await applyBotPreferences(shipId, setup);
-          await db.tlonbotRevivalSetup.setValue((current) => ({
-            ...current,
-            applied: true,
-          }));
-        }
-
-        await onComplete();
-      } catch (error) {
-        applyingRef.current = false;
-        logger.trackError('TlonBot revival setup failed', { error });
-        throw error;
+        recoverTlonbotRevivalDeferredConfig('post_wait_setup').catch((error) =>
+          logger.trackError('TlonBot revival deferred config recovery failed', {
+            error,
+            source: 'post_wait_setup',
+          })
+        );
+        await db.tlonbotRevivalSetup.setValue((current) => ({
+          ...current,
+          applied: true,
+        }));
       }
-    },
-    [onComplete]
-  );
+
+      await onComplete();
+    } catch (error) {
+      applyingRef.current = false;
+      logger.trackError('TlonBot revival setup failed', { error });
+      throw error;
+    }
+  }, [onComplete]);
 
   const checkReadinessNow = useCallback(async () => {
     if (foregroundReadinessCheckRef.current || applyingRef.current) {
@@ -1890,8 +1731,7 @@ function TlonBotSetupPane(props: {
 
     foregroundReadinessCheckRef.current = true;
     try {
-      const setup = await db.tlonbotRevivalSetup.getValue();
-      const shipId = setup.shipId ?? (await db.hostedUserNodeId.getValue());
+      const shipId = await db.hostedUserNodeId.getValue();
 
       if (!shipId) {
         return;
@@ -1899,7 +1739,7 @@ function TlonBotSetupPane(props: {
 
       const isReady = await api.checkNodeIsTlonbotReady(shipId);
       if (isReady) {
-        await applyDeferredSetup(shipId).catch((error) =>
+        await applyDeferredSetup().catch((error) =>
           logger.trackError('Deferred Tlonbot setup failed', {
             error,
           })
@@ -1939,7 +1779,7 @@ function TlonBotSetupPane(props: {
     const checkReadiness = async () => {
       try {
         const setup = await db.tlonbotRevivalSetup.getValue();
-        const shipId = setup.shipId ?? (await db.hostedUserNodeId.getValue());
+        const shipId = await db.hostedUserNodeId.getValue();
 
         if (!shipId) {
           throw new Error('No ship ID found during TlonBot revival setup');
@@ -1961,7 +1801,6 @@ function TlonBotSetupPane(props: {
               await db.tlonbotRevivalSetup.setValue((current) => ({
                 ...current,
                 provisioningStarted: true,
-                shipId: current.shipId ?? shipId,
               }));
             })
             .catch((error) => {
@@ -1978,7 +1817,7 @@ function TlonBotSetupPane(props: {
         });
         if (isReady) {
           if (!cancelled) {
-            await applyDeferredSetup(shipId).catch((error) =>
+            await applyDeferredSetup().catch((error) =>
               logger.trackError('Deferred Tlonbot setup failed', {
                 error,
               })

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -926,7 +926,7 @@ const TLONBOT_REVIVAL_GROUP_IDS = [
   '~ramlud-bintun/v1l3qcoq',
   '~wittyr-witbes/v3s2kbd7',
 ];
-const BOT_PREVIEW_FALLBACK_USER_SHIP_ID = '~nec';
+const BOT_PREVIEW_FALLBACK_USER_SHIP_ID = '~lidlen-pillex';
 
 function prejoinTlonbotRevivalGroups() {
   TLONBOT_REVIVAL_GROUP_IDS.forEach((groupId) => {

--- a/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
+++ b/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
@@ -22,6 +22,7 @@ export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
   const inviteService = useInviteService();
   const cachedInviteLink = db.homeGroupInviteLink.useValue();
   const enabledGroupLinksRef = useRef<string | null>(null);
+  const cachedRecoveredInviteRef = useRef<string | null>(null);
 
   const homeGroupId = useMemo(
     () =>
@@ -59,6 +60,25 @@ export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
     disableLoading: !shouldRecoverFromLure,
   });
 
+  useEffect(() => {
+    if (!enabled || cachedInviteLink || !shareUrl) {
+      return;
+    }
+
+    if (cachedRecoveredInviteRef.current === shareUrl) {
+      return;
+    }
+
+    cachedRecoveredInviteRef.current = shareUrl;
+    db.homeGroupInviteLink.setValue(shareUrl).catch((error) => {
+      cachedRecoveredInviteRef.current = null;
+      logger.trackError('Wayfinding Home Group Invite Cache Failed', {
+        error,
+        groupId: homeGroup?.id,
+      });
+    });
+  }, [cachedInviteLink, enabled, homeGroup?.id, shareUrl]);
+
   const inviteUrl = cachedInviteLink ?? shareUrl ?? null;
   const state = useMemo<HomeGroupInviteState>(() => {
     if (inviteUrl) {
@@ -77,7 +97,11 @@ export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
       return 'unavailable';
     }
 
-    if (lureStatus === 'loading' || lureStatus === 'stale') {
+    if (
+      lureStatus === 'loading' ||
+      lureStatus === 'stale' ||
+      lureStatus === 'unsupported'
+    ) {
       return 'loading';
     }
 

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -131,7 +131,6 @@ export type TlonbotRevivalSetup = Pick<
   applied?: boolean;
   provisioningStarted?: boolean;
   stage?: TlonbotRevivalStage;
-  shipId?: string;
   botName?: string;
   botAvatarUrl?: string | null;
   botAvatarUploadIntent?: Attachment.UploadIntent | null;
@@ -146,21 +145,21 @@ export const tlonbotRevivalSetup = createStorageItem<TlonbotRevivalSetup>({
   },
 });
 
-export type TlonbotRevivalNotificationRestore = {
-  pending: boolean;
-  desiredLevel?: ub.NotificationLevel;
-  createdAt?: number;
-  lastAttemptAt?: number;
-  lastErrorAt?: number;
-  lastErrorMessage?: string;
+export type TlonbotRevivalDeferredConfig = {
+  profileNickname?: string;
+  notificationToken?: string;
+  notificationLevel?: ub.NotificationLevel;
+  botName?: string;
+  botAvatarUrl?: string | null;
+  botAvatarUploadIntent?: Attachment.UploadIntent | null;
+  botProvider?: string;
+  botModel?: string;
 };
 
-export const tlonbotRevivalNotificationRestore =
-  createStorageItem<TlonbotRevivalNotificationRestore>({
-    key: 'tlonbotRevivalNotificationRestore',
-    defaultValue: {
-      pending: false,
-    },
+export const tlonbotRevivalDeferredConfig =
+  createStorageItem<TlonbotRevivalDeferredConfig>({
+    key: 'tlonbotRevivalDeferredConfig',
+    defaultValue: {},
   });
 
 export const didClearPreviousInstall = createStorageItem<boolean>({


### PR DESCRIPTION
## Summary

Reviewing the QA revival telemetry, we found cases where nickname configuration failed after the user advanced past the wait screen. This can show up both in-app and in fallback OG tags on invite links. The operation already had a short retry, but that does not help if the node is truly unreachable during the critical post-provisioning window, for example if Hosting restarts the node after it exceeds allocated resources.

Hosting is working to avoid the node becoming unreachable in this window, but the client should be more resilient too. We already had hardened retry behavior for restoring the notification level, including retrying across force quits. This PR generalizes that approach to the rest of Tlonbot revival configuration.

Revival config values are now persisted in KV under `tlonbotRevivalDeferredConfig`. A new deferred config worker applies each operation and only clears a value after its operation succeeds. The ad hoc retries previously inlined in the splash sequence have been removed in favor of this worker.

The worker waits until the SSE session is active, then applies the deferred operations. If any operation fails, its value remains persisted and recovery retries with backoff until everything succeeds. These failures do not block the user from continuing to invite steps or the home screen. If the app is abandoned or force quit, recovery resumes when the app is reopened.

A completion telemetry event is emitted once all deferred revival config has been successfully applied.

Fixes TLON-5790

## How did I test?

Revival flow on iOS simulator.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
