### PR TITLE
add native db export

### DIFF
--- a/packages/app/features/settings/AppInfoScreen.tsx
+++ b/packages/app/features/settings/AppInfoScreen.tsx
@@ -10,6 +10,7 @@ import { getEmailClients, openComposer } from 'react-native-email-link';
 
 import { NOTIFY_PROVIDER, NOTIFY_SERVICE } from '../../constants';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
+import { downloadDb } from '../../lib/downloadDb';
 import { RootStackParamList } from '../../navigation/types';
 import {
   AppSetting,
@@ -171,7 +172,6 @@ export function AppInfoScreen(props: Props) {
             value={permittedSchedulerId ?? 'Not found'}
             copyable
           />
-
           <XStack
             key="debug-toggle"
             justifyContent="space-between"
@@ -200,6 +200,14 @@ export function AppInfoScreen(props: Props) {
               <Text>Please email support@tlon.io with this log ID:</Text>
               <Text>{logId}</Text>
             </YStack>
+          )}
+          {Platform.OS !== 'web' && (
+            <Button
+              preset="secondaryOutline"
+              marginTop="$xl"
+              onPress={downloadDb}
+              label="Export DB"
+            />
           )}
         </YStack>
       </ScrollView>

--- a/packages/app/lib/downloadDb.native.ts
+++ b/packages/app/lib/downloadDb.native.ts
@@ -1,0 +1,35 @@
+import { Directory, File, Paths } from 'expo-file-system';
+import { Platform, Share } from 'react-native';
+
+import { exportDb } from './nativeDb';
+
+export async function downloadDb(): Promise<string | null> {
+  const timestamp = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
+  const exportFile = new File(Paths.cache, `tlon-${timestamp}.sqlite`);
+  if (exportFile.exists) exportFile.delete();
+  await exportDb(decodeURIComponent(exportFile.uri.replace(/^file:\/\//, '')));
+
+  try {
+    if (Platform.OS === 'ios') {
+      await Share.share({ url: exportFile.uri });
+      return exportFile.uri;
+    }
+
+    if (Platform.OS === 'android') {
+      const destination = (await Directory.pickDirectoryAsync()).createFile(
+        exportFile.name,
+        'application/vnd.sqlite3'
+      );
+      destination.write(await exportFile.bytes());
+      return destination.uri;
+    }
+
+    return null;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (/cancel/i.test(message)) return null;
+    throw e;
+  } finally {
+    if (exportFile.exists) exportFile.delete();
+  }
+}

--- a/packages/app/lib/downloadDb.ts
+++ b/packages/app/lib/downloadDb.ts
@@ -1,0 +1,1 @@
+export const downloadDb = async () => null;

--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -164,6 +164,18 @@ export class NativeDb extends BaseDb {
     return this.connection?.getDbPath();
   }
 
+  async exportDb(destinationPath: string): Promise<void> {
+    await this.ensureDbReady();
+
+    if (!this.connection) {
+      throw new Error('exportDb: attempted before connection was set up');
+    }
+
+    await this.connection.execute(
+      `VACUUM INTO '${destinationPath.replace(/'/g, "''")}'`
+    );
+  }
+
   async ensureDbReady() {
     if (this.didMigrate && this.connection && this.client) {
       return;
@@ -407,6 +419,8 @@ export const setupDb = () => nativeDb.setupDb();
 export const ensureDbReady = () => nativeDb.ensureDbReady();
 export const purgeDb = () => nativeDb.purgeDb();
 export const getDbPath = () => nativeDb.getDbPath();
+export const exportDb = (destinationPath: string) =>
+  nativeDb.exportDb(destinationPath);
 export const resetDb = () => nativeDb.resetDb();
 export const runMigrations = () => nativeDb.runMigrations();
 export const useMigrations = () => useMigrationsBase(nativeDb);


### PR DESCRIPTION
## Summary

Adds a native-only DB export action in App Info.

## Changes

- Adds an Export DB button to the App Info screen on native builds only.
- Exports a clean SQLite snapshot to a temporary cache file.
- Uses the iOS share sheet and the Android folder picker to select export location

## How did I test?

Tested on device