### PR TITLE
Aqua: fast testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ packages/tlon-skill/bin/tlon
 *.tgz
 *.xst
 zod*
+bud
 vere-*
 *.pill
 /rube/zod/

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ packages/tlon-skill/bin/tlon
 *.tgz
 *.xst
 zod*
+bud
 vere-*
 *.pill
 /rube/zod/

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -162,10 +162,12 @@ EOF
 
 # TODO: We should figure out the source ship for this file and delete it
 rm -f $pier/groups/tests/lib/diary-graph.hoon
-rm -f $pier/groups/tests/ph/chat.hoon
 
 # Update the groups desk
 rsync -r desk/ $pier/groups
+
+# Hard-update our tests
+rsync -r --delete desk/tests $pier/groups/tests
 
 result=$( $run_click -t 3 $pier <<EOF
 =/  m  (strand ,vase)  

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -170,7 +170,7 @@ rm -f $pier/groups/tests/for/lure.hoon
 rsync -r desk/ $pier/groups
 
 # Hard-update our tests
-rsync -r --delete desk/tests $pier/groups/tests
+rsync -r --delete desk/tests/ $pier/groups/tests
 
 result=$( $run_click -t 3 $pier <<EOF
 =/  m  (strand ,vase)  

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -90,7 +90,7 @@ http_port=9090
 if [ ! -d $pier_dir ]
 then
   echo "Generating test ship $ship"
-  $vere -F $pier_dir -c $pier_dir -B $pill --http-port $http_port -x
+  $vere -F $pier_dir -c $pier_dir -B $pill --http-port $http_port -t -x
 
   if [ "$?" -ne 0 ]
   then

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -163,6 +163,9 @@ EOF
 # TODO: We should figure out the source ship for this file and delete it
 rm -f $pier/groups/tests/lib/diary-graph.hoon
 
+# FIXME: workaround clay bugs
+rm -f $pier/groups/tests/for/lure.hoon
+
 # Update the groups desk
 rsync -r desk/ $pier/groups
 

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -2,13 +2,13 @@
 
 click=./backend/click
 #ship_manifest=./apps/tlon-web/e2e/shipManifest.json
-ship="~zod"
+ship="~dev"
 pier_dir=${ship#\~}
-pier=$pier_dir-aqua
+pier=$pier_dir
 
 urbit_bin_url="https://urbit.org/install"
 
-arch=`arch`
+arch=`uname -m`
 
 case $OSTYPE in
   linux* )  
@@ -42,34 +42,18 @@ echo $urbit_bin_url
 echo "Running aqua tests"
 
 #download_url=`jq -r ".[\"$ship\"][\"downloadUrl\"]" < $ship_manifest`
-download_url="https://bootstrap.urbit.org/zod-aqua-tests-409k.xst"
+#download_url="https://bootstrap.urbit.org/dev-aqua-409k-2.tar.xz"
 pill_download_url="https://bootstrap.urbit.org/groups-v11-2-2.pill"
 
-archive=`basename $download_url`
+#archive=`basename $download_url`
 pill=`basename $pill_download_url`
 pill_name=`echo $pill | cut -d . -f1`
 
-if [ ! -f $archive ]
-then
-  echo "Downloading ~zod archive $archive"
-  curl -s $download_url > $archive
-fi
-
-# Unpack the pier
-if [ ! -d $pier ]
-then
-  echo "Unpacking pier $archive"
-  tar -xf $archive
-  mv $pier_dir $pier
-fi
-
-if [ ! -d $pier ]
-then
-  echo "Pier $pier not found!"
-  exit 1
-else
-  echo "Pier ready"
-fi
+# if [ ! -f $archive ]
+# then
+#   echo "Downloading ${ship} archive $archive"
+#   curl -s $download_url > $archive
+# fi
 
 if [ ! -f $pill ]
 then
@@ -102,6 +86,18 @@ then
   exit 1
 fi
 
+if [ ! -d $pier_dir ]
+then
+  echo "Booting test ship $ship"
+  $vere -F $pier_dir -c $pier_dir -B $pill -x
+
+  if [ "$?" -ne 0 ]
+  then
+    echo "Failed to boot test ship $ship"
+    exit 1
+  fi
+fi
+
 http_port=9090
 echo "Booting ship"
 ($vere --loom 33 --http-port $http_port -t $pier) &
@@ -120,11 +116,11 @@ echo "Mounting base..."
 $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
-;<  ~  bind:m  (poke [~zod %hood] kiln-unmount+!>(%base))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-unmount+!>(%base))  
 ;<  ~  bind:m  (sleep ~s0)  
 =/  =path  
   [(scot %p our.bowl) %base (scot %da now.bowl) ~]  
-;<  ~  bind:m  (poke [~zod %hood] kiln-mount+!>([path %base]))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-mount+!>([path %base]))  
 (pure:m !>(%ok))  
 EOF
 
