### PR TITLE
Multi-bot thinking indicator for chat channels

### DIFF
--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -42,14 +42,24 @@
 +$  state-0
   $:  %0
       =places
+      want=(set [ship context])
+      subs=(jug context ship)
+  ==
++$  state-1
+  $:  %1
+      =places
       :: ships=(jug ship context)
     ::
-      want=(set [ship context])  ::  desired outgoing subs
-      subs=(jug context ship)    ::  real incoming subs
-      ::TODO  wack=(set ship)    ::  waiting for acks (load prevention)
+      want=(set [ship context])   ::  desired outgoing subs
+      subs=(jug context ship)     ::  real incoming subs
+      tries=(map [ship context] @ud)  ::  consecutive sub nacks
+      ::TODO  wack=(set ship)     ::  waiting for acks (load prevention)
   ==
++$  versioned-state  $%(state-0 state-1)
 ::
 +$  card  card:agent:gall
+::
+++  max-tries  5
 ::
 ++  default-timeout
   |=  =topic
@@ -241,7 +251,7 @@
   ==
 --
 ::
-=|  state-0
+=|  state-1
 =*  state  -
 ::
 %-  agent:dbug
@@ -263,7 +273,13 @@
 ++  on-load
   |=  ole=vase
   ^-  (quip card _this)
-  :_  this(state !<(state-0 ole))
+  =/  old  !<(versioned-state ole)
+  =/  new=state-1
+    ?-  -.old
+      %0  [%1 places.old want.old subs.old ~]
+      %1  old
+    ==
+  :_  this(state new)
   :~  (tell:log %dbug ~['on-load: scheduling setup' >`@ud`~(wyt in want)< >`@ud`~(wyt by subs)<] ~)
       (await-setup now.bowl ~)
   ==
@@ -442,6 +458,7 @@
             (watch-context our.bowl u.new)
         ==
       ?:  &(!add.u.news (~(has in want) u.new))
+        =.  tries  (~(del by tries) u.new)
         :_  this(want (~(del in want) u.new))
         :~  (tell:log %dbug ~['channels/all: removing context' >u.new<] ~)
             (leave-context u.new)
@@ -474,18 +491,31 @@
     ::
         %watch-ack
       ?~  p.sign
+        =.  tries  (~(del by tries) [src.bowl context])
         :_  this
         [(tell:log %dbug ~['context sub ack ok' >src.bowl< >context<] ~)]~
       ::  nacked. nacks are commonly transient (host hasn't synced the
-      ::  group or channel yet), so keep the desire and retry later.
-      ::  dropping the desire would kill presence for this context until
-      ::  the next full setup.
+      ::  group or channel yet), so retry with linear backoff. after
+      ::  +max-tries consecutive nacks, drop the desire so we don't
+      ::  retry forever; the next full setup starts a fresh cycle if
+      ::  the context is still relevant.
       ::
+      =/  try=@ud  +((~(gut by tries) [src.bowl context] 0))
+      ?:  (gth try max-tries)
+        =.  want   (~(del in want) [src.bowl context])
+        =.  tries  (~(del by tries) [src.bowl context])
+        :_  this
+        =-  [(tell:log %warn - ~)]~
+        :*  'context sub nacked, giving up'
+            >[src=src.bowl context=context]<
+            u.p.sign
+        ==
+      =.  tries  (~(put by tries) [src.bowl context] try)
       :_  this
-      :~  (await-setup (add now.bowl ~m5) `[src.bowl context])
+      :~  (await-setup (add now.bowl (mul try ~m5)) `[src.bowl context])
           =-  (tell:log %warn - ~)
           :*  'context sub nacked, will retry'
-              >[src=src.bowl context=context]<
+              >[src=src.bowl context=context try=try]<
               u.p.sign
           ==
       ==
@@ -562,6 +592,13 @@
       =/  dms=(set [ship context])    (dm-contexts bowl)
       =/  chans=(set [ship context])  (channel-contexts bowl)
       =.  want  (~(uni in dms) chans)
+      ::  prune retry counts for contexts we no longer want
+      ::
+      =.  tries
+        %+  roll  ~(tap by tries)
+        |=  [[k=[ship context] n=@ud] acc=(map [ship context] @ud)]
+        ?.  (~(has in want) k)  acc
+        (~(put by acc) k n)
       =/  cards=(list card)  (inflate bowl want)
       :_  this
       %+  weld
@@ -582,6 +619,7 @@
     ::  retry being scheduled and firing. don't resubscribe in that case.
     ::
     ?.  (~(has in want) [ship context])
