### PR TITLE
activity: forbid foreign pokes

### DIFF
--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -225,7 +225,7 @@ ${run_click} $pier "/lib/pill/hoon"<<EOF
 EOF
 
 echo "Preparing aqua snapshot..."
-result=$( $run_click -t 1200 $pier <<EOF
+result=$( $run_click -t 1800 $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =+  tid=~.ci-ph-fleet  
@@ -259,9 +259,8 @@ fi
 
 # Run aqua tests
 #
-# Update to use the generated test snapshot
 echo "Running tests..."
-result=$( $run_click -t 1200 $pier <<EOF
+result=$( $run_click -t 1800 $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =/  ph-tests=path  

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -43,7 +43,7 @@ echo "Running aqua tests"
 
 #download_url=`jq -r ".[\"$ship\"][\"downloadUrl\"]" < $ship_manifest`
 download_url="https://bootstrap.urbit.org/zod-aqua-tests-409k.xst"
-pill_download_url="https://bootstrap.urbit.org/aqua-tests-v10-1-0.pill"
+pill_download_url="https://bootstrap.urbit.org/groups-v11-2-2.pill"
 
 archive=`basename $download_url`
 pill=`basename $pill_download_url`

--- a/desk/app/activity.hoon
+++ b/desk/app/activity.hoon
@@ -348,6 +348,7 @@
   |=  [=mark =vase]
   ~>  %spin.['poke']
   ^+  cor
+  ?>  from-self
   ?+  mark  ~|(bad-poke+mark !!)
       %noun
     ?+  q.vase  ~|(bad-poke+mark !!)


### PR DESCRIPTION
## Summary

The activity agent is only used locally. As such, its api should not be exposed to foreign ships. We protect against foreign access in all watch endpoints, but pokes remained exposed. To fix this we introduce a top-level from-self assertion in +poke.

## Changes

Assert `from-self` at top-level in `+poke`

## How did I test?

Left for automated tests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.