### PR TITLE
fix chat previews after database purge

### DIFF
--- a/packages/app/lib/baseDb.ts
+++ b/packages/app/lib/baseDb.ts
@@ -1,5 +1,5 @@
 import { createDevLogger } from '@tloncorp/shared';
-import { handleChange } from '@tloncorp/shared/db';
+import * as sharedDb from '@tloncorp/shared/db';
 import { perfMark } from '@tloncorp/shared/perfLog';
 import { sql } from 'drizzle-orm';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
@@ -44,6 +44,13 @@ export function useMigrations(db: BaseDb) {
   );
 }
 
+export async function resetDbSyncState() {
+  await sharedDb.headsSyncedAt.resetValue();
+  await sharedDb.changesSyncedAt.resetValue();
+  await sharedDb.didSyncInitialPosts.resetValue();
+  await sharedDb.userHasCompletedFirstSync.resetValue();
+}
+
 export abstract class BaseDb {
   protected client: any = null;
   protected isPolling = false;
@@ -60,7 +67,7 @@ export abstract class BaseDb {
     try {
       const changes = await this.client.select().from(changeLogTable).all();
       for (const change of changes) {
-        handleChange({
+        sharedDb.handleChange({
           table: change.table_name,
           operation: change.operation as 'INSERT' | 'UPDATE' | 'DELETE',
           row: JSON.parse(change.row_data ?? ''),

--- a/packages/app/lib/electronDb.ts
+++ b/packages/app/lib/electronDb.ts
@@ -1,6 +1,5 @@
 import { schema, setClient } from '@tloncorp/shared/db';
 import { handleChange } from '@tloncorp/shared/db';
-import * as kv from '@tloncorp/shared/db';
 import { migrations } from '@tloncorp/shared/db/migrations';
 import { drizzle } from 'drizzle-orm/sqlite-proxy';
 
@@ -8,6 +7,7 @@ import {
   BaseDb,
   changeLogTable,
   logger,
+  resetDbSyncState,
   useMigrations as useMigrationsBase,
 } from './baseDb';
 
@@ -130,8 +130,7 @@ export class ElectronDb extends BaseDb {
     this.client = null;
 
     // reset values related to tracking db sync state
-    await kv.headsSyncedAt.resetValue();
-    await kv.changesSyncedAt.resetValue();
+    await resetDbSyncState();
 
     logger.log('Purged Electron SQLite database, reconnecting');
     await this.setupDb();

--- a/packages/app/lib/nativeDb.test.ts
+++ b/packages/app/lib/nativeDb.test.ts
@@ -85,8 +85,10 @@ const loggerSpies = vi.hoisted(() => ({
 }));
 
 const sharedDbSpies = vi.hoisted(() => ({
+  resetDidSyncInitialPosts: vi.fn(async () => undefined),
   resetHeadsSyncedAt: vi.fn(async () => undefined),
   resetChangesSyncedAt: vi.fn(async () => undefined),
+  resetUserHasCompletedFirstSync: vi.fn(async () => undefined),
   setClient: vi.fn(),
 }));
 
@@ -112,6 +114,7 @@ vi.mock('@tloncorp/shared', () => ({
 
 vi.mock('@tloncorp/shared/db', () => ({
   changesSyncedAt: { resetValue: sharedDbSpies.resetChangesSyncedAt },
+  didSyncInitialPosts: { resetValue: sharedDbSpies.resetDidSyncInitialPosts },
   handleChange: vi.fn(),
   headsSyncedAt: { resetValue: sharedDbSpies.resetHeadsSyncedAt },
   schema: {
@@ -121,6 +124,9 @@ vi.mock('@tloncorp/shared/db', () => ({
     posts: 'posts',
   },
   setClient: sharedDbSpies.setClient,
+  userHasCompletedFirstSync: {
+    resetValue: sharedDbSpies.resetUserHasCompletedFirstSync,
+  },
 }));
 
 vi.mock('@op-engineering/op-sqlite', () => ({
@@ -282,6 +288,12 @@ describe('NativeDb', () => {
     expect(firstConnection.delete).toHaveBeenCalledTimes(1);
     expect(secondConnection.migrateClient).toHaveBeenCalledTimes(1);
     expect(sharedDbSpies.setClient).toHaveBeenCalledTimes(2);
+    expect(sharedDbSpies.resetHeadsSyncedAt).toHaveBeenCalledTimes(1);
+    expect(sharedDbSpies.resetChangesSyncedAt).toHaveBeenCalledTimes(1);
+    expect(sharedDbSpies.resetDidSyncInitialPosts).toHaveBeenCalledTimes(1);
+    expect(sharedDbSpies.resetUserHasCompletedFirstSync).toHaveBeenCalledTimes(
+      1
+    );
   });
 
   it('retries through purge/setup when schema health check fails', async () => {

--- a/packages/app/lib/nativeDb.ts
+++ b/packages/app/lib/nativeDb.ts
@@ -1,6 +1,5 @@
 import { open } from '@op-engineering/op-sqlite';
 import { AnalyticsEvent, AnalyticsSeverity, escapeLog } from '@tloncorp/shared';
-import * as kv from '@tloncorp/shared/db';
 import { schema, setClient } from '@tloncorp/shared/db';
 import { getTableName } from 'drizzle-orm';
 
@@ -8,6 +7,7 @@ import {
   BaseDb,
   enableLogger,
   logger,
+  resetDbSyncState,
   useMigrations as useMigrationsBase,
 } from './baseDb';
 import { OPSQLite$SQLiteConnection } from './opsqliteConnection';
@@ -139,8 +139,7 @@ export class NativeDb extends BaseDb {
       });
 
       // reset values related to tracking db sync state
-      await kv.headsSyncedAt.resetValue();
-      await kv.changesSyncedAt.resetValue();
+      await resetDbSyncState();
 
       logger.trackEvent(AnalyticsEvent.NativeDbDebug, {
         context: 'purgeDb: completed purge, recreating',

--- a/packages/app/lib/webDb.ts
+++ b/packages/app/lib/webDb.ts
@@ -1,17 +1,17 @@
 import type { Schema } from '@tloncorp/shared/db';
-import { schema, setClient } from '@tloncorp/shared/db';
-import {
-  changesSyncedAt,
-  headsSyncedAt,
-  sqliteContent,
-} from '@tloncorp/shared/db';
+import { schema, setClient, sqliteContent } from '@tloncorp/shared/db';
 import { migrations } from '@tloncorp/shared/db/migrations';
 import { readArrayBufferFromBlob } from '@tloncorp/shared/utils';
 import { drizzle } from 'drizzle-orm/sqlite-proxy';
 import { debounce } from 'lodash';
 import { SQLocalDrizzle } from 'sqlocal/drizzle';
 
-import { BaseDb, logger, useMigrations as useMigrationsBase } from './baseDb';
+import {
+  BaseDb,
+  logger,
+  resetDbSyncState,
+  useMigrations as useMigrationsBase,
+} from './baseDb';
 import { TRIGGER_SETUP } from './triggers';
 import migrate from './webMigrator';
 
@@ -103,10 +103,9 @@ export class WebDb extends BaseDb {
 
       // No persisted DB carried sync state forward, so anything we previously
       // tracked in localStorage about "what has been synced" is meaningless.
-      // Reset the sync watermarks so the initial sync refetches heads.
+      // Reset the sync markers so the initial sync hydrates the new DB.
       if (!loadedFromFile) {
-        await headsSyncedAt.resetValue();
-        await changesSyncedAt.resetValue();
+        await resetDbSyncState();
       }
 
       logger.log('sqlocal instance created', { sqlocal: this.sqlocal });
@@ -281,13 +280,13 @@ export class WebDb extends BaseDb {
     if (!this.sqlocal) {
       logger.warn('purgeDb called before setupDb, ignoring');
       await sqliteContent.resetValue();
+      await resetDbSyncState();
       return;
     }
     logger.log('purging sqlite database');
     this.saveToFile.cancel();
     await sqliteContent.resetValue();
-    await headsSyncedAt.resetValue();
-    await changesSyncedAt.resetValue();
+    await resetDbSyncState();
     await this.sqlocal.destroy();
     this.sqlocal = null;
     this.client = null;

--- a/packages/shared/src/db/queries.test.ts
+++ b/packages/shared/src/db/queries.test.ts
@@ -42,6 +42,32 @@ test('inserts all groups', async () => {
   expect(groups.length).toEqual(groupsData.length);
 });
 
+test('insertGroups only invalidates posts when payloads include channels', () => {
+  const tableEffects = queries.insertGroups.meta.tableEffects;
+  if (typeof tableEffects !== 'function') {
+    throw new Error('insertGroups should declare dynamic table effects');
+  }
+
+  const groupWithoutChannels = {
+    id: '~bus/no-channels',
+  } as unknown as Parameters<typeof queries.insertGroups>[0]['groups'][number];
+  const groupWithChannels = {
+    id: '~bus/with-channels',
+    channels: [
+      {
+        id: 'chat/~bus/with-channels/general',
+        groupId: '~bus/with-channels',
+        type: 'chat',
+      },
+    ],
+  } as unknown as Parameters<typeof queries.insertGroups>[0]['groups'][number];
+
+  expect(tableEffects({ groups: [groupWithoutChannels] })).not.toContain(
+    'posts'
+  );
+  expect(tableEffects({ groups: [groupWithChannels] })).toContain('posts');
+});
+
 // A full group payload is authoritative for nav-section memberships, so
 // the local `group_nav_section_channels` rows for those sections must
 // match the incoming payload exactly. Without an explicit delete in
@@ -1696,6 +1722,151 @@ describe('recomputeChannelLastPost', () => {
     // `{ lastPostId: null, lastPostAt: 9999 }` from the nulled sibling.
     expect(group!.lastPostId).toBe('valid-sibling-head');
     expect(group!.lastPostAt).toBe(2000);
+  });
+});
+
+describe('last post repair after channel metadata insert', () => {
+  type TestGroup = Parameters<typeof queries.insertGroups>[0]['groups'][number];
+
+  function testClient() {
+    const client = getClient();
+    if (!client) throw new Error('test db not initialized');
+    return client;
+  }
+
+  function testGroup(groupId: string, channelId?: string): TestGroup {
+    return {
+      id: groupId,
+      currentUserIsMember: true,
+      currentUserIsHost: false,
+      hostUserId: '~zod',
+      channels: channelId ? [{ id: channelId, type: 'chat', groupId }] : [],
+    } as unknown as TestGroup;
+  }
+
+  function testPost({
+    id,
+    channelId,
+    groupId,
+    at,
+    sequenceNum,
+  }: {
+    id: string;
+    channelId: string;
+    groupId?: string;
+    at: number;
+    sequenceNum: number;
+  }): Post {
+    return {
+      id,
+      type: 'chat',
+      channelId,
+      groupId,
+      authorId: '~zod',
+      sentAt: at,
+      receivedAt: at,
+      sequenceNum,
+      content: JSON.stringify([{ inline: ['preview'] }]),
+      syncedAt: at,
+    } as unknown as Post;
+  }
+
+  async function expectPreview({
+    groupId,
+    channelId,
+    postId,
+    at,
+  }: {
+    groupId: string;
+    channelId: string;
+    postId: string;
+    at: number;
+  }) {
+    const post = await testClient().query.posts.findFirst({
+      where: $.eq(schema.posts.id, postId),
+    });
+    expect(post!.groupId).toBe(groupId);
+
+    const channel = await queries.getChannel({ id: channelId });
+    expect(channel!.lastPostId).toBe(postId);
+    expect(channel!.lastPostAt).toBe(at);
+
+    const group = await queries.getGroup({ id: groupId });
+    expect(group!.lastPostId).toBe(postId);
+    expect(group!.lastPostAt).toBe(at);
+  }
+
+  async function insertCachedHead(post: Post) {
+    await queries.insertChannelPosts({ posts: [post] });
+    const inserted = await testClient().query.posts.findFirst({
+      where: $.eq(schema.posts.id, post.id),
+    });
+    expect(inserted!.groupId).toBeNull();
+  }
+
+  test('channel insertion repairs posts that were already cached locally', async () => {
+    const groupId = '~zod/channel-insert-preview-repair';
+    const channelId = 'chat/~zod/channel-insert-preview-repair/general';
+    const post = testPost({
+      id: 'channel-insert-preview-repair-head',
+      channelId,
+      at: 3000,
+      sequenceNum: 8,
+    });
+
+    await insertCachedHead(post);
+    await queries.insertGroups({ groups: [testGroup(groupId)] });
+    await queries.insertChannels([{ id: channelId, type: 'chat', groupId }]);
+    await expectPreview({
+      groupId,
+      channelId,
+      postId: post.id,
+      at: post.receivedAt,
+    });
+  });
+
+  test('group insertion repairs embedded channel posts that were already cached locally', async () => {
+    const groupId = '~zod/group-insert-preview-repair';
+    const channelId = 'chat/~zod/group-insert-preview-repair/general';
+    const post = testPost({
+      id: 'group-insert-preview-repair-head',
+      channelId,
+      at: 4000,
+      sequenceNum: 9,
+    });
+
+    await insertCachedHead(post);
+    await queries.insertGroups({ groups: [testGroup(groupId, channelId)] });
+    await expectPreview({
+      groupId,
+      channelId,
+      postId: post.id,
+      at: post.receivedAt,
+    });
+  });
+
+  test('metadata repair preserves newer server sequence watermarks', async () => {
+    const groupId = '~zod/sequence-watermark-repair';
+    const channelId = 'chat/~zod/sequence-watermark-repair/general';
+    const post = testPost({
+      id: 'sequence-watermark-repair-local-head',
+      channelId,
+      at: 5000,
+      sequenceNum: 50,
+    });
+
+    await insertCachedHead(post);
+    await queries.insertGroups({ groups: [testGroup(groupId)] });
+    await queries.insertChannels([{ id: channelId, type: 'chat', groupId }]);
+    await queries.setLatestChannelSequenceNum({
+      channelId,
+      sequenceNum: 100,
+    });
+
+    await queries.insertGroups({ groups: [testGroup(groupId, channelId)] });
+
+    const channel = await queries.getChannel({ id: channelId });
+    expect(channel!.lastPostSequenceNum).toBe(100);
   });
 });
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1299,21 +1299,30 @@ export const insertGroups = createWriteQuery(
             });
         }
       }
-      await setLastPosts(null, txCtx);
+      const channelIds = groups.flatMap(
+        (g) => g.channels?.map((c) => c.id) ?? []
+      );
+      await setLastPosts(null, txCtx, channelIds);
     });
   },
-  ({ groups }) =>
-    groups.length
-      ? [
-          'groups',
-          'groupRoles',
-          'contacts',
-          'chatMembers',
-          'chatMemberGroupRoles',
-          'channels',
-          'pins',
-        ]
-      : []
+  ({ groups }) => {
+    if (!groups.length) {
+      return [];
+    }
+    const effects: TableName[] = [
+      'groups',
+      'groupRoles',
+      'contacts',
+      'chatMembers',
+      'chatMemberGroupRoles',
+      'channels',
+      'pins',
+    ];
+    if (groups.some((group) => group.channels?.length)) {
+      effects.push('posts');
+    }
+    return effects;
+  }
 );
 
 export const insertGroupPreviews = createWriteQuery(
@@ -2356,7 +2365,11 @@ async function insertChannelsInternal(channels: Channel[], ctx: QueryCtx) {
       await insertMembers({ members: channel.members }, ctx);
     }
   }
-  await setLastPosts(null, ctx);
+  await setLastPosts(
+    null,
+    ctx,
+    channels.map((c) => c.id)
+  );
 }
 
 export const insertChannels = createWriteQuery(
@@ -2377,7 +2390,7 @@ export const insertChannels = createWriteQuery(
       await insertChannelsInternal(channels, txCtx);
     });
   },
-  ['channels']
+  ['channels', 'posts', 'groups']
 );
 
 export const updateChannel = createWriteQuery(
@@ -3633,26 +3646,72 @@ export const getHiddenPosts = createReadQuery(
   ['posts']
 );
 
-async function setLastPosts(newPosts: Post[] | null, ctx: QueryCtx) {
-  if (!newPosts?.length) return;
-
-  const uniqueChannels = new Set(newPosts.map((p) => p.channelId));
+async function setLastPosts(
+  newPosts: Post[] | null,
+  ctx: QueryCtx,
+  affectedChannelIds?: string[]
+) {
+  const channelIds =
+    affectedChannelIds ??
+    (newPosts ? [...new Set(newPosts.map((p) => p.channelId))] : undefined);
 
   // Single-channel fast path — the common receive case.
-  // Monotonic UPDATE driven by the incoming batch avoids the 3 correlated
-  // subqueries the multi-channel path runs. Only advances lastPost* forward.
-  // Paths that need a full recompute after a delete/edit (e.g.
-  // markPostAsDeleted in sync.ts) already explicitly reset lastPostId.
-  if (uniqueChannels.size === 1) {
+  // Monotonic UPDATE driven by the incoming batch avoids correlated subqueries
+  // and only advances lastPost* forward.
+  if (newPosts?.length && channelIds?.length === 1) {
     await setLastPostsMonotonic(newPosts, ctx);
     return;
   }
 
-  const channelIds = Array.from(uniqueChannels);
+  // Multi-channel batches and metadata-only calls (e.g. channels inserted after
+  // heads posts) recompute from local rows. This keeps the result idempotent no
+  // matter whether posts or channel/group metadata were written first.
+  if (channelIds && channelIds.length === 0) {
+    return;
+  }
 
-  // Multi-channel batched fallback (sync bursts spanning many channels).
-  // lastPostId/lastPostAt: point to the newest *previewable* post (not deleted)
-  // lastPostSequenceNum: always the newest post for syncing (even if deleted)
+  const channelIdFilter = channelIds?.length
+    ? inArray($channels.id, channelIds)
+    : undefined;
+  const postChannelIdFilter = channelIds?.length
+    ? inArray($posts.channelId, channelIds)
+    : undefined;
+  const latestLocalSequenceNum = ctx.db
+    .select({ sequenceNum: $posts.sequenceNum })
+    .from($posts)
+    .where(
+      and(
+        eq($posts.channelId, $channels.id),
+        not(eq($posts.type, 'reply')),
+        isNotNull($posts.sequenceNum)
+      )
+    )
+    .orderBy(desc($posts.sequenceNum))
+    .limit(1);
+
+  // Backfill posts whose group could not be known when they were inserted
+  // before their channel row existed.
+  await ctx.db
+    .update($posts)
+    .set({
+      groupId: sql`(SELECT ${$channels.groupId} FROM ${$channels} WHERE ${$channels.id} = ${$posts.channelId})`,
+    })
+    .where(
+      and(
+        isNull($posts.groupId),
+        postChannelIdFilter,
+        sql`EXISTS (
+          SELECT 1 FROM ${$channels}
+          WHERE ${$channels.id} = ${$posts.channelId}
+            AND ${$channels.groupId} IS NOT NULL
+        )`
+      )
+    );
+
+  // lastPostId/lastPostAt: newest previewable post (not deleted).
+  // lastPostSequenceNum: newest sequenced non-reply post for sync tracking,
+  // but only if it advances the existing server-known watermark. Local rows
+  // can be a partial window behind the backend head.
   await ctx.db
     .update($channels)
     .set({
@@ -3680,47 +3739,46 @@ async function setLastPosts(newPosts: Post[] | null, ctx: QueryCtx) {
         )
         .orderBy(desc($posts.receivedAt))
         .limit(1)}`,
-      lastPostSequenceNum: sql`${ctx.db
-        .select({ sequenceNum: $posts.sequenceNum })
-        .from($posts)
-        .where(
-          and(
-            eq($posts.channelId, $channels.id),
-            not(eq($posts.type, 'reply')),
-            isNotNull($posts.sequenceNum)
-          )
-        )
-        .orderBy(desc($posts.sequenceNum))
-        .limit(1)}`,
+      lastPostSequenceNum: sql`CASE
+        WHEN ${latestLocalSequenceNum} IS NULL THEN ${$channels.lastPostSequenceNum}
+        WHEN ${$channels.lastPostSequenceNum} IS NULL THEN ${latestLocalSequenceNum}
+        WHEN ${latestLocalSequenceNum} > ${$channels.lastPostSequenceNum} THEN ${latestLocalSequenceNum}
+        ELSE ${$channels.lastPostSequenceNum}
+      END`,
     })
     .where(
       and(
-        inArray($channels.id, channelIds),
-        or(
-          isNull($channels.lastPostSequenceNum),
-          isNull($channels.lastPostId),
-          lt(
-            $channels.lastPostId,
-            ctx.db
-              .select({ maxId: max($posts.id) })
-              .from($posts)
-              .where(eq($posts.channelId, $channels.id))
-          )
-        )
+        channelIdFilter,
+        sql`EXISTS (
+          SELECT 1 FROM ${$posts}
+          WHERE ${$posts.channelId} = ${$channels.id}
+            AND ${$posts.type} != 'reply'
+        )`
       )
     );
 
-  // Update groups
-  const updatedChannelIds = await ctx.db
-    .select({ id: $channels.id, groupId: $channels.groupId })
-    .from($channels)
-    .where(inArray($channels.id, channelIds));
-
-  const updatedGroupIds: string[] = [
-    ...new Set(updatedChannelIds.map((c) => c.groupId)),
-  ] as string[];
-
-  if (!updatedGroupIds.length) return;
+  // Update only groups touched by the channel set when possible. When doing a
+  // bulk repair, leave the filter undefined and recompute all groups.
+  let groupIdFilter;
+  if (channelIds?.length) {
+    const affectedGroups = await ctx.db
+      .select({ id: $channels.groupId })
+      .from($channels)
+      .where(
+        and(inArray($channels.id, channelIds), isNotNull($channels.groupId))
+      );
+    const affectedGroupIds = [
+      ...new Set(
+        affectedGroups
+          .map((group) => group.id)
+          .filter((id): id is string => id != null)
+      ),
+    ];
+    if (affectedGroupIds.length === 0) {
+      return;
+    }
+    groupIdFilter = inArray($groups.id, affectedGroupIds);
+  }
 
   await ctx.db
     .update($groups)
@@ -3728,31 +3786,35 @@ async function setLastPosts(newPosts: Post[] | null, ctx: QueryCtx) {
       lastPostId: sql`${ctx.db
         .select({ lastPostId: $channels.lastPostId })
         .from($channels)
-        .where(eq($channels.groupId, $groups.id))
+        .where(
+          and(
+            eq($channels.groupId, $groups.id),
+            isNotNull($channels.lastPostId),
+            sql`EXISTS (
+              SELECT 1 FROM ${$posts}
+              WHERE ${$posts.id} = ${$channels.lastPostId}
+            )`
+          )
+        )
         .orderBy(desc($channels.lastPostAt))
         .limit(1)}`,
       lastPostAt: sql`${ctx.db
         .select({ lastPostAt: $channels.lastPostAt })
         .from($channels)
-        .where(eq($channels.groupId, $groups.id))
+        .where(
+          and(
+            eq($channels.groupId, $groups.id),
+            isNotNull($channels.lastPostId),
+            sql`EXISTS (
+              SELECT 1 FROM ${$posts}
+              WHERE ${$posts.id} = ${$channels.lastPostId}
+            )`
+          )
+        )
         .orderBy(desc($channels.lastPostAt))
         .limit(1)}`,
     })
-    .where(
-      and(
-        inArray($groups.id, updatedGroupIds),
-        or(
-          isNull($groups.lastPostId),
-          lt(
-            $groups.lastPostId,
-            ctx.db
-              .select({ maxId: max($posts.id) })
-              .from($posts)
-              .where(eq($posts.groupId, $groups.id))
-          )
-        )
-      )
-    );
+    .where(groupIdFilter);
 }
 
 async function setLastPostsMonotonic(newPosts: Post[], ctx: QueryCtx) {

--- a/packages/shared/src/db/query.test.ts
+++ b/packages/shared/src/db/query.test.ts
@@ -1,8 +1,10 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryObserver } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { setupDb } from '../test/helpers';
 import { client } from './client';
-import { QueryCtx, withTransactionCtx } from './query';
+import { QueryCtx, createWriteQuery, withTransactionCtx } from './query';
+import { queryClient } from './reactQuery';
 
 describe('withTransactionCtx', () => {
   let testCtx: QueryCtx;
@@ -70,5 +72,56 @@ describe('withTransactionCtx', () => {
     });
 
     expect(result).toBe('nested transaction successful');
+  });
+});
+
+describe('query invalidation', () => {
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('invalidates table-dependent queries that are already fetching', async () => {
+    const queryKey = ['currentChats', new Set(['posts'])];
+    let calls = 0;
+    let resolveFetch!: () => void;
+    const fetchGate = new Promise<void>((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    queryClient.setQueryData(queryKey, 'cached');
+
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: async () => {
+        calls++;
+        await fetchGate;
+        return `fresh-${calls}`;
+      },
+    });
+
+    const unsubscribe = observer.subscribe(() => {});
+    const refetch = observer.refetch({ cancelRefetch: false });
+    await Promise.resolve();
+
+    const query = queryClient.getQueryCache().find({ queryKey });
+    expect(query?.state.fetchStatus).toBe('fetching');
+    expect(query?.isStale()).toBe(false);
+
+    const writePosts = createWriteQuery(
+      'testWritePosts',
+      async (_ctx: QueryCtx) => {},
+      ['posts']
+    );
+
+    await writePosts();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(query?.state.isInvalidated).toBe(true);
+    expect(query?.isStale()).toBe(true);
+    expect(calls).toBe(2);
+
+    resolveFetch();
+    await refetch;
+    unsubscribe();
   });
 });

--- a/packages/shared/src/db/query.ts
+++ b/packages/shared/src/db/query.ts
@@ -207,7 +207,6 @@ export async function withCtxOrDefault<T>(
       : 0;
     let scanned = 0;
     queryClient.invalidateQueries({
-      fetchStatus: 'idle',
       predicate: (query) => {
         scanned++;
         const tableKey = query.queryKey[1];

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -601,6 +601,36 @@ test('syncs last posts', async () => {
   );
 });
 
+test('init data repairs latest posts that arrived before channel rows', async () => {
+  const client = getClient();
+  if (!client) throw new Error('test db not initialized');
+
+  await db.headsSyncedAt.resetValue();
+  setScryOutputs([headsData, groupsInitData2]);
+
+  await syncLatestPosts();
+  await syncInitData();
+
+  const missingAfterInit = await client
+    .select({ count: $.countDistinct(db.schema.channels.id) })
+    .from(db.schema.channels)
+    .innerJoin(
+      db.schema.posts,
+      $.eq(db.schema.posts.channelId, db.schema.channels.id)
+    )
+    .where(
+      $.and(
+        $.isNull(db.schema.channels.lastPostId),
+        $.ne(db.schema.posts.type, 'reply'),
+        $.or(
+          $.isNull(db.schema.posts.isDeleted),
+          $.eq(db.schema.posts.isDeleted, false)
+        )
+      )
+    );
+  expect(missingAfterInit[0].count).toBe(0);
+});
+
 test('syncs thread posts', async () => {
   setScryOutput(channelPostWithRepliesData);
   await db.insertChannels([{ id: channelId, type: 'chat' }]);


### PR DESCRIPTION
## Summary

Fixes missing chat previews after a local SQLite purge or fresh database rebuild, and addresses a foreground refetch race that could leave chat-list previews stale after sync. Fixes three issues:
- Sync and init timestamps were not completely reset when we dropped the database
- `setLastPosts` was a no-op when called from `insertChannels`, `insertGroups`, etc.
- Table-based query invalidation skipped queries that were already fetching, so `getChats` could miss writes that landed during an active refetch

Fixes TLON-5915
Fixes TLON-5852

## Changes

- Reset all DB sync markers when native, web, or electron SQLite storage is purged or recreated.
- Make `setLastPosts` repair previews from local rows when channel or group metadata arrives after posts.
- Backfill post `groupId` during last-post repair so posts inserted before channel rows still attach to their group.
- Preserve newer server sequence watermarks while repairing local preview metadata.
- Only invalidate `posts` after group inserts when the incoming payload includes embedded channels.
- Invalidate table-dependent queries even if they are already fetching, so active chat-list refetches get a follow-up read after later writes.
- Add tests for post-before-channel ordering, first-sync init data repair, metadata repair, dynamic table effects, and active-refetch invalidation.

## How did I test?

Reproduced on physical Android device from a clean/purged DB state, then verified previews were repaired after first sync. Also ran:

- `pnpm --filter @tloncorp/shared tsc`
- `pnpm --filter @tloncorp/shared exec vitest run src/db/query.test.ts src/db/queries.test.ts src/store/sync/sync.test.ts`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
- [ ] Onboarding
- [x] State / providers
- [x] Message sync
- [x] Channel display
- [ ] Notifications
- [ ] Other:
