### PR TITLE
fix: route desktop thread activity items to correct channel/dm stack

### DIFF
--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -101,6 +101,23 @@ describe('getActiveTopLevelDrawerRouteName', () => {
     expect(getActiveTopLevelDrawerRouteName(chain)).toBe('Home');
   });
 
+  test('recognizes the real Contacts top-level drawer route (not the stale Profile name)', () => {
+    const chain = makeChain([
+      {
+        type: 'drawer',
+        index: 3,
+        routes: [
+          { name: 'Home' },
+          { name: 'Messages' },
+          { name: 'Activity' },
+          { name: 'Contacts' },
+          { name: 'Settings' },
+        ],
+      },
+    ]);
+    expect(getActiveTopLevelDrawerRouteName(chain)).toBe('Contacts');
+  });
+
   test('returns undefined when no top-level drawer route is active in the chain', () => {
     const chain = makeChain([
       {

--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  NavigationChainNode,
+  getActiveTopLevelDrawerRouteName,
+  getDesktopPostRoute,
+} from './routeHelpers';
+
+// Build a `{ getState, getParent }` chain from innermost -> outermost so we can
+// exercise the parent-walk without a live React Navigation object. The first
+// state is the active (innermost) navigator; each subsequent one is its parent.
+function makeChain(
+  states: { type?: string; index: number; routes: { name: string }[] }[]
+): NavigationChainNode {
+  function nodeAt(i: number): NavigationChainNode | undefined {
+    if (i >= states.length) {
+      return undefined;
+    }
+    return {
+      getState: () => states[i],
+      getParent: () => nodeAt(i + 1),
+    };
+  }
+  return nodeAt(0)!;
+}
+
+describe('getActiveTopLevelDrawerRouteName', () => {
+  test('returns Activity from inside the nested Activity drawer (default inner route)', () => {
+    const chain = makeChain([
+      // inner desktop Activity drawer, default inner screen
+      {
+        type: 'drawer',
+        index: 0,
+        routes: [{ name: 'ActivityEmpty' }, { name: 'GroupSettings' }],
+      },
+      // top-level drawer, Activity active
+      {
+        type: 'drawer',
+        index: 2,
+        routes: [
+          { name: 'Home' },
+          { name: 'Messages' },
+          { name: 'Activity' },
+          { name: 'Contacts' },
+          { name: 'Settings' },
+        ],
+      },
+    ]);
+    expect(getActiveTopLevelDrawerRouteName(chain)).toBe('Activity');
+  });
+
+  test('returns Activity even when inner Activity route is GroupSettings (not the default)', () => {
+    const chain = makeChain([
+      {
+        type: 'drawer',
+        index: 1,
+        routes: [{ name: 'ActivityEmpty' }, { name: 'GroupSettings' }],
+      },
+      {
+        type: 'drawer',
+        index: 2,
+        routes: [
+          { name: 'Home' },
+          { name: 'Messages' },
+          { name: 'Activity' },
+          { name: 'Contacts' },
+          { name: 'Settings' },
+        ],
+      },
+    ]);
+    expect(getActiveTopLevelDrawerRouteName(chain)).toBe('Activity');
+  });
+
+  test('returns the OUTERMOST top-level name for an in-channel chain (not the inner Channel drawer)', () => {
+    const chain = makeChain([
+      // innermost channel stack on a Post screen
+      {
+        type: 'stack',
+        index: 1,
+        routes: [{ name: 'ChannelRoot' }, { name: 'Post' }],
+      },
+      // channel drawer (Channel active) — must NOT be treated as top-level
+      {
+        type: 'drawer',
+        index: 0,
+        routes: [{ name: 'Channel' }, { name: 'DM' }, { name: 'GroupDM' }],
+      },
+      // top-level drawer, Home active
+      {
+        type: 'drawer',
+        index: 0,
+        routes: [
+          { name: 'Home' },
+          { name: 'Messages' },
+          { name: 'Activity' },
+          { name: 'Contacts' },
+          { name: 'Settings' },
+        ],
+      },
+    ]);
+    expect(getActiveTopLevelDrawerRouteName(chain)).toBe('Home');
+  });
+
+  test('returns undefined when no top-level drawer route is active in the chain', () => {
+    const chain = makeChain([
+      {
+        type: 'stack',
+        index: 0,
+        routes: [{ name: 'Post' }],
+      },
+    ]);
+    expect(getActiveTopLevelDrawerRouteName(chain)).toBeUndefined();
+  });
+});
+
+describe('getDesktopPostRoute', () => {
+  const base = {
+    postId: '~author/123.456',
+    authorId: '~author',
+  };
+
+  test('group channel -> wrapper screen Channel with channelId + groupId', () => {
+    const route = getDesktopPostRoute('Home', {
+      ...base,
+      channelId: 'chat/~group/channel',
+      groupId: '~group',
+    });
+    expect(route.name).toBe('Home');
+    expect(route.params.screen).toBe('Channel');
+    expect(route.params.params.channelId).toBe('chat/~group/channel');
+    expect(route.params.params.groupId).toBe('~group');
+    expect(route.params.params.screen).toBe('Post');
+    expect(route.params.params.params).toMatchObject({
+      ...base,
+      channelId: 'chat/~group/channel',
+      groupId: '~group',
+    });
+  });
+
+  test('DM channel -> wrapper screen DM, no groupId key when absent', () => {
+    const route = getDesktopPostRoute('Messages', {
+      ...base,
+      channelId: '~some-user',
+    });
+    expect(route.name).toBe('Messages');
+    expect(route.params.screen).toBe('DM');
+    expect('groupId' in route.params.params).toBe(false);
+    expect(route.params.params.screen).toBe('Post');
+  });
+
+  test('group-DM channel -> wrapper screen GroupDM', () => {
+    const route = getDesktopPostRoute('Home', {
+      ...base,
+      channelId: '0v4.aaaaa.bbbbb',
+    });
+    expect(route.params.screen).toBe('GroupDM');
+  });
+
+  test('selectedPostId is threaded onto both wrapper and nested Post params', () => {
+    const route = getDesktopPostRoute('Home', {
+      ...base,
+      channelId: 'chat/~group/channel',
+      groupId: '~group',
+      selectedPostId: '~author/789.000',
+    });
+    expect(route.params.params.selectedPostId).toBe('~author/789.000');
+    expect(route.params.params.params.selectedPostId).toBe('~author/789.000');
+  });
+
+  test('selectedPostId omitted is preserved as undefined (not coerced) in both places', () => {
+    const route = getDesktopPostRoute('Home', {
+      ...base,
+      channelId: 'chat/~group/channel',
+      groupId: '~group',
+    });
+    expect(route.params.params.selectedPostId).toBeUndefined();
+    expect(route.params.params.params.selectedPostId).toBeUndefined();
+  });
+});

--- a/packages/app/navigation/routeHelpers.ts
+++ b/packages/app/navigation/routeHelpers.ts
@@ -1,0 +1,116 @@
+import { isDmChannelId, isGroupDmChannelId } from '@tloncorp/api/client';
+
+// Pure, side-effect-light navigation route helpers.
+//
+// These live apart from `utils.ts` so they can be unit-tested under Vitest:
+// `utils.ts` pulls in `@tloncorp/ui` and store hooks at module load, which the
+// test transform can't process, but these helpers only depend on the api client
+// and plain navigation-state shapes.
+
+export function screenNameFromChannelId(channelId: string) {
+  return isDmChannelId(channelId)
+    ? 'DM'
+    : isGroupDmChannelId(channelId)
+      ? 'GroupDM'
+      : 'Channel';
+}
+
+// The real desktop top-level drawer route names (see
+// `navigation/desktop/TopLevelDrawer.tsx`). Note this intentionally uses
+// `Contacts`, not the stale `Profile` name still present in `getTab`'s list.
+const TOP_LEVEL_DRAWER_ROUTES = [
+  'Home',
+  'Messages',
+  'Activity',
+  'Contacts',
+  'Settings',
+] as const;
+
+// Minimal navigation surface this helper relies on, so tests can feed plain
+// state objects and a `getParent()` chain instead of a live navigation object.
+type NavigationStateLike = {
+  type?: string;
+  index?: number;
+  routes: { name: string }[];
+};
+
+export type NavigationChainNode = {
+  getState: () => NavigationStateLike | undefined;
+  getParent: () => NavigationChainNode | undefined;
+};
+
+/**
+ * Walk the parent navigator chain and return the name of the active route in
+ * the OUTERMOST top-level drawer (one of `TOP_LEVEL_DRAWER_ROUTES`).
+ *
+ * Returning the outermost (rather than the first drawer encountered) matters:
+ * from inside the desktop Activity drawer the inner drawer's active route is one
+ * of `ActivityEmpty`/`GroupSettings`/`UserProfile`/`EditProfile`, not
+ * `Activity`. Stopping at the first drawer would miss the top-level `Activity`
+ * route. Likewise an in-channel caller sits under a `Channel`/`DM` inner drawer
+ * whose top-level parent is `Home`/`Messages`; we must report the top-level
+ * name so Activity detection stays false for those callers.
+ */
+export function getActiveTopLevelDrawerRouteName(
+  navigation: NavigationChainNode
+): string | undefined {
+  let outermostTopLevel: string | undefined;
+  let current: NavigationChainNode | undefined = navigation;
+
+  while (current) {
+    const state = current.getState();
+    if (state?.type === 'drawer' && state.index != null) {
+      const activeRouteName = state.routes[state.index]?.name;
+      if (
+        activeRouteName &&
+        (TOP_LEVEL_DRAWER_ROUTES as readonly string[]).includes(activeRouteName)
+      ) {
+        // Keep walking; a higher (outer) drawer overrides, so we finish with
+        // the outermost top-level drawer route.
+        outermostTopLevel = activeRouteName;
+      }
+    }
+    current = current.getParent();
+  }
+
+  return outermostTopLevel;
+}
+
+/**
+ * Build a desktop nested route that opens a post's parent thread under the
+ * Home/Messages channel stack. Mirrors `getDesktopChannelRoute`: the wrapper
+ * route carries `channelId`/`groupId`/`selectedPostId` (read by
+ * `HomeNavigator`/`ChannelStack` for sidebar focus and stack remount keys) in
+ * addition to the nested `Post` params. The wrapper screen is derived from the
+ * channel id so DM/group-DM threads route to `DM`/`GroupDM`, not `Channel`.
+ */
+export function getDesktopPostRoute(
+  tab: 'Home' | 'Messages',
+  postParams: {
+    postId: string;
+    authorId: string;
+    channelId: string;
+    groupId?: string;
+    selectedPostId?: string | null;
+  }
+) {
+  const screen = screenNameFromChannelId(postParams.channelId);
+  return {
+    name: tab,
+    params: {
+      screen,
+      pop: true,
+      params: {
+        channelId: postParams.channelId,
+        ...(postParams.groupId ? { groupId: postParams.groupId } : {}),
+        // Preserve null/undefined rather than coercing; mirrors
+        // getDesktopChannelRoute so ChannelStack.navKey() reads the same value
+        // from the wrapper params as the nested Post params.
+        selectedPostId: postParams.selectedPostId,
+        screen: 'Post',
+        pop: true,
+        params: postParams,
+      },
+    },
+  } as const;
+}

--- a/packages/app/navigation/routeHelpers.ts
+++ b/packages/app/navigation/routeHelpers.ts
@@ -16,9 +16,10 @@ export function screenNameFromChannelId(channelId: string) {
 }
 
 // The real desktop top-level drawer route names (see
-// `navigation/desktop/TopLevelDrawer.tsx`). Note this intentionally uses
-// `Contacts`, not the stale `Profile` name still present in `getTab`'s list.
-const TOP_LEVEL_DRAWER_ROUTES = [
+// `navigation/desktop/TopLevelDrawer.tsx`). Shared with `getTab` in `utils.ts`
+// so the two top-level-drawer detectors can't drift. Note the correct name is
+// `Contacts`, not `Profile` (which `getTab` previously hard-coded by mistake).
+export const TOP_LEVEL_DRAWER_ROUTES = [
   'Home',
   'Messages',
   'Activity',

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -4,7 +4,6 @@ import {
   useNavigation as useReactNavigation,
 } from '@react-navigation/native';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { isDmChannelId, isGroupDmChannelId } from '@tloncorp/api/client';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
@@ -16,7 +15,14 @@ import type {
   DesktopBasePathStackParamList,
   MobileBasePathStackParamList,
 } from './BasePathNavigator';
+import {
+  getActiveTopLevelDrawerRouteName,
+  getDesktopPostRoute,
+  screenNameFromChannelId,
+} from './routeHelpers';
 import { CombinedParamList, RootStackParamList } from './types';
+
+export { screenNameFromChannelId } from './routeHelpers';
 
 const logger = createDevLogger('nav-utils', false);
 
@@ -187,11 +193,6 @@ export function useNavigateToPost() {
   const isWindowNarrow = useIsWindowNarrow();
   const navigation = useNavigation();
   const { lastOpenTab } = useGlobalSearch();
-  const activityIndex = navigation
-    .getState()
-    ?.routes.findIndex((route) => route.name === 'Activity');
-  const currentScreenIsActivity =
-    navigation.getState()?.index === activityIndex;
 
   return useCallback(
     (post: db.Post, options?: { selectedPostId?: string | null }) => {
@@ -203,27 +204,23 @@ export function useNavigateToPost() {
         selectedPostId: options?.selectedPostId,
       };
 
+      // Evaluate at press time (not hook-render time) against the live parent
+      // navigator chain. The desktop Activity drawer is nested, so inspecting
+      // only the locally-scoped state misses the top-level `Activity` route.
+      const currentScreenIsActivity =
+        getActiveTopLevelDrawerRouteName(navigation) === 'Activity';
+
       if (!isWindowNarrow && currentScreenIsActivity) {
         const tab = getTab(navigation, lastOpenTab);
         logger.log('navigateToPost', tab, postParams);
 
-        navigation.navigate(
-          tab,
-          {
-            screen: 'Channel',
-            params: {
-              screen: 'Post',
-              params: postParams,
-            },
-          },
-          { pop: true }
-        );
+        navigation.navigate(getDesktopPostRoute(tab, postParams));
         return;
       }
 
       navigation.navigate('Post', postParams, { pop: true });
     },
-    [isWindowNarrow, currentScreenIsActivity, navigation, lastOpenTab]
+    [isWindowNarrow, navigation, lastOpenTab]
   );
 }
 
@@ -537,12 +534,4 @@ export async function getMainGroupRoute(
       pop: true,
     } as const;
   }
-}
-
-export function screenNameFromChannelId(channelId: string) {
-  return isDmChannelId(channelId)
-    ? 'DM'
-    : isGroupDmChannelId(channelId)
-      ? 'GroupDM'
-      : 'Channel';
 }

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -16,6 +16,7 @@ import type {
   MobileBasePathStackParamList,
 } from './BasePathNavigator';
 import {
+  TOP_LEVEL_DRAWER_ROUTES,
   getActiveTopLevelDrawerRouteName,
   getDesktopPostRoute,
   screenNameFromChannelId,
@@ -308,8 +309,7 @@ function getTab(
 
   const last = state.routes[state.index];
   logger.log('last route name', last.name);
-  const drawers = ['Home', 'Messages', 'Activity', 'Profile', 'Settings'];
-  if (!drawers.includes(last.name)) {
+  if (!(TOP_LEVEL_DRAWER_ROUTES as readonly string[]).includes(last.name)) {
     logger.log('not top level drawer, getting tab from parent');
     return getTab(navigation.getParent(), lastOpenTab);
   }


### PR DESCRIPTION
## Summary

Fixes TLON-5858: a bug where clicking a `reply` or `flag-reply` item in the desktop Activity tab did nothing. The shared post-navigation helper now detects the desktop Activity context correctly and opens the thread's parent `Post` under the Home/Messages channel stack. This preserves the existing Home/Messages tab selection via `getTab`/`lastOpenTab` (matching normal post activity routing); only the nested channel-stack screen (`Channel`/`DM`/`GroupDM`) is derived from the post's `channelId`.

## Changes

- Added `packages/app/navigation/routeHelpers.ts`, a side-effect-light module holding pure, unit-testable navigation helpers:
  - `screenNameFromChannelId` — moved here from `utils.ts` and re-exported there, so existing mobile importers are unaffected.
  - `getActiveTopLevelDrawerRouteName` — walks the parent navigator chain via `getParent()` and returns the outermost top-level drawer route name (`Home`/`Messages`/`Activity`/`Contacts`/`Settings`). Returning the outermost route is required because the desktop Activity drawer is nested and in-channel callers sit under a `Channel`/`DM` inner drawer. Typed against a minimal `{ getState, getParent }` interface for testing.
  - `getDesktopPostRoute` — parallels `getDesktopChannelRoute`, deriving the wrapper screen from the channel id (so DM/group-DM threads route to `DM`/`GroupDM` instead of a nonexistent `Channel`) and carrying `channelId`/`groupId`/`selectedPostId` on the wrapper route.
- Updated `useNavigateToPost` in `packages/app/navigation/utils.ts` to compute `currentScreenIsActivity` at press time (inside the callback) via `getActiveTopLevelDrawerRouteName`, and to build the desktop Activity route with `getDesktopPostRoute`. Removed `currentScreenIsActivity` from the `useCallback` deps.
- Added `packages/app/navigation/routeHelpers.test.ts` with 9 tests covering both helpers (nested Activity drawer including a non-default inner route, in-channel chain returning `Home`, no-drawer returning `undefined`, route shape for group-channel/DM/group-DM, and `selectedPostId` passthrough/preservation).
- Centralized the top-level drawer route names into a shared `TOP_LEVEL_DRAWER_ROUTES` constant.

### Root cause

Desktop `reply`/`flag-reply` presses route through `useNavigateToPost`. Its "came from Activity" check inspected only the locally-scoped navigation state, so from inside the nested desktop Activity drawer the scoped routes were `ActivityEmpty`/`GroupSettings`/etc. (no `Activity` route), making the check return false. The press then fell through to `navigation.navigate('Post', …)`, which has no registered `Post` route at that level and was a silent no-op. A secondary latent bug hard-coded `screen: 'Channel'`, which would have misrouted DM/group-DM threads once detection was fixed.

## How did I test?
Manual testing on web/desktop.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: desktop navigation / Activity routing

Behavior note: desktop Activity thread navigation now opens the nested Home/Messages channel `Post` route, so back behavior returns to the channel (matching normal post activity) rather than returning directly to Activity.

## Rollback plan

Revert.

## Screenshots / videos

N/A
