### PR TITLE
channels: only emit react activity for reacts on our own posts

### DIFF
--- a/desk/app/channels.hoon
+++ b/desk/app/channels.hoon
@@ -1822,7 +1822,9 @@
       =/  =message-key
         [[post-author id.post] id.post]
       =/  =source  [%channel nest group.perm.channel]
+      =/  post-is-ours  =(post-author our.bowl)
       =/  del-actions=(list action)
+        ?.  post-is-ours  ~
         %+  roll  ~(tap by old)
         |=  [[=author:d =react:d] actions=(list action)]
         =/  new-react=(unit react:d)  (~(get by new) author)
@@ -1838,6 +1840,7 @@
         ?:  =(author-ship our.bowl)
           :_  actions
           [%read source [%all `now.bowl |]]
+        ?.  post-is-ours  actions
         ?:  (blocked author-ship)  actions
         :_  actions
         [%add %react message-key ~ nest group.perm.channel author react]
@@ -1921,7 +1924,9 @@
       =/  reply-key
         [[reply-author id.reply] id.reply]
       =/  =source  [%thread parent-key nest group.perm.channel]
+      =/  reply-is-ours  =(reply-author our.bowl)
       =/  del-actions=(list action)
+        ?.  reply-is-ours  ~
         %+  roll  ~(tap by old)
         |=  [[=author:d =react:d] actions=(list action)]
         =/  new-react=(unit react:d)  (~(get by new) author)
@@ -1937,6 +1942,7 @@
         ?:  =(author-ship our.bowl)
           :_  actions
           [%read source [%all `now.bowl |]]
+        ?.  reply-is-ours  actions
         ?:  (blocked author-ship)  actions
         :_  actions
         [%add %react reply-key `parent-key nest group.perm.channel author react]


### PR DESCRIPTION
## Summary

We were seeing reactions for others' posts which was not the intention with this feature. This simply filters sending any reaction activity events to only our posts. DMs already handle this case so we only needed to change channels.

## Changes

- `desk/app/channels.hoon` `on-post-react`: gate `%del-event` and `%add %react` emission on `=(post-author our.bowl)`. The `%read source` action for our own reacts is preserved (fires regardless of post authorship).
- `desk/app/channels.hoon` `on-reply-react`: same gating, but on `=(reply-author our.bowl)` — i.e., the reply being reacted to is ours.
- DMs / clubs (`chat.hoon`) are unchanged. They already only emit `%dm-react` events for reacts from others, and DM spaces are small enough that every react is relevant.

## How did I test?

- Traced both handlers end-to-end against the activity routing in `desk/app/activity.hoon:884` (`add-event`) and the volume lookup in `desk/lib/activity.hoon:209` (`get-volume`) to confirm no other code path emits `%add %react` for group channels.
- Verified `on-post-react` / `on-reply-react` are invoked from `ca-u-post` / `ca-u-reply` (`channels.hoon:2573, 2643`), which run on each subscriber's local ship — so the `our.bowl` filter is correctly per-user.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

Behavior change, not a data change — no state version bump or migration needed. Existing activity entries for reacts on others' posts persist until read.

A user who *wanted* to see all reacts on others' posts loses that capability. There is no per-source override for this; if the demand surfaces, the follow-up is to add a `to-self` flag and split `%react` / `%react-to-self` in the event-type, mirroring the `%post-mention` precedent.

## Rollback plan

Revert the commit. `on-post-react` / `on-reply-react` go back to emitting `%add %react` for every non-self, non-blocked react regardless of post authorship.

## Screenshots / videos

N/A