### PR TITLE
tlon-skill: Port release and version-bump workflows into the monorepo

### DIFF
--- a/.github/workflows/tlon-skill-bump-version.yml
+++ b/.github/workflows/tlon-skill-bump-version.yml
@@ -1,0 +1,57 @@
+name: Tlon Skill Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (e.g. 0.4.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: pnpm/action-setup@v3
+
+      - name: Bump version
+        working-directory: packages/tlon-skill
+        env:
+          VERSION: ${{ inputs.version }}
+        run: node scripts/bump-version.js "$VERSION"
+
+      # bump-version.js bumps only the five `version` fields. The workspace no
+      # longer declares registry optionalDependencies and pnpm importers don't
+      # record a workspace package's own version, so the lockfile normally won't
+      # change; create-pull-request commits it only if it does. The real gate is
+      # that CI's `pnpm install --frozen-lockfile` passes on the bump PR.
+      - name: Refresh lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Create bump PR
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          base: develop
+          branch: release/tlon-skill-bump-v${{ inputs.version }}
+          delete-branch: true
+          commit-message: "tlon-skill: v${{ inputs.version }}"
+          title: "tlon-skill: v${{ inputs.version }}"
+          body: |
+            Automated tlon-skill version bump to `${{ inputs.version }}`.
+
+            This workflow opens a PR against `develop` instead of pushing directly, so it plays nicely with branch protection.
+
+            After merging, release by tagging `tlon-skill-v${{ inputs.version }}` or dispatching the **Tlon Skill Build and Publish** workflow.
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/tlon-skill-publish.yml
+++ b/.github/workflows/tlon-skill-publish.yml
@@ -1,0 +1,250 @@
+name: Tlon Skill Build and Publish
+
+# Releases @tloncorp/tlon-skill (and its four platform packages) from the
+# monorepo. Bare `v*` tags collide with app release tags, so this workflow keys
+# off the `tlon-skill-v*` tag prefix and a manual dispatch.
+#
+# Publish auth is npm Trusted Publishing (OIDC + provenance), which is bound to
+# the repository + workflow filename. Before the first real publish, the
+# trusted-publisher config on npmjs.com for all five packages must point at this
+# repo and `tlon-skill-publish.yml` (see the PR description checklist).
+
+on:
+  push:
+    tags:
+      - "tlon-skill-v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip publish)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - uses: pnpm/action-setup@v3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches package version
+        if: github.event_name == 'push'
+        working-directory: packages/tlon-skill
+        run: |
+          version=$(node -p "require('./package.json').version")
+          expected="tlon-skill-v${version}"
+          if [ "${GITHUB_REF_NAME}" != "$expected" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match packages/tlon-skill version (${expected})" >&2
+            exit 1
+          fi
+          echo "Tag matches package version: ${expected}"
+
+      - name: Build api dist
+        run: pnpm build:api
+
+      - name: Check
+        run: pnpm --filter '@tloncorp/tlon-skill' check
+
+  build:
+    needs: quality
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            target: darwin-arm64
+          - os: macos-15-intel
+            target: darwin-x64
+          - os: ubuntu-24.04
+            target: linux-x64
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - uses: pnpm/action-setup@v3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build api dist
+        run: pnpm build:api
+
+      - name: Build binary
+        working-directory: packages/tlon-skill
+        run: node scripts/build-all.js --target=${{ matrix.target }}
+
+      - name: Smoke binary
+        working-directory: packages/tlon-skill
+        run: pnpm release:binary-smoke -- --binary npm/${{ matrix.target }}/tlon
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: packages/tlon-skill/npm/${{ matrix.target }}/tlon
+          if-no-files-found: error
+
+  package:
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - uses: pnpm/action-setup@v3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: binary-*
+          path: packages/tlon-skill/artifacts
+
+      - name: Pack release tarballs
+        working-directory: packages/tlon-skill
+        run: pnpm release:package -- --artifacts-dir artifacts --out-dir release-tarballs
+
+      - name: Upload package tarballs
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-tarballs
+          path: packages/tlon-skill/release-tarballs/*
+          if-no-files-found: error
+
+  package-smoke:
+    needs: package
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            target: darwin-arm64
+          - os: macos-15-intel
+            target: darwin-x64
+          - os: ubuntu-24.04
+            target: linux-x64
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - uses: pnpm/action-setup@v3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download package tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: package-tarballs
+          path: packages/tlon-skill/release-tarballs
+
+      - name: Smoke installed package
+        working-directory: packages/tlon-skill
+        run: pnpm release:package-smoke -- --tarball-dir release-tarballs --target=${{ matrix.target }}
+
+  publish:
+    needs: package-smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - uses: pnpm/action-setup@v3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download package tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: package-tarballs
+          path: packages/tlon-skill/release-tarballs
+
+      - name: Read package version
+        id: package
+        working-directory: packages/tlon-skill
+        run: node -p "'version=' + require('./package.json').version" >> "$GITHUB_OUTPUT"
+
+      - name: Dry run
+        if: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'false' }}"
+        run: 'echo "Dry run: skipping npm publish"'
+
+      - name: Publish platform packages
+        if: "${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run == 'false' }}"
+        working-directory: packages/tlon-skill
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
+            npm publish "release-tarballs/tloncorp-tlon-skill-${target}-${{ steps.package.outputs.version }}.tgz" --access public --provenance
+          done
+
+      - name: Publish root package
+        if: "${{ github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run == 'false' }}"
+        working-directory: packages/tlon-skill
+        run: npm publish "release-tarballs/tloncorp-tlon-skill-${{ steps.package.outputs.version }}.tgz" --access public --provenance

--- a/.prettierignore
+++ b/.prettierignore
@@ -287,6 +287,8 @@ clurd
 /packages/tlon-skill/**/.DS_Store
 /packages/tlon-skill/**/dist
 /packages/tlon-skill/**/coverage/
+/packages/tlon-skill/**/release-tarballs/
+/packages/tlon-skill/**/artifacts/
 /packages/tlon-skill/npm/*/tlon
 /packages/tlon-skill/bin/tlon
 /packages/tlon-skill/.claude/settings.local.json

--- a/packages/tlon-skill/.gitignore
+++ b/packages/tlon-skill/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 .DS_Store
 dist
 coverage/
+# Local release-validation output (CI uses artifact uploads)
+release-tarballs/
+artifacts/
 # Ignore binaries, keep package.json
 npm/*/tlon
 bin/tlon

--- a/packages/tlon-skill/npm/darwin-arm64/package.json
+++ b/packages/tlon-skill/npm/darwin-arm64/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tloncorp/tlon-skill"
+    "url": "https://github.com/tloncorp/landscape-apps.git",
+    "directory": "packages/tlon-skill/npm/darwin-arm64"
   },
   "license": "MIT"
 }

