### PR TITLE
Integrate react activity types into client and notifications

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/UrbitModule.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/UrbitModule.java
@@ -37,6 +37,16 @@ public class UrbitModule extends ReactContextBaseJavaModule {
         SecureStorage.clear();
     }
 
+    // Caches whether the connected backend's %activity supports reactions, so
+    // the notification service can choose the v9 (activity-event-1) vs v8
+    // (activity-event) fetch without scrying for a version itself.
+    @ReactMethod
+    public void setActivitySupportsReactions(boolean supported) {
+        SharedPreferences.Editor editor = SecureStorage.sharedPreferences.edit();
+        editor.putBoolean(SecureStorage.ACTIVITY_SUPPORTS_REACTIONS_KEY, supported);
+        editor.apply();
+    }
+
     @ReactMethod
     public void updateBadgeCount(int count, String uid) {}
 

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/UrbitModule.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/UrbitModule.java
@@ -29,6 +29,9 @@ public class UrbitModule extends ReactContextBaseJavaModule {
         editor.putString(SecureStorage.AUTH_COOKIE_KEY, authCookie.split(";")[0]);
         String uid = Long.toString(System.currentTimeMillis() / 1000L) + "-" + String.format("%06x", new Random().nextInt(0x1000000));
         editor.putString(SecureStorage.CHANNEL_URL, shipUrl + "/~/channel/" + uid);
+        // reset the cached backend capability for the new login; JS re-resolves
+        // it from the ship's version. avoids using a prior ship's v9 mark.
+        editor.remove(SecureStorage.ACTIVITY_SUPPORTS_REACTIONS_KEY);
         editor.apply();
     }
 

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
@@ -174,7 +174,12 @@ public class TalkApi {
     }
 
     public void fetchActivityEvent(String uid, TalkObjectCallback callback) {
-        fetchObject("/apps/groups/~/notify/note/" + uid + "/activity-event-1", callback);
+        // activity-event-1 is the v9-native mark (carries reacts); activity-event
+        // (v8) 404s on reacts. Use v9 only when the app has confirmed the backend
+        // supports it — otherwise an old backend would 404 every notification.
+        String mark = SecureStorage.getBoolean(SecureStorage.ACTIVITY_SUPPORTS_REACTIONS_KEY)
+                ? "activity-event-1" : "activity-event";
+        fetchObject("/apps/groups/~/notify/note/" + uid + "/" + mark, callback);
     }
 
     public void fetchContact(String id, TalkObjectCallback callback) {

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/api/TalkApi.java
@@ -174,7 +174,7 @@ public class TalkApi {
     }
 
     public void fetchActivityEvent(String uid, TalkObjectCallback callback) {
-        fetchObject("/apps/groups/~/notify/note/" + uid + "/activity-event", callback);
+        fetchObject("/apps/groups/~/notify/note/" + uid + "/activity-event-1", callback);
     }
 
     public void fetchContact(String id, TalkObjectCallback callback) {

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/storage/SecureStorage.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/storage/SecureStorage.java
@@ -46,6 +46,9 @@ public class SecureStorage {
         editor.remove(SHIP_URL_KEY);
         editor.remove(AUTH_COOKIE_KEY);
         editor.remove(CHANNEL_URL);
+        // clear cached backend capability so a later login to an older backend
+        // doesn't keep fetching the v9 notification mark (which it would 404)
+        editor.remove(ACTIVITY_SUPPORTS_REACTIONS_KEY);
         editor.apply();
     }
 

--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/storage/SecureStorage.java
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/storage/SecureStorage.java
@@ -15,6 +15,7 @@ public class SecureStorage {
     public static String SHIP_URL_KEY = "shipUrl";
     public static String AUTH_COOKIE_KEY = "authCookie";
     public static String CHANNEL_URL = "channelUrl";
+    public static String ACTIVITY_SUPPORTS_REACTIONS_KEY = "activitySupportsReactions";
 
     public static SharedPreferences sharedPreferences;
 

--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.m
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.m
@@ -13,6 +13,7 @@
 RCT_EXTERN_METHOD(setUrbit:(NSString *)shipName shipUrl:(NSString *)shipUrl authCookie:(NSString *)authCookie)
 RCT_EXTERN_METHOD(clearUrbit)
 RCT_EXTERN_METHOD(setPostHogApiKey:(NSString *)apiKey)
+RCT_EXTERN_METHOD(setActivitySupportsReactions:(BOOL)supported)
 RCT_EXTERN_METHOD(updateBadgeCount:(NSInteger)count uid:(NSString *)uid)
 RCT_EXTERN_METHOD(signalJsReady)
 + (BOOL)requiresMainQueueSetup

--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
@@ -25,6 +25,11 @@ class UrbitModule: NSObject {
 
     @objc func clearUrbit() {
         try? UrbitModule.loginStore.delete()
+        // clear cached backend capability so a later login to an older backend
+        // doesn't keep fetching the v9 notification mark (which it would 404)
+        UserDefaults.forDefaultAppGroup.removeObject(
+            forKey: SettingsStore.activitySupportsReactionsKey
+        )
     }
 
     @objc(setPostHogApiKey:)

--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
@@ -32,6 +32,11 @@ class UrbitModule: NSObject {
         UserDefaults.forDefaultAppGroup.set(apiKey, forKey: "postHogApiKey")
     }
 
+    @objc(setActivitySupportsReactions:)
+    func setActivitySupportsReactions(supported: Bool) {
+        UserDefaults.forDefaultAppGroup.set(supported, forKey: SettingsStore.activitySupportsReactionsKey)
+    }
+
     @objc(updateBadgeCount:uid:)
     func updateBadgeCount(count: Int, uid: String) {
         Task {

--- a/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
+++ b/apps/tlon-mobile/ios/Landscape/UrbitModule.swift
@@ -14,6 +14,11 @@ class UrbitModule: NSObject {
     @objc(setUrbit:shipUrl:authCookie:)
     func setUrbit(shipName: String, shipUrl: String, authCookie _: String) {
         try? UrbitModule.loginStore.save(Login(shipName: shipName, shipUrl: shipUrl))
+        // reset the cached backend capability for the new login; JS re-resolves
+        // it from the ship's version. avoids using a prior ship's v9 mark.
+        UserDefaults.forDefaultAppGroup.removeObject(
+            forKey: SettingsStore.activitySupportsReactionsKey
+        )
 
         Task {
             // Delay this a bit so that js init requests have time to fire

--- a/apps/tlon-mobile/ios/Shared/Networking/PocketNotificationsAPI.swift
+++ b/apps/tlon-mobile/ios/Shared/Networking/PocketNotificationsAPI.swift
@@ -11,6 +11,10 @@ import JavaScriptCore
 
 extension PocketAPI {
   func fetchRawPushNotificationContents(_ uid: String) async throws -> Data {
-    try await fetchData("/apps/groups/~/notify/note/\(uid)/activity-event-1", timeoutInterval: 8)
+    // activity-event-1 is the v9-native mark (carries reacts); activity-event
+    // (v8) 404s on reacts. Use v9 only when the app has confirmed the backend
+    // supports it — otherwise an old backend would 404 every notification.
+    let mark = SettingsStore.activitySupportsReactions ? "activity-event-1" : "activity-event"
+    return try await fetchData("/apps/groups/~/notify/note/\(uid)/\(mark)", timeoutInterval: 8)
   }
 }

--- a/apps/tlon-mobile/ios/Shared/Networking/PocketNotificationsAPI.swift
+++ b/apps/tlon-mobile/ios/Shared/Networking/PocketNotificationsAPI.swift
@@ -11,6 +11,6 @@ import JavaScriptCore
 
 extension PocketAPI {
   func fetchRawPushNotificationContents(_ uid: String) async throws -> Data {
-    try await fetchData("/apps/groups/~/notify/note/\(uid)/activity-event", timeoutInterval: 8)
+    try await fetchData("/apps/groups/~/notify/note/\(uid)/activity-event-1", timeoutInterval: 8)
   }
 }

--- a/apps/tlon-mobile/ios/Shared/Storage/SettingsStore.swift
+++ b/apps/tlon-mobile/ios/Shared/Storage/SettingsStore.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 enum SettingsStore {
+    // Written by the app (via UrbitModule) from the backend's groups version,
+    // read by the notification extension to choose the activity-event mark.
+    static let activitySupportsReactionsKey = "activity.supportsReactions"
+    static var activitySupportsReactions: Bool {
+        UserDefaults.forDefaultAppGroup.bool(forKey: activitySupportsReactionsKey)
+    }
+
     static var disableAvatars: Bool = UserDefaults.forDefaultAppGroup.bool(forKey: "settings.calmEngine.disableAvatars") {
         didSet {
             UserDefaults.forDefaultAppGroup.set(disableNicknames, forKey: "settings.calmEngine.disableAvatars")

--- a/apps/tlon-mobile/src/__uitests__/useNotificationListener.test.ts
+++ b/apps/tlon-mobile/src/__uitests__/useNotificationListener.test.ts
@@ -245,6 +245,96 @@ describe('parseNotificationPayload', () => {
     });
   });
 
+  it('parses channel post react activity to the channel', () => {
+    const result = parseNotificationPayload(
+      payloadFor({
+        react: {
+          key: childKey,
+          parent: null,
+          group: '~sampel-palnet/test',
+          channel: 'chat/~sampel-palnet/test',
+          author: '~sampel-palnet',
+          react: '❤️',
+        },
+      })
+    );
+
+    expect(result).toEqual({
+      meta: { errorsFromExtension: undefined },
+      channelId: 'chat/~sampel-palnet/test',
+      postInfo: null,
+    });
+  });
+
+  it('parses channel reply react activity to the parent thread', () => {
+    const result = parseNotificationPayload(
+      payloadFor({
+        react: {
+          key: childKey,
+          parent: parentKey,
+          group: '~sampel-palnet/test',
+          channel: 'chat/~sampel-palnet/test',
+          author: '~sampel-palnet',
+          react: '❤️',
+        },
+      })
+    );
+
+    expect(result).toEqual({
+      meta: { errorsFromExtension: undefined },
+      channelId: 'chat/~sampel-palnet/test',
+      postInfo: {
+        id: parentId.split('/')[1],
+        authorId: '~sampel-palnet',
+        isDm: false,
+      },
+    });
+  });
+
+  it('parses DM react activity to the DM channel', () => {
+    const result = parseNotificationPayload(
+      payloadFor({
+        'dm-react': {
+          key: childKey,
+          parent: null,
+          whom: { ship: '~sampel-palnet' },
+          author: '~sampel-palnet',
+          react: '❤️',
+        },
+      })
+    );
+
+    expect(result).toEqual({
+      meta: { errorsFromExtension: undefined },
+      channelId: '~sampel-palnet',
+      postInfo: null,
+    });
+  });
+
+  it('parses DM thread react activity to the parent thread', () => {
+    const result = parseNotificationPayload(
+      payloadFor({
+        'dm-react': {
+          key: childKey,
+          parent: parentKey,
+          whom: { club: groupDmId },
+          author: '~sampel-palnet',
+          react: '❤️',
+        },
+      })
+    );
+
+    expect(result).toEqual({
+      meta: { errorsFromExtension: undefined },
+      channelId: groupDmId,
+      postInfo: {
+        id: parentId.split('/')[1],
+        authorId: '~sampel-palnet',
+        isDm: false,
+      },
+    });
+  });
+
   it('ignores malformed activity JSON without throwing', () => {
     expect(() =>
       parseNotificationPayload({ activityEventJsonString: '{' })

--- a/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
+++ b/apps/tlon-mobile/src/components/AuthenticatedApp.tsx
@@ -45,6 +45,7 @@ import { useDeepLinkListener } from '../hooks/useDeepLinkListener';
 import useNotificationListener from '../hooks/useNotificationListener';
 import { usePoorUxShakeReport } from '../hooks/usePoorUxShakeReport';
 import { useSyncAppBadge } from '../hooks/useSyncAppBadge';
+import { useSyncReactionCapability } from '../hooks/useSyncReactionCapability';
 import { inviteSystemContacts } from '../lib/contactsHelpers';
 import { refreshHostingAuth } from '../lib/hostingAuth';
 import { AutomatedTestSyncScreen } from '../screens/e2e/AutomatedTestSyncScreen';
@@ -66,6 +67,7 @@ function AuthenticatedApp() {
   useCheckAppUpdated();
   useFindSuggestedContacts();
   useSyncAppBadge();
+  useSyncReactionCapability();
   const checkForCachedChanges = useCachedChanges();
   const { poorUxReportModal } = usePoorUxShakeReport();
 

--- a/apps/tlon-mobile/src/hooks/useSyncReactionCapability.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncReactionCapability.ts
@@ -1,0 +1,51 @@
+import { UrbitModuleSpec } from '@tloncorp/app/utils/urbitModule';
+import { createDevLogger } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { isVersionBelow } from '@tloncorp/shared/logic';
+import { useEffect } from 'react';
+import { Platform, TurboModuleRegistry } from 'react-native';
+
+// The first deployed %groups release that ships reaction support (the v9
+// activity-event-1 notification mark + react emission). The reactions code is
+// on develop but unreleased; the latest deployed version is 11.2.2, so this is
+// the next release. Below it the flag stays off and the extension falls back to
+// the v8 activity-event mark (v9 would 404 every notification on old backends).
+// TODO(reactions): confirm this matches the release that actually deploys reactions.
+const REACTIONS_MIN_GROUPS_VERSION = '11.3.0';
+
+const UrbitModule =
+  Platform.OS !== 'web'
+    ? (TurboModuleRegistry.get('UrbitModule') as UrbitModuleSpec | null)
+    : null;
+
+const logger = createDevLogger('useSyncReactionCapability', false);
+
+// Mirrors the backend's reaction capability (derived from its groups version)
+// into native storage so the notification extension can pick the v9 vs v8
+// activity-event mark without scrying a version itself.
+export function useSyncReactionCapability() {
+  const appInfo = db.appInfo.useValue();
+  const groupsVersion = appInfo?.groupsVersion;
+
+  useEffect(() => {
+    if (!UrbitModule || !groupsVersion) {
+      return;
+    }
+    // Only enable when we can affirmatively confirm a high-enough version;
+    // anything unparseable (e.g. 'n/a' when the scry failed) stays off so an
+    // old backend never gets v9 fetches that would 404 every notification.
+    const looksLikeSemver = /^\d+\.\d+\.\d+/.test(groupsVersion);
+    const supported =
+      looksLikeSemver &&
+      !isVersionBelow(groupsVersion, REACTIONS_MIN_GROUPS_VERSION);
+
+    try {
+      UrbitModule.setActivitySupportsReactions(supported);
+    } catch (e) {
+      logger.trackError('Failed to sync activity reaction capability', {
+        error: e instanceof Error ? e.message : String(e),
+        groupsVersion,
+      });
+    }
+  }, [groupsVersion]);
+}

--- a/apps/tlon-mobile/src/hooks/useSyncReactionCapability.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncReactionCapability.ts
@@ -1,17 +1,9 @@
 import { UrbitModuleSpec } from '@tloncorp/app/utils/urbitModule';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { isVersionBelow } from '@tloncorp/shared/logic';
+import { backendVersionSupportsReactions } from '@tloncorp/shared/logic';
 import { useEffect } from 'react';
 import { Platform, TurboModuleRegistry } from 'react-native';
-
-// The first deployed %groups release that ships reaction support (the v9
-// activity-event-1 notification mark + react emission). The reactions code is
-// on develop but unreleased; the latest deployed version is 11.2.2, so this is
-// the next release. Below it the flag stays off and the extension falls back to
-// the v8 activity-event mark (v9 would 404 every notification on old backends).
-// TODO(reactions): confirm this matches the release that actually deploys reactions.
-const REACTIONS_MIN_GROUPS_VERSION = '11.3.0';
 
 const UrbitModule =
   Platform.OS !== 'web'
@@ -31,14 +23,7 @@ export function useSyncReactionCapability() {
     if (!UrbitModule || !groupsVersion) {
       return;
     }
-    // Only enable when we can affirmatively confirm a high-enough version;
-    // anything unparseable (e.g. 'n/a' when the scry failed) stays off so an
-    // old backend never gets v9 fetches that would 404 every notification.
-    const looksLikeSemver = /^\d+\.\d+\.\d+/.test(groupsVersion);
-    const supported =
-      looksLikeSemver &&
-      !isVersionBelow(groupsVersion, REACTIONS_MIN_GROUPS_VERSION);
-
+    const supported = backendVersionSupportsReactions(groupsVersion);
     try {
       UrbitModule.setActivitySupportsReactions(supported);
     } catch (e) {

--- a/apps/tlon-mobile/src/hooks/useSyncReactionCapability.ts
+++ b/apps/tlon-mobile/src/hooks/useSyncReactionCapability.ts
@@ -1,7 +1,7 @@
 import { UrbitModuleSpec } from '@tloncorp/app/utils/urbitModule';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { backendVersionSupportsReactions } from '@tloncorp/shared/logic';
+import { activityVersionSupportsReactions } from '@tloncorp/shared/logic';
 import { useEffect } from 'react';
 import { Platform, TurboModuleRegistry } from 'react-native';
 
@@ -23,7 +23,7 @@ export function useSyncReactionCapability() {
     if (!UrbitModule || !groupsVersion) {
       return;
     }
-    const supported = backendVersionSupportsReactions(groupsVersion);
+    const supported = activityVersionSupportsReactions(groupsVersion);
     try {
       UrbitModule.setActivitySupportsReactions(supported);
     } catch (e) {

--- a/apps/tlon-mobile/src/lib/notificationPayload.ts
+++ b/apps/tlon-mobile/src/lib/notificationPayload.ts
@@ -175,6 +175,18 @@ export function parseNotificationPayload(
         case is(ev, 'reply'):
           return channelPostTarget(ev.reply, { parent: ev.reply.parent });
 
+        case is(ev, 'react'):
+          // navigate to the reacted-to content: the thread if it's a reply
+          // react, otherwise the channel
+          return channelPostTarget(ev.react, {
+            parent: ev.react.parent ?? undefined,
+          });
+
+        case is(ev, 'dm-react'):
+          return dmTarget(ev['dm-react'], {
+            parent: ev['dm-react'].parent ?? undefined,
+          });
+
         case is(ev, 'group-ask'):
           return groupAskTarget(ev['group-ask']);
 

--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -211,15 +211,21 @@
     ^-  volume:a
     =/  source  (source:evt event)
     =/  loudness=volume-map:a  (get-volumes:src vs source)
-    =/  type  (event-type event)
-    ?.  ?=(?(%react %dm-react) type)
-      (~(gut by loudness) type [unreads=& notify=|])
+    ?.  ?=(?(%react %dm-react) -.event)
+      (~(gut by loudness) (event-type event) [unreads=& notify=|])
     ::  reactions were added after some volume maps were written, so a stored
-    ::  map may have no react key. reacts notify exactly when posts do, so mirror
-    ::  the map's own %post setting: a source muted before reactions existed
-    ::  stays muted, a loud one still notifies. reacts never carry an unread.
-    =+  post=(~(gut by loudness) %post [*? notify=|])
-    (~(gut by loudness) type [unreads=| notify=notify.post])
+    ::  map may have no react key. a react notifies exactly when the message it
+    ::  targets does, so mirror that type's setting: post/reply (dm-post/dm-reply
+    ::  for dms), choosing the reply variant for thread reactions since a
+    ::  followed thread's map only carries %reply. this keeps a muted source
+    ::  muted and a followed thread's reacts notifying. reacts carry no unread.
+    =/  mirror=event-type:a
+      ?-  -.event
+        %react     ?~(parent.event %post %reply)
+        %dm-react  ?~(parent.event %dm-post %dm-reply)
+      ==
+    =+  base=(~(gut by loudness) mirror [*? notify=|])
+    (~(gut by loudness) (event-type event) [unreads=| notify=notify.base])
   ::
   --
 ::

--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -218,7 +218,7 @@
     ::  map may have no react key. reacts notify exactly when posts do, so mirror
     ::  the map's own %post setting: a source muted before reactions existed
     ::  stays muted, a loud one still notifies. reacts never carry an unread.
-    =+  post=(~(gut by loudness) %post [unreads=& notify=|])
+    =+  post=(~(gut by loudness) %post [*? notify=|])
     (~(gut by loudness) type [unreads=| notify=notify.post])
   ::
   --

--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -211,7 +211,12 @@
     ^-  volume:a
     =/  source  (source:evt event)
     =/  loudness=volume-map:a  (get-volumes:src vs source)
-    (~(gut by loudness) (event-type event) [unreads=& notify=|])
+    =/  type  (event-type event)
+    ::  fall back to the event type's configured default rather than a blanket
+    ::  notify-off, so types absent from a source's volume map (e.g. reacts in a
+    ::  map written before reacts existed) still honor their intended default.
+    =/  fallback  (~(gut by default-volumes:a) type [unreads=& notify=|])
+    (~(gut by loudness) type fallback)
   ::
   --
 ::

--- a/desk/lib/activity.hoon
+++ b/desk/lib/activity.hoon
@@ -212,11 +212,14 @@
     =/  source  (source:evt event)
     =/  loudness=volume-map:a  (get-volumes:src vs source)
     =/  type  (event-type event)
-    ::  fall back to the event type's configured default rather than a blanket
-    ::  notify-off, so types absent from a source's volume map (e.g. reacts in a
-    ::  map written before reacts existed) still honor their intended default.
-    =/  fallback  (~(gut by default-volumes:a) type [unreads=& notify=|])
-    (~(gut by loudness) type fallback)
+    ?.  ?=(?(%react %dm-react) type)
+      (~(gut by loudness) type [unreads=& notify=|])
+    ::  reactions were added after some volume maps were written, so a stored
+    ::  map may have no react key. reacts notify exactly when posts do, so mirror
+    ::  the map's own %post setting: a source muted before reactions existed
+    ::  stays muted, a loud one still notifies. reacts never carry an unread.
+    =+  post=(~(gut by loudness) %post [unreads=& notify=|])
+    (~(gut by loudness) type [unreads=| notify=notify.post])
   ::
   --
 ::

--- a/packages/api/src/__tests__/activity.test.ts
+++ b/packages/api/src/__tests__/activity.test.ts
@@ -5,6 +5,7 @@ import {
   fromInitFeedToBucketedActivityEvents,
 } from '../client/activityApi';
 import type { ActivityEvent } from '../types/models';
+import type * as ub from '../urbit';
 import dmFeed from './fixtures/activityDmFeed.json';
 import dmReplyFeed from './fixtures/activityDmReplyFeed.json';
 import initActivityFeeds from './fixtures/activityInitFeeds.json';
@@ -138,6 +139,98 @@ test('converts a dm reply activity event feed from server to client format', () 
   const events = fromFeedToActivityEvents(dmReplyFeed, 'replies');
   expect(events.length).toBe(1);
   expect(events[0]).toStrictEqual(expectedDmReplyEvent);
+});
+
+const postKey = {
+  id: '~poster/170.141.184.506.853.155.647.879.036.981.225.717.760',
+  time: '170.141.184.506.853.155.647.879.036.981.225.717.760',
+};
+const replyParentKey = {
+  id: '~poster/170.141.184.506.852.591.089.314.701.116.289.581.056',
+  time: '170.141.184.506.852.591.089.314.701.116.289.581.056',
+};
+
+const reactFeed: ub.ActivityBundle[] = [
+  {
+    source: { channel: { nest: 'chat/~host/welcome', group: '~host/group' } },
+    latest: postKey.time,
+    'source-key': 'channel/chat/~host/welcome',
+    events: [
+      {
+        time: postKey.time,
+        event: {
+          notified: true,
+          react: {
+            key: postKey,
+            parent: null,
+            channel: 'chat/~host/welcome',
+            group: '~host/group',
+            author: '~reactor',
+            react: '❤️',
+          },
+        },
+      },
+    ],
+  },
+];
+
+test('converts a channel post react activity event to client format', () => {
+  const events = fromFeedToActivityEvents(reactFeed, 'all');
+  expect(events.length).toBe(1);
+  expect(events[0]).toMatchObject({
+    type: 'react',
+    sourceId: 'channel/chat/~host/welcome',
+    channelId: 'chat/~host/welcome',
+    groupId: '~host/group',
+    // the reacting ship, not the original poster
+    authorId: '~reactor',
+    content: '❤️',
+    isMention: false,
+    shouldNotify: true,
+    bucketId: 'all',
+  });
+  expect(events[0].parentId).toBeUndefined();
+});
+
+const dmReplyReactFeed: ub.ActivityBundle[] = [
+  {
+    source: {
+      'dm-thread': { key: replyParentKey, whom: { ship: '~pondus-watbel' } },
+    },
+    latest: postKey.time,
+    'source-key': 'dm-thread/~pondus-watbel',
+    events: [
+      {
+        time: postKey.time,
+        event: {
+          notified: true,
+          'dm-react': {
+            key: postKey,
+            parent: replyParentKey,
+            whom: { ship: '~pondus-watbel' },
+            author: '~reactor',
+            react: '❤️',
+          },
+        },
+      },
+    ],
+  },
+];
+
+test('converts a dm thread react activity event to client format', () => {
+  const events = fromFeedToActivityEvents(dmReplyReactFeed, 'all');
+  expect(events.length).toBe(1);
+  expect(events[0]).toMatchObject({
+    type: 'react',
+    channelId: '~pondus-watbel',
+    authorId: '~reactor',
+    parentId: replyParentKey.id.split('/')[1],
+    parentAuthorId: '~poster',
+    content: '❤️',
+    isMention: false,
+  });
+  // dm reacts have no group
+  expect(events[0].groupId).toBeUndefined();
 });
 
 test('converts activity init feeds from server to client format', () => {

--- a/packages/api/src/__tests__/activityAction.test.ts
+++ b/packages/api/src/__tests__/activityAction.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'vitest';
 
 import { activityAction } from '../client/activityApi';
-import { setBackendSupportsReactions } from '../client/urbit';
+import { setActivitySupportsReactions } from '../client/urbit';
 import type { ActivityAction } from '../urbit';
 
 const volume = {
@@ -14,11 +14,11 @@ const adjustAction: ActivityAction = {
   adjust: { source: { base: null }, volume },
 };
 
-afterEach(() => setBackendSupportsReactions(false));
+afterEach(() => setActivitySupportsReactions(false));
 
 describe('activityAction mark gating', () => {
   test('uses the v9 mark and keeps react keys when supported', () => {
-    setBackendSupportsReactions(true);
+    setActivitySupportsReactions(true);
     const action = activityAction(adjustAction);
     expect(action.mark).toBe('activity-action-1');
     const sent = action.json as typeof adjustAction;
@@ -27,7 +27,7 @@ describe('activityAction mark gating', () => {
   });
 
   test('uses the v8 mark and strips react keys when unsupported', () => {
-    setBackendSupportsReactions(false);
+    setActivitySupportsReactions(false);
     const action = activityAction(adjustAction);
     expect(action.mark).toBe('activity-action');
     const sent = action.json as typeof adjustAction;
@@ -40,7 +40,7 @@ describe('activityAction mark gating', () => {
   });
 
   test('passes non-adjust actions through unchanged on the v8 mark', () => {
-    setBackendSupportsReactions(false);
+    setActivitySupportsReactions(false);
     const action = activityAction({ 'clear-group-invites': null });
     expect(action.mark).toBe('activity-action');
     expect(action.json).toEqual({ 'clear-group-invites': null });

--- a/packages/api/src/__tests__/activityAction.test.ts
+++ b/packages/api/src/__tests__/activityAction.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { activityAction } from '../client/activityApi';
+import { setBackendSupportsReactions } from '../client/urbit';
+import type { ActivityAction } from '../urbit';
+
+const volume = {
+  post: { unreads: true, notify: true },
+  react: { unreads: false, notify: true },
+  'dm-react': { unreads: false, notify: true },
+};
+
+const adjustAction: ActivityAction = {
+  adjust: { source: { base: null }, volume },
+};
+
+afterEach(() => setBackendSupportsReactions(false));
+
+describe('activityAction mark gating', () => {
+  test('uses the v9 mark and keeps react keys when supported', () => {
+    setBackendSupportsReactions(true);
+    const action = activityAction(adjustAction);
+    expect(action.mark).toBe('activity-action-1');
+    const sent = action.json as typeof adjustAction;
+    expect(sent.adjust.volume).toHaveProperty('react');
+    expect(sent.adjust.volume).toHaveProperty('dm-react');
+  });
+
+  test('uses the v8 mark and strips react keys when unsupported', () => {
+    setBackendSupportsReactions(false);
+    const action = activityAction(adjustAction);
+    expect(action.mark).toBe('activity-action');
+    const sent = action.json as typeof adjustAction;
+    expect(sent.adjust.volume).not.toHaveProperty('react');
+    expect(sent.adjust.volume).not.toHaveProperty('dm-react');
+    // non-react keys are preserved
+    expect(sent.adjust.volume).toHaveProperty('post');
+    // does not mutate the caller's action
+    expect(adjustAction.adjust.volume).toHaveProperty('react');
+  });
+
+  test('passes non-adjust actions through unchanged on the v8 mark', () => {
+    setBackendSupportsReactions(false);
+    const action = activityAction({ 'clear-group-invites': null });
+    expect(action.mark).toBe('activity-action');
+    expect(action.json).toEqual({ 'clear-group-invites': null });
+  });
+});

--- a/packages/api/src/__tests__/volumeMap.test.ts
+++ b/packages/api/src/__tests__/volumeMap.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  NotificationLevel,
+  getLevelFromVolumeMap,
+  getUnreadsFromVolumeMap,
+  getVolumeMap,
+} from '../urbit';
+
+// 'default' and 'medium' produce the same map, which infers back to 'medium'.
+const LEVELS: NotificationLevel[] = ['loud', 'medium', 'soft', 'hush'];
+
+describe('getVolumeMap includes react keys', () => {
+  test.each(LEVELS)(
+    'always writes react and dm-react keys (level=%s)',
+    (level) => {
+      const map = getVolumeMap(level, true);
+      expect(map).toHaveProperty('react');
+      expect(map).toHaveProperty('dm-react');
+    }
+  );
+
+  test.each(LEVELS)(
+    'reacts never contribute to unread badges (level=%s)',
+    (level) => {
+      const map = getVolumeMap(level, true);
+      expect(map.react?.unreads).toBe(false);
+      expect(map['dm-react']?.unreads).toBe(false);
+    }
+  );
+
+  test('muting a source silences reacts', () => {
+    const map = getVolumeMap('hush', true);
+    expect(map.react?.notify).toBe(false);
+    expect(map['dm-react']?.notify).toBe(false);
+  });
+
+  test('reacts notify at loud and medium/default, off at soft', () => {
+    expect(getVolumeMap('loud', false).react?.notify).toBe(true);
+    expect(getVolumeMap('medium', false).react?.notify).toBe(true);
+    expect(getVolumeMap('default', false).react?.notify).toBe(true);
+    expect(getVolumeMap('soft', false).react?.notify).toBe(false);
+  });
+});
+
+describe('react keys do not disturb level inference', () => {
+  test.each(LEVELS)('round-trips level=%s', (level) => {
+    const map = getVolumeMap(level, true);
+    expect(getLevelFromVolumeMap(map)).toBe(level);
+  });
+
+  test('react unreads=false does not hide a badged source', () => {
+    // even though reacts are unreads=false, other events carry the flag
+    expect(getUnreadsFromVolumeMap(getVolumeMap('medium', true))).toBe(true);
+    expect(getUnreadsFromVolumeMap(getVolumeMap('medium', false))).toBe(false);
+  });
+});

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -13,7 +13,7 @@ import {
   parseGroupId,
   udToDate,
 } from './apiUtils';
-import { poke, scry, subscribe } from './urbit';
+import { getBackendSupportsReactions, poke, scry, subscribe } from './urbit';
 import { normalizeUrbitColor } from './utils';
 
 const logger = createDevLogger('activityApi', false);
@@ -63,10 +63,18 @@ export async function getVolumeSettings(): Promise<ub.VolumeSettings> {
 }
 
 export const ACTIVITY_SOURCE_PAGESIZE = 30;
+
+// v6 is the v9-native feed (carries reacts); v5 down-converts to v8 and strips
+// them. Old backends don't serve v6, so only request it once the backend is
+// known to support reactions.
+function feedVersion(): 'v6' | 'v5' {
+  return getBackendSupportsReactions() ? 'v6' : 'v5';
+}
+
 export async function getInitialActivity() {
   const response = await scry<ub.InitActivityFeeds>({
     app: 'activity',
-    path: `/v6/feed/init/${ACTIVITY_SOURCE_PAGESIZE}`,
+    path: `/${feedVersion()}/feed/init/${ACTIVITY_SOURCE_PAGESIZE}`,
   });
 
   const events = fromInitFeedToBucketedActivityEvents(response);
@@ -105,7 +113,7 @@ export async function getPagedActivityByBucket({
     cursor
   );
   const urbitCursor = formatUd(da.fromUnix(cursor).toString());
-  const path = `/v6/feed/${bucket}/${ACTIVITY_SOURCE_PAGESIZE}/${urbitCursor}`;
+  const path = `/${feedVersion()}/feed/${bucket}/${ACTIVITY_SOURCE_PAGESIZE}/${urbitCursor}`;
   const { feed, summaries } = await scry<ub.ActivityFeed>({
     app: 'activity',
     path,
@@ -445,7 +453,9 @@ export type ActivityEvent =
 
 export function subscribeToActivity(handler: (event: ActivityEvent) => void) {
   subscribe<ub.ActivityUpdate>(
-    { app: 'activity', path: '/v5' },
+    // v5 is the v9-native update stream (carries reacts); v4 down-converts to
+    // v8 and drops them. Old backends don't serve v5, so fall back to v4.
+    { app: 'activity', path: getBackendSupportsReactions() ? '/v5' : '/v4' },
     async (update: ub.ActivityUpdate) => {
       logger.log(
         'activity update',
@@ -630,14 +640,28 @@ export function subscribeToActivity(handler: (event: ActivityEvent) => void) {
   );
 }
 
+// The v8 activity-action mark's dejs perks over the v8 event-type set and
+// crashes on react/dm-react volume-map keys. When poking an old backend with
+// the v8 mark, strip those keys so the poke parses (reacts aren't configurable
+// on a backend that doesn't support them anyway).
+function stripReactVolumeKeys(action: ub.ActivityAction): ub.ActivityAction {
+  if (!('adjust' in action) || !action.adjust.volume) {
+    return action;
+  }
+  const volume = { ...action.adjust.volume };
+  delete volume.react;
+  delete volume['dm-react'];
+  return { adjust: { ...action.adjust, volume } };
+}
+
 export function activityAction(action: ub.ActivityAction) {
+  // activity-action-1 (v9) parses react keys; the agent accepts both marks. Old
+  // backends only have the v8 activity-action mark, so use it and strip reacts.
+  const supportsReactions = getBackendSupportsReactions();
   return {
     app: 'activity',
-    // v9 mark: parses react/dm-react volume-map keys. The v8 activity-action
-    // mark's dejs perks over the v8 event-type set and crashes on react keys,
-    // nacking volume pokes. The agent accepts both marks.
-    mark: 'activity-action-1',
-    json: action,
+    mark: supportsReactions ? 'activity-action-1' : 'activity-action',
+    json: supportsReactions ? action : stripReactVolumeKeys(action),
   };
 }
 

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -13,7 +13,7 @@ import {
   parseGroupId,
   udToDate,
 } from './apiUtils';
-import { getBackendSupportsReactions, poke, scry, subscribe } from './urbit';
+import { getActivitySupportsReactions, poke, scry, subscribe } from './urbit';
 import { normalizeUrbitColor } from './utils';
 
 const logger = createDevLogger('activityApi', false);
@@ -68,7 +68,7 @@ export const ACTIVITY_SOURCE_PAGESIZE = 30;
 // them. Old backends don't serve v6, so only request it once the backend is
 // known to support reactions.
 function feedVersion(): 'v6' | 'v5' {
-  return getBackendSupportsReactions() ? 'v6' : 'v5';
+  return getActivitySupportsReactions() ? 'v6' : 'v5';
 }
 
 export async function getInitialActivity() {
@@ -455,7 +455,7 @@ export function subscribeToActivity(handler: (event: ActivityEvent) => void) {
   subscribe<ub.ActivityUpdate>(
     // v5 is the v9-native update stream (carries reacts); v4 down-converts to
     // v8 and drops them. Old backends don't serve v5, so fall back to v4.
-    { app: 'activity', path: getBackendSupportsReactions() ? '/v5' : '/v4' },
+    { app: 'activity', path: getActivitySupportsReactions() ? '/v5' : '/v4' },
     async (update: ub.ActivityUpdate) => {
       logger.log(
         'activity update',
@@ -657,7 +657,7 @@ function stripReactVolumeKeys(action: ub.ActivityAction): ub.ActivityAction {
 export function activityAction(action: ub.ActivityAction) {
   // activity-action-1 (v9) parses react keys; the agent accepts both marks. Old
   // backends only have the v8 activity-action mark, so use it and strip reacts.
-  const supportsReactions = getBackendSupportsReactions();
+  const supportsReactions = getActivitySupportsReactions();
   return {
     app: 'activity',
     mark: supportsReactions ? 'activity-action-1' : 'activity-action',

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -66,7 +66,7 @@ export const ACTIVITY_SOURCE_PAGESIZE = 30;
 export async function getInitialActivity() {
   const response = await scry<ub.InitActivityFeeds>({
     app: 'activity',
-    path: `/v5/feed/init/${ACTIVITY_SOURCE_PAGESIZE}`,
+    path: `/v6/feed/init/${ACTIVITY_SOURCE_PAGESIZE}`,
   });
 
   const events = fromInitFeedToBucketedActivityEvents(response);
@@ -105,7 +105,7 @@ export async function getPagedActivityByBucket({
     cursor
   );
   const urbitCursor = formatUd(da.fromUnix(cursor).toString());
-  const path = `/v5/feed/${bucket}/${ACTIVITY_SOURCE_PAGESIZE}/${urbitCursor}`;
+  const path = `/v6/feed/${bucket}/${ACTIVITY_SOURCE_PAGESIZE}/${urbitCursor}`;
   const { feed, summaries } = await scry<ub.ActivityFeed>({
     app: 'activity',
     path,
@@ -276,6 +276,48 @@ function toActivityEvent({
     };
   }
 
+  if ('react' in event) {
+    const reactEvent = event.react;
+    const { postId } = getInfoFromMessageKey(reactEvent.key);
+    const parent = reactEvent.parent
+      ? getInfoFromMessageKey(reactEvent.parent)
+      : null;
+    return {
+      ...baseFields,
+      type: 'react',
+      postId,
+      parentId: parent?.postId,
+      parentAuthorId: parent?.authorId,
+      // the author is the reacting ship, not the original poster
+      authorId: ub.getReactAuthorShip(reactEvent.author),
+      channelId: reactEvent.channel,
+      groupId: reactEvent.group,
+      // we reuse the content column to carry the raw react value
+      content: reactEvent.react,
+      isMention: false,
+    };
+  }
+
+  if ('dm-react' in event) {
+    const reactEvent = event['dm-react'];
+    const { postId } = getInfoFromMessageKey(reactEvent.key, true);
+    const parent = reactEvent.parent
+      ? getInfoFromMessageKey(reactEvent.parent, true)
+      : null;
+    return {
+      ...baseFields,
+      type: 'react',
+      postId,
+      parentId: parent?.postId,
+      parentAuthorId: parent?.authorId,
+      authorId: ub.getReactAuthorShip(reactEvent.author),
+      channelId:
+        'ship' in reactEvent.whom ? reactEvent.whom.ship : reactEvent.whom.club,
+      content: reactEvent.react,
+      isMention: false,
+    };
+  }
+
   if ('group-ask' in event) {
     return {
       ...baseFields,
@@ -403,7 +445,7 @@ export type ActivityEvent =
 
 export function subscribeToActivity(handler: (event: ActivityEvent) => void) {
   subscribe<ub.ActivityUpdate>(
-    { app: 'activity', path: '/v4' },
+    { app: 'activity', path: '/v5' },
     async (update: ub.ActivityUpdate) => {
       logger.log(
         'activity update',

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -633,7 +633,10 @@ export function subscribeToActivity(handler: (event: ActivityEvent) => void) {
 export function activityAction(action: ub.ActivityAction) {
   return {
     app: 'activity',
-    mark: 'activity-action',
+    // v9 mark: parses react/dm-react volume-map keys. The v8 activity-action
+    // mark's dejs perks over the v8 event-type set and crashes on react keys,
+    // nacking volume pokes. The agent accepts both marks.
+    mark: 'activity-action-1',
     json: action,
   };
 }

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -31,6 +31,7 @@ interface Config
   pendingAuth: Promise<string | void> | null;
   loggingOut: boolean;
   lastStatus: string;
+  backendSupportsReactions: boolean;
 }
 
 type Predicate = (event: any, mark: string) => boolean;
@@ -111,6 +112,21 @@ const config: Config = {
   onQuitOrReset: undefined,
   getCode: undefined,
   handleAuthFailure: undefined,
+  // Off until the app confirms the backend's groups version ships reactions.
+  // Drives which %activity endpoint versions the client uses (feed/sub/marks).
+  backendSupportsReactions: false,
+};
+
+// Whether the connected backend supports reaction activity (v9 %activity
+// endpoints). Set by the app from the backend's groups version; read by the
+// activity client to pick endpoint versions. Defaults false so an old backend
+// gets the pre-reaction (v5 feed / v4 subscription / v8 mark) endpoints.
+export const setBackendSupportsReactions = (value: boolean) => {
+  config.backendSupportsReactions = value;
+};
+
+export const getBackendSupportsReactions = (): boolean => {
+  return config.backendSupportsReactions;
 };
 
 export const client = new Proxy(

--- a/packages/api/src/client/urbit.ts
+++ b/packages/api/src/client/urbit.ts
@@ -31,7 +31,7 @@ interface Config
   pendingAuth: Promise<string | void> | null;
   loggingOut: boolean;
   lastStatus: string;
-  backendSupportsReactions: boolean;
+  activitySupportsReactions: boolean;
 }
 
 type Predicate = (event: any, mark: string) => boolean;
@@ -114,19 +114,19 @@ const config: Config = {
   handleAuthFailure: undefined,
   // Off until the app confirms the backend's groups version ships reactions.
   // Drives which %activity endpoint versions the client uses (feed/sub/marks).
-  backendSupportsReactions: false,
+  activitySupportsReactions: false,
 };
 
 // Whether the connected backend supports reaction activity (v9 %activity
 // endpoints). Set by the app from the backend's groups version; read by the
 // activity client to pick endpoint versions. Defaults false so an old backend
 // gets the pre-reaction (v5 feed / v4 subscription / v8 mark) endpoints.
-export const setBackendSupportsReactions = (value: boolean) => {
-  config.backendSupportsReactions = value;
+export const setActivitySupportsReactions = (value: boolean) => {
+  config.activitySupportsReactions = value;
 };
 
-export const getBackendSupportsReactions = (): boolean => {
-  return config.backendSupportsReactions;
+export const getActivitySupportsReactions = (): boolean => {
+  return config.activitySupportsReactions;
 };
 
 export const client = new Proxy(

--- a/packages/api/src/urbit/activity.ts
+++ b/packages/api/src/urbit/activity.ts
@@ -2,7 +2,7 @@ import { da } from '@urbit/aura';
 import _ from 'lodash';
 
 import type { UnionToIntersection } from '../lib/utilityTypes';
-import { Kind, Story } from './channel';
+import { Author, Kind, React, Story } from './channel';
 import { ContactBookProfile } from './contact';
 import {
   nestToFlag,
@@ -19,6 +19,8 @@ export type ExtendedEventType =
   | 'post-mention'
   | 'reply'
   | 'reply-mention'
+  | 'react'
+  | 'dm-react'
   | 'dm-invite'
   | 'dm-post'
   | 'dm-post-mention'
@@ -170,6 +172,31 @@ export interface ContactEvent {
   };
 }
 
+export interface ReactEvent {
+  react: {
+    key: MessageKey;
+    // present when reacting to a reply; null when reacting to a top-level post
+    parent: MessageKey | null;
+    channel: string;
+    group: string;
+    // the ship that reacted
+    author: Author;
+    react: React;
+  };
+}
+
+export interface DmReactEvent {
+  'dm-react': {
+    key: MessageKey;
+    // present when reacting to a thread reply; null when reacting to the dm
+    parent: MessageKey | null;
+    whom: Whom;
+    // the ship that reacted
+    author: Author;
+    react: React;
+  };
+}
+
 export type ActivityIncomingEvent =
   | GroupKickEvent
   | GroupJoinEvent
@@ -183,6 +210,8 @@ export type ActivityIncomingEvent =
   | DmReplyEvent
   | PostEvent
   | ReplyEvent
+  | ReactEvent
+  | DmReactEvent
   | ContactEvent;
 
 export type ActivityEvent = {
@@ -407,11 +436,18 @@ const notifyOffEvents: ExtendedEventType[] = [
   'group-role',
 ];
 
+// reacts notify like posts (on at loud/medium/default, off at soft/hush). They
+// live outside onEvents/notifyOffEvents so getLevelFromVolumeMap ignores them
+// when inferring a level — adding them there would change level inference.
+const reactEvents: ExtendedEventType[] = ['react', 'dm-react'];
+
 const allEvents: ExtendedEventType[] = [
   'post',
   'post-mention',
   'reply',
   'reply-mention',
+  'react',
+  'dm-react',
   'dm-invite',
   'dm-post',
   'dm-post-mention',
@@ -425,6 +461,13 @@ const allEvents: ExtendedEventType[] = [
   'flag-post',
   'flag-reply',
 ];
+
+// Reacts never contribute to unread badges (the backend excludes them from
+// unread counts), so we always write them with unreads off regardless of the
+// source's unread preference.
+function volumeUnreads(event: ExtendedEventType, unreads: boolean): boolean {
+  return reactEvents.includes(event) ? false : unreads;
+}
 
 export function getUnreadsFromVolumeMap(vmap: VolumeMap): boolean {
   return _.some(vmap, (v) => !!v?.unreads);
@@ -465,29 +508,34 @@ export function getVolumeMap(
   const emptyMap: VolumeMap = {};
   if (level === 'loud') {
     return allEvents.reduce((acc, e) => {
-      acc[e] = { unreads, notify: true };
+      acc[e] = { unreads: volumeUnreads(e, unreads), notify: true };
       return acc;
     }, emptyMap);
   }
 
   if (level === 'hush') {
     return allEvents.reduce((acc, e) => {
-      acc[e] = { unreads, notify: false };
+      acc[e] = { unreads: volumeUnreads(e, unreads), notify: false };
       return acc;
     }, {} as VolumeMap);
   }
 
   return allEvents.reduce((acc, e) => {
+    const u = volumeUnreads(e, unreads);
     if (onEvents.includes(e)) {
-      acc[e] = { unreads, notify: true };
+      acc[e] = { unreads: u, notify: true };
     }
 
     if (notifyOffEvents.includes(e)) {
-      acc[e] = { unreads, notify: false };
+      acc[e] = { unreads: u, notify: false };
     }
 
-    if (e === 'post') {
-      acc[e] = { unreads, notify: level === 'medium' || level === 'default' };
+    // posts and reacts notify at medium/default, off at soft
+    if (e === 'post' || reactEvents.includes(e)) {
+      acc[e] = {
+        unreads: u,
+        notify: level === 'medium' || level === 'default',
+      };
     }
 
     return acc;
@@ -666,6 +714,20 @@ export const isReply = (event: ActivityEvent) => {
   return false;
 };
 
+export const isReact = (event: ActivityEvent) =>
+  'react' in event || 'dm-react' in event;
+
+// The react author/value fields mirror %channels/%chat: the author is either a
+// bare ship or a bot profile, and the react is either a shortcode string or a
+// custom `{ any }` value.
+export function getReactAuthorShip(author: Author): string {
+  return typeof author === 'string' ? author : author.ship;
+}
+
+export function getReactValue(react: React): string {
+  return typeof react === 'string' ? react : react.any;
+}
+
 export const isAsk = (event: ActivityEvent) => 'group-ask' in event;
 
 export const isInvite = (event: ActivityEvent) => 'group-invite' in event;
@@ -718,6 +780,26 @@ export function getSourceForEvent(event: ActivityEvent): Source {
         whom: event['dm-reply'].whom,
       },
     };
+  }
+
+  if ('react' in event) {
+    const { react } = event;
+    return react.parent
+      ? {
+          thread: {
+            key: react.parent,
+            channel: react.channel,
+            group: react.group,
+          },
+        }
+      : { channel: { nest: react.channel, group: react.group } };
+  }
+
+  if ('dm-react' in event) {
+    const react = event['dm-react'];
+    return react.parent
+      ? { 'dm-thread': { key: react.parent, whom: react.whom } }
+      : { dm: react.whom };
   }
 
   if ('group-ask' in event) {
@@ -808,6 +890,14 @@ export function getAuthor(event: ActivityEvent) {
     return getIdParts(event['flag-reply'].key.id).author;
   }
 
+  if ('react' in event) {
+    return getReactAuthorShip(event.react.author);
+  }
+
+  if ('dm-react' in event) {
+    return getReactAuthorShip(event['dm-react'].author);
+  }
+
   if ('group-ask' in event) {
     return event['group-ask'].ship;
   }
@@ -833,6 +923,7 @@ export type ActivityRelevancy =
   | 'groupMeta'
   | 'flaggedPost'
   | 'flaggedReply'
+  | 'reactedToPost'
   | 'groupJoinRequest';
 
 export function getRelevancy(
@@ -841,6 +932,10 @@ export function getRelevancy(
 ): ActivityRelevancy {
   if (isMention(event)) {
     return 'mention';
+  }
+
+  if (isReact(event)) {
+    return 'reactedToPost';
   }
 
   if ('dm-post' in event && 'ship' in event['dm-post'].whom) {

--- a/packages/app/fixtures/activityHelpers.tsx
+++ b/packages/app/fixtures/activityHelpers.tsx
@@ -111,6 +111,19 @@ export const groupDmThreadReplyActivity = (
     )
   );
 
+export const groupReactActivity = (
+  count: number,
+  extraProps?: ReactEventParams
+) =>
+  summary(
+    ...Array.from({ length: count }, (v, i) =>
+      reactEvent({
+        contact: exampleContact(i),
+        ...extraProps,
+      })
+    )
+  );
+
 export const flagPostActivity = (
   count: number,
   extraProps?: PostFlagEventParams
@@ -142,6 +155,7 @@ export const activityItems = {
   groupDmPost: groupDmPostActivity,
   groupDmThreadReply: groupDmThreadReplyActivity,
   dmPost: dmPostActivity,
+  groupReact: groupReactActivity,
   flagPost: flagPostActivity,
   flagReply: flagReplyActivity,
 };
@@ -250,6 +264,39 @@ function groupThreadReplyEvent({
     bucketId: isMention ? 'replies' : 'mentions',
     isMention,
   });
+}
+
+interface ReactEventParams {
+  group?: db.Group;
+  channel?: db.Channel;
+  contact?: db.Contact;
+  react?: string;
+}
+
+function reactEvent({
+  group = fakeGroup,
+  channel = tlonLocalIntros,
+  contact = exampleContacts.fabledFaster,
+  react = '❤️',
+}: ReactEventParams): db.ActivityEvent {
+  return {
+    id: randomId(),
+    bucketId: 'all',
+    sourceId: `channel/${channel.id}`,
+    type: 'react',
+    timestamp: Date.now(),
+    postId: randomId(),
+    authorId: contact.id,
+    author: contact,
+    channelId: channel.id,
+    channel,
+    groupId: group.id,
+    group,
+    // reactions reuse the content column to carry the raw react value
+    content: react,
+    shouldNotify: true,
+    isMention: false,
+  };
 }
 
 interface GroupJoinRequestEventParams {

--- a/packages/app/ui/components/Activity/ActivityListItem.tsx
+++ b/packages/app/ui/components/Activity/ActivityListItem.tsx
@@ -30,6 +30,7 @@ export const ActivityListItem = React.memo(function ActivityListItem({
   if (
     event.type === 'post' ||
     event.type === 'reply' ||
+    event.type === 'react' ||
     event.type === 'flag-post' ||
     event.type === 'flag-reply' ||
     event.type === 'group-ask' ||
@@ -117,7 +118,7 @@ export function ActivityListItemContent({
 
         <YStack>
           <SummaryMessage summary={summary} />
-          {!['group-ask'].includes(summary.type) ? (
+          {!['group-ask', 'react'].includes(summary.type) ? (
             <ActivitySourceContent
               summary={summary}
               pressHandler={pressHandler}

--- a/packages/app/ui/components/Activity/ActivityScreenView.tsx
+++ b/packages/app/ui/components/Activity/ActivityScreenView.tsx
@@ -125,6 +125,44 @@ export function ActivityScreenView({
             console.warn('No parent found for reply', event);
           }
           break;
+        case 'react':
+          // navigate to the reacted-to content: the thread for a react on a
+          // reply, otherwise the channel focused on the reacted post
+          if (event.parent) {
+            logger.trackEvent(AnalyticsEvent.ActionSelectActivityEvent, {
+              type: 'reaction',
+            });
+            goToThread(event.parent);
+          } else if (event.parentId) {
+            logger.trackEvent(AnalyticsEvent.ActionSelectActivityEvent, {
+              type: 'reaction',
+            });
+            goToThread(db.assembleParentPostFromActivityEvent(event));
+          } else if (event.channel) {
+            logger.trackEvent(AnalyticsEvent.ActionSelectActivityEvent, {
+              ...logic.getModelAnalytics({ channel: event.channel }),
+              type: 'reaction',
+            });
+            if (event.postId) {
+              goToChannel(event.channel, event.postId);
+            } else {
+              goToChannel(event.channel);
+            }
+          } else if (event.channelId) {
+            const channel = await db.getChannel({ id: event.channelId });
+            if (channel) {
+              logger.trackEvent(AnalyticsEvent.ActionSelectActivityEvent, {
+                ...logic.getModelAnalytics({ channel }),
+                type: 'reaction',
+              });
+              goToChannel(channel, event.postId ?? undefined);
+            } else {
+              console.warn('No channel found for react', event);
+            }
+          } else {
+            console.warn('No target found for react', event);
+          }
+          break;
         case 'group-ask':
           if (event.group) {
             logger.trackEvent(AnalyticsEvent.ActionSelectActivityEvent, {

--- a/packages/app/ui/components/Activity/ActivitySourceContent.tsx
+++ b/packages/app/ui/components/Activity/ActivitySourceContent.tsx
@@ -170,6 +170,11 @@ function useUniqueSummaryPosts(summary: logic.SourceActivityEvents) {
   return useMemo(() => {
     const seen = new Set();
     return summary.all?.flatMap((event) => {
+      // reacts carry an emoji/custom-react value in `content`, not a story, so
+      // assemblePostFromActivityEvent would choke; they're not source posts.
+      if (event.type === 'react') {
+        return [];
+      }
       if (event.postId && !seen.has(event.postId)) {
         seen.add(event.postId);
         return [getPost(event)];

--- a/packages/app/ui/components/Activity/ActivitySummaryMessage.tsx
+++ b/packages/app/ui/components/Activity/ActivitySummaryMessage.tsx
@@ -25,7 +25,8 @@ function SummaryMessageRaw({
     relevancy !== 'groupJoinRequest' &&
     relevancy !== 'flaggedPost' &&
     relevancy !== 'flaggedReply' &&
-    relevancy !== 'contactUpdate'
+    relevancy !== 'contactUpdate' &&
+    relevancy !== 'reactedToPost'
   ) {
     return null;
   }
@@ -36,6 +37,18 @@ function SummaryMessageRaw({
       <SummaryText>
         <ActivitySummaryAuthorList contactIds={authors.slice(0, 1)} />
         {` mentioned you`}:
+      </SummaryText>
+    );
+  }
+
+  if (relevancy === 'reactedToPost') {
+    const reactValue = reactDisplayValue(newest.content);
+    return (
+      <SummaryText>
+        <ActivitySummaryAuthorList contactIds={authors} />
+        {reactValue
+          ? ` reacted ${reactValue} to your post`
+          : ` reacted to your post`}
       </SummaryText>
     );
   }
@@ -159,6 +172,18 @@ function postVerb(channelType: string) {
       : 'sent';
 }
 
+// Reactions reuse the activity event `content` column to carry the raw react
+// value: a native emoji string, or a custom `{ any }` value.
+function reactDisplayValue(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (content && typeof content === 'object' && 'any' in content) {
+    return String((content as { any: unknown }).any);
+  }
+  return '';
+}
+
 function contactUpdateNoun(event: db.ActivityEvent) {
   if (!event.contactUpdateType) {
     return '';
@@ -185,6 +210,7 @@ type ActivityRelevancy =
   | 'postToChannel'
   | 'flaggedPost'
   | 'flaggedReply'
+  | 'reactedToPost'
   | 'groupJoinRequest'
   | 'contactUpdate';
 
@@ -196,6 +222,10 @@ export function getRelevancy(
 
   if (newest.isMention) {
     return 'mention';
+  }
+
+  if (newest.type === 'react') {
+    return 'reactedToPost';
   }
 
   if (newest.type === 'post' && newest.channel?.type === 'dm') {

--- a/packages/app/ui/components/ListItem.tsx
+++ b/packages/app/ui/components/ListItem.tsx
@@ -15,7 +15,6 @@ import {
 } from './Avatar';
 import ContactName from './ContactName';
 import { GroupAvatar } from './GroupAvatar';
-import { UnreadDot } from './UnreadDot';
 
 export interface BaseListItemProps<T> {
   model: T;
@@ -188,10 +187,6 @@ const ListItemCount = ({
     ? '$positiveBackground'
     : '$secondaryBackground';
   const resolvedBackgroundColor = count < 1 ? undefined : backgroundColor;
-  // With no unread count but notified activity (e.g. a reaction, which is
-  // unreads=|), show a dot instead of an empty badge. Muted chats report
-  // notify=false, so they stay quiet.
-  const showNotifyDot = count < 1 && notified && !muted;
   return (
     <View
       key={getAndroidRoundedBackgroundKey(resolvedBackgroundColor)}
@@ -201,24 +196,18 @@ const ListItemCount = ({
       borderRadius="$l"
       {...rest}
     >
-      {showNotifyDot ? (
-        <ListItemCountNumber testID="UnreadDot">
-          <UnreadDot />
-        </ListItemCountNumber>
-      ) : (
-        <ListItemCountNumber hidden={count < 1}>
-          {muted && (
-            <Icon type="Muted" customSize={[12, 12]} color={foregroundColor} />
-          )}
-          <Text
-            testID="UnreadCountNumber"
-            size="$label/m"
-            color={foregroundColor}
-          >
-            {numberWithMax(count, 256)}
-          </Text>
-        </ListItemCountNumber>
-      )}
+      <ListItemCountNumber hidden={count < 1}>
+        {muted && (
+          <Icon type="Muted" customSize={[12, 12]} color={foregroundColor} />
+        )}
+        <Text
+          testID="UnreadCountNumber"
+          size="$label/m"
+          color={foregroundColor}
+        >
+          {numberWithMax(count, 256)}
+        </Text>
+      </ListItemCountNumber>
     </View>
   );
 };

--- a/packages/app/ui/components/ListItem.tsx
+++ b/packages/app/ui/components/ListItem.tsx
@@ -15,6 +15,7 @@ import {
 } from './Avatar';
 import ContactName from './ContactName';
 import { GroupAvatar } from './GroupAvatar';
+import { UnreadDot } from './UnreadDot';
 
 export interface BaseListItemProps<T> {
   model: T;
@@ -187,6 +188,10 @@ const ListItemCount = ({
     ? '$positiveBackground'
     : '$secondaryBackground';
   const resolvedBackgroundColor = count < 1 ? undefined : backgroundColor;
+  // With no unread count but notified activity (e.g. a reaction, which is
+  // unreads=|), show a dot instead of an empty badge. Muted chats report
+  // notify=false, so they stay quiet.
+  const showNotifyDot = count < 1 && notified && !muted;
   return (
     <View
       key={getAndroidRoundedBackgroundKey(resolvedBackgroundColor)}
@@ -196,18 +201,24 @@ const ListItemCount = ({
       borderRadius="$l"
       {...rest}
     >
-      <ListItemCountNumber hidden={count < 1}>
-        {muted && (
-          <Icon type="Muted" customSize={[12, 12]} color={foregroundColor} />
-        )}
-        <Text
-          testID="UnreadCountNumber"
-          size="$label/m"
-          color={foregroundColor}
-        >
-          {numberWithMax(count, 256)}
-        </Text>
-      </ListItemCountNumber>
+      {showNotifyDot ? (
+        <ListItemCountNumber testID="UnreadDot">
+          <UnreadDot />
+        </ListItemCountNumber>
+      ) : (
+        <ListItemCountNumber hidden={count < 1}>
+          {muted && (
+            <Icon type="Muted" customSize={[12, 12]} color={foregroundColor} />
+          )}
+          <Text
+            testID="UnreadCountNumber"
+            size="$label/m"
+            color={foregroundColor}
+          >
+            {numberWithMax(count, 256)}
+          </Text>
+        </ListItemCountNumber>
+      )}
     </View>
   );
 };

--- a/packages/app/utils/urbitModule.ts
+++ b/packages/app/utils/urbitModule.ts
@@ -4,4 +4,8 @@ export interface UrbitModuleSpec {
   setUrbit(ship: string, url: string, authCookie: string): void;
   updateBadgeCount(count: number, uid: string): void;
   signalJsReady(): void;
+  // Caches whether the connected backend's %activity supports reactions, so the
+  // native notification extension can pick the v9 (activity-event-1) vs v8
+  // (activity-event) fetch without scrying for a version itself.
+  setActivitySupportsReactions(supported: boolean): void;
 }

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -3,6 +3,8 @@ import type * as ub from '@tloncorp/api/urbit';
 import {
   ActivityIncomingEvent,
   getIdParts,
+  getReactAuthorShip,
+  getReactValue,
   getSourceForEvent,
   sourceToString,
 } from '@tloncorp/api/urbit/activity';
@@ -177,6 +179,32 @@ export function renderActivityEventPreview({
       return buildDmNotification(ev['dm-post']);
     case is(ev, 'dm-reply'):
       return buildDmNotification(ev['dm-reply']);
+
+    case is(ev, 'react'):
+      return {
+        notification: {
+          title: postSource({
+            groupId: ev.react.group,
+            channelId: ev.react.channel,
+          }),
+          groupingKey: lit(sourceToString(source)),
+          body: concat([
+            userNickname(getReactAuthorShip(ev.react.author)),
+            lit(` reacted with ${getReactValue(ev.react.react)}`),
+          ]),
+        },
+      };
+
+    case is(ev, 'dm-react'):
+      return {
+        notification: {
+          groupingKey: lit(sourceToString(source)),
+          body: concat([
+            userNickname(getReactAuthorShip(ev['dm-react'].author)),
+            lit(` reacted with ${getReactValue(ev['dm-react'].react)}`),
+          ]),
+        },
+      };
 
     case is(ev, 'dm-invite'):
       return {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -5338,6 +5338,9 @@ export const getUnreadUnseenActivityEvents = createReadQuery(
                   eq($activityEvents.type, 'post'),
                   gt($channelUnreads.count, 0)
                 ),
+                // reacts don't bump an unread count (unreads=|), so gate only on
+                // shouldNotify: a notified, unseen react lights the activity bell
+                eq($activityEvents.type, 'react'),
                 and(
                   gt($groupUnreads.notifyCount, 0),
                   or(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -5338,9 +5338,14 @@ export const getUnreadUnseenActivityEvents = createReadQuery(
                   eq($activityEvents.type, 'post'),
                   gt($channelUnreads.count, 0)
                 ),
-                // reacts don't bump an unread count (unreads=|), so gate only on
-                // shouldNotify: a notified, unseen react lights the activity bell
-                eq($activityEvents.type, 'react'),
+                // reacts don't bump an unread count (unreads=|), so gate on the
+                // source's notify flag instead: a notified react lights the bell
+                // and clears once the chat is read (notify -> false), mirroring
+                // how posts clear via channelUnreads.count
+                and(
+                  eq($activityEvents.type, 'react'),
+                  eq($channelUnreads.notify, true)
+                ),
                 and(
                   gt($groupUnreads.notifyCount, 0),
                   or(

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -5340,11 +5340,15 @@ export const getUnreadUnseenActivityEvents = createReadQuery(
                 ),
                 // reacts don't bump an unread count (unreads=|), so gate on the
                 // source's notify flag instead: a notified react lights the bell
-                // and clears once the chat is read (notify -> false), mirroring
-                // how posts clear via channelUnreads.count
+                // and clears once the source is read (notify -> false), mirroring
+                // how posts clear via channelUnreads.count. reply reacts carry the
+                // notify bit on the thread, top-level reacts on the channel/dm.
                 and(
                   eq($activityEvents.type, 'react'),
-                  eq($channelUnreads.notify, true)
+                  or(
+                    eq($channelUnreads.notify, true),
+                    eq($threadUnreads.notify, true)
+                  )
                 ),
                 and(
                   gt($groupUnreads.notifyCount, 0),

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -1,6 +1,7 @@
 export * from './utilHooks';
 export * from './embed';
 export * from './semver';
+export * from './reactionSupport';
 export * from '@tloncorp/api/lib/types';
 export * from '@tloncorp/api/lib/utils';
 export * as featureFlags from '@tloncorp/api/lib/featureFlags';

--- a/packages/shared/src/logic/reactionSupport.test.ts
+++ b/packages/shared/src/logic/reactionSupport.test.ts
@@ -21,4 +21,22 @@ describe('activityVersionSupportsReactions', () => {
     expect(activityVersionSupportsReactions('n/a')).toBe(false);
     expect(activityVersionSupportsReactions('')).toBe(false);
   });
+
+  // Regression: a semver-looking prefix with an unsupported suffix (e.g. a
+  // 'dirty' docket build below the minimum) must not be treated as
+  // reaction-capable. A loose prefix check would admit it, and the failed
+  // strict parse inside isVersionBelow would then read as "equal" and return
+  // true, pointing an old backend at v9 endpoints it can't serve.
+  test('false for partially parseable versions', () => {
+    expect(activityVersionSupportsReactions('11.2.2 dirty')).toBe(false);
+    expect(activityVersionSupportsReactions('11.2.2-')).toBe(false);
+    expect(activityVersionSupportsReactions('11.2.2.3')).toBe(false);
+    expect(activityVersionSupportsReactions('11.2')).toBe(false);
+    expect(activityVersionSupportsReactions('v11.3.0')).toBe(false);
+  });
+
+  test('still respects valid prerelease/build suffixes at or above the minimum', () => {
+    expect(activityVersionSupportsReactions('11.3.0-rc.1')).toBe(true);
+    expect(activityVersionSupportsReactions('11.3.0+build.5')).toBe(true);
+  });
 });

--- a/packages/shared/src/logic/reactionSupport.test.ts
+++ b/packages/shared/src/logic/reactionSupport.test.ts
@@ -1,24 +1,24 @@
 import { describe, expect, test } from 'vitest';
 
-import { backendVersionSupportsReactions } from './reactionSupport';
+import { activityVersionSupportsReactions } from './reactionSupport';
 
-describe('backendVersionSupportsReactions', () => {
+describe('activityVersionSupportsReactions', () => {
   test('false below the minimum (incl. current deployed version)', () => {
-    expect(backendVersionSupportsReactions('11.2.2')).toBe(false);
-    expect(backendVersionSupportsReactions('11.0.1')).toBe(false);
-    expect(backendVersionSupportsReactions('10.9.9')).toBe(false);
+    expect(activityVersionSupportsReactions('11.2.2')).toBe(false);
+    expect(activityVersionSupportsReactions('11.0.1')).toBe(false);
+    expect(activityVersionSupportsReactions('10.9.9')).toBe(false);
   });
 
   test('true at or above the minimum', () => {
-    expect(backendVersionSupportsReactions('11.3.0')).toBe(true);
-    expect(backendVersionSupportsReactions('11.3.1')).toBe(true);
-    expect(backendVersionSupportsReactions('12.0.0')).toBe(true);
+    expect(activityVersionSupportsReactions('11.3.0')).toBe(true);
+    expect(activityVersionSupportsReactions('11.3.1')).toBe(true);
+    expect(activityVersionSupportsReactions('12.0.0')).toBe(true);
   });
 
   test('false for missing or unparseable versions', () => {
-    expect(backendVersionSupportsReactions(undefined)).toBe(false);
-    expect(backendVersionSupportsReactions(null)).toBe(false);
-    expect(backendVersionSupportsReactions('n/a')).toBe(false);
-    expect(backendVersionSupportsReactions('')).toBe(false);
+    expect(activityVersionSupportsReactions(undefined)).toBe(false);
+    expect(activityVersionSupportsReactions(null)).toBe(false);
+    expect(activityVersionSupportsReactions('n/a')).toBe(false);
+    expect(activityVersionSupportsReactions('')).toBe(false);
   });
 });

--- a/packages/shared/src/logic/reactionSupport.test.ts
+++ b/packages/shared/src/logic/reactionSupport.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { backendVersionSupportsReactions } from './reactionSupport';
+
+describe('backendVersionSupportsReactions', () => {
+  test('false below the minimum (incl. current deployed version)', () => {
+    expect(backendVersionSupportsReactions('11.2.2')).toBe(false);
+    expect(backendVersionSupportsReactions('11.0.1')).toBe(false);
+    expect(backendVersionSupportsReactions('10.9.9')).toBe(false);
+  });
+
+  test('true at or above the minimum', () => {
+    expect(backendVersionSupportsReactions('11.3.0')).toBe(true);
+    expect(backendVersionSupportsReactions('11.3.1')).toBe(true);
+    expect(backendVersionSupportsReactions('12.0.0')).toBe(true);
+  });
+
+  test('false for missing or unparseable versions', () => {
+    expect(backendVersionSupportsReactions(undefined)).toBe(false);
+    expect(backendVersionSupportsReactions(null)).toBe(false);
+    expect(backendVersionSupportsReactions('n/a')).toBe(false);
+    expect(backendVersionSupportsReactions('')).toBe(false);
+  });
+});

--- a/packages/shared/src/logic/reactionSupport.ts
+++ b/packages/shared/src/logic/reactionSupport.ts
@@ -1,0 +1,23 @@
+import { isVersionBelow } from './semver';
+
+// The first deployed %groups release that ships reaction support: the v9
+// %activity endpoints (v6 feed, v5 subscription, activity-action-1 /
+// activity-event-1 marks) plus react emission. The reactions code is on develop
+// but unreleased; the latest deployed version is 11.2.2, so this is the next
+// release. Below it, the client uses the pre-reaction endpoints (v5 feed, v4
+// subscription, v8 marks), which work on older backends.
+// TODO(reactions): confirm this matches the release that actually deploys reactions.
+export const REACTIONS_MIN_GROUPS_VERSION = '11.3.0';
+
+// Whether a backend at the given groups version supports reactions. Conservative
+// by design: anything unparseable (e.g. 'n/a' when the version scry failed)
+// returns false, so we never point the client at v9 endpoints an old backend
+// can't serve.
+export function backendVersionSupportsReactions(
+  groupsVersion?: string | null
+): boolean {
+  if (!groupsVersion || !/^\d+\.\d+\.\d+/.test(groupsVersion)) {
+    return false;
+  }
+  return !isVersionBelow(groupsVersion, REACTIONS_MIN_GROUPS_VERSION);
+}

--- a/packages/shared/src/logic/reactionSupport.ts
+++ b/packages/shared/src/logic/reactionSupport.ts
@@ -1,4 +1,4 @@
-import { isVersionBelow } from './semver';
+import { isVersionBelow, parseVersion } from './semver';
 
 // The first deployed %groups release that ships reaction support: the v9
 // %activity endpoints (v6 feed, v5 subscription, activity-action-1 /
@@ -10,13 +10,16 @@ import { isVersionBelow } from './semver';
 export const REACTIONS_MIN_GROUPS_VERSION = '11.3.0';
 
 // Whether a backend at the given groups version supports reactions. Conservative
-// by design: anything unparseable (e.g. 'n/a' when the version scry failed)
-// returns false, so we never point the client at v9 endpoints an old backend
-// can't serve.
+// by design: anything that isn't a fully valid semver (e.g. 'n/a' when the
+// version scry failed, or a partially parseable '11.2.2 dirty' from docket
+// metadata) returns false, so we never point the client at v9 endpoints an old
+// backend can't serve. A loose prefix check is not enough: it would admit
+// '11.2.2 dirty', which then fails the strict parse inside isVersionBelow and is
+// silently treated as equal to the minimum (returning true).
 export function activityVersionSupportsReactions(
   groupsVersion?: string | null
 ): boolean {
-  if (!groupsVersion || !/^\d+\.\d+\.\d+/.test(groupsVersion)) {
+  if (!groupsVersion || parseVersion(groupsVersion) === null) {
     return false;
   }
   return !isVersionBelow(groupsVersion, REACTIONS_MIN_GROUPS_VERSION);

--- a/packages/shared/src/logic/reactionSupport.ts
+++ b/packages/shared/src/logic/reactionSupport.ts
@@ -13,7 +13,7 @@ export const REACTIONS_MIN_GROUPS_VERSION = '11.3.0';
 // by design: anything unparseable (e.g. 'n/a' when the version scry failed)
 // returns false, so we never point the client at v9 endpoints an old backend
 // can't serve.
-export function backendVersionSupportsReactions(
+export function activityVersionSupportsReactions(
   groupsVersion?: string | null
 ): boolean {
   if (!groupsVersion || !/^\d+\.\d+\.\d+/.test(groupsVersion)) {

--- a/packages/shared/src/logic/semver.ts
+++ b/packages/shared/src/logic/semver.ts
@@ -1,14 +1,17 @@
 const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].+)?$/;
 
-function parse(version: string): [number, number, number] | null {
+// Parse a full semver string into its numeric core, or null if the entire
+// string is not a valid semver (a partially parseable prefix like
+// "11.2.2 dirty" returns null, not [11, 2, 2]).
+export function parseVersion(version: string): [number, number, number] | null {
   const match = SEMVER_RE.exec(version.trim());
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function compareCore(a: string, b: string): number {
-  const parsedA = parse(a);
-  const parsedB = parse(b);
+  const parsedA = parseVersion(a);
+  const parsedB = parseVersion(b);
   if (!parsedA || !parsedB) return 0;
   for (let i = 0; i < 3; i++) {
     if (parsedA[i] !== parsedB[i]) return parsedA[i] - parsedB[i];

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2228,10 +2228,14 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     }
 
     updateSession({ phase: 'low' });
-    // Resolve the backend's reaction capability before the activity feed and
-    // subscription below pick their endpoint versions. Reads the persisted
-    // version (fast/local); syncAppInfo refreshes it for the next run.
-    await syncReactionSupport();
+    // Resolve the backend's reaction capability from the *current* version
+    // before the activity feed and subscription below pick their endpoint
+    // versions, so reactions work on first launch and right after a ship
+    // upgrade rather than only after a restart. Fall back to the last-known
+    // (persisted) version if the fresh fetch fails.
+    await syncAppInfo({ priority: syncStartPriority.low + 1 })
+      .then(() => logger.crumb(`finished syncing app info`))
+      .catch(() => syncReactionSupport().catch(() => {}));
     const lowPriorityPromises = [
       alreadySubscribed
         ? Promise.resolve()
@@ -2262,9 +2266,6 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
       }).then(() =>
         logger.crumb(`finished syncing push notifications setting`)
       ),
-      syncAppInfo({ priority: syncStartPriority.low + 1 }).then(() => {
-        logger.crumb(`finished syncing app info`);
-      }),
       syncSystemContacts({ priority: syncStartPriority.low + 1 }).then(() => {
         logger.crumb(`finished syncing system contacts`);
       }),

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -13,7 +13,7 @@ import { queryClient } from '../../db/reactQuery';
 import { SETTINGS_SINGLETON_KEY } from '../../db/schema';
 import { runIfDev } from '../../debug';
 import { AnalyticsEvent, AnalyticsSeverity } from '../../domain';
-import { backendVersionSupportsReactions } from '../../logic';
+import { activityVersionSupportsReactions } from '../../logic';
 import { perfMark, perfTime } from '../../perfLog';
 import {
   INFINITE_ACTIVITY_QUERY_KEY,
@@ -502,8 +502,8 @@ export const syncSettings = async (ctx?: SyncCtx) => {
 
 export const syncAppInfo = async (ctx?: SyncCtx) => {
   const appInfo = await syncQueue.add('appInfo', ctx, () => api.getAppInfo());
-  api.setBackendSupportsReactions(
-    backendVersionSupportsReactions(appInfo?.groupsVersion)
+  api.setActivitySupportsReactions(
+    activityVersionSupportsReactions(appInfo?.groupsVersion)
   );
   return db.appInfo.setValue(appInfo);
 };
@@ -513,8 +513,8 @@ export const syncAppInfo = async (ctx?: SyncCtx) => {
 // versions. A fresh version is fetched by syncAppInfo, which also updates this.
 export const syncReactionSupport = async () => {
   const appInfo = await db.appInfo.getValue();
-  api.setBackendSupportsReactions(
-    backendVersionSupportsReactions(appInfo?.groupsVersion)
+  api.setActivitySupportsReactions(
+    activityVersionSupportsReactions(appInfo?.groupsVersion)
   );
 };
 

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2235,7 +2235,13 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     // (persisted) version if the fresh fetch fails.
     await syncAppInfo({ priority: syncStartPriority.low + 1 })
       .then(() => logger.crumb(`finished syncing app info`))
-      .catch(() => syncReactionSupport().catch(() => {}));
+      .catch((err) => {
+        logger.trackError(
+          'Failed to sync app info; falling back to persisted version for reaction capability',
+          { error: err instanceof Error ? err.message : String(err) }
+        );
+        return syncReactionSupport().catch(() => {});
+      });
     const lowPriorityPromises = [
       alreadySubscribed
         ? Promise.resolve()

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -13,6 +13,7 @@ import { queryClient } from '../../db/reactQuery';
 import { SETTINGS_SINGLETON_KEY } from '../../db/schema';
 import { runIfDev } from '../../debug';
 import { AnalyticsEvent, AnalyticsSeverity } from '../../domain';
+import { backendVersionSupportsReactions } from '../../logic';
 import { perfMark, perfTime } from '../../perfLog';
 import {
   INFINITE_ACTIVITY_QUERY_KEY,
@@ -501,7 +502,20 @@ export const syncSettings = async (ctx?: SyncCtx) => {
 
 export const syncAppInfo = async (ctx?: SyncCtx) => {
   const appInfo = await syncQueue.add('appInfo', ctx, () => api.getAppInfo());
+  api.setBackendSupportsReactions(
+    backendVersionSupportsReactions(appInfo?.groupsVersion)
+  );
   return db.appInfo.setValue(appInfo);
+};
+
+// Resolves the backend's reaction capability from the last-known (persisted)
+// groups version and applies it to the activity client before it picks endpoint
+// versions. A fresh version is fetched by syncAppInfo, which also updates this.
+export const syncReactionSupport = async () => {
+  const appInfo = await db.appInfo.getValue();
+  api.setBackendSupportsReactions(
+    backendVersionSupportsReactions(appInfo?.groupsVersion)
+  );
 };
 
 export const syncVolumeSettings = async (ctx?: SyncCtx) => {
@@ -2214,6 +2228,10 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
     }
 
     updateSession({ phase: 'low' });
+    // Resolve the backend's reaction capability before the activity feed and
+    // subscription below pick their endpoint versions. Reads the persisted
+    // version (fast/local); syncAppInfo refreshes it for the next run.
+    await syncReactionSupport();
     const lowPriorityPromises = [
       alreadySubscribed
         ? Promise.resolve()


### PR DESCRIPTION
## Summary

Fixes TLON-5962 by implementing the client changes necessary to handle activity events for reactions. This includes native notifications as well as items in the activity feed.

## Changes

- **Client parsing** — handle `%react`/`%dm-react` in `toActivityEvent` (collapse both to db type `react`, author = the reactor, react value stored in the `content` column); add the urbit event types/helpers.
- **Feed rendering** — new "reacted ❤️" summary row + author list in the activity feed, plus a Cosmos fixture.
- **Feed/subscription version bump** — activity feed scry → `/v6`, live subscription → `/v5`. The previously-used `/v5` feed and `/v4` subscription down-convert to v8, which strips react events.
- **Native push** — fetch `activity-event-1` instead of `activity-event` (iOS + Android); the v8 `activity-event` mark returns 404 for reacts, which made the extension fall back to a generic notification. Add `react`/`dm-react` cases to `renderActivityEventPreview`.
- **Volume defaulting (backend)** — `get-volume` now falls back to `default-volumes` per event type instead of a blanket notify-off, so reacts honor their default in sources whose volume map predates reacts.
- **Volume defaulting (client)** — `getVolumeMap` always writes `react`/`dm-react` keys (notify on at loud/medium/default, off at soft/hush), so muting a source also silences its reacts.

## How did I test?

- `@tloncorp/api` unit suite: 209 passing, including new `volumeMap.test.ts` (15) and react conversion cases in `activity.test.ts`.
- `tlon-mobile` notification-parse tests: react/dm-react routing cases added, 18 passing.
- Hoon activity agent tests run against a `~zod` pier (`backend/run-tests.sh`): full `groups` desk compiles/upgrades and all tests pass (including `test-sync-reads-*`, `test-fix-init`).
- Typecheck clean across `api`, `app`, `shared`, `tlon-mobile`.
- Manually verified reacts appear in the in-app feed and produce rich push notifications on device.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

Revert the PR. Changes are additive (new event type handling) plus version bumps; the v6 feed / v5 subscription / `activity-event-1` endpoints are already served by the backend, and the volume changes are backward-compatible. Native push changes require an app rebuild to take or revert effect.

## Screenshots / videos

<!-- Attach any relevant media. -->
