### PR TITLE
Add %context-lens agent for durable owner-side bot run history

### DIFF
--- a/backend/run-tests.sh
+++ b/backend/run-tests.sh
@@ -17,7 +17,7 @@ case $OSTYPE in
         urbit_bin_url="$urbit_bin_url/linux-x86_64/latest"
         arch=x86_64
         ;;
-      arm64  ) 
+      arm64 | aarch64 )
         urbit_bin_url="$urbit_bin_url/linux-aarch64/latest"
         arch=aarch64
         ;;

--- a/desk/app/context-lens.hoon
+++ b/desk/app/context-lens.hoon
@@ -145,7 +145,7 @@
   $(targets t.targets)
 ::
 ++  store
-  |=  [bot=ship =id-run:l payload=json complete=?]
+  |=  [bot=ship =id-run:l payload=@t complete=?]
   ^+  cor
   ::  never demote a finalized run back to partial
   ::

--- a/desk/app/context-lens.hoon
+++ b/desk/app/context-lens.hoon
@@ -16,7 +16,7 @@
 /+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
-::  $state-0: agent state
+::  $state-1: agent state (%0 -> %1 arms the prune timer on upgrade)
 ::
 ::    .owners: ships that receive run fan-out (bot role; ~ = inert)
 ::    .runs: stored run records keyed by bot ship and run id (owner role)
@@ -27,14 +27,21 @@
       runs=(map [bot=ship =id-run:l] run:l)
   ==
 ::
-+$  versioned-state  $%(state-0)
-+$  current-state  state-0
++$  state-1
+  $:  %1
+      owners=(set ship)
+      runs=(map [bot=ship =id-run:l] run:l)
+  ==
+::
++$  versioned-state  $%(state-0 state-1)
++$  current-state  state-1
 ::
 ++  migrate-state
   |=  old=versioned-state
   ^-  current-state
   ?-  -.old
-    %0  old
+    %0  [%1 +.old]
+    %1  old
   ==
 --
 =|  current-state
@@ -47,12 +54,20 @@
   +*  this  .
       def   ~(. (default-agent this %.n) bowl)
       cor   ~(. +> [bowl ~])
-  ++  on-init  `this
+  ++  on-init
+    ^-  (quip card _this)
+    [~[wait-prune:cor] this]
   ++  on-save  !>(state)
+  ::  arm the prune timer exactly once when upgrading from a version
+  ::  that didn't have it; arming on every load would stack timers
+  ::
   ++  on-load
     |=  ole=vase
     ^-  (quip card _this)
-    [~ this(state (migrate-state !<(versioned-state ole)))]
+    =/  old  !<(versioned-state ole)
+    =/  cards=(list card)
+      ?:(?=(%0 -.old) ~[wait-prune:cor] ~)
+    [cards this(state (migrate-state old))]
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
@@ -77,6 +92,7 @@
       =/  bot  (slav %p i.t.t.path)
       =/  =id-run:l  i.t.t.t.path
       ?~  r=(~(get by runs) [bot id-run])  [~ ~]
+      ?:  (expired:cor u.r)  [~ ~]
       ``context-lens-update-1+!>(`update:v1:l`[%run bot id-run u.r])
     ==
   ++  on-agent
@@ -84,7 +100,11 @@
     ^-  (quip card _this)
     =^  cards  state  abet:(agent:cor wire sign)
     [cards this]
-  ++  on-arvo  on-arvo:def
+  ++  on-arvo
+    |=  [=wire =sign-arvo]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(arvo:cor wire sign-arvo)
+    [cards this]
   ++  on-leave  |=(path `this)
   ++  on-fail
     |=  [=term =tang]
@@ -97,10 +117,22 @@
 ++  abet  [(flop cards) state]
 ++  emit  |=(=card cor(cards [card cards]))
 ++  give  |=(=gift:agent:gall (emit %give gift))
-::  retention bounds for stored runs (owner role)
+::  retention bounds for stored runs (owner role): enforced on store
+::  and on a daily timer; reads also filter expired runs so the age
+::  bound holds even if a bot goes quiet between timer fires
 ::
-++  max-runs-per-bot  500
-++  max-run-age  ~d30
+++  max-runs-per-bot  1.000
+++  max-run-age  ~d90
+++  prune-interval  ~d1
+::
+++  wait-prune
+  ^-  card
+  [%pass /prune %arvo %b %wait (add now.bowl prune-interval)]
+::
+++  expired
+  |=  =run:l
+  ^-  ?
+  (lth received.run (sub now.bowl max-run-age))
 ::
 ++  poke
   |=  [=mark =vase]
@@ -164,7 +196,6 @@
 ++  prune
   |=  for=ship
   ^+  cor
-  =/  cutoff=@da  (sub now.bowl max-run-age)
   =/  mine
     %+  skim  ~(tap by runs)
     |=  [[bot=ship *] *]
@@ -172,11 +203,11 @@
   =/  dead
     %+  skim  mine
     |=  [* =run:l]
-    (lth received.run cutoff)
+    (expired run)
   =/  live
     %+  skip  mine
     |=  [* =run:l]
-    (lth received.run cutoff)
+    (expired run)
   =?  dead  (gth (lent live) max-runs-per-bot)
     =/  sorted
       %+  sort  live
@@ -192,8 +223,12 @@
 ::
 ++  recent
   ^-  (list entry:v1:l)
+  =/  fresh
+    %+  skip  ~(tap by runs)
+    |=  [* =run:l]
+    (expired run)
   =/  sorted
-    %+  sort  ~(tap by runs)
+    %+  sort  fresh
     |=  [a=[* =run:l] b=[* =run:l]]
     (gth received.run.a received.run.b)
   %+  turn  (scag 50 sorted)
