### PR TITLE
fix unread query invalidation

### DIFF
--- a/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
@@ -1,6 +1,6 @@
 import { UrbitModuleSpec } from '@tloncorp/app/utils/urbitModule';
 import { createDevLogger } from '@tloncorp/shared';
-import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
 import { useEffect } from 'react';
 import { Platform, TurboModuleRegistry } from 'react-native';
 
@@ -9,23 +9,34 @@ const UrbitModule = TurboModuleRegistry.get('UrbitModule') as UrbitModuleSpec;
 const logger = createDevLogger('useSyncAppBadge', false);
 
 export function useSyncAppBadge() {
+  const { data: baseUnread } = store.useBaseUnread();
+  const { data: notifyingUnreadChannelCount } =
+    store.useUnreadsCountWithoutMuted();
+
   useEffect(() => {
-    db.observeWrites<db.BaseUnread>(db.ObservableField.BaseUnread, (unread) => {
-      if (Platform.OS === 'ios' && unread.notifTimestamp) {
-        try {
-          UrbitModule.updateBadgeCount(
-            unread.notifyCount ?? 0,
-            unread.notifTimestamp
-          );
-        } catch (e) {
-          logger.trackError('Failed to sync OS badge count', {
-            error: e.toString(),
-            errorStack: e.stack,
-            count: unread.notifyCount,
-            updatedAt: unread.updatedAt,
-          });
-        }
-      }
-    });
-  }, []);
+    if (Platform.OS !== 'ios' || !baseUnread?.notifTimestamp) {
+      return;
+    }
+
+    const baseCount = baseUnread.notifyCount ?? 0;
+    // Nonzero badge counts stay backend-driven. Local channel unread state is
+    // only used to clear a stale badge after the last notifying channel is read.
+    const count = notifyingUnreadChannelCount === 0 ? 0 : baseCount;
+
+    try {
+      UrbitModule.updateBadgeCount(count, baseUnread.notifTimestamp);
+    } catch (e) {
+      logger.trackError('Failed to sync OS badge count', {
+        error: e.toString(),
+        errorStack: e.stack,
+        count,
+        updatedAt: baseUnread.updatedAt,
+      });
+    }
+  }, [
+    baseUnread?.notifTimestamp,
+    baseUnread?.notifyCount,
+    baseUnread?.updatedAt,
+    notifyingUnreadChannelCount,
+  ]);
 }

