### PR TITLE
openclaw: pending approvals a2ui reply

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/api",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "files": [
     "dist",

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -1564,7 +1564,7 @@ export default defineChannelPluginEntry({
         if ('error' in result) {
           return { text: result.error };
         }
-        return { text: await result.bridge.getPendingList() };
+        return await result.bridge.getPendingApprovalsReply();
       },
     });
 

--- a/packages/openclaw/src/monitor/approval.test.ts
+++ b/packages/openclaw/src/monitor/approval.test.ts
@@ -6,6 +6,8 @@ import {
   type DisplayContext,
   type PendingApproval,
   buildApprovalA2UIBlob,
+  buildPendingApprovalsA2UIBlob,
+  buildPendingApprovalsResponse,
   createPendingApproval,
   emojiToApprovalAction,
   findPendingApproval,
@@ -396,6 +398,108 @@ describe('buildApprovalA2UIBlob', () => {
     expect(text).toContain('Let the bot join ~robin-dasler/private-garden?');
     expect(text).toContain('Group: ~robin-dasler/private-garden');
     expect(text).not.toContain('this group');
+  });
+});
+
+describe('buildPendingApprovalsA2UIBlob', () => {
+  it('builds a pending requests card with actions for each approval', () => {
+    const blob = buildPendingApprovalsA2UIBlob(
+      [
+        {
+          id: 'da1b2',
+          type: 'dm',
+          requestingShip: '~zod',
+          messagePreview: 'Can you help me find the launch notes?',
+          timestamp: Date.now(),
+        },
+        {
+          id: 'cc3d4',
+          type: 'channel',
+          requestingShip: '~sampel-palnet',
+          channelNest: 'chat/~host/general',
+          timestamp: Date.now(),
+        },
+      ],
+      ctx
+    );
+
+    expect(blob).toBeDefined();
+    expect(A2UI.validateBlobEntry(blob)).toBe(true);
+    const text = JSON.stringify(blob);
+    expect(text).toContain('2 approval requests');
+    expect(text).toContain('DM from Zod');
+    expect(text).toContain('Sender: Zod (~zod)');
+    expect(text).toContain('Message: ');
+    expect(text).toContain('Channel access for Sam Palnet');
+    expect(text).toContain(
+      'Channel: General in Garden Club (chat/~host/general)'
+    );
+    expect(text).toContain('/allow da1b2');
+    expect(text).toContain('/reject cc3d4');
+    expect(text).toContain('/ban cc3d4');
+  });
+
+  it('omits the card when there are no active approvals', () => {
+    expect(buildPendingApprovalsA2UIBlob([], ctx)).toBeUndefined();
+    expect(
+      buildPendingApprovalsA2UIBlob(
+        [
+          {
+            id: 'da1b2',
+            type: 'dm',
+            requestingShip: '~zod',
+            timestamp: Date.now() - APPROVAL_TTL_MS - 1,
+          },
+        ],
+        ctx
+      )
+    ).toBeUndefined();
+  });
+
+  it('omits the card for five or more active approvals', () => {
+    const approvals = Array.from({ length: 5 }, (_, index) => ({
+      id: `d${index}`,
+      type: 'dm' as const,
+      requestingShip: `~ship${index}`,
+      timestamp: Date.now(),
+    }));
+
+    expect(buildPendingApprovalsA2UIBlob(approvals, ctx)).toBeUndefined();
+  });
+});
+
+describe('buildPendingApprovalsResponse', () => {
+  const approval: PendingApproval = {
+    id: 'da1b2',
+    type: 'dm',
+    requestingShip: '~zod',
+    timestamp: Date.now(),
+  };
+
+  it('keeps a text fallback when returning an A2UI card', () => {
+    const response = buildPendingApprovalsResponse(
+      [approval],
+      ctx,
+      () => 'serialized-card'
+    );
+
+    expect(response).toMatchObject({
+      mode: 'ui',
+      blob: 'serialized-card',
+    });
+    expect(response.text).toContain('Zod (~zod)');
+    expect(response.text).toContain('/allow');
+  });
+
+  it('falls back to text when the card cannot be serialized', () => {
+    const response = buildPendingApprovalsResponse(
+      [approval],
+      ctx,
+      () => undefined
+    );
+
+    expect(response.mode).toBe('text');
+    expect(response.text).toContain('Zod (~zod)');
   });
 });
 

--- a/packages/openclaw/src/monitor/approval.test.ts
+++ b/packages/openclaw/src/monitor/approval.test.ts
@@ -602,6 +602,29 @@ describe('buildPendingApprovalsResponse', () => {
     expect(response.mode).toBe('text');
     expect(response.text).toContain('Zod (~zod)');
   });
