### PR TITLE
fix: e2e docker build broken by n package takedown

### DIFF
--- a/apps/tlon-web/rube/Dockerfile
+++ b/apps/tlon-web/rube/Dockerfile
@@ -1,11 +1,12 @@
 # syntax=docker/dockerfile:1.4
 # E2E Test Container for Tlon Web
-FROM ubuntu:22.04
+# Node version pinned to match .nvmrc
+FROM node:22.22.0-bookworm
 
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies
+# Install system dependencies (some already present in the base image; kept explicit)
 RUN apt-get update && apt-get install -y \
     curl \
     git \
@@ -15,13 +16,6 @@ RUN apt-get update && apt-get install -y \
     lsof \
     procps \
     && rm -rf /var/lib/apt/lists/*
-
-# Install Node.js (match version from .nvmrc)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
-    && npm install -g n \
-    && n 22.22.0 \
-    && hash -r
 
 # Install pnpm
 RUN npm install -g pnpm@9.0.5


### PR DESCRIPTION
## Summary

Fixes the "Build E2E Docker Image" step that was failing for every PR with `/bin/sh: 1: n: not found`. The npm package `n` (Node version manager) was replaced on the registry with an empty security-holding stub (`n@0.0.1-security`, published as `latest` on 2026-06-09), so `npm install -g n` now installs a placeholder with no binary. This PR switches the e2e image to the official `node:22.22.0-bookworm` base, removing the dependency on `n` and the live NodeSource setup script entirely.

## Security note: were we exposed?

No. What happened to `n`: on 2026-06-09 at 17:27 UTC, npm staff replaced its `latest` dist-tag with an empty security-holding stub — most likely a preemptive lock amid the ongoing [Shai-Hulud "Miasma" npm worm campaign](https://www.sonatype.com/blog/new-shai-hulud-miasma-wave-hits-hundreds-of-npm-packages), since no malicious version was ever published: three independent registry observers (deps.dev, npmmirror, jsDelivr) all confirm nothing ever existed between the legitimate `10.2.0` (May 2025) and the stub. Our last pre-takedown CI build (17:19 UTC) installed the legitimate, functional `n`; every build after got the inert stub and failed — loudly, not maliciously. Legitimate `n` has no install scripts (it's a plain bash script), and the install ran inside `docker build` where no CI secrets are present. Local dev machines are unaffected unless someone ran `npm install -g n` — and even then, the registry never served a bad version. No credential rotation required.


## Changes

- In `apps/tlon-web/rube/Dockerfile`, changed the base image from `ubuntu:22.04` to `node:22.22.0-bookworm`, pinning the exact Node patch version from `.nvmrc`
- Removed the Node install layer (NodeSource setup script piped to bash, `npm install -g n`, `n 22.22.0`), eliminating both unpinned external build-time dependencies
- Kept the apt system-dependency list verbatim (same package names on bookworm; a few are already present in the base image, which is harmless)
- All subsequent layers are unchanged: pnpm 9.0.5, Playwright `install --with-deps chromium` (Playwright supports bookworm), ship downloads, `build:packages`

## How did I test?

- Reproduced the failure in a clean `ubuntu:22.04` container to confirm the root cause (registry stub, not a code change; CI runners have no Docker layer cache, so every run re-ran the broken install and all branches failed simultaneously)
- Rebuilt the image locally with `pnpm e2e:parallel:build` and verified `node -v` inside the image reports v22.22.0
- This PR's own e2e CI job is the final verification: it builds the image and runs the test shards
- Example failed run for reference: https://github.com/tloncorp/tlon-apps/actions/runs/27224164409

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: N/A


## Rollback plan

Revert.
