### PR TITLE
ops: pull tlon-skill into monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
       - name: Setup PNPM
         uses: pnpm/action-setup@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 .DS_Store
 ops
 bin
+!packages/tlon-skill/bin/
+!packages/tlon-skill/bin/tlon.js
+packages/tlon-skill/bin/tlon
 *.tgz
 *.xst
 zod*

--- a/.prettierignore
+++ b/.prettierignore
@@ -283,6 +283,7 @@ clurd
 # From packages/tlon-skill/.gitignore
 /packages/tlon-skill/**/node_modules/
 /packages/tlon-skill/**/*.log
+/packages/tlon-skill/**/*.bun-build
 /packages/tlon-skill/**/.DS_Store
 /packages/tlon-skill/**/dist
 /packages/tlon-skill/**/coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,9 @@ node_modules
 .DS_Store
 ops
 bin
+!packages/tlon-skill/bin/
+!packages/tlon-skill/bin/tlon.js
+packages/tlon-skill/bin/tlon
 *.tgz
 *.xst
 zod*
@@ -277,5 +280,15 @@ clurd
 /packages/shared/**/.env.test
 # From packages/shared/.prettierignore
 /packages/shared/src/db/migrations
+# From packages/tlon-skill/.gitignore
+/packages/tlon-skill/**/node_modules/
+/packages/tlon-skill/**/*.log
+/packages/tlon-skill/**/.DS_Store
+/packages/tlon-skill/**/dist
+/packages/tlon-skill/**/coverage/
+/packages/tlon-skill/npm/*/tlon
+/packages/tlon-skill/bin/tlon
+/packages/tlon-skill/.claude/settings.local.json
+/packages/tlon-skill/ships/*
 # From packages/ui/.gitignore
 /packages/ui/**/dist/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:web": "pnpm --filter 'tlon-web' dev",
     "e2e": "pnpm --filter 'tlon-web' e2e",
     "test": "npm rebuild better-sqlite3 && pnpm run -r test run -u",
-    "test:ci": "npm rebuild better-sqlite3 && pnpm run -r test run",
+    "test:ci": "npm rebuild better-sqlite3 && pnpm build:api && pnpm run -r test run",
     "lint:all": "pnpm -r lint",
     "patch:expo-share-intent": "node scripts/regenerate-expo-share-intent-patch.mjs",
     "prettier:rebuild-monorepo-ignore": "prettierignore-monorepo"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:shared": "pnpm --filter '@tloncorp/shared' build",
     "build:ui": "pnpm --filter '@tloncorp/ui' build",
     "build:editor": "pnpm --filter '@tloncorp/editor' build",
+    "build:tlon-skill": "pnpm --filter '@tloncorp/tlon-skill' build",
     "build:web": "pnpm --filter 'tlon-web' build",
     "build:mobile": "pnpm --filter 'tlon-mobile' build",
     "build:desktop": "pnpm run build:packages && pnpm --filter 'tlon-desktop' build:prepare",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -69,4 +69,6 @@ export {
   type Mention,
   type PostBlobDataEntry,
 } from './client/content-helpers';
+export { getTextContent } from './client/postContent';
+export { preSig } from './lib/urbit';
 export * from './client';

--- a/packages/tlon-skill/.gitignore
+++ b/packages/tlon-skill/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+*.log
+.DS_Store
+dist
+coverage/
+# Ignore binaries, keep package.json
+npm/*/tlon
+bin/tlon
+.claude/settings.local.json
+ships/*

--- a/packages/tlon-skill/.gitignore
+++ b/packages/tlon-skill/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 *.log
+*.bun-build
 .DS_Store
 dist
 coverage/

--- a/packages/tlon-skill/.npmignore
+++ b/packages/tlon-skill/.npmignore
@@ -1,0 +1,2 @@
+# Don't publish the local dev binary - platform packages provide it
+bin/tlon

--- a/packages/tlon-skill/EXPANSION_PLAN.md
+++ b/packages/tlon-skill/EXPANSION_PLAN.md
@@ -1,0 +1,178 @@
+# Tlon Skill Expansion Plan
+
+Based on analysis of `packages/shared/src/api/` and `packages/shared/src/urbit/` in homestead.
+
+## Current State
+- ✅ `groups.ts` - list, create, info, invite, leave, add-channel
+- ✅ `contacts.ts` - list, get, update-profile  
+- ✅ `channels.ts` - dms, group-dms, groups (listing only)
+- ✅ `messages.ts` - dm, channel, history, search
+- ✅ `activity.ts` - mentions, replies, all, unreads
+- ✅ `notebook-post.ts` - post to diary channels
+
+## Proposed Additions
+
+### 1. Group Administration (`groups.ts`) ✅ COMPLETE
+
+| Command | API | Mark | Status |
+|---------|-----|------|--------|
+| `delete <group>` | groups | group-action-4 | ✅ |
+| `update <group>` | groups | group-action-4 | ✅ |
+| `kick <group> <ships...>` | groups | group-action-4 | ✅ |
+| `ban <group> <ships...>` | groups | group-action-4 | ✅ |
+| `unban <group> <ships...>` | groups | group-action-4 | ✅ |
+| `add-role <group> <role>` | groups | group-action-4 | ✅ |
+| `delete-role <group> <role>` | groups | group-action-4 | ✅ |
+| `assign-role <group> <role> <ships...>` | groups | group-action-4 | ✅ |
+| `remove-role <group> <role> <ships...>` | groups | group-action-4 | ✅ |
+| `set-privacy <group> <public|private|secret>` | groups | group-action-4 | ✅ |
+| `accept-join <group> <ships...>` | groups | group-action-4 | ✅ |
+| `reject-join <group> <ships...>` | groups | group-action-4 | ✅ |
+| `join <group>` | groups | group-join | ✅ |
+| `revoke-invite <group> <ships...>` | groups | group-action-4 | (not implemented - lower priority) |
+
+### 2. Channel Management (`channels.ts` expansion) ✅ COMPLETE
+
+| Command | API | Mark | Status |
+|---------|-----|------|--------|
+| `create <group> <title>` | channels | channel-action-1 | ✅ (in groups.ts add-channel) |
+| `delete <nest>` | groups | group-action-4 | ✅ |
+| `update <nest>` | groups | group-action-4 | ✅ |
+| `info <nest>` | groups | scry | ✅ |
+
+### 3. Posting (`posts.ts` - NEW)
+
+| Command | API | Mark | Description |
+|---------|-----|------|-------------|
+| `send <channel> <message>` | channels | channel-action | Post to channel |
+| `reply <channel> <post-id> <message>` | channels | channel-action | Reply to post |
+| `edit <channel> <post-id> <message>` | channels | channel-action | Edit a post |
+| `delete <channel> <post-id>` | channels | channel-action | Delete a post |
+| `react <channel> <post-id> <emoji>` | channels | channel-action | Add reaction |
+| `unreact <channel> <post-id>` | channels | channel-action | Remove reaction |
+
+### 4. DMs (`dms.ts` - NEW)
+
+| Command | API | Mark | Description |
+|---------|-----|------|-------------|
+| `send <ship> <message>` | chat | chat-dm-action-1 | Send DM |
+| `create-group <ships...>` | chat | chat-club-create | Create group DM |
+| `reply <dm-id> <post-id> <message>` | chat | chat-dm-action-1 | Reply in DM |
+| `react <dm-id> <post-id> <emoji>` | chat | chat-dm-action-1 | React in DM |
+
+### 5. Contacts (`contacts.ts` expansion)
+
+| Command | API | Mark | Description |
+|---------|-----|------|-------------|
+| `add <ship>` | contacts | contact-action-1 | Add a contact |
+| `remove <ship>` | contacts | contact-action-1 | Remove a contact |
+| `sync <ships...>` | contacts | contact-action-1 | Sync profiles from ships |
+
+## Key API Patterns Discovered
+
+### Groups Agent (`group-action-4`)
+```json
+{
+  "group": {
+    "flag": "~ship/group-name",
+    "a-group": {
+      // Operations:
+      "meta": { "title": "", "description": "", "image": "", "cover": "" },
+      "delete": null,
+      "entry": {
+        "privacy": "public" | "private" | "secret",
+        "ban": { "add-ships": [...] } | { "del-ships": [...] },
+        "ask": { "ships": [...], "a-ask": "approve" | "deny" }
+      },
+      "seat": {
+        "ships": [...],
+        "a-seat": { "del": null } | { "add-roles": [...] } | { "del-roles": [...] }
+      },
+      "role": {
+        "roles": ["role-id"],
+        "a-role": { "add": {...} } | { "del": null } | { "edit": {...} }
+      },
+      "channel": {
+        "nest": "chat/~ship/name",
+        "a-channel": { "del": null } | { "edit": {...} } | { "section": "zone-id" }
+      }
+    }
+  }
+}
+```
+
+### Channels Agent (`channel-action-1`)
+```json
+{
+  "create": {
+    "kind": "chat" | "diary" | "heap",
+    "group": "~ship/group-name",
+    "name": "channel-slug",
+    "title": "Display Title",
+    "description": "...",
+    "meta": null,
+    "readers": [],
+    "writers": []
+  }
+}
+```
+
+### Channels Agent (`channel-action` for posts)
+```json
+{
+  "channel": {
+    "nest": "chat/~ship/channel",
+    "action": {
+      "post": {
+        "add": { "content": [...], "author": "~ship", "sent": timestamp }
+      }
+    }
+  }
+}
+```
+
+### Chat Agent (DMs - `chat-dm-action-1`)
+```json
+{
+  "ship": "~recipient",
+  "diff": {
+    "id": "~author/timestamp",
+    "delta": {
+      "add": {
+        "essay": {
+          "content": [...],
+          "sent": timestamp,
+          "author": "~ship",
+          "kind": "/chat",
+          "meta": null,
+          "blob": null
+        },
+        "time": null
+      }
+    }
+  }
+}
+```
+
+## Implementation Priority
+
+### Phase 1 (High Value) ✅ COMPLETE
+1. `posts.ts send/reply` - Enable posting to channels ✅
+2. `dms.ts send` - Enable sending DMs ✅
+3. `contacts.ts add/remove` - Complete contact management ✅
+
+### Phase 2 (Group Admin) ✅ COMPLETE
+4. Group admin commands (kick, ban, roles) ✅
+5. Channel delete/update (via groups.ts add-channel, delete not yet needed)
+
+### Phase 3 (Polish) - Partially Complete
+6. Reactions ✅ (posts.ts react/unreact, dms.ts react/unreact)
+7. Edit/delete posts ✅ (posts.ts delete, dms.ts delete)
+8. Group DM creation (not yet implemented)
+
+## Notes
+
+- All pokes go through HTTP channel API with curl (like existing scripts)
+- Need to handle auth cookies (existing pattern in urbit-client.ts)
+- Response format varies - some pokes return immediately, others need subscription
+- For posts, need to generate proper IDs using `@da` format from timestamp

--- a/packages/tlon-skill/MONOREPO_PROPOSAL.md
+++ b/packages/tlon-skill/MONOREPO_PROPOSAL.md
@@ -1,0 +1,54 @@
+# Monorepo Proposal for Tlon Tools
+
+**Date:** 2026-02-17  
+**Status:** Discussion with team
+
+## Current Pain Points
+
+1. Cross-repo dependency management - pointing to git branches, waiting for merges
+2. Testing friction - local `file:` refs, remembering to change back
+3. Related changes split across multiple PRs
+4. Version coordination between packages
+
+## Proposed Structure
+
+**Monorepo (public):** `tlon-tools` or similar
+```
+packages/
+  api/           # @tloncorp/api (currently api-beta)
+  skill/         # @tloncorp/tlon-skill  
+  openclaw/      # openclaw-tlon plugin
+```
+
+**Separate (private):**
+```
+tlonbot/         # prompts, personality, deployment config
+  └── depends on @tloncorp/tlon-skill (npm)
+```
+
+## Benefits
+
+- Single PR for related changes across api/skill/plugin
+- Workspace linking just works (pnpm/npm workspaces)
+- CI tests everything together
+- Atomic versioning
+- Shared tooling (TypeScript config, linting, build scripts)
+
+## tlonbot Stays Separate
+
+- Private/proprietary content (prompts, personality)
+- Deployment-specific, not a library
+- Different access control needs
+- Stays lean - just consumes published packages
+
+## Open Questions
+
+- What's the long-term plan for api-beta vs upstream @tloncorp/api?
+- Who needs access to what?
+- Release cadence alignment?
+
+## Next Steps
+
+- [ ] Discuss with team
+- [ ] Decide on repo name/location
+- [ ] Migration plan if approved

--- a/packages/tlon-skill/README.md
+++ b/packages/tlon-skill/README.md
@@ -1,0 +1,196 @@
+# Tlon Skill
+
+A CLI tool for interacting with Tlon/Urbit APIs.
+
+## Installation
+
+**npm:**
+```bash
+npm install @tloncorp/tlon-skill
+```
+
+**Direct download (no Node required):**
+```bash
+# macOS ARM64
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.4.0.tgz | tar -xz
+mv package/tlon /usr/local/bin/
+
+# macOS x64
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-x64/-/tlon-skill-darwin-x64-0.4.0.tgz | tar -xz
+
+# Linux x64
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-linux-x64/-/tlon-skill-linux-x64-0.4.0.tgz | tar -xz
+
+# Linux ARM64
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-linux-arm64/-/tlon-skill-linux-arm64-0.4.0.tgz | tar -xz
+```
+
+## Configuration
+
+**Option 1: CLI flags (highest priority)**
+```bash
+# Cookie-based auth (fastest - ship parsed from cookie)
+tlon --url https://your-ship.tlon.network --cookie "urbauth-~your-ship=0v..." contacts self
+
+# Cookie-based auth with explicit ship and code fallback
+tlon --url https://your-ship.tlon.network --ship ~your-ship \
+  --cookie "urbauth-~your-ship=0v..." --code sampel-ticlyt-migfun-falmel contacts self
+
+# Code-based auth (requires all three)
+tlon --url https://your-ship.tlon.network --ship ~your-ship --code sampel-ticlyt-migfun-falmel contacts self
+
+# Use skill-dir or cached credentials for one ship
+tlon --ship ~your-ship contacts self
+
+# Or use a config file
+tlon --config ~/ships/my-ship.json contacts self
+```
+
+Valid CLI credential forms are `--config <file>`, `--url <url> --cookie <cookie>` with optional `--ship` and fallback `--code`, `--url <url> --ship <ship> --code <code>`, and `--ship <ship>` when available in `TLON_SKILL_DIR` or cache. Incomplete or conflicting credential flag sets fail locally instead of merging with environment variables.
+
+Config file format:
+```json
+// Cookie-based (ship derived from cookie)
+{"url": "https://your-ship.tlon.network", "cookie": "urbauth-~your-ship=0v..."}
+
+// Code-based
+{"url": "https://your-ship.tlon.network", "ship": "~your-ship", "code": "sampel-ticlyt-migfun-falmel"}
+```
+
+**Option 2: Environment variables**
+```bash
+# Cookie-based (ship derived from cookie)
+export URBIT_URL="https://your-ship.tlon.network"
+export URBIT_COOKIE="urbauth-~your-ship=0v..."
+
+# Code-based
+export URBIT_URL="https://your-ship.tlon.network"
+export URBIT_SHIP="~your-ship"
+export URBIT_CODE="sampel-ticlyt-migfun-falmel"
+```
+
+`URBIT_*` aliases take precedence over `TLON_*` aliases for the same field. Partial ambient credentials fail locally except ship-only env, which is used for `TLON_SHIP + TLON_SKILL_DIR` or cache lookup.
+
+**Option 3: Skill directory**
+
+When `TLON_SHIP` and `TLON_SKILL_DIR` are set, the CLI loads `ships/<ship>.json` from that skill directory before checking cached credentials.
+
+**Option 4: OpenClaw config**
+
+If you have OpenClaw configured with a Tlon channel, credentials are loaded automatically from JSON config. The default path is `~/.openclaw/openclaw.json`; `OPENCLAW_CONFIG` can point to an explicit JSON config path and is parsed as JSON regardless of extension.
+
+**Resolution order:** CLI credential flags -> `TLON_CONFIG_FILE` -> URL + cookie env -> URL + ship + code env -> `TLON_SHIP + TLON_SKILL_DIR` -> ship-only cache lookup -> OpenClaw JSON -> single cached ship.
+
+## Cookie Caching
+
+The skill caches fresh auth cookies from code login and code fallback to `~/.tlon/cache/<ship>.json`. Provided-cookie flows validate the cookie but do not copy that cookie into cache.
+
+```bash
+# First time - auth and cache
+$ tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh contacts self
+Note: Credentials cached for ~zod. Next time run: tlon --ship ~zod <command>
+
+# After that - select the cached ship
+$ tlon --ship ~zod contacts self
+
+# Multiple cached ships? Specify which one:
+$ tlon --ship ~zod contacts self
+```
+
+Cache entries are ship- and URL-specific. Clear cache: `rm ~/.tlon/cache/*.json`
+
+## Cookie vs Code Authentication
+
+- **Cookie-based auth**: Uses a pre-authenticated session cookie. Faster since it skips login.
+- **Code-based auth**: Performs a login request to get a fresh session cookie.
+
+The ship name is embedded in the cookie (`urbauth-~ship=...`), so you don't need to specify it separately with cookie auth unless you want to override it. You can provide both cookie and code; the cookie is used first and the code is fallback if the cookie has expired.
+
+## Multi-Ship Usage
+
+If you have credentials for multiple ships, you can operate on behalf of any of them:
+
+```bash
+# Act as a different ship
+tlon --config ~/ships/bot.json channels groups
+
+# Or pass credentials directly
+tlon --url https://bot.tlon.network --cookie "urbauth-~bot=0v..." contacts self
+```
+
+## Usage
+
+```bash
+# List your groups
+tlon channels groups
+
+# Create a group channel
+# (preferred alias; tlon groups add-channel still works)
+tlon channels create ~host/group-slug "Projects" --kind chat
+
+# Rename a channel
+tlon channels rename chat/~host/project-updates "Team Updates"
+
+# Get recent mentions
+tlon activity mentions --limit 10
+
+# Fetch DM history
+tlon messages dm ~sampel-palnet --limit 20
+
+# Update your profile
+tlon contacts update-profile --nickname "My Name"
+
+# Create a group
+tlon groups create "My Group" --description "A cool group"
+
+# Create a group for a bot owner
+tlon groups create-owned "My Group" --owner ~owner-ship --description "A cool group"
+
+# Join a public or invited group; private groups without an invite request one
+tlon groups join ~host/group-slug
+
+# Manage group invite flow explicitly
+tlon groups request-invite ~host/group-slug
+tlon groups accept-invite ~host/group-slug
+tlon groups reject-invite ~host/group-slug
+```
+
+## Features
+
+- **Activity**: Mentions, replies, unreads (with nicknames)
+- **Channels**: List DMs, group DMs, subscribed groups (nicknames shown), reader/writer permissions
+- **Contacts**: List, get, update profiles
+- **Groups**: Create, join, invite/request flows, roles, privacy (member nicknames shown)
+- **Hooks**: Manage channel hooks (add, edit, delete, order, config, cron)
+- **Messages**: History, search (author nicknames shown)
+- **DMs**: Group DM send/reply, react, accept/decline
+- **Posts**: React, edit, delete
+- **Notebook**: Post to diary channels
+- **Settings**: Hot-reload plugin config via settings-store
+
+## Development
+
+Use the Node version in `.tool-versions` and Bun `1.3.4`.
+
+```bash
+npm ci
+npm run typecheck
+npm run test:unit
+npm run test:integration
+npm run build:smoke
+npm run check
+```
+
+`npm run check` is the main local quality gate and is also run by CI. Coverage reporting is available with `npm run test:coverage`.
+
+## Documentation
+
+See [SKILL.md](SKILL.md) for full command reference.
+
+## For Hosted Deployments
+
+If you're running this in a hosted/K8s environment with additional features (workspace files, settings-store, click commands), see [@tloncorp/tlonbot](https://github.com/tloncorp/tlonbot).
+
+## License
+
+MIT

--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -1,0 +1,516 @@
+---
+name: tlon
+description: Interact with Tlon/Urbit API. Use for reading activity, message history, contacts, channels, and groups. Also for group/channel administration, profile management, and exposing content to the clearweb.
+---
+
+# Tlon Skill
+
+Use the `tlon` command for reading data, managing channels/groups/contacts, and administration.
+
+## OpenClaw
+
+When running as an OpenClaw skill, use the built-in `message` tool for sending outbound messages (DMs and channel posts). The `tlon` command is for reading data, administration, and management — not for sending messages. The `message` tool routes through the proper delivery infrastructure (threading, bot profile, rate limiting).
+
+### Diary / Notebook Thread Replies
+
+Tlon diary/notebook channels are special: a channel-level `send` creates a **new notebook post/note**. Do **not** use `message` with `action: "send"` in a diary channel unless you intentionally want to create a new notebook post.
+
+For normal conversation inside an existing diary/notebook post, use the `message` tool with `action: "reply"` and reply to the **parent diary post id**, not the newest reply id.
+
+Working pattern:
+
+```json
+{
+  "action": "reply",
+  "channel": "tlon",
+  "target": "diary/~host/slug",
+  "messageId": "170.141.184.507.950.303.933.087.606.997.052.817.408",
+  "message": "Reply text here"
+}
+```
+
+Important details:
+- Use the dotted `@ud` post id format when available.
+- `messageId` should be the parent notebook post/thread id.
+- After sending, verify with `tlon messages post <diary-nest> <parent-post-id>` when correctness matters.
+- If the tool reports success but the reply is not visible under the parent post, treat it as a delivery/plugin issue and do not claim success until verified.
+
+## Installation
+
+**npm (Node.js):**
+
+```bash
+npm install @tloncorp/tlon-skill
+tlon channels groups
+```
+
+**Direct binary (no Node required):**
+
+```bash
+curl -L https://registry.npmjs.org/@tloncorp/tlon-skill-darwin-arm64/-/tlon-skill-darwin-arm64-0.4.0.tgz | tar -xz
+./package/tlon channels groups
+```
+
+Replace `darwin-arm64` with `darwin-x64`, `linux-x64`, or `linux-arm64` as needed.
+
+## Configuration
+
+**CLI Flags (highest priority):**
+
+```bash
+# Cookie-based auth (fastest - ship parsed from cookie name)
+tlon --url https://your-ship.tlon.network --cookie "urbauth-~your-ship=0v..." <command>
+
+# Cookie-based auth with explicit ship and code fallback
+tlon --url https://your-ship.tlon.network --ship ~your-ship \
+  --cookie "urbauth-~your-ship=0v..." --code sampel-ticlyt-migfun-falmel <command>
+
+# Code-based auth (requires url + ship + code)
+tlon --url https://your-ship.tlon.network --ship ~your-ship --code sampel-ticlyt-migfun-falmel <command>
+
+# Use skill-dir or cached credentials for one ship
+tlon --ship ~your-ship <command>
+
+# Or load from a JSON config file
+tlon --config ~/ships/my-ship.json <command>
+```
+
+Valid CLI credential forms are `--config <file>`, `--url <url> --cookie <cookie>` with optional `--ship` and fallback `--code`, `--url <url> --ship <ship> --code <code>`, and `--ship <ship>` when available in `TLON_SKILL_DIR` or cache. Incomplete or conflicting credential flag sets fail locally instead of merging with environment variables.
+
+Config file format:
+
+```json
+// Cookie-based (ship derived from cookie)
+{"url": "...", "cookie": "urbauth-~ship=..."}
+
+// Code-based
+{"url": "...", "ship": "~...", "code": "..."}
+```
+
+**Environment Variables:**
+
+```bash
+# Cookie-based (ship derived from cookie)
+export URBIT_URL="https://your-ship.tlon.network"
+export URBIT_COOKIE="urbauth-~your-ship=0v..."
+
+# Code-based
+export URBIT_URL="https://your-ship.tlon.network"
+export URBIT_SHIP="~your-ship"
+export URBIT_CODE="sampel-ticlyt-migfun-falmel"
+```
+
+`URBIT_*` aliases take precedence over `TLON_*` aliases for the same field. Partial ambient credentials fail locally except ship-only env, which is used for `TLON_SHIP + TLON_SKILL_DIR` or cache lookup.
+
+**Skill directory:** When `TLON_SHIP` and `TLON_SKILL_DIR` are set, the CLI loads `ships/<ship>.json` from that skill directory before checking cached credentials.
+
+**OpenClaw:** If configured with a Tlon channel, credentials load automatically from JSON config. The default path is `~/.openclaw/openclaw.json`; `OPENCLAW_CONFIG` can point to an explicit JSON config path and is parsed as JSON regardless of extension.
+
+**Resolution order:** CLI credential flags → `TLON_CONFIG_FILE` → URL + cookie env → URL + ship + code env → `TLON_SHIP + TLON_SKILL_DIR` → ship-only cache lookup → OpenClaw JSON → single cached ship.
+
+**Cookie vs Code:**
+
+- **Cookie-based:** Uses pre-authenticated session cookie. Ship is parsed from the cookie name (`urbauth-~ship=...`). Fastest option.
+- **Code-based:** Performs login to get a fresh session cookie. Requires URL + ship + code.
+
+You can provide both cookie and code — cookie is used first, code serves as fallback if cookie expires.
+
+## Cookie Caching
+
+The skill caches fresh auth cookies from code login and code fallback to `~/.tlon/cache/<ship>.json`. Provided-cookie flows validate the cookie but do not copy that cookie into cache. This makes subsequent invocations much faster by skipping the login request.
+
+**How it works:**
+
+```bash
+# First time - authenticates and caches
+$ tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh contacts self
+~zod
+Note: Credentials cached for ~zod. Next time run: tlon --ship ~zod <command>
+
+# After that - select the cached ship
+$ tlon --ship ~zod contacts self
+~zod
+
+# With multiple cached ships - specify which one
+$ tlon --ship ~zod contacts self
+$ tlon --ship ~bus contacts self
+```
+
+**Cache behavior:**
+
+- Cached cookies are URL-specific (won't use a cookie for the wrong host)
+- If only one ship is cached, it's auto-selected (no flags needed)
+- If multiple ships are cached, you'll be prompted to specify with `--ship`
+- Code login and code fallback cache fresh cookies; provided-cookie flows do not copy cookies into cache
+
+**Clear cache:** `rm ~/.tlon/cache/*.json`
+
+## Multi-Ship Usage
+
+If you have credentials for multiple ships, you can use this skill to operate on behalf of any of them. This is useful for:
+
+- **Managing multiple identities** — switch between ships without changing environment variables
+- **Bot operations** — act as a bot ship while authenticated as yourself
+- **Moon management** — operate moons from their parent planet
+
+Simply pass the target ship's credentials via CLI flags:
+
+```bash
+# Read channels as ~other-ship
+tlon --url https://other-ship.tlon.network --ship ~other-ship --code their-access-code \
+  channels groups
+
+# Or keep credentials in config files
+tlon --config ~/ships/bot.json channels groups
+tlon --config ~/ships/moon.json contacts self
+```
+
+## Commands
+
+Help and usage errors are handled locally before credential lookup, so `tlon <command> --help` works without a configured ship.
+
+### Activity
+
+Check recent notifications and unread counts. Ships are shown with nicknames when available.
+
+```bash
+tlon activity mentions --limit 10   # Recent mentions (max 25)
+tlon activity replies --limit 10    # Recent replies (max 25)
+tlon activity all --limit 10        # All recent activity (max 25)
+tlon activity unreads               # Unread counts per channel
+```
+
+### Channels
+
+List and manage channels. DMs show nicknames when available.
+
+```bash
+tlon channels dms                                          # List DM contacts (with nicknames)
+tlon channels groups                                       # List subscribed groups
+tlon channels all                                          # List everything
+tlon channels info chat/~host/slug                         # Get channel details
+tlon channels create ~host/slug "Projects" --kind chat     # Create a group channel
+tlon channels rename chat/~host/slug "New Title"           # Rename a channel
+tlon channels update chat/~host/slug --title "New Title"   # Update metadata
+tlon channels delete chat/~host/slug                       # Delete a channel
+
+# Writers (who can post)
+tlon channels add-writers chat/~host/slug admin member     # Add write access
+tlon channels del-writers chat/~host/slug member           # Remove write access
+
+# Readers (who can view - requires group flag)
+tlon channels add-readers ~host/group chat/~host/slug admin    # Restrict viewing
+tlon channels del-readers ~host/group chat/~host/slug admin    # Open viewing
+```
+
+Help works for both the command and subcommands:
+
+```bash
+tlon channels --help
+tlon channels create --help
+tlon channels rename --help
+```
+
+Notes on permissions:
+
+- Empty writers list = anyone in the group can post (default for chat)
+- Empty readers list = anyone in the group can view (default)
+- Diaries default to admin-only writers
+- Roles must exist in the group (use `tlon groups add-role` first)
+
+### Contacts
+
+Manage contacts and profiles.
+
+```bash
+tlon contacts list                                   # List all contacts
+tlon contacts self                                   # Get your own profile
+tlon contacts get ~sampel                            # Get a contact's profile
+tlon contacts sync ~ship1 ~ship2                     # Fetch/sync profiles
+tlon contacts add ~sampel                            # Add a contact
+tlon contacts remove ~sampel                         # Remove a contact
+tlon contacts update-profile --nickname "My Name"    # Update your profile
+```
+
+Options: `--nickname`, `--bio`, `--status`, `--avatar`, `--cover`
+
+### Groups
+
+Full group management.
+
+```bash
+# Basics
+tlon groups list                                         # List your groups
+tlon groups info ~host/slug                              # Get group details
+tlon groups create "Name" [--description "..."]          # Create a group
+tlon groups create-owned "Name" --owner ~ship [--description "..."] # Create group, invite owner, make owner admin
+tlon groups join ~host/slug                              # Join public/invited group, or request invite if private
+tlon groups request-invite ~host/slug                    # Request invite to a private group
+tlon groups accept-invite ~host/slug                     # Accept an existing group invite
+tlon groups reject-invite ~host/slug                     # Reject an existing group invite
+tlon groups cancel-join ~host/slug                       # Cancel a pending join
+tlon groups rescind-request ~host/slug                   # Cancel an invite request
+tlon groups leave ~host/slug                             # Leave a group
+tlon groups delete ~host/slug                            # Delete (host only)
+tlon groups update ~host/slug --title "..." [--description "..."]
+
+# Members (shown with nicknames when available)
+tlon groups invite ~host/slug ~ship1 ~ship2              # Invite members
+tlon groups revoke-invite ~host/slug ~ship1              # Revoke pending member invite
+tlon groups kick ~host/slug ~ship1                       # Kick members
+tlon groups ban ~host/slug ~ship1                        # Ban members
+tlon groups unban ~host/slug ~ship1                      # Unban members
+tlon groups accept-join ~host/slug ~ship1                # Approve a member join request
+tlon groups reject-join ~host/slug ~ship1                # Deny a member join request
+tlon groups set-privacy ~host/slug public|private|secret # Set privacy
+
+# Roles
+tlon groups add-role ~host/slug role-id --title "..."    # Create a role
+tlon groups delete-role ~host/slug role-id               # Delete a role
+tlon groups update-role ~host/slug role-id --title "..." # Update a role
+tlon groups assign-role ~host/slug role-id ~ship1        # Assign role
+tlon groups remove-role ~host/slug role-id ~ship1        # Remove role
+
+# Admin
+tlon groups promote ~host/slug ~ship1 [~ship2 ...]      # Promote member(s) to admin
+tlon groups demote ~host/slug ~ship1 [~ship2 ...]       # Demote member(s) from admin
+
+Roles vs Admin:
+- Regular roles are for organizing members and controlling channel read/write permissions.
+- Admin is a special privilege on top of a role. Admins can manage group settings,
+  channels, members, and roles.
+- `promote` creates an "admin" role (if one doesn't exist), grants it admin privileges,
+  and assigns it to the specified members. `demote` removes that role from them.
+- To grant admin to members who already share a role, use `set-admin` on that role
+  via the backend directly (not yet exposed in the Tlon app UI).
+
+# Channels
+tlon groups add-channel ~host/slug "Name" [--kind chat|diary|heap]
+```
+
+`tlon groups add-channel` remains supported, but for agent/tool use prefer the more discoverable channel-centric form:
+
+```bash
+tlon channels create ~host/slug "Projects" --kind chat
+```
+
+Help works here too:
+
+```bash
+tlon groups --help
+tlon groups add-channel --help
+```
+
+Group format: `~host-ship/group-slug`
+
+Join behavior:
+- `join` first checks whether you are already a member, then checks foreign/unjoined group state for a valid invite.
+- Invited groups and public groups use the backend join action.
+- Private groups without an invite use the invite-request action.
+- Secret groups require an invite.
+
+### Hooks
+
+Manage channel hooks — functions that run on triggers (posts, replies, reactions, crons).
+
+```bash
+# List and inspect
+tlon hooks list                                          # List all hooks
+tlon hooks get 0v1a.2b3c4                                # Get hook details and source
+
+# Manage hooks
+tlon hooks init my-hook --type on-post                   # Create starter template (on-post|cron|moderation)
+tlon hooks add my-hook ./my-hook.hoon                    # Add a new hook from file
+tlon hooks edit 0v1a.2b3c4 --name "New Name"             # Rename a hook
+tlon hooks edit 0v1a.2b3c4 --src ./updated.hoon          # Update source
+tlon hooks delete 0v1a.2b3c4                             # Delete a hook
+
+# Configure for channels
+tlon hooks order chat/~host/slug 0v1a 0v2b 0v3c          # Set execution order
+tlon hooks config 0v1a chat/~host/slug key1=val1         # Configure hook instance
+
+# Scheduled execution
+tlon hooks cron 0v1a ~h1                                 # Run hourly (global)
+tlon hooks cron 0v1a ~m30 --nest chat/~host/slug         # Run every 30m for channel
+tlon hooks rest 0v1a                                     # Stop cron job
+```
+
+Notes:
+
+- Hook IDs are @uv format (e.g., `0v1a.2b3c4...`)
+- Schedules use @dr format: `~h1` (1 hour), `~m30` (30 minutes), `~d1` (1 day)
+- Hooks run in order when triggered; use `order` to set priority
+- Use `config` to pass channel-specific settings to a hook instance
+
+**Writing Hooks:** See `references/hooks.md` for full documentation on writing hooks, including:
+
+- Event types (`on-post`, `on-reply`, `cron`, `wake`)
+- Bowl context (channel, group, config access)
+- Effects (channel actions, group actions, scheduled wakes)
+- Config handling with clam (`;;`)
+
+**Examples:** See `references/hooks-examples/` for starter templates:
+
+- `auto-react.hoon` — React to new posts with emoji
+- `delete-old-posts.hoon` — Cron job to clean up old messages
+- `word-filter.hoon` — Block posts containing banned words
+
+### Messages
+
+Read and search message history. Authors are shown with nicknames when available.
+
+```bash
+tlon messages dm ~sampel --limit 20                      # DM history (max 50)
+tlon messages channel chat/~host/slug --limit 20         # Channel history (max 50)
+tlon messages search "query" --channel chat/~host/slug   # Search messages
+tlon messages context chat/~host/slug 170.141... --limit 5  # Messages around a post
+tlon messages post chat/~host/slug 170.141...            # Fetch single post with replies
+```
+
+Options: `--limit N`, `--resolve-cites`
+
+The `context` command fetches N messages before and after a given post ID — useful for
+finding surrounding conversation when you have a post from search or activity.
+For DMs, use the ship name as the channel: `tlon messages context ~sampel 170.141...`
+
+The `post` command fetches a single post with its replies/thread. For DM posts,
+pass `--author ~ship` (required for DM lookups).
+
+**Tip:** Use `search` to find a message, then `context` with its ID to see the surrounding conversation.
+
+### DMs
+
+Manage direct messages — reactions, invites, and deletions.
+
+```bash
+# Management
+tlon dms react ~sampel ~author/170.141... "👍"           # React to a DM
+tlon dms unreact ~sampel ~author/170.141...              # Remove reaction
+tlon dms delete ~sampel ~author/170.141...               # Delete a DM
+tlon dms accept ~sampel                                  # Accept DM invite
+tlon dms decline ~sampel                                 # Decline DM invite
+```
+
+### Expose
+
+Publish Tlon content to the clearweb via the %expose agent.
+
+```bash
+tlon expose list                                         # List all exposed content
+tlon expose show chat/~host/slug/170.141...              # Expose a post publicly
+tlon expose hide chat/~host/slug/170.141...              # Hide an exposed post
+tlon expose check diary/~host/blog/170.141...            # Check if a post is exposed
+tlon expose url diary/~host/blog/170.141...              # Get the public URL
+```
+
+Cite path formats:
+
+- Simplified: `chat/~host/channel/170.141...` (auto-expands)
+- Full: `/1/chan/chat/~host/channel/msg/170.141...`
+
+Channel kinds map to content types: chat→msg, diary→note, heap→curio
+
+### Posts
+
+Manage channel posts (reactions, edits, deletes).
+
+```bash
+tlon posts react chat/~host/slug 170.141... "👍"         # React to a post
+tlon posts unreact chat/~host/slug 170.141...            # Remove reaction
+tlon posts edit chat/~host/slug 170.141... "New text"    # Edit with plain text
+tlon posts edit diary/~host/slug 170.141... --title "T" --image <url> --content story.json # Edit notebook
+tlon posts delete chat/~host/slug 170.141...             # Delete a post
+```
+
+Edit options for notebooks: `--title`, `--image` (cover URL), `--content` (Story JSON file for rich formatting).
+
+### Notebook
+
+Post to diary/notebook channels.
+
+```bash
+tlon notebook diary/~host/slug "Title"                   # Post with no body
+tlon notebook diary/~host/slug "Title" --content story.json # Post with Story JSON
+tlon notebook diary/~host/slug "Title" --markdown post.md   # Post with Markdown
+cat post.md | tlon notebook diary/~host/slug "Title" --markdown-stdin
+tlon notebook diary/~host/slug "Title" --image <url>     # Post with cover image
+```
+
+The `--content` file should be **Urbit Story JSON**: an array of verses accepted by the ship's `story-json` decoder. Use `--markdown` for Markdown files instead of passing Markdown or editor-export JSON through `--content`.
+
+Working examples:
+
+```json
+[{"inline": ["Hello world"]}]
+```
+
+```json
+[{"block": {"header": {"tag": "h1", "content": ["Title"]}}}]
+```
+
+```json
+[{"inline": ["Use ", {"inline-code": "ha-q"}, " for entity queries."]}]
+```
+
+Important gotcha:
+- Do **not** assume newer block-editor JSON shapes or arbitrary markdown-export JSON will work.
+- If posting fails with a `channel-action-2` cast error mentioning `content -> add -> post -> action -> channel`, the first thing to check is whether the content file matches the ship's Story JSON shape.
+- When debugging, post a minimal one-verse story first so you do not create duplicate full notebook posts.
+
+See the ship-side decoder and types here:
+- `tlon-apps/desk/lib/story-json.hoon`
+- [Story types in tlon-apps](https://github.com/tloncorp/tlon-apps/blob/develop/packages/shared/src/urbit/content.ts)
+
+### Upload
+
+Upload files to Tlon storage from a URL, local path, or stdin.
+
+```bash
+tlon upload https://example.com/image.png         # Upload from URL
+tlon upload ./photo.jpg                            # Upload local file
+tlon upload ~/Pictures/screenshot.png              # Upload with absolute path
+tlon upload ./mystery-file -t image/webp           # Override content type
+cat image.png | tlon upload --stdin -t image/png   # Upload from stdin
+```
+
+Options: `-t`/`--type` (override MIME type), `--stdin` (read from stdin)
+
+Content type is auto-detected from file extension for local files. For stdin, `-t` is recommended (defaults to `application/octet-stream`).
+
+Returns the uploaded URL for use in posts, profiles, etc.
+
+### Settings (OpenClaw)
+
+Manage OpenClaw's Tlon plugin config via Urbit settings-store. Changes apply immediately without gateway restart.
+
+```bash
+tlon settings get                                        # Show all settings
+tlon settings set <key> <json-value>                     # Set a value
+tlon settings delete <key>                               # Delete a setting
+
+# DM allowlist
+tlon settings allow-dm ~ship                             # Add to DM allowlist
+tlon settings remove-dm ~ship                            # Remove from allowlist
+
+# Channel controls
+tlon settings allow-channel chat/~host/slug              # Add to watch list
+tlon settings remove-channel chat/~host/slug             # Remove from watch list
+tlon settings open-channel chat/~host/slug               # Set channel to open
+tlon settings restrict-channel chat/~host/slug [~ship1]  # Set restricted
+
+# Authorization
+tlon settings authorize-ship ~ship                       # Add to default auth
+tlon settings deauthorize-ship ~ship                     # Remove from auth
+```
+
+## Notes
+
+- Ship names should include `~` prefix
+- Post IDs are @ud format with dots (e.g. `170.141.184.507...`)
+- DM post IDs include author prefix (`~ship/170.141...`)
+- Channel nests: `<kind>/~<host>/<name>` (chat, diary, or heap)
+
+## Limits
+
+- Activity: max 25 items
+- Messages: max 50 items

--- a/packages/tlon-skill/bin/tlon.js
+++ b/packages/tlon-skill/bin/tlon.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// Map of platform+arch to package name
+const PLATFORMS = {
+  "darwin-arm64": "@tloncorp/tlon-skill-darwin-arm64",
+  "darwin-x64": "@tloncorp/tlon-skill-darwin-x64",
+  "linux-x64": "@tloncorp/tlon-skill-linux-x64",
+  "linux-arm64": "@tloncorp/tlon-skill-linux-arm64",
+};
+
+function getBinaryPath() {
+  const platform = process.platform;
+  const arch = process.arch;
+  const key = `${platform}-${arch}`;
+
+  // Check for local binary (dev mode)
+  const localBinary = join(__dirname, "tlon");
+  if (existsSync(localBinary)) {
+    return localBinary;
+  }
+
+  const packageName = PLATFORMS[key];
+  if (!packageName) {
+    console.error(`Unsupported platform: ${platform}-${arch}`);
+    console.error(`Supported platforms: ${Object.keys(PLATFORMS).join(", ")}`);
+    process.exit(1);
+  }
+
+  // Try multiple resolution strategies
+  const searchPaths = [
+    // Strategy 1: resolve via require (works when installed normally)
+    () => {
+      try {
+        const packagePath = require.resolve(`${packageName}/package.json`);
+        return join(dirname(packagePath), "tlon");
+      } catch {
+        return null;
+      }
+    },
+    // Strategy 2: sibling in node_modules (when installed as dep of another package)
+    () => {
+      const sibling = join(__dirname, "..", "..", packageName, "tlon");
+      return existsSync(sibling) ? sibling : null;
+    },
+    // Strategy 3: up one more level (nested node_modules)
+    () => {
+      const nested = join(__dirname, "..", "..", "..", packageName, "tlon");
+      return existsSync(nested) ? nested : null;
+    },
+  ];
+
+  for (const search of searchPaths) {
+    const path = search();
+    if (path && existsSync(path)) {
+      // Ensure binary is executable
+      try {
+        chmodSync(path, 0o755);
+      } catch {
+        // Ignore chmod errors (might be read-only filesystem)
+      }
+      return path;
+    }
+  }
+
+  console.error(`Failed to find binary for ${platform}-${arch}`);
+  console.error(`Package ${packageName} may not be installed.`);
+  console.error(`\nTried searching in:`);
+  console.error(`  - require.resolve('${packageName}/package.json')`);
+  console.error(`  - ${join(__dirname, "..", "..", packageName, "tlon")}`);
+  console.error(`\nTry: npm install ${packageName}`);
+  process.exit(1);
+}
+
+const binaryPath = getBinaryPath();
+const args = process.argv.slice(2);
+
+const result = spawnSync(binaryPath, args, {
+  stdio: "inherit",
+  env: process.env,
+});
+
+if (result.error) {
+  console.error(`Failed to run binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/packages/tlon-skill/npm/darwin-arm64/package.json
+++ b/packages/tlon-skill/npm/darwin-arm64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tloncorp/tlon-skill-darwin-arm64",
+  "version": "0.4.0",
+  "description": "Tlon skill binary for macOS ARM64",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": [
+    "tlon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/packages/tlon-skill/npm/darwin-x64/package.json
+++ b/packages/tlon-skill/npm/darwin-x64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tloncorp/tlon-skill-darwin-x64",
+  "version": "0.4.0",
+  "description": "Tlon skill binary for macOS x64",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": [
+    "tlon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/packages/tlon-skill/npm/linux-arm64/package.json
+++ b/packages/tlon-skill/npm/linux-arm64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tloncorp/tlon-skill-linux-arm64",
+  "version": "0.4.0",
+  "description": "Tlon skill binary for Linux arm64",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": [
+    "tlon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/packages/tlon-skill/npm/linux-x64/package.json
+++ b/packages/tlon-skill/npm/linux-x64/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tloncorp/tlon-skill-linux-x64",
+  "version": "0.4.0",
+  "description": "Tlon skill binary for Linux x64",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "bin": {
+    "tlon": "tlon"
+  },
+  "files": [
+    "tlon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/packages/tlon-skill/package.json
+++ b/packages/tlon-skill/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@tloncorp/tlon-skill",
+  "version": "0.4.0",
+  "description": "Tlon/Urbit skill for OpenClaw agents",
+  "type": "module",
+  "bin": {
+    "tlon": "./bin/tlon.js"
+  },
+  "files": [
+    "bin/tlon.js",
+    "scripts/postinstall.js",
+    "SKILL.md",
+    "references/"
+  ],
+  "scripts": {
+    "build": "node scripts/build.js",
+    "build:all": "node scripts/build-all.js",
+    "build:smoke": "pnpm build && bun run scripts/build-smoke.ts",
+    "check": "pnpm typecheck && pnpm test && pnpm build:smoke",
+    "dev:link": "bun run build:all && cp \"npm/$(node -e 'console.log(process.platform + \"-\" + process.arch)')/tlon\" bin/",
+    "release:binary-smoke": "bun run scripts/release-binary-smoke.ts",
+    "release:package": "bun run scripts/release-package.ts",
+    "release:package-smoke": "bun run scripts/release-package-smoke.ts",
+    "test": "pnpm test:unit && pnpm test:integration",
+    "test:coverage": "bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage ./scripts ./tests/unit ./tests/hermetic",
+    "test:integration": "bun test ./tests/hermetic",
+    "test:unit": "bun test ./scripts ./tests/unit",
+    "tsc": "pnpm typecheck",
+    "typecheck": "pnpm typecheck:src && pnpm typecheck:test",
+    "typecheck:src": "tsc -p tsconfig.json --noEmit",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
+    "version": "node scripts/bump-version.js",
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "optionalDependencies": {
+    "@tloncorp/tlon-skill-darwin-arm64": "0.4.0",
+    "@tloncorp/tlon-skill-darwin-x64": "0.4.0",
+    "@tloncorp/tlon-skill-linux-arm64": "0.4.0",
+    "@tloncorp/tlon-skill-linux-x64": "0.4.0"
+  },
+  "devDependencies": {
+    "@tloncorp/api": "workspace:*",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^24.12.4",
+    "@urbit/aura": "^3.0.0",
+    "@urbit/nockjs": "^1.6.0",
+    "typescript": "^5.9.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tloncorp/landscape-apps.git",
+    "directory": "packages/tlon-skill"
+  },
+  "license": "MIT"
+}

--- a/packages/tlon-skill/references/hooks-examples/auto-react.hoon
+++ b/packages/tlon-skill/references/hooks-examples/auto-react.hoon
@@ -1,0 +1,24 @@
+:: Auto-react hook: reacts to new posts with configured emoji
+:: Config: emoji (default 👍)
+::
+|=  [=event:h =bowl:h]
+^-  outcome:h
+::  Extract config with defaults
+=+  ;;(emoji=cord (~(gut by config.bowl) 'emoji' '👍'))
+::  Only react to new posts
+?.  ?=([%on-post %add *] event)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Don't react to our own posts
+?:  =(author.post.event our.bowl)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Need channel context
+?~  channel.bowl
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  React to the post
+=/  react-effect=effect:h
+  :*  %channels
+      %channel
+      nest.u.channel.bowl
+      [%post [%add-react id.post.event our.bowl emoji]]
+  ==
+&+[[[%allowed event] [react-effect ~]] state.hook.bowl]

--- a/packages/tlon-skill/references/hooks-examples/delete-old-posts.hoon
+++ b/packages/tlon-skill/references/hooks-examples/delete-old-posts.hoon
@@ -1,0 +1,18 @@
+:: Disappearing messages: deletes posts older than configured delay
+:: From: https://github.com/tloncorp/hooks/blob/master/hooks/disappearing.hoon
+:: Config: delay (default ~s30 = 30 seconds)
+::
+|=  [=event:h bowl:h]
+^-  outcome:h
+=-  &+[[[%allowed event] -] state.hook]
+?.  ?=(%cron -.event)  ~
+^-  (list effect:h)
+=+  ;;(delay=@dr (~(gut by config) 'delay' ~s30))
+=/  cutoff  (sub now delay)
+?~  channel  ~
+%+  murn
+  (tap:on-v-posts:c (lot:on-v-posts:c posts.u.channel ~ `cutoff))
+|=  [=id-post:c post=(may:c v-post:c)]
+^-  (unit effect:h)
+?:  ?=(%| -.post)  ~
+`[%channels %channel nest.u.channel %post %del id-post]

--- a/packages/tlon-skill/references/hooks-examples/word-filter.hoon
+++ b/packages/tlon-skill/references/hooks-examples/word-filter.hoon
@@ -1,0 +1,52 @@
+:: Word filter hook: blocks posts containing banned words
+:: Config: words (comma-separated list of words to block)
+::
+|=  [=event:h =bowl:h]
+^-  outcome:h
+|^
+::  Only filter new posts
+?.  ?=([%on-post %add *] event)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Get banned words from config (comma-separated)
+=+  ;;(words-cord=cord (~(gut by config.bowl) 'words' ''))
+::  Skip if no words configured
+?:  =('' words-cord)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Split on commas into list of tapes
+=/  banned=(list tape)
+  (split-on-comma (trip words-cord))
+::  Get message content
+=/  content=tape  (extract-text content.post.event)
+::  Check if any banned word appears in content
+=/  has-banned=?
+  %+  lien  banned
+  |=  word=tape
+  !=(~ (find word content))
+::  If found, deny
+?:  has-banned
+  &+[[[%denied `'Message contains prohibited content'] ~] state.hook.bowl]
+::  Otherwise allow
+&+[[[%allowed event] ~] state.hook.bowl]
+::
+++  split-on-comma
+  |=  txt=tape
+  ^-  (list tape)
+  =/  idx  (find "," txt)
+  ?~  idx
+    ?~  txt  *(list tape)
+    ~[txt]
+  :-  (scag u.idx txt)
+  $(txt (slag +(u.idx) txt))
+::
+++  extract-text
+  |=  =story:c
+  ^-  tape
+  ?~  story  ""
+  =/  verse  i.story
+  ?.  ?=(%inline -.verse)  ""
+  ?~  p.verse  ""
+  =/  inl  i.p.verse
+  ?@  inl
+    (trip inl)
+  ""
+--

--- a/packages/tlon-skill/references/hooks.md
+++ b/packages/tlon-skill/references/hooks.md
@@ -1,0 +1,365 @@
+# Tlon Channel Hooks
+
+Hooks are hoon functions that modify events, cause effects, and/or build state for channels.
+
+## Version Compatibility
+
+Hooks are tightly coupled to `channels-server` / `tlon-apps` types.
+When docs/examples drift from runtime types, compilation can fail even if logic is correct.
+
+Recommended practice:
+- Pin your local references to a known `tlon-apps` commit/tag
+- Record that version in PRs when adding/updating hooks
+- Prefer examples in this folder that were verified against the current runtime
+
+## Hook Structure
+
+```hoon
+++  hook
+  $:  id=id-hook
+      version=%0
+      name=@t
+      meta=data:m
+      src=@t
+      compiled=(unit vase)
+      state=vase
+      config=(map nest config)
+  ==
+```
+
+- `id` - unique identifier (@uv format)
+- `version` - the version this hook was written for
+- `name` - human-readable display name
+- `meta` - standard metadata (title/image/desc/cover)
+- `src` - the source code for the hook
+- `compiled` - result of compiling hoon to nock
+- `state` - container to collect/persist data
+- `config` - configurations for each channel
+
+## Events
+
+Hooks respond to four event types:
+
+```hoon
++$  event
+  $%  [%on-post on-post]
+      [%on-reply on-reply]
+      [%cron ~]
+      [%wake waiting-hook]
+  ==
+```
+
+### on-post events
+```hoon
++$  on-post
+  $%  [%add post=v-post]
+      [%edit original=v-post =essay]
+      [%del original=v-post]
+      [%react post=v-post =ship react=(unit react)]
+  ==
+```
+
+### on-reply events
+```hoon
++$  on-reply
+  $%  [%add parent=v-post reply=v-reply]
+      [%edit parent=v-post original=v-reply =memo]
+      [%del parent=v-post original=v-reply]
+      [%react parent=v-post reply=v-reply =ship react=(unit react)]
+  ==
+```
+
+## Bowl (Context)
+
+Hooks receive ambient state via the bowl:
+
+```hoon
++$  bowl
+  $:  channel=(unit [=nest v-channel])   :: current channel (null for global cron)
+      group=(unit group-ui:g)            :: group data
+      channels=v-channels                :: all hosted channels
+      =hook                              :: this hook's data
+      =config                            :: channel-specific config
+      now=time                           :: current time
+      our=ship                           :: host ship
+      src=ship                           :: triggering ship
+      eny=@                              :: entropy
+  ==
+```
+
+**Important:** Access patterns depend on whether you use a face:
+- `|= [=event:h =bowl:h]` (with face) → access via `config.bowl`, `channel.bowl`, `state.hook.bowl`
+- `|= [=event:h bowl:h]` (no face) → access via `config`, `channel`, `state.hook`
+
+## Return Type
+
+```hoon
++$  outcome  (each return tang)
+
++$  return
+  $:  result=event-result
+      effects=(list effect)
+      new-state=vase
+  ==
+
++$  event-result
+  $%  [%allowed =event]      :: allow event, optionally transform it
+      [%denied msg=(unit cord)]  :: block event with optional message
+  ==
+```
+
+## Effects
+
+Hooks can trigger actions on other agents:
+
+```hoon
++$  effect
+  $%  [%channels =a-channels]   :: channel actions
+      [%groups =action:g]       :: group actions (ban, kick, etc)
+      [%activity =action:a]     :: activity actions
+      [%dm =action:dm:ch]       :: DM actions
+      [%contacts =action:co]    :: contact actions
+      [%wait waiting-hook]      :: schedule delayed execution
+  ==
+```
+
+### Channel Effects
+
+The most common effect pattern for channel actions:
+
+```hoon
+::  React to a post
+[%channels %channel nest [%post [%add-react post-id ship emoji]]]
+
+::  Delete a post
+[%channels %channel nest %post %del post-id]
+```
+
+**Note:** Use actual unicode emoji (`'👍'`, `'🔥'`) not shortcodes (`:thumbsup:`).
+
+## Config
+
+Config is `(map @t *)` on the Hoon side.
+From CLI, values are sent as text and then clammed/coerced in-hook.
+Use clam (`;;`) to extract typed values with defaults:
+
+```hoon
+::  With bowl face (=bowl:h)
+=+  ;;(delay=@dr (~(gut by config.bowl) 'delay' ~s30))
+=+  ;;(emoji=cord (~(gut by config.bowl) 'emoji' '👍'))
+
+::  Without bowl face (bowl:h)
+=+  ;;(delay=@dr (~(gut by config) 'delay' ~s30))
+```
+
+CLI tips:
+- Prefer simple text/cord values first (`password=owl-pass`)
+- For booleans/durations, verify with `hooks get <id>` after setting config
+- If a config poke fails, inspect the exact update payload from CLI output
+
+## Plaintext Helper Pattern
+
+The hook subject includes a `flatten` gate via `channel-utils`.
+For moderation/search-like use cases, prefer this default:
+
+```hoon
+=/  text=tape
+  (trip (flatten content.post.event))
+```
+
+`flatten` intentionally focuses on searchable/user-visible text and may skip some structures
+(e.g. code blocks or other rich content forms depending on story shape).
+
+If you need strict/full extraction (including code), implement a custom story walker gate.
+
+## Writing a Hook
+
+Basic hook template (with bowl face):
+
+```hoon
+|=  [=event:h =bowl:h]
+^-  outcome:h
+::  Return success with: [allowed-result effects new-state]
+&+[[[%allowed event] ~] state.hook.bowl]
+```
+
+Basic hook template (without bowl face):
+
+```hoon
+|=  [=event:h bowl:h]
+^-  outcome:h
+::  Return success with: [allowed-result effects new-state]
+&+[[[%allowed event] ~] state.hook]
+```
+
+### Example: Auto-react to new posts
+
+```hoon
+:: Auto-react hook: reacts to new posts with configured emoji
+:: Config: emoji (default 👍)
+::
+|=  [=event:h =bowl:h]
+^-  outcome:h
+::  Extract config with defaults
+=+  ;;(emoji=cord (~(gut by config.bowl) 'emoji' '👍'))
+::  Only react to new posts
+?.  ?=([%on-post %add *] event)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Don't react to our own posts
+?:  =(author.post.event our.bowl)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Need channel context
+?~  channel.bowl
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  React to the post
+=/  react-effect=effect:h
+  :*  %channels
+      %channel
+      nest.u.channel.bowl
+      [%post [%add-react id.post.event our.bowl emoji]]
+  ==
+&+[[[%allowed event] [react-effect ~]] state.hook.bowl]
+```
+
+**Key points:**
+- Check `author.post.event` (not `src.bowl`) for self-detection
+- Check `channel.bowl` for null before accessing `u.channel.bowl`
+- Effect structure: `[%channels %channel nest [%post [%add-react ...]]]`
+- Use actual emoji unicode, not shortcodes
+
+### Example: Disappearing messages (cron)
+
+From [tloncorp/hooks](https://github.com/tloncorp/hooks/blob/master/hooks/disappearing.hoon):
+
+```hoon
+:: Disappearing messages: deletes posts older than configured delay
+:: Config: delay (default ~s30 = 30 seconds)
+::
+|=  [=event:h bowl:h]
+^-  outcome:h
+=-  &+[[[%allowed event] -] state.hook]
+?.  ?=(%cron -.event)  ~
+^-  (list effect:h)
+=+  ;;(delay=@dr (~(gut by config) 'delay' ~s30))
+=/  cutoff  (sub now delay)
+?~  channel  ~
+%+  murn
+  (tap:on-v-posts:c (lot:on-v-posts:c posts.u.channel ~ `cutoff))
+|=  [=id-post:c post=(may:c v-post:c)]
+^-  (unit effect:h)
+?:  ?=(%| -.post)  ~
+`[%channels %channel nest.u.channel %post %del id-post]
+```
+
+**Key points:**
+- Uses `bowl:h` without face → access `config`, `channel`, `state.hook` directly
+- Uses `on-v-posts:c` ordered map with `lot:` for cutoff filtering
+- Uses `(may:c v-post:c)` type - posts can be deleted (`%|`) or present (`%&`)
+- Check `?=(%| -.post)` to skip already-deleted posts
+
+### Example: Word filter
+
+```hoon
+:: Word filter hook: blocks posts containing banned words
+:: Config: words (comma-separated list of words to block)
+::
+|=  [=event:h =bowl:h]
+^-  outcome:h
+|^
+::  Only filter new posts
+?.  ?=([%on-post %add *] event)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Get banned words from config (comma-separated)
+=+  ;;(words-cord=cord (~(gut by config.bowl) 'words' ''))
+::  Skip if no words configured
+?:  =('' words-cord)
+  &+[[[%allowed event] ~] state.hook.bowl]
+::  Split on commas into list of tapes
+=/  banned=(list tape)
+  (split-on-comma (trip words-cord))
+::  Get message content
+=/  content=tape  (extract-text content.post.event)
+::  Check if any banned word appears in content
+=/  has-banned=?
+  %+  lien  banned
+  |=  word=tape
+  !=(~ (find word content))
+::  If found, deny
+?:  has-banned
+  &+[[[%denied `'Message contains prohibited content'] ~] state.hook.bowl]
+::  Otherwise allow
+&+[[[%allowed event] ~] state.hook.bowl]
+::
+++  split-on-comma
+  |=  txt=tape
+  ^-  (list tape)
+  =/  idx  (find "," txt)
+  ?~  idx
+    ?~  txt  *(list tape)
+    ~[txt]
+  :-  (scag u.idx txt)
+  $(txt (slag +(u.idx) txt))
+::
+++  extract-text
+  |=  =story:c
+  ^-  tape
+  ?~  story  ""
+  =/  verse  i.story
+  ?.  ?=(%inline -.verse)  ""
+  ?~  p.verse  ""
+  =/  inl  i.p.verse
+  ?@  inl
+    (trip inl)
+  ""
+--
+```
+
+**Key points:**
+- Access post content via `content.post.event`
+- Use `lien` to check if any word in list matches
+- Helper arms (`++`) for text processing go inside `|^` ... `--`
+- Config supports comma-separated values
+
+## CLI Commands
+
+```bash
+# Add a hook
+tlon hooks add "my-hook" ./hook.hoon
+
+# Configure for a channel
+tlon hooks config <id> chat/~host/channel delay=~m5 emoji=👍
+
+# Set execution order
+tlon hooks order chat/~host/channel <id1> <id2>
+
+# Schedule periodic execution
+tlon hooks cron <id> ~h1 --nest chat/~host/channel
+
+# List hooks
+tlon hooks list
+
+# Watch for hook updates (debugging)
+tlon hooks watch
+```
+
+## Testing Hooks (Dojo)
+
+Test without affecting channels:
+
+```
+-groups!hooks-run <event> [%origin nest optional-state optional-config] <src>
+```
+
+## Common Pitfalls
+
+1. **Bowl face confusion** - `=bowl:h` vs `bowl:h` changes how you access fields
+2. **Wrong effect structure** - channel effects need exact nesting: `[%channels %channel nest ...]`
+3. **Emoji shortcodes** - use actual unicode (`'👍'`), not `:thumbsup:`
+4. **Self-detection** - check `author.post.event`, not `src.bowl`
+5. **Deleted posts** - in cron, posts can be `%|` (deleted) or `%&` (present)
+
+## Type References
+
+- Full hooks types: https://github.com/tloncorp/tlon-apps/blob/develop/desk/sur/hooks.hoon
+- Channel types (v-post, v-reply, etc): https://github.com/tloncorp/tlon-apps/blob/develop/desk/sur/channels.hoon
+- Official hooks examples: https://github.com/tloncorp/hooks

--- a/packages/tlon-skill/references/urbit-api.md
+++ b/packages/tlon-skill/references/urbit-api.md
@@ -1,0 +1,110 @@
+# Urbit HTTP API Reference
+
+Quick reference for the Urbit HTTP API used by this skill.
+
+## Authentication
+
+```typescript
+import { Urbit } from "@urbit/http-api";
+
+const api = await Urbit.authenticate({
+  ship: "sampel-palnet",  // without ~
+  url: "https://myship.tlon.network",
+  code: "lidlut-tabwed-...",
+  verbose: false,
+});
+```
+
+## Core Operations
+
+### Scry (Read)
+```typescript
+const result = await api.scry<T>({ app: "app-name", path: "/path" });
+```
+
+### Poke (Write)
+```typescript
+await api.poke({ app: "app-name", mark: "mark-name", json: { ... } });
+```
+
+### Subscribe (Real-time)
+```typescript
+await api.subscribe({
+  app: "app-name",
+  path: "/path",
+  event: (data) => { ... },
+  quit: () => { ... },
+});
+```
+
+## Contacts Agent
+
+### Scry Paths
+- `/all` - All peers with merged profile data (ContactRolodex)
+- `/v1/book` - All contacts with user overrides (ContactBookScryResult)
+
+### Poke Marks
+- `contact-action` - Legacy profile edits
+  - `{ edit: [{ nickname: "name" }, { bio: "..." }] }`
+- `contact-action-1` - New contact operations
+  - `{ meet: ["~ship1", "~ship2"] }` - Sync profiles
+  - `{ page: { kip: "~ship", contact: {} } }` - Add contact
+  - `{ wipe: ["~ship"] }` - Remove contact
+  - `{ edit: { kip: "~ship", contact: { nickname: {...} } } }` - Edit contact
+
+### Profile Fields
+```typescript
+interface ContactBookProfile {
+  nickname?: { type: "text", value: string };
+  bio?: { type: "text", value: string };
+  status?: { type: "text", value: string };
+  avatar?: { type: "look", value: string };  // URL
+  cover?: { type: "look", value: string };   // URL
+  color?: { type: "tint", value: string };   // Hex without #
+}
+```
+
+## Chat Agent
+
+### Scry Paths
+- `/dm` - List of DM ship names (string[])
+- `/blocked` - Blocked ships
+- `/v3/dm/~ship/writs/newest/{count}/light` - DM message history (light = no replies)
+- `/v3/dm/~ship/writs/newest/{count}/heavy` - DM message history (heavy = with replies)
+- `/v2/dm/~ship/writs/writ/id/{author}/{postId}` - Single DM post with replies
+
+### Poke Marks
+- `chat-dm-action-1` - Send DM
+- `chat-remark-action` - Mark read
+
+## Groups Agent
+
+### Scry Paths
+- `/groups/v2` - All subscribed groups
+- `/groups/v2/~host/group-name` - Specific group
+
+## Channels Agent
+
+### Scry Paths
+- `/v1/hooks/preview/{nest}` - Channel preview
+- `/{nest}/search/...` - Search messages
+
+### Poke Marks
+- `channel-action` - Legacy channel operations
+- `channel-action-1` - New channel operations
+
+## Common Types
+
+### Flag (Group ID)
+Format: `~host/group-name`
+
+### Nest (Channel ID)
+Format: `{kind}/~host/channel-name`
+Kinds: `chat`, `diary`, `heap`
+
+## Tips
+
+1. Ship names in pokes/responses include `~` prefix
+2. Use `formatUd(unixToDa(timestamp))` for message IDs
+3. Profile changes sync automatically to peers
+4. Scries are synchronous reads; pokes are async writes

--- a/packages/tlon-skill/scripts/activity-runtime.ts
+++ b/packages/tlon-skill/scripts/activity-runtime.ts
@@ -1,0 +1,179 @@
+import {
+  type PostContent,
+  getGroupAndChannelUnreads,
+  getInitialActivity,
+  getTextContent,
+} from '@tloncorp/api';
+
+import { ensureClient } from './api-client';
+import type {
+  ActivityDeps,
+  ActivityEvent,
+  ActivityFormatter,
+} from './commands/activity';
+
+function createProcessCommandDeps() {
+  return {
+    stdout: (text: string) => process.stdout.write(text),
+    stderr: (text: string) => process.stderr.write(text),
+  };
+}
+
+function extractText(content: unknown): string {
+  if (!content) return '';
+  const text = getTextContent(content as PostContent);
+  return text || '';
+}
+
+function formatActivityTime(timeStr: string | number): string {
+  try {
+    const str = String(timeStr);
+    const daNum = BigInt(str.replace(/\./g, ''));
+    const daSecond = BigInt('18446744073709551616');
+    const daUnixEpoch = BigInt('170141184475152167957503069145530368000');
+
+    const offset = daSecond / BigInt(2000);
+    const epochAdjusted = offset + (daNum - daUnixEpoch);
+    const unixMs = Math.round(
+      Number((epochAdjusted * BigInt(1000)) / daSecond)
+    );
+
+    const date = new Date(unixMs);
+    if (date.getFullYear() > 2020 && date.getFullYear() < 2100) {
+      return date.toLocaleString();
+    }
+    return 'unknown date';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function formatEvent(event: ActivityEvent): string {
+  const lines: string[] = [];
+  const timeStr = formatActivityTime(event.timestamp);
+
+  if (event.type === 'post') {
+    const author = event.authorId || 'unknown';
+    const text = extractText(event.content);
+    const mention = event.isMention ? ' [MENTION]' : '';
+    lines.push(`📝 Post${mention} by ${author} in ${event.channelId}`);
+    if (event.groupId) lines.push(`   Group: ${event.groupId}`);
+    lines.push(`   Time: ${timeStr}`);
+    lines.push(
+      `   Content: ${text.substring(0, 200)}${text.length > 200 ? '...' : ''}`
+    );
+  }
+
+  if (event.type === 'reply') {
+    const author = event.authorId || 'unknown';
+    const text = extractText(event.content);
+    const mention = event.isMention ? ' [MENTION]' : '';
+    lines.push(`💬 Reply${mention} by ${author} in ${event.channelId}`);
+    if (event.groupId) lines.push(`   Group: ${event.groupId}`);
+    lines.push(`   Time: ${timeStr}`);
+    lines.push(
+      `   Content: ${text.substring(0, 200)}${text.length > 200 ? '...' : ''}`
+    );
+  }
+
+  if (event.type === 'dm-post') {
+    const author = event.authorId || 'unknown';
+    const text = extractText(event.content);
+    const mention = event.isMention ? ' [MENTION]' : '';
+    lines.push(`📨 DM${mention} from ${author}`);
+    if (event.channelId) lines.push(`   To: ${event.channelId}`);
+    lines.push(`   Time: ${timeStr}`);
+    lines.push(
+      `   Content: ${text.substring(0, 200)}${text.length > 200 ? '...' : ''}`
+    );
+  }
+
+  if (event.type === 'dm-reply') {
+    const author = event.authorId || 'unknown';
+    const text = extractText(event.content);
+    const mention = event.isMention ? ' [MENTION]' : '';
+    lines.push(`💬 DM Reply${mention} from ${author}`);
+    if (event.channelId) lines.push(`   To: ${event.channelId}`);
+    lines.push(`   Time: ${timeStr}`);
+    lines.push(
+      `   Content: ${text.substring(0, 200)}${text.length > 200 ? '...' : ''}`
+    );
+  }
+
+  if (event.type === 'group-ask') {
+    lines.push(`🙋 Join request from ${event.groupEventUserId || 'unknown'}`);
+    if (event.groupId) lines.push(`   Group: ${event.groupId}`);
+    lines.push(`   Time: ${timeStr}`);
+  }
+
+  if (event.type === 'group-join') {
+    lines.push(`👋 ${event.groupEventUserId || 'unknown'} joined`);
+    if (event.groupId) lines.push(`   Group: ${event.groupId}`);
+    lines.push(`   Time: ${timeStr}`);
+  }
+
+  if (event.type === 'group-invite') {
+    lines.push(`📩 Invite from ${event.groupEventUserId || 'unknown'}`);
+    if (event.groupId) lines.push(`   Group: ${event.groupId}`);
+    lines.push(`   Time: ${timeStr}`);
+  }
+
+  if (event.type === 'contact') {
+    lines.push(`👤 Contact update from ${event.contactUserId || 'unknown'}`);
+    if (event.contactUpdateType) {
+      lines.push(`   Update: ${event.contactUpdateType}`);
+    }
+    lines.push(`   Time: ${timeStr}`);
+  }
+
+  return lines.join('\n');
+}
+
+function createActivityFormatter(): ActivityFormatter {
+  return {
+    activityHeader: (bucket, count) =>
+      `\n=== ${bucket.toUpperCase()} (${count} events) ===\n`,
+    noActivity: (bucket) => `No ${bucket} activity found.`,
+    event: formatEvent,
+    unreadsHeader: () => '\n=== UNREADS ===\n',
+    noUnreads: () => 'No unreads!',
+    baseUnread: (summary) => {
+      const notify = summary.notify ? '🔔' : '';
+      return `${notify} base\n   Count: ${summary.count ?? 0}, Notify count: ${summary.notifyCount ?? 0}`;
+    },
+    groupUnread: (summary) => {
+      const notify = summary.notify ? '🔔' : '';
+      return `${notify} group/${summary.groupId}\n   Count: ${summary.count ?? 0}, Notify count: ${summary.notifyCount ?? 0}`;
+    },
+    channelUnread: (summary) => {
+      const notify = summary.notify ? '🔔' : '';
+      const lines = [
+        `${notify} channel/${summary.channelId}`,
+        `   Count: ${summary.count ?? 0}, Notify count: ${summary.countWithoutThreads ?? 0}`,
+      ];
+      if (summary.firstUnreadPostId) {
+        lines.push(`   First unread: ${summary.firstUnreadPostId}`);
+      }
+      return lines.join('\n');
+    },
+  };
+}
+
+export function createActivityDeps(): ActivityDeps {
+  return {
+    ...createProcessCommandDeps(),
+    authenticate: async () => {
+      await ensureClient();
+    },
+    activityApi: {
+      getInitialActivity: async () => {
+        const result = await getInitialActivity();
+        return { events: result.events };
+      },
+      getGroupAndChannelUnreads: async () => {
+        return getGroupAndChannelUnreads();
+      },
+    },
+    format: createActivityFormatter(),
+  };
+}

--- a/packages/tlon-skill/scripts/api-client.test.ts
+++ b/packages/tlon-skill/scripts/api-client.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import {
+  type CredentialResolution,
+  type EnsureClientDeps,
+  __resetApiClientForTests,
+  ensureClient,
+} from './api-client';
+
+function resolution(
+  overrides: Omit<Partial<CredentialResolution>, 'config'> & {
+    config?: Partial<CredentialResolution['config']>;
+  } = {}
+): CredentialResolution {
+  const { config: _config, ...rest } = overrides;
+  const cfg = {
+    url: 'https://zod.tlon.network',
+    ship: 'zod',
+    code: '',
+    ..._config,
+  } as CredentialResolution['config'];
+
+  return {
+    config: cfg,
+    origin: 'cli',
+    authKind: cfg.cookie ? 'cookie' : 'code',
+    mayReadAuthCache: false,
+    mayWriteAuthCache: !!cfg.code || !!overrides.fallbackCode,
+    provenance: { selectedBy: 'cli', ship: 'cli' },
+    ...rest,
+  };
+}
+
+function makeDeps(
+  resolved: CredentialResolution,
+  options: { cookieValid?: boolean; freshCookie?: string } = {}
+) {
+  const configureCalls: unknown[] = [];
+  const cacheWrites: Array<{ url: string; ship: string; cookie: string }> = [];
+
+  const deps: EnsureClientDeps = {
+    resolve: () => resolved,
+    configureClient: async (params) => {
+      configureCalls.push(params);
+    },
+    createCookieClient: () => ({}) as any,
+    validateCookie: async () => options.cookieValid ?? true,
+    getAuthenticatedCookie: () =>
+      options.freshCookie ?? 'urbauth-~zod=0v-fresh',
+    cacheCookie: (url, ship, cookie) => {
+      cacheWrites.push({ url, ship, cookie });
+    },
+    setupSubscriptions: async () => {},
+  };
+
+  return { deps, configureCalls, cacheWrites };
+}
+
+const originalConsoleError = console.error;
+
+beforeEach(() => {
+  console.error = () => {};
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+  __resetApiClientForTests();
+});
+
+describe('ensureClient auth/cache policy', () => {
+  it('uses provided cookie first and does not cache it when validation succeeds', async () => {
+    const resolved = resolution({
+      config: { cookie: 'urbauth-~zod=0v-cookie', code: 'fallback-code' },
+      authKind: 'cookie',
+      fallbackCode: 'fallback-code',
+      mayWriteAuthCache: true,
+    });
+    const { deps, configureCalls, cacheWrites } = makeDeps(resolved, {
+      cookieValid: true,
+    });
+
+    await ensureClient([], deps);
+
+    expect(configureCalls).toHaveLength(1);
+    expect(cacheWrites).toEqual([]);
+  });
+
+  it('uses fallback code after a provided cookie expires and caches the fresh cookie', async () => {
+    const resolved = resolution({
+      config: { cookie: 'urbauth-~zod=0v-cookie', code: 'fallback-code' },
+      authKind: 'cookie',
+      fallbackCode: 'fallback-code',
+      mayWriteAuthCache: true,
+    });
+    const { deps, configureCalls, cacheWrites } = makeDeps(resolved, {
+      cookieValid: false,
+      freshCookie: 'urbauth-~zod=0v-fresh',
+    });
+
+    await ensureClient([], deps);
+
+    expect(configureCalls).toHaveLength(2);
+    expect(cacheWrites).toEqual([
+      {
+        url: 'https://zod.tlon.network',
+        ship: 'zod',
+        cookie: 'urbauth-~zod=0v-fresh',
+      },
+    ]);
+  });
+
+  it('does not cache provided-cookie flows without fresh code auth', async () => {
+    const resolved = resolution({
+      config: { cookie: 'urbauth-~zod=0v-cookie' },
+      authKind: 'cookie',
+      mayWriteAuthCache: false,
+    });
+    const { deps, cacheWrites } = makeDeps(resolved, { cookieValid: true });
+
+    await ensureClient([], deps);
+
+    expect(cacheWrites).toEqual([]);
+  });
+
+  it('uses source-aware errors for expired provided cookies without fallback code', async () => {
+    const resolved = resolution({
+      config: { cookie: 'urbauth-~zod=0v-cookie' },
+      origin: 'config-file',
+      authKind: 'cookie',
+      mayWriteAuthCache: false,
+      provenance: {
+        selectedBy: 'env',
+        ship: 'cookie',
+        configPath: '/tmp/zod.json',
+      },
+    });
+    const { deps } = makeDeps(resolved, { cookieValid: false });
+
+    await expect(ensureClient([], deps)).rejects.toThrow(
+      'Cookie credentials for ~zod from config file /tmp/zod.json'
+    );
+  });
+
+  it('identifies expired cached cookies as cache sourced', async () => {
+    const resolved = resolution({
+      config: { cookie: 'urbauth-~zod=0v-cache' },
+      origin: 'ship-cache',
+      authKind: 'cached-cookie',
+      mayReadAuthCache: true,
+      mayWriteAuthCache: false,
+      provenance: {
+        selectedBy: 'env',
+        ship: 'cache',
+        cachePath: '/tmp/cache/zod.json',
+      },
+    });
+    const { deps } = makeDeps(resolved, { cookieValid: false });
+
+    await expect(ensureClient([], deps)).rejects.toThrow(
+      'Cached cookie for ~zod has expired'
+    );
+  });
+
+  it('caches fresh cookies after code login', async () => {
+    const resolved = resolution({
+      config: { code: 'code' },
+      authKind: 'code',
+      mayWriteAuthCache: true,
+    });
+    const { deps, configureCalls, cacheWrites } = makeDeps(resolved, {
+      freshCookie: 'urbauth-~zod=0v-fresh',
+    });
+
+    await ensureClient([], deps);
+
+    expect(configureCalls).toHaveLength(1);
+    expect(cacheWrites).toEqual([
+      {
+        url: 'https://zod.tlon.network',
+        ship: 'zod',
+        cookie: 'urbauth-~zod=0v-fresh',
+      },
+    ]);
+  });
+
+  it('keeps config-file, skill-dir, and OpenClaw cookies out of cache when they validate', async () => {
+    for (const origin of ['config-file', 'skill-dir', 'openclaw'] as const) {
+      __resetApiClientForTests();
+      const resolved = resolution({
+        config: { cookie: 'urbauth-~zod=0v-cookie', code: 'fallback' },
+        origin,
+        authKind: 'cookie',
+        fallbackCode: 'fallback',
+        mayWriteAuthCache: true,
+      });
+      const { deps, cacheWrites } = makeDeps(resolved, { cookieValid: true });
+
+      await ensureClient([], deps);
+
+      expect(cacheWrites).toEqual([]);
+    }
+  });
+
+  it('uses fallback code and caches fresh cookies for expired file-backed cookies', async () => {
+    for (const origin of ['config-file', 'skill-dir', 'openclaw'] as const) {
+      __resetApiClientForTests();
+      const resolved = resolution({
+        config: { cookie: 'urbauth-~zod=0v-cookie', code: 'fallback' },
+        origin,
+        authKind: 'cookie',
+        fallbackCode: 'fallback',
+        mayWriteAuthCache: true,
+      });
+      const { deps, cacheWrites } = makeDeps(resolved, {
+        cookieValid: false,
+        freshCookie: 'urbauth-~zod=0v-fresh',
+      });
+
+      await ensureClient([], deps);
+
+      expect(cacheWrites).toEqual([
+        {
+          url: 'https://zod.tlon.network',
+          ship: 'zod',
+          cookie: 'urbauth-~zod=0v-fresh',
+        },
+      ]);
+    }
+  });
+
+  it('reset hook clears initialized state for isolated tests', async () => {
+    const first = makeDeps(
+      resolution({
+        config: { code: 'first' },
+        authKind: 'code',
+        mayWriteAuthCache: true,
+      })
+    );
+    await ensureClient([], first.deps);
+
+    __resetApiClientForTests();
+
+    const second = makeDeps(
+      resolution({
+        config: { code: 'second' },
+        authKind: 'code',
+        mayWriteAuthCache: true,
+      })
+    );
+    await ensureClient([], second.deps);
+
+    expect(first.configureCalls).toHaveLength(1);
+    expect(second.configureCalls).toHaveLength(1);
+  });
+});

--- a/packages/tlon-skill/scripts/api-client.ts
+++ b/packages/tlon-skill/scripts/api-client.ts
@@ -1,0 +1,369 @@
+/**
+ * API client setup for CLI usage.
+ * Adapts real process/env/filesystem state into the credential resolver and
+ * initializes @tloncorp/api according to the resolver's auth/cache policy.
+ */
+import {
+  Urbit,
+  client,
+  configureClient as configureApiClient,
+  internalRemoveClient,
+  preSig,
+  scry,
+  subscribe,
+} from '@tloncorp/api';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  type CachedAuth,
+  type CliCredentialOverrides,
+  type CredentialResolution,
+  type ResolverFileSystem,
+  type UrbitConfig,
+  getCachePath,
+  normalizeShipName,
+  readCachedEntryForShip,
+  readCachedShipCandidates,
+  resolveCredentials,
+} from './credential-resolver';
+
+export type {
+  AuthKind,
+  CachedAuth,
+  CliCredentialOverrides,
+  CredentialOrigin,
+  CredentialResolution,
+  UrbitConfig,
+} from './credential-resolver';
+
+type SubscriptionApp = 'groups' | 'channels' | 'chat' | 'lanyard';
+
+let initialized = false;
+let subscribed = false;
+let cachedConfig: UrbitConfig | null = null;
+let cachedResolution: CredentialResolution | null = null;
+let cliCredentialOverrides: CliCredentialOverrides | null = null;
+
+const nodeFs: ResolverFileSystem = {
+  exists: (filePath) => fs.existsSync(filePath),
+  readFile: (filePath) => fs.readFileSync(filePath, 'utf-8'),
+  readDir: (dirPath) => fs.readdirSync(dirPath),
+};
+
+function isVerbose(): boolean {
+  const value = process.env.TLON_VERBOSE?.trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+function logSubscriptionUpdate(label: string, event: unknown): void {
+  if (!isVerbose()) return;
+  console.log(`${label} update:`, event);
+}
+
+/**
+ * Get the cache directory, configurable via TLON_CACHE_DIR env var.
+ */
+function getCacheDir(): string {
+  return (
+    process.env.TLON_CACHE_DIR || path.join(os.homedir(), '.tlon', 'cache')
+  );
+}
+
+export function setCliCredentialOverrides(
+  overrides: CliCredentialOverrides | null
+): void {
+  cliCredentialOverrides = overrides;
+  cachedConfig = null;
+  cachedResolution = null;
+}
+
+export function getCredentialResolution(): CredentialResolution {
+  if (cachedResolution) return cachedResolution;
+
+  cachedResolution = resolveCredentials({
+    env: process.env,
+    fs: nodeFs,
+    cacheDir: getCacheDir(),
+    homeDir: os.homedir(),
+    cli: cliCredentialOverrides,
+  });
+  cachedConfig = cachedResolution.config;
+  return cachedResolution;
+}
+
+/**
+ * Get config from CLI overrides, environment, config files, OpenClaw, or cache.
+ */
+export function getConfig(): UrbitConfig {
+  if (cachedConfig) return cachedConfig;
+  return getCredentialResolution().config;
+}
+
+/**
+ * Get all valid cached ship entries.
+ * Invalid cache files are ignored for single-cache discovery, but duplicates fail.
+ */
+export function getCachedShips(): CachedAuth[] {
+  return readCachedShipCandidates(getCacheDir(), nodeFs, {
+    ignoreInvalid: true,
+  }).map(({ cachePath: _cachePath, ...entry }) => entry);
+}
+
+/**
+ * Get cached cookie for a ship+url combo.
+ * Existing invalid, mismatched, or wrong-URL cache files fail clearly.
+ */
+export function getCachedCookie(url: string, ship: string): string | null {
+  const entry = readCachedEntryForShip(getCacheDir(), ship, nodeFs, url);
+  return entry?.cookie ?? null;
+}
+
+/**
+ * Get cached entry for a ship.
+ * Existing invalid or mismatched cache files fail clearly.
+ */
+export function getCachedEntry(ship: string): CachedAuth | null {
+  const entry = readCachedEntryForShip(getCacheDir(), ship, nodeFs);
+  if (!entry) return null;
+  const { cachePath: _cachePath, ...cached } = entry;
+  return cached;
+}
+
+/**
+ * Cache cookie for future use.
+ */
+function cacheCookie(url: string, ship: string, cookie: string): void {
+  try {
+    fs.mkdirSync(getCacheDir(), { recursive: true, mode: 0o700 });
+    const normalizedShip = normalizeShipName(ship);
+    const cachePath = getCachePath(getCacheDir(), normalizedShip);
+    const data: CachedAuth = {
+      url,
+      ship: normalizedShip,
+      cookie,
+      cachedAt: Date.now(),
+    };
+    fs.writeFileSync(cachePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  } catch {
+    // Cache write failure is non-fatal.
+  }
+}
+
+/**
+ * Set up subscriptions required for trackedPoke to receive acks.
+ * Only subscribes to requested apps to minimize overhead.
+ */
+async function setupSubscriptions(subs: SubscriptionApp[]): Promise<void> {
+  if (subscribed) return;
+
+  if (subs.includes('groups')) {
+    await subscribe({ app: 'groups', path: '/v1/groups' }, (e) =>
+      logSubscriptionUpdate('groups', e)
+    );
+  }
+
+  if (subs.includes('channels')) {
+    await subscribe({ app: 'channels', path: '/v4' }, (e) =>
+      logSubscriptionUpdate('channels', e)
+    );
+  }
+
+  if (subs.includes('chat')) {
+    await subscribe({ app: 'chat', path: '/v4' }, (e) =>
+      logSubscriptionUpdate('chat', e)
+    );
+  }
+
+  if (subs.includes('lanyard')) {
+    await subscribe({ app: 'lanyard', path: '/v1/records' }, (e) =>
+      logSubscriptionUpdate('lanyard', e)
+    );
+  }
+
+  subscribed = true;
+}
+
+function createCookieClient(cfg: UrbitConfig, cookie: string): Urbit {
+  const urbit = new Urbit(cfg.url);
+  urbit.cookie = cookie;
+  urbit.nodeId = preSig(cfg.ship);
+  return urbit;
+}
+
+async function validateConfiguredCookie(): Promise<boolean> {
+  try {
+    await scry({ app: 'hood', path: '/kiln/pikes' });
+    return true;
+  } catch (err: any) {
+    const is401 =
+      err?.status === 401 ||
+      (typeof err?.message === 'string' && err.message.includes('401'));
+    return !is401;
+  }
+}
+
+function getAuthenticatedCookie(): string | undefined {
+  try {
+    return client.cookie;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface EnsureClientDeps {
+  resolve: () => CredentialResolution;
+  configureClient: typeof configureApiClient;
+  createCookieClient: (cfg: UrbitConfig, cookie: string) => Urbit;
+  validateCookie: () => Promise<boolean>;
+  getAuthenticatedCookie: () => string | undefined;
+  cacheCookie: (url: string, ship: string, cookie: string) => void;
+  setupSubscriptions: (subs: SubscriptionApp[]) => Promise<void>;
+}
+
+const defaultEnsureClientDeps: EnsureClientDeps = {
+  resolve: getCredentialResolution,
+  configureClient: configureApiClient,
+  createCookieClient,
+  validateCookie: validateConfiguredCookie,
+  getAuthenticatedCookie,
+  cacheCookie,
+  setupSubscriptions,
+};
+
+function describeOrigin(resolution: CredentialResolution): string {
+  switch (resolution.origin) {
+    case 'cli':
+      return 'CLI flags';
+    case 'config-file':
+      return resolution.provenance.configPath
+        ? `config file ${resolution.provenance.configPath}`
+        : 'config file';
+    case 'env-cookie':
+    case 'env-code':
+      return 'environment variables';
+    case 'skill-dir':
+      return resolution.provenance.configPath
+        ? `skill-dir config ${resolution.provenance.configPath}`
+        : 'skill-dir config';
+    case 'openclaw':
+      return resolution.provenance.openclawPath
+        ? `OpenClaw config ${resolution.provenance.openclawPath}`
+        : 'OpenClaw config';
+    case 'ship-cache':
+    case 'single-cache':
+      return resolution.provenance.cachePath
+        ? `cache ${resolution.provenance.cachePath}`
+        : 'cache';
+  }
+}
+
+function cookieValidationError(resolution: CredentialResolution): Error {
+  const ship = preSig(resolution.config.ship);
+  if (resolution.authKind === 'cached-cookie') {
+    return new Error(
+      `Cached cookie for ${ship} has expired and no access code is available to re-authenticate. ` +
+        'Provide --url + --ship + --code to refresh credentials.'
+    );
+  }
+
+  return new Error(
+    `Cookie credentials for ${ship} from ${describeOrigin(resolution)} failed validation ` +
+      'and no fallback code is available. Provide --code or set URBIT_CODE/TLON_CODE.'
+  );
+}
+
+/**
+ * Ensure @tloncorp/api client is configured, connected, and subscribed.
+ * Pass required subscription apps to minimize connection overhead.
+ */
+export async function ensureClient(
+  subs: SubscriptionApp[] = [],
+  depsOverride: Partial<EnsureClientDeps> = {}
+): Promise<UrbitConfig> {
+  const deps: EnsureClientDeps = {
+    ...defaultEnsureClientDeps,
+    ...depsOverride,
+  };
+  const resolution = deps.resolve();
+  const cfg = resolution.config;
+
+  if (!initialized) {
+    let didFreshAuth = false;
+
+    if (cfg.cookie) {
+      await deps.configureClient({
+        shipName: cfg.ship,
+        shipUrl: cfg.url,
+        client: deps.createCookieClient(cfg, cfg.cookie),
+        getCode: resolution.fallbackCode
+          ? async () => resolution.fallbackCode as string
+          : undefined,
+      });
+
+      const cookieValid = await deps.validateCookie();
+      if (!cookieValid) {
+        const fallbackCode = resolution.fallbackCode || cfg.code;
+        if (!fallbackCode) {
+          throw cookieValidationError(resolution);
+        }
+
+        await deps.configureClient({
+          shipName: cfg.ship,
+          shipUrl: cfg.url,
+          getCode: async () => fallbackCode,
+        });
+        didFreshAuth = true;
+      }
+    } else if (cfg.code) {
+      await deps.configureClient({
+        shipName: cfg.ship,
+        shipUrl: cfg.url,
+        getCode: async () => cfg.code,
+      });
+      didFreshAuth = true;
+    } else {
+      throw new Error('No cookie or code available for authentication');
+    }
+
+    if (didFreshAuth && resolution.mayWriteAuthCache) {
+      const freshCookie = deps.getAuthenticatedCookie();
+      if (freshCookie) {
+        deps.cacheCookie(cfg.url, cfg.ship, freshCookie);
+        console.error(
+          `Note: Credentials cached for ${preSig(cfg.ship)}. Next time run: tlon --ship ${preSig(cfg.ship)} <command>`
+        );
+      }
+    }
+
+    await deps.setupSubscriptions(subs);
+    initialized = true;
+  }
+
+  return cfg;
+}
+
+export function __resetApiClientForTests(): void {
+  initialized = false;
+  subscribed = false;
+  cachedConfig = null;
+  cachedResolution = null;
+  cliCredentialOverrides = null;
+  internalRemoveClient();
+}
+
+/**
+ * Get current ship name (with ~).
+ */
+export async function getCurrentShip(): Promise<string> {
+  const cfg = await ensureClient([]);
+  return preSig(cfg.ship);
+}
+
+/**
+ * Normalize ship name to include ~.
+ */
+export function normalizeShip(ship: string): string {
+  return preSig(ship);
+}

--- a/packages/tlon-skill/scripts/build-all.js
+++ b/packages/tlon-skill/scripts/build-all.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Build script for all platforms.
+ * Run locally to build for current platform only.
+ * CI runs this on each platform's runner, or cross-compiles with --target.
+ *
+ * Usage:
+ *   node scripts/build-all.js                    # Build for current platform
+ *   node scripts/build-all.js --target linux-x64 # Cross-compile for linux-x64
+ */
+import { execSync } from 'node:child_process';
+import { cpSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Read version from package.json
+const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'));
+const version = pkg.version;
+
+// Parse --target argument
+const targetArg = process.argv.find((arg) => arg.startsWith('--target='));
+const target = targetArg
+  ? targetArg.split('=')[1]
+  : `${process.platform}-${process.arch}`;
+
+// Map our target names to bun's target names
+const bunTargets = {
+  'darwin-arm64': 'bun-darwin-arm64',
+  'darwin-x64': 'bun-darwin-x64',
+  'linux-x64': 'bun-linux-x64',
+  'linux-arm64': 'bun-linux-arm64',
+};
+
+const bunTarget = bunTargets[target];
+if (!bunTarget) {
+  console.error(`Unknown target: ${target}`);
+  console.error(`Supported targets: ${Object.keys(bunTargets).join(', ')}`);
+  process.exit(1);
+}
+
+console.log(
+  `Building tlon v${version} for ${target} (bun target: ${bunTarget})...`
+);
+
+// Build the binary
+const distDir = join(rootDir, 'dist');
+mkdirSync(distDir, { recursive: true });
+
+const binaryName = target.startsWith('win') ? 'tlon.exe' : 'tlon';
+const binaryPath = join(distDir, binaryName);
+
+execSync(
+  `bun build scripts/main.ts --compile --target=${bunTarget} --outfile ${binaryPath} --define __VERSION__='"${version}"'`,
+  {
+    cwd: rootDir,
+    stdio: 'inherit',
+  }
+);
+
+// Copy to the appropriate npm package directory
+const npmDir = join(rootDir, 'npm', target);
+mkdirSync(npmDir, { recursive: true });
+cpSync(binaryPath, join(npmDir, binaryName));
+
+console.log(`Built and copied to npm/${target}/${binaryName}`);

--- a/packages/tlon-skill/scripts/build-all.js
+++ b/packages/tlon-skill/scripts/build-all.js
@@ -21,11 +21,25 @@ const rootDir = join(__dirname, '..');
 const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'));
 const version = pkg.version;
 
+function parseTargetArg(args) {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--target') {
+      return args[i + 1] ?? '';
+    }
+    if (arg.startsWith('--target=')) {
+      return arg.slice('--target='.length);
+    }
+  }
+  return `${process.platform}-${process.arch}`;
+}
+
 // Parse --target argument
-const targetArg = process.argv.find((arg) => arg.startsWith('--target='));
-const target = targetArg
-  ? targetArg.split('=')[1]
-  : `${process.platform}-${process.arch}`;
+const target = parseTargetArg(process.argv.slice(2));
+if (!target) {
+  console.error('Missing value for --target');
+  process.exit(1);
+}
 
 // Map our target names to bun's target names
 const bunTargets = {

--- a/packages/tlon-skill/scripts/build-smoke.ts
+++ b/packages/tlon-skill/scripts/build-smoke.ts
@@ -1,0 +1,198 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import {
+  CLI_MATRIX_CASES,
+  COMMAND_FAMILIES,
+  type CliCase,
+  normalizeCliOutput,
+} from './cli-test-matrix';
+
+const rootDir = resolve(process.cwd());
+const binaryPath = join(rootDir, 'dist', 'tlon-run');
+const SMOKE_TIMEOUT_MS = 15_000;
+const packageJson = JSON.parse(
+  readFileSync(join(rootDir, 'package.json'), 'utf-8')
+) as { version: string };
+
+type RunOptions = {
+  argsPrefix?: string[];
+  env?: Record<string, string>;
+  prepare?: (tempRoot: string) => {
+    argsPrefix?: string[];
+    env?: Record<string, string>;
+  } | void;
+};
+
+type CliResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+function hermeticEnv(
+  tempRoot: string,
+  extraEnv: Record<string, string> = {}
+): Record<string, string> {
+  const home = join(tempRoot, 'home');
+  const cacheDir = join(tempRoot, 'cache');
+  mkdirSync(home);
+  mkdirSync(cacheDir);
+
+  const env: Record<string, string> = {};
+  for (const key of ['PATH', 'SystemRoot', 'WINDIR']) {
+    const value = process.env[key];
+    if (value) {
+      env[key] = value;
+    }
+  }
+  env.HOME = home;
+  env.TLON_CACHE_DIR = cacheDir;
+  env.OPENCLAW_CONFIG = join(home, 'missing-openclaw.json');
+  return { ...env, ...extraEnv };
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function runBuiltCli(args: string[], options: RunOptions = {}): CliResult {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'tlon-build-smoke-'));
+  try {
+    const prepared = options.prepare?.(tempRoot) ?? {};
+    const argsPrefix = prepared.argsPrefix ?? options.argsPrefix ?? [];
+    const env = {
+      ...(options.env ?? {}),
+      ...(prepared.env ?? {}),
+    };
+    const result = spawnSync(binaryPath, [...argsPrefix, ...args], {
+      cwd: rootDir,
+      env: hermeticEnv(tempRoot, env),
+      encoding: 'utf-8',
+      timeout: SMOKE_TIMEOUT_MS,
+    });
+
+    if (result.error) {
+      fail(`failed to run binary: ${result.error.message}`);
+    }
+
+    return {
+      exitCode: result.status ?? 1,
+      stdout: normalizeCliOutput(result.stdout),
+      stderr: normalizeCliOutput(result.stderr),
+    };
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function assertCliCase(testCase: CliCase, result: CliResult): void {
+  if (result.exitCode !== testCase.expectedExitCode) {
+    fail(
+      `${testCase.name}: expected exit ${testCase.expectedExitCode}, got ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+
+  if (testCase.stdout !== undefined && result.stdout !== testCase.stdout) {
+    fail(
+      `${testCase.name}: unexpected stdout\nexpected:\n${testCase.stdout}\nactual:\n${result.stdout}`
+    );
+  }
+  for (const expected of testCase.stdoutIncludes ?? []) {
+    if (!result.stdout.includes(expected)) {
+      fail(
+        `${testCase.name}: stdout did not include ${JSON.stringify(expected)}\nstdout:\n${result.stdout}`
+      );
+    }
+  }
+  for (const unexpected of testCase.stdoutExcludes ?? []) {
+    if (result.stdout.includes(unexpected)) {
+      fail(
+        `${testCase.name}: stdout included ${JSON.stringify(unexpected)}\nstdout:\n${result.stdout}`
+      );
+    }
+  }
+
+  if (testCase.stderr !== undefined && result.stderr !== testCase.stderr) {
+    fail(
+      `${testCase.name}: unexpected stderr\nexpected:\n${testCase.stderr}\nactual:\n${result.stderr}`
+    );
+  }
+  for (const expected of testCase.stderrIncludes ?? []) {
+    if (!result.stderr.includes(expected)) {
+      fail(
+        `${testCase.name}: stderr did not include ${JSON.stringify(expected)}\nstderr:\n${result.stderr}`
+      );
+    }
+  }
+  for (const unexpected of testCase.stderrExcludes ?? []) {
+    if (result.stderr.includes(unexpected)) {
+      fail(
+        `${testCase.name}: stderr included ${JSON.stringify(unexpected)}\nstderr:\n${result.stderr}`
+      );
+    }
+  }
+}
+
+function assertCase(testCase: CliCase, options: RunOptions = {}): void {
+  const result = runBuiltCli(testCase.args, options);
+  assertCliCase(testCase, result);
+  console.log(`ok - ${testCase.name}`);
+}
+
+assertCase({
+  name: 'tlon-run --version',
+  args: ['--version'],
+  expectedExitCode: 0,
+  stdout: `${packageJson.version}\n`,
+  stderr: '',
+});
+
+for (const testCase of CLI_MATRIX_CASES) {
+  assertCase(testCase);
+}
+
+const hostileHelpCommands = [
+  { name: 'top-level', args: ['--help'] },
+  ...COMMAND_FAMILIES.map((family) => ({
+    name: family,
+    args: [family, '--help'],
+  })),
+];
+
+for (const command of hostileHelpCommands) {
+  assertCase(
+    {
+      name: `${command.name} help with nonexistent TLON_CONFIG_FILE`,
+      args: command.args,
+      expectedExitCode: 0,
+      stderr: '',
+      stdoutIncludes: ['Usage:'],
+    },
+    {
+      prepare: (tempRoot) => ({
+        env: {
+          TLON_CONFIG_FILE: join(tempRoot, `${command.name}-ship.json`),
+        },
+      }),
+    }
+  );
+
+  assertCase(
+    {
+      name: `${command.name} help with CLI --config /nonexistent`,
+      args: command.args,
+      expectedExitCode: 0,
+      stderr: '',
+      stdoutIncludes: ['Usage:'],
+    },
+    {
+      prepare: (tempRoot) => ({
+        argsPrefix: ['--config', join(tempRoot, `${command.name}-ship.json`)],
+      }),
+    }
+  );
+}

--- a/packages/tlon-skill/scripts/build.js
+++ b/packages/tlon-skill/scripts/build.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/**
+ * Build the tlon binary with version injected
+ */
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')
+);
+const version = pkg.version;
+
+console.log(`Building tlon v${version}...`);
+
+const cmd = `bun build scripts/main.ts --compile --outfile dist/tlon-run --define __VERSION__='"${version}"'`;
+console.log(`> ${cmd}`);
+
+try {
+  execSync(cmd, { stdio: 'inherit', cwd: join(__dirname, '..') });
+  console.log('Build complete!');
+} catch (err) {
+  process.exit(1);
+}

--- a/packages/tlon-skill/scripts/bump-version.js
+++ b/packages/tlon-skill/scripts/bump-version.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+/**
+ * Bump version in all package.json files
+ * Usage: node scripts/bump-version.js <version>
+ * Example: node scripts/bump-version.js 0.1.5
+ */
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+const packageFiles = [
+  'package.json',
+  'npm/darwin-arm64/package.json',
+  'npm/darwin-x64/package.json',
+  'npm/linux-x64/package.json',
+  'npm/linux-arm64/package.json',
+];
+
+const packageLockFile = 'package-lock.json';
+const tlonSkillPackagePrefix = '@tloncorp/tlon-skill-';
+
+const newVersion = process.argv[2];
+
+if (!newVersion) {
+  // Read current version
+  const mainPkg = JSON.parse(
+    readFileSync(join(rootDir, 'package.json'), 'utf-8')
+  );
+  console.log(`Current version: ${mainPkg.version}`);
+  console.log('\nUsage: node scripts/bump-version.js <version>');
+  console.log('Example: node scripts/bump-version.js 0.1.5');
+  process.exit(0);
+}
+
+// Validate version format
+if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
+  console.error(`Invalid version format: ${newVersion}`);
+  console.error('Expected format: X.Y.Z or X.Y.Z-tag');
+  process.exit(1);
+}
+
+console.log(`Bumping version to ${newVersion}...\n`);
+
+let failed = false;
+
+function getTlonSkillOptionalDeps(optionalDependencies) {
+  if (!optionalDependencies) {
+    return [];
+  }
+
+  return Object.keys(optionalDependencies).filter((dep) =>
+    dep.startsWith(tlonSkillPackagePrefix)
+  );
+}
+
+function updateTlonSkillOptionalDeps(optionalDependencies) {
+  for (const dep of getTlonSkillOptionalDeps(optionalDependencies)) {
+    optionalDependencies[dep] = newVersion;
+  }
+}
+
+function targetFromPlatformPackage(packageName) {
+  return packageName.slice(tlonSkillPackagePrefix.length);
+}
+
+function getLocalPlatformOptionalDeps(optionalDependencies) {
+  return Object.fromEntries(
+    getTlonSkillOptionalDeps(optionalDependencies).map((dep) => [
+      dep,
+      `file:npm/${targetFromPlatformPackage(dep)}`,
+    ])
+  );
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(join(rootDir, file), 'utf-8'));
+}
+
+function writeJson(file, value) {
+  writeFileSync(join(rootDir, file), JSON.stringify(value, null, 2) + '\n');
+}
+
+function refreshPackageLockFromLocalPlatformPackages(finalRootPackage) {
+  const originalPackageJson = readFileSync(
+    join(rootDir, 'package.json'),
+    'utf-8'
+  );
+  const localPlatformDeps = getLocalPlatformOptionalDeps(
+    finalRootPackage.optionalDependencies
+  );
+
+  const tempRootPackage = structuredClone(finalRootPackage);
+  tempRootPackage.optionalDependencies = {
+    ...tempRootPackage.optionalDependencies,
+    ...localPlatformDeps,
+  };
+
+  try {
+    writeJson('package.json', tempRootPackage);
+    execFileSync(
+      'npm',
+      [
+        'install',
+        '--package-lock-only',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+      ],
+      { cwd: rootDir, stdio: 'inherit' }
+    );
+  } finally {
+    writeFileSync(join(rootDir, 'package.json'), originalPackageJson);
+  }
+
+  const packageLock = readJson(packageLockFile);
+  packageLock.version = newVersion;
+
+  const rootPackage = packageLock.packages?.[''];
+  if (rootPackage) {
+    rootPackage.version = newVersion;
+    rootPackage.optionalDependencies = {
+      ...rootPackage.optionalDependencies,
+      ...finalRootPackage.optionalDependencies,
+    };
+  }
+
+  writeJson(packageLockFile, packageLock);
+}
+
+for (const file of packageFiles) {
+  const filePath = join(rootDir, file);
+  try {
+    const pkg = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const oldVersion = pkg.version;
+    pkg.version = newVersion;
+
+    // Also update optionalDependencies versions in main package.json
+    if (file === 'package.json') {
+      updateTlonSkillOptionalDeps(pkg.optionalDependencies);
+    }
+
+    writeFileSync(filePath, JSON.stringify(pkg, null, 2) + '\n');
+    console.log(`  ${file}: ${oldVersion} → ${newVersion}`);
+  } catch (err) {
+    failed = true;
+    console.error(`  ${file}: ERROR - ${err.message}`);
+  }
+}
+
+try {
+  const oldVersion = readJson(packageLockFile).version;
+  const rootPackage = readJson('package.json');
+  refreshPackageLockFromLocalPlatformPackages(rootPackage);
+  console.log(`  ${packageLockFile}: ${oldVersion} → ${newVersion}`);
+} catch (err) {
+  failed = true;
+  console.error(`  ${packageLockFile}: ERROR - ${err.message}`);
+}
+
+if (failed) {
+  console.error('\nVersion bump failed; see errors above.');
+  process.exit(1);
+}
+
+console.log("\nDone! Don't forget to:");
+console.log('  1. Update CHANGELOG.md (if you have one)');
+console.log('  2. Commit the changes');
+console.log('  3. Tag the release: git tag v' + newVersion);
+console.log('  4. Push: git push && git push --tags');

--- a/packages/tlon-skill/scripts/bump-version.js
+++ b/packages/tlon-skill/scripts/bump-version.js
@@ -5,7 +5,6 @@
  * Usage: node scripts/bump-version.js <version>
  * Example: node scripts/bump-version.js 0.1.5
  */
-import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -21,7 +20,6 @@ const packageFiles = [
   'npm/linux-arm64/package.json',
 ];
 
-const packageLockFile = 'package-lock.json';
 const tlonSkillPackagePrefix = '@tloncorp/tlon-skill-';
 
 const newVersion = process.argv[2];
@@ -64,74 +62,6 @@ function updateTlonSkillOptionalDeps(optionalDependencies) {
   }
 }
 
-function targetFromPlatformPackage(packageName) {
-  return packageName.slice(tlonSkillPackagePrefix.length);
-}
-
-function getLocalPlatformOptionalDeps(optionalDependencies) {
-  return Object.fromEntries(
-    getTlonSkillOptionalDeps(optionalDependencies).map((dep) => [
-      dep,
-      `file:npm/${targetFromPlatformPackage(dep)}`,
-    ])
-  );
-}
-
-function readJson(file) {
-  return JSON.parse(readFileSync(join(rootDir, file), 'utf-8'));
-}
-
-function writeJson(file, value) {
-  writeFileSync(join(rootDir, file), JSON.stringify(value, null, 2) + '\n');
-}
-
-function refreshPackageLockFromLocalPlatformPackages(finalRootPackage) {
-  const originalPackageJson = readFileSync(
-    join(rootDir, 'package.json'),
-    'utf-8'
-  );
-  const localPlatformDeps = getLocalPlatformOptionalDeps(
-    finalRootPackage.optionalDependencies
-  );
-
-  const tempRootPackage = structuredClone(finalRootPackage);
-  tempRootPackage.optionalDependencies = {
-    ...tempRootPackage.optionalDependencies,
-    ...localPlatformDeps,
-  };
-
-  try {
-    writeJson('package.json', tempRootPackage);
-    execFileSync(
-      'npm',
-      [
-        'install',
-        '--package-lock-only',
-        '--ignore-scripts',
-        '--no-audit',
-        '--no-fund',
-      ],
-      { cwd: rootDir, stdio: 'inherit' }
-    );
-  } finally {
-    writeFileSync(join(rootDir, 'package.json'), originalPackageJson);
-  }
-
-  const packageLock = readJson(packageLockFile);
-  packageLock.version = newVersion;
-
-  const rootPackage = packageLock.packages?.[''];
-  if (rootPackage) {
-    rootPackage.version = newVersion;
-    rootPackage.optionalDependencies = {
-      ...rootPackage.optionalDependencies,
-      ...finalRootPackage.optionalDependencies,
-    };
-  }
-
-  writeJson(packageLockFile, packageLock);
-}
-
 for (const file of packageFiles) {
   const filePath = join(rootDir, file);
   try {
@@ -150,16 +80,6 @@ for (const file of packageFiles) {
     failed = true;
     console.error(`  ${file}: ERROR - ${err.message}`);
   }
-}
-
-try {
-  const oldVersion = readJson(packageLockFile).version;
-  const rootPackage = readJson('package.json');
-  refreshPackageLockFromLocalPlatformPackages(rootPackage);
-  console.log(`  ${packageLockFile}: ${oldVersion} → ${newVersion}`);
-} catch (err) {
-  failed = true;
-  console.error(`  ${packageLockFile}: ERROR - ${err.message}`);
 }
 
 if (failed) {

--- a/packages/tlon-skill/scripts/channels.ts
+++ b/packages/tlon-skill/scripts/channels.ts
@@ -1,0 +1,650 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Channel listing and management for Tlon/Urbit
+ *
+ * Usage:
+ *   npx ts-node channels.ts dms        # List DMs
+ *   npx ts-node channels.ts group-dms  # List group DMs (clubs)
+ *   npx ts-node channels.ts groups     # List subscribed groups
+ *   npx ts-node channels.ts all        # List all channels
+ *   npx ts-node channels.ts info <nest>   # Get channel info
+ *   npx ts-node channels.ts create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+ *   npx ts-node channels.ts rename <nest> "New Title"
+ *   npx ts-node channels.ts update <nest> --title "..." [--description "..."]
+ *   npx ts-node channels.ts delete <nest> # Delete a channel (must be group admin)
+ *   npx ts-node channels.ts add-writers <nest> <role1> [role2...]
+ *   npx ts-node channels.ts del-writers <nest> <role1> [role2...]
+ *   npx ts-node channels.ts add-readers <group-flag> <nest> <role1> [role2...]
+ *   npx ts-node channels.ts del-readers <group-flag> <nest> <role1> [role2...]
+ */
+import {
+  addChannelWriters as apiAddWriters,
+  removeChannelWriters as apiRemoveWriters,
+  createChannel,
+  deleteChannel,
+  getGroups,
+  getInitData,
+  poke,
+  updateChannel,
+} from '@tloncorp/api';
+import type { Channel as ApiChannel, Group as ApiGroup } from '@tloncorp/api';
+
+import { ensureClient, getCurrentShip } from './api-client';
+import {
+  getOption,
+  hasOptionValue,
+  isHelpArg,
+  isSubcommandHelpRequest,
+  looksLikePositionalChannelKind,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+} from './cli-utils';
+
+function generateChannelSlug(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyz';
+  const alphanumeric = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let slug = chars[Math.floor(Math.random() * chars.length)];
+  for (let i = 0; i < 7; i++) {
+    slug += alphanumeric[Math.floor(Math.random() * alphanumeric.length)];
+  }
+  return slug;
+}
+
+const CHANNELS_HELP = `Usage: tlon channels <command>
+
+Commands:
+  dms
+  group-dms
+  groups
+  all
+  info <nest>
+  create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+  update <nest> (--title "..." | --description "...")
+  rename <nest> "New Title"
+  delete <nest>
+  add-writers <nest> <role1> [role2...]
+  del-writers <nest> <role1> [role2...]
+  add-readers <group-flag> <nest> <role1> [role2...]
+  del-readers <group-flag> <nest> <role1> [role2...]
+
+Examples:
+  tlon channels create ~host/group-slug "Projects" --kind chat
+  tlon channels rename chat/~host/project-updates "Team Updates"`;
+
+const CHANNELS_COMMAND_HELP: Record<string, string> = {
+  dms: `Usage: tlon channels dms`,
+  'group-dms': `Usage: tlon channels group-dms`,
+  groups: `Usage: tlon channels groups`,
+  all: `Usage: tlon channels all`,
+  info: `Usage: tlon channels info <nest>\nExample: tlon channels info chat/~host/slug`,
+  create: `Usage: tlon channels create <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: tlon channels create ~host/group-slug "Projects" --kind chat`,
+  update: `Usage: tlon channels update <nest> (--title "..." | --description "...")\nExample: tlon channels update chat/~host/slug --title "New Title"`,
+  rename: `Usage: tlon channels rename <nest> "New Title"\nExample: tlon channels rename chat/~host/slug "Project Updates"`,
+  delete: `Usage: tlon channels delete <nest>\nExample: tlon channels delete chat/~host/slug`,
+  'add-writers': `Usage: tlon channels add-writers <nest> <role1> [role2...]\nExample: tlon channels add-writers chat/~host/slug admin`,
+  'del-writers': `Usage: tlon channels del-writers <nest> <role1> [role2...]\nExample: tlon channels del-writers chat/~host/slug member`,
+  'add-readers': `Usage: tlon channels add-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels add-readers ~host/group-slug chat/~host/slug admin`,
+  'del-readers': `Usage: tlon channels del-readers <group-flag> <nest> <role1> [role2...]\nExample: tlon channels del-readers ~host/group-slug chat/~host/slug admin`,
+};
+
+const CHANNEL_UPDATE_FLAGS = ['title', 'description'] as const;
+
+function getChannelsHelp(command?: string) {
+  return command
+    ? CHANNELS_COMMAND_HELP[command] ?? CHANNELS_HELP
+    : CHANNELS_HELP;
+}
+
+function validateChannelsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !CHANNELS_COMMAND_HELP[command]) {
+    printUsageAndExit(CHANNELS_HELP);
+  }
+
+  switch (command) {
+    case 'dms':
+    case 'group-dms':
+    case 'groups':
+    case 'all':
+      return;
+    case 'info':
+    case 'delete': {
+      if (!args[1]) printUsageAndExit(CHANNELS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'create': {
+      if (!args[1] || args[2] === undefined) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP.create);
+      }
+      if (looksLikePositionalChannelKind(args, 2)) {
+        printUsageAndExit(
+          `Error: channel kind must be passed with --kind, not as a positional argument.\n${CHANNELS_COMMAND_HELP.create}`
+        );
+      }
+      return;
+    }
+    case 'update': {
+      if (!args[1]) printUsageAndExit(CHANNELS_COMMAND_HELP.update);
+      if (
+        !CHANNEL_UPDATE_FLAGS.some((flag) =>
+          hasOptionValue(args, flag, CHANNEL_UPDATE_FLAGS)
+        )
+      ) {
+        printUsageAndExit(
+          `Error: At least one of --title or --description is required\n${CHANNELS_COMMAND_HELP.update}`
+        );
+      }
+      return;
+    }
+    case 'rename': {
+      if (!args[1] || !args[2]) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP.rename);
+      }
+      return;
+    }
+    case 'add-writers':
+    case 'del-writers': {
+      if (!args[1] || args.slice(2).length === 0) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+    case 'add-readers':
+    case 'del-readers': {
+      if (!args[1] || !args[2] || args.slice(3).length === 0) {
+        printUsageAndExit(CHANNELS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+  }
+}
+
+// Get DMs
+async function getDms() {
+  const init = await getInitData();
+  const dms = init.channels.filter((channel) => channel.type === 'dm');
+  return dms.map((dm) => ({
+    type: 'dm',
+    id: dm.id,
+    contact: dm.contactId || dm.id,
+  }));
+}
+
+// Get group DMs (clubs)
+async function getGroupDms() {
+  const currentShip = await getCurrentShip();
+  const init = await getInitData();
+  const groupDms = init.channels.filter(
+    (channel) => channel.type === 'groupDm'
+  );
+
+  return groupDms.map((dm) => {
+    const members = dm.members || [];
+    const joined = members.filter((member) => member.status === 'joined');
+    const invited = members.filter((member) => member.status === 'invited');
+    const isJoined = joined.some((member) => member.contactId === currentShip);
+    const isInvited = invited.some(
+      (member) => member.contactId === currentShip
+    );
+
+    return {
+      type: 'groupDm',
+      id: dm.id,
+      title: dm.title || 'Untitled',
+      description: dm.description || '',
+      members: joined.map((member) => member.contactId),
+      invited: invited.map((member) => member.contactId),
+      status: isJoined ? 'joined' : isInvited ? 'invited' : 'unknown',
+    };
+  });
+}
+
+// Get subscribed groups
+async function getGroupsList() {
+  const groups = await getGroupsApi();
+
+  return groups.map((group) => {
+    const channelList = (group.channels || []).map((channel) => ({
+      nest: channel.id,
+      title: channel.title || channel.id,
+      zone: findChannelSectionId(group, channel.id),
+    }));
+
+    return {
+      type: 'group',
+      id: group.id,
+      title: group.title,
+      description: group.description,
+      image: group.iconImage,
+      secret: group.privacy === 'secret',
+      memberCount: group.memberCount ?? (group.members || []).length,
+      channels: channelList,
+    };
+  });
+}
+
+// Get all channels combined
+async function getAll() {
+  const [dms, groupDms, groups] = await Promise.all([
+    getDms(),
+    getGroupDms(),
+    getGroupsList(),
+  ]);
+
+  return {
+    dms,
+    groupDms,
+    groups,
+  };
+}
+
+// Parse nest into components: kind/~host/name -> { kind, host, name, group }
+function parseNest(nest: string): { kind: string; host: string; name: string } {
+  const parts = nest.split('/');
+  if (parts.length !== 3) {
+    throw new Error(`Invalid nest format: ${nest}. Expected: kind/~host/name`);
+  }
+  return {
+    kind: parts[0],
+    host: parts[1].startsWith('~') ? parts[1] : `~${parts[1]}`,
+    name: parts[2],
+  };
+}
+
+// Find which group a channel belongs to
+async function findChannelGroup(
+  nest: string
+): Promise<{ group: ApiGroup; channel: ApiChannel } | null> {
+  const groups = await getGroupsApi();
+  for (const group of groups) {
+    const channel = (group.channels || []).find((c) => c.id === nest);
+    if (channel) {
+      return { group, channel };
+    }
+  }
+  return null;
+}
+
+// Get channel info
+async function getChannelInfo(nest: string) {
+  const { kind, name } = parseNest(nest);
+
+  // Find the group this channel belongs to
+  const match = await findChannelGroup(nest);
+  if (!match) {
+    throw new Error(`Channel ${nest} not found in any group`);
+  }
+
+  const { group, channel } = match;
+
+  console.log(`\n=== ${channel.title || name} ===\n`);
+  console.log(`Nest: ${nest}`);
+  console.log(`Kind: ${kind}`);
+  console.log(`Group: ${group.title} (${group.id})`);
+  console.log(`Zone: ${findChannelSectionId(group, channel.id)}`);
+  console.log(`Description: ${channel.description || '(none)'}`);
+  const readerRoles = (channel.readerRoles || []).map((r) => r.roleId);
+  console.log(
+    `Readers: ${readerRoles.length > 0 ? readerRoles.join(', ') : '(all members)'}`
+  );
+
+  return {
+    nest,
+    kind,
+    group: group.id,
+    groupTitle: group.title,
+    title: channel.title,
+    description: channel.description,
+    zone: findChannelSectionId(group, channel.id),
+    readers: readerRoles,
+  };
+}
+
+async function createChannelInGroup(
+  groupId: string,
+  title: string,
+  kind: 'chat' | 'diary' | 'heap' = 'chat',
+  description = ''
+) {
+  const ship = await getCurrentShip();
+  const name = generateChannelSlug();
+  const nest = `${kind}/${ship}/${name}`;
+
+  console.log(`Adding channel "${title}" to group ${groupId}...`);
+
+  await createChannel({
+    id: nest,
+    kind,
+    group: groupId,
+    name,
+    title,
+    description,
+    meta: null,
+    readers: [],
+    writers: [],
+  });
+
+  console.log(`✅ Channel created!`);
+  console.log(`   Nest: ${nest}`);
+  console.log(`   Title: ${title}`);
+  console.log(`   Group: ${groupId}`);
+  return nest;
+}
+
+// Update channel metadata
+async function updateChannelMeta(
+  nest: string,
+  options: { title?: string; description?: string }
+) {
+  const match = await findChannelGroup(nest);
+  if (!match) {
+    throw new Error(`Channel ${nest} not found in any group`);
+  }
+
+  const { group, channel } = match;
+  const sectionId = findChannelSectionId(group, channel.id) || 'default';
+  const description = options.description ?? channel.description ?? '';
+  const channelContentConfiguration = channel.contentConfiguration ?? undefined;
+  const encodedDescription = JSON.stringify({
+    description,
+    channelContentConfiguration,
+  });
+
+  const channelUpdate = {
+    added: channel.addedToGroupAt ?? Date.now(),
+    meta: {
+      title: options.title ?? channel.title ?? '',
+      description: encodedDescription,
+      image: channel.iconImage || '',
+      cover: channel.coverImage || '',
+    },
+    section: sectionId,
+    readers: (channel.readerRoles || []).map((r) => r.roleId),
+    join: channel.currentUserIsMember ?? true,
+  };
+
+  console.log(`Updating channel ${nest}...`);
+
+  await updateChannel({
+    groupId: group.id,
+    channelId: nest,
+    channel: channelUpdate,
+  });
+
+  console.log(`✅ Channel updated.`);
+  console.log(`   Title: ${channelUpdate.meta.title}`);
+  console.log(`   Description: ${description || '(none)'}`);
+}
+
+// Delete a channel
+async function deleteChannelByNest(nest: string) {
+  const match = await findChannelGroup(nest);
+  if (!match) {
+    throw new Error(`Channel ${nest} not found in any group`);
+  }
+
+  console.log(`Deleting channel ${nest} from group ${match.group.id}...`);
+
+  await deleteChannel({
+    groupId: match.group.id,
+    channelId: nest,
+  });
+
+  console.log(`✅ Channel deleted.`);
+}
+
+async function getGroupsApi(): Promise<ApiGroup[]> {
+  return getGroups();
+}
+
+type GroupNavSection = {
+  sectionId?: string;
+  channels?: Array<{ channelId?: string }>;
+};
+
+function findChannelSectionId(group: ApiGroup, channelId: string): string {
+  const navSections = (group.navSections || []) as GroupNavSection[];
+  const section = navSections.find((nav) =>
+    (nav.channels || []).some((channel) => channel.channelId === channelId)
+  );
+  return section?.sectionId || 'default';
+}
+
+// Add writers to a channel
+async function addWriters(nest: string, roles: string[]) {
+  console.log(`Adding writers to ${nest}: ${roles.join(', ')}...`);
+  await apiAddWriters({ channelId: nest, writers: roles });
+  console.log(`✅ Writers added: ${roles.join(', ')}`);
+}
+
+// Remove writers from a channel
+async function removeWriters(nest: string, roles: string[]) {
+  console.log(`Removing writers from ${nest}: ${roles.join(', ')}...`);
+  await apiRemoveWriters({ channelId: nest, writers: roles });
+  console.log(`✅ Writers removed: ${roles.join(', ')}`);
+}
+
+// Add readers to a channel (requires group context)
+async function addReaders(groupFlag: string, nest: string, roles: string[]) {
+  console.log(
+    `Adding readers to ${nest} in group ${groupFlag}: ${roles.join(', ')}...`
+  );
+  await poke({
+    app: 'groups',
+    mark: 'group-action-4',
+    json: {
+      group: {
+        flag: groupFlag,
+        'a-group': {
+          channel: {
+            nest,
+            'a-channel': {
+              'add-readers': roles,
+            },
+          },
+        },
+      },
+    },
+  });
+  console.log(`✅ Readers added: ${roles.join(', ')}`);
+}
+
+// Remove readers from a channel (requires group context)
+async function removeReaders(groupFlag: string, nest: string, roles: string[]) {
+  console.log(
+    `Removing readers from ${nest} in group ${groupFlag}: ${roles.join(', ')}...`
+  );
+  await poke({
+    app: 'groups',
+    mark: 'group-action-4',
+    json: {
+      group: {
+        flag: groupFlag,
+        'a-group': {
+          channel: {
+            nest,
+            'a-channel': {
+              'del-readers': roles,
+            },
+          },
+        },
+      },
+    },
+  });
+  console.log(`✅ Readers removed: ${roles.join(', ')}`);
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(CHANNELS_HELP);
+  }
+
+  if (isSubcommandHelpRequest(args)) {
+    printHelpAndExit(getChannelsHelp(command));
+  }
+
+  validateChannelsArgs(args);
+
+  try {
+    await ensureClient(['channels']);
+    switch (command) {
+      case 'dms': {
+        const dms = await getDms();
+        console.log(JSON.stringify(dms, null, 2));
+        break;
+      }
+
+      case 'group-dms': {
+        const dms = await getGroupDms();
+        console.log(JSON.stringify(dms, null, 2));
+        break;
+      }
+
+      case 'groups': {
+        const groups = await getGroupsList();
+        console.log(JSON.stringify(groups, null, 2));
+        break;
+      }
+
+      case 'all': {
+        const all = await getAll();
+        console.log(JSON.stringify(all, null, 2));
+        break;
+      }
+
+      case 'info': {
+        const nest = args[1];
+        if (!nest) {
+          console.error(CHANNELS_COMMAND_HELP.info);
+          process.exit(1);
+        }
+        await getChannelInfo(nest);
+        break;
+      }
+
+      case 'create': {
+        const groupId = args[1];
+        const title = args[2];
+        if (!groupId || title === undefined) {
+          console.error(CHANNELS_COMMAND_HELP.create);
+          process.exit(1);
+        }
+        if (looksLikePositionalChannelKind(args, 2)) {
+          console.error(
+            'Error: channel kind must be passed with --kind, not as a positional argument.'
+          );
+          console.error(CHANNELS_COMMAND_HELP.create);
+          process.exit(1);
+        }
+        const kind =
+          (getOption(args, 'kind', 3) as 'chat' | 'diary' | 'heap') || 'chat';
+        const description = getOption(args, 'description', 3) || '';
+        await createChannelInGroup(groupId, title, kind, description);
+        break;
+      }
+
+      case 'update': {
+        const nest = args[1];
+        if (!nest) {
+          console.error(CHANNELS_COMMAND_HELP.update);
+          process.exit(1);
+        }
+
+        const title = getOption(args, 'title');
+        const description = getOption(args, 'description');
+
+        if (!title && !description) {
+          console.error(
+            'Error: At least one of --title or --description is required'
+          );
+          console.error(CHANNELS_COMMAND_HELP.update);
+          process.exit(1);
+        }
+
+        await updateChannelMeta(nest, { title, description });
+        break;
+      }
+
+      case 'rename': {
+        const nest = args[1];
+        const title = args[2];
+        if (!nest || !title) {
+          console.error(CHANNELS_COMMAND_HELP.rename);
+          process.exit(1);
+        }
+        await updateChannelMeta(nest, { title });
+        break;
+      }
+
+      case 'delete': {
+        const nest = args[1];
+        if (!nest) {
+          console.error(CHANNELS_COMMAND_HELP.delete);
+          process.exit(1);
+        }
+        await deleteChannelByNest(nest);
+        break;
+      }
+
+      case 'add-writers': {
+        const nest = args[1];
+        const roles = args.slice(2);
+        if (!nest || roles.length === 0) {
+          console.error(CHANNELS_COMMAND_HELP['add-writers']);
+          process.exit(1);
+        }
+        await addWriters(nest, roles);
+        break;
+      }
+
+      case 'del-writers': {
+        const nest = args[1];
+        const roles = args.slice(2);
+        if (!nest || roles.length === 0) {
+          console.error(CHANNELS_COMMAND_HELP['del-writers']);
+          process.exit(1);
+        }
+        await removeWriters(nest, roles);
+        break;
+      }
+
+      case 'add-readers': {
+        const groupFlag = args[1];
+        const nest = args[2];
+        const roles = args.slice(3);
+        if (!groupFlag || !nest || roles.length === 0) {
+          console.error(CHANNELS_COMMAND_HELP['add-readers']);
+          process.exit(1);
+        }
+        await addReaders(groupFlag, nest, roles);
+        break;
+      }
+
+      case 'del-readers': {
+        const groupFlag = args[1];
+        const nest = args[2];
+        const roles = args.slice(3);
+        if (!groupFlag || !nest || roles.length === 0) {
+          console.error(CHANNELS_COMMAND_HELP['del-readers']);
+          process.exit(1);
+        }
+        await removeReaders(groupFlag, nest, roles);
+        break;
+      }
+
+      default:
+        printUsageAndExit(CHANNELS_HELP);
+    }
+    process.exit(0);
+  } catch (error) {
+    printErrorAndExit(error);
+  }
+}
+
+main();

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -1,0 +1,497 @@
+export const COMMAND_FAMILIES = [
+  'activity',
+  'channels',
+  'contacts',
+  'dms',
+  'expose',
+  'groups',
+  'hooks',
+  'messages',
+  'notebook',
+  'posts',
+  'settings',
+  'upload',
+] as const;
+
+export const SUBCOMMAND_FAMILIES = COMMAND_FAMILIES.filter(
+  (family) => family !== 'notebook' && family !== 'upload'
+);
+
+export type CliCase = {
+  name: string;
+  args: string[];
+  expectedExitCode: number;
+  stdout?: string;
+  stderr?: string;
+  stdoutIncludes?: string[];
+  stderrIncludes?: string[];
+  stdoutExcludes?: string[];
+  stderrExcludes?: string[];
+};
+
+const SCRIPT_ERA_PATTERNS = [
+  'npx ts-node',
+  'Usage: activity.ts',
+  'Usage: channels.ts',
+  'Usage: contacts.ts',
+  'Usage: dms.ts',
+  'Usage: expose.ts',
+  'Usage: groups.ts',
+  'Usage: hooks.ts',
+  'Usage: messages.ts',
+  'Usage: notebook-post.ts',
+  'Usage: posts.ts',
+  'Usage: settings.ts',
+  'Usage: upload.ts',
+  'Example: activity.ts',
+  'Example: channels.ts',
+  'Example: contacts.ts',
+  'Example: dms.ts',
+  'Example: expose.ts',
+  'Example: groups.ts',
+  'Example: hooks.ts',
+  'Example: messages.ts',
+  'Example: notebook-post.ts',
+  'Example: posts.ts',
+  'Example: settings.ts',
+  'Example: upload.ts',
+  'scripts/channels.ts',
+  'scripts/contacts.ts',
+  'scripts/dms.ts',
+  'scripts/expose.ts',
+  'scripts/groups.ts',
+  'scripts/hooks.ts',
+  'scripts/messages.ts',
+  'scripts/notebook-post.ts',
+  'scripts/posts.ts',
+  'scripts/settings.ts',
+];
+
+const STACK_PATTERNS = [
+  '\n    at ',
+  '\n  at ',
+  'api-client.ts:',
+  'notebook-post.ts:',
+  'dist/tlon-run:',
+  'error: Uncaught',
+];
+
+const AUTH_CONFIG_PATTERNS = [
+  'Missing Urbit config',
+  'Multiple cached ships',
+  'Ship config not found',
+  'Invalid config:',
+  'Failed to parse config',
+  'OpenClaw',
+  'TLON_CONFIG_FILE',
+  'TLON_CACHE_DIR',
+  'Using cached credentials',
+  'Credentials cached',
+];
+
+function helpCase(name: string, args: string[], usage: string): CliCase {
+  return {
+    name,
+    args,
+    expectedExitCode: 0,
+    stderr: '',
+    stdoutIncludes: ['Usage:', usage],
+    stdoutExcludes: SCRIPT_ERA_PATTERNS,
+  };
+}
+
+function usageErrorCase(
+  name: string,
+  args: string[],
+  usage = 'Usage:'
+): CliCase {
+  return {
+    name,
+    args,
+    expectedExitCode: 1,
+    stdout: '',
+    stderrIncludes: [usage],
+    stderrExcludes: [
+      ...SCRIPT_ERA_PATTERNS,
+      ...STACK_PATTERNS,
+      ...AUTH_CONFIG_PATTERNS,
+    ],
+  };
+}
+
+function authRequiredCase(name: string, args: string[]): CliCase {
+  return {
+    name,
+    args,
+    expectedExitCode: 1,
+    stdoutExcludes: ['Usage:'],
+    stderrIncludes: ['Missing Urbit config'],
+    stderrExcludes: ['Usage:'],
+  };
+}
+
+export const TOP_LEVEL_HELP_CASE = helpCase(
+  'top-level --help',
+  ['--help'],
+  'tlon'
+);
+
+export const UNKNOWN_TOP_LEVEL_CASE: CliCase = {
+  name: 'unknown top-level command',
+  args: ['definitely-not-a-command'],
+  expectedExitCode: 1,
+  stdout: '',
+  stderrIncludes: [
+    'Unknown command: definitely-not-a-command',
+    'Run "tlon --help" for usage information.',
+  ],
+  stderrExcludes: [...STACK_PATTERNS, ...AUTH_CONFIG_PATTERNS],
+};
+
+export const FAMILY_HELP_CASES: CliCase[] = COMMAND_FAMILIES.flatMap(
+  (family) => [
+    helpCase(`${family} --help`, [family, '--help'], `tlon ${family}`),
+    helpCase(`${family} -h`, [family, '-h'], `tlon ${family}`),
+  ]
+);
+
+export const FAMILY_BARE_CASES: CliCase[] = COMMAND_FAMILIES.map((family) =>
+  usageErrorCase(`${family} bare invocation`, [family], `Usage: tlon ${family}`)
+);
+
+export const INVALID_SUBCOMMAND_CASES: CliCase[] = SUBCOMMAND_FAMILIES.map(
+  (family) =>
+    usageErrorCase(`${family} invalid subcommand`, [
+      family,
+      'definitely-not-a-subcommand',
+    ])
+);
+
+export const MISSING_REQUIRED_CASES: CliCase[] = [
+  usageErrorCase(
+    'channels info missing nest',
+    ['channels', 'info'],
+    'Usage: tlon channels info'
+  ),
+  usageErrorCase(
+    'contacts get missing ship',
+    ['contacts', 'get'],
+    'Usage: tlon contacts get'
+  ),
+  usageErrorCase(
+    'dms send missing args',
+    ['dms', 'send'],
+    'Usage: tlon dms send'
+  ),
+  usageErrorCase(
+    'expose show missing cite',
+    ['expose', 'show'],
+    'Usage: tlon expose show'
+  ),
+  usageErrorCase(
+    'groups info missing id',
+    ['groups', 'info'],
+    'Usage: tlon groups info'
+  ),
+  usageErrorCase(
+    'hooks init missing name',
+    ['hooks', 'init'],
+    'Usage: tlon hooks init'
+  ),
+  usageErrorCase(
+    'messages dm missing ship',
+    ['messages', 'dm'],
+    'Usage: tlon messages dm'
+  ),
+  usageErrorCase('notebook missing args', ['notebook'], 'Usage: tlon notebook'),
+  usageErrorCase(
+    'posts react missing args',
+    ['posts', 'react'],
+    'Usage: tlon posts react'
+  ),
+  usageErrorCase(
+    'settings set missing args',
+    ['settings', 'set'],
+    'Usage: tlon settings set'
+  ),
+  usageErrorCase('upload missing input', ['upload'], 'Usage: tlon upload'),
+];
+
+export const SPECIAL_INPUT_CASES: CliCase[] = [
+  usageErrorCase(
+    'activity unknown trailing arg',
+    ['activity', 'mentions', 'extra'],
+    'Unknown argument: extra'
+  ),
+  usageErrorCase(
+    'activity missing limit value',
+    ['activity', 'mentions', '--limit'],
+    '--limit requires a value'
+  ),
+  usageErrorCase(
+    'activity nonnumeric limit value',
+    ['activity', 'mentions', '--limit', 'abc'],
+    '--limit must be a positive integer'
+  ),
+  usageErrorCase(
+    'contacts update-profile missing option value',
+    ['contacts', 'update-profile', '--nickname'],
+    'Usage: tlon contacts update-profile'
+  ),
+  usageErrorCase(
+    'messages search missing query',
+    ['messages', 'search', '--channel', 'chat/~host/slug'],
+    'Usage: tlon messages search'
+  ),
+  usageErrorCase(
+    'posts edit missing message',
+    ['posts', 'edit', 'chat/~host/channel', '170.141'],
+    'Usage: tlon posts edit'
+  ),
+  usageErrorCase(
+    'groups update missing update option',
+    ['groups', 'update', '~host/group-slug'],
+    'At least one of --title, --description, --image, or --cover is required'
+  ),
+  usageErrorCase(
+    'hooks init invalid type',
+    ['hooks', 'init', 'my-hook', '--type', 'definitely-not-a-type'],
+    'Invalid --type: definitely-not-a-type'
+  ),
+  usageErrorCase(
+    'hooks init missing type value',
+    ['hooks', 'init', 'my-hook', '--type'],
+    'Usage: tlon hooks init'
+  ),
+  usageErrorCase(
+    'hooks init type followed by known option',
+    ['hooks', 'init', 'my-hook', '--type', '--out', 'hook.hoon'],
+    'Usage: tlon hooks init'
+  ),
+  {
+    ...usageErrorCase(
+      'upload unknown option',
+      ['upload', '--definitely-not-an-option'],
+      'Unknown option: --definitely-not-an-option'
+    ),
+    stderrIncludes: [
+      'Error: Unknown option: --definitely-not-an-option',
+      'Usage: tlon upload',
+    ],
+  },
+  usageErrorCase(
+    'upload stdin with positional input',
+    ['upload', '--stdin', 'photo.jpg'],
+    '--stdin cannot be combined with a file or URL'
+  ),
+  usageErrorCase(
+    'upload missing type value',
+    ['upload', 'photo.jpg', '--type'],
+    '--type requires a value'
+  ),
+  {
+    name: 'notebook unknown option',
+    args: [
+      'notebook',
+      'diary/~host/notes',
+      'Title',
+      '--definitely-not-an-option',
+    ],
+    expectedExitCode: 1,
+    stdout: '',
+    stderrIncludes: ['Error: Unknown option: --definitely-not-an-option'],
+    stderrExcludes: [
+      ...SCRIPT_ERA_PATTERNS,
+      ...STACK_PATTERNS,
+      ...AUTH_CONFIG_PATTERNS,
+    ],
+  },
+];
+
+export const NESTED_HELP_CASES: CliCase[] = [
+  helpCase(
+    'channels info --help',
+    ['channels', 'info', '--help'],
+    'Usage: tlon channels info'
+  ),
+  helpCase(
+    'groups info --help',
+    ['groups', 'info', '--help'],
+    'Usage: tlon groups info'
+  ),
+];
+
+export const LITERAL_OPTION_LIKE_VALUE_CASES: CliCase[] = [
+  authRequiredCase('dms send message option-like value reaches auth', [
+    'dms',
+    'send',
+    '0v123',
+    'use',
+    '--help',
+  ]),
+  authRequiredCase('dms reply message option-like value reaches auth', [
+    'dms',
+    'reply',
+    '0v123',
+    '~zod/170.141',
+    'use',
+    '--help',
+  ]),
+  authRequiredCase('posts edit message option-like value reaches auth', [
+    'posts',
+    'edit',
+    'chat/~host/channel',
+    '170.141',
+    'use',
+    '--help',
+  ]),
+  authRequiredCase('messages search query option-like value reaches auth', [
+    'messages',
+    'search',
+    '--channel',
+    '--channel',
+    'chat/~host/channel',
+  ]),
+  authRequiredCase(
+    'contacts update-profile value option-like value reaches auth',
+    ['contacts', 'update-profile', '--status', '--help']
+  ),
+  authRequiredCase('contacts update value option-like value reaches auth', [
+    'contacts',
+    'update',
+    '~zod',
+    '--nickname',
+    '-h',
+  ]),
+  authRequiredCase('channels create title option-like value reaches auth', [
+    'channels',
+    'create',
+    '~host/group',
+    '--roadmap',
+  ]),
+  authRequiredCase('channels create exact flag-name title reaches auth', [
+    'channels',
+    'create',
+    '~host/group',
+    '--kind',
+  ]),
+  authRequiredCase('channels rename title option-like value reaches auth', [
+    'channels',
+    'rename',
+    'chat/~host/channel',
+    '--roadmap',
+  ]),
+  authRequiredCase('channels update title option-like value reaches auth', [
+    'channels',
+    'update',
+    'chat/~host/channel',
+    '--title',
+    '--help',
+  ]),
+  authRequiredCase('groups create title option-like value reaches auth', [
+    'groups',
+    'create',
+    '--roadmap',
+  ]),
+  authRequiredCase('groups create exact flag-name title reaches auth', [
+    'groups',
+    'create',
+    '--description',
+  ]),
+  authRequiredCase('groups create exact global-flag-name title reaches auth', [
+    'groups',
+    'create',
+    '--ship',
+  ]),
+  authRequiredCase('groups create-owned title option-like value reaches auth', [
+    'groups',
+    'create-owned',
+    '--roadmap',
+    '--owner',
+    '~zod',
+  ]),
+  authRequiredCase('groups create-owned exact flag-name title reaches auth', [
+    'groups',
+    'create-owned',
+    '--owner',
+    '--owner',
+    '~zod',
+  ]),
+  authRequiredCase('groups update title option-like value reaches auth', [
+    'groups',
+    'update',
+    '~host/group',
+    '--title',
+    '--help',
+  ]),
+  authRequiredCase('groups add-channel title option-like value reaches auth', [
+    'groups',
+    'add-channel',
+    '~host/group',
+    '--announcements',
+  ]),
+  authRequiredCase('groups add-channel exact flag-name title reaches auth', [
+    'groups',
+    'add-channel',
+    '~host/group',
+    '--kind',
+  ]),
+  authRequiredCase('hooks edit name option-like value reaches auth', [
+    'hooks',
+    'edit',
+    '0v1a',
+    '--name',
+    '--help',
+  ]),
+  authRequiredCase('notebook title option-like value reaches auth', [
+    'notebook',
+    'diary/~host/notes',
+    '--help',
+  ]),
+  authRequiredCase('contacts update-profile empty value reaches auth', [
+    'contacts',
+    'update-profile',
+    '--status',
+    '',
+  ]),
+  authRequiredCase('contacts update empty value reaches auth', [
+    'contacts',
+    'update',
+    '~zod',
+    '--nickname',
+    '',
+  ]),
+  authRequiredCase('channels update empty value reaches auth', [
+    'channels',
+    'update',
+    'chat/~host/channel',
+    '--description',
+    '',
+  ]),
+  authRequiredCase('groups update empty value reaches auth', [
+    'groups',
+    'update',
+    '~host/group',
+    '--description',
+    '',
+  ]),
+];
+
+export const CLI_MATRIX_CASES: CliCase[] = [
+  TOP_LEVEL_HELP_CASE,
+  UNKNOWN_TOP_LEVEL_CASE,
+  ...FAMILY_HELP_CASES,
+  ...FAMILY_BARE_CASES,
+  ...INVALID_SUBCOMMAND_CASES,
+  ...MISSING_REQUIRED_CASES,
+  ...SPECIAL_INPUT_CASES,
+  ...NESTED_HELP_CASES,
+  ...LITERAL_OPTION_LIKE_VALUE_CASES,
+];
+
+export function normalizeCliOutput(text: string): string {
+  return text
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n');
+}

--- a/packages/tlon-skill/scripts/cli-utils.test.ts
+++ b/packages/tlon-skill/scripts/cli-utils.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  getOption,
+  getRequiredOptionValue,
+  hasOptionValue,
+  isCommandHelpRequest,
+  isSubcommandHelpRequest,
+  looksLikePositionalChannelKind,
+  wantsHelp,
+} from './cli-utils';
+
+describe('cli-utils', () => {
+  describe('wantsHelp', () => {
+    it('detects long help flag', () => {
+      expect(wantsHelp(['add-channel', '--help'])).toBe(true);
+    });
+
+    it('detects short help flag', () => {
+      expect(wantsHelp(['update', '-h'])).toBe(true);
+    });
+
+    it('returns false when help is absent', () => {
+      expect(wantsHelp(['groups', 'info', '~zod/test'])).toBe(false);
+    });
+  });
+
+  describe('looksLikePositionalChannelKind', () => {
+    it('detects channel kind passed positionally', () => {
+      const args = ['add-channel', '~zod/test', 'chat', 'Projects'];
+      expect(looksLikePositionalChannelKind(args, 2)).toBe(true);
+    });
+
+    it('does not flag valid --kind usage', () => {
+      const args = ['add-channel', '~zod/test', 'Projects', '--kind', 'chat'];
+      expect(looksLikePositionalChannelKind(args, 2)).toBe(false);
+      expect(getOption(args, 'kind')).toBe('chat');
+    });
+
+    it('preserves empty option values', () => {
+      expect(getOption(['update', '--description', ''], 'description')).toBe(
+        ''
+      );
+    });
+
+    it('can ignore positional values before options', () => {
+      const args = ['create-owned', '--owner', '--owner', '~zod'];
+
+      expect(getOption(args, 'owner', 2)).toBe('~zod');
+    });
+
+    it('does not flag ordinary titles', () => {
+      const args = ['add-channel', '~zod/test', 'Projects'];
+      expect(looksLikePositionalChannelKind(args, 2)).toBe(false);
+    });
+  });
+
+  describe('getRequiredOptionValue', () => {
+    it('returns the following option value', () => {
+      expect(getRequiredOptionValue(['--content', 'story.json'], 0)).toBe(
+        'story.json'
+      );
+    });
+
+    it('fails when the option value is missing', () => {
+      expect(() => getRequiredOptionValue(['--content'], 0)).toThrow(
+        '--content requires a value'
+      );
+    });
+
+    it('fails when the next token is another option', () => {
+      expect(() =>
+        getRequiredOptionValue(['--content', '--markdown', 'post.md'], 0)
+      ).toThrow('--content requires a value');
+    });
+  });
+
+  describe('hasOptionValue', () => {
+    it('allows values that start with dashes when they are not known options', () => {
+      const args = ['update-profile', '--bio', '--starts-with-dashes'];
+
+      expect(hasOptionValue(args, 'bio', ['nickname', 'bio'])).toBe(true);
+    });
+
+    it('treats a following known option as a missing value', () => {
+      const args = ['update-profile', '--bio', '--nickname', 'Pat'];
+
+      expect(hasOptionValue(args, 'bio', ['nickname', 'bio'])).toBe(false);
+    });
+
+    it('treats an empty string as an explicit option value', () => {
+      const args = ['update-profile', '--status', ''];
+
+      expect(hasOptionValue(args, 'status', ['status'])).toBe(true);
+    });
+  });
+
+  describe('explicit help slots', () => {
+    it('detects family subcommand help only in the second slot', () => {
+      expect(isSubcommandHelpRequest(['info', '--help'])).toBe(true);
+      expect(isSubcommandHelpRequest(['info', '-h'])).toBe(true);
+      expect(isSubcommandHelpRequest(['info', '~zod/test', '--help'])).toBe(
+        false
+      );
+    });
+
+    it('detects command-only help only in the first slot', () => {
+      expect(isCommandHelpRequest(['--help'])).toBe(true);
+      expect(isCommandHelpRequest(['-h'])).toBe(true);
+      expect(isCommandHelpRequest(['diary/~zod/test', '--help'])).toBe(false);
+    });
+  });
+});

--- a/packages/tlon-skill/scripts/cli-utils.ts
+++ b/packages/tlon-skill/scripts/cli-utils.ts
@@ -1,0 +1,120 @@
+/**
+ * CLI argument parsing utilities
+ */
+
+/**
+ * Get an option value from command line args
+ * @param args Array of arguments
+ * @param name Option name (without --)
+ * @param startIndex Index to begin searching from
+ * @returns The option value or undefined
+ */
+export function getOption(
+  args: string[],
+  name: string,
+  startIndex = 0
+): string | undefined {
+  const idx = args.indexOf(`--${name}`, startIndex);
+  if (idx !== -1 && args[idx + 1] !== undefined) {
+    return args[idx + 1];
+  }
+  return undefined;
+}
+
+export function hasOptionValue(
+  args: string[],
+  name: string,
+  knownOptionNames: readonly string[] = []
+): boolean {
+  const idx = args.indexOf(`--${name}`);
+  const value = idx !== -1 ? args[idx + 1] : undefined;
+  if (value === undefined) {
+    return false;
+  }
+
+  return !knownOptionNames.some((optionName) => value === `--${optionName}`);
+}
+
+/**
+ * Check if a flag is present in args
+ * @param args Array of arguments
+ * @param name Flag name (without --)
+ * @returns true if flag is present
+ */
+export function hasFlag(args: string[], name: string): boolean {
+  return args.includes(`--${name}`);
+}
+
+/**
+ * Read the value after an option that requires one.
+ */
+export function getRequiredOptionValue(
+  args: string[],
+  index: number,
+  flag = args[index]
+): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+/**
+ * Check if help was requested for a command/subcommand
+ */
+export function wantsHelp(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
+export function isHelpArg(arg: string | undefined): boolean {
+  return arg === '--help' || arg === '-h';
+}
+
+export function isSubcommandHelpRequest(args: string[]): boolean {
+  return args.length === 2 && isHelpArg(args[1]);
+}
+
+export function isCommandHelpRequest(args: string[]): boolean {
+  return args.length === 1 && isHelpArg(args[0]);
+}
+
+export function printHelpAndExit(help: string): never {
+  console.log(help);
+  process.exit(0);
+}
+
+export function printUsageAndExit(help: string): never {
+  console.error(help);
+  process.exit(1);
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function printErrorAndExit(error: unknown): never {
+  console.error(`Error: ${errorMessage(error)}`);
+  process.exit(1);
+}
+
+export const CHANNEL_KINDS = ['chat', 'diary', 'heap'] as const;
+
+/**
+ * Detect the common mistake of passing channel kind positionally instead of via --kind.
+ * Example: groups add-channel <group> chat "Title"
+ */
+export function looksLikePositionalChannelKind(
+  args: string[],
+  titleIndex: number,
+  kindOptionName = 'kind'
+): boolean {
+  const title = args[titleIndex];
+  const nextPositional = args[titleIndex + 1];
+  return (
+    !!title &&
+    CHANNEL_KINDS.includes(title as (typeof CHANNEL_KINDS)[number]) &&
+    !!nextPositional &&
+    !getOption(args, kindOptionName)
+  );
+}

--- a/packages/tlon-skill/scripts/commands/activity.test.ts
+++ b/packages/tlon-skill/scripts/commands/activity.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  ACTIVITY_HELP,
+  type ActivityDeps,
+  type ActivityEvent,
+  run,
+} from './activity';
+import { commandError } from './command';
+
+function makeDeps(
+  options: {
+    events?: ActivityEvent[];
+    getInitialActivity?: ActivityDeps['activityApi']['getInitialActivity'];
+    getGroupAndChannelUnreads?: ActivityDeps['activityApi']['getGroupAndChannelUnreads'];
+  } = {}
+) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls = {
+    authenticate: 0,
+    getInitialActivity: 0,
+    getGroupAndChannelUnreads: 0,
+    eventFormatter: [] as string[],
+  };
+
+  const deps: ActivityDeps = {
+    stdout: (text) => stdout.push(text),
+    stderr: (text) => stderr.push(text),
+    authenticate: async () => {
+      calls.authenticate += 1;
+    },
+    activityApi: {
+      getInitialActivity:
+        options.getInitialActivity ??
+        (async () => {
+          calls.getInitialActivity += 1;
+          return { events: options.events ?? [] };
+        }),
+      getGroupAndChannelUnreads:
+        options.getGroupAndChannelUnreads ??
+        (async () => {
+          calls.getGroupAndChannelUnreads += 1;
+          return {
+            baseUnread: {
+              id: 'base_unreads',
+              updatedAt: 1,
+              count: 1,
+              notify: false,
+              notifyCount: 1,
+            },
+            groupUnreads: [
+              {
+                groupId: '~zod/test',
+                updatedAt: 1,
+                count: 2,
+                notify: false,
+              },
+            ],
+            channelUnreads: [
+              {
+                channelId: 'chat/~zod/test',
+                type: 'channel',
+                updatedAt: 1,
+                count: 3,
+                notify: false,
+                countWithoutThreads: 2,
+              },
+            ],
+            threadActivity: [],
+          };
+        }),
+    },
+    format: {
+      activityHeader: (bucket, count) => `HEADER:${bucket}:${count}`,
+      noActivity: (bucket) => `NO_ACTIVITY:${bucket}`,
+      event: (event) => {
+        calls.eventFormatter.push(event.id);
+        return `EVENT:${event.id}`;
+      },
+      unreadsHeader: () => 'UNREADS',
+      noUnreads: () => 'NO_UNREADS',
+      baseUnread: (summary) => `BASE:${summary.count ?? 0}`,
+      groupUnread: (summary) =>
+        `GROUP:${summary.groupId}:${summary.count ?? 0}`,
+      channelUnread: (summary) =>
+        `CHANNEL:${summary.channelId}:${summary.count ?? 0}`,
+    },
+  };
+
+  return {
+    deps,
+    calls,
+    stdout: () => stdout.join(''),
+    stderr: () => stderr.join(''),
+  };
+}
+
+describe('activity command run', () => {
+  it('prints help without authenticating or calling the API', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['--help'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe(`${ACTIVITY_HELP}\n`);
+    expect(context.stderr()).toBe('');
+    expect(context.calls.authenticate).toBe(0);
+    expect(context.calls.getInitialActivity).toBe(0);
+    expect(context.calls.getGroupAndChannelUnreads).toBe(0);
+  });
+
+  it('fails local usage errors before auth or API work', async () => {
+    const cases = [
+      { args: [] as string[], expected: 'Usage: tlon activity' },
+      { args: ['bogus'], expected: 'Unknown activity command: bogus' },
+      { args: ['mentions', 'extra'], expected: 'Unknown argument: extra' },
+      { args: ['mentions', '--limit'], expected: '--limit requires a value' },
+      {
+        args: ['mentions', '--limit', 'abc'],
+        expected: '--limit must be a positive integer',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const context = makeDeps();
+      const exitCode = await run(testCase.args, context.deps);
+
+      expect(exitCode).toBe(1);
+      expect(context.stdout()).toBe('');
+      expect(context.stderr()).toContain(testCase.expected);
+      expect(context.stderr()).toContain('Usage: tlon activity');
+      expect(context.calls.authenticate).toBe(0);
+      expect(context.calls.getInitialActivity).toBe(0);
+      expect(context.calls.getGroupAndChannelUnreads).toBe(0);
+    }
+  });
+
+  it('authenticates once, reads activity through injected API, and formats through deps', async () => {
+    const context = makeDeps({
+      events: [
+        {
+          id: 'old',
+          bucketId: 'mentions',
+          sourceId: 'source-old',
+          type: 'post',
+          timestamp: 1,
+        },
+        {
+          id: 'reply',
+          bucketId: 'replies',
+          sourceId: 'source-reply',
+          type: 'reply',
+          timestamp: 3,
+        },
+        {
+          id: 'new',
+          bucketId: 'mentions',
+          sourceId: 'source-new',
+          type: 'post',
+          timestamp: 5,
+        },
+      ],
+    });
+
+    const exitCode = await run(['mentions', '--limit', '1'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.getInitialActivity).toBe(1);
+    expect(context.calls.getGroupAndChannelUnreads).toBe(0);
+    expect(context.calls.eventFormatter).toEqual(['new']);
+    expect(context.stdout()).toBe('HEADER:mentions:1\nEVENT:new\n\n');
+    expect(context.stderr()).toBe('');
+  });
+
+  it('uses the injected unreads API and formatter', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['unreads'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.getInitialActivity).toBe(0);
+    expect(context.calls.getGroupAndChannelUnreads).toBe(1);
+    expect(context.stdout()).toContain('UNREADS\n');
+    expect(context.stdout()).toContain('BASE:1\n');
+    expect(context.stdout()).toContain('GROUP:~zod/test:2\n');
+    expect(context.stdout()).toContain('CHANNEL:chat/~zod/test:3\n');
+  });
+
+  it('formats expected command/API failures through the shared command-error path', async () => {
+    const context = makeDeps({
+      getInitialActivity: async () => {
+        throw commandError('activity API unavailable');
+      },
+    });
+
+    const exitCode = await run(['mentions'], context.deps);
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe('Error: activity API unavailable\n');
+    expect(context.calls.authenticate).toBe(1);
+  });
+
+  it('leaves unexpected exceptions for the adapter formatter', async () => {
+    const context = makeDeps({
+      getInitialActivity: async () => {
+        throw new Error('unexpected failure');
+      },
+    });
+
+    await expect(run(['mentions'], context.deps)).rejects.toThrow(
+      'unexpected failure'
+    );
+    expect(context.stderr()).toBe('');
+  });
+});

--- a/packages/tlon-skill/scripts/commands/activity.ts
+++ b/packages/tlon-skill/scripts/commands/activity.ts
@@ -1,0 +1,222 @@
+import type {
+  getGroupAndChannelUnreads,
+  getInitialActivity,
+} from '@tloncorp/api';
+
+import {
+  type CommandDeps,
+  handleExpectedCommandError,
+  isHelpArg,
+  usageError,
+  writeHelp,
+  writeLine,
+} from './command';
+
+export type ActivityInit = Awaited<
+  ReturnType<typeof getGroupAndChannelUnreads>
+>;
+export type ActivityEvent = Awaited<
+  ReturnType<typeof getInitialActivity>
+>['events'][number];
+export type BaseUnread = NonNullable<ActivityInit['baseUnread']>;
+export type GroupUnread = ActivityInit['groupUnreads'][number];
+export type ChannelUnread = ActivityInit['channelUnreads'][number];
+
+export interface ActivityApi {
+  getInitialActivity: () => Promise<{ events: ActivityEvent[] }>;
+  getGroupAndChannelUnreads: () => Promise<ActivityInit>;
+}
+
+export interface ActivityFormatter {
+  activityHeader: (bucket: ActivityBucket, count: number) => string;
+  noActivity: (bucket: ActivityBucket) => string;
+  event: (event: ActivityEvent) => string;
+  unreadsHeader: () => string;
+  noUnreads: () => string;
+  baseUnread: (summary: BaseUnread) => string;
+  groupUnread: (summary: GroupUnread) => string;
+  channelUnread: (summary: ChannelUnread) => string;
+}
+
+export interface ActivityDeps extends CommandDeps {
+  authenticate: () => Promise<void>;
+  activityApi: ActivityApi;
+  format: ActivityFormatter;
+}
+
+export const ACTIVITY_HELP = `Usage: tlon activity <command>
+
+Commands:
+  mentions [--limit N]   Show mention activity
+  replies [--limit N]    Show reply activity
+  all [--limit N]        Show all activity
+  unreads                Show unread counts`;
+
+const ACTIVITY_BUCKET_COMMANDS = ['mentions', 'replies', 'all'] as const;
+type ActivityBucketCommand = (typeof ACTIVITY_BUCKET_COMMANDS)[number];
+export type ActivityBucket = ActivityBucketCommand;
+type ActivityCommand = ActivityBucketCommand | 'unreads';
+
+const ACTIVITY_COMMANDS = new Set<string>([
+  ...ACTIVITY_BUCKET_COMMANDS,
+  'unreads',
+]);
+
+type ParsedActivityArgs =
+  | { kind: 'help' }
+  | { kind: 'activity'; command: ActivityBucketCommand; limit: number }
+  | { kind: 'unreads' };
+
+function isActivityBucketCommand(
+  command: string
+): command is ActivityBucketCommand {
+  return (ACTIVITY_BUCKET_COMMANDS as readonly string[]).includes(command);
+}
+
+function isActivityCommand(command: string): command is ActivityCommand {
+  return ACTIVITY_COMMANDS.has(command);
+}
+
+function parsePositiveInteger(raw: string): number | null {
+  if (!/^[0-9]+$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function parseArgs(args: string[]): ParsedActivityArgs {
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    return { kind: 'help' };
+  }
+
+  if (!command) {
+    throw usageError(ACTIVITY_HELP);
+  }
+
+  if (!isActivityCommand(command)) {
+    throw usageError(`Unknown activity command: ${command}`, ACTIVITY_HELP);
+  }
+
+  let limit = 10;
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (isHelpArg(arg)) {
+      return { kind: 'help' };
+    }
+
+    if (arg === '--limit') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw usageError('--limit requires a value', ACTIVITY_HELP);
+      }
+      const parsed = parsePositiveInteger(value);
+      if (parsed === null) {
+        throw usageError('--limit must be a positive integer', ACTIVITY_HELP);
+      }
+      limit = parsed;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      throw usageError(`Unknown option: ${arg}`, ACTIVITY_HELP);
+    }
+
+    throw usageError(`Unknown argument: ${arg}`, ACTIVITY_HELP);
+  }
+
+  if (isActivityBucketCommand(command)) {
+    return { kind: 'activity', command, limit };
+  }
+
+  return { kind: 'unreads' };
+}
+
+function hasUnread(summary: BaseUnread | GroupUnread | ChannelUnread): boolean {
+  return (summary.count ?? 0) > 0 || !!summary.notify;
+}
+
+async function showActivity(
+  bucket: ActivityBucket,
+  limit: number,
+  deps: ActivityDeps
+): Promise<void> {
+  const { events } = await deps.activityApi.getInitialActivity();
+  const bucketEvents = events
+    .filter((event) => event.bucketId === bucket)
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, limit);
+
+  if (bucketEvents.length === 0) {
+    writeLine(deps.stdout, deps.format.noActivity(bucket));
+    return;
+  }
+
+  writeLine(
+    deps.stdout,
+    deps.format.activityHeader(bucket, bucketEvents.length)
+  );
+
+  for (const event of bucketEvents) {
+    const formatted = deps.format.event(event);
+    if (formatted) {
+      writeLine(deps.stdout, formatted);
+      writeLine(deps.stdout);
+    }
+  }
+}
+
+async function showUnreads(deps: ActivityDeps): Promise<void> {
+  const activity = await deps.activityApi.getGroupAndChannelUnreads();
+
+  writeLine(deps.stdout, deps.format.unreadsHeader());
+
+  const groupEntries = activity.groupUnreads.filter(hasUnread);
+  const channelEntries = activity.channelUnreads.filter(hasUnread);
+
+  if (groupEntries.length === 0 && channelEntries.length === 0) {
+    writeLine(deps.stdout, deps.format.noUnreads());
+    return;
+  }
+
+  if (activity.baseUnread) {
+    writeLine(deps.stdout, deps.format.baseUnread(activity.baseUnread));
+    writeLine(deps.stdout);
+  }
+
+  for (const summary of groupEntries) {
+    writeLine(deps.stdout, deps.format.groupUnread(summary));
+    writeLine(deps.stdout);
+  }
+
+  for (const summary of channelEntries) {
+    writeLine(deps.stdout, deps.format.channelUnread(summary));
+    writeLine(deps.stdout);
+  }
+}
+
+export async function run(args: string[], deps: ActivityDeps): Promise<number> {
+  try {
+    const parsed = parseArgs(args);
+    if (parsed.kind === 'help') {
+      return writeHelp(deps, ACTIVITY_HELP);
+    }
+
+    await deps.authenticate();
+
+    if (parsed.kind === 'unreads') {
+      await showUnreads(deps);
+    } else {
+      await showActivity(parsed.command, parsed.limit, deps);
+    }
+
+    return 0;
+  } catch (error) {
+    const handled = handleExpectedCommandError(error, deps);
+    if (handled !== null) return handled;
+    throw error;
+  }
+}

--- a/packages/tlon-skill/scripts/commands/command-contract.test.ts
+++ b/packages/tlon-skill/scripts/commands/command-contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const commandsDir = join(process.cwd(), 'scripts', 'commands');
+
+function commandSourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) return commandSourceFiles(fullPath);
+    if (!entry.endsWith('.ts') || entry.endsWith('.test.ts')) return [];
+    return [fullPath];
+  });
+}
+
+const forbiddenPatterns = [
+  { name: 'process.exit', pattern: /\bprocess\.exit\b/ },
+  { name: 'process.argv', pattern: /\bprocess\.argv\b/ },
+  { name: 'process.env', pattern: /\bprocess\.env\b/ },
+  { name: 'process.stdin', pattern: /\bprocess\.stdin\b/ },
+  {
+    name: 'console writes',
+    pattern: /\bconsole\.(log|error|warn|info|debug)\b/,
+  },
+  { name: 'fs imports', pattern: /from\s+["'](?:node:)?fs(?:\/promises)?["']/ },
+  { name: 'os imports', pattern: /from\s+["'](?:node:)?os["']/ },
+  { name: 'homedir usage', pattern: /\bhomedir\s*\(/ },
+  { name: 'global fetch calls', pattern: /(^|[^.\w])fetch\s*\(/ },
+  { name: 'Blob construction', pattern: /\bnew\s+Blob\b/ },
+  {
+    name: 'exit helper imports',
+    pattern: /\bprint(?:Help|Usage|Error)AndExit\b/,
+  },
+  {
+    name: 'raw API value imports',
+    pattern:
+      /import\s+(?!type\b)[^;]*from\s+["']@tloncorp\/api(?:\/[^"']*)?["']/,
+  },
+  {
+    name: 'raw API side-effect imports',
+    pattern: /import\s+["']@tloncorp\/api(?:\/[^"']*)?["']/,
+  },
+];
+
+describe('migrated command source contract', () => {
+  for (const filePath of commandSourceFiles(commandsDir)) {
+    it(`${filePath.replace(`${process.cwd()}/`, '')} avoids adapter-only globals`, () => {
+      const source = readFileSync(filePath, 'utf-8');
+
+      for (const forbidden of forbiddenPatterns) {
+        expect(source, forbidden.name).not.toMatch(forbidden.pattern);
+      }
+    });
+  }
+});

--- a/packages/tlon-skill/scripts/commands/command.ts
+++ b/packages/tlon-skill/scripts/commands/command.ts
@@ -1,0 +1,85 @@
+export type CommandWriter = (text: string) => void;
+
+export interface CommandDeps {
+  stdout: CommandWriter;
+  stderr: CommandWriter;
+}
+
+export type CommandRunner<TDeps extends CommandDeps> = (
+  args: string[],
+  deps: TDeps
+) => Promise<number>;
+
+export class CommandError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
+    super(message);
+    this.name = 'CommandError';
+    this.exitCode = exitCode;
+  }
+}
+
+export class UsageError extends CommandError {
+  readonly help: string;
+
+  constructor(message: string | null, help: string) {
+    super(message ?? '', 1);
+    this.name = 'UsageError';
+    this.help = help;
+  }
+}
+
+export function commandError(message: string, exitCode = 1): CommandError {
+  return new CommandError(message, exitCode);
+}
+
+export function usageError(help: string): UsageError;
+export function usageError(message: string, help: string): UsageError;
+export function usageError(messageOrHelp: string, help?: string): UsageError {
+  if (help === undefined) {
+    return new UsageError(null, messageOrHelp);
+  }
+  return new UsageError(messageOrHelp, help);
+}
+
+export function isHelpArg(arg: string | undefined): boolean {
+  return arg === '--help' || arg === '-h';
+}
+
+export function writeLine(writer: CommandWriter, text = ''): void {
+  writer(`${text}\n`);
+}
+
+export function writeHelp(deps: CommandDeps, help: string): number {
+  writeLine(deps.stdout, help);
+  return 0;
+}
+
+export function formatUnexpectedError(error: unknown): string {
+  return `Error: ${errorMessage(error)}\n`;
+}
+
+export function handleExpectedCommandError(
+  error: unknown,
+  deps: CommandDeps
+): number | null {
+  if (error instanceof UsageError) {
+    const message = error.message
+      ? `Error: ${error.message}\n\n${error.help}`
+      : error.help;
+    writeLine(deps.stderr, message);
+    return error.exitCode;
+  }
+
+  if (error instanceof CommandError) {
+    writeLine(deps.stderr, `Error: ${error.message}`);
+    return error.exitCode;
+  }
+
+  return null;
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/tlon-skill/scripts/commands/upload.test.ts
+++ b/packages/tlon-skill/scripts/commands/upload.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  DEFAULT_CONTENT_TYPE,
+  UPLOAD_HELP,
+  type UploadBlobLike,
+  type UploadDeps,
+  run,
+} from './upload';
+
+type TestBlob = UploadBlobLike & {
+  data?: number[];
+  label?: string;
+};
+
+function bytes(values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+function makeDeps(
+  options: {
+    stdin?: Uint8Array;
+    fetchResponse?: UploadDeps['fetch'];
+    fileExists?: boolean;
+    fileBytes?: Uint8Array;
+    resolvedPath?: string;
+    extension?: string;
+    uploadUrl?: string;
+  } = {}
+) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls = {
+    authenticate: 0,
+    readStdin: 0,
+    fetch: [] as string[],
+    resolvePath: [] as string[],
+    exists: [] as string[],
+    readFile: [] as string[],
+    createBlob: [] as Array<{ data: number[]; contentType: string }>,
+    uploadFile: [] as Array<
+      Parameters<UploadDeps['uploadApi']['uploadFile']>[0]
+    >,
+  };
+
+  const deps: UploadDeps = {
+    stdout: (text) => stdout.push(text),
+    stderr: (text) => stderr.push(text),
+    authenticate: async () => {
+      calls.authenticate += 1;
+    },
+    readStdin: async () => {
+      calls.readStdin += 1;
+      return options.stdin ?? bytes([1, 2, 3]);
+    },
+    fetch:
+      options.fetchResponse ??
+      (async (url) => {
+        calls.fetch.push(url);
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          blob: async () => ({ type: 'image/jpeg', size: 3, label: 'remote' }),
+        };
+      }),
+    fileSystem: {
+      resolvePath: (filePath) => {
+        calls.resolvePath.push(filePath);
+        return options.resolvedPath ?? `/resolved/${filePath}`;
+      },
+      exists: (filePath) => {
+        calls.exists.push(filePath);
+        return options.fileExists ?? true;
+      },
+      readFile: (filePath) => {
+        calls.readFile.push(filePath);
+        return options.fileBytes ?? bytes([9, 8, 7]);
+      },
+      basename: (filePath) => filePath.split('/').filter(Boolean).at(-1) ?? '',
+      extension: () => options.extension ?? '.jpg',
+    },
+    createBlob: (data, contentType): TestBlob => {
+      const record = { data: Array.from(data), contentType };
+      calls.createBlob.push(record);
+      return { type: contentType, size: data.byteLength, data: record.data };
+    },
+    uploadApi: {
+      uploadFile: async (input) => {
+        calls.uploadFile.push(input);
+        return { url: options.uploadUrl ?? 'https://storage.example/uploaded' };
+      },
+    },
+  };
+
+  return {
+    deps,
+    calls,
+    stdout: () => stdout.join(''),
+    stderr: () => stderr.join(''),
+  };
+}
+
+describe('upload command run', () => {
+  it('prints help without authenticating or touching IO', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['--help'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe(`${UPLOAD_HELP}\n`);
+    expect(context.stderr()).toBe('');
+    expect(context.calls.authenticate).toBe(0);
+    expect(context.calls.readStdin).toBe(0);
+    expect(context.calls.fetch).toEqual([]);
+    expect(context.calls.resolvePath).toEqual([]);
+    expect(context.calls.uploadFile).toEqual([]);
+  });
+
+  it('fails local usage errors before auth or IO', async () => {
+    const cases = [
+      { args: [] as string[], expected: 'Usage: tlon upload' },
+      {
+        args: ['--definitely-not-an-option'],
+        expected: 'Unknown option: --definitely-not-an-option',
+      },
+      { args: ['-t'], expected: '-t requires a value' },
+      {
+        args: ['--stdin', 'photo.jpg'],
+        expected: '--stdin cannot be combined with a file or URL',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const context = makeDeps();
+      const exitCode = await run(testCase.args, context.deps);
+
+      expect(exitCode).toBe(1);
+      expect(context.stdout()).toBe('');
+      expect(context.stderr()).toContain(testCase.expected);
+      expect(context.stderr()).toContain('Usage: tlon upload');
+      expect(context.calls.authenticate).toBe(0);
+      expect(context.calls.readStdin).toBe(0);
+      expect(context.calls.fetch).toEqual([]);
+      expect(context.calls.resolvePath).toEqual([]);
+      expect(context.calls.uploadFile).toEqual([]);
+    }
+  });
+
+  it('uploads stdin data with injected stdin and Blob construction', async () => {
+    const context = makeDeps({ stdin: bytes([4, 5, 6]) });
+
+    const exitCode = await run(['--stdin', '-t', 'image/png'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe('https://storage.example/uploaded\n');
+    expect(context.stderr()).toBe('');
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.readStdin).toBe(1);
+    expect(context.calls.createBlob).toEqual([
+      { data: [4, 5, 6], contentType: 'image/png' },
+    ]);
+    expect(context.calls.uploadFile).toHaveLength(1);
+    expect(context.calls.uploadFile[0].contentType).toBe('image/png');
+    expect('fileName' in context.calls.uploadFile[0]).toBe(false);
+    expect((context.calls.uploadFile[0].blob as TestBlob).data).toEqual([
+      4, 5, 6,
+    ]);
+  });
+
+  it('rejects empty stdin as an expected command error', async () => {
+    const context = makeDeps({ stdin: bytes([]) });
+
+    const exitCode = await run(['--stdin'], context.deps);
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe('Error: No data received on stdin\n');
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.readStdin).toBe(1);
+    expect(context.calls.uploadFile).toEqual([]);
+  });
+
+  it('uploads URL data with injected fetch', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(
+      ['https://example.com/path/photo.jpg'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.fetch).toEqual(['https://example.com/path/photo.jpg']);
+    expect(context.calls.createBlob).toEqual([]);
+    expect(context.calls.uploadFile).toHaveLength(1);
+    expect(context.calls.uploadFile[0]).toMatchObject({
+      contentType: 'image/jpeg',
+      fileName: 'photo.jpg',
+    });
+  });
+
+  it('uses MIME override for URL uploads', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(
+      ['https://example.com/path/photo.bin', '--type', 'image/webp'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.uploadFile[0]).toMatchObject({
+      contentType: 'image/webp',
+      fileName: 'photo.bin',
+    });
+  });
+
+  it('rejects malformed URLs as expected command errors before fetch', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['https://'], context.deps);
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe('Error: Invalid URL: https://\n');
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.fetch).toEqual([]);
+    expect(context.calls.uploadFile).toEqual([]);
+  });
+
+  it('rejects fetch failures as expected command errors', async () => {
+    const context = makeDeps({
+      fetchResponse: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    const exitCode = await run(
+      ['https://example.com/path/photo.jpg'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe('Error: Failed to fetch: network down\n');
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.uploadFile).toEqual([]);
+  });
+
+  it('rejects blob read failures as expected command errors', async () => {
+    const context = makeDeps({
+      fetchResponse: async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        blob: async () => {
+          throw new Error('body unavailable');
+        },
+      }),
+    });
+
+    const exitCode = await run(
+      ['https://example.com/path/photo.jpg'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(
+      'Error: Failed to read response body: body unavailable\n'
+    );
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.uploadFile).toEqual([]);
+  });
+
+  it('omits URL filenames when the path has no basename', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['https://example.com/'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.uploadFile).toHaveLength(1);
+    expect(context.calls.uploadFile[0].contentType).toBe('image/jpeg');
+    expect('fileName' in context.calls.uploadFile[0]).toBe(false);
+  });
+
+  it('uploads local files with injected filesystem reads', async () => {
+    const context = makeDeps({
+      resolvedPath: '/tmp/photo.jpg',
+      fileBytes: bytes([10, 11]),
+      extension: '.jpg',
+    });
+
+    const exitCode = await run(['./photo.jpg'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.resolvePath).toEqual(['./photo.jpg']);
+    expect(context.calls.exists).toEqual(['/tmp/photo.jpg']);
+    expect(context.calls.readFile).toEqual(['/tmp/photo.jpg']);
+    expect(context.calls.createBlob).toEqual([
+      { data: [10, 11], contentType: 'image/jpeg' },
+    ]);
+    expect(context.calls.uploadFile[0]).toMatchObject({
+      contentType: 'image/jpeg',
+      fileName: 'photo.jpg',
+    });
+    expect((context.calls.uploadFile[0].blob as TestBlob).data).toEqual([
+      10, 11,
+    ]);
+  });
+
+  it('uses MIME override for local file uploads', async () => {
+    const context = makeDeps({
+      resolvedPath: '/tmp/mystery',
+      extension: '',
+    });
+
+    const exitCode = await run(
+      ['/tmp/mystery', '-t', 'image/webp'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.createBlob).toEqual([
+      { data: [9, 8, 7], contentType: 'image/webp' },
+    ]);
+    expect(context.calls.uploadFile[0]).toMatchObject({
+      contentType: 'image/webp',
+      fileName: 'mystery',
+    });
+  });
+
+  it('falls back to the default MIME type for unknown local extensions', async () => {
+    const context = makeDeps({
+      resolvedPath: '/tmp/blob.unknown',
+      extension: '.unknown',
+    });
+
+    const exitCode = await run(['/tmp/blob.unknown'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.createBlob).toEqual([
+      { data: [9, 8, 7], contentType: DEFAULT_CONTENT_TYPE },
+    ]);
+    expect(context.calls.uploadFile[0].contentType).toBe(DEFAULT_CONTENT_TYPE);
+  });
+});

--- a/packages/tlon-skill/scripts/commands/upload.ts
+++ b/packages/tlon-skill/scripts/commands/upload.ts
@@ -1,0 +1,278 @@
+import {
+  type CommandDeps,
+  commandError,
+  errorMessage,
+  handleExpectedCommandError,
+  isHelpArg,
+  usageError,
+  writeHelp,
+  writeLine,
+} from './command';
+
+export const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
+
+export const UPLOAD_HELP = `Usage: tlon upload <url-or-path> [options]
+       tlon upload --stdin [-t mime/type]
+
+Upload a file to Tlon storage from a URL, local path, or stdin.
+Outputs the uploaded URL on success.
+
+Options:
+  --stdin         Read binary data from stdin instead of a file/URL
+  -t, --type      Override content type (e.g., image/png, application/pdf)
+  -h, --help      Show this help
+
+Examples:
+  tlon upload https://example.com/image.png
+  tlon upload ./photo.jpg
+  tlon upload ~/Pictures/screenshot.png
+  tlon upload ./mystery-file -t image/webp
+  cat image.png | tlon upload --stdin -t image/png
+  curl -s https://example.com/img.jpg | tlon upload --stdin -t image/jpeg`;
+
+const MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.avif': 'image/avif',
+  '.heic': 'image/heic',
+  '.heif': 'image/heif',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.avi': 'video/x-msvideo',
+  '.mkv': 'video/x-matroska',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.flac': 'audio/flac',
+  '.m4a': 'audio/mp4',
+  '.pdf': 'application/pdf',
+  '.json': 'application/json',
+  '.txt': 'text/plain',
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.wasm': 'application/wasm',
+  '.zip': 'application/zip',
+  '.gz': 'application/gzip',
+  '.tar': 'application/x-tar',
+};
+
+export interface UploadBlobLike {
+  type?: string;
+  size?: number;
+}
+
+export interface UploadFetchResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  blob: () => Promise<UploadBlobLike>;
+}
+
+export interface UploadFileSystem {
+  resolvePath: (filePath: string) => string;
+  exists: (filePath: string) => boolean;
+  readFile: (filePath: string) => Uint8Array;
+  basename: (filePath: string) => string;
+  extension: (filePath: string) => string;
+}
+
+export interface UploadApi {
+  uploadFile: (input: {
+    blob: UploadBlobLike;
+    contentType: string;
+    fileName?: string;
+  }) => Promise<{ url: string }>;
+}
+
+export interface UploadDeps extends CommandDeps {
+  authenticate: () => Promise<void>;
+  readStdin: () => Promise<Uint8Array>;
+  fetch: (url: string) => Promise<UploadFetchResponse>;
+  fileSystem: UploadFileSystem;
+  createBlob: (data: Uint8Array, contentType: string) => UploadBlobLike;
+  uploadApi: UploadApi;
+}
+
+type ParsedUploadArgs =
+  | { kind: 'help' }
+  | { kind: 'stdin'; contentType: string }
+  | { kind: 'input'; input: string; contentType?: string };
+
+function isUrl(input: string): boolean {
+  return /^https?:\/\//i.test(input);
+}
+
+function mimeFromPath(filePath: string, deps: UploadDeps): string {
+  const ext = deps.fileSystem.extension(filePath).toLowerCase();
+  return MIME_TYPES[ext] || DEFAULT_CONTENT_TYPE;
+}
+
+function parseUrl(input: string): URL {
+  try {
+    return new URL(input);
+  } catch {
+    throw commandError(`Invalid URL: ${input}`);
+  }
+}
+
+function parseArgs(args: string[]): ParsedUploadArgs {
+  let stdinMode = false;
+  let contentType: string | undefined;
+  const positional: string[] = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    if (arg === '--stdin') {
+      stdinMode = true;
+      continue;
+    }
+
+    if (arg === '-t' || arg === '--type') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw usageError(`${arg} requires a value`, UPLOAD_HELP);
+      }
+      contentType = value;
+      i += 1;
+      continue;
+    }
+
+    if (isHelpArg(arg)) {
+      return { kind: 'help' };
+    }
+
+    if (arg.startsWith('-')) {
+      throw usageError(`Unknown option: ${arg}`, UPLOAD_HELP);
+    }
+
+    positional.push(arg);
+  }
+
+  if (stdinMode) {
+    if (positional.length > 0) {
+      throw usageError(
+        '--stdin cannot be combined with a file or URL',
+        UPLOAD_HELP
+      );
+    }
+    return { kind: 'stdin', contentType: contentType || DEFAULT_CONTENT_TYPE };
+  }
+
+  if (positional.length === 0) {
+    throw usageError(UPLOAD_HELP);
+  }
+
+  if (positional.length > 1) {
+    throw usageError(`Unexpected argument: ${positional[1]}`, UPLOAD_HELP);
+  }
+
+  return { kind: 'input', input: positional[0], contentType };
+}
+
+async function uploadFromUrl(
+  imageUrl: string,
+  contentType: string | undefined,
+  deps: UploadDeps
+): Promise<string> {
+  const url = parseUrl(imageUrl);
+
+  let response: UploadFetchResponse;
+  try {
+    response = await deps.fetch(imageUrl);
+  } catch (error) {
+    throw commandError(`Failed to fetch: ${errorMessage(error)}`);
+  }
+
+  if (!response.ok) {
+    throw commandError(
+      `Failed to fetch: ${response.status} ${response.statusText}`
+    );
+  }
+
+  let blob: UploadBlobLike;
+  try {
+    blob = await response.blob();
+  } catch (error) {
+    throw commandError(`Failed to read response body: ${errorMessage(error)}`);
+  }
+
+  const ct = contentType || blob.type || mimeFromPath(imageUrl, deps);
+  const fileName = deps.fileSystem.basename(url.pathname);
+  const uploadInput = fileName
+    ? { blob, contentType: ct, fileName }
+    : { blob, contentType: ct };
+  const result = await deps.uploadApi.uploadFile(uploadInput);
+  return result.url;
+}
+
+async function uploadFromFile(
+  filePath: string,
+  contentType: string | undefined,
+  deps: UploadDeps
+): Promise<string> {
+  const resolved = deps.fileSystem.resolvePath(filePath);
+  if (!deps.fileSystem.exists(resolved)) {
+    throw commandError(`File not found: ${resolved}`);
+  }
+
+  const data = deps.fileSystem.readFile(resolved);
+  const ct = contentType || mimeFromPath(resolved, deps);
+  const blob = deps.createBlob(data, ct);
+  const fileName = deps.fileSystem.basename(resolved);
+  const result = await deps.uploadApi.uploadFile({
+    blob,
+    contentType: ct,
+    fileName,
+  });
+  return result.url;
+}
+
+async function uploadFromStdin(
+  contentType: string,
+  deps: UploadDeps
+): Promise<string> {
+  const data = await deps.readStdin();
+  if (data.byteLength === 0) {
+    throw commandError('No data received on stdin');
+  }
+
+  const blob = deps.createBlob(data, contentType);
+  const result = await deps.uploadApi.uploadFile({ blob, contentType });
+  return result.url;
+}
+
+export async function run(args: string[], deps: UploadDeps): Promise<number> {
+  try {
+    const parsed = parseArgs(args);
+    if (parsed.kind === 'help') {
+      return writeHelp(deps, UPLOAD_HELP);
+    }
+
+    await deps.authenticate();
+
+    const uploadedUrl =
+      parsed.kind === 'stdin'
+        ? await uploadFromStdin(parsed.contentType, deps)
+        : isUrl(parsed.input)
+          ? await uploadFromUrl(parsed.input, parsed.contentType, deps)
+          : await uploadFromFile(parsed.input, parsed.contentType, deps);
+
+    writeLine(deps.stdout, uploadedUrl);
+    return 0;
+  } catch (error) {
+    const handled = handleExpectedCommandError(error, deps);
+    if (handled !== null) return handled;
+    throw error;
+  }
+}

--- a/packages/tlon-skill/scripts/contacts.ts
+++ b/packages/tlon-skill/scripts/contacts.ts
@@ -1,0 +1,358 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Contacts management for Tlon/Urbit
+ *
+ * Usage:
+ *   npx ts-node contacts.ts list                      # List all contacts
+ *   npx ts-node contacts.ts get ~ship                 # Get a contact's profile
+ *   npx ts-node contacts.ts update-profile [options]  # Update your profile
+ */
+import {
+  getContacts,
+  getCurrentUserId,
+  poke,
+  syncUserProfiles,
+  updateContactMetadata,
+} from '@tloncorp/api';
+import type { Contact } from '@tloncorp/api';
+
+import { ensureClient, normalizeShip } from './api-client';
+import {
+  hasOptionValue,
+  isHelpArg,
+  isSubcommandHelpRequest,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+} from './cli-utils';
+
+interface ContactEditField {
+  nickname?: string;
+  bio?: string;
+  status?: string;
+  avatar?: string;
+  cover?: string;
+}
+
+const PROFILE_UPDATE_FLAGS = [
+  'nickname',
+  'bio',
+  'status',
+  'avatar',
+  'cover',
+] as const;
+
+const CONTACTS_HELP = `Usage: tlon contacts <command>
+
+Commands:
+  list                     List all contacts
+  self                     Show your profile
+  get ~ship                Get a contact's profile
+  sync ~ship [~ship2 ...]  Sync profiles
+  add ~ship                Add a contact
+  remove ~ship             Remove a contact
+  update ~ship --nickname <name> --avatar <url>
+                           Update a contact's metadata
+  update-profile [options] Update your profile
+
+Examples:
+  tlon contacts list
+  tlon contacts get ~sampel-palnet
+  tlon contacts update-profile --nickname "New Name"`;
+
+const CONTACTS_COMMAND_HELP: Record<string, string> = {
+  list: 'Usage: tlon contacts list',
+  self: 'Usage: tlon contacts self',
+  get: 'Usage: tlon contacts get ~ship',
+  sync: 'Usage: tlon contacts sync ~ship [~ship2 ...]',
+  add: 'Usage: tlon contacts add ~ship',
+  remove: 'Usage: tlon contacts remove ~ship',
+  del: 'Usage: tlon contacts remove ~ship',
+  update:
+    'Usage: tlon contacts update ~ship [--nickname <name>] [--avatar <url>]',
+  'update-profile':
+    'Usage: tlon contacts update-profile [--nickname <name>] [--bio <text>] [--status <text>] [--avatar <url>] [--cover <url>]',
+};
+
+function getContactsHelp(command?: string): string {
+  return command
+    ? CONTACTS_COMMAND_HELP[command] ?? CONTACTS_HELP
+    : CONTACTS_HELP;
+}
+
+function validateContactsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !CONTACTS_COMMAND_HELP[command]) {
+    printUsageAndExit(CONTACTS_HELP);
+  }
+
+  switch (command) {
+    case 'list':
+    case 'self':
+      return;
+    case 'get':
+    case 'sync':
+    case 'add':
+    case 'remove':
+    case 'del':
+    case 'update': {
+      if (!args[1]) printUsageAndExit(CONTACTS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'update-profile': {
+      if (
+        !PROFILE_UPDATE_FLAGS.some((flag) =>
+          hasOptionValue(args, flag, PROFILE_UPDATE_FLAGS)
+        )
+      ) {
+        printUsageAndExit(CONTACTS_COMMAND_HELP['update-profile']);
+      }
+      return;
+    }
+  }
+}
+
+// Helper to extract profile values
+// Contact has both direct fields (nickname, avatarImage) and peer fields (peerNickname, peerAvatarImage)
+function extractProfile(contact: Contact | null) {
+  if (!contact) return null;
+  return {
+    nickname: contact.nickname ?? contact.peerNickname ?? null,
+    bio: contact.bio ?? null,
+    status: contact.status ?? null,
+    avatar: contact.avatarImage ?? contact.peerAvatarImage ?? null,
+    cover: contact.coverImage ?? null,
+    color: contact.color ?? null,
+  };
+}
+
+// List all contacts and peers
+async function listContacts() {
+  const contacts = await getContacts();
+
+  return contacts.map((contact) => ({
+    ship: contact.id,
+    isContact: !!contact.isContact,
+    profile: extractProfile(contact),
+  }));
+}
+
+// Get a specific contact's profile
+async function getContact(ship: string) {
+  const normalizedShip = normalizeShip(ship);
+  const contacts = await getContacts();
+  const contact = contacts.find((c) => c.id === normalizedShip) || null;
+
+  if (contact) {
+    return {
+      ship: normalizedShip,
+      isContact: !!contact.isContact,
+      profile: extractProfile(contact),
+    };
+  }
+
+  return {
+    ship: normalizedShip,
+    isContact: false,
+    profile: null,
+    note: "Ship not in local contacts. Use 'sync' to fetch their profile.",
+  };
+}
+
+// Sync (fetch) profiles for ships
+async function syncProfiles(ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+  await syncUserProfiles(normalizedShips);
+  return { synced: normalizedShips };
+}
+
+// Update current user's profile
+async function updateProfile(updates: {
+  nickname?: string | null;
+  bio?: string;
+  status?: string;
+  avatar?: string | null;
+  cover?: string;
+}) {
+  const editFields: ContactEditField[] = [];
+
+  if (updates.nickname !== undefined) {
+    editFields.push({ nickname: updates.nickname ?? '' });
+  }
+  if (updates.bio !== undefined) {
+    editFields.push({ bio: updates.bio });
+  }
+  if (updates.status !== undefined) {
+    editFields.push({ status: updates.status });
+  }
+  if (updates.avatar !== undefined) {
+    editFields.push({ avatar: updates.avatar ?? '' });
+  }
+  if (updates.cover !== undefined) {
+    editFields.push({ cover: updates.cover });
+  }
+
+  if (editFields.length === 0) {
+    throw new Error('No profile fields to update');
+  }
+
+  await poke({
+    app: 'contacts',
+    mark: 'contact-action',
+    json: { edit: editFields },
+  });
+
+  return { updated: Object.keys(updates), ship: getCurrentUserId() };
+}
+
+// Get own profile
+async function getSelf() {
+  const currentUserId = getCurrentUserId();
+  const contacts = await getContacts();
+  const contact = contacts.find((c) => c.id === currentUserId) || null;
+
+  return {
+    ship: currentUserId,
+    profile: extractProfile(contact),
+  };
+}
+
+// Add a contact
+async function addContact(ship: string) {
+  const normalizedShip = normalizeShip(ship);
+  await poke({
+    app: 'contacts',
+    mark: 'contact-action-1',
+    json: { page: { kip: normalizedShip, contact: {} } },
+  });
+  return { added: normalizedShip };
+}
+
+// Remove a contact
+async function removeContact(ship: string) {
+  const normalizedShip = normalizeShip(ship);
+  await poke({
+    app: 'contacts',
+    mark: 'contact-action-1',
+    json: { wipe: [normalizedShip] },
+  });
+  return { removed: normalizedShip };
+}
+
+// Update a contact's metadata (nickname/avatar)
+async function updateContact(
+  ship: string,
+  updates: { nickname?: string; avatar?: string }
+) {
+  const normalizedShip = normalizeShip(ship);
+  await updateContactMetadata(normalizedShip, {
+    nickname: updates.nickname,
+    avatarImage: updates.avatar,
+  });
+  return { updated: normalizedShip };
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  try {
+    if (isHelpArg(command)) {
+      printHelpAndExit(CONTACTS_HELP);
+    }
+
+    if (isSubcommandHelpRequest(args)) {
+      printHelpAndExit(getContactsHelp(command));
+    }
+
+    validateContactsArgs(args);
+
+    await ensureClient();
+    let result: any;
+
+    switch (command) {
+      case 'list':
+        result = await listContacts();
+        break;
+
+      case 'self':
+        result = await getSelf();
+        break;
+
+      case 'get':
+        if (!args[1]) {
+          printUsageAndExit(CONTACTS_COMMAND_HELP.get);
+        }
+        result = await getContact(args[1]);
+        break;
+
+      case 'sync':
+        if (!args[1]) {
+          printUsageAndExit(CONTACTS_COMMAND_HELP.sync);
+        }
+        result = await syncProfiles(args.slice(1));
+        break;
+
+      case 'add':
+        if (!args[1]) {
+          printUsageAndExit(CONTACTS_COMMAND_HELP.add);
+        }
+        result = await addContact(args[1]);
+        break;
+
+      case 'remove':
+      case 'del':
+        if (!args[1]) {
+          printUsageAndExit(CONTACTS_COMMAND_HELP.remove);
+        }
+        result = await removeContact(args[1]);
+        break;
+
+      case 'update': {
+        const ship = args[1];
+        if (!ship) {
+          printUsageAndExit(CONTACTS_COMMAND_HELP.update);
+        }
+        const nicknameIdx = args.indexOf('--nickname');
+        const avatarIdx = args.indexOf('--avatar');
+        const nickname = nicknameIdx !== -1 ? args[nicknameIdx + 1] : undefined;
+        const avatar = avatarIdx !== -1 ? args[avatarIdx + 1] : undefined;
+        result = await updateContact(ship, { nickname, avatar });
+        break;
+      }
+
+      case 'update-profile': {
+        const nicknameIdx = args.indexOf('--nickname');
+        const bioIdx = args.indexOf('--bio');
+        const statusIdx = args.indexOf('--status');
+        const avatarIdx = args.indexOf('--avatar');
+        const coverIdx = args.indexOf('--cover');
+
+        const updates = {
+          nickname: nicknameIdx !== -1 ? args[nicknameIdx + 1] : undefined,
+          bio: bioIdx !== -1 ? args[bioIdx + 1] : undefined,
+          status: statusIdx !== -1 ? args[statusIdx + 1] : undefined,
+          avatar: avatarIdx !== -1 ? args[avatarIdx + 1] : undefined,
+          cover: coverIdx !== -1 ? args[coverIdx + 1] : undefined,
+        };
+
+        result = await updateProfile(updates);
+        break;
+      }
+
+      default:
+        printUsageAndExit(CONTACTS_HELP);
+    }
+
+    if (result) {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    process.exit(0);
+  } catch (error) {
+    printErrorAndExit(error);
+  }
+}
+
+main();

--- a/packages/tlon-skill/scripts/credential-flags.test.ts
+++ b/packages/tlon-skill/scripts/credential-flags.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'bun:test';
+
+import { CredentialFlagError, parseGlobalCliOptions } from './credential-flags';
+
+describe('credential flag parsing', () => {
+  it('parses valid credential forms without mutating command args', () => {
+    expect(
+      parseGlobalCliOptions(['--config', 'ship.json', 'contacts', 'self'])
+    ).toEqual({
+      args: ['contacts', 'self'],
+      verbose: false,
+      credentialOverrides: { kind: 'config', configFile: 'ship.json' },
+    });
+
+    expect(
+      parseGlobalCliOptions([
+        '--url',
+        'https://zod',
+        '--cookie',
+        'urbauth-~zod=0v',
+        'contacts',
+      ])
+    ).toEqual({
+      args: ['contacts'],
+      verbose: false,
+      credentialOverrides: {
+        kind: 'cookie',
+        url: 'https://zod',
+        cookie: 'urbauth-~zod=0v',
+        ship: undefined,
+        code: undefined,
+      },
+    });
+
+    expect(
+      parseGlobalCliOptions([
+        '--url',
+        'https://zod',
+        '--ship',
+        '~zod',
+        '--code',
+        'code',
+        'contacts',
+      ])
+    ).toEqual({
+      args: ['contacts'],
+      verbose: false,
+      credentialOverrides: {
+        kind: 'code',
+        url: 'https://zod',
+        ship: '~zod',
+        code: 'code',
+      },
+    });
+
+    expect(
+      parseGlobalCliOptions(['--ship=~zod', '--verbose', 'contacts'])
+    ).toEqual({
+      args: ['contacts'],
+      verbose: true,
+      credentialOverrides: { kind: 'ship', ship: '~zod' },
+    });
+  });
+
+  it('rejects partial or conflicting credential forms', () => {
+    for (const args of [
+      ['--url', 'https://zod', 'contacts'],
+      ['--cookie', 'urbauth-~zod=0v', 'contacts'],
+      ['--ship', '~zod', '--code', 'code', 'contacts'],
+      ['--url', 'https://zod', '--ship', '~zod', 'contacts'],
+      ['--config', 'ship.json', '--cookie', 'urbauth-~zod=0v', 'contacts'],
+    ]) {
+      expect(() => parseGlobalCliOptions(args)).toThrow(CredentialFlagError);
+    }
+  });
+
+  it('rejects duplicate, empty, and missing credential flag values', () => {
+    expect(() =>
+      parseGlobalCliOptions(['--ship', '~zod', '--ship', '~bus', 'contacts'])
+    ).toThrow('Duplicate credential flag: --ship');
+    expect(() => parseGlobalCliOptions(['--cookie=', 'contacts'])).toThrow(
+      'Missing value for --cookie'
+    );
+    expect(() => parseGlobalCliOptions(['--url'])).toThrow(
+      'Missing value for --url'
+    );
+    expect(() =>
+      parseGlobalCliOptions([
+        '--url',
+        '--cookie',
+        'urbauth-~zod=0v',
+        'contacts',
+      ])
+    ).toThrow('Missing value for --url');
+    expect(() => parseGlobalCliOptions(['--url', 'contacts', 'self'])).toThrow(
+      'Missing value for --url'
+    );
+  });
+
+  it('leaves credential-like tokens after the command boundary untouched', () => {
+    expect(parseGlobalCliOptions(['groups', 'create', '--ship'])).toEqual({
+      args: ['groups', 'create', '--ship'],
+      verbose: false,
+      credentialOverrides: null,
+    });
+
+    expect(
+      parseGlobalCliOptions([
+        '--verbose',
+        'channels',
+        'create',
+        '~host/group',
+        '--url',
+      ])
+    ).toEqual({
+      args: ['channels', 'create', '~host/group', '--url'],
+      verbose: true,
+      credentialOverrides: null,
+    });
+
+    expect(
+      parseGlobalCliOptions(['contacts', '--config', 'ship.json'])
+    ).toEqual({
+      args: ['contacts', '--config', 'ship.json'],
+      verbose: false,
+      credentialOverrides: null,
+    });
+  });
+});

--- a/packages/tlon-skill/scripts/credential-flags.ts
+++ b/packages/tlon-skill/scripts/credential-flags.ts
@@ -1,0 +1,133 @@
+import type { CliCredentialOverrides } from './credential-resolver';
+import { TOP_LEVEL_COMMAND_SET } from './top-level-commands';
+
+const CREDENTIAL_FLAGS = ['config', 'url', 'ship', 'code', 'cookie'] as const;
+type CredentialFlag = (typeof CREDENTIAL_FLAGS)[number];
+
+export class CredentialFlagError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CredentialFlagError';
+  }
+}
+
+export interface ParsedGlobalCliOptions {
+  args: string[];
+  verbose: boolean;
+  credentialOverrides: CliCredentialOverrides | null;
+}
+
+function isCredentialFlagName(name: string): name is CredentialFlag {
+  return (CREDENTIAL_FLAGS as readonly string[]).includes(name);
+}
+
+function flagLabel(flag: CredentialFlag): string {
+  return `--${flag}`;
+}
+
+function invalidFormsMessage(): string {
+  return (
+    'Invalid credential flags: use one of ' +
+    '--config <file>, --url <url> --cookie <cookie> [--ship <ship>] [--code <code>], ' +
+    '--url <url> --ship <ship> --code <code>, or --ship <ship> when available in TLON_SKILL_DIR or cache.'
+  );
+}
+
+function buildCredentialOverrides(
+  flags: Partial<Record<CredentialFlag, string>>
+): CliCredentialOverrides | null {
+  const present = CREDENTIAL_FLAGS.filter((flag) => flags[flag] !== undefined);
+  if (present.length === 0) return null;
+
+  const configFile = flags.config;
+  const url = flags.url;
+  const ship = flags.ship;
+  const code = flags.code;
+  const cookie = flags.cookie;
+
+  if (configFile) {
+    if (present.length > 1) {
+      throw new CredentialFlagError(
+        'Invalid credential flags: --config cannot be combined with --url, --ship, --code, or --cookie.'
+      );
+    }
+    return { kind: 'config', configFile };
+  }
+
+  if (url && cookie) {
+    return { kind: 'cookie', url, cookie, ship, code };
+  }
+
+  if (url && ship && code) {
+    return { kind: 'code', url, ship, code };
+  }
+
+  if (ship && !url && !code && !cookie) {
+    return { kind: 'ship', ship };
+  }
+
+  throw new CredentialFlagError(invalidFormsMessage());
+}
+
+export function parseGlobalCliOptions(
+  rawArgs: string[],
+  knownCommands: ReadonlySet<string> = TOP_LEVEL_COMMAND_SET
+): ParsedGlobalCliOptions {
+  const flags: Partial<Record<CredentialFlag, string>> = {};
+  const seen = new Set<CredentialFlag>();
+  const args: string[] = [];
+  let verbose = false;
+
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+
+    if (arg === '--verbose') {
+      verbose = true;
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      const inlineMatch = arg.match(/^--([^=]+)=(.*)$/);
+      const flagName = inlineMatch ? inlineMatch[1] : arg.slice(2);
+
+      if (isCredentialFlagName(flagName)) {
+        const flag = flagName;
+        if (seen.has(flag)) {
+          throw new CredentialFlagError(
+            `Duplicate credential flag: ${flagLabel(flag)}`
+          );
+        }
+        seen.add(flag);
+
+        if (inlineMatch) {
+          const value = inlineMatch[2];
+          if (value.length === 0) {
+            throw new CredentialFlagError(
+              `Missing value for ${flagLabel(flag)}`
+            );
+          }
+          flags[flag] = value;
+          continue;
+        }
+
+        const value = rawArgs[i + 1];
+        if (!value || value.startsWith('--') || knownCommands.has(value)) {
+          throw new CredentialFlagError(`Missing value for ${flagLabel(flag)}`);
+        }
+
+        flags[flag] = value;
+        i += 1;
+        continue;
+      }
+    }
+
+    args.push(...rawArgs.slice(i));
+    break;
+  }
+
+  return {
+    args,
+    verbose,
+    credentialOverrides: buildCredentialOverrides(flags),
+  };
+}

--- a/packages/tlon-skill/scripts/credential-resolver.test.ts
+++ b/packages/tlon-skill/scripts/credential-resolver.test.ts
@@ -1,0 +1,614 @@
+import { describe, expect, it } from 'bun:test';
+import * as path from 'path';
+
+import {
+  type CredentialResolverInput,
+  type ResolverFileSystem,
+  getCachePath,
+  readCachedEntryForShip,
+  resolveCredentials,
+} from './credential-resolver';
+
+const HOME = '/tmp/tlon-home';
+const CACHE_DIR = '/tmp/tlon-cache';
+const SKILL_DIR = '/tmp/tlon-skill-dir';
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function memoryFs(files: Record<string, string>): ResolverFileSystem {
+  return {
+    exists(filePath) {
+      if (files[filePath] !== undefined) return true;
+      return Object.keys(files).some(
+        (entry) => path.dirname(entry) === filePath
+      );
+    },
+    readFile(filePath) {
+      const value = files[filePath];
+      if (value === undefined) {
+        throw new Error(`missing file: ${filePath}`);
+      }
+      return value;
+    },
+    readDir(dirPath) {
+      return Object.keys(files)
+        .filter((entry) => path.dirname(entry) === dirPath)
+        .map((entry) => path.basename(entry));
+    },
+  };
+}
+
+function baseInput(
+  files: Record<string, string> = {},
+  env: Record<string, string | undefined> = {}
+): CredentialResolverInput {
+  return {
+    env,
+    fs: memoryFs(files),
+    cacheDir: CACHE_DIR,
+    homeDir: HOME,
+  };
+}
+
+function cacheFile(
+  ship: string,
+  url = `https://${ship}.tlon.network`,
+  cookie = `urbauth-~${ship}=0v-cache`
+) {
+  return json({ url, ship, cookie, cachedAt: 1 });
+}
+
+describe('credential resolver', () => {
+  it('lets CLI URL+cookie beat ambient TLON_CONFIG_FILE', () => {
+    const result = resolveCredentials({
+      ...baseInput({}, { TLON_CONFIG_FILE: '/tmp/missing.json' }),
+      cli: {
+        kind: 'cookie',
+        url: 'https://cli.tlon.network',
+        cookie: 'urbauth-~zod=0v-cookie',
+      },
+    });
+
+    expect(result.origin).toBe('cli');
+    expect(result.authKind).toBe('cookie');
+    expect(result.config).toMatchObject({
+      url: 'https://cli.tlon.network',
+      ship: 'zod',
+    });
+    expect(result.mayReadAuthCache).toBe(false);
+  });
+
+  it('lets CLI --ship beat ambient URBIT_SHIP for targeted cache lookup', () => {
+    const files = {
+      [getCachePath(CACHE_DIR, 'zod')]: cacheFile('zod'),
+      [getCachePath(CACHE_DIR, 'bus')]: cacheFile('bus'),
+    };
+
+    const result = resolveCredentials({
+      ...baseInput(files, { URBIT_SHIP: '~bus' }),
+      cli: { kind: 'ship', ship: '~zod' },
+    });
+
+    expect(result.origin).toBe('ship-cache');
+    expect(result.config.ship).toBe('zod');
+    expect(result.authKind).toBe('cached-cookie');
+    expect(result.provenance.selectedBy).toBe('cli');
+  });
+
+  it('lets CLI --ship plus TLON_SKILL_DIR beat ambient TLON_CONFIG_FILE and ship cache', () => {
+    const files = {
+      '/tmp/env-config.json': json({
+        url: 'https://env.tlon.network',
+        cookie: 'urbauth-~env=0v-cookie',
+      }),
+      [path.join(SKILL_DIR, 'ships', 'zod.json')]: json({
+        url: 'https://skill.tlon.network',
+        cookie: 'urbauth-~zod=0v-skill',
+      }),
+      [getCachePath(CACHE_DIR, 'zod')]: cacheFile(
+        'zod',
+        'https://cache.tlon.network'
+      ),
+    };
+
+    const result = resolveCredentials({
+      ...baseInput(files, {
+        TLON_CONFIG_FILE: '/tmp/env-config.json',
+        TLON_SKILL_DIR: SKILL_DIR,
+      }),
+      cli: { kind: 'ship', ship: '~zod' },
+    });
+
+    expect(result.origin).toBe('skill-dir');
+    expect(result.config.url).toBe('https://skill.tlon.network');
+    expect(result.provenance.ship).toBe('cli');
+    expect(result.mayReadAuthCache).toBe(false);
+  });
+
+  it('lets CLI --ship use cache when TLON_SKILL_DIR is set but the ship file is missing', () => {
+    const files = {
+      [getCachePath(CACHE_DIR, 'zod')]: cacheFile(
+        'zod',
+        'https://cache.tlon.network'
+      ),
+    };
+
+    const result = resolveCredentials({
+      ...baseInput(files, { TLON_SKILL_DIR: SKILL_DIR }),
+      cli: { kind: 'ship', ship: '~zod' },
+    });
+
+    expect(result.origin).toBe('ship-cache');
+    expect(result.config.url).toBe('https://cache.tlon.network');
+    expect(result.provenance.selectedBy).toBe('cli');
+  });
+
+  it('fails when CLI --ship finds an invalid TLON_SKILL_DIR file even if cache exists', () => {
+    const files = {
+      [path.join(SKILL_DIR, 'ships', 'zod.json')]: json({
+        url: 'https://skill.tlon.network',
+      }),
+      [getCachePath(CACHE_DIR, 'zod')]: cacheFile(
+        'zod',
+        'https://cache.tlon.network'
+      ),
+    };
+
+    expect(() =>
+      resolveCredentials({
+        ...baseInput(files, { TLON_SKILL_DIR: SKILL_DIR }),
+        cli: { kind: 'ship', ship: '~zod' },
+      })
+    ).toThrow('Invalid config');
+  });
+
+  it('preserves URBIT_* alias precedence while allowing mixed aliases for cookie auth', () => {
+    const result = resolveCredentials(
+      baseInput(
+        {},
+        {
+          URBIT_URL: 'https://urbit-url.tlon.network',
+          TLON_URL: 'https://tlon-url.tlon.network',
+          TLON_COOKIE: 'urbauth-~zod=0v-cookie',
+        }
+      )
+    );
+
+    expect(result.origin).toBe('env-cookie');
+    expect(result.config.url).toBe('https://urbit-url.tlon.network');
+    expect(result.config.ship).toBe('zod');
+  });
+
+  it('preserves mixed aliases for URL + ship + code auth', () => {
+    const result = resolveCredentials(
+      baseInput(
+        {},
+        {
+          TLON_URL: 'https://tlon-url.tlon.network',
+          URBIT_SHIP: '~bus',
+          TLON_CODE: 'code-from-tlon',
+        }
+      )
+    );
+
+    expect(result.origin).toBe('env-code');
+    expect(result.authKind).toBe('code');
+    expect(result.config).toMatchObject({
+      url: 'https://tlon-url.tlon.network',
+      ship: 'bus',
+      code: 'code-from-tlon',
+    });
+  });
+
+  it('fails partial ambient credential env instead of falling through', () => {
+    expect(() =>
+      resolveCredentials(
+        baseInput({}, { URBIT_URL: 'https://zod.tlon.network' })
+      )
+    ).toThrow('Invalid ambient credentials');
+    expect(() =>
+      resolveCredentials(
+        baseInput({}, { TLON_COOKIE: 'urbauth-~zod=0v-cookie' })
+      )
+    ).toThrow('Invalid ambient credentials');
+    expect(() =>
+      resolveCredentials(
+        baseInput({}, { TLON_SHIP: '~zod', TLON_CODE: 'code' })
+      )
+    ).toThrow('Invalid ambient credentials');
+  });
+
+  it('allows ship-only ambient env for targeted cache lookup', () => {
+    const files = { [getCachePath(CACHE_DIR, 'zod')]: cacheFile('zod') };
+
+    const result = resolveCredentials(baseInput(files, { TLON_SHIP: '~zod' }));
+
+    expect(result.origin).toBe('ship-cache');
+    expect(result.config.ship).toBe('zod');
+    expect(result.provenance.selectedBy).toBe('env');
+  });
+
+  it('loads TLON_CONFIG_FILE with cookie credentials', () => {
+    const files = {
+      '/tmp/zod.json': json({
+        url: 'https://zod.tlon.network',
+        cookie: 'urbauth-~zod=0v-cookie',
+      }),
+    };
+
+    const result = resolveCredentials(
+      baseInput(files, { TLON_CONFIG_FILE: '/tmp/zod.json' })
+    );
+
+    expect(result.origin).toBe('config-file');
+    expect(result.authKind).toBe('cookie');
+    expect(result.config.ship).toBe('zod');
+  });
+
+  it('does not read cache when TLON_CONFIG_FILE provides code credentials', () => {
+    const files = {
+      '/tmp/zod.json': json({
+        url: 'https://zod.tlon.network',
+        ship: '~zod',
+        code: 'code',
+      }),
+      [getCachePath(CACHE_DIR, 'zod')]: 'not json',
+    };
+
+    const result = resolveCredentials(
+      baseInput(files, { TLON_CONFIG_FILE: '/tmp/zod.json' })
+    );
+
+    expect(result.origin).toBe('config-file');
+    expect(result.authKind).toBe('code');
+    expect(result.mayReadAuthCache).toBe(false);
+  });
+
+  it('derives ship from URL+cookie and lets explicit ship override the cookie ship', () => {
+    const derived = resolveCredentials(
+      baseInput(
+        {},
+        {
+          URBIT_URL: 'https://zod.tlon.network',
+          URBIT_COOKIE: 'urbauth-~zod=0v-cookie',
+        }
+      )
+    );
+    const explicit = resolveCredentials({
+      ...baseInput(),
+      cli: {
+        kind: 'cookie',
+        url: 'https://bus.tlon.network',
+        ship: '~bus',
+        cookie: 'urbauth-~zod=0v-cookie',
+      },
+    });
+
+    expect(derived.config.ship).toBe('zod');
+    expect(derived.provenance.ship).toBe('cookie');
+    expect(explicit.config.ship).toBe('bus');
+    expect(explicit.provenance.ship).toBe('cli');
+  });
+
+  it('does not read cache for URL + ship + code credentials', () => {
+    const files = { [getCachePath(CACHE_DIR, 'zod')]: 'not json' };
+
+    const result = resolveCredentials(
+      baseInput(files, {
+        URBIT_URL: 'https://zod.tlon.network',
+        URBIT_SHIP: '~zod',
+        URBIT_CODE: 'code',
+      })
+    );
+
+    expect(result.origin).toBe('env-code');
+    expect(result.authKind).toBe('code');
+    expect(result.mayReadAuthCache).toBe(false);
+  });
+
+  it('records fallback code for explicit cookie credentials', () => {
+    const result = resolveCredentials({
+      ...baseInput(),
+      cli: {
+        kind: 'cookie',
+        url: 'https://zod.tlon.network',
+        cookie: 'urbauth-~zod=0v-cookie',
+        code: 'fallback-code',
+      },
+    });
+
+    expect(result.authKind).toBe('cookie');
+    expect(result.fallbackCode).toBe('fallback-code');
+    expect(result.mayWriteAuthCache).toBe(true);
+  });
+
+  it('lets TLON_SHIP + TLON_SKILL_DIR beat an existing cache entry', () => {
+    const files = {
+      [path.join(SKILL_DIR, 'ships', 'zod.json')]: json({
+        url: 'https://skill.tlon.network',
+        cookie: 'urbauth-~zod=0v-skill',
+      }),
+      [getCachePath(CACHE_DIR, 'zod')]: cacheFile(
+        'zod',
+        'https://cache.tlon.network'
+      ),
+    };
+
+    const result = resolveCredentials(
+      baseInput(files, { TLON_SHIP: '~zod', TLON_SKILL_DIR: SKILL_DIR })
+    );
+
+    expect(result.origin).toBe('skill-dir');
+    expect(result.config.url).toBe('https://skill.tlon.network');
+  });
+
+  it('lets TLON_SHIP use cache when TLON_SKILL_DIR is set but the ship file is missing', () => {
+    const files = {
+      [getCachePath(CACHE_DIR, 'zod')]: cacheFile(
+        'zod',
+        'https://cache.tlon.network'
+      ),
+    };
+
+    const result = resolveCredentials(
+      baseInput(files, { TLON_SHIP: '~zod', TLON_SKILL_DIR: SKILL_DIR })
+    );
+
+    expect(result.origin).toBe('ship-cache');
+    expect(result.config.url).toBe('https://cache.tlon.network');
+    expect(result.provenance.selectedBy).toBe('env');
+  });
+
+  it('loads OpenClaw JSON fallback and preserves legacy JSON fallbacks', () => {
+    const openclawJson = path.join(HOME, '.openclaw', 'openclaw.json');
+    const clawdbotLegacyJson = path.join(HOME, '.clawdbot', 'moltbot.json');
+    const moltbotLegacyJson = path.join(HOME, '.moltbot', 'moltbot.json');
+
+    const direct = resolveCredentials(
+      baseInput({
+        [openclawJson]: json({
+          channels: {
+            tlon: {
+              url: 'https://zod.tlon.network',
+              cookie: 'urbauth-~zod=0v-openclaw',
+            },
+          },
+        }),
+      })
+    );
+    const clawdbotLegacy = resolveCredentials(
+      baseInput({
+        [clawdbotLegacyJson]: json({
+          channels: {
+            tlon: {
+              url: 'https://bus.tlon.network',
+              ship: '~bus',
+              code: 'legacy-code',
+            },
+          },
+        }),
+      })
+    );
+    const moltbotLegacy = resolveCredentials(
+      baseInput({
+        [moltbotLegacyJson]: json({
+          channels: {
+            tlon: {
+              url: 'https://nec.tlon.network',
+              ship: '~nec',
+              code: 'moltbot-code',
+            },
+          },
+        }),
+      })
+    );
+
+    expect(direct.origin).toBe('openclaw');
+    expect(direct.authKind).toBe('cookie');
+    expect(clawdbotLegacy.origin).toBe('openclaw');
+    expect(clawdbotLegacy.config.ship).toBe('bus');
+    expect(moltbotLegacy.origin).toBe('openclaw');
+    expect(moltbotLegacy.config.ship).toBe('nec');
+  });
+
+  it('skips unusable default OpenClaw JSON and continues to later defaults', () => {
+    const files = {
+      [path.join(HOME, '.openclaw', 'openclaw.json')]: json({ channels: {} }),
+      [path.join(HOME, '.clawdbot', 'moltbot.json')]: json({
+        channels: {
+          tlon: {
+            url: 'https://bus.tlon.network',
+            ship: '~bus',
+            code: 'legacy-code',
+          },
+        },
+      }),
+    };
+
+    const result = resolveCredentials(baseInput(files));
+
+    expect(result.origin).toBe('openclaw');
+    expect(result.provenance.openclawPath).toBe(
+      path.join(HOME, '.clawdbot', 'moltbot.json')
+    );
+    expect(result.config.ship).toBe('bus');
+  });
+
+  it('treats explicit OPENCLAW_CONFIG parse errors and unusable JSON as local errors', () => {
+    expect(() =>
+      resolveCredentials(
+        baseInput(
+          { '/tmp/openclaw.txt': 'not json' },
+          { OPENCLAW_CONFIG: '/tmp/openclaw.txt' }
+        )
+      )
+    ).toThrow('Failed to parse OpenClaw config');
+
+    expect(() =>
+      resolveCredentials(
+        baseInput(
+          { '/tmp/openclaw.json': json({ channels: {} }) },
+          { OPENCLAW_CONFIG: '/tmp/openclaw.json' }
+        )
+      )
+    ).toThrow('missing channels.tlon');
+
+    expect(() =>
+      resolveCredentials(
+        baseInput(
+          {
+            '/tmp/openclaw.json': json({
+              channels: {
+                tlon: { url: '${TLON_URL}', ship: '~zod', code: 'code' },
+              },
+            }),
+          },
+          { OPENCLAW_CONFIG: '/tmp/openclaw.json' }
+        )
+      )
+    ).toThrow('placeholder');
+
+    expect(() =>
+      resolveCredentials(
+        baseInput(
+          {
+            '/tmp/openclaw.json': json({
+              channels: {
+                tlon: { url: 'https://zod.tlon.network', code: 'code' },
+              },
+            }),
+          },
+          { OPENCLAW_CONFIG: '/tmp/openclaw.json' }
+        )
+      )
+    ).toThrow('must have tlon.ship');
+
+    expect(() =>
+      resolveCredentials(
+        baseInput(
+          {
+            '/tmp/openclaw.json': json({
+              channels: {
+                tlon: { url: 'https://zod.tlon.network', ship: '~zod' },
+              },
+            }),
+          },
+          { OPENCLAW_CONFIG: '/tmp/openclaw.json' }
+        )
+      )
+    ).toThrow('must have tlon.code or tlon.cookie');
+  });
+
+  it('does not let stale default YAML mask the real OpenClaw JSON path', () => {
+    const files = {
+      [path.join(HOME, '.openclaw', 'openclaw.yaml')]: 'not json',
+      [path.join(HOME, '.openclaw', 'openclaw.json')]: json({
+        channels: {
+          tlon: {
+            url: 'https://zod.tlon.network',
+            ship: '~zod',
+            code: 'json-code',
+          },
+        },
+      }),
+    };
+
+    const result = resolveCredentials(baseInput(files));
+
+    expect(result.origin).toBe('openclaw');
+    expect(result.config.code).toBe('json-code');
+  });
+
+  it('fails targeted cache lookup when the cache file is invalid or mismatched', () => {
+    expect(() =>
+      readCachedEntryForShip(
+        CACHE_DIR,
+        '~zod',
+        memoryFs({ [getCachePath(CACHE_DIR, 'zod')]: 'not json' })
+      )
+    ).toThrow('Invalid cache entry');
+    expect(() =>
+      readCachedEntryForShip(
+        CACHE_DIR,
+        '~zod',
+        memoryFs({
+          [getCachePath(CACHE_DIR, 'zod')]: json({
+            url: 'https://zod.tlon.network',
+            ship: 'zod',
+          }),
+        })
+      )
+    ).toThrow('must have url, ship, and cookie');
+    expect(() =>
+      readCachedEntryForShip(
+        CACHE_DIR,
+        '~zod',
+        memoryFs({
+          [getCachePath(CACHE_DIR, 'zod')]: json({
+            url: 'https://zod.tlon.network',
+            ship: 'bus',
+            cookie: 'c',
+          }),
+        })
+      )
+    ).toThrow('does not match');
+    expect(() =>
+      readCachedEntryForShip(
+        CACHE_DIR,
+        '~zod',
+        memoryFs({
+          [getCachePath(CACHE_DIR, 'zod')]: cacheFile(
+            'zod',
+            'https://old.tlon.network'
+          ),
+        }),
+        'https://new.tlon.network'
+      )
+    ).toThrow('stored URL');
+  });
+
+  it('auto-selects exactly one cached ship and errors on multiple or duplicate cached ships', () => {
+    const single = resolveCredentials(
+      baseInput({ [getCachePath(CACHE_DIR, 'zod')]: cacheFile('zod') })
+    );
+    expect(single.origin).toBe('single-cache');
+
+    const singleWithInvalid = resolveCredentials(
+      baseInput({
+        [path.join(CACHE_DIR, 'invalid.json')]: json({
+          url: 'https://invalid.tlon.network',
+          ship: 'invalid',
+        }),
+        [getCachePath(CACHE_DIR, 'zod')]: cacheFile('zod'),
+      })
+    );
+    expect(singleWithInvalid.origin).toBe('single-cache');
+    expect(singleWithInvalid.config.ship).toBe('zod');
+
+    expect(() =>
+      resolveCredentials(
+        baseInput({
+          [getCachePath(CACHE_DIR, 'zod')]: cacheFile('zod'),
+          [getCachePath(CACHE_DIR, 'bus')]: cacheFile('bus'),
+        })
+      )
+    ).toThrow('Multiple cached ships');
+
+    expect(() =>
+      resolveCredentials(
+        baseInput({
+          [path.join(CACHE_DIR, 'zod.json')]: cacheFile('zod'),
+          [path.join(CACHE_DIR, '~zod.json')]: cacheFile('~zod'),
+        })
+      )
+    ).toThrow('Duplicate cached credentials');
+  });
+
+  it('reports missing config when no source resolves', () => {
+    expect(() => resolveCredentials(baseInput())).toThrow(
+      'Missing Urbit config'
+    );
+  });
+});

--- a/packages/tlon-skill/scripts/credential-resolver.ts
+++ b/packages/tlon-skill/scripts/credential-resolver.ts
@@ -1,0 +1,714 @@
+import * as path from 'path';
+
+export interface UrbitConfig {
+  url: string;
+  ship: string;
+  /** Access code (required unless cookie is provided/cached) */
+  code: string;
+  /** Pre-authenticated cookie (optional, bypasses code-based auth) */
+  cookie?: string;
+}
+
+export interface CachedAuth {
+  url: string;
+  ship: string;
+  cookie: string;
+  cachedAt?: number;
+}
+
+export type CredentialOrigin =
+  | 'cli'
+  | 'config-file'
+  | 'env-cookie'
+  | 'env-code'
+  | 'skill-dir'
+  | 'openclaw'
+  | 'ship-cache'
+  | 'single-cache';
+
+export type AuthKind = 'cookie' | 'code' | 'cached-cookie';
+
+export type ShipProvenance =
+  | 'cli'
+  | 'env'
+  | 'cookie'
+  | 'config-file'
+  | 'skill-dir'
+  | 'openclaw'
+  | 'cache';
+
+export interface CredentialResolution {
+  config: UrbitConfig;
+  origin: CredentialOrigin;
+  authKind: AuthKind;
+  mayReadAuthCache: boolean;
+  mayWriteAuthCache: boolean;
+  fallbackCode?: string;
+  provenance: {
+    selectedBy?: 'cli' | 'env' | 'fallback';
+    ship?: ShipProvenance;
+    configPath?: string;
+    cachePath?: string;
+    openclawPath?: string;
+  };
+}
+
+export type CliCredentialOverrides =
+  | { kind: 'config'; configFile: string }
+  | {
+      kind: 'cookie';
+      url: string;
+      cookie: string;
+      ship?: string;
+      code?: string;
+    }
+  | { kind: 'code'; url: string; ship: string; code: string }
+  | { kind: 'ship'; ship: string };
+
+export interface ResolverFileSystem {
+  exists(filePath: string): boolean;
+  readFile(filePath: string): string;
+  readDir(dirPath: string): string[];
+}
+
+export interface CredentialResolverInput {
+  env: Record<string, string | undefined>;
+  fs: ResolverFileSystem;
+  cacheDir: string;
+  homeDir: string;
+  cli?: CliCredentialOverrides | null;
+  openclawDefaultPaths?: string[];
+}
+
+interface CachedAuthCandidate extends CachedAuth {
+  cachePath: string;
+}
+
+type TopLevelConfigSource = 'config-file' | 'skill-dir';
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function normalizeShipName(ship: string): string {
+  return ship.replace(/^~/, '');
+}
+
+function withSig(ship: string): string {
+  return `~${normalizeShipName(ship)}`;
+}
+
+export function parseShipFromCookie(cookie: string): string | null {
+  const match = cookie.match(/urbauth-~?([a-z-]+)=/);
+  return match ? match[1] : null;
+}
+
+function parseJsonFile(filePath: string, fsDeps: ResolverFileSystem): unknown {
+  try {
+    return JSON.parse(fsDeps.readFile(filePath));
+  } catch (err: any) {
+    throw new Error(`Failed to parse config ${filePath}: ${err.message}`);
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function makeResolution(
+  config: UrbitConfig,
+  origin: CredentialOrigin,
+  authKind: AuthKind,
+  provenance: CredentialResolution['provenance'],
+  fallbackCode?: string
+): CredentialResolution {
+  return {
+    config,
+    origin,
+    authKind,
+    mayReadAuthCache: authKind === 'cached-cookie',
+    mayWriteAuthCache: authKind === 'code' || !!fallbackCode,
+    fallbackCode,
+    provenance,
+  };
+}
+
+function resolutionFromTopLevelConfig(
+  filePath: string,
+  fsDeps: ResolverFileSystem,
+  origin: TopLevelConfigSource,
+  selectedBy: 'cli' | 'env',
+  shipProvenance: ShipProvenance = origin,
+  forcedShip?: string
+): CredentialResolution {
+  if (!fsDeps.exists(filePath)) {
+    throw new Error(`Ship config not found: ${filePath}`);
+  }
+
+  const data = asObject(parseJsonFile(filePath, fsDeps));
+  if (!nonEmpty(data.url)) {
+    throw new Error('Invalid config: must have url');
+  }
+
+  const code = nonEmpty(data.code) ? data.code : '';
+  const cookie = nonEmpty(data.cookie) ? data.cookie : undefined;
+  if (!code && !cookie) {
+    throw new Error('Invalid config: must have code or cookie');
+  }
+
+  let ship = forcedShip
+    ? normalizeShipName(forcedShip)
+    : nonEmpty(data.ship)
+      ? normalizeShipName(data.ship)
+      : null;
+  if (
+    forcedShip &&
+    nonEmpty(data.ship) &&
+    normalizeShipName(data.ship) !== ship
+  ) {
+    throw new Error(
+      `Invalid config: ship ${withSig(data.ship)} does not match requested ship ${withSig(forcedShip)}`
+    );
+  }
+  let derivedShip = false;
+  if (!ship && cookie) {
+    ship = parseShipFromCookie(cookie);
+    derivedShip = !!ship;
+  }
+  if (!ship) {
+    throw new Error(
+      'Invalid config: must have ship (or cookie with ship in name)'
+    );
+  }
+
+  const config = {
+    url: data.url,
+    ship,
+    code,
+    cookie,
+  };
+  const authKind: AuthKind = cookie ? 'cookie' : 'code';
+  return makeResolution(
+    config,
+    origin,
+    authKind,
+    {
+      selectedBy,
+      ship: forcedShip
+        ? shipProvenance
+        : derivedShip
+          ? 'cookie'
+          : shipProvenance,
+      configPath: filePath,
+    },
+    cookie && code ? code : undefined
+  );
+}
+
+function envAlias(
+  env: Record<string, string | undefined>,
+  urbitName: string,
+  tlonName: string
+): string | undefined {
+  return nonEmpty(env[urbitName])
+    ? env[urbitName]
+    : nonEmpty(env[tlonName])
+      ? env[tlonName]
+      : undefined;
+}
+
+function validateAmbientPartial(
+  url: string | undefined,
+  ship: string | undefined,
+  cookie: string | undefined,
+  code: string | undefined
+): void {
+  const hasAnyCredential = !!url || !!ship || !!cookie || !!code;
+  if (!hasAnyCredential) return;
+
+  const shipOnly = !!ship && !url && !cookie && !code;
+  const cookieForm = !!url && !!cookie;
+  const codeForm = !!url && !!ship && !!code;
+  if (shipOnly || cookieForm || codeForm) return;
+
+  throw new Error(
+    'Invalid ambient credentials: use URBIT_URL/TLON_URL with URBIT_COOKIE/TLON_COOKIE, ' +
+      'or URL + SHIP + CODE. Ship-only env is only valid for skill-dir/cache lookup.'
+  );
+}
+
+function resolutionFromCookie(
+  origin: CredentialOrigin,
+  url: string,
+  cookie: string,
+  ship: string | undefined,
+  code: string | undefined,
+  selectedBy: 'cli' | 'env',
+  explicitShipProvenance: ShipProvenance
+): CredentialResolution {
+  const derivedShip = ship
+    ? normalizeShipName(ship)
+    : parseShipFromCookie(cookie);
+  if (!derivedShip) {
+    throw new Error(
+      'Invalid config: must have ship (or cookie with ship in name)'
+    );
+  }
+
+  const fallbackCode = code || undefined;
+  return makeResolution(
+    {
+      url,
+      ship: derivedShip,
+      code: fallbackCode || '',
+      cookie,
+    },
+    origin,
+    'cookie',
+    {
+      selectedBy,
+      ship: ship ? explicitShipProvenance : 'cookie',
+    },
+    fallbackCode
+  );
+}
+
+function resolutionFromCode(
+  origin: CredentialOrigin,
+  url: string,
+  ship: string,
+  code: string,
+  selectedBy: 'cli' | 'env',
+  shipProvenance: ShipProvenance
+): CredentialResolution {
+  return makeResolution(
+    {
+      url,
+      ship: normalizeShipName(ship),
+      code,
+    },
+    origin,
+    'code',
+    {
+      selectedBy,
+      ship: shipProvenance,
+    }
+  );
+}
+
+export function getDefaultOpenClawConfigPaths(homeDir: string): string[] {
+  return [
+    path.join(homeDir, '.openclaw', 'openclaw.json'),
+    path.join(homeDir, '.clawdbot', 'moltbot.json'),
+    path.join(homeDir, '.moltbot', 'moltbot.json'),
+  ];
+}
+
+function hasPlaceholder(value: string | undefined): boolean {
+  return !!value && (value.includes('${') || /^<[^>]+>$/.test(value));
+}
+
+function parseOpenClawConfig(
+  filePath: string,
+  fsDeps: ResolverFileSystem
+): CredentialResolution {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fsDeps.readFile(filePath));
+  } catch (err: any) {
+    throw new Error(
+      `Failed to parse OpenClaw config ${filePath}: ${err.message}`
+    );
+  }
+
+  const root = asObject(parsed);
+  const channels = asObject(root.channels);
+  const tlon = asObject(channels.tlon);
+
+  if (!root.channels || !channels.tlon) {
+    throw new Error(
+      `OpenClaw config unusable: missing channels.tlon in ${filePath}`
+    );
+  }
+
+  const url = nonEmpty(tlon.url) ? tlon.url : undefined;
+  const code = nonEmpty(tlon.code) ? tlon.code : '';
+  const cookie = nonEmpty(tlon.cookie) ? tlon.cookie : undefined;
+  const rawShip = nonEmpty(tlon.ship) ? tlon.ship : undefined;
+
+  if (
+    hasPlaceholder(url) ||
+    hasPlaceholder(code) ||
+    hasPlaceholder(cookie) ||
+    hasPlaceholder(rawShip)
+  ) {
+    throw new Error(
+      `OpenClaw config unusable: contains placeholder values in ${filePath}`
+    );
+  }
+  if (!url) {
+    throw new Error(
+      `OpenClaw config unusable: missing tlon.url in ${filePath}`
+    );
+  }
+  if (!code && !cookie) {
+    throw new Error(
+      `OpenClaw config unusable: must have tlon.code or tlon.cookie in ${filePath}`
+    );
+  }
+
+  let ship = rawShip ? normalizeShipName(rawShip) : null;
+  let derivedShip = false;
+  if (!ship && cookie) {
+    ship = parseShipFromCookie(cookie);
+    derivedShip = !!ship;
+  }
+  if (!ship) {
+    throw new Error(
+      `OpenClaw config unusable: must have tlon.ship or cookie ship in ${filePath}`
+    );
+  }
+
+  return makeResolution(
+    {
+      url,
+      ship,
+      code,
+      cookie,
+    },
+    'openclaw',
+    cookie ? 'cookie' : 'code',
+    {
+      selectedBy: 'fallback',
+      ship: derivedShip ? 'cookie' : 'openclaw',
+      openclawPath: filePath,
+    },
+    cookie && code ? code : undefined
+  );
+}
+
+function resolveOpenClaw(
+  input: CredentialResolverInput
+): CredentialResolution | null {
+  const explicitPath = input.env.OPENCLAW_CONFIG;
+  if (nonEmpty(explicitPath)) {
+    if (!input.fs.exists(explicitPath)) return null;
+    return parseOpenClawConfig(explicitPath, input.fs);
+  }
+
+  const paths =
+    input.openclawDefaultPaths ?? getDefaultOpenClawConfigPaths(input.homeDir);
+  for (const configPath of paths) {
+    if (!input.fs.exists(configPath)) continue;
+    try {
+      return parseOpenClawConfig(configPath, input.fs);
+    } catch {
+      // Default OpenClaw discovery is best-effort. Explicit OPENCLAW_CONFIG is authoritative.
+    }
+  }
+
+  return null;
+}
+
+export function getCachePath(cacheDir: string, ship: string): string {
+  return path.join(cacheDir, `${normalizeShipName(ship)}.json`);
+}
+
+function cacheError(message: string): Error {
+  return new Error(`Invalid cache entry: ${message}`);
+}
+
+function parseCacheFile(
+  filePath: string,
+  raw: string,
+  expected?: { ship?: string; url?: string }
+): CachedAuthCandidate {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    throw cacheError(`${filePath} is not valid JSON: ${err.message}`);
+  }
+
+  const data = asObject(parsed);
+  if (!nonEmpty(data.url) || !nonEmpty(data.ship) || !nonEmpty(data.cookie)) {
+    throw cacheError(`${filePath} must have url, ship, and cookie`);
+  }
+
+  const storedShip = normalizeShipName(data.ship);
+  const fileShip = normalizeShipName(path.basename(filePath, '.json'));
+  if (fileShip !== storedShip) {
+    throw cacheError(
+      `${filePath} filename ship ${withSig(fileShip)} does not match stored ship ${withSig(storedShip)}`
+    );
+  }
+
+  if (expected?.ship && storedShip !== normalizeShipName(expected.ship)) {
+    throw cacheError(
+      `${filePath} stored ship ${withSig(storedShip)} does not match requested ship ${withSig(expected.ship)}`
+    );
+  }
+
+  if (expected?.url && data.url !== expected.url) {
+    throw cacheError(
+      `${filePath} stored URL ${data.url} does not match requested URL ${expected.url}`
+    );
+  }
+
+  return {
+    url: data.url,
+    ship: storedShip,
+    cookie: data.cookie,
+    cachedAt: typeof data.cachedAt === 'number' ? data.cachedAt : undefined,
+    cachePath: filePath,
+  };
+}
+
+export function readCachedEntryForShip(
+  cacheDir: string,
+  ship: string,
+  fsDeps: ResolverFileSystem,
+  expectedUrl?: string
+): CachedAuthCandidate | null {
+  const normalizedShip = normalizeShipName(ship);
+  const cachePath = getCachePath(cacheDir, normalizedShip);
+  if (!fsDeps.exists(cachePath)) return null;
+  return parseCacheFile(cachePath, fsDeps.readFile(cachePath), {
+    ship: normalizedShip,
+    url: expectedUrl,
+  });
+}
+
+export function readCachedShipCandidates(
+  cacheDir: string,
+  fsDeps: ResolverFileSystem,
+  options: { ignoreInvalid?: boolean } = {}
+): CachedAuthCandidate[] {
+  if (!fsDeps.exists(cacheDir)) return [];
+
+  let files: string[];
+  try {
+    files = fsDeps
+      .readDir(cacheDir)
+      .filter((file) => file.endsWith('.json'))
+      .sort();
+  } catch {
+    return [];
+  }
+
+  const candidates: CachedAuthCandidate[] = [];
+  const seenShips = new Map<string, string>();
+
+  for (const file of files) {
+    const filePath = path.join(cacheDir, file);
+    let candidate: CachedAuthCandidate;
+    try {
+      candidate = parseCacheFile(filePath, fsDeps.readFile(filePath));
+    } catch (err) {
+      if (options.ignoreInvalid) continue;
+      throw err;
+    }
+
+    const previousPath = seenShips.get(candidate.ship);
+    if (previousPath) {
+      throw new Error(
+        `Duplicate cached credentials for ${withSig(candidate.ship)}: ${previousPath} and ${candidate.cachePath}`
+      );
+    }
+    seenShips.set(candidate.ship, candidate.cachePath);
+    candidates.push(candidate);
+  }
+
+  return candidates;
+}
+
+function resolutionFromCachedEntry(
+  entry: CachedAuthCandidate,
+  origin: 'ship-cache' | 'single-cache',
+  selectedBy: 'cli' | 'env' | 'fallback' = origin === 'ship-cache'
+    ? 'env'
+    : 'fallback'
+): CredentialResolution {
+  return makeResolution(
+    {
+      url: entry.url,
+      ship: entry.ship,
+      code: '',
+      cookie: entry.cookie,
+    },
+    origin,
+    'cached-cookie',
+    {
+      selectedBy,
+      ship: 'cache',
+      cachePath: entry.cachePath,
+    }
+  );
+}
+
+function resolveShipOnly(
+  input: CredentialResolverInput,
+  ship: string,
+  selectedBy: 'cli' | 'env',
+  terminalOnCacheMiss: boolean
+): CredentialResolution | null {
+  const normalizedShip = normalizeShipName(ship);
+  const skillDir = input.env.TLON_SKILL_DIR;
+  if (nonEmpty(skillDir)) {
+    const skillConfigPath = path.join(
+      skillDir,
+      'ships',
+      `${normalizedShip}.json`
+    );
+    if (input.fs.exists(skillConfigPath)) {
+      return resolutionFromTopLevelConfig(
+        skillConfigPath,
+        input.fs,
+        'skill-dir',
+        selectedBy,
+        selectedBy === 'cli' ? 'cli' : 'env',
+        normalizedShip
+      );
+    }
+  }
+
+  const cached = readCachedEntryForShip(
+    input.cacheDir,
+    normalizedShip,
+    input.fs
+  );
+  if (cached) {
+    return resolutionFromCachedEntry(cached, 'ship-cache', selectedBy);
+  }
+
+  if (terminalOnCacheMiss) {
+    throw new Error(
+      `No cached credentials found for ${withSig(normalizedShip)}. ` +
+        'Authenticate with --url + --ship + --code, or configure TLON_SKILL_DIR.'
+    );
+  }
+  return null;
+}
+
+function resolveCli(
+  input: CredentialResolverInput,
+  cli: CliCredentialOverrides
+): CredentialResolution {
+  switch (cli.kind) {
+    case 'config':
+      return resolutionFromTopLevelConfig(
+        cli.configFile,
+        input.fs,
+        'config-file',
+        'cli',
+        'config-file'
+      );
+    case 'cookie':
+      return resolutionFromCookie(
+        'cli',
+        cli.url,
+        cli.cookie,
+        cli.ship,
+        cli.code,
+        'cli',
+        'cli'
+      );
+    case 'code':
+      return resolutionFromCode(
+        'cli',
+        cli.url,
+        cli.ship,
+        cli.code,
+        'cli',
+        'cli'
+      );
+    case 'ship':
+      return resolveShipOnly(
+        input,
+        cli.ship,
+        'cli',
+        true
+      ) as CredentialResolution;
+  }
+}
+
+function missingConfigError(): Error {
+  return new Error(
+    'Missing Urbit config. Either:\n' +
+      '  - Use CLI flags: --config <file>, --url + --cookie, --url + --ship + --code, or --ship <ship> when available in TLON_SKILL_DIR or cache\n' +
+      '  - Set TLON_CONFIG_FILE to a JSON config file\n' +
+      '  - Set URBIT_URL/TLON_URL with URBIT_COOKIE/TLON_COOKIE\n' +
+      '  - Set URL + SHIP + CODE via URBIT_* or TLON_* env vars\n' +
+      '  - Set TLON_SHIP + TLON_SKILL_DIR for ships/<ship>.json\n' +
+      '  - Configure Tlon channel in OpenClaw JSON (~/.openclaw/openclaw.json)'
+  );
+}
+
+export function resolveCredentials(
+  input: CredentialResolverInput
+): CredentialResolution {
+  if (input.cli) {
+    return resolveCli(input, input.cli);
+  }
+
+  const configFile = input.env.TLON_CONFIG_FILE;
+  if (nonEmpty(configFile)) {
+    return resolutionFromTopLevelConfig(
+      configFile,
+      input.fs,
+      'config-file',
+      'env',
+      'config-file'
+    );
+  }
+
+  const url = envAlias(input.env, 'URBIT_URL', 'TLON_URL');
+  const ship = envAlias(input.env, 'URBIT_SHIP', 'TLON_SHIP');
+  const cookie = envAlias(input.env, 'URBIT_COOKIE', 'TLON_COOKIE');
+  const code = envAlias(input.env, 'URBIT_CODE', 'TLON_CODE');
+
+  validateAmbientPartial(url, ship, cookie, code);
+
+  if (url && cookie) {
+    return resolutionFromCookie(
+      'env-cookie',
+      url,
+      cookie,
+      ship,
+      code,
+      'env',
+      ship ? 'env' : 'cookie'
+    );
+  }
+
+  if (url && ship && code) {
+    return resolutionFromCode('env-code', url, ship, code, 'env', 'env');
+  }
+
+  if (ship) {
+    const shipResolution = resolveShipOnly(input, ship, 'env', false);
+    if (shipResolution) return shipResolution;
+  }
+
+  const openclawResolution = resolveOpenClaw(input);
+  if (openclawResolution) return openclawResolution;
+
+  const cachedShips = readCachedShipCandidates(input.cacheDir, input.fs, {
+    ignoreInvalid: true,
+  });
+  if (cachedShips.length === 1) {
+    return resolutionFromCachedEntry(cachedShips[0], 'single-cache');
+  }
+  if (cachedShips.length > 1) {
+    const shipList = cachedShips
+      .map((entry) => `  ${withSig(entry.ship)}`)
+      .join('\n');
+    throw new Error(
+      `Multiple cached ships found. Specify which with --ship:\n${shipList}`
+    );
+  }
+
+  throw missingConfigError();
+}

--- a/packages/tlon-skill/scripts/dms.ts
+++ b/packages/tlon-skill/scripts/dms.ts
@@ -1,0 +1,466 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Direct Message management for Tlon
+ *
+ * Note: 1:1 DM send/reply is handled by the openclaw-tlon channel plugin.
+ * This script handles club (group DM) messaging and DM management ops only.
+ *
+ * Usage:
+ *   npx ts-node scripts/dms.ts send <club-id> <message>        (group DMs only)
+ *   npx ts-node scripts/dms.ts reply <club-id> <post-id> <msg> (group DMs only)
+ *   npx ts-node scripts/dms.ts react <ship> <post-id> <emoji>
+ *   npx ts-node scripts/dms.ts unreact <ship> <post-id>
+ *   npx ts-node scripts/dms.ts delete <ship> <post-id>
+ *   npx ts-node scripts/dms.ts accept <ship>
+ *   npx ts-node scripts/dms.ts decline <ship>
+ */
+import {
+  addReaction,
+  deletePost,
+  getCurrentUserId,
+  removeReaction,
+  respondToDMInvite,
+  sendPost,
+  sendReply,
+} from '@tloncorp/api';
+import type { Channel } from '@tloncorp/api';
+
+import { ensureClient, normalizeShip } from './api-client';
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from './cli-utils';
+import { type Story, markdownToStory } from './story';
+
+const DMS_HELP = `Usage: tlon dms <command>
+
+Commands:
+  send <club-id> <message>        Send a message to a group DM
+  reply <club-id> <post-id> <msg> Reply in a group DM (post-id must include author)
+  react <ship> <post-id> <emoji>  React to a DM (post-id must include author)
+  unreact <ship> <post-id>        Remove reaction from a DM (post-id must include author)
+  delete <ship> <post-id>         Delete a DM (post-id may include author)
+  accept <ship>                   Accept a DM invite
+  decline <ship>                  Decline a DM invite`;
+
+const DMS_COMMAND_HELP: Record<string, string> = {
+  send: 'Usage: tlon dms send <club-id> <message>',
+  reply: 'Usage: tlon dms reply <club-id> <post-id> <message>',
+  react: 'Usage: tlon dms react <ship> <post-id> <emoji>',
+  unreact: 'Usage: tlon dms unreact <ship> <post-id>',
+  delete: 'Usage: tlon dms delete <ship> <post-id>',
+  accept: 'Usage: tlon dms accept <ship>',
+  decline: 'Usage: tlon dms decline <ship>',
+};
+
+function getDmsHelp(command?: string): string {
+  return command ? DMS_COMMAND_HELP[command] ?? DMS_HELP : DMS_HELP;
+}
+
+function isDmsMessageHelpLiteral(args: string[]): boolean {
+  const command = args[0];
+  if (command === 'send') {
+    return !!args[1] && wantsHelp(args.slice(2));
+  }
+  if (command === 'reply') {
+    return !!args[1] && !!args[2] && wantsHelp(args.slice(3));
+  }
+  return false;
+}
+
+function validateDmsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !DMS_COMMAND_HELP[command]) {
+    printUsageAndExit(DMS_HELP);
+  }
+
+  switch (command) {
+    case 'send': {
+      const clubId = args[1];
+      const message = args.slice(2).join(' ');
+      if (!clubId || !message) printUsageAndExit(DMS_COMMAND_HELP.send);
+      if (!isClub(clubId)) {
+        printErrorAndExit(
+          'send only supports group DMs (club IDs starting with 0v)'
+        );
+      }
+      return;
+    }
+    case 'reply': {
+      const clubId = args[1];
+      const postId = args[2];
+      const message = args.slice(3).join(' ');
+      if (!clubId || !postId || !message)
+        printUsageAndExit(DMS_COMMAND_HELP.reply);
+      if (!isClub(clubId)) {
+        printErrorAndExit(
+          'reply only supports group DMs (club IDs starting with 0v)'
+        );
+      }
+      return;
+    }
+    case 'react': {
+      if (!args[1] || !args[2] || !args[3])
+        printUsageAndExit(DMS_COMMAND_HELP.react);
+      return;
+    }
+    case 'unreact':
+    case 'delete': {
+      if (!args[1] || !args[2]) printUsageAndExit(DMS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'accept':
+    case 'decline': {
+      if (!args[1]) printUsageAndExit(DMS_COMMAND_HELP[command]);
+      return;
+    }
+  }
+}
+
+// Parse content into Story format with rich markdown support
+function parseContent(message: string): Story {
+  return markdownToStory(message);
+}
+
+// Check if the target is a group DM (club)
+function isClub(whom: string): boolean {
+  return whom.startsWith('0v');
+}
+
+function parsePostId(postId: string): { id: string; authorId?: string } {
+  if (postId.includes('/')) {
+    const [author, id] = postId.split('/');
+    return { id, authorId: normalizeShip(author) };
+  }
+  return { id: postId };
+}
+
+// Send a message to a group DM (club)
+async function sendClubMessage(
+  clubId: string,
+  message: string
+): Promise<{ success: boolean; postId?: string; error?: string }> {
+  const authorId = getCurrentUserId();
+  const sentAt = Date.now();
+  const content = parseContent(message);
+
+  try {
+    await sendPost({
+      channelId: clubId,
+      authorId,
+      sentAt,
+      content,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Reply in a club (group DM)
+async function replyToClub(
+  clubId: string,
+  postId: string,
+  message: string
+): Promise<{ success: boolean; replyId?: string; error?: string }> {
+  const authorId = getCurrentUserId();
+  const sentAt = Date.now();
+  const content = parseContent(message);
+  const parsed = parsePostId(postId);
+
+  if (!parsed.authorId) {
+    return {
+      success: false,
+      error: 'Post ID must include author (e.g., ~ship/123.456)',
+    };
+  }
+
+  try {
+    await sendReply({
+      channelId: clubId,
+      parentId: parsed.id,
+      parentAuthor: parsed.authorId,
+      content,
+      sentAt,
+      authorId,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// React to a DM
+async function reactToDM(
+  ship: string,
+  postId: string,
+  react: string
+): Promise<{ success: boolean; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const our = getCurrentUserId();
+  const parsed = parsePostId(postId);
+
+  if (!parsed.authorId) {
+    return {
+      success: false,
+      error: 'Post ID must include author (e.g., ~ship/123.456)',
+    };
+  }
+
+  try {
+    await addReaction({
+      channelId: normalizedShip,
+      postId: parsed.id,
+      emoji: react,
+      our,
+      postAuthor: parsed.authorId,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Remove reaction from a DM
+async function unreactToDM(
+  ship: string,
+  postId: string
+): Promise<{ success: boolean; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const our = getCurrentUserId();
+  const parsed = parsePostId(postId);
+
+  if (!parsed.authorId) {
+    return {
+      success: false,
+      error: 'Post ID must include author (e.g., ~ship/123.456)',
+    };
+  }
+
+  try {
+    await removeReaction({
+      channelId: normalizedShip,
+      postId: parsed.id,
+      our,
+      postAuthor: parsed.authorId,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Delete a DM
+async function deleteDM(
+  ship: string,
+  postId: string
+): Promise<{ success: boolean; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const authorId = getCurrentUserId();
+  const parsed = parsePostId(postId);
+
+  try {
+    await deletePost(normalizedShip, parsed.id, parsed.authorId ?? authorId);
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Accept a DM invite
+async function acceptDM(
+  ship: string
+): Promise<{ success: boolean; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const channel: Channel = {
+    id: normalizedShip,
+    type: 'dm',
+    currentUserIsMember: false,
+    currentUserIsHost: false,
+    contactId: normalizedShip,
+  };
+
+  try {
+    await respondToDMInvite({ channel, accept: true });
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Decline a DM invite
+async function declineDM(
+  ship: string
+): Promise<{ success: boolean; error?: string }> {
+  const normalizedShip = normalizeShip(ship);
+  const channel: Channel = {
+    id: normalizedShip,
+    type: 'dm',
+    currentUserIsMember: false,
+    currentUserIsHost: false,
+    contactId: normalizedShip,
+  };
+
+  try {
+    await respondToDMInvite({ channel, accept: false });
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(DMS_HELP);
+  }
+
+  if (wantsHelp(args.slice(1)) && !isDmsMessageHelpLiteral(args)) {
+    printHelpAndExit(getDmsHelp(command));
+  }
+
+  validateDmsArgs(args);
+
+  await ensureClient(['chat']);
+
+  switch (command) {
+    case 'send': {
+      const clubId = args[1];
+      const message = args.slice(2).join(' ');
+      if (!clubId || !message) {
+        printUsageAndExit(DMS_COMMAND_HELP.send);
+      }
+      if (!isClub(clubId)) {
+        printErrorAndExit(
+          'send only supports group DMs (club IDs starting with 0v)'
+        );
+      }
+      const result = await sendClubMessage(clubId, message);
+      if (result.success) {
+        console.log('✓ Message sent!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'reply': {
+      const clubId = args[1];
+      const postId = args[2];
+      const message = args.slice(3).join(' ');
+      if (!clubId || !postId || !message) {
+        printUsageAndExit(DMS_COMMAND_HELP.reply);
+      }
+      if (!isClub(clubId)) {
+        printErrorAndExit(
+          'reply only supports group DMs (club IDs starting with 0v)'
+        );
+      }
+      const result = await replyToClub(clubId, postId, message);
+      if (result.success) {
+        console.log('✓ Reply sent!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'react': {
+      const ship = args[1];
+      const postId = args[2];
+      const react = args[3];
+      if (!ship || !postId || !react) {
+        printUsageAndExit(DMS_COMMAND_HELP.react);
+      }
+      const result = await reactToDM(ship, postId, react);
+      if (result.success) {
+        console.log('✓ Reaction added!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'unreact': {
+      const ship = args[1];
+      const postId = args[2];
+      if (!ship || !postId) {
+        printUsageAndExit(DMS_COMMAND_HELP.unreact);
+      }
+      const result = await unreactToDM(ship, postId);
+      if (result.success) {
+        console.log('✓ Reaction removed!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'delete': {
+      const ship = args[1];
+      const postId = args[2];
+      if (!ship || !postId) {
+        printUsageAndExit(DMS_COMMAND_HELP.delete);
+      }
+      const result = await deleteDM(ship, postId);
+      if (result.success) {
+        console.log('✓ DM deleted!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'accept': {
+      const ship = args[1];
+      if (!ship) {
+        printUsageAndExit(DMS_COMMAND_HELP.accept);
+      }
+      const result = await acceptDM(ship);
+      if (result.success) {
+        console.log('✓ DM invite accepted!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'decline': {
+      const ship = args[1];
+      if (!ship) {
+        printUsageAndExit(DMS_COMMAND_HELP.decline);
+      }
+      const result = await declineDM(ship);
+      if (result.success) {
+        console.log('✓ DM invite declined!');
+      } else {
+        console.error(`✗ Failed: ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    default:
+      printUsageAndExit(DMS_HELP);
+  }
+  process.exit(0);
+}
+
+main().catch(printErrorAndExit);

--- a/packages/tlon-skill/scripts/expose.ts
+++ b/packages/tlon-skill/scripts/expose.ts
@@ -1,0 +1,335 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Manage exposed content on the clearweb via %expose agent
+ *
+ * Usage:
+ *   tlon expose list                    # List all exposed content
+ *   tlon expose show <cite-path>        # Expose a post publicly
+ *   tlon expose hide <cite-path>        # Hide an exposed post
+ *   tlon expose check <cite-path>       # Check if a post is exposed
+ *   tlon expose url <cite-path>         # Get the public URL for a post
+ *
+ * Cite path format: /1/chan/<kind>/~<host>/<channel>/<type>/<post-id>
+ * Example: /1/chan/chat/~nocsyx-lassul/my-channel/msg/170.141.184...
+ *
+ * You can also use a simplified format that will be expanded:
+ *   chat/~host/channel/170.141...  ->  /1/chan/chat/~host/channel/msg/170.141...
+ *   diary/~host/channel/170.141... ->  /1/chan/diary/~host/channel/note/170.141...
+ */
+import { poke, scry } from '@tloncorp/api';
+
+import { ensureClient } from './api-client';
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from './cli-utils';
+
+const EXPOSE_HELP = `Usage: tlon expose <command>
+
+Manage public exposure of Tlon content via the %expose agent.
+
+Commands:
+  list                    List all exposed content with public URLs
+  show <cite-path>        Expose a post publicly
+  hide <cite-path>        Hide an exposed post
+  check <cite-path>       Check if a post is exposed
+  url <cite-path>         Get the public URL for a post
+
+Cite path formats:
+  Simplified:  chat/~host/channel/170.141...
+               diary/~host/channel/170.141...
+               heap/~host/channel/170.141...
+
+  Full:        /1/chan/chat/~host/channel/msg/170.141...
+               /1/chan/diary/~host/channel/note/170.141...
+               /1/chan/heap/~host/channel/curio/170.141...
+
+Examples:
+  tlon expose list
+  tlon expose show chat/~nocsyx-lassul/my-channel/170.141.184.507...
+  tlon expose hide chat/~nocsyx-lassul/my-channel/170.141.184.507...
+  tlon expose check diary/~nocsyx-lassul/blog/170.141.184.507...
+  tlon expose url diary/~nocsyx-lassul/blog/170.141.184.507...`;
+
+const EXPOSE_COMMAND_HELP: Record<string, string> = {
+  list: 'Usage: tlon expose list',
+  show: 'Usage: tlon expose show <cite-path>\nExample: tlon expose show chat/~host/channel/170.141...',
+  hide: 'Usage: tlon expose hide <cite-path>',
+  check: 'Usage: tlon expose check <cite-path>',
+  url: 'Usage: tlon expose url <cite-path>',
+};
+
+function getExposeHelp(command?: string): string {
+  return command ? EXPOSE_COMMAND_HELP[command] ?? EXPOSE_HELP : EXPOSE_HELP;
+}
+
+function validateExposeArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !EXPOSE_COMMAND_HELP[command]) {
+    printUsageAndExit(EXPOSE_HELP);
+  }
+  if (command !== 'list' && !args[1]) {
+    printUsageAndExit(EXPOSE_COMMAND_HELP[command]);
+  }
+}
+
+// Expand a simplified cite path to full format
+// chat/~host/channel/170.141... -> /1/chan/chat/~host/channel/msg/170.141...
+function expandCitePath(input: string): string {
+  // Already in full format
+  if (input.startsWith('/1/')) {
+    return input;
+  }
+
+  // Handle simplified format: kind/~host/channel/post-id
+  const parts = input.split('/');
+  if (parts.length < 4) {
+    throw new Error(
+      `Invalid cite path. Expected format: chat/~host/channel/post-id or /1/chan/chat/~host/channel/msg/post-id`
+    );
+  }
+
+  const kind = parts[0]; // chat, diary, heap
+  const host = parts[1]; // ~ship
+  const channel = parts[2]; // channel-name
+  const postId = parts.slice(3).join('/'); // post-id (may have dots)
+
+  // Determine the content type based on channel kind
+  let contentType: string;
+  switch (kind) {
+    case 'chat':
+      contentType = 'msg';
+      break;
+    case 'diary':
+      contentType = 'note';
+      break;
+    case 'heap':
+      contentType = 'curio';
+      break;
+    default:
+      throw new Error(
+        `Unknown channel kind: ${kind}. Expected chat, diary, or heap.`
+      );
+  }
+
+  return `/1/chan/${kind}/${host}/${channel}/${contentType}/${postId}`;
+}
+
+// Convert a cite path to a URL path for the public endpoint
+function citePathToUrlPath(citePath: string): string {
+  // Remove leading /1/ version prefix for URL
+  // /1/chan/chat/~host/channel/msg/123 -> /chan/chat/~host/channel/msg/123
+  if (citePath.startsWith('/1/')) {
+    return citePath.slice(2);
+  }
+  return citePath;
+}
+
+// List all exposed content
+async function listExposed(): Promise<string[]> {
+  try {
+    const result = await scry<unknown>({
+      app: 'expose',
+      path: '/show',
+    });
+
+    // Result is a set of cites, represented as an array or set
+    if (Array.isArray(result)) {
+      return result.map((cite: any) => formatCite(cite));
+    }
+
+    // Handle set representation
+    if (result && typeof result === 'object') {
+      const values = Object.values(result);
+      return values.map((cite: any) => formatCite(cite));
+    }
+
+    return [];
+  } catch (err: any) {
+    if (err?.message?.includes('404') || err?.message?.includes('not found')) {
+      return [];
+    }
+    throw err;
+  }
+}
+
+// Format a cite object to a readable path
+function formatCite(cite: any): string {
+  if (typeof cite === 'string') {
+    return cite;
+  }
+
+  // Handle structured cite format from Urbit
+  // { chan: { nest: [kind, [ship, name]], wer: [type, id, ...] } }
+  if (cite.chan) {
+    const { nest, wer } = cite.chan;
+    const [kind, [ship, name]] = nest;
+    const werPath = Array.isArray(wer) ? wer.join('/') : wer;
+    return `/1/chan/${kind}/~${ship}/${name}/${werPath}`;
+  }
+
+  // Fallback: JSON stringify
+  return JSON.stringify(cite);
+}
+
+// Check if a specific cite is exposed
+async function checkExposed(citePath: string): Promise<boolean> {
+  const fullPath = expandCitePath(citePath);
+
+  try {
+    const result = await scry<boolean>({
+      app: 'expose',
+      path: `/show${fullPath}`,
+    });
+    return !!result;
+  } catch (err: any) {
+    // 404 means not exposed
+    if (err?.message?.includes('404') || err?.message?.includes('not found')) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+// Expose a post publicly
+async function showPost(citePath: string): Promise<void> {
+  const fullPath = expandCitePath(citePath);
+
+  // Convert path string to path array for poke
+  // /1/chan/chat/~host/channel/msg/123 -> ["1", "chan", "chat", "~host", "channel", "msg", "123"]
+  const pathParts = fullPath.split('/').filter((p) => p.length > 0);
+
+  await poke({
+    app: 'expose',
+    mark: 'json',
+    json: {
+      show: pathParts,
+    },
+  });
+}
+
+// Hide an exposed post
+async function hidePost(citePath: string): Promise<void> {
+  const fullPath = expandCitePath(citePath);
+  const pathParts = fullPath.split('/').filter((p) => p.length > 0);
+
+  await poke({
+    app: 'expose',
+    mark: 'json',
+    json: {
+      hide: pathParts,
+    },
+  });
+}
+
+// Get the public URL for an exposed post
+function getPublicUrl(citePath: string, shipUrl: string): string {
+  const fullPath = expandCitePath(citePath);
+  const urlPath = citePathToUrlPath(fullPath);
+  return `${shipUrl}/expose${urlPath}`;
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(EXPOSE_HELP);
+  }
+
+  if (wantsHelp(args.slice(1))) {
+    printHelpAndExit(getExposeHelp(command));
+  }
+
+  validateExposeArgs(args);
+
+  const config = await ensureClient();
+
+  try {
+    switch (command) {
+      case 'list': {
+        const exposed = await listExposed();
+        if (exposed.length === 0) {
+          console.log('No content currently exposed.');
+        } else {
+          console.log(`Exposed content (${exposed.length}):\n`);
+          for (const cite of exposed) {
+            const url = getPublicUrl(cite, config.url);
+            console.log(`  ${cite}`);
+            console.log(`    → ${url}\n`);
+          }
+        }
+        break;
+      }
+
+      case 'show': {
+        const citePath = args[1];
+        if (!citePath) {
+          printUsageAndExit(EXPOSE_COMMAND_HELP.show);
+        }
+
+        await showPost(citePath);
+        const fullPath = expandCitePath(citePath);
+        const url = getPublicUrl(fullPath, config.url);
+        console.log(`✓ Post exposed`);
+        console.log(`  Public URL: ${url}`);
+        break;
+      }
+
+      case 'hide': {
+        const citePath = args[1];
+        if (!citePath) {
+          printUsageAndExit(EXPOSE_COMMAND_HELP.hide);
+        }
+
+        await hidePost(citePath);
+        console.log('✓ Post hidden');
+        break;
+      }
+
+      case 'check': {
+        const citePath = args[1];
+        if (!citePath) {
+          printUsageAndExit(EXPOSE_COMMAND_HELP.check);
+        }
+
+        const isExposed = await checkExposed(citePath);
+        if (isExposed) {
+          const fullPath = expandCitePath(citePath);
+          const url = getPublicUrl(fullPath, config.url);
+          console.log(`✓ Post is exposed`);
+          console.log(`  Public URL: ${url}`);
+        } else {
+          console.log('✗ Post is not exposed');
+        }
+        break;
+      }
+
+      case 'url': {
+        const citePath = args[1];
+        if (!citePath) {
+          printUsageAndExit(EXPOSE_COMMAND_HELP.url);
+        }
+
+        const fullPath = expandCitePath(citePath);
+        const url = getPublicUrl(fullPath, config.url);
+        console.log(url);
+        break;
+      }
+
+      default:
+        printUsageAndExit(EXPOSE_HELP);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    printErrorAndExit(error);
+  }
+}
+
+main();

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -1,0 +1,1537 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Groups API for Tlon
+ *
+ * Usage:
+ *   npx ts-node scripts/groups.ts list
+ *   npx ts-node scripts/groups.ts create "Group Name" [--description "..."]
+ *   npx ts-node scripts/groups.ts create-owned "Group Name" --owner <ship> [--description "..."]
+ *   npx ts-node scripts/groups.ts invite <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts info <group-id>
+ *   npx ts-node scripts/groups.ts leave <group-id>
+ *   npx ts-node scripts/groups.ts join <group-id>
+ *   npx ts-node scripts/groups.ts request-invite <group-id>
+ *   npx ts-node scripts/groups.ts accept-invite <group-id>
+ *   npx ts-node scripts/groups.ts reject-invite <group-id>
+ *   npx ts-node scripts/groups.ts cancel-join <group-id>
+ *   npx ts-node scripts/groups.ts rescind-request <group-id>
+ *   npx ts-node scripts/groups.ts revoke-invite <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts delete <group-id>
+ *   npx ts-node scripts/groups.ts update <group-id> --title "..." [--description "..."] [--image "..."]
+ *   npx ts-node scripts/groups.ts kick <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts ban <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts unban <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts add-role <group-id> <role-id> --title "..." [--description "..."]
+ *   npx ts-node scripts/groups.ts delete-role <group-id> <role-id>
+ *   npx ts-node scripts/groups.ts update-role <group-id> <role-id> --title "..." [--description "..."]
+ *   npx ts-node scripts/groups.ts assign-role <group-id> <role-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts remove-role <group-id> <role-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts set-privacy <group-id> <public|private|secret>
+ *   npx ts-node scripts/groups.ts accept-join <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts reject-join <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts promote <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts demote <group-id> <ship> [<ship2> ...]
+ *   npx ts-node scripts/groups.ts add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+ */
+import {
+  acceptGroupJoin,
+  addGroupRole,
+  addMembersToRole,
+  cancelGroupJoin as apiCancelGroupJoin,
+  joinGroup as apiJoinGroup,
+  banUsersFromGroup,
+  createChannel,
+  createGroup,
+  deleteGroup,
+  deleteGroupRole,
+  getContacts,
+  getCurrentUserId,
+  getGroup,
+  getGroupPreview,
+  getGroups,
+  inviteGroupMembers,
+  kickUsersFromGroup,
+  leaveGroup,
+  poke,
+  rejectGroupInvitation,
+  rejectGroupJoin,
+  removeMembersFromRole,
+  requestGroupInvitation,
+  rescindGroupInvitationRequest,
+  revokeGroupMemberInvites,
+  scry,
+  toClientGroupsFromForeigns,
+  unbanUsersFromGroup,
+  updateGroupMeta,
+  updateGroupPrivacy,
+  updateGroupRole,
+} from '@tloncorp/api';
+import type { Group } from '@tloncorp/api';
+
+import { ensureClient, getCurrentShip, normalizeShip } from './api-client';
+import {
+  getOption,
+  hasOptionValue,
+  isHelpArg,
+  isSubcommandHelpRequest,
+  looksLikePositionalChannelKind,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+} from './cli-utils';
+
+const ADMIN_ROLE_ID = 'admin';
+const GROUP_UPDATE_FLAGS = ['title', 'description', 'image', 'cover'] as const;
+
+// Generate a random short ID for the group
+function generateGroupSlug(): string {
+  // Must be valid @tas: lowercase letters, numbers, hyphens, must start with letter
+  const chars = 'abcdefghijklmnopqrstuvwxyz';
+  const alphanumeric = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let slug = chars[Math.floor(Math.random() * chars.length)];
+  for (let i = 0; i < 7; i++) {
+    slug += alphanumeric[Math.floor(Math.random() * alphanumeric.length)];
+  }
+  return slug;
+}
+
+const GROUPS_HELP = `Usage: tlon groups <command>
+
+Commands:
+  list
+  create "Group Name" [--description "..."]
+  create-owned "Group Name" --owner <ship> [--description "..."]
+  invite <group-id> <ship> [<ship2> ...]
+  info <group-id>
+  leave <group-id>
+  join <group-id>
+  request-invite <group-id>
+  accept-invite <group-id>
+  reject-invite <group-id>
+  cancel-join <group-id>
+  rescind-request <group-id>
+  revoke-invite <group-id> <ship> [<ship2> ...]
+  delete <group-id>
+  update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]
+  kick <group-id> <ship> [<ship2> ...]
+  ban <group-id> <ship> [<ship2> ...]
+  unban <group-id> <ship> [<ship2> ...]
+  add-role <group-id> <role-id> --title "..." [--description "..."]
+  delete-role <group-id> <role-id>
+  update-role <group-id> <role-id> --title "..." [--description "..."]
+  assign-role <group-id> <role-id> <ship> [<ship2> ...]
+  remove-role <group-id> <role-id> <ship> [<ship2> ...]
+  set-privacy <group-id> <public|private|secret>
+  accept-join <group-id> <ship> [<ship2> ...]
+  reject-join <group-id> <ship> [<ship2> ...]
+  promote <group-id> <ship> [<ship2> ...]
+  demote <group-id> <ship> [<ship2> ...]
+  add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]
+
+Examples:
+  tlon groups info ~host/group-slug
+  tlon groups add-channel ~host/group-slug "Projects" --kind chat`;
+
+const GROUPS_COMMAND_HELP: Record<string, string> = {
+  list: `Usage: tlon groups list`,
+  create: `Usage: tlon groups create "Group Name" [--description "..."]\nExample: tlon groups create "Projects" --description "Shared work"`,
+  'create-owned': `Usage: tlon groups create-owned "Group Name" --owner <ship> [--description "..."]\nExample: tlon groups create-owned "Projects" --owner ~nec --description "Shared work"`,
+  invite: `Usage: tlon groups invite <group-id> <ship> [<ship2> ...]\nExample: tlon groups invite ~host/group-slug ~nec ~bud`,
+  info: `Usage: tlon groups info <group-id>\nExample: tlon groups info ~host/group-slug`,
+  leave: `Usage: tlon groups leave <group-id>\nExample: tlon groups leave ~host/group-slug`,
+  join: `Usage: tlon groups join <group-id>\nJoins public or invited groups. For private groups without an invite, requests an invite.\nExample: tlon groups join ~host/group-slug`,
+  'request-invite': `Usage: tlon groups request-invite <group-id>\nExample: tlon groups request-invite ~host/group-slug`,
+  'accept-invite': `Usage: tlon groups accept-invite <group-id>\nExample: tlon groups accept-invite ~host/group-slug`,
+  'reject-invite': `Usage: tlon groups reject-invite <group-id>\nExample: tlon groups reject-invite ~host/group-slug`,
+  'cancel-join': `Usage: tlon groups cancel-join <group-id>\nExample: tlon groups cancel-join ~host/group-slug`,
+  'rescind-request': `Usage: tlon groups rescind-request <group-id>\nExample: tlon groups rescind-request ~host/group-slug`,
+  'revoke-invite': `Usage: tlon groups revoke-invite <group-id> <ship> [<ship2> ...]\nExample: tlon groups revoke-invite ~host/group-slug ~nec`,
+  delete: `Usage: tlon groups delete <group-id>\nExample: tlon groups delete ~host/group-slug`,
+  update: `Usage: tlon groups update <group-id> --title "..." [--description "..."] [--image "..."] [--cover "..."]\nExample: tlon groups update ~host/group-slug --title "New Title"`,
+  kick: `Usage: tlon groups kick <group-id> <ship> [<ship2> ...]\nExample: tlon groups kick ~host/group-slug ~nec`,
+  ban: `Usage: tlon groups ban <group-id> <ship> [<ship2> ...]\nExample: tlon groups ban ~host/group-slug ~nec`,
+  unban: `Usage: tlon groups unban <group-id> <ship> [<ship2> ...]\nExample: tlon groups unban ~host/group-slug ~nec`,
+  'add-role': `Usage: tlon groups add-role <group-id> <role-id> --title "..." [--description "..."]\nExample: tlon groups add-role ~host/group-slug editors --title "Editors"`,
+  'delete-role': `Usage: tlon groups delete-role <group-id> <role-id>\nExample: tlon groups delete-role ~host/group-slug editors`,
+  'update-role': `Usage: tlon groups update-role <group-id> <role-id> --title "..." [--description "..."]\nExample: tlon groups update-role ~host/group-slug editors --title "Writers"`,
+  'assign-role': `Usage: tlon groups assign-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: tlon groups assign-role ~host/group-slug editors ~nec`,
+  'remove-role': `Usage: tlon groups remove-role <group-id> <role-id> <ship> [<ship2> ...]\nExample: tlon groups remove-role ~host/group-slug editors ~nec`,
+  'set-privacy': `Usage: tlon groups set-privacy <group-id> <public|private|secret>\nExample: tlon groups set-privacy ~host/group-slug private`,
+  'accept-join': `Usage: tlon groups accept-join <group-id> <ship> [<ship2> ...]\nExample: tlon groups accept-join ~host/group-slug ~nec`,
+  'reject-join': `Usage: tlon groups reject-join <group-id> <ship> [<ship2> ...]\nExample: tlon groups reject-join ~host/group-slug ~nec`,
+  promote: `Usage: tlon groups promote <group-id> <ship> [<ship2> ...]\nExample: tlon groups promote ~host/group-slug ~nec`,
+  demote: `Usage: tlon groups demote <group-id> <ship> [<ship2> ...]\nExample: tlon groups demote ~host/group-slug ~nec`,
+  'add-channel': `Usage: tlon groups add-channel <group-id> "Channel Name" [--kind chat|diary|heap] [--description "..."]\nExample: tlon groups add-channel ~host/group-slug "Projects" --kind chat`,
+};
+
+function getGroupsHelp(command?: string) {
+  return command ? GROUPS_COMMAND_HELP[command] ?? GROUPS_HELP : GROUPS_HELP;
+}
+
+function validateGroupsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !GROUPS_COMMAND_HELP[command]) {
+    printUsageAndExit(GROUPS_HELP);
+  }
+
+  switch (command) {
+    case 'list':
+      return;
+    case 'create': {
+      const title = args[1];
+      if (title === undefined) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.create);
+      }
+      return;
+    }
+    case 'create-owned': {
+      const title = args[1];
+      const owner = getOption(args, 'owner', 2);
+      if (title === undefined || !owner || owner.startsWith('--')) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['create-owned']);
+      }
+      return;
+    }
+    case 'info':
+    case 'leave':
+    case 'join':
+    case 'request-invite':
+    case 'accept-invite':
+    case 'reject-invite':
+    case 'cancel-join':
+    case 'rescind-request':
+    case 'delete': {
+      if (!args[1]) printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'update': {
+      if (!args[1]) printUsageAndExit(GROUPS_COMMAND_HELP.update);
+      if (
+        !GROUP_UPDATE_FLAGS.some((flag) =>
+          hasOptionValue(args, flag, GROUP_UPDATE_FLAGS)
+        )
+      ) {
+        printUsageAndExit(
+          `Error: At least one of --title, --description, --image, or --cover is required\n${GROUPS_COMMAND_HELP.update}`
+        );
+      }
+      return;
+    }
+    case 'invite':
+    case 'revoke-invite':
+    case 'kick':
+    case 'ban':
+    case 'unban':
+    case 'accept-join':
+    case 'reject-join':
+    case 'promote':
+    case 'demote': {
+      if (!args[1] || args.slice(2).length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+    case 'add-role':
+    case 'delete-role':
+    case 'update-role': {
+      if (!args[1] || !args[2]) printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'assign-role':
+    case 'remove-role': {
+      if (!args[1] || !args[2] || args.slice(3).length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP[command]);
+      }
+      return;
+    }
+    case 'set-privacy': {
+      const privacy = args[2];
+      if (
+        !args[1] ||
+        !privacy ||
+        !['public', 'private', 'secret'].includes(privacy)
+      ) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['set-privacy']);
+      }
+      return;
+    }
+    case 'add-channel': {
+      if (!args[1] || args[2] === undefined) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['add-channel']);
+      }
+      if (looksLikePositionalChannelKind(args, 2)) {
+        printUsageAndExit(
+          `Error: channel kind must be passed with --kind, not as a positional argument.\n${GROUPS_COMMAND_HELP['add-channel']}`
+        );
+      }
+      return;
+    }
+  }
+}
+
+// List all groups
+async function listGroups() {
+  const groups = await getGroups();
+
+  console.log('\n=== YOUR GROUPS ===\n');
+
+  for (const group of groups) {
+    const memberCount = group.memberCount ?? (group.members || []).length;
+    const channelCount = (group.channels || []).length;
+    const privacy = group.privacy || 'unknown';
+
+    console.log(`📁 ${group.title || group.id}`);
+    console.log(`   ID: ${group.id}`);
+    console.log(`   Privacy: ${privacy}`);
+    console.log(`   Members: ${memberCount}, Channels: ${channelCount}`);
+    if (group.description) {
+      console.log(`   Description: ${group.description}`);
+    }
+    console.log('');
+  }
+}
+
+// Build a map of ship -> nickname from contacts
+async function buildNicknameMap(): Promise<Map<string, string>> {
+  const nicknameMap = new Map<string, string>();
+  try {
+    const contacts = await getContacts();
+    for (const contact of contacts) {
+      const nickname = contact.nickname ?? contact.peerNickname;
+      if (nickname) {
+        nicknameMap.set(contact.id, nickname);
+      }
+    }
+  } catch {
+    // Contacts unavailable, continue without nicknames
+  }
+  return nicknameMap;
+}
+
+// Format a ship with optional nickname
+function formatShipWithNickname(
+  ship: string,
+  nicknameMap: Map<string, string>
+): string {
+  const nickname = nicknameMap.get(ship);
+  return nickname ? `${ship} (${nickname})` : ship;
+}
+
+type CreatedGroup = {
+  groupId: string;
+  channelId: string;
+  group: Group;
+};
+
+type CreateGroupWithChannelOptions = {
+  memberIds?: string[];
+};
+
+type OwnerAdminVerification =
+  | { status: 'verified' }
+  | { status: 'missing'; reason: string };
+
+type RawGroupForAdminVerification = {
+  admins?: string[];
+  seats?: Record<string, { roles?: string[] }>;
+  admissions?: {
+    pending?: Record<string, string[]>;
+    invited?: Record<string, unknown>;
+  };
+};
+
+const VERIFY_ATTEMPTS = 5;
+const VERIFY_DELAY_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function groupHasRole(group: Group, roleId: string): boolean {
+  return (group.roles || []).some((role) => role.id === roleId);
+}
+
+function getShipRecordValue<T>(
+  record: Record<string, T> | undefined,
+  ship: string
+): T | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  const direct = record[ship];
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  return Object.entries(record).find(
+    ([key]) => normalizeShip(key) === ship
+  )?.[1];
+}
+
+async function getRawGroupForAdminVerification(
+  groupId: string
+): Promise<RawGroupForAdminVerification> {
+  return scry<RawGroupForAdminVerification>({
+    app: 'groups',
+    path: `/v2/ui/groups/${groupId}`,
+  });
+}
+
+function hasOwnerSeat(
+  rawGroup: RawGroupForAdminVerification,
+  ownerShip: string
+): boolean {
+  return getShipRecordValue(rawGroup.seats, ownerShip) !== undefined;
+}
+
+async function getRawGroupWithOwnerSeat(
+  groupId: string,
+  ownerShip: string
+): Promise<RawGroupForAdminVerification> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const rawGroup = await getRawGroupForAdminVerification(groupId);
+      if (hasOwnerSeat(rawGroup, ownerShip)) {
+        return rawGroup;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < VERIFY_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
+  }
+
+  const suffix = lastError ? `: ${lastError}` : '';
+  throw new Error(
+    `Owner ${ownerShip} was not created as an invited member seat in ${groupId}${suffix}`
+  );
+}
+
+async function getRawOwnerAdminVerification(
+  groupId: string,
+  ownerShip: string
+): Promise<OwnerAdminVerification> {
+  const rawGroup = await getRawGroupForAdminVerification(groupId);
+
+  if (!rawGroup.admins?.includes(ADMIN_ROLE_ID)) {
+    return {
+      status: 'missing',
+      reason: `Group ${groupId} has an "${ADMIN_ROLE_ID}" role, but it is not marked as an admin role.`,
+    };
+  }
+
+  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
+  if (ownerSeat) {
+    if (ownerSeat.roles?.includes(ADMIN_ROLE_ID)) {
+      return { status: 'verified' };
+    }
+
+    return {
+      status: 'missing',
+      reason: `Owner ${ownerShip} is a member of ${groupId}, but does not have the "${ADMIN_ROLE_ID}" role.`,
+    };
+  }
+
+  const pendingRoles = getShipRecordValue(
+    rawGroup.admissions?.pending,
+    ownerShip
+  );
+  if (pendingRoles) {
+    if (pendingRoles.includes(ADMIN_ROLE_ID)) {
+      return {
+        status: 'missing',
+        reason: `Owner ${ownerShip} has a pending invite for ${groupId} with the "${ADMIN_ROLE_ID}" role, but is not a group member seat yet.`,
+      };
+    }
+
+    return {
+      status: 'missing',
+      reason: `Owner ${ownerShip} has a pending invite for ${groupId}, but not with the "${ADMIN_ROLE_ID}" role.`,
+    };
+  }
+
+  const ownerInvite = getShipRecordValue(
+    rawGroup.admissions?.invited,
+    ownerShip
+  );
+  if (ownerInvite) {
+    return {
+      status: 'missing',
+      reason: `Owner ${ownerShip} is invited to ${groupId}, but no pending "${ADMIN_ROLE_ID}" role assignment was found.`,
+    };
+  }
+
+  return {
+    status: 'missing',
+    reason: `Owner ${ownerShip} was not found in members or pending invites for ${groupId}.`,
+  };
+}
+
+async function assignOwnerAdminRole(groupId: string, ownerShip: string) {
+  const rawGroup = await getRawGroupWithOwnerSeat(groupId, ownerShip);
+  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
+
+  if (ownerSeat?.roles?.includes(ADMIN_ROLE_ID)) {
+    console.log(`✅ Owner already has "${ADMIN_ROLE_ID}" role.`);
+    return;
+  }
+
+  console.log(`Assigning owner ${ownerShip} to "${ADMIN_ROLE_ID}" role...`);
+  await addMembersToRole({
+    groupId,
+    roleId: ADMIN_ROLE_ID,
+    ships: [ownerShip],
+  });
+  console.log(`✅ Owner assigned to "${ADMIN_ROLE_ID}" role.`);
+}
+
+async function getGroupWithRetry(groupId: string): Promise<Group> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      return await getGroup(groupId);
+    } catch (err) {
+      lastError = err;
+      if (attempt < VERIFY_ATTEMPTS) {
+        await sleep(VERIFY_DELAY_MS);
+      }
+    }
+  }
+
+  throw new Error(
+    `Could not fetch group ${groupId} for verification: ${lastError}`
+  );
+}
+
+async function verifyGroupCreated(groupId: string): Promise<Group> {
+  console.log(`Verifying group ${groupId}...`);
+  const group = await getGroupWithRetry(groupId);
+
+  if (group.id && group.id !== groupId) {
+    throw new Error(
+      `Created group verification returned ${group.id}, expected ${groupId}.`
+    );
+  }
+
+  console.log(`✅ Group verified.`);
+  return group;
+}
+
+async function setAdminRole(groupId: string, roleId: string) {
+  await poke({
+    app: 'groups',
+    mark: 'group-action-4',
+    json: {
+      group: {
+        flag: groupId,
+        'a-group': {
+          role: {
+            roles: [roleId],
+            'a-role': {
+              'set-admin': null,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+async function ensureAdminRole(groupId: string, group?: Group) {
+  const currentGroup = group ?? (await getGroup(groupId));
+
+  if (!groupHasRole(currentGroup, ADMIN_ROLE_ID)) {
+    console.log(`Creating "${ADMIN_ROLE_ID}" role in ${groupId}...`);
+    await addGroupRole({
+      groupId,
+      roleId: ADMIN_ROLE_ID,
+      meta: { title: 'Admin', description: 'Group administrator' },
+    });
+
+    await setAdminRole(groupId, ADMIN_ROLE_ID);
+  }
+}
+
+async function verifyOwnerAdmin(
+  groupId: string,
+  ownerShip: string
+): Promise<void> {
+  console.log(`Verifying ${ownerShip} admin assignment in ${groupId}...`);
+
+  let lastVerification: OwnerAdminVerification | null = null;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const rawVerification = await getRawOwnerAdminVerification(
+        groupId,
+        ownerShip
+      );
+      if (rawVerification.status === 'verified') {
+        console.log(`✅ Owner admin assignment verified.`);
+        return;
+      }
+      lastVerification = rawVerification;
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < VERIFY_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
+  }
+
+  if (lastVerification) {
+    throw new Error(lastVerification.reason);
+  }
+
+  throw new Error(
+    `Could not verify owner admin assignment for ${ownerShip}: ${lastError}`
+  );
+}
+
+// Get info about a specific group
+async function getGroupInfo(groupId: string) {
+  const [group, nicknameMap] = await Promise.all([
+    getGroup(groupId),
+    buildNicknameMap(),
+  ]);
+
+  console.log(`\n=== ${group.title || groupId} ===\n`);
+  console.log(`ID: ${groupId}`);
+  console.log(`Privacy: ${group.privacy || 'unknown'}`);
+  console.log(`Description: ${group.description || '(none)'}`);
+
+  if (group.iconImage) {
+    console.log(`Icon: ${group.iconImage}`);
+  }
+
+  console.log('\n--- Members ---');
+  for (const member of group.members || []) {
+    const roles = (member.roles || []).map((r: { roleId: string }) => r.roleId);
+    const roleList = roles.length > 0 ? ` [${roles.join(', ')}]` : '';
+    const displayName = formatShipWithNickname(member.contactId, nicknameMap);
+    console.log(`  ${displayName}${roleList}`);
+  }
+
+  if (group.roles && group.roles.length > 0) {
+    console.log('\n--- Roles ---');
+    for (const role of group.roles) {
+      console.log(`  ${role.id}: ${role.title || '(untitled)'}`);
+    }
+  }
+
+  if (group.channels && group.channels.length > 0) {
+    console.log('\n--- Channels ---');
+    for (const channel of group.channels) {
+      const title = channel.title || channel.id;
+      console.log(`  ${title} (${channel.id})`);
+    }
+  }
+
+  if (group.pendingMembers && group.pendingMembers.length > 0) {
+    console.log('\n--- Pending Invites ---');
+    for (const member of group.pendingMembers) {
+      console.log(`  ${formatShipWithNickname(member.contactId, nicknameMap)}`);
+    }
+  }
+
+  if (group.joinRequests && group.joinRequests.length > 0) {
+    console.log('\n--- Join Requests ---');
+    for (const request of group.joinRequests) {
+      console.log(
+        `  ${formatShipWithNickname(request.contactId, nicknameMap)}`
+      );
+    }
+  }
+
+  if (group.bannedMembers && group.bannedMembers.length > 0) {
+    console.log('\n--- Banned Ships ---');
+    for (const ban of group.bannedMembers) {
+      console.log(`  ${formatShipWithNickname(ban.contactId, nicknameMap)}`);
+    }
+  }
+}
+
+// Create a new group
+async function createGroupWithChannel(
+  title: string,
+  description: string = '',
+  options: CreateGroupWithChannelOptions = {}
+): Promise<CreatedGroup> {
+  const ship = await getCurrentShip();
+  const slug = generateGroupSlug();
+  const groupId = `${ship}/${slug}`;
+  const channelSlug = `${slug}-general`;
+  const channelId = `chat/${ship}/${channelSlug}`;
+
+  console.log(`Creating group "${title}" with ID: ${groupId}...`);
+
+  const group: Group = {
+    id: groupId,
+    title,
+    description,
+    hostUserId: getCurrentUserId(),
+    currentUserIsHost: true,
+    currentUserIsMember: true,
+    channels: [
+      {
+        id: channelId,
+        title: 'General',
+        description: 'General chat',
+        type: 'chat',
+        groupId,
+      },
+    ],
+  };
+
+  await createGroup({
+    group,
+    memberIds: options.memberIds,
+  });
+
+  const createdGroup = await verifyGroupCreated(groupId);
+
+  if (description) {
+    console.log(`Setting group description...`);
+    await updateGroupMeta({
+      groupId,
+      meta: {
+        title,
+        description,
+        image: '',
+        cover: '',
+      },
+    });
+  }
+
+  console.log(`✅ Group created successfully!`);
+  console.log(`   ID: ${groupId}`);
+  console.log(`   Title: ${title}`);
+  console.log(`   Description: ${description || '(none)'}`);
+  console.log(`   Channel: ${channelId}`);
+
+  return { groupId, channelId, group: createdGroup };
+}
+
+async function createOwnedGroup(
+  title: string,
+  owner: string,
+  description: string = ''
+) {
+  const ownerShip = normalizeShip(owner);
+  const { groupId, channelId, group } = await createGroupWithChannel(
+    title,
+    description,
+    {
+      memberIds: [ownerShip],
+    }
+  );
+
+  await ensureAdminRole(groupId, group);
+  await assignOwnerAdminRole(groupId, ownerShip);
+  await verifyOwnerAdmin(groupId, ownerShip);
+
+  console.log(`✅ Owned group created successfully!`);
+  console.log(`   ID: ${groupId}`);
+  console.log(`   Title: ${title}`);
+  console.log(`   Description: ${description || '(none)'}`);
+  console.log(`   Owner: ${ownerShip}`);
+  console.log(`   Channel: ${channelId}`);
+
+  return { groupId, channelId, ownerShip };
+}
+
+// Invite ships to a group
+async function inviteToGroup(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Inviting ${normalizedShips.join(', ')} to ${groupId}...`);
+
+  await inviteGroupMembers({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Invitations sent!`);
+}
+
+// Leave a group
+async function leaveGroupById(groupId: string) {
+  console.log(`Leaving group ${groupId}...`);
+
+  await leaveGroup(groupId);
+
+  console.log(`✅ Left group.`);
+}
+
+// Join a group
+async function joinGroupById(groupId: string) {
+  const joinedGroup = await getJoinedGroupState(groupId);
+  if (joinedGroup?.currentUserIsMember) {
+    console.log(`Already a member of ${groupId}.`);
+    return;
+  }
+
+  const foreignGroup = await getForeignGroupState(groupId);
+  if (foreignGroup?.haveInvite) {
+    await acceptInvite(groupId);
+    return;
+  }
+
+  if (foreignGroup?.haveRequestedInvite) {
+    console.log(`Invite already requested for ${groupId}.`);
+    return;
+  }
+
+  const group = foreignGroup ?? (await getGroupPreviewState(groupId));
+
+  if (group?.privacy === 'public') {
+    await joinNow(groupId);
+    return;
+  }
+
+  if (group?.privacy === 'private') {
+    await requestInvite(groupId);
+    return;
+  }
+
+  if (group?.privacy === 'secret') {
+    throw new Error(`Cannot join secret group ${groupId} without an invite.`);
+  }
+
+  console.log(`Group privacy unknown for ${groupId}; attempting join...`);
+  await joinNow(groupId);
+}
+
+async function getJoinedGroupState(groupId: string): Promise<Group | null> {
+  try {
+    return await getGroup(groupId);
+  } catch {
+    return null;
+  }
+}
+
+async function getForeignGroupState(groupId: string): Promise<Group | null> {
+  try {
+    const foreigns = await scry<Record<string, unknown>>({
+      app: 'groups',
+      path: '/v1/foreigns',
+    });
+    const groups = toClientGroupsFromForeigns(foreigns as any);
+    return groups.find((group: Group) => group.id === groupId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function getGroupPreviewState(groupId: string): Promise<Group | null> {
+  try {
+    return await getGroupPreview(groupId);
+  } catch {
+    try {
+      const groups = await getGroups();
+      return groups.find((group) => group.id === groupId) ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+async function joinNow(groupId: string) {
+  console.log(`Joining group ${groupId}...`);
+  await apiJoinGroup(groupId);
+  console.log(`✅ Join requested. Sync may take a moment to show membership.`);
+}
+
+async function requestInvite(groupId: string) {
+  console.log(`Requesting invite to ${groupId}...`);
+  await requestGroupInvitation(groupId);
+  console.log(`✅ Invite requested.`);
+}
+
+async function acceptInvite(groupId: string) {
+  console.log(`Accepting invite to ${groupId}...`);
+  await apiJoinGroup(groupId);
+  console.log(
+    `✅ Invite accepted, joining group. Sync may take a moment to show membership.`
+  );
+}
+
+async function rejectInvite(groupId: string) {
+  console.log(`Rejecting invite to ${groupId}...`);
+  await rejectGroupInvitation(groupId);
+  console.log(`✅ Invite rejected.`);
+}
+
+async function cancelJoin(groupId: string) {
+  console.log(`Canceling join for ${groupId}...`);
+  await apiCancelGroupJoin(groupId);
+  console.log(`✅ Join canceled.`);
+}
+
+async function rescindInviteRequest(groupId: string) {
+  console.log(`Rescinding invite request for ${groupId}...`);
+  await rescindGroupInvitationRequest(groupId);
+  console.log(`✅ Invite request rescinded.`);
+}
+
+async function revokeInvites(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(
+    `Revoking invites for ${normalizedShips.join(', ')} from ${groupId}...`
+  );
+
+  await revokeGroupMemberInvites({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Invites revoked.`);
+}
+
+// Delete a group (must be host)
+async function deleteGroupById(groupId: string) {
+  console.log(`Deleting group ${groupId}...`);
+
+  await deleteGroup(groupId);
+
+  console.log(`✅ Group deleted.`);
+}
+
+// Update group metadata
+async function updateGroup(
+  groupId: string,
+  options: {
+    title?: string;
+    description?: string;
+    image?: string;
+    cover?: string;
+  }
+) {
+  const group = await getGroup(groupId);
+
+  const meta = {
+    title: options.title ?? group.title ?? '',
+    description: options.description ?? group.description ?? '',
+    image: options.image ?? group.iconImage ?? '',
+    cover: options.cover ?? group.coverImage ?? '',
+  };
+
+  console.log(`Updating group ${groupId}...`);
+
+  await updateGroupMeta({
+    groupId,
+    meta,
+  });
+
+  console.log(`✅ Group updated.`);
+  console.log(`   Title: ${meta.title}`);
+  console.log(`   Description: ${meta.description || '(none)'}`);
+}
+
+// Kick members from a group
+async function kickMembers(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Kicking ${normalizedShips.join(', ')} from ${groupId}...`);
+
+  await kickUsersFromGroup({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Members kicked.`);
+}
+
+// Ban members from a group
+async function banMembers(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Banning ${normalizedShips.join(', ')} from ${groupId}...`);
+
+  await banUsersFromGroup({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Members banned.`);
+}
+
+// Unban members from a group
+async function unbanMembers(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Unbanning ${normalizedShips.join(', ')} from ${groupId}...`);
+
+  await unbanUsersFromGroup({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Members unbanned.`);
+}
+
+// Add a role to a group
+async function addRole(
+  groupId: string,
+  roleId: string,
+  options: { title?: string; description?: string }
+) {
+  const title = options.title || roleId;
+  const description = options.description || '';
+
+  console.log(`Adding role "${roleId}" to ${groupId}...`);
+
+  await addGroupRole({
+    groupId,
+    roleId,
+    meta: { title, description },
+  });
+
+  console.log(`✅ Role "${roleId}" added.`);
+  console.log(`   Title: ${title}`);
+}
+
+// Delete a role from a group
+async function deleteRole(groupId: string, roleId: string) {
+  console.log(`Deleting role "${roleId}" from ${groupId}...`);
+
+  await deleteGroupRole({ groupId, roleId });
+
+  console.log(`✅ Role "${roleId}" deleted.`);
+}
+
+// Update a role's metadata
+async function updateRole(
+  groupId: string,
+  roleId: string,
+  options: { title?: string; description?: string }
+) {
+  const group = await getGroup(groupId);
+  const currentRole = (group.roles || []).find((role) => role.id === roleId);
+  if (!currentRole) {
+    throw new Error(`Role "${roleId}" not found in group ${groupId}`);
+  }
+
+  const meta = {
+    title: options.title ?? currentRole.title ?? '',
+    description: options.description ?? currentRole.description ?? '',
+  };
+
+  console.log(`Updating role "${roleId}" in ${groupId}...`);
+
+  await updateGroupRole({ groupId, roleId, meta });
+
+  console.log(`✅ Role "${roleId}" updated.`);
+  console.log(`   Title: ${meta.title}`);
+}
+
+// Assign a role to members
+async function assignRole(groupId: string, roleId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(
+    `Assigning role "${roleId}" to ${normalizedShips.join(', ')} in ${groupId}...`
+  );
+
+  await addMembersToRole({
+    groupId,
+    roleId,
+    ships: normalizedShips,
+  });
+
+  console.log(`✅ Role assigned.`);
+}
+
+// Remove a role from members
+async function removeRole(groupId: string, roleId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(
+    `Removing role "${roleId}" from ${normalizedShips.join(', ')} in ${groupId}...`
+  );
+
+  await removeMembersFromRole({
+    groupId,
+    roleId,
+    ships: normalizedShips,
+  });
+
+  console.log(`✅ Role removed.`);
+}
+
+// Update group privacy
+async function setGroupPrivacy(
+  groupId: string,
+  privacy: 'public' | 'private' | 'secret'
+) {
+  const group = await getGroup(groupId);
+  const oldPrivacy = (group.privacy ?? 'private') as
+    | 'public'
+    | 'private'
+    | 'secret';
+
+  console.log(`Updating privacy for ${groupId} to ${privacy}...`);
+
+  await updateGroupPrivacy({
+    groupId,
+    oldPrivacy,
+    newPrivacy: privacy,
+  });
+
+  console.log(`✅ Privacy updated.`);
+}
+
+// Accept join requests
+async function acceptJoin(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Accepting join requests for ${normalizedShips.join(', ')}...`);
+
+  await acceptGroupJoin({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Join requests accepted.`);
+}
+
+// Reject join requests
+async function rejectJoin(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+
+  console.log(`Rejecting join requests for ${normalizedShips.join(', ')}...`);
+
+  await rejectGroupJoin({
+    groupId,
+    contactIds: normalizedShips,
+  });
+
+  console.log(`✅ Join requests rejected.`);
+}
+
+// Add a channel to an existing group
+async function addChannel(
+  groupId: string,
+  title: string,
+  kind: 'chat' | 'diary' | 'heap' = 'chat',
+  description: string = ''
+) {
+  const ship = await getCurrentShip();
+  const slug = generateGroupSlug();
+  const name = slug;
+  const nest = `${kind}/${ship}/${name}`;
+
+  console.log(`Adding channel "${title}" to group ${groupId}...`);
+
+  await createChannel({
+    id: nest,
+    kind,
+    group: groupId,
+    name,
+    title,
+    description,
+    meta: null,
+    readers: [],
+    writers: [],
+  });
+
+  console.log(`✅ Channel created!`);
+  console.log(`   Nest: ${nest}`);
+  console.log(`   Title: ${title}`);
+  console.log(`   Group: ${groupId}`);
+  return nest;
+}
+
+// Promote a member to admin by assigning them an admin role
+async function promoteMemberToAdmin(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+  await ensureAdminRole(groupId);
+
+  console.log(
+    `Promoting ${normalizedShips.join(', ')} to admin in ${groupId}...`
+  );
+
+  await addMembersToRole({
+    groupId,
+    roleId: ADMIN_ROLE_ID,
+    ships: normalizedShips,
+  });
+
+  console.log(`✅ Members promoted to admin.`);
+}
+
+// Demote a member from admin by removing them from admin roles
+async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
+  const normalizedShips = ships.map(normalizeShip);
+  const group = await getGroup(groupId);
+
+  // Find all admin roles this member might have
+  // For now, check the "admin" role
+  const adminRoles = (group.roles || []).filter((r) => {
+    // We can't easily tell which roles are admin from the group info alone,
+    // so we target the "admin" role specifically
+    return r.id === ADMIN_ROLE_ID;
+  });
+
+  if (adminRoles.length === 0) {
+    console.error(`No "${ADMIN_ROLE_ID}" role found in ${groupId}.`);
+    process.exit(1);
+  }
+
+  for (const role of adminRoles) {
+    console.log(
+      `Removing "${role.id}" role from ${normalizedShips.join(', ')}...`
+    );
+    await removeMembersFromRole({
+      groupId,
+      roleId: role.id,
+      ships: normalizedShips,
+    });
+  }
+
+  console.log(`✅ Members demoted from admin.`);
+}
+
+// Main
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(GROUPS_HELP);
+  }
+
+  if (isSubcommandHelpRequest(args)) {
+    printHelpAndExit(getGroupsHelp(command));
+  }
+
+  validateGroupsArgs(args);
+
+  await ensureClient(['groups', 'channels']);
+
+  switch (command) {
+    case 'list':
+      await listGroups();
+      break;
+
+    case 'create': {
+      const title = args[1];
+      if (title === undefined) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.create);
+      }
+      const description = getOption(args, 'description', 2) || '';
+      await createGroupWithChannel(title, description);
+      break;
+    }
+
+    case 'create-owned': {
+      const title = args[1];
+      const owner = getOption(args, 'owner', 2);
+      if (title === undefined || !owner || owner.startsWith('--')) {
+        console.error(GROUPS_COMMAND_HELP['create-owned']);
+        process.exit(1);
+      }
+      const description = getOption(args, 'description', 2) || '';
+      await createOwnedGroup(title, owner, description);
+      break;
+    }
+
+    case 'invite': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.invite);
+      }
+      await inviteToGroup(groupId, ships);
+      break;
+    }
+
+    case 'info': {
+      const groupId = args[1];
+      if (!groupId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.info);
+      }
+      await getGroupInfo(groupId);
+      break;
+    }
+
+    case 'leave': {
+      const groupId = args[1];
+      if (!groupId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.leave);
+      }
+      await leaveGroupById(groupId);
+      break;
+    }
+
+    case 'join': {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP.join);
+        process.exit(1);
+      }
+      await joinGroupById(groupId);
+      break;
+    }
+
+    case 'request-invite': {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP['request-invite']);
+        process.exit(1);
+      }
+      await requestInvite(groupId);
+      break;
+    }
+
+    case 'accept-invite': {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP['accept-invite']);
+        process.exit(1);
+      }
+      await acceptInvite(groupId);
+      break;
+    }
+
+    case 'reject-invite': {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP['reject-invite']);
+        process.exit(1);
+      }
+      await rejectInvite(groupId);
+      break;
+    }
+
+    case 'cancel-join': {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP['cancel-join']);
+        process.exit(1);
+      }
+      await cancelJoin(groupId);
+      break;
+    }
+
+    case 'rescind-request': {
+      const groupId = args[1];
+      if (!groupId) {
+        console.error(GROUPS_COMMAND_HELP['rescind-request']);
+        process.exit(1);
+      }
+      await rescindInviteRequest(groupId);
+      break;
+    }
+
+    case 'revoke-invite': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        console.error(GROUPS_COMMAND_HELP['revoke-invite']);
+        process.exit(1);
+      }
+      await revokeInvites(groupId, ships);
+      break;
+    }
+
+    case 'delete': {
+      const groupId = args[1];
+      if (!groupId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.delete);
+      }
+      await deleteGroupById(groupId);
+      break;
+    }
+
+    case 'update': {
+      const groupId = args[1];
+      if (!groupId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.update);
+      }
+      const title = getOption(args, 'title');
+      const description = getOption(args, 'description');
+      const image = getOption(args, 'image');
+      const cover = getOption(args, 'cover');
+      await updateGroup(groupId, { title, description, image, cover });
+      break;
+    }
+
+    case 'kick': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.kick);
+      }
+      await kickMembers(groupId, ships);
+      break;
+    }
+
+    case 'ban': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.ban);
+      }
+      await banMembers(groupId, ships);
+      break;
+    }
+
+    case 'unban': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.unban);
+      }
+      await unbanMembers(groupId, ships);
+      break;
+    }
+
+    case 'add-role': {
+      const groupId = args[1];
+      const roleId = args[2];
+      if (!groupId || !roleId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['add-role']);
+      }
+      const title = getOption(args, 'title');
+      const description = getOption(args, 'description');
+      await addRole(groupId, roleId, { title, description });
+      break;
+    }
+
+    case 'delete-role': {
+      const groupId = args[1];
+      const roleId = args[2];
+      if (!groupId || !roleId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['delete-role']);
+      }
+      await deleteRole(groupId, roleId);
+      break;
+    }
+
+    case 'update-role': {
+      const groupId = args[1];
+      const roleId = args[2];
+      if (!groupId || !roleId) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['update-role']);
+      }
+      const title = getOption(args, 'title');
+      const description = getOption(args, 'description');
+      await updateRole(groupId, roleId, { title, description });
+      break;
+    }
+
+    case 'assign-role': {
+      const groupId = args[1];
+      const roleId = args[2];
+      const ships = args.slice(3);
+      if (!groupId || !roleId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['assign-role']);
+      }
+      await assignRole(groupId, roleId, ships);
+      break;
+    }
+
+    case 'remove-role': {
+      const groupId = args[1];
+      const roleId = args[2];
+      const ships = args.slice(3);
+      if (!groupId || !roleId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['remove-role']);
+      }
+      await removeRole(groupId, roleId, ships);
+      break;
+    }
+
+    case 'set-privacy': {
+      const groupId = args[1];
+      const privacy = args[2] as 'public' | 'private' | 'secret';
+      if (
+        !groupId ||
+        !privacy ||
+        !['public', 'private', 'secret'].includes(privacy)
+      ) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['set-privacy']);
+      }
+      await setGroupPrivacy(groupId, privacy);
+      break;
+    }
+
+    case 'accept-join': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['accept-join']);
+      }
+      await acceptJoin(groupId, ships);
+      break;
+    }
+
+    case 'reject-join': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP['reject-join']);
+      }
+      await rejectJoin(groupId, ships);
+      break;
+    }
+
+    case 'promote': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.promote);
+      }
+      await promoteMemberToAdmin(groupId, ships);
+      break;
+    }
+
+    case 'demote': {
+      const groupId = args[1];
+      const ships = args.slice(2);
+      if (!groupId || ships.length === 0) {
+        printUsageAndExit(GROUPS_COMMAND_HELP.demote);
+      }
+      await demoteMemberFromAdmin(groupId, ships);
+      break;
+    }
+
+    case 'add-channel': {
+      const groupId = args[1];
+      const title = args[2];
+      if (!groupId || title === undefined) {
+        console.error(GROUPS_COMMAND_HELP['add-channel']);
+        process.exit(1);
+      }
+      if (looksLikePositionalChannelKind(args, 2)) {
+        console.error(
+          'Error: channel kind must be passed with --kind, not as a positional argument.'
+        );
+        console.error(GROUPS_COMMAND_HELP['add-channel']);
+        process.exit(1);
+      }
+      const kind =
+        (getOption(args, 'kind', 3) as 'chat' | 'diary' | 'heap') || 'chat';
+      const description = getOption(args, 'description', 3) || '';
+      await addChannel(groupId, title, kind, description);
+      break;
+    }
+
+    default:
+      printUsageAndExit(GROUPS_HELP);
+  }
+  process.exit(0);
+}
+
+main().catch(printErrorAndExit);

--- a/packages/tlon-skill/scripts/hooks.ts
+++ b/packages/tlon-skill/scripts/hooks.ts
@@ -1,0 +1,701 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Hooks API for Tlon
+ *
+ * Hooks are functions that run on channel triggers (posts, replies, reactions, crons)
+ * and can produce effects and maintain state.
+ *
+ * Usage:
+ *   npx ts-node scripts/hooks.ts list                              # List all hooks
+ *   npx ts-node scripts/hooks.ts get <id>                          # Get a specific hook
+ *   npx ts-node scripts/hooks.ts add <name> <src-file>             # Add a new hook
+ *   npx ts-node scripts/hooks.ts edit <id> [--name] [--src]        # Edit a hook
+ *   npx ts-node scripts/hooks.ts delete <id>                       # Delete a hook
+ *   npx ts-node scripts/hooks.ts order <nest> <id1> [id2...]       # Set execution order
+ *   npx ts-node scripts/hooks.ts config <id> <nest> <key=value...> # Configure for channel
+ *   npx ts-node scripts/hooks.ts cron <id> <schedule> [--nest]     # Schedule periodic run
+ *   npx ts-node scripts/hooks.ts rest <id> [--nest]                # Stop a cron job
+ */
+import { poke, scry, subscribe, unsubscribe } from '@tloncorp/api';
+import { render } from '@urbit/aura';
+import { Atom, jam } from '@urbit/nockjs';
+import * as fs from 'fs';
+
+import { ensureClient } from './api-client';
+import {
+  getOption,
+  hasFlag,
+  hasOptionValue,
+  isHelpArg,
+  isSubcommandHelpRequest,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+} from './cli-utils';
+
+// Helper to create a cord (UTF-8 string as little-endian atom) from a JS string
+// Atom.fromCord doesnt handle multi-byte UTF-8 (like emojis) correctly
+function cordFromUtf8(s: string): Atom {
+  const bytes = Buffer.from(s, 'utf8');
+  let num = 0n;
+  for (let i = 0; i < bytes.length; i++) {
+    num |= BigInt(bytes[i]) << BigInt(i * 8);
+  }
+  return new Atom(num);
+}
+
+// Types based on sur/hooks.hoon
+interface Hook {
+  id: string;
+  version: string;
+  name: string;
+  meta: Record<string, any>;
+  src: string;
+  compiled: boolean;
+  config: Record<string, Record<string, string>>;
+}
+
+interface Job {
+  hook: string;
+  schedule: { next: string; repeat: string };
+  config: Record<string, string>;
+}
+
+interface Hooks {
+  hooks: Record<string, Hook>;
+  order: Record<string, string[]>;
+  crons: Record<string, Record<string, Job>>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const HOOK_TEMPLATE_TYPES = ['on-post', 'cron', 'moderation', 'bare'] as const;
+type HookTemplateType = (typeof HOOK_TEMPLATE_TYPES)[number];
+const HOOK_INIT_OPTIONS = ['type', 'out', 'force'] as const;
+
+function isHookTemplateType(value: string): value is HookTemplateType {
+  return (HOOK_TEMPLATE_TYPES as readonly string[]).includes(value);
+}
+
+const HOOKS_HELP = `Usage: tlon hooks <command>
+
+Commands:
+  init <name> [--type] [--out]      Create a starter hook template
+  list                              List all hooks
+  get <id>                          Get hook details and source
+  add <name> <src-file>             Add a new hook from file
+  edit <id> [--name] [--src]        Edit hook name or source
+  delete <id>                       Delete a hook
+  order <nest> <id1> [id2...]       Set execution order for channel
+  config <id> <nest> <key=value...> Configure hook for channel (values are nouns serialized as text)
+  cron <id> <schedule> [--nest]     Schedule periodic execution
+  rest <id> [--nest]                Stop a cron job
+
+Hook IDs are @uv format (e.g., 0v1a.2b3c4...)
+Schedule is @dr format (e.g., ~h1 for 1 hour, ~m30 for 30 minutes)
+
+Examples:
+  tlon hooks init my-hook --type on-post
+  tlon hooks add my-hook ./my-hook.hoon
+  tlon hooks config 0v1a.2b3c4 chat/~host/channel key1=value1 key2=value2
+  tlon hooks cron 0v1a.2b3c4 ~h1 --nest chat/~host/channel`;
+
+const HOOKS_COMMAND_HELP: Record<string, string> = {
+  init: 'Usage: tlon hooks init <name> [--type on-post|cron|moderation|bare] [--out <file>] [--force]',
+  list: 'Usage: tlon hooks list',
+  get: 'Usage: tlon hooks get <id>',
+  add: 'Usage: tlon hooks add <name> <src-file>',
+  edit: 'Usage: tlon hooks edit <id> [--name <name>] [--src <file>]',
+  delete: 'Usage: tlon hooks delete <id>',
+  del: 'Usage: tlon hooks delete <id>',
+  order: 'Usage: tlon hooks order <nest> <id1> [id2...]',
+  config: 'Usage: tlon hooks config <id> <nest> <key=value...>',
+  cron: 'Usage: tlon hooks cron <id> <schedule> [--nest <nest>]\n  schedule: @dr format like ~h1 (1 hour) or ~m30 (30 minutes)',
+  rest: 'Usage: tlon hooks rest <id> [--nest <nest>]',
+};
+
+function getHooksHelp(command?: string): string {
+  return command ? HOOKS_COMMAND_HELP[command] ?? HOOKS_HELP : HOOKS_HELP;
+}
+
+function getHookInitType(args: string[]): HookTemplateType {
+  if (!hasFlag(args, 'type')) {
+    return 'on-post';
+  }
+
+  if (!hasOptionValue(args, 'type', HOOK_INIT_OPTIONS)) {
+    printUsageAndExit(HOOKS_COMMAND_HELP.init);
+  }
+
+  const typeRaw = getOption(args, 'type');
+  if (!typeRaw || !isHookTemplateType(typeRaw)) {
+    printUsageAndExit(
+      `Invalid --type: ${typeRaw ?? ''}. Expected one of: on-post, cron, moderation, bare`
+    );
+  }
+
+  return typeRaw;
+}
+
+function validateHooksArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !HOOKS_COMMAND_HELP[command]) {
+    printUsageAndExit(HOOKS_HELP);
+  }
+
+  switch (command) {
+    case 'list':
+      return;
+    case 'init': {
+      if (!args[1]) printUsageAndExit(HOOKS_COMMAND_HELP.init);
+      getHookInitType(args);
+      return;
+    }
+    case 'get':
+    case 'edit':
+    case 'delete':
+    case 'del':
+    case 'rest': {
+      if (!args[1]) printUsageAndExit(HOOKS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'add': {
+      if (!args[1] || !args[2]) printUsageAndExit(HOOKS_COMMAND_HELP.add);
+      return;
+    }
+    case 'order': {
+      const ids = args.slice(2).filter((arg) => !arg.startsWith('--'));
+      if (!args[1] || ids.length === 0)
+        printUsageAndExit(HOOKS_COMMAND_HELP.order);
+      return;
+    }
+    case 'config': {
+      const configPairs = args.slice(3).filter((arg) => !arg.startsWith('--'));
+      if (!args[1] || !args[2] || configPairs.length === 0) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.config);
+      }
+      return;
+    }
+    case 'cron': {
+      if (!args[1] || !args[2]) printUsageAndExit(HOOKS_COMMAND_HELP.cron);
+      return;
+    }
+  }
+}
+
+function getHookTemplate(name: string, type: HookTemplateType): string {
+  const safeName = name.replace(/[^a-zA-Z0-9-_ ]/g, '').trim() || 'my-hook';
+
+  if (type === 'cron') {
+    return `:: ${safeName} (${type})
+:: Deletes posts older than configured delay on cron ticks
+:: Config: delay (default ~m30 = 30 minutes)
+|=  [=event:h bowl:h]
+^-  outcome:h
+=-  &+[[[%allowed event] -] state.hook]
+?.  ?=(%cron -.event)  ~
+^-  (list effect:h)
+=+  ;;(delay=@dr (~(gut by config) 'delay' ~m30))
+=/  cutoff  (sub now delay)
+?~  channel  ~
+%+  murn
+  (tap:on-v-posts:c (lot:on-v-posts:c posts.u.channel ~ \`cutoff))
+|=  [=id-post:c post=(may:c v-post:c)]
+^-  (unit effect:h)
+?:  ?=(%| -.post)  ~
+\`[%channels %channel nest.u.channel %post %del id-post]
+`;
+  }
+
+  if (type === 'moderation') {
+    return `:: ${safeName} (${type})
+:: Blocks posts containing configured words
+:: Config: blocked (comma-separated), reason
+|=  [=event:h =bowl:h]
+^-  outcome:h
+=+  ;;(blocked=cord (~(gut by config.bowl) 'blocked' 'spam,scam'))
+=+  ;;(reason=cord (~(gut by config.bowl) 'reason' 'Message contains blocked content'))
+?.  ?=([%on-post %add *] event)
+  &+[[[%allowed event] ~] state.hook.bowl]
+=/  text=tape
+  (trip (flatten content.post.event))
+=/  bad=(list tape)
+  %+  turn
+    (rash blocked (more com (star ;~(less com prn))))
+  trip
+=/  has-bad=?
+  %+  lien  bad
+  |=  w=tape
+  !=(~ (find w text))
+?:  has-bad
+  &+[[[%denied (some reason)] ~] state.hook.bowl]
+&+[[[%allowed event] ~] state.hook.bowl]
+`;
+  }
+
+  if (type === 'bare') {
+    return `:: ${safeName} (${type})
+|=  [=event:h =bowl:h]
+^-  outcome:h
+&+[[[%allowed event] ~] state.hook.bowl]
+`;
+  }
+
+  return `:: ${safeName} (${type})
+:: Reacts to new posts with configurable emoji
+:: Config: emoji (default 👍)
+|=  [=event:h =bowl:h]
+^-  outcome:h
+=+  ;;(emoji=cord (~(gut by config.bowl) 'emoji' '👍'))
+?.  ?=([%on-post %add *] event)
+  &+[[[%allowed event] ~] state.hook.bowl]
+?:  =(author.post.event our.bowl)
+  &+[[[%allowed event] ~] state.hook.bowl]
+?~  channel.bowl
+  &+[[[%allowed event] ~] state.hook.bowl]
+=/  react-effect=effect:h
+  :*  %channels
+      %channel
+      nest.u.channel.bowl
+      [%post [%add-react id.post.event our.bowl emoji]]
+  ==
+&+[[[%allowed event] [react-effect ~]] state.hook.bowl]
+`;
+}
+
+function initHookTemplate(
+  name: string,
+  type: HookTemplateType,
+  outPath?: string,
+  force: boolean = false
+): void {
+  const path = outPath || `./${name.replace(/\s+/g, '-').toLowerCase()}.hoon`;
+  if (fs.existsSync(path) && !force) {
+    console.error(`Refusing to overwrite existing file: ${path}`);
+    console.error('Use --force to overwrite.');
+    process.exit(1);
+  }
+  const src = getHookTemplate(name, type);
+  fs.writeFileSync(path, src, 'utf-8');
+  console.log(`✅ Created ${type} hook template: ${path}`);
+  console.log('Next: edit the file, then run: tlon hooks add <name> <file>');
+}
+
+async function pokeAndWaitForHooksUpdate(
+  actionName: string,
+  json: Record<string, any>,
+  timeoutMs: number = 5000
+): Promise<void> {
+  let settled = false;
+  let resolveUpdate: ((value: any) => void) | null = null;
+
+  const waitForUpdate = new Promise<any>((resolve) => {
+    resolveUpdate = resolve;
+  });
+
+  const subId = await subscribe<any>(
+    { app: 'channels-server', path: '/v0/hooks' },
+    (update) => {
+      if (settled) return;
+      settled = true;
+      resolveUpdate?.(update);
+    }
+  );
+
+  try {
+    await poke({
+      app: 'channels-server',
+      mark: 'hook-action-0',
+      json,
+    });
+
+    const timeoutPromise = sleep(timeoutMs).then(() => ({ __timeout: true }));
+    const result = await Promise.race([waitForUpdate, timeoutPromise]);
+
+    if (result?.__timeout) {
+      console.log(
+        `⚠️ ${actionName} sent, but timed out waiting for hooks update (${timeoutMs}ms).`
+      );
+      return;
+    }
+
+    console.log(`[hooks update] ${JSON.stringify(result, null, 2)}`);
+
+    const text = JSON.stringify(result).toLowerCase();
+    if (
+      text.includes('error') ||
+      text.includes('fail') ||
+      text.includes('compile')
+    ) {
+      console.log('⚠️ Update may contain an error/compile issue.');
+    }
+  } finally {
+    settled = true;
+    await unsubscribe(subId);
+  }
+}
+
+// List all hooks
+async function listHooks(): Promise<void> {
+  const hooks = await scry<Hooks>({
+    app: 'channels-server',
+    path: '/v0/hooks',
+  });
+
+  console.log('\n=== HOOKS ===\n');
+
+  const hookList = Object.values(hooks.hooks);
+  if (hookList.length === 0) {
+    console.log('No hooks found.');
+    return;
+  }
+
+  for (const hook of hookList) {
+    console.log(`📎 ${hook.name}`);
+    console.log(`   ID: ${hook.id}`);
+    console.log(`   Compiled: ${hook.compiled ? '✓' : '✗'}`);
+
+    const configChannels = Object.keys(hook.config);
+    if (configChannels.length > 0) {
+      console.log(`   Configured for: ${configChannels.join(', ')}`);
+    }
+    console.log('');
+  }
+
+  // Show cron jobs
+  const cronEntries = Object.entries(hooks.crons);
+  if (cronEntries.length > 0) {
+    console.log('=== CRON JOBS ===\n');
+    for (const [hookId, origins] of cronEntries) {
+      const hook = hooks.hooks[hookId];
+      for (const [origin, job] of Object.entries(origins)) {
+        console.log(`⏰ ${hook?.name || hookId}`);
+        console.log(`   Origin: ${origin === 'global' ? 'global' : origin}`);
+        console.log(`   Next: ${job.schedule.next}`);
+        console.log(`   Repeat: ${job.schedule.repeat}`);
+        console.log('');
+      }
+    }
+  }
+}
+
+// Get a specific hook
+async function getHook(id: string): Promise<void> {
+  const hooks = await scry<Hooks>({
+    app: 'channels-server',
+    path: '/v0/hooks',
+  });
+  const hook = hooks.hooks[id];
+
+  if (!hook) {
+    console.error(`Hook not found: ${id}`);
+    process.exit(1);
+  }
+
+  console.log(`\n=== ${hook.name} ===\n`);
+  console.log(`ID: ${hook.id}`);
+  console.log(`Version: ${hook.version}`);
+  console.log(`Compiled: ${hook.compiled ? '✓' : '✗'}`);
+
+  if (Object.keys(hook.meta).length > 0) {
+    console.log(`Meta: ${JSON.stringify(hook.meta)}`);
+  }
+
+  console.log('\n--- Source ---');
+  console.log(hook.src);
+
+  const configChannels = Object.entries(hook.config);
+  if (configChannels.length > 0) {
+    console.log('\n--- Config ---');
+    for (const [nest, cfg] of configChannels) {
+      console.log(`  ${nest}:`);
+      for (const [key, val] of Object.entries(cfg)) {
+        console.log(`    ${key}: ${val}`);
+      }
+    }
+  }
+}
+
+// Add a new hook
+async function addHook(name: string, srcPath: string): Promise<void> {
+  if (!fs.existsSync(srcPath)) {
+    console.error(`Source file not found: ${srcPath}`);
+    process.exit(1);
+  }
+
+  const src = fs.readFileSync(srcPath, 'utf-8');
+
+  console.log(`Adding hook "${name}"...`);
+
+  await pokeAndWaitForHooksUpdate('add', {
+    add: {
+      name,
+      src,
+    },
+  });
+
+  console.log(`✅ Hook "${name}" added.`);
+  console.log("   Note: Check compilation status with 'hooks list'");
+}
+
+// Edit a hook
+async function editHook(
+  id: string,
+  options: { name?: string; srcPath?: string }
+): Promise<void> {
+  if (!options.name && !options.srcPath) {
+    console.error('Error: At least one of --name or --src is required');
+    process.exit(1);
+  }
+
+  const hooks = await scry<Hooks>({
+    app: 'channels-server',
+    path: '/v0/hooks',
+  });
+  const existing = hooks.hooks[id];
+
+  if (!existing) {
+    console.error(`Hook not found: ${id}`);
+    process.exit(1);
+  }
+
+  const edit: Record<string, any> = {
+    id,
+    name: options.name ?? existing.name,
+    meta: existing.meta ?? {},
+    src: existing.src,
+  };
+
+  if (options.srcPath) {
+    if (!fs.existsSync(options.srcPath)) {
+      console.error(`Source file not found: ${options.srcPath}`);
+      process.exit(1);
+    }
+    edit.src = fs.readFileSync(options.srcPath, 'utf-8');
+  }
+
+  console.log(`Editing hook ${id}...`);
+
+  await pokeAndWaitForHooksUpdate('edit', { edit });
+
+  console.log(`✅ Hook ${id} updated.`);
+}
+
+// Delete a hook
+async function deleteHook(id: string): Promise<void> {
+  console.log(`Deleting hook ${id}...`);
+
+  await pokeAndWaitForHooksUpdate('delete', {
+    del: id,
+  });
+
+  console.log(`✅ Hook ${id} deleted.`);
+}
+
+// Set execution order for a channel
+async function setOrder(nest: string, ids: string[]): Promise<void> {
+  console.log(`Setting hook order for ${nest}...`);
+
+  await pokeAndWaitForHooksUpdate('order', {
+    order: {
+      nest,
+      seq: ids,
+    },
+  });
+
+  console.log(`✅ Hook order set: ${ids.join(' → ')}`);
+}
+
+// Configure a hook for a channel
+async function configHook(
+  id: string,
+  nest: string,
+  config: Record<string, string>
+): Promise<void> {
+  console.log(`Configuring hook ${id} for ${nest}...`);
+
+  // Convert config values to jammed @uw encoded nouns
+  const jammedConfig: Record<string, string> = {};
+  for (const [key, value] of Object.entries(config)) {
+    // Convert string value to cord (atom) and jam it
+    const cord = cordFromUtf8(value);
+    jammedConfig[key] = render('uw', jam(cord).number);
+  }
+
+  await pokeAndWaitForHooksUpdate('config', {
+    config: {
+      id,
+      nest,
+      config: jammedConfig,
+    },
+  });
+
+  console.log(`✅ Hook ${id} configured for ${nest}`);
+}
+
+// Schedule a cron job
+async function cronHook(
+  id: string,
+  schedule: string,
+  origin?: string
+): Promise<void> {
+  console.log(`Scheduling hook ${id}...`);
+
+  await pokeAndWaitForHooksUpdate('cron', {
+    cron: {
+      id,
+      origin: origin || null,
+      schedule,
+      config: {},
+    },
+  });
+
+  console.log(`✅ Hook ${id} scheduled with interval ${schedule}`);
+}
+
+// Stop a cron job
+async function restHook(id: string, origin?: string): Promise<void> {
+  console.log(`Stopping cron for hook ${id}...`);
+
+  await pokeAndWaitForHooksUpdate('rest', {
+    rest: {
+      id,
+      origin: origin || null,
+    },
+  });
+
+  console.log(`✅ Cron stopped for hook ${id}`);
+}
+
+// Main CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(HOOKS_HELP);
+  }
+
+  if (isSubcommandHelpRequest(args)) {
+    printHelpAndExit(getHooksHelp(command));
+  }
+
+  validateHooksArgs(args);
+
+  await ensureClient();
+
+  switch (command) {
+    case 'init': {
+      const name = args[1];
+      if (!name) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.init);
+      }
+      const typeRaw = getHookInitType(args);
+      const out = getOption(args, 'out');
+      const force = hasFlag(args, 'force');
+      initHookTemplate(name, typeRaw, out, force);
+      break;
+    }
+
+    case 'list':
+      await listHooks();
+      break;
+
+    case 'get': {
+      const id = args[1];
+      if (!id) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.get);
+      }
+      await getHook(id);
+      break;
+    }
+
+    case 'add': {
+      const name = args[1];
+      const srcPath = args[2];
+      if (!name || !srcPath) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.add);
+      }
+      await addHook(name, srcPath);
+      break;
+    }
+
+    case 'edit': {
+      const id = args[1];
+      if (!id) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.edit);
+      }
+      const name = getOption(args, 'name');
+      const srcPath = getOption(args, 'src');
+      await editHook(id, { name, srcPath });
+      break;
+    }
+
+    case 'delete':
+    case 'del': {
+      const id = args[1];
+      if (!id) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.delete);
+      }
+      await deleteHook(id);
+      break;
+    }
+
+    case 'order': {
+      const nest = args[1];
+      const ids = args.slice(2).filter((a) => !a.startsWith('--'));
+      if (!nest || ids.length === 0) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.order);
+      }
+      await setOrder(nest, ids);
+      break;
+    }
+
+    case 'config': {
+      const id = args[1];
+      const nest = args[2];
+      const configPairs = args.slice(3).filter((a) => !a.startsWith('--'));
+      if (!id || !nest || configPairs.length === 0) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.config);
+      }
+      const config: Record<string, string> = {};
+      for (const pair of configPairs) {
+        const [key, ...valueParts] = pair.split('=');
+        config[key] = valueParts.join('=');
+      }
+      await configHook(id, nest, config);
+      break;
+    }
+
+    case 'cron': {
+      const id = args[1];
+      const schedule = args[2];
+      if (!id || !schedule) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.cron);
+      }
+      const nest = getOption(args, 'nest');
+      await cronHook(id, schedule, nest);
+      break;
+    }
+
+    case 'rest': {
+      const id = args[1];
+      if (!id) {
+        printUsageAndExit(HOOKS_COMMAND_HELP.rest);
+      }
+      const nest = getOption(args, 'nest');
+      await restHook(id, nest);
+      break;
+    }
+
+    default:
+      printUsageAndExit(HOOKS_HELP);
+  }
+
+  process.exit(0);
+}
+
+main().catch(printErrorAndExit);

--- a/packages/tlon-skill/scripts/main.ts
+++ b/packages/tlon-skill/scripts/main.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+
+/**
+ * tlon - Unified CLI for Tlon/Urbit operations
+ *
+ * Usage:
+ *   tlon [options] <command> <subcommand> [args...]
+ *
+ * Commands:
+ *   activity     Activity/notifications (mentions, replies, all, unreads)
+ *   channels     Channel listing and management
+ *   contacts     Contact/profile management
+ *   dms          Direct message operations
+ *   groups       Group management
+ *   messages     Message history and search (dm, channel, history, search, context, post)
+ *   notebook     Post to diary/notebook channels
+ *   posts        Post reactions, edits, deletes
+ *   settings     OpenClaw settings management
+ */
+import { createActivityDeps } from './activity-runtime';
+import { setCliCredentialOverrides } from './api-client';
+import { run as runActivityCommand } from './commands/activity';
+import { formatUnexpectedError } from './commands/command';
+import { run as runUploadCommand } from './commands/upload';
+import { CredentialFlagError, parseGlobalCliOptions } from './credential-flags';
+import { isTopLevelCommand } from './top-level-commands';
+import { createUploadDeps } from './upload-runtime';
+
+// Version is injected at build time via --define
+declare const __VERSION__: string;
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'dev';
+
+function printHelp() {
+  console.log(`tlon v${VERSION} - Tlon/Urbit CLI
+
+Usage:
+  tlon [options] <command> <subcommand> [args...]
+
+Commands:
+  activity     Activity/notifications (mentions, replies, all, unreads)
+  channels     Channel listing and management (dms, groups, info, update, delete, add/del-writers, add/del-readers)
+  contacts     Contact/profile management (list, get, self, sync, add, remove, update-profile)
+  dms          Direct message operations (send, reply, react, unreact, delete, accept, decline)
+  expose       Manage public content exposure (list, show, hide, check, url)
+  groups       Group management (list, create, info, join, request/accept invites, leave, delete, ...)
+  hooks        Channel hooks management (list, add, edit, delete, order, config, cron, rest)
+  messages     Message history and search (dm, channel, history, search, context, post)
+  notebook     Post to diary/notebook channels
+  posts        Post reactions, edits, deletes (react, unreact, edit, delete)
+  settings     OpenClaw settings management (get, set, delete, allow-dm, ...)
+  upload       Upload a file from URL, local path, or stdin
+
+Credential Options (override defaults):
+  --config <file>   Path to JSON config file with url + cookie or url + ship + code
+  --url <url>       Ship URL (e.g., https://your-ship.tlon.network)
+  --ship <~name>    Ship name (uses TLON_SKILL_DIR or cached credentials)
+  --code <code>     Access code (e.g., sampel-ticlyt-migfun-falmel)
+  --cookie <cookie> Pre-authenticated cookie (ship is parsed from cookie name unless --ship is set)
+
+Valid credential forms:
+  --config <file>
+  --url <url> --cookie <cookie> [--ship <ship>] [--code <code>]
+  --url <url> --ship <ship> --code <code>
+  --ship <ship> when available in TLON_SKILL_DIR or cache
+
+Incomplete or conflicting credential flag sets fail locally instead of merging with env vars.
+
+Other Options:
+  --verbose      Enable verbose subscription logging
+  --help, -h     Show this help
+  --version, -v  Show version
+
+Config Resolution (first match wins):
+  1. CLI credential flags
+  2. TLON_CONFIG_FILE env var
+  3. URBIT_URL/TLON_URL + URBIT_COOKIE/TLON_COOKIE
+  4. URL + SHIP + CODE via URBIT_* or TLON_* env vars
+  5. TLON_SHIP + TLON_SKILL_DIR (loads ships/<ship>.json)
+  6. Ship-only cache lookup
+  7. OpenClaw JSON config (~/.openclaw/openclaw.json)
+  8. Single cached ship (auto-select if only one)
+
+Cache writes:
+  Code login and code fallback cache the fresh cookie. Provided-cookie flows do not copy cookies into cache.
+
+Examples:
+  tlon contacts list
+  tlon messages dm ~sampel-palnet --limit 10
+  tlon groups create "My Group" --description "A cool group"
+  tlon groups create-owned "My Group" --owner ~zod
+  tlon groups join ~host/group-slug
+  tlon posts react chat/~host/channel 170.141.184... 👍
+  tlon --config ~/ships/zod.json contacts self
+  tlon --url https://zod.tlon.network --cookie "urbauth-~zod=0v..." contacts self
+  tlon --url https://zod.tlon.network --ship ~zod --code abcd-efgh-ijkl-mnop contacts self
+`);
+}
+
+async function main() {
+  const rawArgs = process.argv.slice(2);
+
+  let parsed;
+  try {
+    parsed = parseGlobalCliOptions(rawArgs);
+  } catch (error: any) {
+    if (error instanceof CredentialFlagError) {
+      console.error('Error:', error.message);
+      console.error('Run "tlon --help" for usage information.');
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  if (parsed.verbose) {
+    process.env.TLON_VERBOSE = '1';
+  }
+
+  setCliCredentialOverrides(parsed.credentialOverrides);
+  const args = parsed.args;
+
+  const command = args[0];
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (command === '--version' || command === '-v') {
+    console.log(VERSION);
+    process.exit(0);
+  }
+
+  if (!isTopLevelCommand(command)) {
+    console.error(`Unknown command: ${command}`);
+    console.error('Run "tlon --help" for usage information.');
+    process.exit(1);
+  }
+
+  const scriptArgs = args.slice(1);
+
+  try {
+    switch (command) {
+      case 'activity': {
+        const exitCode = await runActivityCommand(
+          scriptArgs,
+          createActivityDeps()
+        );
+        process.exit(exitCode);
+        break;
+      }
+      case 'upload': {
+        const exitCode = await runUploadCommand(scriptArgs, createUploadDeps());
+        process.exit(exitCode);
+        break;
+      }
+      case 'channels': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./channels');
+        break;
+      }
+      case 'contacts': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./contacts');
+        break;
+      }
+      case 'dms': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./dms');
+        break;
+      }
+      case 'expose': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./expose');
+        break;
+      }
+      case 'groups': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./groups');
+        break;
+      }
+      case 'hooks': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./hooks');
+        break;
+      }
+      case 'messages': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./messages');
+        break;
+      }
+      case 'notebook': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./notebook-post');
+        break;
+      }
+      case 'posts': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./posts');
+        break;
+      }
+      case 'settings': {
+        process.argv = ['tlon', command, ...scriptArgs];
+        const mod = await import('./settings');
+        break;
+      }
+    }
+  } catch (error: any) {
+    process.stderr.write(formatUnexpectedError(error));
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/tlon-skill/scripts/messages.ts
+++ b/packages/tlon-skill/scripts/messages.ts
@@ -1,0 +1,526 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Messages API for Tlon
+ *
+ * Usage:
+ *   npx ts-node scripts/messages.ts dm ~sampel-palnet [--limit N] [--resolve-cites]
+ *   npx ts-node scripts/messages.ts channel chat/~host/channel-slug [--limit N] [--resolve-cites]
+ *   npx ts-node scripts/messages.ts history "chat/~host/channel-slug" [--limit N] [--resolve-cites]
+ *   npx ts-node scripts/messages.ts search "query" --channel chat/~host/channel-slug
+ *   npx ts-node scripts/messages.ts context <channel|~ship> <postId> [--limit N] [--resolve-cites]
+ *   npx ts-node scripts/messages.ts post <channel|~ship> <postId> [--author ~ship] [--resolve-cites]
+ *
+ * Options:
+ *   --resolve-cites, --quotes   Fetch and display quoted/cited message content
+ */
+import {
+  getChannelPosts,
+  getPostReference,
+  getPostWithReplies,
+  getTextContent,
+  parsePostBlob,
+  searchChannel,
+} from '@tloncorp/api';
+import type { ClientPostBlobData, ContentReference, Post } from '@tloncorp/api';
+
+import { ensureClient, normalizeShip } from './api-client';
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from './cli-utils';
+
+const MESSAGES_HELP = `Usage: tlon messages <command>
+
+Commands:
+  dm ~ship                                    Show DM history
+  channel <nest>                              Show channel messages
+  history <nest>                              Alias for channel
+  search "query" --channel <nest>             Search in channel
+  context <channel|~ship> <postId>            Show messages around a post
+  post <channel|~ship> <postId>               Fetch a single post with replies
+
+Examples:
+  tlon messages dm ~sampel-palnet --limit 10
+  tlon messages channel chat/~host/channel-slug --limit 20
+  tlon messages search "hello" --channel chat/~host/slug
+  tlon messages context chat/~host/slug 170.141.184... --limit 5
+  tlon messages post chat/~host/slug 170.141.184...`;
+
+const MESSAGES_COMMAND_HELP: Record<string, string> = {
+  dm: 'Usage: tlon messages dm ~ship [--limit N] [--resolve-cites]',
+  channel:
+    'Usage: tlon messages channel chat/~host/slug [--limit N] [--resolve-cites]',
+  history:
+    'Usage: tlon messages history "chat/~host/channel-slug" [--limit N] [--resolve-cites]',
+  search: 'Usage: tlon messages search "query" --channel chat/~host/slug',
+  context:
+    'Usage: tlon messages context <channel|~ship> <postId> [--limit N] [--resolve-cites]',
+  post: 'Usage: tlon messages post <channel|~ship> <postId> [--author ~ship] [--resolve-cites]',
+};
+
+function getMessagesHelp(command?: string): string {
+  return command
+    ? MESSAGES_COMMAND_HELP[command] ?? MESSAGES_HELP
+    : MESSAGES_HELP;
+}
+
+function getSearchChannel(args: string[]): string | undefined {
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--channel') {
+      const channel = args[i + 1];
+      return channel && !channel.startsWith('--') ? channel : undefined;
+    }
+  }
+  return undefined;
+}
+
+function isSearchQueryHelpLiteral(args: string[]): boolean {
+  return args[0] === 'search' && isHelpArg(args[1]) && !!getSearchChannel(args);
+}
+
+function validateMessagesArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !MESSAGES_COMMAND_HELP[command]) {
+    printUsageAndExit(MESSAGES_HELP);
+  }
+
+  switch (command) {
+    case 'dm':
+    case 'channel':
+    case 'history': {
+      if (!args[1]) printUsageAndExit(MESSAGES_COMMAND_HELP[command]);
+      return;
+    }
+    case 'search': {
+      if (!args[1] || !getSearchChannel(args)) {
+        printUsageAndExit(MESSAGES_COMMAND_HELP.search);
+      }
+      return;
+    }
+    case 'context':
+    case 'post': {
+      if (!args[1] || !args[2])
+        printUsageAndExit(MESSAGES_COMMAND_HELP[command]);
+      return;
+    }
+  }
+}
+
+// Extract text content from a Story
+function extractText(content: any): string {
+  if (!content) return '';
+  // getTextContent expects an array (Story/Verse[])
+  if (!Array.isArray(content)) {
+    // Handle case where content might be wrapped or in unexpected format
+    if (typeof content === 'string') return content;
+    if (content.story && Array.isArray(content.story)) {
+      return getTextContent(content.story) || '';
+    }
+    return JSON.stringify(content);
+  }
+  return getTextContent(content) || '';
+}
+
+function extractChannelReferences(content: any): ContentReference[] {
+  if (!Array.isArray(content)) return [];
+  return content.filter(
+    (verse) => verse && typeof verse === 'object' && verse.type === 'reference'
+  ) as ContentReference[];
+}
+
+// Format a timestamp
+function formatTime(timeVal: string | number): string {
+  try {
+    const num = typeof timeVal === 'number' ? timeVal : parseInt(timeVal, 10);
+    if (!isNaN(num) && num > 1600000000000) {
+      const date = new Date(num);
+      return date.toLocaleString();
+    }
+    const timeStr = String(timeVal);
+    const daNum = BigInt(timeStr.replace(/\./g, ''));
+    const DA_SECOND = BigInt('18446744073709551616');
+    const DA_UNIX_EPOCH = BigInt('170141184475152167957503069145530368000');
+    const offset = DA_SECOND / BigInt(2000);
+    const epochAdjusted = offset + (daNum - DA_UNIX_EPOCH);
+    const unixMs = Math.round(
+      Number((epochAdjusted * BigInt(1000)) / DA_SECOND)
+    );
+
+    const date = new Date(unixMs);
+    if (date.getFullYear() > 2020 && date.getFullYear() < 2100) {
+      return date.toLocaleString();
+    }
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function resolveCites(post: Post): Promise<string[]> {
+  const references = extractChannelReferences(post.content);
+  if (!references.length) return [];
+
+  const citeTexts: string[] = [];
+  for (const ref of references) {
+    if (ref.referenceType !== 'channel') continue;
+    try {
+      const refPost = await getPostReference({
+        channelId: ref.channelId,
+        postId: ref.postId,
+        replyId: ref.replyId,
+      });
+      const text = extractText(refPost.content);
+      if (text) {
+        citeTexts.push(text);
+      }
+    } catch {
+      // ignore cite failures
+    }
+  }
+  return citeTexts;
+}
+
+async function printPosts(
+  posts: Post[],
+  resolve: boolean,
+  highlightId?: string
+) {
+  if (!posts.length) {
+    console.log('No messages found.');
+    return;
+  }
+
+  const sorted = [...posts].sort((a, b) => a.sentAt - b.sentAt);
+
+  for (const post of sorted) {
+    const author = post.authorId || 'unknown';
+    const time = formatTime(post.sentAt);
+    const text = extractText(post.content);
+    const replySuffix = post.parentId ? ` (reply to ${post.parentId})` : '';
+    const marker = highlightId && post.id === highlightId ? ' ◀ TARGET' : '';
+
+    console.log(`- ${author} @ ${time}${replySuffix}${marker}`);
+    console.log(`  ID: ${post.id}`);
+    if (text) {
+      console.log(`  ${text}`);
+    }
+
+    // Show blob/attachment info (PDFs, files, voice memos)
+    if (post.blob) {
+      try {
+        const blobData: ClientPostBlobData = parsePostBlob(post.blob);
+        for (const entry of blobData) {
+          if (entry.type === 'file') {
+            console.log(
+              `  📎 [${entry.name || 'file'}] (${entry.mimeType || 'unknown'}, ${entry.size ? Math.round(entry.size / 1024) + 'KB' : '?'})`
+            );
+            if (entry.fileUri) console.log(`     ${entry.fileUri}`);
+          } else if (entry.type === 'voicememo') {
+            const dur = entry.duration ? `${Math.round(entry.duration)}s` : '?';
+            console.log(`  🎙️ [voice memo] (${dur})`);
+            if (entry.transcription)
+              console.log(`     "${entry.transcription}"`);
+          } else if (entry.type === 'video') {
+            console.log(
+              `  🎬 [${entry.name || 'video'}] (${entry.mimeType || 'video'})`
+            );
+          }
+        }
+      } catch {
+        console.log(`  [blob: ${post.blob.slice(0, 100)}...]`);
+      }
+    }
+
+    if (resolve) {
+      const cites = await resolveCites(post);
+      for (const cite of cites) {
+        console.log(`  > ${cite}`);
+      }
+    }
+
+    console.log('');
+  }
+}
+
+// Fetch DM messages via the chat agent (not channels)
+async function fetchDmMessages(
+  ship: string,
+  limit: number = 20,
+  resolveCites: boolean = false
+): Promise<void> {
+  const normalizedShip = normalizeShip(ship);
+
+  console.log(`Fetching DMs with: ${normalizedShip}`);
+  console.log(`Limit: ${limit}${resolveCites ? ' (resolving quotes)' : ''}\n`);
+
+  try {
+    const data = await getChannelPosts({
+      channelId: normalizedShip,
+      mode: 'newest',
+      count: limit,
+      includeReplies: true,
+    });
+
+    console.log(`=== DMs with ${normalizedShip} (${data.posts.length}) ===\n`);
+    await printPosts(data.posts, resolveCites);
+  } catch (error: any) {
+    console.error(`Error fetching DMs: ${error.message}`);
+  }
+}
+
+// Fetch messages from a channel
+async function fetchMessages(
+  channel: string,
+  limit: number = 20,
+  resolveCites: boolean = false
+): Promise<void> {
+  console.log(`Fetching messages from: ${channel}`);
+  console.log(`Limit: ${limit}${resolveCites ? ' (resolving quotes)' : ''}\n`);
+
+  try {
+    const data = await getChannelPosts({
+      channelId: channel,
+      mode: 'newest',
+      count: limit,
+      includeReplies: true,
+    });
+
+    console.log(`=== Messages in ${channel} (${data.posts.length}) ===\n`);
+    await printPosts(data.posts, resolveCites);
+  } catch (error: any) {
+    console.error(`Error fetching messages: ${error.message}`);
+    console.log(
+      'Note: Check that the channel path is correct (e.g., chat/~host/slug)'
+    );
+  }
+}
+
+// Search messages in a channel
+async function searchMessages(query: string, channel: string): Promise<void> {
+  console.log(`Searching "${query}" in: ${channel}\n`);
+
+  try {
+    const results = await searchChannel({
+      channelId: channel,
+      query,
+    });
+
+    if (!results.posts.length) {
+      console.log('No results found.');
+      return;
+    }
+
+    console.log(`Found ${results.posts.length} results:\n`);
+    await printPosts(results.posts, false);
+  } catch (error: any) {
+    console.error(`Error searching messages: ${error.message}`);
+  }
+}
+
+// Fetch context around a specific post (messages before and after)
+// Uses the backend's native %around scry which fetches N posts in each
+// direction plus the target post itself in a single request.
+async function fetchContext(
+  channelId: string,
+  postId: string,
+  limit: number = 10,
+  resolve: boolean = false
+): Promise<void> {
+  console.log(`Fetching context around post ${postId} in ${channelId}`);
+  console.log(
+    `Limit: ${limit} messages each direction${resolve ? ' (resolving quotes)' : ''}\n`
+  );
+
+  try {
+    // The backend supports %around mode which fetches N older + N newer + the
+    // target post in one scry. The JS API types only declare "older"|"newer"
+    // but the path builder is generic, so "around" just works at runtime.
+    const data = await getChannelPosts({
+      channelId,
+      cursor: postId,
+      mode: 'around' as any,
+      count: limit,
+      includeReplies: true,
+    });
+
+    console.log(
+      `=== Context around ${postId} (${data.posts.length} messages) ===\n`
+    );
+
+    await printPosts(data.posts, resolve, postId);
+  } catch (error: any) {
+    console.error(`Error fetching context: ${error.message}`);
+  }
+}
+
+async function getPostWithOptionalAuthor({
+  channelId,
+  postId,
+  authorId,
+}: {
+  channelId: string;
+  postId: string;
+  authorId?: string;
+}) {
+  return getPostWithReplies({
+    channelId,
+    postId,
+    authorId: authorId ?? '',
+  });
+}
+
+// Fetch a single post (with replies if it's a thread)
+async function fetchPost(
+  channelId: string,
+  postId: string,
+  authorId?: string,
+  resolve: boolean = false
+): Promise<void> {
+  console.log(`Fetching post ${postId} from ${channelId}\n`);
+
+  try {
+    const post = await getPostWithOptionalAuthor({
+      channelId,
+      postId,
+      authorId,
+    });
+
+    if (!post) {
+      console.log('Post not found.');
+      return;
+    }
+
+    const author = post.authorId || 'unknown';
+    const time = formatTime(post.sentAt);
+    const text = extractText(post.content);
+
+    console.log(`=== Post ${postId} ===\n`);
+    console.log(`Author: ${author}`);
+    console.log(`Time: ${time}`);
+    console.log(`ID: ${post.id}`);
+    if (text) {
+      console.log(`\n${text}`);
+    }
+
+    if (resolve) {
+      const cites = await resolveCites(post);
+      for (const cite of cites) {
+        console.log(`\n> ${cite}`);
+      }
+    }
+
+    if (post.replies && post.replies.length > 0) {
+      console.log(`\n--- Replies (${post.replies.length}) ---\n`);
+      await printPosts(post.replies, resolve);
+    }
+  } catch (error: any) {
+    console.error(`Error fetching post: ${error.message}`);
+  }
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(MESSAGES_HELP);
+  }
+
+  if (wantsHelp(args.slice(1)) && !isSearchQueryHelpLiteral(args)) {
+    printHelpAndExit(getMessagesHelp(command));
+  }
+
+  validateMessagesArgs(args);
+
+  await ensureClient();
+
+  // Parse --limit flag
+  let limit = 20;
+  const limitIdx = args.indexOf('--limit');
+  if (limitIdx !== -1 && args[limitIdx + 1]) {
+    limit = parseInt(args[limitIdx + 1], 10);
+  }
+
+  const resolveCites =
+    args.includes('--resolve-cites') || args.includes('--quotes');
+
+  try {
+    switch (command) {
+      case 'dm': {
+        const ship = args[1];
+        if (!ship) {
+          printUsageAndExit(MESSAGES_COMMAND_HELP.dm);
+        }
+        await fetchDmMessages(ship, limit, resolveCites);
+        break;
+      }
+
+      case 'channel': {
+        const channelPath = args[1];
+        if (!channelPath) {
+          printUsageAndExit(MESSAGES_COMMAND_HELP.channel);
+        }
+        await fetchMessages(channelPath, limit, resolveCites);
+        break;
+      }
+
+      case 'history': {
+        const channelPath = args[1];
+        if (!channelPath) {
+          printUsageAndExit(MESSAGES_COMMAND_HELP.history);
+        }
+        await fetchMessages(channelPath, limit, resolveCites);
+        break;
+      }
+
+      case 'search': {
+        const query = args[1];
+        const channel = getSearchChannel(args);
+
+        if (!query || !channel) {
+          printUsageAndExit(MESSAGES_COMMAND_HELP.search);
+        }
+        await searchMessages(query, channel);
+        break;
+      }
+
+      case 'context': {
+        const target = args[1];
+        const postId = args[2];
+        if (!target || !postId) {
+          printUsageAndExit(MESSAGES_COMMAND_HELP.context);
+        }
+        await fetchContext(target, postId, limit, resolveCites);
+        break;
+      }
+
+      case 'post': {
+        const target = args[1];
+        const postId = args[2];
+        if (!target || !postId) {
+          printUsageAndExit(MESSAGES_COMMAND_HELP.post);
+        }
+        let author: string | undefined;
+        const authorIdx = args.indexOf('--author');
+        if (authorIdx !== -1 && args[authorIdx + 1]) {
+          author = normalizeShip(args[authorIdx + 1]);
+        }
+        await fetchPost(target, postId, author, resolveCites);
+        break;
+      }
+
+      default:
+        printUsageAndExit(MESSAGES_HELP);
+    }
+    process.exit(0);
+  } catch (error) {
+    printErrorAndExit(error);
+  }
+}
+
+main();

--- a/packages/tlon-skill/scripts/notebook-content.test.ts
+++ b/packages/tlon-skill/scripts/notebook-content.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test';
+
+import { normalizeNotebookContent } from './notebook-content';
+
+describe('normalizeNotebookContent', () => {
+  it('keeps Story content unchanged', () => {
+    const story = [{ inline: ['Body'] }];
+
+    expect(normalizeNotebookContent(story)).toEqual(story);
+  });
+
+  it('accepts empty Story content', () => {
+    expect(normalizeNotebookContent([])).toEqual([]);
+  });
+
+  it('accepts common Story block and inline shapes', () => {
+    const story = [
+      { inline: ['Use ', { 'inline-code': 'ha-q' }, ' here'] },
+      { block: { header: { tag: 'h2', content: [{ bold: ['Title'] }] } } },
+      { block: { code: { code: 'const value = 1;', lang: 'ts' } } },
+      {
+        block: {
+          image: {
+            src: 'https://example.com/image.png',
+            height: 100,
+            width: 200,
+            alt: '',
+          },
+        },
+      },
+      { block: { rule: null } },
+    ];
+
+    expect(normalizeNotebookContent(story)).toEqual(story);
+  });
+
+  it('passes through ship-supported Story shapes that are not locally modeled', () => {
+    const story = [
+      { block: { listing: [{ inline: ['Item'] }] } },
+      {
+        block: {
+          link: {
+            href: 'https://example.com',
+            content: [{ inline: ['Example'] }],
+          },
+        },
+      },
+      {
+        inline: [
+          { cite: { chan: { nest: 'chat/~host/slug', where: '170.141' } } },
+        ],
+      },
+      { inline: [{ task: { checked: false, content: ['Todo'] } }] },
+      { inline: [{ sect: 'Section' }] },
+      { inline: [{ block: { rule: null } }] },
+    ];
+
+    expect(normalizeNotebookContent(story)).toEqual(story);
+  });
+
+  it('rejects arrays that are not Story verse arrays', () => {
+    expect(() => normalizeNotebookContent([1, 2])).toThrow(
+      'Unsupported notebook content JSON'
+    );
+    expect(() => normalizeNotebookContent([{}])).toThrow(
+      'Unsupported notebook content JSON'
+    );
+    expect(() => normalizeNotebookContent([{ inline: 'Body' }])).toThrow(
+      'Unsupported notebook content JSON'
+    );
+    expect(() => normalizeNotebookContent([{ block: {} }])).toThrow(
+      'Unsupported notebook content JSON'
+    );
+    expect(() =>
+      normalizeNotebookContent([{ inline: [], block: { rule: null } }])
+    ).toThrow('Unsupported notebook content JSON');
+    expect(() =>
+      normalizeNotebookContent([{ inline: ['ok'], foo: 1 }])
+    ).toThrow('Unsupported notebook content JSON');
+    expect(() =>
+      normalizeNotebookContent([{ block: { rule: null }, foo: 1 }])
+    ).toThrow('Unsupported notebook content JSON');
+  });
+
+  it('rejects ProseMirror-style rich-text JSON instead of guessing', () => {
+    expect(() =>
+      normalizeNotebookContent({
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ text: 'Body' }] }],
+      })
+    ).toThrow('Unsupported notebook content JSON');
+  });
+
+  it('rejects unsupported explicit content instead of returning title-only content', () => {
+    expect(() => normalizeNotebookContent({ unsupported: true })).toThrow(
+      'Unsupported notebook content JSON'
+    );
+  });
+});

--- a/packages/tlon-skill/scripts/notebook-content.ts
+++ b/packages/tlon-skill/scripts/notebook-content.ts
@@ -1,0 +1,30 @@
+const UNSUPPORTED_CONTENT_ERROR =
+  'Unsupported notebook content JSON: expected a Story array';
+
+export type NotebookStoryVerse =
+  | { inline: unknown[] }
+  | { block: Record<string, unknown> };
+export type NotebookStory = NotebookStoryVerse[];
+
+function isPlainObject(value: any): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isStoryVerseEnvelope(value: any): boolean {
+  if (!isPlainObject(value)) return false;
+
+  const keys = Object.keys(value);
+  if (keys.length !== 1) return false;
+
+  if (keys[0] === 'inline') return Array.isArray(value.inline);
+  if (keys[0] === 'block') {
+    return isPlainObject(value.block) && Object.keys(value.block).length === 1;
+  }
+  return false;
+}
+
+export function normalizeNotebookContent(raw: any): NotebookStory {
+  if (Array.isArray(raw) && raw.every(isStoryVerseEnvelope))
+    return raw as NotebookStory;
+  throw new Error(UNSUPPORTED_CONTENT_ERROR);
+}

--- a/packages/tlon-skill/scripts/notebook-post.ts
+++ b/packages/tlon-skill/scripts/notebook-post.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Post to a Tlon notebook (diary channel)
+ *
+ * Usage:
+ *   npx ts-node scripts/notebook-post.ts <nest> <title> [--image <url>] [--content <json-file>] [--stdin] [--markdown <file>] [--markdown-stdin]
+ *
+ * Examples:
+ *   npx ts-node scripts/notebook-post.ts diary/~host/channel "My Post Title"
+ *   npx ts-node scripts/notebook-post.ts diary/~host/channel "My Post" --image https://example.com/cover.png
+ *   npx ts-node scripts/notebook-post.ts diary/~host/channel "My Post" --content story.json
+ *   npx ts-node scripts/notebook-post.ts diary/~host/channel "My Post" --markdown article.md
+ *
+ * If no explicit content is provided, creates a post with a title and empty body.
+ * --content and --stdin accept Story JSON. Use --markdown or --markdown-stdin
+ * for Markdown input.
+ */
+import { getCurrentUserId, sendPost } from '@tloncorp/api';
+import type { Story } from '@tloncorp/api';
+import * as fs from 'fs';
+
+import { ensureClient } from './api-client';
+import {
+  getRequiredOptionValue,
+  isCommandHelpRequest,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+} from './cli-utils';
+import {
+  type NotebookStory,
+  normalizeNotebookContent,
+} from './notebook-content';
+import { markdownToStory } from './story';
+
+interface PostResult {
+  success: boolean;
+  error?: string;
+  messageId?: string;
+}
+
+const NOTEBOOK_HELP = `Usage: tlon notebook <nest> <title> [options]
+
+Arguments:
+  nest    Diary channel nest (e.g., diary/~host/channel-name)
+  title   Post title
+
+Options:
+  --image <url>     Cover image URL
+  --content <file>  JSON file with Story JSON
+  --stdin           Read Story JSON from stdin
+  --markdown <file> Markdown file to convert to Story
+  --markdown-stdin  Read Markdown from stdin
+
+If no content is provided, creates a post with a title and empty body.
+
+Examples:
+  tlon notebook diary/~host/notes "Hello World"
+  tlon notebook diary/~host/notes "My Post" --image https://example.com/img.png
+  echo '[{"inline":["Hello!"]}]' | tlon notebook diary/~host/notes "Test" --stdin
+  tlon notebook diary/~host/notes "Markdown Post" --markdown post.md`;
+
+function toApiStory(content: NotebookStory): Story {
+  return content as unknown as Story;
+}
+
+export async function postToNotebook(
+  nest: string,
+  title: string,
+  content: NotebookStory,
+  image?: string
+): Promise<PostResult> {
+  const authorId = getCurrentUserId();
+  const sentAt = Date.now();
+
+  try {
+    await sendPost({
+      channelId: nest,
+      authorId,
+      sentAt,
+      content: toApiStory(content),
+      metadata: {
+        title,
+        description: '',
+        image: image || '',
+        cover: '',
+      },
+    });
+
+    return { success: true };
+  } catch (err: any) {
+    return { success: false, error: err.message };
+  }
+}
+
+// CLI handling
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (isCommandHelpRequest(args)) {
+    printHelpAndExit(NOTEBOOK_HELP);
+  }
+
+  if (args.length < 2) {
+    printUsageAndExit(NOTEBOOK_HELP);
+  }
+
+  const nest = args[0];
+  const title = args[1];
+
+  let image: string | undefined;
+  let content: NotebookStory = [];
+  let contentSource: string | undefined;
+
+  const claimContentSource = (source: string) => {
+    if (contentSource) {
+      throw new Error(
+        `Only one content source can be provided (${contentSource} and ${source})`
+      );
+    }
+    contentSource = source;
+  };
+
+  const readStdin = async (): Promise<string> => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+  };
+
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--image') {
+      image = getRequiredOptionValue(args, i);
+      i++;
+    } else if (args[i] === '--content') {
+      claimContentSource('--content');
+      const file = getRequiredOptionValue(args, i);
+      const data = fs.readFileSync(file, 'utf-8');
+      content = normalizeNotebookContent(JSON.parse(data));
+      i++;
+    } else if (args[i] === '--stdin') {
+      claimContentSource('--stdin');
+      const data = await readStdin();
+      content = normalizeNotebookContent(JSON.parse(data));
+    } else if (args[i] === '--markdown') {
+      claimContentSource('--markdown');
+      const file = getRequiredOptionValue(args, i);
+      const data = fs.readFileSync(file, 'utf-8');
+      content = markdownToStory(data);
+      i++;
+    } else if (args[i] === '--markdown-stdin') {
+      claimContentSource('--markdown-stdin');
+      const data = await readStdin();
+      content = markdownToStory(data);
+    } else {
+      throw new Error(`Unknown option: ${args[i]}`);
+    }
+  }
+
+  console.log(`Posting to: ${nest}`);
+  console.log(`Title: ${title}`);
+  if (image) console.log(`Image: ${image}`);
+
+  await ensureClient(['channels']);
+  const result = await postToNotebook(nest, title, content, image);
+
+  if (result.success) {
+    console.log(`✓ Posted successfully!`);
+    process.exit(0);
+  } else {
+    console.error(`✗ Failed: ${result.error}`);
+    process.exit(1);
+  }
+}
+
+main().catch(printErrorAndExit);

--- a/packages/tlon-skill/scripts/postinstall.js
+++ b/packages/tlon-skill/scripts/postinstall.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+/**
+ * Postinstall script - verify binary is available for this platform
+ */
+import { chmodSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const PLATFORMS = {
+  'darwin-arm64': '@tloncorp/tlon-skill-darwin-arm64',
+  'darwin-x64': '@tloncorp/tlon-skill-darwin-x64',
+  'linux-x64': '@tloncorp/tlon-skill-linux-x64',
+  'linux-arm64': '@tloncorp/tlon-skill-linux-arm64',
+};
+
+const platform = process.platform;
+const arch = process.arch;
+const key = `${platform}-${arch}`;
+
+const packageName = PLATFORMS[key];
+if (!packageName) {
+  console.warn(
+    `[tlon-skill] Warning: No binary available for ${platform}-${arch}`
+  );
+  console.warn(
+    `[tlon-skill] Supported platforms: ${Object.keys(PLATFORMS).join(', ')}`
+  );
+  process.exit(0); // Don't fail install
+}
+
+// Try to find and chmod the binary
+function findBinary() {
+  // Check local dev binary
+  const localBin = join(__dirname, '..', 'bin', 'tlon');
+  if (existsSync(localBin)) {
+    return localBin;
+  }
+
+  // Check via require.resolve
+  try {
+    const pkgPath = require.resolve(`${packageName}/package.json`);
+    const binPath = join(dirname(pkgPath), 'tlon');
+    if (existsSync(binPath)) {
+      return binPath;
+    }
+  } catch {
+    // Not found via require
+  }
+
+  // Check sibling node_modules
+  const sibling = join(__dirname, '..', '..', packageName, 'tlon');
+  if (existsSync(sibling)) {
+    return sibling;
+  }
+
+  return null;
+}
+
+const binaryPath = findBinary();
+
+if (binaryPath) {
+  try {
+    chmodSync(binaryPath, 0o755);
+    console.log(`[tlon-skill] Binary ready: ${binaryPath}`);
+  } catch (err) {
+    // chmod might fail on some filesystems, that's ok
+    console.log(`[tlon-skill] Binary found: ${binaryPath}`);
+  }
+} else {
+  console.warn(
+    `[tlon-skill] Warning: Could not find binary for ${platform}-${arch}`
+  );
+  console.warn(
+    `[tlon-skill] The ${packageName} package may not have installed correctly.`
+  );
+  console.warn(`[tlon-skill] Try: npm install ${packageName}`);
+}

--- a/packages/tlon-skill/scripts/posts.ts
+++ b/packages/tlon-skill/scripts/posts.ts
@@ -1,0 +1,440 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Channel post management for Tlon
+ *
+ * Note: Sending and replying to channel posts is handled by the openclaw-tlon
+ * channel plugin. This script handles reactions, edits, and deletes only.
+ *
+ * Usage:
+ *   npx ts-node scripts/posts.ts react <channel> <post-id> <emoji>
+ *   npx ts-node scripts/posts.ts unreact <channel> <post-id>
+ *   npx ts-node scripts/posts.ts edit <channel> <post-id> <message>
+ *   npx ts-node scripts/posts.ts delete <channel> <post-id>
+ *
+ * Channel format: chat/~host/channel-name, diary/~host/channel-name, heap/~host/channel-name
+ */
+import {
+  addReaction,
+  deletePost,
+  editPost,
+  getChannelPosts,
+  getCurrentUserId,
+  removeReaction,
+} from '@tloncorp/api';
+import type { Post } from '@tloncorp/api';
+import * as fs from 'fs';
+
+import { ensureClient } from './api-client';
+import {
+  hasOptionValue,
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from './cli-utils';
+import { type Story, markdownToStory } from './story';
+
+const POSTS_HELP = `Usage: tlon posts <command>
+
+Note: Sending and replying to posts is handled by the Tlon channel plugin.
+
+Commands:
+  react <channel> <post-id> <emoji>     React to a post with an emoji
+  unreact <channel> <post-id>           Remove your reaction from a post
+  edit <channel> <post-id> <message>    Edit a post [--title <t>] [--image <url>] [--content <json>]
+  delete <channel> <post-id>            Delete a post
+
+Edit options:
+  --title <title>      Set/update notebook post title
+  --image <url>        Set/update cover image (notebooks)
+  --content <file>     Use Story JSON file for rich content (notebooks)
+
+Examples:
+  tlon posts edit chat/~host/channel 170.141... "Updated message"
+  tlon posts edit diary/~host/notes 170.141... --title "New Title" --image https://example.com/cover.jpg --content article.json
+
+Channel format: chat/~host/channel-name, diary/~host/name, heap/~host/name
+Use 'tlon messages channel <nest> --limit N' to see post IDs.`;
+
+const POSTS_COMMAND_HELP: Record<string, string> = {
+  react: 'Usage: tlon posts react <channel> <post-id> <emoji>',
+  unreact: 'Usage: tlon posts unreact <channel> <post-id>',
+  edit: 'Usage: tlon posts edit <channel> <post-id> <message> [--title <title>] [--image <url>] [--content <json-file>]',
+  delete: 'Usage: tlon posts delete <channel> <post-id>',
+};
+
+const POSTS_UNSUPPORTED_COMMAND_ERRORS: Record<string, string> = {
+  send: 'Channel post send is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon instead.',
+  reply:
+    'Channel post reply is handled by the Tlon channel plugin.\nUse the channel message tool with channel=tlon and replyTo instead.',
+};
+
+const POST_EDIT_OPTION_FLAGS = ['title', 'content', 'image'] as const;
+
+function getPostsHelp(command?: string): string {
+  return command ? POSTS_COMMAND_HELP[command] ?? POSTS_HELP : POSTS_HELP;
+}
+
+function firstPostEditFlagIndex(args: string[]): number {
+  const flagIndexes = POST_EDIT_OPTION_FLAGS.map((flag) =>
+    args.indexOf(`--${flag}`)
+  ).filter((idx) => idx !== -1);
+  return flagIndexes.length > 0 ? Math.min(...flagIndexes) : args.length;
+}
+
+function getPostEditMessage(args: string[]): string {
+  return args.slice(3, firstPostEditFlagIndex(args)).join(' ');
+}
+
+function isPostEditMessageHelpLiteral(args: string[]): boolean {
+  return (
+    args[0] === 'edit' &&
+    !!args[1] &&
+    !!args[2] &&
+    wantsHelp(args.slice(3, firstPostEditFlagIndex(args)))
+  );
+}
+
+function validatePostsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command) {
+    printUsageAndExit(POSTS_HELP);
+  }
+  if (POSTS_UNSUPPORTED_COMMAND_ERRORS[command]) {
+    printErrorAndExit(POSTS_UNSUPPORTED_COMMAND_ERRORS[command]);
+  }
+  if (!POSTS_COMMAND_HELP[command]) {
+    printUsageAndExit(POSTS_HELP);
+  }
+
+  switch (command) {
+    case 'react': {
+      if (!args[1] || !args[2] || !args[3])
+        printUsageAndExit(POSTS_COMMAND_HELP.react);
+      return;
+    }
+    case 'unreact':
+    case 'delete': {
+      if (!args[1] || !args[2]) printUsageAndExit(POSTS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'edit': {
+      if (!args[1] || !args[2]) printUsageAndExit(POSTS_COMMAND_HELP.edit);
+      const message = getPostEditMessage(args);
+      if (
+        !message &&
+        !hasOptionValue(args, 'content', POST_EDIT_OPTION_FLAGS)
+      ) {
+        printUsageAndExit(POSTS_COMMAND_HELP.edit);
+      }
+      return;
+    }
+  }
+}
+
+// Strip optional ~ship/ prefix from a post ID, returning just the numeric part
+function extractNumericId(id: string): string {
+  const slash = id.indexOf('/');
+  return slash >= 0 ? id.slice(slash + 1) : id;
+}
+
+// Format a post ID as @ud (with dots every 3 digits)
+// This is required for reactions to work properly
+function formatUd(id: string): string {
+  const clean = id.replace(/\./g, '');
+  const parts: string[] = [];
+  for (let i = clean.length; i > 0; i -= 3) {
+    parts.unshift(clean.slice(Math.max(0, i - 3), i));
+  }
+  return parts.join('.');
+}
+
+// Parse content into Story format with rich markdown support
+function parseContent(message: string): Story {
+  return markdownToStory(message);
+}
+
+// Fetch existing post to preserve metadata during edits
+async function fetchExistingPost(
+  nest: string,
+  postId: string
+): Promise<Post | null> {
+  const formattedId = formatUd(extractNumericId(postId));
+  try {
+    const data = await getChannelPosts({
+      channelId: nest,
+      mode: 'around',
+      cursor: formattedId,
+      count: 1,
+      includeReplies: false,
+    });
+
+    // Find the exact post by ID
+    const post = data.posts.find(
+      (p) => formatUd(extractNumericId(p.id)) === formattedId
+    );
+    return post || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+// React to a post
+async function reactToPost(
+  nest: string,
+  postId: string,
+  react: string
+): Promise<{ success: boolean; error?: string }> {
+  const our = getCurrentUserId();
+  const formattedId = formatUd(extractNumericId(postId));
+
+  try {
+    await addReaction({
+      channelId: nest,
+      postId: formattedId,
+      emoji: react,
+      our,
+      postAuthor: our,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Remove reaction from a post
+async function unreactToPost(
+  nest: string,
+  postId: string
+): Promise<{ success: boolean; error?: string }> {
+  const our = getCurrentUserId();
+  const formattedId = formatUd(extractNumericId(postId));
+
+  try {
+    await removeReaction({
+      channelId: nest,
+      postId: formattedId,
+      our,
+      postAuthor: our,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Edit a post (channels only, not DMs)
+// Note: postId must be in @da format
+async function editChannelPost(
+  nest: string,
+  postId: string,
+  newContent: string,
+  metadata?: {
+    title?: string;
+    image?: string;
+    description?: string;
+    cover?: string;
+  }
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const authorId = getCurrentUserId();
+    const sentAt = Date.now();
+    const content = parseContent(newContent);
+
+    await editPost({
+      channelId: nest,
+      postId: formatUd(extractNumericId(postId)),
+      authorId,
+      sentAt,
+      content,
+      metadata,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Edit a post with pre-parsed Story content (for rich notebook editing)
+async function editChannelPostWithContent(
+  nest: string,
+  postId: string,
+  content: Story,
+  metadata?: {
+    title?: string;
+    image?: string;
+    description?: string;
+    cover?: string;
+  }
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const authorId = getCurrentUserId();
+    const sentAt = Date.now();
+
+    await editPost({
+      channelId: nest,
+      postId: formatUd(extractNumericId(postId)),
+      authorId,
+      sentAt,
+      content,
+      metadata,
+    });
+
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// Delete a post
+// Note: postId must be in @da format (e.g., "170.141.184.507.800.833.818.237.178.278.053.937.152")
+async function deleteChannelPost(
+  nest: string,
+  postId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await deletePost(
+      nest,
+      formatUd(extractNumericId(postId)),
+      getCurrentUserId()
+    );
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, error: error.message };
+  }
+}
+
+// CLI
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (isHelpArg(command)) {
+    printHelpAndExit(POSTS_HELP);
+  }
+
+  if (wantsHelp(args.slice(1)) && !isPostEditMessageHelpLiteral(args)) {
+    printHelpAndExit(getPostsHelp(command));
+  }
+
+  validatePostsArgs(args);
+
+  await ensureClient(['channels']);
+
+  try {
+    switch (command) {
+      case 'react': {
+        const [_, channel, postId, emoji] = args;
+        if (!channel || !postId || !emoji) {
+          printUsageAndExit(POSTS_COMMAND_HELP.react);
+        }
+        const result = await reactToPost(channel, postId, emoji);
+        if (!result.success) {
+          console.error(`Error: ${result.error}`);
+          process.exit(1);
+        }
+        console.log('✓ Reaction added');
+        break;
+      }
+
+      case 'unreact': {
+        const [_, channel, postId] = args;
+        if (!channel || !postId) {
+          printUsageAndExit(POSTS_COMMAND_HELP.unreact);
+        }
+        const result = await unreactToPost(channel, postId);
+        if (!result.success) {
+          console.error(`Error: ${result.error}`);
+          process.exit(1);
+        }
+        console.log('✓ Reaction removed');
+        break;
+      }
+
+      case 'edit': {
+        const channel = args[1];
+        const postId = args[2];
+        const titleIdx = args.indexOf('--title');
+        const contentIdx = args.indexOf('--content');
+        const imageIdx = args.indexOf('--image');
+
+        const newTitle = titleIdx !== -1 ? args[titleIdx + 1] : undefined;
+        const contentFile =
+          contentIdx !== -1 ? args[contentIdx + 1] : undefined;
+        const newImage = imageIdx !== -1 ? args[imageIdx + 1] : undefined;
+
+        if (!channel || !postId) {
+          printUsageAndExit(POSTS_COMMAND_HELP.edit);
+        }
+
+        // Fetch existing post to preserve metadata not being explicitly changed
+        const existingPost = await fetchExistingPost(channel, postId);
+
+        // Merge: new values override existing, existing values preserved if not specified
+        const metadata: {
+          title?: string;
+          image?: string;
+          description?: string;
+          cover?: string;
+        } = {
+          title: newTitle ?? existingPost?.title ?? undefined,
+          image: newImage ?? existingPost?.image ?? undefined,
+          description: existingPost?.description ?? undefined,
+          cover: existingPost?.cover ?? undefined,
+        };
+
+        let result;
+        if (contentFile) {
+          // Rich content from JSON file
+          const jsonContent = fs.readFileSync(contentFile, 'utf-8');
+          const content = JSON.parse(jsonContent) as Story;
+          result = await editChannelPostWithContent(
+            channel,
+            postId,
+            content,
+            metadata
+          );
+        } else {
+          // Plain text/markdown message
+          const message = getPostEditMessage(args);
+          if (!message) {
+            printUsageAndExit(POSTS_COMMAND_HELP.edit);
+          }
+          result = await editChannelPost(channel, postId, message, metadata);
+        }
+
+        if (!result.success) {
+          console.error(`Error: ${result.error}`);
+          process.exit(1);
+        }
+        console.log('✓ Post edited');
+        break;
+      }
+
+      case 'delete': {
+        const channel = args[1];
+        const postId = args[2];
+        if (!channel || !postId) {
+          printUsageAndExit(POSTS_COMMAND_HELP.delete);
+        }
+        const result = await deleteChannelPost(channel, postId);
+        if (!result.success) {
+          console.error(`Error: ${result.error}`);
+          process.exit(1);
+        }
+        console.log('✓ Post deleted');
+        break;
+      }
+    }
+    process.exit(0);
+  } catch (error) {
+    printErrorAndExit(error);
+  }
+}
+
+main();

--- a/packages/tlon-skill/scripts/release-binary-smoke.ts
+++ b/packages/tlon-skill/scripts/release-binary-smoke.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { fail, smokeCliBinary } from './release-utils';
+
+function argValue(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+
+  const index = process.argv.indexOf(name);
+  if (index !== -1) {
+    return process.argv[index + 1];
+  }
+
+  return undefined;
+}
+
+const rootDir = process.cwd();
+const binaryArg = argValue('--binary');
+if (!binaryArg) {
+  fail('Usage: bun run scripts/release-binary-smoke.ts --binary <path>');
+}
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(rootDir, 'package.json'), 'utf-8')
+) as { version: string };
+
+smokeCliBinary(resolve(rootDir, binaryArg), packageJson.version, rootDir);
+console.log(`ok - smoked ${binaryArg}`);

--- a/packages/tlon-skill/scripts/release-package-smoke.ts
+++ b/packages/tlon-skill/scripts/release-package-smoke.ts
@@ -1,0 +1,337 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+import {
+  PLATFORM_PACKAGES,
+  TARGETS,
+  type Target,
+  assertExecutableFile,
+  assertPlatformTarball,
+  assertRootTarball,
+  baseEnv,
+  currentTarget,
+  fail,
+  isTarget,
+  nodeModulesPackagePath,
+  npmPackFilename,
+  runCommand,
+  sha256File,
+  smokeCliBinary,
+} from './release-utils';
+
+type RootPackageJson = {
+  name: string;
+  version: string;
+  optionalDependencies?: Record<string, string>;
+};
+
+type LockPackage = {
+  version?: string;
+  resolved?: string;
+  optionalDependencies?: Record<string, string>;
+};
+
+type PackageLock = {
+  packages?: Record<string, LockPackage>;
+};
+
+type BinaryHashes = Partial<
+  Record<
+    Target,
+    {
+      packageName: string;
+      sha256: string;
+      stagedPath: string;
+    }
+  >
+>;
+
+function argValue(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+
+  const index = process.argv.indexOf(name);
+  if (index !== -1) {
+    return process.argv[index + 1];
+  }
+
+  return undefined;
+}
+
+function parseTarget(): Target {
+  const value = argValue('--target') ?? currentTarget();
+  if (!isTarget(value)) {
+    fail(`Unknown target ${value}. Supported targets: ${TARGETS.join(', ')}`);
+  }
+  return value;
+}
+
+function requirePath(path: string, label: string): void {
+  if (!existsSync(path)) {
+    fail(`Missing ${label}: ${path}`);
+  }
+}
+
+function assertLockResolvedFromTarball(
+  lock: PackageLock,
+  packageName: string,
+  expectedVersion: string,
+  tarballPath: string
+): void {
+  const key = `node_modules/${packageName}`;
+  const entry = lock.packages?.[key];
+  if (!entry) {
+    fail(`package-lock.json is missing ${key}`);
+  }
+  if (entry.version !== expectedVersion) {
+    fail(
+      `${key} version ${entry.version ?? '<missing>'} did not match ${expectedVersion}`
+    );
+  }
+  if (!entry.resolved?.startsWith('file:')) {
+    fail(
+      `${key} did not resolve from a local file tarball: ${entry.resolved ?? '<missing>'}`
+    );
+  }
+  if (!entry.resolved.includes(basename(tarballPath))) {
+    fail(
+      `${key} resolved to ${entry.resolved}, expected ${basename(tarballPath)}`
+    );
+  }
+}
+
+function assertRootDeclaresNativeOptionalDependency(
+  installedRootPackageJson: RootPackageJson,
+  rootLockEntry: LockPackage | undefined,
+  nativePackageName: string
+): void {
+  const expectedVersion = installedRootPackageJson.version;
+  const packageJsonVersion =
+    installedRootPackageJson.optionalDependencies?.[nativePackageName];
+  if (packageJsonVersion !== expectedVersion) {
+    fail(
+      `Installed root package optionalDependencies.${nativePackageName} was ${packageJsonVersion ?? '<missing>'}, expected ${expectedVersion}`
+    );
+  }
+
+  const lockVersion = rootLockEntry?.optionalDependencies?.[nativePackageName];
+  if (lockVersion !== expectedVersion) {
+    fail(
+      `package-lock root optionalDependencies.${nativePackageName} was ${lockVersion ?? '<missing>'}, expected ${expectedVersion}`
+    );
+  }
+}
+
+function assertWrapperBinResolvesToRootWrapper(
+  wrapperPath: string,
+  rootPackageDir: string
+): void {
+  const expectedWrapper = join(rootPackageDir, 'bin', 'tlon.js');
+  const actual = realpathSync(wrapperPath);
+  const expected = realpathSync(expectedWrapper);
+  if (actual !== expected) {
+    fail(
+      `node_modules/.bin/tlon resolved to ${actual}, expected root wrapper ${expected}`
+    );
+  }
+}
+
+function assertNoRunnableNonNativePackages(
+  projectDir: string,
+  target: Target
+): void {
+  for (const otherTarget of TARGETS) {
+    if (otherTarget === target) {
+      continue;
+    }
+    const packageDir = nodeModulesPackagePath(
+      projectDir,
+      PLATFORM_PACKAGES[otherTarget]
+    );
+    const binaryPath = join(packageDir, 'tlon');
+    if (!existsSync(binaryPath)) {
+      continue;
+    }
+
+    const stat = statSync(binaryPath);
+    if (stat.isFile() && (stat.mode & 0o111) !== 0) {
+      fail(
+        `Non-native package ${PLATFORM_PACKAGES[otherTarget]} installed runnable binary ${binaryPath}`
+      );
+    }
+  }
+}
+
+const rootDir = process.cwd();
+const target = parseTarget();
+const runtimeTarget = currentTarget();
+if (target !== runtimeTarget) {
+  fail(
+    `Package smoke target ${target} must match native runner ${runtimeTarget}`
+  );
+}
+
+const tarballDir = resolve(
+  rootDir,
+  argValue('--tarball-dir') ?? 'release-tarballs'
+);
+const packageJson = JSON.parse(
+  readFileSync(join(rootDir, 'package.json'), 'utf-8')
+) as RootPackageJson;
+const nativePackageName = PLATFORM_PACKAGES[target];
+const rootTarball = join(
+  tarballDir,
+  npmPackFilename(packageJson.name, packageJson.version)
+);
+const nativeTarball = join(
+  tarballDir,
+  npmPackFilename(nativePackageName, packageJson.version)
+);
+const hashesPath = join(tarballDir, 'binary-hashes.json');
+
+requirePath(rootTarball, 'root tarball');
+requirePath(nativeTarball, `${target} tarball`);
+requirePath(hashesPath, 'binary hash manifest');
+assertRootTarball(rootTarball, rootDir);
+assertPlatformTarball(nativeTarball, rootDir, target);
+
+const hashes = JSON.parse(readFileSync(hashesPath, 'utf-8')) as BinaryHashes;
+const expectedHash = hashes[target]?.sha256;
+if (!expectedHash) {
+  fail(`binary-hashes.json is missing ${target}`);
+}
+if (hashes[target]?.packageName !== nativePackageName) {
+  fail(
+    `binary-hashes.json package for ${target} did not match ${nativePackageName}`
+  );
+}
+
+const tempRoot = mkdtempSync(join(tmpdir(), 'tlon-package-smoke-'));
+try {
+  const projectDir = join(tempRoot, 'project');
+  const cacheDir = join(tempRoot, 'npm-cache');
+  const userConfig = join(tempRoot, 'npmrc');
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(
+    join(projectDir, 'package.json'),
+    JSON.stringify({ private: true }, null, 2),
+    'utf-8'
+  );
+  writeFileSync(
+    userConfig,
+    [
+      'registry=http://127.0.0.1:9/',
+      'fetch-retries=0',
+      'fetch-timeout=1000',
+      'fetch-retry-mintimeout=1000',
+      'fetch-retry-maxtimeout=1000',
+      'audit=false',
+      'fund=false',
+      '',
+    ].join('\n'),
+    'utf-8'
+  );
+
+  runCommand(
+    'npm',
+    [
+      '--cache',
+      cacheDir,
+      '--userconfig',
+      userConfig,
+      'install',
+      '--fetch-retries=0',
+      '--fetch-timeout=1000',
+      '--fetch-retry-mintimeout=1000',
+      '--fetch-retry-maxtimeout=1000',
+      '--no-audit',
+      '--fund=false',
+      rootTarball,
+      nativeTarball,
+    ],
+    {
+      cwd: projectDir,
+      env: baseEnv(tempRoot),
+    }
+  );
+
+  const lock = JSON.parse(
+    readFileSync(join(projectDir, 'package-lock.json'), 'utf-8')
+  ) as PackageLock;
+  assertLockResolvedFromTarball(
+    lock,
+    packageJson.name,
+    packageJson.version,
+    rootTarball
+  );
+  assertLockResolvedFromTarball(
+    lock,
+    nativePackageName,
+    packageJson.version,
+    nativeTarball
+  );
+
+  const rootPackageDir = nodeModulesPackagePath(projectDir, packageJson.name);
+  const rootLockEntry = lock.packages?.[`node_modules/${packageJson.name}`];
+  const installedRootPackageJson = JSON.parse(
+    readFileSync(join(rootPackageDir, 'package.json'), 'utf-8')
+  ) as RootPackageJson;
+  assertRootDeclaresNativeOptionalDependency(
+    installedRootPackageJson,
+    rootLockEntry,
+    nativePackageName
+  );
+
+  const rootLocalBinary = join(rootPackageDir, 'bin', 'tlon');
+  if (existsSync(rootLocalBinary)) {
+    fail(`Installed root package must not contain ${rootLocalBinary}`);
+  }
+
+  const nativePackageDir = nodeModulesPackagePath(
+    projectDir,
+    nativePackageName
+  );
+  const nativePackageJson = JSON.parse(
+    readFileSync(join(nativePackageDir, 'package.json'), 'utf-8')
+  ) as RootPackageJson;
+  if (nativePackageJson.name !== nativePackageName) {
+    fail(`Installed native package name did not match ${nativePackageName}`);
+  }
+  if (nativePackageJson.version !== packageJson.version) {
+    fail(
+      `Installed native package version ${nativePackageJson.version} did not match ${packageJson.version}`
+    );
+  }
+
+  const nativeBinary = join(nativePackageDir, 'tlon');
+  assertExecutableFile(nativeBinary, `${target} installed native binary`);
+  const installedHash = sha256File(nativeBinary);
+  if (installedHash !== expectedHash) {
+    fail(
+      `${target} installed binary hash ${installedHash} did not match workflow-built hash ${expectedHash}`
+    );
+  }
+
+  assertNoRunnableNonNativePackages(projectDir, target);
+
+  const wrapper = join(projectDir, 'node_modules', '.bin', 'tlon');
+  assertWrapperBinResolvesToRootWrapper(wrapper, rootPackageDir);
+  smokeCliBinary(wrapper, packageJson.version, projectDir);
+  console.log(`ok - package smoke passed for ${target}`);
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/packages/tlon-skill/scripts/release-package.ts
+++ b/packages/tlon-skill/scripts/release-package.ts
@@ -1,0 +1,335 @@
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+import {
+  PLATFORM_PACKAGES,
+  TARGETS,
+  type Target,
+  assertExecutableFile,
+  assertPlatformTarball,
+  assertRootTarball,
+  baseEnv,
+  currentTarget,
+  fail,
+  isTarget,
+  npmPackFilename,
+  runCommand,
+  sha256File,
+} from './release-utils';
+
+type RootPackageJson = {
+  name: string;
+  version: string;
+  files?: string[];
+};
+
+type PackOutput = Array<{
+  filename: string;
+}>;
+
+type BinaryHashes = Partial<
+  Record<
+    Target,
+    {
+      packageName: string;
+      sha256: string;
+      stagedPath: string;
+    }
+  >
+>;
+
+function argValue(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = process.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+
+  const index = process.argv.indexOf(name);
+  if (index !== -1) {
+    return process.argv[index + 1];
+  }
+
+  return undefined;
+}
+
+function parseTargets(): Target[] {
+  const value = argValue('--targets') ?? argValue('--target');
+  if (!value) {
+    return [...TARGETS];
+  }
+  if (value === 'current') {
+    return [currentTarget()];
+  }
+
+  const targets = value.split(',').map((target) => target.trim());
+  if (targets.length === 0) {
+    fail('--targets must include at least one target');
+  }
+  return targets.map((target) => {
+    if (!isTarget(target)) {
+      fail(
+        `Unknown target ${target}. Supported targets: ${TARGETS.join(', ')}`
+      );
+    }
+    return target;
+  });
+}
+
+function requirePath(path: string, label: string): void {
+  if (!existsSync(path)) {
+    fail(`Missing ${label}: ${path}`);
+  }
+}
+
+function ensureEmptyOutputDir(outDir: string): void {
+  mkdirSync(outDir, { recursive: true });
+  const entries = readdirSync(outDir);
+  if (entries.length > 0) {
+    fail(`Output directory must be empty: ${outDir}`);
+  }
+}
+
+function copyRequired(
+  source: string,
+  destination: string,
+  label: string
+): void {
+  requirePath(source, label);
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(source, destination, { recursive: true });
+}
+
+function copyOptional(source: string, destination: string): void {
+  if (!existsSync(source)) {
+    return;
+  }
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(source, destination, { recursive: true });
+}
+
+function assertRootFilesField(packageJson: RootPackageJson): void {
+  const files = packageJson.files ?? [];
+  const required = [
+    'bin/tlon.js',
+    'scripts/postinstall.js',
+    'SKILL.md',
+    'references/',
+  ];
+
+  for (const entry of required) {
+    if (!files.includes(entry)) {
+      fail(`Root package.json files is missing ${entry}`);
+    }
+  }
+  for (const forbidden of ['bin', 'bin/']) {
+    if (files.includes(forbidden)) {
+      fail(`Root package.json files must not include ${forbidden}`);
+    }
+  }
+}
+
+function parsePackOutput(stdout: string): PackOutput {
+  const jsonStart = stdout.indexOf('[');
+  if (jsonStart === -1) {
+    fail(`npm pack did not return JSON:\n${stdout}`);
+  }
+
+  try {
+    const parsed = JSON.parse(stdout.slice(jsonStart)) as PackOutput;
+    if (parsed.length !== 1 || !parsed[0]?.filename) {
+      fail(`Unexpected npm pack JSON:\n${stdout}`);
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`Failed to parse npm pack JSON: ${message}\n${stdout}`);
+  }
+}
+
+function packDirectory(
+  packageDir: string,
+  outDir: string,
+  cacheDir: string,
+  userConfig: string,
+  env: Record<string, string>
+): string {
+  const result = runCommand(
+    'npm',
+    [
+      '--cache',
+      cacheDir,
+      '--userconfig',
+      userConfig,
+      'pack',
+      '--json',
+      '--pack-destination',
+      outDir,
+    ],
+    {
+      cwd: packageDir,
+      env,
+    }
+  );
+
+  const [packed] = parsePackOutput(result.stdout);
+  const tarballPath = resolve(outDir, packed.filename);
+  requirePath(tarballPath, 'packed tarball');
+  return tarballPath;
+}
+
+function stageRootPackage(rootDir: string, stageDir: string): RootPackageJson {
+  const packageJsonPath = join(rootDir, 'package.json');
+  const packageJson = JSON.parse(
+    readFileSync(packageJsonPath, 'utf-8')
+  ) as RootPackageJson;
+  assertRootFilesField(packageJson);
+
+  copyRequired(
+    packageJsonPath,
+    join(stageDir, 'package.json'),
+    'root package.json'
+  );
+  copyRequired(
+    join(rootDir, 'bin', 'tlon.js'),
+    join(stageDir, 'bin', 'tlon.js'),
+    'bin/tlon.js'
+  );
+  copyRequired(
+    join(rootDir, 'scripts', 'postinstall.js'),
+    join(stageDir, 'scripts', 'postinstall.js'),
+    'scripts/postinstall.js'
+  );
+  copyRequired(
+    join(rootDir, 'SKILL.md'),
+    join(stageDir, 'SKILL.md'),
+    'SKILL.md'
+  );
+  copyRequired(
+    join(rootDir, 'references'),
+    join(stageDir, 'references'),
+    'references'
+  );
+  copyOptional(join(rootDir, 'README.md'), join(stageDir, 'README.md'));
+  copyOptional(join(rootDir, 'LICENSE'), join(stageDir, 'LICENSE'));
+
+  return packageJson;
+}
+
+function stagePlatformPackage(
+  rootDir: string,
+  stageDir: string,
+  artifactsDir: string,
+  target: Target
+): { stagedBinaryPath: string; packageStageDir: string; sha256: string } {
+  const artifactPath = join(artifactsDir, `binary-${target}`, 'tlon');
+  requirePath(artifactPath, `${target} build artifact`);
+
+  const sourcePackageDir = join(rootDir, 'npm', target);
+  const sourcePackageJson = join(sourcePackageDir, 'package.json');
+  const packageStageDir = join(stageDir, 'npm', target);
+  const stagedBinaryPath = join(packageStageDir, 'tlon');
+  copyRequired(
+    sourcePackageJson,
+    join(packageStageDir, 'package.json'),
+    `${target} package.json`
+  );
+  copyRequired(artifactPath, stagedBinaryPath, `${target} build artifact`);
+  chmodSync(stagedBinaryPath, 0o755);
+  assertExecutableFile(stagedBinaryPath, `${target} package-stage binary`);
+
+  return {
+    stagedBinaryPath,
+    packageStageDir,
+    sha256: sha256File(stagedBinaryPath),
+  };
+}
+
+const rootDir = process.cwd();
+const artifactsDir = resolve(
+  rootDir,
+  argValue('--artifacts-dir') ?? 'artifacts'
+);
+const outDir = resolve(rootDir, argValue('--out-dir') ?? 'release-tarballs');
+const targets = parseTargets();
+
+ensureEmptyOutputDir(outDir);
+
+const tempRoot = mkdtempSync(join(tmpdir(), 'tlon-release-package-'));
+try {
+  const cacheDir = join(tempRoot, 'npm-cache');
+  const userConfig = join(tempRoot, 'npmrc');
+  const env = baseEnv(tempRoot);
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(userConfig, 'audit=false\nfund=false\n', 'utf-8');
+
+  const rootStageDir = join(tempRoot, 'root');
+  const packageJson = stageRootPackage(rootDir, rootStageDir);
+  const rootTarball = packDirectory(
+    rootStageDir,
+    outDir,
+    cacheDir,
+    userConfig,
+    env
+  );
+  const expectedRootTarball = resolve(
+    outDir,
+    npmPackFilename(packageJson.name, packageJson.version)
+  );
+  if (rootTarball !== expectedRootTarball) {
+    fail(`Unexpected root tarball name: ${rootTarball}`);
+  }
+  assertRootTarball(rootTarball, rootDir);
+  console.log(`ok - packed ${rootTarball}`);
+
+  const hashes: BinaryHashes = {};
+  for (const target of targets) {
+    const staged = stagePlatformPackage(
+      rootDir,
+      tempRoot,
+      artifactsDir,
+      target
+    );
+    const tarball = packDirectory(
+      staged.packageStageDir,
+      outDir,
+      cacheDir,
+      userConfig,
+      env
+    );
+    const expectedTarball = resolve(
+      outDir,
+      npmPackFilename(PLATFORM_PACKAGES[target], packageJson.version)
+    );
+    if (tarball !== expectedTarball) {
+      fail(`Unexpected ${target} tarball name: ${tarball}`);
+    }
+    assertPlatformTarball(tarball, rootDir, target);
+    hashes[target] = {
+      packageName: PLATFORM_PACKAGES[target],
+      sha256: staged.sha256,
+      stagedPath: `npm/${target}/tlon`,
+    };
+    console.log(`ok - packed ${tarball}`);
+  }
+
+  writeFileSync(
+    join(outDir, 'binary-hashes.json'),
+    `${JSON.stringify(hashes, null, 2)}\n`,
+    'utf-8'
+  );
+  console.log(`ok - wrote ${join(outDir, 'binary-hashes.json')}`);
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/packages/tlon-skill/scripts/release-utils.ts
+++ b/packages/tlon-skill/scripts/release-utils.ts
@@ -1,0 +1,326 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { normalizeCliOutput } from './cli-test-matrix';
+
+export const TARGETS = [
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-x64',
+  'linux-arm64',
+] as const;
+
+export type Target = (typeof TARGETS)[number];
+
+export const PLATFORM_PACKAGES: Record<Target, string> = {
+  'darwin-arm64': '@tloncorp/tlon-skill-darwin-arm64',
+  'darwin-x64': '@tloncorp/tlon-skill-darwin-x64',
+  'linux-x64': '@tloncorp/tlon-skill-linux-x64',
+  'linux-arm64': '@tloncorp/tlon-skill-linux-arm64',
+};
+
+export const CLI_TIMEOUT_MS = 15_000;
+export const NPM_TIMEOUT_MS = 120_000;
+
+export type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+export function isTarget(value: string): value is Target {
+  return TARGETS.includes(value as Target);
+}
+
+export function currentTarget(): Target {
+  const target = `${process.platform}-${process.arch}`;
+  if (!isTarget(target)) {
+    fail(`Unsupported runtime target: ${target}`);
+  }
+  return target;
+}
+
+export function npmPackFilename(packageName: string, version: string): string {
+  return `${packageName.replace(/^@/, '').replace('/', '-')}-${version}.tgz`;
+}
+
+export function nodeModulesPackagePath(
+  projectDir: string,
+  packageName: string
+): string {
+  if (packageName.startsWith('@')) {
+    const [scope, name] = packageName.split('/');
+    if (!scope || !name) {
+      fail(`Invalid scoped package name: ${packageName}`);
+    }
+    return join(projectDir, 'node_modules', scope, name);
+  }
+  return join(projectDir, 'node_modules', packageName);
+}
+
+export function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+export function assertExecutableFile(path: string, label: string): void {
+  if (!existsSync(path)) {
+    fail(`Missing ${label}: ${path}`);
+  }
+  const stat = statSync(path);
+  if (!stat.isFile()) {
+    fail(`${label} is not a file: ${path}`);
+  }
+  if ((stat.mode & 0o111) === 0) {
+    fail(`${label} is not executable: ${path}`);
+  }
+}
+
+export function baseEnv(
+  _tempRoot: string,
+  extraEnv: Record<string, string> = {}
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of [
+    'PATH',
+    'HOME',
+    'SystemRoot',
+    'WINDIR',
+    'ASDF_DIR',
+    'ASDF_DATA_DIR',
+  ]) {
+    const value = process.env[key];
+    if (value) {
+      env[key] = value;
+    }
+  }
+  return { ...env, ...extraEnv };
+}
+
+export function hermeticCliEnv(
+  tempRoot: string,
+  extraEnv: Record<string, string> = {}
+): Record<string, string> {
+  const home = join(tempRoot, 'home');
+  const cacheDir = join(tempRoot, 'cache');
+  mkdirSync(home, { recursive: true });
+  mkdirSync(cacheDir, { recursive: true });
+
+  return {
+    ...baseEnv(tempRoot),
+    HOME: home,
+    TLON_CACHE_DIR: cacheDir,
+    OPENCLAW_CONFIG: join(home, 'missing-openclaw.json'),
+    ...extraEnv,
+  };
+}
+
+export function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env?: Record<string, string>;
+    timeoutMs?: number;
+    allowFailure?: boolean;
+  }
+): CommandResult {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: 'utf-8',
+    timeout: options.timeoutMs ?? NPM_TIMEOUT_MS,
+  });
+
+  if (result.error) {
+    fail(`Failed to run ${command} ${args.join(' ')}: ${result.error.message}`);
+  }
+
+  const commandResult = {
+    exitCode: result.status ?? 1,
+    stdout: normalizeCliOutput(result.stdout),
+    stderr: normalizeCliOutput(result.stderr),
+  };
+
+  if (!options.allowFailure && commandResult.exitCode !== 0) {
+    fail(
+      `${command} ${args.join(' ')} exited ${commandResult.exitCode}\nstdout:\n${commandResult.stdout}\nstderr:\n${commandResult.stderr}`
+    );
+  }
+
+  return commandResult;
+}
+
+export function runCli(
+  binaryPath: string,
+  args: string[],
+  options: {
+    cwd: string;
+    tempRoot: string;
+  }
+): CommandResult {
+  return runCommand(binaryPath, args, {
+    cwd: options.cwd,
+    env: hermeticCliEnv(options.tempRoot),
+    timeoutMs: CLI_TIMEOUT_MS,
+    allowFailure: true,
+  });
+}
+
+export function assertCliSuccess(
+  name: string,
+  result: CommandResult,
+  assertions: {
+    stdout?: string;
+    stderr?: string;
+    stdoutIncludes?: string[];
+  } = {}
+): void {
+  if (result.exitCode !== 0) {
+    fail(
+      `${name}: expected exit 0, got ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+  if (assertions.stdout !== undefined && result.stdout !== assertions.stdout) {
+    fail(
+      `${name}: unexpected stdout\nexpected:\n${assertions.stdout}\nactual:\n${result.stdout}`
+    );
+  }
+  if (assertions.stderr !== undefined && result.stderr !== assertions.stderr) {
+    fail(
+      `${name}: unexpected stderr\nexpected:\n${assertions.stderr}\nactual:\n${result.stderr}`
+    );
+  }
+  for (const expected of assertions.stdoutIncludes ?? []) {
+    if (!result.stdout.includes(expected)) {
+      fail(
+        `${name}: stdout did not include ${JSON.stringify(expected)}\nstdout:\n${result.stdout}`
+      );
+    }
+  }
+}
+
+export function smokeCliBinary(
+  binaryPath: string,
+  expectedVersion: string,
+  cwd: string
+): void {
+  assertExecutableFile(binaryPath, 'CLI binary');
+
+  const tempRoot = mkdtempSync(join(tmpdir(), 'tlon-release-cli-'));
+  try {
+    assertCliSuccess(
+      `${basename(binaryPath)} --version`,
+      runCli(binaryPath, ['--version'], { cwd, tempRoot }),
+      {
+        stdout: `${expectedVersion}\n`,
+        stderr: '',
+      }
+    );
+    assertCliSuccess(
+      `${basename(binaryPath)} --help`,
+      runCli(binaryPath, ['--help'], { cwd, tempRoot }),
+      {
+        stderr: '',
+        stdoutIncludes: ['Usage:'],
+      }
+    );
+    assertCliSuccess(
+      `${basename(binaryPath)} activity --help`,
+      runCli(binaryPath, ['activity', '--help'], { cwd, tempRoot }),
+      {
+        stderr: '',
+        stdoutIncludes: ['Usage: tlon activity'],
+      }
+    );
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+export function listTarballFiles(tarballPath: string, cwd: string): string[] {
+  const result = runCommand('tar', ['-tzf', tarballPath], {
+    cwd,
+    timeoutMs: 30_000,
+  });
+  return result.stdout
+    .split('\n')
+    .filter(Boolean)
+    .map((entry) => entry.replace(/^package\//, ''))
+    .filter(Boolean)
+    .sort();
+}
+
+export function assertRootTarball(tarballPath: string, cwd: string): void {
+  const files = listTarballFiles(tarballPath, cwd);
+  if (!files.includes('bin/tlon.js')) {
+    fail(`Root tarball is missing bin/tlon.js: ${tarballPath}`);
+  }
+  if (files.includes('bin/tlon')) {
+    fail(`Root tarball must not contain bin/tlon: ${tarballPath}`);
+  }
+
+  const unexpected = files.filter((file) => {
+    if (
+      file === 'package.json' ||
+      file === 'README.md' ||
+      file === 'LICENSE' ||
+      file === 'SKILL.md' ||
+      file === 'bin/tlon.js' ||
+      file === 'scripts/postinstall.js'
+    ) {
+      return false;
+    }
+    return !file.startsWith('references/');
+  });
+
+  if (unexpected.length > 0) {
+    fail(
+      `Root tarball contains unexpected files:\n${unexpected
+        .map((file) => `  - ${file}`)
+        .join('\n')}`
+    );
+  }
+}
+
+export function assertPlatformTarball(
+  tarballPath: string,
+  cwd: string,
+  target: Target
+): void {
+  const files = listTarballFiles(tarballPath, cwd);
+  for (const required of ['package.json', 'tlon']) {
+    if (!files.includes(required)) {
+      fail(`${target} tarball is missing ${required}: ${tarballPath}`);
+    }
+  }
+
+  const unexpected = files.filter(
+    (file) =>
+      file !== 'package.json' &&
+      file !== 'tlon' &&
+      file !== 'README.md' &&
+      file !== 'LICENSE'
+  );
+  if (unexpected.length > 0) {
+    fail(
+      `${target} tarball contains unexpected files:\n${unexpected
+        .map((file) => `  - ${file}`)
+        .join('\n')}`
+    );
+  }
+}

--- a/packages/tlon-skill/scripts/settings.ts
+++ b/packages/tlon-skill/scripts/settings.ts
@@ -1,0 +1,392 @@
+#!/usr/bin/env npx ts-node
+
+/**
+ * Manage OpenClaw settings in Urbit settings-store.
+ *
+ * Usage:
+ *   npx ts-node scripts/settings.ts get
+ *   npx ts-node scripts/settings.ts set dmAllowlist '["~nocsyx-lassul", "~sabrys-nocwyd"]'
+ *   npx ts-node scripts/settings.ts allow-dm ~ship
+ *   npx ts-node scripts/settings.ts allow-channel chat/~host/channel
+ *   npx ts-node scripts/settings.ts open-channel chat/~host/channel
+ *   npx ts-node scripts/settings.ts set-rule chat/~host/channel open
+ *   npx ts-node scripts/settings.ts set-rule chat/~host/channel restricted ~ship1 ~ship2
+ */
+import { poke, scry } from '@tloncorp/api';
+
+import { ensureClient, normalizeShip } from './api-client';
+import {
+  isHelpArg,
+  printErrorAndExit,
+  printHelpAndExit,
+  printUsageAndExit,
+  wantsHelp,
+} from './cli-utils';
+
+const SETTINGS_DESK = 'moltbot';
+const SETTINGS_BUCKET = 'tlon';
+
+const SETTINGS_HELP = `Usage: tlon settings <command>
+
+Commands:
+  get                              Show all settings
+  set <key> <json>                 Set a setting value
+  delete <key>                     Delete a setting
+
+  allow-dm <ship>                  Add ship to DM allowlist
+  remove-dm <ship>                 Remove ship from DM allowlist
+
+  allow-channel <nest>             Add channel to watched list
+  remove-channel <nest>            Remove channel from watched list
+
+  open-channel <nest>              Set channel to open mode (anyone can interact)
+  restrict-channel <nest> [ships]  Set channel to restricted mode
+
+  authorize-ship <ship>            Add to default authorized ships
+  deauthorize-ship <ship>          Remove from default authorized ships
+
+Examples:
+  tlon settings allow-dm ~nocsyx-lassul
+  tlon settings open-channel chat/~nocsyx-lassul/bongtable
+  tlon settings set showModelSig true`;
+
+const SETTINGS_COMMAND_HELP: Record<string, string> = {
+  get: 'Usage: tlon settings get',
+  set: 'Usage: tlon settings set <key> <json-value>',
+  delete: 'Usage: tlon settings delete <key>',
+  del: 'Usage: tlon settings delete <key>',
+  'allow-dm': 'Usage: tlon settings allow-dm <ship>',
+  'add-dm': 'Usage: tlon settings allow-dm <ship>',
+  'remove-dm': 'Usage: tlon settings remove-dm <ship>',
+  'allow-channel': 'Usage: tlon settings allow-channel <channel-nest>',
+  'add-channel': 'Usage: tlon settings allow-channel <channel-nest>',
+  'remove-channel': 'Usage: tlon settings remove-channel <channel-nest>',
+  'open-channel': 'Usage: tlon settings open-channel <channel-nest>',
+  'restrict-channel':
+    'Usage: tlon settings restrict-channel <channel-nest> [ships...]',
+  'set-rule':
+    'Usage: tlon settings set-rule <channel-nest> <open|restricted> [ships...]',
+  'authorize-ship': 'Usage: tlon settings authorize-ship <ship>',
+  'add-auth': 'Usage: tlon settings authorize-ship <ship>',
+  'deauthorize-ship': 'Usage: tlon settings deauthorize-ship <ship>',
+  'remove-auth': 'Usage: tlon settings deauthorize-ship <ship>',
+};
+
+function getSettingsHelp(command?: string): string {
+  return command
+    ? SETTINGS_COMMAND_HELP[command] ?? SETTINGS_HELP
+    : SETTINGS_HELP;
+}
+
+function validateSettingsArgs(args: string[]): void {
+  const command = args[0];
+  if (!command || !SETTINGS_COMMAND_HELP[command]) {
+    printUsageAndExit(SETTINGS_HELP);
+  }
+
+  switch (command) {
+    case 'get':
+      return;
+    case 'set': {
+      if (!args[1] || args[2] === undefined)
+        printUsageAndExit(SETTINGS_COMMAND_HELP.set);
+      return;
+    }
+    case 'delete':
+    case 'del':
+    case 'allow-dm':
+    case 'add-dm':
+    case 'remove-dm':
+    case 'allow-channel':
+    case 'add-channel':
+    case 'remove-channel':
+    case 'open-channel':
+    case 'restrict-channel':
+    case 'authorize-ship':
+    case 'add-auth':
+    case 'deauthorize-ship':
+    case 'remove-auth': {
+      if (!args[1]) printUsageAndExit(SETTINGS_COMMAND_HELP[command]);
+      return;
+    }
+    case 'set-rule': {
+      const mode = args[2];
+      if (!args[1] || !mode || (mode !== 'open' && mode !== 'restricted')) {
+        printUsageAndExit(SETTINGS_COMMAND_HELP['set-rule']);
+      }
+      return;
+    }
+  }
+}
+
+async function getSettings(): Promise<Record<string, unknown>> {
+  try {
+    const result = await scry<{
+      all: Record<string, Record<string, Record<string, unknown>>>;
+    }>({
+      app: 'settings',
+      path: '/all',
+    });
+    return (
+      (result?.all?.[SETTINGS_DESK]?.[SETTINGS_BUCKET] as Record<
+        string,
+        unknown
+      >) ?? {}
+    );
+  } catch (err: any) {
+    if (err?.message?.includes('404') || err?.message?.includes('not found')) {
+      return {};
+    }
+    throw err;
+  }
+}
+
+async function putEntry(key: string, value: unknown): Promise<void> {
+  await poke({
+    app: 'settings',
+    mark: 'settings-event',
+    json: {
+      'put-entry': {
+        desk: SETTINGS_DESK,
+        'bucket-key': SETTINGS_BUCKET,
+        'entry-key': key,
+        value,
+      },
+    },
+  });
+  console.log(`✓ Set ${key}`);
+}
+
+async function delEntry(key: string): Promise<void> {
+  await poke({
+    app: 'settings',
+    mark: 'settings-event',
+    json: {
+      'del-entry': {
+        desk: SETTINGS_DESK,
+        'bucket-key': SETTINGS_BUCKET,
+        'entry-key': key,
+      },
+    },
+  });
+  console.log(`✓ Deleted ${key}`);
+}
+
+async function addToArray(key: string, item: string): Promise<void> {
+  const settings = await getSettings();
+  const current = (settings[key] as string[]) ?? [];
+  const normalized =
+    key === 'dmAllowlist' || key === 'defaultAuthorizedShips'
+      ? normalizeShip(item)
+      : item;
+
+  if (current.includes(normalized)) {
+    console.log(`${normalized} already in ${key}`);
+    return;
+  }
+
+  await putEntry(key, [...current, normalized]);
+}
+
+async function removeFromArray(key: string, item: string): Promise<void> {
+  const settings = await getSettings();
+  const current = (settings[key] as string[]) ?? [];
+  const normalized =
+    key === 'dmAllowlist' || key === 'defaultAuthorizedShips'
+      ? normalizeShip(item)
+      : item;
+
+  const updated = current.filter((x) => x !== normalized);
+  if (updated.length === current.length) {
+    console.log(`${normalized} not in ${key}`);
+    return;
+  }
+
+  await putEntry(key, updated);
+}
+
+function parseChannelRules(
+  value: unknown
+): Record<string, { mode?: string; allowedShips?: string[] }> {
+  if (!value) return {};
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof value === 'object') {
+    return value as Record<string, { mode?: string; allowedShips?: string[] }>;
+  }
+  return {};
+}
+
+async function setChannelRule(
+  channel: string,
+  mode: 'open' | 'restricted',
+  allowedShips?: string[]
+): Promise<void> {
+  const settings = await getSettings();
+  const rules = parseChannelRules(settings.channelRules);
+
+  const rule: Record<string, unknown> = { mode };
+  if (mode === 'restricted' && allowedShips?.length) {
+    rule.allowedShips = allowedShips.map(normalizeShip);
+  }
+
+  // Store as JSON string (settings-store doesn't support nested objects)
+  await putEntry('channelRules', JSON.stringify({ ...rules, [channel]: rule }));
+}
+
+async function main() {
+  const rawArgs = process.argv.slice(2);
+  const command = rawArgs[0];
+  const args = rawArgs.slice(1);
+
+  try {
+    if (isHelpArg(command)) {
+      printHelpAndExit(SETTINGS_HELP);
+    }
+
+    if (wantsHelp(args)) {
+      printHelpAndExit(getSettingsHelp(command));
+    }
+
+    validateSettingsArgs(rawArgs);
+
+    await ensureClient();
+    switch (command) {
+      case 'get': {
+        const settings = await getSettings();
+        console.log(JSON.stringify(settings, null, 2));
+        break;
+      }
+
+      case 'set': {
+        const [key, jsonValue] = args;
+        if (!key || jsonValue === undefined) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP.set);
+        }
+        const value = JSON.parse(jsonValue);
+        await putEntry(key, value);
+        break;
+      }
+
+      case 'delete':
+      case 'del': {
+        const [key] = args;
+        if (!key) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP.delete);
+        }
+        await delEntry(key);
+        break;
+      }
+
+      case 'allow-dm':
+      case 'add-dm': {
+        const [ship] = args;
+        if (!ship) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['allow-dm']);
+        }
+        await addToArray('dmAllowlist', ship);
+        break;
+      }
+
+      case 'remove-dm': {
+        const [ship] = args;
+        if (!ship) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['remove-dm']);
+        }
+        await removeFromArray('dmAllowlist', ship);
+        break;
+      }
+
+      case 'allow-channel':
+      case 'add-channel': {
+        const [channel] = args;
+        if (!channel) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['allow-channel']);
+        }
+        await addToArray('groupChannels', channel);
+        break;
+      }
+
+      case 'remove-channel': {
+        const [channel] = args;
+        if (!channel) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['remove-channel']);
+        }
+        await removeFromArray('groupChannels', channel);
+        break;
+      }
+
+      case 'open-channel': {
+        const [channel] = args;
+        if (!channel) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['open-channel']);
+        }
+        await setChannelRule(channel, 'open');
+        console.log(`✓ Opened ${channel} to all`);
+        break;
+      }
+
+      case 'restrict-channel': {
+        const [channel, ...ships] = args;
+        if (!channel) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['restrict-channel']);
+        }
+        await setChannelRule(
+          channel,
+          'restricted',
+          ships.length ? ships : undefined
+        );
+        console.log(
+          `✓ Restricted ${channel}${ships.length ? ` to ${ships.join(', ')}` : ''}`
+        );
+        break;
+      }
+
+      case 'set-rule': {
+        const [channel, mode, ...ships] = args;
+        if (!channel || !mode || (mode !== 'open' && mode !== 'restricted')) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['set-rule']);
+        }
+        await setChannelRule(
+          channel,
+          mode as 'open' | 'restricted',
+          ships.length ? ships : undefined
+        );
+        break;
+      }
+
+      case 'authorize-ship':
+      case 'add-auth': {
+        const [ship] = args;
+        if (!ship) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['authorize-ship']);
+        }
+        await addToArray('defaultAuthorizedShips', ship);
+        break;
+      }
+
+      case 'deauthorize-ship':
+      case 'remove-auth': {
+        const [ship] = args;
+        if (!ship) {
+          printUsageAndExit(SETTINGS_COMMAND_HELP['deauthorize-ship']);
+        }
+        await removeFromArray('defaultAuthorizedShips', ship);
+        break;
+      }
+
+      default:
+        printUsageAndExit(SETTINGS_HELP);
+    }
+    process.exit(0);
+  } finally {
+    // no-op: @tloncorp/api client is process-scoped
+  }
+}
+
+main().catch(printErrorAndExit);

--- a/packages/tlon-skill/scripts/story.test.ts
+++ b/packages/tlon-skill/scripts/story.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+
+import { markdownToStory } from './story';
+
+describe('markdownToStory', () => {
+  it('treats literal hashtag lines as paragraph text', () => {
+    expect(markdownToStory('#todo')).toEqual([{ inline: ['#todo'] }]);
+  });
+
+  it('still starts a new block for markdown headings after paragraph text', () => {
+    expect(markdownToStory('intro\n# Heading\nbody')).toEqual([
+      { inline: ['intro'] },
+      { block: { header: { tag: 'h1', content: ['Heading'] } } },
+      { inline: ['body'] },
+    ]);
+  });
+});

--- a/packages/tlon-skill/scripts/story.ts
+++ b/packages/tlon-skill/scripts/story.ts
@@ -1,0 +1,283 @@
+/**
+ * Tlon Story Format - Rich text converter
+ *
+ * Converts markdown-like text to Tlon's story format.
+ * Based on the openclaw-tlon plugin's story.ts
+ */
+
+// Inline content types
+export type StoryInline =
+  | string
+  | { bold: StoryInline[] }
+  | { italics: StoryInline[] }
+  | { strike: StoryInline[] }
+  | { blockquote: StoryInline[] }
+  | { 'inline-code': string }
+  | { code: string }
+  | { ship: string }
+  | { link: { href: string; content: string } }
+  | { break: null }
+  | { tag: string };
+
+// Block content types
+export type StoryBlock =
+  | {
+      header: {
+        tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+        content: StoryInline[];
+      };
+    }
+  | { code: { code: string; lang: string } }
+  | { image: { src: string; height: number; width: number; alt: string } }
+  | { rule: null };
+
+// A verse is either a block or inline content
+export type StoryVerse = { block: StoryBlock } | { inline: StoryInline[] };
+
+// A story is a list of verses
+export type Story = StoryVerse[];
+
+/**
+ * Parse inline markdown formatting (bold, italic, code, links, mentions)
+ */
+function parseInlineMarkdown(text: string): StoryInline[] {
+  const result: StoryInline[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    // Ship mentions: ~sampel-palnet
+    const shipMatch = remaining.match(/^(~[a-z][-a-z0-9]*)/);
+    if (shipMatch) {
+      result.push({ ship: shipMatch[1] });
+      remaining = remaining.slice(shipMatch[0].length);
+      continue;
+    }
+
+    // Bold: **text** or __text__
+    const boldMatch = remaining.match(/^\*\*(.+?)\*\*|^__(.+?)__/);
+    if (boldMatch) {
+      const content = boldMatch[1] || boldMatch[2];
+      result.push({ bold: parseInlineMarkdown(content) });
+      remaining = remaining.slice(boldMatch[0].length);
+      continue;
+    }
+
+    // Italics: *text* or _text_ (but not inside words for _)
+    const italicsMatch = remaining.match(
+      /^\*([^*]+?)\*|^_([^_]+?)_(?![a-zA-Z0-9])/
+    );
+    if (italicsMatch) {
+      const content = italicsMatch[1] || italicsMatch[2];
+      result.push({ italics: parseInlineMarkdown(content) });
+      remaining = remaining.slice(italicsMatch[0].length);
+      continue;
+    }
+
+    // Strikethrough: ~~text~~
+    const strikeMatch = remaining.match(/^~~(.+?)~~/);
+    if (strikeMatch) {
+      result.push({ strike: parseInlineMarkdown(strikeMatch[1]) });
+      remaining = remaining.slice(strikeMatch[0].length);
+      continue;
+    }
+
+    // Inline code: `code`
+    const codeMatch = remaining.match(/^`([^`]+)`/);
+    if (codeMatch) {
+      result.push({ 'inline-code': codeMatch[1] });
+      remaining = remaining.slice(codeMatch[0].length);
+      continue;
+    }
+
+    // Links: [text](url)
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+    if (linkMatch) {
+      result.push({ link: { href: linkMatch[2], content: linkMatch[1] } });
+      remaining = remaining.slice(linkMatch[0].length);
+      continue;
+    }
+
+    // Plain URL detection
+    const urlMatch = remaining.match(/^(https?:\/\/[^\s<>"\]]+)/);
+    if (urlMatch) {
+      result.push({ link: { href: urlMatch[1], content: urlMatch[1] } });
+      remaining = remaining.slice(urlMatch[0].length);
+      continue;
+    }
+
+    // Plain text: consume until next special character
+    const plainMatch = remaining.match(/^[^*_`~\[#~\n]+/);
+    if (plainMatch) {
+      result.push(plainMatch[0]);
+      remaining = remaining.slice(plainMatch[0].length);
+      continue;
+    }
+
+    // Single special char that didn't match a pattern
+    result.push(remaining[0]);
+    remaining = remaining.slice(1);
+  }
+
+  // Merge adjacent strings
+  return mergeAdjacentStrings(result);
+}
+
+/**
+ * Merge adjacent string elements in an inline array
+ */
+function mergeAdjacentStrings(inlines: StoryInline[]): StoryInline[] {
+  const result: StoryInline[] = [];
+  for (const item of inlines) {
+    if (
+      typeof item === 'string' &&
+      typeof result[result.length - 1] === 'string'
+    ) {
+      result[result.length - 1] = (result[result.length - 1] as string) + item;
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+/**
+ * Convert markdown text to Tlon story format
+ */
+export function markdownToStory(markdown: string): Story {
+  const story: Story = [];
+  const lines = markdown.split('\n');
+  let i = 0;
+  const isHeaderLine = (line: string) => /^(#{1,6})\s+(.+)$/.test(line);
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code block: ```lang\ncode\n```
+    if (line.startsWith('```')) {
+      const lang = line.slice(3).trim() || 'plaintext';
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      story.push({
+        block: {
+          code: {
+            code: codeLines.join('\n'),
+            lang,
+          },
+        },
+      });
+      i++; // skip closing ```
+      continue;
+    }
+
+    // Headers: # H1, ## H2, etc.
+    const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headerMatch) {
+      const level = headerMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6;
+      const tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+      story.push({
+        block: {
+          header: {
+            tag,
+            content: parseInlineMarkdown(headerMatch[2]),
+          },
+        },
+      });
+      i++;
+      continue;
+    }
+
+    // Horizontal rule: --- or ***
+    if (/^(-{3,}|\*{3,})$/.test(line.trim())) {
+      story.push({ block: { rule: null } });
+      i++;
+      continue;
+    }
+
+    // Blockquote: > text
+    if (line.startsWith('> ')) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith('> ')) {
+        quoteLines.push(lines[i].slice(2));
+        i++;
+      }
+      const quoteText = quoteLines.join('\n');
+      story.push({
+        inline: [{ blockquote: parseInlineMarkdown(quoteText) }],
+      });
+      continue;
+    }
+
+    // Empty line - skip
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Regular paragraph - collect consecutive non-empty lines
+    const paragraphLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !isHeaderLine(lines[i]) &&
+      !lines[i].startsWith('```') &&
+      !lines[i].startsWith('> ') &&
+      !/^(-{3,}|\*{3,})$/.test(lines[i].trim())
+    ) {
+      paragraphLines.push(lines[i]);
+      i++;
+    }
+
+    if (paragraphLines.length > 0) {
+      const paragraphText = paragraphLines.join('\n');
+      const inlines = parseInlineMarkdown(paragraphText);
+
+      // Replace \n in strings with break elements
+      const withBreaks: StoryInline[] = [];
+      for (const inline of inlines) {
+        if (typeof inline === 'string' && inline.includes('\n')) {
+          const parts = inline.split('\n');
+          for (let j = 0; j < parts.length; j++) {
+            if (parts[j]) withBreaks.push(parts[j]);
+            if (j < parts.length - 1) withBreaks.push({ break: null });
+          }
+        } else {
+          withBreaks.push(inline);
+        }
+      }
+
+      if (withBreaks.length > 0) {
+        story.push({ inline: withBreaks });
+      }
+    }
+  }
+
+  return story;
+}
+
+/**
+ * Convert plain text to simple story (just handles ship mentions and breaks)
+ */
+export function textToStory(text: string): Story {
+  const inlines: StoryInline[] = [];
+  const parts = text.split(/(~[a-z]+-[a-z]+(?:-[a-z]+)*)/g);
+
+  for (const part of parts) {
+    if (!part) continue;
+
+    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
+      inlines.push({ ship: part });
+    } else {
+      const lines = part.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i]) inlines.push(lines[i]);
+        if (i < lines.length - 1) inlines.push({ break: null });
+      }
+    }
+  }
+
+  return [{ inline: inlines }];
+}

--- a/packages/tlon-skill/scripts/top-level-commands.ts
+++ b/packages/tlon-skill/scripts/top-level-commands.ts
@@ -1,0 +1,26 @@
+export const TOP_LEVEL_COMMANDS = [
+  'activity',
+  'channels',
+  'contacts',
+  'dms',
+  'expose',
+  'groups',
+  'hooks',
+  'messages',
+  'notebook',
+  'posts',
+  'settings',
+  'upload',
+] as const;
+
+export type TopLevelCommand = (typeof TOP_LEVEL_COMMANDS)[number];
+
+export const TOP_LEVEL_COMMAND_SET: ReadonlySet<string> = new Set(
+  TOP_LEVEL_COMMANDS
+);
+
+export function isTopLevelCommand(
+  command: string | undefined
+): command is TopLevelCommand {
+  return command !== undefined && TOP_LEVEL_COMMAND_SET.has(command);
+}

--- a/packages/tlon-skill/scripts/upload-runtime.ts
+++ b/packages/tlon-skill/scripts/upload-runtime.ts
@@ -1,0 +1,80 @@
+import { uploadFile as apiUploadFile } from '@tloncorp/api';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { ensureClient } from './api-client';
+import type { UploadBlobLike, UploadDeps } from './commands/upload';
+
+const STDIN_TIMEOUT_MS = 30_000;
+
+function createProcessCommandDeps() {
+  return {
+    stdout: (text: string) => process.stdout.write(text),
+    stderr: (text: string) => process.stderr.write(text),
+  };
+}
+
+function bytesToBlobPart(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(
+    bytes.buffer as ArrayBuffer,
+    bytes.byteOffset,
+    bytes.byteLength
+  );
+}
+
+async function readStdin(): Promise<Uint8Array> {
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const timer = setTimeout(() => {
+      process.stdin.destroy();
+      reject(
+        new Error(
+          'stdin read timed out after 30s - did you forget to pipe input?'
+        )
+      );
+    }, STDIN_TIMEOUT_MS);
+
+    process.stdin.on('data', (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    process.stdin.on('end', () => {
+      clearTimeout(timer);
+      resolve(Buffer.concat(chunks));
+    });
+    process.stdin.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+export function createUploadDeps(): UploadDeps {
+  return {
+    ...createProcessCommandDeps(),
+    authenticate: async () => {
+      await ensureClient();
+    },
+    readStdin,
+    fetch: (url) => fetch(url),
+    fileSystem: {
+      resolvePath: (filePath) => path.resolve(filePath),
+      exists: (filePath) => fs.existsSync(filePath),
+      readFile: (filePath) => fs.readFileSync(filePath),
+      basename: (filePath) => path.basename(filePath),
+      extension: (filePath) => path.extname(filePath),
+    },
+    createBlob: (data, contentType): UploadBlobLike => {
+      return new Blob([bytesToBlobPart(data)], { type: contentType });
+    },
+    uploadApi: {
+      uploadFile: async ({ blob, contentType, fileName }) => {
+        const result = await apiUploadFile({
+          blob: blob as Blob,
+          contentType,
+          fileName,
+        });
+        return { url: result.url };
+      },
+    },
+  };
+}

--- a/packages/tlon-skill/tests/hermetic/cli.test.ts
+++ b/packages/tlon-skill/tests/hermetic/cli.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import {
+  CLI_MATRIX_CASES,
+  COMMAND_FAMILIES,
+  type CliCase,
+  normalizeCliOutput,
+} from '../../scripts/cli-test-matrix';
+
+const rootDir = resolve(process.cwd());
+const cleanupPaths: string[] = [];
+const CLI_TIMEOUT_MS = 15_000;
+
+type RunContext = {
+  tempRoot: string;
+  home: string;
+  cacheDir: string;
+};
+
+type RunOptions = {
+  env?: Record<string, string>;
+  prepare?: (context: RunContext) => {
+    argsPrefix?: string[];
+    cacheDir?: string;
+    env?: Record<string, string>;
+    cleanup?: () => void;
+  } | void;
+};
+
+type CliResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function hermeticEnv(
+  home: string,
+  cacheDir: string,
+  openclawConfig: string
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ['PATH', 'SystemRoot', 'WINDIR']) {
+    const value = process.env[key];
+    if (value) {
+      env[key] = value;
+    }
+  }
+  env.HOME = home;
+  env.TLON_CACHE_DIR = cacheDir;
+  env.OPENCLAW_CONFIG = openclawConfig;
+  return env;
+}
+
+async function runBunScript(
+  entrypoint: string,
+  args: string[],
+  options: RunOptions = {}
+): Promise<CliResult> {
+  const tempRoot = makeTempDir('tlon-hermetic-');
+  const home = join(tempRoot, 'home');
+  const cacheDir = join(tempRoot, 'cache');
+  mkdirSync(home);
+  mkdirSync(cacheDir);
+
+  const context: RunContext = { tempRoot, home, cacheDir };
+  const prepared = options.prepare?.(context) ?? {};
+  const openclawConfig = join(home, 'missing-openclaw.json');
+  const env = {
+    ...hermeticEnv(home, prepared.cacheDir ?? cacheDir, openclawConfig),
+    ...prepared.env,
+    ...options.env,
+  };
+
+  try {
+    const proc = Bun.spawn(
+      [process.execPath, entrypoint, ...(prepared.argsPrefix ?? []), ...args],
+      {
+        cwd: rootDir,
+        env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }
+    );
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const output = Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    const timeoutFailure = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        proc.kill('SIGKILL');
+        output.catch(() => {});
+        reject(
+          new Error(
+            `CLI timed out after ${CLI_TIMEOUT_MS}ms: ${entrypoint} ${args.join(' ')}`
+          )
+        );
+      }, CLI_TIMEOUT_MS);
+    });
+
+    let stdout: string;
+    let stderr: string;
+    let exitCode: number;
+    try {
+      [stdout, stderr, exitCode] = await Promise.race([output, timeoutFailure]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+
+    return {
+      exitCode,
+      stdout: normalizeCliOutput(stdout),
+      stderr: normalizeCliOutput(stderr),
+    };
+  } finally {
+    prepared.cleanup?.();
+  }
+}
+
+async function runCli(
+  args: string[],
+  options: RunOptions = {}
+): Promise<CliResult> {
+  return runBunScript('scripts/main.ts', args, options);
+}
+
+afterEach(() => {
+  while (cleanupPaths.length > 0) {
+    const dir = cleanupPaths.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function expectCliCase(result: CliResult, testCase: CliCase) {
+  expect(result.exitCode).toBe(testCase.expectedExitCode);
+
+  if (testCase.stdout !== undefined) {
+    expect(result.stdout).toBe(testCase.stdout);
+  }
+  for (const expected of testCase.stdoutIncludes ?? []) {
+    expect(result.stdout).toContain(expected);
+  }
+  for (const unexpected of testCase.stdoutExcludes ?? []) {
+    expect(result.stdout).not.toContain(unexpected);
+  }
+
+  if (testCase.stderr !== undefined) {
+    expect(result.stderr).toBe(testCase.stderr);
+  }
+  for (const expected of testCase.stderrIncludes ?? []) {
+    expect(result.stderr).toContain(expected);
+  }
+  for (const unexpected of testCase.stderrExcludes ?? []) {
+    expect(result.stderr).not.toContain(unexpected);
+  }
+}
+
+const hostileHelpCommands = [
+  { name: 'top-level', args: ['--help'] },
+  ...COMMAND_FAMILIES.map((family) => ({
+    name: family,
+    args: [family, '--help'],
+  })),
+];
+
+describe('CLI hermetic subprocess behavior', () => {
+  it('prints source CLI version without host credentials', async () => {
+    const result = await runCli(['--version']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('dev\n');
+    expect(result.stderr).toBe('');
+  });
+
+  for (const testCase of CLI_MATRIX_CASES) {
+    it(testCase.name, async () => {
+      const result = await runCli(testCase.args);
+      expectCliCase(result, testCase);
+    });
+  }
+
+  for (const command of hostileHelpCommands) {
+    it(`prints ${command.name} help with nonexistent TLON_CONFIG_FILE`, async () => {
+      const result = await runCli(command.args, {
+        prepare: ({ home }) => ({
+          env: { TLON_CONFIG_FILE: join(home, 'missing-ship.json') },
+        }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Usage:');
+      expect(result.stderr).toBe('');
+    });
+
+    it(`prints ${command.name} help with CLI --config /nonexistent`, async () => {
+      const result = await runCli(command.args, {
+        prepare: ({ home }) => ({
+          argsPrefix: ['--config', join(home, 'missing-ship.json')],
+        }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Usage:');
+      expect(result.stderr).toBe('');
+    });
+  }
+
+  describe('global credential flag validation', () => {
+    it('fails malformed global credential flags before activity dispatch', async () => {
+      const result = await runCli([
+        '--url',
+        'https://cli.tlon.network',
+        'activity',
+        '--help',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Invalid credential flags');
+      expect(result.stderr).not.toContain('Usage: tlon activity');
+      expect(result.stderr).not.toContain('Missing Urbit config');
+    });
+
+    for (const command of ['activity', 'upload'] as const) {
+      it(`strips valid global credential flags before ${command} help dispatch`, async () => {
+        const result = await runCli(
+          [
+            '--url',
+            'https://cli.tlon.network',
+            '--cookie',
+            'urbauth-~zod=0v-cookie',
+            command,
+            '--help',
+          ],
+          {
+            prepare: ({ home }) => ({
+              env: { TLON_CONFIG_FILE: join(home, 'missing-ship.json') },
+            }),
+          }
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain(`Usage: tlon ${command}`);
+        expect(result.stderr).toBe('');
+      });
+    }
+
+    it('fails partial CLI credential flags before merging ambient env', async () => {
+      const result = await runCli(
+        ['--url', 'https://cli.tlon.network', 'contacts', 'self'],
+        {
+          env: {
+            URBIT_COOKIE: 'urbauth-~zod=0v-cookie',
+            URBIT_SHIP: '~zod',
+            URBIT_CODE: 'code',
+          },
+        }
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Invalid credential flags');
+      expect(result.stderr).not.toContain('Missing Urbit config');
+    });
+
+    it('fails conflicting credential forms before command import/auth lookup', async () => {
+      const result = await runCli([
+        '--config',
+        'ship.json',
+        '--url',
+        'https://zod.tlon.network',
+        '--cookie',
+        'urbauth-~zod=0v-cookie',
+        'contacts',
+        'self',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('--config cannot be combined');
+    });
+
+    it('fails duplicate credential flags', async () => {
+      const result = await runCli([
+        '--ship',
+        '~zod',
+        '--ship',
+        '~bus',
+        'contacts',
+        'self',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Duplicate credential flag: --ship');
+    });
+
+    it('fails empty credential flag values', async () => {
+      const result = await runCli(['--cookie=', 'contacts', 'self']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Missing value for --cookie');
+    });
+
+    it('fails missing values when the next token is absent or the command', async () => {
+      const absent = await runCli(['--url']);
+      const command = await runCli(['--url', 'contacts', 'self']);
+
+      expect(absent.exitCode).toBe(1);
+      expect(absent.stderr).toContain('Missing value for --url');
+      expect(command.exitCode).toBe(1);
+      expect(command.stderr).toContain('Missing value for --url');
+    });
+
+    it('accepts valid CLI credentials while ignoring ambient TLON_CONFIG_FILE during parsing', async () => {
+      const result = await runCli(
+        [
+          '--url',
+          'https://cli.tlon.network',
+          '--cookie',
+          'urbauth-~zod=0v-cookie',
+          'definitely-not-a-command',
+        ],
+        {
+          prepare: ({ home }) => ({
+            env: { TLON_CONFIG_FILE: join(home, 'missing-ship.json') },
+          }),
+        }
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        'Unknown command: definitely-not-a-command'
+      );
+      expect(result.stderr).not.toContain('Ship config not found');
+    });
+  });
+});

--- a/packages/tlon-skill/tsconfig.json
+++ b/packages/tlon-skill/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./scripts",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "scripts/**/*.test.ts",
+    "scripts/**/*.spec.ts",
+    "tests/**/*.ts"
+  ]
+}

--- a/packages/tlon-skill/tsconfig.test.json
+++ b/packages/tlon-skill/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "declaration": false,
+    "types": ["node", "bun-types"]
+  },
+  "include": ["scripts/**/*.test.ts", "scripts/**/*.spec.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,7 +824,7 @@ importers:
         version: 0.19.12(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sqlocal:
         specifier: ^0.14.1
-        version: 0.14.2(drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1))
+        version: 0.14.2(drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)(bun-types@1.3.14))
       urbit-ob:
         specifier: ^5.0.1
         version: 5.0.1
@@ -1149,7 +1149,7 @@ importers:
         version: 4.8.0
       sqlocal:
         specifier: ^0.14.1
-        version: 0.14.2(drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1))
+        version: 0.14.2(drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)(bun-types@1.3.14))
       tamagui:
         specifier: ~2.0.0-rc.41
         version: 2.0.0-rc.41(react-dom@19.1.0(react@19.1.0))(react-native-gesture-handler@2.28.0(patch_hash=4tgd2pyadl6scffs4ygpr5laoq)(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(sf-symbols-typescript@2.2.0)
@@ -1269,7 +1269,7 @@ importers:
         version: 3.0.0
       drizzle-orm:
         specifier: 0.39.3
-        version: 0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)
+        version: 0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)(bun-types@1.3.14)
       expo-contacts:
         specifier: '*'
         version: 15.0.11(expo@54.0.33(@babel/core@7.29.0)(graphql@16.6.0)(react-native-webview@13.15.0(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1316,6 +1316,40 @@ importers:
       vitest:
         specifier: ^1.4.0
         version: 1.5.0(@types/node@20.19.31)(jsdom@23.2.0)(lightningcss@1.31.1)(terser@5.46.0)
+
+  packages/tlon-skill:
+    optionalDependencies:
+      '@tloncorp/tlon-skill-darwin-arm64':
+        specifier: 0.4.0
+        version: 0.4.0
+      '@tloncorp/tlon-skill-darwin-x64':
+        specifier: 0.4.0
+        version: 0.4.0
+      '@tloncorp/tlon-skill-linux-arm64':
+        specifier: 0.4.0
+        version: 0.4.0
+      '@tloncorp/tlon-skill-linux-x64':
+        specifier: 0.4.0
+        version: 0.4.0
+    devDependencies:
+      '@tloncorp/api':
+        specifier: workspace:*
+        version: link:../api
+      '@types/bun':
+        specifier: ^1.3.14
+        version: 1.3.14
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.12.4
+      '@urbit/aura':
+        specifier: ^3.0.0
+        version: 3.0.0
+      '@urbit/nockjs':
+        specifier: ^1.6.0
+        version: 1.6.0
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
 
   packages/ui:
     dependencies:
@@ -5658,6 +5692,30 @@ packages:
   '@tloncorp/mock-http-api@1.2.0':
     resolution: {integrity: sha512-uDv+7J6enXeZqP1lX7vsyCiAkVbQL0yXQZSUBFMRtmW8LW7BhRqW6hmN+Pk3jcaUSDLUHh8TWjnEx9kNoS9QPQ==}
 
+  '@tloncorp/tlon-skill-darwin-arm64@0.4.0':
+    resolution: {integrity: sha512-2hpHiKUDOqXkEeoCOu2yk5cBsQZno61wk1iPlDluYj5XXc8YRWwaLTYtAbhWj2giNI9UE4+B81n9eT+4lphF9w==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@tloncorp/tlon-skill-darwin-x64@0.4.0':
+    resolution: {integrity: sha512-VoYzNgoUufFUHiCjV5jerog/iuEVB+2sD86xkPYHm9WUfbETiAj+cWkKbl0lLSKasqtUtS7qgpslbBJzS0SeZg==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@tloncorp/tlon-skill-linux-arm64@0.4.0':
+    resolution: {integrity: sha512-2GnUO0jgybLE7qONOXGQZY5qrttEPaPN8U9RhgIyjFmViJuA8laQsQyaXu0d1/HVTxQ77tLzVHCIHBg5waT1Bg==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@tloncorp/tlon-skill-linux-x64@0.4.0':
+    resolution: {integrity: sha512-rdcm64J1+8t36to4IS7CNb0y+THUHqqISSkwKq2EPvuLrOuhL9pvgnIE+oO3qBezvNXJRo36GQPM2G05MosTYg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -5695,6 +5753,9 @@ packages:
 
   '@types/better-sqlite3@7.6.9':
     resolution: {integrity: sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==}
+
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -5797,6 +5858,9 @@ packages:
 
   '@types/node@20.19.31':
     resolution: {integrity: sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -6812,6 +6876,9 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -12679,6 +12746,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.21.3:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
@@ -20307,6 +20377,18 @@ snapshots:
       core-js: 3.41.0
       path-to-regexp: 6.2.1
 
+  '@tloncorp/tlon-skill-darwin-arm64@0.4.0':
+    optional: true
+
+  '@tloncorp/tlon-skill-darwin-x64@0.4.0':
+    optional: true
+
+  '@tloncorp/tlon-skill-linux-arm64@0.4.0':
+    optional: true
+
+  '@tloncorp/tlon-skill-linux-x64@0.4.0':
+    optional: true
+
   '@tootallnate/once@2.0.0': {}
 
   '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.2.5)':
@@ -20354,6 +20436,10 @@ snapshots:
   '@types/better-sqlite3@7.6.9':
     dependencies:
       '@types/node': 20.19.31
+
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -20474,6 +20560,10 @@ snapshots:
   '@types/node@20.19.31':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -21815,6 +21905,10 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 24.12.4
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
@@ -22666,12 +22760,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1):
+  drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)(bun-types@1.3.14):
     optionalDependencies:
       '@op-engineering/op-sqlite': 15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.9
       better-sqlite3: 11.8.1
+      bun-types: 1.3.14
 
   dunder-proto@1.0.1:
     dependencies:
@@ -28132,12 +28227,12 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
-  sqlocal@0.14.2(drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)):
+  sqlocal@0.14.2(drizzle-orm@0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)(bun-types@1.3.14)):
     dependencies:
       '@sqlite.org/sqlite-wasm': 3.50.1-build1
       coincident: 1.2.3
     optionalDependencies:
-      drizzle-orm: 0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)
+      drizzle-orm: 0.39.3(patch_hash=wokcg55yjcq5vebl5wtmbpawhe)(@op-engineering/op-sqlite@15.2.5(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.9)(better-sqlite3@11.8.1)(bun-types@1.3.14)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -28847,6 +28942,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   undici@6.21.3: {}
 


### PR DESCRIPTION
## Summary

As discussed, pulls the [tlon-skill](https://github.com/tloncorp/tlon-skill) CLI into the monorepo. This'll make it easier to make cross-package changes without needing to sequence PRs across different repos.


## Changes

- Copies over the source files from `tlon-skill` at `7a195f534825ea081bafe9e9ed14784c90f3c4e0`
- Replaced internal `npm` calls with `pnpm`
- Shuffles `tlon-skill`'s `@tloncorp/api` dependency from published semver module to a workspace one
- Root script for `build:tlon-skill`
- Updated `test:ci` to build the API module and run the existing skill Bun tests
- Updated `.gitignore` and `.prettierignore`
- Ran prettier to normalize the file formatting

## How did I test?

I updated `openclaw-tlon` locally and pointed it at the `tlon-apps` version. Confirmed it loads and can use the CLI

## Risks and impact

- Safe to rollback without consulting PR author? Yes


