### PR TITLE
fix(openclaw): persist inbound Tlon session route so replies stop leaking to webchat

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -11,10 +11,12 @@ import {
   setGatewayStatusManager,
 } from './src/gateway-status.js';
 import { resolveBridgeForCommand } from './src/monitor/command-auth.js';
+import { isRouteDebugEnabled } from './src/monitor/session-routing.js';
 import { handleOwnerListenCommand } from './src/owner-listen-command.js';
 import { setTlonRuntime } from './src/runtime.js';
 import { getSessionRole } from './src/session-roles.js';
-import { recordToolCall } from './src/telemetry.js';
+import { parseTlonTarget } from './src/targets.js';
+import { recordToolCall, reportOutboundRoute } from './src/telemetry.js';
 import { resolveTlonBinary } from './src/tlon-binary.js';
 import { checkBlockedSendOperation } from './src/tlon-tool-guard.js';
 import {
@@ -423,6 +425,48 @@ export default defineChannelPluginEntry({
         durationMs: event.durationMs,
         error: event.error,
       });
+    });
+
+    // ── Route diagnostics ───────────────────────────────────────────────
+    // Fires for every outbound send OpenClaw routes — the primary streamed
+    // reply (resolves to `tlon`) and route-dependent sends (the shared
+    // `message` tool, subagents, which can resolve elsewhere). `ctx.channelId`
+    // is where the send resolved; `routedToTlon: false` (e.g. `webchat`) is the
+    // leak this work targets. Read-only; never alters delivery.
+    //
+    // Two sinks: a PostHog event (the primary, fleet-wide signal — gated by the
+    // existing telemetry config, on in hosted prod) so we can count how often
+    // sends land off-Tlon; and a debug-gated local log for single-gateway
+    // triage.
+    api.on('message_sending', (event, ctx) => {
+      const resolvedChannel = ctx.channelId;
+      const routedToTlon = resolvedChannel === 'tlon';
+      // Only infer target kind for Tlon targets; a webchat target id is not a
+      // Tlon target and must not be misclassified.
+      const parsedTarget = routedToTlon ? parseTlonTarget(event.to) : null;
+      const targetKind =
+        parsedTarget?.kind === 'dm'
+          ? 'dm'
+          : parsedTarget?.kind === 'channel'
+            ? 'group'
+            : 'unknown';
+
+      reportOutboundRoute({ resolvedChannel, routedToTlon, targetKind });
+
+      if (isRouteDebugEnabled()) {
+        api.logger.info(
+          `[tlon][route-debug] message_sending ${JSON.stringify({
+            channelId: ctx.channelId,
+            to: event.to,
+            routedToTlon,
+            targetKind,
+            sessionKey: ctx.sessionKey ?? null,
+            conversationId: ctx.conversationId ?? null,
+            messageId: ctx.messageId ?? null,
+            threadId: event.threadId ?? null,
+          })}`
+        );
+      }
     });
 
     // ── Slash commands for approval & admin ────────────────────────────

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -15,13 +15,13 @@ import {
 
 import { tlonMessageActions } from './actions.js';
 import { tlonChannelConfigSchema } from './config-schema.js';
+import { resolveTlonOutboundSessionRoute } from './session-route.js';
 import {
   applyTlonSetupConfig,
   createTlonSetupWizardBase,
   resolveTlonSetupConfigured,
   tlonSetupAdapter,
 } from './setup-core.js';
-import { resolveTlonOutboundSessionRoute } from './session-route.js';
 import { formatTargetHint, normalizeShip, parseTlonTarget } from './targets.js';
 import { listTlonAccountIds, resolveTlonAccount } from './types.js';
 

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -21,6 +21,7 @@ import {
   resolveTlonSetupConfigured,
   tlonSetupAdapter,
 } from './setup-core.js';
+import { resolveTlonOutboundSessionRoute } from './session-route.js';
 import { formatTargetHint, normalizeShip, parseTlonTarget } from './targets.js';
 import { listTlonAccountIds, resolveTlonAccount } from './types.js';
 
@@ -115,6 +116,7 @@ export const tlonPlugin = createChatChannelPlugin({
         }),
     },
     messaging: {
+      targetPrefixes: ['tlon'],
       normalizeTarget: (target) => {
         const parsed = parseTlonTarget(target);
         if (!parsed) {
@@ -125,10 +127,21 @@ export const tlonPlugin = createChatChannelPlugin({
         }
         return parsed.nest;
       },
+      parseExplicitTarget: ({ raw }) => {
+        const parsed = parseTlonTarget(raw);
+        if (!parsed) {
+          return null;
+        }
+        return parsed.kind === 'dm'
+          ? { to: parsed.ship, chatType: 'direct' }
+          : { to: parsed.nest, chatType: 'group' };
+      },
       targetResolver: {
         looksLikeId: (target) => Boolean(parseTlonTarget(target)),
         hint: formatTargetHint(),
       },
+      resolveOutboundSessionRoute: (params) =>
+        resolveTlonOutboundSessionRoute(params),
     },
     actions: tlonMessageActions,
     agentPrompt: {

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -471,11 +471,11 @@ export async function monitorTlonProvider(
   });
 
   // Outer try/finally wraps everything from slot publication onward.
-  // The reviewer's P2: a synchronous throw between slot publication and
-  // the inner try at ~line 2719 (constructor, queue setup, bridge
-  // setup, channel discovery, future edits in this large pre-try
-  // region) would leave the shared slot orphaned. This outer finally
-  // catches all of those and runs cleanup unconditionally.
+  // A synchronous throw between slot publication and the inner try
+  // (constructor, queue setup, bridge setup, channel discovery, future
+  // edits in this large pre-try region) would leave the shared slot
+  // orphaned. This outer finally catches all of those and runs cleanup
+  // unconditionally.
   try {
     const computingPresence = createComputingPresenceTracker({ runtime });
 

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -42,7 +42,7 @@ import {
   normalizeShip,
   parseChannelNest,
 } from '../targets.js';
-import { createTlonTelemetry } from '../telemetry.js';
+import { createTlonTelemetry, setOutboundRouteReporter } from '../telemetry.js';
 import { resolveTlonAccount } from '../types.js';
 import { configureTlonApiWithPoke } from '../urbit/api-client.js';
 import { authenticate } from '../urbit/auth.js';
@@ -101,6 +101,12 @@ import {
 import { createOwnerReplyPersistenceQueue } from './owner-reply-persistence.js';
 import { createPendingNudgePersistenceQueue } from './pending-nudge-persistence.js';
 import { createProcessedMessageTracker } from './processed-messages.js';
+import {
+  type TlonInboundRouteRecord,
+  isRouteDebugEnabled,
+  recordTlonRouteAndDispatch,
+  routeUpdateWillSkipByPin,
+} from './session-routing.js';
 import { resolveSettingsMirrorSync } from './settings-sync.js';
 import {
   type ParsedCite,
@@ -543,6 +549,18 @@ export async function monitorTlonProvider(
       config: account.telemetry,
       runtime,
     });
+
+    // Bridge route-resolution telemetry from the global `message_sending` hook
+    // to this account's telemetry client. Reports every route-dependent send so
+    // we can measure how often a reply lands on webchat instead of Tlon.
+    setOutboundRouteReporter((event) =>
+      telemetry?.captureOutboundRoute({
+        ...event,
+        ownerShip:
+          getEffectiveOwnerShip(account.accountId) ?? effectiveOwnerShip,
+        botShip: botShipName,
+      })
+    );
 
     // Track threads we've participated in (by parentId) - respond without mention requirement
     const participatedThreads = new Set<string>();
@@ -2255,6 +2273,45 @@ export async function monitorTlonProvider(
         }),
       });
 
+      // ── Durable session-route persistence ───────────────────────
+      // The streamed reply below goes out through our own `deliver` callback
+      // and does not consult session metadata. But later route-dependent sends
+      // (the shared `message` tool, subagents, system-event turns) resolve
+      // their destination from the session store; without a persisted Tlon
+      // route they fall back to webchat. recordTlonRouteAndDispatch (below)
+      // records the route before dispatch and fails open — never blocks the
+      // reply.
+      const routeDebug: ((rec: TlonInboundRouteRecord) => void) | undefined =
+        isRouteDebugEnabled()
+          ? (rec) =>
+              runtime.log?.(
+                `[tlon][route-debug] inbound ${JSON.stringify({
+                  messageId,
+                  agentId: route.agentId,
+                  sessionKey: route.sessionKey,
+                  mainSessionKey: route.mainSessionKey,
+                  lastRoutePolicy: route.lastRoutePolicy,
+                  matchedBy: route.matchedBy,
+                  provider: ctxPayload.Provider,
+                  surface: ctxPayload.Surface,
+                  originatingChannel: ctxPayload.OriginatingChannel,
+                  originatingTo: ctxPayload.OriginatingTo,
+                  ctxSessionKey: ctxPayload.SessionKey,
+                  isGroup,
+                  groupChannel: groupChannel ?? null,
+                  senderShip,
+                  parentId: parentId ?? null,
+                  deliverParentId: deliverParentId ?? null,
+                  recordSessionKey: rec.recordSessionKey,
+                  lastRouteSessionKey: rec.lastRouteSessionKey,
+                  target: rec.target,
+                  hadUpdateLastRoute: Boolean(rec.updateLastRoute),
+                  pinWillSkip: routeUpdateWillSkipByPin(rec.updateLastRoute),
+                  skippedReason: rec.skippedReason ?? null,
+                })}`
+              )
+          : undefined;
+
       const dispatchStartTime = Date.now();
       const replyTelemetry = telemetry?.startReply({
         sessionKey: route.sessionKey,
@@ -2364,106 +2421,149 @@ export async function monitorTlonProvider(
       let dispatchError: unknown;
 
       try {
-        dispatchResult =
-          await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-            ctx: ctxPayload,
-            cfg,
-            replyOptions,
-            dispatcherOptions: {
-              responsePrefix,
-              humanDelay,
-              typingCallbacks,
-              deliver: async (payload: ReplyPayload) => {
-                let replyText = payload.text;
-                if (!replyText) {
-                  return;
-                }
-
-                // Process any block directives in the response (strips them from text)
-                replyText = await processBlockDirectives(replyText, senderShip);
-                if (!replyText) {
-                  return;
-                } // Response was only a directive
-
-                // Use settings store value if set, otherwise fall back to file config
-                const showSignature = effectiveShowModelSig;
-                if (showSignature) {
-                  const modelCfg = cfg.agents?.defaults?.model;
-                  const modelInfo =
-                    selectedModel ||
-                    (payload as { metadata?: { model?: string } }).metadata
-                      ?.model ||
-                    (payload as { model?: string }).model ||
-                    (route as { model?: string }).model ||
-                    (typeof modelCfg === 'string'
-                      ? modelCfg
-                      : modelCfg?.primary);
-                  replyText = `${replyText}\n\n_[Generated by ${formatModelName(modelInfo)}]_`;
-                }
-
-                // Add addendum if this is the last response before bot rate limit
-                if (isGroup && groupChannel && knownBotShips.has(senderShip)) {
-                  const count = consecutiveBotMessages.get(groupChannel) ?? 0;
-                  if (maxBotResponses > 0 && count === maxBotResponses) {
-                    const otherBot = formatShipWithNickname(senderShip);
-                    replyText += `\n\n---\n_This is my last response to ${otherBot} for now. To continue our conversation, someone will need to mention me._`;
+        dispatchResult = await recordTlonRouteAndDispatch({
+          session: core.channel.session,
+          cfg,
+          route,
+          ctxPayload,
+          ctxSessionKey: ctxPayload.SessionKey,
+          isGroup,
+          groupChannel,
+          senderShip,
+          parentId,
+          deliverParentId,
+          effectiveOwnerShip,
+          effectiveDmAllowlist,
+          messageId,
+          sessionStore: cfg.session?.store,
+          logError: (msg) => runtime.error?.(msg),
+          // Routine skip / pin-skip diagnostics are debug-gated to avoid
+          // high-volume logs for expected policy cases.
+          logDebug: isRouteDebugEnabled()
+            ? (msg) => runtime.log?.(msg)
+            : undefined,
+          onRecord: routeDebug,
+          dispatch: () =>
+            core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+              ctx: ctxPayload,
+              cfg,
+              replyOptions,
+              dispatcherOptions: {
+                responsePrefix,
+                humanDelay,
+                typingCallbacks,
+                deliver: async (payload: ReplyPayload) => {
+                  let replyText = payload.text;
+                  if (!replyText) {
+                    return;
                   }
-                }
 
-                if (isGroup && groupChannel) {
-                  // Send to any channel type (chat, heap, diary) using the nest directly
-                  await sendChannelPost({
-                    botProfile: getBotProfile(),
-                    fromShip: botShipName,
-                    nest: groupChannel,
-                    story: markdownToStory(replyText),
-                    replyToId: deliverParentId ?? undefined,
-                  });
-                  // Track thread participation for future replies without mention
-                  if (deliverParentId) {
-                    participatedThreads.add(String(deliverParentId));
+                  // Process any block directives in the response (strips them from text)
+                  replyText = await processBlockDirectives(
+                    replyText,
+                    senderShip
+                  );
+                  if (!replyText) {
+                    return;
+                  } // Response was only a directive
+
+                  // Use settings store value if set, otherwise fall back to file config
+                  const showSignature = effectiveShowModelSig;
+                  if (showSignature) {
+                    const modelCfg = cfg.agents?.defaults?.model;
+                    const modelInfo =
+                      selectedModel ||
+                      (payload as { metadata?: { model?: string } }).metadata
+                        ?.model ||
+                      (payload as { model?: string }).model ||
+                      (route as { model?: string }).model ||
+                      (typeof modelCfg === 'string'
+                        ? modelCfg
+                        : modelCfg?.primary);
+                    replyText = `${replyText}\n\n_[Generated by ${formatModelName(modelInfo)}]_`;
+                  }
+
+                  // Add addendum if this is the last response before bot rate limit
+                  if (
+                    isGroup &&
+                    groupChannel &&
+                    knownBotShips.has(senderShip)
+                  ) {
+                    const count = consecutiveBotMessages.get(groupChannel) ?? 0;
+                    if (maxBotResponses > 0 && count === maxBotResponses) {
+                      const otherBot = formatShipWithNickname(senderShip);
+                      replyText += `\n\n---\n_This is my last response to ${otherBot} for now. To continue our conversation, someone will need to mention me._`;
+                    }
+                  }
+
+                  if (isRouteDebugEnabled()) {
                     runtime.log?.(
-                      `[tlon] Now tracking thread for future replies: ${deliverParentId}`
+                      `[tlon][route-debug] deliver ${JSON.stringify({
+                        messageId,
+                        isGroup,
+                        destination: isGroup
+                          ? groupChannel ?? null
+                          : senderShip,
+                        deliverParentId: deliverParentId ?? null,
+                      })}`
                     );
                   }
-                } else {
-                  await sendDm({
-                    botProfile: getBotProfile(),
-                    fromShip: botShipName,
-                    toShip: senderShip,
-                    text: replyText,
-                    replyToId: deliverParentId
-                      ? String(deliverParentId)
-                      : undefined,
-                  });
-                }
 
-                if (presenceConversationId) {
-                  await computingPresence.stopRun({
-                    conversationId: presenceConversationId,
-                    runId: presenceRunId,
-                  });
-                }
+                  if (isGroup && groupChannel) {
+                    // Send to any channel type (chat, heap, diary) using the nest directly
+                    await sendChannelPost({
+                      botProfile: getBotProfile(),
+                      fromShip: botShipName,
+                      nest: groupChannel,
+                      story: markdownToStory(replyText),
+                      replyToId: deliverParentId ?? undefined,
+                    });
+                    // Track thread participation for future replies without mention
+                    if (deliverParentId) {
+                      participatedThreads.add(String(deliverParentId));
+                      runtime.log?.(
+                        `[tlon] Now tracking thread for future replies: ${deliverParentId}`
+                      );
+                    }
+                  } else {
+                    await sendDm({
+                      botProfile: getBotProfile(),
+                      fromShip: botShipName,
+                      toShip: senderShip,
+                      text: replyText,
+                      replyToId: deliverParentId
+                        ? String(deliverParentId)
+                        : undefined,
+                    });
+                  }
 
-                deliveredMessageCount += 1;
-                replyCharCount += replyText.length;
-                replyWordCount += replyText.trim()
-                  ? replyText.trim().split(/\s+/).length
-                  : 0;
-                replyMediaCount += Array.isArray(payload.mediaUrls)
-                  ? payload.mediaUrls.length
-                  : payload.mediaUrl
-                    ? 1
+                  if (presenceConversationId) {
+                    await computingPresence.stopRun({
+                      conversationId: presenceConversationId,
+                      runId: presenceRunId,
+                    });
+                  }
+
+                  deliveredMessageCount += 1;
+                  replyCharCount += replyText.length;
+                  replyWordCount += replyText.trim()
+                    ? replyText.trim().split(/\s+/).length
                     : 0;
+                  replyMediaCount += Array.isArray(payload.mediaUrls)
+                    ? payload.mediaUrls.length
+                    : payload.mediaUrl
+                      ? 1
+                      : 0;
+                },
+                onError: (err, info) => {
+                  const dispatchDuration = Date.now() - dispatchStartTime;
+                  runtime.error?.(
+                    `[tlon] ${info.kind} reply failed after ${dispatchDuration}ms: ${String(err)}`
+                  );
+                },
               },
-              onError: (err, info) => {
-                const dispatchDuration = Date.now() - dispatchStartTime;
-                runtime.error?.(
-                  `[tlon] ${info.kind} reply failed after ${dispatchDuration}ms: ${String(err)}`
-                );
-              },
-            },
-          });
+            }),
+        });
       } catch (error) {
         dispatchError = error;
         throw error;
@@ -3988,6 +4088,7 @@ export async function monitorTlonProvider(
       await ownerReplyPersistence.flush();
       await pendingNudgePersistence.flush();
       clearShadowsForAccount(account.accountId);
+      setOutboundRouteReporter(null);
       await telemetry?.close();
       try {
         await api?.close();

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -106,6 +106,7 @@ import {
   isRouteDebugEnabled,
   recordTlonRouteAndDispatch,
   routeUpdateWillSkipByPin,
+  tlonDeliveryContext,
 } from './session-routing.js';
 import { resolveSettingsMirrorSync } from './settings-sync.js';
 import {
@@ -2690,6 +2691,11 @@ export async function monitorTlonProvider(
                 core.system.enqueueSystemEvent(eventText, {
                   sessionKey: route.sessionKey,
                   contextKey: `tlon:reaction:${nest}:${postId}:${reactEmoji}:${ship}`,
+                  // Route any resulting system/heartbeat turn back to Tlon.
+                  deliveryContext: tlonDeliveryContext(
+                    `tlon:${nest}`,
+                    route.accountId
+                  ),
                 });
               }
             } catch (err: any) {
@@ -3110,6 +3116,11 @@ export async function monitorTlonProvider(
                 core.system.enqueueSystemEvent(eventText, {
                   sessionKey: route.sessionKey,
                   contextKey: `tlon:dm-reaction:${messageId}:${reactEmoji}:${reactAuthor}:${action}`,
+                  // Route any resulting system/heartbeat turn back to Tlon.
+                  deliveryContext: tlonDeliveryContext(
+                    `tlon:${partnerShip || reactAuthor}`,
+                    route.accountId
+                  ),
                 });
                 runtime.log?.(`[tlon] DM_REACTION: ${eventText}`);
               }
@@ -3614,7 +3625,14 @@ export async function monitorTlonProvider(
                             const memberDisplay = formatShipWithNickname(ship);
                             core.system.enqueueSystemEvent(
                               `[${memberDisplay} joined group ${groupFlag}]`,
-                              { sessionKey: route.sessionKey }
+                              {
+                                sessionKey: route.sessionKey,
+                                // Route any resulting system turn back to Tlon.
+                                deliveryContext: tlonDeliveryContext(
+                                  `tlon:${nest}`,
+                                  route.accountId
+                                ),
+                              }
                             );
                             runtime.log?.(
                               `[tlon] Member joined: ${ship} → ${groupFlag}`

--- a/packages/openclaw/src/monitor/session-routing.persistence.test.ts
+++ b/packages/openclaw/src/monitor/session-routing.persistence.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadSessionStore } from 'openclaw/plugin-sdk/config-runtime';
+import { recordInboundSession } from 'openclaw/plugin-sdk/conversation-runtime';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import type { ResolvedAgentRoute } from 'openclaw/plugin-sdk/routing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildTlonInboundRouteRecord } from './session-routing.js';
+
+// Proves the durable route written by buildTlonInboundRouteRecord + the real
+// SDK `recordInboundSession` lands under `lastRouteSessionKey` where the
+// delivery consumer reads it — i.e. a later route-dependent send resolves Tlon
+// instead of falling back to webchat.
+
+function makeRoute(
+  overrides: Partial<ResolvedAgentRoute> = {}
+): ResolvedAgentRoute {
+  return {
+    agentId: 'default',
+    channel: 'tlon',
+    accountId: 'default',
+    sessionKey: 'tlon:main',
+    mainSessionKey: 'tlon:main',
+    lastRoutePolicy: 'main',
+    matchedBy: 'default',
+    ...overrides,
+  };
+}
+
+const cfg = { session: { dmScope: 'main' } } as unknown as OpenClawConfig;
+
+let dir: string;
+let storePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tlon-route-'));
+  storePath = join(dir, 'sessions.json');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function persist(record: ReturnType<typeof buildTlonInboundRouteRecord>) {
+  const tasks: Array<Promise<unknown>> = [];
+  const errors: unknown[] = [];
+  await recordInboundSession({
+    storePath,
+    sessionKey: record.recordSessionKey,
+    ctx: {
+      SessionKey: record.recordSessionKey,
+      Provider: 'tlon',
+      Surface: 'tlon',
+      OriginatingChannel: 'tlon',
+      OriginatingTo: record.target ?? undefined,
+      ChatType: 'direct',
+      SenderId: '~zod',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    updateLastRoute: record.updateLastRoute,
+    onRecordError: (err) => errors.push(err),
+    trackSessionMetaTask: (task) => tasks.push(task),
+  });
+  await Promise.all(tasks);
+  expect(errors).toEqual([]);
+}
+
+describe('Tlon route persistence (real SDK store)', () => {
+  it('persists a DM route under lastRouteSessionKey for the consumer to resolve', async () => {
+    const record = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+    });
+
+    await persist(record);
+
+    const entry = loadSessionStore(storePath)[record.lastRouteSessionKey];
+    expect(entry).toBeDefined();
+    expect(entry?.deliveryContext?.channel).toBe('tlon');
+    expect(entry?.deliveryContext?.to).toBe('tlon:~zod');
+    expect(entry?.lastChannel).toBe('tlon');
+    expect(entry?.lastTo).toBe('tlon:~zod');
+  });
+
+  it('persists a group/channel route under a session-specific key', async () => {
+    const record = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute({
+        sessionKey: 'tlon:group:chat/~host/general',
+        lastRoutePolicy: 'session',
+      }),
+      isGroup: true,
+      groupChannel: 'chat/~host/general',
+      senderShip: '~nec',
+    });
+
+    await persist(record);
+
+    const entry = loadSessionStore(storePath)[record.lastRouteSessionKey];
+    expect(entry).toBeDefined();
+    expect(entry?.lastChannel).toBe('tlon');
+    expect(entry?.lastTo).toBe('tlon:chat/~host/general');
+  });
+
+  it('clears stale thread state when a later unthreaded route is recorded', async () => {
+    const threaded = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+      deliverParentId: 'thread-1',
+    });
+    await persist(threaded);
+    expect(
+      loadSessionStore(storePath)[threaded.lastRouteSessionKey]?.lastThreadId
+    ).toBe('thread-1');
+
+    const unthreaded = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+    });
+    await persist(unthreaded);
+    expect(
+      loadSessionStore(storePath)[unthreaded.lastRouteSessionKey]?.lastThreadId
+    ).toBeUndefined();
+  });
+
+  it('owner pin blocks a non-owner DM from overwriting the main route and fires onSkip', async () => {
+    // Owner establishes the durable main-session route (owner === sender, no skip).
+    const owner = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+      effectiveOwnerShip: '~zod',
+    });
+    await persist(owner);
+    expect(loadSessionStore(storePath)[owner.lastRouteSessionKey]?.lastTo).toBe(
+      'tlon:~zod'
+    );
+
+    // A non-owner DM resolves to the same main session but must not clobber it.
+    const intruder = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~nec',
+      effectiveOwnerShip: '~zod',
+    });
+    const update = intruder.updateLastRoute;
+    if (!update?.mainDmOwnerPin) {
+      throw new Error('expected a mainDmOwnerPin for a non-owner main DM');
+    }
+
+    const skips: Array<{ ownerRecipient: string; senderRecipient: string }> =
+      [];
+    await recordInboundSession({
+      storePath,
+      sessionKey: intruder.recordSessionKey,
+      ctx: {
+        SessionKey: intruder.recordSessionKey,
+        Provider: 'tlon',
+        ChatType: 'direct',
+        SenderId: '~nec',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      updateLastRoute: {
+        ...update,
+        mainDmOwnerPin: {
+          ...update.mainDmOwnerPin,
+          onSkip: (p) => skips.push(p),
+        },
+      },
+      onRecordError: (err) => {
+        throw err;
+      },
+    });
+
+    // Route unchanged, and the skip was observable rather than silent.
+    expect(
+      loadSessionStore(storePath)[intruder.lastRouteSessionKey]?.lastTo
+    ).toBe('tlon:~zod');
+    expect(skips).toEqual([
+      { ownerRecipient: '~zod', senderRecipient: '~nec' },
+    ]);
+  });
+});

