### PR TITLE
Mythos Cleanup: mobile shell fixes

### DIFF
--- a/apps/tlon-mobile/src/App.main.tsx
+++ b/apps/tlon-mobile/src/App.main.tsx
@@ -61,15 +61,15 @@ const useSplashHider = () => {
 
   useEffect(() => {
     const onComplete = () => {
-      try {
-        withRetry(async () => {
-          await SplashScreen.hideAsync();
-          setSplashHidden(true);
-          splashscreenLogger.trackEvent('Splash screen hidden');
-        });
-      } catch (err) {
+      withRetry(async () => {
+        await SplashScreen.hideAsync();
+        setSplashHidden(true);
+        splashscreenLogger.trackEvent('Splash screen hidden');
+      }).catch((err) => {
+        // withRetry returns a promise; a try/catch around the call can't
+        // observe its rejection
         splashscreenLogger.trackError('Failed to hide splash screen', err);
-      }
+      });
     };
 
     // check if progress completed before mounting

--- a/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
+++ b/apps/tlon-mobile/src/hooks/useDeepLinkListener.ts
@@ -55,7 +55,9 @@ export const useDeepLinkListener = () => {
                 lure.invitedGroupId
               );
 
-              store.redeemInviteIfNeeded(lure);
+              store.redeemInviteIfNeeded(lure).catch((e) => {
+                logger.error('Failed to redeem invite', lure, e);
+              });
               const previewGroupId = lure.invitedGroupId || lure.group;
               if (previewGroupId) {
                 reset([

--- a/apps/tlon-mobile/src/lib/hostingAuth.ts
+++ b/apps/tlon-mobile/src/lib/hostingAuth.ts
@@ -16,6 +16,7 @@ export async function refreshHostingAuth(options: { force?: boolean } = {}) {
 
   if (__DEV__) {
     logger.log('development mode, skipping');
+    return;
   }
 
   const expired = await db.hostingAuthExpired.getValue();


### PR DESCRIPTION
## Summary

Part of the Mythos Cleanup audit (see #5908, #5909, #5910, #5911). Three small fixes in `apps/tlon-mobile`:

- **App.main `useSplashHider`** — `try { withRetry(...) } catch` can't observe an async rejection, so a persistent `SplashScreen.hideAsync` failure was an unhandled rejection and `trackError` never fired. Now handled with `.catch`.
- **`useDeepLinkListener`** — `store.redeemInviteIfNeeded(lure)` was fire-and-forget with no rejection handler; a failed redeem produced an unhandled rejection and no log.
- **`hostingAuth.refreshHostingAuth`** — the `__DEV__` guard logged "development mode, skipping" but didn't `return`, so dev builds hit the hosting heartbeat anyway.

## Test plan

- [ ] `pnpm tsc` in apps/tlon-mobile (passes locally)
- [ ] Dev build: confirm "skipping" log with no subsequent hosting heartbeat request
- [ ] Launch app normally — splash hides as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)