### PR TITLE
Dismiss long-press message menu when tapping empty space around it

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -184,14 +184,15 @@ export function ChatMessageActions({
     }
     case 'immediate': {
       return (
-        <Animated.View style={animatedStyles}>
+        <Animated.View style={animatedStyles} pointerEvents="box-none">
           <View
             width={width}
             height={height}
             onLayout={handleLayout}
             paddingHorizontal="$xl"
+            pointerEvents="box-none"
           >
-            <YStack gap="$xs">
+            <YStack gap="$xs" pointerEvents="box-none">
               {canWrite && (
                 <EmojiToolbar
                   post={post}

--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -16,7 +16,7 @@ export function Modal(props: ComponentProps<typeof RNModal>) {
     <RNModal transparent={true} {...props}>
       <ZStack flex={1}>
         <Overlay onPress={onDismiss} />
-        <View flex={1} position="absolute">
+        <View flex={1} position="absolute" pointerEvents="box-none">
           {props.children}
         </View>
       </ZStack>


### PR DESCRIPTION
## Summary

The long-press message action menu didn't reliably dismiss. Tapping the empty area beside the menu — to the right of the emoji bar or the action list — did nothing; you had to find the thin strip below the menu to close it. This makes the menu dismiss when you tap in the empty space around it.

## Changes

In immediate (long-press) mode the menu's content can be nearly full-width (the message preview), so the menu's bounding box covers most of the screen. The container views in that box used the default `pointerEvents="auto"`, so taps in their empty areas were swallowed instead of reaching the `Overlay` backdrop that calls `onDismiss`.

Set `pointerEvents="box-none"` so empty-area taps fall through to the backdrop, while the menu's actual widgets (emoji bar, message preview, action buttons) still receive their own taps:

- `ChatMessageActions/Component.tsx` (immediate mode): the `Animated.View` → `View` → `YStack` wrapper chain.
- `packages/ui/src/components/Modal.tsx`: the content wrapper `<View flex={1} position="absolute">` that sits above the backdrop.

Both wrappers have to pass the tap through for it to reach the backdrop. The `Modal` wrapper is a transparent positioning layer that should never have captured touches in its empty areas, so `box-none` is the correct behavior for it.

## How did I test?

iOS simulator (iPhone 15 Pro Max), fresh `develop` build. Long-pressed a wide chat message and tapped around the menu:

- **Before:** tapping right of the emoji bar / action list left the menu open; only a tap in the strip below it dismissed.
- **After:** tapping in the empty space around the menu (right of the emoji bar, right of the action list, right of the text) dismisses; tapping the widgets themselves — the emoji bar, the message, the buttons — still behaves as before.

Videos below.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: the shared `@tloncorp/ui` `Modal` (used by all modal overlays)

The only non-local change is `Modal.tsx`, also used by the message-actions fixture and `MediaViewerScreen`. `box-none` only lets a tap through when it doesn't land on an interactive child, so the practical effect elsewhere is correct tap-outside-to-dismiss, not lost interactions. Worst case is a modal that intended an empty inner area to stay inert now dismissing — none of the current consumers rely on that.

## Rollback plan

Revert the commit. It's a small, props-only change — no state, migrations, or native code — so removing the `pointerEvents="box-none"` props restores the prior behavior.

## Screenshots / videos

**Before** — tapping right of the menu / emoji bar does nothing; only the bottom dismisses:

https://github.com/user-attachments/assets/f09108a2-4430-4962-8198-9310edfd5fd6

**After** — tapping the empty space to the right of the action menu, the message text, and the emoji bar all dismiss:

https://github.com/user-attachments/assets/46b22f1b-46ac-4605-8c4e-5bd5e4480249
