### PR TITLE
Mythos Cleanup: web app fixes

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -469,7 +469,6 @@ function ConnectedWebApp() {
   const session = store.useCurrentSession();
   const hasSyncedRef = React.useRef(false);
   const telemetry = useTelemetry();
-  useFindSuggestedContacts();
 
   const isNewSignup = useMemo(() => {
     return logic.detectWebSignup();

--- a/apps/tlon-web/src/logic/useAppUpdates.ts
+++ b/apps/tlon-web/src/logic/useAppUpdates.ts
@@ -65,7 +65,8 @@ export default function useAppUpdates() {
       } else if (initialHash !== pike.hash && !needsUpdate) {
         // wait 5 minutes before showing the update prompt in case there
         // are multiple updates in quick succession
-        setTimeout(() => setNeedsUpdate(true), 5 * 60 * 1000);
+        const timeout = setTimeout(() => setNeedsUpdate(true), 5 * 60 * 1000);
+        return () => clearTimeout(timeout);
       }
     }
   }, [pike, initialHash, needsUpdate]);

--- a/apps/tlon-web/vite.config.mts
+++ b/apps/tlon-web/vite.config.mts
@@ -44,6 +44,14 @@ export default ({ mode }: { mode: string }) => {
   const shouldUploadSourcemaps =
     process.env.CI === 'true' && Boolean(process.env.SENTRY_AUTH_TOKEN);
 
+  // why-did-you-render's jsx runtime wraps every createElement call and pulls
+  // the library into the bundle, so only opt in when WDYR is actually enabled
+  // (see src/wdyr.ts) rather than in every production build
+  const wdyrJsxImportSource =
+    process.env.VITE_ENABLE_WDYR === 'true'
+      ? '@welldone-software/why-did-you-render'
+      : undefined;
+
   // eslint-disable-next-line
   const base = (mode: string) => {
     console.log('mode', mode);
@@ -65,7 +73,7 @@ export default ({ mode }: { mode: string }) => {
       return [
         basicSsl() as Plugin,
         react({
-          jsxImportSource: '@welldone-software/why-did-you-render',
+          jsxImportSource: wdyrJsxImportSource,
         }) as PluginOption[],
       ];
     }
@@ -81,7 +89,7 @@ export default ({ mode }: { mode: string }) => {
               'react-native-worklets/plugin',
             ],
           },
-          jsxImportSource: '@welldone-software/why-did-you-render',
+          jsxImportSource: wdyrJsxImportSource,
         }) as PluginOption[],
         svgr({
           include: '**/*.svg',
@@ -113,7 +121,7 @@ export default ({ mode }: { mode: string }) => {
             'react-native-worklets/plugin',
           ],
         },
-        jsxImportSource: '@welldone-software/why-did-you-render',
+        jsxImportSource: wdyrJsxImportSource,
       }) as PluginOption[],
       svgr({
         include: '**/*.svg',


### PR DESCRIPTION
## Summary

Part of the Mythos Cleanup audit (see #5908, #5909, #5910, #5911, #5912). Three fixes in `apps/tlon-web`:

- **Drop why-did-you-render from production bundles** — all three plugin branches in `vite.config.mts` set `jsxImportSource: '@welldone-software/why-did-you-render'`, which routes every `createElement` through WDYR's jsx runtime and pulls the library into prod/electron builds. Meanwhile the actual WDYR init in `src/main.tsx` is commented out, so this was pure overhead. The import source is now gated behind `VITE_ENABLE_WDYR=true` (the same flag the commented-out init references).
- **Duplicate `useFindSuggestedContacts`** — `ConnectedWebApp` called it directly and again via the `AppRoutes` child it renders, running the suggestion scan twice. Removed the parent call.
- **`useAppUpdates`** — the 5-minute "show update prompt" `setTimeout` was never cleared, so it could fire `setNeedsUpdate` after unmount.

## Test plan

- [ ] `pnpm tsc` in apps/tlon-web (passes locally)
- [ ] `pnpm build:web` succeeds and the bundle no longer includes `@welldone-software/why-did-you-render`
- [ ] Dev: `VITE_ENABLE_WDYR=true` + re-enabling the wdyr.ts import still works
- [ ] Web app loads and contact suggestions still populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)