### PR TITLE
Fix orphan role picker sheet on assign/remove

### DIFF
--- a/packages/app/ui/components/ActionSheet.tsx
+++ b/packages/app/ui/components/ActionSheet.tsx
@@ -149,6 +149,7 @@ const ActionSheetComponent = ({
   closeButton,
   footerComponent,
   unmountOnClose,
+  stackBehavior,
   ...props
 }: PropsWithChildren<
   ActionSheetProps &
@@ -159,6 +160,7 @@ const ActionSheetComponent = ({
       | 'hasScrollableContent'
       | 'keyboardBehavior'
       | 'unmountOnClose'
+      | 'stackBehavior'
     >
 >) => {
   const mode = useAdaptiveMode(forcedMode);
@@ -357,6 +359,7 @@ const ActionSheetComponent = ({
       footerComponent={footerComponent}
       hasScrollableContent={hasScrollableContent}
       unmountOnClose={unmountOnClose}
+      stackBehavior={stackBehavior}
       frameStyle={{}}
     >
       <ActionSheetContext.Provider value={actionSheetContextValue}>

--- a/packages/app/ui/components/BottomSheetWrapper.native.tsx
+++ b/packages/app/ui/components/BottomSheetWrapper.native.tsx
@@ -146,6 +146,7 @@ export const BottomSheetWrapper = forwardRef<
       enableContentPanningGesture,
       enableDynamicSizing,
       unmountOnClose = false,
+      stackBehavior,
     },
     ref
   ) => {
@@ -465,6 +466,7 @@ export const BottomSheetWrapper = forwardRef<
           key={mountKey}
           ref={bottomSheetModalRef}
           accessibilityViewIsModal={true}
+          stackBehavior={stackBehavior}
           {...commonProps}
           {...commonOverrides}
         >

--- a/packages/app/ui/components/BottomSheetWrapper.types.ts
+++ b/packages/app/ui/components/BottomSheetWrapper.types.ts
@@ -51,6 +51,15 @@ export interface BottomSheetWrapperProps {
    * sheets that exhibit Android render desync after close (TLON-5664).
    */
   unmountOnClose?: boolean;
+
+  /**
+   * Forwards Gorhom's `BottomSheetModal` `stackBehavior` prop on native;
+   * ignored on web. Use `'push'` for a modal presented from within another
+   * presented modal so Gorhom does not call `.minimize()` on the parent;
+   * the default `'switch'` minimizes the parent, which our wrapper interprets
+   * as a user dismissal (see TLON-5891).
+   */
+  stackBehavior?: 'replace' | 'push' | 'switch';
 }
 
 export interface BottomSheetScrollViewProps {

--- a/packages/app/ui/components/BottomSheetWrapper.web.tsx
+++ b/packages/app/ui/components/BottomSheetWrapper.web.tsx
@@ -30,6 +30,7 @@ export const BottomSheetWrapper = forwardRef<
       enablePanDownToClose: _enablePanDownToClose,
       keyboardBehavior: _keyboardBehavior,
       android_keyboardInputMode: _android_keyboardInputMode,
+      stackBehavior: _stackBehavior,
     },
     ref
   ) => {

--- a/packages/app/ui/components/GroupMemberProfileSheet.tsx
+++ b/packages/app/ui/components/GroupMemberProfileSheet.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { useCurrentUserId } from '../contexts/appDataContext';
@@ -8,7 +9,7 @@ import { ProfileSheet } from './ProfileSheet';
 // Match BottomSheetWrapper's `quick` transition (250ms) + small buffer for
 // Gorhom to fully unmount the modal portal entry before the React tree is
 // torn down by `onDismiss`. See TLON-5891.
-const PARENT_CLOSE_ANIMATION_MS = 300;
+const PARENT_CLOSE_ANIMATION_MS = Platform.OS === 'web' ? 0 : 300;
 
 export function GroupMemberProfileSheet({
   selectedContact,
@@ -51,13 +52,6 @@ export function GroupMemberProfileSheet({
     [groupMembers, selectedContact]
   );
 
-  const handlePressGoToProfile = useCallback(() => {
-    if (selectedContact && onPressGoToProfile) {
-      onDismiss();
-      onPressGoToProfile(selectedContact);
-    }
-  }, [selectedContact, onPressGoToProfile, onDismiss]);
-
   // Local "is the parent sheet open" state. Controlling it (rather than
   // hardcoding `open={true}`) lets us trigger Gorhom's dismiss animation on
   // the parent BottomSheetModal before signalling the caller to unmount via
@@ -66,27 +60,56 @@ export function GroupMemberProfileSheet({
   // leaving a visible "orphan" sheet — the same class of bug we just fixed
   // for the nested role picker (TLON-5891).
   const [parentOpen, setParentOpen] = useState(true);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearDismissTimer = useCallback(() => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, []);
+
+  const dismiss = useCallback(
+    (afterDismiss?: () => void) => {
+      setParentOpen(false);
+      clearDismissTimer();
+
+      const finishDismiss = () => {
+        dismissTimerRef.current = null;
+        onDismiss();
+        afterDismiss?.();
+      };
+
+      if (PARENT_CLOSE_ANIMATION_MS === 0) {
+        finishDismiss();
+        return;
+      }
+
+      dismissTimerRef.current = setTimeout(
+        finishDismiss,
+        PARENT_CLOSE_ANIMATION_MS
+      );
+    },
+    [clearDismissTimer, onDismiss]
+  );
+
+  const handlePressGoToProfile = useCallback(() => {
+    if (selectedContact && onPressGoToProfile) {
+      dismiss(() => onPressGoToProfile(selectedContact));
+    }
+  }, [selectedContact, onPressGoToProfile, dismiss]);
 
   // Re-arm `parentOpen` when the caller mounts us for a different member.
   // GMPS only renders ProfileSheet when `selectedContact` is non-null, so
   // this effect catches the null → contact transition.
   useEffect(() => {
     if (selectedContact) {
+      clearDismissTimer();
       setParentOpen(true);
     }
-  }, [selectedContact]);
+  }, [selectedContact, clearDismissTimer]);
 
-  // When the parent sheet has been told to close (either by a user gesture
-  // or by a role-action's deferred parent dismiss), wait for the close
-  // animation to finish, then signal the caller to unmount us. By this
-  // point Gorhom has already removed the parent's portal entry via
-  // `enableDismissOnClose`, so the unmount is clean.
-  useEffect(() => {
-    if (!parentOpen) {
-      const timer = setTimeout(onDismiss, PARENT_CLOSE_ANIMATION_MS);
-      return () => clearTimeout(timer);
-    }
-  }, [parentOpen, onDismiss]);
+  useEffect(() => () => clearDismissTimer(), [clearDismissTimer]);
 
   if (!selectedContact) {
     return null;
@@ -97,7 +120,7 @@ export function GroupMemberProfileSheet({
       open={parentOpen}
       onOpenChange={(open) => {
         if (!open) {
-          setParentOpen(false);
+          dismiss();
         }
       }}
       contactId={selectedContact}

--- a/packages/app/ui/components/GroupMemberProfileSheet.tsx
+++ b/packages/app/ui/components/GroupMemberProfileSheet.tsx
@@ -1,9 +1,14 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { useCurrentUserId } from '../contexts/appDataContext';
 import { useIsAdmin } from '../utils';
 import { ProfileSheet } from './ProfileSheet';
+
+// Match BottomSheetWrapper's `quick` transition (250ms) + small buffer for
+// Gorhom to fully unmount the modal portal entry before the React tree is
+// torn down by `onDismiss`. See TLON-5891.
+const PARENT_CLOSE_ANIMATION_MS = 300;
 
 export function GroupMemberProfileSheet({
   selectedContact,
@@ -53,16 +58,46 @@ export function GroupMemberProfileSheet({
     }
   }, [selectedContact, onPressGoToProfile, onDismiss]);
 
+  // Local "is the parent sheet open" state. Controlling it (rather than
+  // hardcoding `open={true}`) lets us trigger Gorhom's dismiss animation on
+  // the parent BottomSheetModal before signalling the caller to unmount via
+  // `onDismiss`. Without this, the parent's React component would be torn
+  // down while its Gorhom queue entry was still at a visible snap point,
+  // leaving a visible "orphan" sheet — the same class of bug we just fixed
+  // for the nested role picker (TLON-5891).
+  const [parentOpen, setParentOpen] = useState(true);
+
+  // Re-arm `parentOpen` when the caller mounts us for a different member.
+  // GMPS only renders ProfileSheet when `selectedContact` is non-null, so
+  // this effect catches the null → contact transition.
+  useEffect(() => {
+    if (selectedContact) {
+      setParentOpen(true);
+    }
+  }, [selectedContact]);
+
+  // When the parent sheet has been told to close (either by a user gesture
+  // or by a role-action's deferred parent dismiss), wait for the close
+  // animation to finish, then signal the caller to unmount us. By this
+  // point Gorhom has already removed the parent's portal entry via
+  // `enableDismissOnClose`, so the unmount is clean.
+  useEffect(() => {
+    if (!parentOpen) {
+      const timer = setTimeout(onDismiss, PARENT_CLOSE_ANIMATION_MS);
+      return () => clearTimeout(timer);
+    }
+  }, [parentOpen, onDismiss]);
+
   if (!selectedContact) {
     return null;
   }
 
   return (
     <ProfileSheet
-      open={true}
+      open={parentOpen}
       onOpenChange={(open) => {
         if (!open) {
-          onDismiss();
+          setParentOpen(false);
         }
       }}
       contactId={selectedContact}

--- a/packages/app/ui/components/GroupMemberProfileSheet.tsx
+++ b/packages/app/ui/components/GroupMemberProfileSheet.tsx
@@ -1,15 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Platform } from 'react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useGroupContext } from '../../hooks/useGroupContext';
 import { useCurrentUserId } from '../contexts/appDataContext';
+import { useSheetCloseAfterAnimation } from '../hooks/useSheetCloseAfterAnimation';
 import { useIsAdmin } from '../utils';
 import { ProfileSheet } from './ProfileSheet';
-
-// Match BottomSheetWrapper's `quick` transition (250ms) + small buffer for
-// Gorhom to fully unmount the modal portal entry before the React tree is
-// torn down by `onDismiss`. See TLON-5891.
-const PARENT_CLOSE_ANIMATION_MS = Platform.OS === 'web' ? 0 : 300;
 
 export function GroupMemberProfileSheet({
   selectedContact,
@@ -60,37 +55,18 @@ export function GroupMemberProfileSheet({
   // leaving a visible "orphan" sheet — the same class of bug we just fixed
   // for the nested role picker (TLON-5891).
   const [parentOpen, setParentOpen] = useState(true);
-  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearDismissTimer = useCallback(() => {
-    if (dismissTimerRef.current) {
-      clearTimeout(dismissTimerRef.current);
-      dismissTimerRef.current = null;
-    }
-  }, []);
+  const { closeAfterAnimation, cancel: cancelDismiss } =
+    useSheetCloseAfterAnimation();
 
   const dismiss = useCallback(
     (afterDismiss?: () => void) => {
       setParentOpen(false);
-      clearDismissTimer();
-
-      const finishDismiss = () => {
-        dismissTimerRef.current = null;
+      closeAfterAnimation(() => {
         onDismiss();
         afterDismiss?.();
-      };
-
-      if (PARENT_CLOSE_ANIMATION_MS === 0) {
-        finishDismiss();
-        return;
-      }
-
-      dismissTimerRef.current = setTimeout(
-        finishDismiss,
-        PARENT_CLOSE_ANIMATION_MS
-      );
+      });
     },
-    [clearDismissTimer, onDismiss]
+    [closeAfterAnimation, onDismiss]
   );
 
   const handlePressGoToProfile = useCallback(() => {
@@ -104,12 +80,10 @@ export function GroupMemberProfileSheet({
   // this effect catches the null → contact transition.
   useEffect(() => {
     if (selectedContact) {
-      clearDismissTimer();
+      cancelDismiss();
       setParentOpen(true);
     }
-  }, [selectedContact, clearDismissTimer]);
-
-  useEffect(() => () => clearDismissTimer(), [clearDismissTimer]);
+  }, [selectedContact, cancelDismiss]);
 
   if (!selectedContact) {
     return null;

--- a/packages/app/ui/components/ProfileSheet.tsx
+++ b/packages/app/ui/components/ProfileSheet.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import { isWeb } from 'tamagui';
 
@@ -8,31 +8,74 @@ import { useCurrentUserId } from '../contexts/appDataContext';
 import { ActionGroup, ActionSheet, createActionGroups } from './ActionSheet';
 import { ProfileBlock } from './ProfileBlock';
 
+// Wait for the inner picker's `quick` (250ms) dismiss animation to complete
+// — and for Gorhom to remove it from the modal stack via
+// `enableDismissOnClose` — before telling the parent profile sheet to close.
+// Without this delay, dismissing the parent first races the inner's
+// teardown and re-introduces the orphan modal class of bug (TLON-5891).
+const PARENT_CLOSE_DELAY_MS = 300;
+
 function RoleAssignmentSheet({
   onAssignRole,
   onRemoveRole,
   roles,
   selectedUserRoles,
+  contactIsHost,
+  closeParent,
   ...actionProps
 }: {
   onAssignRole: (roleId: string) => void;
   onRemoveRole: (roleId: string) => void;
   roles: db.GroupRole[];
   selectedUserRoles: string[];
+  contactIsHost: boolean;
+  closeParent: () => void;
 } & Parameters<typeof ActionSheet.Action>[0]) {
   const [open, setOpen] = useState(false);
+  // Suppresses rapid double-taps between the role tap and the inner sheet's
+  // open=false commit. Reset on the false → true edge so the picker is fully
+  // usable on the next open (including immediately after a host/admin guard).
+  const closingRef = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      closingRef.current = false;
+    }
+  }, [open]);
 
   const handleRoleAction = (role: db.GroupRole) => {
+    if (closingRef.current) {
+      return;
+    }
     if (!role.id) {
       console.error('Role ID is required');
       return;
     }
+    // Host/admin guard: the group host cannot have their `admin` role removed.
+    // Tapping it closes the inner picker (acknowledging the tap) but does
+    // NOT mutate state and does NOT close the parent profile sheet.
+    const isGuardedHostAdmin =
+      contactIsHost &&
+      role.id === 'admin' &&
+      selectedUserRoles.includes(role.id);
+
+    closingRef.current = true;
+
+    if (isGuardedHostAdmin) {
+      setOpen(false);
+      return;
+    }
+
     if (selectedUserRoles.includes(role.id)) {
       onRemoveRole(role.id);
     } else {
       onAssignRole(role.id);
     }
     setOpen(false);
+    // Owned by ProfileSheet (not here), so an optimistic role mutation that
+    // unmounts the admin action group — and `RoleAssignmentSheet` with it —
+    // doesn't cancel the pending parent close. See TLON-5891 follow-up.
+    closeParent();
   };
 
   const roleActions = (
@@ -60,6 +103,9 @@ function RoleAssignmentSheet({
       onOpenChange={setOpen}
       mode="popover"
       modal
+      // Nested inside the parent ProfileSheet's BottomSheetModal. Use `push` so
+      // Gorhom does not minimize the parent on present (TLON-5891).
+      stackBehavior="push"
       trigger={
         <ActionSheet.Action
           {...actionProps}
@@ -113,6 +159,47 @@ export function ProfileSheet({
   const contactIsHost = groupHostId === contactId;
   const contactIsAdmin = selectedUserRoles?.includes('admin');
 
+  // Owns the deferred parent-close timer used by `RoleAssignmentSheet`'s
+  // role-action flow. Owned here (not in `RoleAssignmentSheet`) because the
+  // role action that schedules the close can also unmount the admin action
+  // group as a side effect — e.g. a non-host admin self-demoting via the
+  // checked `admin` role flips `currentUserIsAdmin` to false, which drops
+  // the admin action group and unmounts `RoleAssignmentSheet`. Owning the
+  // timer at this level keeps it alive across that subtree churn.
+  // Cleanup is tied to `contactId` changes and to ProfileSheet unmount
+  // (the `useEffect` below covers both) — NOT to RoleAssignmentSheet unmount.
+  const parentCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  // Stable reference to the latest `onOpenChange` so the timer's callback
+  // doesn't read a stale closure if the prop identity changes between
+  // schedule and fire.
+  const onOpenChangeRef = useRef(onOpenChange);
+  useEffect(() => {
+    onOpenChangeRef.current = onOpenChange;
+  }, [onOpenChange]);
+  const requestParentClose = useCallback(() => {
+    if (parentCloseTimerRef.current) {
+      clearTimeout(parentCloseTimerRef.current);
+    }
+    parentCloseTimerRef.current = setTimeout(() => {
+      parentCloseTimerRef.current = null;
+      onOpenChangeRef.current(false);
+    }, PARENT_CLOSE_DELAY_MS);
+  }, []);
+  // Cancel any pending parent-close timer when the contact changes (so a
+  // stale timer from a previous member's role action doesn't close a freshly
+  // opened profile) or when ProfileSheet unmounts entirely.
+  useEffect(
+    () => () => {
+      if (parentCloseTimerRef.current) {
+        clearTimeout(parentCloseTimerRef.current);
+        parentCloseTimerRef.current = null;
+      }
+    },
+    [contactId]
+  );
+
   const handleBlock = useCallback(() => {
     if (contact && contact.isBlocked) {
       store.unblockUser(contactId);
@@ -165,16 +252,13 @@ export function ProfileSheet({
             <RoleAssignmentSheet
               roles={roles}
               selectedUserRoles={selectedUserRoles ?? []}
+              contactIsHost={contactIsHost}
+              closeParent={requestParentClose}
               onAssignRole={(roleId: string) => {
                 onPressAsignRole?.(roleId);
-                onOpenChange(false);
               }}
               onRemoveRole={(roleId: string) => {
-                if (contactIsHost && roleId === 'admin') {
-                  return;
-                }
                 onPressRemoveRole?.(roleId);
-                onOpenChange(false);
               }}
               {...props}
             />

--- a/packages/app/ui/components/ProfileSheet.tsx
+++ b/packages/app/ui/components/ProfileSheet.tsx
@@ -22,6 +22,7 @@ function RoleAssignmentSheet({
   selectedUserRoles,
   contactIsHost,
   closeParent,
+  cancelParentClose,
   ...actionProps
 }: {
   onAssignRole: (roleId: string) => void;
@@ -30,6 +31,7 @@ function RoleAssignmentSheet({
   selectedUserRoles: string[];
   contactIsHost: boolean;
   closeParent: () => void;
+  cancelParentClose: () => void;
 } & Parameters<typeof ActionSheet.Action>[0]) {
   const [open, setOpen] = useState(false);
   // Suppresses rapid double-taps between the role tap and the inner sheet's
@@ -40,8 +42,9 @@ function RoleAssignmentSheet({
   useEffect(() => {
     if (open) {
       closingRef.current = false;
+      cancelParentClose();
     }
-  }, [open]);
+  }, [open, cancelParentClose]);
 
   const handleRoleAction = (role: db.GroupRole) => {
     if (closingRef.current) {
@@ -178,11 +181,16 @@ export function ProfileSheet({
   useEffect(() => {
     onOpenChangeRef.current = onOpenChange;
   }, [onOpenChange]);
-  const requestParentClose = useCallback(() => {
+
+  const clearParentCloseTimer = useCallback(() => {
     if (parentCloseTimerRef.current) {
       clearTimeout(parentCloseTimerRef.current);
       parentCloseTimerRef.current = null;
     }
+  }, []);
+
+  const requestParentClose = useCallback(() => {
+    clearParentCloseTimer();
 
     if (PARENT_CLOSE_DELAY_MS === 0) {
       onOpenChangeRef.current(false);
@@ -193,18 +201,19 @@ export function ProfileSheet({
       parentCloseTimerRef.current = null;
       onOpenChangeRef.current(false);
     }, PARENT_CLOSE_DELAY_MS);
-  }, []);
-  // Cancel any pending parent-close timer when the contact changes (so a
-  // stale timer from a previous member's role action doesn't close a freshly
-  // opened profile) or when ProfileSheet unmounts entirely.
+  }, [clearParentCloseTimer]);
+
+  // Cancel any pending parent-close timer when another close path takes over,
+  // when the contact changes, or when ProfileSheet unmounts entirely.
+  useEffect(() => {
+    if (!open) {
+      clearParentCloseTimer();
+    }
+  }, [open, clearParentCloseTimer]);
+
   useEffect(
-    () => () => {
-      if (parentCloseTimerRef.current) {
-        clearTimeout(parentCloseTimerRef.current);
-        parentCloseTimerRef.current = null;
-      }
-    },
-    [contactId]
+    () => () => clearParentCloseTimer(),
+    [contactId, clearParentCloseTimer]
   );
 
   const handleBlock = useCallback(() => {
@@ -261,6 +270,7 @@ export function ProfileSheet({
               selectedUserRoles={selectedUserRoles ?? []}
               contactIsHost={contactIsHost}
               closeParent={requestParentClose}
+              cancelParentClose={clearParentCloseTimer}
               onAssignRole={(roleId: string) => {
                 onPressAsignRole?.(roleId);
               }}

--- a/packages/app/ui/components/ProfileSheet.tsx
+++ b/packages/app/ui/components/ProfileSheet.tsx
@@ -1,19 +1,13 @@
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Platform } from 'react-native';
+import { Alert } from 'react-native';
 import { isWeb } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts/appDataContext';
+import { useSheetCloseAfterAnimation } from '../hooks/useSheetCloseAfterAnimation';
 import { ActionGroup, ActionSheet, createActionGroups } from './ActionSheet';
 import { ProfileBlock } from './ProfileBlock';
-
-// Wait for the inner picker's `quick` (250ms) dismiss animation to complete
-// — and for Gorhom to remove it from the modal stack via
-// `enableDismissOnClose` — before telling the parent profile sheet to close.
-// Without this delay, dismissing the parent first races the inner's
-// teardown and re-introduces the orphan modal class of bug (TLON-5891).
-const PARENT_CLOSE_DELAY_MS = Platform.OS === 'web' ? 0 : 300;
 
 function RoleAssignmentSheet({
   onAssignRole,
@@ -162,49 +156,31 @@ export function ProfileSheet({
   const contactIsHost = groupHostId === contactId;
   const contactIsAdmin = selectedUserRoles?.includes('admin');
 
-  // Owns the deferred parent-close timer used by `RoleAssignmentSheet`'s
-  // role-action flow. Owned here (not in `RoleAssignmentSheet`) because the
-  // role action that schedules the close can also unmount the admin action
-  // group as a side effect — e.g. a non-host admin self-demoting via the
-  // checked `admin` role flips `currentUserIsAdmin` to false, which drops
-  // the admin action group and unmounts `RoleAssignmentSheet`. Owning the
-  // timer at this level keeps it alive across that subtree churn.
-  // Cleanup is tied to `contactId` changes and to ProfileSheet unmount
-  // (the `useEffect` below covers both) — NOT to RoleAssignmentSheet unmount.
-  const parentCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-  // Stable reference to the latest `onOpenChange` so the timer's callback
-  // doesn't read a stale closure if the prop identity changes between
-  // schedule and fire.
+  // Owns the deferred parent-close used by `RoleAssignmentSheet`'s role-action
+  // flow. Owned here (not in `RoleAssignmentSheet`) because the role action
+  // that schedules the close can also unmount the admin action group as a side
+  // effect — e.g. a non-host admin self-demoting via the checked `admin` role
+  // flips `currentUserIsAdmin` to false, which drops the admin action group and
+  // unmounts `RoleAssignmentSheet`. Owning it at this level keeps the pending
+  // close alive across that subtree churn.
+  const { closeAfterAnimation, cancel: clearParentCloseTimer } =
+    useSheetCloseAfterAnimation();
+
+  // Stable reference to the latest `onOpenChange` so the deferred close doesn't
+  // read a stale closure if the prop identity changes between schedule and fire.
   const onOpenChangeRef = useRef(onOpenChange);
   useEffect(() => {
     onOpenChangeRef.current = onOpenChange;
   }, [onOpenChange]);
 
-  const clearParentCloseTimer = useCallback(() => {
-    if (parentCloseTimerRef.current) {
-      clearTimeout(parentCloseTimerRef.current);
-      parentCloseTimerRef.current = null;
-    }
-  }, []);
-
   const requestParentClose = useCallback(() => {
-    clearParentCloseTimer();
+    closeAfterAnimation(() => onOpenChangeRef.current(false));
+  }, [closeAfterAnimation]);
 
-    if (PARENT_CLOSE_DELAY_MS === 0) {
-      onOpenChangeRef.current(false);
-      return;
-    }
-
-    parentCloseTimerRef.current = setTimeout(() => {
-      parentCloseTimerRef.current = null;
-      onOpenChangeRef.current(false);
-    }, PARENT_CLOSE_DELAY_MS);
-  }, [clearParentCloseTimer]);
-
-  // Cancel any pending parent-close timer when another close path takes over,
-  // when the contact changes, or when ProfileSheet unmounts entirely.
+  // Cancel any pending parent-close when another close path takes over, when
+  // the contact changes, or when ProfileSheet unmounts entirely. The hook
+  // already cancels on unmount; this also covers the `!open` and contactId
+  // transitions, which the hook does not.
   useEffect(() => {
     if (!open) {
       clearParentCloseTimer();

--- a/packages/app/ui/components/ProfileSheet.tsx
+++ b/packages/app/ui/components/ProfileSheet.tsx
@@ -1,7 +1,7 @@
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
 import { isWeb } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts/appDataContext';
@@ -13,7 +13,7 @@ import { ProfileBlock } from './ProfileBlock';
 // `enableDismissOnClose` — before telling the parent profile sheet to close.
 // Without this delay, dismissing the parent first races the inner's
 // teardown and re-introduces the orphan modal class of bug (TLON-5891).
-const PARENT_CLOSE_DELAY_MS = 300;
+const PARENT_CLOSE_DELAY_MS = Platform.OS === 'web' ? 0 : 300;
 
 function RoleAssignmentSheet({
   onAssignRole,
@@ -181,7 +181,14 @@ export function ProfileSheet({
   const requestParentClose = useCallback(() => {
     if (parentCloseTimerRef.current) {
       clearTimeout(parentCloseTimerRef.current);
+      parentCloseTimerRef.current = null;
     }
+
+    if (PARENT_CLOSE_DELAY_MS === 0) {
+      onOpenChangeRef.current(false);
+      return;
+    }
+
     parentCloseTimerRef.current = setTimeout(() => {
       parentCloseTimerRef.current = null;
       onOpenChangeRef.current(false);

--- a/packages/app/ui/hooks/useSheetCloseAfterAnimation.ts
+++ b/packages/app/ui/hooks/useSheetCloseAfterAnimation.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+// Wait for BottomSheetWrapper's `quick` (250ms) dismiss animation to complete
+// — and for Gorhom to remove the sheet from the modal stack — before running a
+// follow-up action (unmounting the React tree, or closing a parent sheet).
+// Running the follow-up first races Gorhom's teardown and leaves a visible
+// orphan modal. On web there is no Gorhom modal stack, so close immediately;
+// the previous 300ms delay caused the group-ban-core.spec.ts e2e race.
+// See TLON-5891.
+export const SHEET_CLOSE_ANIMATION_MS = Platform.OS === 'web' ? 0 : 300;
+
+/**
+ * Defers a close-related action until a Gorhom bottom sheet has had time to
+ * play its dismiss animation and leave the modal stack. Returns a scheduler
+ * that runs the action after the grace window (immediately when the window is
+ * `0`, e.g. web) plus a `cancel` to drop a pending action when a competing
+ * close/open path takes over. The pending action is also cancelled on unmount,
+ * so a stale timer can't fire into a later reopened sheet.
+ */
+export function useSheetCloseAfterAnimation(
+  delayMs: number = SHEET_CLOSE_ANIMATION_MS
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const closeAfterAnimation = useCallback(
+    (onClosed: () => void) => {
+      cancel();
+
+      if (delayMs === 0) {
+        onClosed();
+        return;
+      }
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onClosed();
+      }, delayMs);
+    },
+    [cancel, delayMs]
+  );
+
+  useEffect(() => cancel, [cancel]);
+
+  return { closeAfterAnimation, cancel };
+}


### PR DESCRIPTION
## Summary

Fixes TLON-5891. Tapping a role in the role-assignment sheet left a stale, orphaned picker visible, made the parent profile sheet flicker, and let a second tap toggle the role back. Root cause was a nested-modal interaction with `@gorhom/bottom-sheet`'s default `stackBehavior='switch'`. The fix dismisses both sheets through Gorhom's normal animation flow instead of yanking the React subtree out from under the queue.

## Changes

Root cause: when the inner role picker presented, Gorhom called `.minimize()` on the parent (default `stackBehavior='switch'`). Our `BottomSheetWrapper` interpreted the resulting `onChange(-1)` as a user dismissal, propagated `onOpenChange(false)` up to the caller, and unmounted the entire `GroupMemberProfileSheet` subtree. The inner Gorhom modal was never told to dismiss, so it remained in `BottomSheetModalProvider._sheetsQueue` as a visible orphan rendering its last-rendered (stale, no-checkmark) state.

- `BottomSheetWrapper.types.ts` / `BottomSheetWrapper.native.tsx` / `BottomSheetWrapper.web.tsx` — added optional `stackBehavior?: 'replace' | 'push' | 'switch'` prop and forwarded it to Gorhom on native; web wrapper accepts and ignores it defensively.
- `ActionSheet.tsx` — exposes `stackBehavior`, destructured separately so it is routed only to `BottomSheetWrapper` on native and is not leaked into the Tamagui `<Sheet>` on web.
- `ProfileSheet.tsx` — sets `stackBehavior="push"` on the nested role-picker `ActionSheet` so the parent is no longer minimized. After a successful role tap, the inner picker closes via `setOpen(false)` and `ProfileSheet` schedules a 300ms `requestParentClose()` so the parent animates closed through Gorhom's normal dismiss flow. The deferred-close timer is owned by `ProfileSheet` (not by `RoleAssignmentSheet`) so that a self-demoting non-host admin — whose role mutation unmounts the admin action group and the picker as a side effect — does not cancel its own parent-close timer. Cleanup is tied to `contactId` change / `ProfileSheet` unmount. Host/admin guard preserved (the host's own `admin` row closes the picker only, no mutation, parent stays open) and `closingRef` suppresses double-taps.
- `GroupMemberProfileSheet.tsx` — owns local `parentOpen` state driving `ProfileSheet`'s `open` prop, so a caller-initiated close runs through Gorhom's animate-to-`-1` and `enableDismissOnClose` cleanup before the caller unmounts the subtree. Hidden from callers  (`GroupMembersScreenView.tsx` and `chatDetails.tsx` are unchanged).

## How did I test?

Manual QA on iOS and Android

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: group member role management UI (admin-facing)

Notes:

- The 300ms `PARENT_CLOSE_DELAY_MS` / `PARENT_CLOSE_ANIMATION_MS` are heuristics matched to `BottomSheetWrapper`'s `quick` transition duration. If that duration changes these need to move with it. Cleaner long-term fix would be to plumb Gorhom's `onDismiss` through `BottomSheetWrapper` and anchor parent-close to actual animation completion, probably out of scope here.
- `stackBehavior` is now plumbed through the wrapper, but `RoleAssignmentSheet` is the only consumer at the moment. We actually don't have nested-modal sheets anywhere else in the  app. If anyone *adds* a new nested-modal sheet in the future, they should know to set `stackBehavior="push"`.

## Rollback plan

Revert.

## Screenshots / videos

https://github.com/user-attachments/assets/e27d5e22-d849-4b41-9f0b-fbda95f86b26