### PR TITLE
fix: add left padding to voice memo recorder

### DIFF
--- a/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
@@ -66,10 +66,7 @@ export const AudioRecorder = forwardRef<
       }) => void;
       onCancel?: (audioFilePath: string | null) => void;
       dangerouslyOverrideIsAudioAvailable?: boolean;
-      /** If provided, will use this number as a paddingHorizontal *except* for
-       * leading edge of waveform. Use this instead of paddingHorizontal to
-       * show waveform starting flush against the left edge of the container
-       * while still having padding on the right edge. */
+      /** Horizontal padding applied to both edges of the container. */
       contentInsetHorizontal?: number;
     } & (
       | {
@@ -374,7 +371,7 @@ export const AudioRecorder = forwardRef<
       {...(contentInsetHorizontal == null
         ? null
         : {
-            paddingStart: state.live ? undefined : contentInsetHorizontal,
+            paddingStart: contentInsetHorizontal,
             paddingEnd: contentInsetHorizontal,
           })}
       {...forwardedProps}


### PR DESCRIPTION
## Summary

While recording a voice memo, the recorder had no left padding — the dotted waveform ran flush against the left edge of the sheet, while the right side (timer + stop button) was properly inset.

## Changes

- `AudioRecorder` now applies `contentInsetHorizontal` as `paddingStart` while recording too — before, it was only applied during playback, leaving the waveform flush left while recording.

The flush-left look was on purpose at the component level — [f1dd723ea](https://github.com/tloncorp/tlon-apps/commit/f1dd723ea5c9a241303685c783c394d636610a19) added `contentInsetHorizontal` specifically to keep the recording waveform flush against the container edge, which presumably made sense for a container whose edge wasn't the screen edge. In the current recorder sheet it is the screen edge, so the waveform running off the edge just looks broken. If flush-left is ever wanted again, callers can pass `contentInsetHorizontal` per edge — no caller currently sets it.

## How did I test?

- Ran the iOS app on an iPhone 17 Pro simulator, started a voice memo from the attachment sheet in a chat channel, and checked that the waveform now starts with the same inset as the right edge — both while recording and after stopping.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: voice memo recorder (visual-only)

## Rollback plan

Revert this commit.

## Screenshots / videos

Before (recording) | After (recording) | After (stopped)
:---:|:---:|:---:
<img width="390" height="407" alt="image" src="https://github.com/user-attachments/assets/7744bd9c-d5b6-442d-84c4-2927dfb649d2" /> | <img width="391" height="396" alt="image" src="https://github.com/user-attachments/assets/aa2756b8-5ff2-4304-97dc-f9756643dc47" /> | <img width="391" height="396" alt="image" src="https://github.com/user-attachments/assets/a72969ec-73da-439c-b908-93d09d46e0cf" />
