### PR TITLE
reel: fix profile update race condition

### DIFF
--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -6,8 +6,8 @@ ship="~bud"
 pier_dir=${ship#\~}
 pier=$pier_dir
 
-urbit_bin_url="https://bootstrap.urbit.org/vere/live/v4.4"
-vere_ver="vere-v4.4"
+urbit_bin_url="https://bootstrap.urbit.org/vere/live/v4.5"
+vere_ver="vere-v4.5"
 arch=`uname -m`
 
 case $OSTYPE in

--- a/desk/app/bait.hoon
+++ b/desk/app/bait.hoon
@@ -308,7 +308,8 @@
       ::
       %bait-update
     =+  !<([=token:reel update=metadata:reel] vase)
-    ?~  meta=(~(get by token-metadata) token)  `this
+    ?~  meta=(~(get by token-metadata) token)
+      `this
     ::  update the invite
     ::
     =.  token-metadata
@@ -330,7 +331,8 @@
     ::
     =+  id=(rap 3 (scot %p p.flag) '/' q.flag ~)
     ::  only the group host is allowed to update associated invites
-    ?.  =(p.flag src.bowl)  `this
+    ?.  =(p.flag src.bowl)
+      `this
     =.  token-metadata
       %+  roll  ~(tap in (~(get ju stable-id) id))
       |=  [=token:reel =_token-metadata]

--- a/desk/app/groups.hoon
+++ b/desk/app/groups.hoon
@@ -1887,10 +1887,6 @@
     |=  =u-group:g
     ~>  %spin.['se-update']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-update {<flag>} u-group={<u-group>}"
-    ::  ==
     =/  time
       |-
       =/  update  (get:log-on:g group-log now.bowl)
@@ -2103,10 +2099,6 @@
       (se-admit src.bowl tok)
     =/  has-token=?  ?=(^ tok)
     =/  joined=?  (se-is-joined src.bowl)
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-join {<flag>} src={<src.bowl>} privacy={<privacy.ad>} has-token={<has-token>} access={<access>} joined={<joined>}"
-    ::  ==
     ~|  %se-c-join-access-denied
     ?>  access
     ?:  joined  se-core
@@ -2127,10 +2119,6 @@
     ?<  ?=(%secret privacy.ad)
     ?>  (lte (met 3 (jam story)) size-limit)
     =/  joined=?  (se-is-joined src.bowl)
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-ask {<flag>} src={<src.bowl>} privacy={<privacy.ad>} joined={<joined>}"
-    ::  ==
     ?:  joined  se-core
     ?:  ?=(%public privacy.ad)
       ::  public group: wait until we receive the ask watch
@@ -2234,10 +2222,6 @@
     ::
     =*  se-src-is-admin   (se-is-admin src.bowl)
     =*  se-src-is-member  (se-is-member src.bowl)
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-group {<flag>} src={<src.bowl>} command={<-.c-group>} admin={<se-src-is-admin>} member={<se-src-is-member>}"
-    ::  ==
     ::
     ?-    -.c-group
         %meta
@@ -2285,10 +2269,6 @@
     |=  =c-entry:g
     ~>  %spin.['se-c-entry']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-entry {<flag>} src={<src.bowl>} command={<-.c-entry>}"
-    ::  ==
     ?-  -.c-entry
       %privacy  (se-c-entry-privacy privacy.c-entry)
       %ban      (se-c-entry-ban c-ban.c-entry)
@@ -2302,10 +2282,6 @@
     |=  =privacy:g
     ~>  %spin.['se-c-entry-privacy']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-entry-privacy {<flag>} src={<src.bowl>} old={<privacy.ad>} new={<privacy>}"
-    ::  ==
     =.  privacy.ad  privacy
     (se-update [%entry %privacy privacy])
   ::  +se-c-entry-ban: execute an entry ban command
@@ -2327,10 +2303,6 @@
     |=  =c-ban:g
     ~>  %spin.['se-c-entry-ban']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-entry-ban {<flag>} src={<src.bowl>} c-ban={<c-ban>}"
-    ::  ==
     ::  disallow operations affecting the host
     ?<  ?|  ?&  ?=(?(%add-ships %del-ships) -.c-ban)
                 (~(has in ships.c-ban) our.bowl)
@@ -2442,10 +2414,6 @@
     |=  =c-token:g
     ~>  %spin.['se-c-entry-token']
     ^-  [(unit token:g) _se-core]
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-entry-token {<flag>} src={<src.bowl>} c-token={<c-token>}"
-    ::  ==
     ?-    -.c-token
         %add
       =*  c-token-add  c-token-add.c-token
@@ -2531,10 +2499,6 @@
     |=  [ships=(set ship) =c-pending:g]
     ~>  %spin.['se-c-entry-pending']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-entry-pending {<flag>} src={<src.bowl>} ships={<ships>} c-pending={<c-pending>}"
-    ::  ==
     ?<  ?&  ?=(%add -.c-pending)
             (~(any in ships) se-is-banned)
         ==
@@ -2590,10 +2554,6 @@
     ~>  %spin.['se-c-entry-ask']
     ^+  se-core
     =/  request-ships=(set ship)  ~(key by requests.ad)
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-entry-ask {<flag>} src={<src.bowl>} ships={<ships>} c-ask={<c-ask>} requests={<request-ships>}"
-    ::  ==
     ?-    c-ask
         %approve
       =/  reqs=(set ship)
@@ -2648,10 +2608,6 @@
     ~>  %spin.['se-c-seat']
     ^+  se-core
     =/  user-join  =(ships (sy src.bowl ~))
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-c-seat {<flag>} src={<src.bowl>} ships={<ships>} c-seat={<c-seat>} user-join={<user-join>}"
-    ::  ==
     ::
     ?-    -.c-seat
         %add
@@ -3164,10 +3120,6 @@
     |=  =path
     ~>  %spin.['se-watch']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-watch {<flag>} src={<src.bowl>} path={<path>}"
-    ::  ==
     ?+    path  ~|(se-watch-bad+path !!)
         ::  receive updates since .time
         ::
@@ -3297,10 +3249,6 @@
     |=  =ship
     ~>  %spin.['se-watch-ask']
     ^+  se-core
-    ::=.  cor
-    ::  %+  tell:log  %dbug
-    ::  :~  leaf+"+se-watch-ask {<flag>} src={<src.bowl>} ship={<ship>} privacy={<privacy.ad>}"
-    ::  ==
     ?.  =(%public privacy.ad)  ::TMI
       :: for a private group we wait until the request is approved
       se-core
@@ -3530,7 +3478,7 @@
     ^+  go-core
     =*  log  ~(. l `'group-join')
     ?:  go-has-sub  go-core
-    ::=.  cor  (tell:log %dbug leaf+"+go-safe-sub subscribing to {<flag>}" ~)
+    =.  cor  (tell:log %dbug leaf+"+go-safe-sub subscribing to {<flag>}" ~)
     (go-start-updates delay)
   ::  +go-leave-subs: leave group subscriptions
   ::
@@ -4634,7 +4582,6 @@
     =/  r-groups-9=r-groups:v9:gv  [flag r-group]
     =/  v1-paths  ~[/v1/groups [%v1 go-area]]
     =*  log  ~(. l `'group-join')
-    ::=.  cor  (tell:log %dbug leaf+"+go-response /v1/groups fact {<r-groups-9>}" ~)
     =.  cor  (give %fact v1-paths group-response-1+!>(r-groups-9))
     ::  v0 backcompat
     ::
@@ -4814,7 +4761,6 @@
     =/  foreign-8  (v8:foreign:v10:gc foreign)
     =/  foreigns-8=foreigns:v8:gv  (my flag^foreign-8 ~)
     =*  log  ~(. l `'group-join')
-    ::=.  cor  (tell:log %dbug leaf+"+fi-give-update /v1/foreigns fact {<foreigns-8>}" ~)
     =.  cor  (give %fact ~[/v1/foreigns] foreigns-1+!>(foreigns-8))
     =.  cor  (give %fact ~[/gangs/updates] gangs+!>(`gangs:v2:gv`(my flag^gang-2 ~)))
     fi-core
@@ -4929,7 +4875,6 @@
       =.  progress  `%error
       fi-core
     =.  progress  `%join
-    ::=.  cor  (tell:log %dbug leaf+"+fi-join with token {<tok>}" ~)
     =.  cor  (emit (join:fi-pass tok))
     =.  cor
       %-  submit-activity
@@ -4970,7 +4915,6 @@
       =.  cor  (fail:log 'group join failed' u.p)
       =.  progress  `%error
       fi-core
-    ::=.  cor  (tell:log %dbug leaf+"group {<flag>} joined successfully" ~)
     =.  progress  `%done
     fi-core
   ::  +fi-error: end a foreign sequence with an error

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -250,7 +250,7 @@
       %+  turn  ~(tap by our-metadata)
       |=  [token=cord =metadata:reel]
       ^-  card
-      [%pass /describe %agent [civ %bait] %poke %bait-describe !>([token metadata])]
+      [%pass /bait %agent [civ %bait] %poke %bait-describe !>([token metadata])]
     ==
   ::
       %reel-bite
@@ -338,7 +338,7 @@
     =.  open-describes  (~(put by open-describes) nonce |)
     =.  stable-id  (~(put by stable-id) id nonce)
     :_  this
-    ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce metadata])]]
+    ~[[%pass /bait %agent [civ %bait] %poke %bait-describe !>([nonce metadata])]]
   ::
       %reel-confirmation
     ?>  =(civ src.bowl)
@@ -373,7 +373,7 @@
     =/  path  (stab (cat 3 '/v1/id-link/' id))
     ?.  sync
       [%give %fact ~[path] %json !>(s+url)]~
-    :~  [%pass /update/open %agent [civ %bait] %poke bait-update+!>([token u.md])]
+    :~  [%pass /bait %agent [civ %bait] %poke bait-update+!>([token u.md])]
         [%give %fact ~[path] %json !>(s+url)]
     ==
   ::
@@ -386,7 +386,7 @@
           ~[leaf+"invite link removed"]
         ~['event'^s+'Invite Link Removed' 'lure-id'^s+token]
     :_  this(our-metadata (~(del by our-metadata) token))
-    ~[[%pass /undescribe %agent [civ %bait] %poke %bait-undescribe !>(token)]]
+    ~[[%pass /bait %agent [civ %bait] %poke %bait-undescribe !>(token)]]
   ::  old pokes for getting links, we no longer use these because all links
   ::  are unique to that ship/user and can be scried out
   ::
@@ -421,16 +421,10 @@
     %-  (fail:log %poke-ack 'profile update failed' u.p.sign)
     `this
   ::
-      [%update %open ~]
+      [%bait ~]
     ?>  ?=(%poke-ack -.sign)
     ?~  p.sign  `this
-    %-  (fail:log %poke-ack 'open update failed' u.p.sign)
-    `this
-  ::
-      [%update %group ~]
-    ?>  ?=(%poke-ack -.sign)
-    ?~  p.sign  `this
-    %-  (fail:log %poke-ack 'group meta update failed' u.p.sign)
+    %-  (fail:log %poke-ack 'bait operation failed' u.p.sign)
     `this
   ::
       [%contacts ~]
@@ -526,7 +520,7 @@
         %+  roll  updates
         |=  [[=token:reel update=metadata:reel] caz=(list card) =_open-describes]
         =/  cad=card
-          [%pass /update/profile %agent [civ %bait] %poke bait-update+!>([token update])]
+          [%pass /bait %agent [civ %bait] %poke bait-update+!>([token update])]
         :-  [cad caz]
         ?.  (~(has by ^open-describes) token)
           open-describes
@@ -587,7 +581,7 @@
       ?.  =(p.flag our.bowl)
         `this
       :_  this
-      [%pass /update/group %agent [civ %bait] %poke bait-update-group+!>([flag update])]~
+      [%pass /bait %agent [civ %bait] %poke bait-update-group+!>([flag update])]~
     ==
   ::
       [%token-link @ name=@ ~]

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -344,7 +344,7 @@
     ?>  =(civ src.bowl)
     =+  !<(confirmation:reel vase)
     =+  log=~(. l bowl 'flow'^s+'lure' ~)
-    =/  sync=?  (~(got by open-describes) nonce)
+    =/  sync=?  (~(gut by open-describes) nonce |)
     =.  open-describes  (~(del by open-describes) nonce)
     =/  ids=(list [id=cord =token:reel])
       %+  skim  ~(tap by stable-id)

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -10,6 +10,7 @@
       state-4
       state-5
       state-6
+      state-7
   ==
 ::
 ::  vic: URL of bait service
@@ -78,13 +79,26 @@
       stable-id=(map cord token:reel)
       =^subs:s
   ==
++$  state-7
+  $:  %7
+      vic=@t
+      civ=ship
+      our-profile=contact:t
+      our-metadata=(map token:reel metadata:v1:reel)
+      open-link-requests=(set (pair ship cord))
+      ::
+      :: outstanding describes. true when metadata had been modified.
+      open-describes=(map token:reel ?)  
+      stable-id=(map cord token:reel)
+      =^subs:s
+  ==
 ::
 ::  url with old style token
 ++  url-for-token
   |=  [vic=cord token=cord]
   (cat 3 vic token)
 --
-=|  state-6
+=|  state-7
 =*  state  -
 ::
 %-  agent:dbug
@@ -194,7 +208,14 @@
     :_  old(- %6)
     =+  wait=(~(rad og eny.bowl) ~h1)
     [%pass /load/profile %arvo %b %wait (add now.bowl wait)]~
-  ?>  ?=(%6 -.old)
+  =?  old  ?=(%6 -.old)
+    %=  old  -  %7
+        open-describes  
+      %-  ~(gas by *(map token:reel ?))
+      ^-  (list (pair token:reel ?))
+      (turn ~(tap in open-describes.old) (late &))  ::  force sync on open describes
+    ==
+  ?>  ?=(%7 -.old)
   =.  state  old
   :_  this
   %+  weld  caz
@@ -221,7 +242,11 @@
         %set-ship
       ::  since we're changing providers, we need to regenerate links
       ::  we'll use whatever key we currently have as the nonce
-      :_  this(civ civ.command, open-describes ~(key by our-metadata))
+      =/  opens
+        %-  ~(gas by *(map token:reel ?))
+        ^-  (list (pair token:reel ?))
+        (turn ~(tap in ~(key by our-metadata)) (late |))
+      :_  this(civ civ.command, open-describes opens)
       %+  turn  ~(tap by our-metadata)
       |=  [token=cord =metadata:reel]
       ^-  card
@@ -310,7 +335,7 @@
     =?  our-metadata  ?=(^ old-token)
       (~(del by our-metadata) u.old-token)
     =.  our-metadata  (~(put by our-metadata) nonce metadata)
-    =.  open-describes  (~(put in open-describes) nonce)
+    =.  open-describes  (~(put by open-describes) nonce |)
     =.  stable-id  (~(put by stable-id) id nonce)
     :_  this
     ~[[%pass /describe %agent [civ %bait] %poke %bait-describe !>([nonce metadata])]]
@@ -319,10 +344,10 @@
     ?>  =(civ src.bowl)
     =+  !<(confirmation:reel vase)
     =+  log=~(. l bowl 'flow'^s+'lure' ~)
-    =.  open-describes  (~(del in open-describes) nonce)
+    =/  sync=?  (~(got by open-describes) nonce)
+    =.  open-describes  (~(del by open-describes) nonce)
     =/  ids=(list [id=cord =token:reel])
-      %+  skim
-        ~(tap by stable-id)
+      %+  skim  ~(tap by stable-id)
       |=  [key=cord =token:reel]
       =(nonce token)
     ?~  ids
@@ -342,12 +367,15 @@
           ~[leaf+"invite link for {(trip id)} created"]
         ~['event'^s+'Invite Link Created' 'lure-id'^s+token]
     :_  %_  this  our-metadata
-          ::  swap out the nonce for the token in our-metadata
           (~(put by (~(del by our-metadata) nonce)) token u.md)
         ==
     =/  url  (cat 3 vic token)
     =/  path  (stab (cat 3 '/v1/id-link/' id))
-    ~[[%give %fact ~[path] %json !>(s+url)]]
+    ?.  sync
+      [%give %fact ~[path] %json !>(s+url)]~
+    :~  [%pass /update/open %agent [civ %bait] %poke bait-update+!>([token u.md])]
+        [%give %fact ~[path] %json !>(s+url)]
+    ==
   ::
       %reel-undescribe
     ?>  =(our.bowl src.bowl)
@@ -391,6 +419,12 @@
     ?>  ?=(%poke-ack -.sign)
     ?~  p.sign  `this
     %-  (fail:log %poke-ack 'profile update failed' u.p.sign)
+    `this
+  ::
+      [%update %open ~]
+    ?>  ?=(%poke-ack -.sign)
+    ?~  p.sign  `this
+    %-  (fail:log %poke-ack 'open update failed' u.p.sign)
     `this
   ::
       [%update %group ~]
@@ -453,15 +487,16 @@
       ::  update our lure links with new nickname, avatar image
       ::  and color. also update open-graph metadata.
       ::
-      =^  caz=(list card)  our-metadata
-        %+  ~(rib by our-metadata)  *(list card)
-        |=  [[=token:reel meta=metadata:reel] caz=(list card)]
-        ^-  [(list card) [token:reel metadata:reel]]
+      =*  token-update  ,[token:reel metadata:reel]
+      =^  updates=(list token-update)  our-metadata
+        %+  ~(rib by our-metadata)  *(list token-update)
+        |=  [[=token:reel meta=metadata:reel] ups=(list token-update)]
+        ^-  [(list token-update) [token:reel metadata:reel]]
         =;  new-update=_update
           :_  :-  token
               meta(fields (~(uni by fields.meta) fields.new-update))
-          :_  caz
-          [%pass /update/profile %agent [civ %bait] %poke bait-update+!>([token new-update])]
+          :_  ups
+          [token new-update]
         ::  insert open-graph metadata into update
         ::
         =+  type=(~(get by fields.meta) %'inviteType')
@@ -487,6 +522,15 @@
           update
         ::  unknown invite type, ignore
         update
+      =^  caz=(list card)  open-describes
+        %+  roll  updates
+        |=  [[=token:reel update=metadata:reel] caz=(list card) =_open-describes]
+        =/  cad=card
+          [%pass /update/profile %agent [civ %bait] %poke bait-update+!>([token update])]
+        :-  [cad caz]
+        ?.  (~(has by ^open-describes) token)
+          open-describes
+        (~(put by open-describes) token &)
       [caz this]
     ==
   ::
@@ -537,9 +581,11 @@
           our-metadata
         %+  ~(put by our-metadata)  u.token
         u.our-meta(fields (~(uni by fields.u.our-meta) fields.update))
+      =+  log=~(. l bowl 'flow'^s+'lure' 'lure-id'^s+id 'has-token'^s+?:(?=(^ token) 'true' 'false') ~)
       ::  update the bait provider if we are the group host
       ::
-      ?.  =(p.flag our.bowl)  `this
+      ?.  =(p.flag our.bowl)
+        `this
       :_  this
       [%pass /update/group %agent [civ %bait] %poke bait-update-group+!>([flag update])]~
     ==
@@ -577,7 +623,7 @@
       [%v1 %id-link id=*]
     =/  id  (crip +:(spud id.pole))
     ?~  token=(~(get by stable-id) id)  `this
-    ?:  (~(has in open-describes) u.token)
+    ?:  (~(has by open-describes) u.token)
       ::  when the confirmation comes back we'll send the fact
       `this
     =/  url  (cat 3 vic u.token)

--- a/desk/app/reel.hoon
+++ b/desk/app/reel.hoon
@@ -88,7 +88,7 @@
       open-link-requests=(set (pair ship cord))
       ::
       :: outstanding describes. true when metadata had been modified.
-      open-describes=(map token:reel ?)  
+      open-describes=(map token:reel ?)
       stable-id=(map cord token:reel)
       =^subs:s
   ==
@@ -210,7 +210,7 @@
     [%pass /load/profile %arvo %b %wait (add now.bowl wait)]~
   =?  old  ?=(%6 -.old)
     %=  old  -  %7
-        open-describes  
+        open-describes
       %-  ~(gas by *(map token:reel ?))
       ^-  (list (pair token:reel ?))
       (turn ~(tap in open-describes.old) (late &))  ::  force sync on open describes

--- a/desk/lib/ph/io.hoon
+++ b/desk/lib/ph/io.hoon
@@ -427,7 +427,7 @@
 ::
 ++  scry-aqua
   |*  [=mold =ship pax=path]
-  =/  m  (strand ,mold)
+  =/  m  (strand mold)
   ^-  form:m
   ;<  =bowl:spider  bind:m  get-bowl
   =/  aqua-pax=path

--- a/desk/lib/ph/test.hoon
+++ b/desk/lib/ph/test.hoon
@@ -139,6 +139,33 @@
   =+  .^(=dais:clay %cb /(scot %p our.bowl)/groups/(scot %da now.bowl)/[mark])
   =/  =vase  (vale:dais noun.p.q.unix-effect)
   (pure:m [mark vase])
+::  +wait-for-app-fact: receive a gall fact from a virtual ship and unpack it
+::
+++  wait-for-app-fact-value
+  |*  [=mold =wire [our=ship dap=term]]
+  =/  m  (strand mold)
+  ^-  form:m
+  %^  (set-timeout-err mold)  timeout
+    :~  'wait-for-app-fact-value'
+        leaf+"expected a fact from {<our>}/{<dap>}"
+        leaf+"on wire {<wire>}"
+    ==
+  ;<  =bowl:strand  bind:m  get-bowl
+  |-
+  =*  loop  $
+  ;<  =^cage  bind:m  (take-fact /effect/unto)
+  ?>  ?=(%aqua-effect p.cage)
+  =+  !<(=aqua-effect q.cage)
+  =/  [from=^ship =unix-effect]  aqua-effect
+  ?.  =(from our)  loop
+  ?.  =(wire p.unix-effect)  loop
+  ?.  ?=([%unto %raw-fact *] q.unix-effect)  loop
+  =*  mark  mark.p.q.unix-effect
+  ::  note: this assumes that the marks on the virtual ship and the host match
+  ::
+  =+  .^(=dais:clay %cb /(scot %p our.bowl)/groups/(scot %da now.bowl)/[mark])
+  =/  =vase  (vale:dais noun.p.q.unix-effect)
+  (pure:m !<(mold vase))
 ::  +ex-equal: expect .actual to be equal to .expected
 ::
 ++  ex-equal
@@ -196,7 +223,7 @@
       ==
     (ex-equal q.fact q.ex-fact)
   (pure:m ~)
-::  +ex-app-fact-mark: expect app fact with a mark on a wire
+::  +ex-app-fact-mark: expect app fact with a given mark on a wire
 ::
 ++  ex-app-fact-mark
   |=  [=wire =dock =mark]

--- a/desk/tests/app/reel.hoon
+++ b/desk/tests/app/reel.hoon
@@ -2,14 +2,14 @@
 /+  *test-agent, test, s=subscriber, t=contacts, reel-utils=reel
 /=  reel-agent  /app/reel
 |%
-+$  state-5
-  $:  %6
++$  state-7
+  $:  %7
       vic=@t
       civ=ship
       our-profile=contact:t
       our-metadata=(map token:reel metadata:reel)
       open-link-requests=(set (pair ship cord))
-      open-describes=(set token:reel)
+      open-describes=(map token:reel ?)
       stable-id=(map cord token:reel)
       =^subs:s
   ==
@@ -67,7 +67,7 @@
   ;<  caz=(list card)  bind:m  (do-poke reel-describe+!>([id metadata]))
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /describe [provider %bait] bait-describe+!>([nonce (v1:metadata:v0:conv:reel-utils metadata)]))
+    :~  (ex-poke /bait [provider %bait] bait-describe+!>([nonce (v1:metadata:v0:conv:reel-utils metadata)]))
     ==
   ;<  *  bind:m  (set-src provider)
   ;<  caz=(list card)  bind:m  (do-poke reel-confirmation+!>([nonce token]))
@@ -152,7 +152,7 @@
   ;<  caz=(list card)  bind:m  (do-poke reel-describe+!>(['~sampel-palnet/sunrise' group-invite-meta]))
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /describe [provider %bait] bait-describe+!>(`[nonce:reel metadata:reel]`[nonce group-invite-meta]))
+    :~  (ex-poke /bait [provider %bait] bait-describe+!>(`[nonce:reel metadata:reel]`[nonce group-invite-meta]))
     ==
   ::  when the agent receives a confirmation, it registers the group invite
   ::  link locally.
@@ -171,7 +171,7 @@
   ;<  caz=(list card)  bind:m  (do-poke reel-describe+!>(['~zod/personal-invite-link' personal-invite-meta]))
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /describe [provider %bait] bait-describe+!>([nonce personal-invite-meta]))
+    :~  (ex-poke /bait [provider %bait] bait-describe+!>([nonce personal-invite-meta]))
     ==
   ::  when the agent receives a confirmation, it registers the personal invite
   ::  link locally.
@@ -231,7 +231,7 @@
     ==
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /update/group [provider %bait] bait-update-group+!>([~sampel-palnet^%sunrise update]))
+    :~  (ex-poke /bait [provider %bait] bait-update-group+!>([~sampel-palnet^%sunrise update]))
     ==
   ;<  =metadata:reel  bind:m
     (get-full-peek metadata:reel /x/v1/metadata/~sampel-palnet/sunrise)
@@ -268,7 +268,7 @@
     ==
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /update/group [provider %bait] bait-update-group+!>([~sampel-palnet^%sunrise update]))
+    :~  (ex-poke /bait [provider %bait] bait-update-group+!>([~sampel-palnet^%sunrise update]))
     ==
   ::  when a group is deleted, the group host updates the provider with
   ::  invitedGroupDeleted set to true.
@@ -284,7 +284,7 @@
     ==
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /update/group [provider %bait] bait-update-group+!>([~sampel-palnet^%sunrise update]))
+    :~  (ex-poke /bait [provider %bait] bait-update-group+!>([~sampel-palnet^%sunrise update]))
     ==
   ;<  =metadata:reel  bind:m
     (get-full-peek metadata:reel /x/v1/metadata/~sampel-palnet/sunrise)
@@ -354,8 +354,8 @@
     ==
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /update/profile [provider %bait] bait-update+!>([~.0v2 personal-update]))
-        (ex-poke /update/profile [provider %bait] bait-update+!>([~.0v1 group-update]))
+    :~  (ex-poke /bait [provider %bait] bait-update+!>([~.0v2 personal-update]))
+        (ex-poke /bait [provider %bait] bait-update+!>([~.0v1 group-update]))
     ==
   ::  verify that the personal invite has been updated locally
   ::

--- a/desk/tests/app/reel.hoon
+++ b/desk/tests/app/reel.hoon
@@ -354,8 +354,8 @@
     ==
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-poke /update/profile [provider %bait] bait-update+!>([~.0v1 group-update]))
-        (ex-poke /update/profile [provider %bait] bait-update+!>([~.0v2 personal-update]))
+    :~  (ex-poke /update/profile [provider %bait] bait-update+!>([~.0v2 personal-update]))
+        (ex-poke /update/profile [provider %bait] bait-update+!>([~.0v1 group-update]))
     ==
   ::  verify that the personal invite has been updated locally
   ::

--- a/desk/tests/ph/platform/lure.hoon
+++ b/desk/tests/ph/platform/lure.hoon
@@ -98,6 +98,17 @@
     [%deal [p.dock p.dock /aqua] q.dock %raw-poke page]
   [%event p.dock /g/aqua/deal task]
 ::
+++  scry-reel-bait
+  |=  her=ship
+  =/  m  (strand ,[vic=cord civ=ship])
+  ^-  form:m
+  ;<  now=@da  bind:m  get-time
+  ;<  bait=(unit [vic=cord civ=ship])  bind:m
+    %^  scry-aqua  (unit ,[vic=cord civ=ship])
+      her
+    /gx/(scot %p her)/reel/(scot %da now)/v1/bait/noun
+  (pure:m (need bait))
+::
 ++  generate-lure-invite
   |=  =metadata:v1:r
   =/  m  (strand @t)
@@ -123,87 +134,6 @@
   ;<  ~  bind:m  (poke-app [~zod %grouper] grouper-enable+my-test-group-id)
   ;<  invite-link=@t  bind:m  (generate-lure-invite lure-group-metadata)
   (ex-not-equal !>(invite-link) !>(''))
-::
-::  +ph-test-lure-race-group: check group metadata update race condition 
-::
-::  scenario
-::
-::  ~zod hosts a group and starts creating a lure invite. before the bait
-::  provider confirms the lure token, ~zod updates the group title. this
-::  triggers an update to be sent to the provider, causing the invite
-::  metadata to be updated.
-::
-++  ph-test-lure-race-group
-  =/  m  (strand ,~)
-  ^-  form:m
-  ;<  ~  bind:m  create-test-group
-  ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] /v1/id-link/~zod/test-group)
-  =/  describe-event=aqua-event
-    (poke-app-event [~zod %reel] reel-describe+[my-test-group-id lure-group-metadata])
-  =/  =c-groups:g
-    [%group my-test-flag [%meta ['Racing Group' 'Fast racing' '' '']]]
-  =/  group-meta-event=aqua-event
-    (poke-app-event [~zod %groups] group-command+c-groups)
-  ;<  ~  bind:m  (send-events ~[describe-event group-meta-event])
-  ;<  kag=cage  bind:m  (wait-for-app-fact /~zod/reel/v1/id-link [~zod %reel])
-  ?>  =(%json p.kag)
-  =+  !<(=json q.kag)
-  ?>  ?=(%s -.json)
-  ;<  =bowl:strand  bind:m  get-bowl
-  =/  aqua-pax
-    /gx/~loshut-lonreg/bait/(scot %da now.bowl)/metadata/noun
-  ;<  token-metadata=(unit (map token:r metadata:v1:r))  bind:m
-    (scry-aqua (unit (map token:r metadata:v1:r)) ~loshut-lonreg aqua-pax)
-  =/  metadata-map=(map token:r metadata:v1:r)
-    (need token-metadata)
-  =/  metadata-count=@ud  (lent ~(tap by metadata-map))
-  ;<  ~  bind:m  (ex-equal !>(metadata-count) !>(`@ud`1))
-  =/  metadata=metadata:v1:r
-    (need (head ~(tap by metadata-map)))
-  ;<  ~  bind:m
-    (ex-equal !>((~(get by fields.metadata) %'invitedGroupTitle')) !>(`'Racing Group'))
-  ;<  ~  bind:m
-    (ex-equal !>((~(get by fields.metadata) %'invitedGroupDescription')) !>(`'Fast racing'))
-  (pure:m ~)
-::
-::  +ph-test-lure-race-profile: check profile update race condition
-::
-::  scenario
-::
-::  ~zod hosts a group and starts creating a lure invite. before the bait
-::  provider confirms the lure token, ~zod updates his profile nickname,
-::  marking the outstanding lure invite as modified. when confirmation
-::  arrives, ~zod sends out an update to the bait provider.
-::
-++  ph-test-lure-race-profile
-  =/  m  (strand ,~)
-  ^-  form:m
-  ;<  ~  bind:m  create-test-group
-  ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] /v1/id-link/~zod/test-group)
-  =/  describe-event=aqua-event
-    (poke-app-event [~zod %reel] reel-describe+[my-test-group-id lure-group-metadata])
-  =/  profile-event=aqua-event
-    (poke-app-event [~zod %contacts] contact-action-1+[%self (nickname-profile 'Racing Driver')])
-  ;<  ~  bind:m  (send-events ~[describe-event profile-event])
-  ;<  kag=cage  bind:m  (wait-for-app-fact /~zod/reel/v1/id-link [~zod %reel])
-  ?>  =(%json p.kag)
-  =+  !<(=json q.kag)
-  ?>  ?=(%s -.json)
-  ;<  ~  bind:m  (sleep ~s3)
-  ;<  =bowl:strand  bind:m  get-bowl
-  =/  aqua-pax
-    /gx/~loshut-lonreg/bait/(scot %da now.bowl)/metadata/noun
-  ;<  token-metadata=(unit (map token:r metadata:v1:r))  bind:m
-    (scry-aqua (unit (map token:r metadata:v1:r)) ~loshut-lonreg aqua-pax)
-  =/  metadata-map=(map token:r metadata:v1:r)
-    (need token-metadata)
-  =/  metadata-count=@ud  (lent ~(tap by metadata-map))
-  ;<  ~  bind:m  (ex-equal !>(metadata-count) !>(`@ud`1))
-  =/  metadata=metadata:v1:r
-    (need (head ~(tap by metadata-map)))
-  ;<  ~  bind:m
-    (ex-equal !>((~(get by fields.metadata) %'inviterNickname')) !>(`'Racing Driver'))
-  (pure:m ~)
 ::
 ++  eyre-authenticate
   |=  =ship
