### PR TITLE
update signup flow to allow for plain signups + invites

### DIFF
--- a/apps/tlon-mobile/src/hooks/useReviveSavedOnboarding.ts
+++ b/apps/tlon-mobile/src/hooks/useReviveSavedOnboarding.ts
@@ -1,6 +1,5 @@
 import { NavigationProp, useNavigation } from '@react-navigation/native';
 import * as api from '@tloncorp/api';
-import { useLureMetadata } from '@tloncorp/app/contexts/branch';
 import { useShip } from '@tloncorp/app/contexts/ship';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import { signupData } from '@tloncorp/shared/db';
@@ -15,7 +14,6 @@ import { useOnboardingHelpers } from './useOnboardingHelpers';
 const logger = createDevLogger('OnboardingRevive', true);
 
 export function useReviveSavedOnboarding() {
-  const inviteMeta = useLureMetadata();
   const navigation = useNavigation<NavigationProp<OnboardingStackParamList>>();
   const { isAuthenticated } = useShip();
   const signupContext = useSignupContext();
@@ -103,30 +101,27 @@ export function useReviveSavedOnboarding() {
       return false;
     }
 
-    if (inviteMeta) {
-      logger.crumb(`attempting to revive onboarding session`, {
-        email: savedSignup.email,
-        phoneNumber: savedSignup.phoneNumber,
-      });
-      const routeStack = await getOnboardingRouteStack(savedSignup);
-      logger.crumb(`computed onboarding route stack`, routeStack);
+    logger.crumb(`attempting to revive onboarding session`, {
+      email: savedSignup.email,
+      phoneNumber: savedSignup.phoneNumber,
+    });
+    const routeStack = await getOnboardingRouteStack(savedSignup);
+    logger.crumb(`computed onboarding route stack`, routeStack);
 
-      if (routeStack) {
-        logger.trackEvent(AnalyticsEvent.OnboardingSessionRevived, {
-          route: routeStack[routeStack.length - 1],
-        });
-        navigation.reset({
-          index: 1,
-          routes: routeStack,
-        });
-        return true;
-      }
+    if (routeStack) {
+      logger.trackEvent(AnalyticsEvent.OnboardingSessionRevived, {
+        route: routeStack[routeStack.length - 1],
+      });
+      navigation.reset({
+        index: routeStack.length - 1,
+        routes: routeStack,
+      });
+      return true;
     }
 
     return false;
   }, [
     getOnboardingRouteStack,
-    inviteMeta,
     isAuthenticated,
     navigation,
     onboardingHelpers,

--- a/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/CheckOTPScreen.tsx
@@ -148,8 +148,9 @@ export const CheckOTPScreen = ({ navigation, route: { params } }: Props) => {
             return;
           }
           if (maybeAccountIssue === store.HostingAccountIssue.NoInventory) {
-            logger.trackError(AnalyticsEvent.InvitedUserFailedInventoryCheck, {
+            logger.trackError(AnalyticsEvent.SignupFailedInventoryCheck, {
               severity: AnalyticsSeverity.Critical,
+              hadInvite: Boolean(inviteMetadata?.id),
             });
             navigation.navigate('JoinWaitList', {});
             return;

--- a/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
@@ -193,9 +193,9 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
                 preset="secondaryOutline"
                 marginBottom="$l"
                 width="100%"
-                label="No invite? Join waitlist"
+                label="Sign up without an invite"
                 centered
-                onPress={() => navigation.navigate('JoinWaitList', {})}
+                onPress={() => navigation.navigate('Signup')}
               />
             </YStack>
           </YStack>

--- a/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
@@ -5,11 +5,12 @@ import { useTelemetryId } from '@tloncorp/app/hooks/useTelemetry';
 import {
   Button,
   Field,
-  Image,
   LoadingSpinner,
+  OnboardingTextBlock,
   Pressable,
   ScreenHeader,
   TextInput,
+  TlonText,
   View,
   XStack,
   YStack,
@@ -132,14 +133,6 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
       <ScreenHeader
         backgroundColor="$secondaryBackground"
         backAction={() => navigation.goBack()}
-        rightControls={
-          <ScreenHeader.TextButton
-            disabled={!lureMeta}
-            onPress={() => navigation.navigate('Signup')}
-          >
-            Next
-          </ScreenHeader.TextButton>
-        }
       />
       <SafeAreaView style={{ flex: 1 }}>
         <Pressable
@@ -148,14 +141,16 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
           onPress={() => Keyboard.dismiss()}
         >
           <YStack marginTop="$4xl" paddingHorizontal="$2xl" flex={1}>
-            <XStack justifyContent="center">
-              <Image
-                width={80}
-                height={80}
-                source={require('../../../assets/images/welcome-icon.png')}
-              />
-            </XStack>
-            <YStack marginTop="$6xl" flex={1} justifyContent="space-between">
+            <OnboardingTextBlock>
+              <TlonText.Text size="$label/xl" color="$primaryText">
+                Have an invite?
+              </TlonText.Text>
+              <TlonText.Text size="$body" color="$secondaryText">
+                If someone invited you to Tlon Messenger, enter it now to stay
+                connected.
+              </TlonText.Text>
+            </OnboardingTextBlock>
+            <YStack marginTop="$2xl" flex={1}>
               <YStack>
                 <Controller
                   control={control}
@@ -188,15 +183,15 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
                 <XStack marginTop="$2xl" justifyContent="center">
                   {checkingInput && <LoadingSpinner />}
                 </XStack>
+                <Button
+                  preset="secondaryOutline"
+                  marginTop="$4xl"
+                  width="100%"
+                  label="I don't have an invite"
+                  centered
+                  onPress={() => navigation.navigate('Signup')}
+                />
               </YStack>
-              <Button
-                preset="secondaryOutline"
-                marginBottom="$l"
-                width="100%"
-                label="Sign up without an invite"
-                centered
-                onPress={() => navigation.navigate('Signup')}
-              />
             </YStack>
           </YStack>
         </Pressable>

--- a/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/ReserveShipScreen.tsx
@@ -85,14 +85,12 @@ function BootStepDisplay(props: {
       },
     ];
 
-    if (props.withInvites) {
-      steps.push({
-        description: 'Finding peers on the network',
-        icon: 'ChannelGalleries',
-        startExclusive: NodeBootPhase.CONNECTING,
-        endInclusive: NodeBootPhase.ACCEPTING_INVITES,
-      });
-    }
+    steps.push({
+      description: 'Finding peers on the network',
+      icon: 'ChannelGalleries',
+      startExclusive: NodeBootPhase.CONNECTING,
+      endInclusive: NodeBootPhase.ACCEPTING_INVITES,
+    });
 
     return steps;
   }, [props.withInvites]);

--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -195,7 +195,7 @@ export const SignupScreen = ({ navigation }: Props) => {
     <View flex={1} backgroundColor="$secondaryBackground">
       <ScreenHeader
         backgroundColor="$secondaryBackground"
-        title="Accept invite"
+        title={lureMeta ? 'Accept invite' : 'Sign up'}
         loadingSubtitle={isSubmitting ? 'Loading…' : null}
         backAction={goBack}
       />

--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -116,8 +116,9 @@ export const SignupScreen = ({ navigation }: Props) => {
         lure: lureMeta?.id,
       });
       if (!enabled) {
-        logger.trackError(AnalyticsEvent.InvitedUserFailedInventoryCheck, {
+        logger.trackError(AnalyticsEvent.SignupFailedInventoryCheck, {
           severity: AnalyticsSeverity.Critical,
+          hadInvite: Boolean(lureMeta?.id),
         });
         navigation.navigate('JoinWaitList', {});
         return;

--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -99,14 +99,21 @@ export const WelcomeScreen = ({ navigation }: Props) => {
                 </YStack>
               </Pressable>
             ) : (
-              <>
+              <YStack gap="$l">
                 <OnboardingButton
                   onPress={() => {
-                    navigation.navigate('PasteInviteLink');
+                    navigation.navigate('Signup');
                   }}
                   label="Sign up"
                 />
-              </>
+                <OnboardingButton
+                  secondary
+                  onPress={() => {
+                    navigation.navigate('PasteInviteLink');
+                  }}
+                  label="I have an invite code"
+                />
+              </YStack>
             )}
           </YStack>
           <XStack justifyContent="center">

--- a/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx
@@ -99,21 +99,12 @@ export const WelcomeScreen = ({ navigation }: Props) => {
                 </YStack>
               </Pressable>
             ) : (
-              <YStack gap="$l">
-                <OnboardingButton
-                  onPress={() => {
-                    navigation.navigate('Signup');
-                  }}
-                  label="Sign up"
-                />
-                <OnboardingButton
-                  secondary
-                  onPress={() => {
-                    navigation.navigate('PasteInviteLink');
-                  }}
-                  label="I have an invite code"
-                />
-              </YStack>
+              <OnboardingButton
+                onPress={() => {
+                  navigation.navigate('PasteInviteLink');
+                }}
+                label="Sign up"
+              />
             )}
           </YStack>
           <XStack justifyContent="center">

--- a/packages/api/src/client/hostingApi.ts
+++ b/packages/api/src/client/hostingApi.ts
@@ -613,11 +613,19 @@ export const getHostingAvailability = async (params: {
   email?: string;
   lure?: string;
   priorityToken?: string;
-}) =>
-  hostingFetch<{
+}) => {
+  // Only include keys that are actually set — `new URLSearchParams({lure: undefined})`
+  // serializes to the literal string "undefined", which the backend would then try to
+  // match/bite as a lure. Omitting `lure` is what selects the open (no-group) signup path.
+  const query = new URLSearchParams();
+  if (params.email) query.set('email', params.email);
+  if (params.lure) query.set('lure', params.lure);
+  if (params.priorityToken) query.set('priorityToken', params.priorityToken);
+  return hostingFetch<{
     enabled: boolean;
     validEmail: boolean;
-  }>(`/v1/sign-up?${new URLSearchParams(params)}`);
+  }>(`/v1/sign-up?${query}`);
+};
 
 export const addUserToWaitlist = async ({
   email,

--- a/packages/api/src/types/analytics.ts
+++ b/packages/api/src/types/analytics.ts
@@ -7,7 +7,7 @@ export enum AnalyticsEvent {
   LoggedInBeforeSignup = 'Logged In Without Signing Up',
   FailedSignupOTP = 'Failed to send Signup OTP',
   FailedLoginOTP = 'Failed to send Login OTP',
-  InvitedUserFailedInventoryCheck = 'Invited User Failed Inventory Check',
+  SignupFailedInventoryCheck = 'Signup Failed Inventory Check',
   PersonalInvitePressed = 'Personal Invite Shown',
   ChannelTemplateSetup = 'Channel Created from Template',
   ChannelLoadComplete = 'Channel Load Complete',

--- a/packages/app/contexts/branch.tsx
+++ b/packages/app/contexts/branch.tsx
@@ -11,11 +11,7 @@ import {
 } from 'react';
 import branch from 'react-native-branch';
 
-import {
-  DEFAULT_LURE,
-  DEFAULT_PRIORITY_TOKEN,
-  MCP_OAUTH_COMPLETION_PATH,
-} from '../constants';
+import { MCP_OAUTH_COMPLETION_PATH } from '../constants';
 import { useGroupNavigation } from '../hooks/useGroupNavigation';
 import { getPathFromWer } from '../utils/string';
 import { useShip } from './ship';
@@ -61,9 +57,11 @@ export const useSignupParams = () => {
     );
   }
 
+  // No lure fallback: when there's no real invite, these stay undefined so the
+  // signup flow sends no lure → backend routes to the default (no-group) policy.
   return {
-    lureId: context.lure?.id ?? DEFAULT_LURE,
-    priorityToken: context.priorityToken ?? DEFAULT_PRIORITY_TOKEN,
+    lureId: context.lure?.id,
+    priorityToken: context.priorityToken,
   };
 };
 

--- a/packages/app/hooks/useBootSequence.ts
+++ b/packages/app/hooks/useBootSequence.ts
@@ -214,17 +214,15 @@ export function useBootSequence() {
         });
       });
 
-      // bypass wayfinding creation for now
-      const signedUpWithInvite = Boolean(lureMeta?.id);
-      return signedUpWithInvite
-        ? NodeBootPhase.CHECKING_FOR_INVITE
-        : NodeBootPhase.READY;
+      return NodeBootPhase.CHECKING_FOR_INVITE;
     }
 
     //
