### PR TITLE
Add A2UI chat action confirmation

### DIFF
--- a/docs/post-blobs.md
+++ b/docs/post-blobs.md
@@ -86,9 +86,9 @@ The current renderer expects one `createSurface` message and one `updateComponen
 The supported v1 client subset is intentionally small:
 
 - components: `Card`, `Column`, `Row`, `Text`, `Divider`, and `Button`
-- button actions: `tlon.sendMessage`, currently scoped to explicit compile-request cards (for example, sending `lore confirm compile`) through the current draft context after user confirmation
+- button actions: `tlon.sendMessage`, currently scoped to post-ingest compile-request cards (for example, sending `lore confirm compile`) through the current draft context after user confirmation
 - rendering policy: A2UI blocks render in chat-like surfaces (DMs, group DMs, and group/channel chats) and are suppressed in search/read-only render paths where no active chat context is available
-- action policy: buttons are disabled when the current user cannot draft/send in that context. Pressing an enabled compile-request button opens a confirmation prompt that shows the A2UI action name, button label/fallback, exact text that will be sent, and destination channel/context before anything is sent.
+- action policy: buttons are disabled when the current user cannot draft/send in that context. Pressing an enabled post-ingest compile-request button opens a confirmation prompt that shows the A2UI action name, button label/fallback, exact text that will be sent, and destination channel/context before anything is sent.
 - validation limits: component count, tree depth, text length, button count, and expanded render size
 
 ## Read/write behavior

--- a/docs/post-blobs.md
+++ b/docs/post-blobs.md
@@ -86,9 +86,9 @@ The current renderer expects one `createSurface` message and one `updateComponen
 The supported v1 client subset is intentionally small:
 
 - components: `Card`, `Column`, `Row`, `Text`, `Divider`, and `Button`
-- button actions: `tlon.sendMessage`, which sends text through the current draft context after user confirmation
+- button actions: `tlon.sendMessage`, currently scoped to explicit compile-request cards (for example, sending `lore confirm compile`) through the current draft context after user confirmation
 - rendering policy: A2UI blocks render in chat-like surfaces (DMs, group DMs, and group/channel chats) and are suppressed in search/read-only render paths where no active chat context is available
-- action policy: buttons are disabled when the current user cannot draft/send in that context. Pressing an enabled button opens a confirmation prompt that shows the A2UI action name, button label/fallback, exact text that will be sent, and destination channel/context before anything is sent.
+- action policy: buttons are disabled when the current user cannot draft/send in that context. Pressing an enabled compile-request button opens a confirmation prompt that shows the A2UI action name, button label/fallback, exact text that will be sent, and destination channel/context before anything is sent.
 - validation limits: component count, tree depth, text length, button count, and expanded render size
 
 ## Read/write behavior