--- a/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
@@ -11,7 +11,7 @@ const logger = createDevLogger('useSyncAppBadge', false);
 export function useSyncAppBadge() {
   const { data: baseUnread } = store.useBaseUnread();
   const { data: notifyingUnreadSourceCount } =
-    store.useUnreadsCountWithoutMuted();
+    store.useNotifyingUnreadSourceCount();
 
   useEffect(() => {
     if (Platform.OS !== 'ios' || !baseUnread?.notifTimestamp) {

--- a/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncAppBadge.ts
@@ -10,7 +10,7 @@ const logger = createDevLogger('useSyncAppBadge', false);
 
 export function useSyncAppBadge() {
   const { data: baseUnread } = store.useBaseUnread();
-  const { data: notifyingUnreadChannelCount } =
+  const { data: notifyingUnreadSourceCount } =
     store.useUnreadsCountWithoutMuted();
 
   useEffect(() => {
@@ -19,9 +19,9 @@ export function useSyncAppBadge() {
     }
 
     const baseCount = baseUnread.notifyCount ?? 0;
-    // Nonzero badge counts stay backend-driven. Local channel unread state is
-    // only used to clear a stale badge after the last notifying channel is read.
-    const count = notifyingUnreadChannelCount === 0 ? 0 : baseCount;
+    // Nonzero badge counts stay backend-driven. Local unread state is only
+    // used to clear a stale badge after the last notifying source is read.
+    const count = notifyingUnreadSourceCount === 0 ? 0 : baseCount;
 
     try {
       UrbitModule.updateBadgeCount(count, baseUnread.notifTimestamp);
@@ -37,6 +37,6 @@ export function useSyncAppBadge() {
     baseUnread?.notifTimestamp,
     baseUnread?.notifyCount,
     baseUnread?.updatedAt,
-    notifyingUnreadChannelCount,
+    notifyingUnreadSourceCount,
   ]);
 }

--- a/packages/api/src/__tests__/unreads.test.ts
+++ b/packages/api/src/__tests__/unreads.test.ts
@@ -178,8 +178,29 @@ test('converts a group unread from server to client format', () => {
   expect(toGroupUnread(groupId, summary)).toStrictEqual(expectedGroupUnread);
 });
 
+const baseUnread: Record<string, ub.ActivitySummary> = {
+  base: {
+    unread: null,
+    count: 12,
+    recency: 946684800001,
+    notify: true,
+    'notify-count': 4,
+    'recency-uv': '0v42',
+  },
+};
+
+const expectedBaseUnread = {
+  id: 'base_unreads',
+  updatedAt: 946684800001,
+  count: 12,
+  notify: true,
+  notifyCount: 4,
+  notifTimestamp: '0v42',
+};
+
 test('converts a set of unreads from server to client format', () => {
   const unreads: ub.Activity = {
+    ...baseUnread,
     ...channelUnread,
     ...threadUnread,
     ...dmUnread,
@@ -192,6 +213,7 @@ test('converts a set of unreads from server to client format', () => {
   expect(clientUnreads.threadActivity.length).toBe(2);
   expect(clientUnreads.groupUnreads.length).toBe(1);
 
+  expect(clientUnreads.baseUnread).toStrictEqual(expectedBaseUnread);
   expect(clientUnreads.channelUnreads[0]).toStrictEqual(expectedChannelUnread);
   expect(clientUnreads.channelUnreads[1]).toStrictEqual(expectedDMUnread);
   expect(clientUnreads.threadActivity[0]).toStrictEqual(expectedThreadUnread);

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -1023,6 +1023,7 @@ export const toClientUnreads = (activity: ub.Activity): db.ActivityInit => {
         updatedAt: summary.recency,
         notifTimestamp: summary['recency-uv'],
       };
+      return;
     }
     const [activityId, ...rest] = sourceId.split('/');
     if (activityId === 'ship' || activityId === 'club') {

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -1021,6 +1021,7 @@ export const toClientUnreads = (activity: ub.Activity): db.ActivityInit => {
         notify: summary.notify,
         notifyCount: summary['notify-count'],
         updatedAt: summary.recency,
+        notifTimestamp: summary['recency-uv'],
       };
     }
     const [activityId, ...rest] = sourceId.split('/');

--- a/packages/app/features/top/QueryBenchScreen.tsx
+++ b/packages/app/features/top/QueryBenchScreen.tsx
@@ -178,8 +178,8 @@ export function QueryBenchScreen() {
       // Unreads
       {
         id: 'getNotifyingUnreadSourceCount',
-        label: 'getNotifyingUnreadSourceCount({})',
-        run: () => db.getNotifyingUnreadSourceCount({}),
+        label: 'getNotifyingUnreadSourceCount()',
+        run: () => db.getNotifyingUnreadSourceCount(),
       },
       {
         id: 'getUnreads',

--- a/packages/app/features/top/QueryBenchScreen.tsx
+++ b/packages/app/features/top/QueryBenchScreen.tsx
@@ -177,9 +177,9 @@ export function QueryBenchScreen() {
 
       // Unreads
       {
-        id: 'getUnreadsCountWithoutMuted',
-        label: 'getUnreadsCountWithoutMuted({})',
-        run: () => db.getUnreadsCountWithoutMuted({}),
+        id: 'getNotifyingUnreadSourceCount',
+        label: 'getNotifyingUnreadSourceCount({})',
+        run: () => db.getNotifyingUnreadSourceCount({}),
       },
       {
         id: 'getUnreads',

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -2,6 +2,7 @@ import {
   AnalyticsEvent,
   AnalyticsSeverity,
   createDevLogger,
+  isUnreadActivityCleared,
   syncContactDiscovery,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
@@ -232,7 +233,7 @@ async function updatePresentedNotifications() {
   const fullyReadChannels = new Set<string>();
   for await (const channelId of allChannelIds) {
     const channel = await db.getChannelWithRelations({ id: channelId });
-    if (channel?.unread?.count === 0 && !channel.unread.notify) {
+    if (isUnreadActivityCleared(channel?.unread)) {
       fullyReadChannels.add(channelId);
     }
   }
@@ -256,7 +257,7 @@ async function updatePresentedNotifications() {
 }
 
 export function useUpdatePresentedNotifications() {
-  const { data: unreadCount } = store.useUnreadsCountWithoutMuted();
+  const { data: unreadCount } = store.useNotifyingUnreadSourceCount();
   useEffect(() => {
     updatePresentedNotifications().catch((err) => {
       console.error('Failed to update presented notifications:', err);

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -233,7 +233,7 @@ async function updatePresentedNotifications() {
   const fullyReadChannels = new Set<string>();
   for await (const channelId of allChannelIds) {
     const channel = await db.getChannelWithRelations({ id: channelId });
-    if (isUnreadActivityCleared(channel?.unread)) {
+    if (channel?.unread && isUnreadActivityCleared(channel.unread)) {
       fullyReadChannels.add(channelId);
     }
   }

--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -232,7 +232,7 @@ async function updatePresentedNotifications() {
   const fullyReadChannels = new Set<string>();
   for await (const channelId of allChannelIds) {
     const channel = await db.getChannelWithRelations({ id: channelId });
-    if (channel?.unread?.count === 0) {
+    if (channel?.unread?.count === 0 && !channel.unread.notify) {
       fullyReadChannels.add(channelId);
     }
   }

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -14,6 +14,7 @@ import {
   uploadAsset,
   useChannelPreview,
   useGroupPreview,
+  useLiveThreadUnreadsByChannel,
   usePostReference as usePostReferenceHook,
   usePostWithRelations,
 } from '@tloncorp/shared';
@@ -417,7 +418,28 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const inView = useIsFocused();
     const isUserActive = useIsUserActive();
     const hasLoaded = !!(posts && channel);
-    const hasUnreads = (channel?.unread?.countWithoutThreads ?? 0) > 0;
+    const shouldCheckThreadReadActivity =
+      channel?.type === 'dm' || channel?.type === 'groupDm';
+    const { data: threadReadActivity, isFetched: threadReadActivityFetched } =
+      useLiveThreadUnreadsByChannel(
+        shouldCheckThreadReadActivity ? channel?.id ?? null : null
+      );
+    const hasThreadReadActivity =
+      shouldCheckThreadReadActivity &&
+      (threadReadActivity?.length ?? 0) > 0;
+    const threadReadActivityKnown =
+      !shouldCheckThreadReadActivity || threadReadActivityFetched;
+    const unreadCount = channel?.unread?.count ?? 0;
+    const unreadCountWithoutThreads =
+      channel?.unread?.countWithoutThreads ?? 0;
+    // Channel notify can include child thread activity. Avoid shallow channel
+    // reads for child-only notifications; the thread screen clears those.
+    const hasReadActivity =
+      unreadCountWithoutThreads > 0 ||
+      (!!channel?.unread?.notify &&
+        unreadCount === unreadCountWithoutThreads &&
+        threadReadActivityKnown &&
+        !hasThreadReadActivity);
 
     useEffect(() => {
       const clearShowTimeout = () => {
@@ -481,13 +503,14 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     useEffect(() => {
       // Only mark as read when user is actively using the app (not idle)
       // This prevents auto-marking on desktop when user is AFK
-      if (hasUnreads && hasLoaded && inView && isUserActive) {
+      if (hasReadActivity && hasLoaded && inView && isUserActive) {
         // add slight delay to allow high priority tasks to hit the sync queue first
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           markRead();
         }, 150);
+        return () => clearTimeout(timeoutId);
       }
-    }, [hasUnreads, hasLoaded, inView, isUserActive, markRead]);
+    }, [hasReadActivity, hasLoaded, inView, isUserActive, markRead]);
 
     const handleRefPress = useCallback(
       (refChannel: db.Channel, post: db.Post) => {

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -15,7 +15,7 @@ import {
   uploadAsset,
   useChannelPreview,
   useGroupPreview,
-  useLiveThreadUnreadActivityCountByChannel,
+  useLiveThreadUnreadsByChannel,
   usePostReference as usePostReferenceHook,
   usePostWithRelations,
 } from '@tloncorp/shared';
@@ -421,14 +421,12 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const hasLoaded = !!(posts && channel);
     const shouldCheckThreadUnreadActivity =
       channel?.type === 'dm' || channel?.type === 'groupDm';
-    const {
-      data: threadUnreadActivityCount,
-      isFetched: threadUnreadActivityFetched,
-    } = useLiveThreadUnreadActivityCountByChannel(
-      shouldCheckThreadUnreadActivity ? channel?.id ?? null : null
-    );
+    const { data: threadUnreads, isFetched: threadUnreadActivityFetched } =
+      useLiveThreadUnreadsByChannel(
+        shouldCheckThreadUnreadActivity ? channel?.id ?? null : null
+      );
     const hasChildThreadUnreadActivity =
-      shouldCheckThreadUnreadActivity && (threadUnreadActivityCount ?? 0) > 0;
+      shouldCheckThreadUnreadActivity && (threadUnreads?.length ?? 0) > 0;
     const childThreadUnreadActivityKnown =
       !shouldCheckThreadUnreadActivity || threadUnreadActivityFetched;
     const hasUnreadActivity = hasMainChannelUnreadActivity({

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -419,20 +419,20 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const inView = useIsFocused();
     const isUserActive = useIsUserActive();
     const hasLoaded = !!(posts && channel);
-    const shouldCheckThreadReadActivity =
+    const shouldCheckThreadUnreadActivity =
       channel?.type === 'dm' || channel?.type === 'groupDm';
     const {
-      data: threadReadActivityCount,
-      isFetched: threadReadActivityFetched,
+      data: threadUnreadActivityCount,
+      isFetched: threadUnreadActivityFetched,
     } = useLiveThreadUnreadActivityCountByChannel(
-      shouldCheckThreadReadActivity ? channel?.id ?? null : null
+      shouldCheckThreadUnreadActivity ? channel?.id ?? null : null
     );
     const hasChildThreadUnreadActivity =
-      shouldCheckThreadReadActivity &&
-      (threadReadActivityCount ?? 0) > 0;
+      shouldCheckThreadUnreadActivity &&
+      (threadUnreadActivityCount ?? 0) > 0;
     const childThreadUnreadActivityKnown =
-      !shouldCheckThreadReadActivity || threadReadActivityFetched;
-    const hasReadActivity = hasMainChannelUnreadActivity({
+      !shouldCheckThreadUnreadActivity || threadUnreadActivityFetched;
+    const hasUnreadActivity = hasMainChannelUnreadActivity({
       unread: channel?.unread,
       childThreadUnreadActivityKnown,
       hasChildThreadUnreadActivity,
@@ -500,14 +500,14 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     useEffect(() => {
       // Only mark as read when user is actively using the app (not idle)
       // This prevents auto-marking on desktop when user is AFK
-      if (hasReadActivity && hasLoaded && inView && isUserActive) {
+      if (hasUnreadActivity && hasLoaded && inView && isUserActive) {
         // add slight delay to allow high priority tasks to hit the sync queue first
         const timeoutId = setTimeout(() => {
           markRead();
         }, 150);
         return () => clearTimeout(timeoutId);
       }
-    }, [hasReadActivity, hasLoaded, inView, isUserActive, markRead]);
+    }, [hasUnreadActivity, hasLoaded, inView, isUserActive, markRead]);
 
     const handleRefPress = useCallback(
       (refChannel: db.Channel, post: db.Post) => {

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -10,8 +10,8 @@ import {
   DraftInputId,
   createDevLogger,
   finalizeAndSendPost,
-  hasMainChannelUnreadActivity,
   isChatChannel as getIsChatChannel,
+  hasMainChannelUnreadActivity,
   uploadAsset,
   useChannelPreview,
   useGroupPreview,
@@ -428,8 +428,7 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
       shouldCheckThreadUnreadActivity ? channel?.id ?? null : null
     );
     const hasChildThreadUnreadActivity =
-      shouldCheckThreadUnreadActivity &&
-      (threadUnreadActivityCount ?? 0) > 0;
+      shouldCheckThreadUnreadActivity && (threadUnreadActivityCount ?? 0) > 0;
     const childThreadUnreadActivityKnown =
       !shouldCheckThreadUnreadActivity || threadUnreadActivityFetched;
     const hasUnreadActivity = hasMainChannelUnreadActivity({

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -499,10 +499,9 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
       // This prevents auto-marking on desktop when user is AFK
       if (hasUnreadActivity && hasLoaded && inView && isUserActive) {
         // add slight delay to allow high priority tasks to hit the sync queue first
-        const timeoutId = setTimeout(() => {
+        setTimeout(() => {
           markRead();
         }, 150);
-        return () => clearTimeout(timeoutId);
       }
     }, [hasUnreadActivity, hasLoaded, inView, isUserActive, markRead]);
 

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -420,7 +420,11 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const isUserActive = useIsUserActive();
     const hasLoaded = !!(posts && channel);
     const shouldCheckThreadUnreadActivity =
-      channel?.type === 'dm' || channel?.type === 'groupDm';
+      channel?.type === 'dm' ||
+      channel?.type === 'groupDm' ||
+      (channel?.unread?.notify === true &&
+        channel.unread.count === 0 &&
+        channel.unread.countWithoutThreads === 0);
     const { data: threadUnreads, isFetched: threadUnreadActivityFetched } =
       useLiveThreadUnreadsByChannel(
         shouldCheckThreadUnreadActivity ? channel?.id ?? null : null

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -10,11 +10,12 @@ import {
   DraftInputId,
   createDevLogger,
   finalizeAndSendPost,
+  hasMainChannelUnreadActivity,
   isChatChannel as getIsChatChannel,
   uploadAsset,
   useChannelPreview,
   useGroupPreview,
-  useLiveThreadUnreadsByChannel,
+  useLiveThreadUnreadActivityCountByChannel,
   usePostReference as usePostReferenceHook,
   usePostWithRelations,
 } from '@tloncorp/shared';
@@ -420,26 +421,22 @@ export const Channel = forwardRef<ChannelMethods, ChannelProps>(
     const hasLoaded = !!(posts && channel);
     const shouldCheckThreadReadActivity =
       channel?.type === 'dm' || channel?.type === 'groupDm';
-    const { data: threadReadActivity, isFetched: threadReadActivityFetched } =
-      useLiveThreadUnreadsByChannel(
-        shouldCheckThreadReadActivity ? channel?.id ?? null : null
-      );
-    const hasThreadReadActivity =
+    const {
+      data: threadReadActivityCount,
+      isFetched: threadReadActivityFetched,
+    } = useLiveThreadUnreadActivityCountByChannel(
+      shouldCheckThreadReadActivity ? channel?.id ?? null : null
+    );
+    const hasChildThreadUnreadActivity =
       shouldCheckThreadReadActivity &&
-      (threadReadActivity?.length ?? 0) > 0;
-    const threadReadActivityKnown =
+      (threadReadActivityCount ?? 0) > 0;
+    const childThreadUnreadActivityKnown =
       !shouldCheckThreadReadActivity || threadReadActivityFetched;
-    const unreadCount = channel?.unread?.count ?? 0;
-    const unreadCountWithoutThreads =
-      channel?.unread?.countWithoutThreads ?? 0;
-    // Channel notify can include child thread activity. Avoid shallow channel
-    // reads for child-only notifications; the thread screen clears those.
-    const hasReadActivity =
-      unreadCountWithoutThreads > 0 ||
-      (!!channel?.unread?.notify &&
-        unreadCount === unreadCountWithoutThreads &&
-        threadReadActivityKnown &&
-        !hasThreadReadActivity);
+    const hasReadActivity = hasMainChannelUnreadActivity({
+      unread: channel?.unread,
+      childThreadUnreadActivityKnown,
+      hasChildThreadUnreadActivity,
+    });
 
     useEffect(() => {
       const clearShowTimeout = () => {

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -484,13 +484,13 @@ function useMarkThreadAsReadEffect(
     channel: db.Channel;
     parent: db.Post;
     mostRecentlyReceivedReply: db.Post;
-    hasThreadReadActivity: boolean;
+    hasThreadUnreadActivity: boolean;
   } | null
 ) {
   const store = useStore();
   const shouldMarkRead = opts?.shouldMarkRead ?? false;
   const latestReplyId = opts?.mostRecentlyReceivedReply?.id ?? null;
-  const hasThreadReadActivity = opts?.hasThreadReadActivity ?? false;
+  const hasThreadUnreadActivity = opts?.hasThreadUnreadActivity ?? false;
 
   // Ref captures the latest opts so the effect can read current values
   // without depending on the unstable inline object identity.
@@ -498,16 +498,16 @@ function useMarkThreadAsReadEffect(
   optsRef.current = opts;
 
   // Single effect with two trigger signals:
-  //   - hasThreadReadActivity: authoritative signal (SSE pushed unread/notify state).
+  //   - hasThreadUnreadActivity: authoritative signal (SSE pushed unread/notify state).
   //   - latestReplyId: secondary signal (thread sync delivered a new post,
-  //     allowing immediate mark-read if hasThreadReadActivity is already true).
+  //     allowing immediate mark-read if hasThreadUnreadActivity is already true).
   //
-  // Guard: only acts when hasThreadReadActivity is true.
+  // Guard: only acts when hasThreadUnreadActivity is true.
   //   - false -> true: guard passes, marks read.
   //   - true -> false (read state cleared): guard returns early, no poke sent.
-  // This directly mirrors Channel/index.tsx's read-activity guard.
+  // This directly mirrors Channel/index.tsx's unread-activity guard.
   useEffect(() => {
-    if (!shouldMarkRead || !hasThreadReadActivity) return;
+    if (!shouldMarkRead || !hasThreadUnreadActivity) return;
     const current = optsRef.current;
     if (current == null) return;
     const { channel, parent, mostRecentlyReceivedReply } = current;
@@ -521,7 +521,7 @@ function useMarkThreadAsReadEffect(
       });
     }, 150);
     return () => clearTimeout(timeoutId);
-  }, [shouldMarkRead, hasThreadReadActivity, latestReplyId, store]);
+  }, [shouldMarkRead, hasThreadUnreadActivity, latestReplyId, store]);
 }
 
 function SinglePostView({
@@ -594,7 +594,7 @@ function SinglePostView({
   const { data: liveThreadUnread } = store.useLiveThreadUnreadByParentId(
     parentPost.id
   );
-  const hasThreadReadActivity = hasUnreadActivity(liveThreadUnread);
+  const hasThreadUnreadActivity = hasUnreadActivity(liveThreadUnread);
 
   const { data: threadPosts } = store.useThreadPosts({
     postId: parentPost.id,
@@ -719,7 +719,7 @@ function SinglePostView({
           mostRecentlyReceivedReply: threadPosts[0],
           parent: parentPost,
           shouldMarkRead: isFocusedPost && hasLoadedReplies && isUserActive,
-          hasThreadReadActivity,
+          hasThreadUnreadActivity,
         }
   );
 

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -483,13 +483,13 @@ function useMarkThreadAsReadEffect(
     channel: db.Channel;
     parent: db.Post;
     mostRecentlyReceivedReply: db.Post;
-    hasThreadUnreads: boolean;
+    hasThreadReadActivity: boolean;
   } | null
 ) {
   const store = useStore();
   const shouldMarkRead = opts?.shouldMarkRead ?? false;
   const latestReplyId = opts?.mostRecentlyReceivedReply?.id ?? null;
-  const hasThreadUnreads = opts?.hasThreadUnreads ?? false;
+  const hasThreadReadActivity = opts?.hasThreadReadActivity ?? false;
 
   // Ref captures the latest opts so the effect can read current values
   // without depending on the unstable inline object identity.
@@ -497,16 +497,16 @@ function useMarkThreadAsReadEffect(
   optsRef.current = opts;
 
   // Single effect with two trigger signals:
-  //   - hasThreadUnreads: authoritative signal (SSE pushed unread count > 0).
+  //   - hasThreadReadActivity: authoritative signal (SSE pushed unread/notify state).
   //   - latestReplyId: secondary signal (thread sync delivered a new post,
-  //     allowing immediate mark-read if hasThreadUnreads is already true).
+  //     allowing immediate mark-read if hasThreadReadActivity is already true).
   //
-  // Guard: only acts when hasThreadUnreads is true.
+  // Guard: only acts when hasThreadReadActivity is true.
   //   - false -> true: guard passes, marks read.
-  //   - true -> false (unread state cleared): guard returns early, no poke sent.
-  // This directly mirrors Channel/index.tsx:292-301's `if (hasUnreads && ...)`.
+  //   - true -> false (read state cleared): guard returns early, no poke sent.
+  // This directly mirrors Channel/index.tsx's read-activity guard.
   useEffect(() => {
-    if (!shouldMarkRead || !hasThreadUnreads) return;
+    if (!shouldMarkRead || !hasThreadReadActivity) return;
     const current = optsRef.current;
     if (current == null) return;
     const { channel, parent, mostRecentlyReceivedReply } = current;
@@ -520,7 +520,7 @@ function useMarkThreadAsReadEffect(
       });
     }, 150);
     return () => clearTimeout(timeoutId);
-  }, [shouldMarkRead, hasThreadUnreads, latestReplyId, store]);
+  }, [shouldMarkRead, hasThreadReadActivity, latestReplyId, store]);
 }
 
 function SinglePostView({
@@ -593,9 +593,8 @@ function SinglePostView({
   const { data: liveThreadUnread } = store.useLiveThreadUnreadByParentId(
     parentPost.id
   );
-  const hasThreadUnreads = !!(
-    liveThreadUnread?.count && liveThreadUnread.count > 0
-  );
+  const hasThreadReadActivity =
+    (liveThreadUnread?.count ?? 0) > 0 || !!liveThreadUnread?.notify;
 
   const { data: threadPosts } = store.useThreadPosts({
     postId: parentPost.id,
@@ -720,7 +719,7 @@ function SinglePostView({
           mostRecentlyReceivedReply: threadPosts[0],
           parent: parentPost,
           shouldMarkRead: isFocusedPost && hasLoadedReplies && isUserActive,
-          hasThreadUnreads,
+          hasThreadReadActivity,
         }
   );
 

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -3,6 +3,7 @@ import * as urbit from '@tloncorp/api/urbit';
 import { JSONContent } from '@tloncorp/api/urbit';
 import {
   DraftInputId,
+  hasUnreadActivity,
   isChatChannel as getIsChatChannel,
   makePrettyDayAndTime,
   useDebouncedValue,
@@ -593,8 +594,7 @@ function SinglePostView({
   const { data: liveThreadUnread } = store.useLiveThreadUnreadByParentId(
     parentPost.id
   );
-  const hasThreadReadActivity =
-    (liveThreadUnread?.count ?? 0) > 0 || !!liveThreadUnread?.notify;
+  const hasThreadReadActivity = hasUnreadActivity(liveThreadUnread);
 
   const { data: threadPosts } = store.useThreadPosts({
     postId: parentPost.id,

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -3,8 +3,8 @@ import * as urbit from '@tloncorp/api/urbit';
 import { JSONContent } from '@tloncorp/api/urbit';
 import {
   DraftInputId,
-  hasUnreadActivity,
   isChatChannel as getIsChatChannel,
+  hasUnreadActivity,
   makePrettyDayAndTime,
   useDebouncedValue,
 } from '@tloncorp/shared';

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -17,7 +17,7 @@ import {
 import initResponse from '../test/init.json';
 import suggestedContactsResponse from '../test/suggestedContacts.json';
 import * as queries from './queries';
-import { Post } from './types';
+import { ChannelUnread, GroupUnread, Post, ThreadUnreadState } from './types';
 
 const groupsData = toClientGroupsV7(
   groupsResponse as unknown as Record<string, ub.GroupV7>,
@@ -856,28 +856,61 @@ test('setJoinedGroupChannels: does not reset membership for channels not in the 
   }
 });
 
+const unreadTestChannelId = 'chat/~zod/react-clear/general';
+const unreadTestGroupId = '~zod/react-clear';
+
+function makeChannelUnread(
+  overrides: Partial<ChannelUnread> = {}
+): ChannelUnread {
+  return {
+    channelId: unreadTestChannelId,
+    type: 'channel',
+    count: 0,
+    countWithoutThreads: 0,
+    notify: true,
+    updatedAt: 100,
+    firstUnreadPostId: null,
+    firstUnreadPostReceivedAt: null,
+    ...overrides,
+  };
+}
+
+function makeGroupUnread(overrides: Partial<GroupUnread> = {}): GroupUnread {
+  return {
+    groupId: unreadTestGroupId,
+    count: 0,
+    notify: true,
+    notifyCount: 1,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+function makeThreadUnread(
+  overrides: Partial<ThreadUnreadState> = {}
+): ThreadUnreadState {
+  return {
+    channelId: unreadTestChannelId,
+    threadId: 'thread-react',
+    count: 0,
+    notify: true,
+    updatedAt: 100,
+    firstUnreadPostId: null,
+    firstUnreadPostReceivedAt: null,
+    ...overrides,
+  };
+}
+
 test('clearChannelUnread clears notification-only channel activity', async () => {
   const client = getClient();
   if (!client) throw new Error('test db not initialized');
 
-  const channelId = 'chat/~zod/react-clear/general';
-  await queries.insertChannelUnreads([
-    {
-      channelId,
-      type: 'channel',
-      count: 0,
-      countWithoutThreads: 0,
-      notify: true,
-      updatedAt: 100,
-      firstUnreadPostId: null,
-      firstUnreadPostReceivedAt: null,
-    },
-  ]);
+  await queries.insertChannelUnreads([makeChannelUnread()]);
 
-  await queries.clearChannelUnread(channelId);
+  await queries.clearChannelUnread(unreadTestChannelId);
 
   const unread = await client.query.channelUnreads.findFirst({
-    where: $.eq(schema.channelUnreads.channelId, channelId),
+    where: $.eq(schema.channelUnreads.channelId, unreadTestChannelId),
   });
   expect(unread).toMatchObject({
     count: 0,
@@ -886,43 +919,12 @@ test('clearChannelUnread clears notification-only channel activity', async () =>
   });
 });
 
-test('unmuted unread count includes notification-only sources', async () => {
-  const channelId = 'chat/~zod/react-clear/general';
-  const threadId = 'thread-react';
-  await queries.insertGroupUnreads([
-    {
-      groupId: '~zod/react-clear',
-      count: 0,
-      notify: true,
-      notifyCount: 1,
-      updatedAt: 100,
-    },
-  ]);
-  await queries.insertChannelUnreads([
-    {
-      channelId,
-      type: 'channel',
-      count: 0,
-      countWithoutThreads: 0,
-      notify: true,
-      updatedAt: 100,
-      firstUnreadPostId: null,
-      firstUnreadPostReceivedAt: null,
-    },
-  ]);
-  await queries.insertThreadUnreads([
-    {
-      channelId,
-      threadId,
-      count: 0,
-      notify: true,
-      updatedAt: 100,
-      firstUnreadPostId: null,
-      firstUnreadPostReceivedAt: null,
-    },
-  ]);
+test('notifying unread source count includes notification-only sources', async () => {
+  await queries.insertGroupUnreads([makeGroupUnread()]);
+  await queries.insertChannelUnreads([makeChannelUnread()]);
+  await queries.insertThreadUnreads([makeThreadUnread()]);
 
-  expect(await queries.getUnreadsCountWithoutMuted({})).toBe(3);
+  expect(await queries.getNotifyingUnreadSourceCount({})).toBe(3);
 });
 
 test('group unread writes invalidate group detail queries', () => {
@@ -947,59 +949,36 @@ test('insertChannelUnreads updates nested thread unread conflicts', async () => 
   const client = getClient();
   if (!client) throw new Error('test db not initialized');
 
-  const channelId = 'chat/~zod/react-clear/general';
   const threadId = 'nested-thread-react';
   await queries.insertChannelUnreads([
-    {
-      channelId,
-      type: 'channel',
+    makeChannelUnread({
       count: 1,
-      countWithoutThreads: 0,
-      notify: true,
-      updatedAt: 100,
-      firstUnreadPostId: null,
-      firstUnreadPostReceivedAt: null,
       threadUnreads: [
-        {
-          channelId,
+        makeThreadUnread({
           threadId,
           count: 1,
-          notify: true,
-          updatedAt: 100,
-          firstUnreadPostId: null,
-          firstUnreadPostReceivedAt: null,
-        },
+        }),
       ],
-    },
+    }),
   ]);
 
   await queries.insertChannelUnreads([
-    {
-      channelId,
-      type: 'channel',
-      count: 0,
-      countWithoutThreads: 0,
+    makeChannelUnread({
       notify: false,
       updatedAt: 200,
-      firstUnreadPostId: null,
-      firstUnreadPostReceivedAt: null,
       threadUnreads: [
-        {
-          channelId,
+        makeThreadUnread({
           threadId,
-          count: 0,
           notify: false,
           updatedAt: 200,
-          firstUnreadPostId: null,
-          firstUnreadPostReceivedAt: null,
-        },
+        }),
       ],
-    },
+    }),
   ]);
 
   const unread = await client.query.threadUnreads.findFirst({
     where: $.and(
-      $.eq(schema.threadUnreads.channelId, channelId),
+      $.eq(schema.threadUnreads.channelId, unreadTestChannelId),
       $.eq(schema.threadUnreads.threadId, threadId)
     ),
   });
@@ -1014,29 +993,26 @@ test('thread unread queries treat notification-only activity as unread until cle
   const client = getClient();
   if (!client) throw new Error('test db not initialized');
 
-  const channelId = 'chat/~zod/react-clear/general';
   const threadId = 'thread-react';
-  await queries.insertThreadUnreads([
-    {
-      channelId,
-      threadId,
-      count: 0,
-      notify: true,
-      updatedAt: 100,
-      firstUnreadPostId: null,
-      firstUnreadPostReceivedAt: null,
-    },
-  ]);
+  await queries.insertThreadUnreads([makeThreadUnread({ threadId })]);
 
   expect(
-    await queries.getThreadUnreadsByChannel({ channelId, excludeRead: true })
+    await queries.getThreadUnreadsByChannel({
+      channelId: unreadTestChannelId,
+      excludeRead: true,
+    })
   ).toHaveLength(1);
+  expect(
+    await queries.getThreadUnreadActivityCountByChannel({
+      channelId: unreadTestChannelId,
+    })
+  ).toBe(1);
 
-  await queries.clearThreadUnread({ channelId, threadId });
+  await queries.clearThreadUnread({ channelId: unreadTestChannelId, threadId });
 
   const unread = await client.query.threadUnreads.findFirst({
     where: $.and(
-      $.eq(schema.threadUnreads.channelId, channelId),
+      $.eq(schema.threadUnreads.channelId, unreadTestChannelId),
       $.eq(schema.threadUnreads.threadId, threadId)
     ),
   });
@@ -1045,8 +1021,16 @@ test('thread unread queries treat notification-only activity as unread until cle
     notify: false,
   });
   expect(
-    await queries.getThreadUnreadsByChannel({ channelId, excludeRead: true })
+    await queries.getThreadUnreadsByChannel({
+      channelId: unreadTestChannelId,
+      excludeRead: true,
+    })
   ).toHaveLength(0);
+  expect(
+    await queries.getThreadUnreadActivityCountByChannel({
+      channelId: unreadTestChannelId,
+    })
+  ).toBe(0);
 });
 
 // TLON-5606: `getPendingPosts` feeds the main-channel pending-merge layer.

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -924,7 +924,48 @@ test('notifying unread source count includes notification-only sources', async (
   await queries.insertChannelUnreads([makeChannelUnread()]);
   await queries.insertThreadUnreads([makeThreadUnread()]);
 
-  expect(await queries.getNotifyingUnreadSourceCount({})).toBe(3);
+  expect(await queries.getNotifyingUnreadSourceCount()).toBe(3);
+});
+
+test('group unread count updates clear notification state when count reaches zero', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  const groupId = '~zod/decrement-clear';
+  await queries.insertGroupUnreads([
+    makeGroupUnread({ groupId, count: 3, notify: true, notifyCount: 2 }),
+  ]);
+
+  await queries.updateGroupUnreadCount({ groupId, decrement: 3 });
+
+  const unread = await client.query.groupUnreads.findFirst({
+    where: $.eq(schema.groupUnreads.groupId, groupId),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    notify: false,
+    notifyCount: 0,
+  });
+});
+
+test('channel unread count updates clear notification state when count reaches zero', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  const channelId = 'chat/~zod/decrement-clear/general';
+  await queries.insertChannelUnreads([
+    makeChannelUnread({ channelId, count: 3, notify: true }),
+  ]);
+
+  await queries.updateChannelUnreadCount({ channelId, decrement: 3 });
+
+  const unread = await client.query.channelUnreads.findFirst({
+    where: $.eq(schema.channelUnreads.channelId, channelId),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    notify: false,
+  });
 });
 
 test('group unread writes invalidate group detail queries', () => {

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -856,6 +856,199 @@ test('setJoinedGroupChannels: does not reset membership for channels not in the 
   }
 });
 
+test('clearChannelUnread clears notification-only channel activity', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  const channelId = 'chat/~zod/react-clear/general';
+  await queries.insertChannelUnreads([
+    {
+      channelId,
+      type: 'channel',
+      count: 0,
+      countWithoutThreads: 0,
+      notify: true,
+      updatedAt: 100,
+      firstUnreadPostId: null,
+      firstUnreadPostReceivedAt: null,
+    },
+  ]);
+
+  await queries.clearChannelUnread(channelId);
+
+  const unread = await client.query.channelUnreads.findFirst({
+    where: $.eq(schema.channelUnreads.channelId, channelId),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    countWithoutThreads: 0,
+    notify: false,
+  });
+});
+
+test('unmuted unread count includes notification-only sources', async () => {
+  const channelId = 'chat/~zod/react-clear/general';
+  const threadId = 'thread-react';
+  await queries.insertGroupUnreads([
+    {
+      groupId: '~zod/react-clear',
+      count: 0,
+      notify: true,
+      notifyCount: 1,
+      updatedAt: 100,
+    },
+  ]);
+  await queries.insertChannelUnreads([
+    {
+      channelId,
+      type: 'channel',
+      count: 0,
+      countWithoutThreads: 0,
+      notify: true,
+      updatedAt: 100,
+      firstUnreadPostId: null,
+      firstUnreadPostReceivedAt: null,
+    },
+  ]);
+  await queries.insertThreadUnreads([
+    {
+      channelId,
+      threadId,
+      count: 0,
+      notify: true,
+      updatedAt: 100,
+      firstUnreadPostId: null,
+      firstUnreadPostReceivedAt: null,
+    },
+  ]);
+
+  expect(await queries.getUnreadsCountWithoutMuted({})).toBe(3);
+});
+
+test('group unread writes invalidate group detail queries', () => {
+  expect(queries.getGroup.meta.tableDependencies).toEqual(
+    expect.arrayContaining(['groupUnreads'])
+  );
+  expect(queries.getPersonalGroup.meta.tableDependencies).toEqual(
+    expect.arrayContaining(['groupUnreads'])
+  );
+  expect(queries.getBotHomeGroup.meta.tableDependencies).toEqual(
+    expect.arrayContaining(['groupUnreads'])
+  );
+});
+
+test('channel unread count updates invalidate channel unreads', () => {
+  expect(queries.updateChannelUnreadCount.meta.tableEffects).toEqual([
+    'channelUnreads',
+  ]);
+});
+
+test('insertChannelUnreads updates nested thread unread conflicts', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  const channelId = 'chat/~zod/react-clear/general';
+  const threadId = 'nested-thread-react';
+  await queries.insertChannelUnreads([
+    {
+      channelId,
+      type: 'channel',
+      count: 1,
+      countWithoutThreads: 0,
+      notify: true,
+      updatedAt: 100,
+      firstUnreadPostId: null,
+      firstUnreadPostReceivedAt: null,
+      threadUnreads: [
+        {
+          channelId,
+          threadId,
+          count: 1,
+          notify: true,
+          updatedAt: 100,
+          firstUnreadPostId: null,
+          firstUnreadPostReceivedAt: null,
+        },
+      ],
+    },
+  ]);
+
+  await queries.insertChannelUnreads([
+    {
+      channelId,
+      type: 'channel',
+      count: 0,
+      countWithoutThreads: 0,
+      notify: false,
+      updatedAt: 200,
+      firstUnreadPostId: null,
+      firstUnreadPostReceivedAt: null,
+      threadUnreads: [
+        {
+          channelId,
+          threadId,
+          count: 0,
+          notify: false,
+          updatedAt: 200,
+          firstUnreadPostId: null,
+          firstUnreadPostReceivedAt: null,
+        },
+      ],
+    },
+  ]);
+
+  const unread = await client.query.threadUnreads.findFirst({
+    where: $.and(
+      $.eq(schema.threadUnreads.channelId, channelId),
+      $.eq(schema.threadUnreads.threadId, threadId)
+    ),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    notify: false,
+    updatedAt: 200,
+  });
+});
+
+test('thread unread queries treat notification-only activity as unread until cleared', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  const channelId = 'chat/~zod/react-clear/general';
+  const threadId = 'thread-react';
+  await queries.insertThreadUnreads([
+    {
+      channelId,
+      threadId,
+      count: 0,
+      notify: true,
+      updatedAt: 100,
+      firstUnreadPostId: null,
+      firstUnreadPostReceivedAt: null,
+    },
+  ]);
+
+  expect(
+    await queries.getThreadUnreadsByChannel({ channelId, excludeRead: true })
+  ).toHaveLength(1);
+
+  await queries.clearThreadUnread({ channelId, threadId });
+
+  const unread = await client.query.threadUnreads.findFirst({
+    where: $.and(
+      $.eq(schema.threadUnreads.channelId, channelId),
+      $.eq(schema.threadUnreads.threadId, threadId)
+    ),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    notify: false,
+  });
+  expect(
+    await queries.getThreadUnreadsByChannel({ channelId, excludeRead: true })
+  ).toHaveLength(0);
+});
+
 // TLON-5606: `getPendingPosts` feeds the main-channel pending-merge layer.
 // Once a failed optimistic row is marked deleted, it must not come back as a
 // "pending" row and ghost the bottom of the chat scroller.

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -1043,11 +1043,6 @@ test('thread unread queries treat notification-only activity as unread until cle
       excludeRead: true,
     })
   ).toHaveLength(1);
-  expect(
-    await queries.getThreadUnreadActivityCountByChannel({
-      channelId: unreadTestChannelId,
-    })
-  ).toBe(1);
 
   await queries.clearThreadUnread({ channelId: unreadTestChannelId, threadId });
 
@@ -1067,11 +1062,6 @@ test('thread unread queries treat notification-only activity as unread until cle
       excludeRead: true,
     })
   ).toHaveLength(0);
-  expect(
-    await queries.getThreadUnreadActivityCountByChannel({
-      channelId: unreadTestChannelId,
-    })
-  ).toBe(0);
 });
 
 // TLON-5606: `getPendingPosts` feeds the main-channel pending-merge layer.

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -919,6 +919,48 @@ test('clearChannelUnread clears notification-only channel activity', async () =>
   });
 });
 
+test('channel unread clears preserve notify while a thread notification remains', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  await queries.insertChannelUnreads([
+    makeChannelUnread({ count: 1, countWithoutThreads: 1 }),
+  ]);
+  await queries.insertThreadUnreads([makeThreadUnread()]);
+
+  await queries.clearChannelUnread(unreadTestChannelId);
+
+  const unread = await client.query.channelUnreads.findFirst({
+    where: $.eq(schema.channelUnreads.channelId, unreadTestChannelId),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    countWithoutThreads: 0,
+    notify: true,
+  });
+
+  const decrementChannelId = 'chat/~zod/decrement-preserve-thread/general';
+  await queries.insertChannelUnreads([
+    makeChannelUnread({ channelId: decrementChannelId, count: 3 }),
+  ]);
+  await queries.insertThreadUnreads([
+    makeThreadUnread({ channelId: decrementChannelId }),
+  ]);
+
+  await queries.updateChannelUnreadCount({
+    channelId: decrementChannelId,
+    decrement: 3,
+  });
+
+  const decrementedUnread = await client.query.channelUnreads.findFirst({
+    where: $.eq(schema.channelUnreads.channelId, decrementChannelId),
+  });
+  expect(decrementedUnread).toMatchObject({
+    count: 0,
+    notify: true,
+  });
+});
+
 test('notifying unread source count includes notification-only sources', async () => {
   await queries.insertGroupUnreads([makeGroupUnread()]);
   await queries.insertChannelUnreads([makeChannelUnread()]);
@@ -945,6 +987,34 @@ test('group unread count updates clear notification state when count reaches zer
     count: 0,
     notify: false,
     notifyCount: 0,
+  });
+});
+
+test('group unread count updates preserve notification state while a thread notification remains', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  const groupId = groupsData[0].id;
+  const channelId = 'chat/~zod/decrement-preserve-thread/general';
+  await queries.insertGroups({ groups: [groupsData[0]] });
+  await queries.insertChannels([{ id: channelId, type: 'chat', groupId }]);
+  await queries.insertGroupUnreads([
+    makeGroupUnread({ groupId, count: 3, notify: true, notifyCount: 1 }),
+  ]);
+  await queries.insertChannelUnreads([
+    makeChannelUnread({ channelId, count: 0, notify: true }),
+  ]);
+  await queries.insertThreadUnreads([makeThreadUnread({ channelId })]);
+
+  await queries.updateGroupUnreadCount({ groupId, decrement: 3 });
+
+  const unread = await client.query.groupUnreads.findFirst({
+    where: $.eq(schema.groupUnreads.groupId, groupId),
+  });
+  expect(unread).toMatchObject({
+    count: 0,
+    notify: true,
+    notifyCount: 1,
   });
 });
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1931,23 +1931,6 @@ function threadUnreadActivityPredicate() {
   return or(ne($threadUnreads.count, 0), eq($threadUnreads.notify, true));
 }
 
-export const getThreadUnreadActivityCountByChannel = createReadQuery(
-  'getThreadUnreadActivityCountByChannel',
-  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
-    const result = await ctx.db
-      .select({ count: count() })
-      .from($threadUnreads)
-      .where(
-        and(
-          eq($threadUnreads.channelId, channelId),
-          threadUnreadActivityPredicate()
-        )
-      );
-    return result[0]?.count ?? 0;
-  },
-  ['threadUnreads']
-);
-
 export interface GetUnreadsOptions {
   orderBy?: 'updatedAt';
   includeFullyRead?: boolean;
@@ -4977,15 +4960,14 @@ export const insertChannelUnreads = createWriteQuery(
       }
     });
   },
-  (unreads) =>
-    unreads.length
-      ? [
-          'channelUnreads',
-          ...(unreads.some((u) => (u.threadUnreads?.length ?? 0) > 0)
-            ? (['threadUnreads'] as const)
-            : []),
-        ]
-      : []
+  (unreads) => {
+    if (unreads.length === 0) {
+      return [];
+    }
+    return unreads.some((u) => (u.threadUnreads?.length ?? 0) > 0)
+      ? ['channelUnreads', 'threadUnreads']
+      : ['channelUnreads'];
+  }
 );
 
 export const clearChannelUnread = createWriteQuery(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -4949,59 +4949,6 @@ export const clearGroupUnread = createWriteQuery(
   ['groupUnreads']
 );
 
-export const clearStaleNotificationOnlyGroupUnread = createWriteQuery(
-  'clearStaleNotificationOnlyGroupUnread',
-  async ({ groupId }: { groupId: string }, ctx: QueryCtx) => {
-    const groupUnread = await ctx.db.query.groupUnreads.findFirst({
-      where: eq($groupUnreads.groupId, groupId),
-    });
-    if (!groupUnread?.notify || (groupUnread.count ?? 0) > 0) {
-      return false;
-    }
-
-    const [notifyingChannels] = await ctx.db
-      .select({ count: count() })
-      .from($channelUnreads)
-      .innerJoin($channels, eq($channelUnreads.channelId, $channels.id))
-      .where(
-        and(eq($channels.groupId, groupId), eq($channelUnreads.notify, true))
-      );
-    if ((notifyingChannels?.count ?? 0) > 0) {
-      return false;
-    }
-
-    const [notifyingThreads] = await ctx.db
-      .select({ count: count() })
-      .from($threadUnreads)
-      .innerJoin($channels, eq($threadUnreads.channelId, $channels.id))
-      .where(
-        and(eq($channels.groupId, groupId), eq($threadUnreads.notify, true))
-      );
-    if ((notifyingThreads?.count ?? 0) > 0) {
-      return false;
-    }
-
-    const [joinRequests] = await ctx.db
-      .select({ count: count() })
-      .from($groupJoinRequests)
-      .where(eq($groupJoinRequests.groupId, groupId));
-    const [flaggedPosts] = await ctx.db
-      .select({ count: count() })
-      .from($groupFlaggedPosts)
-      .where(eq($groupFlaggedPosts.groupId, groupId));
-    if ((joinRequests?.count ?? 0) > 0 || (flaggedPosts?.count ?? 0) > 0) {
-      return false;
-    }
-
-    await ctx.db
-      .update($groupUnreads)
-      .set({ notifyCount: 0, count: 0, notify: false })
-      .where(eq($groupUnreads.groupId, groupId));
-    return true;
-  },
-  ['groupUnreads']
-);
-
 export const insertChannelUnreads = createWriteQuery(
   'insertChannelUnreads',
   async (unreads: ChannelUnread[], ctx: QueryCtx) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1904,24 +1904,25 @@ export const removeChatMembers = createWriteQuery(
 export const getNotifyingUnreadSourceCount = createReadQuery(
   'getNotifyingUnreadSourceCount',
   async (ctx: QueryCtx) => {
-    const channelResult = await ctx.db
+    const channelCountResult = await ctx.db
       .select({ count: count() })
       .from($channelUnreads)
       .where(eq($channelUnreads.notify, true));
 
-    const groupResult = await ctx.db
+    const groupCountResult = await ctx.db
       .select({ count: count() })
       .from($groupUnreads)
       .where(eq($groupUnreads.notify, true));
-    const threadResult = await ctx.db
+    const threadCountResult = await ctx.db
       .select({ count: count() })
       .from($threadUnreads)
       .where(eq($threadUnreads.notify, true));
 
+    // Each query returns one aggregate row; sum the row counts.
     return (
-      (channelResult[0]?.count ?? 0) +
-      (groupResult[0]?.count ?? 0) +
-      (threadResult[0]?.count ?? 0)
+      (channelCountResult[0]?.count ?? 0) +
+      (groupCountResult[0]?.count ?? 0) +
+      (threadCountResult[0]?.count ?? 0)
     );
   },
   ['channelUnreads', 'groupUnreads', 'threadUnreads']
@@ -1929,6 +1930,49 @@ export const getNotifyingUnreadSourceCount = createReadQuery(
 
 function threadUnreadActivityPredicate() {
   return or(ne($threadUnreads.count, 0), eq($threadUnreads.notify, true));
+}
+
+async function hasNotifyingThreadUnreadByChannel(
+  ctx: QueryCtx,
+  channelId: string
+) {
+  const result = await ctx.db
+    .select({ channelId: $threadUnreads.channelId })
+    .from($threadUnreads)
+    .where(
+      and(
+        eq($threadUnreads.channelId, channelId),
+        eq($threadUnreads.notify, true)
+      )
+    )
+    .limit(1);
+
+  return result.length > 0;
+}
+
+async function getNotifyingChildChannelCountByGroup(
+  ctx: QueryCtx,
+  groupId: string
+) {
+  const channelResult = await ctx.db
+    .select({ channelId: $channelUnreads.channelId })
+    .from($channelUnreads)
+    .innerJoin($channels, eq($channelUnreads.channelId, $channels.id))
+    .where(
+      and(eq($channels.groupId, groupId), eq($channelUnreads.notify, true))
+    );
+
+  const threadResult = await ctx.db
+    .selectDistinct({ channelId: $threadUnreads.channelId })
+    .from($threadUnreads)
+    .innerJoin($channels, eq($threadUnreads.channelId, $channels.id))
+    .where(
+      and(eq($channels.groupId, groupId), eq($threadUnreads.notify, true))
+    );
+
+  return new Set(
+    [...channelResult, ...threadResult].map((row) => row.channelId)
+  ).size;
 }
 
 export interface GetUnreadsOptions {
@@ -4922,11 +4966,20 @@ export const updateGroupUnreadCount = createWriteQuery(
       const existingCount = existingUnread.count ?? 0;
       const nextCount = existingCount - decrement;
       if (existingCount && nextCount >= 0) {
+        const remainingNotifyCount =
+          nextCount === 0
+            ? await getNotifyingChildChannelCountByGroup(ctx, groupId)
+            : null;
         return ctx.db
           .update($groupUnreads)
           .set({
             count: nextCount,
-            ...(nextCount === 0 ? { notify: false, notifyCount: 0 } : {}),
+            ...(remainingNotifyCount !== null
+              ? {
+                  notify: remainingNotifyCount > 0,
+                  notifyCount: remainingNotifyCount,
+                }
+              : {}),
           })
           .where(eq($groupUnreads.groupId, groupId));
       }
@@ -4987,12 +5040,16 @@ export const insertChannelUnreads = createWriteQuery(
 export const clearChannelUnread = createWriteQuery(
   'clearChannelUnread',
   async (channelId: string, ctx: QueryCtx) => {
+    const hasThreadNotification = await hasNotifyingThreadUnreadByChannel(
+      ctx,
+      channelId
+    );
     return ctx.db
       .update($channelUnreads)
       .set({
         count: 0,
         countWithoutThreads: 0,
-        notify: false,
+        notify: hasThreadNotification,
         firstUnreadPostId: null,
       })
       .where(eq($channelUnreads.channelId, channelId));
@@ -5014,11 +5071,17 @@ export const updateChannelUnreadCount = createWriteQuery(
       const existingCount = existingUnread.count ?? 0;
       const nextCount = existingCount - decrement;
       if (existingCount && nextCount >= 0) {
+        const hasThreadNotification =
+          nextCount === 0
+            ? await hasNotifyingThreadUnreadByChannel(ctx, channelId)
+            : null;
         return ctx.db
           .update($channelUnreads)
           .set({
             count: nextCount,
-            ...(nextCount === 0 ? { notify: false } : {}),
+            ...(hasThreadNotification !== null
+              ? { notify: hasThreadNotification }
+              : {}),
           })
           .where(eq($channelUnreads.channelId, channelId));
       }

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -4319,6 +4319,7 @@ export const getPersonalGroup = createReadQuery(
   [
     'groups',
     'channelUnreads',
+    'groupUnreads',
     'volumeSettings',
     'channels',
     'groupJoinRequests',
@@ -4339,6 +4340,7 @@ export const getBotHomeGroup = createReadQuery(
   [
     'groups',
     'channelUnreads',
+    'groupUnreads',
     'volumeSettings',
     'channels',
     'groupJoinRequests',
@@ -4397,6 +4399,7 @@ export const getGroup = createReadQuery(
   [
     'groups',
     'channelUnreads',
+    'groupUnreads',
     'volumeSettings',
     'channels',
     'groupJoinRequests',
@@ -4956,7 +4959,7 @@ export const clearChannelUnread = createWriteQuery(
 );
 
 export const updateChannelUnreadCount = createWriteQuery(
-  'updateGroupUnreadCount',
+  'updateChannelUnreadCount',
   async (
     { channelId, decrement }: { channelId: string; decrement: number },
     ctx: QueryCtx
@@ -4975,7 +4978,7 @@ export const updateChannelUnreadCount = createWriteQuery(
       }
     }
   },
-  ['groupUnreads']
+  ['channelUnreads']
 );
 
 export const insertThreadUnreads = createWriteQuery(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -4949,6 +4949,59 @@ export const clearGroupUnread = createWriteQuery(
   ['groupUnreads']
 );
 
+export const clearStaleNotificationOnlyGroupUnread = createWriteQuery(
+  'clearStaleNotificationOnlyGroupUnread',
+  async ({ groupId }: { groupId: string }, ctx: QueryCtx) => {
+    const groupUnread = await ctx.db.query.groupUnreads.findFirst({
+      where: eq($groupUnreads.groupId, groupId),
+    });
+    if (!groupUnread?.notify || (groupUnread.count ?? 0) > 0) {
+      return false;
+    }
+
+    const [notifyingChannels] = await ctx.db
+      .select({ count: count() })
+      .from($channelUnreads)
+      .innerJoin($channels, eq($channelUnreads.channelId, $channels.id))
+      .where(
+        and(eq($channels.groupId, groupId), eq($channelUnreads.notify, true))
+      );
+    if ((notifyingChannels?.count ?? 0) > 0) {
+      return false;
+    }
+
+    const [notifyingThreads] = await ctx.db
+      .select({ count: count() })
+      .from($threadUnreads)
+      .innerJoin($channels, eq($threadUnreads.channelId, $channels.id))
+      .where(
+        and(eq($channels.groupId, groupId), eq($threadUnreads.notify, true))
+      );
+    if ((notifyingThreads?.count ?? 0) > 0) {
+      return false;
+    }
+
+    const [joinRequests] = await ctx.db
+      .select({ count: count() })
+      .from($groupJoinRequests)
+      .where(eq($groupJoinRequests.groupId, groupId));
+    const [flaggedPosts] = await ctx.db
+      .select({ count: count() })
+      .from($groupFlaggedPosts)
+      .where(eq($groupFlaggedPosts.groupId, groupId));
+    if ((joinRequests?.count ?? 0) > 0 || (flaggedPosts?.count ?? 0) > 0) {
+      return false;
+    }
+
+    await ctx.db
+      .update($groupUnreads)
+      .set({ notifyCount: 0, count: 0, notify: false })
+      .where(eq($groupUnreads.groupId, groupId));
+    return true;
+  },
+  ['groupUnreads']
+);
+
 export const insertChannelUnreads = createWriteQuery(
   'insertChannelUnreads',
   async (unreads: ChannelUnread[], ctx: QueryCtx) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1903,20 +1903,11 @@ export const removeChatMembers = createWriteQuery(
 
 export const getNotifyingUnreadSourceCount = createReadQuery(
   'getNotifyingUnreadSourceCount',
-  async ({ type }: { type?: ChannelUnread['type'] }, ctx: QueryCtx) => {
+  async (ctx: QueryCtx) => {
     const channelResult = await ctx.db
       .select({ count: count() })
       .from($channelUnreads)
-      .where(() =>
-        and(
-          $channelUnreads.notify,
-          type ? eq($channelUnreads.type, type) : undefined
-        )
-      );
-
-    if (type) {
-      return channelResult[0]?.count ?? 0;
-    }
+      .where(eq($channelUnreads.notify, true));
 
     const groupResult = await ctx.db
       .select({ count: count() })
@@ -1933,11 +1924,12 @@ export const getNotifyingUnreadSourceCount = createReadQuery(
       (threadResult[0]?.count ?? 0)
     );
   },
-  ({ type }): TableName[] =>
-    type
-      ? ['channelUnreads']
-      : ['channelUnreads', 'groupUnreads', 'threadUnreads']
+  ['channelUnreads', 'groupUnreads', 'threadUnreads']
 );
+
+function threadUnreadActivityPredicate() {
+  return or(ne($threadUnreads.count, 0), eq($threadUnreads.notify, true));
+}
 
 export const getThreadUnreadActivityCountByChannel = createReadQuery(
   'getThreadUnreadActivityCountByChannel',
@@ -1948,7 +1940,7 @@ export const getThreadUnreadActivityCountByChannel = createReadQuery(
       .where(
         and(
           eq($threadUnreads.channelId, channelId),
-          or(not(eq($threadUnreads.count, 0)), eq($threadUnreads.notify, true))
+          threadUnreadActivityPredicate()
         )
       );
     return result[0]?.count ?? 0;
@@ -4931,10 +4923,14 @@ export const updateGroupUnreadCount = createWriteQuery(
 
     if (existingUnread) {
       const existingCount = existingUnread.count ?? 0;
-      if (existingCount && existingCount - decrement >= 0) {
+      const nextCount = existingCount - decrement;
+      if (existingCount && nextCount >= 0) {
         return ctx.db
           .update($groupUnreads)
-          .set({ count: existingCount - decrement })
+          .set({
+            count: nextCount,
+            ...(nextCount === 0 ? { notify: false, notifyCount: 0 } : {}),
+          })
           .where(eq($groupUnreads.groupId, groupId));
       }
     }
@@ -5020,10 +5016,14 @@ export const updateChannelUnreadCount = createWriteQuery(
 
     if (existingUnread) {
       const existingCount = existingUnread.count ?? 0;
-      if (existingCount && existingCount - decrement >= 0) {
+      const nextCount = existingCount - decrement;
+      if (existingCount && nextCount >= 0) {
         return ctx.db
           .update($channelUnreads)
-          .set({ count: existingCount - decrement })
+          .set({
+            count: nextCount,
+            ...(nextCount === 0 ? { notify: false } : {}),
+          })
           .where(eq($channelUnreads.channelId, channelId));
       }
     }
@@ -5055,12 +5055,7 @@ export const getThreadUnreadsByChannel = createReadQuery(
     return ctx.db.query.threadUnreads.findMany({
       where: and(
         eq($threadUnreads.channelId, channelId),
-        excludeRead
-          ? or(
-              not(eq($threadUnreads.count, 0)),
-              eq($threadUnreads.notify, true)
-            )
-          : undefined
+        excludeRead ? threadUnreadActivityPredicate() : undefined
       ),
     });
   },

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2128,6 +2128,20 @@ export const getChannelUnread = createReadQuery(
   ['channelUnreads']
 );
 
+export const getNotifyingChannelUnreadsByGroup = createReadQuery(
+  'getNotifyingChannelUnreadsByGroup',
+  async ({ groupId }: { groupId: string }, ctx: QueryCtx) => {
+    return ctx.db
+      .select(getTableColumns($channelUnreads))
+      .from($channelUnreads)
+      .innerJoin($channels, eq($channelUnreads.channelId, $channels.id))
+      .where(
+        and(eq($channels.groupId, groupId), eq($channelUnreads.notify, true))
+      );
+  },
+  ['channelUnreads', 'channels']
+);
+
 export const getGroupUnread = createReadQuery(
   'getGroupUnread',
   async ({ groupId }: { groupId: string }, ctx: QueryCtx) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1904,19 +1904,39 @@ export const removeChatMembers = createWriteQuery(
 export const getUnreadsCountWithoutMuted = createReadQuery(
   'getUnreadsCountWithoutMuted',
   async ({ type }: { type?: ChannelUnread['type'] }, ctx: QueryCtx) => {
-    const result = await ctx.db
+    const channelResult = await ctx.db
       .select({ count: count() })
       .from($channelUnreads)
       .where(() =>
         and(
           $channelUnreads.notify,
-          gt($channelUnreads.count, 0),
           type ? eq($channelUnreads.type, type) : undefined
         )
       );
-    return result[0]?.count ?? 0;
+
+    if (type) {
+      return channelResult[0]?.count ?? 0;
+    }
+
+    const groupResult = await ctx.db
+      .select({ count: count() })
+      .from($groupUnreads)
+      .where(eq($groupUnreads.notify, true));
+    const threadResult = await ctx.db
+      .select({ count: count() })
+      .from($threadUnreads)
+      .where(eq($threadUnreads.notify, true));
+
+    return (
+      (channelResult[0]?.count ?? 0) +
+      (groupResult[0]?.count ?? 0) +
+      (threadResult[0]?.count ?? 0)
+    );
   },
-  ['channelUnreads']
+  ({ type }): TableName[] =>
+    type
+      ? ['channelUnreads']
+      : ['channelUnreads', 'groupUnreads', 'threadUnreads']
 );
 
 export interface GetUnreadsOptions {
@@ -4939,12 +4959,20 @@ export const insertChannelUnreads = createWriteQuery(
           .values(threadUnreads)
           .onConflictDoUpdate({
             target: [$threadUnreads.threadId, $threadUnreads.channelId],
-            set: conflictUpdateSetAll($channelUnreads),
+            set: conflictUpdateSetAll($threadUnreads),
           });
       }
     });
   },
-  (unreads) => (unreads.length ? ['channelUnreads'] : [])
+  (unreads) =>
+    unreads.length
+      ? [
+          'channelUnreads',
+          ...(unreads.some((u) => (u.threadUnreads?.length ?? 0) > 0)
+            ? (['threadUnreads'] as const)
+            : []),
+        ]
+      : []
 );
 
 export const clearChannelUnread = createWriteQuery(
@@ -4952,7 +4980,12 @@ export const clearChannelUnread = createWriteQuery(
   async (channelId: string, ctx: QueryCtx) => {
     return ctx.db
       .update($channelUnreads)
-      .set({ count: 0, countWithoutThreads: 0, firstUnreadPostId: null })
+      .set({
+        count: 0,
+        countWithoutThreads: 0,
+        notify: false,
+        firstUnreadPostId: null,
+      })
       .where(eq($channelUnreads.channelId, channelId));
   },
   ['channelUnreads']
@@ -5005,7 +5038,12 @@ export const getThreadUnreadsByChannel = createReadQuery(
     return ctx.db.query.threadUnreads.findMany({
       where: and(
         eq($threadUnreads.channelId, channelId),
-        excludeRead ? not(eq($threadUnreads.count, 0)) : undefined
+        excludeRead
+          ? or(
+              not(eq($threadUnreads.count, 0)),
+              eq($threadUnreads.notify, true)
+            )
+          : undefined
       ),
     });
   },
@@ -5020,7 +5058,7 @@ export const clearThreadUnread = createWriteQuery(
   ) => {
     return ctx.db
       .update($threadUnreads)
-      .set({ count: 0, firstUnreadPostId: null })
+      .set({ count: 0, notify: false, firstUnreadPostId: null })
       .where(
         and(
           eq($threadUnreads.channelId, channelId),
@@ -5036,7 +5074,7 @@ export const clearChannelThreadUnreads = createWriteQuery(
   async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
     return ctx.db
       .update($threadUnreads)
-      .set({ count: 0, firstUnreadPostId: null })
+      .set({ count: 0, notify: false, firstUnreadPostId: null })
       .where(eq($threadUnreads.channelId, channelId));
   },
   ['threadUnreads']

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1901,8 +1901,8 @@ export const removeChatMembers = createWriteQuery(
   ['chatMembers', 'groups']
 );
 
-export const getUnreadsCountWithoutMuted = createReadQuery(
-  'getUnreadsCountWithoutMuted',
+export const getNotifyingUnreadSourceCount = createReadQuery(
+  'getNotifyingUnreadSourceCount',
   async ({ type }: { type?: ChannelUnread['type'] }, ctx: QueryCtx) => {
     const channelResult = await ctx.db
       .select({ count: count() })
@@ -1937,6 +1937,23 @@ export const getUnreadsCountWithoutMuted = createReadQuery(
     type
       ? ['channelUnreads']
       : ['channelUnreads', 'groupUnreads', 'threadUnreads']
+);
+
+export const getThreadUnreadActivityCountByChannel = createReadQuery(
+  'getThreadUnreadActivityCountByChannel',
+  async ({ channelId }: { channelId: string }, ctx: QueryCtx) => {
+    const result = await ctx.db
+      .select({ count: count() })
+      .from($threadUnreads)
+      .where(
+        and(
+          eq($threadUnreads.channelId, channelId),
+          or(not(eq($threadUnreads.count, 0)), eq($threadUnreads.notify, true))
+        )
+      );
+    return result[0]?.count ?? 0;
+  },
+  ['threadUnreads']
 );
 
 export interface GetUnreadsOptions {

--- a/packages/shared/src/store/activityActions.ts
+++ b/packages/shared/src/store/activityActions.ts
@@ -171,12 +171,15 @@ export async function setDefaultNotificationLevel(
 }
 
 export async function markAllRead() {
+  const baseUnread = await db.getBaseUnread();
+
   await db.insertBaseUnread({
     id: BASE_UNREADS_SINGLETON_KEY,
     count: 0,
     updatedAt: Date.now(),
     notify: false,
     notifyCount: 0,
+    notifTimestamp: baseUnread?.notifTimestamp,
   });
   await api.readAll();
 }

--- a/packages/shared/src/store/channelActions.test.ts
+++ b/packages/shared/src/store/channelActions.test.ts
@@ -88,17 +88,9 @@ test('markChannelRead clears stale notification-only group unread after channel 
   });
 });
 
-test('markChannelRead preserves notification-only group unread when another group notification is present', async () => {
-  const client = getClient();
-  if (!client) throw new Error('test db not initialized');
-
+test('markChannelRead preserves notification-only group unread when it does not match the channel notification', async () => {
   await insertGroupAndChannel();
-  await client.insert(schema.groupJoinRequests).values({
-    groupId,
-    contactId: '~nec',
-    requestedAt: 100,
-  });
-  await db.insertGroupUnreads([makeGroupUnread()]);
+  await db.insertGroupUnreads([makeGroupUnread({ updatedAt: 200 })]);
   await db.insertChannelUnreads([makeChannelUnread()]);
 
   await markChannelRead({ id: channelId, groupId });
@@ -114,7 +106,7 @@ test('markChannelRead preserves notification-only group unread when another grou
   });
 });
 
-test('markChannelRead preserves notification-only group unread when another channel still notifies', async () => {
+test('markChannelRead preserves notification-only group unread when it has multiple notifying items', async () => {
   const otherChannelId = 'chat/~zod/stale-notify/random';
 
   await insertGroupAndChannel();

--- a/packages/shared/src/store/channelActions.test.ts
+++ b/packages/shared/src/store/channelActions.test.ts
@@ -106,15 +106,17 @@ test('markChannelRead preserves notification-only group unread when it does not 
   });
 });
 
-test('markChannelRead preserves notification-only group unread when it has multiple notifying items', async () => {
+test('markChannelRead decrements notification-only group unread when it has multiple notifying channels', async () => {
   const otherChannelId = 'chat/~zod/stale-notify/random';
 
   await insertGroupAndChannel();
   await insertGroupAndChannel({ id: otherChannelId });
-  await db.insertGroupUnreads([makeGroupUnread({ notifyCount: 2 })]);
+  await db.insertGroupUnreads([
+    makeGroupUnread({ notifyCount: 2, updatedAt: 200 }),
+  ]);
   await db.insertChannelUnreads([
-    makeChannelUnread(),
-    makeChannelUnread({ channelId: otherChannelId }),
+    makeChannelUnread({ updatedAt: 200 }),
+    makeChannelUnread({ channelId: otherChannelId, updatedAt: 100 }),
   ]);
 
   await markChannelRead({ id: channelId, groupId });
@@ -126,6 +128,47 @@ test('markChannelRead preserves notification-only group unread when it has multi
   expect(await db.getGroupUnread({ groupId })).toMatchObject({
     count: 0,
     notify: true,
-    notifyCount: 2,
+    notifyCount: 1,
+    updatedAt: 100,
+  });
+
+  await markChannelRead({ id: otherChannelId, groupId });
+
+  expect(await db.getGroupUnread({ groupId })).toMatchObject({
+    count: 0,
+    notify: false,
+    notifyCount: 0,
+  });
+});
+
+test('markChannelRead decrements group count and notify count for notifying message unreads', async () => {
+  const otherChannelId = 'chat/~zod/stale-notify/random';
+
+  await insertGroupAndChannel();
+  await insertGroupAndChannel({ id: otherChannelId });
+  await db.insertGroupUnreads([
+    makeGroupUnread({ count: 2, notifyCount: 2, updatedAt: 200 }),
+  ]);
+  await db.insertChannelUnreads([
+    makeChannelUnread({
+      count: 1,
+      countWithoutThreads: 1,
+      updatedAt: 200,
+    }),
+    makeChannelUnread({
+      channelId: otherChannelId,
+      count: 1,
+      countWithoutThreads: 1,
+      updatedAt: 100,
+    }),
+  ]);
+
+  await markChannelRead({ id: channelId, groupId });
+
+  expect(await db.getGroupUnread({ groupId })).toMatchObject({
+    count: 1,
+    notify: true,
+    notifyCount: 1,
+    updatedAt: 100,
   });
 });

--- a/packages/shared/src/store/channelActions.test.ts
+++ b/packages/shared/src/store/channelActions.test.ts
@@ -1,0 +1,139 @@
+import { poke } from '@tloncorp/api';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import * as db from '../db';
+import * as schema from '../db/schema';
+import { getClient, setupDatabaseTestSuite } from '../test/helpers';
+import { markChannelRead } from './channelActions';
+
+setupDatabaseTestSuite();
+
+const groupId = '~zod/stale-notify';
+const channelId = 'chat/~zod/stale-notify/general';
+
+async function insertGroupAndChannel({
+  id = channelId,
+  group = groupId,
+}: {
+  id?: string;
+  group?: string;
+} = {}) {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  await client
+    .insert(schema.groups)
+    .values({
+      id: group,
+      currentUserIsMember: true,
+      currentUserIsHost: false,
+      hostUserId: '~zod',
+    })
+    .onConflictDoNothing();
+  await client.insert(schema.channels).values({
+    id,
+    type: 'chat',
+    groupId: group,
+  });
+}
+
+function makeChannelUnread(
+  overrides: Partial<db.ChannelUnread> = {}
+): db.ChannelUnread {
+  return {
+    channelId,
+    type: 'channel',
+    count: 0,
+    countWithoutThreads: 0,
+    notify: true,
+    updatedAt: 100,
+    firstUnreadPostId: null,
+    firstUnreadPostReceivedAt: null,
+    ...overrides,
+  };
+}
+
+function makeGroupUnread(
+  overrides: Partial<db.GroupUnread> = {}
+): db.GroupUnread {
+  return {
+    groupId,
+    count: 0,
+    notify: true,
+    notifyCount: 1,
+    updatedAt: 100,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.mocked(poke).mockClear();
+});
+
+test('markChannelRead clears stale notification-only group unread after channel notification is read', async () => {
+  await insertGroupAndChannel();
+  await db.insertGroupUnreads([makeGroupUnread()]);
+  await db.insertChannelUnreads([makeChannelUnread()]);
+
+  await markChannelRead({ id: channelId, groupId });
+
+  expect(await db.getChannelUnread({ channelId })).toMatchObject({
+    count: 0,
+    notify: false,
+  });
+  expect(await db.getGroupUnread({ groupId })).toMatchObject({
+    count: 0,
+    notify: false,
+    notifyCount: 0,
+  });
+});
+
+test('markChannelRead preserves notification-only group unread when another group notification is present', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  await insertGroupAndChannel();
+  await client.insert(schema.groupJoinRequests).values({
+    groupId,
+    contactId: '~nec',
+    requestedAt: 100,
+  });
+  await db.insertGroupUnreads([makeGroupUnread()]);
+  await db.insertChannelUnreads([makeChannelUnread()]);
+
+  await markChannelRead({ id: channelId, groupId });
+
+  expect(await db.getChannelUnread({ channelId })).toMatchObject({
+    count: 0,
+    notify: false,
+  });
+  expect(await db.getGroupUnread({ groupId })).toMatchObject({
+    count: 0,
+    notify: true,
+    notifyCount: 1,
+  });
+});
+
+test('markChannelRead preserves notification-only group unread when another channel still notifies', async () => {
+  const otherChannelId = 'chat/~zod/stale-notify/random';
+
+  await insertGroupAndChannel();
+  await insertGroupAndChannel({ id: otherChannelId });
+  await db.insertGroupUnreads([makeGroupUnread({ notifyCount: 2 })]);
+  await db.insertChannelUnreads([
+    makeChannelUnread(),
+    makeChannelUnread({ channelId: otherChannelId }),
+  ]);
+
+  await markChannelRead({ id: channelId, groupId });
+
+  expect(await db.getChannelUnread({ channelId })).toMatchObject({
+    count: 0,
+    notify: false,
+  });
+  expect(await db.getGroupUnread({ groupId })).toMatchObject({
+    count: 0,
+    notify: true,
+    notifyCount: 2,
+  });
+});

--- a/packages/shared/src/store/channelActions.test.ts
+++ b/packages/shared/src/store/channelActions.test.ts
@@ -1,4 +1,5 @@
 import { poke } from '@tloncorp/api';
+import * as $ from 'drizzle-orm';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import * as db from '../db';
@@ -66,6 +67,21 @@ function makeGroupUnread(
   };
 }
 
+function makeThreadUnread(
+  overrides: Partial<db.ThreadUnreadState> = {}
+): db.ThreadUnreadState {
+  return {
+    channelId,
+    threadId: 'thread-notify',
+    count: 0,
+    notify: true,
+    updatedAt: 100,
+    firstUnreadPostId: null,
+    firstUnreadPostReceivedAt: null,
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   vi.mocked(poke).mockClear();
 });
@@ -106,6 +122,22 @@ test('markChannelRead preserves notification-only group unread when it does not 
   });
 });
 
+test('markChannelRead clears final notifying message group unread', async () => {
+  await insertGroupAndChannel();
+  await db.insertGroupUnreads([makeGroupUnread({ count: 1, notifyCount: 1 })]);
+  await db.insertChannelUnreads([
+    makeChannelUnread({ count: 1, countWithoutThreads: 1 }),
+  ]);
+
+  await markChannelRead({ id: channelId, groupId });
+
+  expect(await db.getGroupUnread({ groupId })).toMatchObject({
+    count: 0,
+    notify: false,
+    notifyCount: 0,
+  });
+});
+
 test('markChannelRead decrements notification-only group unread when it has multiple notifying channels', async () => {
   const otherChannelId = 'chat/~zod/stale-notify/random';
 
@@ -138,6 +170,34 @@ test('markChannelRead decrements notification-only group unread when it has mult
     count: 0,
     notify: false,
     notifyCount: 0,
+  });
+});
+
+test('markChannelRead includes threads when clearing channel notify', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  await insertGroupAndChannel();
+  await db.insertChannelUnreads([
+    makeChannelUnread({
+      count: 1,
+      countWithoutThreads: 0,
+      threadUnreads: [makeThreadUnread({ count: 1 })],
+    }),
+  ]);
+
+  await markChannelRead({ id: channelId, includeThreads: true });
+
+  expect(await db.getChannelUnread({ channelId })).toMatchObject({
+    count: 0,
+    notify: false,
+  });
+  const threadUnread = await client.query.threadUnreads.findFirst({
+    where: $.eq(schema.threadUnreads.channelId, channelId),
+  });
+  expect(threadUnread).toMatchObject({
+    count: 0,
+    notify: false,
   });
 });
 

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -610,6 +610,9 @@ export async function markChannelRead({
   logger.log(`marking channel as read`, id, 'includeThreads', includeThreads);
   // optimistic update
   const existingUnread = await db.getChannelUnread({ channelId: id });
+  const existingGroupUnread = groupId
+    ? await db.getGroupUnread({ groupId })
+    : null;
   if (existingUnread) {
     await db.clearChannelUnread(id);
   }
@@ -631,6 +634,14 @@ export async function markChannelRead({
       decrement: existingCount,
     });
   }
+  const shouldClearStaleGroupNotification =
+    groupId &&
+    existingUnread?.notify === true &&
+    (existingUnread.count ?? 0) === 0 &&
+    (existingUnread.countWithoutThreads ?? 0) === 0;
+  const clearedStaleGroupNotification = shouldClearStaleGroupNotification
+    ? await db.clearStaleNotificationOnlyGroupUnread({ groupId })
+    : false;
 
   const existingChannel = await db.getChannel({ id });
 
@@ -657,6 +668,9 @@ export async function markChannelRead({
     }
     if (existingThreadUnreads.length > 0) {
       await db.insertThreadUnreads(existingThreadUnreads);
+    }
+    if (clearedStaleGroupNotification && existingGroupUnread) {
+      await db.insertGroupUnreads([existingGroupUnread]);
     }
   }
 }

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -613,9 +613,6 @@ export async function markChannelRead({
   const existingGroupUnread = groupId
     ? await db.getGroupUnread({ groupId })
     : null;
-  if (existingUnread) {
-    await db.clearChannelUnread(id);
-  }
 
   let existingThreadUnreads: db.ThreadUnreadState[] = [];
   if (includeThreads) {
@@ -624,6 +621,9 @@ export async function markChannelRead({
       excludeRead: true,
     });
     await db.clearChannelThreadUnreads({ channelId: id });
+  }
+  if (existingUnread) {
+    await db.clearChannelUnread(id);
   }
 
   const remainingNotifyingChannelUnreads =
@@ -642,7 +642,8 @@ export async function markChannelRead({
   const shouldUpdateGroupNotification =
     existingUnread?.notify === true &&
     existingGroupUnread?.notify === true &&
-    ((existingGroupUnread.notifyCount ?? 0) > 1 ||
+    (existingCount > 0 ||
+      (existingGroupUnread.notifyCount ?? 0) > 1 ||
       (channelUnreadWasNotificationOnly &&
         groupUnreadLooksLikeSameNotification));
   const nextGroupUnread = existingGroupUnread
@@ -655,13 +656,15 @@ export async function markChannelRead({
     );
   }
   if (nextGroupUnread && shouldUpdateGroupNotification) {
+    const remainingNotifyCount = remainingNotifyingChannelUnreads.length;
     nextGroupUnread.notifyCount = Math.max(
       (nextGroupUnread.notifyCount ?? 0) - 1,
+      remainingNotifyCount,
       0
     );
     if (
-      nextGroupUnread.notifyCount === remainingNotifyingChannelUnreads.length &&
-      remainingNotifyingChannelUnreads.length > 0
+      nextGroupUnread.notifyCount === remainingNotifyCount &&
+      remainingNotifyCount > 0
     ) {
       // Keep the "same notification" guard valid if the newest channel
       // notification was the one just cleared.

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -626,14 +626,11 @@ export async function markChannelRead({
     await db.clearChannelThreadUnreads({ channelId: id });
   }
 
+  const remainingNotifyingChannelUnreads =
+    groupId && existingUnread?.notify === true
+      ? await db.getNotifyingChannelUnreadsByGroup({ groupId })
+      : [];
   const existingCount = existingUnread?.count ?? 0;
-  if (groupId && existingCount > 0) {
-    // optimitically update group unread count
-    await db.updateGroupUnreadCount({
-      groupId,
-      decrement: existingCount,
-    });
-  }
   const channelUnreadWasNotificationOnly =
     existingUnread?.notify === true &&
     (existingUnread.count ?? 0) === 0 &&
@@ -641,14 +638,54 @@ export async function markChannelRead({
   const groupUnreadLooksLikeSameNotification =
     existingGroupUnread?.notify === true &&
     (existingGroupUnread.count ?? 0) === 0 &&
-    (existingGroupUnread.notifyCount ?? 0) <= 1 &&
     existingGroupUnread.updatedAt === existingUnread?.updatedAt;
-  const shouldClearStaleGroupNotification =
+  const shouldUpdateGroupNotification =
+    existingUnread?.notify === true &&
+    existingGroupUnread?.notify === true &&
+    ((existingGroupUnread.notifyCount ?? 0) > 1 ||
+      (channelUnreadWasNotificationOnly &&
+        groupUnreadLooksLikeSameNotification));
+  const nextGroupUnread = existingGroupUnread
+    ? { ...existingGroupUnread }
+    : null;
+  if (nextGroupUnread && existingCount > 0) {
+    nextGroupUnread.count = Math.max(
+      (nextGroupUnread.count ?? 0) - existingCount,
+      0
+    );
+  }
+  if (nextGroupUnread && shouldUpdateGroupNotification) {
+    nextGroupUnread.notifyCount = Math.max(
+      (nextGroupUnread.notifyCount ?? 0) - 1,
+      0
+    );
+    if (
+      nextGroupUnread.notifyCount === remainingNotifyingChannelUnreads.length &&
+      remainingNotifyingChannelUnreads.length > 0
+    ) {
+      // Keep the "same notification" guard valid if the newest channel
+      // notification was the one just cleared.
+      nextGroupUnread.updatedAt = Math.max(
+        ...remainingNotifyingChannelUnreads.map((unread) => unread.updatedAt)
+      );
+    }
+    nextGroupUnread.notify = nextGroupUnread.notifyCount > 0;
+  }
+  let didUpdateGroupUnread = false;
+  if (
     groupId &&
-    channelUnreadWasNotificationOnly &&
-    groupUnreadLooksLikeSameNotification;
-  if (shouldClearStaleGroupNotification) {
-    await db.clearGroupUnread(groupId);
+    nextGroupUnread &&
+    (existingCount > 0 || shouldUpdateGroupNotification)
+  ) {
+    if (
+      (nextGroupUnread.count ?? 0) === 0 &&
+      (nextGroupUnread.notifyCount ?? 0) === 0
+    ) {
+      await db.clearGroupUnread(groupId);
+    } else {
+      await db.insertGroupUnreads([nextGroupUnread]);
+    }
+    didUpdateGroupUnread = true;
   }
 
   const existingChannel = await db.getChannel({ id });
@@ -677,7 +714,7 @@ export async function markChannelRead({
     if (existingThreadUnreads.length > 0) {
       await db.insertThreadUnreads(existingThreadUnreads);
     }
-    if (shouldClearStaleGroupNotification && existingGroupUnread) {
+    if (didUpdateGroupUnread && existingGroupUnread) {
       await db.insertGroupUnreads([existingGroupUnread]);
     }
   }

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -634,14 +634,22 @@ export async function markChannelRead({
       decrement: existingCount,
     });
   }
-  const shouldClearStaleGroupNotification =
-    groupId &&
+  const channelUnreadWasNotificationOnly =
     existingUnread?.notify === true &&
     (existingUnread.count ?? 0) === 0 &&
     (existingUnread.countWithoutThreads ?? 0) === 0;
-  const clearedStaleGroupNotification = shouldClearStaleGroupNotification
-    ? await db.clearStaleNotificationOnlyGroupUnread({ groupId })
-    : false;
+  const groupUnreadLooksLikeSameNotification =
+    existingGroupUnread?.notify === true &&
+    (existingGroupUnread.count ?? 0) === 0 &&
+    (existingGroupUnread.notifyCount ?? 0) <= 1 &&
+    existingGroupUnread.updatedAt === existingUnread?.updatedAt;
+  const shouldClearStaleGroupNotification =
+    groupId &&
+    channelUnreadWasNotificationOnly &&
+    groupUnreadLooksLikeSameNotification;
+  if (shouldClearStaleGroupNotification) {
+    await db.clearGroupUnread(groupId);
+  }
 
   const existingChannel = await db.getChannel({ id });
 
@@ -669,7 +677,7 @@ export async function markChannelRead({
     if (existingThreadUnreads.length > 0) {
       await db.insertThreadUnreads(existingThreadUnreads);
     }
-    if (clearedStaleGroupNotification && existingGroupUnread) {
+    if (shouldClearStaleGroupNotification && existingGroupUnread) {
       await db.insertGroupUnreads([existingGroupUnread]);
     }
   }

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -181,7 +181,7 @@ export const useNotifyingUnreadSourceCount = () => {
       'notifyingUnreadSourceCount',
       useKeyFromQueryDeps(db.getNotifyingUnreadSourceCount),
     ],
-    queryFn: () => db.getNotifyingUnreadSourceCount({}),
+    queryFn: () => db.getNotifyingUnreadSourceCount(),
   });
 };
 

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -291,10 +291,7 @@ export const useLiveThreadUnreadByParentId = (parentPostId: string | null) => {
 };
 
 export const useLiveThreadUnreadsByChannel = (channelId: string | null) => {
-  const depsKey = useMemo(
-    () => (channelId ? keyFromQueryDeps(db.getThreadUnreadsByChannel) : null),
-    [channelId]
-  );
+  const depsKey = useKeyFromQueryDeps(db.getThreadUnreadsByChannel);
 
   return useQuery({
     enabled: !!channelId,

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -290,6 +290,24 @@ export const useLiveThreadUnreadByParentId = (parentPostId: string | null) => {
   });
 };
 
+export const useLiveThreadUnreadsByChannel = (channelId: string | null) => {
+  const depsKey = useMemo(
+    () => (channelId ? keyFromQueryDeps(db.getThreadUnreadsByChannel) : null),
+    [channelId]
+  );
+
+  return useQuery({
+    enabled: !!channelId,
+    queryKey: ['liveThreadUnreadsByChannel', depsKey, channelId],
+    queryFn: async () => {
+      if (!channelId) {
+        return [];
+      }
+      return db.getThreadUnreadsByChannel({ channelId, excludeRead: true });
+    },
+  });
+};
+
 export const useLiveChannelUnread = (unread: db.ChannelUnread | null) => {
   const depsKey = useMemo(
     () => (unread ? keyFromQueryDeps(db.getChannelUnread) : null),

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -290,25 +290,23 @@ export const useLiveThreadUnreadByParentId = (parentPostId: string | null) => {
   });
 };
 
-export const useLiveThreadUnreadActivityCountByChannel = (
-  channelId: string | null
-) => {
+export const useLiveThreadUnreadsByChannel = (channelId: string | null) => {
   const depsKey = useMemo(
-    () =>
-      channelId
-        ? keyFromQueryDeps(db.getThreadUnreadActivityCountByChannel)
-        : null,
+    () => (channelId ? keyFromQueryDeps(db.getThreadUnreadsByChannel) : null),
     [channelId]
   );
 
   return useQuery({
     enabled: !!channelId,
-    queryKey: ['liveThreadUnreadActivityCountByChannel', depsKey, channelId],
+    queryKey: ['liveThreadUnreadsByChannel', depsKey, channelId],
     queryFn: async () => {
       if (!channelId) {
-        return 0;
+        return [];
       }
-      return db.getThreadUnreadActivityCountByChannel({ channelId });
+      return db.getThreadUnreadsByChannel({
+        channelId,
+        excludeRead: true,
+      });
     },
   });
 };

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -175,13 +175,13 @@ export const useContacts = () => {
   });
 };
 
-export const useUnreadsCountWithoutMuted = () => {
+export const useNotifyingUnreadSourceCount = () => {
   return useQuery({
     queryKey: [
-      'unreadsCount',
-      useKeyFromQueryDeps(db.getUnreadsCountWithoutMuted),
+      'notifyingUnreadSourceCount',
+      useKeyFromQueryDeps(db.getNotifyingUnreadSourceCount),
     ],
-    queryFn: () => db.getUnreadsCountWithoutMuted({}),
+    queryFn: () => db.getNotifyingUnreadSourceCount({}),
   });
 };
 
@@ -290,20 +290,25 @@ export const useLiveThreadUnreadByParentId = (parentPostId: string | null) => {
   });
 };
 
-export const useLiveThreadUnreadsByChannel = (channelId: string | null) => {
+export const useLiveThreadUnreadActivityCountByChannel = (
+  channelId: string | null
+) => {
   const depsKey = useMemo(
-    () => (channelId ? keyFromQueryDeps(db.getThreadUnreadsByChannel) : null),
+    () =>
+      channelId
+        ? keyFromQueryDeps(db.getThreadUnreadActivityCountByChannel)
+        : null,
     [channelId]
   );
 
   return useQuery({
     enabled: !!channelId,
-    queryKey: ['liveThreadUnreadsByChannel', depsKey, channelId],
+    queryKey: ['liveThreadUnreadActivityCountByChannel', depsKey, channelId],
     queryFn: async () => {
       if (!channelId) {
-        return [];
+        return 0;
       }
-      return db.getThreadUnreadsByChannel({ channelId, excludeRead: true });
+      return db.getThreadUnreadActivityCountByChannel({ channelId });
     },
   });
 };

--- a/packages/shared/src/store/index.ts
+++ b/packages/shared/src/store/index.ts
@@ -14,6 +14,7 @@ export * from './dmActions';
 export * from './useNegotiation';
 export * from './activityActions';
 export * from './useActivityFetchers';
+export * from './unreadActivity';
 export * from './session';
 export * from './contactActions';
 export * from './clientActions';

--- a/packages/shared/src/store/unreadActivity.ts
+++ b/packages/shared/src/store/unreadActivity.ts
@@ -1,0 +1,37 @@
+type UnreadActivity = {
+  count?: number | null;
+  notify?: boolean | null;
+};
+
+type ChannelUnreadActivity = UnreadActivity & {
+  countWithoutThreads?: number | null;
+};
+
+export function hasUnreadActivity(unread?: UnreadActivity | null) {
+  return (unread?.count ?? 0) > 0 || unread?.notify === true;
+}
+
+export function isUnreadActivityCleared(unread?: UnreadActivity | null) {
+  return !hasUnreadActivity(unread);
+}
+
+export function hasMainChannelUnreadActivity({
+  unread,
+  hasChildThreadUnreadActivity = false,
+  childThreadUnreadActivityKnown = true,
+}: {
+  unread?: ChannelUnreadActivity | null;
+  hasChildThreadUnreadActivity?: boolean;
+  childThreadUnreadActivityKnown?: boolean;
+}) {
+  const count = unread?.count ?? 0;
+  const countWithoutThreads = unread?.countWithoutThreads ?? 0;
+
+  return (
+    countWithoutThreads > 0 ||
+    (!!unread?.notify &&
+      count === countWithoutThreads &&
+      childThreadUnreadActivityKnown &&
+      !hasChildThreadUnreadActivity)
+  );
+}

--- a/packages/shared/src/store/unreadActivity.ts
+++ b/packages/shared/src/store/unreadActivity.ts
@@ -26,12 +26,13 @@ export function hasMainChannelUnreadActivity({
 }) {
   const count = unread?.count ?? 0;
   const countWithoutThreads = unread?.countWithoutThreads ?? 0;
+  const hasMainUnreadCount = countWithoutThreads > 0;
+  const notifyBelongsToMainChannel = count === countWithoutThreads;
+  const childThreadStateIsClear =
+    childThreadUnreadActivityKnown && !hasChildThreadUnreadActivity;
 
   return (
-    countWithoutThreads > 0 ||
-    (!!unread?.notify &&
-      count === countWithoutThreads &&
-      childThreadUnreadActivityKnown &&
-      !hasChildThreadUnreadActivity)
+    hasMainUnreadCount ||
+    (!!unread?.notify && notifyBelongsToMainChannel && childThreadStateIsClear)
   );
 }


### PR DESCRIPTION
## Summary

Fixes several unread state mismatches that could leave group, channel, activity, or badge state stale or inconsistent. Group and channel unread queries now invalidate from the tables they actually read, notification-only activity such as reactions is treated as unread activity, and badge/presented-notification gates now follow the backend `notify` signal instead of only message counts.

Fixes TLON-5871

## Changes

- Added missing unread query invalidation for group detail state and fixed channel unread count invalidation.
- Preserved base unread notification timestamps when deriving local unread rows for badge updates.
- Switched badge and presented notification gates to count local notifying unread sources, including notification-only rows.
- Mark channel/thread notification-only activity as read when the user opens the relevant source.
- Added shared unread activity helpers and a child thread unread activity count so parent DMs do not clear while a child thread is still notifying.
- Fixed nested thread unread upserts from channel unread inserts.
- Added DB/API coverage for base unread conversion, notification-only clearing, query invalidation metadata, and nested/thread unread behavior.

## How did I test?

Tested on device

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [x] Notifications

## Rollback plan

Revert.