--- a/packages/tlon-skill/npm/darwin-x64/package.json
+++ b/packages/tlon-skill/npm/darwin-x64/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tloncorp/tlon-skill"
+    "url": "https://github.com/tloncorp/landscape-apps.git",
+    "directory": "packages/tlon-skill/npm/darwin-x64"
   },
   "license": "MIT"
 }

--- a/packages/tlon-skill/npm/linux-arm64/package.json
+++ b/packages/tlon-skill/npm/linux-arm64/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tloncorp/tlon-skill"
+    "url": "https://github.com/tloncorp/landscape-apps.git",
+    "directory": "packages/tlon-skill/npm/linux-arm64"
   },
   "license": "MIT"
 }

--- a/packages/tlon-skill/npm/linux-x64/package.json
+++ b/packages/tlon-skill/npm/linux-x64/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tloncorp/tlon-skill"
+    "url": "https://github.com/tloncorp/landscape-apps.git",
+    "directory": "packages/tlon-skill/npm/linux-x64"
   },
   "license": "MIT"
 }

--- a/packages/tlon-skill/package.json
+++ b/packages/tlon-skill/package.json
@@ -32,16 +32,10 @@
     "version": "node scripts/bump-version.js",
     "postinstall": "node scripts/postinstall.js"
   },
