### PR TITLE
feat: tap or drag voice memo waveform to seek

### DIFF
--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -64,6 +64,9 @@ const DUMMY_WAVEFORM_VALUES = [
   1, 0.5, 1, 0.2, 0.8, 0.4, 0.6, 0.3, 0.7, 0.1, 0.9, 0.5, 1, 0.4, 0.6,
 ];
 
+const WAVEFORM_CANDLE_WIDTH = 3;
+const WAVEFORM_CANDLE_SPACING = 1;
+
 export const BlockWrapper = styled(View, {
   name: 'ContentBlock',
   context: ContentContext,
@@ -267,7 +270,15 @@ export function VoiceMemoBlock({
     if (duration === 0 || width <= 0) {
       return;
     }
-    seekTo(clamp(x / width, 0, 1) * duration);
+    // The waveform draws whole candles only, so its drawn strip can be
+    // narrower than the container; map the gesture over the strip so
+    // positions line up with the candles.
+    const candleSize = WAVEFORM_CANDLE_WIDTH + WAVEFORM_CANDLE_SPACING;
+    const drawnExtent = Math.floor(width / candleSize) * candleSize;
+    if (drawnExtent <= 0) {
+      return;
+    }
+    seekTo(clamp(x / drawnExtent, 0, 1) * duration);
   });
 
   // throttled so scrubbing doesn't spam the native player with seeks
@@ -368,8 +379,8 @@ export function VoiceMemoBlock({
                 }}
               >
                 <Waveform
-                  candleWidth={3}
-                  candleSpacing={1}
+                  candleWidth={WAVEFORM_CANDLE_WIDTH}
+                  candleSpacing={WAVEFORM_CANDLE_SPACING}
                   candlePlaybackPosition={candlePlaybackPosition}
                   values={
                     block.voiceMemo.waveformPreview ?? DUMMY_WAVEFORM_VALUES

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -288,11 +288,14 @@ export function VoiceMemoBlock({
   );
 
   const seekGesture = useMemo(() => {
+    const hitSlop = { top: 12, bottom: 12 };
     const tap = Gesture.Tap()
       .runOnJS(true)
+      .hitSlop(hitSlop)
       .onEnd((e) => seekToWaveformX(e.x));
     const pan = Gesture.Pan()
       .runOnJS(true)
+      .hitSlop(hitSlop)
       // activate on horizontal drags only, leaving vertical scrolling to the
       // channel list
       .activeOffsetX([-10, 10])
@@ -371,9 +374,10 @@ export function VoiceMemoBlock({
             <GestureDetector gesture={seekGesture}>
               <View
                 flex={1}
-                // enlarge the touch target beyond the waveform's 22px height
-                paddingVertical={12}
-                marginVertical={-12}
+                // expands UIKit hit testing so slop touches reach the
+                // gesture handler on iOS; the gestures' own hitSlop covers
+                // RNGH's bounds check (and Android)
+                hitSlop={{ top: 12, bottom: 12 }}
                 onLayout={(e) => {
                   waveformWidthRef.current = e.nativeEvent.layout.width;
                 }}

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -257,8 +257,15 @@ export function VoiceMemoBlock({
   block,
   ...props
 }: { block: cn.VoiceMemoBlockData } & ComponentProps<typeof Reference.Frame>) {
-  const { togglePlayback, seekTo, progress, status, isThisSourceLoaded } =
-    useNowPlayingController({ sourceUri: block.voiceMemo.fileUri });
+  const {
+    togglePlayback,
+    seekTo,
+    beginScrub,
+    endScrub,
+    progress,
+    status,
+    isThisSourceLoaded,
+  } = useNowPlayingController({ sourceUri: block.voiceMemo.fileUri });
 
   const waveformWidthRef = useRef(0);
   const seekToWaveformX = useMutableCallback((x: number) => {
@@ -300,13 +307,16 @@ export function VoiceMemoBlock({
       // channel list
       .activeOffsetX([-10, 10])
       .failOffsetY([-10, 10])
+      // pause a playing memo while scrubbing, resume on release
+      .onStart(() => beginScrub())
       .onUpdate((e) => throttledSeekToWaveformX(e.x))
       .onEnd((e) => {
         throttledSeekToWaveformX.cancel();
         seekToWaveformX(e.x);
-      });
+      })
+      .onFinalize(() => endScrub());
     return Gesture.Race(pan, tap);
-  }, [seekToWaveformX, throttledSeekToWaveformX]);
+  }, [seekToWaveformX, throttledSeekToWaveformX, beginScrub, endScrub]);
 
   const candlePlaybackPosition = useMemo(() => {
     const candleCount = block.voiceMemo.waveformPreview

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -270,10 +270,14 @@ export function VoiceMemoBlock({
   const waveformWidthRef = useRef(0);
   const seekToWaveformX = useMutableCallback((x: number) => {
     const width = waveformWidthRef.current;
-    const duration =
+    // the loaded duration can be 0 before expo-audio has determined it; fall
+    // back to the memo's metadata duration
+    const loadedDuration =
       progress?.loadState === 'loaded' && isThisSourceLoaded
         ? progress.duration
-        : block.voiceMemo.duration ?? 0;
+        : 0;
+    const duration =
+      loadedDuration > 0 ? loadedDuration : block.voiceMemo.duration ?? 0;
     if (duration === 0 || width <= 0) {
       return;
     }

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -260,15 +260,14 @@ export function VoiceMemoBlock({
   const waveformWidthRef = useRef(0);
   const seekToWaveformX = useMutableCallback((x: number) => {
     const width = waveformWidthRef.current;
-    if (
-      progress?.loadState !== 'loaded' ||
-      !isThisSourceLoaded ||
-      progress.duration === 0 ||
-      width <= 0
-    ) {
+    const duration =
+      progress?.loadState === 'loaded' && isThisSourceLoaded
+        ? progress.duration
+        : block.voiceMemo.duration ?? 0;
+    if (duration === 0 || width <= 0) {
       return;
     }
-    seekTo(clamp(x / width, 0, 1) * progress.duration);
+    seekTo(clamp(x / width, 0, 1) * duration);
   });
 
   // throttled so scrubbing doesn't spam the native player with seeks

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -1,4 +1,5 @@
 import { isValidUrl, makePrettyTimeFromMs } from '@tloncorp/api/lib/utils';
+import { useMutableCallback } from '@tloncorp/shared';
 import type * as cn from '@tloncorp/shared/logic';
 import {
   ForwardingProps,
@@ -10,7 +11,7 @@ import {
   useCopy,
 } from '@tloncorp/ui';
 import { ImageLoadEventData } from 'expo-image';
-import { clamp } from 'lodash';
+import { clamp, throttle } from 'lodash';
 import React, {
   ComponentProps,
   ComponentType,
@@ -30,7 +31,11 @@ import {
   Platform,
   View as RNView,
 } from 'react-native';
-import { ScrollView as GHScrollView } from 'react-native-gesture-handler';
+import {
+  ScrollView as GHScrollView,
+  Gesture,
+  GestureDetector,
+} from 'react-native-gesture-handler';
 import { ScrollView, View, ViewStyle, XStack, YStack, styled } from 'tamagui';
 
 import { useNowPlayingController } from '../../contexts/nowPlaying';
@@ -249,8 +254,46 @@ export function VoiceMemoBlock({
   block,
   ...props
 }: { block: cn.VoiceMemoBlockData } & ComponentProps<typeof Reference.Frame>) {
-  const { togglePlayback, progress, status, isThisSourceLoaded } =
+  const { togglePlayback, seekTo, progress, status, isThisSourceLoaded } =
     useNowPlayingController({ sourceUri: block.voiceMemo.fileUri });
+
+  const waveformWidthRef = useRef(0);
+  const seekToWaveformX = useMutableCallback((x: number) => {
+    const width = waveformWidthRef.current;
+    if (
+      progress?.loadState !== 'loaded' ||
+      !isThisSourceLoaded ||
+      progress.duration === 0 ||
+      width <= 0
+    ) {
+      return;
+    }
+    seekTo(clamp(x / width, 0, 1) * progress.duration);
+  });
+
+  // throttled so scrubbing doesn't spam the native player with seeks
+  const throttledSeekToWaveformX = useMemo(
+    () => throttle(seekToWaveformX, 100),
+    [seekToWaveformX]
+  );
+
+  const seekGesture = useMemo(() => {
+    const tap = Gesture.Tap()
+      .runOnJS(true)
+      .onEnd((e) => seekToWaveformX(e.x));
+    const pan = Gesture.Pan()
+      .runOnJS(true)
+      // activate on horizontal drags only, leaving vertical scrolling to the
+      // channel list
+      .activeOffsetX([-10, 10])
+      .failOffsetY([-10, 10])
+      .onUpdate((e) => throttledSeekToWaveformX(e.x))
+      .onEnd((e) => {
+        throttledSeekToWaveformX.cancel();
+        seekToWaveformX(e.x);
+      });
+    return Gesture.Race(pan, tap);
+  }, [seekToWaveformX, throttledSeekToWaveformX]);
 
   const candlePlaybackPosition = useMemo(() => {
     const candleCount = block.voiceMemo.waveformPreview
@@ -315,13 +358,29 @@ export function VoiceMemoBlock({
             })()}
           </Pressable>
           <XStack flex={1} gap={9} alignItems="center">
-            <Waveform
-              candleWidth={3}
-              candleSpacing={1}
-              candlePlaybackPosition={candlePlaybackPosition}
-              values={block.voiceMemo.waveformPreview ?? DUMMY_WAVEFORM_VALUES}
-              style={{ flex: 1, height: 22 }}
-            />
+            <GestureDetector gesture={seekGesture}>
+              <View
+                flex={1}
+                // enlarge the touch target beyond the waveform's 22px height
+                paddingVertical={12}
+                marginVertical={-12}
+                onLayout={(e) => {
+                  waveformWidthRef.current = e.nativeEvent.layout.width;
+                }}
+              >
+                <Waveform
+                  candleWidth={3}
+                  candleSpacing={1}
+                  candlePlaybackPosition={candlePlaybackPosition}
+                  values={
+                    block.voiceMemo.waveformPreview ?? DUMMY_WAVEFORM_VALUES
+                  }
+                  // the Skia canvas would otherwise capture touches meant for
+                  // the seek gesture
+                  style={{ height: 22, pointerEvents: 'none' }}
+                />
+              </View>
+            </GestureDetector>
             {block.voiceMemo.duration != null && (
               <Text size="$label/s" color="$secondaryText">
                 {progress?.loadState === 'loaded'

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -283,9 +283,11 @@ export function VoiceMemoBlock({
     }
     // The waveform draws whole candles only, so its drawn strip can be
     // narrower than the container; map the gesture over the strip so
-    // positions line up with the candles.
+    // positions line up with the candles. The last candle ends one spacing
+    // short of the candle slots, so drop the trailing spacing.
     const candleSize = WAVEFORM_CANDLE_WIDTH + WAVEFORM_CANDLE_SPACING;
-    const drawnExtent = Math.floor(width / candleSize) * candleSize;
+    const candleCount = Math.floor(width / candleSize);
+    const drawnExtent = candleCount * candleSize - WAVEFORM_CANDLE_SPACING;
     if (drawnExtent <= 0) {
       return;
     }

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -188,6 +188,19 @@ export function NowPlayingProvider({
       },
       async seekTo(seconds: number) {
         await audioPlayer.seekTo(seconds);
+
+        // Emit synthetic progress immediately so the UI updates without
+        // waiting for the next native playbackStatusUpdate tick (which may
+        // not come at all while paused)
+        if (mediaItemRef.current) {
+          eventEmitter.emit('progress', {
+            sourceUrl: mediaItemRef.current.url,
+            isPlaying: isPlayingRef.current,
+            loadState: 'loaded',
+            currentTime: seconds,
+            duration: toSeconds(audioPlayer.duration),
+          });
+        }
       },
       get nowPlaying() {
         return mediaItemRef.current;
@@ -375,6 +388,14 @@ export function useNowPlayingController({
     }
   }, [nowPlaying, sourceUri, isThisSourceLoaded]);
 
+  const seekTo = useCallback(
+    (seconds: number) => {
+      if (!isThisSourceLoaded) return;
+      nowPlaying.seekTo(seconds);
+    },
+    [nowPlaying, isThisSourceLoaded]
+  );
+
   const status = useMemo<null | 'playing' | 'paused' | 'loading'>(() => {
     // Playback requested but not confirmed by expo-audio yet
     if (playbackIntent && !progress?.isPlaying) {
@@ -411,6 +432,7 @@ export function useNowPlayingController({
 
   return {
     togglePlayback,
+    seekTo,
     progress,
     status,
     isThisSourceLoaded,

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -416,11 +416,12 @@ export function useNowPlayingController({
     }
   }, [nowPlaying, sourceUri, isThisSourceLoaded, loadSource]);
 
-  // Seeking an unloaded source loads it (paused) first. While the load is in
-  // flight, remember only the latest requested position so scrubbing doesn't
-  // race multiple loads.
-  const pendingSeekRef = useRef<number | null>(null);
-  const isLoadingForSeekRef = useRef(false);
+  // Seeking an unloaded source loads it (paused) first. The guard and pending
+  // position are keyed by url so that if this hook is reused for a different
+  // memo mid-load, the new seek isn't blocked by the old load and the old
+  // load can't apply its position to the new source.
+  const pendingSeekRef = useRef<{ url: string; seconds: number } | null>(null);
+  const seekLoadUrlRef = useRef<string | null>(null);
   const seekTo = useCallback(
     (seconds: number) => {
       if (sourceUri == null) return;
@@ -433,22 +434,31 @@ export function useNowPlayingController({
         });
         return;
       }
-      pendingSeekRef.current = seconds;
-      if (isLoadingForSeekRef.current) return;
-      isLoadingForSeekRef.current = true;
+      // remember only the latest requested position for this url so scrubbing
+      // doesn't race multiple loads
+      pendingSeekRef.current = { url: sourceUri, seconds };
+      if (seekLoadUrlRef.current === sourceUri) return;
+      const url = sourceUri;
+      seekLoadUrlRef.current = url;
       loadSource()
         .then(() => {
-          if (pendingSeekRef.current != null) {
+          const pending = pendingSeekRef.current;
+          if (pending != null && pending.url === url) {
             // hold the guard until the seek itself completes
-            return nowPlaying.seekTo(pendingSeekRef.current);
+            return nowPlaying.seekTo(pending.seconds);
           }
         })
         .catch((e) => {
           console.error('Failed to load voice memo for seek', e);
         })
         .finally(() => {
-          isLoadingForSeekRef.current = false;
-          pendingSeekRef.current = null;
+          // only clear if a newer seek-load for another url hasn't taken over
+          if (seekLoadUrlRef.current === url) {
+            seekLoadUrlRef.current = null;
+          }
+          if (pendingSeekRef.current?.url === url) {
+            pendingSeekRef.current = null;
+          }
         });
     },
     [nowPlaying, sourceUri, isThisSourceLoaded, loadSource]

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -420,6 +420,23 @@ export function useNowPlayingController({
     [nowPlaying, sourceUri, isThisSourceLoaded]
   );
 
+  // Scrubbing pauses a playing source for the duration of the gesture and
+  // resumes it on release.
+  const wasPlayingBeforeScrubRef = useRef(false);
+  const beginScrub = useCallback(() => {
+    wasPlayingBeforeScrubRef.current =
+      isThisSourceLoaded && nowPlaying.isPlaying;
+    if (wasPlayingBeforeScrubRef.current) {
+      nowPlaying.pause();
+    }
+  }, [nowPlaying, isThisSourceLoaded]);
+  const endScrub = useCallback(() => {
+    if (wasPlayingBeforeScrubRef.current) {
+      wasPlayingBeforeScrubRef.current = false;
+      nowPlaying.play();
+    }
+  }, [nowPlaying]);
+
   const status = useMemo<null | 'playing' | 'paused' | 'loading'>(() => {
     // Playback requested but not confirmed by expo-audio yet
     if (playbackIntent && !progress?.isPlaying) {
@@ -457,6 +474,8 @@ export function useNowPlayingController({
   return {
     togglePlayback,
     seekTo,
+    beginScrub,
+    endScrub,
     progress,
     status,
     isThisSourceLoaded,

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -359,20 +359,32 @@ export function useNowPlayingController({
 
   // Play and seek share one in-flight load of this source: a second
   // replace() for the same URL would supersede the first one in the provider
-  // and reject its callbacks (dropping a pending play or seek).
-  const inFlightLoadRef = useRef<Promise<void> | null>(null);
+  // and reject its callbacks (dropping a pending play or seek). Keyed by url
+  // so a sourceUri change mid-load (this hook can be reused for a different
+  // memo) starts a fresh load instead of reusing the stale promise.
+  const inFlightLoadRef = useRef<{
+    url: string;
+    promise: Promise<void>;
+  } | null>(null);
   const loadSource = useCallback(() => {
     if (sourceUri == null) {
       return Promise.reject(new Error('No source to load'));
     }
-    if (inFlightLoadRef.current == null) {
-      inFlightLoadRef.current = nowPlaying
-        .replace({ url: sourceUri })
-        .finally(() => {
-          inFlightLoadRef.current = null;
-        });
+    const existing = inFlightLoadRef.current;
+    if (existing != null && existing.url === sourceUri) {
+      return existing.promise;
     }
-    return inFlightLoadRef.current;
+    const entry: { url: string; promise: Promise<void> } = {
+      url: sourceUri,
+      promise: nowPlaying.replace({ url: sourceUri }).finally(() => {
+        // only clear if a newer load hasn't replaced this entry
+        if (inFlightLoadRef.current === entry) {
+          inFlightLoadRef.current = null;
+        }
+      }),
+    };
+    inFlightLoadRef.current = entry;
+    return entry.promise;
   }, [nowPlaying, sourceUri]);
 
   const togglePlayback = useCallback(() => {
@@ -416,7 +428,9 @@ export function useNowPlayingController({
       // checking it covers the gap before the progress event re-renders
       // `isThisSourceLoaded`
       if (isThisSourceLoaded || nowPlaying.nowPlaying?.url === sourceUri) {
-        nowPlaying.seekTo(seconds);
+        nowPlaying.seekTo(seconds).catch((e) => {
+          console.error('Failed to seek voice memo', e);
+        });
         return;
       }
       pendingSeekRef.current = seconds;

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -19,7 +19,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Platform } from 'react-native';
 
 import { useAppStatusChange } from '../../hooks/useAppStatusChange';
 
@@ -179,8 +178,8 @@ export function NowPlayingProvider({
             sourceUrl: mediaItemRef.current.url,
             isPlaying: false,
             loadState: 'loaded',
-            currentTime: toSeconds(audioPlayer.currentTime),
-            duration: toSeconds(audioPlayer.duration),
+            currentTime: audioPlayer.currentTime,
+            duration: audioPlayer.duration,
           });
         }
 
@@ -198,7 +197,7 @@ export function NowPlayingProvider({
             isPlaying: isPlayingRef.current,
             loadState: 'loaded',
             currentTime: seconds,
-            duration: toSeconds(audioPlayer.duration),
+            duration: audioPlayer.duration,
           });
         }
       },
@@ -233,8 +232,8 @@ export function NowPlayingProvider({
         const playback: PlaybackState = status.isLoaded
           ? {
               loadState: 'loaded',
-              currentTime: toSeconds(status.currentTime),
-              duration: toSeconds(status.duration),
+              currentTime: status.currentTime,
+              duration: status.duration,
             }
           : { loadState: status.isBuffering ? 'loading' : 'empty' };
 
@@ -462,13 +461,4 @@ export function useNowPlayingController({
     status,
     isThisSourceLoaded,
   };
-}
-
-function toSeconds(expoAudioUnit: number): number {
-  if (Platform.OS === 'web') {
-    // web is in milliseconds!
-    return expoAudioUnit / 1000;
-  } else {
-    return expoAudioUnit;
-  }
 }

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -412,7 +412,10 @@ export function useNowPlayingController({
   const seekTo = useCallback(
     (seconds: number) => {
       if (sourceUri == null) return;
-      if (isThisSourceLoaded) {
+      // `nowPlaying.nowPlaying` is set synchronously when a load resolves;
+      // checking it covers the gap before the progress event re-renders
+      // `isThisSourceLoaded`
+      if (isThisSourceLoaded || nowPlaying.nowPlaying?.url === sourceUri) {
         nowPlaying.seekTo(seconds);
         return;
       }
@@ -422,7 +425,8 @@ export function useNowPlayingController({
       loadSource()
         .then(() => {
           if (pendingSeekRef.current != null) {
-            nowPlaying.seekTo(pendingSeekRef.current);
+            // hold the guard until the seek itself completes
+            return nowPlaying.seekTo(pendingSeekRef.current);
           }
         })
         .catch((e) => {

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -388,12 +388,37 @@ export function useNowPlayingController({
     }
   }, [nowPlaying, sourceUri, isThisSourceLoaded]);
 
+  // Seeking an unloaded source loads it (paused) first. While the load is in
+  // flight, remember only the latest requested position so scrubbing doesn't
+  // race multiple replace() calls.
+  const pendingSeekRef = useRef<number | null>(null);
+  const isLoadingForSeekRef = useRef(false);
   const seekTo = useCallback(
     (seconds: number) => {
-      if (!isThisSourceLoaded) return;
-      nowPlaying.seekTo(seconds);
+      if (sourceUri == null) return;
+      if (isThisSourceLoaded) {
+        nowPlaying.seekTo(seconds);
+        return;
+      }
+      pendingSeekRef.current = seconds;
+      if (isLoadingForSeekRef.current) return;
+      isLoadingForSeekRef.current = true;
+      nowPlaying
+        .replace({ url: sourceUri })
+        .then(() => {
+          if (pendingSeekRef.current != null) {
+            nowPlaying.seekTo(pendingSeekRef.current);
+          }
+        })
+        .catch((e) => {
+          console.error('Failed to load voice memo for seek', e);
+        })
+        .finally(() => {
+          isLoadingForSeekRef.current = false;
+          pendingSeekRef.current = null;
+        });
     },
-    [nowPlaying, isThisSourceLoaded]
+    [nowPlaying, sourceUri, isThisSourceLoaded]
   );
 
   const status = useMemo<null | 'playing' | 'paused' | 'loading'>(() => {

--- a/packages/app/ui/contexts/nowPlaying.tsx
+++ b/packages/app/ui/contexts/nowPlaying.tsx
@@ -357,6 +357,24 @@ export function useNowPlayingController({
     }
   }, [playbackIntent, progress, isThisSourceLoaded]);
 
+  // Play and seek share one in-flight load of this source: a second
+  // replace() for the same URL would supersede the first one in the provider
+  // and reject its callbacks (dropping a pending play or seek).
+  const inFlightLoadRef = useRef<Promise<void> | null>(null);
+  const loadSource = useCallback(() => {
+    if (sourceUri == null) {
+      return Promise.reject(new Error('No source to load'));
+    }
+    if (inFlightLoadRef.current == null) {
+      inFlightLoadRef.current = nowPlaying
+        .replace({ url: sourceUri })
+        .finally(() => {
+          inFlightLoadRef.current = null;
+        });
+    }
+    return inFlightLoadRef.current;
+  }, [nowPlaying, sourceUri]);
+
   const togglePlayback = useCallback(() => {
     if (sourceUri == null) return;
     if (isThisSourceLoaded) {
@@ -375,8 +393,7 @@ export function useNowPlayingController({
       // doesn't cause the effect to immediately clear the new intent
       wasLoadedRef.current = false;
       setPlaybackIntent('will-buffer');
-      nowPlaying
-        .replace({ url: sourceUri })
+      loadSource()
         .then(() => {
           nowPlaying.play();
         })
@@ -385,11 +402,11 @@ export function useNowPlayingController({
           setPlaybackIntent(false);
         });
     }
-  }, [nowPlaying, sourceUri, isThisSourceLoaded]);
+  }, [nowPlaying, sourceUri, isThisSourceLoaded, loadSource]);
 
   // Seeking an unloaded source loads it (paused) first. While the load is in
   // flight, remember only the latest requested position so scrubbing doesn't
-  // race multiple replace() calls.
+  // race multiple loads.
   const pendingSeekRef = useRef<number | null>(null);
   const isLoadingForSeekRef = useRef(false);
   const seekTo = useCallback(
@@ -402,8 +419,7 @@ export function useNowPlayingController({
       pendingSeekRef.current = seconds;
       if (isLoadingForSeekRef.current) return;
       isLoadingForSeekRef.current = true;
-      nowPlaying
-        .replace({ url: sourceUri })
+      loadSource()
         .then(() => {
           if (pendingSeekRef.current != null) {
             nowPlaying.seekTo(pendingSeekRef.current);
@@ -417,7 +433,7 @@ export function useNowPlayingController({
           pendingSeekRef.current = null;
         });
     },
-    [nowPlaying, sourceUri, isThisSourceLoaded]
+    [nowPlaying, sourceUri, isThisSourceLoaded, loadSource]
   );
 
   // Scrubbing pauses a playing source for the duration of the gesture and


### PR DESCRIPTION
## Summary

Tapping the waveform on a voice memo did nothing on iOS and Android — there was no way to seek within a memo. This adds tap-to-seek and drag-to-scrub on the voice memo waveform. Found while migrating audio playback away from `expo-av`.

Related: #5917 independently fixes the waveform highlight alignment during playback.

## Changes

- `VoiceMemoBlock` wraps the waveform in a `GestureDetector` (tap + horizontal pan) that turns the touch position into a fraction of the memo's duration and seeks the player. The `seekTo` API already existed on the now-playing context but was never hooked up to any UI. Pan seeks are throttled to 100ms so scrubbing doesn't spam the native player, and the pan only activates on horizontal drags so vertical channel scrolling still works.
- The waveform's Skia canvas swallows touches on native, so it's rendered with `pointerEvents: 'none'` (same workaround `AudioRecorder` uses for its waveform).
- `NowPlayingProvider.seekTo` now sends a progress update right after seeking so the timer and waveform highlight move immediately — expo-audio doesn't send progress updates while paused.
- Touch positions are measured against the drawn candle strip rather than the container width — the waveform only draws whole candles, so the strip can be slightly narrower than the container.
- Scrubbing a playing memo pauses it during the drag and resumes it on release (standard scrubber behavior); a plain tap keeps playing through the seek.
- Play and seek share a single load of a source: seeking while a play-started load is still running (or the other way around) waits for that load instead of starting a second one that would cancel it and drop the pending play/seek. If the loaded duration isn't known yet (expo-audio can briefly report 0), seeks fall back to the memo's metadata duration.
- Fixes the memo timer on web: expo-audio's web implementation reports `currentTime`/`duration` in seconds (plain `HTMLMediaElement` units), but the progress pipeline divided by 1000 as if they were milliseconds — so the timer always read 0:00 and seeking a loaded memo landed at ~0. The conversion is removed.

Seeking a memo that hasn't been played yet loads it (paused) with the playhead at the tapped position, so play starts from there. While the load is running, only the latest requested position is kept, so scrubbing an unloaded memo can't kick off multiple loads.

## How did I test?

- iOS simulator (iPhone 17 Pro): played a memo, tapped at ~70% of the waveform — timer jumped from 0:01 to 0:04 of a 6s memo; scrubbed left/right while paused — timer and candle highlight followed the drag; vertical scrolling over the waveform still scrolls the channel.
- Seek before playing: without pressing play, tapped a memo's waveform at ~50% — it loaded paused with the timer at 0:02; pressing play continued from there. Scrubbing a different never-played memo loaded it at the drag's end position and unloaded the previous one.
- Checked frame-by-frame that playback pauses when a drag starts and resumes on release.
- Checked that taps land within one candle (±2pt) of the tap point.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: voice memo playback

## Rollback plan

Revert these commits.

## Screenshots / videos

https://github.com/user-attachments/assets/6293c66b-7610-4d8e-ba07-6f1bd103c925
