### PR TITLE
gallery: @mention-pattern reply action for comments, blue dot

### DIFF
--- a/apps/tlon-web/e2e/gallery-functionality.spec.ts
+++ b/apps/tlon-web/e2e/gallery-functionality.spec.ts
@@ -178,6 +178,52 @@ test('should test gallery functionality', async ({ zodSetup, tenSetup }) => {
       .getByText('Edited via long-press')
   ).toBeVisible();
 
+  // Add a comment from ~ten so ~zod gets an unread + a comment to Reply to
+  await tenPage.getByTestId('Post').first().click();
+  await expect(
+    tenPage.getByTestId('GalleryPostContent').getByText('Edited via long-press')
+  ).toBeVisible({ timeout: 10000 });
+  await helpers.sendMessage(tenPage, 'Comment from ten');
+  await helpers.navigateBack(tenPage);
+
+  // ~zod (still on the gallery grid) should see the unread dot once ~ten's
+  // comment syncs across
+  await expect(zodPage.getByTestId('GalleryPostUnreadDot')).toBeVisible({
+    timeout: 15000,
+  });
+
+  // ~zod opens the post and uses the new Reply action on ~ten's comment
+  await zodPage.getByTestId('Post').first().click();
+  await expect(
+    zodPage.getByTestId('GalleryPostContent').getByText('Edited via long-press')
+  ).toBeVisible({ timeout: 10000 });
+  await expect(
+    zodPage.getByText('Comment from ten', { exact: true })
+  ).toBeVisible({ timeout: 10000 });
+
+  await helpers.longPressMessage(zodPage, 'Comment from ten');
+  await zodPage.getByText('Reply', { exact: true }).click();
+
+  // replyToComment prefills a mention of the comment author
+  await expect(zodPage.getByTestId('SelectedMention-~ten')).toBeVisible({
+    timeout: 5000,
+  });
+
+  // Send the prefilled reply directly — using helpers.sendMessage here would
+  // clear the prefilled mention via page.fill().
+  await zodPage.getByTestId('MessageInputSendButton').click({ force: true });
+  await expect(zodPage.getByTestId('SelectedMention-~ten')).not.toBeVisible({
+    timeout: 5000,
+  });
+
+  // Back to the gallery grid for the report/delete flow below
+  await helpers.navigateBack(zodPage);
+  await expect(
+    zodPage
+      .getByTestId('GalleryPostContentPreview')
+      .getByText('Edited via long-press')
+  ).toBeVisible();
+
   // Report the post as ~zod
   await helpers.longPressMessage(zodPage, 'Edited via long-press');
   await zodPage.getByText('Report post').click();

--- a/packages/api/src/types/ChannelActions.ts
+++ b/packages/api/src/types/ChannelActions.ts
@@ -3,6 +3,7 @@ import type * as db from './models';
 export type Id =
   | 'debugJson'
   | 'quote'
+  | 'replyToComment'
   | 'startThread'
   | 'muteThread'
   | 'viewReactions'
@@ -39,6 +40,7 @@ export function channelActionIdsFor({
       return [];
     case 'gallery':
       actions = [
+        'replyToComment',
         'startThread',
         'muteThread',
         'copyRef',
@@ -101,7 +103,12 @@ export function channelActionIdsFor({
 
   // Filter out write-dependent actions if user cannot write
   if (canWrite === false) {
-    const writeOnlyActions: Id[] = ['quote', 'startThread', 'edit'];
+    const writeOnlyActions: Id[] = [
+      'quote',
+      'replyToComment',
+      'startThread',
+      'edit',
+    ];
     actions = actions.filter((action) => !writeOnlyActions.includes(action));
   }
 
@@ -118,6 +125,7 @@ const STATIC_SPECS = {
   edit: { isNetworkDependent: true },
   muteThread: { isNetworkDependent: true },
   quote: { isNetworkDependent: true },
+  replyToComment: { isNetworkDependent: true },
   forward: { isNetworkDependent: true },
   report: { isNetworkDependent: true },
   startThread: { isNetworkDependent: true },

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -1,3 +1,4 @@
+import { JSONContent } from '@tloncorp/api/urbit';
 import { ChannelAction } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Attachment } from '@tloncorp/shared/domain';
@@ -143,6 +144,14 @@ const ConnectedAction = memo(function ConnectedAction({
         // Quote needs the active composer surface. Search/detail surfaces can
         // render actions without one, so hide Quote there.
         return !!draftInputContext?.canStartDraft;
+      case 'replyToComment':
+        // Only show on actual comments (replies), and only where a composer
+        // is mounted to receive the prefilled mention.
+        return (
+          !!post.parentId &&
+          post.authorId !== currentUserId &&
+          !!draftInputContext?.canStartDraft
+        );
       default:
         return true;
     }
@@ -304,6 +313,9 @@ export async function handleAction({
         addAttachment({ type: 'reference', reference, path });
       }
       break;
+    case 'replyToComment':
+      await prependMentionToDraft(draftTextTarget, post.authorId);
+      break;
     case 'edit':
       onEdit?.();
       break;
@@ -370,6 +382,55 @@ async function prependTextToDraft(
       }))
     )
   );
+  ctx.startDraft?.();
+}
+
+async function prependMentionToDraft(
+  ctx: DraftTextTarget | null | undefined,
+  authorId: string
+) {
+  if (!ctx) {
+    throw new Error('Cannot prepend mention without a draft input context');
+  }
+
+  const draft = await ctx.getDraft();
+  const firstChild = draft?.content?.[0]?.content?.[0];
+  // No-op if the draft already starts with this mention.
+  if (
+    firstChild?.type === 'mention' &&
+    firstChild.attrs?.id === authorId
+  ) {
+    ctx.startDraft?.();
+    return;
+  }
+
+  const mentionNode: JSONContent = {
+    type: 'mention',
+    attrs: { id: authorId },
+  };
+  const spaceNode: JSONContent = { type: 'text', text: ' ' };
+
+  // Splice the mention + space into the first paragraph of the existing
+  // draft. Editing the JSON directly preserves the trailing space, which
+  // textAndMentionsToContent would otherwise trim away on an empty draft.
+  const existingDocContent = draft?.content ?? [];
+  const [firstBlock, ...restBlocks] = existingDocContent;
+  const firstParagraphContent =
+    firstBlock?.type === 'paragraph' ? firstBlock.content ?? [] : [];
+
+  const nextFirstParagraph: JSONContent = {
+    type: 'paragraph',
+    content: [mentionNode, spaceNode, ...firstParagraphContent],
+  };
+  const nextDocContent =
+    firstBlock?.type === 'paragraph'
+      ? [nextFirstParagraph, ...restBlocks]
+      : [nextFirstParagraph, ...existingDocContent];
+
+  await ctx.storeDraft({
+    ...(draft ?? { type: 'doc' }),
+    content: nextDocContent,
+  });
   ctx.startDraft?.();
 }
 
@@ -446,6 +507,9 @@ export function useDisplaySpecForChannelActionId(
 
       case 'quote':
         return { label: 'Quote' };
+
+      case 'replyToComment':
+        return { label: 'Reply' };
 
       case 'report':
         return {

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -396,10 +396,7 @@ async function prependMentionToDraft(
   const draft = await ctx.getDraft();
   const firstChild = draft?.content?.[0]?.content?.[0];
   // No-op if the draft already starts with this mention.
-  if (
-    firstChild?.type === 'mention' &&
-    firstChild.attrs?.id === authorId
-  ) {
+  if (firstChild?.type === 'mention' && firstChild.attrs?.id === authorId) {
     ctx.startDraft?.();
     return;
   }

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -303,7 +303,14 @@ export function GalleryPostFooter({
     }
   }, [isWindowNarrow]);
 
-  const { data: threadUnread } = store.useLiveThreadUnreadByParentId(post.id);
+  // Ride the ['post', id] per-post invalidation channel instead of the
+  // table-wide one — the gallery grid mounts one footer per post, so a
+  // table-level invalidation would refetch every footer on any thread_unreads
+  // write. See db/changeListener.ts.
+  const { data: postWithUnread } = store.usePostWithThreadUnreads({
+    id: post.id,
+  });
+  const threadUnread = postWithUnread?.threadUnread;
   const unreadCount = threadUnread?.count ?? 0;
   const isNotify = threadUnread?.notify ?? false;
 

--- a/packages/app/ui/components/GalleryPost/GalleryPost.tsx
+++ b/packages/app/ui/components/GalleryPost/GalleryPost.tsx
@@ -27,6 +27,7 @@ import { useCurrentUserId } from '../../contexts/appDataContext';
 import { useChannelContext } from '../../contexts/channel';
 import type { MinimalRenderItemProps } from '../../contexts/componentsKits';
 import { useRequests } from '../../contexts/requests';
+import { useStore } from '../../contexts/storeContext';
 import { useCanWrite } from '../../utils/channelUtils';
 import { DetailViewAuthorRow } from '../AuthorRow';
 import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component';
@@ -37,6 +38,7 @@ import { Reference } from '../ContentReference/Reference';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
 import { usePostContent } from '../PostContent/contentUtils';
 import { PostModeration } from '../PostModeration';
+import { UnreadDot } from '../UnreadDot';
 import { useBoundHandler } from '../listItems/listItemUtils';
 import { GalleryContentRenderer } from './GalleryContentRenderer';
 
@@ -292,6 +294,7 @@ export function GalleryPostFooter({
   onPressRetry?: () => void;
 } & ComponentProps<typeof XStack>) {
   const isWindowNarrow = useIsWindowNarrow();
+  const store = useStore();
   const retryVerb = useMemo(() => {
     if (isWindowNarrow) {
       return 'Tap';
@@ -299,6 +302,10 @@ export function GalleryPostFooter({
       return 'Click';
     }
   }, [isWindowNarrow]);
+
+  const { data: threadUnread } = store.useLiveThreadUnreadByParentId(post.id);
+  const unreadCount = threadUnread?.count ?? 0;
+  const isNotify = threadUnread?.notify ?? false;
 
   return (
     <View width="100%" pointerEvents="box-none">
@@ -325,6 +332,12 @@ export function GalleryPostFooter({
           </Pressable>
         ) : (
           <XStack alignItems="center" gap="$xs" justifyContent="center">
+            {unreadCount > 0 && (
+              <UnreadDot
+                testID="GalleryPostUnreadDot"
+                color={isNotify ? 'primary' : 'neutral'}
+              />
+            )}
             <Text size="$label/m" color="$tertiaryText">
               {post.replyCount}
             </Text>


### PR DESCRIPTION
## Summary

Adds a "reply" action to Gallery comments that pre-fills the comment author's @p into the draft, allowing the user to mention the comment author directly. Fixes TLON-4695 where @HoonMasterWalt felt strange replying to the entire comment thread rather than a single comment.

Also adds an unread or notification marker for qualifying posts in Galleries, something we've been missing for some time.

## Changes

- Adds a `prependMentionToDraft` method to `MessageActions` which accepts an input @p and pre-fills a mention into the draft input context. 
- Makes use of this method in `replyToComment` for Gallery comment threads. I could foresee this being useful elsewhere, but is limited to this application for now.
- Adds a notification-aware `UnreadDot` to Gallery blocks. Appears gray if new comments are present, is blue if there's a notification-qualifying reply in there.

## How did I test?

Interactively, on desktop/web.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

git revert

## Screenshots / videos

https://github.com/user-attachments/assets/d3160561-0be1-4e65-830d-c42bb96e9117


