### PR TITLE
fix stuck sends on missing poke ack

### DIFF
--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -559,7 +559,7 @@ export class Urbit {
     });
 
     this.outstandingPokes.forEach((poke) => {
-      poke.onError?.('Channel was reaped');
+      poke.onError?.(new ReapError('Channel was reaped'));
     });
     this.outstandingPokes = new Map();
   }

--- a/packages/api/src/http-api/Urbit.ts
+++ b/packages/api/src/http-api/Urbit.ts
@@ -15,6 +15,7 @@ import {
   FatalError,
   Message,
   NounPokeInterface,
+  PokeAckTimeoutError,
   PokeHandlers,
   PokeInterface,
   ReapError,
@@ -28,6 +29,7 @@ import {
 import { hexString, unpackJamBytes } from './utils';
 
 const logger = createDevLogger('UrbitHttpApi', false);
+const DEFAULT_POKE_ACK_TIMEOUT = 30000;
 const isBrowser =
   typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
@@ -768,17 +770,34 @@ export class Urbit {
     };
 
     return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(ackTimer);
+        this.outstandingPokes.delete(message.id);
+      };
       this.outstandingPokes.set(message.id, {
         onSuccess: () => {
+          cleanup();
           onSuccess();
           resolve(message.id);
         },
         onError: (err) => {
+          cleanup();
           onError(err);
           reject(err);
         },
       });
-      this.sendJSONtoChannel(message).catch(reject);
+
+      const ackTimer = setTimeout(() => {
+        cleanup();
+        const err = new PokeAckTimeoutError(DEFAULT_POKE_ACK_TIMEOUT);
+        onError(err);
+        reject(err);
+      }, DEFAULT_POKE_ACK_TIMEOUT);
+
+      this.sendJSONtoChannel(message).catch((err) => {
+        cleanup();
+        reject(err);
+      });
     });
   }
 

--- a/packages/api/src/http-api/types.ts
+++ b/packages/api/src/http-api/types.ts
@@ -156,6 +156,13 @@ export interface PokeHandlers {
   onError?: (e: any) => void;
 }
 
+export class PokeAckTimeoutError extends Error {
+  constructor(timeout: number) {
+    super(`Poke ack timed out after ${timeout}ms`);
+    this.name = 'PokeAckTimeoutError';
+  }
+}
+
 export type PokeInterface<T> = PokeHandlers & Poke<T>;
 export type NounPokeInterface = PokeHandlers & NounPoke;
 

--- a/packages/shared/src/store/SessionActionQueue.ts
+++ b/packages/shared/src/store/SessionActionQueue.ts
@@ -1,16 +1,21 @@
 import { logger } from './postActions/logger';
 import { Session, getSession, subscribeToSession } from './session';
 