+      =.  tries  (~(del by tries) [ship context])
       :_  this
       [(tell:log %dbug ~['setup(specific): no longer wanted, skipping' >ship< >context<] ~)]~
     ?:  (~(has by wex.bowl) [%context context] ship dap.bowl)

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -321,7 +321,11 @@
         %+  give-update
           (~(del ju subs) context.key.cmd src.bowl)
         [disclose.cmd %set +>.cmd]
-      ?.  (~(has in disclose.cmd) our.bowl)
+      ::  an empty disclose means public, which includes ourselves.
+      ::  without this, the host's own client never sees presence
+      ::  for contexts it hosts.
+      ::
+      ?.  |(=(~ disclose.cmd) (~(has in disclose.cmd) our.bowl))
         [fus this]
       ::TODO  send response too?
       :_  this(places (put-presence places +>.cmd))
@@ -472,13 +476,18 @@
       ?~  p.sign
         :_  this
         [(tell:log %dbug ~['context sub ack ok' >src.bowl< >context<] ~)]~
-      ::  nacked, can't do anything, drop desire
+      ::  nacked. nacks are commonly transient (host hasn't synced the
+      ::  group or channel yet), so keep the desire and retry later.
+      ::  dropping the desire would kill presence for this context until
+      ::  the next full setup.
       ::