+
+  it('falls back to text when display values make the card invalid', () => {
+    let serializeCalled = false;
+    let fallbackError: unknown;
+    const response = buildPendingApprovalsResponse(
+      [approval],
+      {
+        ...ctx,
+        contactNames: new Map([['~zod', 'Z'.repeat(1_001)]]),
+      },
+      () => {
+        serializeCalled = true;
+        return 'serialized-card';
+      },
+      (error) => {
+        fallbackError = error;
+      }
+    );
+
+    expect(response.mode).toBe('text');
+    expect(serializeCalled).toBe(false);
+    expect(fallbackError).toBeInstanceOf(Error);
+  });
 });
 
 describe('formatApprovalConfirmation', () => {

--- a/packages/openclaw/src/monitor/approval.test.ts
+++ b/packages/openclaw/src/monitor/approval.test.ts
@@ -245,6 +245,107 @@ describe('buildApprovalA2UIBlob', () => {
     }
   });
 
+  it('adds view message navigation for dm and channel approvals with source messages', () => {
+    const dm = buildApprovalA2UIBlob({
+      id: 'da1b2',
+      type: 'dm',
+      requestingShip: '~sampel-palnet',
+      timestamp: 1,
+      messagePreview: 'Hello, I would like to chat with your bot.',
+      originalMessage: {
+        messageId: '170.141.184.507',
+        messageText: 'Hello, I would like to chat with your bot.',
+        messageContent: [],
+        timestamp: 1,
+      },
+    });
+    const channel = buildApprovalA2UIBlob(
+      {
+        id: 'c3d4e',
+        type: 'channel',
+        requestingShip: '~littel-wolfur',
+        channelNest: 'chat/~host/general',
+        timestamp: 1,
+        messagePreview: '@bot can you review this build before I merge?',
+        originalMessage: {
+          messageId: '170.141.184.621',
+          messageText: '@bot can you review this build before I merge?',
+          messageContent: [],
+          timestamp: 1,
+          parentId: '170.141.184.600',
+          parentAuthorId: '~host',
+        },
+      },
+      ctx
+    );
+
+    expect(A2UI.validateBlobEntry(dm)).toBe(true);
+    expect(A2UI.validateBlobEntry(channel)).toBe(true);
+    expect(JSON.stringify(dm)).toContain('View message');
+    expect(JSON.stringify(dm)).toContain('"name":"tlon.navigate"');
+    expect(JSON.stringify(dm)).toContain('"channelId":"~sampel-palnet"');
+    expect(JSON.stringify(dm)).toContain('"postId":"170.141.184.507"');
+    expect(JSON.stringify(channel)).toContain(
+      '"channelId":"chat/~host/general"'
+    );
+    expect(JSON.stringify(channel)).toContain('"parentId":"170.141.184.600"');
+    expect(JSON.stringify(channel)).toContain('"parentAuthorId":"~host"');
+    expect(JSON.stringify(channel)).toContain('"groupId":"~host/cool-group"');
+  });
+
+  it('hides source navigation when the notification recipient cannot see the bot source', () => {
+    const sourceMessage = {
+      messageId: '170.141.184.507',
+      messageText: 'Please let me in',
+      messageContent: [],
+      timestamp: 1,
+    };
+    const dm = buildApprovalA2UIBlob(
+      {
+        id: 'da1b2',
+        type: 'dm',
+        requestingShip: '~sampel-palnet',
+        timestamp: 1,
+        originalMessage: sourceMessage,
+      },
+      undefined,
+      { includeSourceNavigation: false }
+    );
+    const channel = buildApprovalA2UIBlob(
+      {
+        id: 'c3d4e',
+        type: 'channel',
+        requestingShip: '~littel-wolfur',
+        channelNest: 'chat/~host/general',
+        timestamp: 1,
+        originalMessage: sourceMessage,
+      },
+      ctx,
+      { includeSourceNavigation: false }
+    );
+
+    for (const approval of [dm, channel]) {
+      expect(A2UI.validateBlobEntry(approval)).toBe(true);
+      expect(JSON.stringify(approval)).not.toContain('View message');
+      expect(JSON.stringify(approval)).not.toContain('tlon.navigate');
+    }
+  });
+
+  it('does not add view message navigation to group invites', () => {
+    const approval = buildApprovalA2UIBlob({
+      id: 'g5f6a',
+      type: 'group',
+      requestingShip: '~robin-dasler',
+      groupFlag: '~robin-dasler/garden-club',
+      groupTitle: 'Garden Club',
+      timestamp: 1,
+    });
+
+    expect(A2UI.validateBlobEntry(approval)).toBe(true);
+    expect(JSON.stringify(approval)).not.toContain('View message');
+    expect(JSON.stringify(approval)).not.toContain('tlon.navigate');
+  });
+
   it('formats the visible notification text by request type', () => {
     expect(
       formatApprovalRequestNotification(

--- a/packages/openclaw/src/monitor/approval.ts
+++ b/packages/openclaw/src/monitor/approval.ts
@@ -33,6 +33,7 @@ export type CreateApprovalParams = {
     messageContent: unknown;
     timestamp: number;
     parentId?: string;
+    parentAuthorId?: string;
     isThreadReply?: boolean;
     blob?: string;
   };
@@ -66,6 +67,10 @@ export type DisplayContext = {
   channelGroups?: Map<string, string>;
   /** Map from group flag (~host/name) to human-readable group title */
   groupNames?: Map<string, string>;
+};
+
+export type ApprovalA2UIOptions = {
+  includeSourceNavigation?: boolean;
 };
 
 function displayShipName(ship: string, ctx?: DisplayContext): string {
@@ -225,6 +230,7 @@ type ApprovalA2UIParams = {
   groupName?: string;
   groupFlag?: string;
   groupTitle?: string;
+  sourceTarget?: A2UI.NavigationTarget;
 };
 
 function approvalRequesterName(params: ApprovalA2UIParams): string {
@@ -320,12 +326,14 @@ function buildApprovalA2UIBlobFromParams(
   const contextLines = approvalContextLines(params);
   const contextIds = contextLines.map((_, index) => `context${index}`);
   const copy = approvalCopy(params);
+  const actionChildren = ['allow', 'reject', 'ban'];
   const bodyChildren = [
     'eyebrow',
     'title',
     'titleDivider',
     ...contextIds,
     ...(copy ? ['copy'] : []),
+    ...(params.sourceTarget ? ['sourceAction'] : []),
     'divider',
     'details',
     'actions',
@@ -347,6 +355,9 @@ function buildApprovalA2UIBlobFromParams(
           text: copy,
         },
       ]
+    : [];
+  const sourceActionComponents: A2UI.Component[] = params.sourceTarget
+    ? [{ id: 'sourceAction', component: 'Row', children: ['viewMessage'] }]
     : [];
 
   const components: A2UI.Component[] = [
@@ -371,6 +382,7 @@ function buildApprovalA2UIBlobFromParams(
     { id: 'titleDivider', component: 'Divider' },
     ...contextComponents,
     ...copyComponents,
+    ...sourceActionComponents,
     { id: 'divider', component: 'Divider' },
     {
       id: 'details',
@@ -386,8 +398,29 @@ function buildApprovalA2UIBlobFromParams(
     {
       id: 'actions',
       component: 'Row',
-      children: ['allow', 'reject', 'ban'],
+      children: actionChildren,
     },
+    ...(params.sourceTarget
+      ? [
+          {
+            id: 'viewMessage',
+            component: 'Button',
+            variant: 'secondary',
+            child: 'viewMessageLabel',
+            action: {
+              event: {
+                name: A2UI.action.navigate,
+                context: { target: params.sourceTarget },
+              },
+            },
+          } as const,
+          {
+            id: 'viewMessageLabel',
+            component: 'Text',
+            text: 'View message',
+          } as const,
+        ]
+      : []),
     {
       id: 'allow',
       component: 'Button',
@@ -473,9 +506,45 @@ function displayGroupForApproval(
   return titleOverride || ctx?.groupNames?.get(flag) || flag;
 }
 
-export function buildApprovalA2UIBlob(
+function approvalSourceTarget(
   approval: PendingApproval,
   ctx?: DisplayContext
+): A2UI.NavigationTarget | undefined {
+  const messageId = approval.originalMessage?.messageId;
+  if (!messageId) {
+    return undefined;
+  }
+
+  const base = {
+    type: 'message' as const,
+    postId: messageId,
+    authorId: approval.requestingShip,
+    parentId: approval.originalMessage?.parentId,
+    parentAuthorId: approval.originalMessage?.parentAuthorId,
+  };
+
+  if (approval.type === 'dm') {
+    return {
+      ...base,
+      channelId: approval.requestingShip,
+    };
+  }
+
+  if (approval.type === 'channel' && approval.channelNest) {
+    return {
+      ...base,
+      channelId: approval.channelNest,
+      groupId: ctx?.channelGroups?.get(approval.channelNest),
+    };
+  }
+
+  return undefined;
+}
+
+export function buildApprovalA2UIBlob(
+  approval: PendingApproval,
+  ctx?: DisplayContext,
+  options: ApprovalA2UIOptions = {}
 ): TlonA2UIBlob {
   return buildApprovalA2UIBlobFromParams({
     type: approval.type,
@@ -494,6 +563,10 @@ export function buildApprovalA2UIBlob(
       approval.groupTitle,
       ctx
     ),
+    sourceTarget:
+      options.includeSourceNavigation === false
+        ? undefined
+        : approvalSourceTarget(approval, ctx),
   });
 }
 

--- a/packages/openclaw/src/monitor/approval.ts
+++ b/packages/openclaw/src/monitor/approval.ts
@@ -498,6 +498,168 @@ export function buildApprovalA2UIBlob(
 }
 
 // ============================================================================
+// Pending Requests A2UI
+// ============================================================================
+
+const MAX_PENDING_APPROVALS_A2UI = 4;
+
+function shouldUsePendingApprovalsA2UI(
+  activeApprovals: PendingApproval[]
+): boolean {
+  return (
+    activeApprovals.length > 0 &&
+    activeApprovals.length <= MAX_PENDING_APPROVALS_A2UI
+  );
+}
+
+function pendingItemFields(
+  approval: PendingApproval,
+  ctx?: DisplayContext
+): { title: string; context: string; preview?: string } {
+  const name = displayShipName(approval.requestingShip, ctx);
+  const ship = displayShipWithId(approval.requestingShip, ctx);
+  const preview = approval.messagePreview
+    ? `Message: "${truncate(approval.messagePreview, 100)}"`
+    : undefined;
+
+  switch (approval.type) {
+    case 'dm':
+      return { title: `DM from ${name}`, context: `Sender: ${ship}`, preview };
+    case 'channel':
+      return {
+        title: `Channel access for ${name}`,
+        context: `Channel: ${displayChannel(approval.channelNest ?? '', ctx)}`,
+        preview,
+      };
+    case 'group':
+      return {
+        title: `Group invite from ${name}`,
+        context: `Group: ${displayGroup(approval.groupFlag ?? '', ctx, approval.groupTitle)}`,
+      };
+  }
+  return assertNever(approval.type);
+}
+
+export function buildPendingApprovalsA2UIBlob(
+  approvals: PendingApproval[],
+  ctx?: DisplayContext
+): TlonA2UIBlob | undefined {
+  const active = pruneExpired(approvals);
+  if (!shouldUsePendingApprovalsA2UI(active)) {
+    return undefined;
+  }
+
+  const text = (
+    id: string,
+    value: string,
+    variant?: A2UI.Text['variant']
+  ): A2UI.Component =>
+    variant
+      ? { id, component: 'Text', variant, text: value }
+      : { id, component: 'Text', text: value };
+  const button = (
+    id: string,
+    labelId: string,
+    command: string,
+    variant?: A2UI.Button['variant']
+  ): A2UI.Component => ({
+    id,
+    component: 'Button',
+    ...(variant ? { variant } : {}),
+    child: labelId,
+    action: {
+      event: {
+        name: A2UI.action.sendMessage,
+        context: { text: command },
+      },
+    },
+  });
+
+  const bodyChildren = ['eyebrow', 'title', 'titleDivider'];
+  const components: A2UI.Component[] = [
+    { id: 'root', component: 'Card', child: 'body' },
+    { id: 'body', component: 'Column', children: bodyChildren },
+    text('eyebrow', 'Pending requests', 'caption'),
+    text(
+      'title',
+      `${active.length} approval ${active.length === 1 ? 'request' : 'requests'}`,
+      'h3'
+    ),
+    { id: 'titleDivider', component: 'Divider' },
+    text('allowLabel', 'Allow'),
+    text('rejectLabel', 'Reject'),
+    text('blockLabel', 'Block'),
+  ];
+
+  for (const [index, approval] of active.entries()) {
+    const prefix = `item${index}`;
+    const fields = pendingItemFields(approval, ctx);
+
+    if (index > 0) {
+      const dividerId = `${prefix}Divider`;
+      bodyChildren.push(dividerId);
+      components.push({ id: dividerId, component: 'Divider' });
+    }
+
+    bodyChildren.push(prefix);
+    components.push(
+      {
+        id: prefix,
+        component: 'Column',
+        children: [
+          `${prefix}Title`,
+          `${prefix}Context`,
+          ...(fields.preview ? [`${prefix}Preview`] : []),
+          `${prefix}Actions`,
+        ],
+      },
+      text(`${prefix}Title`, fields.title, 'h4'),
+      text(`${prefix}Context`, fields.context, 'caption'),
+      ...(fields.preview
+        ? [text(`${prefix}Preview`, fields.preview, 'caption')]
+        : []),
+      {
+        id: `${prefix}Actions`,
+        component: 'Row',
+        children: [`${prefix}Allow`, `${prefix}Reject`, `${prefix}Block`],
+      },
+      button(
+        `${prefix}Allow`,
+        'allowLabel',
+        `/allow ${approval.id}`,
+        'primary'
+      ),
+      button(`${prefix}Reject`, 'rejectLabel', `/reject ${approval.id}`),
+      button(
+        `${prefix}Block`,
+        'blockLabel',
+        `/ban ${approval.id}`,
+        'borderless'
+      )
+    );
+  }
+
+  return makeA2UIBlob('pending-approvals', 'root', components);
+}
+
+export function buildPendingApprovalsResponse(
+  approvals: PendingApproval[],
+  ctx: DisplayContext | undefined,
+  serializeBlob: (blob: TlonA2UIBlob) => string | undefined
+): { text: string; mode: 'text' } | { text: string; mode: 'ui'; blob: string } {
+  const text = formatPendingList(approvals, ctx);
+  if (!shouldUsePendingApprovalsA2UI(approvals)) {
+    return { text, mode: 'text' };
+  }
+
+  const blob = buildPendingApprovalsA2UIBlob(approvals, ctx);
+  const serialized = blob ? serializeBlob(blob) : undefined;
+  return serialized
+    ? { text, blob: serialized, mode: 'ui' }
+    : { text, mode: 'text' };
+}
+
+// ============================================================================
 // Approval Lookup & Removal
 // ============================================================================
 

--- a/packages/openclaw/src/monitor/approval.ts
+++ b/packages/openclaw/src/monitor/approval.ts
@@ -718,18 +718,24 @@ export function buildPendingApprovalsA2UIBlob(
 export function buildPendingApprovalsResponse(
   approvals: PendingApproval[],
   ctx: DisplayContext | undefined,
-  serializeBlob: (blob: TlonA2UIBlob) => string | undefined
+  serializeBlob: (blob: TlonA2UIBlob) => string | undefined,
+  onError?: (error: unknown) => void
 ): { text: string; mode: 'text' } | { text: string; mode: 'ui'; blob: string } {
   const text = formatPendingList(approvals, ctx);
   if (!shouldUsePendingApprovalsA2UI(approvals)) {
     return { text, mode: 'text' };
   }
 
-  const blob = buildPendingApprovalsA2UIBlob(approvals, ctx);
-  const serialized = blob ? serializeBlob(blob) : undefined;
-  return serialized
-    ? { text, blob: serialized, mode: 'ui' }
-    : { text, mode: 'text' };
+  try {
+    const blob = buildPendingApprovalsA2UIBlob(approvals, ctx);
+    const serialized = blob ? serializeBlob(blob) : undefined;
+    return serialized
+      ? { text, blob: serialized, mode: 'ui' }
+      : { text, mode: 'text' };
+  } catch (error) {
+    onError?.(error);
+    return { text, mode: 'text' };
+  }
 }
 
 // ============================================================================

--- a/packages/openclaw/src/monitor/command-auth.test.ts
+++ b/packages/openclaw/src/monitor/command-auth.test.ts
@@ -15,7 +15,7 @@ function makeBridge(ownerShip: string | null): ApprovalCommandBridge {
   return {
     ownerShip,
     handleAction: async () => 'ok',
-    getPendingList: async () => 'none',
+    getPendingApprovalsReply: async () => ({ text: 'none' }),
     getBlockedList: async () => 'none',
     handleUnblock: async () => 'ok',
     isOwnedChannel: () => false,

--- a/packages/openclaw/src/monitor/command-bridge.ts
+++ b/packages/openclaw/src/monitor/command-bridge.ts
@@ -13,8 +13,11 @@ export interface ApprovalCommandBridge {
     action: 'approve' | 'deny' | 'block',
     id?: string
   ): Promise<string>;
-  /** Get formatted pending approvals list. */
-  getPendingList(): Promise<string>;
+  /** Build the /pending command response. */
+  getPendingApprovalsReply(): Promise<{
+    text?: string;
+    channelData?: Record<string, unknown>;
+  }>;
   /** Get formatted blocked ships list. */
   getBlockedList(): Promise<string>;
   /** Handle /unban ~ship. Returns response text. */

--- a/packages/openclaw/src/monitor/history.test.ts
+++ b/packages/openclaw/src/monitor/history.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type TlonHistoryEntry,
   buildThreadContextMessage,
+  fetchParentPostAuthor,
   fetchParentPostHistoryEntry,
   renderHistoryContent,
   retainThreadContextMessages,
@@ -197,6 +198,30 @@ describe('renderHistoryContent', () => {
 });
 
 describe('fetchParentPostHistoryEntry', () => {
+  it('extracts an author from a media-only parent post', async () => {
+    const api = {
+      scry: async () => ({
+        post: {
+          essay: {
+            author: { ship: '~nec', nickname: 'Nec' },
+            sent: 123,
+            content: [],
+            blob: '[{"type":"file","version":1}]',
+          },
+          seal: { id: '170.141.184.507' },
+        },
+      }),
+    };
+
+    const author = await fetchParentPostAuthor(
+      api,
+      'chat/~ship/general',
+      '170141184507'
+    );
+
+    expect(author).toBe('~nec');
+  });
+
   it('extracts parent post text from memo-shaped post payloads', async () => {
     const api = {
       scry: async () => ({
@@ -281,6 +306,29 @@ describe('fetchParentPostHistoryEntry', () => {
       timestamp: 999,
       id: '170.141.184.507.939.843.704.966.283.402.546.249.728',
     });
+  });
+
+  it('extracts a parent author from a bot profile', async () => {
+    const api = {
+      scry: async () => ({
+        post: {
+          essay: {
+            author: { ship: '~nec', nickname: 'Nec' },
+            sent: 123,
+            content: [{ inline: ['Parent post'] }],
+          },
+          seal: { id: '170.141.184.507' },
+        },
+      }),
+    };
+
+    const entry = await fetchParentPostHistoryEntry(
+      api,
+      'chat/~ship/general',
+      '170141184507'
+    );
+
+    expect(entry?.author).toBe('~nec');
   });
 });
 

--- a/packages/openclaw/src/monitor/history.ts
+++ b/packages/openclaw/src/monitor/history.ts
@@ -34,6 +34,16 @@ export type TlonHistoryEntry = {
 
 export const MAX_THREAD_CONTEXT_MESSAGES = 20;
 
+type ParentPostEssay = {
+  author?: string | { ship?: string };
+  content?: unknown;
+  sent?: number;
+};
+
+type ParentPostSeal = {
+  id?: string;
+};
+
 function normalizeMessageId(id: string | number | undefined | null): string {
   return String(id ?? '').replace(/\./g, '');
 }
@@ -252,15 +262,12 @@ export async function fetchThreadHistory(
   }
 }
 
-/**
- * Fetch the parent post body for a thread.
- */
-export async function fetchParentPostHistoryEntry(
+async function fetchParentPost(
   api: { scry: (path: string) => Promise<unknown> },
   channelNest: string,
   parentId: string,
   runtime?: RuntimeEnv
-): Promise<TlonHistoryEntry | null> {
+): Promise<{ essay: ParentPostEssay; seal?: ParentPostSeal } | null> {
   try {
     // Mirrors resolveCiteContent: channels +on-peek matches `[%post time=@ ~]`, mark goes in `.json` extension.
     const scryPath = `/channels/v4/${channelNest}/posts/post/${formatUd(parentId)}.json`;
@@ -270,24 +277,67 @@ export async function fetchParentPostHistoryEntry(
     const post = data?.post ?? data;
     const essay = post?.essay || post?.memo || post?.['r-post']?.set?.essay;
     const seal = post?.seal || post?.['r-post']?.set?.seal;
-    const content = extractMessageText(essay?.content || []);
-    if (!content) {
-      runtime?.log?.(`[tlon] Parent post has no text content: ${parentId}`);
-      return null;
-    }
-
-    return {
-      author: typeof essay?.author === 'string' ? essay.author : 'unknown',
-      content,
-      timestamp: essay?.sent || Date.now(),
-      id: seal?.id || parentId,
-    };
+    return essay ? { essay, seal } : null;
   } catch (error: any) {
     runtime?.log?.(
       `[tlon] Error fetching parent post: ${error?.message ?? String(error)}`
     );
     return null;
   }
+}
+
+function parentPostAuthor(essay?: ParentPostEssay): string | null {
+  if (typeof essay?.author === 'string') {
+    return essay.author;
+  }
+  if (typeof essay?.author?.ship === 'string') {
+    return essay.author.ship;
+  }
+  return null;
+}
+
+/**
+ * Fetch a parent post's author without requiring text content.
+ */
+export async function fetchParentPostAuthor(
+  api: { scry: (path: string) => Promise<unknown> },
+  channelNest: string,
+  parentId: string,
+  runtime?: RuntimeEnv
+): Promise<string | null> {
+  const parentPost = await fetchParentPost(api, channelNest, parentId, runtime);
+  return parentPostAuthor(parentPost?.essay);
+}
+
+/**
+ * Fetch the parent post body for a thread.
+ */
+export async function fetchParentPostHistoryEntry(
+  api: { scry: (path: string) => Promise<unknown> },
+  channelNest: string,
+  parentId: string,
+  runtime?: RuntimeEnv
+): Promise<TlonHistoryEntry | null> {
+  const parentPost = await fetchParentPost(api, channelNest, parentId, runtime);
+  if (!parentPost) {
+    return null;
+  }
+
+  const { essay, seal } = parentPost;
+  const content = extractMessageText(essay.content || []);
+  if (!content) {
+    runtime?.log?.(`[tlon] Parent post has no text content: ${parentId}`);
+    return null;
+  }
+
+  const author = parentPostAuthor(essay) ?? 'unknown';
+
+  return {
+    author,
+    content,
+    timestamp: essay.sent || Date.now(),
+    id: seal?.id || parentId,
+  };
 }
 
 export function retainThreadContextMessages(

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -114,6 +114,7 @@ import {
   buildThreadContextMessage,
   cacheMessage,
   fetchChannelHistory,
+  fetchParentPostAuthor,
   fetchThreadContextHistory,
   getChannelHistory,
   lookupCachedMessage,
@@ -974,7 +975,13 @@ export async function monitorTlonProvider(
       ctx: DisplayContext
     ): string | undefined {
       try {
-        return serializeBlobField(buildApprovalA2UIBlob(approval, ctx));
+        return serializeBlobField(
+          buildApprovalA2UIBlob(approval, ctx, {
+            // Source messages live on the bot's account. A separate owner may
+            // not have the corresponding DM or group channel in local state.
+            includeSourceNavigation: effectiveOwnerShip === botShipName,
+          })
+        );
       } catch (err) {
         runtime.error?.(
           `[tlon] Failed to build approval A2UI blob: ${String(err)}`
@@ -3747,6 +3754,17 @@ export async function monitorTlonProvider(
             if (!normalizedAllowed.includes(senderShip)) {
               // If owner is configured, queue approval request
               if (effectiveOwnerShip) {
+                const cachedParentAuthor = parentId
+                  ? lookupCachedMessage(nest, parentId)?.author
+                  : undefined;
+                const parentAuthor = parentId
+                  ? cachedParentAuthor && cachedParentAuthor !== 'unknown'
+                    ? cachedParentAuthor
+                    : await fetchParentPostAuthor(api, nest, parentId, runtime)
+                  : null;
+                const parentAuthorId = parentAuthor
+                  ? normalizeShip(parentAuthor)
+                  : undefined;
                 const approval = createPendingApproval(
                   {
                     type: 'channel',
@@ -3759,6 +3777,7 @@ export async function monitorTlonProvider(
                       messageContent: content.content,
                       timestamp: content.sent || Date.now(),
                       parentId: parentId ?? undefined,
+                      parentAuthorId,
                       isThreadReply,
                       blob: content.blob ?? undefined,
                     },
@@ -4100,6 +4119,11 @@ export async function monitorTlonProvider(
                   messageText,
                   messageContent: dmContent.content,
                   timestamp: dmContent.sent || Date.now(),
+                  parentId: dmReplyParentId,
+                  parentAuthorId: dmReplyParentId
+                    ? lookupCachedMessage(dmCacheKey, dmReplyParentId)?.author
+                    : undefined,
+                  isThreadReply: isDmThreadReply,
                   blob: dmContent.blob ?? undefined,
                 },
               },

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -2058,6 +2058,11 @@ export async function monitorTlonProvider(
               );
               return undefined;
             }
+          },
+          (err) => {
+            runtime.error?.(
+              `[tlon] Failed to build pending approvals A2UI blob: ${String(err)}`
+            );
           }
         );
 

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -91,13 +91,13 @@ import {
   type DisplayContext,
   type PendingApproval,
   buildApprovalA2UIBlob,
+  buildPendingApprovalsResponse,
   createPendingApproval,
   emojiToApprovalAction,
   findPendingApproval,
   formatApprovalConfirmation,
   formatApprovalRequestNotification,
   formatBlockedList,
-  formatPendingList,
   isExpired,
   normalizeNotificationId,
   pruneExpired,
@@ -1732,6 +1732,34 @@ export async function monitorTlonProvider(
       }
     }
 
+    function getReplyBlob(payload: ReplyPayload): string | undefined {
+      const blob = (payload.channelData?.tlon as { blob?: unknown } | undefined)
+        ?.blob;
+      return typeof blob === 'string' ? blob : undefined;
+    }
+
+    // Merge serialized post-blob fields (each a JSON array of entries) into one,
+    // so a reply can carry both an a2ui card and a context-lens reference.
+    function combineBlobFields(
+      ...fields: Array<string | undefined>
+    ): string | undefined {
+      const entries: unknown[] = [];
+      for (const field of fields) {
+        if (!field) {
+          continue;
+        }
+        try {
+          const parsed = JSON.parse(field);
+          if (Array.isArray(parsed)) {
+            entries.push(...parsed);
+          }
+        } catch {
+          // Skip a malformed blob field rather than dropping the whole message.
+        }
+      }
+      return entries.length > 0 ? JSON.stringify(entries) : undefined;
+    }
+
     // Regex to match block directives in agent responses
     // Format: [BLOCK_USER: ~ship-name | reason for blocking]
     const blockDirectiveRegex = /\[BLOCK_USER:\s*(~[\w-]+)\s*\|\s*(.+?)\]/g;
@@ -2007,8 +2035,33 @@ export async function monitorTlonProvider(
         return executeApprovalAction(approval, action);
       },
 
-      async getPendingList() {
-        return formatPendingList(pendingApprovals, buildDisplayContext());
+      async getPendingApprovalsReply() {
+        pendingApprovals = pruneExpired(pendingApprovals);
+        await savePendingApprovals();
+
+        const pending = buildPendingApprovalsResponse(
+          pendingApprovals,
+          buildDisplayContext(),
+          (blob) => {
+            try {
+              return serializeBlobField(blob);
+            } catch (err) {
+              runtime.error?.(
+                `[tlon] Failed to serialize pending approvals A2UI blob: ${String(err)}`
+              );
+              return undefined;
+            }
+          }
+        );
+
+        if (pending.mode === 'ui') {
+          return {
+            text: pending.text,
+            channelData: { tlon: { blob: pending.blob } },
+          };
+        }
+
+        return { text: pending.text };
       },
 
       async getBlockedList() {
@@ -3154,8 +3207,9 @@ export async function monitorTlonProvider(
                   },
                   deliver: async (payload: ReplyPayload) => {
                     contextLenses.setStatus(lens.lensId, 'delivering');
-                    let replyText = payload.text;
-                    if (!replyText) {
+                    const blob = getReplyBlob(payload);
+                    let replyText = payload.text ?? '';
+                    if (!replyText && !blob) {
                       const hasMedia = Array.isArray(payload.mediaUrls)
                         ? payload.mediaUrls.length > 0
                         : Boolean(payload.mediaUrl);
@@ -3168,18 +3222,20 @@ export async function monitorTlonProvider(
                     }
 
                     // Process any block directives in the response (strips them from text)
-                    replyText = await processBlockDirectives(
-                      replyText,
-                      senderShip
-                    );
-                    if (!replyText) {
+                    if (replyText) {
+                      replyText = await processBlockDirectives(
+                        replyText,
+                        senderShip
+                      );
+                    }
+                    if (!replyText && !blob) {
                       recordDeliverySkip('block_directive_only');
                       return;
                     } // Response was only a directive
 
                     // Use settings store value if set, otherwise fall back to file config
                     const showSignature = effectiveShowModelSig;
-                    if (showSignature) {
+                    if (showSignature && replyText) {
                       const modelCfg = cfg.agents?.defaults?.model;
                       const modelInfo =
                         selectedModel ||
@@ -3222,8 +3278,9 @@ export async function monitorTlonProvider(
 
                     sendAttemptCount += 1;
                     let outputMessageId: string | null = null;
-                    const contextLensBlob = buildContextLensReferenceBlobField(
-                      lens.lensId
+                    const replyBlob = combineBlobFields(
+                      blob,
+                      buildContextLensReferenceBlobField(lens.lensId)
                     );
                     if (isGroup && groupChannel) {
                       // Send to any channel type (chat, heap, diary) using the nest directly
@@ -3233,7 +3290,7 @@ export async function monitorTlonProvider(
                         nest: groupChannel,
                         story: markdownToStory(replyText),
                         replyToId: deliverParentId ?? undefined,
-                        blob: contextLensBlob,
+                        blob: replyBlob,
                       });
                       outputMessageId = result.messageId;
                       // Track thread participation for future replies without mention
@@ -3252,7 +3309,7 @@ export async function monitorTlonProvider(
                         replyToId: deliverParentId
                           ? String(deliverParentId)
                           : undefined,
-                        blob: contextLensBlob,
+                        blob: replyBlob,
                       });
                       outputMessageId = result.messageId;
                     }

--- a/packages/openclaw/src/settings.ts
+++ b/packages/openclaw/src/settings.ts
@@ -28,6 +28,7 @@ export type PendingApproval = {
     messageContent: unknown;
     timestamp: number;
     parentId?: string;
+    parentAuthorId?: string;
     isThreadReply?: boolean;
     blob?: string;
   };


### PR DESCRIPTION
## Summary

Adds actionable A2UI approval cards for pending requests and links approval cards back to their source messages.

## Changes

- Render `/pending` as an A2UI card for 1–4 active approvals, while preserving the plain-text response as a fallback
- Fall back to text if the card cannot be built or serialized
- Merge A2UI reply blobs with Context Lens reference blobs during delivery
- Add source-message navigation to DM and channel approval cards when the owner can access the bot's source conversation
- Preserve thread parent authors so source links can open the correct reply
- Bump `@tloncorp/api` to 0.0.9 for the shared navigation target schema
- Migrate the pending-card and source-link work from `tloncorp/openclaw-tlon#154` and `#158` onto the A2UI stack

## How did I test?

- `pnpm --dir packages/openclaw tsc --noEmit`
- OpenClaw unit tests: 46 files, 784 tests passing
- Prettier check on changed OpenClaw files
- ESLint on changed OpenClaw files: no errors