+type OperationMetadata = Record<string, unknown>;
+
 class SessionActionQueue {
   connected: boolean = true;
 
   pendingOperations: {
-    action: () => Promise<any>;
-    resolve: (result: any) => void;
+    action: () => Promise<unknown>;
+    resolve: (result: unknown) => void;
     reject: (err: unknown) => void;
+    metadata?: OperationMetadata;
+    enqueuedAt: number;
   }[] = [];
 
   private isProcessing: boolean = false;
+  private loggedOfflineBlock: boolean = false;
 
   constructor() {
     this.setConnectedFromSession(getSession());
@@ -24,14 +29,19 @@ class SessionActionQueue {
     this.connected =
       session?.channelStatus === 'active' ||
       session?.channelStatus === 'reconnected';
+    if (this.connected) {
+      this.loggedOfflineBlock = false;
+    }
   }
 
-  add<T>(action: () => Promise<T>) {
+  add<T>(action: () => Promise<T>, metadata?: OperationMetadata) {
     return new Promise<T>((resolve, reject) => {
       const operation = {
-        action,
-        resolve,
+        enqueuedAt: Date.now(),
+        action: action as () => Promise<unknown>,
+        resolve: (result: unknown) => resolve(result as T),
         reject,
+        metadata,
       };
       this.pendingOperations.push(operation);
       if (this.pendingOperations.length === 1) {
@@ -52,6 +62,10 @@ class SessionActionQueue {
       while (this.pendingOperations.length > 0) {
         if (!this.connected) {
           logger.log('not connected, quitting queue processing');
+          if (!this.loggedOfflineBlock) {
+            this.loggedOfflineBlock = true;
+            this.trackQueueEvent('blocked_offline', this.pendingOperations[0]);
+          }
           return;
         }
 
@@ -63,6 +77,10 @@ class SessionActionQueue {
           try {
             operation.resolve(await promise);
           } catch (e) {
+            this.trackQueueEvent('failed', operation, {
+              errorType: e instanceof Error ? e.name : typeof e,
+              errorMessage: e instanceof Error ? e.message : String(e),
+            });
             operation.reject(e);
           }
         }
@@ -70,6 +88,23 @@ class SessionActionQueue {
     } finally {
       this.isProcessing = false;
     }
+  }
+
+  private trackQueueEvent(
+    phase: string,
+    operation?: (typeof this.pendingOperations)[number],
+    extra?: OperationMetadata
+  ) {
+    const session = getSession();
+    logger.trackEvent('Session Action Queue Debug', {
+      phase,
+      queueDepth: this.pendingOperations.length,
+      connected: this.connected,
+      channelStatus: session?.channelStatus ?? null,
+      queuedMs: operation ? Date.now() - operation.enqueuedAt : undefined,
+      ...operation?.metadata,
+      ...extra,
+    });
   }
 }
 

--- a/packages/shared/src/store/postActions/postActions.ts
+++ b/packages/shared/src/store/postActions/postActions.ts
@@ -368,6 +368,7 @@ async function _sendPost({
     // the client didn't get the confirmation
     const errorMsg = e.message?.toLowerCase() || '';
     const isConnectionRelated =
+      e.name === 'PokeAckTimeoutError' ||
       errorMsg === 'aborted' ||
       errorMsg.includes('channel was reaped') ||
       errorMsg.includes('fetch timed out');

--- a/packages/shared/src/store/postActions/postActions.ts
+++ b/packages/shared/src/store/postActions/postActions.ts
@@ -274,73 +274,74 @@ async function _sendPost({
       channelId: channel.id,
       parentId: cachePost.parentId ?? null,
     };
-    const trackSendDebug = (
-      phase: string,
-      extra?: Record<string, unknown>
-    ) => logger.trackEvent('Post Send Debug', { ...debug, phase, ...extra });
+    const trackSendDebug = (phase: string, extra?: Record<string, unknown>) =>
+      logger.trackEvent('Post Send Debug', { ...debug, phase, ...extra });
 
     // Ensure uploads are started. Uploads are likely already started in UI,
     // but may as well make sure they're started here to avoid blocking in
     // SessionActionQueue.
     const finalizedPostDataPromise = buildFinalizedPostData();
 
-    await sessionActionQueue.add(async () => {
-      logger.crumb('finalizing post');
-      trackSendDebug('queue_action_started');
-      const finalizedPostData = await finalizedPostDataPromise;
+    await sessionActionQueue.add(
+      async () => {
+        logger.crumb('finalizing post');
+        trackSendDebug('queue_action_started');
+        const finalizedPostData = await finalizedPostDataPromise;
 
-      logger.crumb('updating post in db with finalized data');
-      await db.updatePost({
-        id: cachePost.id,
-        ...db.buildPostUpdate({
+        logger.crumb('updating post in db with finalized data');
+        await db.updatePost({
           id: cachePost.id,
-          content: finalizedPostData.content,
-          metadata: finalizedPostData.metadata,
-          blob: finalizedPostData.blob,
-          deliveryStatus: 'pending',
-          parentId: finalizedPostData.replyToPostId,
-        }),
-      });
+          ...db.buildPostUpdate({
+            id: cachePost.id,
+            content: finalizedPostData.content,
+            metadata: finalizedPostData.metadata,
+            blob: finalizedPostData.blob,
+            deliveryStatus: 'pending',
+            parentId: finalizedPostData.replyToPostId,
+          }),
+        });
 
-      // Send to the appropriate API endpoint based on whether this is a reply
-      if (finalizedPostData.replyToPostId != null) {
-        // Reply - look up parent author from DB
-        const parentPost = await db.getPost({
-          postId: finalizedPostData.replyToPostId,
-        });
-        if (parentPost == null) {
-          throw new Error(
-            `Parent post ${finalizedPostData.replyToPostId} not found for thread send`
-          );
+        // Send to the appropriate API endpoint based on whether this is a reply
+        if (finalizedPostData.replyToPostId != null) {
+          // Reply - look up parent author from DB
+          const parentPost = await db.getPost({
+            postId: finalizedPostData.replyToPostId,
+          });
+          if (parentPost == null) {
+            throw new Error(
+              `Parent post ${finalizedPostData.replyToPostId} not found for thread send`
+            );
+          }
+          logger.crumb('sending reply to API');
+          trackSendDebug('api_send_started', { operation: 'sendReply' });
+          return api.sendReply({
+            channelId: channel.id,
+            parentId: finalizedPostData.replyToPostId,
+            parentAuthor: parentPost.authorId,
+            authorId,
+            content: finalizedPostData.content,
+            blob: finalizedPostData.blob,
+            sentAt: cachePost.sentAt,
+          });
+        } else {
+          // Non-reply
+          logger.crumb('sending post to API');
+          trackSendDebug('api_send_started', { operation: 'sendPost' });
+          return api.sendPost({
+            channelId: channel.id,
+            authorId,
+            content: finalizedPostData.content,
+            blob: finalizedPostData.blob,
+            metadata: finalizedPostData.metadata,
+            sentAt: cachePost.sentAt,
+          });
         }
-        logger.crumb('sending reply to API');
-        trackSendDebug('api_send_started', { operation: 'sendReply' });
-        return api.sendReply({
-          channelId: channel.id,
-          parentId: finalizedPostData.replyToPostId,
-          parentAuthor: parentPost.authorId,
-          authorId,
-          content: finalizedPostData.content,
-          blob: finalizedPostData.blob,
-          sentAt: cachePost.sentAt,
-        });
-      } else {
-        // Non-reply
-        logger.crumb('sending post to API');
-        trackSendDebug('api_send_started', { operation: 'sendPost' });
-        return api.sendPost({
-          channelId: channel.id,
-          authorId,
-          content: finalizedPostData.content,
-          blob: finalizedPostData.blob,
-          metadata: finalizedPostData.metadata,
-          sentAt: cachePost.sentAt,
-        });
+      },
+      {
+        operation: cachePost.parentId == null ? 'sendPost' : 'sendReply',
+        ...debug,
       }
-    }, {
-      operation: cachePost.parentId == null ? 'sendPost' : 'sendReply',
-      ...debug,
-    });
+    );
     logger.crumb('sent post to backend, syncing channel message delivery');
     sync.syncChannelMessageDelivery({ channelId: channel.id });
 

--- a/packages/shared/src/store/postActions/postActions.ts
+++ b/packages/shared/src/store/postActions/postActions.ts
@@ -269,6 +269,15 @@ async function _sendPost({
   logger.crumb('done optimistic update');
   try {
     logger.crumb('enqueuing sending post to backend');
+    const debug = {
+      postId: cachePost.id,
+      channelId: channel.id,
+      parentId: cachePost.parentId ?? null,
+    };
+    const trackSendDebug = (
+      phase: string,
+      extra?: Record<string, unknown>
+    ) => logger.trackEvent('Post Send Debug', { ...debug, phase, ...extra });
 
     // Ensure uploads are started. Uploads are likely already started in UI,
     // but may as well make sure they're started here to avoid blocking in
@@ -277,6 +286,7 @@ async function _sendPost({
 
     await sessionActionQueue.add(async () => {
       logger.crumb('finalizing post');
+      trackSendDebug('queue_action_started');
       const finalizedPostData = await finalizedPostDataPromise;
 
       logger.crumb('updating post in db with finalized data');
@@ -304,6 +314,7 @@ async function _sendPost({
           );
         }
         logger.crumb('sending reply to API');
+        trackSendDebug('api_send_started', { operation: 'sendReply' });
         return api.sendReply({
           channelId: channel.id,
           parentId: finalizedPostData.replyToPostId,
@@ -316,6 +327,7 @@ async function _sendPost({
       } else {
         // Non-reply
         logger.crumb('sending post to API');
+        trackSendDebug('api_send_started', { operation: 'sendPost' });
         return api.sendPost({
           channelId: channel.id,
           authorId,
@@ -325,6 +337,9 @@ async function _sendPost({
           sentAt: cachePost.sentAt,
         });
       }
+    }, {
+      operation: cachePost.parentId == null ? 'sendPost' : 'sendReply',
+      ...debug,
     });
     logger.crumb('sent post to backend, syncing channel message delivery');
     sync.syncChannelMessageDelivery({ channelId: channel.id });


### PR DESCRIPTION
## Summary

This makes plain pokes time out instead of keeping the send queue stuck forever. When a send times out waiting for the poke ack, we mark the optimistic post as `needs_verification` so sync can decide whether the ship accepted it.

Fixes TLON-5844

## Changes

- Add a poke ack timeout for plain `Urbit.poke()`.
- Treat poke ack timeout as a connection-related send error, moving the post to `needs_verification`.
- Add focused send/queue logging for blocked offline, queue action started, API send started, and queue failures.

## How did I test?

Tested on device
