### PR TITLE
ci: port openclaw publish, deploy, and tlonbot-smoke workflows

### DIFF
--- a/.github/workflows/openclaw-ci.yml
+++ b/.github/workflows/openclaw-ci.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # The postbuild step regenerates openclaw.plugin.json from
+      # src/config-schema.ts; the checked-in copy must stay in sync (it's
+      # what the npm package stages and what installers read from git).
+      - name: Check openclaw.plugin.json is up to date
+        run: |
+          git diff --exit-code openclaw.plugin.json || \
+            (echo "::error::openclaw.plugin.json is stale. Run 'pnpm build' in packages/openclaw and commit the regenerated manifest." && exit 1)
+
       - name: Run unit tests
         run: npx vitest run src/ --exclude src/config-schema.test.ts
 

--- a/.github/workflows/openclaw-deploy.yml
+++ b/.github/workflows/openclaw-deploy.yml
@@ -11,6 +11,12 @@ on:
     # Runtime inputs of the deployed plugin only — docs, tests, and the dev
     # harness don't warrant a ship restart. (Production pulls the develop
     # branch ref at restart, so a missed trigger self-heals on the next one.)
+    #
+    # Deliberately NOT watching packages/api or packages/tlon-skill: the
+    # deployed plugin resolves its workspace:^ deps to *published npm
+    # versions* (resolve-workspace-deps.mjs --registry), so develop merges
+    # to those packages change nothing on ships — dep changes reach
+    # production via an npm publish followed by a restart.
     paths:
       - "packages/openclaw/src/**"
       - "packages/openclaw/index.ts"

--- a/.github/workflows/openclaw-deploy.yml
+++ b/.github/workflows/openclaw-deploy.yml
@@ -103,7 +103,7 @@ jobs:
             echo "Restarting tlawn (non-internal) ships"
           fi
 
-          for ctx in gke_prod-f0181862_us-east5_us-east5-cluster1 admin@ovh-oregon-1 admin@ovh-oregon-2; do
+          for ctx in gke_prod-f0181862_us-east5_us-east5-cluster1 admin@ovh-oregon-1 admin@ovh-oregon-2 admin@ovh-oregon-3; do
             echo "=== Restarting ships in context: $ctx ==="
             kubectl --context "$ctx" get ships -n tlon -ojson \
               | jq -r "$JQ_FILTER" \

--- a/.github/workflows/openclaw-deploy.yml
+++ b/.github/workflows/openclaw-deploy.yml
@@ -8,8 +8,19 @@ name: Restart OpenClaw Ships
 on:
   push:
     branches: [develop]
+    # Runtime inputs of the deployed plugin only — docs, tests, and the dev
+    # harness don't warrant a ship restart. (Production pulls the develop
+    # branch ref at restart, so a missed trigger self-heals on the next one.)
     paths:
       - "packages/openclaw/src/**"
+      - "packages/openclaw/index.ts"
+      - "packages/openclaw/setup-entry.ts"
+      - "packages/openclaw/setup-api.ts"
+      - "packages/openclaw/package.json"
+      - "packages/openclaw/openclaw.plugin.json"
+      - "packages/openclaw/tsconfig.json"
+      - "packages/openclaw/scripts/**"
+      - "packages/openclaw/.npmrc"
   workflow_dispatch:
     inputs:
       mode:

