### PR TITLE
groups: fix pending join not preserving roles

### DIFF
--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -2646,6 +2646,8 @@
         =+  seat=(~(got by seats.group.se-core) ship)
         =?  roles.seat  ?=(^ roles)
           (~(uni in roles.seat) u.roles)
+        =.  seats.group.se-core
+          (~(put by seats.group.se-core) ship seat)
         (se-update:se-core %seat (sy ship ~) [%add seat])
       ::  send invites to manually added ships
       ::


### PR DESCRIPTION
## Summary

Found while expanding test coverage. The group host would actually emit a fact containing assigned roles, but would not update them in the state. Fortunately, aqua sees the perspective of both ships, and so when we examine the final group creation fact we could see the roles were missing.

## Changes

1. Fix pending join not preserving roles.

## How did I test?

Tested in aqua on #5874. Here we only backport the fix.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.