### PR TITLE
tests: use synchronous execution in click with vere v4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Detect desk file changes
         id: desk_changes
         run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -q '^desk/'; then
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -q '^desk/\|^backend/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -141,7 +141,7 @@ jobs:
       - name: Detect desk file changes
         id: desk_changes
         run: |
-          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -q '^desk/'; then
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" | grep -q '^desk/\|^backend/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/backend/click
+++ b/backend/click
@@ -92,7 +92,8 @@ EOF
 full() {
   $CLICK_CMD "$HOON" $DEPS |
   $EVAL_CMD eval --jam $JAM_OPTS |
-  socat -t $TIMEOUT -,ignoreeof UNIX-CONNECT:"$PIER/.urb/conn.sock" |
+  # 30m total inactivity timeout
+  socat -T 1800 -t $TIMEOUT -,ignoreeof UNIX-CONNECT:"$PIER/.urb/conn.sock" |
   $EVAL_CMD eval --cue $CUE_OPTS
 }
 

--- a/backend/click
+++ b/backend/click
@@ -92,7 +92,7 @@ EOF
 full() {
   $CLICK_CMD "$HOON" $DEPS |
   $EVAL_CMD eval --jam $JAM_OPTS |
-  socat -T $TIMEOUT -,ignoreeof UNIX-CONNECT:"$PIER/.urb/conn.sock" |
+  socat -t $TIMEOUT -,ignoreeof UNIX-CONNECT:"$PIER/.urb/conn.sock" |
   $EVAL_CMD eval --cue $CUE_OPTS
 }
 

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -112,8 +112,8 @@ function await_ship
 
 await_ship
 
-# Allow 20m for longest running operations
-TIMEOUT=1200
+# Allow 10m for longest running operations
+TIMEOUT=600
 
 run_click="$click -t $TIMEOUT -b $vere -i - -kp"
 

--- a/backend/run-aqua-tests.sh
+++ b/backend/run-aqua-tests.sh
@@ -112,7 +112,10 @@ function await_ship
 
 await_ship
 
-run_click="$click -b $vere -i - -kp"
+# Allow 20m for longest running operations
+TIMEOUT=1200
+
+run_click="$click -t $TIMEOUT -b $vere -i - -kp"
 
 # Mount %base
 echo "Mounting base..."
@@ -140,7 +143,6 @@ $run_click $pier <<EOF
 (pure:m !>(%ok))  
 EOF
 
-sleep 5
 # Insert the jammed pill
 
 if [ ! -f "${pier}/groups/${pill_name}.jam" ]
@@ -172,7 +174,7 @@ rsync -r desk/ $pier/groups
 
 rsync -r --delete desk/tests/ $pier/groups/tests
 
-result=$( $run_click -t 3 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  hash=@uvI  bind:m  (scry @uvI %cz /groups)  
 (pure:m !>(hash))  
@@ -181,17 +183,18 @@ EOF
 desk_hash_a=`echo $result | sed 's/\[0 %avow 0 %noun \(.*\)\]/\1/'`
 
 echo "Updating groups desk"
-${run_click} -t 10 $pier <<EOF
+${run_click} $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  our=ship  bind:m  get-our  
 ;<  ~  bind:m  (poke [our %hood] kiln-commit+!>([%groups |]))  
 (pure:m !>(%ok))  
 EOF
 
+sleep 3
 echo "Awaiting desk update..."
 await_ship
 
-result=$( $run_click -t 3 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  hash=@uvI  bind:m  (scry @uvI %cz /groups)  
 (pure:m !>(hash))  
@@ -207,7 +210,7 @@ then
 fi
 
 echo "Starting %aqua..."
-${run_click} -t 10 $pier "/lib/pill/hoon"<<EOF
+${run_click} $pier "/lib/pill/hoon"<<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl    
 ;<  ~  bind:m  (poke [our.bowl %hood] kiln-nuke+!>([%aqua |]))  
@@ -224,7 +227,7 @@ ${run_click} -t 10 $pier "/lib/pill/hoon"<<EOF
 EOF
 
 echo "Preparing aqua snapshot..."
-result=$( $run_click -t 900 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =+  tid=~.ci-ph-fleet  
@@ -259,7 +262,7 @@ fi
 # Run aqua tests
 #
 echo "Running tests..."
-result=$( $run_click -t 1200 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =/  ph-tests=path  

--- a/backend/run-tests.sh
+++ b/backend/run-tests.sh
@@ -148,7 +148,7 @@ rm -f $pier/groups/tests/lib/diary-graph.hoon
 # Update the groups desk
 rsync -r desk/ $pier/groups
 
-result=$( $run_click -t 3 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  hash=@uvI  bind:m  (scry @uvI %cz /groups)  
 (pure:m !>(hash))  
@@ -171,7 +171,7 @@ do
   sleep 3
 done
 
-result=$( $run_click -t 3 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  hash=@uvI  bind:m  (scry @uvI %cz /groups)  
 (pure:m !>(hash))  
@@ -188,7 +188,7 @@ fi
 
 # Run the unit tests
 echo "Running tests..."
-result=$( $run_click -t 420 $pier <<EOF
+result=$( $run_click $pier <<EOF
 =/  m  (strand ,vase)  
 ;<  =bowl  bind:m  get-bowl  
 =/  tests=path  


### PR DESCRIPTION
## Summary

Vere v4.4 shipped with an important update to newt that we requested in https://github.com/urbit/vere/pull/892. Rather than close the write descriptor when the read descriptor is closed, the runtime now allows for separate closure. This enables click, when used with netcat or socat, to effectively achieve synchronous thread execution.

Many thanks to @joemfb and @pkova for shipping the changes in the runtime.

## Changes

1. Adjust socat arguments in backend click to use `-t` option, which allows for early completion.
2. Introduce a global timeout of `20m` to allow plenty of headroom in running aqua tests.

## How did I test?

Run the tests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.