### PR TITLE
Fix backend CI desk change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Detect desk file changes
         id: desk_changes
         run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -q '^desk/'; then
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -q '^desk/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -127,7 +127,7 @@ jobs:
       - name: Detect desk file changes
         id: desk_changes
         run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" | grep -q '^desk/'; then
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -q '^desk/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The backend CI jobs were sometimes running their backend commands on PRs that did not touch `desk/`. The change detector was using a two-endpoint diff between the PR base SHA and head SHA, which can include files changed on the base branch after the PR branch split.

This updates both backend change detectors to use GitHub's PR-style three-dot diff range. That makes the `desk/` check reflect only files changed by the PR itself, so the backend jobs can still start and cleanly skip when no backend files are part of the PR.

This fixes the false positive seen on PR #5831, where the workflow detected `desk/app/channels.hoon` and `desk/desk.docket-0` even though the PR's changed files were all outside `desk/`.

## Testing

- Verified the linked PR base/head comparison no longer reports `desk/` changes with the three-dot diff.
- Ran `git diff --check .github/workflows/ci.yml`.