### PR TITLE
fix flaky prod smoke test: reboot ship and retry desk commit on vere crash

### DIFF
--- a/apps/tlon-web/rube/index.ts
+++ b/apps/tlon-web/rube/index.ts
@@ -573,9 +573,10 @@ const bootShip = (
   binaryPath: string,
   pierPath: string,
   httpPort: string,
-  ship: ShipName
+  ship: ShipName,
+  options: { resume?: boolean } = {}
 ) => {
-  if (FRESH_BOOT) {
+  if (FRESH_BOOT && !options.resume) {
     // For fresh boot, use -F to create a new fakeship
     // pierPath is e.g. dist/zod/zod - parent dir is dist/zod/
     const parentDir = path.dirname(pierPath);
@@ -839,6 +840,54 @@ const getPortsFromFiles = async () =>
     resolve();
   });
 
+const rebootShip = async (ship: Ship) => {
+  const shipName = ship.ship as ShipName;
+  const pierPath = IN_CONTAINER
+    ? ship.extractPath
+    : path.join(ship.extractPath, shipName);
+
+  // The ship runs daemonized (-d), so shipProcesses only tracks the
+  // launcher. Kill any surviving runtime for this pier by path. Matching
+  // on the pier path catches both the king and the serf (<pier>/.run),
+  // and bracketing the first character keeps the pattern from matching
+  // this command's own shell.
+  const pierPattern = pierPath.replace(/^(.)/, '[$1]');
+  await execPromise(
+    `pids=$(ps aux | grep "${pierPattern}" | awk '{print $2}'); [ -n "$pids" ] && echo "$pids" | xargs kill -9 2>/dev/null || true`
+  );
+
+  // A crashed runtime leaves .http.ports behind; remove it so its
+  // reappearance tells us the rebooted ship is actually listening.
+  const httpPortsFile = path.join(pierPath, '.http.ports');
+  if (fs.existsSync(httpPortsFile)) {
+    fs.rmSync(httpPortsFile);
+  }
+
+  const binaryPath = path.join(WORKSPACE_DIR, 'urbit_extracted', 'urbit');
+  console.log(`Rebooting ~${shipName} at ${pierPath}`);
+  bootShip(binaryPath, pierPath, ship.httpPort, shipName, { resume: true });
+
+  // The loopback port is OS-assigned and changes across reboots, so poll
+  // until we can parse a fresh one rather than just waiting for the file.
+  const maxAttempts = 60;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (fs.existsSync(httpPortsFile)) {
+      const lines = fs.readFileSync(httpPortsFile, 'utf8').split('\n');
+      const port = lines.map(parseLoopbackPort).find(Boolean);
+      if (port) {
+        ships[shipName].loopbackPort = port;
+        console.log(`Rebooted ~${shipName}; loopback port is now ${port}`);
+        return;
+      }
+    }
+    await sleep(1000);
+  }
+
+  throw new Error(
+    `~${shipName} did not come back up within ${maxAttempts}s of rebooting`
+  );
+};
+
 const mountDesks = async () => {
   console.log('Mounting desks on all ships');
 
@@ -875,15 +924,36 @@ const commitDesks = async (shipsNeedingUpdates: string[]) => {
     }
 
     if (shipsNeedingUpdates.includes(ship.ship)) {
-      await hoodCommand(
-        ship.ship as ShipName,
-        `commit %groups`,
-        ship.loopbackPort
-      );
-      await assertShipHealthy(
-        ship.ship as ShipName,
-        'post-commit ship health check'
-      );
+      // The vere runtime can segfault while rescanning the mounted desk
+      // during the commit (u3_readdir_r in pkg/vere/io/unix.c). The crash
+      // is memory-layout dependent, so rebooting the pier and re-running
+      // the (idempotent) commit nearly always succeeds.
+      const maxAttempts = 4;
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+          await hoodCommand(
+            ship.ship as ShipName,
+            `commit %groups`,
+            ship.loopbackPort
+          );
+          await assertShipHealthy(
+            ship.ship as ShipName,
+            'post-commit ship health check'
+          );
+          break;
+        } catch (error) {
+          if (
+            !(error instanceof ShipUnavailableError) ||
+            attempt === maxAttempts
+          ) {
+            throw error;
+          }
+          console.log(
+            `~${ship.ship} became unreachable during desk commit (attempt ${attempt}/${maxAttempts}), rebooting and retrying...`
+          );
+          await rebootShip(ship);
+        }
+      }
     }
   }
 };


### PR DESCRIPTION
## Summary

Fixes the frequently failing "Run Production Build Smoke Test" CI step by making the rube desk-commit phase recover from vere runtime crashes. The runtime can segfault while rescanning the mounted desk during `commit %groups` (unchecked `memcpy` in `u3_readdir_r`, pkg/vere/io/unix.c), which surfaces as `ShipUnavailableError: Ship ~zod became unreachable during post-commit ship health check`. The crash is memory-layout dependent, so rebooting the pier and re-running the idempotent commit nearly always succeeds.

## Changes

All changes are in `apps/tlon-web/rube/index.ts`:

-   Wrapped each ship's `commit %groups` and post-commit health check in `commitDesks` with a retry loop (up to 4 attempts). On `ShipUnavailableError`, the crashed pier is rebooted and the commit re-run; the commit is idempotent, so this is safe whether the crash happened before or after the commit event landed. Any other error still fails immediately.
-   Added a `rebootShip` helper that kills surviving runtime processes by pier path (ships run daemonized with `-d`, so the tracked child is just the launcher; matching the pier path catches both king and serf), removes the stale `.http.ports` file the crashed runtime leaves behind, reboots via `bootShip`, and polls for the new OS-assigned loopback port (it changes across reboots) before updating the ship record.
-   Added a `resume` option to `bootShip` so a reboot resumes the existing pier even when `FRESH_BOOT=true` is set.

Notes:

-   The parallel E2E CI shards use the same `commitDesks` path and get the same protection.
-   This is an infra-level mitigation; the underlying bug should be fixed upstream in urbit/vere. Pinning an older vere is not an option because the bug is long-standing and the newest vere is required to run the newest %base/%groups on the test ships. The crash signature is documented in a code comment.
-   The workflow-level retry (`pnpm e2e:prod:smoke:force || retry`) remains as a backstop.

## How did I test?

-   Fault injection locally (macOS): ran rube setup with `SHIP_NAME=ten` and SIGKILLed the ship runtime exactly as the commit phase started. This reproduced the identical CI failure signature (post-commit health check ECONNRESET then ECONNREFUSED), and the new code recovered: detected the failure on attempt 1/4, rebooted the pier, picked up the changed loopback port (12321 to 12323), re-committed, and setup completed with `SHIP_SETUP_COMPLETE`.
-   Attempted to reproduce the real segfault in a linux/amd64 Docker container (Rosetta-emulated) with the exact CI ingredients (latest linux-x86_64 vere, rube-ten25.tgz pier, repo desk copied over the mount): 80 commit cycles across overlayfs and ext4-with-directory-churn configurations produced zero crashes. The bug appears to need the memory layout of real x86 hardware, so validation against the genuine segfault will come from CI runs of this branch, where the crash fires frequently. Example failing run before this change: https://github.com/tloncorp/tlon-apps/actions/runs/27295336301/job/80626392474 (PR #5921), where both the first attempt and the workflow-level retry crashed identically.
-   `pnpm rube:compile` passes.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [x] Other: E2E/CI test infrastructure (rube ship setup)

## Rollback plan

Revert.