### PR TITLE
fix note autosave: stop save echo clobbering drafts, flush on exit

### DIFF
--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -7,8 +7,8 @@ import {
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Button, Text } from '@tloncorp/ui';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, Platform } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, AppState, Platform } from 'react-native';
 import { Input, ScrollView, TextArea, XStack, YStack } from 'tamagui';
 
 import { createActionGroups } from '../ActionSheet';
@@ -29,6 +29,37 @@ import { buildFolderRows, formatNoteDate } from './notesTree';
 
 type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
 
+// Long enough that we don't fire a save on every typing pause; exits are
+// covered by the flush paths and the draft stash either way.
+const AUTOSAVE_DEBOUNCE_MS = 10_000;
+
+const draftStashKey = (notebookFlag: string, noteId: number) =>
+  `${notebookFlag}/${noteId}`;
+
+// Drop a note's stash, optionally only when it still holds exactly the
+// content that was just saved — keystrokes stashed after the save started
+// must survive until their own save lands.
+function clearDraftStash(
+  notebookFlag: string,
+  noteId: number,
+  ifMatches?: { title: string; body: string }
+) {
+  void db.notesNoteDrafts.setValue((stashes) => {
+    const key = draftStashKey(notebookFlag, noteId);
+    const stash = stashes[key];
+    if (!stash) return stashes;
+    if (
+      ifMatches &&
+      (stash.title !== ifMatches.title || stash.body !== ifMatches.body)
+    ) {
+      return stashes;
+    }
+    const next = { ...stashes };
+    delete next[key];
+    return next;
+  });
+}
+
 export function NotesNoteDetail({
   noteId,
   notebookFlag,
@@ -38,7 +69,10 @@ export function NotesNoteDetail({
   notebookFlag: string | null | undefined;
   onDeleted?: () => void;
 }) {
-  const [draftNoteId, setDraftNoteId] = useState<string | null>(null);
+  // The note snapshot the drafts are based on. Dirtiness and the save's
+  // expectedRevision are computed against this, not the live row, so a row
+  // update can't silently absorb or clobber unsaved edits.
+  const [draftBase, setDraftBase] = useState<db.NotesNote | null>(null);
   const [titleDraft, setTitleDraft] = useState('');
   const [bodyDraft, setBodyDraft] = useState('');
   const [saveState, setSaveState] = useState<SaveState>('idle');
@@ -60,12 +94,13 @@ export function NotesNoteDetail({
     return notes.find((note) => note.noteId === noteId) ?? null;
   }, [noteId, notes]);
 
-  const draftsMatchSelectedNote = draftNoteId === (selectedNote?.id ?? null);
+  const draftsMatchSelectedNote = draftBase?.id === selectedNote?.id;
   const isDirty = Boolean(
     selectedNote &&
+      draftBase &&
       draftsMatchSelectedNote &&
-      ((titleDraft.trim() || 'Untitled') !== selectedNote.title ||
-        bodyDraft !== selectedNote.bodyMd)
+      ((titleDraft.trim() || 'Untitled') !== draftBase.title ||
+        bodyDraft !== draftBase.bodyMd)
   );
   const folderRows = useMemo(
     () => buildFolderRows(folders, rootFolderId, { includeRoot: true }),
@@ -85,22 +120,67 @@ export function NotesNoteDetail({
     }
   }, [bodyDraft]);
 
+  // Load drafts when the selection changes. While the same note stays
+  // selected, adopt row updates only when the editor is clean: the synced
+  // echo of our own save must not overwrite keystrokes typed while the save
+  // was in flight. A remote edit that lands while dirty keeps the stale base
+  // revision, so the next save fails the revision check instead of silently
+  // overwriting the remote work.
   useEffect(() => {
-    setDraftNoteId(selectedNote?.id ?? null);
+    const sameNote = (selectedNote?.id ?? null) === (draftBase?.id ?? null);
+    if (sameNote && (isDirty || selectedNote === draftBase)) return;
+    setDraftBase(selectedNote ?? null);
     setTitleDraft(selectedNote?.title ?? '');
     setBodyDraft(selectedNote?.bodyMd ?? '');
-    setSaveState('idle');
-    setError(null);
-  }, [selectedNote?.id, selectedNote?.bodyMd, selectedNote?.title]);
+    if (!sameNote) {
+      setSaveState('idle');
+      setError(null);
+    }
+  }, [draftBase, isDirty, selectedNote]);
+
+  // All saves go through one chain so each rebases onto the revision the
+  // previous save produced instead of racing the backend revision check.
+  const saveChainRef = useRef<Promise<db.NotesNote | null>>(
+    Promise.resolve(null)
+  );
+  const runSave = useCallback(
+    (flag: string, base: db.NotesNote, title: string, body: string) => {
+      const next = saveChainRef.current
+        .catch(() => null)
+        .then((prevSaved) =>
+          saveNotebookNote({
+            notebookFlag: flag,
+            note: prevSaved && prevSaved.id === base.id ? prevSaved : base,
+            title,
+            body,
+          })
+        );
+      saveChainRef.current = next.then(
+        (updated) => updated ?? null,
+        () => null
+      );
+      return next;
+    },
+    []
+  );
 
   const saveSelectedNote = useCallback(async () => {
-    if (!notebookFlag || !selectedNote || !isDirty || !canEdit) return;
+    if (!notebookFlag || !draftBase || !isDirty || !canEdit) return;
     setSaveState('saving');
     setError(null);
     try {
-      await saveNotebookNote({
+      const updated = await runSave(
         notebookFlag,
-        note: selectedNote,
+        draftBase,
+        titleDraft,
+        bodyDraft
+      );
+      // Rebase onto the saved revision; keystrokes typed during the save
+      // leave the drafts dirty against it, so the next cycle saves them.
+      if (updated) {
+        setDraftBase(updated);
+      }
+      clearDraftStash(notebookFlag, draftBase.noteId, {
         title: titleDraft,
         body: bodyDraft,
       });
@@ -109,16 +189,116 @@ export function NotesNoteDetail({
       setSaveState('error');
       setError(errorMessage(e, 'Failed to save note'));
     }
-  }, [bodyDraft, canEdit, isDirty, notebookFlag, selectedNote, titleDraft]);
+  }, [bodyDraft, canEdit, draftBase, isDirty, notebookFlag, runSave, titleDraft]);
 
   useEffect(() => {
-    if (!isDirty || !canEdit) return;
+    if (!isDirty || !canEdit || saveState === 'saving') return;
     setSaveState('dirty');
     const timeout = setTimeout(() => {
       saveSelectedNote();
-    }, 1500);
+    }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(timeout);
-  }, [canEdit, isDirty, saveSelectedNote]);
+  }, [canEdit, isDirty, saveSelectedNote, saveState]);
+
+  // Snapshot of the latest committed editor state, for flushes that run
+  // outside the React data flow (unmount cleanup, AppState changes). Synced
+  // in an effect so a selection-change cleanup still sees the previous
+  // note's drafts rather than the new render's.
+  const flushCtxRef = useRef<{
+    flag: string | null | undefined;
+    base: db.NotesNote | null;
+    title: string;
+    body: string;
+    canEdit: boolean;
+  } | null>(null);
+  useEffect(() => {
+    flushCtxRef.current = {
+      flag: notebookFlag,
+      base: draftBase,
+      title: titleDraft,
+      body: bodyDraft,
+      canEdit,
+    };
+  });
+
+  const flushPendingSave = useCallback(() => {
+    const ctx = flushCtxRef.current;
+    if (!ctx || !ctx.flag || !ctx.base || !ctx.canEdit) return;
+    const dirty =
+      (ctx.title.trim() || 'Untitled') !== ctx.base.title ||
+      ctx.body !== ctx.base.bodyMd;
+    if (!dirty) return;
+    const { flag, base, title, body } = ctx;
+    runSave(flag, base, title, body)
+      .then((updated) => {
+        clearDraftStash(flag, base.noteId, { title, body });
+        // No-ops after unmount; while mounted (background flush) rebase so
+        // the next cycle doesn't re-send a stale revision.
+        if (updated) {
+          setDraftBase(updated);
+        }
+        setSaveState('saved');
+      })
+      .catch(() => {});
+  }, [runSave]);
+
+  // Flush unsaved work when switching notes or unmounting — the poke
+  // outlives the component.
+  const selectedNoteRowId = selectedNote?.id ?? null;
+  useEffect(() => {
+    return () => flushPendingSave();
+  }, [flushPendingSave, selectedNoteRowId]);
+
+  // Flush when the app backgrounds; process death would drop the debounce.
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (status) => {
+      if (status === 'background' || status === 'inactive') {
+        flushPendingSave();
+      }
+    });
+    return () => subscription.remove();
+  }, [flushPendingSave]);
+
+  // Stash drafts as crash insurance between autosave cycles. Stashes are
+  // cleared by the save paths above once their content lands, never just
+  // because the editor is clean — a fresh mount is clean too, and must not
+  // destroy a stash before the restore effect below has read it.
+  useEffect(() => {
+    if (!notebookFlag || !draftBase || !isDirty) return;
+    void db.notesNoteDrafts.setValue((stashes) => ({
+      ...stashes,
+      [draftStashKey(notebookFlag, draftBase.noteId)]: {
+        title: titleDraft,
+        body: bodyDraft,
+        baseRevision: draftBase.revision,
+        stashedAt: Date.now(),
+      },
+    }));
+  }, [bodyDraft, draftBase, isDirty, notebookFlag, titleDraft]);
+
+  // Restore a stashed draft after a crash/kill. Only restore while the
+  // editor is clean and the row is still at the stash's base revision —
+  // then pushing the restored draft can't clobber anyone's newer work. A
+  // stash from an older revision is superseded; drop it.
+  useEffect(() => {
+    if (!notebookFlag || !draftBase || isDirty) return;
+    let cancelled = false;
+    void db.notesNoteDrafts.getValue().then((stashes) => {
+      const stash = stashes[draftStashKey(notebookFlag, draftBase.noteId)];
+      if (cancelled || !stash) return;
+      if (stash.baseRevision !== draftBase.revision) {
+        clearDraftStash(notebookFlag, draftBase.noteId);
+        return;
+      }
+      if (stash.title !== draftBase.title || stash.body !== draftBase.bodyMd) {
+        setTitleDraft(stash.title);
+        setBodyDraft(stash.body);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [draftBase, isDirty, notebookFlag]);
 
   const runDeleteSelectedNote = useCallback(async () => {
     if (!notebookFlag || !selectedNote || !canEdit) return;

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -263,6 +263,22 @@ export const channelSortPreference = createStorageItem<ChannelSortPreference>({
   defaultValue: 'recency',
 });
 
+export type NotesNoteDraft = {
+  title: string;
+  body: string;
+  baseRevision: number;
+  stashedAt: number;
+};
+
+/** Crash insurance for the notes editor: drafts stashed between autosave
+ * cycles, keyed by `${notebookFlag}/${noteId}`. Cleared once saved. */
+export const notesNoteDrafts = createStorageItem<
+  Record<string, NotesNoteDraft>
+>({
+  key: 'notesNoteDrafts',
+  defaultValue: {},
+});
+
 export type NotesTreeViewPreference = 'outline' | 'notes';
 
 export const notesTreeViewPreference =


### PR DESCRIPTION
Drafts now track the note snapshot they're based on, so the synced echo of a save can't overwrite keystrokes typed while it was in flight, and a remote edit while dirty fails the revision check instead of being silently overwritten. Saves serialize through one chain, each rebasing onto the previous result. Unsaved work flushes on note switch, unmount, and app background, and drafts stash to storage as crash insurance, restored only while the row is still at the stash's base revision. Autosave debounce goes to 10s now that exits are covered explicitly.

## Summary

<!-- Briefly describe what this pull request does in 1-3 sentences. -->

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
