### PR TITLE
signup: avoid showing web prompt immediately on home screen

### DIFF
--- a/packages/app/ui/components/WebAppSplashSheet.tsx
+++ b/packages/app/ui/components/WebAppSplashSheet.tsx
@@ -18,11 +18,22 @@ export function useWebAppSplash() {
 
   useEffect(() => {
     let cancelled = false;
-    db.getSettings().then((settings) => {
-      if (!cancelled && !settings?.webAppSplashDismissed) {
+    async function maybeOpenSplash() {
+      const settings = await db.getSettings();
+      if (settings?.webAppSplashDismissed) {
+        return;
+      }
+
+      const openCount = await db.webAppSplashOpenCount.getValue();
+      const nextOpenCount = openCount + 1;
+      await db.webAppSplashOpenCount.setValue(nextOpenCount);
+
+      if (!cancelled && nextOpenCount >= 2) {
         setOpen(true);
       }
-    });
+    }
+
+    maybeOpenSplash();
     return () => {
       cancelled = true;
     };

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -199,6 +199,11 @@ export const lastAnonymousAppOpenAt = createStorageItem<number | null>({
   defaultValue: null,
 });
 
+export const webAppSplashOpenCount = createStorageItem<number>({
+  key: 'webAppSplashOpenCount',
+  defaultValue: 0,
+});
+
 export const finishingSelfHostedLogin = createStorageItem<boolean>({
   key: 'finishingSelfHostedLogin',
   defaultValue: false,


### PR DESCRIPTION
## Summary

We recently added a "Try Tlon on Web" sheet to make mobile signups aware of our web app. Right now, it displays immediately when you land in the app. This creates issues for our E2E test, but also feels jarring — you have to both register the information about web while also seeing the home screen in the background for the first time.

I'd like to defer this slightly so it's shown the second time the app is opened rather than immediately.

## Changes

- add key value variable to track opens for the web prompt
- only display it after the app has been opened at least twice

## How did I test?

iOS sim

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
