### PR TITLE
fix iOS clipboard image paste crash

### DIFF
--- a/packages/app/ui/components/AttachmentSheet.tsx
+++ b/packages/app/ui/components/AttachmentSheet.tsx
@@ -116,11 +116,8 @@ export default function AttachmentSheet({
           throw new Error('No image data available in clipboard');
         }
 
-        // TODO: we're doing two layers of conversion here:
-        //   clipboardData -> ImagePickerAsset -> UploadIntent
-        // `createImageAssetFromClipboardData` in particular lies about the
-        // image's dimensions - we should probably remove one layer
-        const clipboardAsset = createImageAssetFromClipboardData(clipboardData);
+        const clipboardAsset =
+          await createImageAssetFromClipboardData(clipboardData);
         const atts = [
           Attachment.UploadIntent.fromImagePickerAsset(clipboardAsset),
         ];

--- a/packages/app/ui/utils/clipboardUtils.test.ts
+++ b/packages/app/ui/utils/clipboardUtils.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { createImageAssetFromClipboardData } from './clipboardUtils';
+
+const fileSystemMocks = vi.hoisted(() => ({
+  EncodingType: {
+    Base64: 'base64',
+  },
+  cacheDirectory: 'file:///cache/',
+  makeDirectoryAsync: vi.fn(),
+  writeAsStringAsync: vi.fn(),
+}));
+
+const imageMocks = vi.hoisted(() => ({
+  imageSize: vi.fn(),
+}));
+
+const fileMocks = vi.hoisted(() => ({
+  getFileSize: vi.fn(),
+}));
+
+vi.mock('expo-file-system/legacy', () => fileSystemMocks);
+vi.mock('../../utils/images', () => imageMocks);
+vi.mock('../../utils/files', () => fileMocks);
+vi.mock('expo-clipboard', () => ({}));
+vi.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+  },
+}));
+
+beforeEach(() => {
+  fileSystemMocks.makeDirectoryAsync.mockReset();
+  fileSystemMocks.writeAsStringAsync.mockReset();
+  imageMocks.imageSize.mockReset();
+  imageMocks.imageSize.mockResolvedValue([640, 480]);
+  fileMocks.getFileSize.mockReset();
+  fileMocks.getFileSize.mockReturnValue(3);
+  vi.spyOn(Date, 'now').mockReturnValue(123);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('writes base64 clipboard images to a cache file', async () => {
+  const asset = await createImageAssetFromClipboardData({
+    data: 'AAAA',
+    mimeType: 'image/png',
+  });
+
+  expect(fileSystemMocks.makeDirectoryAsync).toHaveBeenCalledWith(
+    'file:///cache/clipboard-images/',
+    { intermediates: true }
+  );
+  expect(fileSystemMocks.writeAsStringAsync).toHaveBeenCalledWith(
+    'file:///cache/clipboard-images/clipboard-123.png',
+    'AAAA',
+    { encoding: 'base64' }
+  );
+  expect(imageMocks.imageSize).toHaveBeenCalledWith(
+    'file:///cache/clipboard-images/clipboard-123.png'
+  );
+  expect(asset).toMatchObject({
+    assetId: 'clipboard-123',
+    uri: 'file:///cache/clipboard-images/clipboard-123.png',
+    width: 640,
+    height: 480,
+    fileName: 'clipboard-image.png',
+    fileSize: 3,
+    mimeType: 'image/png',
+    type: 'image',
+  });
+});
+
+test('uses the mime type embedded in data uris', async () => {
+  const asset = await createImageAssetFromClipboardData({
+    data: 'data:image/jpeg;base64,AAAA',
+    mimeType: 'image/png',
+  });
+
+  expect(fileSystemMocks.writeAsStringAsync).toHaveBeenCalledWith(
+    'file:///cache/clipboard-images/clipboard-123.jpg',
+    'AAAA',
+    { encoding: 'base64' }
+  );
+  expect(asset).toMatchObject({
+    uri: 'file:///cache/clipboard-images/clipboard-123.jpg',
+    fileName: 'clipboard-image.jpg',
+    mimeType: 'image/jpeg',
+  });
+});

--- a/packages/app/ui/utils/clipboardUtils.ts
+++ b/packages/app/ui/utils/clipboardUtils.ts
@@ -1,6 +1,43 @@
 import * as Clipboard from 'expo-clipboard';
-import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system/legacy';
+import type * as ImagePicker from 'expo-image-picker';
 import { Platform } from 'react-native';
+
+import { getFileSize } from '../../utils/files';
+import { imageSize } from '../../utils/images';
+
+const CLIPBOARD_IMAGE_DIR = `${FileSystem.cacheDirectory ?? ''}clipboard-images/`;
+const CLIPBOARD_IMAGE_EXTENSIONS: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/png': '.png',
+};
+
+function getClipboardImageExtension(mimeType: string): string {
+  return CLIPBOARD_IMAGE_EXTENSIONS[mimeType.toLowerCase()] ?? '.png';
+}
+
+function normalizeClipboardImageData({
+  data,
+  mimeType,
+}: {
+  data: string;
+  mimeType: string;
+}) {
+  const match = data.match(/^data:([^;,]+)?(;base64)?,(.*)$/s);
+  if (!match) {
+    return { base64Data: data, mimeType };
+  }
+
+  if (match[2] !== ';base64') {
+    throw new Error('Clipboard image data must be base64 encoded');
+  }
+
+  return {
+    base64Data: match[3],
+    mimeType: match[1] || mimeType,
+  };
+}
 
 export const tryGetImageWithFormat = async (
   getter: () => Promise<{ data: string } | null>,
@@ -46,24 +83,42 @@ export const getClipboardImageWithFallbacks = async (): Promise<{
   return null;
 };
 
-export const createImageAssetFromClipboardData = (clipboardData: {
+export const createImageAssetFromClipboardData = async (clipboardData: {
   data: string;
   mimeType: string;
-}): ImagePicker.ImagePickerAsset => {
-  const { data: imageData, mimeType } = clipboardData;
+}): Promise<ImagePicker.ImagePickerAsset> => {
+  if (!FileSystem.cacheDirectory) {
+    throw new Error('File system cache directory is unavailable');
+  }
 
-  const uri = imageData.startsWith('data:')
-    ? imageData
-    : `data:${mimeType};base64,${imageData}`;
+  const { base64Data, mimeType } = normalizeClipboardImageData(clipboardData);
+  const extension = getClipboardImageExtension(mimeType);
+  const id = `clipboard-${Date.now()}`;
+  const uri = `${CLIPBOARD_IMAGE_DIR}${id}${extension}`;
+
+  await FileSystem.makeDirectoryAsync(CLIPBOARD_IMAGE_DIR, {
+    intermediates: true,
+  });
+  await FileSystem.writeAsStringAsync(uri, base64Data, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+
+  let width = 300;
+  let height = 300;
+  try {
+    [width, height] = await imageSize(uri);
+  } catch {
+    // Fall back to a square preview if React Native cannot read dimensions.
+  }
 
   return {
-    assetId: `clipboard-${Date.now()}`,
+    assetId: id,
     uri,
-    width: 300,
-    height: 300,
-    fileName:
-      mimeType === 'image/jpeg' ? 'clipboard-image.jpg' : 'clipboard-image.png',
-    fileSize: 0,
+    width,
+    height,
+    fileName: `clipboard-image${extension}`,
+    fileSize: getFileSize(uri) ?? 0,
+    mimeType,
     type: 'image',
     duration: undefined,
     exif: undefined,


### PR DESCRIPTION
## Summary

Fixes issues pasting images as post attachments -- we were passing around a massive base64 string as the image uri, which could cause issues in various places. We now write the bytes to cache and pass around a local uri before upload.

Fixes TLON-5848

## Changes

- Write clipboard image base64 data into the app cache before creating the image asset.
- Preserve clipboard image MIME type, dimensions, and file size when possible.
- Add focused coverage for plain base64 clipboard images and data URI clipboard images.

## How did I test?

Tested on device