@@ -211,4 +246,27 @@
       ((slog 'context-lens: run fan-out nacked' u.p.sign) cor)
     ==
   ==
+::
+++  arvo
+  |=  [=wire sign=sign-arvo]
+  ^+  cor
+  ?+  wire  cor
+      [%prune ~]
+    ?.  ?=([%behn %wake *] sign)  cor
+    =?  cor  ?=(^ error.sign)
+      ((slog 'context-lens: prune wake failed' u.error.sign) cor)
+    =.  cor  prune-all
+    (emit wait-prune)
+  ==
+::
+++  prune-all
+  ^+  cor
+  =/  bots=(list ship)
+    %~  tap  in
+    %-  ~(gas in *(set ship))
+    (turn ~(tap by runs) |=([[bot=ship *] *] bot))
+  |-  ^+  cor
+  ?~  bots  cor
+  =.  cor  (prune i.bots)
+  $(bots t.bots)
 --

--- a/desk/app/context-lens.hoon
+++ b/desk/app/context-lens.hoon
@@ -68,6 +68,7 @@
   ++  on-peek
     |=  =path
     ^-  (unit (unit cage))
+    ?>  =(src our):bowl
     ?+  path  [~ ~]
         [%x %recent ~]
       ``context-lens-update-1+!>(`update:v1:l`[%runs recent:cor])

--- a/desk/app/context-lens.hoon
+++ b/desk/app/context-lens.hoon
@@ -147,11 +147,13 @@
 ++  store
   |=  [bot=ship =id-run:l payload=@t complete=?]
   ^+  cor
-  ::  never demote a finalized run back to partial
+  ::  drop late partials once a run is finalized: overwriting would
+  ::  pair complete=& with a stale partial payload (and fact it out)
   ::
   =/  prev  (~(get by runs) [bot id-run])
-  =/  comp  |(complete ?&(?=(^ prev) complete.u.prev))
-  =/  =run:l  [comp now.bowl payload]
+  ?:  &(?=(^ prev) complete.u.prev !complete)
+    cor
+  =/  =run:l  [complete now.bowl payload]
   =.  runs  (~(put by runs) [bot id-run] run)
   =.  cor  (prune bot)
   (give %fact ~[/v1] %context-lens-update-1 !>(`update:v1:l`[%run bot id-run run]))