@@ -133,11 +129,11 @@ echo "Mounting groups..."
 $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
-;<  ~  bind:m  (poke [~zod %hood] kiln-unmount+!>(%groups))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-unmount+!>(%groups))  
 ;<  ~  bind:m  (sleep ~s0)  
 =/  =path  
   [(scot %p our.bowl) %groups (scot %da now.bowl) ~]  
-;<  ~  bind:m  (poke [~zod %hood] kiln-mount+!>([path %groups]))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-mount+!>([path %groups]))  
 (pure:m !>(%ok))  
 EOF
 
@@ -160,7 +156,7 @@ echo "Updating base desk..."
 $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  our=ship  bind:m  get-our  
-;<  ~  bind:m  (poke [~zod %hood] kiln-commit+!>([%base |]))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-commit+!>([%base |]))  
 (pure:m !>(%ok))  
 EOF
 
@@ -183,7 +179,7 @@ echo "Updating groups desk"
 ${run_click} $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  our=ship  bind:m  get-our  
-;<  ~  bind:m  (poke [~zod %hood] kiln-commit+!>([%groups |]))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-commit+!>([%groups |]))  
 (pure:m !>(%ok))  
 EOF
 
@@ -205,7 +201,7 @@ desk_hash_b=`echo $result | sed 's/\[0 %avow 0 %noun \(.*\)\]/\1/'`
 if [ $desk_hash_a == $desk_hash_b ]
 then
   echo "Desk upgrade failed ❌"
-  kill -TERM $vere_pid
+  #kill -TERM $vere_pid
   exit 1
 fi
 
@@ -213,16 +209,23 @@ echo "Starting aqua..."
 ${run_click} $pier "/lib/pill/hoon"<<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl    
