### PR TITLE
Onboarding sandbox: web UI + orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules
 /packages/hermes-tlon-adapter/.env
 __pycache__/
 *.py[cod]
+# onboarding sandbox: editable copies of private tlonbot prompts — never commit
+/scripts/onboarding-sandbox/.sandbox-prompts
 # local dev Urbit piers parked at the repo root
 /rus/
 ops

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ node_modules
 /packages/hermes-tlon-adapter/.env
 __pycache__/
 *.py[cod]
-# onboarding sandbox: editable copies of private tlonbot prompts — never commit
+# onboarding sandbox: editable copies of private tlonbot prompts/intro — never commit
 /scripts/onboarding-sandbox/.sandbox-prompts
+/scripts/onboarding-sandbox/.sandbox-intro.md
 # local dev Urbit piers parked at the repo root
 /rus/
 ops

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,8 @@ node_modules
 /packages/hermes-tlon-adapter/.env
 __pycache__/
 *.py[cod]
+/scripts/onboarding-sandbox/.sandbox-prompts
+/scripts/onboarding-sandbox/.sandbox-intro.md
 /rus/
 ops
 bin

--- a/apps/onboarding-sandbox/package.json
+++ b/apps/onboarding-sandbox/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@tloncorp/onboarding-sandbox-web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Onboarding sandbox web control plane (Phase 2): node control server + UI over the orchestrator. Phase-2 step 1 is a zero-dep skeleton; the editor/diff/model-selector UI will move to Vite+React.",
+  "scripts": {
+    "dev": "node server.mjs"
+  }
+}

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -548,6 +548,12 @@
       async function run(cmd) {
         if (busy) return;
         setBusy(true);
+        // start renders the on-disk sandbox prompts (via reset), so flush the
+        // dirty item first or the first run uses the pre-edit text.
+        if (cmd === 'start' && dirty && current && !(await saveItem())) {
+          setBusy(false);
+          return;
+        }
         await stream(cmd, 'cmd=' + cmd);
         setBusy(false);
         refreshStatus();

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -239,7 +239,7 @@
             Save &amp; reset onboarding
           </button>
           <button
-            onclick="location.href='/api/export'"
+            onclick="location.href='/api/export?token='+encodeURIComponent(window.__TOKEN__||'')"
             title="Download your edits as a .patch file to share with a developer"
           >
             Export patch
@@ -269,6 +269,21 @@
         dirty = false,
         busy = false,
         diffOpen = false;
+
+      // Per-run token (injected by the server) sent on every /api/* call so a
+      // cross-origin page can't drive the sandbox. EventSource and the export
+      // link append it to their URLs themselves (below).
+      const TOKEN = window.__TOKEN__ || '';
+      const _fetch = window.fetch.bind(window);
+      window.fetch = (input, init) => {
+        if (typeof input === 'string' && input.startsWith('/api/')) {
+          input +=
+            (input.includes('?') ? '&' : '?') +
+            'token=' +
+            encodeURIComponent(TOKEN);
+        }
+        return _fetch(input, init);
+      };
 
       async function refreshStatus() {
         try {
@@ -478,7 +493,9 @@
           const feed = $('feed');
           $('activity').style.display = '';
           feed.textContent += `\n=== ${label} ===\n`;
-          const es = new EventSource('/api/stream?' + qs);
+          const es = new EventSource(
+            '/api/stream?' + qs + '&token=' + encodeURIComponent(TOKEN)
+          );
           es.addEventListener('line', (e) => {
             feed.textContent += e.data + '\n';
             feed.scrollTop = feed.scrollHeight;

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -37,6 +37,8 @@
     <button id="b-down" onclick="run('down')">Stop</button>
   </header>
 
+  <div id="setup" style="display:none; padding:.7rem 1.2rem; background:#fff7e6; border-bottom:1px solid #e0c989; font-size:13px;"></div>
+
   <main>
     <ul id="items"></ul>
     <div class="pane">
@@ -70,6 +72,28 @@
           : `<span class="dot down"></span>Down — click Start`;
         if (s.model) { const sel = $('model'); if ([...sel.options].some((o) => o.value === s.model)) sel.value = s.model; }
       } catch (e) { $('status').textContent = 'status error'; }
+    }
+
+    async function checkPreflight() {
+      let p; try { p = await (await fetch('/api/preflight')).json(); } catch { return; }
+      const box = $('setup');
+      if (p.docker && p.key) { box.style.display = 'none'; return; }
+      let html = '';
+      if (!p.docker) html += `⚠️ <b>Docker isn't running.</b> Start Docker Desktop, then <a href="#" onclick="checkPreflight();return false">re-check</a>.<br>`;
+      if (!p.key) html += `🔑 <b>No provider key set.</b> OpenRouter API key: ` +
+        `<input id="keyin" type="password" size="36" placeholder="sk-or-..."> ` +
+        `<button onclick="saveKey()">Validate &amp; save</button> <span id="keymsg"></span>`;
+      box.innerHTML = html; box.style.display = 'block';
+    }
+    async function saveKey() {
+      const key = $('keyin').value.trim(); const msg = $('keymsg');
+      if (!key) { msg.textContent = 'enter a key'; return; }
+      msg.textContent = 'validating…';
+      try {
+        const r = await fetch('/api/provider-key', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ key }) });
+        const j = await r.json();
+        if (j.ok) { msg.textContent = 'saved ✓'; checkPreflight(); } else msg.textContent = j.error || 'failed';
+      } catch (e) { msg.textContent = 'error: ' + e; }
     }
 
     async function loadItems() {
@@ -177,7 +201,7 @@
       setBusy(false); refreshStatus();
     }
 
