### PR TITLE
fix: call isSameDay in isLastPostOfBlock day-boundary check

### DIFF
--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -262,8 +262,9 @@ const Scroller = forwardRef(
         const isLastPostOfBlock =
           post.type !== 'notice' &&
           (post.type === 'chat' || post.type === 'reply') &&
-          ((nextItem && nextItem.authorId !== post.authorId) ||
-            !isSameDay(post.receivedAt ?? 0, nextItem?.receivedAt ?? 0));
+          nextItem != null &&
+          (nextItem.authorId !== post.authorId ||
+            !isSameDay(post.receivedAt ?? 0, nextItem.receivedAt ?? 0));
         const showAuthor =
           post.type === 'note' ||
           post.type === 'block' ||
@@ -800,7 +801,8 @@ const ScrollerItem = React.memo(BaseScrollerItem, (prev, next) => {
     prev.onLongPressPost === next.onLongPressPost &&
     prev.activeMessage === next.activeMessage &&
     prev.itemWidth === next.itemWidth &&
-    prev.displayDebugMode === next.displayDebugMode;
+    prev.displayDebugMode === next.displayDebugMode &&
+    prev.isLastPostOfBlock === next.isLastPostOfBlock;
 
   return isItemEqual && areOtherPropsEqual && isIndexEqual;
 });

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -262,7 +262,8 @@ const Scroller = forwardRef(
         const isLastPostOfBlock =
           post.type !== 'notice' &&
           (post.type === 'chat' || post.type === 'reply') &&
-          ((nextItem && nextItem.authorId !== post.authorId) || !isSameDay);
+          ((nextItem && nextItem.authorId !== post.authorId) ||
+            !isSameDay(post.receivedAt ?? 0, nextItem?.receivedAt ?? 0));
         const showAuthor =
           post.type === 'note' ||
           post.type === 'block' ||


### PR DESCRIPTION
## Summary
- In `Scroller.tsx`, `isLastPostOfBlock` used `!isSameDay` — negating the imported function reference rather than calling it. A function is always truthy, so the term was permanently `false` and the day-boundary condition never fired.
- Same-author message blocks were therefore never treated as ended at day breaks, giving wrong block-end spacing/styling right where the day divider splits a group.
- Fix mirrors the `isFirstPostOfDay` pattern a few lines up, but looks forward at `nextItem` (this check decides whether the *next* post starts a new block).

## Test plan
- [ ] Send messages from the same author spanning a day boundary; verify the earlier message gets block-end treatment before the date divider
- [ ] Verify normal same-day author grouping is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)