### PR TITLE
tlon-skill: stop reporting false success on rejected group admin actions

### DIFF
--- a/packages/tlon-skill/scripts/commands/groups-verification.test.ts
+++ b/packages/tlon-skill/scripts/commands/groups-verification.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  type RawGroupForAdminVerification,
+  actingShipCanAdminister,
+  getShipRecordValue,
+  seatHasRole,
+  shipIsBanned,
+  shipIsSeated,
+} from './groups-verification';
+
+// Minimal stand-in for the real `preSig`-based normalizer: ensure a leading sig.
+const normalizeShip = (ship: string): string =>
+  ship.startsWith('~') ? ship : `~${ship}`;
+
+const HOST = '~ravmel-ropdyl';
+const ADMIN = '~admin-ship';
+const MEMBER = '~lorhep-binfen';
+
+describe('getShipRecordValue', () => {
+  it('returns undefined for a missing record', () => {
+    expect(getShipRecordValue(undefined, MEMBER, normalizeShip)).toBeUndefined();
+  });
+
+  it('matches on the raw key directly', () => {
+    const record = { [MEMBER]: { roles: ['admin'] } };
+    expect(getShipRecordValue(record, MEMBER, normalizeShip)).toEqual({
+      roles: ['admin'],
+    });
+  });
+
+  it('falls back to a normalized comparison for unnormalized keys', () => {
+    // record key has the sig, lookup ship does not
+    const record = { '~zod': 7 };
+    expect(getShipRecordValue(record, 'zod', normalizeShip)).toBe(7);
+  });
+
+  it('returns undefined when the ship is absent', () => {
+    expect(
+      getShipRecordValue({ [HOST]: 1 }, MEMBER, normalizeShip)
+    ).toBeUndefined();
+  });
+});
+
+describe('seatHasRole', () => {
+  const group: RawGroupForAdminVerification = {
+    seats: { [MEMBER]: { roles: ['admin', 'editor'] } },
+  };
+
+  it('is true when the seat holds the role', () => {
+    expect(seatHasRole(group, MEMBER, 'admin', normalizeShip)).toBe(true);
+  });
+
+  it('is false when the seat lacks the role', () => {
+    expect(seatHasRole(group, MEMBER, 'moderator', normalizeShip)).toBe(false);
+  });
+
+  it('is false when the ship has no seat', () => {
+    expect(seatHasRole(group, HOST, 'admin', normalizeShip)).toBe(false);
+  });
+});
+
+describe('shipIsSeated', () => {
+  const group: RawGroupForAdminVerification = {
+    seats: { [MEMBER]: { roles: [] } },
+  };
+
+  it('is true for a seated ship', () => {
+    expect(shipIsSeated(group, MEMBER, normalizeShip)).toBe(true);
+  });
+
+  it('is false for a ship without a seat', () => {
+    expect(shipIsSeated(group, HOST, normalizeShip)).toBe(false);
+  });
+});
+
+describe('shipIsBanned', () => {
+  const group: RawGroupForAdminVerification = {
+    admissions: { banned: { ships: ['~zod'] } },
+  };
+
+  it('is true for a banned ship (normalized match)', () => {
+    expect(shipIsBanned(group, 'zod', normalizeShip)).toBe(true);
+  });
+
+  it('is false for a ship that is not banned', () => {
+    expect(shipIsBanned(group, MEMBER, normalizeShip)).toBe(false);
+  });
+
+  it('is false when there is no ban list', () => {
+    expect(shipIsBanned({}, MEMBER, normalizeShip)).toBe(false);
+  });
+});
+
+describe('actingShipCanAdminister', () => {
+  it('allows the host even without a seat', () => {
+    const group: RawGroupForAdminVerification = {};
+    expect(actingShipCanAdminister(group, HOST, HOST, normalizeShip)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('allows a member holding a role listed in admins', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['admin'],
+      seats: { [ADMIN]: { roles: ['admin'] } },
+    };
+    expect(actingShipCanAdminister(group, ADMIN, HOST, normalizeShip)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('allows a custom (non-"admin") admin role id', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['steward'],
+      seats: { [ADMIN]: { roles: ['steward'] } },
+    };
+    expect(actingShipCanAdminister(group, ADMIN, HOST, normalizeShip)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('refuses a non-admin member and names the host', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['admin'],
+      seats: { [MEMBER]: { roles: ['member'] } },
+    };
+    const result = actingShipCanAdminister(group, MEMBER, HOST, normalizeShip);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain(MEMBER);
+      expect(result.reason).toContain(HOST);
+    }
+  });
+
+  it('refuses a ship that is not in the group', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['admin'],
+      seats: { [HOST]: { roles: ['admin'] } },
+    };
+    const result = actingShipCanAdminister(group, MEMBER, HOST, normalizeShip);
+    expect(result.ok).toBe(false);
+  });
+
+  it('refuses when a seated member holds no role marked admin', () => {
+    // member holds the "admin" role string, but the group does not mark it admin
+    const group: RawGroupForAdminVerification = {
+      admins: [],
+      seats: { [MEMBER]: { roles: ['admin'] } },
+    };
+    expect(actingShipCanAdminister(group, MEMBER, HOST, normalizeShip).ok).toBe(
+      false
+    );
+  });
+});
+
+describe('batch verification predicate', () => {
+  // Mirrors how the groups.ts batch loop filters targets against one scry snapshot:
+  // of two targets, only the unverified one should remain.
+  it('identifies only the ship that did not gain the role', () => {
+    const promoted = '~zod';
+    const notPromoted = '~nec';
+    const group: RawGroupForAdminVerification = {
+      seats: {
+        [promoted]: { roles: ['admin'] },
+        [notPromoted]: { roles: ['member'] },
+      },
+    };
+
+    const unverified = [promoted, notPromoted].filter(
+      (ship) => !seatHasRole(group, ship, 'admin', normalizeShip)
+    );
+
+    expect(unverified).toEqual([notPromoted]);
+  });
+});

