### PR TITLE
chore: bump openclaw test rube ships to v27

### DIFF
--- a/packages/openclaw/dev/docker-compose.test.yml
+++ b/packages/openclaw/dev/docker-compose.test.yml
@@ -22,22 +22,22 @@ services:
         cd /data
 
         echo "==> Downloading zod..."
-        curl -fSL https://bootstrap.urbit.org/rube-zod25.tgz -o rube-zod25.tgz || { echo "Failed to download zod"; exit 1; }
-        ls -la rube-zod25.tgz
+        curl -fSL https://bootstrap.urbit.org/rube-zod27.tgz -o rube-zod27.tgz || { echo "Failed to download zod"; exit 1; }
+        ls -la rube-zod27.tgz
         echo "==> Extracting zod..."
-        tar xzf rube-zod25.tgz || { echo "Failed to extract zod"; exit 1; }
+        tar xzf rube-zod27.tgz || { echo "Failed to extract zod"; exit 1; }
 
         echo "==> Downloading ten..."
-        curl -fSL https://bootstrap.urbit.org/rube-ten25.tgz -o rube-ten25.tgz || { echo "Failed to download ten"; exit 1; }
-        ls -la rube-ten25.tgz
+        curl -fSL https://bootstrap.urbit.org/rube-ten27.tgz -o rube-ten27.tgz || { echo "Failed to download ten"; exit 1; }
+        ls -la rube-ten27.tgz
         echo "==> Extracting ten..."
-        tar xzf rube-ten25.tgz || { echo "Failed to extract ten"; exit 1; }
+        tar xzf rube-ten27.tgz || { echo "Failed to extract ten"; exit 1; }
 
         echo "==> Downloading mug..."
-        curl -fSL https://bootstrap.urbit.org/rube-mug25.tgz -o rube-mug25.tgz || { echo "Failed to download mug"; exit 1; }
-        ls -la rube-mug25.tgz
+        curl -fSL https://bootstrap.urbit.org/rube-mug27.tgz -o rube-mug27.tgz || { echo "Failed to download mug"; exit 1; }
+        ls -la rube-mug27.tgz
         echo "==> Extracting mug..."
-        tar xzf rube-mug25.tgz || { echo "Failed to extract mug"; exit 1; }
+        tar xzf rube-mug27.tgz || { echo "Failed to extract mug"; exit 1; }
 
         echo "==> Downloading vere..."
         curl -fSL https://urbit.org/install/linux-x86_64/latest | tar xz || { echo "Failed to download vere"; exit 1; }


### PR DESCRIPTION
The openclaw integration test compose file still pulled rube-zod25, rube-ten25, and rube-mug25. Bump to v27 to match the rube ships used by the web e2e suite (shipManifest.json, rube/Dockerfile).

## Summary

<!-- Briefly describe what this pull request does in 1-3 sentences. -->

## Changes

<!-- Outline specific changes made in this PR. -->

## How did I test?

<!-- Describe your testing process. -->

## Risks and impact

- Safe to rollback without consulting PR author? (Yes | No)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

<!-- Describe the steps to revert these changes if needed. -->

## Screenshots / videos

<!-- Attach any relevant media. -->