--- a/desk/app/context-lens.hoon
+++ b/desk/app/context-lens.hoon
@@ -1,0 +1,211 @@
+::  lens: per-run bot introspection relay and store
+::
+::    one agent, two roles:
+::
+::    - bot ship: the openclaw gateway pokes %context-lens-action-1 locally with
+::      run records; we fan them out to configured owners as
+::      %context-lens-signal-1 pokes (ames retries until ack).
+::    - owner ship: stores runs from bot ships keyed [bot id-run] (the
+::      poke source is the trust anchor), gives facts on /v1, and
+::      answers scries for clients.
+::
+::    run payloads are opaque JSON with an inner schemaVersion; the
+::    gateway enforces size caps and truncation before poking.
+::
+/-  l=context-lens
+/+  default-agent, verb, dbug
+|%
++$  card  card:agent:gall
+::  $state-0: agent state
+::
+::    .owners: ships that receive run fan-out (bot role; ~ = inert)
+::    .runs: stored run records keyed by bot ship and run id (owner role)
+::
++$  state-0
+  $:  %0
+      owners=(set ship)
+      runs=(map [bot=ship =id-run:l] run:l)
+  ==
+::
++$  versioned-state  $%(state-0)
++$  current-state  state-0
+::
+++  migrate-state
+  |=  old=versioned-state
+  ^-  current-state
+  ?-  -.old
+    %0  old
+  ==
+--
+=|  current-state
+=*  state  -
+%-  agent:dbug
+%^  verb  |  %warn
+^-  agent:gall
+=<
+  |_  =bowl:gall
+  +*  this  .
+      def   ~(. (default-agent this %.n) bowl)
+      cor   ~(. +> [bowl ~])
+  ++  on-init  `this
+  ++  on-save  !>(state)
+  ++  on-load
+    |=  ole=vase
+    ^-  (quip card _this)
+    [~ this(state (migrate-state !<(versioned-state ole)))]
+  ++  on-poke
+    |=  [=mark =vase]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(poke:cor mark vase)
+    [cards this]
+  ++  on-watch
+    |=  =path
+    ^-  (quip card _this)
+    ?>  =(src our):bowl
+    ?+  path  (on-watch:def path)
+      [%v1 ~]  `this
+    ==
+  ++  on-peek
+    |=  =path
+    ^-  (unit (unit cage))
+    ?+  path  [~ ~]
+        [%x %recent ~]
+      ``context-lens-update-1+!>(`update:v1:l`[%runs recent:cor])
+    ::
+        [%x %run @ @ ~]
+      =/  bot  (slav %p i.t.t.path)
+      =/  =id-run:l  i.t.t.t.path
+      ?~  r=(~(get by runs) [bot id-run])  [~ ~]
+      ``context-lens-update-1+!>(`update:v1:l`[%run bot id-run u.r])
+    ==
+  ++  on-agent
+    |=  [=wire =sign:agent:gall]
+    ^-  (quip card _this)
+    =^  cards  state  abet:(agent:cor wire sign)
+    [cards this]
+  ++  on-arvo  on-arvo:def
+  ++  on-leave  |=(path `this)
+  ++  on-fail
+    |=  [=term =tang]
+    ^-  (quip card _this)
+    %-  (slog 'context-lens: on-fail' >term< tang)
+    [~ this]
+  --
+|_  [=bowl:gall cards=(list card)]
+++  cor   .
+++  abet  [(flop cards) state]
+++  emit  |=(=card cor(cards [card cards]))
+++  give  |=(=gift:agent:gall (emit %give gift))
+::  retention bounds for stored runs (owner role)
+::
+++  max-runs-per-bot  500
+++  max-run-age  ~d30
+::
+++  poke
+  |=  [=mark =vase]
+  ^+  cor
+  ?+  mark  ~|(bad-poke-mark+mark !!)
+      %context-lens-action-1
+    ?>  =(src our):bowl
+    =+  !<(=action:v1:l vase)
+    ?-  -.action
+      %configure  cor(owners owners.action)
+      %run-event  (fan-out %run-event +.action)
+      %run-final  (fan-out %run-final +.action)
+    ==
+  ::
+      %context-lens-signal-1
+    =+  !<(=signal:v1:l vase)
+    ?-  -.signal
+      %run-event  (store src.bowl id-run.signal payload.signal |)
+      %run-final  (store src.bowl id-run.signal payload.signal &)
+    ==
+  ==
+::
+++  fan-out
+  |=  =signal:v1:l
+  ^+  cor
+  =/  targets  ~(tap in owners)
+  |-  ^+  cor
+  ?~  targets  cor
+  =.  cor
+    ?:  =(i.targets our.bowl)
+      ::  self-owned bot: store directly, no network hop
+      %:  store
+        our.bowl
+        id-run.signal
+        payload.signal
+        ?=(%run-final -.signal)
+      ==
+    %-  emit
+    :^    %pass
+        /signal/(scot %p i.targets)/(scot %t id-run.signal)
+      %agent
+    [[i.targets %context-lens] %poke %context-lens-signal-1 !>(signal)]
+  $(targets t.targets)
+::
+++  store
+  |=  [bot=ship =id-run:l payload=json complete=?]
+  ^+  cor
+  ::  never demote a finalized run back to partial
+  ::
+  =/  prev  (~(get by runs) [bot id-run])
+  =/  comp  |(complete ?&(?=(^ prev) complete.u.prev))
+  =/  =run:l  [comp now.bowl payload]
+  =.  runs  (~(put by runs) [bot id-run] run)
+  =.  cor  (prune bot)
+  (give %fact ~[/v1] %context-lens-update-1 !>(`update:v1:l`[%run bot id-run run]))
+::
+::  +prune: enforce per-bot retention (age, then count cap)
+::
+++  prune
+  |=  for=ship
+  ^+  cor
+  =/  cutoff=@da  (sub now.bowl max-run-age)
+  =/  mine
+    %+  skim  ~(tap by runs)
+    |=  [[bot=ship *] *]
+    =(bot for)
+  =/  dead
+    %+  skim  mine
+    |=  [* =run:l]
+    (lth received.run cutoff)
+  =/  live
+    %+  skip  mine
+    |=  [* =run:l]
+    (lth received.run cutoff)
+  =?  dead  (gth (lent live) max-runs-per-bot)
+    =/  sorted
+      %+  sort  live
+      |=  [a=[* =run:l] b=[* =run:l]]
+      (lth received.run.a received.run.b)
+    (weld dead (scag (sub (lent live) max-runs-per-bot) sorted))
+  =/  keys  (turn dead |=([k=[bot=ship =id-run:l] *] k))
+  |-  ^+  cor
+  ?~  keys  cor
+  $(runs (~(del by runs) i.keys), keys t.keys)
+::
+::  +recent: newest stored runs across all bots, for scry backfill
+::
+++  recent
+  ^-  (list entry:v1:l)
+  =/  sorted
+    %+  sort  ~(tap by runs)
+    |=  [a=[* =run:l] b=[* =run:l]]
+    (gth received.run.a received.run.b)
+  %+  turn  (scag 50 sorted)
+  |=  [[bot=ship =id-run:l] =run:l]
+  [bot id-run run]
+::
+++  agent
+  |=  [=wire =sign:agent:gall]
+  ^+  cor
+  ?+  wire  cor
+      [%signal *]
+    ?+  -.sign  cor
+        %poke-ack
+      ?~  p.sign  cor
+      ((slog 'context-lens: run fan-out nacked' u.p.sign) cor)
+    ==
+  ==
+--

--- a/desk/desk.bill
+++ b/desk/desk.bill
@@ -20,4 +20,5 @@
     %metagrab
     %gateway-status
     %presence
+    %context-lens
 ==

--- a/desk/mar/context-lens/action-1.hoon
+++ b/desk/mar/context-lens/action-1.hoon
@@ -1,0 +1,41 @@
+::  context-lens-action-1: mark for lens inbound actions
+::
+/-  l=context-lens
+|_  =action:v1:l
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  action
+  ++  json
+    =,  enjs:format
+    ^-  ^json
+    ?-  -.action
+        %configure
+      %-  frond  :-  'configure'
+      %-  frond  :-  'owners'
+      a+(turn ~(tap in owners.action) |=(=ship s+(scot %p ship)))
+    ::
+        %run-event
+      %-  frond  :-  'run-event'
+      (pairs ~[['id' s+id-run.action] ['payload' payload.action]])
+    ::
+        %run-final
+      %-  frond  :-  'run-final'
+      (pairs ~[['id' s+id-run.action] ['payload' payload.action]])
+    ==
+  --
+++  grab
+  |%
+  ++  noun  action:v1:l
+  ++  json
+    |=  jon=^json
+    ^-  action:v1:l
+    =,  dejs:format
+    %.  jon
+    %-  of
+    :~  [%configure (ot ~[owners+(cu ~(gas in *(set ship)) (ar (se %p)))])]
+        [%run-event (ot ~[id+so payload+|=(j=^json j)])]
+        [%run-final (ot ~[id+so payload+|=(j=^json j)])]
+    ==
+  --
+--

--- a/desk/mar/context-lens/action-1.hoon
+++ b/desk/mar/context-lens/action-1.hoon
@@ -13,15 +13,16 @@
         %configure
       %-  frond  :-  'configure'
       %-  frond  :-  'owners'
-      a+(turn ~(tap in owners.action) |=(=ship s+(scot %p ship)))
+      ::  @p face: =,  enjs:format shadows the ship type with its +ship arm
+      a+(turn ~(tap in owners.action) |=(her=@p s+(scot %p her)))
     ::
         %run-event
       %-  frond  :-  'run-event'
-      (pairs ~[['id' s+id-run.action] ['payload' payload.action]])
+      (pairs ~[['id' s+id-run.action] ['payload' s+payload.action]])
     ::
         %run-final
       %-  frond  :-  'run-final'
-      (pairs ~[['id' s+id-run.action] ['payload' payload.action]])
+      (pairs ~[['id' s+id-run.action] ['payload' s+payload.action]])
     ==
   --
 ++  grab
@@ -34,8 +35,8 @@
     %.  jon
     %-  of
     :~  [%configure (ot ~[owners+(cu ~(gas in *(set ship)) (ar (se %p)))])]
-        [%run-event (ot ~[id+so payload+|=(j=^json j)])]
-        [%run-final (ot ~[id+so payload+|=(j=^json j)])]
+        [%run-event (ot ~[id+so payload+so])]
+        [%run-final (ot ~[id+so payload+so])]
     ==
   --
 --

--- a/desk/mar/context-lens/signal-1.hoon
+++ b/desk/mar/context-lens/signal-1.hoon
@@ -1,0 +1,14 @@
+::  context-lens-signal-1: mark for bot-ship to owner-ship run fan-out
+::
+/-  l=context-lens
+|_  =signal:v1:l
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  signal
+  --
+++  grab
+  |%
+  ++  noun  signal:v1:l
+  --
+--

--- a/desk/mar/context-lens/update-1.hoon
+++ b/desk/mar/context-lens/update-1.hoon
@@ -1,0 +1,34 @@
+::  context-lens-update-1: mark for lens outbound updates and scry results
+::
+/-  l=context-lens
+|_  =update:v1:l
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  update
+  ++  json
+    |^
+    =,  enjs:format
+    ^-  ^json
+    ?-  -.update
+      %run   (frond 'run' (entry entry.update))
+      %runs  (frond 'runs' a+(turn entries.update entry))
+    ==
+    ++  entry
+      |=  e=entry:v1:l
+      ^-  ^json
+      =,  enjs:format
+      %-  pairs
+      :~  ['bot' s+(scot %p bot.e)]
+          ['id' s+id-run.e]
+          ['complete' b+complete.run.e]
+          ['received' s+(scot %da received.run.e)]
+          ['payload' payload.run.e]
+      ==
+    --
+  --
+++  grab
+  |%
+  ++  noun  update:v1:l
+  --
+--

--- a/desk/mar/context-lens/update-1.hoon
+++ b/desk/mar/context-lens/update-1.hoon
@@ -23,7 +23,7 @@
           ['id' s+id-run.e]
           ['complete' b+complete.run.e]
           ['received' s+(scot %da received.run.e)]
-          ['payload' payload.run.e]
+          ['payload' s+payload.run.e]
       ==
     --
   --

--- a/desk/sur/context-lens.hoon
+++ b/desk/sur/context-lens.hoon
@@ -6,13 +6,16 @@
 +$  id-run  @t
 ::  $run: a stored run record
 ::
-::    payload is opaque JSON with an inner schemaVersion; ships relay
-::    and store it without interpreting its contents.
+::    payload is opaque serialized JSON with an inner schemaVersion;
+::    ships relay and store it without interpreting its contents.
+::    it is a cord rather than a $json because embedding the recursive
+::    $json type in mark sample types makes ford's tube nest checks
+::    diverge (stack overflow on every json conversion build).
 ::
 +$  run
   $:  complete=?
       received=@da
-      payload=json
+      payload=@t
   ==
 ::  $entry: a run plus its identity, as exposed to observers
 ::
@@ -21,14 +24,14 @@
 ::
 +$  action
   $%  [%configure owners=(set ship)]
-      [%run-event =id-run payload=json]
-      [%run-final =id-run payload=json]
+      [%run-event =id-run payload=@t]
+      [%run-final =id-run payload=@t]
   ==
 ::  $signal: bot-ship to owner-ship fan-out pokes
 ::
 +$  signal
-  $%  [%run-event =id-run payload=json]
-      [%run-final =id-run payload=json]
+  $%  [%run-event =id-run payload=@t]
+      [%run-final =id-run payload=@t]
   ==
 ::  $update: outbound subscription facts and scry results
 ::

--- a/desk/sur/context-lens.hoon
+++ b/desk/sur/context-lens.hoon
@@ -1,0 +1,41 @@
+::  lens: shared types for the per-run bot introspection agent
+::
+|%
+::  $id-run: gateway-assigned run identifier (the lensId stamped on posts)
+::
++$  id-run  @t
+::  $run: a stored run record
+::
+::    payload is opaque JSON with an inner schemaVersion; ships relay
+::    and store it without interpreting its contents.
+::
++$  run
+  $:  complete=?
+      received=@da
+      payload=json
+  ==
+::  $entry: a run plus its identity, as exposed to observers
+::
++$  entry  [bot=ship =id-run =run]
+::  $action: inbound poke protocol from openclaw-tlon (local gateway only)
+::
++$  action
+  $%  [%configure owners=(set ship)]
+      [%run-event =id-run payload=json]
+      [%run-final =id-run payload=json]
+  ==
+::  $signal: bot-ship to owner-ship fan-out pokes
+::
++$  signal
+  $%  [%run-event =id-run payload=json]
+      [%run-final =id-run payload=json]
+  ==
+::  $update: outbound subscription facts and scry results
+::
++$  update
+  $%  [%run =entry]
+      [%runs entries=(list entry)]
+  ==
+::
+++  v1  .
+--

--- a/desk/tests/app/context-lens.hoon
+++ b/desk/tests/app/context-lens.hoon
@@ -10,7 +10,7 @@
       owners=(set ship)
       runs=(map [bot=ship =id-run:l] run:l)
   ==
-++  payload  ^-  json  s+'run-record'
+++  payload  ^-  @t  '{"schemaVersion":1,"summary":"run-record"}'
 ++  setup
   =/  m  (mare ,~)
   ^-  form:m

--- a/desk/tests/app/context-lens.hoon
+++ b/desk/tests/app/context-lens.hoon
@@ -114,7 +114,7 @@
   =+  !<(=update:v1:l q.res)
   ?>  ?=(%run -.update)
   (ex-equal !>(complete.run.entry.update) !>(&))
-++  test-late-event-does-not-demote-final
+++  test-late-event-after-final-is-dropped
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
@@ -122,13 +122,15 @@
   ;<  *  bind:m
     %-  (do-as ~zod)
     (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'lens-4' payload]))
-  ;<  *  bind:m
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
+  ;<  caz=(list card)  bind:m
     %-  (do-as ~zod)
-    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-event 'lens-4' payload]))
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-event 'lens-4' '{"partial":true}']))
+  ;<  ~  bind:m  (ex-cards caz ~)
   ;<  res=cage  bind:m  (got-peek /x/run/(scot %p ~zod)/lens-4)
   =+  !<(=update:v1:l q.res)
   ?>  ?=(%run -.update)
-  (ex-equal !>(complete.run.entry.update) !>(&))
+  (ex-equal !>(run.entry.update) !>(`run:l`[& ~2024.1.1 payload]))
 ++  test-old-runs-pruned-by-age
   %-  eval-mare
   =/  m  (mare ,~)

--- a/desk/tests/app/context-lens.hoon
+++ b/desk/tests/app/context-lens.hoon
@@ -157,4 +157,21 @@
   %-  ex-fail
   %-  (do-as ~zod)
   (do-watch /v1)
+::  +get-peek calls +on-peek bare (no +mock), so a ?> crash would take
+::  down the runner; mule the calls directly instead of using +ex-fail
+::
+++  test-peek-rejects-foreign-ship
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (set-src ~zod)
+  |=  s=state
+  =/  recent  (mule |.((~(on-peek agent.s bowl.s) /x/recent)))
+  ?:  ?=(%& -.recent)
+    |+~['expected foreign /x/recent peek to crash']
+  =/  run  (mule |.((~(on-peek agent.s bowl.s) /x/run/(scot %p ~zod)/lens-1)))
+  ?:  ?=(%& -.run)
+    |+~['expected foreign /x/run peek to crash']
+  &+[~ s]
 --

--- a/desk/tests/app/context-lens.hoon
+++ b/desk/tests/app/context-lens.hoon
@@ -1,0 +1,158 @@
+::  tests for %context-lens agent
+::
+/-  l=context-lens
+/+  *test-agent
+/=  agent  /app/context-lens
+|%
+++  dap  %context-lens
++$  state-0
+  $:  %0
+      owners=(set ship)
+      runs=(map [bot=ship =id-run:l] run:l)
+  ==
+++  payload  ^-  json  s+'run-record'
+++  setup
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  *  bind:m  (do-init dap agent)
+  ::  do-init resets the bowl, so set the clock after it
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.1)))
+  (pure:m ~)
+++  configure
+  |=  owners=(set ship)
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m
+    (do-poke %context-lens-action-1 !>(`action:v1:l`[%configure owners]))
+  (pure:m ~)
+++  test-configure-sets-owners
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m
+    (do-poke %context-lens-action-1 !>(`action:v1:l`[%configure (silt ~[~bus])]))
+  ;<  ~  bind:m  (ex-cards caz ~)
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-0 !<(vase q.res))
+  (ex-equal !>(owners.st) !>((silt ~[~bus])))
+++  test-action-from-foreign-ship-crashes
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-poke %context-lens-action-1 !>(`action:v1:l`[%configure (silt ~[~zod])]))
+++  test-run-final-fans-out-to-owners
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure (silt ~[~bus]))
+  ;<  caz=(list card)  bind:m
+    (do-poke %context-lens-action-1 !>(`action:v1:l`[%run-final 'lens-1' payload]))
+  %+  ex-cards  caz
+  :~  %-  ex-poke
+      :*  /signal/(scot %p ~bus)/(scot %t 'lens-1')
+          [~bus %context-lens]
+          %context-lens-signal-1
+          !>(`signal:v1:l`[%run-final 'lens-1' payload])
+      ==
+  ==
+++  test-self-owner-stores-without-network-hop
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure (silt ~[~dev]))
+  ;<  caz=(list card)  bind:m
+    (do-poke %context-lens-action-1 !>(`action:v1:l`[%run-final 'lens-1' payload]))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  %-  ex-fact
+        :*  ~[/v1]
+            %context-lens-update-1
+            !>(`update:v1:l`[%run ~dev 'lens-1' [& ~2024.1.1 payload]])
+        ==
+    ==
+  ;<  res=cage  bind:m  (got-peek /x/run/(scot %p ~dev)/lens-1)
+  =+  !<(=update:v1:l q.res)
+  (ex-equal !>(update) !>(`update:v1:l`[%run ~dev 'lens-1' [& ~2024.1.1 payload]]))
+++  test-signal-stores-keyed-by-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-event 'lens-2' payload]))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  %-  ex-fact
+        :*  ~[/v1]
+            %context-lens-update-1
+            !>(`update:v1:l`[%run ~zod 'lens-2' [| ~2024.1.1 payload]])
+        ==
+    ==
+  ;<  res=cage  bind:m  (got-peek /x/run/(scot %p ~zod)/lens-2)
+  =+  !<(=update:v1:l q.res)
+  (ex-equal !>(update) !>(`update:v1:l`[%run ~zod 'lens-2' [| ~2024.1.1 payload]]))
+++  test-final-marks-run-complete
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-event 'lens-3' payload]))
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'lens-3' payload]))
+  ;<  res=cage  bind:m  (got-peek /x/run/(scot %p ~zod)/lens-3)
+  =+  !<(=update:v1:l q.res)
+  ?>  ?=(%run -.update)
+  (ex-equal !>(complete.run.entry.update) !>(&))
+++  test-late-event-does-not-demote-final
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'lens-4' payload]))
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-event 'lens-4' payload]))
+  ;<  res=cage  bind:m  (got-peek /x/run/(scot %p ~zod)/lens-4)
+  =+  !<(=update:v1:l q.res)
+  ?>  ?=(%run -.update)
+  (ex-equal !>(complete.run.entry.update) !>(&))
+++  test-old-runs-pruned-by-age
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'old-run' payload]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d31))))
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'new-run' payload]))
+  ;<  res=cage  bind:m  (got-peek /x/recent)
+  =+  !<(=update:v1:l q.res)
+  ?>  ?=(%runs -.update)
+  ;<  ~  bind:m  (ex-equal !>((lent entries.update)) !>(1))
+  ?>  ?=(^ entries.update)
+  (ex-equal !>(id-run.i.entries.update) !>('new-run'))
+++  test-watch-rejects-foreign-ship
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-watch /v1)
+--

--- a/desk/tests/app/context-lens.hoon
+++ b/desk/tests/app/context-lens.hoon
@@ -10,6 +10,11 @@
       owners=(set ship)
       runs=(map [bot=ship =id-run:l] run:l)
   ==
++$  state-1
+  $:  %1
+      owners=(set ship)
+      runs=(map [bot=ship =id-run:l] run:l)
+  ==
 ++  payload  ^-  @t  '{"schemaVersion":1,"summary":"run-record"}'
 ++  setup
   =/  m  (mare ,~)
@@ -35,7 +40,7 @@
     (do-poke %context-lens-action-1 !>(`action:v1:l`[%configure (silt ~[~bus])]))
   ;<  ~  bind:m  (ex-cards caz ~)
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   (ex-equal !>(owners.st) !>((silt ~[~bus])))
 ++  test-action-from-foreign-ship-crashes
   %-  eval-mare
@@ -139,7 +144,7 @@
   ;<  *  bind:m
     %-  (do-as ~zod)
     (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'old-run' payload]))
-  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d31))))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
   ;<  *  bind:m
     %-  (do-as ~zod)
     (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'new-run' payload]))
@@ -149,6 +154,62 @@
   ;<  ~  bind:m  (ex-equal !>((lent entries.update)) !>(1))
   ?>  ?=(^ entries.update)
   (ex-equal !>(id-run.i.entries.update) !>('new-run'))
+++  test-init-arms-prune-timer
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
+  ;<  caz=(list card)  bind:m  (do-init dap agent)
+  (ex-cards caz (ex-arvo /prune %b %wait (add *@da ~d1)) ~)
+::  upgrading from %0 arms the timer; reloading at %1 must not stack
+::  a second one
+::
+++  test-load-from-0-arms-prune-timer-once
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m
+    (do-load agent `!>(`state-0`[%0 ~ ~]))
+  ;<  ~  bind:m
+    (ex-cards caz (ex-arvo /prune %b %wait (add ~2024.1.1 ~d1)) ~)
+  ;<  caz=(list card)  bind:m  (do-load agent ~)
+  (ex-cards caz ~)
+++  test-prune-wake-reclaims-and-rearms
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'old-run' payload]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
+  ;<  caz=(list card)  bind:m  (do-arvo /prune [%behn %wake ~])
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  (ex-arvo /prune %b %wait (add (add ~2024.1.1 ~d91) ~d1))
+    ==
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-1 !<(vase q.res))
+  (ex-equal !>(~(wyt by runs.st)) !>(0))
+::  even with no timer fire or new store, expired runs must not be
+::  served by /x/recent or /x/run
+::
+++  test-expired-runs-hidden-from-reads
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as ~zod)
+    (do-poke %context-lens-signal-1 !>(`signal:v1:l`[%run-final 'old-run' payload]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
+  ;<  res=cage  bind:m  (got-peek /x/recent)
+  =+  !<(=update:v1:l q.res)
+  ?>  ?=(%runs -.update)
+  ;<  ~  bind:m  (ex-equal !>((lent entries.update)) !>(0))
+  ;<  run=(unit (unit cage))  bind:m  (get-peek /x/run/(scot %p ~zod)/old-run)
+  (ex-equal !>(?=([~ ~] run)) !>(&))
 ++  test-watch-rejects-foreign-ship
   %-  eval-mare
   =/  m  (mare ,~)

--- a/docs/context-lens.md
+++ b/docs/context-lens.md
@@ -15,7 +15,7 @@ The openclaw gateway records a run record per bot response and stamps the result
 
 A self-owned bot (owner ship == bot ship) is handled without a network hop: the fan-out stores directly.
 
-Run payloads are opaque JSON with an inner `schemaVersion`. The gateway enforces size caps and truncation before poking; the ship relays and stores without interpreting the contents.
+Run payloads are opaque serialized JSON (a cord, `@t`) with an inner `schemaVersion`. The gateway enforces size caps and truncation before poking; the ship relays and stores without interpreting the contents. The payload is a cord rather than a `$json` because embedding the recursive `$json` type in mark sample types makes ford's tube nest checks diverge — every json conversion build for the desk stack-overflows.
 
 ## state model
 
@@ -31,7 +31,7 @@ runs    (map [bot=ship id-run=@t] run)   stored run records (owner role)
 ```
 complete  ?      whether a %run-final has been received for this id
 received  @da    when the latest poke for this id arrived
-payload   json   opaque run record
+payload   @t     opaque serialized-JSON run record
 ```
 
 `%run-event` upserts a partial record (`complete=|`); `%run-final` marks it complete. A finalized run is never demoted back to partial by a late `%run-event`.
@@ -49,23 +49,23 @@ Enforced per bot on every store:
 
 ```
 [%configure owners=(set ship)]            set fan-out targets
-[%run-event id-run=@t payload=json]       incremental run milestone
-[%run-final id-run=@t payload=json]       finalized run record
+[%run-event id-run=@t payload=@t]       incremental run milestone
+[%run-final id-run=@t payload=@t]       finalized run record
 ```
 
 JSON poke form (as sent by the gateway over Eyre):
 
 ```json
 { "configure": { "owners": ["~sampel-palnet"] } }
-{ "run-event": { "id": "<lensId>", "payload": { ... } } }
-{ "run-final": { "id": "<lensId>", "payload": { ... } } }
+{ "run-event": { "id": "<lensId>", "payload": "<serialized JSON>" } }
+{ "run-final": { "id": "<lensId>", "payload": "<serialized JSON>" } }
 ```
 
 ### `%context-lens-signal-1` (cross-ship, bot → owner)
 
 ```
-[%run-event id-run=@t payload=json]
-[%run-final id-run=@t payload=json]
+[%run-event id-run=@t payload=@t]
+[%run-final id-run=@t payload=@t]
 ```
 
 Accepted from any ship; records are keyed by the sending ship, so a malicious ship can only write under its own identity. Storage is bounded by per-bot retention. Clients decide which bots they care about.
@@ -82,7 +82,7 @@ Accepted from any ship; records are keyed by the sending ship, so a malicious sh
 `entry` is `[bot=ship id-run=@t run]`. The update mark grows to JSON for Eyre:
 
 ```json
-{ "run": { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": { ... } } }
+{ "run": { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": "<serialized JSON>" } }
 ```
 
 ## integration notes

--- a/docs/context-lens.md
+++ b/docs/context-lens.md
@@ -1,0 +1,92 @@
+# %context-lens
+
+Ship-native agent for per-run bot introspection ("context lens"). Makes a bot's run records — trigger, tool calls, timings, output — durable on the owner's ship and reachable from any client (including mobile), without the client ever talking to the gateway.
+
+One agent, two roles. The same code runs on every ship; which role is active is determined by who pokes it.
+
+The agent is named `%context-lens` (not `%lens`) because `%base` already bills a `%lens` agent (the HTTP dojo API); gall agent names are global across desks, and the collision makes the groups desk commit silently fail.
+
+## overview
+
+The openclaw gateway records a run record per bot response and stamps the resulting channel post with a pointer blob (`{type: 'tlon-context-lens', lensId, botShip}`). The gateway's own HTTP/SSE routes only work for desktop clients that can reach it directly; gateway disk is also not durable on hosted infrastructure. `%context-lens` moves the durable home to the owner's ship:
+
+-   **bot ship role**: the local gateway pokes `%context-lens-action-1` with run records; the agent fans them out to configured owners as `%context-lens-signal-1` pokes. Ames retries until ack, so owner-ship downtime or gateway restarts don't drop finalized runs once poked.
+-   **owner ship role**: stores incoming runs keyed `[bot id-run]` — the poke source (`src.bowl`) is the trust anchor for `bot` — gives facts on `/v1`, and answers scries for clients.
+
+A self-owned bot (owner ship == bot ship) is handled without a network hop: the fan-out stores directly.
+
+Run payloads are opaque JSON with an inner `schemaVersion`. The gateway enforces size caps and truncation before poking; the ship relays and stores without interpreting the contents.
+
+## state model
+
+State is `state-0`, defined in the app file:
+
+```
+owners  (set ship)                       fan-out targets (bot role); ~ means inert
+runs    (map [bot=ship id-run=@t] run)   stored run records (owner role)
+```
+
+`run` (in `desk/sur/context-lens.hoon`):
+
+```
+complete  ?      whether a %run-final has been received for this id
+received  @da    when the latest poke for this id arrived
+payload   json   opaque run record
+```
+
+`%run-event` upserts a partial record (`complete=|`); `%run-final` marks it complete. A finalized run is never demoted back to partial by a late `%run-event`.
+
+### retention
+
+Enforced per bot on every store:
+
+-   runs older than 30 days are dropped
+-   at most 500 live runs per bot; oldest beyond the cap are dropped
+
+## poke surface
+
+### `%context-lens-action-1` (local gateway only, `?> =(src our)`)
+
+```
+[%configure owners=(set ship)]            set fan-out targets
+[%run-event id-run=@t payload=json]       incremental run milestone
+[%run-final id-run=@t payload=json]       finalized run record
+```
+
+JSON poke form (as sent by the gateway over Eyre):
+
+```json
+{ "configure": { "owners": ["~sampel-palnet"] } }
+{ "run-event": { "id": "<lensId>", "payload": { ... } } }
+{ "run-final": { "id": "<lensId>", "payload": { ... } } }
+```
+
+### `%context-lens-signal-1` (cross-ship, bot → owner)
+
+```
+[%run-event id-run=@t payload=json]
+[%run-final id-run=@t payload=json]
+```
+
+Accepted from any ship; records are keyed by the sending ship, so a malicious ship can only write under its own identity. Storage is bounded by per-bot retention. Clients decide which bots they care about.
+
+## subscription surface
+
+-   `/v1` (local only, `?> =(src our)`): `%context-lens-update-1` facts, one `[%run entry]` per stored run. No initial backfill fact — clients scry `/x/recent` for backfill.
+
+## scry surface
+
+-   `/x/recent` → `%context-lens-update-1` `[%runs (list entry)]` — newest 50 runs across all bots
+-   `/x/run/[ship]/[id-run]` → `%context-lens-update-1` `[%run entry]`, or empty (`[~ ~]`) when absent
+
+`entry` is `[bot=ship id-run=@t run]`. The update mark grows to JSON for Eyre:
+
+```json
+{ "run": { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": { ... } } }
+```
+
+## integration notes
+
+-   The gateway (openclaw-tlon) pokes `%configure` on monitor activation and `%run-event` / `%run-final` from its context-lens event stream. Lens recording is config-gated on the gateway side (`channels.tlon.contextLens`).
+-   Clients store runs in a local `context_lens_runs` table, subscribe to `/v1` for live updates, and scry on cache miss. The channel post pointer blob carries `botShip` so the client knows which `[bot id-run]` key to look up.
+-   The gateway's HTTP/SSE routes remain an optional desktop enhancement for fine-grained live streaming; `%context-lens` is the durable source of truth.

--- a/docs/context-lens.md
+++ b/docs/context-lens.md
@@ -19,7 +19,7 @@ Run payloads are opaque serialized JSON (a cord, `@t`) with an inner `schemaVers
 
 ## state model
 
-State is `state-0`, defined in the app file:
+State is `state-1`, defined in the app file (the `%0` → `%1` upgrade arms the retention timer exactly once; the shape is unchanged):
 
 ```
 owners  (set ship)                       fan-out targets (bot role); ~ means inert
@@ -38,10 +38,16 @@ payload   @t     opaque serialized-JSON run record
 
 ### retention
 
-Enforced per bot on every store:
+Bounds, per bot:
 
--   runs older than 30 days are dropped
--   at most 500 live runs per bot; oldest beyond the cap are dropped
+-   runs older than 90 days are dropped
+-   at most 1000 live runs per bot; oldest beyond the cap are dropped
+
+Enforcement happens in three places:
+
+-   **on store**: every incoming signal prunes that bot's runs
+-   **on a daily timer**: a recurring behn wake on the `/prune` wire prunes all bots, so storage is reclaimed even when a bot stops sending signals
+-   **on read**: `/x/recent` and `/x/run` filter expired runs, so the age bound holds observably regardless of timer or signal cadence (gall scries cannot mutate state, so this is a filter, not a prune)
 
 ## poke surface
 
@@ -77,7 +83,7 @@ Accepted from any ship; records are keyed by the sending ship, so a malicious sh
 ## scry surface
 
 -   `/x/recent` → `%context-lens-update-1` `[%runs (list entry)]` — newest 50 runs across all bots
--   `/x/run/[ship]/[id-run]` → `%context-lens-update-1` `[%run entry]`, or empty (`[~ ~]`) when absent
+-   `/x/run/[ship]/[id-run]` → `%context-lens-update-1` `[%run entry]`, or empty (`[~ ~]`) when absent or expired
 
 `entry` is `[bot=ship id-run=@t run]`. The update mark grows to JSON for Eyre:
 


### PR DESCRIPTION
## Summary

- Adds the `%context-lens` gall agent (split out of #5925 so the ship-side store can land and be vetted independently of the client UI). One agent, two roles:
  - **Bot ship**: accepts `%context-lens-action-1` pokes from the local OpenClaw gateway and fans run records out to configured owners as `%context-lens-signal-1` pokes (ames retries until ack).
  - **Owner ship**: stores runs keyed `[bot id-run]` with `src.bowl` as the trust anchor, gives `%context-lens-update-1` facts on `/v1`, and answers `/x/recent` and `/x/run` scries with per-bot retention (1000 runs / 90 days), enforced on store, on a daily behn timer, and filtered at read time.
- Run payloads relay as cords (serialized JSON) rather than `$json` to keep the agent schema-agnostic.
- Named `%context-lens` rather than `%lens` because `%base` already bills `%lens` and gall agent names are global across desks — the collision makes the groups desk commit silently revert.
- Also fixes arm64/aarch64 vere arch detection in `backend/run-tests.sh` so the desk test suite runs on Linux arm64.

## Dependencies

This is the ship-side hub of a three-part stack — it has no code dependencies on the other PRs, but they depend on it:

- **Upstream producer**: tloncorp/openclaw-tlon#161 — the gateway pokes this agent on the bot ship with finalized runs. Without this agent installed, those pokes nack harmlessly (the gateway logs and continues).
- **Downstream consumer**: #5925 — the client UI subscribes to `/v1`, scries `/x/recent` / `/x/run`, and pokes `%configure` via `lensApi`. Without this agent, the client's lens subscription no-ops gracefully and the UI shows no run history.
- **Suggested landing order**: this PR → #5925 → openclaw-tlon#161 (any order is safe, but this order means no consumer ever points at a missing agent).

## Test plan

- [x] `desk/tests/app/context-lens.hoon` covers configure, run-final fan-out, owner-side store/retention, and scries (`backend/run-tests.sh`)
- [x] Exercised end-to-end against dev ship `~malmur-halmex` with the gateway and client PRs (run records fan out, facts drive live client updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
