### PR TITLE
fix: persist mobile app promo banner dismissal to server settings

### DIFF
--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -47,6 +47,7 @@ function getBucket(key: string): string {
     case 'enableTelemetry':
     case 'tlonbotConfig':
     case 'webAppSplashDismissed':
+    case 'mobileAppPromoDismissed':
       return 'groups';
     case 'disableAvatars':
     case 'disableNicknames':
@@ -152,6 +153,8 @@ export const toClientSettings = (
     disableTlonInfraEnhancement:
       settings.desk.groups?.disableTlonInfraEnhancement ?? false,
     webAppSplashDismissed: settings.desk.groups?.webAppSplashDismissed ?? false,
+    mobileAppPromoDismissed:
+      settings.desk.groups?.mobileAppPromoDismissed ?? false,
   };
 };
 

--- a/packages/api/src/types/models.ts
+++ b/packages/api/src/types/models.ts
@@ -255,6 +255,7 @@ export interface Settings {
   completedWayfindingTutorial?: boolean;
   disableTlonInfraEnhancement?: boolean;
   webAppSplashDismissed?: boolean;
+  mobileAppPromoDismissed?: boolean;
 }
 
 export interface VolumeSettings {

--- a/packages/api/src/urbit/settings.ts
+++ b/packages/api/src/urbit/settings.ts
@@ -80,6 +80,7 @@ export type GroupsSettings = {
   completedWayfindingTutorial?: boolean;
   disableTlonInfraEnhancement?: boolean;
   webAppSplashDismissed?: boolean;
+  mobileAppPromoDismissed?: boolean;
 } & Record<string, unknown>;
 
 export type TalkSettings = {

--- a/packages/app/ui/components/MobileAppPromoBanner.tsx
+++ b/packages/app/ui/components/MobileAppPromoBanner.tsx
@@ -54,13 +54,7 @@ export function MobileAppPromoBanner() {
   }
 
   return (
-    <View
-      position="absolute"
-      bottom="$xl"
-      left="$xl"
-      right="$xl"
-      zIndex={10}
-    >
+    <View position="absolute" bottom="$xl" left="$xl" right="$xl" zIndex={10}>
       <View
         position="relative"
         backgroundColor="$background"

--- a/packages/app/ui/components/MobileAppPromoBanner.tsx
+++ b/packages/app/ui/components/MobileAppPromoBanner.tsx
@@ -1,37 +1,47 @@
-import { getConstants } from '@tloncorp/shared/domain';
+import * as store from '@tloncorp/shared/store';
 import { Icon, Image, TlonText } from '@tloncorp/ui';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Platform, Pressable } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
 import { TLON_APP_STORE_URL, TLON_PLAY_STORE_URL } from '../../constants';
-import { useNag } from '../../hooks/useNag';
 
 export function MobileAppPromoBanner() {
   const [isVisible, setIsVisible] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
   const isE2eRun = (globalThis as any).TLON_IS_E2E === true;
   const isWeb = Platform.OS === 'web';
 
-  const nag = useNag({
-    key: 'mobileAppPromoBanner',
-    refreshInterval: 0,
-    refreshCycle: 0,
-    initialDelay: 500,
-  });
+  const { data: settings, isLoading } = store.useSettings();
 
+  // Wait for settings to load from the server before deciding. The dismissal
+  // is persisted in settings-store (per-account, synced), so once dismissed it
+  // stays dismissed across reloads, payloads, and devices. `dismissed` hides it
+  // immediately on click, ahead of the settings write round-tripping.
+  const shouldShow =
+    isWeb &&
+    !isE2eRun &&
+    !isLoading &&
+    !dismissed &&
+    settings?.mobileAppPromoDismissed !== true;
+
+  // Default to hidden and only reveal after `shouldShow` has held for the
+  // delay. This debounces the initial settings load/sync so a late-arriving
+  // "dismissed" value suppresses the banner before it ever paints.
   useEffect(() => {
-    if (!isE2eRun && nag.shouldShow) {
-      const timer = setTimeout(() => setIsVisible(true), 300);
-      return () => clearTimeout(timer);
+    if (!shouldShow) {
+      setIsVisible(false);
+      return;
     }
-  }, [isE2eRun, nag.shouldShow]);
+    const timer = setTimeout(() => setIsVisible(true), 500);
+    return () => clearTimeout(timer);
+  }, [shouldShow]);
 
   const handleDismiss = useCallback(() => {
     setIsVisible(false);
-    setTimeout(() => {
-      nag.eliminate();
-    }, 200);
-  }, [nag]);
+    setDismissed(true);
+    store.dismissMobileAppPromo();
+  }, []);
 
   const handleLinkPress = useCallback((url: string) => {
     if (typeof window !== 'undefined') {
@@ -39,7 +49,7 @@ export function MobileAppPromoBanner() {
     }
   }, []);
 
-  if (!isWeb || isE2eRun || !nag.shouldShow) {
+  if (!isVisible) {
     return null;
   }
 
@@ -49,7 +59,6 @@ export function MobileAppPromoBanner() {
       bottom="$xl"
       left="$xl"
       right="$xl"
-      pointerEvents={isVisible ? 'auto' : 'none'}
       zIndex={10}
     >
       <View

--- a/packages/shared/src/db/migrations/0000_real_rhino.sql
+++ b/packages/shared/src/db/migrations/0000_real_rhino.sql
@@ -409,7 +409,8 @@ CREATE TABLE `settings` (
 	`completed_wayfinding_splash` integer,
 	`completed_wayfinding_tutorial` integer,
 	`disable_tlon_infra_enhancement` integer,
-	`web_app_splash_dismissed` integer
+	`web_app_splash_dismissed` integer,
+	`mobile_app_promo_dismissed` integer
 );
 --> statement-breakpoint
 CREATE TABLE `system_contact_sent_invites` (

--- a/packages/shared/src/db/migrations/meta/0000_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "cc577004-959d-47bc-9759-f4eb6af9f5f7",
+  "id": "b3c5a540-1b40-4dc1-988d-3585a29c43e9",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "activity_event_contact_group_pins": {
@@ -2779,6 +2779,13 @@
         },
         "web_app_splash_dismissed": {
           "name": "web_app_splash_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_app_promo_dismissed": {
+          "name": "mobile_app_promo_dismissed",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1779481783452,
-      "tag": "0000_daily_silver_fox",
+      "when": 1780682104236,
+      "tag": "0000_real_rhino",
       "breakpoints": true
     }
   ]

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -1,7 +1,7 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 
 import journal from './meta/_journal.json';
-import m0000 from './0000_daily_silver_fox.sql';
+import m0000 from './0000_real_rhino.sql';
 
   export default {
     journal,

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -77,6 +77,7 @@ export const settings = sqliteTable('settings', {
   completedWayfindingTutorial: boolean('completed_wayfinding_tutorial'),
   disableTlonInfraEnhancement: boolean('disable_tlon_infra_enhancement'),
   webAppSplashDismissed: boolean('web_app_splash_dismissed'),
+  mobileAppPromoDismissed: boolean('mobile_app_promo_dismissed'),
 });
 
 export const systemContacts = sqliteTable(

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -115,6 +115,17 @@ export async function dismissWebAppSplash() {
   }
 }
 
+export async function dismissMobileAppPromo() {
+  // optimistic update
+  await db.insertSettings({ mobileAppPromoDismissed: true });
+  try {
+    await withRetry(() => api.setSetting('mobileAppPromoDismissed', true));
+  } catch (e) {
+    // don't rollback the optimistic update; we want to avoid re-nagging the
+    // user if the remote write fails
+  }
+}
+
 export async function completeWayfindingTutorial() {
   // optimistic update
   await db.insertSettings({ completedWayfindingTutorial: true });


### PR DESCRIPTION
## Summary

Mimics what we did for the desktop splash, this prevents it from showing up whenever new web UI globs get installed.

## Changes

- Added a synced `mobileAppPromoDismissed` setting in the `groups` desk bucket (schema column, api types/urbit types, `getBucket` + `toClientSettings` mapping), regenerated the Drizzle migration.
- Added a `dismissMobileAppPromo()` store action (optimistic `insertSettings` + `withRetry(setSetting)`, no rollback on remote failure), mirroring `dismissWebAppSplash`.
- Reworked `MobileAppPromoBanner` to read dismissal from `useSettings()` instead of `useNag`/localStorage, waiting for settings to load before deciding.
- Banner now defaults to hidden and only reveals after the show decision holds for a debounce window, so a late-arriving dismissed value never flashes on reload.
- Dropped the unused `getConstants` import.

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit. The added `mobile_app_promo_dismissed` setting is additive and ignored by the prior code; no data cleanup required.

## Screenshots / videos

<!-- Attach any relevant media. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