--- a/docs/post-blobs.md
+++ b/docs/post-blobs.md
@@ -86,8 +86,9 @@ The current renderer expects one `createSurface` message and one `updateComponen
 The supported v1 client subset is intentionally small:
 
 - components: `Card`, `Column`, `Row`, `Text`, `Divider`, and `Button`
-- button actions: `tlon.sendMessage`, which sends visible text in the current DM
-- rendering policy: A2UI blocks render only in direct messages for now
+- button actions: `tlon.sendMessage`, which sends text through the current draft context after user confirmation
+- rendering policy: A2UI blocks render in chat-like surfaces (DMs, group DMs, and group/channel chats) and are suppressed in search/read-only render paths where no active chat context is available
+- action policy: buttons are disabled when the current user cannot draft/send in that context. Pressing an enabled button opens a confirmation prompt that shows the A2UI action name, button label/fallback, exact text that will be sent, and destination channel/context before anything is sent.
 - validation limits: component count, tree depth, text length, button count, and expanded render size
 
 ## Read/write behavior

--- a/packages/api/src/__tests__/a2ui.test.ts
+++ b/packages/api/src/__tests__/a2ui.test.ts
@@ -51,6 +51,37 @@ describe('a2ui blob entries', () => {
     expect(A2UI.validateBlobEntry(a2uiBlobEntry)).toBe(true);
   });
 
+  test('validates direct poke button actions', () => {
+    expect(
+      A2UI.validateBlobEntry({
+        ...a2uiBlobEntry,
+        messages: [
+          a2uiBlobEntry.messages[0],
+          {
+            version: 'v0.9',
+            updateComponents: {
+              surfaceId: 'weather-card',
+              root: 'root',
+              components: [
+                { id: 'root', component: 'Button', child: 'label', action: {
+                  event: {
+                    name: 'tlon.poke',
+                    context: {
+                      app: 'a2ui',
+                      mark: 'a2ui-action',
+                      json: { userAction: { name: 'lore.compile.confirm' } },
+                    },
+                  },
+                } },
+                { id: 'label', component: 'Text', text: 'Compile now' },
+              ],
+            },
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+
   test('parsePostBlob parses supported a2ui entries', () => {
     const blob = appendToPostBlob(undefined, a2uiBlobEntry);
 

--- a/packages/api/src/__tests__/a2ui.test.ts
+++ b/packages/api/src/__tests__/a2ui.test.ts
@@ -63,16 +63,21 @@ describe('a2ui blob entries', () => {
               surfaceId: 'weather-card',
               root: 'root',
               components: [
-                { id: 'root', component: 'Button', child: 'label', action: {
-                  event: {
-                    name: 'tlon.poke',
-                    context: {
-                      app: 'a2ui',
-                      mark: 'a2ui-action',
-                      json: { userAction: { name: 'lore.compile.confirm' } },
+                {
+                  id: 'root',
+                  component: 'Button',
+                  child: 'label',
+                  action: {
+                    event: {
+                      name: 'tlon.poke',
+                      context: {
+                        app: 'a2ui',
+                        mark: 'a2ui-action',
+                        json: { userAction: { name: 'lore.compile.confirm' } },
+                      },
                     },
                   },
-                } },
+                },
                 { id: 'label', component: 'Text', text: 'Compile now' },
               ],
             },

--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -140,7 +140,9 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 function isValidBoundedString(value: unknown, maxLength: number) {
-  return typeof value === 'string' && value.length > 0 && value.length <= maxLength;
+  return (
+    typeof value === 'string' && value.length > 0 && value.length <= maxLength
+  );
 }
 
 function isValidPokeEvent(event: Record<string, unknown>) {
@@ -155,7 +157,9 @@ function isValidPokeEvent(event: Record<string, unknown>) {
     return false;
   }
   try {
-    return JSON.stringify(context.json ?? null).length <= LIMITS.maxPokeJsonLength;
+    return (
+      JSON.stringify(context.json ?? null).length <= LIMITS.maxPokeJsonLength
+    );
   } catch {
     return false;
   }
@@ -338,7 +342,9 @@ function indexComponents(
       if (component.action.event.name === ACTION_SEND_MESSAGE) {
         totalTextLength += component.action.event.context?.text?.length ?? 0;
       } else {
-        totalTextLength += JSON.stringify(component.action.event.context.json ?? null).length;
+        totalTextLength += JSON.stringify(
+          component.action.event.context.json ?? null
+        ).length;
       }
     } else if (component.component === 'Text') {
       totalTextLength += component.text.length;

--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 const ACTION_SEND_MESSAGE = 'tlon.sendMessage';
+const ACTION_POKE = 'tlon.poke';
 
 type ComponentBase = {
   id: string;
@@ -37,8 +38,17 @@ export namespace A2UI {
     };
   };
 
+  export type PokeEvent = {
+    name: typeof ACTION_POKE;
+    context: {
+      app: string;
+      mark: string;
+      json: unknown;
+    };
+  };
+
   export type EventAction = {
-    event: SendMessageEvent;
+    event: SendMessageEvent | PokeEvent;
   };
 
   export type ButtonAction = EventAction;
@@ -88,6 +98,9 @@ const LIMITS = {
   maxButtons: 8,
   maxTextNodeLength: 1000,
   maxButtonMessageLength: 1000,
+  maxPokeAppLength: 128,
+  maxPokeMarkLength: 128,
+  maxPokeJsonLength: 8 * 1024,
   maxTotalTextLength: 8000,
 } as const;
 
@@ -124,6 +137,28 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidBoundedString(value: unknown, maxLength: number) {
+  return typeof value === 'string' && value.length > 0 && value.length <= maxLength;
+}
+
+function isValidPokeEvent(event: Record<string, unknown>) {
+  const context = event.context;
+  if (!isPlainObject(context)) {
+    return false;
+  }
+  if (!isValidBoundedString(context.app, LIMITS.maxPokeAppLength)) {
+    return false;
+  }
+  if (!isValidBoundedString(context.mark, LIMITS.maxPokeMarkLength)) {
+    return false;
+  }
+  try {
+    return JSON.stringify(context.json ?? null).length <= LIMITS.maxPokeJsonLength;
+  } catch {
+    return false;
+  }
 }
 
 function isValidWeight(value: unknown): boolean {
@@ -210,12 +245,13 @@ function validateComponent(component: unknown): component is A2UI.Component {
         isValidButtonVariant(component.variant) &&
         isPlainObject(action) &&
         isPlainObject(event) &&
-        event.name === ACTION_SEND_MESSAGE &&
-        (context === undefined || isPlainObject(context)) &&
-        (context === undefined ||
-          context.text === undefined ||
-          (typeof context.text === 'string' &&
-            context.text.length <= LIMITS.maxButtonMessageLength))
+        ((event.name === ACTION_SEND_MESSAGE &&
+          (context === undefined || isPlainObject(context)) &&
+          (context === undefined ||
+            context.text === undefined ||
+            (typeof context.text === 'string' &&
+              context.text.length <= LIMITS.maxButtonMessageLength))) ||
+          (event.name === ACTION_POKE && isValidPokeEvent(event)))
       );
     }
     default:
@@ -299,7 +335,11 @@ function indexComponents(
     byId.set(component.id, component);
     if (component.component === 'Button') {
       buttonCount += 1;
-      totalTextLength += component.action.event.context?.text?.length ?? 0;
+      if (component.action.event.name === ACTION_SEND_MESSAGE) {
+        totalTextLength += component.action.event.context?.text?.length ?? 0;
+      } else {
+        totalTextLength += JSON.stringify(component.action.event.context.json ?? null).length;
+      }
     } else if (component.component === 'Text') {
       totalTextLength += component.text.length;
     }
@@ -405,6 +445,7 @@ export const blobEntrySchema = z.custom<A2UI.BlobEntry>(validateBlobEntry);
 export const A2UI = {
   action: {
     sendMessage: ACTION_SEND_MESSAGE,
+    poke: ACTION_POKE,
   },
   getUpdateMessage,
   getRootComponentId,

--- a/packages/app/fixtures/A2UI.fixture.tsx
+++ b/packages/app/fixtures/A2UI.fixture.tsx
@@ -271,9 +271,9 @@ function makeCompileRequestA2UI({
 
 const compileRequestA2UI = makeCompileRequestA2UI({
   surfaceId: 'lore-compile-request',
-  title: 'Compile the wiki now?',
-  metadata: ['Requested by ~malmur-halmex', 'Channel: %lore Inbox'],
-  copy: 'This will run the sidecar compiler and mirror updated lore wiki/media outputs.',
+  title: 'New lore is ready to compile',
+  metadata: ['Ingested: The Bitter Lesson', 'Channel: %lore Inbox'],
+  copy: 'The source has been saved. Compile now to update the wiki and mirror fresh outputs.',
 });
 
 const basicComponentsA2UI: A2UI.BlobEntry = {
@@ -498,7 +498,7 @@ const weatherPost = makePost(
 
 const compileRequestPost = makePost(
   exampleContacts.groupAdmin,
-  [verse.inline('Lore compile request')],
+  [verse.inline('lore: ✓ “The Bitter Lesson” → AI & Technology notebook')],
   {
     blob: appendToPostBlob(undefined, compileRequestA2UI),
     channelId: tlonLocalIntros.id,

--- a/packages/app/fixtures/A2UI.fixture.tsx
+++ b/packages/app/fixtures/A2UI.fixture.tsx
@@ -604,7 +604,7 @@ const channelApprovalPost = makePost(
   [verse.inline('Channel mention request from Littel Wolfur (~littel-wolfur)')],
   {
     blob: appendToPostBlob(undefined, channelApprovalA2UI),
-    channelId: dmChannelId,
+    channelId: tlonLocalIntros.id,
     replyCount: 0,
   }
 );
@@ -614,7 +614,7 @@ const groupApprovalPost = makePost(
   [verse.inline('Group invite request from Robin Dasler (~robin-dasler)')],
   {
     blob: appendToPostBlob(undefined, groupApprovalA2UI),
-    channelId: dmChannelId,
+    channelId: tlonLocalIntros.id,
     replyCount: 0,
   }
 );
@@ -637,11 +637,14 @@ const examplePosts = [
   basicComponentsPost,
 ];
 
-function A2UIDraftProvider({ children }: PropsWithChildren) {
+function A2UIDraftProvider({
+  canStartDraft = true,
+  children,
+}: PropsWithChildren<{ canStartDraft?: boolean }>) {
   const [shouldBlur, setShouldBlur] = useState(false);
   const draftContext = useMemo<DraftInputContext>(
     () => ({
-      canStartDraft: true,
+      canStartDraft,
       channel: tlonLocalIntros,
       clearDraft: async () => {},
       configuration: {} as Record<string, JSONValue>,
@@ -659,7 +662,7 @@ function A2UIDraftProvider({ children }: PropsWithChildren) {
       startDraft: () => {},
       storeDraft: async (_content: JSONContent) => {},
     }),
-    [shouldBlur]
+    [canStartDraft, shouldBlur]
   );
 
   return (
@@ -724,9 +727,38 @@ function A2UIExamplesFixture() {
   );
 }
 
+function A2UIReadOnlyExamplesFixture() {
+  return (
+    <FixtureWrapper fillWidth fillHeight>
+      <ChannelProvider value={{ channel: tlonLocalIntros }}>
+        <A2UIDraftProvider canStartDraft={false}>
+          <ScrollView
+            flex={1}
+            contentContainerStyle={{
+              alignItems: 'flex-start',
+              flexDirection: 'column',
+              paddingHorizontal: '$m',
+              paddingVertical: '$2xl',
+            }}
+          >
+            <View maxWidth={520} width="100%">
+              <ChatMessage
+                post={channelApprovalPost}
+                showAuthor={true}
+                showReplies={true}
+              />
+            </View>
+          </ScrollView>
+        </A2UIDraftProvider>
+      </ChannelProvider>
+    </FixtureWrapper>
+  );
+}
+
 export default {
   BasicComponents: () => <A2UIFixture post={basicComponentsPost} />,
   Weather: () => <A2UIFixture post={weatherPost} />,
   ConfirmationDialog: () => <A2UIFixture post={confirmationPost} />,
   Examples: () => <A2UIExamplesFixture />,
+  ReadOnlyDisabledActions: () => <A2UIReadOnlyExamplesFixture />,
 };

--- a/packages/app/fixtures/A2UI.fixture.tsx
+++ b/packages/app/fixtures/A2UI.fixture.tsx
@@ -256,8 +256,22 @@ function makeCompileRequestA2UI({
               child: 'compileLabel',
               action: {
                 event: {
-                  name: 'tlon.sendMessage',
-                  context: { text: 'lore confirm compile' },
+                  name: 'tlon.poke',
+                  context: {
+                    app: 'a2ui',
+                    mark: 'a2ui-action',
+                    json: {
+                      userAction: {
+                        name: 'lore.compile.confirm',
+                        surfaceId,
+                        sourceComponentId: 'compile',
+                      },
+                      tlonContext: {
+                        actionHostShip: '~malmur-halmex',
+                        channelId: 'chat/~malmur-halmex/wjtysuq1-general',
+                      },
+                    },
+                  },
                 },
               },
             },

--- a/packages/app/fixtures/A2UI.fixture.tsx
+++ b/packages/app/fixtures/A2UI.fixture.tsx
@@ -178,44 +178,18 @@ const weatherA2UI: A2UI.BlobEntry = {
   ],
 };
 
-function makeApprovalA2UI({
+function makeCompileRequestA2UI({
   surfaceId,
-  eyebrow,
   title,
   metadata,
   copy,
-  allowNote,
-  requestId,
 }: {
   surfaceId: string;
-  eyebrow: string;
   title: string;
   metadata: string[];
-  copy?: string;
-  allowNote: string;
-  requestId: string;
+  copy: string;
 }): A2UI.BlobEntry {
   const metadataChildren = metadata.map((_, index) => `metadata-${index}`);
-  const bodyChildren = copy
-    ? [
-        'eyebrow',
-        'title',
-        'titleDivider',
-        ...metadataChildren,
-        'copy',
-        'divider',
-        'details',
-        'actions',
-      ]
-    : [
-        'eyebrow',
-        'title',
-        'titleDivider',
-        ...metadataChildren,
-        'divider',
-        'details',
-        'actions',
-      ];
 
   return {
     type: 'a2ui',
@@ -234,24 +208,26 @@ function makeApprovalA2UI({
           surfaceId,
           root: 'root',
           components: [
-            { id: 'root', component: 'Card', child: 'body' },
+            { id: 'root', component: 'Card', child: 'main-column' },
             {
-              id: 'body',
+              id: 'main-column',
               component: 'Column',
-              children: bodyChildren,
+              children: [
+                'eyebrow',
+                'title',
+                'titleDivider',
+                ...metadataChildren,
+                'copy',
+                'actions',
+              ],
             },
             {
               id: 'eyebrow',
               component: 'Text',
               variant: 'caption',
-              text: eyebrow,
+              text: 'Lore compile request',
             },
-            {
-              id: 'title',
-              component: 'Text',
-              variant: 'h3',
-              text: title,
-            },
+            { id: 'title', component: 'Text', variant: 'h2', text: title },
             { id: 'titleDivider', component: 'Divider' },
             ...metadata.map(
               (line, index) =>
@@ -262,71 +238,30 @@ function makeApprovalA2UI({
                   text: line,
                 }) as const
             ),
-            ...(copy
-              ? [
-                  {
-                    id: 'copy',
-                    component: 'Text',
-                    variant: 'caption',
-                    text: copy,
-                  } as const,
-                ]
-              : []),
-            { id: 'divider', component: 'Divider' },
             {
-              id: 'details',
-              component: 'Column',
-              children: ['allowNote'],
-            },
-            {
-              id: 'allowNote',
+              id: 'copy',
               component: 'Text',
               variant: 'caption',
-              text: allowNote,
+              text: copy,
             },
             {
               id: 'actions',
               component: 'Row',
-              children: ['allow', 'reject', 'ban'],
+              children: ['compile'],
             },
             {
-              id: 'allow',
+              id: 'compile',
               component: 'Button',
               variant: 'primary',
-              child: 'allowLabel',
+              child: 'compileLabel',
               action: {
                 event: {
                   name: 'tlon.sendMessage',
-                  context: { text: `/allow ${requestId}` },
+                  context: { text: 'lore confirm compile' },
                 },
               },
             },
-            { id: 'allowLabel', component: 'Text', text: 'Allow' },
-            {
-              id: 'reject',
-              component: 'Button',
-              child: 'rejectLabel',
-              action: {
-                event: {
-                  name: 'tlon.sendMessage',
-                  context: { text: `/reject ${requestId}` },
-                },
-              },
-            },
-            { id: 'rejectLabel', component: 'Text', text: 'Reject' },
-            {
-              id: 'ban',
-              component: 'Button',
-              variant: 'borderless',
-              child: 'banLabel',
-              action: {
-                event: {
-                  name: 'tlon.sendMessage',
-                  context: { text: `/ban ${requestId}` },
-                },
-              },
-            },
-            { id: 'banLabel', component: 'Text', text: 'Block' },
+            { id: 'compileLabel', component: 'Text', text: 'Compile now' },
           ],
         },
       },
@@ -334,39 +269,11 @@ function makeApprovalA2UI({
   };
 }
 
-const confirmationA2UI = makeApprovalA2UI({
-  surfaceId: 'confirm-dm-sampel',
-  eyebrow: 'DM access',
-  title: 'Allow Sam Palnet to DM the bot?',
-  metadata: ['Sender: Sam Palnet (~sampel-palnet)'],
-  copy: 'Message: "Hello, I would like to chat with your bot..."',
-  allowNote:
-    'The bot will be able to read and reply to future DMs from this user.',
-  requestId: 'da1b2',
-});
-
-const channelApprovalA2UI = makeApprovalA2UI({
-  surfaceId: 'confirm-channel-littel',
-  eyebrow: 'Channel access',
-  title: 'Let the bot reply to Littel Wolfur in Design?',
-  metadata: [
-    'Sender: Littel Wolfur (~littel-wolfur)',
-    'Channel: Design',
-    'Group: Garden Club',
-  ],
-  copy: 'Message: "@bearclawd can you review this build before I merge?"',
-  allowNote:
-    'The bot will be able to read and reply to this user in this channel.',
-  requestId: 'c3d4e',
-});
-
-const groupApprovalA2UI = makeApprovalA2UI({
-  surfaceId: 'confirm-group-robin',
-  eyebrow: 'Group invite',
-  title: 'Let the bot join Garden Club?',
-  metadata: ['Inviter: Robin Dasler (~robin-dasler)', 'Group: Garden Club'],
-  allowNote: 'The bot will be able to read and respond in channels it joins.',
-  requestId: 'g5f6a',
+const compileRequestA2UI = makeCompileRequestA2UI({
+  surfaceId: 'lore-compile-request',
+  title: 'Compile the wiki now?',
+  metadata: ['Requested by ~malmur-halmex', 'Channel: %lore Inbox'],
+  copy: 'This will run the sidecar compiler and mirror updated lore wiki/media outputs.',
 });
 
 const basicComponentsA2UI: A2UI.BlobEntry = {
@@ -589,31 +496,11 @@ const weatherPost = makePost(
   }
 );
 
-const confirmationPost = makePost(
+const compileRequestPost = makePost(
   exampleContacts.groupAdmin,
-  [verse.inline('DM request from Sam Palnet (~sampel-palnet)')],
+  [verse.inline('Lore compile request')],
   {
-    blob: appendToPostBlob(undefined, confirmationA2UI),
-    channelId: dmChannelId,
-    replyCount: 0,
-  }
-);
-
-const channelApprovalPost = makePost(
-  exampleContacts.mark,
-  [verse.inline('Channel mention request from Littel Wolfur (~littel-wolfur)')],
-  {
-    blob: appendToPostBlob(undefined, channelApprovalA2UI),
-    channelId: tlonLocalIntros.id,
-    replyCount: 0,
-  }
-);
-
-const groupApprovalPost = makePost(
-  exampleContacts.groupAdmin,
-  [verse.inline('Group invite request from Robin Dasler (~robin-dasler)')],
-  {
-    blob: appendToPostBlob(undefined, groupApprovalA2UI),
+    blob: appendToPostBlob(undefined, compileRequestA2UI),
     channelId: tlonLocalIntros.id,
     replyCount: 0,
   }
@@ -629,13 +516,7 @@ const basicComponentsPost = makePost(
   }
 );
 
-const examplePosts = [
-  weatherPost,
-  confirmationPost,
-  channelApprovalPost,
-  groupApprovalPost,
-  basicComponentsPost,
-];
+const examplePosts = [weatherPost, compileRequestPost, basicComponentsPost];
 
 function A2UIDraftProvider({
   canStartDraft = true,
@@ -743,7 +624,7 @@ function A2UIReadOnlyExamplesFixture() {
           >
             <View maxWidth={520} width="100%">
               <ChatMessage
-                post={channelApprovalPost}
+                post={compileRequestPost}
                 showAuthor={true}
                 showReplies={true}
               />
@@ -758,7 +639,7 @@ function A2UIReadOnlyExamplesFixture() {
 export default {
   BasicComponents: () => <A2UIFixture post={basicComponentsPost} />,
   Weather: () => <A2UIFixture post={weatherPost} />,
-  ConfirmationDialog: () => <A2UIFixture post={confirmationPost} />,
+  CompileRequest: () => <A2UIFixture post={compileRequestPost} />,
   Examples: () => <A2UIExamplesFixture />,
   ReadOnlyDisabledActions: () => <A2UIReadOnlyExamplesFixture />,
 };

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -24,7 +24,7 @@ import { ReactionsDisplay } from './ReactionsDisplay';
 import {
   getA2UIConfirmationDescription,
   getA2UIDestinationLabel,
-  getA2UIPokePayload,
+  getA2UIPokeConfirmationCopy,
   getA2UISendText,
   isA2UIRenderableChatContext,
 } from './a2uiActions';
@@ -44,7 +44,8 @@ type PendingA2UIPokeAction = {
   app: string;
   mark: string;
   json: unknown;
-  jsonPreview: string;
+  actionLabel: string;
+  actionDescription: string;
 };
 
 type PendingA2UIAction = PendingA2UISendMessageAction | PendingA2UIPokeAction;
@@ -152,6 +153,10 @@ export function StaticChatMessage({
       }
 
       if (action.event.name === A2UI.action.poke) {
+        const confirmationCopy = getA2UIPokeConfirmationCopy(
+          action,
+          buttonLabel
+        );
         setPendingA2UIAction({
           kind: 'poke',
           action,
@@ -159,7 +164,8 @@ export function StaticChatMessage({
           app: action.event.context.app,
           mark: action.event.context.mark,
           json: action.event.context.json,
-          jsonPreview: getA2UIPokePayload(action),
+          actionLabel: confirmationCopy.actionLabel,
+          actionDescription: confirmationCopy.description,
         });
       }
     },
@@ -226,9 +232,8 @@ export function StaticChatMessage({
       : getA2UIConfirmationDescription({
           actionName: pendingA2UIAction.action.event.name,
           buttonLabel: pendingA2UIAction.buttonLabel,
-          app: pendingA2UIAction.app,
-          mark: pendingA2UIAction.mark,
-          json: pendingA2UIAction.jsonPreview,
+          actionLabel: pendingA2UIAction.actionLabel,
+          description: pendingA2UIAction.actionDescription,
         })
     : '';
 

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -266,7 +266,9 @@ export function StaticChatMessage({
         title="Confirm A2UI action"
         description={a2uiConfirmationDescription}
         confirmText={
-          pendingA2UIAction?.kind === 'sendMessage' ? 'Send message' : 'Run action'
+          pendingA2UIAction?.kind === 'sendMessage'
+            ? 'Send message'
+            : 'Run action'
         }
         open={!!pendingA2UIAction}
         onOpenChange={(open) => {

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -1,3 +1,4 @@
+import * as api from '@tloncorp/api';
 import * as db from '@tloncorp/shared/db';
 import { A2UI } from '@tloncorp/shared/logic';
 import { ConfirmDialog, Text } from '@tloncorp/ui';
@@ -23,16 +24,30 @@ import { ReactionsDisplay } from './ReactionsDisplay';
 import {
   getA2UIConfirmationDescription,
   getA2UIDestinationLabel,
+  getA2UIPokePayload,
   getA2UISendText,
   isA2UIRenderableChatContext,
 } from './a2uiActions';
 
-type PendingA2UIAction = {
+type PendingA2UISendMessageAction = {
+  kind: 'sendMessage';
   action: A2UI.Button['action'];
   buttonLabel: string;
   sendText: string;
   destination: string;
 };
+
+type PendingA2UIPokeAction = {
+  kind: 'poke';
+  action: A2UI.Button['action'];
+  buttonLabel: string;
+  app: string;
+  mark: string;
+  json: unknown;
+  jsonPreview: string;
+};
+
+type PendingA2UIAction = PendingA2UISendMessageAction | PendingA2UIPokeAction;
 
 /**
  * Renders a chat message with minimal interactivity (no pressable, no overflow
@@ -113,51 +128,80 @@ export function StaticChatMessage({
       fallbackText: string,
       buttonLabel: string
     ) => {
-      if (action.event.name !== A2UI.action.sendMessage) {
+      if (action.event.name === A2UI.action.sendMessage) {
+        if (!draftInputContext || draftInputContext.canStartDraft === false) {
+          return;
+        }
+
+        const text = getA2UISendText(action, fallbackText);
+        if (!text) {
+          return;
+        }
+
+        setPendingA2UIAction({
+          kind: 'sendMessage',
+          action,
+          buttonLabel: buttonLabel.trim() || fallbackText.trim(),
+          sendText: text,
+          destination: getA2UIDestinationLabel({
+            channel: draftInputContext.channel,
+            group: draftInputContext.group,
+          }),
+        });
         return;
       }
 
-      if (!draftInputContext || draftInputContext.canStartDraft === false) {
-        return;
+      if (action.event.name === A2UI.action.poke) {
+        setPendingA2UIAction({
+          kind: 'poke',
+          action,
+          buttonLabel: buttonLabel.trim() || fallbackText.trim(),
+          app: action.event.context.app,
+          mark: action.event.context.mark,
+          json: action.event.context.json,
+          jsonPreview: getA2UIPokePayload(action),
+        });
       }
-
-      const text = getA2UISendText(action, fallbackText);
-      if (!text) {
-        return;
-      }
-
-      setPendingA2UIAction({
-        action,
-        buttonLabel: buttonLabel.trim() || fallbackText.trim(),
-        sendText: text,
-        destination: getA2UIDestinationLabel({
-          channel: draftInputContext.channel,
-          group: draftInputContext.group,
-        }),
-      });
     },
     [draftInputContext]
   );
 
   const handleConfirmA2UIAction = useCallback(() => {
-    if (!pendingA2UIAction || !draftInputContext) {
+    if (!pendingA2UIAction) {
       return;
     }
 
-    const actionToSend = pendingA2UIAction;
+    const actionToRun = pendingA2UIAction;
     setPendingA2UIAction(null);
 
-    draftInputContext
-      .sendPostFromDraft({
-        channelId: draftInputContext.channel.id,
-        content: [actionToSend.sendText],
-        attachments: [],
-        channelType: draftInputContext.channel.type,
-        replyToPostId: draftInputContext.replyToPost?.id ?? null,
-        isEdit: false,
+    if (actionToRun.kind === 'sendMessage') {
+      if (!draftInputContext) {
+        return;
+      }
+
+      draftInputContext
+        .sendPostFromDraft({
+          channelId: draftInputContext.channel.id,
+          content: [actionToRun.sendText],
+          attachments: [],
+          channelType: draftInputContext.channel.type,
+          replyToPostId: draftInputContext.replyToPost?.id ?? null,
+          isEdit: false,
+        })
+        .catch((e) => {
+          console.error('Failed to send A2UI action', e);
+        });
+      return;
+    }
+
+    api
+      .poke({
+        app: actionToRun.app,
+        mark: actionToRun.mark,
+        json: actionToRun.json,
       })
       .catch((e) => {
-        console.error('Failed to send A2UI action', e);
+        console.error('Failed to poke A2UI action', e);
       });
   }, [draftInputContext, pendingA2UIAction]);
 
@@ -172,12 +216,20 @@ export function StaticChatMessage({
     draftInputContext.canStartDraft !== false;
 
   const a2uiConfirmationDescription = pendingA2UIAction
-    ? getA2UIConfirmationDescription({
-        actionName: pendingA2UIAction.action.event.name,
-        buttonLabel: pendingA2UIAction.buttonLabel,
-        sendText: pendingA2UIAction.sendText,
-        destination: pendingA2UIAction.destination,
-      })
+    ? pendingA2UIAction.kind === 'sendMessage'
+      ? getA2UIConfirmationDescription({
+          actionName: pendingA2UIAction.action.event.name,
+          buttonLabel: pendingA2UIAction.buttonLabel,
+          sendText: pendingA2UIAction.sendText,
+          destination: pendingA2UIAction.destination,
+        })
+      : getA2UIConfirmationDescription({
+          actionName: pendingA2UIAction.action.event.name,
+          buttonLabel: pendingA2UIAction.buttonLabel,
+          app: pendingA2UIAction.app,
+          mark: pendingA2UIAction.mark,
+          json: pendingA2UIAction.jsonPreview,
+        })
     : '';
 
   const postContent = usePostContent(post);
@@ -208,7 +260,9 @@ export function StaticChatMessage({
       <ConfirmDialog
         title="Confirm A2UI action"
         description={a2uiConfirmationDescription}
-        confirmText="Send message"
+        confirmText={
+          pendingA2UIAction?.kind === 'sendMessage' ? 'Send message' : 'Run action'
+        }
         open={!!pendingA2UIAction}
         onOpenChange={(open) => {
           if (!open) {

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -1,8 +1,7 @@
-import { isDmChannelId } from '@tloncorp/api/client';
 import * as db from '@tloncorp/shared/db';
 import { A2UI } from '@tloncorp/shared/logic';
-import { Text } from '@tloncorp/ui';
-import { ComponentProps, useCallback, useMemo } from 'react';
+import { ConfirmDialog, Text } from '@tloncorp/ui';
+import { ComponentProps, useCallback, useMemo, useState } from 'react';
 import { View, XStack, YStack, isWeb } from 'tamagui';
 
 import { CHAT_REF_LIKE_MAX_WIDTH } from '../../../constants';
@@ -21,6 +20,19 @@ import { ChatMessageDeliveryStatus } from './ChatMessageDeliveryStatus';
 import { ChatMessageHighlight } from './ChatMessageHighlight';
 import { ChatMessageReplySummary } from './ChatMessageReplySummary';
 import { ReactionsDisplay } from './ReactionsDisplay';
+import {
+  getA2UIConfirmationDescription,
+  getA2UIDestinationLabel,
+  getA2UISendText,
+  isA2UIRenderableChatContext,
+} from './a2uiActions';
+
+type PendingA2UIAction = {
+  action: A2UI.Button['action'];
+  buttonLabel: string;
+  sendText: string;
+  destination: string;
+};
 
 /**
  * Renders a chat message with minimal interactivity (no pressable, no overflow
@@ -60,6 +72,8 @@ export function StaticChatMessage({
 }) {
   const isNotice = post.type === 'notice';
   const draftInputContext = useDraftInputContext();
+  const [pendingA2UIAction, setPendingA2UIAction] =
+    useState<PendingA2UIAction | null>(null);
 
   if (isNotice) {
     showAuthor = false;
@@ -94,7 +108,11 @@ export function StaticChatMessage({
   }, [onPressRetry, post]);
 
   const handleA2UIAction = useCallback(
-    async (action: A2UI.Button['action'], fallbackText: string) => {
+    (
+      action: A2UI.Button['action'],
+      fallbackText: string,
+      buttonLabel: string
+    ) => {
       if (action.event.name !== A2UI.action.sendMessage) {
         return;
       }
@@ -103,28 +121,64 @@ export function StaticChatMessage({
         return;
       }
 
-      const message = action.event.context?.text ?? fallbackText;
-      const text = message.trim();
+      const text = getA2UISendText(action, fallbackText);
       if (!text) {
         return;
       }
 
-      await draftInputContext.sendPostFromDraft({
-        channelId: draftInputContext.channel.id,
-        content: [text],
-        attachments: [],
-        channelType: draftInputContext.channel.type,
-        replyToPostId: null,
-        isEdit: false,
+      setPendingA2UIAction({
+        action,
+        buttonLabel: buttonLabel.trim() || fallbackText.trim(),
+        sendText: text,
+        destination: getA2UIDestinationLabel({
+          channel: draftInputContext.channel,
+          group: draftInputContext.group,
+        }),
       });
     },
     [draftInputContext]
   );
-  const canRenderA2UI = isDmChannelId(post.channelId);
+
+  const handleConfirmA2UIAction = useCallback(() => {
+    if (!pendingA2UIAction || !draftInputContext) {
+      return;
+    }
+
+    const actionToSend = pendingA2UIAction;
+    setPendingA2UIAction(null);
+
+    draftInputContext
+      .sendPostFromDraft({
+        channelId: draftInputContext.channel.id,
+        content: [actionToSend.sendText],
+        attachments: [],
+        channelType: draftInputContext.channel.type,
+        replyToPostId: draftInputContext.replyToPost?.id ?? null,
+        isEdit: false,
+      })
+      .catch((e) => {
+        console.error('Failed to send A2UI action', e);
+      });
+  }, [draftInputContext, pendingA2UIAction]);
+
+  const canRenderA2UI = isA2UIRenderableChatContext({
+    channel: draftInputContext?.channel,
+    postChannelId: post.channelId,
+    searchQuery,
+  });
   const canHandleA2UIAction =
     canRenderA2UI &&
     !!draftInputContext &&
     draftInputContext.canStartDraft !== false;
+
+  const a2uiConfirmationDescription = pendingA2UIAction
+    ? getA2UIConfirmationDescription({
+        actionName: pendingA2UIAction.action.event.name,
+        buttonLabel: pendingA2UIAction.buttonLabel,
+        sendText: pendingA2UIAction.sendText,
+        destination: pendingA2UIAction.destination,
+      })
+    : '';
 
   const postContent = usePostContent(post);
   const lastEditPostContent = usePostLastEditContent(post);
@@ -151,6 +205,18 @@ export function StaticChatMessage({
 
   return (
     <YStack key={post.id}>
+      <ConfirmDialog
+        title="Confirm A2UI action"
+        description={a2uiConfirmationDescription}
+        confirmText="Send message"
+        open={!!pendingA2UIAction}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingA2UIAction(null);
+          }
+        }}
+        onConfirm={handleConfirmA2UIAction}
+      />
       {isHighlighted && <ChatMessageHighlight active={isHighlighted} />}
       {showAuthor ? (
         <AuthorRow

--- a/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
@@ -88,10 +88,7 @@ describe('A2UI chat actions', () => {
   test('describes direct poke actions without exposing app, mark, or JSON', () => {
     const action = pokeAction();
     const json = getA2UIPokePayload(action);
-    const confirmationCopy = getA2UIPokeConfirmationCopy(
-      action,
-      'Compile now'
-    );
+    const confirmationCopy = getA2UIPokeConfirmationCopy(action, 'Compile now');
     const description = getA2UIConfirmationDescription({
       actionName: 'tlon.poke',
       buttonLabel: 'Compile now',

--- a/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest';
 import {
   getA2UIConfirmationDescription,
   getA2UIDestinationLabel,
+  getA2UIPokePayload,
   getA2UISendText,
   isA2UIRenderableChatContext,
 } from './a2uiActions';
@@ -12,6 +13,17 @@ const sendMessageAction = (text?: string): A2UI.Button['action'] => ({
   event: {
     name: 'tlon.sendMessage',
     context: text === undefined ? undefined : { text },
+  },
+});
+
+const pokeAction = (): A2UI.Button['action'] => ({
+  event: {
+    name: 'tlon.poke',
+    context: {
+      app: 'a2ui',
+      mark: 'a2ui-action',
+      json: { userAction: { name: 'lore.compile.confirm' } },
+    },
   },
 });
 
@@ -70,5 +82,21 @@ describe('A2UI chat actions', () => {
         destination,
       })
     ).toContain('Will send: /allow c3d4e');
+  });
+
+  test('describes direct poke actions with app, mark, and JSON', () => {
+    const action = pokeAction();
+    const json = getA2UIPokePayload(action);
+
+    expect(json).toContain('lore.compile.confirm');
+    expect(
+      getA2UIConfirmationDescription({
+        actionName: 'tlon.poke',
+        buttonLabel: 'Compile now',
+        app: 'a2ui',
+        mark: 'a2ui-action',
+        json,
+      })
+    ).toContain('App: %a2ui');
   });
 });

--- a/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest';
 import {
   getA2UIConfirmationDescription,
   getA2UIDestinationLabel,
+  getA2UIPokeConfirmationCopy,
   getA2UIPokePayload,
   getA2UISendText,
   isA2UIRenderableChatContext,
@@ -84,19 +85,26 @@ describe('A2UI chat actions', () => {
     ).toContain('Will send: /allow c3d4e');
   });
 
-  test('describes direct poke actions with app, mark, and JSON', () => {
+  test('describes direct poke actions without exposing app, mark, or JSON', () => {
     const action = pokeAction();
     const json = getA2UIPokePayload(action);
+    const confirmationCopy = getA2UIPokeConfirmationCopy(
+      action,
+      'Compile now'
+    );
+    const description = getA2UIConfirmationDescription({
+      actionName: 'tlon.poke',
+      buttonLabel: 'Compile now',
+      actionLabel: confirmationCopy.actionLabel,
+      description: confirmationCopy.description,
+    });
 
     expect(json).toContain('lore.compile.confirm');
-    expect(
-      getA2UIConfirmationDescription({
-        actionName: 'tlon.poke',
-        buttonLabel: 'Compile now',
-        app: 'a2ui',
-        mark: 'a2ui-action',
-        json,
-      })
-    ).toContain('App: %a2ui');
+    expect(description).toContain('Action: Compile lore wiki');
+    expect(description).toContain('No chat message will be sent.');
+    expect(description).not.toContain('App: %a2ui');
+    expect(description).not.toContain('Mark: %a2ui-action');
+    expect(description).not.toContain('JSON:');
+    expect(description).not.toContain('lore.compile.confirm');
   });
 });

--- a/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.test.ts
@@ -1,0 +1,74 @@
+import type { A2UI } from '@tloncorp/shared/logic';
+import { describe, expect, test } from 'vitest';
+
+import {
+  getA2UIConfirmationDescription,
+  getA2UIDestinationLabel,
+  getA2UISendText,
+  isA2UIRenderableChatContext,
+} from './a2uiActions';
+
+const sendMessageAction = (text?: string): A2UI.Button['action'] => ({
+  event: {
+    name: 'tlon.sendMessage',
+    context: text === undefined ? undefined : { text },
+  },
+});
+
+describe('A2UI chat actions', () => {
+  test('renders in chat-like channel contexts and DMs, but not search', () => {
+    expect(
+      isA2UIRenderableChatContext({
+        channel: { type: 'chat' },
+        postChannelId: 'chat/~zod/general',
+      })
+    ).toBe(true);
+    expect(
+      isA2UIRenderableChatContext({
+        channel: { type: 'notebook' },
+        postChannelId: 'diary/~zod/notes',
+      })
+    ).toBe(false);
+    expect(
+      isA2UIRenderableChatContext({
+        postChannelId: '~sampel-palnet',
+      })
+    ).toBe(true);
+    expect(
+      isA2UIRenderableChatContext({
+        postChannelId: 'chat/~zod/general',
+      })
+    ).toBe(false);
+    expect(
+      isA2UIRenderableChatContext({
+        channel: { type: 'chat' },
+        postChannelId: 'chat/~zod/general',
+        searchQuery: 'allow',
+      })
+    ).toBe(false);
+  });
+
+  test('uses explicit action context text as the send text', () => {
+    expect(getA2UISendText(sendMessageAction('/allow c3d4e'), 'Allow')).toBe(
+      '/allow c3d4e'
+    );
+    expect(getA2UISendText(sendMessageAction(), 'Allow')).toBe('Allow');
+  });
+
+  test('describes hidden send text and destination in the confirmation copy', () => {
+    const destination = getA2UIDestinationLabel({
+      channel: { id: 'chat/~zod/design', type: 'chat', title: 'Design' },
+      group: { id: '~zod/garden', title: 'Garden Club' },
+    });
+
+    expect(destination).toBe('Design in Garden Club');
+    expect(
+      getA2UIConfirmationDescription({
+        actionName: 'tlon.sendMessage',
+        buttonLabel: 'Allow',
+        sendText: '/allow c3d4e',
+        destination,
+      })
+    ).toContain('Will send: /allow c3d4e');
+  });
+});

--- a/packages/app/ui/components/ChatMessage/a2uiActions.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.ts
@@ -1,0 +1,75 @@
+import { isDmChannelId } from '@tloncorp/api/client';
+import type * as db from '@tloncorp/shared/db';
+import type { A2UI } from '@tloncorp/shared/logic';
+
+const CHAT_LIKE_CHANNEL_TYPES: db.ChannelType[] = ['chat', 'dm', 'groupDm'];
+
+export function isA2UIRenderableChatContext({
+  channel,
+  postChannelId,
+  searchQuery,
+}: {
+  channel?: Pick<db.Channel, 'type'> | null;
+  postChannelId: string;
+  searchQuery?: string;
+}) {
+  if (searchQuery) {
+    return false;
+  }
+
+  if (channel) {
+    return CHAT_LIKE_CHANNEL_TYPES.includes(channel.type);
+  }
+
+  return isDmChannelId(postChannelId);
+}
+
+export function getA2UISendText(
+  action: A2UI.Button['action'],
+  fallbackText: string
+) {
+  return (action.event.context?.text ?? fallbackText).trim();
+}
+
+export function getA2UIDestinationLabel({
+  channel,
+  group,
+}: {
+  channel?: Pick<db.Channel, 'id' | 'title' | 'type'> | null;
+  group?: Pick<db.Group, 'id' | 'title'> | null;
+}) {
+  if (!channel) {
+    return 'current conversation';
+  }
+
+  const channelTitle = channel.title?.trim() || channel.id;
+  const groupTitle = group?.title?.trim();
+
+  switch (channel.type) {
+    case 'dm':
+      return `DM with ${channelTitle}`;
+    case 'groupDm':
+      return `Group DM: ${channelTitle}`;
+    default:
+      return groupTitle ? `${channelTitle} in ${groupTitle}` : channelTitle;
+  }
+}
+
+export function getA2UIConfirmationDescription({
+  actionName,
+  buttonLabel,
+  sendText,
+  destination,
+}: {
+  actionName: string;
+  buttonLabel: string;
+  sendText: string;
+  destination: string;
+}) {
+  return [
+    `Action: ${actionName}`,
+    `Button: ${buttonLabel || 'Untitled button'}`,
+    `Will send: ${sendText}`,
+    `Destination: ${destination}`,
+  ].join('\n');
+}

--- a/packages/app/ui/components/ChatMessage/a2uiActions.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.ts
@@ -42,6 +42,49 @@ export function getA2UIPokePayload(action: A2UI.Button['action']) {
   return JSON.stringify(action.event.context.json ?? null, null, 2);
 }
 
+function getUserActionName(json: unknown) {
+  if (
+    typeof json !== 'object' ||
+    json === null ||
+    !('userAction' in json) ||
+    typeof json.userAction !== 'object' ||
+    json.userAction === null ||
+    !('name' in json.userAction) ||
+    typeof json.userAction.name !== 'string'
+  ) {
+    return '';
+  }
+
+  return json.userAction.name;
+}
+
+export function getA2UIPokeConfirmationCopy(
+  action: A2UI.Button['action'],
+  buttonLabel: string
+) {
+  if (action.event.name !== 'tlon.poke') {
+    return {
+      actionLabel: 'Run action',
+      description: 'This will run the requested action.',
+    };
+  }
+
+  const userActionName = getUserActionName(action.event.context.json);
+  if (userActionName === 'lore.compile.confirm') {
+    return {
+      actionLabel: 'Compile lore wiki',
+      description:
+        'This will run the lore compiler and mirror updated wiki/media outputs. No chat message will be sent.',
+    };
+  }
+
+  return {
+    actionLabel: buttonLabel.trim() || 'Run app action',
+    description:
+      'This will run the requested app action. No chat message will be sent.',
+  };
+}
+
 export function getA2UIDestinationLabel({
   channel,
   group,
@@ -69,39 +112,31 @@ export function getA2UIDestinationLabel({
 export function getA2UIConfirmationDescription({
   actionName,
   buttonLabel,
+  actionLabel,
+  description,
   sendText,
   destination,
-  app,
-  mark,
-  json,
 }: {
   actionName: string;
   buttonLabel: string;
+  actionLabel?: string;
+  description?: string;
   sendText?: string;
   destination?: string;
-  app?: string;
-  mark?: string;
-  json?: string;
 }) {
   const lines = [
-    `Action: ${actionName}`,
+    `Action: ${actionLabel || actionName}`,
     `Button: ${buttonLabel || 'Untitled button'}`,
   ];
 
+  if (description) {
+    lines.push(description);
+  }
   if (sendText) {
     lines.push(`Will send: ${sendText}`);
   }
   if (destination) {
     lines.push(`Destination: ${destination}`);
-  }
-  if (app) {
-    lines.push(`App: %${app}`);
-  }
-  if (mark) {
-    lines.push(`Mark: %${mark}`);
-  }
-  if (json) {
-    lines.push(`JSON: ${json}`);
   }
 
   return lines.join('\n');

--- a/packages/app/ui/components/ChatMessage/a2uiActions.ts
+++ b/packages/app/ui/components/ChatMessage/a2uiActions.ts
@@ -28,7 +28,18 @@ export function getA2UISendText(
   action: A2UI.Button['action'],
   fallbackText: string
 ) {
+  if (action.event.name !== 'tlon.sendMessage') {
+    return '';
+  }
   return (action.event.context?.text ?? fallbackText).trim();
+}
+
+export function getA2UIPokePayload(action: A2UI.Button['action']) {
+  if (action.event.name !== 'tlon.poke') {
+    return '';
+  }
+
+  return JSON.stringify(action.event.context.json ?? null, null, 2);
 }
 
 export function getA2UIDestinationLabel({
@@ -60,16 +71,38 @@ export function getA2UIConfirmationDescription({
   buttonLabel,
   sendText,
   destination,
+  app,
+  mark,
+  json,
 }: {
   actionName: string;
   buttonLabel: string;
-  sendText: string;
-  destination: string;
+  sendText?: string;
+  destination?: string;
+  app?: string;
+  mark?: string;
+  json?: string;
 }) {
-  return [
+  const lines = [
     `Action: ${actionName}`,
     `Button: ${buttonLabel || 'Untitled button'}`,
-    `Will send: ${sendText}`,
-    `Destination: ${destination}`,
-  ].join('\n');
+  ];
+
+  if (sendText) {
+    lines.push(`Will send: ${sendText}`);
+  }
+  if (destination) {
+    lines.push(`Destination: ${destination}`);
+  }
+  if (app) {
+    lines.push(`App: %${app}`);
+  }
+  if (mark) {
+    lines.push(`Mark: %${mark}`);
+  }
+  if (json) {
+    lines.push(`JSON: ${json}`);
+  }
+
+  return lines.join('\n');
 }

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -154,10 +154,13 @@ export function A2UIBlock({
       const fallbackText = buttonLabel;
       const sendText =
         component.action.event.name === A2UI.action.sendMessage
-          ? (component.action.event.context?.text ?? fallbackText)
+          ? component.action.event.context?.text ?? fallbackText
           : fallbackText;
 
-      if (component.action.event.name === A2UI.action.sendMessage && !sendText.trim()) {
+      if (
+        component.action.event.name === A2UI.action.sendMessage &&
+        !sendText.trim()
+      ) {
         return;
       }
 

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -152,9 +152,12 @@ export function A2UIBlock({
         components
       );
       const fallbackText = buttonLabel;
-      const sendText = component.action.event.context?.text ?? fallbackText;
+      const sendText =
+        component.action.event.name === A2UI.action.sendMessage
+          ? (component.action.event.context?.text ?? fallbackText)
+          : fallbackText;
 
-      if (!sendText.trim()) {
+      if (component.action.event.name === A2UI.action.sendMessage && !sendText.trim()) {
         return;
       }
 

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -147,15 +147,18 @@ export function A2UIBlock({
 
   const handleButtonPress = useCallback(
     (component: A2UI.Button) => {
-      const fallbackText =
-        component.action.event.context?.text ??
-        getComponentText(components.get(component.child), components);
+      const buttonLabel = getComponentText(
+        components.get(component.child),
+        components
+      );
+      const fallbackText = buttonLabel;
+      const sendText = component.action.event.context?.text ?? fallbackText;
 
-      if (!fallbackText.trim()) {
+      if (!sendText.trim()) {
         return;
       }
 
-      context.onA2UIAction?.(component.action, fallbackText);
+      context.onA2UIAction?.(component.action, fallbackText, buttonLabel);
     },
     [components, context]
   );

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -32,7 +32,8 @@ export interface ContentContextProps {
   onLongPress?: () => void;
   onA2UIAction?: (
     action: A2UI.Button['action'],
-    fallbackText: string
+    fallbackText: string,
+    buttonLabel: string
   ) => void | Promise<void>;
   searchQuery?: string;
 }


### PR DESCRIPTION
## Summary
- render A2UI blobs in chat-like contexts beyond DMs
- add A2UI button handling for `tlon.sendMessage` actions
- scope the initial action UX to post-ingest lore compile-request cards
- require a confirmation dialog before sending the compile confirmation text
- disable A2UI actions when the current context cannot draft/send
- add fixtures, docs, and unit coverage for action helpers

## UX
For this slice, the button belongs inside the agent's post-ingest result card. When a user drops new material into the `%lore` Inbox and ingestion succeeds, the reply can include an A2UI compile-request card with a **Compile now** button at the bottom. Pressing it opens a confirmation prompt showing the action, button label, exact text (`lore confirm compile`), and destination. The compile only runs after the user confirms and that message is sent through the normal draft/send path.

## Tests
- `pnpm --filter @tloncorp/app exec vitest run ui/components/ChatMessage/a2uiActions.test.ts`
- `pnpm --filter @tloncorp/app tsc`