--- a/packages/openclaw/src/monitor/session-routing.test.ts
+++ b/packages/openclaw/src/monitor/session-routing.test.ts
@@ -9,6 +9,7 @@ import {
   recordTlonInboundRoute,
   recordTlonRouteAndDispatch,
   routeUpdateWillSkipByPin,
+  tlonDeliveryContext,
 } from './session-routing.js';
 
 function makeRoute(
@@ -321,6 +322,23 @@ describe('recordTlonInboundRoute', () => {
 
     expect(logDebug).toHaveBeenCalledTimes(1);
     expect(logError).not.toHaveBeenCalled();
+  });
+});
+
+describe('tlonDeliveryContext', () => {
+  it('builds a Tlon delivery context for a channel nest target', () => {
+    expect(tlonDeliveryContext('tlon:chat/~host/general', 'acct-1')).toEqual({
+      channel: 'tlon',
+      to: 'tlon:chat/~host/general',
+      accountId: 'acct-1',
+    });
+  });
+
+  it('omits accountId when not provided', () => {
+    expect(tlonDeliveryContext('tlon:~zod')).toEqual({
+      channel: 'tlon',
+      to: 'tlon:~zod',
+    });
   });
 });
 

--- a/packages/openclaw/src/monitor/session-routing.test.ts
+++ b/packages/openclaw/src/monitor/session-routing.test.ts
@@ -1,0 +1,512 @@
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import type { ResolvedAgentRoute } from 'openclaw/plugin-sdk/routing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type TlonInboundRouteInput,
+  buildTlonInboundRouteRecord,
+  recordRouteThenDispatch,
+  recordTlonInboundRoute,
+  recordTlonRouteAndDispatch,
+  routeUpdateWillSkipByPin,
+} from './session-routing.js';
+
+function makeRoute(
+  overrides: Partial<ResolvedAgentRoute> = {}
+): ResolvedAgentRoute {
+  return {
+    agentId: 'default',
+    channel: 'tlon',
+    accountId: 'default',
+    sessionKey: 'tlon:main',
+    mainSessionKey: 'tlon:main',
+    lastRoutePolicy: 'main',
+    matchedBy: 'default',
+    ...overrides,
+  };
+}
+
+function cfgWithDmScope(dmScope?: string): OpenClawConfig {
+  return { session: dmScope ? { dmScope } : {} } as unknown as OpenClawConfig;
+}
+
+function dmInput(
+  overrides: Partial<TlonInboundRouteInput> = {}
+): TlonInboundRouteInput {
+  return {
+    cfg: cfgWithDmScope('main'),
+    route: makeRoute(),
+    isGroup: false,
+    senderShip: '~zod',
+    ...overrides,
+  };
+}
+
+function groupInput(
+  overrides: Partial<TlonInboundRouteInput> = {}
+): TlonInboundRouteInput {
+  return {
+    cfg: cfgWithDmScope('main'),
+    // group peers resolve to a session-specific route, not the main session
+    route: makeRoute({
+      sessionKey: 'tlon:group:chat/~host/general',
+      lastRoutePolicy: 'session',
+    }),
+    isGroup: true,
+    groupChannel: 'chat/~host/general',
+    senderShip: '~nec',
+    ...overrides,
+  };
+}
+
+describe('buildTlonInboundRouteRecord — DM', () => {
+  it('records channel tlon, provider-qualified to, and no thread id', () => {
+    const r = buildTlonInboundRouteRecord(dmInput({ senderShip: '~zod' }));
+    expect(r.target).toBe('tlon:~zod');
+    expect(r.updateLastRoute?.channel).toBe('tlon');
+    expect(r.updateLastRoute?.to).toBe('tlon:~zod');
+    expect(r.updateLastRoute?.threadId).toBeUndefined();
+  });
+
+  it('records threadId from deliverParentId', () => {
+    const r = buildTlonInboundRouteRecord(dmInput({ deliverParentId: '123' }));
+    expect(r.updateLastRoute?.threadId).toBe('123');
+  });
+
+  it('records threadId from parentId when no deliverParentId', () => {
+    const r = buildTlonInboundRouteRecord(dmInput({ parentId: '456' }));
+    expect(r.updateLastRoute?.threadId).toBe('456');
+  });
+
+  it('omits threadId for an unthreaded DM (lets SDK clear stale thread state)', () => {
+    const r = buildTlonInboundRouteRecord(dmInput());
+    expect(r.updateLastRoute).toBeDefined();
+    expect('threadId' in (r.updateLastRoute ?? {})).toBe(false);
+  });
+
+  it('writes updateLastRoute.sessionKey as lastRouteSessionKey even when it differs from recordSessionKey', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({
+        route: makeRoute({
+          sessionKey: 'tlon:peer',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+        ctxSessionKey: 'tlon:ctx',
+      })
+    );
+    // policy 'main' => last-route key collapses to mainSessionKey
+    expect(r.lastRouteSessionKey).toBe('tlon:main');
+    expect(r.recordSessionKey).toBe('tlon:ctx');
+    expect(r.updateLastRoute?.sessionKey).toBe('tlon:main');
+  });
+});
+
+describe('buildTlonInboundRouteRecord — DM main-session pinning', () => {
+  it('pins the configured owner against a different sender', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveOwnerShip: '~zod' })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin).toEqual({
+      ownerRecipient: '~zod',
+      senderRecipient: '~nec',
+    });
+  });
+
+  it('prefers the configured owner over a single allowlist entry', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({
+        senderShip: '~nec',
+        effectiveOwnerShip: '~zod',
+        effectiveDmAllowlist: ['~bus'],
+      })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin?.ownerRecipient).toBe('~zod');
+  });
+
+  it('pins a single-owner allowlist when no owner is configured', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveDmAllowlist: ['~bus'] })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin?.ownerRecipient).toBe('~bus');
+  });
+
+  it('does not pin a wildcard allowlist', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveDmAllowlist: ['*'] })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
+  it('does not pin a multi-entry allowlist with no configured owner', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveDmAllowlist: ['~bus', '~rch'] })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
+  it('does not pin an isolated per-channel-peer session', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({
+        cfg: cfgWithDmScope('per-channel-peer'),
+        route: makeRoute({
+          sessionKey: 'tlon:peer:~nec',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'session',
+        }),
+        senderShip: '~nec',
+        effectiveOwnerShip: '~zod',
+      })
+    );
+    expect(r.updateLastRoute).toBeDefined();
+    expect(r.updateLastRoute?.sessionKey).toBe('tlon:peer:~nec');
+    expect(r.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+});
+
+describe('buildTlonInboundRouteRecord — group/channel', () => {
+  it('records a provider-qualified channel nest target for a session-specific route', () => {
+    const r = buildTlonInboundRouteRecord(groupInput());
+    expect(r.target).toBe('tlon:chat/~host/general');
+    expect(r.updateLastRoute?.to).toBe('tlon:chat/~host/general');
+    expect(r.updateLastRoute?.sessionKey).toBe('tlon:group:chat/~host/general');
+  });
+
+  it('records group thread id from deliverParentId ?? parentId', () => {
+    const r = buildTlonInboundRouteRecord(groupInput({ parentId: 't1' }));
+    expect(r.updateLastRoute?.threadId).toBe('t1');
+  });
+
+  it('skips updateLastRoute (but not origin metadata) when groupChannel is missing', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: undefined })
+    );
+    expect(r.updateLastRoute).toBeUndefined();
+    expect(r.target).toBeNull();
+    expect(r.skippedReason).toBe('group-missing-channel');
+  });
+
+  it('skips updateLastRoute when the group route resolves to the main session', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({
+        route: makeRoute({
+          sessionKey: 'tlon:main',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+      })
+    );
+    expect(r.updateLastRoute).toBeUndefined();
+    expect(r.target).toBe('tlon:chat/~host/general');
+    expect(r.skippedReason).toBe('group-route-targets-main-session');
+  });
+
+  it('skips updateLastRoute for a malformed group nest', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: 'not-a-valid-nest' })
+    );
+    expect(r.updateLastRoute).toBeUndefined();
+    expect(r.target).toBeNull();
+    expect(r.skippedReason).toBe('group-invalid-channel');
+  });
+
+  it('canonicalizes the group nest before storing it', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: 'CHAT/~ZOD/General' })
+    );
+    expect(r.updateLastRoute?.to).toBe('tlon:chat/~zod/General');
+  });
+});
+
+describe('recordTlonInboundRoute', () => {
+  it('records under recordSessionKey with the durable route under lastRouteSessionKey', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const record = buildTlonInboundRouteRecord(
+      dmInput({
+        route: makeRoute({
+          sessionKey: 'tlon:peer',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+        ctxSessionKey: 'tlon:ctx',
+        senderShip: '~zod',
+      })
+    );
+
+    await recordTlonInboundRoute({
+      session: { recordInboundSession },
+      storePath: '/tmp/store.json',
+      ctxPayload: { SessionKey: 'tlon:ctx' },
+      record,
+    });
+
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    const arg = recordInboundSession.mock.calls[0][0];
+    expect(arg.sessionKey).toBe('tlon:ctx');
+    expect(arg.updateLastRoute.sessionKey).toBe('tlon:main');
+    expect(arg.updateLastRoute.to).toBe('tlon:~zod');
+  });
+
+  it('fails open and logs when recordInboundSession throws', async () => {
+    const recordInboundSession = vi.fn().mockRejectedValue(new Error('boom'));
+    const logError = vi.fn();
+    const record = buildTlonInboundRouteRecord(dmInput());
+
+    await expect(
+      recordTlonInboundRoute({
+        session: { recordInboundSession },
+        storePath: '/tmp/store.json',
+        ctxPayload: {},
+        record,
+        logError,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError.mock.calls[0][0]).toContain(
+      'failed recording inbound session route'
+    );
+  });
+
+  it('records origin metadata and warns (logError) for a missing-channel group route', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const logError = vi.fn();
+    const logDebug = vi.fn();
+    const record = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: undefined })
+    );
+
+    await recordTlonInboundRoute({
+      session: { recordInboundSession },
+      storePath: '/tmp/store.json',
+      ctxPayload: {},
+      record,
+      logError,
+      logDebug,
+    });
+
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(
+      recordInboundSession.mock.calls[0][0].updateLastRoute
+    ).toBeUndefined();
+    // Anomalous case is visible outside debug; routine debug log is not used.
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError.mock.calls[0][0]).toContain('group-missing-channel');
+    expect(logDebug).not.toHaveBeenCalled();
+  });
+
+  it('debug-logs (logDebug, not logError) a routine main-session group skip', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const logError = vi.fn();
+    const logDebug = vi.fn();
+    const record = buildTlonInboundRouteRecord(
+      groupInput({
+        route: makeRoute({
+          sessionKey: 'tlon:main',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+      })
+    );
+    expect(record.skippedReason).toBe('group-route-targets-main-session');
+
+    await recordTlonInboundRoute({
+      session: { recordInboundSession },
+      storePath: '/tmp/store.json',
+      ctxPayload: {},
+      record,
+      logError,
+      logDebug,
+    });
+
+    expect(logDebug).toHaveBeenCalledTimes(1);
+    expect(logError).not.toHaveBeenCalled();
+  });
+});
+
+describe('routeUpdateWillSkipByPin', () => {
+  it('is true when a pin owner differs from the sender', () => {
+    const record = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveOwnerShip: '~zod' })
+    );
+    expect(routeUpdateWillSkipByPin(record.updateLastRoute)).toBe(true);
+  });
+
+  it('is false when the pinned owner is the sender', () => {
+    const record = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~zod', effectiveOwnerShip: '~zod' })
+    );
+    expect(routeUpdateWillSkipByPin(record.updateLastRoute)).toBe(false);
+  });
+
+  it('is false when there is no pin', () => {
+    const record = buildTlonInboundRouteRecord(dmInput({ senderShip: '~zod' }));
+    expect(routeUpdateWillSkipByPin(record.updateLastRoute)).toBe(false);
+    expect(routeUpdateWillSkipByPin(undefined)).toBe(false);
+  });
+});
+
+describe('recordRouteThenDispatch', () => {
+  it('records before dispatching and returns the dispatch result', async () => {
+    const calls: string[] = [];
+    const result = await recordRouteThenDispatch({
+      record: async () => {
+        calls.push('record');
+      },
+      dispatch: async () => {
+        calls.push('dispatch');
+        return 'dispatched';
+      },
+    });
+    expect(calls).toEqual(['record', 'dispatch']);
+    expect(result).toBe('dispatched');
+  });
+
+  it('does not dispatch if the record step rejects', async () => {
+    const dispatch = vi.fn();
+    await expect(
+      recordRouteThenDispatch({
+        record: async () => {
+          throw new Error('record failed');
+        },
+        dispatch,
+      })
+    ).rejects.toThrow('record failed');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordTlonRouteAndDispatch (monitor boundary)', () => {
+  function mockSession() {
+    const order: string[] = [];
+    const recordInboundSession = vi.fn().mockImplementation(async () => {
+      order.push('record');
+    });
+    const resolveStorePath = vi.fn().mockReturnValue('/tmp/store.json');
+    return { order, recordInboundSession, resolveStorePath };
+  }
+
+  it('records the route before dispatching for a DM', async () => {
+    const { order, recordInboundSession, resolveStorePath } = mockSession();
+    const dispatch = vi.fn().mockImplementation(async () => {
+      order.push('dispatch');
+      return 'ok';
+    });
+
+    const result = await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: { SessionKey: 'tlon:main' } as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      dispatch,
+    });
+
+    expect(result).toBe('ok');
+    expect(order).toEqual(['record', 'dispatch']);
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession.mock.calls[0][0].updateLastRoute.to).toBe(
+      'tlon:~zod'
+    );
+  });
+
+  it('records the route before dispatching for a group message', async () => {
+    const { order, recordInboundSession, resolveStorePath } = mockSession();
+    const dispatch = vi.fn().mockImplementation(async () => {
+      order.push('dispatch');
+    });
+
+    await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute({
+        sessionKey: 'tlon:group:chat/~host/general',
+        lastRoutePolicy: 'session',
+      }),
+      ctxPayload: { SessionKey: 'tlon:group:chat/~host/general' } as never,
+      ctxSessionKey: 'tlon:group:chat/~host/general',
+      isGroup: true,
+      groupChannel: 'chat/~host/general',
+      senderShip: '~nec',
+      dispatch,
+    });
+
+    expect(order).toEqual(['record', 'dispatch']);
+    expect(recordInboundSession.mock.calls[0][0].updateLastRoute.to).toBe(
+      'tlon:chat/~host/general'
+    );
+  });
+
+  it('passes the built record to onRecord', async () => {
+    const { recordInboundSession, resolveStorePath } = mockSession();
+    const onRecord = vi.fn();
+
+    await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: {} as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      onRecord,
+      dispatch: async () => undefined,
+    });
+
+    expect(onRecord).toHaveBeenCalledTimes(1);
+    expect(onRecord.mock.calls[0][0].target).toBe('tlon:~zod');
+  });
+
+  it('still dispatches when recording fails (fail open)', async () => {
+    const recordInboundSession = vi.fn().mockRejectedValue(new Error('boom'));
+    const resolveStorePath = vi.fn().mockReturnValue('/tmp/store.json');
+    const dispatch = vi.fn().mockResolvedValue('ok');
+    const logError = vi.fn();
+
+    const result = await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: {} as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      logError,
+      dispatch,
+    });
+
+    expect(result).toBe('ok');
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalled();
+  });
+
+  it('still dispatches when resolveStorePath throws (fail open)', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const resolveStorePath = vi.fn().mockImplementation(() => {
+      throw new Error('bad store config');
+    });
+    const dispatch = vi.fn().mockResolvedValue('ok');
+    const logError = vi.fn();
+
+    const result = await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: {} as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      logError,
+      dispatch,
+    });
+
+    expect(result).toBe('ok');
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(logError.mock.calls[0][0]).toContain(
+      'failed resolving session store path'
+    );
+  });
+});