-  "optionalDependencies": {
-    "@tloncorp/tlon-skill-darwin-arm64": "0.4.0",
-    "@tloncorp/tlon-skill-darwin-x64": "0.4.0",
-    "@tloncorp/tlon-skill-linux-arm64": "0.4.0",
-    "@tloncorp/tlon-skill-linux-x64": "0.4.0"
-  },
   "devDependencies": {
     "@tloncorp/api": "workspace:*",
     "@types/bun": "^1.3.14",
-    "@types/node": "^24.12.4",
+    "@types/node": "^22.10.0",
     "@urbit/aura": "^3.0.0",
     "@urbit/nockjs": "^1.6.0",
     "typescript": "^5.9.3"

--- a/packages/tlon-skill/scripts/bump-version.js
+++ b/packages/tlon-skill/scripts/bump-version.js
@@ -20,8 +20,6 @@ const packageFiles = [
   'npm/linux-arm64/package.json',
 ];
 
-const tlonSkillPackagePrefix = '@tloncorp/tlon-skill-';
-
 const newVersion = process.argv[2];
 
 if (!newVersion) {
@@ -46,33 +44,12 @@ console.log(`Bumping version to ${newVersion}...\n`);
 
 let failed = false;
 
-function getTlonSkillOptionalDeps(optionalDependencies) {
-  if (!optionalDependencies) {
-    return [];
-  }
-
-  return Object.keys(optionalDependencies).filter((dep) =>
-    dep.startsWith(tlonSkillPackagePrefix)
-  );
-}
-
-function updateTlonSkillOptionalDeps(optionalDependencies) {
-  for (const dep of getTlonSkillOptionalDeps(optionalDependencies)) {
-    optionalDependencies[dep] = newVersion;
-  }
-}
-
 for (const file of packageFiles) {
   const filePath = join(rootDir, file);
   try {
     const pkg = JSON.parse(readFileSync(filePath, 'utf-8'));
     const oldVersion = pkg.version;
     pkg.version = newVersion;
-
-    // Also update optionalDependencies versions in main package.json
-    if (file === 'package.json') {
-      updateTlonSkillOptionalDeps(pkg.optionalDependencies);
-    }
 
     writeFileSync(filePath, JSON.stringify(pkg, null, 2) + '\n');
     console.log(`  ${file}: ${oldVersion} → ${newVersion}`);
@@ -89,6 +66,9 @@ if (failed) {
 
 console.log("\nDone! Don't forget to:");
 console.log('  1. Update CHANGELOG.md (if you have one)');
-console.log('  2. Commit the changes');
-console.log('  3. Tag the release: git tag v' + newVersion);
-console.log('  4. Push: git push && git push --tags');
+console.log('  2. Commit the changes and merge to develop');
+console.log(
+  '  3. Release by tagging tlon-skill-v' +
+    newVersion +
+    ' or dispatching the tlon-skill-publish workflow'
+);

--- a/packages/tlon-skill/scripts/release-package.ts
+++ b/packages/tlon-skill/scripts/release-package.ts
@@ -32,6 +32,7 @@ type RootPackageJson = {
   name: string;
   version: string;
   files?: string[];
+  optionalDependencies?: Record<string, string>;
 };
 
 type PackOutput = Array<{
@@ -140,6 +141,40 @@ function assertRootFilesField(packageJson: RootPackageJson): void {
   }
 }
 
+function injectPlatformOptionalDependencies(
+  packageJson: RootPackageJson
+): RootPackageJson {
+  const optionalDependencies: Record<string, string> = {};
+  for (const target of TARGETS) {
+    optionalDependencies[PLATFORM_PACKAGES[target]] = packageJson.version;
+  }
+  return { ...packageJson, optionalDependencies };
+}
+
+function assertStagedOptionalDependencies(
+  packageJson: RootPackageJson,
+  version: string
+): void {
+  const optionalDependencies = packageJson.optionalDependencies ?? {};
+  const expected = new Set(TARGETS.map((target) => PLATFORM_PACKAGES[target]));
+
+  for (const target of TARGETS) {
+    const name = PLATFORM_PACKAGES[target];
+    const pinned = optionalDependencies[name];
+    if (pinned !== version) {
+      fail(
+        `Staged root manifest optionalDependencies.${name} was ${pinned ?? '<missing>'}, expected ${version}`
+      );
+    }
+  }
+
+  for (const name of Object.keys(optionalDependencies)) {
+    if (!expected.has(name)) {
+      fail(`Staged root manifest has unexpected optionalDependency ${name}`);
+    }
+  }
+}
+
 function parsePackOutput(stdout: string): PackOutput {
   const jsonStart = stdout.indexOf('[');
   if (jsonStart === -1) {
@@ -196,10 +231,17 @@ function stageRootPackage(rootDir: string, stageDir: string): RootPackageJson {
   ) as RootPackageJson;
   assertRootFilesField(packageJson);
 
-  copyRequired(
-    packageJsonPath,
+  // The workspace manifest no longer declares the platform packages as
+  // optionalDependencies (local dev uses dev:link). Inject the four pins at the
+  // current version into the staged manifest so the published wrapper resolves
+  // its native binary, then assert the injection before packing.
+  const stagedPackageJson = injectPlatformOptionalDependencies(packageJson);
+  assertStagedOptionalDependencies(stagedPackageJson, packageJson.version);
+  mkdirSync(stageDir, { recursive: true });
+  writeFileSync(
     join(stageDir, 'package.json'),
-    'root package.json'
+    `${JSON.stringify(stagedPackageJson, null, 2)}\n`,
+    'utf-8'
   );
   copyRequired(
     join(rootDir, 'bin', 'tlon.js'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1318,19 +1318,6 @@ importers:
         version: 1.5.0(@types/node@20.19.31)(jsdom@23.2.0)(lightningcss@1.31.1)(terser@5.46.0)
 
   packages/tlon-skill:
-    optionalDependencies:
-      '@tloncorp/tlon-skill-darwin-arm64':
-        specifier: 0.4.0
-        version: 0.4.0
-      '@tloncorp/tlon-skill-darwin-x64':
-        specifier: 0.4.0
-        version: 0.4.0
-      '@tloncorp/tlon-skill-linux-arm64':
-        specifier: 0.4.0
-        version: 0.4.0
-      '@tloncorp/tlon-skill-linux-x64':
-        specifier: 0.4.0
-        version: 0.4.0
     devDependencies:
       '@tloncorp/api':
         specifier: workspace:*
@@ -1339,8 +1326,8 @@ importers:
         specifier: ^1.3.14
         version: 1.3.14
       '@types/node':
-        specifier: ^24.12.4
-        version: 24.12.4
+        specifier: ^22.10.0
+        version: 22.19.20
       '@urbit/aura':
         specifier: ^3.0.0
         version: 3.0.0
@@ -5692,30 +5679,6 @@ packages:
   '@tloncorp/mock-http-api@1.2.0':
     resolution: {integrity: sha512-uDv+7J6enXeZqP1lX7vsyCiAkVbQL0yXQZSUBFMRtmW8LW7BhRqW6hmN+Pk3jcaUSDLUHh8TWjnEx9kNoS9QPQ==}
 
-  '@tloncorp/tlon-skill-darwin-arm64@0.4.0':
-    resolution: {integrity: sha512-2hpHiKUDOqXkEeoCOu2yk5cBsQZno61wk1iPlDluYj5XXc8YRWwaLTYtAbhWj2giNI9UE4+B81n9eT+4lphF9w==}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
-
-  '@tloncorp/tlon-skill-darwin-x64@0.4.0':
-    resolution: {integrity: sha512-VoYzNgoUufFUHiCjV5jerog/iuEVB+2sD86xkPYHm9WUfbETiAj+cWkKbl0lLSKasqtUtS7qgpslbBJzS0SeZg==}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@tloncorp/tlon-skill-linux-arm64@0.4.0':
-    resolution: {integrity: sha512-2GnUO0jgybLE7qONOXGQZY5qrttEPaPN8U9RhgIyjFmViJuA8laQsQyaXu0d1/HVTxQ77tLzVHCIHBg5waT1Bg==}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
-
-  '@tloncorp/tlon-skill-linux-x64@0.4.0':
-    resolution: {integrity: sha512-rdcm64J1+8t36to4IS7CNb0y+THUHqqISSkwKq2EPvuLrOuhL9pvgnIE+oO3qBezvNXJRo36GQPM2G05MosTYg==}
-    cpu: [x64]
-    os: [linux]
-    hasBin: true
-
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -5859,8 +5822,8 @@ packages:
   '@types/node@20.19.31':
     resolution: {integrity: sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==}
 
-  '@types/node@24.12.4':
-    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+  '@types/node@22.19.20':
+    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -12746,9 +12709,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.21.3:
     resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
@@ -20377,18 +20337,6 @@ snapshots:
       core-js: 3.41.0
       path-to-regexp: 6.2.1
 
-  '@tloncorp/tlon-skill-darwin-arm64@0.4.0':
-    optional: true
-
-  '@tloncorp/tlon-skill-darwin-x64@0.4.0':
-    optional: true
-
-  '@tloncorp/tlon-skill-linux-arm64@0.4.0':
-    optional: true
-
-  '@tloncorp/tlon-skill-linux-x64@0.4.0':
-    optional: true
-
   '@tootallnate/once@2.0.0': {}
 
   '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.2.5)':
@@ -20561,9 +20509,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.12.4':
+  '@types/node@22.19.20':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -21907,7 +21855,7 @@ snapshots:
 
   bun-types@1.3.14:
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 22.19.20
 
   bundle-name@4.1.0:
     dependencies:
@@ -28942,8 +28890,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
-
-  undici-types@7.16.0: {}
 
   undici@6.21.3: {}
 


### PR DESCRIPTION
## Summary

Gives `@tloncorp/tlon-skill` a release path from the monorepo (PR 2 of 3 for the current phase of TLON-5771). The 2026-06-02 import carried the release _scripts_ (`release-package.ts`, `release-package-smoke.ts`, `release-binary-smoke.ts`, `bump-version.js`) but none of the workflows that invoke them, so the only existing publish path runs from the now-stale standalone repo. This ports the standalone `publish.yml` and `bump-version.yml` into the monorepo, adapted for the pnpm workspace, and removes a lockfile foot-gun that blocked bumping to an unpublished version.

The ported workflows preserve the contract from the tlon-skill repo: the `quality → build → package → package-smoke → publish` chain, the GitHub-hosted runner matrix, tarball assertions, minimal per-job permissions, and dry-run semantics.

## Changes

### Workflows

-   Added `.github/workflows/tlon-skill-publish.yml`. Ported from the standalone `publish.yml` with monorepo adaptations:
    -   **Trigger:** `tlon-skill-v*` tag prefix (bare `v*` collides with app release tags) plus `workflow_dispatch` with a `dry_run` input (default `true`). Dropped `workflow_call` (nothing calls it).
    -   **Toolchain (every job):** `actions/setup-node@v4` with `node-version-file: .nvmrc` (Node 22.22.0), `oven-sh/setup-bun@v2` Bun 1.3.4, `pnpm/action-setup@v3`, then `pnpm install --frozen-lockfile` at the repo root, replacing the standalone `npm ci`.
    -   **api dist:** `quality` and `build` run `pnpm build:api` from the repo root before any tlon-skill typecheck/bundle step. `package`/`package-smoke`/`publish` operate on downloaded artifacts and don't need it.
    -   **Root vs package commands:** root-only scripts run at the repo root; package commands use per-step `working-directory: packages/tlon-skill`. No job-wide package working-directory (it would break `pnpm build:api`). Artifact `path:` values carry the `packages/tlon-skill/` prefix, and downloads land where the scripts' `--artifacts-dir`/`--tarball-dir` flags point.
    -   **Tag/version guard:** an early step in `quality` asserts, on tag pushes, that `github.ref_name == tlon-skill-v<version from packages/tlon-skill/package.json>` and fails fast on mismatch. `workflow_dispatch` dry runs are exempt.
    -   **Runners:** kept the source matrix labels exactly (`macos-15`/darwin-arm64, `macos-15-intel`/darwin-x64, `ubuntu-24.04`/linux-x64, `ubuntu-24.04-arm`/linux-arm64). Not switched to the Blacksmith labels `ci.yml` uses: those don't exist for these macOS/arm64 targets, and the release pipeline deliberately pins a specific runner image per platform so native builds and smokes run on known OS versions.
    -   **publish:** unchanged dry-run short-circuit, then `npm publish <tarball> --access public --provenance` (four platform packages first, root last). `id-token: write` is scoped to this job only.
-   Added `.github/workflows/tlon-skill-bump-version.yml`. Ported from `bump-version.yml`:
    -   `workflow_dispatch` with a `version` input; `node scripts/bump-version.js <version>` in `packages/tlon-skill` (passed via env var, not interpolated into the shell, to avoid injection).
    -   Replaced the `npm ci` verification steps with `pnpm install --lockfile-only` at the repo root. `create-pull-request` commits `pnpm-lock.yaml` only if it changed (with the pack-time-injection change below it normally won't). The real gate is that CI's `pnpm install --frozen-lockfile` passes on the bump PR.
    -   **Known caveat:** PRs created with the default `GITHUB_TOKEN` do not trigger `pull_request` workflows (GitHub limitation), so bump PRs will show **no CI checks** until a human closes/reopens them or pushes a commit. Do not merge a bump PR with zero checks; re-trigger CI first. (Same latent behavior existed in the standalone repo; switching the workflow to a PAT/GitHub App token would fix it properly.)
    -   PR-instead-of-push flow targeting `develop`; PR body and `bump-version.js`'s printed instructions updated from `master`/`v<version>` to `develop`/`tlon-skill-v<version>`.
    -   `peter-evans/create-pull-request` is **SHA-pinned** (`22a9089…` = v7); official `actions/*`, `oven-sh/setup-bun`, and `pnpm/action-setup` stay tag-pinned per repo convention.

### Pack-time injection of the platform optional dependencies

The root `pnpm-lock.yaml` pinned the four platform packages at exact registry versions via `packages/tlon-skill` → `optionalDependencies`. Bumping to an unpublished version breaks installs: pnpm silently excludes an unresolvable optional dependency and omits its specifier from the lockfile, so the next `pnpm install --frozen-lockfile` fails with `ERR_PNPM_OUTDATED_LOCKFILE`. Fixed by moving the pins out of the workspace manifest and injecting them at pack time:

-   Removed `optionalDependencies` from `packages/tlon-skill/package.json`. The workspace never depends on registry copies of its own binaries (local dev uses `dev:link`); this also stops every monorepo `pnpm install` from downloading the published 0.4.0 binaries.
-   `release-package.ts` now injects the four `@tloncorp/tlon-skill-<target>` pins (at the current package version) into the **staged** root `package.json` at pack time, and asserts the staged manifest carries all four pins at the exact version (and no stray pins) before packing.
-   `bump-version.js` no longer rewrites root `optionalDependencies`; it bumps the five `version` fields only.
-   `release-package-smoke.ts` needed no change: it already reads optional-dependency resolution from the installed tarball manifest (which now carries the injected pins), and its assertions (root tarball has `bin/tlon.js` and not `bin/tlon`; platform tarball has its binary; native optional package resolves from the local tarball with matching version + binary hash) continue to hold.
-   Refreshed `pnpm-lock.yaml`: the changes are the removal of the four tlon-skill platform-package entries plus the `@types/node` realignment under the tlon-skill importer (see Misc). No unrelated re-resolution churn. `pnpm install --frozen-lockfile` passes.

### Misc

-   Added `release-tarballs/` and `artifacts/` to `packages/tlon-skill/.gitignore`: local runs of the release-validation chain write these directories (CI consumes them via artifact uploads, so they were never ignored before).
-   Aligned `@types/node` with the Node 22 toolchain (`^24.12.4` → `^22.10.0`); the package previously declared Node 24 types against the repo's Node 22.22.0 pin. The lockfile impact is 7 insertions / 12 deletions, all under the tlon-skill importer: `bun-types` (which declares `@types/node: '*'`) dedupes onto the same v22 copy, and `undici-types@7.16.0` drops out of the tree entirely.

### Platform package metadata

The four `packages/tlon-skill/npm/*/package.json` manifests still pointed `repository.url` at `https://github.com/tloncorp/tlon-skill`. Updated all four to the monorepo URL with a package-specific `directory` (e.g. `packages/tlon-skill/npm/darwin-arm64`), matching the root package's metadata so npm and provenance point at the monorepo.

## How did I test?

Local equivalents of the workflow steps on darwin-arm64, all green:

-   `pnpm --filter '@tloncorp/tlon-skill' typecheck`: exit 0.
-   `node scripts/build-all.js --target=darwin-arm64` → `pnpm release:binary-smoke -- --binary npm/darwin-arm64/tlon` → `pnpm release:package -- --artifacts-dir <dir> --out-dir release-tarballs` → `pnpm release:package-smoke -- --tarball-dir release-tarballs --target=darwin-arm64`: full chain passes; package smoke validates native resolution, version, and binary hash from the local tarball.
-   Verified the packed root tarball's `package.json` carries all four injected platform pins at `0.4.0`.
-   `pnpm install --frozen-lockfile` passes on the refreshed lockfile; confirmed the lockfile diff is limited to the tlon-skill optional-dependency removal and the `@types/node` realignment.
-   `pnpm --filter '@tloncorp/tlon-skill' typecheck` passes on both tsconfigs under `@types/node` 22.
-   `node scripts/bump-version.js 0.4.1` bumps the five version fields, leaves root `optionalDependencies` absent, and prints the `develop`/`tlon-skill-v0.4.1` instructions.
-   Both workflow files parse as valid YAML; job graph reviewed against the source (chain, matrix, artifact flow, per-job permissions, timeouts).
-   `pnpm prettier --check` on touched `.ts`/`.js` files: clean.

The full `workflow_dispatch` dry run is a **post-merge** gate (a new workflow file generally isn't dispatchable until it exists on the default branch). See the checklist below.

## Out-of-band follow-ups

These cannot be performed from the PR and a dry run will not catch the first one:

1. **npm Trusted Publishing reconfiguration (hard prerequisite before the first real publish).** npm Trusted Publishing is bound to repo + workflow filename. Before the first real tag, the trusted-publisher settings on npmjs.com for **all five** packages (`@tloncorp/tlon-skill` and the four `@tloncorp/tlon-skill-<target>` platform packages) must be updated to point at this repository and `tlon-skill-publish.yml`. If the org uses a token instead, wire `NODE_AUTH_TOKEN` from repo secrets onto the publish steps.
2. **Post-merge dry-run gate (run immediately after merge, before any real tag).** `gh workflow run tlon-skill-publish.yml -f dry_run=true` must complete `quality`, all four builds, `package`, all four package-smokes, and artifact upload, skipping only the `npm publish` calls. (Pre-merge, a best-effort `gh workflow run … --ref <branch>` may not be dispatchable until the file is on `develop`.)
3. **Decommission the standalone repo.** After the dry run proves the pipeline, disable/remove the standalone repo's `publish.yml`, `bump-version.yml`, and `ci.yml`, then archive the repository. Until then a stray `v*` tag there can publish stale code.

## Notes / decisions

-   `@tloncorp/api` is a `workspace:*` dependency, so release binaries bundle workspace HEAD rather than a published api version; release notes/versioning must account for unreleased api changes.

## Out of scope

-   Command/test code changes (PRs 1 and 3).
-   Changing the package version or performing an actual publish.
-   A scheduled live-integration test workflow (planned separately).