### PR TITLE
[codex] Add browser notifications

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -8,6 +8,7 @@ import {
   Route,
 } from '@react-navigation/native';
 import { ENABLED_LOGGERS } from '@tloncorp/app/constants';
+import useBrowserNotifications from '@tloncorp/app/hooks/useBrowserNotifications';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
 import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
@@ -441,6 +442,7 @@ function ConnectedWebApp() {
   const hasSyncedRef = React.useRef(false);
   const telemetry = useTelemetry();
   useFindSuggestedContacts();
+  useBrowserNotifications(dbIsLoaded);
 
   const isNewSignup = useMemo(() => {
     return logic.detectWebSignup();

--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -2,10 +2,12 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as ub from '@tloncorp/api/urbit';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
+import { Button } from '@tloncorp/ui';
 import { ComponentProps, useCallback, useMemo } from 'react';
 import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useBrowserNotificationPermission } from '../../hooks/useBrowserNotificationPermission';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { RootStackParamList } from '../../navigation/types';
 import {
@@ -28,11 +30,25 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
   const baseVolumeSetting = store.useBaseVolumeLevel();
   const { data: exceptions } = store.useVolumeExceptions();
   const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
+  const browserNotifications = useBrowserNotificationPermission();
 
   const numExceptions = useMemo(
     () => (exceptions?.channels.length ?? 0) + (exceptions?.groups.length ?? 0),
     [exceptions]
   );
+
+  const browserPermissionLabel = useMemo(() => {
+    switch (browserNotifications.permission) {
+      case 'granted':
+        return 'Enabled';
+      case 'denied':
+        return 'Blocked in browser';
+      case 'default':
+        return 'Not enabled';
+      default:
+        return 'Unsupported';
+    }
+  }, [browserNotifications.permission]);
 
   const setLevel = useCallback(
     async (level: ub.NotificationLevel) => {
@@ -82,6 +98,24 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
             value={baseVolumeSetting}
             onChange={setLevel}
           />
+
+          {browserNotifications.isSupported ? (
+            <YStack marginTop="$xl" gap="$m">
+              <TlonText.Text size="$label/2xl">
+                Browser notifications
+              </TlonText.Text>
+              <TlonText.Text size="$label/m" color="$secondaryText">
+                {browserPermissionLabel}
+              </TlonText.Text>
+              {browserNotifications.canRequestPermission ? (
+                <Button
+                  preset="primary"
+                  label="Enable"
+                  onPress={browserNotifications.requestPermission}
+                />
+              ) : null}
+            </YStack>
+          ) : null}
           {numExceptions > 0 ? (
             <ExceptionsDisplay
               channels={exceptions?.channels ?? []}

--- a/packages/app/hooks/useBrowserNotificationPermission.ts
+++ b/packages/app/hooks/useBrowserNotificationPermission.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type BrowserNotificationPermission = NotificationPermission | 'unsupported';
+
+function getBrowserNotificationPermission(): BrowserNotificationPermission {
+  if (
+    typeof window === 'undefined' ||
+    !window.isSecureContext ||
+    !('Notification' in window)
+  ) {
+    return 'unsupported';
+  }
+
+  return window.Notification.permission;
+}
+
+export function useBrowserNotificationPermission() {
+  const [permission, setPermission] = useState<BrowserNotificationPermission>(
+    getBrowserNotificationPermission
+  );
+
+  useEffect(() => {
+    setPermission(getBrowserNotificationPermission());
+  }, []);
+
+  const requestPermission = useCallback(async () => {
+    if (
+      typeof window === 'undefined' ||
+      !window.isSecureContext ||
+      !('Notification' in window)
+    ) {
+      setPermission('unsupported');
+      return 'unsupported';
+    }
+
+    const nextPermission = await window.Notification.requestPermission();
+    setPermission(nextPermission);
+    return nextPermission;
+  }, []);
+
+  return useMemo(
+    () => ({
+      isSupported: permission !== 'unsupported',
+      permission,
+      hasPermission: permission === 'granted',
+      canRequestPermission: permission === 'default',
+      requestPermission,
+    }),
+    [permission, requestPermission]
+  );
+}

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -1,0 +1,144 @@
+import * as api from '@tloncorp/api';
+import { createDevLogger } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { getTextContent } from '@tloncorp/shared/logic';
+import { useCallback, useEffect, useRef } from 'react';
+
+const logger = createDevLogger('useBrowserNotifications', false);
+
+interface NotificationData {
+  type: string;
+  channelId?: string;
+  groupId?: string;
+}
+
+function canUseBrowserNotifications() {
+  return (
+    typeof window !== 'undefined' &&
+    window.isSecureContext &&
+    'Notification' in window
+  );
+}
+
+function hasNotificationPermission() {
+  return (
+    canUseBrowserNotifications() && window.Notification.permission === 'granted'
+  );
+}
+
+export default function useBrowserNotifications(isClientReady: boolean) {
+  const processedNotifications = useRef<Set<string>>(new Set());
+  const subscribedRef = useRef(false);
+
+  const showActivityNotification = useCallback(
+    async (activityEvent: db.ActivityEvent) => {
+      if (!canUseBrowserNotifications()) {
+        return;
+      }
+
+      const notificationKey = activityEvent.id;
+      if (processedNotifications.current.has(notificationKey)) {
+        return;
+      }
+
+      processedNotifications.current.add(notificationKey);
+      if (processedNotifications.current.size > 100) {
+        processedNotifications.current = new Set(
+          Array.from(processedNotifications.current).slice(-50)
+        );
+      }
+
+      if (!hasNotificationPermission()) {
+        return;
+      }
+
+      if (!activityEvent.channelId) {
+        logger.error('No channel ID in activity event:', activityEvent);
+        return;
+      }
+
+      try {
+        const channel = await db.getChannelWithRelations({
+          id: activityEvent.channelId,
+        });
+        if (!channel) {
+          return;
+        }
+
+        const contactId = activityEvent.authorId;
+        const contact = contactId
+          ? await db.getContact({ id: contactId })
+          : null;
+        const contactName = contact?.nickname ?? contactId ?? 'Unknown';
+        const contentText = activityEvent.content
+          ? getTextContent(activityEvent.content as api.PostContent)
+          : '';
+
+        let title = channel.title ?? contactName ?? 'New message';
+        let body = contentText || 'New message';
+
+        if (activityEvent.groupId) {
+          const group = await db.getGroup({ id: activityEvent.groupId });
+          if (group) {
+            title = `${title} in ${group.title}`;
+            body = contentText
+              ? `${contactName ?? 'Someone'}: ${contentText}`
+              : `New message in ${group.title}`;
+          }
+        }
+
+        const notification = new window.Notification(title, {
+          body,
+          tag: notificationKey,
+          data: {
+            type: 'channel',
+            channelId: activityEvent.channelId,
+            groupId: channel.groupId ?? undefined,
+          } satisfies NotificationData,
+        });
+
+        notification.onclick = () => {
+          window.focus();
+        };
+      } catch (error) {
+        logger.error(
+          'Error processing channel activity for browser notifications',
+          error
+        );
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (
+      !isClientReady ||
+      subscribedRef.current ||
+      !canUseBrowserNotifications()
+    ) {
+      return;
+    }
+
+    subscribedRef.current = true;
+
+    const handleActivityEvent = (event: api.ActivityEvent) => {
+      if (event.type !== 'addActivityEvent') {
+        return;
+      }
+
+      const activityEvent =
+        event.events.find((e) => e.bucketId === 'all') ?? event.events[0];
+
+      if (activityEvent?.shouldNotify) {
+        showActivityNotification(activityEvent);
+      }
+    };
+
+    try {
+      api.subscribeToActivity(handleActivityEvent);
+    } catch (error) {
+      subscribedRef.current = false;
+      logger.error('Error subscribing to browser notification activity', error);
+    }
+  }, [isClientReady, showActivityNotification]);
+}


### PR DESCRIPTION
## Summary

Adds true browser Notification API support for Tlon web while the tab is open or backgrounded.

- subscribes the web app to `%activity` updates and emits native browser notifications for `shouldNotify` activity events
- adds a browser notification permission hook with secure-context/support guards
- exposes a browser notification permission row in notification settings using the current `master` settings UI

## Notes

This does not implement closed-tab Web Push. That would require service worker `push` handling plus PushManager/VAPID/provider support.

The remote does not have a branch named `stable`, so this branch is based on `origin/master`, which appears to be the stable/release branch.

## Validation

- `git diff --check` passed
- On the original working branch before rebasing to `master`: `pnpm --filter 'tlon-web' tsc` passed and `pnpm --filter 'tlon-web' build` passed
- After rebasing to `origin/master`, `pnpm --filter 'tlon-web' tsc --pretty false` is blocked by existing stable-branch/local dependency issues unrelated to this patch, including `@urbit/aura` export mismatches and missing native/web dependency typings
- After reinstalling `master` dependencies with `pnpm install --frozen-lockfile --force`, `pnpm --filter 'tlon-web' build` starts and transforms the app but is blocked by an existing `expo-audio` web export mismatch (`PLAYBACK_STATUS_UPDATE` is not exported by `ExpoAudio.web.js`)

## Manual Test

Verified locally against `https://malmur-halmex.tlon.network` through the web dev server. Browser permission state appears under Settings -> Notification settings -> Browser notifications, and blocked origins report `Blocked in browser`.