### PR TITLE
activity: fix v9 json conversions

### DIFF
--- a/desk/lib/activity-json.hoon
+++ b/desk/lib/activity-json.hoon
@@ -261,6 +261,31 @@
       :~  time+s+(scot %ud time.te)
           event+(event event.te)
       ==
+    ++  update
+      |=  u=update:v9:av
+      %+  frond  -.u
+      ?-  -.u
+        %add  (added +.u)
+        %del  (source +.u)
+        %read  (read +.u)
+        %activity  (activity +.u |)
+        %adjust  (adjusted +.u)
+        %allow-notifications  (allowed +.u)
+      ==
+    ++  added
+      |=  [src=source:v9:av te=time-event:v9:av]
+      %-  pairs
+      :~  source+(source src)
+          source-key+s+(string-source src)
+          time+(time time.te)
+          event+(event event.te)
+      ==
+    ++  adjusted
+      |=  [s=source:v9:av v=(unit volume-map:v9:av)]
+      %-  pairs
+      :~  source+(source s)
+          volume+?~(v ~ (volume-map u.v))
+      ==
     --
   ::
   ++  v8


### PR DESCRIPTION
## Summary

We missed a few JSON conversions in activity. This was found on 408k, which builds all marks, but we back-port the fix. 

## Changes

1. Fill in missing activity JSON conversions.

## How did I test?

Compiled.

## Risks and impact

- Safe to rollback without consulting PR author? Yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan
Revert.
