### PR TITLE
activity: default %react volume to silent

### DIFF
--- a/desk/sur/activity.hoon
+++ b/desk/sur/activity.hoon
@@ -257,7 +257,7 @@
   %-  my
   :~  [%post & &]
       [%reply & |]
-      [%react | &]
+      [%react | |]
       [%post-mention & &]
       [%reply-mention & &]
       [%dm-invite & &]


### PR DESCRIPTION
## Summary

All reacts in groups were producing notifications, which I not what we wanted. This silences them by default, however doesn't address the fact that right now your only option would be to turn all reactions on or all reactions off. We should probably follow up with another PR to make this work similar to mentions so that you can have notifications for reactions to your posts vs others.

## Changes

- `desk/sur/activity.hoon`: change `default-volumes` entry for `%react` from `[| &]` (no unread, notify) to `[| |]` (no unread, no notify). `%dm-react` is left at `[| &]`.

## How did I test?

- Verified the diff is the single-line default change.
- Traced the volume lookup through `lib/activity.hoon:get-volume` and `app/activity.hoon:add-event` (line 902 gates the `/v4/notifications` and `/v5/notifications` facts on `notify`).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

Only affects fresh defaults. Users who already migrated through v9→v10 have `[%react | &]` baked into their stored `%base` volume-map and will need a manual poke to pick up the new default.

A follow-up branch will distinguish "react on my post" from "react on others' posts" so reacts on your own posts can notify independently (mirroring `%post-mention`).

## Rollback plan

Revert this commit. Defaults flip back to `[%react | &]`; users who never customized their react volume start notifying on reacts again.

## Screenshots / videos

N/A