--- a/.github/workflows/openclaw-deploy.yml
+++ b/.github/workflows/openclaw-deploy.yml
@@ -1,0 +1,95 @@
+name: Restart OpenClaw Ships
+
+# Restarts the hosted openclaw ship pods so they pick up plugin changes.
+# Pushes to develop touching plugin source restart the internal ships;
+# tlawn (prod) restarts are workflow_dispatch-only, a deliberate human
+# action decoupled from the develop -> master release sync cadence.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "packages/openclaw/src/**"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Which ships to restart"
+        required: true
+        type: choice
+        options:
+          - internal
+          - tlawn
+
+jobs:
+  restart-ships:
+    name: Restart Ships
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check deploy credentials
+        id: creds
+        run: |
+          if [ -z "${{ secrets.GCP_SA_KEY }}" ]; then
+            echo "::warning::GCP_SA_KEY secret is not set; skipping ship restart"
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud
+        if: steps.creds.outputs.present == 'true'
+        uses: google-github-actions/setup-gcloud@v0.3.0
+        with:
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          project_id: prod-f0181862
+
+      - name: Get GKE credentials
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          export USE_GKE_GCLOUD_AUTH_PLUGIN=True
+          gcloud container clusters get-credentials us-east5-cluster1 --zone us-east5 --project prod-f0181862
+
+      - name: Set up kubeconfig for OVH cluster
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          echo "${{ secrets.KUBECONFIG_B64 }}" | base64 -d >> "$HOME/.kube/config"
+
+      - name: Install tools
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+          sudo apt-get install -y -qq jq
+          gcloud components install gke-gcloud-auth-plugin --quiet
+
+      - name: Determine mode
+        id: mode
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=internal" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Restart ships
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          MODE="${{ steps.mode.outputs.mode }}"
+
+          if [ "$MODE" = "internal" ]; then
+            JQ_FILTER='.items[] | select(.spec.internal == true) | .metadata.name'
+            echo "Restarting internal ships"
+          else
+            JQ_FILTER='.items[] | select(.spec.tlawn.enabled == true and .spec.internal != true) | .metadata.name'
+            echo "Restarting tlawn (non-internal) ships"
+          fi
+
+          for ctx in gke_prod-f0181862_us-east5_us-east5-cluster1 admin@ovh-oregon-1 admin@ovh-oregon-2; do
+            echo "=== Restarting ships in context: $ctx ==="
+            kubectl --context "$ctx" get ships -n tlon -ojson \
+              | jq -r "$JQ_FILTER" \
+              | xargs -I {} sh -c 'kubectl --context "'"$ctx"'" rollout restart sts {} -n tlon &'
+            wait
+          done