--- a/packages/tlon-skill/scripts/commands/groups-verification.test.ts
+++ b/packages/tlon-skill/scripts/commands/groups-verification.test.ts
@@ -126,6 +126,25 @@ describe('seatHasAdminRole', () => {
     const group: RawGroupForAdminVerification = { admins: ['admin'] };
     expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(false);
   });
+
+  it('stays true while any admin role remains (partial demote)', () => {
+    // Group marks both `admin` and `steward` as admin; the member held both and
+    // only `admin` was removed — they are still an admin via `steward`, so a
+    // demote that stopped here must not report success.
+    const group: RawGroupForAdminVerification = {
+      admins: ['admin', 'steward'],
+      seats: { [MEMBER]: { roles: ['steward'] } },
+    };
+    expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(true);
+  });
+
+  it('is false once all admin roles are removed', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['admin', 'steward'],
+      seats: { [MEMBER]: { roles: ['member'] } },
+    };
+    expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(false);
+  });
 });
 
 describe('actingShipCanAdminister', () => {

--- a/packages/tlon-skill/scripts/commands/groups-verification.test.ts
+++ b/packages/tlon-skill/scripts/commands/groups-verification.test.ts
@@ -4,6 +4,7 @@ import {
   type RawGroupForAdminVerification,
   actingShipCanAdminister,
   getShipRecordValue,
+  seatHasAdminRole,
   seatHasRole,
   shipIsBanned,
   shipIsSeated,
@@ -91,6 +92,39 @@ describe('shipIsBanned', () => {
 
   it('is false when there is no ban list', () => {
     expect(shipIsBanned({}, MEMBER, normalizeShip)).toBe(false);
+  });
+});
+
+describe('seatHasAdminRole', () => {
+  it('is true when the seat holds a role marked admin', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['admin'],
+      seats: { [MEMBER]: { roles: ['admin'] } },
+    };
+    expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(true);
+  });
+
+  it('is true for a custom admin role id', () => {
+    const group: RawGroupForAdminVerification = {
+      admins: ['steward'],
+      seats: { [MEMBER]: { roles: ['steward'] } },
+    };
+    expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(true);
+  });
+
+  it('is false when the seat holds an "admin"-named role the group does not mark admin', () => {
+    // The seat has a role whose id is "admin", but it is not in `admins`, so it
+    // grants no admin privileges — a `promote` here must not report success.
+    const group: RawGroupForAdminVerification = {
+      admins: [],
+      seats: { [MEMBER]: { roles: ['admin'] } },
+    };
+    expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(false);
+  });
+
+  it('is false when the ship has no seat', () => {
+    const group: RawGroupForAdminVerification = { admins: ['admin'] };
+    expect(seatHasAdminRole(group, MEMBER, normalizeShip)).toBe(false);
   });
 });
 

--- a/packages/tlon-skill/scripts/commands/groups-verification.test.ts
+++ b/packages/tlon-skill/scripts/commands/groups-verification.test.ts
@@ -19,7 +19,9 @@ const MEMBER = '~lorhep-binfen';
 
 describe('getShipRecordValue', () => {
   it('returns undefined for a missing record', () => {
-    expect(getShipRecordValue(undefined, MEMBER, normalizeShip)).toBeUndefined();
+    expect(
+      getShipRecordValue(undefined, MEMBER, normalizeShip)
+    ).toBeUndefined();
   });
 
   it('matches on the raw key directly', () => {

--- a/packages/tlon-skill/scripts/commands/groups-verification.ts
+++ b/packages/tlon-skill/scripts/commands/groups-verification.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure, side-effect-free predicates for verifying group admin state.
+ *
+ * Kept free of `./api-client` (and therefore of the live `@tloncorp/api` client
+ * singleton) so it can be unit-tested without standing up the API client. Ship
+ * normalization is threaded in via a `normalizeShip` argument rather than imported,
+ * for the same reason — callers pass the canonical normalizer.
+ */
+
+/**
+ * Narrow view of the `/v2/ui/groups/{id}` scry response — only the fields the
+ * admin-verification flows read. A subset of `@tloncorp/api`'s `GroupV7`.
+ */
+export type RawGroupForAdminVerification = {
+  admins?: string[];
+  seats?: Record<string, { roles?: string[] }>;
+  admissions?: {
+    banned?: { ships?: string[] };
+    pending?: Record<string, string[]>;
+    invited?: Record<string, unknown>;
+  };
+};
+
+export type NormalizeShip = (ship: string) => string;
+
+/**
+ * Look up a ship-keyed record value, matching on the raw key first and falling
+ * back to a normalized comparison so unnormalized record keys still resolve.
+ */
+export function getShipRecordValue<T>(
+  record: Record<string, T> | undefined,
+  ship: string,
+  normalizeShip: NormalizeShip
+): T | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  const direct = record[ship];
+  if (direct !== undefined) {
+    return direct;
+  }
+
+  const target = normalizeShip(ship);
+  return Object.entries(record).find(
+    ([key]) => normalizeShip(key) === target
+  )?.[1];
+}
+
+/** Does the ship's seat currently hold `roleId`? */
+export function seatHasRole(
+  rawGroup: RawGroupForAdminVerification,
+  ship: string,
+  roleId: string,
+  normalizeShip: NormalizeShip
+): boolean {
+  const seat = getShipRecordValue(rawGroup.seats, ship, normalizeShip);
+  return seat?.roles?.includes(roleId) ?? false;
+}
+
+/** Is the ship currently seated (a member) in the group? */
+export function shipIsSeated(
+  rawGroup: RawGroupForAdminVerification,
+  ship: string,
+  normalizeShip: NormalizeShip
+): boolean {
+  return getShipRecordValue(rawGroup.seats, ship, normalizeShip) !== undefined;
+}
+
+/** Is the ship currently in the group's ban list? */
+export function shipIsBanned(
+  rawGroup: RawGroupForAdminVerification,
+  ship: string,
+  normalizeShip: NormalizeShip
+): boolean {
+  const banned = rawGroup.admissions?.banned?.ships ?? [];
+  const target = normalizeShip(ship);
+  return banned.some((bandedShip) => normalizeShip(bandedShip) === target);
+}
+
+/**
+ * May the acting ship perform admin mutations on this group? The host can always
+ * administer; otherwise the acting ship's seat must hold a role the group marks as
+ * an admin role (`rawGroup.admins`), which covers custom admin roles, not just the
+ * literal `admin` role.
+ *
+ * The `reason` states only the permission fact (no command verb) — the caller
+ * prepends the action-specific wording.
+ */
+export function actingShipCanAdminister(
+  rawGroup: RawGroupForAdminVerification,
+  actingShip: string,
+  hostShip: string,
+  normalizeShip: NormalizeShip
+): { ok: true } | { ok: false; reason: string } {
+  const normalizedActing = normalizeShip(actingShip);
+  const normalizedHost = normalizeShip(hostShip);
+
+  if (normalizedActing === normalizedHost) {
+    return { ok: true };
+  }
+
+  const adminRoles = rawGroup.admins ?? [];
+  const seat = getShipRecordValue(rawGroup.seats, actingShip, normalizeShip);
+  const isAdmin =
+    seat?.roles?.some((roleId) => adminRoles.includes(roleId)) ?? false;
+
+  if (isAdmin) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    reason: `you (${normalizedActing}) are not an admin of this group. It's hosted by ${normalizedHost}. Ask the host to grant admin.`,
+  };
+}

--- a/packages/tlon-skill/scripts/commands/groups-verification.ts
+++ b/packages/tlon-skill/scripts/commands/groups-verification.ts
@@ -75,7 +75,24 @@ export function shipIsBanned(
 ): boolean {
   const banned = rawGroup.admissions?.banned?.ships ?? [];
   const target = normalizeShip(ship);
-  return banned.some((bandedShip) => normalizeShip(bandedShip) === target);
+  return banned.some((bannedShip) => normalizeShip(bannedShip) === target);
+}
+
+/**
+ * Does the ship's seat hold a role the group actually marks as an admin role
+ * (`rawGroup.admins`)? This is the real test of admin status — a seat can hold a
+ * role whose id is `admin` without that role being marked admin, in which case it
+ * grants no admin privileges. Covers custom admin roles, not just the literal
+ * `admin` role.
+ */
+export function seatHasAdminRole(
+  rawGroup: RawGroupForAdminVerification,
+  ship: string,
+  normalizeShip: NormalizeShip
+): boolean {
+  const adminRoles = rawGroup.admins ?? [];
+  const seat = getShipRecordValue(rawGroup.seats, ship, normalizeShip);
+  return seat?.roles?.some((roleId) => adminRoles.includes(roleId)) ?? false;
 }
 
 /**
@@ -100,12 +117,7 @@ export function actingShipCanAdminister(
     return { ok: true };
   }
 
-  const adminRoles = rawGroup.admins ?? [];
-  const seat = getShipRecordValue(rawGroup.seats, actingShip, normalizeShip);
-  const isAdmin =
-    seat?.roles?.some((roleId) => adminRoles.includes(roleId)) ?? false;
-
-  if (isAdmin) {
+  if (seatHasAdminRole(rawGroup, actingShip, normalizeShip)) {
     return { ok: true };
   }
 

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -1338,13 +1338,24 @@ async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
   console.log(
     `Removing admin roles (${adminRoles.join(', ')}) from ${normalizedShips.join(', ')}...`
   );
-  for (const roleId of adminRoles) {
-    await removeMembersFromRole({
-      groupId,
-      roleId,
-      ships: normalizedShips,
-    });
-  }
+  // Send all role removals as one seat action. The host checks `se-src-is-admin`
+  // once, while the acting ship is still an admin, so a self-demotion can't revoke
+  // our own permission part-way through and get the remaining removals rejected.
+  await poke({
+    app: 'groups',
+    mark: 'group-action-4',
+    json: {
+      group: {
+        flag: groupId,
+        'a-group': {
+          seat: {
+            ships: normalizedShips,
+            'a-seat': { 'del-roles': adminRoles },
+          },
+        },
+      },
+    },
+  });
 
   await verifyShipsAreAdmin(groupId, normalizedShips, 'absent');
   console.log(`✅ Members demoted from admin.`);

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -71,14 +71,6 @@ import type { Group } from '@tloncorp/api';
 
 import { ensureClient, getCurrentShip, normalizeShip } from './api-client';
 import {
-  type RawGroupForAdminVerification,
-  actingShipCanAdminister,
-  getShipRecordValue,
-  seatHasRole,
-  shipIsBanned,
-  shipIsSeated,
-} from './commands/groups-verification';
-import {
   getOption,
   hasOptionValue,
   isHelpArg,
@@ -88,6 +80,14 @@ import {
   printHelpAndExit,
   printUsageAndExit,
 } from './cli-utils';
+import {
+  type RawGroupForAdminVerification,
+  actingShipCanAdminister,
+  getShipRecordValue,
+  seatHasRole,
+  shipIsBanned,
+  shipIsSeated,
+} from './commands/groups-verification';
 
 const ADMIN_ROLE_ID = 'admin';
 const GROUP_UPDATE_FLAGS = ['title', 'description', 'image', 'cover'] as const;
@@ -364,7 +364,9 @@ function hasOwnerSeat(
   rawGroup: RawGroupForAdminVerification,
   ownerShip: string
 ): boolean {
-  return getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip) !== undefined;
+  return (
+    getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip) !== undefined
+  );
 }
 
 async function getRawGroupWithOwnerSeat(
@@ -407,7 +409,11 @@ async function getRawOwnerAdminVerification(
     };
   }
 
-  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip);
+  const ownerSeat = getShipRecordValue(
+    rawGroup.seats,
+    ownerShip,
+    normalizeShip
+  );
   if (ownerSeat) {
     if (ownerSeat.roles?.includes(ADMIN_ROLE_ID)) {
       return { status: 'verified' };
@@ -458,7 +464,11 @@ async function getRawOwnerAdminVerification(
 
 async function assignOwnerAdminRole(groupId: string, ownerShip: string) {
   const rawGroup = await getRawGroupWithOwnerSeat(groupId, ownerShip);
-  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip);
+  const ownerSeat = getShipRecordValue(
+    rawGroup.seats,
+    ownerShip,
+    normalizeShip
+  );
 
   if (ownerSeat?.roles?.includes(ADMIN_ROLE_ID)) {
     console.log(`✅ Owner already has "${ADMIN_ROLE_ID}" role.`);
@@ -615,7 +625,10 @@ async function assertActingShipCanAdminister(
 async function verifyShips(
   groupId: string,
   ships: string[],
-  isSatisfied: (rawGroup: RawGroupForAdminVerification, ship: string) => boolean,
+  isSatisfied: (
+    rawGroup: RawGroupForAdminVerification,
+    ship: string
+  ) => boolean,
   describeFailure: (unverified: string[]) => string
 ): Promise<void> {
   let unverified = [...ships];

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -553,13 +553,18 @@ async function ensureAdminRole(groupId: string, group?: Group) {
     return;
   }
 
-  // The role already exists — make sure the group actually marks it as an admin
-  // role. A role named `admin` that isn't in `admins` grants no privileges, so
-  // promoting into it would otherwise assign a powerless role.
+  // The role already exists. It must already be an admin role — do NOT silently
+  // mark it, since `setAdminRole` would grant admin to every existing holder of
+  // the role, not just the promote target. A role named `admin` that the group
+  // intentionally does not mark admin is a collision we refuse rather than
+  // repurpose.
   const rawGroup = await getRawGroupForAdminVerification(groupId);
   if (!rawGroup.admins?.includes(ADMIN_ROLE_ID)) {
-    console.log(`Marking "${ADMIN_ROLE_ID}" role as admin in ${groupId}...`);
-    await setAdminRole(groupId, ADMIN_ROLE_ID);
+    throw new Error(
+      `Group ${groupId} has an "${ADMIN_ROLE_ID}" role that is not configured as an admin role. ` +
+        `Refusing to promote — marking it admin would grant admin to all existing holders. ` +
+        `Resolve the role configuration first.`
+    );
   }
 }
 

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -550,6 +550,16 @@ async function ensureAdminRole(groupId: string, group?: Group) {
     });
 
     await setAdminRole(groupId, ADMIN_ROLE_ID);
+    return;
+  }
+
+  // The role already exists — make sure the group actually marks it as an admin
+  // role. A role named `admin` that isn't in `admins` grants no privileges, so
+  // promoting into it would otherwise assign a powerless role.
+  const rawGroup = await getRawGroupForAdminVerification(groupId);
+  if (!rawGroup.admins?.includes(ADMIN_ROLE_ID)) {
+    console.log(`Marking "${ADMIN_ROLE_ID}" role as admin in ${groupId}...`);
+    await setAdminRole(groupId, ADMIN_ROLE_ID);
   }
 }
 
@@ -1310,32 +1320,28 @@ async function promoteMemberToAdmin(groupId: string, ships: string[]) {
   console.log(`✅ Members promoted to admin.`);
 }
 
-// Demote a member from admin by removing them from admin roles
+// Demote a member from admin by removing them from every admin-marked role
 async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
   await assertActingShipCanAdminister(groupId, 'demote');
-  const group = await getGroup(groupId);
 
-  // Find all admin roles this member might have
-  // For now, check the "admin" role
-  const adminRoles = (group.roles || []).filter((r) => {
-    // We can't easily tell which roles are admin from the group info alone,
-    // so we target the "admin" role specifically
-    return r.id === ADMIN_ROLE_ID;
-  });
+  // Remove every role the group marks as admin (`rawGroup.admins`), not just the
+  // literal `admin` role — otherwise a member with a custom admin role stays an
+  // admin and verification below would fail on a partial mutation.
+  const rawGroup = await getRawGroupForAdminVerification(groupId);
+  const adminRoles = rawGroup.admins ?? [];
 
   if (adminRoles.length === 0) {
-    console.error(`No "${ADMIN_ROLE_ID}" role found in ${groupId}.`);
-    process.exit(1);
+    throw new Error(`No admin roles found in ${groupId}.`);
   }
 
-  for (const role of adminRoles) {
-    console.log(
-      `Removing "${role.id}" role from ${normalizedShips.join(', ')}...`
-    );
+  console.log(
+    `Removing admin roles (${adminRoles.join(', ')}) from ${normalizedShips.join(', ')}...`
+  );
+  for (const roleId of adminRoles) {
     await removeMembersFromRole({
       groupId,
-      roleId: role.id,
+      roleId,
       ships: normalizedShips,
     });
   }

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -84,6 +84,7 @@ import {
   type RawGroupForAdminVerification,
   actingShipCanAdminister,
   getShipRecordValue,
+  seatHasAdminRole,
   seatHasRole,
   shipIsBanned,
   shipIsSeated,
@@ -670,6 +671,27 @@ async function verifyShipsHaveRole(
       expect === 'present'
         ? `Could not verify ${unverified.join(', ')} gained role ${roleId} in ${groupId}`
         : `Could not verify ${unverified.join(', ')} lost role ${roleId} in ${groupId} (still present)`
+  );
+}
+
+// Verify admin status by the group's actual `admins` markings, not the literal
+// `admin` role id — assigning a role named `admin` that the group doesn't mark as
+// admin grants no privileges, and we must not report that as success.
+async function verifyShipsAreAdmin(
+  groupId: string,
+  ships: string[],
+  expect: 'present' | 'absent'
+): Promise<void> {
+  await verifyShips(
+    groupId,
+    ships,
+    (rawGroup, ship) =>
+      seatHasAdminRole(rawGroup, ship, normalizeShip) ===
+      (expect === 'present'),
+    (unverified) =>
+      expect === 'present'
+        ? `Could not verify ${unverified.join(', ')} gained admin in ${groupId}`
+        : `Could not verify ${unverified.join(', ')} lost admin in ${groupId} (still admin)`
   );
 }
 
@@ -1284,7 +1306,7 @@ async function promoteMemberToAdmin(groupId: string, ships: string[]) {
     ships: normalizedShips,
   });
 
-  await verifyShipsHaveRole(groupId, normalizedShips, ADMIN_ROLE_ID, 'present');
+  await verifyShipsAreAdmin(groupId, normalizedShips, 'present');
   console.log(`✅ Members promoted to admin.`);
 }
 
@@ -1318,7 +1340,7 @@ async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
     });
   }
 
-  await verifyShipsHaveRole(groupId, normalizedShips, ADMIN_ROLE_ID, 'absent');
+  await verifyShipsAreAdmin(groupId, normalizedShips, 'absent');
   console.log(`✅ Members demoted from admin.`);
 }
 

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -606,6 +606,12 @@ async function verifyOwnerAdmin(
   );
 }
 
+// The host is the ship in the group flag (`~host/slug`). The backend treats it as
+// an admin unconditionally (`se-is-admin`), regardless of seats or roles.
+function getGroupHost(groupId: string): string {
+  return normalizeShip(groupId.split('/')[0]);
+}
+
 /**
  * Refuse an admin mutation up front when the acting ship can't perform it, instead
  * of firing a poke that a foreign host silently drops while the CLI reports success.
@@ -619,7 +625,7 @@ async function assertActingShipCanAdminister(
   action: string
 ): Promise<void> {
   const actingShip = normalizeShip(getCurrentUserId());
-  const hostShip = normalizeShip(groupId.split('/')[0]);
+  const hostShip = getGroupHost(groupId);
   const rawGroup = await getRawGroupForAdminVerification(groupId);
   const result = actingShipCanAdminister(
     rawGroup,
@@ -1329,6 +1335,15 @@ async function promoteMemberToAdmin(groupId: string, ships: string[]) {
 async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
   await assertActingShipCanAdminister(groupId, 'demote');
+
+  // The host is an admin unconditionally, so it can't be demoted. Refuse up front
+  // rather than strip its roles and falsely report success on a no-op.
+  const hostShip = getGroupHost(groupId);
+  if (normalizedShips.includes(hostShip)) {
+    throw new Error(
+      `Cannot demote the host (${hostShip}) of ${groupId} — the host is always an admin.`
+    );
+  }
 
   // Remove every role the group marks as admin (`rawGroup.admins`), not just the
   // literal `admin` role — otherwise a member with a custom admin role stays an

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -71,6 +71,14 @@ import type { Group } from '@tloncorp/api';
 
 import { ensureClient, getCurrentShip, normalizeShip } from './api-client';
 import {
+  type RawGroupForAdminVerification,
+  actingShipCanAdminister,
+  getShipRecordValue,
+  seatHasRole,
+  shipIsBanned,
+  shipIsSeated,
+} from './commands/groups-verification';
+import {
   getOption,
   hasOptionValue,
   isHelpArg,
@@ -332,15 +340,6 @@ type OwnerAdminVerification =
   | { status: 'verified' }
   | { status: 'missing'; reason: string };
 
-type RawGroupForAdminVerification = {
-  admins?: string[];
-  seats?: Record<string, { roles?: string[] }>;
-  admissions?: {
-    pending?: Record<string, string[]>;
-    invited?: Record<string, unknown>;
-  };
-};
-
 const VERIFY_ATTEMPTS = 5;
 const VERIFY_DELAY_MS = 500;
 
@@ -350,24 +349,6 @@ function sleep(ms: number): Promise<void> {
 
 function groupHasRole(group: Group, roleId: string): boolean {
   return (group.roles || []).some((role) => role.id === roleId);
-}
-
-function getShipRecordValue<T>(
-  record: Record<string, T> | undefined,
-  ship: string
-): T | undefined {
-  if (!record) {
-    return undefined;
-  }
-
-  const direct = record[ship];
-  if (direct !== undefined) {
-    return direct;
-  }
-
-  return Object.entries(record).find(
-    ([key]) => normalizeShip(key) === ship
-  )?.[1];
 }
 
 async function getRawGroupForAdminVerification(
@@ -383,7 +364,7 @@ function hasOwnerSeat(
   rawGroup: RawGroupForAdminVerification,
   ownerShip: string
 ): boolean {
-  return getShipRecordValue(rawGroup.seats, ownerShip) !== undefined;
+  return getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip) !== undefined;
 }
 
 async function getRawGroupWithOwnerSeat(
@@ -426,7 +407,7 @@ async function getRawOwnerAdminVerification(
     };
   }
 
-  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
+  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip);
   if (ownerSeat) {
     if (ownerSeat.roles?.includes(ADMIN_ROLE_ID)) {
       return { status: 'verified' };
@@ -440,7 +421,8 @@ async function getRawOwnerAdminVerification(
 
   const pendingRoles = getShipRecordValue(
     rawGroup.admissions?.pending,
-    ownerShip
+    ownerShip,
+    normalizeShip
   );
   if (pendingRoles) {
     if (pendingRoles.includes(ADMIN_ROLE_ID)) {
@@ -458,7 +440,8 @@ async function getRawOwnerAdminVerification(
 
   const ownerInvite = getShipRecordValue(
     rawGroup.admissions?.invited,
-    ownerShip
+    ownerShip,
+    normalizeShip
   );
   if (ownerInvite) {
     return {
@@ -475,7 +458,7 @@ async function getRawOwnerAdminVerification(
 
 async function assignOwnerAdminRole(groupId: string, ownerShip: string) {
   const rawGroup = await getRawGroupWithOwnerSeat(groupId, ownerShip);
-  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip);
+  const ownerSeat = getShipRecordValue(rawGroup.seats, ownerShip, normalizeShip);
 
   if (ownerSeat?.roles?.includes(ADMIN_ROLE_ID)) {
     console.log(`✅ Owner already has "${ADMIN_ROLE_ID}" role.`);
@@ -594,6 +577,116 @@ async function verifyOwnerAdmin(
 
   throw new Error(
     `Could not verify owner admin assignment for ${ownerShip}: ${lastError}`
+  );
+}
+
+/**
+ * Refuse an admin mutation up front when the acting ship can't perform it, instead
+ * of firing a poke that a foreign host silently drops while the CLI reports success.
+ *
+ * A poke ack means "my ship forwarded this," not "the host applied it" — so this
+ * reads the group's actual state and checks the acting ship is the host or an admin
+ * before any mutation runs. `action` is the user-facing verb (e.g. "promote").
+ */
+async function assertActingShipCanAdminister(
+  groupId: string,
+  action: string
+): Promise<void> {
+  const actingShip = normalizeShip(getCurrentUserId());
+  const hostShip = normalizeShip(groupId.split('/')[0]);
+  const rawGroup = await getRawGroupForAdminVerification(groupId);
+  const result = actingShipCanAdminister(
+    rawGroup,
+    actingShip,
+    hostShip,
+    normalizeShip
+  );
+
+  if (!result.ok) {
+    throw new Error(`Can't ${action} in ${groupId}: ${result.reason}`);
+  }
+}
+
+/**
+ * Scry-poll the group's actual state until every target ship satisfies `isSatisfied`,
+ * or attempts are exhausted. One scry per attempt covers all ships — never poll per
+ * ship. On exhaustion, throws naming the still-unverified ships via `describeFailure`.
+ */
+async function verifyShips(
+  groupId: string,
+  ships: string[],
+  isSatisfied: (rawGroup: RawGroupForAdminVerification, ship: string) => boolean,
+  describeFailure: (unverified: string[]) => string
+): Promise<void> {
+  let unverified = [...ships];
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const rawGroup = await getRawGroupForAdminVerification(groupId);
+      unverified = ships.filter((ship) => !isSatisfied(rawGroup, ship));
+      if (unverified.length === 0) {
+        return;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < VERIFY_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
+  }
+
+  const suffix = lastError ? ` (last error: ${lastError})` : '';
+  throw new Error(`${describeFailure(unverified)}${suffix}`);
+}
+
+async function verifyShipsHaveRole(
+  groupId: string,
+  ships: string[],
+  roleId: string,
+  expect: 'present' | 'absent'
+): Promise<void> {
+  await verifyShips(
+    groupId,
+    ships,
+    (rawGroup, ship) =>
+      seatHasRole(rawGroup, ship, roleId, normalizeShip) ===
+      (expect === 'present'),
+    (unverified) =>
+      expect === 'present'
+        ? `Could not verify ${unverified.join(', ')} gained role ${roleId} in ${groupId}`
+        : `Could not verify ${unverified.join(', ')} lost role ${roleId} in ${groupId} (still present)`
+  );
+}
+
+async function verifyShipsRemoved(
+  groupId: string,
+  ships: string[]
+): Promise<void> {
+  await verifyShips(
+    groupId,
+    ships,
+    (rawGroup, ship) => !shipIsSeated(rawGroup, ship, normalizeShip),
+    (unverified) =>
+      `Could not verify ${unverified.join(', ')} were removed from ${groupId} (still members)`
+  );
+}
+
+async function verifyShipsBanned(
+  groupId: string,
+  ships: string[],
+  expect: 'present' | 'absent'
+): Promise<void> {
+  await verifyShips(
+    groupId,
+    ships,
+    (rawGroup, ship) =>
+      shipIsBanned(rawGroup, ship, normalizeShip) === (expect === 'present'),
+    (unverified) =>
+      expect === 'present'
+        ? `Could not verify ${unverified.join(', ')} were banned from ${groupId}`
+        : `Could not verify ${unverified.join(', ')} were unbanned from ${groupId} (still banned)`
   );
 }
 
@@ -941,6 +1034,7 @@ async function updateGroup(
 // Kick members from a group
 async function kickMembers(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'kick');
 
   console.log(`Kicking ${normalizedShips.join(', ')} from ${groupId}...`);
 
@@ -949,12 +1043,14 @@ async function kickMembers(groupId: string, ships: string[]) {
     contactIds: normalizedShips,
   });
 
+  await verifyShipsRemoved(groupId, normalizedShips);
   console.log(`✅ Members kicked.`);
 }
 
 // Ban members from a group
 async function banMembers(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'ban');
 
   console.log(`Banning ${normalizedShips.join(', ')} from ${groupId}...`);
 
@@ -963,12 +1059,14 @@ async function banMembers(groupId: string, ships: string[]) {
     contactIds: normalizedShips,
   });
 
+  await verifyShipsBanned(groupId, normalizedShips, 'present');
   console.log(`✅ Members banned.`);
 }
 
 // Unban members from a group
 async function unbanMembers(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'unban');
 
   console.log(`Unbanning ${normalizedShips.join(', ')} from ${groupId}...`);
 