-    loadModels().then(refreshStatus); loadItems();
+    loadModels().then(refreshStatus); loadItems(); checkPreflight();
   </script>
 </body>
 </html>

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -25,7 +25,9 @@
     textarea { flex:1; width:100%; box-sizing:border-box; border:0; padding:1rem; font:13px/1.5 ui-monospace,Menlo,monospace; resize:none; outline:none; }
     .runbar { padding:.6rem 1rem; border-top:1px solid var(--bd); display:flex; gap:.6rem; align-items:center; }
     .runbar small{color:#888}
-    pre#feed { margin:0; background:#111; color:#d8d8d8; padding:.8rem 1rem; height:160px; overflow:auto; white-space:pre-wrap; font-size:12px; }
+    .feedhead { display:flex; align-items:center; padding:.35rem 1rem; font-size:12px; color:#888; background:#f3f3f3; border-top:1px solid var(--bd); }
+    .feedhead button { font-size:11px; padding:.1rem .5rem; }
+    pre#feed { margin:0; background:#111; color:#d8d8d8; padding:.8rem 1rem; height:140px; overflow:auto; white-space:pre-wrap; font-size:12px; }
   </style>
 </head>
 <body>
@@ -47,16 +49,19 @@
         <b id="editTitle">Select an item</b>
         <button id="b-diff" onclick="toggleDiff()" disabled>Diff</button>
         <button id="b-save" onclick="saveItem()" disabled>Save</button>
-        <button id="b-reset-item" onclick="resetItem()" disabled>Reset to source</button>
+        <button id="b-reset-item" onclick="resetItem()" disabled title="restore this item to the shipped original">Discard changes</button>
       </div>
       <textarea id="editor" disabled placeholder="Select a prompt or the intro DM on the left…"></textarea>
       <pre id="diff" style="display:none; flex:1; margin:0; overflow:auto; padding:1rem; background:#0d1117; color:#c9d1d9; font:13px/1.5 ui-monospace,Menlo,monospace; white-space:pre-wrap;"></pre>
       <div class="runbar">
-        <button class="primary" id="b-savereset" onclick="saveAndReset()">Save &amp; reset onboarding</button>
-        <button onclick="location.href='/api/export'">Export patch</button>
-        <small>writes your edits, then replays first-run (clear → render → intro)</small>
+        <button class="primary" id="b-savereset" onclick="saveAndReset()" title="Save your edits, then replay the bot's first-run (clear → render → intro)">Save &amp; reset onboarding</button>
+        <button onclick="location.href='/api/export'" title="Download your edits as a .patch file to share with a developer">Export patch</button>
+        <button onclick="resetAll()" title="Discard your edits to every prompt and the intro, restoring the shipped originals">Discard all changes</button>
       </div>
-      <pre id="feed"></pre>
+      <div id="activity" style="display:none">
+        <div class="feedhead"><span>Activity log</span><button onclick="clearFeed()" style="margin-left:auto">clear</button></div>
+        <pre id="feed"></pre>
+      </div>
     </div>
   </main>
 
@@ -142,6 +147,15 @@
       dirty = false; await selectItem(current);
     }
 
+    async function resetAll() {
+      if (busy) return;
+      if (!confirm('Discard all your edits to every prompt and the intro, restoring the shipped originals?')) return;
+      await fetch('/api/reset-prompts', { method: 'POST' });
+      dirty = false;
+      await loadItems();
+      if (current) await selectItem(current);
+    }
+
     function renderDiff(text) {
       return text.split('\n').map((l) => {
         const e = l.replace(/&/g, '&amp;').replace(/</g, '&lt;');
@@ -170,6 +184,7 @@
     function stream(label, qs) {
       return new Promise((resolve) => {
         const feed = $('feed');
+        $('activity').style.display = '';
         feed.textContent += `\n=== ${label} ===\n`;
         const es = new EventSource('/api/stream?' + qs);
         es.addEventListener('line', (e) => { feed.textContent += e.data + '\n'; feed.scrollTop = feed.scrollHeight; });
@@ -177,6 +192,8 @@
         es.onerror = () => { es.close(); resolve(); };
       });
     }
+
+    function clearFeed() { $('feed').textContent = ''; $('activity').style.display = 'none'; }
 
     async function run(cmd) {
       if (busy) return; setBusy(true);

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -377,6 +377,7 @@
       }
 
       async function selectItem(name) {
+        if (busy) return; // don't re-enable the editor while a command is streaming
         if (dirty && !confirm('Discard unsaved changes?')) return;
         const it = await (
           await fetch('/api/prompts/' + encodeURIComponent(name))

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -5,80 +5,136 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Onboarding Sandbox</title>
   <style>
-    body { font: 14px/1.5 -apple-system, system-ui, sans-serif; max-width: 820px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
-    h1 { font-size: 1.3rem; }
-    #status { padding: .75rem 1rem; border: 1px solid #ddd; border-radius: 8px; background: #fafafa; }
-    .dot { display: inline-block; width: .6rem; height: .6rem; border-radius: 50%; margin-right: .4rem; vertical-align: middle; }
-    .up { background: #2e9e44; } .down { background: #bbb; }
-    .actions { margin: 1rem 0; display: flex; gap: .5rem; flex-wrap: wrap; }
-    button { font: inherit; padding: .4rem .9rem; border: 1px solid #ccc; border-radius: 6px; background: #fff; cursor: pointer; }
-    button.primary { background: #1a1a1a; color: #fff; border-color: #1a1a1a; }
-    button:disabled { opacity: .5; cursor: default; }
-    a.owner { font-weight: 600; }
-    pre#feed { background: #111; color: #d8d8d8; padding: 1rem; border-radius: 8px; height: 320px; overflow: auto; white-space: pre-wrap; font-size: 12px; }
+    :root { --bd:#ddd; --bg:#fafafa; --ink:#1a1a1a; }
+    body { font: 14px/1.5 -apple-system, system-ui, sans-serif; margin: 0; color: var(--ink); }
+    header { padding: .8rem 1.2rem; border-bottom: 1px solid var(--bd); display:flex; align-items:center; gap:1rem; flex-wrap:wrap; }
+    header h1 { font-size: 1.05rem; margin: 0; }
+    #status { flex: 1; min-width: 240px; }
+    .dot { display:inline-block; width:.6rem; height:.6rem; border-radius:50%; margin-right:.35rem; vertical-align:middle; }
+    .up{background:#2e9e44}.down{background:#bbb}.mod{background:#e0991b}
+    button { font:inherit; padding:.35rem .8rem; border:1px solid #ccc; border-radius:6px; background:#fff; cursor:pointer; }
+    button.primary{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
+    button:disabled{opacity:.5;cursor:default}
+    main { display:grid; grid-template-columns: 220px 1fr; gap:0; height: calc(100vh - 58px); }
+    #items { border-right:1px solid var(--bd); overflow:auto; padding:.5rem; margin:0; list-style:none; }
+    #items li { padding:.4rem .6rem; border-radius:6px; cursor:pointer; }
+    #items li:hover{background:var(--bg)} #items li.sel{background:#eef}
+    .pane { display:flex; flex-direction:column; min-width:0; }
+    .editbar { padding:.5rem 1rem; border-bottom:1px solid var(--bd); display:flex; align-items:center; gap:.6rem; }
+    .editbar b{flex:1}
+    textarea { flex:1; width:100%; box-sizing:border-box; border:0; padding:1rem; font:13px/1.5 ui-monospace,Menlo,monospace; resize:none; outline:none; }
+    .runbar { padding:.6rem 1rem; border-top:1px solid var(--bd); display:flex; gap:.6rem; align-items:center; }
+    .runbar small{color:#888}
+    pre#feed { margin:0; background:#111; color:#d8d8d8; padding:.8rem 1rem; height:160px; overflow:auto; white-space:pre-wrap; font-size:12px; }
   </style>
 </head>
 <body>
-  <h1>Onboarding Sandbox</h1>
-  <div id="status">loading…</div>
-
-  <div class="actions">
+  <header>
+    <h1>Onboarding Sandbox</h1>
+    <span id="status">loading…</span>
     <button id="b-start" onclick="run('start')">Start</button>
-    <button id="b-reset" class="primary" onclick="run('reset')">Save &amp; reset onboarding</button>
     <button id="b-down" onclick="run('down')">Stop</button>
-    <button onclick="refresh()">Refresh</button>
-  </div>
+  </header>
 
-  <h3>Activity</h3>
-  <pre id="feed"></pre>
+  <main>
+    <ul id="items"></ul>
+    <div class="pane">
+      <div class="editbar">
+        <b id="editTitle">Select an item</b>
+        <button id="b-save" onclick="saveItem()" disabled>Save</button>
+        <button id="b-reset-item" onclick="resetItem()" disabled>Reset to source</button>
+      </div>
+      <textarea id="editor" disabled placeholder="Select a prompt or the intro DM on the left…"></textarea>
+      <div class="runbar">
+        <button class="primary" id="b-savereset" onclick="saveAndReset()">Save &amp; reset onboarding</button>
+        <small>writes your edits, then replays first-run (clear → render → intro)</small>
+      </div>
+      <pre id="feed"></pre>
+    </div>
+  </main>
 
   <script>
     const $ = (id) => document.getElementById(id);
-    let busy = false;
+    let current = null, dirty = false, busy = false;
 
-    async function refresh() {
+    async function refreshStatus() {
       try {
         const s = await (await fetch('/api/status')).json();
-        if (s.up) {
-          $('status').innerHTML =
-            `<span class="dot up"></span><b>Running</b> — gateway ${s.gateway}` +
-            (s.model ? `, model <code>${s.model}</code>` : '') +
-            ` &nbsp;·&nbsp; <a class="owner" href="${s.owner.url}" target="_blank">Open chat as ${s.owner.ship}</a>` +
-            ` <small>(code ${s.owner.code})</small>`;
-        } else {
-          $('status').innerHTML = `<span class="dot down"></span><b>Down</b> — click Start`;
-        }
-      } catch (e) {
-        $('status').textContent = 'status error: ' + e;
+        $('status').innerHTML = s.up
+          ? `<span class="dot up"></span>Running · gateway ${s.gateway}${s.model?` · <code>${s.model}</code>`:''}` +
+            ` · <a href="${s.owner.url}" target="_blank">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
+          : `<span class="dot down"></span>Down — click Start`;
+      } catch (e) { $('status').textContent = 'status error'; }
+    }
+
+    async function loadItems() {
+      const { items } = await (await fetch('/api/prompts')).json();
+      const ul = $('items');
+      ul.innerHTML = '';
+      for (const it of items) {
+        const li = document.createElement('li');
+        if (it.name === current) li.className = 'sel';
+        li.innerHTML = (it.modified ? '<span class="dot mod" title="modified"></span>' : '<span class="dot" style="background:transparent"></span>') +
+          (it.label || it.name);
+        li.onclick = () => selectItem(it.name);
+        ul.appendChild(li);
       }
     }
 
-    function run(cmd) {
-      if (busy) return;
-      busy = true;
-      ['b-start', 'b-reset', 'b-down'].forEach((id) => ($(id).disabled = true));
-      const feed = $('feed');
-      feed.textContent += `\n=== ${cmd} ===\n`;
-      const es = new EventSource('/api/stream?cmd=' + encodeURIComponent(cmd));
-      es.addEventListener('line', (e) => {
-        feed.textContent += e.data + '\n';
-        feed.scrollTop = feed.scrollHeight;
-      });
-      es.addEventListener('done', (e) => {
-        feed.textContent += `(exit ${e.data})\n`;
-        es.close();
-        busy = false;
-        ['b-start', 'b-reset', 'b-down'].forEach((id) => ($(id).disabled = false));
-        refresh();
-      });
-      es.onerror = () => {
-        es.close();
-        busy = false;
-        ['b-start', 'b-reset', 'b-down'].forEach((id) => ($(id).disabled = false));
-      };
+    async function selectItem(name) {
+      if (dirty && !confirm('Discard unsaved changes?')) return;
+      const it = await (await fetch('/api/prompts/' + encodeURIComponent(name))).json();
+      current = name; dirty = false;
+      $('editTitle').textContent = name === 'intro' ? 'Intro DM' : name;
+      const ed = $('editor');
+      ed.value = it.content; ed.disabled = false;
+      $('b-save').disabled = true; $('b-reset-item').disabled = !it.modified;
+      loadItems();
     }
 
-    refresh();
+    $('editor').addEventListener('input', () => { dirty = true; $('b-save').disabled = false; });
+
+    async function saveItem() {
+      if (!current) return;
+      await fetch('/api/prompts/' + encodeURIComponent(current), { method: 'PUT', body: $('editor').value });
+      dirty = false; $('b-save').disabled = true;
+      await loadItems(); await selectItemQuiet();
+    }
+    async function selectItemQuiet() { if (current) { const it = await (await fetch('/api/prompts/'+encodeURIComponent(current))).json(); $('b-reset-item').disabled = !it.modified; } }
+
+    async function resetItem() {
+      if (!current) return;
+      await fetch('/api/prompts/' + encodeURIComponent(current) + '/reset', { method: 'POST' });
+      dirty = false; await selectItem(current);
+    }
+
+    function setBusy(b) { busy = b; ['b-start','b-down','b-savereset'].forEach(id => $(id).disabled = b); }
+
+    function stream(cmd) {
+      return new Promise((resolve) => {
+        const feed = $('feed');
+        feed.textContent += `\n=== ${cmd} ===\n`;
+        const es = new EventSource('/api/stream?cmd=' + encodeURIComponent(cmd));
+        es.addEventListener('line', (e) => { feed.textContent += e.data + '\n'; feed.scrollTop = feed.scrollHeight; });
+        es.addEventListener('done', (e) => { feed.textContent += `(exit ${e.data})\n`; es.close(); resolve(); });
+        es.onerror = () => { es.close(); resolve(); };
+      });
+    }
+
+    async function run(cmd) {
+      if (busy) return; setBusy(true);
+      await stream(cmd);
+      setBusy(false); refreshStatus();
+    }
+
+    async function saveAndReset() {
+      if (busy) return; setBusy(true);
+      if (dirty && current) await saveItem();
+      await stream('reset');
+      setBusy(false); refreshStatus();
+    }
+
+    refreshStatus(); loadItems();
   </script>
 </body>
 </html>

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -32,6 +32,7 @@
   <header>
     <h1>Onboarding Sandbox</h1>
     <span id="status">loading…</span>
+    <label>Model <select id="model" onchange="setModel(this.value)" title="switch the bot's model (reloads the gateway)"></select></label>
     <button id="b-start" onclick="run('start')">Start</button>
     <button id="b-down" onclick="run('down')">Stop</button>
   </header>
@@ -67,6 +68,7 @@
           ? `<span class="dot up"></span>Running · gateway ${s.gateway}${s.model?` · <code>${s.model}</code>`:''}` +
             ` · <a href="${s.owner.url}" target="_blank">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
           : `<span class="dot down"></span>Down — click Start`;
+        if (s.model) { const sel = $('model'); if ([...sel.options].some((o) => o.value === s.model)) sel.value = s.model; }
       } catch (e) { $('status').textContent = 'status error'; }
     }
 
@@ -137,13 +139,13 @@
       }
     }
 
-    function setBusy(b) { busy = b; ['b-start','b-down','b-savereset'].forEach(id => $(id).disabled = b); }
+    function setBusy(b) { busy = b; ['b-start','b-down','b-savereset','model'].forEach(id => $(id).disabled = b); }
 
-    function stream(cmd) {
+    function stream(label, qs) {
       return new Promise((resolve) => {
         const feed = $('feed');
-        feed.textContent += `\n=== ${cmd} ===\n`;
-        const es = new EventSource('/api/stream?cmd=' + encodeURIComponent(cmd));
+        feed.textContent += `\n=== ${label} ===\n`;
+        const es = new EventSource('/api/stream?' + qs);
         es.addEventListener('line', (e) => { feed.textContent += e.data + '\n'; feed.scrollTop = feed.scrollHeight; });
         es.addEventListener('done', (e) => { feed.textContent += `(exit ${e.data})\n`; es.close(); resolve(); });
         es.onerror = () => { es.close(); resolve(); };
@@ -152,18 +154,30 @@
 
     async function run(cmd) {
       if (busy) return; setBusy(true);
-      await stream(cmd);
+      await stream(cmd, 'cmd=' + cmd);
+      setBusy(false); refreshStatus();
+    }
+
+    async function loadModels() {
+      try {
+        const { models } = await (await fetch('/api/models')).json();
+        $('model').innerHTML = models.map((m) => `<option value="${m}">${m}</option>`).join('');
+      } catch {}
+    }
+    async function setModel(m) {
+      if (busy || !m) return; setBusy(true);
+      await stream('set-model ' + m, 'cmd=set-model&model=' + encodeURIComponent(m));
       setBusy(false); refreshStatus();
     }
 
     async function saveAndReset() {
       if (busy) return; setBusy(true);
       if (dirty && current) await saveItem();
-      await stream('reset');
+      await stream('reset', 'cmd=reset');
       setBusy(false); refreshStatus();
     }
 
-    refreshStatus(); loadItems();
+    loadModels().then(refreshStatus); loadItems();
   </script>
 </body>
 </html>

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -41,12 +41,15 @@
     <div class="pane">
       <div class="editbar">
         <b id="editTitle">Select an item</b>
+        <button id="b-diff" onclick="toggleDiff()" disabled>Diff</button>
         <button id="b-save" onclick="saveItem()" disabled>Save</button>
         <button id="b-reset-item" onclick="resetItem()" disabled>Reset to source</button>
       </div>
       <textarea id="editor" disabled placeholder="Select a prompt or the intro DM on the left…"></textarea>
+      <pre id="diff" style="display:none; flex:1; margin:0; overflow:auto; padding:1rem; background:#0d1117; color:#c9d1d9; font:13px/1.5 ui-monospace,Menlo,monospace; white-space:pre-wrap;"></pre>
       <div class="runbar">
         <button class="primary" id="b-savereset" onclick="saveAndReset()">Save &amp; reset onboarding</button>
+        <button onclick="location.href='/api/export'">Export patch</button>
         <small>writes your edits, then replays first-run (clear → render → intro)</small>
       </div>
       <pre id="feed"></pre>
@@ -55,7 +58,7 @@
 
   <script>
     const $ = (id) => document.getElementById(id);
-    let current = null, dirty = false, busy = false;
+    let current = null, dirty = false, busy = false, diffOpen = false;
 
     async function refreshStatus() {
       try {
@@ -84,11 +87,14 @@
     async function selectItem(name) {
       if (dirty && !confirm('Discard unsaved changes?')) return;
       const it = await (await fetch('/api/prompts/' + encodeURIComponent(name))).json();
-      current = name; dirty = false;
+      current = name; dirty = false; diffOpen = false;
       $('editTitle').textContent = name === 'intro' ? 'Intro DM' : name;
       const ed = $('editor');
-      ed.value = it.content; ed.disabled = false;
-      $('b-save').disabled = true; $('b-reset-item').disabled = !it.modified;
+      ed.value = it.content; ed.disabled = false; ed.style.display = '';
+      $('diff').style.display = 'none';
+      $('b-save').disabled = true;
+      $('b-reset-item').disabled = !it.modified;
+      $('b-diff').disabled = false; $('b-diff').textContent = 'Diff';
       loadItems();
     }
 
@@ -106,6 +112,29 @@
       if (!current) return;
       await fetch('/api/prompts/' + encodeURIComponent(current) + '/reset', { method: 'POST' });
       dirty = false; await selectItem(current);
+    }
+
+    function renderDiff(text) {
+      return text.split('\n').map((l) => {
+        const e = l.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+        if (l.startsWith('+') && !l.startsWith('+++')) return `<span style="color:#7ee787">${e}</span>`;
+        if (l.startsWith('-') && !l.startsWith('---')) return `<span style="color:#ff7b72">${e}</span>`;
+        if (l.startsWith('@@')) return `<span style="color:#79c0ff">${e}</span>`;
+        return e;
+      }).join('\n');
+    }
+    async function toggleDiff() {
+      if (!current) return;
+      diffOpen = !diffOpen;
+      if (diffOpen) {
+        const t = await (await fetch('/api/prompts/' + encodeURIComponent(current) + '/diff')).text();
+        $('diff').innerHTML = t.trim() ? renderDiff(t) : '(no changes vs source)';
+        $('editor').style.display = 'none'; $('diff').style.display = 'block';
+        $('b-diff').textContent = 'Edit';
+      } else {
+        $('editor').style.display = ''; $('diff').style.display = 'none';
+        $('b-diff').textContent = 'Diff';
+      }
     }
 
     function setBusy(b) { busy = b; ['b-start','b-down','b-savereset'].forEach(id => $(id).disabled = b); }

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -32,7 +32,8 @@
   <header>
     <h1>Onboarding Sandbox</h1>
     <span id="status">loading…</span>
-    <label>Model <select id="model" onchange="setModel(this.value)" title="switch the bot's model (reloads the gateway)"></select></label>
+    <label>Model <input id="model" list="modellist" size="34" placeholder="type to search any OpenRouter model…" title="any OpenRouter model — type to search" /><datalist id="modellist"></datalist></label>
+    <button id="b-setmodel" onclick="setModel(document.getElementById('model').value)">Set</button>
     <button id="b-start" onclick="run('start')">Start</button>
     <button id="b-down" onclick="run('down')">Stop</button>
   </header>
@@ -70,7 +71,7 @@
           ? `<span class="dot up"></span>Running · gateway ${s.gateway}${s.model?` · <code>${s.model}</code>`:''}` +
             ` · <a href="${s.owner.url}" target="_blank">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
           : `<span class="dot down"></span>Down — click Start`;
-        if (s.model) { const sel = $('model'); if ([...sel.options].some((o) => o.value === s.model)) sel.value = s.model; }
+        if (s.model && document.activeElement !== $('model')) $('model').value = s.model;
       } catch (e) { $('status').textContent = 'status error'; }
     }
 
@@ -125,6 +126,7 @@
     }
 
     $('editor').addEventListener('input', () => { dirty = true; $('b-save').disabled = false; });
+    $('model').addEventListener('keydown', (e) => { if (e.key === 'Enter') setModel($('model').value); });
 
     async function saveItem() {
       if (!current) return;
@@ -163,7 +165,7 @@
       }
     }
 
-    function setBusy(b) { busy = b; ['b-start','b-down','b-savereset','model'].forEach(id => $(id).disabled = b); }
+    function setBusy(b) { busy = b; ['b-start','b-down','b-savereset','model','b-setmodel'].forEach(id => $(id).disabled = b); }
 
     function stream(label, qs) {
       return new Promise((resolve) => {
@@ -185,7 +187,7 @@
     async function loadModels() {
       try {
         const { models } = await (await fetch('/api/models')).json();
-        $('model').innerHTML = models.map((m) => `<option value="${m}">${m}</option>`).join('');
+        $('modellist').innerHTML = models.map((m) => `<option value="${m}"></option>`).join('');
       } catch {}
     }
     async function setModel(m) {

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -239,6 +239,7 @@
             Save &amp; reset onboarding
           </button>
           <button
+            id="b-export"
             onclick="exportPatch()"
             title="Download your edits as a .patch file to share with a developer"
           >
@@ -317,11 +318,13 @@
           return;
         }
         const box = $('setup');
-        if (p.docker && p.key) {
+        if (p.docker && p.key && p.tlonbot) {
           box.style.display = 'none';
           return;
         }
         let html = '';
+        if (!p.tlonbot)
+          html += `⚠️ <b>tlonbot checkout not found.</b> Check out the private tlonbot repo next to tlon-apps (or set TLONBOT_DIR), then <a href="#" onclick="checkPreflight();return false">re-check</a>.<br>`;
         if (!p.docker)
           html += `⚠️ <b>Docker isn't running.</b> Start Docker Desktop, then <a href="#" onclick="checkPreflight();return false">re-check</a>.<br>`;
         if (!p.key)
@@ -404,15 +407,22 @@
       });
 
       async function saveItem() {
-        if (!current) return;
-        await fetch('/api/prompts/' + encodeURIComponent(current), {
+        if (!current) return false;
+        const res = await fetch('/api/prompts/' + encodeURIComponent(current), {
           method: 'PUT',
           body: $('editor').value,
         });
+        if (!res.ok) {
+          alert(
+            'Save failed (' + res.status + '). Your edit is kept — try again.'
+          );
+          return false;
+        }
         dirty = false;
         $('b-save').disabled = true;
         await loadItems();
         await selectItemQuiet();
+        return true;
       }
       async function selectItemQuiet() {
         if (current) {
@@ -424,10 +434,15 @@
       }
 
       async function resetItem() {
-        if (!current) return;
-        await fetch('/api/prompts/' + encodeURIComponent(current) + '/reset', {
-          method: 'POST',
-        });
+        if (!current || busy) return;
+        const res = await fetch(
+          '/api/prompts/' + encodeURIComponent(current) + '/reset',
+          { method: 'POST' }
+        );
+        if (!res.ok) {
+          alert('Discard failed (' + res.status + ').');
+          return;
+        }
         dirty = false;
         await selectItem(current);
       }
@@ -440,7 +455,11 @@
           )
         )
           return;
-        await fetch('/api/reset-prompts', { method: 'POST' });
+        const res = await fetch('/api/reset-prompts', { method: 'POST' });
+        if (!res.ok) {
+          alert('Discard all failed (' + res.status + ').');
+          return;
+        }
         dirty = false;
         await loadItems();
         if (current) await selectItem(current);
@@ -483,9 +502,17 @@
 
       function setBusy(b) {
         busy = b;
-        ['b-start', 'b-down', 'b-savereset', 'model', 'b-setmodel'].forEach(
-          (id) => ($(id).disabled = b)
-        );
+        [
+          'b-start',
+          'b-down',
+          'b-savereset',
+          'model',
+          'b-setmodel',
+          'b-save',
+          'b-reset-item',
+          'b-export',
+          'editor',
+        ].forEach((id) => ($(id).disabled = b));
       }
 
       function stream(label, qs) {
@@ -547,7 +574,10 @@
       async function saveAndReset() {
         if (busy) return;
         setBusy(true);
-        if (dirty && current) await saveItem();
+        if (dirty && current && !(await saveItem())) {
+          setBusy(false);
+          return;
+        }
         await stream('reset', 'cmd=reset');
         setBusy(false);
         refreshStatus();
@@ -556,7 +586,8 @@
       // Flush the unsaved textarea first so the exported patch includes the
       // edits the tester can see (the server builds it from on-disk files).
       async function exportPatch() {
-        if (dirty && current) await saveItem();
+        if (busy) return;
+        if (dirty && current && !(await saveItem())) return;
         location.href = '/api/export?token=' + encodeURIComponent(TOKEN);
       }
 

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Onboarding Sandbox</title>
+  <style>
+    body { font: 14px/1.5 -apple-system, system-ui, sans-serif; max-width: 820px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+    h1 { font-size: 1.3rem; }
+    #status { padding: .75rem 1rem; border: 1px solid #ddd; border-radius: 8px; background: #fafafa; }
+    .dot { display: inline-block; width: .6rem; height: .6rem; border-radius: 50%; margin-right: .4rem; vertical-align: middle; }
+    .up { background: #2e9e44; } .down { background: #bbb; }
+    .actions { margin: 1rem 0; display: flex; gap: .5rem; flex-wrap: wrap; }
+    button { font: inherit; padding: .4rem .9rem; border: 1px solid #ccc; border-radius: 6px; background: #fff; cursor: pointer; }
+    button.primary { background: #1a1a1a; color: #fff; border-color: #1a1a1a; }
+    button:disabled { opacity: .5; cursor: default; }
+    a.owner { font-weight: 600; }
+    pre#feed { background: #111; color: #d8d8d8; padding: 1rem; border-radius: 8px; height: 320px; overflow: auto; white-space: pre-wrap; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <h1>Onboarding Sandbox</h1>
+  <div id="status">loading…</div>
+
+  <div class="actions">
+    <button id="b-start" onclick="run('start')">Start</button>
+    <button id="b-reset" class="primary" onclick="run('reset')">Save &amp; reset onboarding</button>
+    <button id="b-down" onclick="run('down')">Stop</button>
+    <button onclick="refresh()">Refresh</button>
+  </div>
+
+  <h3>Activity</h3>
+  <pre id="feed"></pre>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+    let busy = false;
+
+    async function refresh() {
+      try {
+        const s = await (await fetch('/api/status')).json();
+        if (s.up) {
+          $('status').innerHTML =
+            `<span class="dot up"></span><b>Running</b> — gateway ${s.gateway}` +
+            (s.model ? `, model <code>${s.model}</code>` : '') +
+            ` &nbsp;·&nbsp; <a class="owner" href="${s.owner.url}" target="_blank">Open chat as ${s.owner.ship}</a>` +
+            ` <small>(code ${s.owner.code})</small>`;
+        } else {
+          $('status').innerHTML = `<span class="dot down"></span><b>Down</b> — click Start`;
+        }
+      } catch (e) {
+        $('status').textContent = 'status error: ' + e;
+      }
+    }
+
+    function run(cmd) {
+      if (busy) return;
+      busy = true;
+      ['b-start', 'b-reset', 'b-down'].forEach((id) => ($(id).disabled = true));
+      const feed = $('feed');
+      feed.textContent += `\n=== ${cmd} ===\n`;
+      const es = new EventSource('/api/stream?cmd=' + encodeURIComponent(cmd));
+      es.addEventListener('line', (e) => {
+        feed.textContent += e.data + '\n';
+        feed.scrollTop = feed.scrollHeight;
+      });
+      es.addEventListener('done', (e) => {
+        feed.textContent += `(exit ${e.data})\n`;
+        es.close();
+        busy = false;
+        ['b-start', 'b-reset', 'b-down'].forEach((id) => ($(id).disabled = false));
+        refresh();
+      });
+      es.onerror = () => {
+        es.close();
+        busy = false;
+        ['b-start', 'b-reset', 'b-down'].forEach((id) => ($(id).disabled = false));
+      };
+    }
+
+    refresh();
+  </script>
+</body>
+</html>

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -1,234 +1,544 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Onboarding Sandbox</title>
-  <style>
-    :root { --bd:#ddd; --bg:#fafafa; --ink:#1a1a1a; }
-    body { font: 14px/1.5 -apple-system, system-ui, sans-serif; margin: 0; color: var(--ink); }
-    header { padding: .8rem 1.2rem; border-bottom: 1px solid var(--bd); display:flex; align-items:center; gap:1rem; flex-wrap:wrap; }
-    header h1 { font-size: 1.05rem; margin: 0; }
-    #status { flex: 1; min-width: 240px; }
-    .dot { display:inline-block; width:.6rem; height:.6rem; border-radius:50%; margin-right:.35rem; vertical-align:middle; }
-    .up{background:#2e9e44}.down{background:#bbb}.mod{background:#e0991b}
-    button { font:inherit; padding:.35rem .8rem; border:1px solid #ccc; border-radius:6px; background:#fff; cursor:pointer; }
-    button.primary{background:#1a1a1a;color:#fff;border-color:#1a1a1a}
-    button:disabled{opacity:.5;cursor:default}
-    main { display:grid; grid-template-columns: 220px 1fr; gap:0; height: calc(100vh - 58px); }
-    #items { border-right:1px solid var(--bd); overflow:auto; padding:.5rem; margin:0; list-style:none; }
-    #items li { padding:.4rem .6rem; border-radius:6px; cursor:pointer; }
-    #items li:hover{background:var(--bg)} #items li.sel{background:#eef}
-    .pane { display:flex; flex-direction:column; min-width:0; }
-    .editbar { padding:.5rem 1rem; border-bottom:1px solid var(--bd); display:flex; align-items:center; gap:.6rem; }
-    .editbar b{flex:1}
-    textarea { flex:1; width:100%; box-sizing:border-box; border:0; padding:1rem; font:13px/1.5 ui-monospace,Menlo,monospace; resize:none; outline:none; }
-    .runbar { padding:.6rem 1rem; border-top:1px solid var(--bd); display:flex; gap:.6rem; align-items:center; }
-    .runbar small{color:#888}
-    .feedhead { display:flex; align-items:center; padding:.35rem 1rem; font-size:12px; color:#888; background:#f3f3f3; border-top:1px solid var(--bd); }
-    .feedhead button { font-size:11px; padding:.1rem .5rem; }
-    pre#feed { margin:0; background:#111; color:#d8d8d8; padding:.8rem 1rem; height:140px; overflow:auto; white-space:pre-wrap; font-size:12px; }
-  </style>
-</head>
-<body>
-  <header>
-    <h1>Onboarding Sandbox</h1>
-    <span id="status">loading…</span>
-    <label>Model <input id="model" list="modellist" size="34" placeholder="type to search any OpenRouter model…" title="any OpenRouter model — type to search" /><datalist id="modellist"></datalist></label>
-    <button id="b-setmodel" onclick="setModel(document.getElementById('model').value)">Set</button>
-    <button id="b-start" onclick="run('start')">Start</button>
-    <button id="b-down" onclick="run('down')">Stop</button>
-  </header>
-
-  <div id="setup" style="display:none; padding:.7rem 1.2rem; background:#fff7e6; border-bottom:1px solid #e0c989; font-size:13px;"></div>
-
-  <main>
-    <ul id="items"></ul>
-    <div class="pane">
-      <div class="editbar">
-        <b id="editTitle">Select an item</b>
-        <button id="b-diff" onclick="toggleDiff()" disabled>Diff</button>
-        <button id="b-save" onclick="saveItem()" disabled>Save</button>
-        <button id="b-reset-item" onclick="resetItem()" disabled title="restore this item to the shipped original">Discard changes</button>
-      </div>
-      <textarea id="editor" disabled placeholder="Select a prompt or the intro DM on the left…"></textarea>
-      <pre id="diff" style="display:none; flex:1; margin:0; overflow:auto; padding:1rem; background:#0d1117; color:#c9d1d9; font:13px/1.5 ui-monospace,Menlo,monospace; white-space:pre-wrap;"></pre>
-      <div class="runbar">
-        <button class="primary" id="b-savereset" onclick="saveAndReset()" title="Save your edits, then replay the bot's first-run (clear → render → intro)">Save &amp; reset onboarding</button>
-        <button onclick="location.href='/api/export'" title="Download your edits as a .patch file to share with a developer">Export patch</button>
-        <button onclick="resetAll()" title="Discard your edits to every prompt and the intro, restoring the shipped originals">Discard all changes</button>
-      </div>
-      <div id="activity" style="display:none">
-        <div class="feedhead"><span>Activity log</span><button onclick="clearFeed()" style="margin-left:auto">clear</button></div>
-        <pre id="feed"></pre>
-      </div>
-    </div>
-  </main>
-
-  <script>
-    const $ = (id) => document.getElementById(id);
-    let current = null, dirty = false, busy = false, diffOpen = false;
-
-    async function refreshStatus() {
-      try {
-        const s = await (await fetch('/api/status')).json();
-        $('status').innerHTML = s.up
-          ? `<span class="dot up"></span>Running · gateway ${s.gateway}${s.model?` · <code>${s.model}</code>`:''}` +
-            ` · <a href="${s.owner.url}" target="_blank" title="Opens on a fresh port after each reset — click again post-reset to get a clean conversation">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
-          : `<span class="dot down"></span>Down — click Start`;
-        if (s.model && document.activeElement !== $('model')) $('model').value = s.model;
-        // reset + model-switch need a running stack; disable them when down
-        const live = !!s.up;
-        $('b-savereset').disabled = !live;
-        $('b-setmodel').disabled = !live;
-        $('b-savereset').title = live
-          ? "Save your edits, then replay the bot's first-run (clear → render → intro)"
-          : 'Start the sandbox first, then you can reset onboarding';
-        $('b-setmodel').title = live ? 'switch the bot model (reloads the gateway)' : 'Start the sandbox first to switch models';
-      } catch (e) { $('status').textContent = 'status error'; }
-    }
-
-    async function checkPreflight() {
-      let p; try { p = await (await fetch('/api/preflight')).json(); } catch { return; }
-      const box = $('setup');
-      if (p.docker && p.key) { box.style.display = 'none'; return; }
-      let html = '';
-      if (!p.docker) html += `⚠️ <b>Docker isn't running.</b> Start Docker Desktop, then <a href="#" onclick="checkPreflight();return false">re-check</a>.<br>`;
-      if (!p.key) html += `🔑 <b>No provider key set.</b> OpenRouter API key: ` +
-        `<input id="keyin" type="password" size="36" placeholder="sk-or-..."> ` +
-        `<button onclick="saveKey()">Validate &amp; save</button> <span id="keymsg"></span>`;
-      box.innerHTML = html; box.style.display = 'block';
-    }
-    async function saveKey() {
-      const key = $('keyin').value.trim(); const msg = $('keymsg');
-      if (!key) { msg.textContent = 'enter a key'; return; }
-      msg.textContent = 'validating…';
-      try {
-        const r = await fetch('/api/provider-key', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ key }) });
-        const j = await r.json();
-        if (j.ok) { msg.textContent = 'saved ✓'; checkPreflight(); } else msg.textContent = j.error || 'failed';
-      } catch (e) { msg.textContent = 'error: ' + e; }
-    }
-
-    async function loadItems() {
-      const { items } = await (await fetch('/api/prompts')).json();
-      const ul = $('items');
-      ul.innerHTML = '';
-      for (const it of items) {
-        const li = document.createElement('li');
-        if (it.name === current) li.className = 'sel';
-        li.innerHTML = (it.modified ? '<span class="dot mod" title="modified"></span>' : '<span class="dot" style="background:transparent"></span>') +
-          (it.label || it.name);
-        li.onclick = () => selectItem(it.name);
-        ul.appendChild(li);
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Onboarding Sandbox</title>
+    <style>
+      :root {
+        --bd: #ddd;
+        --bg: #fafafa;
+        --ink: #1a1a1a;
       }
-    }
+      body {
+        font:
+          14px/1.5 -apple-system,
+          system-ui,
+          sans-serif;
+        margin: 0;
+        color: var(--ink);
+      }
+      header {
+        padding: 0.8rem 1.2rem;
+        border-bottom: 1px solid var(--bd);
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+      header h1 {
+        font-size: 1.05rem;
+        margin: 0;
+      }
+      #status {
+        flex: 1;
+        min-width: 240px;
+      }
+      .dot {
+        display: inline-block;
+        width: 0.6rem;
+        height: 0.6rem;
+        border-radius: 50%;
+        margin-right: 0.35rem;
+        vertical-align: middle;
+      }
+      .up {
+        background: #2e9e44;
+      }
+      .down {
+        background: #bbb;
+      }
+      .mod {
+        background: #e0991b;
+      }
+      button {
+        font: inherit;
+        padding: 0.35rem 0.8rem;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+      }
+      button.primary {
+        background: #1a1a1a;
+        color: #fff;
+        border-color: #1a1a1a;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+      main {
+        display: grid;
+        grid-template-columns: 220px 1fr;
+        gap: 0;
+        height: calc(100vh - 58px);
+      }
+      #items {
+        border-right: 1px solid var(--bd);
+        overflow: auto;
+        padding: 0.5rem;
+        margin: 0;
+        list-style: none;
+      }
+      #items li {
+        padding: 0.4rem 0.6rem;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      #items li:hover {
+        background: var(--bg);
+      }
+      #items li.sel {
+        background: #eef;
+      }
+      .pane {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+      }
+      .editbar {
+        padding: 0.5rem 1rem;
+        border-bottom: 1px solid var(--bd);
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+      }
+      .editbar b {
+        flex: 1;
+      }
+      textarea {
+        flex: 1;
+        width: 100%;
+        box-sizing: border-box;
+        border: 0;
+        padding: 1rem;
+        font:
+          13px/1.5 ui-monospace,
+          Menlo,
+          monospace;
+        resize: none;
+        outline: none;
+      }
+      .runbar {
+        padding: 0.6rem 1rem;
+        border-top: 1px solid var(--bd);
+        display: flex;
+        gap: 0.6rem;
+        align-items: center;
+      }
+      .runbar small {
+        color: #888;
+      }
+      .feedhead {
+        display: flex;
+        align-items: center;
+        padding: 0.35rem 1rem;
+        font-size: 12px;
+        color: #888;
+        background: #f3f3f3;
+        border-top: 1px solid var(--bd);
+      }
+      .feedhead button {
+        font-size: 11px;
+        padding: 0.1rem 0.5rem;
+      }
+      pre#feed {
+        margin: 0;
+        background: #111;
+        color: #d8d8d8;
+        padding: 0.8rem 1rem;
+        height: 140px;
+        overflow: auto;
+        white-space: pre-wrap;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Onboarding Sandbox</h1>
+      <span id="status">loading…</span>
+      <label
+        >Model
+        <input
+          id="model"
+          list="modellist"
+          size="34"
+          placeholder="type to search any OpenRouter model…"
+          title="any OpenRouter model — type to search" /><datalist
+          id="modellist"
+        ></datalist
+      ></label>
+      <button
+        id="b-setmodel"
+        onclick="setModel(document.getElementById('model').value)"
+      >
+        Set
+      </button>
+      <button id="b-start" onclick="run('start')">Start</button>
+      <button id="b-down" onclick="run('down')">Stop</button>
+    </header>
 
-    async function selectItem(name) {
-      if (dirty && !confirm('Discard unsaved changes?')) return;
-      const it = await (await fetch('/api/prompts/' + encodeURIComponent(name))).json();
-      current = name; dirty = false; diffOpen = false;
-      $('editTitle').textContent = name === 'intro' ? 'Intro DM' : name;
-      const ed = $('editor');
-      ed.value = it.content; ed.disabled = false; ed.style.display = '';
-      $('diff').style.display = 'none';
-      $('b-save').disabled = true;
-      $('b-reset-item').disabled = !it.modified;
-      $('b-diff').disabled = false; $('b-diff').textContent = 'Diff';
-      loadItems();
-    }
+    <div
+      id="setup"
+      style="
+        display: none;
+        padding: 0.7rem 1.2rem;
+        background: #fff7e6;
+        border-bottom: 1px solid #e0c989;
+        font-size: 13px;
+      "
+    ></div>
 
-    $('editor').addEventListener('input', () => { dirty = true; $('b-save').disabled = false; });
-    $('model').addEventListener('keydown', (e) => { if (e.key === 'Enter' && !$('b-setmodel').disabled) setModel($('model').value); });
+    <main>
+      <ul id="items"></ul>
+      <div class="pane">
+        <div class="editbar">
+          <b id="editTitle">Select an item</b>
+          <button id="b-diff" onclick="toggleDiff()" disabled>Diff</button>
+          <button id="b-save" onclick="saveItem()" disabled>Save</button>
+          <button
+            id="b-reset-item"
+            onclick="resetItem()"
+            disabled
+            title="restore this item to the shipped original"
+          >
+            Discard changes
+          </button>
+        </div>
+        <textarea
+          id="editor"
+          disabled
+          placeholder="Select a prompt or the intro DM on the left…"
+        ></textarea>
+        <pre
+          id="diff"
+          style="
+            display: none;
+            flex: 1;
+            margin: 0;
+            overflow: auto;
+            padding: 1rem;
+            background: #0d1117;
+            color: #c9d1d9;
+            font:
+              13px/1.5 ui-monospace,
+              Menlo,
+              monospace;
+            white-space: pre-wrap;
+          "
+        ></pre>
+        <div class="runbar">
+          <button
+            class="primary"
+            id="b-savereset"
+            onclick="saveAndReset()"
+            title="Save your edits, then replay the bot's first-run (clear → render → intro)"
+          >
+            Save &amp; reset onboarding
+          </button>
+          <button
+            onclick="location.href='/api/export'"
+            title="Download your edits as a .patch file to share with a developer"
+          >
+            Export patch
+          </button>
+          <button
+            onclick="resetAll()"
+            title="Discard your edits to every prompt and the intro, restoring the shipped originals"
+          >
+            Discard all changes
+          </button>
+        </div>
+        <div id="activity" style="display: none">
+          <div class="feedhead">
+            <span>Activity log</span
+            ><button onclick="clearFeed()" style="margin-left: auto">
+              clear
+            </button>
+          </div>
+          <pre id="feed"></pre>
+        </div>
+      </div>
+    </main>
 
-    async function saveItem() {
-      if (!current) return;
-      await fetch('/api/prompts/' + encodeURIComponent(current), { method: 'PUT', body: $('editor').value });
-      dirty = false; $('b-save').disabled = true;
-      await loadItems(); await selectItemQuiet();
-    }
-    async function selectItemQuiet() { if (current) { const it = await (await fetch('/api/prompts/'+encodeURIComponent(current))).json(); $('b-reset-item').disabled = !it.modified; } }
+    <script>
+      const $ = (id) => document.getElementById(id);
+      let current = null,
+        dirty = false,
+        busy = false,
+        diffOpen = false;
 
-    async function resetItem() {
-      if (!current) return;
-      await fetch('/api/prompts/' + encodeURIComponent(current) + '/reset', { method: 'POST' });
-      dirty = false; await selectItem(current);
-    }
+      async function refreshStatus() {
+        try {
+          const s = await (await fetch('/api/status')).json();
+          $('status').innerHTML = s.up
+            ? `<span class="dot up"></span>Running · gateway ${s.gateway}${s.model ? ` · <code>${s.model}</code>` : ''}` +
+              ` · <a href="${s.owner.url}" target="_blank" title="Opens on a fresh port after each reset — click again post-reset to get a clean conversation">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
+            : `<span class="dot down"></span>Down — click Start`;
+          if (s.model && document.activeElement !== $('model'))
+            $('model').value = s.model;
+          // reset + model-switch need a running stack; disable them when down
+          const live = !!s.up;
+          $('b-savereset').disabled = !live;
+          $('b-setmodel').disabled = !live;
+          $('b-savereset').title = live
+            ? "Save your edits, then replay the bot's first-run (clear → render → intro)"
+            : 'Start the sandbox first, then you can reset onboarding';
+          $('b-setmodel').title = live
+            ? 'switch the bot model (reloads the gateway)'
+            : 'Start the sandbox first to switch models';
+        } catch (e) {
+          $('status').textContent = 'status error';
+        }
+      }
 
-    async function resetAll() {
-      if (busy) return;
-      if (!confirm('Discard all your edits to every prompt and the intro, restoring the shipped originals?')) return;
-      await fetch('/api/reset-prompts', { method: 'POST' });
-      dirty = false;
-      await loadItems();
-      if (current) await selectItem(current);
-    }
+      async function checkPreflight() {
+        let p;
+        try {
+          p = await (await fetch('/api/preflight')).json();
+        } catch {
+          return;
+        }
+        const box = $('setup');
+        if (p.docker && p.key) {
+          box.style.display = 'none';
+          return;
+        }
+        let html = '';
+        if (!p.docker)
+          html += `⚠️ <b>Docker isn't running.</b> Start Docker Desktop, then <a href="#" onclick="checkPreflight();return false">re-check</a>.<br>`;
+        if (!p.key)
+          html +=
+            `🔑 <b>No provider key set.</b> OpenRouter API key: ` +
+            `<input id="keyin" type="password" size="36" placeholder="sk-or-..."> ` +
+            `<button onclick="saveKey()">Validate &amp; save</button> <span id="keymsg"></span>`;
+        box.innerHTML = html;
+        box.style.display = 'block';
+      }
+      async function saveKey() {
+        const key = $('keyin').value.trim();
+        const msg = $('keymsg');
+        if (!key) {
+          msg.textContent = 'enter a key';
+          return;
+        }
+        msg.textContent = 'validating…';
+        try {
+          const r = await fetch('/api/provider-key', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ key }),
+          });
+          const j = await r.json();
+          if (j.ok) {
+            msg.textContent = 'saved ✓';
+            checkPreflight();
+          } else msg.textContent = j.error || 'failed';
+        } catch (e) {
+          msg.textContent = 'error: ' + e;
+        }
+      }
 
-    function renderDiff(text) {
-      return text.split('\n').map((l) => {
-        const e = l.replace(/&/g, '&amp;').replace(/</g, '&lt;');
-        if (l.startsWith('+') && !l.startsWith('+++')) return `<span style="color:#7ee787">${e}</span>`;
-        if (l.startsWith('-') && !l.startsWith('---')) return `<span style="color:#ff7b72">${e}</span>`;
-        if (l.startsWith('@@')) return `<span style="color:#79c0ff">${e}</span>`;
-        return e;
-      }).join('\n');
-    }
-    async function toggleDiff() {
-      if (!current) return;
-      diffOpen = !diffOpen;
-      if (diffOpen) {
-        const t = await (await fetch('/api/prompts/' + encodeURIComponent(current) + '/diff')).text();
-        $('diff').innerHTML = t.trim() ? renderDiff(t) : '(no changes vs source)';
-        $('editor').style.display = 'none'; $('diff').style.display = 'block';
-        $('b-diff').textContent = 'Edit';
-      } else {
-        $('editor').style.display = ''; $('diff').style.display = 'none';
+      async function loadItems() {
+        const { items } = await (await fetch('/api/prompts')).json();
+        const ul = $('items');
+        ul.innerHTML = '';
+        for (const it of items) {
+          const li = document.createElement('li');
+          if (it.name === current) li.className = 'sel';
+          li.innerHTML =
+            (it.modified
+              ? '<span class="dot mod" title="modified"></span>'
+              : '<span class="dot" style="background:transparent"></span>') +
+            (it.label || it.name);
+          li.onclick = () => selectItem(it.name);
+          ul.appendChild(li);
+        }
+      }
+
+      async function selectItem(name) {
+        if (dirty && !confirm('Discard unsaved changes?')) return;
+        const it = await (
+          await fetch('/api/prompts/' + encodeURIComponent(name))
+        ).json();
+        current = name;
+        dirty = false;
+        diffOpen = false;
+        $('editTitle').textContent = name === 'intro' ? 'Intro DM' : name;
+        const ed = $('editor');
+        ed.value = it.content;
+        ed.disabled = false;
+        ed.style.display = '';
+        $('diff').style.display = 'none';
+        $('b-save').disabled = true;
+        $('b-reset-item').disabled = !it.modified;
+        $('b-diff').disabled = false;
         $('b-diff').textContent = 'Diff';
+        loadItems();
       }
-    }
 
-    function setBusy(b) { busy = b; ['b-start','b-down','b-savereset','model','b-setmodel'].forEach(id => $(id).disabled = b); }
-
-    function stream(label, qs) {
-      return new Promise((resolve) => {
-        const feed = $('feed');
-        $('activity').style.display = '';
-        feed.textContent += `\n=== ${label} ===\n`;
-        const es = new EventSource('/api/stream?' + qs);
-        es.addEventListener('line', (e) => { feed.textContent += e.data + '\n'; feed.scrollTop = feed.scrollHeight; });
-        es.addEventListener('done', (e) => { feed.textContent += `(exit ${e.data})\n`; es.close(); resolve(); });
-        es.onerror = () => { es.close(); resolve(); };
+      $('editor').addEventListener('input', () => {
+        dirty = true;
+        $('b-save').disabled = false;
       });
-    }
+      $('model').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !$('b-setmodel').disabled)
+          setModel($('model').value);
+      });
 
-    function clearFeed() { $('feed').textContent = ''; $('activity').style.display = 'none'; }
+      async function saveItem() {
+        if (!current) return;
+        await fetch('/api/prompts/' + encodeURIComponent(current), {
+          method: 'PUT',
+          body: $('editor').value,
+        });
+        dirty = false;
+        $('b-save').disabled = true;
+        await loadItems();
+        await selectItemQuiet();
+      }
+      async function selectItemQuiet() {
+        if (current) {
+          const it = await (
+            await fetch('/api/prompts/' + encodeURIComponent(current))
+          ).json();
+          $('b-reset-item').disabled = !it.modified;
+        }
+      }
 
-    async function run(cmd) {
-      if (busy) return; setBusy(true);
-      await stream(cmd, 'cmd=' + cmd);
-      setBusy(false); refreshStatus();
-    }
+      async function resetItem() {
+        if (!current) return;
+        await fetch('/api/prompts/' + encodeURIComponent(current) + '/reset', {
+          method: 'POST',
+        });
+        dirty = false;
+        await selectItem(current);
+      }
 
-    async function loadModels() {
-      try {
-        const { models } = await (await fetch('/api/models')).json();
-        $('modellist').innerHTML = models.map((m) => `<option value="${m}"></option>`).join('');
-      } catch {}
-    }
-    async function setModel(m) {
-      if (busy || !m) return; setBusy(true);
-      await stream('set-model ' + m, 'cmd=set-model&model=' + encodeURIComponent(m));
-      setBusy(false); refreshStatus();
-    }
+      async function resetAll() {
+        if (busy) return;
+        if (
+          !confirm(
+            'Discard all your edits to every prompt and the intro, restoring the shipped originals?'
+          )
+        )
+          return;
+        await fetch('/api/reset-prompts', { method: 'POST' });
+        dirty = false;
+        await loadItems();
+        if (current) await selectItem(current);
+      }
 
-    async function saveAndReset() {
-      if (busy) return; setBusy(true);
-      if (dirty && current) await saveItem();
-      await stream('reset', 'cmd=reset');
-      setBusy(false); refreshStatus();
-    }
+      function renderDiff(text) {
+        return text
+          .split('\n')
+          .map((l) => {
+            const e = l.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+            if (l.startsWith('+') && !l.startsWith('+++'))
+              return `<span style="color:#7ee787">${e}</span>`;
+            if (l.startsWith('-') && !l.startsWith('---'))
+              return `<span style="color:#ff7b72">${e}</span>`;
+            if (l.startsWith('@@'))
+              return `<span style="color:#79c0ff">${e}</span>`;
+            return e;
+          })
+          .join('\n');
+      }
+      async function toggleDiff() {
+        if (!current) return;
+        diffOpen = !diffOpen;
+        if (diffOpen) {
+          const t = await (
+            await fetch('/api/prompts/' + encodeURIComponent(current) + '/diff')
+          ).text();
+          $('diff').innerHTML = t.trim()
+            ? renderDiff(t)
+            : '(no changes vs source)';
+          $('editor').style.display = 'none';
+          $('diff').style.display = 'block';
+          $('b-diff').textContent = 'Edit';
+        } else {
+          $('editor').style.display = '';
+          $('diff').style.display = 'none';
+          $('b-diff').textContent = 'Diff';
+        }
+      }
 
-    loadModels().then(refreshStatus); loadItems(); checkPreflight();
-  </script>
-</body>
+      function setBusy(b) {
+        busy = b;
+        ['b-start', 'b-down', 'b-savereset', 'model', 'b-setmodel'].forEach(
+          (id) => ($(id).disabled = b)
+        );
+      }
+
+      function stream(label, qs) {
+        return new Promise((resolve) => {
+          const feed = $('feed');
+          $('activity').style.display = '';
+          feed.textContent += `\n=== ${label} ===\n`;
+          const es = new EventSource('/api/stream?' + qs);
+          es.addEventListener('line', (e) => {
+            feed.textContent += e.data + '\n';
+            feed.scrollTop = feed.scrollHeight;
+          });
+          es.addEventListener('done', (e) => {
+            feed.textContent += `(exit ${e.data})\n`;
+            es.close();
+            resolve();
+          });
+          es.onerror = () => {
+            es.close();
+            resolve();
+          };
+        });
+      }
+
+      function clearFeed() {
+        $('feed').textContent = '';
+        $('activity').style.display = 'none';
+      }
+
+      async function run(cmd) {
+        if (busy) return;
+        setBusy(true);
+        await stream(cmd, 'cmd=' + cmd);
+        setBusy(false);
+        refreshStatus();
+      }
+
+      async function loadModels() {
+        try {
+          const { models } = await (await fetch('/api/models')).json();
+          $('modellist').innerHTML = models
+            .map((m) => `<option value="${m}"></option>`)
+            .join('');
+        } catch {}
+      }
+      async function setModel(m) {
+        if (busy || !m) return;
+        setBusy(true);
+        await stream(
+          'set-model ' + m,
+          'cmd=set-model&model=' + encodeURIComponent(m)
+        );
+        setBusy(false);
+        refreshStatus();
+      }
+
+      async function saveAndReset() {
+        if (busy) return;
+        setBusy(true);
+        if (dirty && current) await saveItem();
+        await stream('reset', 'cmd=reset');
+        setBusy(false);
+        refreshStatus();
+      }
+
+      loadModels().then(refreshStatus);
+      loadItems();
+      checkPreflight();
+    </script>
+  </body>
 </html>

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -239,7 +239,7 @@
             Save &amp; reset onboarding
           </button>
           <button
-            onclick="location.href='/api/export?token='+encodeURIComponent(window.__TOKEN__||'')"
+            onclick="exportPatch()"
             title="Download your edits as a .patch file to share with a developer"
           >
             Export patch
@@ -551,6 +551,13 @@
         await stream('reset', 'cmd=reset');
         setBusy(false);
         refreshStatus();
+      }
+
+      // Flush the unsaved textarea first so the exported patch includes the
+      // edits the tester can see (the server builds it from on-disk files).
+      async function exportPatch() {
+        if (dirty && current) await saveItem();
+        location.href = '/api/export?token=' + encodeURIComponent(TOKEN);
       }
 
       loadModels().then(refreshStatus);

--- a/apps/onboarding-sandbox/public/index.html
+++ b/apps/onboarding-sandbox/public/index.html
@@ -74,9 +74,17 @@
         const s = await (await fetch('/api/status')).json();
         $('status').innerHTML = s.up
           ? `<span class="dot up"></span>Running · gateway ${s.gateway}${s.model?` · <code>${s.model}</code>`:''}` +
-            ` · <a href="${s.owner.url}" target="_blank">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
+            ` · <a href="${s.owner.url}" target="_blank" title="Opens on a fresh port after each reset — click again post-reset to get a clean conversation">Open chat as ${s.owner.ship}</a> <small>(${s.owner.code})</small>`
           : `<span class="dot down"></span>Down — click Start`;
         if (s.model && document.activeElement !== $('model')) $('model').value = s.model;
+        // reset + model-switch need a running stack; disable them when down
+        const live = !!s.up;
+        $('b-savereset').disabled = !live;
+        $('b-setmodel').disabled = !live;
+        $('b-savereset').title = live
+          ? "Save your edits, then replay the bot's first-run (clear → render → intro)"
+          : 'Start the sandbox first, then you can reset onboarding';
+        $('b-setmodel').title = live ? 'switch the bot model (reloads the gateway)' : 'Start the sandbox first to switch models';
       } catch (e) { $('status').textContent = 'status error'; }
     }
 
@@ -131,7 +139,7 @@
     }
 
     $('editor').addEventListener('input', () => { dirty = true; $('b-save').disabled = false; });
-    $('model').addEventListener('keydown', (e) => { if (e.key === 'Enter') setModel($('model').value); });
+    $('model').addEventListener('keydown', (e) => { if (e.key === 'Enter' && !$('b-setmodel').disabled) setModel($('model').value); });
 
     async function saveItem() {
       if (!current) return;

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -1,27 +1,46 @@
-// Onboarding sandbox control server (Phase 2, step 1 — zero-dep skeleton).
+// Onboarding sandbox control server (Phase 2).
 //
-// Thin HTTP/SSE layer over the orchestrator (scripts/onboarding-sandbox/run.sh).
-// It spawns whitelisted orchestrator subcommands and streams their output to the
-// browser as the activity feed; it embeds NO Urbit/stack logic. Built-in modules
-// only (no deps / no install). Binds to localhost.
+// Thin HTTP/SSE layer over the orchestrator (scripts/onboarding-sandbox/run.sh)
+// plus prompt-file CRUD on the gitignored sandbox copies. Embeds NO Urbit/stack
+// logic. Built-in modules only (no deps / no install). Binds to localhost.
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile, readdir, copyFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, '..', '..');
 const RUN = join(REPO_ROOT, 'scripts', 'onboarding-sandbox', 'run.sh');
+const SBX = join(REPO_ROOT, 'scripts', 'onboarding-sandbox');
+const SANDBOX_DIR = join(SBX, '.sandbox-prompts');
+const SANDBOX_INTRO = join(SBX, '.sandbox-intro.md');
+const TLONBOT_DIR = process.env.TLONBOT_DIR || join(REPO_ROOT, '..', 'tlonbot');
+const SRC_PROMPTS = join(TLONBOT_DIR, 'prompts');
+const SRC_INTRO = join(TLONBOT_DIR, 'tests', 'dev', 'onboarding-intro.md');
 const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
 
-// Only these orchestrator subcommands may ever be spawned.
 const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
 
 const send = (res, code, type, body) => {
   res.writeHead(code, { 'content-type': type });
   res.end(body);
 };
+const json = (res, code, obj) => send(res, code, 'application/json', JSON.stringify(obj));
+const readOr = async (p) => {
+  try { return await readFile(p, 'utf8'); } catch { return ''; }
+};
+const readBody = (req) =>
+  new Promise((resolve) => { let b = ''; req.on('data', (d) => (b += d)); req.on('end', () => resolve(b)); });
+
+// Map an item name to its sandbox + source paths. `intro` is the welcome DM;
+// otherwise a prompt .md file (validated — no path traversal).
+function itemPaths(name) {
+  if (name === 'intro') return { sandbox: SANDBOX_INTRO, source: SRC_INTRO, kind: 'intro' };
+  if (/^[A-Za-z0-9_.-]+\.md$/.test(name) && !name.includes('..'))
+    return { sandbox: join(SANDBOX_DIR, name), source: join(SRC_PROMPTS, name), kind: 'prompt' };
+  return null;
+}
 
 const runCapture = (args) =>
   new Promise((resolve) => {
@@ -29,58 +48,77 @@ const runCapture = (args) =>
     let out = '';
     p.stdout.on('data', (d) => (out += d));
     p.on('close', () => resolve(out));
-    p.on('error', (e) => resolve(JSON.stringify({ up: false, error: String(e) })));
+    p.on('error', () => resolve(''));
   });
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
+  const { pathname } = url;
   try {
-    if (req.method === 'GET' && url.pathname === '/') {
-      const html = await readFile(join(HERE, 'public', 'index.html'));
-      return send(res, 200, 'text/html; charset=utf-8', html);
+    if (req.method === 'GET' && pathname === '/') {
+      return send(res, 200, 'text/html; charset=utf-8', await readFile(join(HERE, 'public', 'index.html')));
     }
 
-    if (req.method === 'GET' && url.pathname === '/api/status') {
+    if (req.method === 'GET' && pathname === '/api/status') {
       const out = await runCapture(['status', '--json']);
       return send(res, 200, 'application/json', out.trim() || '{"up":false}');
     }
 
-    if (req.method === 'GET' && url.pathname === '/api/stream') {
+    if (req.method === 'GET' && pathname === '/api/stream') {
       const cmd = url.searchParams.get('cmd') || '';
       if (!STREAM_CMDS.has(cmd)) return send(res, 400, 'text/plain', `unknown cmd: ${cmd}`);
-      res.writeHead(200, {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-        connection: 'keep-alive',
-      });
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' });
       const emit = (event, data) => res.write(`event: ${event}\ndata: ${data}\n\n`);
       emit('line', `$ onboarding ${cmd}`);
       const p = spawn(RUN, [cmd], { cwd: REPO_ROOT });
-      const pipe = (stream) => {
+      const pipe = (s) => {
         let buf = '';
-        stream.on('data', (d) => {
+        s.on('data', (d) => {
           buf += d;
           let i;
-          while ((i = buf.indexOf('\n')) >= 0) {
-            emit('line', buf.slice(0, i));
-            buf = buf.slice(i + 1);
-          }
+          while ((i = buf.indexOf('\n')) >= 0) { emit('line', buf.slice(0, i)); buf = buf.slice(i + 1); }
         });
-        stream.on('end', () => buf && emit('line', buf));
+        s.on('end', () => buf && emit('line', buf));
       };
-      pipe(p.stdout);
-      pipe(p.stderr);
-      p.on('close', (code) => {
-        emit('done', String(code ?? -1));
-        res.end();
-      });
-      p.on('error', (e) => {
-        emit('line', `spawn error: ${e}`);
-        emit('done', '-1');
-        res.end();
-      });
+      pipe(p.stdout); pipe(p.stderr);
+      p.on('close', (code) => { emit('done', String(code ?? -1)); res.end(); });
+      p.on('error', (e) => { emit('line', `spawn error: ${e}`); emit('done', '-1'); res.end(); });
       req.on('close', () => p.kill());
       return;
+    }
+
+    // --- prompt CRUD (sandbox copies) ---
+    if (req.method === 'GET' && pathname === '/api/prompts') {
+      await runCapture(['init']); // ensure sandbox copies exist (idempotent)
+      const items = [];
+      let files = [];
+      try { files = (await readdir(SANDBOX_DIR)).filter((f) => f.endsWith('.md')).sort(); } catch {}
+      for (const f of files) {
+        const [sb, src] = [await readOr(join(SANDBOX_DIR, f)), await readOr(join(SRC_PROMPTS, f))];
+        items.push({ name: f, kind: 'prompt', modified: sb !== src });
+      }
+      const [iSb, iSrc] = [await readOr(SANDBOX_INTRO), await readOr(SRC_INTRO)];
+      items.push({ name: 'intro', kind: 'intro', label: 'Intro DM', modified: iSb !== iSrc });
+      return json(res, 200, { items });
+    }
+
+    const m = pathname.match(/^\/api\/prompts\/([^/]+)(\/reset)?$/);
+    if (m) {
+      const it = itemPaths(decodeURIComponent(m[1]));
+      if (!it) return json(res, 400, { error: 'bad item name' });
+      if (m[2] && req.method === 'POST') {            // reset to source
+        await copyFile(it.source, it.sandbox);
+        return json(res, 200, { ok: true });
+      }
+      if (req.method === 'GET') {
+        const content = await readOr(it.sandbox);
+        const source = await readOr(it.source);
+        return json(res, 200, { name: decodeURIComponent(m[1]), kind: it.kind, content, source, modified: content !== source });
+      }
+      if (req.method === 'PUT') {                       // save edit
+        await writeFile(it.sandbox, await readBody(req));
+        return json(res, 200, { ok: true });
+      }
     }
 
     send(res, 404, 'text/plain', 'not found');

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -21,6 +21,11 @@ const SRC_INTRO = join(TLONBOT_DIR, 'tests', 'dev', 'onboarding-intro.md');
 const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
 
 const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
+// Selectable models for v1 — scoped to the configured provider (OpenRouter);
+// cross-provider needs per-provider keys (first-run setup). Override via env.
+const MODELS = (process.env.ONBOARDING_MODELS ||
+  'openrouter/minimax/minimax-m2.5,openrouter/minimax/minimax-m2.7,openrouter/openai/gpt-4o-mini,openrouter/anthropic/claude-3.5-sonnet')
+  .split(',').map((s) => s.trim()).filter(Boolean);
 
 const send = (res, code, type, body) => {
   res.writeHead(code, { 'content-type': type });
@@ -91,13 +96,26 @@ const server = createServer(async (req, res) => {
       return send(res, 200, 'application/json', out.trim() || '{"up":false}');
     }
 
+    if (req.method === 'GET' && pathname === '/api/models') {
+      return json(res, 200, { models: MODELS });
+    }
+
     if (req.method === 'GET' && pathname === '/api/stream') {
       const cmd = url.searchParams.get('cmd') || '';
-      if (!STREAM_CMDS.has(cmd)) return send(res, 400, 'text/plain', `unknown cmd: ${cmd}`);
+      let args;
+      if (cmd === 'set-model') {
+        const model = url.searchParams.get('model') || '';
+        if (!MODELS.includes(model)) return send(res, 400, 'text/plain', `unknown model: ${model}`);
+        args = ['set-model', model];
+      } else if (STREAM_CMDS.has(cmd)) {
+        args = [cmd];
+      } else {
+        return send(res, 400, 'text/plain', `unknown cmd: ${cmd}`);
+      }
       res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' });
       const emit = (event, data) => res.write(`event: ${event}\ndata: ${data}\n\n`);
-      emit('line', `$ onboarding ${cmd}`);
-      const p = spawn(RUN, [cmd], { cwd: REPO_ROOT });
+      emit('line', `$ onboarding ${args.join(' ')}`);
+      const p = spawn(RUN, args, { cwd: REPO_ROOT });
       const pipe = (s) => {
         let buf = '';
         s.on('data', (d) => {

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -4,7 +4,7 @@
 // plus prompt-file CRUD on the gitignored sandbox copies. Embeds NO Urbit/stack
 // logic. Built-in modules only (no deps / no install). Binds to localhost.
 import { createServer } from 'node:http';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { readFile, writeFile, readdir, copyFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -40,6 +40,33 @@ function itemPaths(name) {
   if (/^[A-Za-z0-9_.-]+\.md$/.test(name) && !name.includes('..'))
     return { sandbox: join(SANDBOX_DIR, name), source: join(SRC_PROMPTS, name), kind: 'prompt' };
   return null;
+}
+
+// Path an item would have in the tlonbot repo (so exported patches apply there).
+const tlonRel = (name) => (name === 'intro' ? 'tests/dev/onboarding-intro.md' : 'prompts/' + name);
+
+// Unified diff (source -> sandbox) for one item, labelled with tlonbot paths.
+function unifiedDiff(name) {
+  const it = itemPaths(name);
+  const rel = tlonRel(name);
+  const r = spawnSync('diff', ['-u', '-L', 'a/' + rel, '-L', 'b/' + rel, it.source, it.sandbox], { encoding: 'utf8' });
+  return r.stdout || ''; // diff exits 1 when files differ — expected, not an error
+}
+
+// List editable items (prompts + intro) with modified flags; ensures the sandbox
+// copies exist first (idempotent).
+async function listItems() {
+  await runCapture(['init']);
+  const items = [];
+  let files = [];
+  try { files = (await readdir(SANDBOX_DIR)).filter((f) => f.endsWith('.md')).sort(); } catch {}
+  for (const f of files) {
+    const [sb, src] = [await readOr(join(SANDBOX_DIR, f)), await readOr(join(SRC_PROMPTS, f))];
+    items.push({ name: f, kind: 'prompt', modified: sb !== src });
+  }
+  const [iSb, iSrc] = [await readOr(SANDBOX_INTRO), await readOr(SRC_INTRO)];
+  items.push({ name: 'intro', kind: 'intro', label: 'Intro DM', modified: iSb !== iSrc });
+  return items;
 }
 
 const runCapture = (args) =>
@@ -89,33 +116,43 @@ const server = createServer(async (req, res) => {
 
     // --- prompt CRUD (sandbox copies) ---
     if (req.method === 'GET' && pathname === '/api/prompts') {
-      await runCapture(['init']); // ensure sandbox copies exist (idempotent)
-      const items = [];
-      let files = [];
-      try { files = (await readdir(SANDBOX_DIR)).filter((f) => f.endsWith('.md')).sort(); } catch {}
-      for (const f of files) {
-        const [sb, src] = [await readOr(join(SANDBOX_DIR, f)), await readOr(join(SRC_PROMPTS, f))];
-        items.push({ name: f, kind: 'prompt', modified: sb !== src });
-      }
-      const [iSb, iSrc] = [await readOr(SANDBOX_INTRO), await readOr(SRC_INTRO)];
-      items.push({ name: 'intro', kind: 'intro', label: 'Intro DM', modified: iSb !== iSrc });
-      return json(res, 200, { items });
+      return json(res, 200, { items: await listItems() });
     }
 
-    const m = pathname.match(/^\/api\/prompts\/([^/]+)(\/reset)?$/);
+    if (req.method === 'GET' && pathname === '/api/export') {
+      const mods = (await listItems()).filter((i) => i.modified);
+      let patch = '';
+      for (const i of mods) {
+        let d = unifiedDiff(i.name);
+        if (d && !d.endsWith('\n')) d += '\n';
+        patch += `diff --git a/${tlonRel(i.name)} b/${tlonRel(i.name)}\n` + d;
+      }
+      res.writeHead(200, {
+        'content-type': 'text/x-patch; charset=utf-8',
+        'content-disposition': 'attachment; filename="onboarding-prompts.patch"',
+      });
+      return res.end(patch || '# no local changes\n');
+    }
+
+    const m = pathname.match(/^\/api\/prompts\/([^/]+)(?:\/(reset|diff))?$/);
     if (m) {
-      const it = itemPaths(decodeURIComponent(m[1]));
+      const rawName = decodeURIComponent(m[1]);
+      const it = itemPaths(rawName);
       if (!it) return json(res, 400, { error: 'bad item name' });
-      if (m[2] && req.method === 'POST') {            // reset to source
+      const action = m[2];
+      if (action === 'reset' && req.method === 'POST') {       // reset to source
         await copyFile(it.source, it.sandbox);
         return json(res, 200, { ok: true });
       }
-      if (req.method === 'GET') {
+      if (action === 'diff' && req.method === 'GET') {         // unified diff
+        return send(res, 200, 'text/plain; charset=utf-8', unifiedDiff(rawName));
+      }
+      if (!action && req.method === 'GET') {
         const content = await readOr(it.sandbox);
         const source = await readOr(it.source);
-        return json(res, 200, { name: decodeURIComponent(m[1]), kind: it.kind, content, source, modified: content !== source });
+        return json(res, 200, { name: rawName, kind: it.kind, content, source, modified: content !== source });
       }
-      if (req.method === 'PUT') {                       // save edit
+      if (!action && req.method === 'PUT') {                    // save edit
         await writeFile(it.sandbox, await readBody(req));
         return json(res, 200, { ok: true });
       }

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -3,12 +3,12 @@
 // Thin HTTP/SSE layer over the orchestrator (scripts/onboarding-sandbox/run.sh)
 // plus prompt-file CRUD on the gitignored sandbox copies. Embeds NO Urbit/stack
 // logic. Built-in modules only (no deps / no install). Binds to localhost.
+import { spawn, spawnSync } from 'node:child_process';
+import { copyFile, readFile, readdir, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import net from 'node:net';
-import { spawn, spawnSync } from 'node:child_process';
-import { readFile, writeFile, readdir, copyFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, '..', '..');
@@ -24,24 +24,38 @@ const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
 const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
 // Offline fallback list — used only if the OpenRouter models API can't be
 // reached. The live list comes from openRouterModels(). Override via env.
-const MODELS = (process.env.ONBOARDING_MODELS ||
-  'openrouter/minimax/minimax-m2.5,openrouter/minimax/minimax-m2.7,openrouter/openai/gpt-4o-mini,openrouter/anthropic/claude-3.5-sonnet')
-  .split(',').map((s) => s.trim()).filter(Boolean);
+const MODELS = (
+  process.env.ONBOARDING_MODELS ||
+  'openrouter/minimax/minimax-m2.5,openrouter/minimax/minimax-m2.7,openrouter/openai/gpt-4o-mini,openrouter/anthropic/claude-3.5-sonnet'
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 // Live list of every OpenRouter model (public endpoint, no auth), cached 1h.
 // Returns `openrouter/<id>` ids matching the bot's MODEL format; null on failure.
-let _modelsCache = null, _modelsCacheAt = 0;
+let _modelsCache = null,
+  _modelsCacheAt = 0;
 async function openRouterModels() {
-  if (_modelsCache && Date.now() - _modelsCacheAt < 3600000) return _modelsCache;
+  if (_modelsCache && Date.now() - _modelsCacheAt < 3600000)
+    return _modelsCache;
   try {
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort(), 8000);
-    const r = await fetch('https://openrouter.ai/api/v1/models', { signal: ctrl.signal });
+    const r = await fetch('https://openrouter.ai/api/v1/models', {
+      signal: ctrl.signal,
+    });
     clearTimeout(t);
     if (r.ok) {
       const j = await r.json();
-      const list = (j.data || []).map((m) => 'openrouter/' + m.id).filter((s) => s !== 'openrouter/').sort();
-      if (list.length) { _modelsCache = list; _modelsCacheAt = Date.now(); }
+      const list = (j.data || [])
+        .map((m) => 'openrouter/' + m.id)
+        .filter((s) => s !== 'openrouter/')
+        .sort();
+      if (list.length) {
+        _modelsCache = list;
+        _modelsCacheAt = Date.now();
+      }
     }
   } catch {}
   return _modelsCache;
@@ -51,37 +65,64 @@ const send = (res, code, type, body) => {
   res.writeHead(code, { 'content-type': type });
   res.end(body);
 };
-const json = (res, code, obj) => send(res, code, 'application/json', JSON.stringify(obj));
+const json = (res, code, obj) =>
+  send(res, code, 'application/json', JSON.stringify(obj));
 const readOr = async (p) => {
-  try { return await readFile(p, 'utf8'); } catch { return ''; }
+  try {
+    return await readFile(p, 'utf8');
+  } catch {
+    return '';
+  }
 };
 
 // first-run preflight helpers
 const ENV_FILE = join(TLONBOT_DIR, 'tests', '.env');
 const dockerOk = () => {
-  try { return spawnSync('docker', ['info'], { timeout: 5000, stdio: 'ignore' }).status === 0; } catch { return false; }
+  try {
+    return (
+      spawnSync('docker', ['info'], { timeout: 5000, stdio: 'ignore' })
+        .status === 0
+    );
+  } catch {
+    return false;
+  }
 };
-const keyPresent = async () => /^OPENROUTER_API_KEY=.+/m.test(await readOr(ENV_FILE));
+const keyPresent = async () =>
+  /^OPENROUTER_API_KEY=.+/m.test(await readOr(ENV_FILE));
 const readBody = (req) =>
-  new Promise((resolve) => { let b = ''; req.on('data', (d) => (b += d)); req.on('end', () => resolve(b)); });
+  new Promise((resolve) => {
+    let b = '';
+    req.on('data', (d) => (b += d));
+    req.on('end', () => resolve(b));
+  });
 
 // Map an item name to its sandbox + source paths. `intro` is the welcome DM;
 // otherwise a prompt .md file (validated — no path traversal).
 function itemPaths(name) {
-  if (name === 'intro') return { sandbox: SANDBOX_INTRO, source: SRC_INTRO, kind: 'intro' };
+  if (name === 'intro')
+    return { sandbox: SANDBOX_INTRO, source: SRC_INTRO, kind: 'intro' };
   if (/^[A-Za-z0-9_.-]+\.md$/.test(name) && !name.includes('..'))
-    return { sandbox: join(SANDBOX_DIR, name), source: join(SRC_PROMPTS, name), kind: 'prompt' };
+    return {
+      sandbox: join(SANDBOX_DIR, name),
+      source: join(SRC_PROMPTS, name),
+      kind: 'prompt',
+    };
   return null;
 }
 
 // Path an item would have in the tlonbot repo (so exported patches apply there).
-const tlonRel = (name) => (name === 'intro' ? 'tests/dev/onboarding-intro.md' : 'prompts/' + name);
+const tlonRel = (name) =>
+  name === 'intro' ? 'tests/dev/onboarding-intro.md' : 'prompts/' + name;
 
 // Unified diff (source -> sandbox) for one item, labelled with tlonbot paths.
 function unifiedDiff(name) {
   const it = itemPaths(name);
   const rel = tlonRel(name);
-  const r = spawnSync('diff', ['-u', '-L', 'a/' + rel, '-L', 'b/' + rel, it.source, it.sandbox], { encoding: 'utf8' });
+  const r = spawnSync(
+    'diff',
+    ['-u', '-L', 'a/' + rel, '-L', 'b/' + rel, it.source, it.sandbox],
+    { encoding: 'utf8' }
+  );
   return r.stdout || ''; // diff exits 1 when files differ — expected, not an error
 }
 
@@ -91,13 +132,25 @@ async function listItems() {
   await runCapture(['init']);
   const items = [];
   let files = [];
-  try { files = (await readdir(SANDBOX_DIR)).filter((f) => f.endsWith('.md')).sort(); } catch {}
+  try {
+    files = (await readdir(SANDBOX_DIR))
+      .filter((f) => f.endsWith('.md'))
+      .sort();
+  } catch {}
   for (const f of files) {
-    const [sb, src] = [await readOr(join(SANDBOX_DIR, f)), await readOr(join(SRC_PROMPTS, f))];
+    const [sb, src] = [
+      await readOr(join(SANDBOX_DIR, f)),
+      await readOr(join(SRC_PROMPTS, f)),
+    ];
     items.push({ name: f, kind: 'prompt', modified: sb !== src });
   }
   const [iSb, iSrc] = [await readOr(SANDBOX_INTRO), await readOr(SRC_INTRO)];
-  items.push({ name: 'intro', kind: 'intro', label: 'Intro DM', modified: iSb !== iSrc });
+  items.push({
+    name: 'intro',
+    kind: 'intro',
+    label: 'Intro DM',
+    modified: iSb !== iSrc,
+  });
   return items;
 }
 
@@ -122,25 +175,41 @@ let proxyPort = null;
 // Parse the canonical owner Eyre target (host/port) from `status --json`.
 async function ownerTarget() {
   try {
-    const o = JSON.parse((await runCapture(['status', '--json'])).trim() || '{}');
+    const o = JSON.parse(
+      (await runCapture(['status', '--json'])).trim() || '{}'
+    );
     if (!o.up || !o.owner?.url) return null;
     const u = new URL(o.owner.url);
-    return { host: u.hostname === 'localhost' ? '127.0.0.1' : u.hostname, port: Number(u.port) };
-  } catch { return null; }
+    return {
+      host: u.hostname === 'localhost' ? '127.0.0.1' : u.hostname,
+      port: Number(u.port),
+    };
+  } catch {
+    return null;
+  }
 }
 
 function closeProxy() {
-  if (proxyServer) { try { proxyServer.close(); } catch {} proxyServer = null; }
+  if (proxyServer) {
+    try {
+      proxyServer.close();
+    } catch {}
+    proxyServer = null;
+  }
   proxyPort = null;
 }
 
 // Start a fresh proxy on an OS-assigned port forwarding to the owner ship.
 async function rotateProxy() {
   const target = await ownerTarget();
-  if (!target) { closeProxy(); return; }
+  if (!target) {
+    closeProxy();
+    return;
+  }
   const next = net.createServer((client) => {
     const upstream = net.connect(target.port, target.host);
-    client.pipe(upstream); upstream.pipe(client);
+    client.pipe(upstream);
+    upstream.pipe(client);
     client.on('error', () => upstream.destroy());
     upstream.on('error', () => client.destroy());
   });
@@ -151,17 +220,28 @@ async function rotateProxy() {
   const old = proxyServer;
   proxyServer = next;
   proxyPort = next.address().port;
-  if (old) { try { old.close(); } catch {} } // stops new conns; existing tabs drain
+  if (old) {
+    try {
+      old.close();
+    } catch {}
+  } // stops new conns; existing tabs drain
 }
 
-async function ensureProxy() { if (!proxyServer) await rotateProxy(); }
+async function ensureProxy() {
+  if (!proxyServer) await rotateProxy();
+}
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const { pathname } = url;
   try {
     if (req.method === 'GET' && pathname === '/') {
-      return send(res, 200, 'text/html; charset=utf-8', await readFile(join(HERE, 'public', 'index.html')));
+      return send(
+        res,
+        200,
+        'text/html; charset=utf-8',
+        await readFile(join(HERE, 'public', 'index.html'))
+      );
     }
 
     if (req.method === 'GET' && pathname === '/api/status') {
@@ -170,15 +250,16 @@ const server = createServer(async (req, res) => {
       try {
         const o = JSON.parse(txt);
         if (o.up) {
-          await ensureProxy();            // first status after the stack is up
+          await ensureProxy(); // first status after the stack is up
           if (o.owner?.url && proxyPort) {
             const u = new URL(o.owner.url);
-            u.hostname = 'localhost'; u.port = String(proxyPort);
+            u.hostname = 'localhost';
+            u.port = String(proxyPort);
             o.owner.url = u.toString();
             txt = JSON.stringify(o);
           }
         } else {
-          closeProxy();                   // stack down → drop the proxy
+          closeProxy(); // stack down → drop the proxy
         }
       } catch {}
       return send(res, 200, 'application/json', txt);
@@ -195,18 +276,30 @@ const server = createServer(async (req, res) => {
 
     if (req.method === 'POST' && pathname === '/api/provider-key') {
       let key = '';
-      try { key = (JSON.parse(await readBody(req)).key || '').trim(); } catch {}
+      try {
+        key = (JSON.parse(await readBody(req)).key || '').trim();
+      } catch {}
       if (!key) return json(res, 400, { ok: false, error: 'no key provided' });
-      let valid = false, detail = '';
+      let valid = false,
+        detail = '';
       try {
         const ctrl = new AbortController();
         const t = setTimeout(() => ctrl.abort(), 8000);
-        const r = await fetch('https://openrouter.ai/api/v1/key', { headers: { authorization: 'Bearer ' + key }, signal: ctrl.signal });
+        const r = await fetch('https://openrouter.ai/api/v1/key', {
+          headers: { authorization: 'Bearer ' + key },
+          signal: ctrl.signal,
+        });
         clearTimeout(t);
         valid = r.ok;
         if (!valid) detail = 'provider returned HTTP ' + r.status;
-      } catch (e) { detail = String(e.message || e); }
-      if (!valid) return json(res, 400, { ok: false, error: 'key rejected (' + detail + ')' });
+      } catch (e) {
+        detail = String(e.message || e);
+      }
+      if (!valid)
+        return json(res, 400, {
+          ok: false,
+          error: 'key rejected (' + detail + ')',
+        });
       await runCapture(['set-key', key]);
       return json(res, 200, { ok: true });
     }
@@ -216,15 +309,21 @@ const server = createServer(async (req, res) => {
       let args;
       if (cmd === 'set-model') {
         const model = url.searchParams.get('model') || '';
-        if (!/^openrouter\/[A-Za-z0-9/_.:-]+$/.test(model)) return send(res, 400, 'text/plain', `invalid model: ${model}`);
+        if (!/^openrouter\/[A-Za-z0-9/_.:-]+$/.test(model))
+          return send(res, 400, 'text/plain', `invalid model: ${model}`);
         args = ['set-model', model];
       } else if (STREAM_CMDS.has(cmd)) {
         args = [cmd];
       } else {
         return send(res, 400, 'text/plain', `unknown cmd: ${cmd}`);
       }
-      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' });
-      const emit = (event, data) => res.write(`event: ${event}\ndata: ${data}\n\n`);
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      });
+      const emit = (event, data) =>
+        res.write(`event: ${event}\ndata: ${data}\n\n`);
       emit('line', `$ onboarding ${args.join(' ')}`);
       const p = spawn(RUN, args, { cwd: REPO_ROOT });
       const pipe = (s) => {
@@ -232,19 +331,33 @@ const server = createServer(async (req, res) => {
         s.on('data', (d) => {
           buf += d;
           let i;
-          while ((i = buf.indexOf('\n')) >= 0) { emit('line', buf.slice(0, i)); buf = buf.slice(i + 1); }
+          while ((i = buf.indexOf('\n')) >= 0) {
+            emit('line', buf.slice(0, i));
+            buf = buf.slice(i + 1);
+          }
         });
         s.on('end', () => buf && emit('line', buf));
       };
-      pipe(p.stdout); pipe(p.stderr);
+      pipe(p.stdout);
+      pipe(p.stderr);
       p.on('close', async (code) => {
         // give the tester a fresh-origin (clean-cache) owner link after each
         // start/reset; tear the proxy down on stop
-        if (code === 0 && (cmd === 'start' || cmd === 'reset')) { try { await rotateProxy(); } catch {} }
-        else if (cmd === 'down') { closeProxy(); }
-        emit('done', String(code ?? -1)); res.end();
+        if (code === 0 && (cmd === 'start' || cmd === 'reset')) {
+          try {
+            await rotateProxy();
+          } catch {}
+        } else if (cmd === 'down') {
+          closeProxy();
+        }
+        emit('done', String(code ?? -1));
+        res.end();
       });
-      p.on('error', (e) => { emit('line', `spawn error: ${e}`); emit('done', '-1'); res.end(); });
+      p.on('error', (e) => {
+        emit('line', `spawn error: ${e}`);
+        emit('done', '-1');
+        res.end();
+      });
       req.on('close', () => p.kill());
       return;
     }
@@ -264,7 +377,8 @@ const server = createServer(async (req, res) => {
       }
       res.writeHead(200, {
         'content-type': 'text/x-patch; charset=utf-8',
-        'content-disposition': 'attachment; filename="onboarding-prompts.patch"',
+        'content-disposition':
+          'attachment; filename="onboarding-prompts.patch"',
       });
       return res.end(patch || '# no local changes\n');
     }
@@ -272,7 +386,9 @@ const server = createServer(async (req, res) => {
     if (req.method === 'POST' && pathname === '/api/reset-prompts') {
       for (const it of await listItems()) {
         const p = itemPaths(it.name);
-        try { await copyFile(p.source, p.sandbox); } catch {}
+        try {
+          await copyFile(p.source, p.sandbox);
+        } catch {}
       }
       return json(res, 200, { ok: true });
     }
@@ -283,19 +399,33 @@ const server = createServer(async (req, res) => {
       const it = itemPaths(rawName);
       if (!it) return json(res, 400, { error: 'bad item name' });
       const action = m[2];
-      if (action === 'reset' && req.method === 'POST') {       // reset to source
+      if (action === 'reset' && req.method === 'POST') {
+        // reset to source
         await copyFile(it.source, it.sandbox);
         return json(res, 200, { ok: true });
       }
-      if (action === 'diff' && req.method === 'GET') {         // unified diff
-        return send(res, 200, 'text/plain; charset=utf-8', unifiedDiff(rawName));
+      if (action === 'diff' && req.method === 'GET') {
+        // unified diff
+        return send(
+          res,
+          200,
+          'text/plain; charset=utf-8',
+          unifiedDiff(rawName)
+        );
       }
       if (!action && req.method === 'GET') {
         const content = await readOr(it.sandbox);
         const source = await readOr(it.source);
-        return json(res, 200, { name: rawName, kind: it.kind, content, source, modified: content !== source });
+        return json(res, 200, {
+          name: rawName,
+          kind: it.kind,
+          content,
+          source,
+          modified: content !== source,
+        });
       }
-      if (!action && req.method === 'PUT') {                    // save edit
+      if (!action && req.method === 'PUT') {
+        // save edit
         await writeFile(it.sandbox, await readBody(req));
         return json(res, 200, { ok: true });
       }

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -201,6 +201,14 @@ const server = createServer(async (req, res) => {
       return res.end(patch || '# no local changes\n');
     }
 
+    if (req.method === 'POST' && pathname === '/api/reset-prompts') {
+      for (const it of await listItems()) {
+        const p = itemPaths(it.name);
+        try { await copyFile(p.source, p.sandbox); } catch {}
+      }
+      return json(res, 200, { ok: true });
+    }
+
     const m = pathname.match(/^\/api\/prompts\/([^/]+)(?:\/(reset|diff))?$/);
     if (m) {
       const rawName = decodeURIComponent(m[1]);

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -35,6 +35,13 @@ const json = (res, code, obj) => send(res, code, 'application/json', JSON.string
 const readOr = async (p) => {
   try { return await readFile(p, 'utf8'); } catch { return ''; }
 };
+
+// first-run preflight helpers
+const ENV_FILE = join(TLONBOT_DIR, 'tests', '.env');
+const dockerOk = () => {
+  try { return spawnSync('docker', ['info'], { timeout: 5000, stdio: 'ignore' }).status === 0; } catch { return false; }
+};
+const keyPresent = async () => /^OPENROUTER_API_KEY=.+/m.test(await readOr(ENV_FILE));
 const readBody = (req) =>
   new Promise((resolve) => { let b = ''; req.on('data', (d) => (b += d)); req.on('end', () => resolve(b)); });
 
@@ -98,6 +105,28 @@ const server = createServer(async (req, res) => {
 
     if (req.method === 'GET' && pathname === '/api/models') {
       return json(res, 200, { models: MODELS });
+    }
+
+    if (req.method === 'GET' && pathname === '/api/preflight') {
+      return json(res, 200, { docker: dockerOk(), key: await keyPresent() });
+    }
+
+    if (req.method === 'POST' && pathname === '/api/provider-key') {
+      let key = '';
+      try { key = (JSON.parse(await readBody(req)).key || '').trim(); } catch {}
+      if (!key) return json(res, 400, { ok: false, error: 'no key provided' });
+      let valid = false, detail = '';
+      try {
+        const ctrl = new AbortController();
+        const t = setTimeout(() => ctrl.abort(), 8000);
+        const r = await fetch('https://openrouter.ai/api/v1/key', { headers: { authorization: 'Bearer ' + key }, signal: ctrl.signal });
+        clearTimeout(t);
+        valid = r.ok;
+        if (!valid) detail = 'provider returned HTTP ' + r.status;
+      } catch (e) { detail = String(e.message || e); }
+      if (!valid) return json(res, 400, { ok: false, error: 'key rejected (' + detail + ')' });
+      await runCapture(['set-key', key]);
+      return json(res, 200, { ok: true });
     }
 
     if (req.method === 'GET' && pathname === '/api/stream') {

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -4,6 +4,7 @@
 // plus prompt-file CRUD on the gitignored sandbox copies. Embeds NO Urbit/stack
 // logic. Built-in modules only (no deps / no install). Binds to localhost.
 import { createServer } from 'node:http';
+import net from 'node:net';
 import { spawn, spawnSync } from 'node:child_process';
 import { readFile, writeFile, readdir, copyFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -109,6 +110,52 @@ const runCapture = (args) =>
     p.on('error', () => resolve(''));
   });
 
+// --- owner cache-busting proxy ---------------------------------------------
+// The web client caches the conversation in IndexedDB keyed by ORIGIN (incl.
+// port), and a backend nuke doesn't purge it. So after each start/reset we
+// expose ~ten's Eyre on a FRESH localhost port: a new origin = empty client
+// cache = clean sync from the (already-cleared) backend. This is a transparent
+// TCP forward to the port the stack already publishes — no Urbit logic here.
+let proxyServer = null;
+let proxyPort = null;
+
+// Parse the canonical owner Eyre target (host/port) from `status --json`.
+async function ownerTarget() {
+  try {
+    const o = JSON.parse((await runCapture(['status', '--json'])).trim() || '{}');
+    if (!o.up || !o.owner?.url) return null;
+    const u = new URL(o.owner.url);
+    return { host: u.hostname === 'localhost' ? '127.0.0.1' : u.hostname, port: Number(u.port) };
+  } catch { return null; }
+}
+
+function closeProxy() {
+  if (proxyServer) { try { proxyServer.close(); } catch {} proxyServer = null; }
+  proxyPort = null;
+}
+
+// Start a fresh proxy on an OS-assigned port forwarding to the owner ship.
+async function rotateProxy() {
+  const target = await ownerTarget();
+  if (!target) { closeProxy(); return; }
+  const next = net.createServer((client) => {
+    const upstream = net.connect(target.port, target.host);
+    client.pipe(upstream); upstream.pipe(client);
+    client.on('error', () => upstream.destroy());
+    upstream.on('error', () => client.destroy());
+  });
+  await new Promise((resolve, reject) => {
+    next.once('error', reject);
+    next.listen(0, '127.0.0.1', resolve);
+  });
+  const old = proxyServer;
+  proxyServer = next;
+  proxyPort = next.address().port;
+  if (old) { try { old.close(); } catch {} } // stops new conns; existing tabs drain
+}
+
+async function ensureProxy() { if (!proxyServer) await rotateProxy(); }
+
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const { pathname } = url;
@@ -119,7 +166,22 @@ const server = createServer(async (req, res) => {
 
     if (req.method === 'GET' && pathname === '/api/status') {
       const out = await runCapture(['status', '--json']);
-      return send(res, 200, 'application/json', out.trim() || '{"up":false}');
+      let txt = out.trim() || '{"up":false}';
+      try {
+        const o = JSON.parse(txt);
+        if (o.up) {
+          await ensureProxy();            // first status after the stack is up
+          if (o.owner?.url && proxyPort) {
+            const u = new URL(o.owner.url);
+            u.hostname = 'localhost'; u.port = String(proxyPort);
+            o.owner.url = u.toString();
+            txt = JSON.stringify(o);
+          }
+        } else {
+          closeProxy();                   // stack down → drop the proxy
+        }
+      } catch {}
+      return send(res, 200, 'application/json', txt);
     }
 
     if (req.method === 'GET' && pathname === '/api/models') {
@@ -175,7 +237,13 @@ const server = createServer(async (req, res) => {
         s.on('end', () => buf && emit('line', buf));
       };
       pipe(p.stdout); pipe(p.stderr);
-      p.on('close', (code) => { emit('done', String(code ?? -1)); res.end(); });
+      p.on('close', async (code) => {
+        // give the tester a fresh-origin (clean-cache) owner link after each
+        // start/reset; tear the proxy down on stop
+        if (code === 0 && (cmd === 'start' || cmd === 'reset')) { try { await rotateProxy(); } catch {} }
+        else if (cmd === 'down') { closeProxy(); }
+        emit('done', String(code ?? -1)); res.end();
+      });
       p.on('error', (e) => { emit('line', `spawn error: ${e}`); emit('done', '-1'); res.end(); });
       req.on('close', () => p.kill());
       return;

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -253,14 +253,16 @@ const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const { pathname } = url;
   try {
-    // CSRF + DNS-rebinding guard: /api/* requires the per-run token and a
-    // localhost Host. GET / is exempt — it delivers the token to the page.
+    // DNS-rebinding guard on EVERY request, including GET / — otherwise a
+    // rebound foreign domain could read the token from the page and replay it
+    // straight to localhost. Only real localhost Hosts are allowed.
+    const host = (req.headers.host || '').split(':')[0];
+    if (host !== 'localhost' && host !== '127.0.0.1')
+      return send(res, 403, 'text/plain', 'forbidden');
+    // CSRF guard: /api/* additionally requires the per-run token.
     if (pathname.startsWith('/api/')) {
-      const host = (req.headers.host || '').split(':')[0];
-      const hostOk = host === 'localhost' || host === '127.0.0.1';
       const t = url.searchParams.get('token') || req.headers['x-sandbox-token'];
-      if (!hostOk || t !== TOKEN)
-        return send(res, 403, 'text/plain', 'forbidden');
+      if (t !== TOKEN) return send(res, 403, 'text/plain', 'forbidden');
     }
 
     if (req.method === 'GET' && pathname === '/') {

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -4,6 +4,7 @@
 // plus prompt-file CRUD on the gitignored sandbox copies. Embeds NO Urbit/stack
 // logic. Built-in modules only (no deps / no install). Binds to localhost.
 import { spawn, spawnSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { copyFile, readFile, readdir, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import net from 'node:net';
@@ -20,6 +21,10 @@ const TLONBOT_DIR = process.env.TLONBOT_DIR || join(REPO_ROOT, '..', 'tlonbot');
 const SRC_PROMPTS = join(TLONBOT_DIR, 'prompts');
 const SRC_INTRO = join(TLONBOT_DIR, 'tests', 'dev', 'onboarding-intro.md');
 const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
+// Per-run CSRF token: injected into the served page and required on /api/*, so a
+// drive-by page in the browser can't trigger sandbox commands on this localhost
+// port. Paired with a Host check below to also defend DNS rebinding.
+const TOKEN = randomBytes(24).toString('hex');
 
 const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
 // Offline fallback list — used only if the OpenRouter models API can't be
@@ -163,6 +168,19 @@ const runCapture = (args) =>
     p.on('error', () => resolve(''));
   });
 
+// Like runCapture, but feeds `input` on stdin and closes it — for secrets (the
+// provider key) so they never land in the child's argv (visible via ps/proc).
+const runWithStdin = (args, input) =>
+  new Promise((resolve) => {
+    const p = spawn(RUN, args, { cwd: REPO_ROOT });
+    let out = '';
+    p.stdout.on('data', (d) => (out += d));
+    p.on('close', () => resolve(out));
+    p.on('error', () => resolve(''));
+    p.stdin.write(input);
+    p.stdin.end();
+  });
+
 // --- owner cache-busting proxy ---------------------------------------------
 // The web client caches the conversation in IndexedDB keyed by ORIGIN (incl.
 // port), and a backend nuke doesn't purge it. So after each start/reset we
@@ -235,12 +253,26 @@ const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const { pathname } = url;
   try {
+    // CSRF + DNS-rebinding guard: /api/* requires the per-run token and a
+    // localhost Host. GET / is exempt — it delivers the token to the page.
+    if (pathname.startsWith('/api/')) {
+      const host = (req.headers.host || '').split(':')[0];
+      const hostOk = host === 'localhost' || host === '127.0.0.1';
+      const t = url.searchParams.get('token') || req.headers['x-sandbox-token'];
+      if (!hostOk || t !== TOKEN)
+        return send(res, 403, 'text/plain', 'forbidden');
+    }
+
     if (req.method === 'GET' && pathname === '/') {
+      const html = await readFile(join(HERE, 'public', 'index.html'), 'utf8');
       return send(
         res,
         200,
         'text/html; charset=utf-8',
-        await readFile(join(HERE, 'public', 'index.html'))
+        html.replace(
+          '</head>',
+          `<script>window.__TOKEN__=${JSON.stringify(TOKEN)}</script></head>`
+        )
       );
     }
 
@@ -300,7 +332,7 @@ const server = createServer(async (req, res) => {
           ok: false,
           error: 'key rejected (' + detail + ')',
         });
-      await runCapture(['set-key', key]);
+      await runWithStdin(['set-key'], key);
       return json(res, 200, { ok: true });
     }
 

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -1,0 +1,94 @@
+// Onboarding sandbox control server (Phase 2, step 1 — zero-dep skeleton).
+//
+// Thin HTTP/SSE layer over the orchestrator (scripts/onboarding-sandbox/run.sh).
+// It spawns whitelisted orchestrator subcommands and streams their output to the
+// browser as the activity feed; it embeds NO Urbit/stack logic. Built-in modules
+// only (no deps / no install). Binds to localhost.
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+const RUN = join(REPO_ROOT, 'scripts', 'onboarding-sandbox', 'run.sh');
+const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
+
+// Only these orchestrator subcommands may ever be spawned.
+const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
+
+const send = (res, code, type, body) => {
+  res.writeHead(code, { 'content-type': type });
+  res.end(body);
+};
+
+const runCapture = (args) =>
+  new Promise((resolve) => {
+    const p = spawn(RUN, args, { cwd: REPO_ROOT });
+    let out = '';
+    p.stdout.on('data', (d) => (out += d));
+    p.on('close', () => resolve(out));
+    p.on('error', (e) => resolve(JSON.stringify({ up: false, error: String(e) })));
+  });
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  try {
+    if (req.method === 'GET' && url.pathname === '/') {
+      const html = await readFile(join(HERE, 'public', 'index.html'));
+      return send(res, 200, 'text/html; charset=utf-8', html);
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/status') {
+      const out = await runCapture(['status', '--json']);
+      return send(res, 200, 'application/json', out.trim() || '{"up":false}');
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/stream') {
+      const cmd = url.searchParams.get('cmd') || '';
+      if (!STREAM_CMDS.has(cmd)) return send(res, 400, 'text/plain', `unknown cmd: ${cmd}`);
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      });
+      const emit = (event, data) => res.write(`event: ${event}\ndata: ${data}\n\n`);
+      emit('line', `$ onboarding ${cmd}`);
+      const p = spawn(RUN, [cmd], { cwd: REPO_ROOT });
+      const pipe = (stream) => {
+        let buf = '';
+        stream.on('data', (d) => {
+          buf += d;
+          let i;
+          while ((i = buf.indexOf('\n')) >= 0) {
+            emit('line', buf.slice(0, i));
+            buf = buf.slice(i + 1);
+          }
+        });
+        stream.on('end', () => buf && emit('line', buf));
+      };
+      pipe(p.stdout);
+      pipe(p.stderr);
+      p.on('close', (code) => {
+        emit('done', String(code ?? -1));
+        res.end();
+      });
+      p.on('error', (e) => {
+        emit('line', `spawn error: ${e}`);
+        emit('done', '-1');
+        res.end();
+      });
+      req.on('close', () => p.kill());
+      return;
+    }
+
+    send(res, 404, 'text/plain', 'not found');
+  } catch (e) {
+    send(res, 500, 'text/plain', String(e));
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () =>
+  console.log(`onboarding sandbox control server: http://127.0.0.1:${PORT}`)
+);

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -5,7 +5,13 @@
 // logic. Built-in modules only (no deps / no install). Binds to localhost.
 import { spawn, spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { copyFile, readFile, readdir, writeFile } from 'node:fs/promises';
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  writeFile,
+} from 'node:fs/promises';
 import { createServer } from 'node:http';
 import net from 'node:net';
 import { dirname, join } from 'node:path';
@@ -111,15 +117,32 @@ const readBody = (req) =>
 // Map an item name to its sandbox + source paths. `intro` is the welcome DM;
 // otherwise a prompt .md file (validated — no path traversal).
 function itemPaths(name) {
+  // `base` mirrors run.sh's .sandbox-prompts/.base snapshot (source content at
+  // copy time); discarding must update it too or run.sh later treats the
+  // reset-to-source copy as a user edit.
   if (name === 'intro')
-    return { sandbox: SANDBOX_INTRO, source: SRC_INTRO, kind: 'intro' };
+    return {
+      sandbox: SANDBOX_INTRO,
+      source: SRC_INTRO,
+      base: join(SANDBOX_DIR, '.base', '.intro'),
+      kind: 'intro',
+    };
   if (/^[A-Za-z0-9_.-]+\.md$/.test(name) && !name.includes('..'))
     return {
       sandbox: join(SANDBOX_DIR, name),
       source: join(SRC_PROMPTS, name),
+      base: join(SANDBOX_DIR, '.base', name),
       kind: 'prompt',
     };
   return null;
+}
+
+// Reset a sandbox item to source AND update its base snapshot, so run.sh sees it
+// as unedited (== base) and keeps refreshing it on future upstream changes.
+async function discardToSource(it) {
+  await copyFile(it.source, it.sandbox);
+  await mkdir(dirname(it.base), { recursive: true });
+  await copyFile(it.source, it.base);
 }
 
 // Path an item would have in the tlonbot repo (so exported patches apply there).
@@ -438,7 +461,7 @@ const server = createServer(async (req, res) => {
       for (const it of await listItems()) {
         const p = itemPaths(it.name);
         try {
-          await copyFile(p.source, p.sandbox);
+          await discardToSource(p);
         } catch {}
       }
       return json(res, 200, { ok: true });
@@ -451,8 +474,8 @@ const server = createServer(async (req, res) => {
       if (!it) return json(res, 400, { error: 'bad item name' });
       const action = m[2];
       if (action === 'reset' && req.method === 'POST') {
-        // reset to source
-        await copyFile(it.source, it.sandbox);
+        // reset to source (+ base, so it reads as unedited going forward)
+        await discardToSource(it);
         return json(res, 200, { ok: true });
       }
       if (action === 'diff' && req.method === 'GET') {

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -21,11 +21,30 @@ const SRC_INTRO = join(TLONBOT_DIR, 'tests', 'dev', 'onboarding-intro.md');
 const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
 
 const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
-// Selectable models for v1 — scoped to the configured provider (OpenRouter);
-// cross-provider needs per-provider keys (first-run setup). Override via env.
+// Offline fallback list — used only if the OpenRouter models API can't be
+// reached. The live list comes from openRouterModels(). Override via env.
 const MODELS = (process.env.ONBOARDING_MODELS ||
   'openrouter/minimax/minimax-m2.5,openrouter/minimax/minimax-m2.7,openrouter/openai/gpt-4o-mini,openrouter/anthropic/claude-3.5-sonnet')
   .split(',').map((s) => s.trim()).filter(Boolean);
+
+// Live list of every OpenRouter model (public endpoint, no auth), cached 1h.
+// Returns `openrouter/<id>` ids matching the bot's MODEL format; null on failure.
+let _modelsCache = null, _modelsCacheAt = 0;
+async function openRouterModels() {
+  if (_modelsCache && Date.now() - _modelsCacheAt < 3600000) return _modelsCache;
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 8000);
+    const r = await fetch('https://openrouter.ai/api/v1/models', { signal: ctrl.signal });
+    clearTimeout(t);
+    if (r.ok) {
+      const j = await r.json();
+      const list = (j.data || []).map((m) => 'openrouter/' + m.id).filter((s) => s !== 'openrouter/').sort();
+      if (list.length) { _modelsCache = list; _modelsCacheAt = Date.now(); }
+    }
+  } catch {}
+  return _modelsCache;
+}
 
 const send = (res, code, type, body) => {
   res.writeHead(code, { 'content-type': type });
@@ -104,7 +123,8 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'GET' && pathname === '/api/models') {
-      return json(res, 200, { models: MODELS });
+      const list = await openRouterModels();
+      return json(res, 200, { models: list && list.length ? list : MODELS });
     }
 
     if (req.method === 'GET' && pathname === '/api/preflight') {
@@ -134,7 +154,7 @@ const server = createServer(async (req, res) => {
       let args;
       if (cmd === 'set-model') {
         const model = url.searchParams.get('model') || '';
-        if (!MODELS.includes(model)) return send(res, 400, 'text/plain', `unknown model: ${model}`);
+        if (!/^openrouter\/[A-Za-z0-9/_.:-]+$/.test(model)) return send(res, 400, 'text/plain', `invalid model: ${model}`);
         args = ['set-model', model];
       } else if (STREAM_CMDS.has(cmd)) {
         args = [cmd];

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -5,6 +5,7 @@
 // logic. Built-in modules only (no deps / no install). Binds to localhost.
 import { spawn, spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import {
   copyFile,
   mkdir,
@@ -107,6 +108,10 @@ const dockerOk = () => {
 };
 const keyPresent = async () =>
   /^OPENROUTER_API_KEY=.+/m.test(await readOr(ENV_FILE));
+// The orchestrator needs the sibling tlonbot checkout; if it's missing, run.sh
+// aborts and the UI would otherwise look blank/silent. Surface it in preflight.
+const tlonbotOk = () =>
+  existsSync(join(TLONBOT_DIR, 'tests', 'dev', 'onboarding.sh'));
 const readBody = (req) =>
   new Promise((resolve) => {
     let b = '';
@@ -158,7 +163,14 @@ function unifiedDiff(name) {
     ['-u', '-L', 'a/' + rel, '-L', 'b/' + rel, it.source, it.sandbox],
     { encoding: 'utf8' }
   );
-  return r.stdout || ''; // diff exits 1 when files differ — expected, not an error
+  // diff exits 0 (same) or 1 (differ — expected); a spawn error or status > 1 is
+  // a real failure and must not be silently rendered as "no changes".
+  if (r.error || (typeof r.status === 'number' && r.status > 1)) {
+    throw new Error(
+      'diff failed: ' + (r.error?.message || r.stderr || `status ${r.status}`)
+    );
+  }
+  return r.stdout || '';
 }
 
 // List editable items (prompts + intro) with modified flags; ensures the sandbox
@@ -221,19 +233,27 @@ const runWithStdin = (args, input) =>
 // TCP forward to the port the stack already publishes — no Urbit logic here.
 let proxyServer = null;
 let proxyPort = null;
+let rotating = null; // serializes rotateProxy so concurrent callers can't leak a listener
 
-// Parse the canonical owner Eyre target (host/port) from `status --json`.
-async function ownerTarget() {
+// Derive the owner Eyre target (host/port) from a parsed `status --json` object.
+function targetFromStatus(o) {
+  if (!o || !o.up || !o.owner?.url) return null;
   try {
-    const o = JSON.parse(
-      (await runCapture(['status', '--json'])).trim() || '{}'
-    );
-    if (!o.up || !o.owner?.url) return null;
     const u = new URL(o.owner.url);
     return {
       host: u.hostname === 'localhost' ? '127.0.0.1' : u.hostname,
       port: Number(u.port),
     };
+  } catch {
+    return null;
+  }
+}
+
+async function ownerTarget() {
+  try {
+    return targetFromStatus(
+      JSON.parse((await runCapture(['status', '--json'])).trim() || '{}')
+    );
   } catch {
     return null;
   }
@@ -250,35 +270,44 @@ function closeProxy() {
 }
 
 // Start a fresh proxy on an OS-assigned port forwarding to the owner ship.
-async function rotateProxy() {
-  const target = await ownerTarget();
-  if (!target) {
-    closeProxy();
-    return;
-  }
-  const next = net.createServer((client) => {
-    const upstream = net.connect(target.port, target.host);
-    client.pipe(upstream);
-    upstream.pipe(client);
-    client.on('error', () => upstream.destroy());
-    upstream.on('error', () => client.destroy());
+// Serialized: a second caller during an in-flight rotation joins it rather than
+// creating a parallel listener (which would orphan one). `target` lets callers
+// that already parsed status (e.g. /api/status) skip a second shell-out.
+async function rotateProxy(target) {
+  if (rotating) return rotating;
+  rotating = (async () => {
+    const t = target ?? (await ownerTarget());
+    if (!t) {
+      closeProxy();
+      return;
+    }
+    const next = net.createServer((client) => {
+      const upstream = net.connect(t.port, t.host);
+      client.pipe(upstream);
+      upstream.pipe(client);
+      client.on('error', () => upstream.destroy());
+      upstream.on('error', () => client.destroy());
+    });
+    await new Promise((resolve, reject) => {
+      next.once('error', reject);
+      next.listen(0, '127.0.0.1', resolve);
+    });
+    const old = proxyServer;
+    proxyServer = next;
+    proxyPort = next.address().port;
+    if (old) {
+      try {
+        old.close();
+      } catch {}
+    } // stops new conns; existing tabs drain
+  })().finally(() => {
+    rotating = null;
   });
-  await new Promise((resolve, reject) => {
-    next.once('error', reject);
-    next.listen(0, '127.0.0.1', resolve);
-  });
-  const old = proxyServer;
-  proxyServer = next;
-  proxyPort = next.address().port;
-  if (old) {
-    try {
-      old.close();
-    } catch {}
-  } // stops new conns; existing tabs drain
+  return rotating;
 }
 
-async function ensureProxy() {
-  if (!proxyServer) await rotateProxy();
+async function ensureProxy(target) {
+  if (!proxyServer) await rotateProxy(target);
 }
 
 const server = createServer(async (req, res) => {
@@ -316,7 +345,7 @@ const server = createServer(async (req, res) => {
       try {
         const o = JSON.parse(txt);
         if (o.up) {
-          await ensureProxy(); // first status after the stack is up
+          await ensureProxy(targetFromStatus(o)); // first status after the stack is up
           if (o.owner?.url && proxyPort) {
             const u = new URL(o.owner.url);
             u.hostname = 'localhost';
@@ -337,7 +366,11 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'GET' && pathname === '/api/preflight') {
-      return json(res, 200, { docker: dockerOk(), key: await keyPresent() });
+      return json(res, 200, {
+        docker: dockerOk(),
+        key: await keyPresent(),
+        tlonbot: tlonbotOk(),
+      });
     }
 
     if (req.method === 'POST' && pathname === '/api/provider-key') {
@@ -458,12 +491,20 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'POST' && pathname === '/api/reset-prompts') {
+      const failed = [];
       for (const it of await listItems()) {
         const p = itemPaths(it.name);
         try {
           await discardToSource(p);
-        } catch {}
+        } catch {
+          failed.push(it.name);
+        }
       }
+      if (failed.length)
+        return json(res, 500, {
+          ok: false,
+          error: 'failed to reset: ' + failed.join(', '),
+        });
       return json(res, 200, { ok: true });
     }
 

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -173,10 +173,12 @@ const runCapture = (args) =>
 const runWithStdin = (args, input) =>
   new Promise((resolve) => {
     const p = spawn(RUN, args, { cwd: REPO_ROOT });
-    let out = '';
+    let out = '',
+      err = '';
     p.stdout.on('data', (d) => (out += d));
-    p.on('close', () => resolve(out));
-    p.on('error', () => resolve(''));
+    p.stderr.on('data', (d) => (err += d));
+    p.on('close', (code) => resolve({ code: code ?? -1, out, err }));
+    p.on('error', (e) => resolve({ code: -1, out, err: String(e) }));
     p.stdin.write(input);
     p.stdin.end();
   });
@@ -334,7 +336,15 @@ const server = createServer(async (req, res) => {
           ok: false,
           error: 'key rejected (' + detail + ')',
         });
-      await runWithStdin(['set-key'], key);
+      const saved = await runWithStdin(['set-key'], key);
+      if (saved.code !== 0) {
+        const why =
+          saved.err.trim() || saved.out.trim() || `exit ${saved.code}`;
+        return json(res, 500, {
+          ok: false,
+          error: 'failed to save key: ' + why,
+        });
+      }
       return json(res, 200, { ok: true });
     }
 

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -26,6 +26,13 @@ const PORT = Number(process.env.ONBOARDING_WEB_PORT || 4400);
 // port. Paired with a Host check below to also defend DNS rebinding.
 const TOKEN = randomBytes(24).toString('hex');
 
+// Settable model ids. Used both to FILTER the offered list and to VALIDATE
+// set-model, so the picker never offers a model the control plane will reject
+// (e.g. `~`-prefixed aliases — excluded here, and a tilde is unsafe in the
+// control plane's shell anyway). Keeps `:` for OpenRouter `:free`/`:nitro`
+// variants; the tlonbot cmd_set_model pattern matches this set.
+const MODEL_RE = /^openrouter\/[A-Za-z0-9/_.:-]+$/;
+
 const STREAM_CMDS = new Set(['start', 'reset', 'down', 'status', 'logs']);
 // Offline fallback list — used only if the OpenRouter models API can't be
 // reached. The live list comes from openRouterModels(). Override via env.
@@ -55,7 +62,7 @@ async function openRouterModels() {
       const j = await r.json();
       const list = (j.data || [])
         .map((m) => 'openrouter/' + m.id)
-        .filter((s) => s !== 'openrouter/')
+        .filter((s) => MODEL_RE.test(s))
         .sort();
       if (list.length) {
         _modelsCache = list;
@@ -353,7 +360,7 @@ const server = createServer(async (req, res) => {
       let args;
       if (cmd === 'set-model') {
         const model = url.searchParams.get('model') || '';
-        if (!/^openrouter\/[A-Za-z0-9/_.:-]+$/.test(model))
+        if (!MODEL_RE.test(model))
           return send(res, 400, 'text/plain', `invalid model: ${model}`);
         args = ['set-model', model];
       } else if (STREAM_CMDS.has(cmd)) {

--- a/apps/onboarding-sandbox/server.mjs
+++ b/apps/onboarding-sandbox/server.mjs
@@ -221,6 +221,10 @@ const runWithStdin = (args, input) =>
     p.stderr.on('data', (d) => (err += d));
     p.on('close', (code) => resolve({ code: code ?? -1, out, err }));
     p.on('error', (e) => resolve({ code: -1, out, err: String(e) }));
+    // The child may exit before reading stdin (e.g. run.sh aborts on a missing
+    // TLONBOT_DIR), which EPIPEs this write; swallow it so it doesn't crash the
+    // server — the close handler still reports the real failure.
+    p.stdin.on('error', () => {});
     p.stdin.write(input);
     p.stdin.end();
   });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "onboarding:reset": "scripts/onboarding-sandbox/run.sh reset",
     "onboarding:logs": "scripts/onboarding-sandbox/run.sh logs",
     "onboarding:down": "scripts/onboarding-sandbox/run.sh down",
+    "onboarding:web": "node apps/onboarding-sandbox/server.mjs",
     "build:api": "pnpm --filter '@tloncorp/api' build",
     "dev:api": "pnpm --filter '@tloncorp/api' watch",
     "build:shared": "pnpm --filter '@tloncorp/shared' build",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "name": "tlon-apps",
   "type": "module",
   "scripts": {
+    "onboarding": "scripts/onboarding-sandbox/run.sh start",
+    "onboarding:reset": "scripts/onboarding-sandbox/run.sh reset",
+    "onboarding:logs": "scripts/onboarding-sandbox/run.sh logs",
+    "onboarding:down": "scripts/onboarding-sandbox/run.sh down",
     "build:api": "pnpm --filter '@tloncorp/api' build",
     "dev:api": "pnpm --filter '@tloncorp/api' watch",
     "build:shared": "pnpm --filter '@tloncorp/shared' build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,8 @@ importers:
         specifier: ^1.2.2
         version: 1.5.0(@types/node@22.19.20)(jsdom@23.2.0)(lightningcss@1.31.1)(terser@5.46.0)
 
+  apps/onboarding-sandbox: {}
+
   apps/tlon-desktop:
     dependencies:
       '@tloncorp/app':
@@ -1210,6 +1212,8 @@ importers:
         specifier: ^1.0.4
         version: 1.5.0(@types/node@22.19.20)(jsdom@23.2.0)(lightningcss@1.31.1)(terser@5.46.0)
 
+  packages/hermes-tlon-adapter: {}
+
   packages/openclaw:
     dependencies:
       '@tloncorp/api':
@@ -1246,8 +1250,6 @@ importers:
       vitest:
         specifier: ^4.0.0
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.3)(jsdom@23.2.0)(msw@0.44.2(encoding@0.1.13)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@1.21.0)(terser@5.46.0)(yaml@2.8.2))
-
-  packages/hermes-tlon-adapter: {}
 
   packages/scripts:
     dependencies:

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -31,11 +31,24 @@ ensure_sandbox() {
       exit 1
     fi
   done
-  if [ ! -d "$SANDBOX_DIR" ] || [ -z "$(ls -A "$SANDBOX_DIR" 2>/dev/null)" ]; then
-    echo "Initializing sandbox prompt copies from $TLONBOT_DIR/prompts ..."
-    mkdir -p "$SANDBOX_DIR"
-    cp "$TLONBOT_DIR"/prompts/*.md "$SANDBOX_DIR"/
-  fi
+  # Sync the prompt SET with the source (tlonbot) on every run, preserving the
+  # tester's edits: add source files missing from the sandbox, prune sandbox
+  # files removed upstream, and leave files present in both untouched. (Renames
+  # show up as prune + add, so an edit to a renamed file is lost — rare.)
+  mkdir -p "$SANDBOX_DIR"
+  local f base added=0 pruned=0
+  for f in "$TLONBOT_DIR"/prompts/*.md; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f")"
+    if [ ! -f "$SANDBOX_DIR/$base" ]; then cp "$f" "$SANDBOX_DIR/$base"; added=$((added + 1)); fi
+  done
+  for f in "$SANDBOX_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    base="$(basename "$f")"
+    if [ ! -f "$TLONBOT_DIR/prompts/$base" ]; then rm -f "$f"; pruned=$((pruned + 1)); fi
+  done
+  [ "$added" -gt 0 ]  && echo "sandbox prompts: added $added new file(s) from $TLONBOT_DIR/prompts"
+  [ "$pruned" -gt 0 ] && echo "sandbox prompts: pruned $pruned file(s) removed upstream"
   if [ ! -f "$SANDBOX_INTRO" ] && [ -f "$SRC_INTRO" ]; then
     echo "Initializing sandbox intro copy from $SRC_INTRO ..."
     cp "$SRC_INTRO" "$SANDBOX_INTRO"

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -49,6 +49,8 @@ ensure_sandbox() {
     name="$(basename "$f")"; sbx="$SANDBOX_DIR/$name"; bse="$base_dir/$name"
     if [ ! -f "$sbx" ]; then
       cp "$f" "$sbx"; cp "$f" "$bse"; added=$((added + 1))
+    elif cmp -s "$sbx" "$f"; then
+      cmp -s "$bse" "$f" || cp "$f" "$bse"                 # sandbox already matches source: rebaseline (e.g. the edit was merged upstream)
     elif [ ! -f "$bse" ]; then
       cp "$f" "$bse"                                       # legacy copy: start tracking
     elif cmp -s "$sbx" "$bse" && ! cmp -s "$f" "$bse"; then
@@ -71,7 +73,9 @@ ensure_sandbox() {
     echo "Initializing sandbox intro copy from $SRC_INTRO ..."
     cp "$SRC_INTRO" "$SANDBOX_INTRO"; cp "$SRC_INTRO" "$intro_base"
   elif [ -f "$SANDBOX_INTRO" ] && [ -f "$SRC_INTRO" ]; then
-    if [ ! -f "$intro_base" ]; then
+    if cmp -s "$SANDBOX_INTRO" "$SRC_INTRO"; then
+      cmp -s "$intro_base" "$SRC_INTRO" || cp "$SRC_INTRO" "$intro_base"   # sandbox matches source: rebaseline
+    elif [ ! -f "$intro_base" ]; then
       cp "$SRC_INTRO" "$intro_base"
     elif cmp -s "$SANDBOX_INTRO" "$intro_base" && ! cmp -s "$SRC_INTRO" "$intro_base"; then
       cp "$SRC_INTRO" "$SANDBOX_INTRO"; cp "$SRC_INTRO" "$intro_base"

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# tlon-apps onboarding-sandbox orchestrator (Phase 1 CLI).
+#
+# Thin caller of the tlonbot control plane (tests/dev/onboarding.sh) via the
+# sibling checkout. This (public) side owns ONLY: locating the tlonbot checkout,
+# the sandbox prompt-copy lifecycle, and the `pnpm onboarding*` command surface.
+# It knows NO Urbit/stack internals — all of that lives in tlonbot.
+#
+# Seam: expects a `tlonbot` checkout (private repo) at $TLONBOT_DIR (default: a
+# sibling of this repo), matching the openclaw/dev convention.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+TLONBOT_DIR="${TLONBOT_DIR:-$REPO_ROOT/../tlonbot}"
+CONTROL="$TLONBOT_DIR/tests/dev/onboarding.sh"
+SANDBOX_DIR="$HERE/.sandbox-prompts"
+
+[ -d "$TLONBOT_DIR" ] || { echo "ERROR: tlonbot checkout not found at $TLONBOT_DIR — set TLONBOT_DIR." >&2; exit 1; }
+[ -x "$CONTROL" ]     || { echo "ERROR: control plane not found/executable: $CONTROL" >&2; exit 1; }
+
+# Editable sandbox copies of tlonbot/prompts. Private content in a public repo,
+# so the path MUST be gitignored — the initializer refuses otherwise.
+ensure_sandbox_prompts() {
+  if ! git -C "$REPO_ROOT" check-ignore -q "$SANDBOX_DIR"; then
+    echo "ERROR: $SANDBOX_DIR is not gitignored — refusing to copy private prompts" >&2
+    echo "       into a tracked path. Add it to .gitignore first." >&2
+    exit 1
+  fi
+  if [ ! -d "$SANDBOX_DIR" ] || [ -z "$(ls -A "$SANDBOX_DIR" 2>/dev/null)" ]; then
+    echo "Initializing sandbox prompt copies from $TLONBOT_DIR/prompts ..."
+    mkdir -p "$SANDBOX_DIR"
+    cp "$TLONBOT_DIR"/prompts/*.md "$SANDBOX_DIR"/
+  fi
+}
+
+case "${1:-}" in
+  start|"")
+    ensure_sandbox_prompts
+    "$CONTROL" start "$SANDBOX_DIR"
+    ;;
+  reset)
+    ensure_sandbox_prompts
+    "$CONTROL" reset "$SANDBOX_DIR"
+    ;;
+  logs)   "$CONTROL" logs ;;
+  status) "$CONTROL" status ;;
+  down)   "$CONTROL" down ;;
+  *) echo "usage: pnpm onboarding | onboarding:reset | onboarding:logs | onboarding:down" >&2; exit 1 ;;
+esac

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -51,9 +51,10 @@ case "${1:-}" in
     ensure_sandbox
     TLONBOT_INTRO_FILE="$SANDBOX_INTRO" "$CONTROL" reset "$SANDBOX_DIR"
     ;;
-  init)   ensure_sandbox ;;
-  logs)   "$CONTROL" logs ;;
-  status) shift; "$CONTROL" status "$@" ;;
-  down)   "$CONTROL" down ;;
+  init)      ensure_sandbox ;;
+  logs)      "$CONTROL" logs ;;
+  status)    shift; "$CONTROL" status "$@" ;;
+  set-model) shift; "$CONTROL" set-model "$@" ;;
+  down)      "$CONTROL" down ;;
   *) echo "usage: pnpm onboarding | onboarding:reset | onboarding:logs | onboarding:down" >&2; exit 1 ;;
 esac

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -32,11 +32,11 @@ ensure_sandbox() {
     fi
   done
   # Sync the prompt SET with the source (tlonbot) on every run, preserving the
-  # tester's edits: add source files missing from the sandbox, prune sandbox
-  # files removed upstream, and leave files present in both untouched. (Renames
-  # show up as prune + add, so an edit to a renamed file is lost — rare.)
+  # tester's edits: add source files missing from the sandbox, quarantine sandbox
+  # files removed upstream (never delete — these gitignored copies are the only
+  # copy of the tester's edits), and leave files present in both untouched.
   mkdir -p "$SANDBOX_DIR"
-  local f base added=0 pruned=0
+  local f base added=0 orphaned=0 orphan_dir="$SANDBOX_DIR/.orphaned"
   for f in "$TLONBOT_DIR"/prompts/*.md; do
     [ -f "$f" ] || continue
     base="$(basename "$f")"
@@ -45,10 +45,12 @@ ensure_sandbox() {
   for f in "$SANDBOX_DIR"/*.md; do
     [ -f "$f" ] || continue
     base="$(basename "$f")"
-    if [ ! -f "$TLONBOT_DIR/prompts/$base" ]; then rm -f "$f"; pruned=$((pruned + 1)); fi
+    if [ ! -f "$TLONBOT_DIR/prompts/$base" ]; then
+      mkdir -p "$orphan_dir"; mv "$f" "$orphan_dir/$base"; orphaned=$((orphaned + 1))
+    fi
   done
-  [ "$added" -gt 0 ]  && echo "sandbox prompts: added $added new file(s) from $TLONBOT_DIR/prompts"
-  [ "$pruned" -gt 0 ] && echo "sandbox prompts: pruned $pruned file(s) removed upstream"
+  [ "$added" -gt 0 ]    && echo "sandbox prompts: added $added new file(s) from $TLONBOT_DIR/prompts"
+  [ "$orphaned" -gt 0 ] && echo "sandbox prompts: moved $orphaned removed-upstream file(s) to $orphan_dir (preserved, not deleted)"
   if [ ! -f "$SANDBOX_INTRO" ] && [ -f "$SRC_INTRO" ]; then
     echo "Initializing sandbox intro copy from $SRC_INTRO ..."
     cp "$SRC_INTRO" "$SANDBOX_INTRO"

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -55,7 +55,7 @@ case "${1:-}" in
   logs)      "$CONTROL" logs ;;
   status)    shift; "$CONTROL" status "$@" ;;
   set-model) shift; "$CONTROL" set-model "$@" ;;
-  set-key)   shift; "$CONTROL" set-key "$@" ;;
+  set-key)   "$CONTROL" set-key ;;   # key arrives on stdin (kept out of argv)
   down)      "$CONTROL" down ;;
   *) echo "usage: pnpm onboarding | onboarding:reset | onboarding:logs | onboarding:down" >&2; exit 1 ;;
 esac

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -55,6 +55,7 @@ case "${1:-}" in
   logs)      "$CONTROL" logs ;;
   status)    shift; "$CONTROL" status "$@" ;;
   set-model) shift; "$CONTROL" set-model "$@" ;;
+  set-key)   shift; "$CONTROL" set-key "$@" ;;
   down)      "$CONTROL" down ;;
   *) echo "usage: pnpm onboarding | onboarding:reset | onboarding:logs | onboarding:down" >&2; exit 1 ;;
 esac

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -44,7 +44,7 @@ case "${1:-}" in
     "$CONTROL" reset "$SANDBOX_DIR"
     ;;
   logs)   "$CONTROL" logs ;;
-  status) "$CONTROL" status ;;
+  status) shift; "$CONTROL" status "$@" ;;
   down)   "$CONTROL" down ;;
   *) echo "usage: pnpm onboarding | onboarding:reset | onboarding:logs | onboarding:down" >&2; exit 1 ;;
 esac

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -14,35 +14,44 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$HERE/../.." && pwd)"
 TLONBOT_DIR="${TLONBOT_DIR:-$REPO_ROOT/../tlonbot}"
 CONTROL="$TLONBOT_DIR/tests/dev/onboarding.sh"
-SANDBOX_DIR="$HERE/.sandbox-prompts"
+SANDBOX_DIR="$HERE/.sandbox-prompts"           # editable prompt copies (→ workspace)
+SANDBOX_INTRO="$HERE/.sandbox-intro.md"         # editable welcome-DM copy (→ send-intro)
+SRC_INTRO="$TLONBOT_DIR/tests/dev/onboarding-intro.md"
 
 [ -d "$TLONBOT_DIR" ] || { echo "ERROR: tlonbot checkout not found at $TLONBOT_DIR — set TLONBOT_DIR." >&2; exit 1; }
 [ -x "$CONTROL" ]     || { echo "ERROR: control plane not found/executable: $CONTROL" >&2; exit 1; }
 
-# Editable sandbox copies of tlonbot/prompts. Private content in a public repo,
-# so the path MUST be gitignored — the initializer refuses otherwise.
-ensure_sandbox_prompts() {
-  if ! git -C "$REPO_ROOT" check-ignore -q "$SANDBOX_DIR"; then
-    echo "ERROR: $SANDBOX_DIR is not gitignored — refusing to copy private prompts" >&2
-    echo "       into a tracked path. Add it to .gitignore first." >&2
-    exit 1
-  fi
+# Editable sandbox copies of the private tlonbot prompts + intro. These hold
+# private content in a public repo, so the paths MUST be gitignored — the
+# initializer refuses otherwise.
+ensure_sandbox() {
+  for p in "$SANDBOX_DIR" "$SANDBOX_INTRO"; do
+    if ! git -C "$REPO_ROOT" check-ignore -q "$p"; then
+      echo "ERROR: $p is not gitignored — refusing to copy private content into a tracked path." >&2
+      exit 1
+    fi
+  done
   if [ ! -d "$SANDBOX_DIR" ] || [ -z "$(ls -A "$SANDBOX_DIR" 2>/dev/null)" ]; then
     echo "Initializing sandbox prompt copies from $TLONBOT_DIR/prompts ..."
     mkdir -p "$SANDBOX_DIR"
     cp "$TLONBOT_DIR"/prompts/*.md "$SANDBOX_DIR"/
   fi
+  if [ ! -f "$SANDBOX_INTRO" ] && [ -f "$SRC_INTRO" ]; then
+    echo "Initializing sandbox intro copy from $SRC_INTRO ..."
+    cp "$SRC_INTRO" "$SANDBOX_INTRO"
+  fi
 }
 
 case "${1:-}" in
   start|"")
-    ensure_sandbox_prompts
-    "$CONTROL" start "$SANDBOX_DIR"
+    ensure_sandbox
+    TLONBOT_INTRO_FILE="$SANDBOX_INTRO" "$CONTROL" start "$SANDBOX_DIR"
     ;;
   reset)
-    ensure_sandbox_prompts
-    "$CONTROL" reset "$SANDBOX_DIR"
+    ensure_sandbox
+    TLONBOT_INTRO_FILE="$SANDBOX_INTRO" "$CONTROL" reset "$SANDBOX_DIR"
     ;;
+  init)   ensure_sandbox ;;
   logs)   "$CONTROL" logs ;;
   status) shift; "$CONTROL" status "$@" ;;
   down)   "$CONTROL" down ;;

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -43,7 +43,7 @@ ensure_sandbox() {
   local src_dir="$TLONBOT_DIR/prompts"
   local base_dir="$SANDBOX_DIR/.base" orphan_dir="$SANDBOX_DIR/.orphaned"
   mkdir -p "$SANDBOX_DIR" "$base_dir"
-  local f name sbx bse added=0 refreshed=0 orphaned=0
+  local f name sbx bse dest n2 added=0 refreshed=0 orphaned=0
   for f in "$src_dir"/*.md; do
     [ -f "$f" ] || continue
     name="$(basename "$f")"; sbx="$SANDBOX_DIR/$name"; bse="$base_dir/$name"
@@ -61,7 +61,10 @@ ensure_sandbox() {
     [ -f "$f" ] || continue
     name="$(basename "$f")"
     if [ ! -f "$src_dir/$name" ]; then
-      mkdir -p "$orphan_dir"; mv "$f" "$orphan_dir/$name"; rm -f "$base_dir/$name"; orphaned=$((orphaned + 1))
+      mkdir -p "$orphan_dir"
+      dest="$orphan_dir/$name"; n2=1
+      while [ -e "$dest" ]; do dest="$orphan_dir/$name.$n2"; n2=$((n2 + 1)); done  # don't clobber an earlier quarantine
+      mv "$f" "$dest"; rm -f "$base_dir/$name"; orphaned=$((orphaned + 1))
     fi
   done
   [ "$added" -gt 0 ]     && echo "sandbox prompts: added $added new file(s) from $src_dir"

--- a/scripts/onboarding-sandbox/run.sh
+++ b/scripts/onboarding-sandbox/run.sh
@@ -31,29 +31,52 @@ ensure_sandbox() {
       exit 1
     fi
   done
-  # Sync the prompt SET with the source (tlonbot) on every run, preserving the
-  # tester's edits: add source files missing from the sandbox, quarantine sandbox
-  # files removed upstream (never delete — these gitignored copies are the only
-  # copy of the tester's edits), and leave files present in both untouched.
-  mkdir -p "$SANDBOX_DIR"
-  local f base added=0 orphaned=0 orphan_dir="$SANDBOX_DIR/.orphaned"
-  for f in "$TLONBOT_DIR"/prompts/*.md; do
+  # Sync the prompt SET with the source (tlonbot) on every run. A hidden .base/
+  # records the source content at copy time, so we can tell the tester's edits
+  # from unedited-but-stale copies:
+  #   - new file              -> copy to sandbox + base
+  #   - unedited & src changed -> refresh sandbox + base (fixes staleness AND the
+  #                               false "modified" flag for files the user never touched)
+  #   - edited (!= base)      -> preserve, never clobber
+  #   - legacy (no base yet)  -> record current source as base, leave the copy (self-heals next change)
+  #   - removed upstream      -> quarantine (never delete) + drop its base
+  local src_dir="$TLONBOT_DIR/prompts"
+  local base_dir="$SANDBOX_DIR/.base" orphan_dir="$SANDBOX_DIR/.orphaned"
+  mkdir -p "$SANDBOX_DIR" "$base_dir"
+  local f name sbx bse added=0 refreshed=0 orphaned=0
+  for f in "$src_dir"/*.md; do
     [ -f "$f" ] || continue
-    base="$(basename "$f")"
-    if [ ! -f "$SANDBOX_DIR/$base" ]; then cp "$f" "$SANDBOX_DIR/$base"; added=$((added + 1)); fi
+    name="$(basename "$f")"; sbx="$SANDBOX_DIR/$name"; bse="$base_dir/$name"
+    if [ ! -f "$sbx" ]; then
+      cp "$f" "$sbx"; cp "$f" "$bse"; added=$((added + 1))
+    elif [ ! -f "$bse" ]; then
+      cp "$f" "$bse"                                       # legacy copy: start tracking
+    elif cmp -s "$sbx" "$bse" && ! cmp -s "$f" "$bse"; then
+      cp "$f" "$sbx"; cp "$f" "$bse"; refreshed=$((refreshed + 1))   # unedited + upstream changed
+    fi
   done
   for f in "$SANDBOX_DIR"/*.md; do
     [ -f "$f" ] || continue
-    base="$(basename "$f")"
-    if [ ! -f "$TLONBOT_DIR/prompts/$base" ]; then
-      mkdir -p "$orphan_dir"; mv "$f" "$orphan_dir/$base"; orphaned=$((orphaned + 1))
+    name="$(basename "$f")"
+    if [ ! -f "$src_dir/$name" ]; then
+      mkdir -p "$orphan_dir"; mv "$f" "$orphan_dir/$name"; rm -f "$base_dir/$name"; orphaned=$((orphaned + 1))
     fi
   done
-  [ "$added" -gt 0 ]    && echo "sandbox prompts: added $added new file(s) from $TLONBOT_DIR/prompts"
-  [ "$orphaned" -gt 0 ] && echo "sandbox prompts: moved $orphaned removed-upstream file(s) to $orphan_dir (preserved, not deleted)"
+  [ "$added" -gt 0 ]     && echo "sandbox prompts: added $added new file(s) from $src_dir"
+  [ "$refreshed" -gt 0 ] && echo "sandbox prompts: refreshed $refreshed unedited file(s) from upstream"
+  [ "$orphaned" -gt 0 ]  && echo "sandbox prompts: moved $orphaned removed-upstream file(s) to $orphan_dir (preserved, not deleted)"
+  # intro: same base-tracking as the prompts (single file)
+  local intro_base="$base_dir/.intro"
   if [ ! -f "$SANDBOX_INTRO" ] && [ -f "$SRC_INTRO" ]; then
     echo "Initializing sandbox intro copy from $SRC_INTRO ..."
-    cp "$SRC_INTRO" "$SANDBOX_INTRO"
+    cp "$SRC_INTRO" "$SANDBOX_INTRO"; cp "$SRC_INTRO" "$intro_base"
+  elif [ -f "$SANDBOX_INTRO" ] && [ -f "$SRC_INTRO" ]; then
+    if [ ! -f "$intro_base" ]; then
+      cp "$SRC_INTRO" "$intro_base"
+    elif cmp -s "$SANDBOX_INTRO" "$intro_base" && ! cmp -s "$SRC_INTRO" "$intro_base"; then
+      cp "$SRC_INTRO" "$SANDBOX_INTRO"; cp "$SRC_INTRO" "$intro_base"
+      echo "sandbox intro: refreshed from upstream (unedited)"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

Adds a one-command, disposable onboarding sandbox so non-technical teammates can test changes to the onboarding bot (prompts, the welcome DM, and the model) by actually talking to the bot through the real first-run flow, with no dev environment and no code.

This is the public-repo side: a thin orchestrator plus a zero-dependency web control server and UI. All Urbit and stack mechanics live in the private tlonbot repo and are driven via a sibling checkout (see [paired PR](https://github.com/tloncorp/tlonbot/pull/100)). No private content is committed here; the editable prompt and intro copies are gitignored.

## What you get

Run `pnpm onboarding:web`, open `http://127.0.0.1:4400`, and you can:

- Edit every onboarding prompt and the intro DM in the browser, with a per-file Diff view.
- Pick any OpenRouter model (live list, around 336 models, type-ahead search).
- Start the stack, then "Open chat as owner" to chat with the bot as a real user and watch the live first-run experience.
- Save & reset onboarding to replay first-run in seconds (fast nuke-based reset, no pier rebuild).
- Export patch to hand your edits to a dev as a `.patch`.
- First-run setup that checks Docker is running and validates your OpenRouter key.

## What's added

| File | What |
|---|---|
| `scripts/onboarding-sandbox/run.sh` | Thin orchestrator. Locates the sibling tlonbot checkout, manages gitignored sandbox copies of the prompts and intro, and exposes the `pnpm onboarding*` surface. Knows no Urbit internals; delegates all stack mechanics to tlonbot. |
| `apps/onboarding-sandbox/server.mjs` | Zero-dependency Node control server (built-in `http`/`net` only). HTTP and SSE over the orchestrator; prompt CRUD on the sandbox copies; status; live OpenRouter model list; Docker and key preflight; provider-key validation; and the cache-busting owner proxy. |
| `apps/onboarding-sandbox/public/index.html` | UI: prompt and intro editor, diff, export patch, model selector, discard (per-file and all), collapsible activity log, first-run setup banner. |
| `package.json` | `onboarding`, `onboarding:web`, `onboarding:reset`, `onboarding:down`, and related scripts. |
| `.gitignore` | Ignore the sandbox prompt and intro copies (private content must never be committed to this public repo). |

## How it works

1. The web control server shells out to `run.sh`, which calls the tlonbot control plane over a sibling checkout.
2. Start brings up a Docker stack (three fakezod ships, `~zod`/`~ten`/`~mug`, plus the openclaw gateway) and runs first-run. Onboarding uses the bot (`~zod`) and owner (`~ten`); `~mug` comes with the shared stack but is unused here.
3. Save & reset writes your edits, then replays first-run by nuking ship state (fast) and re-sending a fresh intro DM.
4. "Open chat as owner" opens the owner ship's real Tlon web client, so you experience onboarding exactly as a new user would.

## Design notes

- Zero runtime dependencies in the sandbox app (built-in Node modules only). Nothing to install, fast to reason about.
- Fast reset via nuke/revive instead of rebuilding piers.
- Clean chat on every reset. The Tlon web client caches the conversation per browser-origin and has no logout, so a backend reset alone would leave stale messages. The control server serves the owner ship on a fresh proxy port on each reset, so a new origin gives an empty client cache and a clean conversation in the tester's own browser. (Chosen after evaluating a bookmarklet, backend message deletes, and a Playwright-driven browser.)
- Strict cross-repo boundary. tlonbot owns all stack mechanics; this side is a thin caller. Private prompt and intro content is copied into gitignored paths only.

## Testing

- Validated end to end against the live Docker stack: reset/replay loop, send-intro, prompt render, model switching, and a full onboarding conversation.
- UI flows smoke-tested in headless Chromium: editor, diff, export, model selector, discard, first-run key entry, and clean-reset proxy rotation.

## Follow-ups (not in this PR)

- The sandbox runs the ships' frozen rube pier desk, so a backend agent added later needs a rube pier bump (or a desk-deploy step) before it is available in the sandbox.
- Adding the ability to test against the hermes agent and its prompts.