--- a/.github/workflows/openclaw-dispatch-tlonbot-smoke.yml
+++ b/.github/workflows/openclaw-dispatch-tlonbot-smoke.yml
@@ -1,0 +1,39 @@
+name: Dispatch tlonbot smoke
+
+# When a commit touching the openclaw plugin lands on develop (post-PR
+# merge), trigger tlonbot's e2e smoke workflow with this commit's SHA as
+# the plugin ref. tlonbot pins its bot container's plugin checkout to that
+# exact SHA, so the smoke is pinned to "did this specific plugin commit
+# play nicely with tlonbot's prompts/persona".
+#
+# We trust the openclaw CI workflow's PR-gating to have already passed for
+# this commit; this workflow does not re-run any tests, just dispatches.
+# The repo/path payload fields tell tlonbot to clone tlon-apps and find
+# the plugin at packages/openclaw (it falls back to the legacy
+# openclaw-tlon repo when they are absent).
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "packages/openclaw/**"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger tlonbot smoke
+        env:
+          GH_TOKEN: ${{ secrets.TLONBOT_DISPATCH_TOKEN }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::warning::TLONBOT_DISPATCH_TOKEN secret is not set; skipping dispatch"
+            exit 0
+          fi
+          echo "Dispatching tlonbot smoke for plugin ref $GITHUB_SHA"
+          gh api repos/tloncorp/tlonbot/dispatches \
+            --method POST \
+            --field event_type=tlonbot-smoke-test \
+            --field 'client_payload[ref]='"$GITHUB_SHA" \
+            --field 'client_payload[repo]=tloncorp/tlon-apps' \
+            --field 'client_payload[path]=packages/openclaw'

--- a/.github/workflows/openclaw-publish.yml
+++ b/.github/workflows/openclaw-publish.yml
@@ -52,11 +52,20 @@ jobs:
         working-directory: packages/openclaw
         run: pnpm build
 
-      - name: Upload build artifacts
+      # Stage the publish package HERE, next to the build outputs: the
+      # postbuild step regenerates openclaw.plugin.json from the config
+      # schema, and staging from a fresh checkout in the publish job could
+      # ship a stale checked-in manifest (or any future generated file).
+      # The publish job consumes the staged .publish/ verbatim.
+      - name: Prepare clean publish package
+        working-directory: packages/openclaw
+        run: node scripts/prepare-publish-package.js
+
+      - name: Upload publish package
         uses: actions/upload-artifact@v4
         with:
-          name: openclaw-dist
-          path: packages/openclaw/dist/
+          name: openclaw-publish-package
+          path: packages/openclaw/.publish/
 
   publish:
     needs: build
@@ -70,28 +79,22 @@ jobs:
     if: (startsWith(github.ref, 'refs/tags/openclaw-v') && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
 
     steps:
-      - uses: actions/checkout@v4
-
       # Node 24 here for npm >= 11.5, required for OIDC trusted publishing
-      # (tokenless --provenance). No pnpm install happens in this job; the
-      # prepare/resolve scripts are dependency-free node.
+      # (tokenless --provenance). No checkout: this job publishes the staged
+      # package from the build job verbatim, so nothing here can drift from
+      # the build's outputs.
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Download build artifacts
+      - name: Download publish package
         uses: actions/download-artifact@v4
         with:
-          name: openclaw-dist
-          path: packages/openclaw/dist/
-
-      - name: Prepare clean publish package
-        working-directory: packages/openclaw
-        run: node scripts/prepare-publish-package.js
+          name: openclaw-publish-package
+          path: .publish/
 
       - name: Verify publish package contents
-        working-directory: packages/openclaw
         run: |
           echo "--- .publish/package.json ---"
           cat .publish/package.json
@@ -105,7 +108,6 @@ jobs:
 
       - name: Publish to npm
         if: github.event_name == 'push' || github.event.inputs.dry_run == 'false'
-        working-directory: packages/openclaw
         env:
           NPM_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}
         run: npm publish ./.publish --access public --provenance --tag "$NPM_TAG"

--- a/.github/workflows/openclaw-publish.yml
+++ b/.github/workflows/openclaw-publish.yml
@@ -52,7 +52,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: (startsWith(github.ref, 'refs/tags/openclaw-v') && github.event_name == 'push') || github.event.inputs.dry_run == 'false'
+    # Runs for tag pushes and for ALL manual dispatches — a dry run exercises
+    # publish staging and verification; only the final npm publish step is
+    # gated on dry_run being off.
+    if: (startsWith(github.ref, 'refs/tags/openclaw-v') && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +92,12 @@ jobs:
           npm pack --dry-run ./.publish
 
       - name: Publish to npm
+        if: github.event_name == 'push' || github.event.inputs.dry_run == 'false'
         working-directory: packages/openclaw
         env:
           NPM_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}
         run: npm publish ./.publish --access public --provenance --tag "$NPM_TAG"
+
+      - name: Dry run complete
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'false'
+        run: echo "Dry run — package staged and verified, npm publish skipped."

--- a/.github/workflows/openclaw-publish.yml
+++ b/.github/workflows/openclaw-publish.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify tag matches package version
+        if: github.event_name == 'push'
+        working-directory: packages/openclaw
+        run: |
+          version=$(node -p "require('./package.json').version")
+          expected="openclaw-v${version}"
+          if [ "${GITHUB_REF_NAME}" != "$expected" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match packages/openclaw version (${expected})" >&2
+            exit 1
+          fi
+          echo "Tag matches package version: ${expected}"
+
       - name: Run tests
         working-directory: packages/openclaw
         run: pnpm test

--- a/.github/workflows/openclaw-publish.yml
+++ b/.github/workflows/openclaw-publish.yml
@@ -1,0 +1,95 @@
+name: Publish @tloncorp/openclaw
+
+on:
+  push:
+    tags:
+      - "openclaw-v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip publish)"
+        type: boolean
+        default: true
+      npm_tag:
+        description: "npm tag to publish to, defaults to latest"
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      # Node 22 (repo default), not the old repo's Node 24: the monorepo
+      # install rebuilds better-sqlite3, which has no prebuilds for Node 24.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        working-directory: packages/openclaw
+        run: pnpm test
+
+      - name: Build
+        working-directory: packages/openclaw
+        run: pnpm build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-dist
+          path: packages/openclaw/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    if: (startsWith(github.ref, 'refs/tags/openclaw-v') && github.event_name == 'push') || github.event.inputs.dry_run == 'false'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 24 here for npm >= 11.5, required for OIDC trusted publishing
+      # (tokenless --provenance). No pnpm install happens in this job; the
+      # prepare/resolve scripts are dependency-free node.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: openclaw-dist
+          path: packages/openclaw/dist/
+
+      - name: Prepare clean publish package
+        working-directory: packages/openclaw
+        run: node scripts/prepare-publish-package.js
+
+      - name: Verify publish package contents
+        working-directory: packages/openclaw
+        run: |
+          echo "--- .publish/package.json ---"
+          cat .publish/package.json
+          echo
+          if grep -q 'workspace:' .publish/package.json; then
+            echo "::error::unresolved workspace dependency in .publish/package.json"
+            exit 1
+          fi
+          echo "--- npm pack dry-run ---"
+          npm pack --dry-run ./.publish
+
+      - name: Publish to npm
+        working-directory: packages/openclaw
+        env:
+          NPM_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}
+        run: npm publish ./.publish --access public --provenance --tag "$NPM_TAG"

--- a/.github/workflows/openclaw-publish.yml
+++ b/.github/workflows/openclaw-publish.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           name: openclaw-publish-package
           path: packages/openclaw/.publish/
+          # Required: the action treats everything under a dot-directory as
+          # hidden and would otherwise upload an empty artifact. Safe here —
+          # .publish/ is exactly the public npm package contents.
+          include-hidden-files: true
+          if-no-files-found: error
 
   publish:
     needs: build


### PR DESCRIPTION
## Summary

Stacked on #5930. Ports the remaining three CI/CD workflows from `tloncorp/openclaw-tlon` so the old repo's automation can be switched off at the end of the transition window: npm publish, ship-restart deploy, and the tlonbot smoke dispatch. Companion PR in `tloncorp/tlonbot` (linked below) teaches the smoke harness to check out the plugin from this monorepo.

All three workflows are inert or fail-safe until ops steps land (see the secrets table): publish needs the npm Trusted Publisher flip, deploy warn-skips without its GCP secrets, and the smoke dispatch warn-skips without its token.

## Changes

1. **`.github/workflows/openclaw-publish.yml`** (port of publish.yml): tag scheme `openclaw-v*` (precedent: `desktop-v*`), or `workflow_dispatch` with `dry_run`/`npm_tag` inputs. Build job runs root install + plugin test/build and uploads `packages/openclaw/dist`; publish job stages `.publish/` via `prepare-publish-package.js` (which resolves `workspace:^` deps — added in #5930), hard-fails on any leftover `workspace:` spec, then `npm publish --provenance`.
    - *Deviation: build job uses Node 22 (repo `.nvmrc`) instead of the old repo's Node 24* — the monorepo install rebuilds `better-sqlite3`, which has no Node 24 prebuilds. The publish job keeps Node 24 for npm ≥ 11.5 (OIDC trusted publishing); it does no installs.
2. **`.github/workflows/openclaw-deploy.yml`** (port of deploy.yml): pushes to `develop` touching `packages/openclaw/src/**` restart **internal** ships; **tlawn (prod) is `workflow_dispatch`-only** — the old `stable → tlawn` auto-trigger is intentionally dropped so prod restarts stay a deliberate action, decoupled from the develop→master release sync. Restart job body is otherwise verbatim (GKE + OVH contexts, jq ship filters).
    - *Deviation: a first step warn-skips the whole job when `GCP_SA_KEY` is unset*, so develop pushes stay green until secrets are provisioned.
3. **`.github/workflows/openclaw-dispatch-tlonbot-smoke.yml`** (port of dispatch-tlonbot-smoke.yml): on develop pushes touching `packages/openclaw/**`, dispatches `tlonbot-smoke-test` with the commit SHA, now also sending `repo: tloncorp/tlon-apps` and `path: packages/openclaw` so tlonbot checks out the monorepo. Keeps the warn-skip when the token secret is unset.

**Companion PR:** [tloncorp/tlonbot#97](https://github.com/tloncorp/tlonbot/pull/97) — both plugin consumers (smoke harness *and* production `tlawn.py`) accept the monorepo layout via env vars (`TLON_PLUGIN_REPO` / `TLON_PLUGIN_SUBPATH`): sparse blobless checkout, workspace-dep resolution before install, repo-aware ref defaults (`develop`/`master` for tlon-apps). Legacy defaults everywhere, so merging changes nothing until the deployment env is flipped.

## How did I test?

- `actionlint` (via `rhysd/actionlint` Docker image) passes on all three workflows.
- Trigger semantics, job bodies, and `if:` gates diffed against the old repo's workflows; deviations are only the ones listed above.
- Live validation is structurally limited pre-merge: `workflow_dispatch` only appears once the workflow exists on the default branch, and push triggers only fire on develop. Post-merge runbook below covers the first live exercises (publish dry-run, manual internal restart).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
    - [x] Other: CI/CD workflows only (no app or package code)

### Secrets / ops checklist (none block merging; workflows skip gracefully)

| Item | For | Provisioning |
| --- | --- | --- |
| `GCP_SA_EMAIL`, `GCP_SA_KEY` | openclaw-deploy | Same SA the old repo uses (project `prod-f0181862`); mint a fresh key via IAM. The existing `GCP_SERVICE_KEY` secret is a different SA (glob uploads) — don't reuse. |
| `KUBECONFIG_B64` | openclaw-deploy (OVH) | From the OVH cluster admins (base64 kubeconfig with `admin@ovh-oregon-{1,2}` contexts). |
| `TLONBOT_DISPATCH_TOKEN` | smoke dispatch | Fine-grained PAT on `tloncorp/tlonbot` with **Contents: read & write** (repository_dispatch needs write; the read-only `TLONBOT_TOKEN` PAT won't work). Add only after the companion tlonbot PR lands. |
| npm Trusted Publisher | openclaw-publish | npm-side setting: re-point `@tloncorp/openclaw` from `tloncorp/openclaw-tlon`/`publish.yml` to `tloncorp/tlon-apps`/`openclaw-publish.yml`. Until flipped, only dry-runs succeed. Never both repos publishable at once. |

### Transition note: production still deploys old-repo code until the env flip

tlonbot's production `tlawn.py` re-fetches the plugin from **openclaw-tlon git** (`master` for internal, `stable` for tlawn) on every pod restart. The companion tlonbot PR adds env-gated monorepo support; until `TLON_PLUGIN_REPO`/`TLON_PLUGIN_SUBPATH` are set on the ship deployments, restarts — from either repo's deploy workflow — keep deploying openclaw-tlon code, so plugin changes landing only in this monorepo do not reach ships. Do the env flip **early in the transition** (one internal ship first), not at freeze.

## First-release runbook (post-merge)

1. Land the companion tlonbot PR; add `TLONBOT_DISPATCH_TOKEN`.
2. Provision deploy secrets; one manual `workflow_dispatch mode=internal`, observe pod restarts, before trusting the push trigger.
3. `openclaw-publish.yml` dispatch with `dry_run=true`; verify `.publish` contents in logs.
4. Flip the npm trusted publisher; disable the old repo's publish.yml the same day.
5. Bump plugin to 0.4.4, tag `openclaw-v0.4.4`, publish to a test dist-tag first (`npm_tag: dist-test`), smoke-install, then promote to `latest`.
6. Flip production to the monorepo: set `TLON_PLUGIN_REPO=tloncorp/tlon-apps` + `TLON_PLUGIN_SUBPATH=packages/openclaw` on one internal ship's deployment, verify clone/build/start, then roll out; disable the old repo's deploy.yml once proven (avoid double restarts).

## Rollback plan

Revert