### PR TITLE
fix (openclaw): build dev tlon-skill override from the monorepo package

### DIFF
--- a/packages/openclaw/dev/build-local-skill-override.sh
+++ b/packages/openclaw/dev/build-local-skill-override.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-PLUGIN_DIR="${PLUGIN_DIR:-/workspace/openclaw-tlon}"
-TLON_SKILL_DIR="${TLON_SKILL_DIR:-/workspace/tlon-skill}"
+# /workspace/tlon is the container-local plugin copy openclaw actually loads
+# (the entrypoint installs there); link the override into it, matching
+# build-local-api-override.sh. The bind-mounted /workspace/openclaw-tlon is
+# not on plugins.load.paths, so linking there would be a no-op.
+PLUGIN_DIR="${PLUGIN_DIR:-/workspace/tlon}"
+# Build from the in-monorepo package so workspace/hoisted deps resolve
+# (@tloncorp/api symlink + @urbit/* at the monorepo root). Compose sets this
+# explicitly; the default mirrors it for standalone invocations.
+TLON_SKILL_DIR="${TLON_SKILL_DIR:-/workspace/tlon-apps/packages/tlon-skill}"
 
 if [ ! -f "$TLON_SKILL_DIR/package.json" ]; then
   echo "==> No local tlon-skill checkout found at $TLON_SKILL_DIR; using published @tloncorp/tlon-skill"

--- a/packages/openclaw/dev/docker-compose.yml
+++ b/packages/openclaw/dev/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       # Inside the container, the local tlon-apps/homestead checkout is always mounted here.
       # This must not use the host absolute path from .env.
       - TLON_APPS_DIR=/workspace/tlon-apps
-      # Inside the container, the local tlon-skill checkout is always mounted here.
-      # This must not use the host absolute path from .env.
-      - TLON_SKILL_DIR=/workspace/tlon-skill
+      # The tlon-skill override builds from the in-monorepo package so its
+      # workspace deps resolve: @tloncorp/api via the symlink into
+      # packages/api, and @urbit/* hoisted to the monorepo root node_modules.
+      # Must point inside the /workspace/tlon-apps mount, not a standalone one.
+      - TLON_SKILL_DIR=/workspace/tlon-apps/packages/tlon-skill
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     volumes:
@@ -27,12 +29,10 @@ services:
       # Mount tlonbot for config and prompts. Defaults to a checkout sitting
       # next to the tlon-apps monorepo root; override with TLONBOT_DIR.
       - ${TLONBOT_DIR:-../../../../tlonbot}:/workspace/tlonbot
-      # The containing tlon-apps monorepo, for dev-only @tloncorp/api override
-      # builds. Defaults to the repo this package lives in.
+      # The containing tlon-apps monorepo, for dev-only @tloncorp/api and
+      # @tloncorp/tlon-skill override builds. Both override scripts build from
+      # packages/* inside this mount so workspace/hoisted deps resolve.
       - ${TLON_APPS_DIR:-../../..}:/workspace/tlon-apps
-      # The in-monorepo tlon-skill package, for the dev-only
-      # @tloncorp/tlon-skill override (built from source in the container).
-      - ${TLON_SKILL_DIR:-../../tlon-skill}:/workspace/tlon-skill
       # Persist OpenClaw state
       - openclaw-state:/root/.openclaw
       # Config from tlonbot (copied + patched by entrypoint, not mounted directly)


### PR DESCRIPTION
## Summary

`pnpm dev` from `packages/openclaw` failed when building the local `@tloncorp/tlon-skill` override: bun couldn't resolve the skill's deps (`@tloncorp/api`, `@urbit/aura`, `@urbit/nockjs`) and the entrypoint died.

Migration fallout from the monorepo move (#5930/#5931): the api override was updated to build from inside the mounted monorepo, but the skill override was left pointing at a standalone `/workspace/tlon-skill` mount. Under the hoisted workspace layout, `packages/tlon-skill`'s deps don't live in its own `node_modules` — `@tloncorp/api` is a symlink into `packages/api` and the `@urbit/*` packages are hoisted to the monorepo root — so neither resolves from an isolated mount. CI never caught it: the integration/smoke suites use `entrypoint.test.sh`, which doesn't run the override scripts.

## Changes

-   **`dev/docker-compose.yml`**: point `TLON_SKILL_DIR` at `/workspace/tlon-apps/packages/tlon-skill` (inside the already-mounted monorepo) and drop the now-redundant standalone `/workspace/tlon-skill` mount. Building there lets the `@tloncorp/api` symlink and the hoisted `@urbit/*` deps resolve.
-   **`dev/build-local-skill-override.sh`**: update the two defaults to match `build-local-api-override.sh` — build source → the in-monorepo package, and `PLUGIN_DIR` → `/workspace/tlon` (the plugin copy openclaw actually loads). The latter fixes a second latent bug: the override was linking into the bind-mounted source dir, which isn't on `plugins.load.paths`, so local skill edits silently had no effect.

## Testing

Brought the dev stack up twice against a local `.env`: the skill now compiles from source, links into `/workspace/tlon/node_modules/@tloncorp/tlon-skill -> /workspace/tlon-apps/packages/tlon-skill`, and the gateway starts with no resolution errors.