### PR TITLE
Dedupe phone-number libraries (drop google-libphonenumber)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
       "@tamagui/sheet@2.0.0-rc.41": "patches/@tamagui__sheet@2.0.0-rc.41.patch",
       "@tamagui/static@2.0.0-rc.41": "patches/@tamagui__static@2.0.0-rc.41.patch",
       "react-native-reanimated@4.1.6": "patches/react-native-reanimated@4.1.6.patch",
-      "react-native-gesture-handler@2.28.0": "patches/react-native-gesture-handler@2.28.0.patch"
+      "react-native-gesture-handler@2.28.0": "patches/react-native-gesture-handler@2.28.0.patch",
+      "react-native-phone-input@1.3.7": "patches/react-native-phone-input@1.3.7.patch"
     },
     "allowNonAppliedPatches": true,
     "overrides": {

--- a/patches/README.md
+++ b/patches/README.md
@@ -221,3 +221,49 @@ Removal:
 Remove this patch once `react-native-gesture-handler` ships a version of
 `ReanimatedSwipeable` that disables pointer events on the hidden action
 container, and we confirm the Android repro no longer needs the local fix.
+
+## react-native-phone-input@1.3.7
+
+Why:
+The package bundles `google-libphonenumber` (~688KB) solely for phone-number
+parsing, validation, and as-you-type formatting. We already ship
+`libphonenumber-js` (smaller, tree-shakeable, used directly across onboarding
+and the API layer), so the app carries two phone-number libraries. This patch
+points `react-native-phone-input` at `libphonenumber-js` instead, dropping
+`google-libphonenumber` from the bundle entirely (~570KB off the release JS
+bundle).
+
+What it does:
+In `dist/PhoneNumber.js`, replaces google-libphonenumber's `PhoneNumberUtil`
+(`parse` / `isValidNumber` / `getNumberType`) and `AsYouTypeFormatter` with the
+`libphonenumber-js` equivalents (`parsePhoneNumberFromString`, `.isValid()`,
+`.getType()`, `AsYouType`). The component supplies lowercase iso2 region codes
+(e.g. `us`), but libphonenumber-js requires an uppercase `CountryCode` (`US`),
+so the patch uppercases the region before each call.
+
+Note: libphonenumber-js formats the national number with spaces
+(`+1 202 555 0123`) where google-libphonenumber used dashes
+(`+1 202-555-0123`). Validation, country detection, and the submitted value are
+unchanged; only the separator style differs.
+
+Local patch:
+`patches/react-native-phone-input@1.3.7.patch`
+
+Upstream:
+- `react-native-phone-input` `1.4.1` (latest as of June 2026) still depends on
+  `google-libphonenumber@^3.2.32`, so there is no upstream version to upgrade
+  to; the durable fix is to upstream the `libphonenumber-js` switch.
+
+Validation:
+- Rebuild the app and open the phone-number screen (signup phone entry or
+  "Log in with phone number").
+- Type a number and confirm as-you-type formatting, the country flag, and
+  validation (the submit button enabling on a valid number) all work; check a
+  non-US country too.
+- Confirm `google-libphonenumber` no longer appears in the release bundle.
+
+Removal:
+Remove this patch once `react-native-phone-input` ships a version that no longer
+depends on `google-libphonenumber` (or we replace the component with a
+`libphonenumber-js`-based input), and we confirm the phone-number flow still
+works without the local patch.

--- a/patches/react-native-phone-input@1.3.7.patch
+++ b/patches/react-native-phone-input@1.3.7.patch
@@ -1,0 +1,64 @@
+diff --git a/dist/PhoneNumber.js b/dist/PhoneNumber.js
+index 489949d1434f0e0c78443238bff0fd23f89f4b21..c6a4488d583dc074adcf4452889cdc3cb52073ea 100644
+--- a/dist/PhoneNumber.js
++++ b/dist/PhoneNumber.js
+@@ -4,11 +4,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
+ };
+ Object.defineProperty(exports, "__esModule", { value: true });
+ const lodash_1 = __importDefault(require("lodash"));
+-const google_libphonenumber_1 = __importDefault(require("google-libphonenumber"));
++const libphonenumber_js_1 = require("libphonenumber-js");
+ const country_1 = __importDefault(require("./country"));
+-const numberType_json_1 = __importDefault(require("./resources/numberType.json")); // eslint-disable-line @typescript-eslint/no-unused-vars
+-const phoneUtil = google_libphonenumber_1.default.PhoneNumberUtil.getInstance();
+-const asYouTypeFormatter = google_libphonenumber_1.default.AsYouTypeFormatter;
++// react-native-phone-input uses lowercase iso2 ("us"); libphonenumber-js
++// requires an uppercase CountryCode ("US") or it returns undefined.
++const toCountryCode = (iso2) => (iso2 ? iso2.toUpperCase() : undefined);
+ class PhoneNumber {
+     // eslint-disable-next-line class-methods-use-this
+     getAllCountries() {
+@@ -61,7 +61,7 @@ class PhoneNumber {
+     // eslint-disable-next-line class-methods-use-this
+     parse(number, iso2) {
+         try {
+-            return phoneUtil.parse(number, iso2);
++            return libphonenumber_js_1.parsePhoneNumberFromString(number, toCountryCode(iso2)) || null;
+         }
+         catch (err) {
+             console.log(`Exception was thrown: ${err.toString()}`);
+@@ -71,28 +71,22 @@ class PhoneNumber {
+     isValidNumber(number, iso2) {
+         const phoneInfo = this.parse(number, iso2);
+         if (phoneInfo) {
+-            return phoneUtil.isValidNumber(phoneInfo);
++            return phoneInfo.isValid();
+         }
+         return false;
+     }
+     // eslint-disable-next-line class-methods-use-this
+     format(number, iso2) {
+-        const formatter = new asYouTypeFormatter(iso2); // eslint-disable-line new-cap
+-        let formatted;
+-        number.replace(/-/g, '')
++        const formatter = new libphonenumber_js_1.AsYouType(toCountryCode(iso2));
++        const stripped = number.replace(/-/g, '')
+             .replace(/ /g, '')
+             .replace(/\(/g, '')
+-            .replace(/\)/g, '')
+-            .split('')
+-            .forEach((n) => {
+-            formatted = formatter.inputDigit(n);
+-        });
+-        return formatted;
++            .replace(/\)/g, '');
++        return formatter.input(stripped);
+     }
+     getNumberType(number, iso2) {
+         const phoneInfo = this.parse(number, iso2);
+-        const typeIndex = phoneInfo ? phoneUtil.getNumberType(phoneInfo) : -1;
+-        return lodash_1.default.findKey(numberType_json_1.default, (noType) => noType === typeIndex);
++        return phoneInfo ? phoneInfo.getType() : undefined;
+     }
+     // eslint-disable-next-line class-methods-use-this
+     getCountryDataByCode(iso2) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ patchedDependencies:
   react-native-gesture-handler@2.28.0:
     hash: 4tgd2pyadl6scffs4ygpr5laoq
     path: patches/react-native-gesture-handler@2.28.0.patch
+  react-native-phone-input@1.3.7:
+    hash: 5tif7xag4kpfani635ei6tsx5q
+    path: patches/react-native-phone-input@1.3.7.patch
   react-native-reanimated@4.1.6:
     hash: db23afiqndxmbpjbpxlpwqprzi
     path: patches/react-native-reanimated@4.1.6.patch
@@ -445,7 +448,7 @@ importers:
         version: 1.11.0(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       react-native-phone-input:
         specifier: ^1.3.7
-        version: 1.3.7(@react-native-picker/picker@2.11.4(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+        version: 1.3.7(patch_hash=5tif7xag4kpfani635ei6tsx5q)(@react-native-picker/picker@2.11.4(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       react-native-polyfill-globals:
         specifier: ^3.1.0
         version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(react-native-url-polyfill@2.0.0(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
@@ -31194,7 +31197,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  react-native-phone-input@1.3.7(@react-native-picker/picker@2.11.4(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+  react-native-phone-input@1.3.7(patch_hash=5tif7xag4kpfani635ei6tsx5q)(@react-native-picker/picker@2.11.4(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@react-native-picker/picker': 2.11.4(react-native@0.81.5(patch_hash=uszx554kwcqz53utcvfh7ypuii)(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/metro-config@0.81.5(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       google-libphonenumber: 3.2.34


### PR DESCRIPTION
## Summary

The app bundles **two** phone-number libraries: `libphonenumber-js` (used directly in ~7 places for parse/validate) and `google-libphonenumber` (~688KB), the latter pulled in *only* by `react-native-phone-input`. This patches `react-native-phone-input` to use `libphonenumber-js` instead, dropping `google-libphonenumber` from the bundle entirely (~570KB off the release JS bundle in measurement).

## Changes

- `pnpm patch react-native-phone-input@1.3.7` → rewrites `dist/PhoneNumber.js` to use `libphonenumber-js` (`parsePhoneNumberFromString`, `AsYouType`, `.isValid()`, `.getType()`) in place of google-libphonenumber's `PhoneNumberUtil` + `AsYouTypeFormatter`.
- Normalizes the component's lowercase iso2 (e.g. `us`) to the uppercase `CountryCode` libphonenumber-js requires (`US`) — without this every parse/validate silently returns nothing.

## How did I test?

- **Functional test** of the patched module: parse / format / validate / number-type / country-detection across US + international numbers, including the lowercase-iso2 path.
- **On-device** (Galaxy A03s), phone-login screen: typed a number and verified as-you-type formatting, validation (Send button enabling), and the country flag. Before/after below.
- **Bundle**: confirmed `google-libphonenumber` (`i18n.phonenumbers` namespace) is gone from the release bundle; the JS bundle shrank ~570KB.

⚠️ **One visible change:** libphonenumber-js formats the national part with **spaces** (`+1 202 555 0123`) where google used **dashes** (`+1 202-555-0123`). Validation, country detection, and the value submitted are unchanged — only the separator style differs (see the video). Flagging in case design wants the dashes kept.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — revert this PR (removes the patch, restores google-libphonenumber).
- Affects important code area:
  - [x] Onboarding (phone-number input in signup + phone login)
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: any flow using the `PhoneInput` component
- The patch is pinned to `react-native-phone-input@1.3.7` (must be re-applied if bumped — and 1.4.x still depends on google-libphonenumber, so upstream won't fix this soon; worth upstreaming the libphonenumber-js switch). Before merge, QA the full phone flow: signup phone entry, **non-US countries**, paste, and edit/delete-while-typing.

## Rollback plan

Revert this PR — drops the patch and restores `google-libphonenumber`. No data/schema impact.

## Screenshots / videos

Phone login on a Galaxy A03s — **left: google-libphonenumber (before), right: libphonenumber-js (after)**. Same number, same as-you-type behavior + validation; note the dash→space separator difference.

https://github.com/user-attachments/assets/5bd2aaf7-783c-4228-9970-4b3df4ef13ad
