### PR TITLE
fix: align voice memo waveform highlight with playback position

### DIFF
--- a/packages/app/ui/components/AudioRecorder/Waveform.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.tsx
@@ -74,6 +74,7 @@ export function Waveform({
   const scaledCandlePlaybackPosition = useMemo(() => {
     if (
       maxVisibleCandleCount == null ||
+      values.length === 0 ||
       values.length === maxVisibleCandleCount
     ) {
       return candlePlaybackPosition;

--- a/packages/app/ui/components/AudioRecorder/Waveform.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.tsx
@@ -71,14 +71,17 @@ export function Waveform({
     return out;
   }, [values, maxVisibleCandleCount]);
 
+  // `candlePlaybackPosition` is an index into `values`; rescale it over the
+  // drawn candles (padded or simplified to `maxVisibleCandleCount`) so the
+  // highlight spans the whole strip, filler candles included
   const scaledCandlePlaybackPosition = useMemo(() => {
     if (
       maxVisibleCandleCount == null ||
-      values.length <= maxVisibleCandleCount
+      values.length === maxVisibleCandleCount
     ) {
       return candlePlaybackPosition;
     }
-    return Math.floor(
+    return Math.round(
       (candlePlaybackPosition / values.length) * maxVisibleCandleCount
     );
   }, [candlePlaybackPosition, values.length, maxVisibleCandleCount]);
@@ -111,10 +114,10 @@ export function Waveform({
                 height={Math.max(5, layout.height * (heightRatio ?? 0))}
                 r={40}
                 color={
-                  heightRatio == null
-                    ? candleInactiveColor
-                    : index < scaledCandlePlaybackPosition
-                      ? candleActiveColor
+                  index < scaledCandlePlaybackPosition
+                    ? candleActiveColor
+                    : heightRatio == null
+                      ? candleInactiveColor
                       : candleUnplayedColor
                 }
               />

--- a/packages/app/ui/components/AudioRecorder/Waveform.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.tsx
@@ -71,9 +71,6 @@ export function Waveform({
     return out;
   }, [values, maxVisibleCandleCount]);
 
-  // `candlePlaybackPosition` is an index into `values`; rescale it over the
-  // drawn candles (padded or simplified to `maxVisibleCandleCount`) so the
-  // highlight spans the whole strip, filler candles included
   const scaledCandlePlaybackPosition = useMemo(() => {
     if (
       maxVisibleCandleCount == null ||

--- a/packages/app/ui/components/AudioRecorder/Waveform.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.tsx
@@ -78,9 +78,7 @@ export function Waveform({
     ) {
       return candlePlaybackPosition;
     }
-    return Math.round(
-      (candlePlaybackPosition / values.length) * maxVisibleCandleCount
-    );
+    return (candlePlaybackPosition / values.length) * maxVisibleCandleCount;
   }, [candlePlaybackPosition, values.length, maxVisibleCandleCount]);
 
   const effectiveVisualRange = useMemo(() => {

--- a/packages/app/ui/components/AudioRecorder/Waveform.web.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.web.tsx
@@ -73,6 +73,7 @@ export function Waveform({
   const scaledCandlePlaybackPosition = useMemo(() => {
     if (
       maxVisibleCandleCount == null ||
+      values.length === 0 ||
       values.length === maxVisibleCandleCount
     ) {
       return candlePlaybackPosition;

--- a/packages/app/ui/components/AudioRecorder/Waveform.web.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.web.tsx
@@ -73,11 +73,11 @@ export function Waveform({
   const scaledCandlePlaybackPosition = useMemo(() => {
     if (
       maxVisibleCandleCount == null ||
-      values.length <= maxVisibleCandleCount
+      values.length === maxVisibleCandleCount
     ) {
       return candlePlaybackPosition;
     }
-    return Math.floor(
+    return Math.round(
       (candlePlaybackPosition / values.length) * maxVisibleCandleCount
     );
   }, [candlePlaybackPosition, values.length, maxVisibleCandleCount]);
@@ -111,10 +111,10 @@ export function Waveform({
                 rx={candleWidth / 2}
                 ry={candleWidth / 2}
                 fill={
-                  heightRatio == null
-                    ? candleInactiveColor
-                    : index < scaledCandlePlaybackPosition
-                      ? candleActiveColor
+                  index < scaledCandlePlaybackPosition
+                    ? candleActiveColor
+                    : heightRatio == null
+                      ? candleInactiveColor
                       : candleUnplayedColor
                 }
               />

--- a/packages/app/ui/components/AudioRecorder/Waveform.web.tsx
+++ b/packages/app/ui/components/AudioRecorder/Waveform.web.tsx
@@ -77,9 +77,7 @@ export function Waveform({
     ) {
       return candlePlaybackPosition;
     }
-    return Math.round(
-      (candlePlaybackPosition / values.length) * maxVisibleCandleCount
-    );
+    return (candlePlaybackPosition / values.length) * maxVisibleCandleCount;
   }, [candlePlaybackPosition, values.length, maxVisibleCandleCount]);
 
   const effectiveVisualRange = useMemo(() => {

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -263,10 +263,12 @@ export function VoiceMemoBlock({
     ) {
       return 0;
     }
+    // candles highlight when index < position, so position may reach
+    // candleCount to highlight the full waveform at the end
     return clamp(
-      Math.floor((progress.currentTime / progress.duration) * candleCount),
+      Math.round((progress.currentTime / progress.duration) * candleCount),
       0,
-      candleCount - 1
+      candleCount
     );
   }, [progress, block.voiceMemo.waveformPreview, isThisSourceLoaded]);
 

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -263,8 +263,10 @@ export function VoiceMemoBlock({
     ) {
       return 0;
     }
+    // fractional position; the Waveform quantizes once against the candles
+    // it actually draws
     return clamp(
-      Math.round((progress.currentTime / progress.duration) * candleCount),
+      (progress.currentTime / progress.duration) * candleCount,
       0,
       candleCount
     );

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -263,8 +263,6 @@ export function VoiceMemoBlock({
     ) {
       return 0;
     }
-    // candles highlight when index < position, so position may reach
-    // candleCount to highlight the full waveform at the end
     return clamp(
       Math.round((progress.currentTime / progress.duration) * candleCount),
       0,

--- a/packages/app/ui/components/PostContent/BlockRenderer.tsx
+++ b/packages/app/ui/components/PostContent/BlockRenderer.tsx
@@ -263,8 +263,6 @@ export function VoiceMemoBlock({
     ) {
       return 0;
     }
-    // fractional position; the Waveform quantizes once against the candles
-    // it actually draws
     return clamp(
       (progress.currentTime / progress.duration) * candleCount,
       0,


### PR DESCRIPTION
## Summary

The voice memo waveform highlight didn't line up with the actual playback position — it sat a few candles left of the true position and never filled the waveform at the end of a memo. Noticed while working on #5916 (waveform seek), but independent of it: the misalignment is visible during plain playback.

## Changes

- The playhead position is now converted to a candle index once, against the candles actually drawn, and it can reach the last candle. Before, the position was rounded in two places at different scales, which put the highlight off by up to half a candle, and an off-by-one comparison meant the last candle could never light up.
- Filler candles now light up once the playhead passes them. When a memo has fewer waveform values than fit in the row, the waveform pads it with filler candles to fill the width — and the color logic checked "is this filler?" before "has the playhead passed it?", so filler bars stayed grey forever (e.g. 51 drawn vs 50 values left one dead bar at the end). The playhead check now wins, and the highlight is spread over all drawn candles (filler included) so the whole strip fills at the end of playback. Candles past the playhead keep the filler/unplayed distinction for themes that color them differently.

## How did I test?

- iOS simulator (iPhone 17 Pro): watched the highlight edge frame-by-frame through a full playback — it tracks the elapsed time and fills the waveform at the end (before, it stopped ~5 candles short).
- Checked the bar colors with the playhead at the end — every drawn bar, including the filler bar, takes the active color.
- Web (Chrome against a dev ship): checked the SVG candle fills in the DOM during a full playback — the highlight covers the drawn strip (42/84 candles when parked at 50%) and reaches 84/84, filler included, at the end.
- Before/after videos of a full playback below.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: voice memo playback

## Rollback plan

Revert these commits.

## Screenshots / videos

**Before** — highlight lags and never reaches the end:

https://github.com/user-attachments/assets/62710833-1f7e-4008-a0ab-dcf3932b4523

**After** — highlight tracks playback and fills the waveform:

https://github.com/user-attachments/assets/48bdcee7-c705-4ec7-a031-0672dad27c59

**Web** — candle state sampled live from the DOM during playback, rendered for visibility (the long parked stretch is the memo buffering):

https://github.com/user-attachments/assets/3734f4a5-08d2-415c-9f78-515885910213
