### PR TITLE
native: required app update screen

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -92,6 +92,24 @@ const useSplashHider = () => {
 const App = () => {
   const isDarkMode = useIsDarkMode();
   const updateRequired = useRequiredUpdate();
+
+  if (updateRequired) {
+    return (
+      <View height={'100%'} width={'100%'} backgroundColor="$background">
+        <RequiredUpdateScreen />
+        <StatusBar
+          backgroundColor={isDarkMode ? 'black' : 'white'}
+          barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+        />
+      </View>
+    );
+  }
+
+  return <MainApp />;
+};
+
+const MainApp = () => {
+  const isDarkMode = useIsDarkMode();
   const {
     isLoading,
     connected,
@@ -113,18 +131,6 @@ const App = () => {
   useEffect(() => {
     registerBackgroundSyncTask();
   }, []);
-
-  if (updateRequired) {
-    return (
-      <View height={'100%'} width={'100%'} backgroundColor="$background">
-        <RequiredUpdateScreen />
-        <StatusBar
-          backgroundColor={isDarkMode ? 'black' : 'white'}
-          barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-        />
-      </View>
-    );
-  }
 
   return (
     <View height={'100%'} width={'100%'} backgroundColor="$background">

--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -12,9 +12,11 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import ErrorBoundary from '@tloncorp/app/ErrorBoundary';
 import { BranchProvider } from '@tloncorp/app/contexts/branch';
+import { RequiredUpdateScreen } from '@tloncorp/app/features/RequiredUpdateScreen';
 import { useHandleLogout } from '@tloncorp/app/hooks/useHandleLogout';
 import { useIsDarkMode } from '@tloncorp/app/hooks/useIsDarkMode';
 import { useNavigationLogging } from '@tloncorp/app/hooks/useNavigationLogger';
+import { useRequiredUpdate } from '@tloncorp/app/hooks/useRequiredUpdate';
 import { useResetDb } from '@tloncorp/app/hooks/useResetDb';
 import { useMigrations } from '@tloncorp/app/lib/nativeDb';
 import { splashScreenProgress } from '@tloncorp/app/lib/splashscreen';
@@ -89,6 +91,7 @@ const useSplashHider = () => {
 // Android notification tap handler passes initial params here
 const App = () => {
   const isDarkMode = useIsDarkMode();
+  const updateRequired = useRequiredUpdate();
   const {
     isLoading,
     connected,
@@ -110,6 +113,18 @@ const App = () => {
   useEffect(() => {
     registerBackgroundSyncTask();
   }, []);
+
+  if (updateRequired) {
+    return (
+      <View height={'100%'} width={'100%'} backgroundColor="$background">
+        <RequiredUpdateScreen />
+        <StatusBar
+          backgroundColor={isDarkMode ? 'black' : 'white'}
+          barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+        />
+      </View>
+    );
+  }
 
   return (
     <View height={'100%'} width={'100%'} backgroundColor="$background">

--- a/packages/app/features/RequiredUpdateScreen.tsx
+++ b/packages/app/features/RequiredUpdateScreen.tsx
@@ -1,0 +1,25 @@
+import { Text, View } from '@tloncorp/ui';
+import { YStack } from 'tamagui';
+
+export function RequiredUpdateScreen() {
+  return (
+    <View flex={1} backgroundColor="$background" padding="$2xl">
+      <YStack flex={1} justifyContent="center" alignItems="center">
+        <YStack gap="$m" alignItems="center" maxWidth={400}>
+          <Text fontSize="$xl" color="$primaryText" textAlign="center">
+            Update Required
+          </Text>
+          <Text
+            fontSize="$m"
+            color="$secondaryText"
+            textAlign="center"
+            lineHeight="$m"
+          >
+            You're running an older version of Tlon that's no longer supported.
+            Please update to continue.
+          </Text>
+        </YStack>
+      </YStack>
+    </View>
+  );
+}

--- a/packages/app/features/RequiredUpdateScreen.tsx
+++ b/packages/app/features/RequiredUpdateScreen.tsx
@@ -1,11 +1,28 @@
-import { Text, View } from '@tloncorp/ui';
+import { Button, Text, View } from '@tloncorp/ui';
+import { useCallback } from 'react';
+import { Linking, Platform } from 'react-native';
 import { YStack } from 'tamagui';
 
+import { TLON_APP_STORE_URL, TLON_PLAY_STORE_URL } from '../constants';
+
 export function RequiredUpdateScreen() {
+  const storeUrl =
+    Platform.OS === 'ios' ? TLON_APP_STORE_URL : TLON_PLAY_STORE_URL;
+  const storeName = Platform.OS === 'ios' ? 'App Store' : 'Play Store';
+
+  const handleUpdatePress = useCallback(() => {
+    Linking.openURL(storeUrl);
+  }, [storeUrl]);
+
   return (
     <View flex={1} backgroundColor="$background" padding="$2xl">
       <YStack flex={1} justifyContent="center" alignItems="center">
-        <YStack gap="$m" alignItems="center" maxWidth={400}>
+        <YStack
+          gap="$m"
+          alignItems="center"
+          maxWidth={400}
+          marginHorizontal="$m"
+        >
           <Text fontSize="$xl" color="$primaryText" textAlign="center">
             Update Required
           </Text>
@@ -18,6 +35,12 @@ export function RequiredUpdateScreen() {
             You're running an older version of Tlon that's no longer supported.
             Please update to continue.
           </Text>
+          <Button
+            marginTop="$2xl"
+            preset="hero"
+            label={`View in ${storeName}`}
+            onPress={handleUpdatePress}
+          />
         </YStack>
       </YStack>
     </View>

--- a/packages/app/hooks/useRequiredUpdate.ts
+++ b/packages/app/hooks/useRequiredUpdate.ts
@@ -10,12 +10,7 @@ const logger = createDevLogger('useRequiredUpdate', false);
 
 type PlatformKey = 'ios' | 'android';
 
-interface MinVersionResponse {
-  ios?: { minVersion?: string };
-  android?: { minVersion?: string };
-}
-
-async function fetchMinVersion(endpoint: string): Promise<MinVersionResponse> {
+async function fetchMinVersion(endpoint: string): Promise<unknown> {
   const response = await fetch(`${endpoint}/minVersion`);
   if (!response.ok) {
     throw new Error(`minVersion request failed: ${response.status}`);
@@ -29,24 +24,39 @@ function currentPlatform(): PlatformKey | null {
   return null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function getMinVersion(data: unknown, platform: PlatformKey): string | null {
+  if (!isRecord(data)) return null;
+
+  const platformData = data[platform];
+  if (!isRecord(platformData)) return null;
+
+  const minVersion = platformData.minVersion;
+  return typeof minVersion === 'string' && minVersion.trim()
+    ? minVersion
+    : null;
+}
+
 export function useRequiredUpdate(): boolean {
   const platform = currentPlatform();
-  const currentVersion = Application.nativeApplicationVersion ?? '0.0.0';
+  const currentVersion = Application.nativeApplicationVersion;
   const enabled = !!platform && !!INVITE_SERVICE_ENDPOINT;
 
   const query = useQuery({
     queryKey: ['required-update', INVITE_SERVICE_ENDPOINT],
     queryFn: () => fetchMinVersion(INVITE_SERVICE_ENDPOINT),
     refetchInterval: POLL_INTERVAL_MS,
-    refetchOnWindowFocus: true,
     retry: 1,
     staleTime: POLL_INTERVAL_MS,
     enabled,
   });
 
-  if (!platform || !query.data) return false;
+  if (!platform || !currentVersion || !query.data) return false;
 
-  const minVersion = query.data[platform]?.minVersion;
+  const minVersion = getMinVersion(query.data, platform);
   if (!minVersion) return false;
 
   const required = isVersionBelow(currentVersion, minVersion);

--- a/packages/app/hooks/useRequiredUpdate.ts
+++ b/packages/app/hooks/useRequiredUpdate.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import { createDevLogger, isVersionBelow } from '@tloncorp/shared';
+import * as Application from 'expo-application';
+import { Platform } from 'react-native';
+
+import { INVITE_SERVICE_ENDPOINT } from '../constants';
+
+const POLL_INTERVAL_MS = 10 * 60 * 1000;
+const logger = createDevLogger('useRequiredUpdate', false);
+
+type PlatformKey = 'ios' | 'android';
+
+interface MinVersionResponse {
+  ios?: { minVersion?: string };
+  android?: { minVersion?: string };
+}
+
+async function fetchMinVersion(endpoint: string): Promise<MinVersionResponse> {
+  const response = await fetch(`${endpoint}/minVersion`);
+  if (!response.ok) {
+    throw new Error(`minVersion request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+function currentPlatform(): PlatformKey | null {
+  if (Platform.OS === 'ios') return 'ios';
+  if (Platform.OS === 'android') return 'android';
+  return null;
+}
+
+export function useRequiredUpdate(): boolean {
+  const platform = currentPlatform();
+  const currentVersion = Application.nativeApplicationVersion ?? '0.0.0';
+  const enabled = !!platform && !!INVITE_SERVICE_ENDPOINT;
+
+  const query = useQuery({
+    queryKey: ['required-update', INVITE_SERVICE_ENDPOINT],
+    queryFn: () => fetchMinVersion(INVITE_SERVICE_ENDPOINT),
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchOnWindowFocus: true,
+    retry: 1,
+    staleTime: POLL_INTERVAL_MS,
+    enabled,
+  });
+
+  if (!platform || !query.data) return false;
+
+  const minVersion = query.data[platform]?.minVersion;
+  if (!minVersion) return false;
+
+  const required = isVersionBelow(currentVersion, minVersion);
+  if (required) {
+    logger.log('Required update detected', { currentVersion, minVersion });
+  }
+  return required;
+}

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -1,5 +1,6 @@
 export * from './utilHooks';
 export * from './embed';
+export * from './semver';
 export * from '@tloncorp/api/lib/types';
 export * from '@tloncorp/api/lib/utils';
 export * as featureFlags from '@tloncorp/api/lib/featureFlags';

--- a/packages/shared/src/logic/semver.test.ts
+++ b/packages/shared/src/logic/semver.test.ts
@@ -1,45 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { compareSemver, isVersionBelow } from './semver';
-
-describe('compareSemver', () => {
-  it('returns 0 for equal versions', () => {
-    expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
-  });
-
-  it('compares major versions', () => {
-    expect(compareSemver('2.0.0', '1.0.0')).toBeGreaterThan(0);
-    expect(compareSemver('1.0.0', '2.0.0')).toBeLessThan(0);
-  });
-
-  it('compares minor versions', () => {
-    expect(compareSemver('1.2.0', '1.1.0')).toBeGreaterThan(0);
-    expect(compareSemver('1.1.0', '1.2.0')).toBeLessThan(0);
-  });
-
-  it('compares patch versions', () => {
-    expect(compareSemver('1.0.2', '1.0.1')).toBeGreaterThan(0);
-    expect(compareSemver('1.0.1', '1.0.2')).toBeLessThan(0);
-  });
-
-  it('handles numeric comparison, not lexicographic', () => {
-    expect(compareSemver('1.10.0', '1.9.0')).toBeGreaterThan(0);
-  });
-
-  it('ignores prerelease and build metadata', () => {
-    expect(compareSemver('1.2.3-beta', '1.2.3')).toBe(0);
-    expect(compareSemver('1.2.3+build.1', '1.2.3')).toBe(0);
-  });
-
-  it('returns 0 for unparseable versions (fail-open)', () => {
-    expect(compareSemver('not-a-version', '1.0.0')).toBe(0);
-    expect(compareSemver('1.0.0', '')).toBe(0);
-  });
-});
+import { isVersionBelow } from './semver';
 
 describe('isVersionBelow', () => {
   it('returns true when current is older than minimum', () => {
     expect(isVersionBelow('1.0.0', '1.0.1')).toBe(true);
+    expect(isVersionBelow('1.1.0', '1.2.0')).toBe(true);
     expect(isVersionBelow('8.9.0', '9.0.0')).toBe(true);
   });
 
@@ -49,10 +15,23 @@ describe('isVersionBelow', () => {
 
   it('returns false when current is newer than minimum', () => {
     expect(isVersionBelow('1.0.1', '1.0.0')).toBe(false);
+    expect(isVersionBelow('1.2.0', '1.1.0')).toBe(false);
     expect(isVersionBelow('9.0.0', '8.9.0')).toBe(false);
+  });
+
+  it('compares components numerically, not lexicographically', () => {
+    expect(isVersionBelow('1.9.0', '1.10.0')).toBe(true);
+    expect(isVersionBelow('1.10.0', '1.9.0')).toBe(false);
+  });
+
+  it('treats prerelease and build metadata as equal to the core version', () => {
+    expect(isVersionBelow('1.2.3-beta', '1.2.3')).toBe(false);
+    expect(isVersionBelow('1.2.3', '1.2.3-beta')).toBe(false);
+    expect(isVersionBelow('1.2.3+build.1', '1.2.3')).toBe(false);
   });
 
   it('returns false when versions cannot be parsed (fail-open)', () => {
     expect(isVersionBelow('garbage', '1.0.0')).toBe(false);
+    expect(isVersionBelow('1.0.0', '')).toBe(false);
   });
 });

--- a/packages/shared/src/logic/semver.test.ts
+++ b/packages/shared/src/logic/semver.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareSemver, isVersionBelow } from './semver';
+
+describe('compareSemver', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
+  });
+
+  it('compares major versions', () => {
+    expect(compareSemver('2.0.0', '1.0.0')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.0', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('compares minor versions', () => {
+    expect(compareSemver('1.2.0', '1.1.0')).toBeGreaterThan(0);
+    expect(compareSemver('1.1.0', '1.2.0')).toBeLessThan(0);
+  });
+
+  it('compares patch versions', () => {
+    expect(compareSemver('1.0.2', '1.0.1')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.1', '1.0.2')).toBeLessThan(0);
+  });
+
+  it('handles numeric comparison, not lexicographic', () => {
+    expect(compareSemver('1.10.0', '1.9.0')).toBeGreaterThan(0);
+  });
+
+  it('ignores prerelease and build metadata', () => {
+    expect(compareSemver('1.2.3-beta', '1.2.3')).toBe(0);
+    expect(compareSemver('1.2.3+build.1', '1.2.3')).toBe(0);
+  });
+
+  it('returns 0 for unparseable versions (fail-open)', () => {
+    expect(compareSemver('not-a-version', '1.0.0')).toBe(0);
+    expect(compareSemver('1.0.0', '')).toBe(0);
+  });
+});
+
+describe('isVersionBelow', () => {
+  it('returns true when current is older than minimum', () => {
+    expect(isVersionBelow('1.0.0', '1.0.1')).toBe(true);
+    expect(isVersionBelow('8.9.0', '9.0.0')).toBe(true);
+  });
+
+  it('returns false when current equals minimum', () => {
+    expect(isVersionBelow('1.0.0', '1.0.0')).toBe(false);
+  });
+
+  it('returns false when current is newer than minimum', () => {
+    expect(isVersionBelow('1.0.1', '1.0.0')).toBe(false);
+    expect(isVersionBelow('9.0.0', '8.9.0')).toBe(false);
+  });
+
+  it('returns false when versions cannot be parsed (fail-open)', () => {
+    expect(isVersionBelow('garbage', '1.0.0')).toBe(false);
+  });
+});

--- a/packages/shared/src/logic/semver.test.ts
+++ b/packages/shared/src/logic/semver.test.ts
@@ -34,4 +34,10 @@ describe('isVersionBelow', () => {
     expect(isVersionBelow('garbage', '1.0.0')).toBe(false);
     expect(isVersionBelow('1.0.0', '')).toBe(false);
   });
+
+  it('rejects core versions with empty prerelease or build suffix', () => {
+    expect(isVersionBelow('1.2.3-', '1.2.4')).toBe(false);
+    expect(isVersionBelow('1.2.3+', '1.2.4')).toBe(false);
+    expect(isVersionBelow('1.2.4', '1.2.3-')).toBe(false);
+  });
 });

--- a/packages/shared/src/logic/semver.ts
+++ b/packages/shared/src/logic/semver.ts
@@ -6,7 +6,7 @@ function parse(version: string): [number, number, number] | null {
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
-export function compareSemver(a: string, b: string): number {
+function compareCore(a: string, b: string): number {
   const parsedA = parse(a);
   const parsedB = parse(b);
   if (!parsedA || !parsedB) return 0;
@@ -17,5 +17,5 @@ export function compareSemver(a: string, b: string): number {
 }
 
 export function isVersionBelow(current: string, minimum: string): boolean {
-  return compareSemver(current, minimum) < 0;
+  return compareCore(current, minimum) < 0;
 }

--- a/packages/shared/src/logic/semver.ts
+++ b/packages/shared/src/logic/semver.ts
@@ -1,4 +1,4 @@
-const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].+)?$/;
 
 function parse(version: string): [number, number, number] | null {
   const match = SEMVER_RE.exec(version.trim());

--- a/packages/shared/src/logic/semver.ts
+++ b/packages/shared/src/logic/semver.ts
@@ -1,0 +1,21 @@
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+function parse(version: string): [number, number, number] | null {
+  const match = SEMVER_RE.exec(version.trim());
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function compareSemver(a: string, b: string): number {
+  const parsedA = parse(a);
+  const parsedB = parse(b);
+  if (!parsedA || !parsedB) return 0;
+  for (let i = 0; i < 3; i++) {
+    if (parsedA[i] !== parsedB[i]) return parsedA[i] - parsedB[i];
+  }
+  return 0;
+}
+
+export function isVersionBelow(current: string, minimum: string): boolean {
+  return compareSemver(current, minimum) < 0;
+}


### PR DESCRIPTION
## Summary

Adds a force-update mechanism for the mobile app. The app polls a new `/minVersion` endpoint on serverless-infra every 10 minutes; if the user's `nativeApplicationVersion` is below the returned minimum for their platform, a non-dismissible full-screen blocker takes over above onboarding, splash, and the authenticated app. Fixes TLON-5906

## Changes

- `packages/shared/src/logic/semver.ts` — small `compareSemver` / `isVersionBelow` util (no external semver dep), with unit tests covering ordering, numeric-vs-lexicographic comparison, prerelease/build metadata, and fail-open on unparseable input.
- `packages/app/hooks/useRequiredUpdate.ts` — React Query hook that fetches `${INVITE_SERVICE_ENDPOINT}/minVersion` every 10 min, compares `Application.nativeApplicationVersion` against the per-platform minimum, and returns a boolean. Fail-open on network/parse errors.
- `packages/app/features/RequiredUpdateScreen.tsx` — full-screen non-dismissible blocker.
- `apps/tlon-mobile/src/App.main.tsx` — short-circuits the inner `App` to render `RequiredUpdateScreen` (with `StatusBar`) when `useRequiredUpdate()` returns true, before onboarding/splash/auth flows.
- Companion serverless-infra change (separate repo) adds a `GET /api/minVersion` handler returning `{ ios: { minVersion }, android: { minVersion } }` with `Cache-Control: public, s-maxage=60`. Versions are hardcoded constants in the handler; bump them to force an update.

## How did I test?

Did not run the mobile app against a live serverless deploy yet. Things to do: 

1. Merge https://github.com/tloncorp/serverless-infra/pull/2 and deploy with the constants set below the current version on `develop` (`9.0.0`) to confirm the app boots normally (IOW set to `8.3.2`)
2. Bump to `9.0.1` to confirm the blocker takes over above the onboarding stack and survives a relaunch

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Onboarding (blocker mounts above onboarding stack)
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: mobile app boot path (`App.main.tsx`)

Failure modes worth flagging:
- The fetch is fail-open: network error, non-OK response, missing field, or unparseable version all evaluate to "not required". A misconfigured endpoint cannot block users; only a deliberately bumped constant can.
- Conversely, if `MIN_VERSION_*` is set too high in serverless-infra, every user on a lower version is blocked until they update from the store. There is no client-side override.

## Rollback plan

Two independent rollback paths:

1. **Server-side (fastest):** edit `MIN_VERSION_IOS` / `MIN_VERSION_ANDROID` in `serverless-infra/api/minVersion.ts` back to a permissive value (e.g. `"0.0.0"`) and redeploy. Within 60s (CDN cache) + 10 min (client poll) users unblock without an app update.
3. **Client-side:** revert this PR's four commits (`logic: add semver compare util`, `app: add useRequiredUpdate hook`, `app: add RequiredUpdateScreen`, `mobile: gate app on required update`) and cut a new mobile build. Only needed if the hook itself is misbehaving.

## Screenshots / videos

_TODO: add a screenshot of the `RequiredUpdateScreen` once captured in the simulator._