@@ -328,6 +258,75 @@
     ;<  ~  bind:m
       (ex-equal !>(whom) !>(`whom:c`[%ship ~zod]))
     (ex-equal !>(-.response.resp) !>(%add))
+  (pure:m ~)
+::  +ph-test-lure-race-group: check group metadata update race condition
+::
+::  scenario
+::
+::  ~zod hosts a group and starts creating a lure invite. before the bait
+::  provider confirms the lure token, ~zod updates the group title. this
+::  triggers an update to be sent out to the provider, causing the invite
+::  metadata to be updated.
+::
+++  ph-test-lure-race-group
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  ~  bind:m  create-test-group
+  ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] /v1/id-link/~zod/test-group)
+  =/  describe-event=aqua-event
+    (poke-app-event [~zod %reel] reel-describe+[my-test-group-id lure-group-metadata])
+  =/  =c-groups:g
+    [%group my-test-flag [%meta ['Racing Group' 'Fast racing' '' '']]]
+  =/  group-meta-event=aqua-event
+    (poke-app-event [~zod %groups] group-command+c-groups)
+  ;<  ~  bind:m  (send-events ~[describe-event group-meta-event])
+  ;<  [vic=cord civ=ship]  bind:m  (scry-reel-bait ~zod)
+  ;<  =json  bind:m  (wait-for-app-fact-value json /~zod/reel/v1/id-link [~zod %reel])
+  ?>  ?=(%s -.json)
+  =/  token=token:r  (rsh [3 (met 3 vic)] p.json)
+  ;<  =bowl:strand  bind:m  get-bowl
+  =/  aqua-pax
+    /gx/~loshut-lonreg/bait/(scot %da now.bowl)/[token]/metadata/noun
+  ;<  metadata=(unit metadata:v1:r)  bind:m
+    (scry-aqua (unit metadata:v1:r) ~loshut-lonreg aqua-pax)
+  =/  metadata=metadata:v1:r  (need metadata)
+  ;<  ~  bind:m
+    (ex-equal !>((~(get by fields.metadata) %'invitedGroupTitle')) !>(`'Racing Group'))
+  ;<  ~  bind:m
+    (ex-equal !>((~(get by fields.metadata) %'invitedGroupDescription')) !>(`'Fast racing'))
+  (pure:m ~)
+::  +ph-test-lure-race-profile: check profile update race condition
+::
+::  scenario
+::
+::  ~zod hosts a group and starts creating a lure invite. before the bait
+::  provider confirms the lure token, ~zod updates his profile nickname,
+::  marking the outstanding lure invite as modified. when confirmation
+::  arrives, ~zod sends out an update to the bait provider.
+::
+++  ph-test-lure-race-profile
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  ~  bind:m  create-test-group
+  ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] /v1/id-link/~zod/test-group)
+  =/  describe-event=aqua-event
+    (poke-app-event [~zod %reel] reel-describe+[my-test-group-id lure-group-metadata])
+  =/  profile-event=aqua-event
+    (poke-app-event [~zod %contacts] contact-action-1+[%self (nickname-profile 'Racing Driver')])
+  ;<  ~  bind:m  (send-events ~[describe-event profile-event])
+  ;<  [vic=cord civ=ship]  bind:m  (scry-reel-bait ~zod)
+  ;<  =json  bind:m  (wait-for-app-fact-value json /~zod/reel/v1/id-link [~zod %reel])
+  ?>  ?=(%s -.json)
+  =/  token=token:r  (rsh [3 (met 3 vic)] p.json)
+  ;<  ~  bind:m  (sleep ~s3)
+  ;<  =bowl:strand  bind:m  get-bowl
+  =/  aqua-pax
+    /gx/~loshut-lonreg/bait/(scot %da now.bowl)/[token]/metadata/noun
+  ;<  metadata=(unit metadata:v1:r)  bind:m
+    (scry-aqua (unit metadata:v1:r) ~loshut-lonreg aqua-pax)
+  =/  metadata=metadata:v1:r  (need metadata)
+  ;<  ~  bind:m
+    (ex-equal !>((~(get by fields.metadata) %'inviterNickname')) !>(`'Racing Driver'))
   (pure:m ~)
 --
 

--- a/desk/tests/ph/platform/lure.hoon
+++ b/desk/tests/ph/platform/lure.hoon
@@ -284,6 +284,7 @@
   ;<  =json  bind:m  (wait-for-app-fact-value json /~zod/reel/v1/id-link [~zod %reel])
   ?>  ?=(%s -.json)
   =/  token=token:r  (rsh [3 (met 3 vic)] p.json)
+  ;<  ~  bind:m  (sleep ~s3)
   ;<  =bowl:strand  bind:m  get-bowl
   =/  aqua-pax
     /gx/~loshut-lonreg/bait/(scot %da now.bowl)/[token]/metadata/noun

--- a/desk/tests/ph/platform/lure.hoon
+++ b/desk/tests/ph/platform/lure.hoon
@@ -1,5 +1,5 @@
 /-  spider
-/-  c=chat, g=groups, gv=groups-ver, r=reel
+/-  c=chat, g=groups, gv=groups-ver, r=reel, t=contacts
 /+  *ph-io, *ph-test
 =,  strand=strand:spider
 ::
@@ -84,6 +84,19 @@
       [%'invitedGroupId' '~zod/personal-invite-link']
       [%'bite-type' '2']
   ==
+++  nickname-profile
+  |=  nickname=@t
+  ^-  contact:t
+  %-  ~(gas by *(map @tas value:t))
+  :~  [%nickname text+nickname]
+  ==
+::
+++  poke-app-event
+  |=  [=dock =page]
+  ^-  aqua-event
+  =/  =task:gall
+    [%deal [p.dock p.dock /aqua] q.dock %raw-poke page]
+  [%event p.dock /g/aqua/deal task]
 ::
 ++  generate-lure-invite
   |=  =metadata:v1:r
@@ -110,6 +123,87 @@
   ;<  ~  bind:m  (poke-app [~zod %grouper] grouper-enable+my-test-group-id)
   ;<  invite-link=@t  bind:m  (generate-lure-invite lure-group-metadata)
   (ex-not-equal !>(invite-link) !>(''))
+::
+::  +ph-test-lure-race-group: check group metadata update race condition 
+::
+::  scenario
+::
+::  ~zod hosts a group and starts creating a lure invite. before the bait
+::  provider confirms the lure token, ~zod updates the group title. this
+::  triggers an update to be sent to the provider, causing the invite
+::  metadata to be updated.
+::
+++  ph-test-lure-race-group
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  ~  bind:m  create-test-group
+  ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] /v1/id-link/~zod/test-group)
+  =/  describe-event=aqua-event
+    (poke-app-event [~zod %reel] reel-describe+[my-test-group-id lure-group-metadata])
+  =/  =c-groups:g
+    [%group my-test-flag [%meta ['Racing Group' 'Fast racing' '' '']]]
+  =/  group-meta-event=aqua-event
+    (poke-app-event [~zod %groups] group-command+c-groups)
+  ;<  ~  bind:m  (send-events ~[describe-event group-meta-event])
+  ;<  kag=cage  bind:m  (wait-for-app-fact /~zod/reel/v1/id-link [~zod %reel])
+  ?>  =(%json p.kag)
+  =+  !<(=json q.kag)
+  ?>  ?=(%s -.json)
+  ;<  =bowl:strand  bind:m  get-bowl
+  =/  aqua-pax
+    /gx/~loshut-lonreg/bait/(scot %da now.bowl)/metadata/noun
+  ;<  token-metadata=(unit (map token:r metadata:v1:r))  bind:m
+    (scry-aqua (unit (map token:r metadata:v1:r)) ~loshut-lonreg aqua-pax)
+  =/  metadata-map=(map token:r metadata:v1:r)
+    (need token-metadata)
+  =/  metadata-count=@ud  (lent ~(tap by metadata-map))
+  ;<  ~  bind:m  (ex-equal !>(metadata-count) !>(`@ud`1))
+  =/  metadata=metadata:v1:r
+    (need (head ~(tap by metadata-map)))
+  ;<  ~  bind:m
+    (ex-equal !>((~(get by fields.metadata) %'invitedGroupTitle')) !>(`'Racing Group'))
+  ;<  ~  bind:m
+    (ex-equal !>((~(get by fields.metadata) %'invitedGroupDescription')) !>(`'Fast racing'))
+  (pure:m ~)
+::
+::  +ph-test-lure-race-profile: check profile update race condition
+::
+::  scenario
+::
+::  ~zod hosts a group and starts creating a lure invite. before the bait
+::  provider confirms the lure token, ~zod updates his profile nickname,
+::  marking the outstanding lure invite as modified. when confirmation
+::  arrives, ~zod sends out an update to the bait provider.
+::
+++  ph-test-lure-race-profile
+  =/  m  (strand ,~)
+  ^-  form:m
+  ;<  ~  bind:m  create-test-group
+  ;<  ~  bind:m  (watch-app /~zod/reel/v1/id-link [~zod %reel] /v1/id-link/~zod/test-group)
+  =/  describe-event=aqua-event
+    (poke-app-event [~zod %reel] reel-describe+[my-test-group-id lure-group-metadata])
+  =/  profile-event=aqua-event
+    (poke-app-event [~zod %contacts] contact-action-1+[%self (nickname-profile 'Racing Driver')])
+  ;<  ~  bind:m  (send-events ~[describe-event profile-event])
+  ;<  kag=cage  bind:m  (wait-for-app-fact /~zod/reel/v1/id-link [~zod %reel])
+  ?>  =(%json p.kag)
+  =+  !<(=json q.kag)
+  ?>  ?=(%s -.json)
+  ;<  ~  bind:m  (sleep ~s3)
+  ;<  =bowl:strand  bind:m  get-bowl
+  =/  aqua-pax
+    /gx/~loshut-lonreg/bait/(scot %da now.bowl)/metadata/noun
+  ;<  token-metadata=(unit (map token:r metadata:v1:r))  bind:m
+    (scry-aqua (unit (map token:r metadata:v1:r)) ~loshut-lonreg aqua-pax)
+  =/  metadata-map=(map token:r metadata:v1:r)
+    (need token-metadata)
+  =/  metadata-count=@ud  (lent ~(tap by metadata-map))
+  ;<  ~  bind:m  (ex-equal !>(metadata-count) !>(`@ud`1))
+  =/  metadata=metadata:v1:r
+    (need (head ~(tap by metadata-map)))
+  ;<  ~  bind:m
+    (ex-equal !>((~(get by fields.metadata) %'inviterNickname')) !>(`'Racing Driver'))
+  (pure:m ~)
 ::
 ++  eyre-authenticate
   |=  =ship


### PR DESCRIPTION
## Summary

There are two possible race conditions in lure. The first one occurs from the perspective of the client, when a user updates group metadata before the confirmation was received. This can not be solved purely at the backend, but we introduce a test to verify this scenario behaves as expected from the backend perspective.

Secondly, there is a real race condition that can occur when the user profile is updated. In such case, any unconfirmed lure invitations would be targeted for updated with a temporary nonce.

We fix this by augmenting `open-describes` with a sync flag that indicates whether the metadata have been modified since the request for confirmation was sent. In this way, when we receive confirmation, we check the flag and immediately send an update request to the bait provider. 

CC @latter-bolden 

Fixes TLON-5971

## Changes

1. Implement a safe mechanism for reel to update unconfirmed lure invites.
2. Add two aqua tests for two potential race conditions when updating an unconfirmed lure invitation.
3. Includes changes from #5979 to fix test flakiness.

## How did I test?

Tests pass, indicating the two possible scenarios of updates caused by profile or group metadata update are now race free.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert. 