-      :_  this(want (~(del in want) src.bowl context))
-      =-  [(tell:log %warn - ~)]~
-      :*  'context sub nacked, dropping desire'
-          >[src=src.bowl context=context]<
-          u.p.sign
+      :_  this
+      :~  (await-setup (add now.bowl ~m5) `[src.bowl context])
+          =-  (tell:log %warn - ~)
+          :*  'context sub nacked, will retry'
+              >[src=src.bowl context=context]<
+              u.p.sign
+          ==
       ==
     ::
         %fact
@@ -569,6 +578,12 @@
     =/  =ship  (slav %p i.t.wire)
     ?<  =(ship our.bowl)  ::  don't subscribe to ourselves
     =*  context  t.t.wire
+    ::  the desire may have been dropped (context left) between the nack
+    ::  retry being scheduled and firing. don't resubscribe in that case.
+    ::
+    ?.  (~(has in want) [ship context])
+      :_  this
+      [(tell:log %dbug ~['setup(specific): no longer wanted, skipping' >ship< >context<] ~)]~
     ?:  (~(has by wex.bowl) [%context context] ship dap.bowl)
       :_  this
       [(tell:log %dbug ~['setup(specific): already subscribed, skipping' >ship< >context<] ~)]~

--- a/packages/app/ui/components/Channel/ThinkingState.tsx
+++ b/packages/app/ui/components/Channel/ThinkingState.tsx
@@ -1,18 +1,58 @@
+import type * as db from '@tloncorp/shared/db';
 import { Text } from '@tloncorp/ui';
-import { Spinner, View, XStack } from 'tamagui';
+import { AnimatePresence, Spinner, View, XStack } from 'tamagui';
 
+import { ContactAvatar } from '../Avatar';
 import { useConversationComputingState } from './useConversationComputingState';
 
-export function ThinkingState({ conversationId }: { conversationId: string }) {
+const MAX_VISIBLE_AVATARS = 3;
+
+export function ThinkingState({
+  conversationId,
+  channelType,
+}: {
+  conversationId: string;
+  channelType: db.Channel['type'];
+}) {
   const computingState = useConversationComputingState(conversationId);
 
   if (!computingState) {
     return null;
   }
 
+  const showAvatars =
+    channelType !== 'dm' || computingState.ships.length >= 2;
+  const visibleShips = computingState.ships.slice(0, MAX_VISIBLE_AVATARS);
+  const overflowCount = computingState.ships.length - visibleShips.length;
+
   return (
     <View paddingHorizontal="$l" paddingTop="$xs" paddingBottom="$s">
       <XStack alignItems="center" gap="$s">
+        {showAvatars && (
+          <XStack alignItems="center">
+            <AnimatePresence>
+              {visibleShips.map((shipState, index) => (
+                <View
+                  key={shipState.ship}
+                  transition="quick"
+                  scale={1}
+                  opacity={1}
+                  enterStyle={{ scale: 0.5, opacity: 0 }}
+                  exitStyle={{ scale: 0.5, opacity: 0 }}
+                  marginLeft={index === 0 ? 0 : -6}
+                  zIndex={visibleShips.length - index}
+                >
+                  <ContactAvatar contactId={shipState.ship} size="$xl" />
+                </View>
+              ))}
+            </AnimatePresence>
+            {overflowCount > 0 && (
+              <Text size="$label/s" color="$tertiaryText" marginLeft="$xs">
+                +{overflowCount}
+              </Text>
+            )}
+          </XStack>
+        )}
         <Spinner size="small" color="$tertiaryText" />
         <Text size="$label/m" color="$tertiaryText" flexShrink={1}>
           {computingState.label}

--- a/packages/app/ui/components/Channel/ThinkingState.tsx
+++ b/packages/app/ui/components/Channel/ThinkingState.tsx
@@ -20,8 +20,7 @@ export function ThinkingState({
     return null;
   }
 
-  const showAvatars =
-    channelType !== 'dm' || computingState.ships.length >= 2;
+  const showAvatars = channelType !== 'dm' || computingState.ships.length >= 2;
   const visibleShips = computingState.ships.slice(0, MAX_VISIBLE_AVATARS);
   const overflowCount = computingState.ships.length - visibleShips.length;
 

--- a/packages/app/ui/components/Channel/useConversationComputingState.ts
+++ b/packages/app/ui/components/Channel/useConversationComputingState.ts
@@ -6,42 +6,87 @@ import {
 import { useConversationPresence } from '@tloncorp/shared';
 import { useMemo } from 'react';
 
-type ConversationComputingState = {
+import { useCalm, useContactIndex } from '../../contexts/appDataContext';
+import { resolveContactNameProps } from '../contactNameResolver';
+
+export type ShipComputingState = {
+  ship: string;
+  label: string;
+  toolCalls: ComputingToolCall[];
+};
+
+export type ConversationComputingState = {
+  ships: ShipComputingState[];
   label: string;
   toolCalls: ComputingToolCall[];
 };
 
 export function useConversationComputingState(conversationId: string) {
   const presenceStates = useConversationPresence(conversationId);
+  const contactIndex = useContactIndex();
+  const calm = useCalm();
 
   return useMemo<ConversationComputingState | null>(() => {
-    const activeStates = presenceStates
-      .filter((status) => status.key.topic === 'computing')
-      .sort((left, right) => right.timing.since - left.timing.since);
+    const ships: ShipComputingState[] = [];
 
-    const activeState = activeStates[0];
-    if (!activeState) {
+    for (const status of presenceStates) {
+      if (status.key.topic !== 'computing') {
+        continue;
+      }
+
+      const parsedStatus = parseComputingStatus(status.display.blob);
+      if (parsedStatus && !parsedStatus.thinking) {
+        continue;
+      }
+
+      const label =
+        status.display.text?.trim() ||
+        (parsedStatus ? getComputingStatusText(parsedStatus) : null) ||
+        'Thinking...';
+
+      const toolCalls =
+        parsedStatus?.toolCalls.filter((toolCall) => {
+          return parsedStatus.toolCalls.length > 1 || toolCall.label !== label;
+        }) ?? [];
+
+      ships.push({ ship: status.key.ship, label, toolCalls });
+    }
+
+    if (ships.length === 0) {
       return null;
     }
 
-    const parsedStatus = parseComputingStatus(activeState.display.blob);
-    if (parsedStatus && !parsedStatus.thinking) {
-      return null;
+    // Sort by ship (not timing.since) so heartbeat re-publishes don't reorder.
+    ships.sort((left, right) => left.ship.localeCompare(right.ship));
+
+    if (ships.length === 1) {
+      return {
+        ships,
+        label: ships[0].label,
+        toolCalls: ships[0].toolCalls,
+      };
     }
 
-    const label =
-      activeState.display.text?.trim() ||
-      (parsedStatus ? getComputingStatusText(parsedStatus) : null) ||
-      'Thinking...';
-
-    const toolCalls =
-      parsedStatus?.toolCalls.filter((toolCall) => {
-        return parsedStatus.toolCalls.length > 1 || toolCall.label !== label;
-      }) ?? [];
+    if (ships.length === 2) {
+      const [first, second] = ships.map((shipState) => {
+        const resolved = resolveContactNameProps({
+          contact: contactIndex?.[shipState.ship] ?? null,
+          contactId: shipState.ship,
+          calmDisableNicknames: calm.disableNicknames,
+        });
+        return resolved.children || shipState.ship;
+      });
+      return {
+        ships,
+        label: `${first} and ${second} are thinking...`,
+        toolCalls: [],
+      };
+    }
 
     return {
-      label,
-      toolCalls,
+      ships,
+      label: `${ships.length} bots are thinking...`,
+      toolCalls: [],
     };
-  }, [presenceStates]);
+  }, [presenceStates, contactIndex, calm.disableNicknames]);
 }

--- a/packages/app/ui/components/Channel/useShouldShowThinkingState.ts
+++ b/packages/app/ui/components/Channel/useShouldShowThinkingState.ts
@@ -9,7 +9,7 @@ export function useShouldShowThinkingState(channel: db.Channel) {
   const canRead = useCanRead(channel, currentUserId);
 
   const shouldShowThinkingState = useMemo(
-    () => canRead && channel.type === 'dm',
+    () => canRead && (channel.type === 'dm' || channel.type === 'chat'),
     [canRead, channel.type]
   );
 

--- a/packages/app/ui/components/DetailView.tsx
+++ b/packages/app/ui/components/DetailView.tsx
@@ -4,6 +4,8 @@ import { ReactNode, useMemo } from 'react';
 import { View, YStack, getTokenValue } from 'tamagui';
 
 import Scroller, { ScrollAnchor } from './Channel/Scroller';
+import { ThinkingState } from './Channel/ThinkingState';
+import { useShouldShowThinkingState } from './Channel/useShouldShowThinkingState';
 import { ChatMessage } from './ChatMessage';
 import { GalleryPostDetailView } from './GalleryPost/GalleryPost';
 import { NotebookPostDetailView } from './NotebookPost/NotebookPost';
@@ -65,6 +67,19 @@ export const DetailView = ({
         };
   }, [isChat]);
 
+  const shouldShowThinkingState = useShouldShowThinkingState(channel);
+  // Computing presence is channel-scoped, so this shows bots thinking
+  // anywhere in the channel, not just in this thread. The ideal end state is
+  // thread-scoped presence contexts (e.g. /channel/chat/~host/name/thread/<id>)
+  // published by the gateway, with the channel view aggregating by prefix.
+  const listBottomComponent = useMemo(
+    () =>
+      shouldShowThinkingState ? (
+        <ThinkingState conversationId={channel.id} channelType={channel.type} />
+      ) : undefined,
+    [shouldShowThinkingState, channel.id, channel.type]
+  );
+
   const listHeaderComponent = useMemo(() => {
     if (isChat) {
       return undefined;
@@ -120,6 +135,7 @@ export const DetailView = ({
         activeMessage={activeMessage}
         setActiveMessage={setActiveMessage}
         listHeaderComponent={listHeaderComponent}
+        listBottomComponent={listBottomComponent}
       />
     </View>
   );

--- a/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
+++ b/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
@@ -49,9 +49,12 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
     const listBottomComponent = useMemo(
       () =>
         shouldShowThinkingState ? (
-          <ThinkingState conversationId={ctx.channel.id} />
+          <ThinkingState
+            conversationId={ctx.channel.id}
+            channelType={ctx.channel.type}
+          />
         ) : undefined,
-      [shouldShowThinkingState, ctx.channel.id]
+      [shouldShowThinkingState, ctx.channel.id, ctx.channel.type]
     );
 
     const renderEmptyComponent = useCallback(() => {


### PR DESCRIPTION
## Summary
- Reworks `useConversationComputingState` to return per-ship computing states with a combined label ("X and Y are thinking...", "N bots are thinking..."), sorted by ship so heartbeat re-publishes don't reorder.
- Rewrites `ThinkingState` as an animated avatar stack (max 3 avatars + "+N" overflow) and enables it in group chat channels (`dm` + `chat`), gated on read permission.
- Shows the thinking indicator in thread views (`DetailView`), above the reply composer.
- Fixes two `%presence` agent bugs:
  - **Host blind spot**: a `%set` with empty `disclose` (= public) was fanned out to subscribers but never stored on the context host itself, so the host's own client never saw presence for channels it hosts.
  - **Bounded nack retry**: a nacked context watch previously dropped the desire permanently (one transient nack = no presence until next full setup). Now retries with linear backoff (try × 5min) via a new `tries` map in `%1` state, giving up after 5 consecutive nacks so a permanently-failing host doesn't become an eternal timer.

## Known limitation: thread indicator is channel-scoped
Computing presence contexts are keyed by channel/DM only (`/channel/chat/~host/name`), so the indicator in a thread reflects bots thinking **anywhere in that channel**, not specifically in that thread. The ideal end state is thread-scoped presence contexts (e.g. `/channel/chat/~host/name/thread/<parent-post-id>`) published by the gateway, with the channel view aggregating thread contexts by prefix. That requires changes across the presence agent, the gateway publisher, and the client presence API, so it's deferred to a follow-up.

## Test plan
- [x] `tsc --noEmit` clean on packages/app
- [x] Hoon build check on a live ship (incl. `%0` → `%1` state migration)
- [x] iOS sim, live ships: DM single-bot indicator; group channel two-ship avatar stack + combined label; remote-channel presence mirror populates during a run and clears at run end
- [x] 3-ship and 4-ship (+1 overflow) states verified via mocked presence
- [x] Thread view indicator verified via mocked presence (iOS sim)
- [x] Gallery/notebook channels show no indicator
- [ ] Desktop web spot-check
- [ ] Android pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)