### PR TITLE
devex: route script-shell via TLON_SHELL so windows can use git bash

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 node-linker=hoisted
+script-shell=${TLON_SHELL-/bin/bash}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,19 @@ To identify which component to modify:
 -   Builds on top of web application
 -   Uses Electron for native desktop features
 
+### Windows Development
+
+Several `package.json` scripts use Unix shell tools (`rm -rf`, `cp -R`, `mkdir -p`). `.npmrc` routes pnpm's `script-shell` through `${TLON_SHELL-/bin/bash}` so those scripts work everywhere:
+
+-   **macOS/Linux**: nothing to do — `TLON_SHELL` is unset and pnpm falls back to `/bin/bash`.
+-   **Windows**: install [Git for Windows](https://git-scm.com/download/win), then point pnpm at its bash:
+    ```powershell
+    [System.Environment]::SetEnvironmentVariable("TLON_SHELL", "C:\Program Files\Git\bin\bash.exe", "User")
+    ```
+    Open a fresh terminal so the env var is loaded. Do **not** rely on bare `bash` on PATH — on Windows it usually resolves to `C:\Windows\System32\bash.exe` (WSL), which runs scripts inside Linux with the wrong filesystem view.
+
+Also: use the pinned Node version (`.nvmrc` → 22.22.0). Node 24+ has no prebuilt binaries for `better-sqlite3@11.x` and will fall back to compiling via node-gyp, which needs VS Build Tools + Windows SDK installed.
+
 ### Shell Script Compatibility
 
 When writing or modifying bash scripts, ensure compatibility with both macOS and Linux:

--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -18,7 +18,8 @@ afterEvaluate {
     ) {
         description = "Bundle JS for TalkMessagingService"
         workingDir workspaceRoot
-        commandLine "pnpm", "run", "--filter", "scripts", "build"
+        def pnpmExe = org.gradle.internal.os.OperatingSystem.current().isWindows() ? "pnpm.cmd" : "pnpm"
+        commandLine pnpmExe, "run", "--filter", "scripts", "build"
     }
     def copyTask = tasks.create(
             name: "copyNotificationServiceJsBundle",


### PR DESCRIPTION
## Summary

Several package.json scripts use Unix shell tools (`rm -rf`, `cp -R`, `mkdir -p`) that fail on Windows' default `cmd.exe`. Pointing pnpm's script-shell at `${TLON_SHELL-/bin/bash}` lets Windows contributors set `TLON_SHELL` to Git Bash without rewriting any existing scripts; Unix users keep `/bin/bash` automatically via the default-value expansion. Documents the Windows setup in `CLAUDE.md`, including the WSL-bash trap on `PATH` and the Node 22 pin needed for prebuilt `better-sqlite3` binaries.

## Changes

- Tells pnpm to run all package.json scripts through whatever $TLON_SHELL points to, falling back to /bin/bash when the env var is unset
- Updates CLAUDE.md to tell the robots what to do when initializing on Windows

## How did I test?

![](https://media.tenor.com/HZOA9SNt57YAAAAC/doc-brown-bttf.gif)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: dev environment

## Rollback plan

git revert

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5e375320-9967-49cb-a959-0b0b1d102236" />

