### PR TITLE
Mythos Cleanup: ui primitives fixes

### DIFF
--- a/packages/ui/src/components/Carousel.tsx
+++ b/packages/ui/src/components/Carousel.tsx
@@ -173,8 +173,8 @@ const _Carousel = React.forwardRef<
               onScroll={handleScroll}
               ref={scrollRef}
               scrollEventThrottle={33}
-              showsVerticalScrollIndicator={scrollDirection !== 'vertical'}
-              showsHorizontalScrollIndicator={scrollDirection !== 'horizontal'}
+              showsVerticalScrollIndicator={scrollDirection === 'vertical'}
+              showsHorizontalScrollIndicator={scrollDirection === 'horizontal'}
               snapToInterval={snapToInterval}
               renderItem={({ item, index }) => (
                 <CarouselItemContext.Provider value={{ index }}>

--- a/packages/ui/src/components/ConfirmDialog.tsx
+++ b/packages/ui/src/components/ConfirmDialog.tsx
@@ -45,9 +45,11 @@ export function ConfirmDialog({
         },
       },
     ]);
-    // Only run when open changes - not when callbacks are recreated
+    // Only run when open changes - not when callbacks are recreated. Other
+    // props in deps would re-fire a duplicate native Alert while one is
+    // already showing.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, title, description, confirmText, cancelText, destructive]);
+  }, [open]);
 
   // Web: use Tamagui Dialog
   if (Platform.OS === 'web') {

--- a/packages/ui/src/components/FilePreview.tsx
+++ b/packages/ui/src/components/FilePreview.tsx
@@ -85,8 +85,16 @@ FilePreview.fileExtensionFrom = (opts: {
     case 'video/mp4':
       return 'mp4';
     default:
-      return (
-        opts.filename?.split('.').at(-1) ?? opts.uri?.split('.').at(-1) ?? null
-      );
+      return extensionOf(opts.filename) ?? extensionOf(opts.uri) ?? null;
   }
 };
+
+function extensionOf(name?: string): string | null {
+  if (name == null) {
+    return null;
+  }
+  const segments = name.split('.');
+  // without a dot there is no extension; the old `.at(-1)` fallback returned
+  // the entire string (e.g. a full URL) as the "extension"
+  return segments.length > 1 ? segments.at(-1) ?? null : null;
+}

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -115,5 +115,9 @@ function isValidImageSource(source: any) {
 }
 
 function isPlaceholderAsset(source: any) {
-  return typeof source === 'object' && source.uri === PLACEHOLDER_ASSET_URI;
+  return (
+    source != null &&
+    typeof source === 'object' &&
+    source.uri === PLACEHOLDER_ASSET_URI
+  );
 }

--- a/packages/ui/src/components/Pressable.tsx
+++ b/packages/ui/src/components/Pressable.tsx
@@ -106,7 +106,7 @@ const Pressable = forwardRef<any, PressableProps>(
     // On web, we skip this check as it interferes with styled() components
     const hasInteractionHandler = isWeb
       ? true // Always consider web components interactive
-      : (action == null ? onPress : onPressLink) ||
+      : ((to ?? action) == null ? onPress : onPressLink) ||
         onPressIn ||
         onPressOut ||
         onLongPress;

--- a/packages/ui/src/hooks/useCopy.ts
+++ b/packages/ui/src/hooks/useCopy.ts
@@ -1,21 +1,28 @@
 import * as Clipboard from 'expo-clipboard';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export function useCopy(copied: string) {
   const [didCopy, setDidCopy] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const doCopy = useCallback(async () => {
     await Clipboard.setStringAsync(copied);
     setDidCopy(true);
 
-    const timeout = setTimeout(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
       setDidCopy(false);
     }, 2000);
-
-    return () => {
-      setDidCopy(false);
-      clearTimeout(timeout);
-    };
   }, [copied]);
 
   return { doCopy, didCopy };


### PR DESCRIPTION
## Summary

Part of the Mythos Cleanup audit (see #5908, #5909, #5910). Six small correctness fixes in `packages/ui`:

- **Image `isPlaceholderAsset`** — `typeof null === 'object'`, so a null source threw on `source.uri`. Added a null guard.
- **`useCopy`** — the 2s reset timeout's cleanup closure was returned from `doCopy` but no caller ever invoked it: repeated copies stacked timers and unmount left a pending `setState`. The timer now lives in a ref, is cleared on re-copy, and cleared on unmount.
- **Carousel** — scroll indicator conditions were inverted (`!==` instead of `===`), showing the cross-axis indicator and hiding the scroll-axis one.
- **ConfirmDialog** — the effect's comment says "only run when open changes," but deps included title/description/etc., so a prop change while open re-fired a duplicate native Alert. Deps are now `[open]`.
- **FilePreview `fileExtensionFrom`** — `split('.').at(-1)` returns the whole string when there's no dot, so extensionless filenames/URLs were rendered as the "extension." Now returns null when no dot exists.
- **Pressable** — `hasInteractionHandler` only counted the link handler when `action` was set; a `to`-only Pressable with no explicit `onPress` was marked non-interactive and disabled, blocking navigation. Now counts the link handler whenever `to` or `action` is present (matching the render-path `onPressLink ?? onPress` logic).

## Test plan

- [ ] `pnpm tsc` in packages/ui (passes locally)
- [ ] Copy a code/link twice quickly — "Copied" indicator resets correctly, no flicker from stacked timers
- [ ] Open a vertical media carousel — vertical indicator shows, horizontal doesn't
- [ ] Mobile: open a ConfirmDialog and trigger a prop update — only one Alert appears
- [ ] Attach a file with no extension — no full-URL label baked into the file icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)