@@ -977,6 +1075,7 @@ async function unbanMembers(groupId: string, ships: string[]) {
     contactIds: normalizedShips,
   });
 
+  await verifyShipsBanned(groupId, normalizedShips, 'absent');
   console.log(`✅ Members unbanned.`);
 }
 
@@ -1038,6 +1137,7 @@ async function updateRole(
 // Assign a role to members
 async function assignRole(groupId: string, roleId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'assign roles');
 
   console.log(
     `Assigning role "${roleId}" to ${normalizedShips.join(', ')} in ${groupId}...`
@@ -1049,12 +1149,14 @@ async function assignRole(groupId: string, roleId: string, ships: string[]) {
     ships: normalizedShips,
   });
 
+  await verifyShipsHaveRole(groupId, normalizedShips, roleId, 'present');
   console.log(`✅ Role assigned.`);
 }
 
 // Remove a role from members
 async function removeRole(groupId: string, roleId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'remove roles');
 
   console.log(
     `Removing role "${roleId}" from ${normalizedShips.join(', ')} in ${groupId}...`
@@ -1066,6 +1168,7 @@ async function removeRole(groupId: string, roleId: string, ships: string[]) {
     ships: normalizedShips,
   });
 
+  await verifyShipsHaveRole(groupId, normalizedShips, roleId, 'absent');
   console.log(`✅ Role removed.`);
 }
 
