### PR TITLE
fix android rounded unread badges

### DIFF
--- a/packages/app/ui/components/Badge.tsx
+++ b/packages/app/ui/components/Badge.tsx
@@ -2,6 +2,8 @@ import { Pressable } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
 import { ColorTokens, SizableText, SizeTokens, View } from 'tamagui';
 
+import { getAndroidRoundedBackgroundKey } from '../utils';
+
 export type BadgeType = 'positive' | 'warning' | 'neutral' | 'tertiary';
 export type BadgeSize = 'default' | 'micro';
 
@@ -34,6 +36,7 @@ export function Badge({
   type = 'positive',
   size = 'default',
   onPress,
+  backgroundColor = badgeBackground[type],
   ...props
 }: {
   text: string;
@@ -43,7 +46,8 @@ export function Badge({
 } & ComponentProps<typeof View>) {
   const content = (
     <View
-      backgroundColor={badgeBackground[type]}
+      key={getAndroidRoundedBackgroundKey(backgroundColor)}
+      backgroundColor={backgroundColor}
       paddingVertical={badgePaddingVertical[size]}
       paddingHorizontal={badgePaddingHorizontal[size]}
       borderRadius="$xl"

--- a/packages/app/ui/components/ListItem.tsx
+++ b/packages/app/ui/components/ListItem.tsx
@@ -6,7 +6,7 @@ import { ColorTokens, styled, withStaticProperties } from 'tamagui';
 import { View, XStack, YStack } from 'tamagui';
 
 import { useBlockedAuthor } from '../../hooks/useBlockedAuthor';
-import { numberWithMax } from '../utils';
+import { getAndroidRoundedBackgroundKey, numberWithMax } from '../utils';
 import {
   ChannelAvatar,
   ContactAvatar,
@@ -186,11 +186,13 @@ const ListItemCount = ({
   const backgroundColor: ColorTokens = notified
     ? '$positiveBackground'
     : '$secondaryBackground';
+  const resolvedBackgroundColor = count < 1 ? undefined : backgroundColor;
   return (
     <View
+      key={getAndroidRoundedBackgroundKey(resolvedBackgroundColor)}
       opacity={opacity}
       paddingHorizontal={'$m'}
-      backgroundColor={count < 1 ? undefined : backgroundColor}
+      backgroundColor={resolvedBackgroundColor}
       borderRadius="$l"
       {...rest}
     >

--- a/packages/app/ui/components/NavBar/NavIcon.tsx
+++ b/packages/app/ui/components/NavBar/NavIcon.tsx
@@ -5,6 +5,7 @@ import { View } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
 import { Circle, ColorTokens, isWeb } from 'tamagui';
 
+import { getAndroidRoundedBackgroundKey } from '../../utils';
 import { ContactAvatar } from '../Avatar';
 
 export function AvatarNavIcon({
@@ -71,6 +72,7 @@ export default function NavIcon({
   shouldShowUnreads?: boolean;
 }) {
   const resolvedType = isActive && activeType ? activeType : type;
+  const unreadDotBackgroundColor = hasUnreads ? '$blue' : 'transparent';
   const props: Omit<ComponentProps<typeof Pressable>, 'children'> = isWeb
     ? {
         pressStyle: { backgroundColor: '$activeBorder' },
@@ -100,14 +102,9 @@ export default function NavIcon({
           alignItems="center"
         >
           <Circle
-            // Workaround for facebook/react-native#52415: on Android new
-            // arch, a View whose backgroundColor transitions from
-            // transparent to opaque loses its border-radius clipping.
-            // Keying on hasUnreads forces a fresh mount so the dot is
-            // rendered as a circle.
-            key={hasUnreads ? 'unread' : 'read'}
+            key={getAndroidRoundedBackgroundKey(unreadDotBackgroundColor)}
             size="$s"
-            backgroundColor={hasUnreads ? '$blue' : 'transparent'}
+            backgroundColor={unreadDotBackgroundColor}
           />
         </View>
       ) : null}

--- a/packages/app/ui/components/UnreadDot.tsx
+++ b/packages/app/ui/components/UnreadDot.tsx
@@ -1,16 +1,20 @@
 import { ComponentProps } from 'react';
 import { Circle } from 'tamagui';
 
+import { getAndroidRoundedBackgroundKey } from '../utils';
+
 export function UnreadDot(
   props: ComponentProps<typeof Circle> & { color?: 'primary' | 'neutral' }
 ) {
+  const backgroundColor =
+    props.backgroundColor ??
+    (props.color === 'neutral' ? '$neutralUnreadDot' : '$positiveActionText');
+
   return (
     <Circle
-      key={props.color ?? 'primary'}
+      key={getAndroidRoundedBackgroundKey(backgroundColor)}
       size="$m"
-      backgroundColor={
-        props.color === 'neutral' ? '$neutralUnreadDot' : '$positiveActionText'
-      }
+      backgroundColor={backgroundColor}
       {...props}
     />
   );

--- a/packages/app/ui/utils/index.ts
+++ b/packages/app/ui/utils/index.ts
@@ -5,6 +5,7 @@ export * from './colorUtils';
 export * from './user';
 export * from './animation';
 export * from './themeUtils';
+export * from './roundedBackground';
 
 // WIP: Temporary export to avoid breaking imports.
 export * from '@tloncorp/ui';

--- a/packages/app/ui/utils/roundedBackground.ts
+++ b/packages/app/ui/utils/roundedBackground.ts
@@ -1,0 +1,12 @@
+// Workaround for facebook/react-native#52415:
+// Android Fabric can lose border radius when a rounded view mounts with a
+// transparent/empty background and later becomes opaque. The upstream fix is
+// tracked in facebook/react-native#56588. Keying small rounded badge/dot views
+// by their resolved background forces a fresh native view for that transition.
+export function getAndroidRoundedBackgroundKey(backgroundColor: unknown) {
+  return `android-rounded-background:${
+    backgroundColor == null || backgroundColor === false
+      ? 'empty'
+      : String(backgroundColor)
+  }`;
+}


### PR DESCRIPTION
## Summary

Fixes Android unread badges and dots sometimes rendering square after their background changes from empty to colored. This is caused by an upstream react issue -- we already had a fix for it in a few places. This PR deduplicates the workaround by creating a helper we can use in various contexts.

Fixes TLON-5868

## Changes

- Add a shared rounded background prop helper for the Android Fabric border-radius issue.
- Use it for dynamic badge and unread dot surfaces.

## How did I test?

Tested on device