### PR TITLE
add a2ui navigation actions

### DIFF
--- a/docs/post-blobs.md
+++ b/docs/post-blobs.md
@@ -89,6 +89,7 @@ The supported v1 client subset is intentionally small:
 - button actions:
   - `tlon.sendMessage`, which sends explicit action text in the current DM
   - `tlon.navigate`, which can navigate to a message, channel, group, profile, chat details, or chat volume screen
+    - message reply targets should include `parentAuthorId` when `parentId` is not already prefixed as `~author/id`
 - rendering policy: A2UI blocks render only in direct messages for now
 - validation limits: component count, tree depth, text length, and expanded render size
 

--- a/docs/post-blobs.md
+++ b/docs/post-blobs.md
@@ -86,9 +86,11 @@ The current renderer expects one `createSurface` message and one `updateComponen
 The supported v1 client subset is intentionally small:
 
 - components: `Card`, `Column`, `Row`, `Text`, `Divider`, and `Button`
-- button actions: `tlon.sendMessage`, which sends visible text in the current DM
+- button actions:
+  - `tlon.sendMessage`, which sends explicit action text in the current DM
+  - `tlon.navigate`, which can navigate to a message, channel, group, profile, chat details, or chat volume screen
 - rendering policy: A2UI blocks render only in direct messages for now
-- validation limits: component count, tree depth, text length, button count, and expanded render size
+- validation limits: component count, tree depth, text length, and expanded render size
 
 ## Read/write behavior
 

--- a/packages/api/src/__tests__/a2ui.test.ts
+++ b/packages/api/src/__tests__/a2ui.test.ts
@@ -82,6 +82,7 @@ describe('a2ui blob entries', () => {
                           channelId: 'chat/~zod/general',
                           postId: '170.141.184.507',
                           parentId: '170.141.184.000',
+                          parentAuthorId: '~nec',
                           authorId: '~sampel-palnet',
                           groupId: '~zod/garden',
                         },

--- a/packages/api/src/__tests__/a2ui.test.ts
+++ b/packages/api/src/__tests__/a2ui.test.ts
@@ -57,6 +57,143 @@ describe('a2ui blob entries', () => {
     expect(parsePostBlob(blob)).toEqual([a2uiBlobEntry]);
   });
 
+  test('validates navigate button actions', () => {
+    expect(
+      A2UI.validateBlobEntry({
+        ...a2uiBlobEntry,
+        messages: [
+          a2uiBlobEntry.messages[0],
+          {
+            version: 'v0.9',
+            updateComponents: {
+              surfaceId: 'weather-card',
+              root: 'root',
+              components: [
+                {
+                  id: 'root',
+                  component: 'Button',
+                  child: 'label',
+                  action: {
+                    event: {
+                      name: A2UI.action.navigate,
+                      context: {
+                        target: {
+                          type: 'message',
+                          channelId: 'chat/~zod/general',
+                          postId: '170.141.184.507',
+                          parentId: '170.141.184.000',
+                          authorId: '~sampel-palnet',
+                          groupId: '~zod/garden',
+                        },
+                      },
+                    },
+                  },
+                },
+                { id: 'label', component: 'Text', text: 'View message' },
+              ],
+            },
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  test('rejects malformed navigate targets', () => {
+    expect(
+      A2UI.validateBlobEntry({
+        ...a2uiBlobEntry,
+        messages: [
+          a2uiBlobEntry.messages[0],
+          {
+            version: 'v0.9',
+            updateComponents: {
+              surfaceId: 'weather-card',
+              root: 'root',
+              components: [
+                {
+                  id: 'root',
+                  component: 'Button',
+                  child: 'label',
+                  action: {
+                    event: {
+                      name: A2UI.action.navigate,
+                      context: {
+                        target: {
+                          type: 'message',
+                          postId: '170.141.184.507',
+                        },
+                      },
+                    },
+                  },
+                },
+                { id: 'label', component: 'Text', text: 'View message' },
+              ],
+            },
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+
+  test('requires explicit send message text for button actions', () => {
+    const buttonWithoutText = {
+      ...a2uiBlobEntry,
+      messages: [
+        a2uiBlobEntry.messages[0],
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 'weather-card',
+            root: 'root',
+            components: [
+              {
+                id: 'root',
+                component: 'Button',
+                child: 'label',
+                action: {
+                  event: {
+                    name: A2UI.action.sendMessage,
+                  },
+                },
+              },
+              { id: 'label', component: 'Text', text: 'Refresh' },
+            ],
+          },
+        },
+      ],
+    };
+    const buttonWithBlankText = {
+      ...buttonWithoutText,
+      messages: [
+        a2uiBlobEntry.messages[0],
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 'weather-card',
+            root: 'root',
+            components: [
+              {
+                id: 'root',
+                component: 'Button',
+                child: 'label',
+                action: {
+                  event: {
+                    name: A2UI.action.sendMessage,
+                    context: { text: '   ' },
+                  },
+                },
+              },
+              { id: 'label', component: 'Text', text: 'Refresh' },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(A2UI.validateBlobEntry(buttonWithoutText)).toBe(false);
+    expect(A2UI.validateBlobEntry(buttonWithBlankText)).toBe(false);
+  });
+
   test('rejects unsupported a2ui components and actions', () => {
     expect(
       parsePostBlob(

--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 const ACTION_SEND_MESSAGE = 'tlon.sendMessage';
+const ACTION_NAVIGATE = 'tlon.navigate';
 
 type ComponentBase = {
   id: string;
@@ -32,13 +33,70 @@ export namespace A2UI {
 
   export type SendMessageEvent = {
     name: typeof ACTION_SEND_MESSAGE;
-    context?: {
-      text?: string;
+    context: {
+      text: string;
+    };
+  };
+
+  export type MessageNavigationTarget = {
+    type: 'message';
+    channelId: string;
+    postId: string;
+    parentId?: string;
+    authorId?: string;
+    groupId?: string;
+  };
+
+  export type ChannelNavigationTarget = {
+    type: 'channel';
+    channelId: string;
+    groupId?: string;
+    selectedPostId?: string;
+  };
+
+  export type GroupNavigationTarget = {
+    type: 'group';
+    groupId: string;
+  };
+
+  export type ProfileNavigationTarget = {
+    type: 'profile';
+    userId: string;
+    groupId?: string;
+    channelId?: string;
+  };
+
+  export type ChatDetailsNavigationTarget = {
+    type: 'chatDetails';
+    chatType: 'group' | 'channel';
+    chatId: string;
+    groupId?: string;
+  };
+
+  export type ChatVolumeNavigationTarget = {
+    type: 'chatVolume';
+    chatType: 'group' | 'channel';
+    chatId: string;
+    groupId?: string;
+  };
+
+  export type NavigationTarget =
+    | MessageNavigationTarget
+    | ChannelNavigationTarget
+    | GroupNavigationTarget
+    | ProfileNavigationTarget
+    | ChatDetailsNavigationTarget
+    | ChatVolumeNavigationTarget;
+
+  export type NavigateEvent = {
+    name: typeof ACTION_NAVIGATE;
+    context: {
+      target: NavigationTarget;
     };
   };
 
   export type EventAction = {
-    event: SendMessageEvent;
+    event: SendMessageEvent | NavigateEvent;
   };
 
   export type ButtonAction = EventAction;
@@ -85,9 +143,9 @@ const LIMITS = {
   maxComponents: 50,
   maxDepth: 8,
   maxChildren: 12,
-  maxButtons: 8,
   maxTextNodeLength: 1000,
   maxButtonMessageLength: 1000,
+  maxNavigationTargetIdLength: 500,
   maxTotalTextLength: 8000,
 } as const;
 
@@ -124,6 +182,13 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidTargetId(value: unknown): value is string {
+  return (
+    isNonEmptyString(value) &&
+    value.length <= LIMITS.maxNavigationTargetIdLength
+  );
 }
 
 function isValidWeight(value: unknown): boolean {
@@ -170,6 +235,79 @@ function isValidButtonVariant(value: unknown): boolean {
   );
 }
 
+function isValidChatType(value: unknown): value is 'group' | 'channel' {
+  return value === 'group' || value === 'channel';
+}
+
+function isValidOptionalTargetId(value: unknown): boolean {
+  return value === undefined || isValidTargetId(value);
+}
+
+function validateNavigationTarget(
+  target: unknown
+): target is A2UI.NavigationTarget {
+  if (!isPlainObject(target)) {
+    return false;
+  }
+
+  switch (target.type) {
+    case 'message':
+      return (
+        isValidTargetId(target.channelId) &&
+        isValidTargetId(target.postId) &&
+        isValidOptionalTargetId(target.parentId) &&
+        isValidOptionalTargetId(target.authorId) &&
+        isValidOptionalTargetId(target.groupId)
+      );
+    case 'channel':
+      return (
+        isValidTargetId(target.channelId) &&
+        isValidOptionalTargetId(target.groupId) &&
+        isValidOptionalTargetId(target.selectedPostId)
+      );
+    case 'group':
+      return isValidTargetId(target.groupId);
+    case 'profile':
+      return (
+        isValidTargetId(target.userId) &&
+        isValidOptionalTargetId(target.groupId) &&
+        isValidOptionalTargetId(target.channelId)
+      );
+    case 'chatDetails':
+    case 'chatVolume':
+      return (
+        isValidChatType(target.chatType) &&
+        isValidTargetId(target.chatId) &&
+        isValidOptionalTargetId(target.groupId)
+      );
+    default:
+      return false;
+  }
+}
+
+function validateButtonAction(action: unknown): action is A2UI.ButtonAction {
+  if (!isPlainObject(action) || !isPlainObject(action.event)) {
+    return false;
+  }
+
+  const { event } = action;
+  const context = event.context;
+
+  if (event.name === ACTION_SEND_MESSAGE) {
+    return (
+      isPlainObject(context) &&
+      isNonEmptyString(context.text) &&
+      context.text.length <= LIMITS.maxButtonMessageLength
+    );
+  }
+
+  if (event.name === ACTION_NAVIGATE) {
+    return isPlainObject(context) && validateNavigationTarget(context.target);
+  }
+
+  return false;
+}
+
 function validateComponent(component: unknown): component is A2UI.Component {
   if (!isPlainObject(component) || !isNonEmptyString(component.id)) {
     return false;
@@ -201,21 +339,12 @@ function validateComponent(component: unknown): component is A2UI.Component {
       return true;
     case 'Button': {
       const action = component.action;
-      const event = isPlainObject(action) ? action.event : null;
-      const context = isPlainObject(event) ? event.context : undefined;
       return (
         isNonEmptyString(component.child) &&
         (component.disabled === undefined ||
           typeof component.disabled === 'boolean') &&
         isValidButtonVariant(component.variant) &&
-        isPlainObject(action) &&
-        isPlainObject(event) &&
-        event.name === ACTION_SEND_MESSAGE &&
-        (context === undefined || isPlainObject(context)) &&
-        (context === undefined ||
-          context.text === undefined ||
-          (typeof context.text === 'string' &&
-            context.text.length <= LIMITS.maxButtonMessageLength))
+        validateButtonAction(action)
       );
     }
     default:
@@ -289,7 +418,6 @@ function indexComponents(
   components: A2UI.Component[]
 ): Map<string, A2UI.Component> | null {
   const byId = new Map<string, A2UI.Component>();
-  let buttonCount = 0;
   let totalTextLength = 0;
 
   for (const component of components) {
@@ -298,17 +426,15 @@ function indexComponents(
     }
     byId.set(component.id, component);
     if (component.component === 'Button') {
-      buttonCount += 1;
-      totalTextLength += component.action.event.context?.text?.length ?? 0;
+      if (component.action.event.name === ACTION_SEND_MESSAGE) {
+        totalTextLength += component.action.event.context.text.length;
+      }
     } else if (component.component === 'Text') {
       totalTextLength += component.text.length;
     }
   }
 
-  if (
-    buttonCount > LIMITS.maxButtons ||
-    totalTextLength > LIMITS.maxTotalTextLength
-  ) {
+  if (totalTextLength > LIMITS.maxTotalTextLength) {
     return null;
   }
 
@@ -405,6 +531,7 @@ export const blobEntrySchema = z.custom<A2UI.BlobEntry>(validateBlobEntry);
 export const A2UI = {
   action: {
     sendMessage: ACTION_SEND_MESSAGE,
+    navigate: ACTION_NAVIGATE,
   },
   getUpdateMessage,
   getRootComponentId,

--- a/packages/api/src/client/a2ui.ts
+++ b/packages/api/src/client/a2ui.ts
@@ -43,6 +43,7 @@ export namespace A2UI {
     channelId: string;
     postId: string;
     parentId?: string;
+    parentAuthorId?: string;
     authorId?: string;
     groupId?: string;
   };
@@ -256,6 +257,7 @@ function validateNavigationTarget(
         isValidTargetId(target.channelId) &&
         isValidTargetId(target.postId) &&
         isValidOptionalTargetId(target.parentId) &&
+        isValidOptionalTargetId(target.parentAuthorId) &&
         isValidOptionalTargetId(target.authorId) &&
         isValidOptionalTargetId(target.groupId)
       );

--- a/packages/app/fixtures/A2UI.fixture.tsx
+++ b/packages/app/fixtures/A2UI.fixture.tsx
@@ -186,6 +186,7 @@ function makeApprovalA2UI({
   copy,
   allowNote,
   requestId,
+  viewMessageTarget,
 }: {
   surfaceId: string;
   eyebrow: string;
@@ -194,8 +195,13 @@ function makeApprovalA2UI({
   copy?: string;
   allowNote: string;
   requestId: string;
+  viewMessageTarget?: A2UI.NavigationTarget;
 }): A2UI.BlobEntry {
   const metadataChildren = metadata.map((_, index) => `metadata-${index}`);
+  const actionChildren = ['allow', 'reject', 'ban'];
+  const sourceActionComponents: A2UI.Component[] = viewMessageTarget
+    ? [{ id: 'sourceAction', component: 'Row', children: ['viewMessage'] }]
+    : [];
   const bodyChildren = copy
     ? [
         'eyebrow',
@@ -203,6 +209,7 @@ function makeApprovalA2UI({
         'titleDivider',
         ...metadataChildren,
         'copy',
+        ...(viewMessageTarget ? ['sourceAction'] : []),
         'divider',
         'details',
         'actions',
@@ -212,6 +219,7 @@ function makeApprovalA2UI({
         'title',
         'titleDivider',
         ...metadataChildren,
+        ...(viewMessageTarget ? ['sourceAction'] : []),
         'divider',
         'details',
         'actions',
@@ -272,6 +280,7 @@ function makeApprovalA2UI({
                   } as const,
                 ]
               : []),
+            ...sourceActionComponents,
             { id: 'divider', component: 'Divider' },
             {
               id: 'details',
@@ -287,8 +296,29 @@ function makeApprovalA2UI({
             {
               id: 'actions',
               component: 'Row',
-              children: ['allow', 'reject', 'ban'],
+              children: actionChildren,
             },
+            ...(viewMessageTarget
+              ? [
+                  {
+                    id: 'viewMessage',
+                    component: 'Button',
+                    variant: 'secondary',
+                    child: 'viewMessageLabel',
+                    action: {
+                      event: {
+                        name: 'tlon.navigate',
+                        context: { target: viewMessageTarget },
+                      },
+                    },
+                  } as const,
+                  {
+                    id: 'viewMessageLabel',
+                    component: 'Text',
+                    text: 'View message',
+                  } as const,
+                ]
+              : []),
             {
               id: 'allow',
               component: 'Button',
@@ -343,6 +373,12 @@ const confirmationA2UI = makeApprovalA2UI({
   allowNote:
     'The bot will be able to read and reply to future DMs from this user.',
   requestId: 'da1b2',
+  viewMessageTarget: {
+    type: 'message',
+    channelId: dmChannelId,
+    postId: '170.141.184.507',
+    authorId: '~sampel-palnet',
+  },
 });
 
 const channelApprovalA2UI = makeApprovalA2UI({
@@ -358,6 +394,13 @@ const channelApprovalA2UI = makeApprovalA2UI({
   allowNote:
     'The bot will be able to read and reply to this user in this channel.',
   requestId: 'c3d4e',
+  viewMessageTarget: {
+    type: 'message',
+    channelId: 'chat/~zod/design',
+    postId: '170.141.184.621',
+    authorId: '~littel-wolfur',
+    groupId: '~zod/garden-club',
+  },
 });
 
 const groupApprovalA2UI = makeApprovalA2UI({
@@ -545,7 +588,7 @@ const basicComponentsA2UI: A2UI.BlobEntry = {
           {
             id: 'buttonRowTwo',
             component: 'Row',
-            children: ['borderlessButton', 'disabledButton'],
+            children: ['borderlessButton', 'navigateButton', 'disabledButton'],
           },
           {
             id: 'borderlessButton',
@@ -560,6 +603,24 @@ const basicComponentsA2UI: A2UI.BlobEntry = {
             },
           },
           { id: 'borderlessLabel', component: 'Text', text: 'Borderless' },
+          {
+            id: 'navigateButton',
+            component: 'Button',
+            variant: 'secondary',
+            child: 'navigateLabel',
+            action: {
+              event: {
+                name: 'tlon.navigate',
+                context: {
+                  target: {
+                    type: 'profile',
+                    userId: '~sampel-palnet',
+                  },
+                },
+              },
+            },
+          },
+          { id: 'navigateLabel', component: 'Text', text: 'Navigate' },
           {
             id: 'disabledButton',
             component: 'Button',

--- a/packages/app/hooks/useA2UINavigation.ts
+++ b/packages/app/hooks/useA2UINavigation.ts
@@ -1,0 +1,167 @@
+import { createDevLogger } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { A2UI } from '@tloncorp/shared/logic';
+import { useCallback } from 'react';
+
+import { useRootNavigation } from '../navigation/utils';
+
+const logger = createDevLogger('a2ui-navigation', false);
+
+function isChatChannel(channel: db.Channel): boolean {
+  return ['chat', 'dm', 'groupDm'].includes(channel.type);
+}
+
+function formatNumericPostId(value: string): string {
+  const compact = value.replace(/\./g, '');
+  if (!/^\d+$/.test(compact)) {
+    return value;
+  }
+
+  return compact.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+}
+
+function normalizePostId(postId: string): string {
+  const separator = postId.indexOf('/');
+  if (separator === -1) {
+    return formatNumericPostId(postId);
+  }
+
+  return `${postId.slice(0, separator + 1)}${formatNumericPostId(
+    postId.slice(separator + 1)
+  )}`;
+}
+
+async function getPost(postId: string): Promise<db.Post | null> {
+  try {
+    return await db.getPost({ postId });
+  } catch (error) {
+    logger.log('failed to resolve post', { postId, error });
+    return null;
+  }
+}
+
+async function getChannel(channelId: string): Promise<db.Channel | null> {
+  try {
+    return await db.getChannel({ id: channelId });
+  } catch (error) {
+    logger.log('failed to resolve channel', { channelId, error });
+    return null;
+  }
+}
+
+function postFromTarget(
+  target: A2UI.MessageNavigationTarget,
+  postId: string,
+  authorId?: string
+): db.Post | null {
+  if (!authorId) {
+    return null;
+  }
+
+  return {
+    id: postId,
+    channelId: target.channelId,
+    groupId: target.groupId,
+    authorId,
+  } as db.Post;
+}
+
+export function useA2UINavigation() {
+  const rootNavigation = useRootNavigation();
+
+  const navigateToMessage = useCallback(
+    async (target: A2UI.MessageNavigationTarget) => {
+      const postId = normalizePostId(target.postId);
+      const parentId = target.parentId
+        ? normalizePostId(target.parentId)
+        : undefined;
+      const channel = await getChannel(target.channelId);
+      if (!channel) {
+        logger.log('missing channel for message target', target);
+        return;
+      }
+
+      if (isChatChannel(channel)) {
+        if (parentId) {
+          const parentPost = await getPost(parentId);
+          const parentTarget = postFromTarget(
+            target,
+            parentId,
+            parentPost?.authorId ?? target.authorId
+          );
+          if (!parentTarget) {
+            logger.log('missing parent post author for message target', target);
+            return;
+          }
+          rootNavigation.navigateToPost(parentTarget, {
+            selectedPostId: postId,
+          });
+          return;
+        }
+
+        rootNavigation.navigateToChannel(channel, postId);
+        return;
+      }
+
+      const post =
+        (await getPost(postId)) ??
+        postFromTarget(target, postId, target.authorId);
+      if (!post) {
+        logger.log('missing post author for message target', target);
+        return;
+      }
+
+      rootNavigation.navigateToPost(post);
+    },
+    [rootNavigation]
+  );
+
+  return useCallback(
+    async (target: A2UI.NavigationTarget) => {
+      switch (target.type) {
+        case 'message':
+          await navigateToMessage(target);
+          return;
+        case 'channel': {
+          const channel = await getChannel(target.channelId);
+          if (!channel) {
+            logger.log('missing channel target', target);
+            return;
+          }
+          rootNavigation.navigateToChannel(
+            channel,
+            target.selectedPostId
+              ? normalizePostId(target.selectedPostId)
+              : undefined
+          );
+          return;
+        }
+        case 'group':
+          await rootNavigation.navigateToGroup(target.groupId);
+          return;
+        case 'profile':
+          rootNavigation.navigation.navigate('UserProfile', {
+            userId: target.userId,
+            groupId: target.groupId,
+            channelId: target.channelId,
+          });
+          return;
+        case 'chatDetails':
+          rootNavigation.navigateToChatDetails({
+            type: target.chatType,
+            id: target.chatId,
+            groupId: target.groupId,
+          });
+          return;
+        case 'chatVolume':
+          rootNavigation.navigateToChatVolume({
+            type: target.chatType,
+            id: target.chatId,
+            groupId: target.groupId,
+          });
+          return;
+      }
+    },
+    [navigateToMessage, rootNavigation]
+  );
+}

--- a/packages/app/hooks/useA2UINavigation.ts
+++ b/packages/app/hooks/useA2UINavigation.ts
@@ -1,3 +1,4 @@
+import { getCanonicalPostId } from '@tloncorp/api/client';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { A2UI } from '@tloncorp/shared/logic';
@@ -9,26 +10,6 @@ const logger = createDevLogger('a2ui-navigation', false);
 
 function isChatChannel(channel: db.Channel): boolean {
   return ['chat', 'dm', 'groupDm'].includes(channel.type);
-}
-
-function formatNumericPostId(value: string): string {
-  const compact = value.replace(/\./g, '');
-  if (!/^\d+$/.test(compact)) {
-    return value;
-  }
-
-  return compact.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-}
-
-function normalizePostId(postId: string): string {
-  const separator = postId.indexOf('/');
-  if (separator === -1) {
-    return formatNumericPostId(postId);
-  }
-
-  return `${postId.slice(0, separator + 1)}${formatNumericPostId(
-    postId.slice(separator + 1)
-  )}`;
 }
 
 async function getPost(postId: string): Promise<db.Post | null> {
@@ -71,9 +52,9 @@ export function useA2UINavigation() {
 
   const navigateToMessage = useCallback(
     async (target: A2UI.MessageNavigationTarget) => {
-      const postId = normalizePostId(target.postId);
+      const postId = getCanonicalPostId(target.postId);
       const parentId = target.parentId
-        ? normalizePostId(target.parentId)
+        ? getCanonicalPostId(target.parentId)
         : undefined;
       const channel = await getChannel(target.channelId);
       if (!channel) {
@@ -131,7 +112,7 @@ export function useA2UINavigation() {
           rootNavigation.navigateToChannel(
             channel,
             target.selectedPostId
-              ? normalizePostId(target.selectedPostId)
+              ? getCanonicalPostId(target.selectedPostId)
               : undefined
           );
           return;

--- a/packages/app/hooks/useA2UINavigation.ts
+++ b/packages/app/hooks/useA2UINavigation.ts
@@ -12,6 +12,20 @@ function isChatChannel(channel: db.Channel): boolean {
   return ['chat', 'dm', 'groupDm'].includes(channel.type);
 }
 
+function getAuthorFromPrefixedPostId(postId?: string): string | undefined {
+  if (!postId?.startsWith('~')) {
+    return undefined;
+  }
+
+  const separator = postId.indexOf('/');
+  if (separator === -1) {
+    return undefined;
+  }
+
+  const authorId = postId.slice(0, separator);
+  return authorId.length > 1 ? authorId : undefined;
+}
+
 async function getPost(postId: string): Promise<db.Post | null> {
   try {
     return await db.getPost({ postId });
@@ -68,7 +82,9 @@ export function useA2UINavigation() {
           const parentTarget = postFromTarget(
             target,
             parentId,
-            parentPost?.authorId ?? target.authorId
+            parentPost?.authorId ??
+              target.parentAuthorId ??
+              getAuthorFromPrefixedPostId(target.parentId)
           );
           if (!parentTarget) {
             logger.log('missing parent post author for message target', target);

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -122,6 +122,26 @@ export function StaticChatMessage({
     },
     [draftInputContext, navigateToA2UITarget]
   );
+
+  const isA2UIActionAvailable = useCallback(
+    (action: A2UI.Button['action']) => {
+      if (action.event.name === A2UI.action.navigate) {
+        return true;
+      }
+
+      if (action.event.name === A2UI.action.sendMessage) {
+        return Boolean(
+          draftInputContext &&
+            draftInputContext.canStartDraft !== false &&
+            action.event.context.text.trim()
+        );
+      }
+
+      return false;
+    },
+    [draftInputContext]
+  );
+
   const canRenderA2UI = isDmChannelId(post.channelId);
 
   const postContent = usePostContent(post);
@@ -213,6 +233,9 @@ export function StaticChatMessage({
             getImageViewerId={(src) => getPostImageViewerId(post.id, src)}
             onLongPress={handleLongPress}
             onA2UIAction={canRenderA2UI ? handleA2UIAction : undefined}
+            isA2UIActionAvailable={
+              canRenderA2UI ? isA2UIActionAvailable : undefined
+            }
             searchQuery={searchQuery}
           />
         )}

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -6,6 +6,7 @@ import { ComponentProps, useCallback, useMemo } from 'react';
 import { View, XStack, YStack, isWeb } from 'tamagui';
 
 import { CHAT_REF_LIKE_MAX_WIDTH } from '../../../constants';
+import { useA2UINavigation } from '../../../hooks/useA2UINavigation';
 import { getPostImageViewerId } from '../../../utils/mediaViewer';
 import AuthorRow from '../AuthorRow';
 import { A2UIBlock } from '../PostContent/A2UIBlock';
@@ -60,6 +61,7 @@ export function StaticChatMessage({
 }) {
   const isNotice = post.type === 'notice';
   const draftInputContext = useDraftInputContext();
+  const navigateToA2UITarget = useA2UINavigation();
 
   if (isNotice) {
     showAuthor = false;
@@ -94,8 +96,9 @@ export function StaticChatMessage({
   }, [onPressRetry, post]);
 
   const handleA2UIAction = useCallback(
-    async (action: A2UI.Button['action'], fallbackText: string) => {
-      if (action.event.name !== A2UI.action.sendMessage) {
+    async (action: A2UI.Button['action']) => {
+      if (action.event.name === A2UI.action.navigate) {
+        await navigateToA2UITarget(action.event.context.target);
         return;
       }
 
@@ -103,8 +106,7 @@ export function StaticChatMessage({
         return;
       }
 
-      const message = action.event.context?.text ?? fallbackText;
-      const text = message.trim();
+      const text = action.event.context.text.trim();
       if (!text) {
         return;
       }
@@ -118,13 +120,9 @@ export function StaticChatMessage({
         isEdit: false,
       });
     },
-    [draftInputContext]
+    [draftInputContext, navigateToA2UITarget]
   );
   const canRenderA2UI = isDmChannelId(post.channelId);
-  const canHandleA2UIAction =
-    canRenderA2UI &&
-    !!draftInputContext &&
-    draftInputContext.canStartDraft !== false;
 
   const postContent = usePostContent(post);
   const lastEditPostContent = usePostLastEditContent(post);
@@ -214,7 +212,7 @@ export function StaticChatMessage({
             onPressImage={handleImagePressed}
             getImageViewerId={(src) => getPostImageViewerId(post.id, src)}
             onLongPress={handleLongPress}
-            onA2UIAction={canHandleA2UIAction ? handleA2UIAction : undefined}
+            onA2UIAction={canRenderA2UI ? handleA2UIAction : undefined}
             searchQuery={searchQuery}
           />
         )}

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -133,7 +133,7 @@ export function A2UIBlock({
   block,
   ...props
 }: { block: A2UIBlockData } & ComponentProps<typeof YStack>) {
-  const context = useContentContext();
+  const { isA2UIActionAvailable, onA2UIAction } = useContentContext();
   const update = A2UI.getUpdateMessage(block.a2ui);
   const root = A2UI.getRootComponentId(block.a2ui);
   const components = useMemo(() => {
@@ -154,9 +154,9 @@ export function A2UIBlock({
         return;
       }
 
-      context.onA2UIAction?.(component.action);
+      onA2UIAction?.(component.action);
     },
-    [context]
+    [onA2UIAction]
   );
 
   const renderComponent = useCallback(
@@ -256,7 +256,10 @@ export function A2UIBlock({
             />
           );
         case 'Button': {
-          const disabled = component.disabled || !context.onA2UIAction;
+          const disabled =
+            component.disabled ||
+            !onA2UIAction ||
+            isA2UIActionAvailable?.(component.action) === false;
           const label = getComponentText(
             components.get(component.child),
             components
@@ -286,7 +289,7 @@ export function A2UIBlock({
         }
       }
     },
-    [components, context.onA2UIAction, handleButtonPress]
+    [components, handleButtonPress, isA2UIActionAvailable, onA2UIAction]
   );
 
   if (!root) {

--- a/packages/app/ui/components/PostContent/A2UIBlock.tsx
+++ b/packages/app/ui/components/PostContent/A2UIBlock.tsx
@@ -147,17 +147,16 @@ export function A2UIBlock({
 
   const handleButtonPress = useCallback(
     (component: A2UI.Button) => {
-      const fallbackText =
-        component.action.event.context?.text ??
-        getComponentText(components.get(component.child), components);
-
-      if (!fallbackText.trim()) {
+      if (
+        component.action.event.name === A2UI.action.sendMessage &&
+        !component.action.event.context.text.trim()
+      ) {
         return;
       }
 
-      context.onA2UIAction?.(component.action, fallbackText);
+      context.onA2UIAction?.(component.action);
     },
-    [components, context]
+    [context]
   );
 
   const renderComponent = useCallback(

--- a/packages/app/ui/components/PostContent/ContentRenderer.tsx
+++ b/packages/app/ui/components/PostContent/ContentRenderer.tsx
@@ -57,6 +57,7 @@ function ContentRenderer({
   getImageViewerId,
   onLongPress,
   onA2UIAction,
+  isA2UIActionAvailable,
   isNotice,
   searchQuery,
   ...rest
@@ -69,6 +70,7 @@ function ContentRenderer({
       getImageViewerId={getImageViewerId}
       onLongPress={onLongPress}
       onA2UIAction={onA2UIAction}
+      isA2UIActionAvailable={isA2UIActionAvailable}
       isNotice={isNotice}
       searchQuery={searchQuery}
     >

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -30,10 +30,7 @@ export interface ContentContextProps {
   onPressImage?: (src: string) => void;
   getImageViewerId?: (src: string) => string | undefined;
   onLongPress?: () => void;
-  onA2UIAction?: (
-    action: A2UI.Button['action'],
-    fallbackText: string
-  ) => void | Promise<void>;
+  onA2UIAction?: (action: A2UI.Button['action']) => void | Promise<void>;
   searchQuery?: string;
 }
 

--- a/packages/app/ui/components/PostContent/contentUtils.tsx
+++ b/packages/app/ui/components/PostContent/contentUtils.tsx
@@ -31,6 +31,7 @@ export interface ContentContextProps {
   getImageViewerId?: (src: string) => string | undefined;
   onLongPress?: () => void;
   onA2UIAction?: (action: A2UI.Button['action']) => void | Promise<void>;
+  isA2UIActionAvailable?: (action: A2UI.Button['action']) => boolean;
   searchQuery?: string;
 }
 


### PR DESCRIPTION
## Summary
Adds generic A2UI navigation actions so A2UI buttons can jump to Tlon destinations, including source messages behind approval prompts.

## Changes
- add `tlon.navigate` targets and validation to the A2UI API
- route A2UI actions through app navigation for messages, channels, groups, profiles, and detail screens
- update fixtures/docs and require explicit send-message action text

## How did I test?

Tested on device