### PR TITLE
fix (openclaw): default dev tlon-skill override to the prebuilt binary

### DIFF
--- a/packages/openclaw/dev/build-local-skill-override.sh
+++ b/packages/openclaw/dev/build-local-skill-override.sh
@@ -44,19 +44,27 @@ ln -s "$TLON_SKILL_DIR" "$TARGET"
 # After symlinking, the fallback resolves from the realpath ($TLON_SKILL_DIR/bin/)
 # walking up via the local checkout's node_modules — which on a darwin host won't
 # have the linux binary package installed. So we always produce $TLON_SKILL_DIR/bin/tlon
-# inside the container, either by rebuilding from source (preferred — picks up local
-# edits) or by hydrating the matching platform-arch binary from openclaw-tlon's npm
-# install (fallback when no source is present).
+# inside the container, either by hydrating the matching platform-arch binary from
+# the plugin's npm install (the default — works on any Docker backend) or, when
+# opted in, by rebuilding from source to pick up local edits.
 # bin/tlon is gitignored in tlon-skill, so writing it through the bind mount won't
 # pollute the host working tree.
+#
+# Why the source build is opt-in: `bun build --compile` writes a temp file and
+# renames it onto --outfile. On VirtioFS bind mounts (Docker Desktop) the temp
+# lands at the host realpath while --outfile is the mount path, and the
+# cross-namespace rename fails with ENOENT. The npm-installed skill already
+# ships a working prebuilt binary, so source-from-build is only needed when
+# actively editing tlon-skill — set TLON_SKILL_FROM_SOURCE=1 for that.
 ARCH_KEY=$(node -e 'console.log(process.platform + "-" + process.arch)')
 echo "==> Container platform-arch: $ARCH_KEY"
 
-if [ -f "$TLON_SKILL_DIR/scripts/main.ts" ] && command -v bun >/dev/null 2>&1; then
+if [ -n "${TLON_SKILL_FROM_SOURCE:-}" ] && [ -f "$TLON_SKILL_DIR/scripts/main.ts" ] && command -v bun >/dev/null 2>&1; then
   # Build from source so local edits to tlon-skill scripts/*.ts show up in the CLI.
   # bun --compile bundles all deps into the binary; the host's node_modules (bind
-  # mounted) is reused since tlon-skill's deps are pure JS.
-  echo "==> Rebuilding tlon-skill from source for $ARCH_KEY..."
+  # mounted) is reused since tlon-skill's deps are pure JS. Note: may fail on
+  # VirtioFS (see above) — fall back by unsetting TLON_SKILL_FROM_SOURCE.
+  echo "==> Rebuilding tlon-skill from source for $ARCH_KEY (TLON_SKILL_FROM_SOURCE set)..."
   if [ ! -d "$TLON_SKILL_DIR/node_modules" ]; then
     echo "==> Installing tlon-skill deps (bun install)..."
     (cd "$TLON_SKILL_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
@@ -72,8 +80,7 @@ if [ -f "$TLON_SKILL_DIR/scripts/main.ts" ] && command -v bun >/dev/null 2>&1; t
   echo "==> Built $TLON_SKILL_DIR/bin/tlon from source"
 else
   if [ -f "$TLON_SKILL_DIR/scripts/main.ts" ]; then
-    echo "==> Source present but bun not installed; falling back to npm-installed binary."
-    echo "==> Add bun to dev/Dockerfile to rebuild from source on container start."
+    echo "==> Using prebuilt tlon-skill binary (set TLON_SKILL_FROM_SOURCE=1 to rebuild from local source)."
   fi
   # Always overwrite bin/tlon — never trust whatever is already there. The local
   # checkout may carry a host-built darwin binary (e.g. from `pnpm dev:link`),


### PR DESCRIPTION
## Summary

`pnpm dev` from `packages/openclaw` failed for Walt on docker desktop's VirtioFS file-sharing backend while building the local `@tloncorp/tlon-skill` override:

```
failed to rename /run/host_virtiofs/Users/.../packages/tlon-skill/.xxx.bun-build
  to /workspace/tlon-apps/packages/tlon-skill/dist/tlon: ENOENT
```

`bun build --compile` writes its output to a temp file and renames it onto `--outfile`. On VirtioFS the temp lands at the host _realpath_ (`/run/host_virtiofs/…`) while `--outfile` is the _mount_ path (`/workspace/…`); those are two namespaces for the same directory and the cross-namespace rename fails with `ENOENT`. Other backends (e.g. gRPC FUSE) don't have that realpath divergence, so the build only fails on some setups.

The entrypoint already installs `@tloncorp/tlon-skill` from npm — including a working prebuilt platform binary — before the override runs. Building from source only matters when you're actively editing tlon-skill's source, a power-user case. So building-from-source by default was breaking the common "just run the bot" path for no benefit.

## Change

`dev/build-local-skill-override.sh`: gate the source build behind an opt-in `TLON_SKILL_FROM_SOURCE=1`. The default now hydrates the prebuilt binary from the plugin's npm install (a plain `cp`, no bun `--compile`, so the VirtioFS rename issue can't occur). Anyone editing tlon-skill source sets the flag to restore the rebuild-on-start behavior.

## Testing

Brought the dev stack up locally with the new default (flag unset): the override skips the source build, hydrates the `linux-arm64` prebuilt binary, links it into `/workspace/tlon/node_modules/@tloncorp/tlon-skill`, and the gateway reaches `ready` with the tlon tool registered and the firehose connected.

Caveat: I can't reproduce VirtioFS locally (my Docker backend builds fine either way), so I couldn't reproduce the original failure myself. Going to test with Walt to see if this fixes the issue.