@@ -1155,6 +1258,7 @@ async function addChannel(
 // Promote a member to admin by assigning them an admin role
 async function promoteMemberToAdmin(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'promote');
   await ensureAdminRole(groupId);
 
   console.log(
@@ -1167,12 +1271,14 @@ async function promoteMemberToAdmin(groupId: string, ships: string[]) {
     ships: normalizedShips,
   });
 
+  await verifyShipsHaveRole(groupId, normalizedShips, ADMIN_ROLE_ID, 'present');
   console.log(`✅ Members promoted to admin.`);
 }
 
 // Demote a member from admin by removing them from admin roles
 async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
   const normalizedShips = ships.map(normalizeShip);
+  await assertActingShipCanAdminister(groupId, 'demote');
   const group = await getGroup(groupId);
 
   // Find all admin roles this member might have
@@ -1199,6 +1305,7 @@ async function demoteMemberFromAdmin(groupId: string, ships: string[]) {
     });
   }
 
+  await verifyShipsHaveRole(groupId, normalizedShips, ADMIN_ROLE_ID, 'absent');
   console.log(`✅ Members demoted from admin.`);
 }
 

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -619,6 +619,11 @@ function getGroupHost(groupId: string): string {
  * A poke ack means "my ship forwarded this," not "the host applied it" — so this
  * reads the group's actual state and checks the acting ship is the host or an admin
  * before any mutation runs. `action` is the user-facing verb (e.g. "promote").
+ *
+ * Retries like the post-poke verification paths: on a foreign-hosted group the local
+ * snapshot can lag a just-granted admin role, so a single stale read shouldn't hard
+ * fail an action the host would now accept. The happy path returns on the first
+ * attempt; only a (transient or genuine) rejection waits.
  */
 async function assertActingShipCanAdminister(
   groupId: string,
@@ -626,17 +631,39 @@ async function assertActingShipCanAdminister(
 ): Promise<void> {
   const actingShip = normalizeShip(getCurrentUserId());
   const hostShip = getGroupHost(groupId);
-  const rawGroup = await getRawGroupForAdminVerification(groupId);
-  const result = actingShipCanAdminister(
-    rawGroup,
-    actingShip,
-    hostShip,
-    normalizeShip
-  );
 
-  if (!result.ok) {
-    throw new Error(`Can't ${action} in ${groupId}: ${result.reason}`);
+  let lastReason: string | null = null;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const rawGroup = await getRawGroupForAdminVerification(groupId);
+      const result = actingShipCanAdminister(
+        rawGroup,
+        actingShip,
+        hostShip,
+        normalizeShip
+      );
+      if (result.ok) {
+        return;
+      }
+      lastReason = result.reason;
+    } catch (err) {
+      lastError = err;
+    }
+
+    if (attempt < VERIFY_ATTEMPTS) {
+      await sleep(VERIFY_DELAY_MS);
+    }
   }
+
+  if (lastReason) {
+    throw new Error(`Can't ${action} in ${groupId}: ${lastReason}`);
+  }
+
+  throw new Error(
+    `Can't ${action} in ${groupId}: could not read group state: ${lastError}`
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes TLON-5954: broken admin promotion (and the other state-changing admin commands) in the `tlon-skill` `groups` CLI, where actions against a group hosted on another ship printed `✅` on a local poke ack even when the remote host rejected the change. The acting ship now confirms its permission before mutating and verifies the resulting state by scry before reporting success.

## Changes

- In `packages/tlon-skill/scripts/groups.ts`, added a pre-flight permission check (`assertActingShipCanAdminister`) that reads the group's actual state and refuses when the acting ship is neither the host nor an admin, with an error naming the acting ship and host plus a non-zero exit. It retries with the same `VERIFY_ATTEMPTS`/`VERIFY_DELAY_MS` as the verification paths so a stale local snapshot on a foreign-hosted group doesn't reject a just-granted admin; the happy path still returns on the first attempt.
- In `packages/tlon-skill/scripts/groups.ts`, added batched post-poke scry-poll verification (`verifyShips`, `verifyShipsHaveRole`, `verifyShipsAreAdmin`, `verifyShipsRemoved`, `verifyShipsBanned`) that confirms the change landed before printing `✅`, using one scry per attempt against all target ships and throwing naming only the still-unverified ships on failure.
- Wired the pre-flight check and verification into the 7 affected commands (promote, demote, assign-role, remove-role, kick, ban, unban) and replaced the unconditional `✅` lines with post-verification output. `assign-role`/`remove-role` verify the **specific role** was gained/lost; `promote`/`demote` verify **true admin status** — that the seat holds (or no longer holds) any role the group marks as admin (`admins`), not the literal `admin` role id; `kick` verifies the seat was removed; and `ban`/`unban` verify the ban-list state.
- Hardened the admin mutations against partial or false success (from review feedback):
  - `demote` removes **every** admin-marked role (sourced from `admins`, not just the literal `admin`) in a **single atomic `del-roles` seat poke**, so a self-inclusive demotion can't strip the caller's own admin role part-way through and get the remaining removals rejected — the backend checks `se-src-is-admin` once per action.
  - `demote` refuses to demote the **group host**, which is an admin unconditionally (`se-is-admin`), instead of stripping roles and reporting a no-op as success.
  - `promote` refuses an unmarked `admin`-role **collision**: if a group already has a non-admin role whose id is `admin`, `ensureAdminRole` throws rather than marking it admin, since marking it would grant admin to every existing holder of that role, not just the promote target.
- Added `packages/tlon-skill/scripts/commands/groups-verification.ts` with pure, side-effect-free predicates (`actingShipCanAdminister`, `seatHasRole`, `seatHasAdminRole`, `shipIsSeated`, `shipIsBanned`, `getShipRecordValue`) and the `RawGroupForAdminVerification` type, extended with `admissions.banned.ships`. The module avoids importing `./api-client` or `@tloncorp/api` so it stays unit-testable and passes the existing `command-contract.test.ts` forbidden-globals scan.
- Added `packages/tlon-skill/scripts/commands/groups-verification.test.ts` with bun:test coverage for host/admin/custom-admin-role/non-admin/absent ships, normalized-key lookups, role/seat/ban present-absent checks, partial multi-target failures that name only the unverified ship, and the admin-role-collision and partial-demote (still-admin) predicates.
- Moved `getShipRecordValue` and `RawGroupForAdminVerification` into the new module (`getShipRecordValue` now takes a `normalizeShip` argument) and updated the 5 `create-owned` callers accordingly.

## How did I test?

- `bun test ./scripts` (103 pass), including the new `groups-verification.test.ts` unit coverage.
- `bun test ./tests/hermetic` (135 pass).
- `pnpm typecheck` across src and test (clean).
- Reused the verification pattern already proven by `create-owned`'s `verifyOwnerAdmin`, which reads `/v2/ui/groups/{id}` rather than trusting the poke ack.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: `tlon-skill`

Notes for reviewers:
- The pre-flight check and verification add scry round-trips to these commands. The happy path stays fast (the pre-flight returns on its first attempt when the ship is already a synced admin/host); only a rejection or a lagging foreign-host snapshot waits out the retries (worst case about 2.5s, reusing `VERIFY_ATTEMPTS=5` / `VERIFY_DELAY_MS=500`).
- Admin permission and `promote`/`demote` verification are checked against the group's raw `admins` role-id list rather than the literal `admin` role, so custom admin roles work.
- ban/unban verification depends on `admissions.banned.ships` being present in the `/v2/ui/groups/{id}` response (confirmed against the `Admissions` interface in `packages/api/src/urbit/groups.ts`).
- Intentionally does not introduce `trackedPoke`: scry-polling the resulting state is the source of truth, which is correct for the foreign-host case where the host emits no rejection fact.
- No CLI syntax changes, no `@tloncorp/api` changes. Failure is signaled purely via a non-zero exit. The change stays out of the in-progress TLON-5771 `run(args, deps)` runner migration while extracting the new module in a way compatible with it.

## Rollback plan

Revert

## Out of scope / follow-ups
- `tlonbot` prompt-layer mitigations