--- a/packages/openclaw/src/monitor/session-routing.ts
+++ b/packages/openclaw/src/monitor/session-routing.ts
@@ -9,8 +9,8 @@ import { canonicalizeNest, normalizeShip } from '../targets.js';
 
 /**
  * Durable last-route update for a Tlon inbound turn. Mirrors the SDK's
- * `InboundLastRouteUpdate` shape; the Phase 2 call site passes this straight to
- * `core.channel.session.recordInboundSession`, which type-checks it against the
+ * `InboundLastRouteUpdate` shape; the monitor's record call site passes this
+ * straight to `core.channel.session.recordInboundSession`, which type-checks it against the
  * real SDK type. We keep a local alias here so the pure helper has no dependency
  * on internal SDK type paths.
  *
@@ -73,7 +73,7 @@ export type TlonInboundRouteRecord = {
  * route. Pure: no I/O, no SDK store access. The caller passes the result to
  * `recordInboundSession` (see `recordTlonInboundRoute`).
  *
- * Routing rules (see the routing-gap plan, Phase 1):
+ * Routing rules:
  * - DM: persist `tlon:<senderShip>`. When the last-route session is the agent
  *   main session and a single owner is pinned, attach `mainDmOwnerPin` so a
  *   non-owner DM cannot silently overwrite the owner/main route.
@@ -435,7 +435,7 @@ export function tlonDeliveryContext(
   return { channel: 'tlon', to, ...(accountId ? { accountId } : {}) };
 }
 
-/** Phase 0 diagnostic gate: enabled via `TLON_OPENCLAW_ROUTE_DEBUG=1`. */
+/** Route-debug gate: enabled via `TLON_OPENCLAW_ROUTE_DEBUG=1`. */
 export function isRouteDebugEnabled(): boolean {
   return process.env.TLON_OPENCLAW_ROUTE_DEBUG === '1';
 }