-    // CHECKING_FOR_INVITE [optional]: if we used an invite code to signup, see if we got the invites
+    // CHECKING_FOR_INVITE [optional]: wait for signup DMs/groups to arrive
     //
     if (bootPhase === NodeBootPhase.CHECKING_FOR_INVITE) {
+      const signedUpWithInvite = Boolean(lureMeta?.id);
+
       // always add the inviter as a contact first
       if (lureMeta?.inviterUserId) {
         const contact = await db.getContact({ id: lureMeta.inviterUserId });
@@ -246,12 +244,15 @@ export function useBootSequence() {
         store.pinGroup(botHomeGroup);
       }
 
-      const requiredInvites =
-        lureMeta?.inviteType === 'user' ? invitedDm : invitedGroup && invitedDm;
+      const requiredInvites = signedUpWithInvite
+        ? lureMeta?.inviteType === 'user'
+          ? invitedDm
+          : invitedGroup && invitedDm
+        : tlonTeamDM;
 
       if (requiredInvites) {
         logger.trackEvent(AnalyticsEvent.InviteDebug, {
-          context: 'confirmed node has the invites',
+          context: 'confirmed node has signup DMs/invites',
         });
         return NodeBootPhase.ACCEPTING_INVITES;
       }
@@ -263,17 +264,18 @@ export function useBootSequence() {
     }
 
     //
-    // ACCEPTING_INVITES [optional]: join the invited groups
+    // ACCEPTING_INVITES [optional]: accept signup DMs and join invited groups
     //
     if (bootPhase === NodeBootPhase.ACCEPTING_INVITES) {
+      const signedUpWithInvite = Boolean(lureMeta?.id);
       const { invitedDm, invitedGroup, tlonTeamDM } =
         await BootHelpers.getInvitedGroupAndDm(lureMeta);
 
       // if expected items aren't there, re-run this step
       if (
         !tlonTeamDM ||
-        !invitedDm ||
-        (lureMeta?.inviteType === 'group' && !invitedGroup)
+        (signedUpWithInvite &&
+          (!invitedDm || (lureMeta?.inviteType === 'group' && !invitedGroup)))
       ) {
         return NodeBootPhase.ACCEPTING_INVITES;
       }
@@ -316,7 +318,10 @@ export function useBootSequence() {
           store.syncGroup(invitedGroup?.id, undefined, { force: true });
           store.syncGroup(GETTING_STARTED_GROUP_ID, undefined, { force: true });
         }
-        if (invitedDm && invitedDm.isDmInvite) {
+        if (
+          (tlonTeamDM && tlonTeamDM.isDmInvite) ||
+          (invitedDm && invitedDm.isDmInvite)
+        ) {
           store.syncDms();
         }
       }, 5000);
@@ -406,11 +411,7 @@ export function useBootSequence() {
           during: 'mobile signup (useBootSequence)',
           severity: AnalyticsSeverity.Critical,
         });
-        const signedUpWithInvite = Boolean(lureMeta?.id);
-        const nextBootPhase = signedUpWithInvite
-          ? NodeBootPhase.CHECKING_FOR_INVITE
-          : NodeBootPhase.READY;
-        setBootPhase(nextBootPhase);
+        setBootPhase(NodeBootPhase.CHECKING_FOR_INVITE);
         return;
       }
     }

