### PR TITLE
chatDetails: allow non-host admins to delete channels

### DIFF
--- a/packages/app/features/top/chatDetails.tsx
+++ b/packages/app/features/top/chatDetails.tsx
@@ -504,12 +504,21 @@ export function LeaveActionsSection({
 
   const groupTitle = useGroupTitle(group);
 
+  const currentUserId = useCurrentUserId();
+  const groupIdForAdminCheck =
+    entityType === 'group' ? group?.id : channel?.groupId;
+  const currentUserIsAdmin = useIsAdmin(
+    groupIdForAdminCheck ?? '',
+    currentUserId
+  );
+
   const isHost =
     entityType === 'group'
       ? group?.currentUserIsHost
       : channel?.currentUserIsHost ?? false;
   const canLeave = !isHost;
-  const canDelete = isHost;
+  const canDelete =
+    isHost || (entityType === 'channel' && currentUserIsAdmin);
 
   const chatTitle =
     entityType === 'group'

--- a/packages/app/features/top/chatDetails.tsx
+++ b/packages/app/features/top/chatDetails.tsx
@@ -517,8 +517,7 @@ export function LeaveActionsSection({
       ? group?.currentUserIsHost
       : channel?.currentUserIsHost ?? false;
   const canLeave = !isHost;
-  const canDelete =
-    isHost || (entityType === 'channel' && currentUserIsAdmin);
+  const canDelete = isHost || (entityType === 'channel' && currentUserIsAdmin);
 
   const chatTitle =
     entityType === 'group'


### PR DESCRIPTION
## Summary

Fixes TLON-5870 where non-host admins were unable to delete channels in a group.

## Changes

- Adds a "is current user admin" check to the chatDetails screen
- Determines if the current user/admin is also a host
- Asserts they can't leave if they're a host, but...
- ...they can delete if they're a host, we're looking at a channel, and they're also an admin of the group.

## How did I test?

Tested in simulator.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: group admin

## Rollback plan

git revert

## Screenshots / videos

<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/7e990099-f54e-42df-9fe7-09d8dc897e39" />
