### PR TITLE
BlockRenderer: fix table rendering on mobile

### DIFF
--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -30,6 +30,7 @@ import {
   Linking,
   Platform,
 } from 'react-native';
+import { ScrollView as GHScrollView } from 'react-native-gesture-handler';
 import { ScrollView, View, ViewStyle, XStack, YStack, styled } from 'tamagui';
 
 import { useNowPlayingController } from '../../contexts/nowPlaying';
@@ -695,8 +696,6 @@ function alignToTextAlign(
 
 const TABLE_MAX_COLUMN_WIDTH = 280;
 
-type TablePhase = 'measure-natural' | 'measure-wrapped' | 'done';
-
 export function TableBlock({ block }: { block: cn.TableBlockData }) {
   const columnCount = Math.max(
     block.header.cells.length,
@@ -705,119 +704,73 @@ export function TableBlock({ block }: { block: cn.TableBlockData }) {
   const allRows = [block.header, ...block.rows];
   const totalCells = columnCount * allRows.length;
 
-  const naturalDimsRef = useRef<Map<string, { w: number; h: number }>>(
-    new Map()
-  );
-  const finalHeightsRef = useRef<Map<string, number>>(new Map());
-  const pendingRef = useRef<Set<string>>(new Set());
-
-  const [phase, setPhase] = useState<TablePhase>('measure-natural');
+  const naturalWidthsRef = useRef<Map<string, number>>(new Map());
   const [columnWidths, setColumnWidths] = useState<number[] | null>(null);
-  const [rowHeights, setRowHeights] = useState<number[] | null>(null);
 
   // Reset measurement state when the block changes — ContentRenderer keys
   // children by array index, so an edited post can land a new table at the
   // same index and reuse this component instance.
   useEffect(() => {
-    setPhase('measure-natural');
     setColumnWidths(null);
-    setRowHeights(null);
-    naturalDimsRef.current.clear();
-    finalHeightsRef.current.clear();
-    pendingRef.current.clear();
+    naturalWidthsRef.current.clear();
   }, [block]);
-
-  const finalizeHeights = useCallback(() => {
-    const heights: number[] = [];
-    for (let row = 0; row < allRows.length; row++) {
-      let max = 0;
-      for (let col = 0; col < columnCount; col++) {
-        max = Math.max(max, finalHeightsRef.current.get(`${row}-${col}`) ?? 0);
-      }
-      heights.push(max);
-    }
-    setRowHeights(heights);
-    setPhase('done');
-  }, [columnCount, allRows.length]);
 
   const handleCellLayout = useCallback(
     (rowIdx: number, colIdx: number) => (e: LayoutChangeEvent) => {
+      if (columnWidths !== null) return;
       const key = `${rowIdx}-${colIdx}`;
-      const { width, height } = e.nativeEvent.layout;
-
-      if (phase === 'measure-natural') {
-        naturalDimsRef.current.set(key, { w: width, h: height });
-        if (naturalDimsRef.current.size < totalCells) return;
-
-        const widths: number[] = [];
-        for (let col = 0; col < columnCount; col++) {
-          let max = 0;
-          for (let row = 0; row < allRows.length; row++) {
-            max = Math.max(max, naturalDimsRef.current.get(`${row}-${col}`)!.w);
-          }
-          widths.push(Math.min(max, TABLE_MAX_COLUMN_WIDTH));
-        }
-
-        // For cells whose natural width fits the (possibly capped) column,
-        // their natural height is the final height. For cells that exceed the
-        // cap, we mark them pending — they'll re-layout after widths apply.
+      naturalWidthsRef.current.set(key, e.nativeEvent.layout.width);
+      if (naturalWidthsRef.current.size < totalCells) return;
+      const widths: number[] = [];
+      for (let col = 0; col < columnCount; col++) {
+        let max = 0;
         for (let row = 0; row < allRows.length; row++) {
-          for (let col = 0; col < columnCount; col++) {
-            const k = `${row}-${col}`;
-            const dims = naturalDimsRef.current.get(k)!;
-            if (dims.w > widths[col]) {
-              pendingRef.current.add(k);
-            } else {
-              finalHeightsRef.current.set(k, dims.h);
-            }
-          }
+          max = Math.max(max, naturalWidthsRef.current.get(`${row}-${col}`)!);
         }
-
-        setColumnWidths(widths);
-
-        if (pendingRef.current.size === 0) {
-          finalizeHeights();
-        } else {
-          setPhase('measure-wrapped');
-        }
-        return;
+        widths.push(Math.min(max, TABLE_MAX_COLUMN_WIDTH));
       }
-
-      if (phase === 'measure-wrapped') {
-        if (!pendingRef.current.has(key)) return;
-        finalHeightsRef.current.set(key, height);
-        pendingRef.current.delete(key);
-        if (pendingRef.current.size === 0) {
-          finalizeHeights();
-        }
-      }
+      setColumnWidths(widths);
     },
-    [phase, columnCount, allRows.length, totalCells, finalizeHeights]
+    [columnWidths, columnCount, allRows.length, totalCells]
   );
 
+  const totalWidth = columnWidths?.reduce((a, b) => a + b, 0);
+
+  // Use react-native-gesture-handler's ScrollView so horizontal pans aren't
+  // swallowed by the vertical FlatList that wraps each chat message —
+  // RN's stock ScrollView shares the JS responder system with the parent and
+  // loses the gesture race; the GH version uses native gesture recognizers.
   return (
-    <ScrollView horizontal width="100%" maxWidth="100%">
-      <XStack opacity={phase === 'done' ? 1 : 0}>
-        {Array.from({ length: columnCount }).map((_, colIdx) => {
-          const align = block.align[colIdx] ?? null;
-          const textAlign = alignToTextAlign(align);
-          const colWidth = columnWidths?.[colIdx];
+    <GHScrollView
+      horizontal
+      style={{ width: '100%', maxWidth: '100%' }}
+      showsHorizontalScrollIndicator={false}
+    >
+      <YStack {...(totalWidth != null ? { width: totalWidth } : {})}>
+        {allRows.map((row, rowIdx) => {
+          const isHeader = rowIdx === 0;
           return (
-            <YStack key={colIdx}>
-              {allRows.map((row, rowIdx) => {
+            <XStack
+              key={rowIdx}
+              flexShrink={0}
+              borderBottomWidth={rowIdx < allRows.length - 1 ? 1 : 0}
+              borderColor="$border"
+            >
+              {Array.from({ length: columnCount }).map((_, colIdx) => {
                 const cell = row.cells[colIdx] ?? { content: [] };
-                const isHeader = rowIdx === 0;
-                const rowHeight = rowHeights?.[rowIdx];
+                const align = block.align[colIdx] ?? null;
+                const textAlign = alignToTextAlign(align);
+                const colWidth = columnWidths?.[colIdx];
                 return (
                   <View
-                    key={rowIdx}
+                    key={colIdx}
+                    flexShrink={0}
                     paddingVertical="$xl"
                     paddingLeft={colIdx === 0 ? 0 : '$l'}
                     paddingRight="$l"
-                    borderBottomWidth={rowIdx < allRows.length - 1 ? 1 : 0}
-                    borderColor="$border"
-                    {...(colWidth != null ? { width: colWidth } : {})}
-                    {...(rowHeight != null ? { minHeight: rowHeight } : {})}
+                    {...(colWidth != null
+                      ? { width: colWidth }
+                      : { maxWidth: TABLE_MAX_COLUMN_WIDTH })}
                     onLayout={handleCellLayout(rowIdx, colIdx)}
                   >
                     <LineRenderer
@@ -829,11 +782,11 @@ export function TableBlock({ block }: { block: cn.TableBlockData }) {
                   </View>
                 );
               })}
-            </YStack>
+            </XStack>
           );
         })}
-      </XStack>
-    </ScrollView>
+      </YStack>
+    </GHScrollView>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes TLON-5840 by making several changes to the Markdown table renderer in `BlockRenderer`.

## Changes

1. Implements a simpler cell measurement pass by (1) swapping from a column-major layout to a row-major layout and (2) setting a default width for cells and then measuring/adjusting rather than using a state machine. This cuts down on measurement time significantly and therefore...
2. Eliminates the opacity switch when finished measuring. We were seeing the table not initially appear in TLON-5840 because React Native was not properly retargeting the element ref and would miss the `opacity=1` switch.
3. Uses `react-native-gesture-handler` for a horizontal ScrollView around the table element within the Chat scroller. The Tamagui JS events in `ScrollView` were getting eaten by the parent element; this uses native gestures and works.


## How did I test?

Reproduced the issues in the iOS simulator using an existing Markdown table which rendered fine on the web. Applied fixes, re-tested in sim, confirmed working.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Channel display
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

git revert

## Screenshots / videos

Forthcoming.