--- a/packages/openclaw/src/monitor/session-routing.ts
+++ b/packages/openclaw/src/monitor/session-routing.ts
@@ -1,0 +1,425 @@
+import { resolvePinnedMainDmOwnerFromAllowlist } from 'openclaw/plugin-sdk/conversation-runtime';
+import type { OpenClawConfig, PluginRuntime } from 'openclaw/plugin-sdk/core';
+import {
+  type ResolvedAgentRoute,
+  resolveInboundLastRouteSessionKey,
+} from 'openclaw/plugin-sdk/routing';
+
+import { canonicalizeNest, normalizeShip } from '../targets.js';
+
+/**
+ * Durable last-route update for a Tlon inbound turn. Mirrors the SDK's
+ * `InboundLastRouteUpdate` shape; the Phase 2 call site passes this straight to
+ * `core.channel.session.recordInboundSession`, which type-checks it against the
+ * real SDK type. We keep a local alias here so the pure helper has no dependency
+ * on internal SDK type paths.
+ *
+ * NOTE: `sessionKey` here is the *last-route* session key (where the consumer
+ * reads delivery state from), which is NOT necessarily the same as the
+ * top-level `sessionKey` used for origin metadata. `recordInboundSession`
+ * writes durable delivery state under `update.sessionKey`.
+ */
+export type TlonUpdateLastRoute = {
+  sessionKey: string;
+  channel: 'tlon';
+  to: string;
+  accountId?: string;
+  threadId?: string | number;
+  mainDmOwnerPin?: {
+    ownerRecipient: string;
+    senderRecipient: string;
+    onSkip?: (params: {
+      ownerRecipient: string;
+      senderRecipient: string;
+    }) => void;
+  };
+};
+
+export type TlonInboundRouteInput = {
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  /** The finalized inbound ctx; only `SessionKey` is read. */
+  ctxSessionKey?: string | null;
+  isGroup: boolean;
+  groupChannel?: string | null;
+  senderShip: string;
+  parentId?: string | number | null;
+  deliverParentId?: string | number | null;
+  effectiveOwnerShip?: string | null;
+  effectiveDmAllowlist?: string[];
+};
+
+export type TlonInboundRouteRecord = {
+  /** Session key for origin-metadata recording (`recordSessionMetaFromInbound`). */
+  recordSessionKey: string;
+  /** Session key the durable delivery route is written under (and read from). */
+  lastRouteSessionKey: string;
+  /** Provider-qualified delivery target, or null when it cannot be built. */
+  target: string | null;
+  /**
+   * The durable route update, or `undefined` when route persistence is
+   * intentionally skipped (origin metadata is still recorded by the caller).
+   */
+  updateLastRoute?: TlonUpdateLastRoute;
+  /** Set when `updateLastRoute` is omitted, for a distinctive caller log. */
+  skippedReason?:
+    | 'group-missing-channel'
+    | 'group-invalid-channel'
+    | 'group-route-targets-main-session';
+};
+
+/**
+ * Build the parameters for persisting a Tlon inbound turn's durable session
+ * route. Pure: no I/O, no SDK store access. The caller passes the result to
+ * `recordInboundSession` (see `recordTlonInboundRoute`).
+ *
+ * Routing rules (see the routing-gap plan, Phase 1):
+ * - DM: persist `tlon:<senderShip>`. When the last-route session is the agent
+ *   main session and a single owner is pinned, attach `mainDmOwnerPin` so a
+ *   non-owner DM cannot silently overwrite the owner/main route.
+ * - Group/channel: persist `tlon:<groupChannel>` only when the last-route
+ *   session is NOT the main session (avoid clobbering a broad shared session).
+ *   Skip — but still record origin metadata — when `groupChannel` is missing.
+ */
+export function buildTlonInboundRouteRecord(
+  input: TlonInboundRouteInput
+): TlonInboundRouteRecord {
+  const {
+    cfg,
+    route,
+    ctxSessionKey,
+    isGroup,
+    groupChannel,
+    senderShip,
+    parentId,
+    deliverParentId,
+    effectiveOwnerShip,
+    effectiveDmAllowlist,
+  } = input;
+
+  const recordSessionKey = ctxSessionKey ?? route.sessionKey;
+  const lastRouteSessionKey = resolveInboundLastRouteSessionKey({
+    route,
+    sessionKey: recordSessionKey,
+  });
+
+  const rawThread = deliverParentId ?? parentId;
+  const threadId =
+    rawThread != null && rawThread !== '' ? String(rawThread) : undefined;
+
+  const base = { recordSessionKey, lastRouteSessionKey };
+
+  if (isGroup) {
+    const nest = groupChannel?.trim();
+    if (!nest) {
+      return { ...base, target: null, skippedReason: 'group-missing-channel' };
+    }
+    // Validate/canonicalize the nest before storing. Firehose nests are already
+    // canonical, but config/settings-watched values can be malformed; a bad
+    // nest would otherwise persist an unusable `lastTo`.
+    const canonicalNest = canonicalizeNest(nest);
+    if (!canonicalNest) {
+      return { ...base, target: null, skippedReason: 'group-invalid-channel' };
+    }
+    const target = `tlon:${canonicalNest}`;
+    // Don't overwrite a broad shared main session with a per-group route.
+    if (lastRouteSessionKey === route.mainSessionKey) {
+      return {
+        ...base,
+        target,
+        skippedReason: 'group-route-targets-main-session',
+      };
+    }
+    return {
+      ...base,
+      target,
+      updateLastRoute: {
+        sessionKey: lastRouteSessionKey,
+        channel: 'tlon',
+        to: target,
+        ...(route.accountId ? { accountId: route.accountId } : {}),
+        ...(threadId !== undefined ? { threadId } : {}),
+      },
+    };
+  }
+
+  // DM
+  const target = `tlon:${senderShip}`;
+  const mainDmOwnerPin = resolveMainDmOwnerPin({
+    cfg,
+    route,
+    lastRouteSessionKey,
+    senderShip,
+    effectiveOwnerShip,
+    effectiveDmAllowlist,
+  });
+
+  return {
+    ...base,
+    target,
+    updateLastRoute: {
+      sessionKey: lastRouteSessionKey,
+      channel: 'tlon',
+      to: target,
+      ...(route.accountId ? { accountId: route.accountId } : {}),
+      ...(threadId !== undefined ? { threadId } : {}),
+      ...(mainDmOwnerPin ? { mainDmOwnerPin } : {}),
+    },
+  };
+}
+
+function resolveMainDmOwnerPin(params: {
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  lastRouteSessionKey: string;
+  senderShip: string;
+  effectiveOwnerShip?: string | null;
+  effectiveDmAllowlist?: string[];
+}): TlonUpdateLastRoute['mainDmOwnerPin'] | undefined {
+  const {
+    cfg,
+    route,
+    lastRouteSessionKey,
+    senderShip,
+    effectiveOwnerShip,
+    effectiveDmAllowlist,
+  } = params;
+
+  // Only the main session can be clobbered by another DM sender; isolated
+  // per-peer sessions need no pin.
+  if (lastRouteSessionKey !== route.mainSessionKey) {
+    return undefined;
+  }
+
+  const sender = senderShip.trim();
+  if (!sender) {
+    return undefined;
+  }
+
+  // Tlon's configured owner (`ownerShip`) is separate from `dmAllowlist`, and
+  // owner DMs are valid even when the owner isn't allowlisted. Prefer pinning
+  // the configured owner; otherwise fall back to the SDK's allowlist semantics
+  // (which only pin when there is exactly one allowed sender).
+  const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
+    dmScope: cfg.session?.dmScope,
+    allowFrom: effectiveOwnerShip ? [effectiveOwnerShip] : effectiveDmAllowlist,
+    normalizeEntry: normalizeShip,
+  });
+  if (!pinnedOwner) {
+    return undefined;
+  }
+
+  return {
+    ownerRecipient: pinnedOwner,
+    senderRecipient: normalizeShip(sender),
+  };
+}
+
+/**
+ * The slice of `core.channel.session` used by `recordTlonInboundRoute`. Typed
+ * from the SDK runtime so the call site validates our `updateLastRoute` shape
+ * against the real `InboundLastRouteUpdate` (e.g. that `channel: 'tlon'` and the
+ * pin shape are accepted).
+ */
+type SessionRecorder = Pick<
+  PluginRuntime['channel']['session'],
+  'recordInboundSession'
+>;
+type RecordInboundCtx = Parameters<
+  SessionRecorder['recordInboundSession']
+>[0]['ctx'];
+
+/**
+ * Persist a Tlon inbound turn's session route. Always records origin metadata
+ * (even when `record.updateLastRoute` is omitted) and fails open: a persistence
+ * failure is logged but never blocks the live reply.
+ */
+export async function recordTlonInboundRoute(deps: {
+  session: SessionRecorder;
+  storePath: string;
+  ctxPayload: RecordInboundCtx;
+  record: TlonInboundRouteRecord;
+  messageId?: string;
+  accountId?: string;
+  logError?: (msg: string) => void;
+  logDebug?: (msg: string) => void;
+}): Promise<void> {
+  const { session, storePath, ctxPayload, record, messageId, accountId } = deps;
+
+  if (
+    record.skippedReason === 'group-missing-channel' ||
+    record.skippedReason === 'group-invalid-channel'
+  ) {
+    // Anomalous (a group turn with no/malformed channel nest); surface outside
+    // debug too.
+    deps.logError?.(
+      `[tlon] route persistence skipped (${record.skippedReason}): ` +
+        `messageId=${messageId ?? '?'} lastRouteSessionKey=${record.lastRouteSessionKey}`
+    );
+  } else if (record.skippedReason) {
+    // Normal policy outcome (e.g. a group route that targets the shared main
+    // session); debug-only to avoid high-volume logs for an expected case.
+    deps.logDebug?.(
+      `[tlon] route persistence skipped (${record.skippedReason}): ` +
+        `messageId=${messageId ?? '?'} lastRouteSessionKey=${record.lastRouteSessionKey} ` +
+        `target=${record.target ?? '(none)'}`
+    );
+  }
+
+  // When a main-session DM is pinned to an owner, the SDK skips the durable
+  // route update for a non-owner sender. Wire an onSkip so that decision is
+  // observable instead of silently looking like a successful write.
+  const pin = record.updateLastRoute?.mainDmOwnerPin;
+  const updateLastRoute: TlonUpdateLastRoute | undefined =
+    record.updateLastRoute
+      ? {
+          ...record.updateLastRoute,
+          ...(pin
+            ? {
+                mainDmOwnerPin: {
+                  ...pin,
+                  onSkip: ({ ownerRecipient, senderRecipient }) =>
+                    deps.logDebug?.(
+                      `[tlon] durable route update skipped by owner pin: ` +
+                        `messageId=${messageId ?? '?'} owner=${ownerRecipient} ` +
+                        `sender=${senderRecipient} lastRouteSessionKey=${record.lastRouteSessionKey}`
+                    ),
+                },
+              }
+            : {}),
+        }
+      : undefined;
+
+  try {
+    await session.recordInboundSession({
+      storePath,
+      sessionKey: record.recordSessionKey,
+      ctx: ctxPayload,
+      updateLastRoute,
+      onRecordError: (err) => {
+        deps.logError?.(`[tlon] failed updating session meta: ${String(err)}`);
+      },
+    });
+  } catch (err) {
+    deps.logError?.(
+      `[tlon] failed recording inbound session route: ${String(err)} ` +
+        `(messageId=${messageId ?? '?'} storePath=${storePath} ` +
+        `recordSessionKey=${record.recordSessionKey} ` +
+        `lastRouteSessionKey=${record.lastRouteSessionKey} ` +
+        `target=${record.target ?? '(none)'} accountId=${accountId ?? '(none)'} ` +
+        `hadUpdateLastRoute=${Boolean(record.updateLastRoute)})`
+    );
+  }
+}
+
+/**
+ * Whether the SDK will skip the durable route update because a main-session DM
+ * is pinned to an owner different from the sender. A built `updateLastRoute`
+ * does not guarantee a write, so diagnostics should report this rather than
+ * imply the route was persisted.
+ */
+export function routeUpdateWillSkipByPin(
+  update?: TlonUpdateLastRoute
+): boolean {
+  const pin = update?.mainDmOwnerPin;
+  if (!pin) {
+    return false;
+  }
+  return pin.ownerRecipient !== pin.senderRecipient;
+}
+
+/**
+ * Run the durable route-record step before reply dispatch. The bug this fixes
+ * lives at exactly this boundary: route-dependent sends that happen during
+ * dispatch must observe the persisted route, so recording must complete first.
+ * Keeping this ordering in one place gives the monitor a testable guard.
+ */
+export async function recordRouteThenDispatch<T>(steps: {
+  record: () => Promise<void>;
+  dispatch: () => Promise<T>;
+}): Promise<T> {
+  await steps.record();
+  return steps.dispatch();
+}
+
+/**
+ * The monitor's "build ctx → record route → dispatch" boundary, as a single
+ * testable unit (this is where the original webchat-leak bug lived). Builds the
+ * Tlon route record, persists it, and only then runs `dispatch`. The monitor
+ * delegates its entire record+dispatch to this so the ordering is covered by a
+ * unit test rather than only by the monitor's structure.
+ */
+export async function recordTlonRouteAndDispatch<T>(params: {
+  session: Pick<
+    PluginRuntime['channel']['session'],
+    'recordInboundSession' | 'resolveStorePath'
+  >;
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  ctxPayload: RecordInboundCtx;
+  ctxSessionKey?: string | null;
+  isGroup: boolean;
+  groupChannel?: string | null;
+  senderShip: string;
+  parentId?: string | number | null;
+  deliverParentId?: string | number | null;
+  effectiveOwnerShip?: string | null;
+  effectiveDmAllowlist?: string[];
+  messageId?: string;
+  sessionStore?: string;
+  logError?: (msg: string) => void;
+  logDebug?: (msg: string) => void;
+  /** Called with the built record, before persistence (used for debug logging). */
+  onRecord?: (record: TlonInboundRouteRecord) => void;
+  dispatch: () => Promise<T>;
+}): Promise<T> {
+  const record = buildTlonInboundRouteRecord({
+    cfg: params.cfg,
+    route: params.route,
+    ctxSessionKey: params.ctxSessionKey,
+    isGroup: params.isGroup,
+    groupChannel: params.groupChannel,
+    senderShip: params.senderShip,
+    parentId: params.parentId,
+    deliverParentId: params.deliverParentId,
+    effectiveOwnerShip: params.effectiveOwnerShip,
+    effectiveDmAllowlist: params.effectiveDmAllowlist,
+  });
+  params.onRecord?.(record);
+
+  return recordRouteThenDispatch({
+    // Fail open across the *entire* persistence step — including
+    // resolveStorePath, which can throw on bad session-store config — so a
+    // persistence failure never suppresses the live Tlon reply.
+    record: async () => {
+      let storePath: string;
+      try {
+        storePath = params.session.resolveStorePath(params.sessionStore, {
+          agentId: params.route.agentId,
+        });
+      } catch (err) {
+        params.logError?.(
+          `[tlon] failed resolving session store path: ${String(err)} ` +
+            `(messageId=${params.messageId ?? '?'})`
+        );
+        return;
+      }
+      await recordTlonInboundRoute({
+        session: params.session,
+        storePath,
+        ctxPayload: params.ctxPayload,
+        record,
+        messageId: params.messageId,
+        accountId: params.route.accountId,
+        logError: params.logError,
+        logDebug: params.logDebug,
+      });
+    },
+    dispatch: params.dispatch,
+  });
+}
+
+/** Phase 0 diagnostic gate: enabled via `TLON_OPENCLAW_ROUTE_DEBUG=1`. */
+export function isRouteDebugEnabled(): boolean {
+  return process.env.TLON_OPENCLAW_ROUTE_DEBUG === '1';
+}

