### PR TITLE
fix(ci): repair invalid build-and-glob workflow file

### DIFF
--- a/.github/workflows/build-and-glob.yml
+++ b/.github/workflows/build-and-glob.yml
@@ -34,8 +34,12 @@ jobs:
         run: echo "gitHash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Build packages
         run: pnpm build:all
+        env:
+          VITE_GIT_HASH: ${{ steps.gitHash.outputs.gitHash }}
       - working-directory: ./apps/tlon-web
         run: pnpm build
+        env:
+          VITE_GIT_HASH: ${{ steps.gitHash.outputs.gitHash }}
       - uses: actions/upload-artifact@v4
         with:
           name: "ui-dist"
@@ -49,7 +53,6 @@ jobs:
       VITE_INVITE_SERVICE_ENDPOINT: ${{ secrets.VITE_INVITE_SERVICE_ENDPOINT}}
       VITE_POST_HOG_API_KEY: ${{ secrets.VITE_POST_HOG_API_KEY}}
       VITE_OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY}}
-      VITE_GIT_HASH: ${{ steps.gitHash.outputs.gitHash }}
       NODE_OPTIONS: --max-old-space-size=6144
   glob:
     runs-on: ubuntu-latest
@@ -71,6 +74,7 @@ jobs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"
       - name: "glob"
+        id: "glob"
         uses: ./.github/actions/glob
         with:
           folder: "apps/tlon-web/dist/*"


### PR DESCRIPTION
## Summary
- `${{ steps.gitHash.outputs.gitHash }}` in **job-level** `env` is invalid — the `steps` context only exists at step level. GitHub has treated `build-and-glob.yml` as an invalid workflow file since #4841, flagging a failed run on every push to every branch (zero successful runs in the workflow's recent history). Moved `VITE_GIT_HASH` to step-level `env` on the two build steps.
- The "Commit and Push Glob" step references `steps.glob.outputs.hash`, but the glob step had no `id` — which is why glob commits on develop read `update glob:  [skip actions]` with an empty hash. Added `id: glob`.

## Test plan
- [ ] Push event no longer produces a failed "Invalid workflow file" run for build-and-glob
- [ ] Manual `workflow_dispatch` run builds and globs successfully, with the hash present in the glob commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)