### PR TITLE
deploy: speed up gcloud IAP tunnel upload with NumPy

### DIFF
--- a/.github/helpers/deploy.sh
+++ b/.github/helpers/deploy.sh
@@ -41,6 +41,20 @@ fi
 # Package the assembled, self-contained desk.
 tar czf "$workdir/desk.tgz" -C "$workdir" assembled
 
+# --- Speed up the IAP tunnel ------------------------------------------------
+# gcloud's IAP TCP forwarding is a single-threaded Python websocket proxy. With
+# NumPy available its upload path is dramatically faster (gcloud prints a
+# warning recommending this). The whole assembled desk is shipped UP through
+# this tunnel, so without NumPy the scp below takes ~4 min. CLOUDSDK_PYTHON_-
+# SITEPACKAGES lets gcloud's bundled interpreter see the system-installed numpy.
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+if ! python3 -c 'import numpy' >/dev/null 2>&1; then
+  echo "Installing NumPy to speed up the IAP tunnel..."
+  pip3 install --user numpy \
+    || pip3 install --user --break-system-packages numpy \
+    || echo "WARNING: NumPy install failed; tunnel upload will be slow."
+fi
+
 # --- SSH key setup ----------------------------------------------------------
 sshpriv=$(mktemp "${TMPDIR:-/tmp/}ssh.XXXXXXXXX")
 sshpub=$sshpriv.pub


### PR DESCRIPTION
## Summary

Speeds up new flow, although it'll still be slower than before. Still investigating options.

## Changes

- `.github/helpers/deploy.sh`: install NumPy on the runner and export `CLOUDSDK_PYTHON_SITEPACKAGES=1` before the `gcloud compute scp`/`ssh` calls, so gcloud's bundled interpreter can use NumPy to speed up the IAP TCP-forwarding tunnel.

## How did I test?

Inspecting the canary deploy logs ([job 82187434309](https://github.com/tloncorp/tlon-apps/actions/runs/27775326728/job/82187434309)), the 6m12s "Deploy" step breaks down as ~2 min assemble + **~4 min `scp` of `desk.tgz` up through the IAP tunnel**. gcloud emits `WARNING: To increase the performance of the tunnel, consider installing NumPy.` twice. This change applies that fix; the real test is timing the next canary deploy after merge.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: CI/CD deploy tooling only — no app or backend code

## Rollback plan

Revert this commit. No runtime impact; only the deploy runner's tunnel performance changes.

## Screenshots / videos

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