--- a/packages/openclaw/src/monitor/session-routing.ts
+++ b/packages/openclaw/src/monitor/session-routing.ts
@@ -419,6 +419,22 @@ export async function recordTlonRouteAndDispatch<T>(params: {
   });
 }
 
+/**
+ * Build a Tlon `deliveryContext` for an enqueued system event (reactions,
+ * group-join notices). System-event turns resolve delivery from the event's
+ * `deliveryContext` or the session store; attaching this ensures a later
+ * system/heartbeat turn driven by the event routes to Tlon instead of falling
+ * back to webchat, even on a session that hasn't persisted an inbound route yet.
+ * `to` is the provider-qualified target (`tlon:~ship` for DMs, `tlon:<nest>` for
+ * channels), matching `OriginatingTo` and the durable route.
+ */
+export function tlonDeliveryContext(
+  to: string,
+  accountId?: string
+): { channel: 'tlon'; to: string; accountId?: string } {
+  return { channel: 'tlon', to, ...(accountId ? { accountId } : {}) };
+}
+
 /** Phase 0 diagnostic gate: enabled via `TLON_OPENCLAW_ROUTE_DEBUG=1`. */
 export function isRouteDebugEnabled(): boolean {
   return process.env.TLON_OPENCLAW_ROUTE_DEBUG === '1';

--- a/packages/openclaw/src/session-route.test.ts
+++ b/packages/openclaw/src/session-route.test.ts
@@ -1,0 +1,103 @@
+import type { ChannelOutboundSessionRouteParams } from 'openclaw/plugin-sdk/core';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import { describe, expect, it } from 'vitest';
+
+import { tlonPlugin } from './channel.js';
+import { resolveTlonOutboundSessionRoute } from './session-route.js';
+
+const cfg = {} as unknown as OpenClawConfig;
+
+function params(
+  overrides: Partial<ChannelOutboundSessionRouteParams> & { target: string }
+): ChannelOutboundSessionRouteParams {
+  return {
+    cfg,
+    agentId: 'default',
+    accountId: 'default',
+    ...overrides,
+  } as ChannelOutboundSessionRouteParams;
+}
+
+describe('resolveTlonOutboundSessionRoute', () => {
+  it.each(['dm/~sampel-palnet', '~sampel-palnet', 'tlon:~sampel-palnet'])(
+    'resolves %s to a direct Tlon route',
+    (target) => {
+      const route = resolveTlonOutboundSessionRoute(params({ target }));
+      expect(route).not.toBeNull();
+      expect(route?.chatType).toBe('direct');
+      expect(route?.peer).toEqual({ kind: 'direct', id: '~sampel-palnet' });
+      expect(route?.to).toBe('tlon:~sampel-palnet');
+      expect(route?.from).toBe('tlon:~sampel-palnet');
+    }
+  );
+
+  it.each([
+    'chat/~host/general',
+    'group:~host/general',
+    'tlon:chat/~host/general',
+  ])('resolves %s to a group Tlon route', (target) => {
+    const route = resolveTlonOutboundSessionRoute(params({ target }));
+    expect(route).not.toBeNull();
+    expect(route?.chatType).toBe('group');
+    expect(route?.peer).toEqual({ kind: 'group', id: 'chat/~host/general' });
+    expect(route?.to).toBe('tlon:chat/~host/general');
+    expect(route?.from).toBe('tlon:group:chat/~host/general');
+  });
+
+  it('preserves account id in the route', () => {
+    const route = resolveTlonOutboundSessionRoute(
+      params({ target: '~zod', accountId: 'acct-2' })
+    );
+    expect(route).not.toBeNull();
+  });
+
+  it('preserves thread id', () => {
+    const route = resolveTlonOutboundSessionRoute(
+      params({ target: '~zod', threadId: 'thr-1' })
+    );
+    expect(route?.threadId).toBe('thr-1');
+  });
+
+  it('omits thread id when not provided', () => {
+    const route = resolveTlonOutboundSessionRoute(params({ target: '~zod' }));
+    expect(route?.threadId).toBeUndefined();
+  });
+
+  it('returns null for invalid targets', () => {
+    expect(
+      resolveTlonOutboundSessionRoute(params({ target: 'not a target!!' }))
+    ).toBeNull();
+    expect(resolveTlonOutboundSessionRoute(params({ target: '' }))).toBeNull();
+  });
+});
+
+describe('tlonPlugin messaging surface (Phase 4 wiring)', () => {
+  const messaging = tlonPlugin.messaging;
+
+  it('declares tlon as an explicit target prefix', () => {
+    expect(messaging?.targetPrefixes).toContain('tlon');
+  });
+
+  it('parseExplicitTarget returns a canonical DM target', () => {
+    expect(messaging?.parseExplicitTarget?.({ raw: 'tlon:~ship' })).toEqual({
+      to: '~ship',
+      chatType: 'direct',
+    });
+  });
+
+  it('parseExplicitTarget returns a canonical group target', () => {
+    expect(
+      messaging?.parseExplicitTarget?.({ raw: 'tlon:chat/~host/general' })
+    ).toEqual({ to: 'chat/~host/general', chatType: 'group' });
+  });
+
+  it('parseExplicitTarget returns null for a non-Tlon target', () => {
+    expect(
+      messaging?.parseExplicitTarget?.({ raw: 'not a target!!' })
+    ).toBeNull();
+  });
+
+  it('wires resolveOutboundSessionRoute', () => {
+    expect(typeof messaging?.resolveOutboundSessionRoute).toBe('function');
+  });
+});

--- a/packages/openclaw/src/session-route.test.ts
+++ b/packages/openclaw/src/session-route.test.ts
@@ -71,7 +71,7 @@ describe('resolveTlonOutboundSessionRoute', () => {
   });
 });
 
