### PR TITLE
Bump desk to 11.4.0; set as reactions minimum

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -4,7 +4,7 @@
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
     glob-http+['https://bootstrap.urbit.org/glob-0v1.eao15.c842d.7d6j5.nm1ni.2r6aa.glob' 0v1.eao15.c842d.7d6j5.nm1ni.2r6aa]
     base+'groups'
-    version+[11 3 0]
+    version+[11 4 0]
     website+'https://tlon.io'
     license+'MIT'
 ==

--- a/packages/shared/src/logic/reactionSupport.test.ts
+++ b/packages/shared/src/logic/reactionSupport.test.ts
@@ -4,14 +4,15 @@ import { activityVersionSupportsReactions } from './reactionSupport';
 
 describe('activityVersionSupportsReactions', () => {
   test('false below the minimum (incl. current deployed version)', () => {
+    expect(activityVersionSupportsReactions('11.3.0')).toBe(false);
     expect(activityVersionSupportsReactions('11.2.2')).toBe(false);
     expect(activityVersionSupportsReactions('11.0.1')).toBe(false);
     expect(activityVersionSupportsReactions('10.9.9')).toBe(false);
   });
 
   test('true at or above the minimum', () => {
-    expect(activityVersionSupportsReactions('11.3.0')).toBe(true);
-    expect(activityVersionSupportsReactions('11.3.1')).toBe(true);
+    expect(activityVersionSupportsReactions('11.4.0')).toBe(true);
+    expect(activityVersionSupportsReactions('11.4.1')).toBe(true);
     expect(activityVersionSupportsReactions('12.0.0')).toBe(true);
   });
 
@@ -32,11 +33,11 @@ describe('activityVersionSupportsReactions', () => {
     expect(activityVersionSupportsReactions('11.2.2-')).toBe(false);
     expect(activityVersionSupportsReactions('11.2.2.3')).toBe(false);
     expect(activityVersionSupportsReactions('11.2')).toBe(false);
-    expect(activityVersionSupportsReactions('v11.3.0')).toBe(false);
+    expect(activityVersionSupportsReactions('v11.4.0')).toBe(false);
   });
 
   test('still respects valid prerelease/build suffixes at or above the minimum', () => {
-    expect(activityVersionSupportsReactions('11.3.0-rc.1')).toBe(true);
-    expect(activityVersionSupportsReactions('11.3.0+build.5')).toBe(true);
+    expect(activityVersionSupportsReactions('11.4.0-rc.1')).toBe(true);
+    expect(activityVersionSupportsReactions('11.4.0+build.5')).toBe(true);
   });
 });

--- a/packages/shared/src/logic/reactionSupport.ts
+++ b/packages/shared/src/logic/reactionSupport.ts
@@ -2,12 +2,11 @@ import { isVersionBelow, parseVersion } from './semver';
 
 // The first deployed %groups release that ships reaction support: the v9
 // %activity endpoints (v6 feed, v5 subscription, activity-action-1 /
-// activity-event-1 marks) plus react emission. The reactions code is on develop
-// but unreleased; the latest deployed version is 11.2.2, so this is the next
-// release. Below it, the client uses the pre-reaction endpoints (v5 feed, v4
+// activity-event-1 marks) plus react emission. 11.4.0 is the confirmed
+// reactions release; 11.3.0 is the previous release without it. Below the
+// minimum, the client uses the pre-reaction endpoints (v5 feed, v4
 // subscription, v8 marks), which work on older backends.
-// TODO(reactions): confirm this matches the release that actually deploys reactions.
-export const REACTIONS_MIN_GROUPS_VERSION = '11.3.0';
+export const REACTIONS_MIN_GROUPS_VERSION = '11.4.0';
 
 // Whether a backend at the given groups version supports reactions. Conservative
 // by design: anything that isn't a fully valid semver (e.g. 'n/a' when the


### PR DESCRIPTION
## Summary

Since 408 going out is 11.3 needed to bump versions here for the minimum react compat

## Changes

- Bump the `%groups` desk docket version from `[11 3 0]` to `[11 4 0]`.
- Raise `REACTIONS_MIN_GROUPS_VERSION` from `11.3.0` to `11.4.0` so reactions are gated on the 11.4.0 backend release.
- Update `reactionSupport` tests and the explanatory comment (11.4.0 is the confirmed reactions release; 11.3.0 is the previous release without it).

## How did I test?

`vitest run src/logic/reactionSupport.test.ts` — 5 tests pass.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [x] Other: reaction support gating / desk version

## Rollback plan

Revert this commit. No state migration involved.

## Screenshots / videos

<!-- Attach any relevant media. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