--- a/packages/app/lib/bootHelpers.ts
+++ b/packages/app/lib/bootHelpers.ts
@@ -56,11 +56,22 @@ async function getInvitedGroupAndDm(lureMeta: AppInvite | null): Promise<{
   personalGroup: db.Group | null;
   botHomeGroup: db.Group | null;
 }> {
-  if (!lureMeta) {
-    throw new Error('no stored invite found, cannot check');
-  }
-  const { invitedGroupId, inviterUserId, inviteType } = lureMeta;
   const tlonTeam = `~wittyr-witbes`;
+  const tlonTeamDM = await db.getChannel({ id: tlonTeam });
+  const personalGroup = await db.getPersonalGroup();
+  const botHomeGroup = await db.getBotHomeGroup();
+
+  if (!lureMeta) {
+    return {
+      invitedDm: null,
+      invitedGroup: null,
+      tlonTeamDM,
+      personalGroup,
+      botHomeGroup,
+    };
+  }
+
+  const { invitedGroupId, inviterUserId, inviteType } = lureMeta;
   const isPersonalInvite = inviteType === 'user';
   if (!inviterUserId || (!isPersonalInvite && !invitedGroupId)) {
     logger.trackEvent(AnalyticsEvent.InviteError, {
@@ -73,12 +84,9 @@ async function getInvitedGroupAndDm(lureMeta: AppInvite | null): Promise<{
   }
   // use api client to see if you have pending DM and group invite
   const invitedDm = await db.getChannel({ id: inviterUserId });
-  const tlonTeamDM = await db.getChannel({ id: tlonTeam });
-  const personalGroup = await db.getPersonalGroup();
   const invitedGroup = isPersonalInvite
     ? null
     : await db.getGroup({ id: invitedGroupId! });
-  const botHomeGroup = await db.getBotHomeGroup();
 
   return { invitedDm, invitedGroup, tlonTeamDM, personalGroup, botHomeGroup };
 }

--- a/packages/shared/src/store/hostingActions.ts
+++ b/packages/shared/src/store/hostingActions.ts
@@ -34,8 +34,9 @@ export async function signUpHostedUser(params: {
   otp: string;
   email?: string;
   phoneNumber?: string;
-  inviteId: string;
-  priorityToken: string;
+  // Both absent for open (no-invite) signups; the API call omits them from the body.
+  inviteId?: string;
+  priorityToken?: string;
   recaptcha: {
     token: string;
     platform: 'ios' | 'android' | 'web' | 'ios_test' | 'android_test';


### PR DESCRIPTION
## Summary

Opens up registration through the mobile app by adding an un-gated signup path alongside the existing invite flow. When a user has no invite, the app now sends no lure (instead of falling back to DEFAULT_LURE), so the backend routes them to the default no-group policy; users with an invite still paste/deeplink a code and join the inviter's group as before. Also fixes a URLSearchParams bug where an absent lure serialized to the literal string "undefined", and updates the welcome/signup screens to surface both paths. Update the copy as you see fit, but this should work fine against the /v1/sign-up endpoint for regular sign-ups and invites. 
## Changes

- `packages/app/contexts/branch.tsx` — useSignupParams no longer falls back to DEFAULT_LURE/DEFAULT_PRIORITY_TOKEN; lureId/priorityToken stay undefined when there's no invite, so un-invited signups send no lure. Removed the now-unused imports.
- `packages/api/src/client/hostingApi.ts` — getHostingAvailability builds its query string conditionally (only sets email/lure/priorityToken when present), fixing the bug where new URLSearchParams({lure: undefined}) serialized to the literal string "undefined".
- `packages/shared/src/store/hostingActions.ts` — signUpHostedUser's inviteId and priorityToken params are now optional (omitted from the request body for open signups).
- `apps/tlon-mobile/src/screens/Onboarding/WelcomeScreen.tsx` — with no invite, "Sign up" now navigates straight to Signup (open path); added a secondary "I have an invite code" button → PasteInviteLink.
- `apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx` — screen title is "Accept invite" only when there's a lure, otherwise "Sign up".
- `apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx` — the fallback button changed from "No invite? Join waitlist" (→ JoinWaitList) to "Sign up without an invite" (→ Signup).
## How did I test?

have not tested (don't have the tooling for that locally)

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [X] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
