### PR TITLE
Tap active bottom tab to scroll to top

### DIFF
--- a/packages/app/features/chat-list/ChatList.tsx
+++ b/packages/app/features/chat-list/ChatList.tsx
@@ -1,4 +1,4 @@
-import { FlashList, ListRenderItem } from '@shopify/flash-list';
+import { FlashList, FlashListRef, ListRenderItem } from '@shopify/flash-list';
 import * as db from '@tloncorp/shared/db';
 import { isEqual } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
@@ -29,12 +29,14 @@ export const ChatList = React.memo(function ChatListComponent({
   onLoad,
   disableScrollAnchoring,
   scrollerTestID,
+  scrollRef,
 }: {
   data: SectionedChatData;
   onPressItem?: (chat: db.Chat) => void;
   onLoad?: () => void;
   disableScrollAnchoring?: boolean;
   scrollerTestID?: string;
+  scrollRef?: React.RefObject<FlashListRef<ChatListItemData> | null>;
 }) {
   const flashListProps = useMemo(
     () => buildChatListFlashListProps({ data, disableScrollAnchoring }),
@@ -112,6 +114,7 @@ export const ChatList = React.memo(function ChatListComponent({
 
   return (
     <FlashList
+      ref={scrollRef}
       data={listItems}
       contentContainerStyle={contentContainerStyle}
       keyExtractor={getChatKey}

--- a/packages/app/features/top/ActivityScreen.tsx
+++ b/packages/app/features/top/ActivityScreen.tsx
@@ -3,10 +3,12 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useMemo } from 'react';
+import { FlatList } from 'react-native';
 import { useTheme } from 'tamagui';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { useScrollTabToTop } from '../../hooks/useScrollTabToTop';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
 import { useFeatureFlag } from '../../lib/featureFlags';
 import { RootStackParamList } from '../../navigation/types';
@@ -19,6 +21,7 @@ export function ActivityScreen(props: Props) {
   const theme = useTheme();
   const isFocused = useIsFocused();
   const currentUserId = useCurrentUserId();
+  const { scrollRef, onPressActiveTab } = useScrollTabToTop<FlatList>();
   const [contactsTabEnabled] = useFeatureFlag('contactsTab');
   const { performGroupAction } = useGroupActions();
   const { navigateToChannel, navigateToPost } = useRootNavigation();
@@ -113,6 +116,7 @@ export function ActivityScreen(props: Props) {
           loadingSubtitle={loadingSubtitle}
           onNavigateToContacts={handleNavigateToContacts}
           onInviteFriends={handleInviteFriends}
+          scrollRef={scrollRef}
         />
         <NavBarView
           navigateToContacts={() =>
@@ -124,6 +128,7 @@ export function ActivityScreen(props: Props) {
           navigateToNotifications={() =>
             props.navigation.navigate('Activity', undefined, { pop: true })
           }
+          onPressActiveTab={onPressActiveTab}
           currentRoute="Activity"
           currentUserId={currentUserId}
           showContactsTab={contactsTabEnabled}

--- a/packages/app/features/top/ChatListScreen.tsx
+++ b/packages/app/features/top/ChatListScreen.tsx
@@ -4,6 +4,7 @@ import {
   useNavigation,
 } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { FlashListRef } from '@shopify/flash-list';
 import { markInvitesRead } from '@tloncorp/api';
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
@@ -20,6 +21,7 @@ import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useFilteredChats } from '../../hooks/useFilteredChats';
 import { TabName } from '../../hooks/useFilteredChats';
 import { useGroupActions } from '../../hooks/useGroupActions';
+import { useScrollTabToTop } from '../../hooks/useScrollTabToTop';
 import { useSyncStatus } from '../../hooks/useSyncStatus';
 import { reportChatListFirstPaint } from '../../lib/chatListSettleTelemetry';
 import type { RootStackParamList } from '../../navigation/types';
@@ -42,7 +44,7 @@ import {
 import SystemNotices from '../../ui/components/SystemNotices';
 import WayfindingNotice from '../../ui/components/Wayfinding/Notices';
 import { identifyTlonEmployee } from '../../utils/posthog';
-import { ChatList } from '../chat-list/ChatList';
+import { ChatList, ChatListItemData } from '../chat-list/ChatList';
 import { ChatListSearch } from '../chat-list/ChatListSearch';
 import { ChatListTabs } from '../chat-list/ChatListTabs';
 import { CreateChatSheet, CreateChatSheetMethods } from './CreateChatSheet';
@@ -80,6 +82,8 @@ export function ChatListScreenView({
   const [personalInviteOpen, setPersonalInviteOpen] = useState(false);
   const personalInvite = db.personalInviteLink.useValue();
   const { isOpen, setIsOpen } = useGlobalSearch();
+  const { scrollRef: chatListRef, onPressActiveTab } =
+    useScrollTabToTop<FlashListRef<ChatListItemData>>();
 
   const [activeTab, setActiveTab] = useState<TabName>('home');
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
@@ -450,6 +454,7 @@ export function ChatListScreenView({
                     data={displayData}
                     onPressItem={onPressChat}
                     onLoad={handleChatListLoad}
+                    scrollRef={chatListRef}
                   />
                 )}
               </>
@@ -473,6 +478,7 @@ export function ChatListScreenView({
           navigateToNotifications={() => {
             navigation.navigate('Activity', undefined, { pop: true });
           }}
+          onPressActiveTab={onPressActiveTab}
           currentRoute="ChatList"
           currentUserId={currentUser}
         />

--- a/packages/app/features/top/ContactsScreen.tsx
+++ b/packages/app/features/top/ContactsScreen.tsx
@@ -2,12 +2,13 @@ import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { useCallback, useMemo } from 'react';
-import { Alert } from 'react-native';
+import { Alert, SectionList } from 'react-native';
 import { useTheme } from 'tamagui';
 
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useInviteSystemContactHandler } from '../../hooks/useInviteSystemContactHandler';
 import { useMarkMatchesSeen } from '../../hooks/useMarkMatchesSeen';
+import { useScrollTabToTop } from '../../hooks/useScrollTabToTop';
 import type { RootStackParamList } from '../../navigation/types';
 import {
   AppDataContextProvider,
@@ -36,6 +37,8 @@ export default function ContactsScreen(props: Props) {
     inviteLink
   );
   const currentUser = useCurrentUserId();
+  const { scrollRef, onPressActiveTab } =
+    useScrollTabToTop<SectionList<db.Contact>>();
 
   const { data: userContacts } = store.useUserContacts();
   const { data: contacts } = store.useContacts();
@@ -128,6 +131,7 @@ export default function ContactsScreen(props: Props) {
             onAddContact={onAddContact}
             onContactLongPress={onContactLongPress}
             onInviteSystemContact={handleInviteSystemContact}
+            scrollRef={scrollRef}
           />
           <NavBarView
             navigateToContacts={() => {
@@ -139,6 +143,7 @@ export default function ContactsScreen(props: Props) {
             navigateToNotifications={() => {
               navigate('Activity', undefined, { pop: true });
             }}
+            onPressActiveTab={onPressActiveTab}
             currentRoute="Contacts"
             currentUserId={currentUser}
           />

--- a/packages/app/hooks/useScrollTabToTop.ts
+++ b/packages/app/hooks/useScrollTabToTop.ts
@@ -1,0 +1,51 @@
+import { RefObject, useCallback, useRef } from 'react';
+
+// The subset of scroll methods exposed by the list/scroll components used by
+// the main tabs: FlashList/FlatList expose `scrollToOffset`, ScrollView exposes
+// `scrollTo`, and SectionList exposes neither but returns its underlying
+// ScrollView via `getScrollResponder`.
+type ScrollableNode = {
+  scrollToTop?: () => void;
+  scrollTo?: (opts: { x?: number; y?: number; animated?: boolean }) => void;
+  scrollToOffset?: (opts: { offset: number; animated?: boolean }) => void;
+  getScrollResponder?: () => ScrollableNode | null | undefined;
+};
+
+export function scrollContainerToTop(node: ScrollableNode | null | undefined) {
+  if (!node) {
+    return;
+  }
+
+  const scrollable =
+    typeof node.scrollToTop === 'function' ||
+    typeof node.scrollTo === 'function' ||
+    typeof node.scrollToOffset === 'function'
+      ? node
+      : node.getScrollResponder?.() ?? node;
+
+  if (typeof scrollable.scrollToTop === 'function') {
+    scrollable.scrollToTop();
+  } else if (typeof scrollable.scrollToOffset === 'function') {
+    scrollable.scrollToOffset({ offset: 0, animated: true });
+  } else if (typeof scrollable.scrollTo === 'function') {
+    scrollable.scrollTo({ x: 0, y: 0, animated: true });
+  }
+}
+
+// Tapping the already-active tab in the bottom NavBar scrolls that tab's list
+// back to the top. The app uses a custom NavBar over a stack navigator (not a
+// tab navigator), so React Navigation's `useScrollToTop` — which relies on the
+// `tabPress` event — doesn't apply; the NavBar invokes `onPressActiveTab`
+// directly instead.
+export function useScrollTabToTop<T>(): {
+  scrollRef: RefObject<T | null>;
+  onPressActiveTab: () => void;
+} {
+  const scrollRef = useRef<T | null>(null);
+
+  const onPressActiveTab = useCallback(() => {
+    scrollContainerToTop(scrollRef.current as ScrollableNode | null);
+  }, []);
+
+  return { scrollRef, onPressActiveTab };
+}

--- a/packages/app/ui/components/Activity/ActivityScreenView.tsx
+++ b/packages/app/ui/components/Activity/ActivityScreenView.tsx
@@ -38,6 +38,7 @@ export function ActivityScreenView({
   loadingSubtitle,
   onNavigateToContacts,
   onInviteFriends,
+  scrollRef,
 }: {
   isFocused: boolean;
   goToChannel: (channel: db.Channel, selectedPostId?: string) => void;
@@ -51,6 +52,7 @@ export function ActivityScreenView({
   loadingSubtitle?: string | null;
   onNavigateToContacts?: () => void;
   onInviteFriends?: () => void;
+  scrollRef?: React.RefObject<FlatList | null>;
 }) {
   const store = useStore();
   const { data: activitySeenMarker } = store.useActivitySeenMarker();
@@ -248,6 +250,7 @@ export function ActivityScreenView({
       loadingSubtitle={loadingSubtitle}
       onNavigateToContacts={onNavigateToContacts}
       onInviteFriends={onInviteFriends}
+      scrollRef={scrollRef}
     />
   );
 }
@@ -269,6 +272,7 @@ export function ActivityScreenContent({
   loadingSubtitle,
   onNavigateToContacts,
   onInviteFriends,
+  scrollRef,
 }: {
   activeTab: db.ActivityBucket;
   onPressTab: (tab: db.ActivityBucket) => void;
@@ -286,6 +290,7 @@ export function ActivityScreenContent({
   loadingSubtitle?: string | null;
   onNavigateToContacts?: () => void;
   onInviteFriends?: () => void;
+  scrollRef?: React.RefObject<FlatList | null>;
 }) {
   const [selectedGroup, setSelectedGroup] = useState<db.Group | null>(null);
   const [personalInviteOpen, setPersonalInviteOpen] = useState(false);
@@ -364,6 +369,7 @@ export function ActivityScreenContent({
               </XStack>
             ) : (
               <FlatList
+                ref={scrollRef}
                 data={events}
                 renderItem={renderItem}
                 keyExtractor={keyExtractor}

--- a/packages/app/ui/components/ContactsScreenView.tsx
+++ b/packages/app/ui/components/ContactsScreenView.tsx
@@ -1,6 +1,6 @@
 import * as db from '@tloncorp/shared/db';
 import { SectionListHeader } from '@tloncorp/ui';
-import { useCallback, useMemo } from 'react';
+import { RefObject, useCallback, useMemo } from 'react';
 import { SectionList } from 'react-native';
 import { View, XStack, getTokenValue } from 'tamagui';
 
@@ -19,6 +19,7 @@ interface Props {
   onAddContact: (contact: db.Contact) => void;
   onContactLongPress: (contact: db.Contact) => void;
   onInviteSystemContact: (contact: db.SystemContact) => void;
+  scrollRef?: RefObject<SectionList<db.Contact> | null>;
 }
 
 interface Section {
@@ -165,6 +166,7 @@ export function ContactsScreenView(props: Props) {
   return (
     <View flex={1}>
       <SectionList
+        ref={props.scrollRef}
         sections={sections}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}

--- a/packages/app/ui/components/NavBarView.tsx
+++ b/packages/app/ui/components/NavBarView.tsx
@@ -10,12 +10,15 @@ export const NavBarView = ({
   navigateToHome,
   navigateToNotifications,
   navigateToContacts,
+  onPressActiveTab,
   currentRoute,
   currentUserId,
 }: {
   navigateToHome: () => void;
   navigateToNotifications: () => void;
   navigateToContacts?: () => void;
+  // Called when the tab that's already active is tapped again (scroll to top).
+  onPressActiveTab?: () => void;
   currentRoute: string;
   currentUserId: string;
   showContactsTab?: boolean;
@@ -26,6 +29,13 @@ export const NavBarView = ({
       return routeName.includes(currentRoute);
     }
     return currentRoute === routeName;
+  };
+  const pressTab = (routeName: string, navigate?: () => void) => {
+    if (isRouteActive(routeName) && onPressActiveTab) {
+      onPressActiveTab();
+    } else {
+      navigate?.();
+    }
   };
   const haveUnreadUnseenActivity = store.useHaveUnreadUnseenActivity();
   const isWindowNarrow = useIsWindowNarrow();
@@ -58,19 +68,19 @@ export const NavBarView = ({
         activeType="HomeFilled"
         isActive={isRouteActive('ChatList')}
         hasUnreads={false}
-        onPress={navigateToHome}
+        onPress={() => pressTab('ChatList', navigateToHome)}
       />
       <NavIcon
         type="Notifications"
         activeType="NotificationsFilled"
         hasUnreads={haveUnreadUnseenActivity}
         isActive={isRouteActive('Activity')}
-        onPress={navigateToNotifications}
+        onPress={() => pressTab('Activity', navigateToNotifications)}
       />
       <AvatarNavIcon
         id={currentUserId}
         focused={isRouteActive('Contacts')}
-        onPress={navigateToContacts}
+        onPress={() => pressTab('Contacts', navigateToContacts)}
         onLongPress={openStatusSheet}
       />
       {showStatusSheet && (


### PR DESCRIPTION
## Summary

Re-tapping the tab you're already on now scrolls that tab's list back to the top — the standard mobile gesture — on all three main tabs: Home (ChatList), Notifications (Activity), and Contacts.

## Changes

The app uses a custom `NavBarView` over a stack navigator, not a tab navigator, so React Navigation's `useScrollToTop` doesn't apply (it relies on the `tabPress` event only tab navigators emit). So this wires it directly:

- `NavBarView` routes a press on the **already-active** tab to a new optional `onPressActiveTab` callback; inactive taps still navigate exactly as before, so there's no change when switching tabs.
- A small `useScrollTabToTop` hook hands each tab screen a `scrollRef` + an `onPressActiveTab` handler. Each screen threads the ref down to its list and passes the handler to `NavBarView`.
- `scrollContainerToTop` covers the three list kinds in play: `FlashList`/`FlatList` via `scrollToOffset`, `SectionList` via its scroll responder, `ScrollView` via `scrollTo`.

Settings isn't a bottom tab (it's reached from a gear in the Contacts header), so it's out of scope.

## How did I test?

On an Android emulator running a `develop` build: for each tab, scrolled the list down, tapped the active tab icon, and confirmed it animates back to the top. Inactive-tab taps still switch tabs as before. Video below.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: bottom nav + main tab screens (additive; inactive-tab navigation unchanged)

## Rollback plan

Revert this PR. It's a single additive commit — no migrations, schema, or state changes.

## Screenshots / videos

https://github.com/user-attachments/assets/f886866c-bf28-45e9-bbd9-5595fdd85dc0