-describe('tlonPlugin messaging surface (Phase 4 wiring)', () => {
+describe('tlonPlugin messaging surface (explicit-target wiring)', () => {
   const messaging = tlonPlugin.messaging;
 
   it('declares tlon as an explicit target prefix', () => {

--- a/packages/openclaw/src/session-route.ts
+++ b/packages/openclaw/src/session-route.ts
@@ -6,7 +6,7 @@ import {
 import { parseTlonTarget } from './targets.js';
 
 /**
- * Channel-native outbound session-route builder for Tlon (Phase 4).
+ * Channel-native outbound session-route builder for Tlon.
  *
  * Lets explicit outbound sends to a Tlon target (e.g. the shared `message` tool
  * with `to: tlon:~ship`) derive a stable Tlon session route, so they resolve

--- a/packages/openclaw/src/session-route.ts
+++ b/packages/openclaw/src/session-route.ts
@@ -1,0 +1,54 @@
+import {
+  type ChannelOutboundSessionRouteParams,
+  buildChannelOutboundSessionRoute,
+} from 'openclaw/plugin-sdk/core';
+
+import { parseTlonTarget } from './targets.js';
+
+/**
+ * Channel-native outbound session-route builder for Tlon (Phase 4).
+ *
+ * Lets explicit outbound sends to a Tlon target (e.g. the shared `message` tool
+ * with `to: tlon:~ship`) derive a stable Tlon session route, so they resolve
+ * to Tlon even when the current turn's surface is something else. Returns
+ * `null` for non-Tlon / unparseable targets so core can fall through.
+ */
+export function resolveTlonOutboundSessionRoute(
+  params: ChannelOutboundSessionRouteParams
+) {
+  const parsed = parseTlonTarget(params.target);
+  if (!parsed) {
+    return null;
+  }
+
+  const threadId =
+    params.threadId != null && params.threadId !== ''
+      ? params.threadId
+      : undefined;
+
+  if (parsed.kind === 'dm') {
+    return buildChannelOutboundSessionRoute({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      channel: 'tlon',
+      accountId: params.accountId,
+      peer: { kind: 'direct', id: parsed.ship },
+      chatType: 'direct',
+      from: `tlon:${parsed.ship}`,
+      to: `tlon:${parsed.ship}`,
+      ...(threadId !== undefined ? { threadId } : {}),
+    });
+  }
+
+  return buildChannelOutboundSessionRoute({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: 'tlon',
+    accountId: params.accountId,
+    peer: { kind: 'group', id: parsed.nest },
+    chatType: 'group',
+    from: `tlon:group:${parsed.nest}`,
+    to: `tlon:${parsed.nest}`,
+    ...(threadId !== undefined ? { threadId } : {}),
+  });
+}

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { _testing, createTlonTelemetry, recordToolCall } from './telemetry.js';
+import {
+  _testing,
+  createTlonTelemetry,
+  recordToolCall,
+  reportOutboundRoute,
+  setOutboundRouteReporter,
+} from './telemetry.js';
 
 const postHogMocks = vi.hoisted(() => ({
   identify: vi.fn(),
@@ -439,5 +445,83 @@ describe('telemetry tool tracking', () => {
     const capturedEvent = await captureReply();
     expect(capturedEvent?.event).toBe('TlonBot Reply Handled');
     expect(capturedEvent?.properties.outcome).toBe('responded');
+  });
+});
+
+describe('outbound route telemetry', () => {
+  beforeEach(() => {
+    postHogMocks.identify.mockClear();
+    postHogMocks.capture.mockClear();
+    setOutboundRouteReporter(null);
+  });
+
+  function createEnabledTelemetry() {
+    return createTlonTelemetry({
+      config: { enabled: true, apiKey: 'phc_test', host: null },
+    });
+  }
+
+  it('captures a webchat (off-Tlon) send as the tracked leak', () => {
+    const telemetry = createEnabledTelemetry();
+    telemetry?.captureOutboundRoute({
+      ownerShip: '~zod',
+      botShip: '~nec',
+      resolvedChannel: 'webchat',
+      routedToTlon: false,
+      targetKind: 'unknown',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Outbound Routed');
+    expect(call.distinctId).toBe('~zod');
+    expect(call.properties.resolvedChannel).toBe('webchat');
+    expect(call.properties.routedToTlon).toBe(false);
+  });
+
+  it('captures a healthy Tlon send', () => {
+    const telemetry = createEnabledTelemetry();
+    telemetry?.captureOutboundRoute({
+      ownerShip: '~zod',
+      botShip: '~nec',
+      resolvedChannel: 'tlon',
+      routedToTlon: true,
+      targetKind: 'dm',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties.routedToTlon).toBe(true);
+    expect(call.properties.targetKind).toBe('dm');
+  });
+
+  it('skips capture when ownerShip is not configured', () => {
+    const telemetry = createEnabledTelemetry();
+    telemetry?.captureOutboundRoute({
+      ownerShip: null,
+      botShip: '~nec',
+      resolvedChannel: 'webchat',
+      routedToTlon: false,
+      targetKind: 'unknown',
+    });
+    expect(postHogMocks.capture).not.toHaveBeenCalled();
+  });
+
+  it('reportOutboundRoute forwards to the registered reporter, and null clears it', () => {
+    const reporter = vi.fn();
+    setOutboundRouteReporter(reporter);
+    reportOutboundRoute({
+      resolvedChannel: 'webchat',
+      routedToTlon: false,
+      targetKind: 'unknown',
+    });
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter.mock.calls[0][0].routedToTlon).toBe(false);
+
+    setOutboundRouteReporter(null);
+    reportOutboundRoute({
+      resolvedChannel: 'tlon',
+      routedToTlon: true,
+      targetKind: 'dm',
+    });
+    expect(reporter).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -1,7 +1,7 @@
 import type { RuntimeEnv } from 'openclaw/plugin-sdk/runtime';
 import { PostHog } from 'posthog-node';
 
-import { sharedMap } from './shared-state.js';
+import { sharedMap, sharedSlot } from './shared-state.js';
 import type { TlonTelemetryConfig } from './types.js';
 
 type ToolCallRecord = {
@@ -116,14 +116,36 @@ export interface TlonReplyTelemetrySession {
   capture(result: TlonReplyTelemetryResult): Promise<void>;
 }
 
+/**
+ * One outbound send seen by OpenClaw's `message_sending` hook, tagged with which
+ * channel it resolved to. This fires for both the primary streamed reply (which
+ * resolves to `tlon`, so `routedToTlon: true`) and route-dependent sends (the
+ * shared `message` tool, subagents — which can resolve elsewhere). So
+ * `routedToTlon: false` is the meaningful signal: a send that went somewhere
+ * users can't see (e.g. webchat) — the bug this tracks. The `true` events
+ * include healthy primary replies, so prefer the off-Tlon count over a raw rate.
+ */
+export type TlonOutboundRouteEvent = {
+  resolvedChannel: string;
+  routedToTlon: boolean;
+  targetKind: 'dm' | 'group' | 'unknown';
+};
+
 export interface TlonTelemetryClient {
   startReply(params: TlonReplyTelemetryStart): TlonReplyTelemetrySession;
   captureHeartbeatNudge(event: TlonHeartbeatNudgeEvent): void;
   captureHeartbeatReengagement(event: TlonHeartbeatReengagementEvent): void;
+  captureOutboundRoute(
+    event: TlonOutboundRouteEvent & {
+      ownerShip?: string | null;
+      botShip: string;
+    }
+  ): void;
   close(): Promise<void>;
 }
 
 const TLON_TELEMETRY_EVENT_NAME = 'TlonBot Reply Handled';
+const TLON_OUTBOUND_ROUTED_EVENT = 'TlonBot Outbound Routed';
 const TLON_HEARTBEAT_NUDGE_EVENT = 'TlonBot Heartbeat Nudge Sent';
 const TLON_HEARTBEAT_REENGAGED_EVENT = 'TlonBot Heartbeat Nudge Reengaged';
 const TLON_TELEMETRY_LOG_SOURCE = 'openclawPlugin';
@@ -321,6 +343,31 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     });
   }
 
+  captureOutboundRoute(
+    event: TlonOutboundRouteEvent & {
+      ownerShip?: string | null;
+      botShip: string;
+    }
+  ): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_OUTBOUND_ROUTED_EVENT,
+      properties: {
+        logSource: TLON_TELEMETRY_LOG_SOURCE,
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        resolvedChannel: event.resolvedChannel,
+        routedToTlon: event.routedToTlon,
+        targetKind: event.targetKind,
+      },
+    });
+  }
+
   private ensureIdentified(ownerShip: string, botShip: string): boolean {
     if (!ownerShip) {
       if (!this.missingOwnerWarningLogged) {
@@ -433,6 +480,30 @@ export function createTlonTelemetry(params: {
     host: params.config.host,
     runtime: params.runtime,
   });
+}
+
+/**
+ * Bridge so the global `message_sending` hook (registered in the extension
+ * entry) can report route resolutions to the per-account telemetry client
+ * (created in the monitor's runtime context). The two run in separate plugin
+ * module contexts, so this must go through the shared-state slot, not a plain
+ * module singleton. The monitor publishes a reporter bound to its telemetry
+ * client + owner/bot ships; the hook calls `reportOutboundRoute`.
+ */
+export type OutboundRouteReporter = (event: TlonOutboundRouteEvent) => void;
+
+const outboundRouteReporterSlot = sharedSlot<OutboundRouteReporter>(
+  'telemetry.outboundRouteReporter'
+);
+
+export function setOutboundRouteReporter(
+  reporter: OutboundRouteReporter | null
+): void {
+  outboundRouteReporterSlot.set(reporter);
+}
+
+export function reportOutboundRoute(event: TlonOutboundRouteEvent): void {
+  outboundRouteReporterSlot.get()?.(event);
 }
 
 export const _testing = {


### PR DESCRIPTION
## Summary

Hopefully fixes the Tlon OpenClaw plugin "bot stopped responding" reports (where the bot was actually responding in webchat). The plugin never persisted a durable session route for inbound Tlon turns, so route-dependent sends fell back to webchat. This persists the Tlon route on every accepted inbound turn, bringing the plugin in line with how OpenClaw's other messenger channels (Telegram, Discord, iMessage, Slack, WhatsApp) all behave.

## Changes

-   Added `buildTlonInboundRouteRecord` and `recordTlonInboundRoute` in `packages/openclaw/src/monitor/session-routing.ts` to build and persist the Tlon delivery route for each inbound turn. Persistence is fail-open: an error logs but never blocks the live reply.
-   Added `recordTlonRouteAndDispatch` to record the route before dispatch (the boundary where the leak occurred), and wired the monitor (`packages/openclaw/src/monitor/index.ts`) to route its record-and-dispatch through it.
-   DM main-session pin: when a DM resolves to the agent main session, pin the configured owner so a non-owner DM can't overwrite the owner route. Respects Tlon's separate `ownerShip` and `dmAllowlist`.
-   Group routes: validate and canonicalize the channel nest before storing; skip persistence (origin metadata still recorded) when the nest is missing or malformed, or when the route resolves to the shared main session.
-   System events: attach a Tlon `deliveryContext` to the reaction and group-join `enqueueSystemEvent` calls (`packages/openclaw/src/monitor/index.ts`) so a later system/heartbeat turn driven by those events resolves to Tlon rather than webchat, even on a session with no persisted inbound route yet. Uses a shared `tlonDeliveryContext` helper.
-   Added `resolveTlonOutboundSessionRoute` in `packages/openclaw/src/session-route.ts` and wired `targetPrefixes: ['tlon']`, `parseExplicitTarget`, and `resolveOutboundSessionRoute` in `packages/openclaw/src/channel.ts` so explicit `tlon:` targets route to Tlon even from another surface.
-   Added a `TlonBot Outbound Routed` PostHog event (via OpenClaw's `message_sending` hook in `packages/openclaw/index.ts`) so we can measure how often a send lands on Tlon vs webchat — see Rollout. No message content; properties are `resolvedChannel`, `routedToTlon`, `targetKind`, plus the owner/bot ship identifiers the existing telemetry already attaches. Gated by the existing telemetry config (`enabled` + `apiKey`, and skipped when `ownerShip` isn't configured). Plus debug-gated local logs (`TLON_OPENCLAW_ROUTE_DEBUG=1`) at inbound dispatch and in the deliver callback for single-gateway triage.

## How did I test?

-   `pnpm --filter @tloncorp/openclaw tsc` clean; lint 0 errors.
-   `pnpm --filter @tloncorp/openclaw test`: 617 tests pass across 38 files.
-   New unit tests cover the route helper (DM/group/thread, owner pin, nest canonicalization, session key resolution), the record-before-dispatch ordering, fail-open behavior, the plugin wiring, and a real-SDK store round-trip proving durable fields land under the consumer's key (including stale-thread clearing and owner-pin skip).

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area: openclaw plugin

## Rollout / validation

There's no automated end-to-end test that a send actually lands on Tlon vs webchat, so we validate in prod via telemetry.

Primary signal: the `TlonBot Outbound Routed` PostHog event fires from OpenClaw's `message_sending` hook for every routed send — both the primary streamed reply (which resolves to `tlon`) and the route-dependent sends (the `message` tool, subagents, which can resolve elsewhere) — each tagged `routedToTlon`. Since users can't access webchat, a `routedToTlon: false` is an off-Tlon delivery and should be investigated as a likely webchat leak. Track the **count** of `routedToTlon: false` (broken down by `resolvedChannel`, scoped to Tlon-origin sessions where possible) and watch it collapse after deploy; it's also a natural thing to alert on. Prefer the absolute off-Tlon count over a raw rate, since the `true` events include healthy primary replies and dilute the denominator. This is on in hosted prod already (gated by `telemetry.enabled` + `apiKey`, and skipped when `ownerShip` isn't configured), so there's no env var to flip; it stays off for third-party OSS installs that don't configure
telemetry.

For deeper single-gateway triage you can also set `TLON_OPENCLAW_ROUTE_DEBUG=1` to enable verbose local route logs (off by default to avoid spamming third-party operators). Error-level logs (persistence failures, malformed/missing group nests) are always on regardless.

## Rollback plan

Revert and re-deploy the plugin.