### PR TITLE
openclaw: add a2ui approval cards

### DIFF
--- a/packages/openclaw/src/monitor/approval.test.ts
+++ b/packages/openclaw/src/monitor/approval.test.ts
@@ -1,14 +1,16 @@
+import { A2UI } from '@tloncorp/api';
 import { describe, expect, it } from 'vitest';
 
 import {
   APPROVAL_TTL_MS,
   type DisplayContext,
   type PendingApproval,
+  buildApprovalA2UIBlob,
   createPendingApproval,
   emojiToApprovalAction,
   findPendingApproval,
   formatApprovalConfirmation,
-  formatApprovalRequest,
+  formatApprovalRequestNotification,
   formatBlockedList,
   formatPendingList,
   generateApprovalId,
@@ -54,9 +56,9 @@ describe('createPendingApproval', () => {
       type: 'group',
       requestingShip: '~zod',
       groupFlag: '~host/my-group',
-      groupTitle: 'My Cool Group',
+      groupTitle: 'Garden Club',
     });
-    expect(approval.groupTitle).toBe('My Cool Group');
+    expect(approval.groupTitle).toBe('Garden Club');
   });
 });
 
@@ -188,71 +190,212 @@ describe('findPendingApproval', () => {
 // ---------------------------------------------------------------------------
 
 const ctx: DisplayContext = {
-  channelNames: new Map([['chat/~host/general', 'general']]),
-  groupNames: new Map([['~host/cool-group', 'Cool Group']]),
+  contactNames: new Map([
+    ['~sampel-palnet', 'Sam Palnet'],
+    ['~littel-wolfur', 'Littel Wolfur'],
+    ['~robin-dasler', 'Robin Dasler'],
+    ['~zod', 'Zod'],
+  ]),
+  channelNames: new Map([['chat/~host/general', 'General']]),
+  channelGroups: new Map([['chat/~host/general', '~host/cool-group']]),
+  groupNames: new Map([['~host/cool-group', 'Garden Club']]),
 };
 
-describe('formatApprovalRequest', () => {
-  it('DM request shows ship, reaction hints, and slash command hints', () => {
-    const approval = createPendingApproval({
+describe('buildApprovalA2UIBlob', () => {
+  it('builds approval cards with slash command actions', () => {
+    for (const approval of [
+      buildApprovalA2UIBlob({
+        id: 'da1b2',
+        type: 'dm',
+        requestingShip: '~sampel-palnet',
+        timestamp: 1,
+        messagePreview: 'Hello, I would like to chat with your bot.',
+      }),
+      buildApprovalA2UIBlob({
+        id: 'c3d4e',
+        type: 'channel',
+        requestingShip: '~littel-wolfur',
+        channelNest: 'chat/~zod/design',
+        timestamp: 1,
+        messagePreview: '@bot can you review this build before I merge?',
+      }),
+      buildApprovalA2UIBlob({
+        id: 'g5f6a',
+        type: 'group',
+        requestingShip: '~robin-dasler',
+        groupFlag: '~robin-dasler/garden-club',
+        groupTitle: 'Garden Club',
+        timestamp: 1,
+      }),
+    ]) {
+      expect(A2UI.validateBlobEntry(approval)).toBe(true);
+      const text = JSON.stringify(approval);
+      expect(text).toContain('/allow ');
+      expect(text).toContain('/reject ');
+      expect(text).toContain('/ban ');
+      if (
+        text.includes('Hello, I would') ||
+        text.includes('@bot can you review')
+      ) {
+        expect(text).toContain('Message: ');
+      }
+      expect(text).not.toContain('New approval request');
+    }
+  });
+
+  it('formats the visible notification text by request type', () => {
+    expect(
+      formatApprovalRequestNotification(
+        {
+          type: 'dm',
+          requestingShip: '~sampel-palnet',
+        },
+        ctx
+      )
+    ).toBe('DM request from Sam Palnet (~sampel-palnet)');
+    expect(
+      formatApprovalRequestNotification(
+        {
+          type: 'channel',
+          requestingShip: '~littel-wolfur',
+        },
+        ctx
+      )
+    ).toBe('Channel mention request from Littel Wolfur (~littel-wolfur)');
+    expect(
+      formatApprovalRequestNotification(
+        {
+          type: 'group',
+          requestingShip: '~robin-dasler',
+        },
+        ctx
+      )
+    ).toBe('Group invite request from Robin Dasler (~robin-dasler)');
+  });
+
+  it('uses request type as the card eyebrow', () => {
+    expect(
+      JSON.stringify(
+        buildApprovalA2UIBlob({
+          id: 'da1b2',
+          type: 'dm',
+          requestingShip: '~sampel-palnet',
+          timestamp: 1,
+        })
+      )
+    ).toContain('DM access');
+    expect(
+      JSON.stringify(
+        buildApprovalA2UIBlob({
+          id: 'cc3d4',
+          type: 'channel',
+          requestingShip: '~sampel-palnet',
+          channelNest: 'chat/~host/general',
+          timestamp: 1,
+        })
+      )
+    ).toContain('Channel access');
+    expect(
+      JSON.stringify(
+        buildApprovalA2UIBlob({
+          id: 'g5f6e',
+          type: 'group',
+          requestingShip: '~sampel-palnet',
+          groupFlag: '~host/cool-group',
+          timestamp: 1,
+        })
+      )
+    ).toContain('Group invite');
+  });
+
+  it('shows labeled metadata on dm cards', () => {
+    const approval = buildApprovalA2UIBlob({
+      id: 'da1b2',
       type: 'dm',
       requestingShip: '~sampel-palnet',
-      messagePreview: 'Hello there',
+      timestamp: 1,
     });
-    const text = formatApprovalRequest(approval, ctx);
-    expect(text).toContain('~sampel-palnet');
-    expect(text).toContain('"Hello there"');
-    expect(text).toContain(
-      'React to this message: 👍 approve · 👎 deny · 🛑 block'
+
+    expect(A2UI.validateBlobEntry(approval)).toBe(true);
+    expect(JSON.stringify(approval)).toContain('Sender: ~sampel-palnet');
+  });
+
+  it('uses display context for channel and group labels', () => {
+    const approval = buildApprovalA2UIBlob(
+      {
+        id: 'cc3d4',
+        type: 'channel',
+        requestingShip: '~zod',
+        channelNest: 'chat/~host/general',
+        timestamp: 1,
+      },
+      ctx
     );
-    expect(text).toContain('Or use a slash command:');
-    expect(text).toContain(`/allow ${approval.id}`);
-    expect(text).toContain(`/reject ${approval.id}`);
-    expect(text).toContain(`/ban ${approval.id}`);
+
+    expect(A2UI.validateBlobEntry(approval)).toBe(true);
+    const text = JSON.stringify(approval);
+    expect(text).toContain('Let the bot reply to Zod in General?');
+    expect(text).toContain('Sender: Zod (~zod)');
+    expect(text).toContain('Channel: General');
+    expect(text).toContain('Group: Garden Club');
+    expect(text).not.toContain('General in Garden Club (chat/~host/general)');
+    expect(text).toContain('/allow cc3d4');
   });
 
-  it('channel request shows channel name and ship', () => {
-    const approval = createPendingApproval({
-      type: 'channel',
-      requestingShip: '~sampel-palnet',
-      channelNest: 'chat/~host/general',
-      messagePreview: 'Hey @bot',
-    });
-    const text = formatApprovalRequest(approval, ctx);
-    expect(text).toContain('~sampel-palnet');
-    expect(text).toContain('general (chat/~host/general)');
-    expect(text).toContain(`/allow ${approval.id}`);
+  it('falls back to channel name when group name is unavailable', () => {
+    const approval = buildApprovalA2UIBlob(
+      {
+        id: 'cc3d4',
+        type: 'channel',
+        requestingShip: '~zod',
+        channelNest: 'chat/~host/general',
+        timestamp: 1,
+      },
+      { contactNames: ctx.contactNames, channelNames: ctx.channelNames }
+    );
+
+    expect(A2UI.validateBlobEntry(approval)).toBe(true);
+    const text = JSON.stringify(approval);
+    expect(text).toContain('Let the bot reply to Zod in General?');
+    expect(text).toContain('Sender: Zod (~zod)');
+    expect(text).toContain('Channel: General');
+    expect(text).not.toContain('general (chat/~host/general)');
   });
 
-  it('group request shows group title', () => {
-    const approval = createPendingApproval({
+  it('shows labeled metadata on group invite cards', () => {
+    const approval = buildApprovalA2UIBlob(
+      {
+        id: 'g5f6e',
+        type: 'group',
+        requestingShip: '~robin-dasler',
+        groupFlag: '~robin-dasler/garden-club',
+        groupTitle: 'Garden Club',
+        timestamp: 1,
+      },
+      ctx
+    );
+
+    expect(A2UI.validateBlobEntry(approval)).toBe(true);
+    const text = JSON.stringify(approval);
+    expect(text).toContain('Let the bot join Garden Club?');
+    expect(text).toContain('Inviter: Robin Dasler (~robin-dasler)');
+    expect(text).toContain('Group: Garden Club');
+  });
+
+  it('keeps the group flag visible when no group title is available', () => {
+    const approval = buildApprovalA2UIBlob({
+      id: 'g5f6e',
       type: 'group',
-      requestingShip: '~sampel-palnet',
-      groupFlag: '~host/cool-group',
+      requestingShip: '~robin-dasler',
+      groupFlag: '~robin-dasler/private-garden',
+      timestamp: 1,
     });
-    const text = formatApprovalRequest(approval, ctx);
-    expect(text).toContain('Cool Group (~host/cool-group)');
-    expect(text).toContain(`/allow ${approval.id}`);
-  });
 
-  it('group request uses groupTitle field over context', () => {
-    const approval = createPendingApproval({
-      type: 'group',
-      requestingShip: '~zod',
-      groupFlag: '~host/other-group',
-      groupTitle: 'Other Title',
-    });
-    const text = formatApprovalRequest(approval, ctx);
-    expect(text).toContain('Other Title (~host/other-group)');
-  });
-
-  it('works without context', () => {
-    const approval = createPendingApproval({
-      type: 'dm',
-      requestingShip: '~zod',
-    });
-    const text = formatApprovalRequest(approval);
-    expect(text).toContain('~zod');
+    expect(A2UI.validateBlobEntry(approval)).toBe(true);
+    const text = JSON.stringify(approval);
+    expect(text).toContain('Let the bot join ~robin-dasler/private-garden?');
+    expect(text).toContain('Group: ~robin-dasler/private-garden');
+    expect(text).not.toContain('this group');
   });
 });
 
@@ -265,13 +408,13 @@ describe('formatApprovalConfirmation', () => {
       timestamp: 1,
     };
     expect(formatApprovalConfirmation(approval, 'approve', ctx)).toContain(
-      '~sampel-palnet'
+      'Sam Palnet (~sampel-palnet)'
     );
     expect(formatApprovalConfirmation(approval, 'deny', ctx)).toContain(
-      '~sampel-palnet'
+      'Sam Palnet (~sampel-palnet)'
     );
     expect(formatApprovalConfirmation(approval, 'block', ctx)).toContain(
-      '~sampel-palnet'
+      'Sam Palnet (~sampel-palnet)'
     );
   });
 
@@ -284,7 +427,7 @@ describe('formatApprovalConfirmation', () => {
       timestamp: 1,
     };
     expect(formatApprovalConfirmation(approval, 'approve', ctx)).toContain(
-      'general (chat/~host/general)'
+      'General in Garden Club (chat/~host/general)'
     );
   });
 
@@ -297,7 +440,7 @@ describe('formatApprovalConfirmation', () => {
       timestamp: 1,
     };
     expect(formatApprovalConfirmation(approval, 'approve', ctx)).toContain(
-      'Cool Group (~host/cool-group)'
+      'Garden Club (~host/cool-group)'
     );
   });
 
@@ -319,15 +462,15 @@ describe('formatApprovalConfirmation', () => {
 
 describe('formatBlockedList', () => {
   it('shows empty state', () => {
-    expect(formatBlockedList([])).toBe('No ships are currently blocked.');
+    expect(formatBlockedList([])).toBe('No users are currently blocked.');
   });
 
   it('shows ships', () => {
     const text = formatBlockedList(['~sampel-palnet', '~zod']);
     expect(text).toContain('~sampel-palnet');
     expect(text).toContain('~zod');
-    expect(text).toContain('Blocked ships (2):');
-    expect(text).toContain('`/unban ~ship-name`');
+    expect(text).toContain('Blocked users (2):');
+    expect(text).toContain('`/unban ~sampel-palnet`');
   });
 });
 
@@ -373,7 +516,7 @@ describe('formatPendingList', () => {
       },
     ];
     const text = formatPendingList(approvals, ctx);
-    expect(text).toContain('~zod');
+    expect(text).toContain('Zod (~zod)');
   });
 
   it('shows channel names for channel approvals', () => {
@@ -387,7 +530,7 @@ describe('formatPendingList', () => {
       },
     ];
     const text = formatPendingList(approvals, ctx);
-    expect(text).toContain('general (chat/~host/general)');
+    expect(text).toContain('General in Garden Club (chat/~host/general)');
   });
 
   it('shows group names for group approvals', () => {
@@ -401,7 +544,7 @@ describe('formatPendingList', () => {
       },
     ];
     const text = formatPendingList(approvals, ctx);
-    expect(text).toContain('Cool Group (~host/cool-group)');
+    expect(text).toContain('Garden Club (~host/cool-group)');
   });
 
   it('includes slash command usage hint', () => {

--- a/packages/openclaw/src/monitor/approval.ts
+++ b/packages/openclaw/src/monitor/approval.ts
@@ -1,3 +1,4 @@
+import { A2UI } from '@tloncorp/api';
 import { randomUUID } from 'node:crypto';
 
 /**
@@ -8,11 +9,16 @@ import { randomUUID } from 'node:crypto';
  * (/allow, /reject, /ban).
  */
 import { APPROVAL_TTL_MS, type PendingApproval } from '../settings.js';
+import { type TlonA2UIBlob, makeA2UIBlob } from '../urbit/blob.js';
 
 export type { PendingApproval };
 export { APPROVAL_TTL_MS };
 
 export type ApprovalType = 'dm' | 'channel' | 'group';
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected approval type: ${String(value)}`);
+}
 
 export type CreateApprovalParams = {
   type: ApprovalType;
@@ -32,21 +38,59 @@ export type CreateApprovalParams = {
   };
 };
 
+export function formatApprovalRequestNotification(
+  approval: Pick<PendingApproval, 'type' | 'requestingShip'>,
+  ctx?: DisplayContext
+): string {
+  const ship = displayShipWithId(approval.requestingShip, ctx);
+  if (approval.type === 'dm') {
+    return `DM request from ${ship}`;
+  }
+  if (approval.type === 'channel') {
+    return `Channel mention request from ${ship}`;
+  }
+  return `Group invite request from ${ship}`;
+}
+
 // ============================================================================
 // Display Context — pass human-readable names without breaking purity
 // ============================================================================
 
 /** Display hints for human-readable formatting. Callers resolve these from caches/lookups. */
 export type DisplayContext = {
+  /** Map from ship (~sampel-palnet) to human-readable contact nickname */
+  contactNames?: Map<string, string>;
   /** Map from channel nest (chat/~host/name) to human-readable channel display name */
   channelNames?: Map<string, string>;
+  /** Map from channel nest (chat/~host/name) to containing group flag */
+  channelGroups?: Map<string, string>;
   /** Map from group flag (~host/name) to human-readable group title */
   groupNames?: Map<string, string>;
 };
 
+function displayShipName(ship: string, ctx?: DisplayContext): string {
+  return ctx?.contactNames?.get(ship) || ship;
+}
+
+function displayShipWithId(ship: string, ctx?: DisplayContext): string {
+  const name = ctx?.contactNames?.get(ship);
+  return name ? `${name} (${ship})` : ship;
+}
+
 function displayChannel(nest: string, ctx?: DisplayContext): string {
   const name = ctx?.channelNames?.get(nest);
-  return name ? `${name} (${nest})` : nest;
+  const groupFlag = ctx?.channelGroups?.get(nest);
+  const groupName = groupFlag ? ctx?.groupNames?.get(groupFlag) : undefined;
+  if (name && groupName) {
+    return `${name} in ${groupName} (${nest})`;
+  }
+  if (name) {
+    return `${name} (${nest})`;
+  }
+  if (groupName) {
+    return `${groupName} (${nest})`;
+  }
+  return nest;
 }
 
 function displayGroup(
@@ -116,7 +160,7 @@ export function pruneExpired(approvals: PendingApproval[]): PendingApproval[] {
 
 /**
  * Generate a short approval ID: type-prefix char + 4 hex chars.
- * e.g. "da1b2" for dm, "cc3d4" for channel, "g5f6e" for group.
+ * e.g. "da1b2" for dm, "cc3d4" for channel, "g5f6e" for group invite.
  */
 export function generateApprovalId(
   type: ApprovalType,
@@ -165,79 +209,292 @@ function truncate(text: string, maxLength: number): string {
 }
 
 // ============================================================================
-// Approval Request Formatting
+// Approval Request A2UI
 // ============================================================================
 
-const REACTION_HINT = 'React to this message: 👍 approve · 👎 deny · 🛑 block';
+type ApprovalA2UIParams = {
+  type: ApprovalType;
+  requestId: string;
+  requestingShip: string;
+  requestingShipName?: string;
+  requestingShipLabel?: string;
+  messagePreview?: string;
+  channelName?: string;
+  channelContext?: string;
+  channelNest?: string;
+  groupName?: string;
+  groupFlag?: string;
+  groupTitle?: string;
+};
 
-function actionHintsDm(id: string): string {
-  return [
-    REACTION_HINT,
-    '',
-    'Or use a slash command:',
-    `  /allow ${id} — allow this ship to DM`,
-    `  /reject ${id} — decline (they can try again)`,
-    `  /ban ${id} — block this ship`,
-  ].join('\n');
+function approvalRequesterName(params: ApprovalA2UIParams): string {
+  return params.requestingShipName ?? params.requestingShip;
 }
 
-function actionHintsChannel(id: string): string {
-  return [
-    REACTION_HINT,
-    '',
-    'Or use a slash command:',
-    `  /allow ${id} — allow this ship in this channel`,
-    `  /reject ${id} — decline (they can try again)`,
-    `  /ban ${id} — block this ship`,
-  ].join('\n');
+function approvalRequesterLabel(params: ApprovalA2UIParams): string {
+  return params.requestingShipLabel ?? params.requestingShip;
 }
 
-function actionHintsGroup(id: string): string {
-  return [
-    REACTION_HINT,
-    '',
-    'Or use a slash command:',
-    `  /allow ${id} — join this group`,
-    `  /reject ${id} — decline the invite`,
-    `  /ban ${id} — block this ship`,
-  ].join('\n');
+function approvalTarget(params: ApprovalA2UIParams): string | undefined {
+  if (params.type === 'channel') {
+    return params.channelName;
+  }
+  if (params.type === 'group') {
+    return params.groupName ?? params.groupTitle;
+  }
+  return undefined;
 }
 
-/**
- * Format a notification message for the owner about a pending approval.
- */
-export function formatApprovalRequest(
-  approval: PendingApproval,
-  ctx?: DisplayContext
-): string {
-  const preview = approval.messagePreview
-    ? `\n"${truncate(approval.messagePreview, 100)}"`
-    : '';
-
-  switch (approval.type) {
+function approvalTitle(params: ApprovalA2UIParams): string {
+  const target = approvalTarget(params);
+  switch (params.type) {
     case 'dm':
-      return [
-        `DM request from ${approval.requestingShip}`,
-        preview,
-        '',
-        actionHintsDm(approval.id),
-      ].join('\n');
+      return `Allow ${approvalRequesterName(params)} to DM the bot?`;
+    case 'channel':
+      return `Let the bot reply to ${approvalRequesterName(params)} in ${approvalChannelLabel(params)}?`;
+    case 'group':
+      return `Let the bot join ${truncate(target ?? 'this group', 60)}?`;
+  }
+  return assertNever(params.type);
+}
 
+function approvalEyebrow(params: ApprovalA2UIParams): string {
+  switch (params.type) {
+    case 'dm':
+      return 'DM access';
+    case 'channel':
+      return 'Channel access';
+    case 'group':
+      return 'Group invite';
+  }
+  return assertNever(params.type);
+}
+
+function approvalChannelLabel(params: ApprovalA2UIParams): string {
+  return params.channelName ?? params.channelNest ?? 'this channel';
+}
+
+function approvalContextLines(params: ApprovalA2UIParams): string[] {
+  switch (params.type) {
+    case 'dm':
+      return [`Sender: ${approvalRequesterLabel(params)}`];
     case 'channel':
       return [
-        `${approval.requestingShip} mentioned the bot in ${displayChannel(approval.channelNest ?? '', ctx)}`,
-        preview,
-        '',
-        actionHintsChannel(approval.id),
-      ].join('\n');
-
+        `Sender: ${approvalRequesterLabel(params)}`,
+        `Channel: ${approvalChannelLabel(params)}`,
+        ...(params.channelContext ? [`Group: ${params.channelContext}`] : []),
+      ];
     case 'group':
       return [
-        `Group invite from ${approval.requestingShip} to join ${displayGroup(approval.groupFlag ?? '', ctx, approval.groupTitle)}`,
-        '',
-        actionHintsGroup(approval.id),
-      ].join('\n');
+        `Inviter: ${approvalRequesterLabel(params)}`,
+        ...(approvalTarget(params) || params.groupFlag
+          ? [`Group: ${approvalTarget(params) ?? params.groupFlag}`]
+          : []),
+      ];
   }
+  return assertNever(params.type);
+}
+
+function approvalCopy(params: ApprovalA2UIParams): string | undefined {
+  if (params.messagePreview) {
+    return `Message: "${truncate(params.messagePreview, 100)}"`;
+  }
+  return undefined;
+}
+
+function approvalAllowNote(params: ApprovalA2UIParams): string {
+  switch (params.type) {
+    case 'dm':
+      return 'The bot will be able to read and reply to future DMs from this user.';
+    case 'channel':
+      return 'The bot will be able to read and reply to this user in this channel.';
+    case 'group':
+      return 'The bot will be able to read and respond in channels it joins.';
+  }
+  return assertNever(params.type);
+}
+
+function buildApprovalA2UIBlobFromParams(
+  params: ApprovalA2UIParams
+): TlonA2UIBlob {
+  const contextLines = approvalContextLines(params);
+  const contextIds = contextLines.map((_, index) => `context${index}`);
+  const copy = approvalCopy(params);
+  const bodyChildren = [
+    'eyebrow',
+    'title',
+    'titleDivider',
+    ...contextIds,
+    ...(copy ? ['copy'] : []),
+    'divider',
+    'details',
+    'actions',
+  ];
+  const contextComponents: A2UI.Component[] = contextLines.map(
+    (line, index) => ({
+      id: `context${index}`,
+      component: 'Text',
+      variant: 'caption',
+      text: line,
+    })
+  );
+  const copyComponents: A2UI.Component[] = copy
+    ? [
+        {
+          id: 'copy',
+          component: 'Text',
+          variant: 'caption',
+          text: copy,
+        },
+      ]
+    : [];
+
+  const components: A2UI.Component[] = [
+    { id: 'root', component: 'Card', child: 'body' },
+    {
+      id: 'body',
+      component: 'Column',
+      children: bodyChildren,
+    },
+    {
+      id: 'eyebrow',
+      component: 'Text',
+      variant: 'caption',
+      text: approvalEyebrow(params),
+    },
+    {
+      id: 'title',
+      component: 'Text',
+      variant: 'h3',
+      text: approvalTitle(params),
+    },
+    { id: 'titleDivider', component: 'Divider' },
+    ...contextComponents,
+    ...copyComponents,
+    { id: 'divider', component: 'Divider' },
+    {
+      id: 'details',
+      component: 'Column',
+      children: ['allowNote'],
+    },
+    {
+      id: 'allowNote',
+      component: 'Text',
+      variant: 'caption',
+      text: approvalAllowNote(params),
+    },
+    {
+      id: 'actions',
+      component: 'Row',
+      children: ['allow', 'reject', 'ban'],
+    },
+    {
+      id: 'allow',
+      component: 'Button',
+      variant: 'primary',
+      child: 'allowLabel',
+      action: {
+        event: {
+          name: A2UI.action.sendMessage,
+          context: { text: `/allow ${params.requestId}` },
+        },
+      },
+    },
+    { id: 'allowLabel', component: 'Text', text: 'Allow' },
+    {
+      id: 'reject',
+      component: 'Button',
+      child: 'rejectLabel',
+      action: {
+        event: {
+          name: A2UI.action.sendMessage,
+          context: { text: `/reject ${params.requestId}` },
+        },
+      },
+    },
+    { id: 'rejectLabel', component: 'Text', text: 'Reject' },
+    {
+      id: 'ban',
+      component: 'Button',
+      variant: 'borderless',
+      child: 'banLabel',
+      action: {
+        event: {
+          name: A2UI.action.sendMessage,
+          context: { text: `/ban ${params.requestId}` },
+        },
+      },
+    },
+    { id: 'banLabel', component: 'Text', text: 'Block' },
+  ];
+
+  return makeA2UIBlob(`approval-${params.requestId}`, 'root', components);
+}
+
+function displayChannelForApproval(
+  nest: string | undefined,
+  ctx?: DisplayContext
+): string | undefined {
+  if (!nest) {
+    return undefined;
+  }
+  return ctx?.channelNames?.get(nest) ?? 'this channel';
+}
+
+function displayChannelContextForApproval(
+  nest: string | undefined,
+  ctx?: DisplayContext
+): string | undefined {
+  if (!nest) {
+    return undefined;
+  }
+  const groupFlag = ctx?.channelGroups?.get(nest);
+  const groupName = groupFlag ? ctx?.groupNames?.get(groupFlag) : undefined;
+  if (groupName) {
+    return groupName;
+  }
+  if (groupFlag) {
+    return groupFlag;
+  }
+  return undefined;
+}
+
+function displayGroupForApproval(
+  flag: string | undefined,
+  titleOverride: string | undefined,
+  ctx?: DisplayContext
+): string | undefined {
+  if (!flag && !titleOverride) {
+    return undefined;
+  }
+  if (!flag) {
+    return titleOverride;
+  }
+  return titleOverride || ctx?.groupNames?.get(flag) || flag;
+}
+
+export function buildApprovalA2UIBlob(
+  approval: PendingApproval,
+  ctx?: DisplayContext
+): TlonA2UIBlob {
+  return buildApprovalA2UIBlobFromParams({
+    type: approval.type,
+    requestId: approval.id,
+    requestingShip: approval.requestingShip,
+    requestingShipName: displayShipName(approval.requestingShip, ctx),
+    requestingShipLabel: displayShipWithId(approval.requestingShip, ctx),
+    messagePreview: approval.messagePreview,
+    channelNest: approval.channelNest,
+    channelName: displayChannelForApproval(approval.channelNest, ctx),
+    channelContext: displayChannelContextForApproval(approval.channelNest, ctx),
+    groupFlag: approval.groupFlag,
+    groupTitle: approval.groupTitle,
+    groupName: displayGroupForApproval(
+      approval.groupFlag,
+      approval.groupTitle,
+      ctx
+    ),
+  });
 }
 
 // ============================================================================
@@ -318,7 +575,7 @@ export function formatApprovalConfirmation(
   action: 'approve' | 'deny' | 'block',
   ctx?: DisplayContext
 ): string {
-  const ship = approval.requestingShip;
+  const ship = displayShipWithId(approval.requestingShip, ctx);
 
   if (action === 'block') {
     return `Blocked ${ship}. They will no longer be able to contact the bot.`;
@@ -327,14 +584,14 @@ export function formatApprovalConfirmation(
   switch (approval.type) {
     case 'dm':
       if (action === 'approve') {
-        return `Approved DM access for ${ship}. They can now message the bot.`;
+        return `Approved DM access for ${ship}. They will be able to message the bot.`;
       }
       return `Denied DM request from ${ship}.`;
 
     case 'channel': {
       const channel = displayChannel(approval.channelNest ?? '', ctx);
       if (action === 'approve') {
-        return `Approved ${ship} for ${channel}. They can now interact in this channel.`;
+        return `Approved ${ship} for ${channel}. They will be able to interact in this channel.`;
       }
       return `Denied ${ship} for ${channel}.`;
     }
@@ -351,6 +608,7 @@ export function formatApprovalConfirmation(
       return `Denied group invite from ${ship} to ${group}.`;
     }
   }
+  return assertNever(approval.type);
 }
 
 // ============================================================================
@@ -358,18 +616,18 @@ export function formatApprovalConfirmation(
 // ============================================================================
 
 /**
- * Format the list of blocked ships for display to owner.
+ * Format the list of blocked users for display to owner.
  */
 export function formatBlockedList(ships: string[]): string {
   if (ships.length === 0) {
-    return 'No ships are currently blocked.';
+    return 'No users are currently blocked.';
   }
   const lines = ships.map((s) => `  ${s}`);
   return [
-    `Blocked ships (${ships.length}):`,
+    `Blocked users (${ships.length}):`,
     ...lines,
     '',
-    'To unban: `/unban ~ship-name`',
+    'To unban: `/unban ~sampel-palnet`',
   ].join('\n');
 }
 
@@ -386,7 +644,7 @@ export function formatPendingList(
   }
 
   const entries = active.map((a) => {
-    const ship = a.requestingShip;
+    const ship = displayShipWithId(a.requestingShip, ctx);
     const preview = a.messagePreview
       ? `\n    "${truncate(a.messagePreview, 80)}"`
       : '';
@@ -399,6 +657,7 @@ export function formatPendingList(
       case 'group':
         return `  #${a.id} - Group invite from ${ship} to ${displayGroup(a.groupFlag ?? '', ctx, a.groupTitle)}`;
     }
+    return assertNever(a.type);
   });
 
   return [

--- a/packages/openclaw/src/monitor/discovery.ts
+++ b/packages/openclaw/src/monitor/discovery.ts
@@ -30,9 +30,23 @@ export async function fetchGroupChanges(
 export interface InitData {
   channels: string[];
   channelToGroup: Map<string, string>;
+  /** Map from channel nest to human-readable channel title */
+  channelNames: Map<string, string>;
   /** Map from group flag to human-readable group title */
   groupNames: Map<string, string>;
   foreigns: Foreigns | null;
+}
+
+function extractTitle(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+  const metadata = value as {
+    meta?: { title?: unknown };
+    title?: unknown;
+  };
+  const title = metadata.meta?.title ?? metadata.title;
+  return typeof title === 'string' && title.trim() ? title.trim() : undefined;
 }
 
 /**
@@ -49,6 +63,7 @@ export async function fetchInitData(
 
     const channels: string[] = [];
     const channelToGroup = new Map<string, string>();
+    const channelNames = new Map<string, string>();
     const groupNames = new Map<string, string>();
     if (initData?.groups) {
       for (const [groupFlag, groupData] of Object.entries(
@@ -56,12 +71,14 @@ export async function fetchInitData(
       )) {
         if (groupData && typeof groupData === 'object') {
           // Extract group title from metadata
-          const title = groupData.meta?.title;
-          if (title && typeof title === 'string') {
+          const title = extractTitle(groupData);
+          if (title) {
             groupNames.set(groupFlag, title);
           }
           if (groupData.channels) {
-            for (const channelNest of Object.keys(groupData.channels)) {
+            for (const [channelNest, channelData] of Object.entries(
+              groupData.channels
+            )) {
               if (
                 channelNest.startsWith('chat/') ||
                 channelNest.startsWith('heap/') ||
@@ -69,6 +86,10 @@ export async function fetchInitData(
               ) {
                 channels.push(channelNest);
                 channelToGroup.set(channelNest, groupFlag);
+                const channelTitle = extractTitle(channelData);
+                if (channelTitle) {
+                  channelNames.set(channelNest, channelTitle);
+                }
               }
             }
           }
@@ -92,7 +113,7 @@ export async function fetchInitData(
       }
     }
 
-    return { channels, channelToGroup, groupNames, foreigns };
+    return { channels, channelToGroup, channelNames, groupNames, foreigns };
   } catch (error: any) {
     runtime.log?.(
       `[tlon] Init data fetch failed: ${error?.message ?? String(error)}`
@@ -100,6 +121,7 @@ export async function fetchInitData(
     return {
       channels: [],
       channelToGroup: new Map(),
+      channelNames: new Map(),
       groupNames: new Map(),
       foreigns: null,
     };

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -57,7 +57,10 @@ import { createTlonTelemetry } from '../telemetry.js';
 import { resolveTlonAccount } from '../types.js';
 import { configureTlonApiWithPoke } from '../urbit/api-client.js';
 import { authenticate } from '../urbit/auth.js';
-import { serializeContextLensReferenceBlob } from '../urbit/blob.js';
+import {
+  serializeBlobField,
+  serializeContextLensReferenceBlob,
+} from '../urbit/blob.js';
 import { ssrfPolicyFromAllowPrivateNetwork } from '../urbit/context.js';
 import { describeError } from '../urbit/errors.js';
 import type { DmInvite, Foreigns } from '../urbit/foreigns.js';
@@ -67,11 +70,12 @@ import { markdownToStory } from '../urbit/story.js';
 import {
   type DisplayContext,
   type PendingApproval,
+  buildApprovalA2UIBlob,
   createPendingApproval,
   emojiToApprovalAction,
   findPendingApproval,
   formatApprovalConfirmation,
-  formatApprovalRequest,
+  formatApprovalRequestNotification,
   formatBlockedList,
   formatPendingList,
   isExpired,
@@ -675,18 +679,37 @@ export async function monitorTlonProvider(
 
     // Group name cache for human-readable display (flag -> title)
     const groupNameCache = new Map<string, string>();
+    const channelNameCache = new Map<string, string>();
+
+    function extractMetadataTitle(value: unknown): string | undefined {
+      if (!value || typeof value !== 'object') {
+        return undefined;
+      }
+      const metadata = value as { meta?: { title?: unknown }; title?: unknown };
+      const title = metadata.meta?.title ?? metadata.title;
+      return typeof title === 'string' && title.trim()
+        ? title.trim()
+        : undefined;
+    }
 
     // Build display context for approval formatting
     function buildDisplayContext(): DisplayContext {
       const channelNames = new Map<string, string>();
       for (const nest of watchedChannels) {
+        const title = channelNameCache.get(nest);
+        if (title) {
+          channelNames.set(nest, title);
+          continue;
+        }
         const parsed = parseChannelNest(nest);
         if (parsed) {
           channelNames.set(nest, parsed.channelName);
         }
       }
       return {
+        contactNames: nicknameCache,
         channelNames,
+        channelGroups: channelToGroup,
         groupNames: groupNameCache,
       };
     }
@@ -707,6 +730,19 @@ export async function monitorTlonProvider(
       }
     }
 
+    function buildApprovalBlobField(
+      approval: PendingApproval,
+      ctx: DisplayContext
+    ): string | undefined {
+      try {
+        return serializeBlobField(buildApprovalA2UIBlob(approval, ctx));
+      } catch (err) {
+        runtime.error?.(
+          `[tlon] Failed to build approval A2UI blob: ${String(err)}`
+        );
+        return undefined;
+      }
+    }
     // Migrate file config to settings store (seed on first run)
     async function migrateConfigToSettings() {
       const migrations: Array<{
@@ -1099,16 +1135,25 @@ export async function monitorTlonProvider(
       })();
     }
 
-    // Run channel discovery AFTER settings are loaded (so settings store value is used)
-    if (effectiveAutoDiscoverChannels) {
+    // Fetch group metadata AFTER settings are loaded so approval cards can display
+    // friendly group names for both auto-discovered and manually configured channels.
+    const shouldFetchGroupMetadata =
+      effectiveAutoDiscoverChannels ||
+      account.groupChannels.length > 0 ||
+      Boolean(currentSettings.groupChannels?.length) ||
+      effectiveAutoAcceptGroupInvites;
+    if (shouldFetchGroupMetadata) {
       try {
         const initData = await fetchInitData(api, runtime);
-        if (initData.channels.length > 0) {
+        if (effectiveAutoDiscoverChannels && initData.channels.length > 0) {
           groupChannels = initData.channels;
         }
         // Populate channel-to-group mapping for member hint injection
         for (const [nest, groupFlag] of initData.channelToGroup) {
           channelToGroup.set(nest, groupFlag);
+        }
+        for (const [nest, title] of initData.channelNames) {
+          channelNameCache.set(nest, title);
         }
         // Populate group name cache for human-readable display
         for (const [flag, title] of initData.groupNames) {
@@ -1415,7 +1460,8 @@ export async function monitorTlonProvider(
 
     // Helper to send DM notification to owner. Returns the message ID if sent successfully.
     async function sendOwnerNotification(
-      message: string
+      message: string,
+      blob?: string
     ): Promise<string | undefined> {
       if (!effectiveOwnerShip) {
         runtime.log?.(
@@ -1429,6 +1475,7 @@ export async function monitorTlonProvider(
           fromShip: botShipName,
           toShip: effectiveOwnerShip,
           text: message,
+          blob,
         });
         runtime.log?.(
           `[tlon] Sent notification to owner ${effectiveOwnerShip}`
@@ -1543,8 +1590,11 @@ export async function monitorTlonProvider(
         // Saving before sendOwnerNotification causes a race: the settings subscription
         // event replaces pendingApprovals in-memory, so the notificationMessageId
         // set on the old object reference is lost.
-        const existMsg = formatApprovalRequest(existing, buildDisplayContext());
-        const existNotifId = await sendOwnerNotification(existMsg);
+        const displayContext = buildDisplayContext();
+        const existNotifId = await sendOwnerNotification(
+          formatApprovalRequestNotification(existing, displayContext),
+          buildApprovalBlobField(existing, displayContext)
+        );
         if (existNotifId) {
           existing.notificationMessageId =
             normalizeNotificationId(existNotifId);
@@ -1555,8 +1605,11 @@ export async function monitorTlonProvider(
 
       // Send notification before saving so notificationMessageId is included
       // in the single save. See comment above about the settings subscription race.
-      const message = formatApprovalRequest(approval, buildDisplayContext());
-      const notifId = await sendOwnerNotification(message);
+      const displayContext = buildDisplayContext();
+      const notifId = await sendOwnerNotification(
+        formatApprovalRequestNotification(approval, displayContext),
+        buildApprovalBlobField(approval, displayContext)
+      );
       if (notifId) {
         approval.notificationMessageId = normalizeNotificationId(notifId);
       }
@@ -4027,6 +4080,11 @@ export async function monitorTlonProvider(
                       !channelNest.startsWith('diary/')
                     ) {
                       continue;
+                    }
+
+                    const channelTitle = extractMetadataTitle(_channelData);
+                    if (channelTitle) {
+                      channelNameCache.set(channelNest, channelTitle);
                     }
 
                     // If this is a new channel we're not watching yet, add it

--- a/packages/openclaw/src/urbit/blob.ts
+++ b/packages/openclaw/src/urbit/blob.ts
@@ -1,3 +1,5 @@
+import { A2UI, appendToPostBlob } from '@tloncorp/api';
+
 export function serializeContextLensReferenceBlob(
   lensId: string,
   botShip?: string
@@ -10,4 +12,36 @@ export function serializeContextLensReferenceBlob(
       ...(botShip ? { botShip } : {}),
     },
   ]);
+}
+
+export const TLON_A2UI_CATALOG_ID = 'tlon.a2ui.basic.v1';
+export type TlonA2UIBlob = A2UI.BlobEntry;
+
+export function makeA2UIBlob(
+  surfaceId: string,
+  root: string,
+  components: A2UI.Component[]
+): TlonA2UIBlob {
+  const blob: TlonA2UIBlob = {
+    type: 'a2ui',
+    version: 1,
+    messages: [
+      {
+        version: 'v0.9',
+        createSurface: { surfaceId, catalogId: TLON_A2UI_CATALOG_ID },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: { surfaceId, root, components },
+      },
+    ],
+  };
+  if (!A2UI.validateBlobEntry(blob)) {
+    throw new Error('invalid a2ui blob');
+  }
+  return blob;
+}
+
+export function serializeBlobField(entry: TlonA2UIBlob): string {
+  return appendToPostBlob(undefined, entry);
 }


### PR DESCRIPTION
## Summary
Renders approval requests (DM / channel-mention / group-invite) as interactive **a2ui cards** in the owner's client — friendly names, approve/deny actions — plus the supporting a2ui blob helpers.

- a2ui blob construction (`makeA2UIBlob` / `serializeBlobField`, catalog id)
- approval cards with friendly names + metadata
- group-invite approval retry + fallback label

## Stacking / migration
- Migrated from **tloncorp/openclaw-tlon#151** (authored by Dan Brewster). Rebased onto current master, squashed (10→1), relocated to `packages/openclaw`.
- **Based on #5936** (context-lens) → retarget down the stack as each merges (#5935 ← #5936 ← this). First PR of the a2ui stack (#154, #158 to follow on top).

## Integration notes (a2ui × context-lens)
Both features touch the same files; reconciled as follows:
- `src/urbit/blob.ts`: **unions** the a2ui helpers with context-lens's reference-blob serializer (filename collision, independent functions).
- `src/monitor/media.ts`: keeps context-lens's positive `isDownloadableBlobEntry` allowlist, which already excludes a2ui blobs — supersedes #151's denylist while preserving identical behavior.
- `src/monitor/index.ts`: keeps both blob-field builders.
- `package.json`/lockfile `@tloncorp/api` bump dropped — the monorepo resolves it via `workspace:^`.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] Unit tests: 643/643 passing (`pnpm test` in `packages/openclaw`)
- [x] `openclaw.plugin.json` manifest in sync (no config-schema change)
- [x] Rebase validated independently in openclaw-tlon (tsc + 566 tests) before relocation