### PR TITLE
fix notification preview preload

### DIFF
--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -337,10 +337,6 @@ export const syncLatestChanges = async ({
   const doneFetching = Date.now();
   logger.log(`fetched latest changes: ${doneFetching - start}ms`, result);
 
-  const topLevelPosts = result.posts.filter(
-    (post) =>
-      !post.parentId && post.type !== 'reply' && post.sequenceNum != null
-  );
   // before we insert the changes, confirm they're not stale from a delayed bg sync
   // or previous app open. Use time since method began as delayed bg sync or previous
   // app open. Use time since method began as a heuristic
@@ -357,10 +353,10 @@ export const syncLatestChanges = async ({
     () => db.insertChanges(result, queryCtx),
     { posts: result.posts.length }
   );
-  await perfTime(
+  const topLevelPosts = await perfTime(
     'syncLatestChanges.notifyListeners',
-    async () => notifyChannelPostListenersFromLatestChanges(topLevelPosts),
-    { topLevelPosts: topLevelPosts.length }
+    () => notifyChannelPostListenersFromLatestChanges(result.posts),
+    (topLevelPosts) => ({ topLevelPosts })
   );
   logger.trackEvent('sync changes debug', {
     context: 'inserted changes',
@@ -404,7 +400,7 @@ export const syncLatestChanges = async ({
   );
   perfStop({
     posts: result.posts.length,
-    topLevelPosts: topLevelPosts.length,
+    topLevelPosts,
     hadChanges: String(hadChanges),
   });
   return {
@@ -419,18 +415,22 @@ export const syncLatestChanges = async ({
 };
 
 function notifyChannelPostListenersFromLatestChanges(posts: db.Post[]) {
-  if (!posts.length) {
-    return;
-  }
-
   const seenIds = new Set<string>();
+  let notified = 0;
   for (const post of posts) {
-    if (seenIds.has(post.id)) {
+    if (
+      post.parentId ||
+      post.type === 'reply' ||
+      post.sequenceNum == null ||
+      seenIds.has(post.id)
+    ) {
       continue;
     }
     seenIds.add(post.id);
     addToChannelPosts(post);
+    notified++;
   }
+  return notified;
 }
 
 export const syncCachedChanges = async (input: {
@@ -442,6 +442,7 @@ export const syncCachedChanges = async (input: {
   if (syncedAt && input.begin <= syncedAt && input.end > syncedAt) {
     // cached changes are valid, insert them
     await db.insertChanges(input.changes);
+    notifyChannelPostListenersFromLatestChanges(input.changes.posts);
     await db.changesSyncedAt.setValue(input.end);
     return true;
   }

--- a/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
+++ b/packages/shared/src/store/useChannelPosts/useChannelPosts.ts
@@ -51,13 +51,11 @@ export const useChannelPosts = (options: UseChannelPostsParams) => {
 
   const queryKey = useMemo(
     () => [
-      [
-        ...queryKeyPrefix,
-        options.channelId,
-        options.cursorPostId,
-        options.filterDeleted,
-        mountTime,
-      ],
+      ...queryKeyPrefix,
+      options.channelId,
+      options.cursorPostId,
+      options.filterDeleted,
+      mountTime,
     ],
     [options.channelId, options.cursorPostId, options.filterDeleted, mountTime]
   );


### PR DESCRIPTION
## Summary

This fixes notification-tapped channels showing stale cached posts by making channel post queries invalidatable and notifying the open channel when cached sync changes are inserted.

Fixes TLON-5846
Fixes TLON-5851

## Changes

- Flatten the useChannelPosts React Query key so clearChannelPostsQueries can invalidate it by prefix.
- Notify channel post listeners after valid cached changes are inserted, while filtering replies, unsequenced posts, and duplicate ids.

## How did I test?

Tested on device