### PR TITLE
web: don't set native badge count

### DIFF
--- a/packages/app/ui/components/Activity/ActivityScreenView.tsx
+++ b/packages/app/ui/components/Activity/ActivityScreenView.tsx
@@ -264,7 +264,9 @@ export function ActivityScreenContent({
 
   const markAllRead = useCallback(async () => {
     console.log('Marking all activity as read');
-    await setBadgeCountAsync(0);
+    if (!isWeb) {
+      await setBadgeCountAsync(0);
+    }
     await store.markAllRead();
   }, []);
 


### PR DESCRIPTION
## Summary

We're seeing an uncaught error in the console when attempting to *Mark all as read* from Activity on web. The problem is `expo-notifications` web implementation for `setBadgeCountAsync` has a dynamic import in the compiled code. It attempts to `require('badgin')`, but `require` isn't available in browser.

Seems to be a new issue after upgrading `expo-notifications` to the *Expo 54* compatible version. It only repros if you build for production.

## Changes

The easiest fix is just to add a `if (!isWeb)` wrapper around the `setBadgeCountAsync` call. With that we no longer see the error.

I don't know if some web targets use the badging though? Maybe PWA? cc @patosullivan 

## How did I test?

From `tlon-web` directory, run `pnpm build` and `pnpm serve`. Before the change, *Mark all as read* triggers the error. With the change it does not. You may need to clear the cache to ensure you see the new build.


## Risks and impact
- Safe to rollback without consulting PR author? Yes

Fixes TLON-5861