-;<  ~  bind:m  (poke [~zod %hood] kiln-nuke+!>([%aqua |]))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-nuke+!>([%aqua |]))  
 =+  .^(=cone:clay %cx /(scot %p p.byk.bowl)//(scot %da now.bowl)/domes)  
 =/  =dome:clay  (~(gut by cone) [p.byk.bowl %base] *dome:clay)  
 ;<  ~      bind:m  (sleep ~s0)  
-;<  ~  bind:m  (poke [~zod %hood] kiln-rein+!>([%base (~(put by ren.dome) %aqua &)]))  
+;<  ~  bind:m  (poke [${ship} %hood] kiln-rein+!>([%base (~(put by ren.dome) %aqua &)]))  
 =+  .^(pil=@ %cx /(scot %p p.byk.bowl)/groups/(scot %da now.bowl)/${pill_name}/jam)  
 =/  pill  ;;(pill:pill (cue pil))  
-;<  ~  bind:m  (poke [~zod %aqua] pill+!>(pill))  
+;<  ~  bind:m  (poke [${ship} %aqua] pill+!>(pill))  
 (pure:m !>(%ok))  
 EOF
+
+echo "Awaiting aqua boot..."
+sleep 3
+while ! curl -s "http://localhost:$http_port"
+do
+  sleep 3
+done
 
 echo "Preparing aqua snapshot..."
 result=$( $run_click -t 1800 $pier <<EOF

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -2,7 +2,7 @@
 
 click=./backend/click
 #ship_manifest=./apps/tlon-web/e2e/shipManifest.json
-ship="~dev"
+ship="~bud"
 pier_dir=${ship#\~}
 pier=$pier_dir
 
@@ -228,7 +228,7 @@ do
 done
 
 echo "Preparing aqua snapshot..."
-result=$( $run_click -t 600 $pier <<EOF
+result=$( $run_click -t 900 $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =+  tid=~.ci-ph-fleet  

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -86,19 +86,19 @@ then
   exit 1
 fi
 
+http_port=9090
 if [ ! -d $pier_dir ]
 then
-  echo "Booting test ship $ship"
-  $vere -F $pier_dir -c $pier_dir -B $pill -x
+  echo "Generating test ship $ship"
+  $vere -F $pier_dir -c $pier_dir -B $pill --http-port $http_port -x
 
   if [ "$?" -ne 0 ]
   then
-    echo "Failed to boot test ship $ship"
+    echo "Failed to generate test ship $ship"
     exit 1
   fi
 fi
 
-http_port=9090
 echo "Booting ship"
 ($vere --loom 33 --http-port $http_port -t $pier) &
 vere_pid=$!
@@ -201,7 +201,7 @@ desk_hash_b=`echo $result | sed 's/\[0 %avow 0 %noun \(.*\)\]/\1/'`
 if [ $desk_hash_a == $desk_hash_b ]
 then
   echo "Desk upgrade failed ❌"
-  #kill -TERM $vere_pid
+  kill -TERM $vere_pid
   exit 1
 fi
 
@@ -228,7 +228,7 @@ do
 done
 
 echo "Preparing aqua snapshot..."
-result=$( $run_click -t 1800 $pier <<EOF
+result=$( $run_click -t 600 $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =+  tid=~.ci-ph-fleet  
@@ -263,7 +263,7 @@ fi
 # Run aqua tests
 #
 echo "Running tests..."
-result=$( $run_click -t 1800 $pier <<EOF
+result=$( $run_click -t 1200 $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =/  ph-tests=path  

--- a/desk/ted/ph/fleet.hoon
+++ b/desk/ted/ph/fleet.hoon
@@ -88,11 +88,10 @@
   ?~  fleet  (pure:n ~)
   ;<  ~  bind:n  (sync-desk i.fleet %groups)
   $(fleet t.fleet)
-::  allow agents time to cool down. it takes about a minute
-::  for ames connections to be established.
+::  allow agents time to cool down to process
+::  any cards that might have been emitted.
 ::
-~>  %slog.1^(crip "Cooling down %groups agents...")
-;<  ~  bind:m  (sleep ~m1)
+;<  ~  bind:m  (sleep ~s5)
 ;<  ~  bind:m  (end-test:ph-io vane-tids)
 ;<  =bowl:spider  bind:m  get-bowl
 =/  snap-id=@t

--- a/desk/ted/ph/fleet.hoon
+++ b/desk/ted/ph/fleet.hoon
@@ -22,6 +22,20 @@
   =.  raw-files
     |-
     =*  loop  $
+    ::  compare hashes
+    =/  host-cz=@uvI
+      .^(@uvI %cz (weld sab path))
+    =/  aqua-cz=(unit @uvI)
+      ;;  (unit @uvI)
+      ::FIXME  this works with a mold in a wet gate.
+      ::       see +scry-aqua in /lib/ph/io.hoon.
+      .^  (unit *)  %gx  (scot %p our.bowl)  %aqua  (scot %da now.bowl)
+          %i  (scot %p her)  :: aqua scry
+          %cz
+          (snoc (weld /(scot %p her)/[desk]/(scot %da now.bowl) path) %noun)
+      ==
+    ?:  &(?=(^ aqua-cz) =(host-cz u.aqua-cz))
+      raw-files
     =+  .^(=arch %cy (weld sab path))
     =.  raw-files
       %+  roll  ~(tap in ~(key by dir.arch))

--- a/desk/ted/ph/fleet.hoon
+++ b/desk/ted/ph/fleet.hoon
@@ -22,20 +22,6 @@
   =.  raw-files
     |-
     =*  loop  $
-    ::  compare hashes
-    =/  host-cz=@uvI
-      .^(@uvI %cz (weld sab path))
-    =/  aqua-cz=(unit @uvI)
-      ;;  (unit @uvI)
-      ::FIXME  this works with a mold in a wet gate.
-      ::       see +scry-aqua in /lib/ph/io.hoon.
-      .^  (unit *)  %gx  (scot %p our.bowl)  %aqua  (scot %da now.bowl)
-          %i  (scot %p her)  :: aqua scry
-          %cz
-          (snoc (weld /(scot %p her)/[desk]/(scot %da now.bowl) path) %noun)
-      ==
-    ?:  &(?=(^ aqua-cz) =(host-cz u.aqua-cz))
-      raw-files
     =+  .^(=arch %cy (weld sab path))
     =.  raw-files
       %+  roll  ~(tap in ~(key by dir.arch))

--- a/desk/ted/ph/test.hoon
+++ b/desk/ted/ph/test.hoon
@@ -175,6 +175,7 @@
   ::  allow virtual vanes to run before we restore snapshot
   ;<  vane-tids=(map term tid:spider)  bind:n  start-simple:ph-io
   ;<  ~  bind:n  (send-events:ph-io [%restore-snap snap]~)
+  ~>  %slog.1^leaf+"Testing {<name>}"
   ;<  now-1=@da  bind:n  get-time
   ;<  =thread-result  bind:n  (await-test-thread test)
   ;<  now-2=@da  bind:n  get-time

--- a/desk/tests/ph/platform/lure.hoon
+++ b/desk/tests/ph/platform/lure.hoon
@@ -81,7 +81,7 @@
       [%'inviterNickname' 'Aqua Zod']
       [%'inviterAvatarImage' 'https://zod.arvo.network/avatar.png']
       [%'inviteType' 'user']
-      [%'invitedGroupId' '']
+      [%'invitedGroupId' '~zod/personal-invite-link']
       [%'bite-type' '2']
   ==
 ::
@@ -111,10 +111,11 @@
   |=  =metadata:v1:r
   =/  m  (strand @t)
   ^-  form:m
-  =+  lure-path=(stab (cat 3 '/v1/id-link/' my-test-group-id))
+  =+  group-id=(~(got by fields.metadata) %'invitedGroupId')
+  =+  lure-path=(stab (cat 3 '/v1/id-link/' group-id))
   ;<  ~  bind:m  (poke-app [~zod %reel] verb+[%volume %info])
   ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] lure-path)
-  ;<  ~  bind:m  (poke-app [~zod %reel] reel-describe+[my-test-group-id metadata])
+  ;<  ~  bind:m  (poke-app [~zod %reel] reel-describe+[group-id metadata])
   ;<  kag=cage  bind:m  (wait-for-app-fact /~zod/reel/v1/id-link [~zod %reel])
   ;<  ~  bind:m  (leave-app /~zod/reel/v1/id-link [~zod %reel])
   ;<  ~  bind:m  (ex-equal !>(p.kag) !>(%json))

--- a/desk/tests/ph/platform/lure.hoon
+++ b/desk/tests/ph/platform/lure.hoon
@@ -91,7 +91,7 @@
   ^-  form:m
   ;<  =bowl:strand  bind:m  get-bowl
   =/  aqua-pax
-    /gx/(scot %p ship)/reel/(scot %da now.bowl)/v1/bait/noun/noun
+    /gx/(scot %p ship)/reel/(scot %da now.bowl)/v1/bait/noun
   ;<  [bait=(unit [vic=@t civ=@p])]  bind:m
     (scry-aqua (unit ,[vic=@t civ=@p]) ship aqua-pax)
   (pure:m (need bait))
@@ -102,7 +102,7 @@
   ^-  form:m
   ;<  =bowl:strand  bind:m  get-bowl
   =/  aqua-pax
-    /gx/(scot %p ship)/reel/(scot %da now.bowl)/v1/service/noun/noun
+    /gx/(scot %p ship)/reel/(scot %da now.bowl)/v1/service/noun
   ;<  vic=(unit @t)  bind:m
     (scry-aqua (unit @t) ship aqua-pax)
   (pure:m (need vic))


### PR DESCRIPTION
## Summary

This PR speeds up aqua tests significantly by using a test ship primed with a pill to enable fast booting of aqua ships, finally ending the long performance debugging saga.

We also optimize virtual desk sync by checking hashes.

## Changes

1. Boot a test ship from pill each time in the test runner.
2. ~Compare file hashes in clay before syncing to virtual ship. (It is a reasonable optimization, but it seems any gains are dwarfed by compile time anyway)~ This did not play well with clay's %into. Furthermore, compile time is dominant for virtual desk update.
3. Workaround a ridiculous clay bug where the deleted files don't sync. In this case old tests were permanently stuck in the desk, causing duplicate testing hard-to-spot failures.

## How did I test?

Run the tests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.
