### PR TITLE
tlon-skill: Port posts react command runner to tlon-skill and restore build-smoke CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Run Tests
         run: pnpm test:ci
 
+      - name: tlon-skill build smoke
+        run: pnpm --filter '@tloncorp/tlon-skill' build:smoke
+
       - name: Build packages
         run: pnpm build:all
         env:

--- a/packages/tlon-skill/scripts/build-smoke.ts
+++ b/packages/tlon-skill/scripts/build-smoke.ts
@@ -5,8 +5,8 @@ import { join, resolve } from 'node:path';
 
 import {
   CLI_MATRIX_CASES,
-  COMMAND_FAMILIES,
   type CliCase,
+  HOSTILE_HELP_COMMANDS,
   normalizeCliOutput,
 } from './cli-test-matrix';
 
@@ -155,15 +155,7 @@ for (const testCase of CLI_MATRIX_CASES) {
   assertCase(testCase);
 }
 
-const hostileHelpCommands = [
-  { name: 'top-level', args: ['--help'] },
-  ...COMMAND_FAMILIES.map((family) => ({
-    name: family,
-    args: [family, '--help'],
-  })),
-];
-
-for (const command of hostileHelpCommands) {
+for (const command of HOSTILE_HELP_COMMANDS) {
   assertCase(
     {
       name: `${command.name} help with nonexistent TLON_CONFIG_FILE`,

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -319,9 +319,39 @@ export const NESTED_HELP_CASES: CliCase[] = [
     ['groups', 'info', '--help'],
     'Usage: tlon groups info'
   ),
+  helpCase(
+    'posts react --help',
+    ['posts', 'react', '--help'],
+    'Usage: tlon posts react'
+  ),
+  helpCase(
+    'posts react --help with global credentials',
+    [
+      '--url',
+      'https://cli.tlon.network',
+      '--cookie',
+      'urbauth-~zod=0v-cookie',
+      'posts',
+      'react',
+      '--help',
+    ],
+    'Usage: tlon posts react'
+  ),
+  helpCase(
+    'posts unreact --help',
+    ['posts', 'unreact', '--help'],
+    'Usage: tlon posts unreact'
+  ),
 ];
 
 export const LITERAL_OPTION_LIKE_VALUE_CASES: CliCase[] = [
+  authRequiredCase('posts react valid args reaches auth', [
+    'posts',
+    'react',
+    'chat/~host/channel',
+    '170.141',
+    '👍',
+  ]),
   authRequiredCase('dms send message option-like value reaches auth', [
     'dms',
     'send',
@@ -487,6 +517,23 @@ export const CLI_MATRIX_CASES: CliCase[] = [
   ...SPECIAL_INPUT_CASES,
   ...NESTED_HELP_CASES,
   ...LITERAL_OPTION_LIKE_VALUE_CASES,
+];
+
+export type HostileHelpCommand = {
+  name: string;
+  args: string[];
+};
+
+// Help paths that must perform no credential lookup even under hostile config:
+// the top-level help, every command family's `<family> --help`, and the
+// migrated nested `posts react --help` path.
+export const HOSTILE_HELP_COMMANDS: HostileHelpCommand[] = [
+  { name: 'top-level', args: ['--help'] },
+  ...COMMAND_FAMILIES.map((family) => ({
+    name: family,
+    args: [family, '--help'],
+  })),
+  { name: 'posts react', args: ['posts', 'react', '--help'] },
 ];
 
 export function normalizeCliOutput(text: string): string {

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'bun:test';
+
+import { commandError } from './command';
+import {
+  POSTS_REACT_HELP,
+  type PostReactionInput,
+  type PostsDeps,
+  run,
+} from './posts';
+
+function makeDeps(
+  options: {
+    currentUserId?: string;
+    authenticate?: () => Promise<void>;
+    addReaction?: (input: PostReactionInput) => Promise<void>;
+  } = {}
+) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const calls = {
+    authenticate: 0,
+    getCurrentUserId: 0,
+    addReaction: [] as PostReactionInput[],
+    order: [] as string[],
+  };
+
+  const deps: PostsDeps = {
+    stdout: (text) => stdout.push(text),
+    stderr: (text) => stderr.push(text),
+    authenticate: async () => {
+      calls.authenticate += 1;
+      calls.order.push('authenticate');
+      await options.authenticate?.();
+    },
+    getCurrentUserId: () => {
+      calls.getCurrentUserId += 1;
+      calls.order.push('getCurrentUserId');
+      return options.currentUserId ?? '~zod';
+    },
+    postsApi: {
+      addReaction: async (input) => {
+        calls.addReaction.push(input);
+        calls.order.push('addReaction');
+        await options.addReaction?.(input);
+      },
+    },
+  };
+
+  return {
+    deps,
+    calls,
+    stdout: () => stdout.join(''),
+    stderr: () => stderr.join(''),
+  };
+}
+
+describe('posts command run', () => {
+  it('prints react help without authenticating or calling the API', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['react', '--help'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe(`${POSTS_REACT_HELP}\n`);
+    expect(context.stderr()).toBe('');
+    expect(context.calls.authenticate).toBe(0);
+    expect(context.calls.getCurrentUserId).toBe(0);
+    expect(context.calls.addReaction).toEqual([]);
+  });
+
+  it('prints react help for help tokens in positional slots', async () => {
+    const cases = [
+      ['react', 'chat/~host/channel', '--help'],
+      ['react', 'chat/~host/channel', '170.141', '-h'],
+      ['react', 'chat/~host/channel', '170.141', '👍', '--help'],
+    ];
+
+    for (const args of cases) {
+      const context = makeDeps();
+      const exitCode = await run(args, context.deps);
+
+      expect(exitCode).toBe(0);
+      expect(context.stdout()).toBe(`${POSTS_REACT_HELP}\n`);
+      expect(context.stderr()).toBe('');
+      expect(context.calls.authenticate).toBe(0);
+      expect(context.calls.getCurrentUserId).toBe(0);
+      expect(context.calls.addReaction).toEqual([]);
+    }
+  });
+
+  it('returns a usage error for non-react subcommands without auth or API work', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(['unreact'], context.deps);
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_REACT_HELP}\n`);
+    expect(context.calls.authenticate).toBe(0);
+    expect(context.calls.getCurrentUserId).toBe(0);
+    expect(context.calls.addReaction).toEqual([]);
+  });
+
+  it('fails missing react args before auth or API work', async () => {
+    const cases = [
+      ['react'],
+      ['react', 'chat/~host/channel'],
+      ['react', 'chat/~host/channel', '170.141'],
+    ];
+
+    for (const args of cases) {
+      const context = makeDeps();
+      const exitCode = await run(args, context.deps);
+
+      expect(exitCode).toBe(1);
+      expect(context.stdout()).toBe('');
+      expect(context.stderr()).toBe(`${POSTS_REACT_HELP}\n`);
+      expect(context.calls.authenticate).toBe(0);
+      expect(context.calls.getCurrentUserId).toBe(0);
+      expect(context.calls.addReaction).toEqual([]);
+    }
+  });
+
+  it('builds reaction payloads for dotted, undotted, and author-prefixed post ids', async () => {
+    const cases = [
+      { rawPostId: '170.141.184', expectedPostId: '170.141.184' },
+      { rawPostId: '170141184', expectedPostId: '170.141.184' },
+      { rawPostId: '~sampel/170141184', expectedPostId: '170.141.184' },
+    ];
+
+    for (const testCase of cases) {
+      const context = makeDeps({ currentUserId: '~bus' });
+      const exitCode = await run(
+        ['react', 'chat/~host/channel', testCase.rawPostId, '👍'],
+        context.deps
+      );
+
+      expect(exitCode).toBe(0);
+      expect(context.calls.addReaction).toEqual([
+        {
+          channelId: 'chat/~host/channel',
+          postId: testCase.expectedPostId,
+          emoji: '👍',
+          our: '~bus',
+          postAuthor: '~bus',
+        },
+      ]);
+    }
+  });
+
+  it('authenticates once, reads the current user once, and writes success output', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+
+    const exitCode = await run(
+      ['react', 'chat/~host/channel', '170141184', '🔥'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe('✓ Reaction added\n');
+    expect(context.stderr()).toBe('');
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.getCurrentUserId).toBe(1);
+    expect(context.calls.addReaction).toHaveLength(1);
+    expect(context.calls.order).toEqual([
+      'authenticate',
+      'getCurrentUserId',
+      'addReaction',
+    ]);
+    expect(context.calls.addReaction[0]).toMatchObject({
+      channelId: 'chat/~host/channel',
+      postId: '170.141.184',
+      emoji: '🔥',
+      our: '~nec',
+      postAuthor: '~nec',
+    });
+  });
+
+  it('ignores extra args after the emoji', async () => {
+    const context = makeDeps();
+
+    const exitCode = await run(
+      ['react', 'chat/~host/channel', '170141184', '👍', 'ignored'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toBe('✓ Reaction added\n');
+    expect(context.stderr()).toBe('');
+    expect(context.calls.addReaction).toHaveLength(1);
+    expect(context.calls.addReaction[0].emoji).toBe('👍');
+  });
+
+  it('formats expected facade failures through the shared command-error path', async () => {
+    const context = makeDeps({
+      addReaction: async () => {
+        throw commandError('reaction API unavailable');
+      },
+    });
+
+    const exitCode = await run(
+      ['react', 'chat/~host/channel', '170141184', '👍'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe('Error: reaction API unavailable\n');
+    expect(context.calls.authenticate).toBe(1);
+    expect(context.calls.getCurrentUserId).toBe(1);
+    expect(context.calls.addReaction).toHaveLength(1);
+  });
+
+  it('leaves unexpected exceptions for the adapter formatter', async () => {
+    const context = makeDeps({
+      addReaction: async () => {
+        throw new Error('unexpected reaction failure');
+      },
+    });
+
+    await expect(
+      run(['react', 'chat/~host/channel', '170141184', '👍'], context.deps)
+    ).rejects.toThrow('unexpected reaction failure');
+
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe('');
+  });
+});

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -1,0 +1,108 @@
+import {
+  type CommandDeps,
+  handleExpectedCommandError,
+  isHelpArg,
+  usageError,
+  writeHelp,
+  writeLine,
+} from './command';
+
+export const POSTS_REACT_HELP =
+  'Usage: tlon posts react <channel> <post-id> <emoji>';
+
+export interface PostReactionInput {
+  channelId: string;
+  postId: string;
+  emoji: string;
+  our: string;
+  postAuthor: string;
+}
+
+export interface PostsApi {
+  addReaction: (input: PostReactionInput) => Promise<void>;
+}
+
+export interface PostsDeps extends CommandDeps {
+  authenticate: () => Promise<void>;
+  getCurrentUserId: () => string;
+  postsApi: PostsApi;
+}
+
+type ParsedPostsArgs =
+  | { kind: 'help' }
+  | { kind: 'react'; channelId: string; postId: string; emoji: string };
+
+function extractNumericId(id: string): string {
+  const slash = id.indexOf('/');
+  return slash >= 0 ? id.slice(slash + 1) : id;
+}
+
+function formatUd(id: string): string {
+  const clean = id.replace(/\./g, '');
+  const parts: string[] = [];
+  for (let i = clean.length; i > 0; i -= 3) {
+    parts.unshift(clean.slice(Math.max(0, i - 3), i));
+  }
+  return parts.join('.');
+}
+
+function formatPostId(postId: string): string {
+  return formatUd(extractNumericId(postId));
+}
+
+function parseArgs(args: string[]): ParsedPostsArgs {
+  const command = args[0];
+
+  if (command !== 'react') {
+    throw usageError(POSTS_REACT_HELP);
+  }
+
+  if (args.slice(1).some(isHelpArg)) {
+    return { kind: 'help' };
+  }
+
+  const channelId = args[1];
+  const postId = args[2];
+  const emoji = args[3];
+
+  if (!channelId || !postId || !emoji) {
+    throw usageError(POSTS_REACT_HELP);
+  }
+
+  return { kind: 'react', channelId, postId, emoji };
+}
+
+async function reactToPost(
+  channelId: string,
+  postId: string,
+  emoji: string,
+  deps: PostsDeps
+): Promise<void> {
+  const our = deps.getCurrentUserId();
+  await deps.postsApi.addReaction({
+    channelId,
+    postId: formatPostId(postId),
+    emoji,
+    our,
+    postAuthor: our,
+  });
+}
+
+export async function run(args: string[], deps: PostsDeps): Promise<number> {
+  try {
+    const parsed = parseArgs(args);
+    if (parsed.kind === 'help') {
+      return writeHelp(deps, POSTS_REACT_HELP);
+    }
+
+    await deps.authenticate();
+    await reactToPost(parsed.channelId, parsed.postId, parsed.emoji, deps);
+
+    writeLine(deps.stdout, '✓ Reaction added');
+    return 0;
+  } catch (error) {
+    const handled = handleExpectedCommandError(error, deps);
+    if (handled !== null) return handled;
+    throw error;
+  }
+}

--- a/packages/tlon-skill/scripts/main.ts
+++ b/packages/tlon-skill/scripts/main.ts
@@ -21,8 +21,10 @@ import { createActivityDeps } from './activity-runtime';
 import { setCliCredentialOverrides } from './api-client';
 import { run as runActivityCommand } from './commands/activity';
 import { formatUnexpectedError } from './commands/command';
+import { run as runPostsCommand } from './commands/posts';
 import { run as runUploadCommand } from './commands/upload';
 import { CredentialFlagError, parseGlobalCliOptions } from './credential-flags';
+import { createPostsDeps } from './posts-runtime';
 import { isTopLevelCommand } from './top-level-commands';
 import { createUploadDeps } from './upload-runtime';
 
@@ -194,6 +196,11 @@ async function main() {
         break;
       }
       case 'posts': {
+        if (scriptArgs[0] === 'react') {
+          const exitCode = await runPostsCommand(scriptArgs, createPostsDeps());
+          process.exit(exitCode);
+          break;
+        }
         process.argv = ['tlon', command, ...scriptArgs];
         const mod = await import('./posts');
         break;

--- a/packages/tlon-skill/scripts/posts-runtime.ts
+++ b/packages/tlon-skill/scripts/posts-runtime.ts
@@ -1,0 +1,34 @@
+import {
+  addReaction as apiAddReaction,
+  getCurrentUserId as apiGetCurrentUserId,
+} from '@tloncorp/api';
+
+import { ensureClient } from './api-client';
+import { commandError, errorMessage } from './commands/command';
+import type { PostReactionInput, PostsDeps } from './commands/posts';
+
+function createProcessCommandDeps() {
+  return {
+    stdout: (text: string) => process.stdout.write(text),
+    stderr: (text: string) => process.stderr.write(text),
+  };
+}
+
+export function createPostsDeps(): PostsDeps {
+  return {
+    ...createProcessCommandDeps(),
+    authenticate: async () => {
+      await ensureClient(['channels']);
+    },
+    getCurrentUserId: () => apiGetCurrentUserId(),
+    postsApi: {
+      addReaction: async (input: PostReactionInput) => {
+        try {
+          await apiAddReaction(input);
+        } catch (error) {
+          throw commandError(errorMessage(error));
+        }
+      },
+    },
+  };
+}

--- a/packages/tlon-skill/tests/hermetic/cli.test.ts
+++ b/packages/tlon-skill/tests/hermetic/cli.test.ts
@@ -5,8 +5,8 @@ import { join, resolve } from 'node:path';
 
 import {
   CLI_MATRIX_CASES,
-  COMMAND_FAMILIES,
   type CliCase,
+  HOSTILE_HELP_COMMANDS,
   normalizeCliOutput,
 } from '../../scripts/cli-test-matrix';
 
@@ -170,14 +170,6 @@ function expectCliCase(result: CliResult, testCase: CliCase) {
   }
 }
 
-const hostileHelpCommands = [
-  { name: 'top-level', args: ['--help'] },
-  ...COMMAND_FAMILIES.map((family) => ({
-    name: family,
-    args: [family, '--help'],
-  })),
-];
-
 describe('CLI hermetic subprocess behavior', () => {
   it('prints source CLI version without host credentials', async () => {
     const result = await runCli(['--version']);
@@ -194,7 +186,7 @@ describe('CLI hermetic subprocess behavior', () => {
     });
   }
 
-  for (const command of hostileHelpCommands) {
+  for (const command of HOSTILE_HELP_COMMANDS) {
     it(`prints ${command.name} help with nonexistent TLON_CONFIG_FILE`, async () => {
       const result = await runCli(command.args, {
         prepare: ({ home }) => ({


### PR DESCRIPTION
## Summary

Re-integrates work into the in-monorepo `packages/tlon-skill` CLI as PR 1 of 3 stacked PRs for the current phase of TLON-5771. The monorepo import predated standalone PR #93 (the `posts react` migration) and dropped the built-binary CI gate, so this ports the migration and restores the gate. This is a port of already-reviewed code (standalone PR: [tloncorp/tlon-skill#93](https://github.com/tloncorp/tlon-skill/pull/93); diff-of-record is commit [`253a73d`](https://github.com/tloncorp/tlon-skill/commit/253a73d35feb80b7d02cc137bc347693e18cb9df)), reformatted with monorepo prettier; logic is unchanged.

## Changes

- Added `packages/tlon-skill/scripts/commands/posts.ts`, a pure `posts react` runner (`run(args, deps): Promise<number>`) with self-contained `extractNumericId`, `formatUd`, and `formatPostId` helpers. These are deliberately not imported from the legacy `scripts/posts.ts` (which auto-runs on import). Help short-circuits before auth, and missing args throw usage errors before auth.
- Added `packages/tlon-skill/scripts/posts-runtime.ts`, the process-backed deps. `authenticate` calls `ensureClient(['channels'])`, the current user is read via `@tloncorp/api`, and `addReaction` failures are rethrown as `commandError`.
- Added `packages/tlon-skill/scripts/commands/posts.test.ts`, in-process tests with fake deps covering the help short-circuit, the missing-arg matrix before auth, post-id formatting (dotted, undotted, `~ship/`-prefixed), the exact `✓ Reaction added` output, CommandError formatting, and unexpected-error propagation. Includes one addition over the standalone file: a `run(['unreact'], deps)` test pinning that non-`react` subcommands return a usage error with no auth or API calls (the runner becomes the posts-family dispatcher in a later PR).
- Updated `scripts/main.ts` so that in `case 'posts'`, `posts react ...` routes through the migrated runner (without mutating `process.argv`). All other `posts` paths still fall through to the legacy import-side-effect module.
- Updated `scripts/cli-test-matrix.ts` with matrix cases (`posts react --help`, the same with global `--url`/`--cookie` flags to prove they are stripped before dispatch, `posts unreact --help` to prove non-react paths stay on the legacy dispatch, and an auth-required `posts react chat/~host/channel 170.141 👍` case). Also centralized the hostile-help command list into a new exported `HOSTILE_HELP_COMMANDS` and added a nested `posts react --help` entry.
- Updated `tests/hermetic/cli.test.ts` and `scripts/build-smoke.ts` to consume the shared `HOSTILE_HELP_COMMANDS` instead of each rebuilding the list, removing duplication and adding nested-subcommand help coverage to both the source hermetic suite and the built-binary suite.
- Updated `.github/workflows/ci.yml` with a `tlon-skill build smoke` step (`pnpm --filter '@tloncorp/tlon-skill' build:smoke`) after "Run Tests" and before "Build packages". This restores the built-binary golden matrix gate dropped in the monorepo move; it compiles the binary via bun `--compile` and runs the full golden matrix under a hermetic env. Bun 1.3.4 is already set up earlier in the job.

Decisions worth noting:

- The coverage artifact from the standalone `ci.yml` was not ported. The suite is subprocess-heavy, so Bun coverage mostly measures the test process; the plan treats coverage as reporting-only. `test:coverage` remains in `package.json` for local use.
- The root `test:ci` trailing-arg quirk (`pnpm run -r test run` appends `run` to tlon-skill's chained `test` script, producing `bun test ./tests/hermetic run` where `run` acts as a bun path filter) was verified harmless (all tests still execute). Documenting it here rather than changing the shared root script, since other packages rely on the `run` arg for vitest.

## How did I test?

- `pnpm --filter '@tloncorp/tlon-skill' check` (typecheck plus 93 unit tests, 141 hermetic tests, build smoke), exit 0.
- `pnpm --filter '@tloncorp/tlon-skill' test run` passes 234 tests, reproducing the root `test:ci` trailing-arg shape.
- `pnpm prettier --check` on all touched files, clean.
- Built golden matrix confirms the new cases pass, including `posts react --help` under hostile `TLON_CONFIG_FILE=/nonexistent` and `--config /nonexistent` (exit 0, prints usage, empty stderr, no credential lookup).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: skill

## Rollback plan

Revert