### PR TITLE
fix reaction taps

### DIFF
--- a/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
+++ b/packages/app/ui/components/ChatMessage/ReactionsDisplay.tsx
@@ -178,13 +178,10 @@ export function ReactionsDisplay({
               <Tooltip.Trigger
                 borderRadius="$s"
                 cursor="pointer"
-                onPress={() => handleModifyYourReaction(reaction.value)}
-                onLongPress={
-                  isWeb ? undefined : () => handleOpenReactions(post)
-                }
                 testID="ReactionDisplay"
               >
-                <XStack
+                <Pressable
+                  flexDirection="row"
                   justifyContent="center"
                   alignItems="center"
                   backgroundColor={
@@ -202,17 +199,20 @@ export function ReactionsDisplay({
                       : '$border'
                   }
                   gap={'$s'}
-                  disabled={
-                    !canWrite ||
-                    (reactionDetails.self.didReact &&
-                      reaction.value !== reactionDetails.self.value)
+                  onPress={
+                    canWrite
+                      ? () => handleModifyYourReaction(reaction.value)
+                      : undefined
+                  }
+                  onLongPress={
+                    isWeb ? undefined : () => handleOpenReactions(post)
                   }
                 >
                   <SizableEmoji emojiInput={reaction.value} fontSize="$s" />
                   {reaction.count > 0 && (
                     <Text size="$label/m">{reaction.count}</Text>
                   )}
-                </XStack>
+                </Pressable>
               </Tooltip.Trigger>
               <ReactionTooltipContent reaction={reaction} />
             </Tooltip>


### PR DESCRIPTION
## Summary

Fixes iOS reaction chips so tapping an existing emoji adds your reaction. The native tooltip trigger does not own the press target, so the chip now keeps the tooltip wrapper while the rendered button handles taps. 

Fixes TLON-5943

## Changes

- Move reaction tap and long-press handlers from `Tooltip.Trigger` to the rendered reaction chip.

## How did I test?

Tested on device