### PR TITLE
ui: better volume settings language

### DIFF
--- a/apps/tlon-web/e2e/group-channel-management.spec.ts
+++ b/apps/tlon-web/e2e/group-channel-management.spec.ts
@@ -261,7 +261,7 @@ test('should handle channel management operations', async ({ zodPage }) => {
   await expect(page.getByText('Group info')).toBeVisible({ timeout: 5000 });
 
   // Test notification settings
-  await helpers.setGroupNotifications(page, 'All activity');
+  await helpers.setGroupNotifications(page, 'All group activity');
 
   // Close the notification sheet by clicking the first back button (in the sheet header)
   await helpers.navigateBack(page);

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -1089,14 +1089,18 @@ export async function setGroupPrivacy(
  */
 export async function setGroupNotifications(
   page: Page,
-  level: 'All activity' | 'Posts, mentions, and replies' | 'Nothing'
+  level:
+    | 'All group activity'
+    | 'Group posts, mentions, and replies'
+    | 'Mentions and replies'
+    | 'Nothing'
 ) {
   // Ensure session is stable before changing notifications
   await waitForSessionStability(page);
 
   await page.getByTestId('GroupNotifications').click();
   await expect(
-    page.getByText('Posts, mentions, and replies', { exact: true })
+    page.getByText('Group posts, mentions, and replies', { exact: true })
   ).toBeVisible();
   await page.getByText(level).click();
 }

--- a/packages/app/features/top/ChatVolumeScreen.tsx
+++ b/packages/app/features/top/ChatVolumeScreen.tsx
@@ -1,7 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import * as ub from '@tloncorp/api/urbit';
-import * as store from '@tloncorp/shared/store';
 import { useCallback } from 'react';
 
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
@@ -16,6 +14,7 @@ import {
   ScreenHeader,
   View,
   useChatOptions,
+  useChatVolumeOptions,
   useIsWindowNarrow,
 } from '../../ui';
 
@@ -48,28 +47,6 @@ export function ChatVolumeScreen(props: Props) {
   );
 }
 
-export const volumeOptions: {
-  title: string;
-  value: ub.NotificationLevel;
-}[] = [
-  {
-    title: 'All activity',
-    value: 'loud',
-  },
-  {
-    title: 'Posts, mentions, and replies',
-    value: 'medium',
-  },
-  {
-    title: 'Mentions and replies',
-    value: 'soft',
-  },
-  {
-    title: 'Nothing',
-    value: 'hush',
-  },
-];
-
 function ChatVolumeScreenView({
   chatType,
   chatId,
@@ -81,18 +58,9 @@ function ChatVolumeScreenView({
 }) {
   const navigation = useNavigation();
   const { navigateToChatDetails } = useRootNavigation();
-  const { updateVolume, group, channel } = useChatOptions();
+  const { group, channel } = useChatOptions();
+  const { currentLevel, options, updateVolume } = useChatVolumeOptions();
   const isWindowNarrow = useIsWindowNarrow();
-
-  const { data: currentChannelVolume } = store.useChannelVolumeLevel(
-    channel?.id ?? ''
-  );
-  const { data: currentGroupVolume } = store.useGroupVolumeLevel(
-    group?.id ?? ''
-  );
-
-  const currentVolumeLevel =
-    chatType === 'channel' ? currentChannelVolume : currentGroupVolume;
 
   const handleGoBack = useCallback(() => {
     // On mobile, just go back. On desktop, navigate explicitly since
@@ -130,8 +98,8 @@ function ChatVolumeScreenView({
       />
       <Form.FormFrame backgroundType="secondary">
         <Form.RadioInput
-          options={volumeOptions}
-          value={currentVolumeLevel}
+          options={options}
+          value={currentLevel}
           onChange={updateVolume}
         />
       </Form.FormFrame>

--- a/packages/app/ui/components/ChatOptionsSheet.tsx
+++ b/packages/app/ui/components/ChatOptionsSheet.tsx
@@ -16,6 +16,7 @@ import { Popover, isWeb } from 'tamagui';
 
 import { useCurrentUserId } from '../contexts/appDataContext';
 import { useChatOptions } from '../contexts/chatOptions/useChatOptions';
+import { useChatVolumeOptions } from '../contexts/chatOptions/useChatVolumeOptions';
 import * as utils from '../utils';
 import {
   Action,
@@ -24,7 +25,6 @@ import {
   createActionGroups,
 } from './ActionSheet';
 import { ListItem } from './ListItem';
-import { useNotificationLevelOptions } from './NotificationLevelSelector';
 
 function getNotificationTitle(
   volumeSettings: { level: ub.NotificationLevel } | null | undefined,
@@ -851,33 +851,18 @@ function NotificationsSheetContent({
   onPressBack: () => void;
 }) {
   const isWindowNarrow = useIsWindowNarrow();
-  const { updateVolume, group, channel } = useChatOptions();
-  const { data: currentChannelVolume } = store.useChannelVolumeLevel(
-    channel?.id ?? ''
-  );
-  const { data: currentGroupVolume } = store.useGroupVolumeLevel(
-    group?.id ?? ''
-  );
-  const currentVolumeLevel = channel?.id
-    ? currentChannelVolume
-    : currentGroupVolume;
-
-  // Use shared hook with 'loud' level for channel/group overrides
-  const notificationOptions = useNotificationLevelOptions({
-    includeLoud: true,
-    shortDescriptions: true,
-  });
+  const { currentLevel, options, updateVolume } = useChatVolumeOptions();
 
   const notificationActions = useMemo(
     () =>
       createActionGroups([
         'neutral',
-        ...notificationOptions.map(
+        ...options.map(
           ({ title, value }): Action => ({
             title,
-            accent: currentVolumeLevel === value ? 'positive' : 'neutral',
+            accent: currentLevel === value ? 'positive' : 'neutral',
             action: () => updateVolume(value),
-            endIcon: currentVolumeLevel === value ? 'Checkmark' : undefined,
+            endIcon: currentLevel === value ? 'Checkmark' : undefined,
           })
         ),
         !isWindowNarrow && {
@@ -886,13 +871,7 @@ function NotificationsSheetContent({
           startIcon: 'ChevronLeft',
         },
       ]),
-    [
-      currentVolumeLevel,
-      updateVolume,
-      isWindowNarrow,
-      onPressBack,
-      notificationOptions,
-    ]
+    [currentLevel, updateVolume, isWindowNarrow, onPressBack, options]
   );
   return (
     <ChatOptionsSheetContent

--- a/packages/app/ui/components/NotificationLevelSelector.tsx
+++ b/packages/app/ui/components/NotificationLevelSelector.tsx
@@ -4,66 +4,134 @@ import { Platform } from 'react-native';
 
 import { RadioInput, RadioInputOption } from './Form/inputs';
 
+// 'base' is the app-wide default (covers DMs and groups); 'group' and
+// 'channel' are per-group/channel volume overrides that don't affect DMs;
+// 'dm' is a per-DM override.
+export type NotificationLevelContext = 'base' | 'group' | 'channel' | 'dm';
+
+// Derives the volume-menu context for a per-chat override. With no channel
+// it's a group override; a DM/group-DM channel keeps DM labels; anything else
+// is a group channel.
+export function getNotificationLevelContext(
+  channel?: { id?: string | null; type?: string | null } | null
+): NotificationLevelContext {
+  if (!channel?.id) {
+    return 'group';
+  }
+  return channel.type === 'dm' || channel.type === 'groupDm' ? 'dm' : 'channel';
+}
+
 export type NotificationLevelOptionsConfig = {
   includeLoud?: boolean;
   shortDescriptions?: boolean;
+  context?: NotificationLevelContext;
 };
+
+// Levels shown for each context, in display order. 'loud' is dropped when
+// `includeLoud` is false (base settings). DMs have no posts/mentions/replies
+// distinction, so they get a simple all-or-nothing choice.
+const CONTEXT_LEVELS: Record<NotificationLevelContext, ub.NotificationLevel[]> =
+  {
+    base: ['loud', 'medium', 'soft', 'hush'],
+    group: ['loud', 'medium', 'soft', 'hush'],
+    channel: ['loud', 'medium', 'soft', 'hush'],
+    dm: ['medium', 'hush'],
+  };
+
+// Per-context titles for each level.
+const LEVEL_TITLES: Record<
+  NotificationLevelContext,
+  Partial<Record<ub.NotificationLevel, string>>
+> = {
+  base: {
+    loud: 'All activity',
+    medium: 'All DMs and group posts',
+    soft: 'DMs, mentions, and replies only',
+    hush: 'Nothing',
+  },
+  group: {
+    loud: 'All group activity',
+    medium: 'Group posts, mentions, and replies',
+    soft: 'Mentions and replies',
+    hush: 'Nothing',
+  },
+  channel: {
+    loud: 'All channel activity',
+    medium: 'Channel posts, mentions, and replies',
+    soft: 'Mentions and replies',
+    hush: 'Nothing',
+  },
+  dm: {
+    medium: 'All messages',
+    hush: 'Nothing',
+  },
+};
+
+// Long-form descriptions keyed by level. 'medium' in a DM and 'hush' on/off
+// native are special-cased in getLevelDescription.
+const LEVEL_DESCRIPTIONS: Partial<Record<ub.NotificationLevel, string>> = {
+  loud: 'Notify for all activity in this channel or group.',
+  medium:
+    'Notify for all posts, mentions, and replies in groups. Direct messages always notify unless muted.',
+  soft: 'Notify only when someone mentions you or replies to your posts. Direct messages always notify unless muted.',
+};
+
+const DM_MEDIUM_DESCRIPTION = 'Notify for every message in this conversation.';
+const HUSH_DESCRIPTION_NATIVE =
+  'No notifications for anything, even if push notifications are enabled on your device.';
+const HUSH_DESCRIPTION_WEB = 'No notifications for anything.';
+
+function getLevelTitle(
+  level: ub.NotificationLevel,
+  context: NotificationLevelContext
+): string {
+  return LEVEL_TITLES[context][level] ?? '';
+}
+
+function getLevelDescription(
+  level: ub.NotificationLevel,
+  context: NotificationLevelContext,
+  isNative: boolean,
+  shortDescriptions: boolean
+): string | undefined {
+  if (shortDescriptions) {
+    return undefined;
+  }
+  if (level === 'hush') {
+    return isNative ? HUSH_DESCRIPTION_NATIVE : HUSH_DESCRIPTION_WEB;
+  }
+  if (level === 'medium' && context === 'dm') {
+    return DM_MEDIUM_DESCRIPTION;
+  }
+  return LEVEL_DESCRIPTIONS[level];
+}
 
 export function useNotificationLevelOptions(
   config: NotificationLevelOptionsConfig = {}
 ) {
-  const { includeLoud = false, shortDescriptions = false } = config;
+  const {
+    includeLoud = false,
+    shortDescriptions = false,
+    context = 'base',
+  } = config;
   const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
 
-  return useMemo<RadioInputOption<ub.NotificationLevel>[]>(() => {
-    const options: RadioInputOption<ub.NotificationLevel>[] = [];
-
-    // 'loud' level is only available for individual channel/group overrides
-    if (includeLoud) {
-      options.push({
-        title: 'All activity',
-        value: 'loud' as ub.NotificationLevel,
-        description: shortDescriptions
-          ? undefined
-          : 'Notify for all activity in this channel or group.',
-      });
-    }
-
-    // 'medium' level is available for both base settings and overrides
-    options.push({
-      title: includeLoud
-        ? 'DMs, posts, mentions, and replies'
-        : 'All DMs and group posts',
-      value: 'medium' as ub.NotificationLevel,
-      description: shortDescriptions
-        ? undefined
-        : 'Notify for all posts, mentions, and replies in groups. Direct messages always notify unless muted.',
-    });
-
-    // 'soft' level is available for both base settings and overrides
-    options.push({
-      title: includeLoud
-        ? 'DMs, mentions, and replies'
-        : 'DMs, mentions, and replies only',
-      value: 'soft' as ub.NotificationLevel,
-      description: shortDescriptions
-        ? undefined
-        : 'Notify only when someone mentions you or replies to your posts. Direct messages always notify unless muted.',
-    });
-
-    // 'hush' level is available for both base settings and overrides
-    options.push({
-      title: 'Nothing',
-      value: 'hush' as ub.NotificationLevel,
-      description: shortDescriptions
-        ? undefined
-        : isNative
-          ? 'No notifications for anything, even if push notifications are enabled on your device.'
-          : 'No notifications for anything.',
-    });
-
-    return options;
-  }, [includeLoud, shortDescriptions, isNative]);
+  return useMemo<RadioInputOption<ub.NotificationLevel>[]>(
+    () =>
+      CONTEXT_LEVELS[context]
+        .filter((level) => includeLoud || level !== 'loud')
+        .map((value) => ({
+          value,
+          title: getLevelTitle(value, context),
+          description: getLevelDescription(
+            value,
+            context,
+            isNative,
+            shortDescriptions
+          ),
+        })),
+    [includeLoud, shortDescriptions, isNative, context]
+  );
 }
 
 export function NotificationLevelSelector({

--- a/packages/app/ui/components/NotificationLevelSelector.tsx
+++ b/packages/app/ui/components/NotificationLevelSelector.tsx
@@ -134,6 +134,23 @@ export function useNotificationLevelOptions(
   );
 }
 
+// A stored level may not appear in the current menu — e.g. a DM that inherited
+// a base 'soft'/'loud' level or carries a legacy 'soft'/'loud' override, while
+// the DM menu only offers all-or-nothing. Map such a level to a displayed
+// option so the menu always shows a checked row: a notifying level collapses
+// to the most permissive offered option, 'hush' (muted) is always available.
+// Purely presentational — the stored value only changes when the user taps.
+export function normalizeLevelToOptions(
+  level: ub.NotificationLevel | null | undefined,
+  options: RadioInputOption<ub.NotificationLevel>[]
+): ub.NotificationLevel | null | undefined {
+  if (!level || options.some((option) => option.value === level)) {
+    return level;
+  }
+  const fallback = options.find((option) => option.value !== 'hush');
+  return fallback?.value ?? level;
+}
+
 export function NotificationLevelSelector({
   value,
   onChange,

--- a/packages/app/ui/components/NotificationLevelSelector.tsx
+++ b/packages/app/ui/components/NotificationLevelSelector.tsx
@@ -134,17 +134,26 @@ export function useNotificationLevelOptions(
   );
 }
 
-// A stored level may not appear in the current menu — e.g. a DM that inherited
-// a base 'soft'/'loud' level or carries a legacy 'soft'/'loud' override, while
-// the DM menu only offers all-or-nothing. Map such a level to a displayed
-// option so the menu always shows a checked row: a notifying level collapses
-// to the most permissive offered option, 'hush' (muted) is always available.
-// Purely presentational — the stored value only changes when the user taps.
+// An explicit stored level may not appear in the current menu — e.g. a DM that
+// carries a legacy 'soft'/'loud' override, while the DM menu only offers
+// all-or-nothing. Map such a level to a displayed option so the menu always
+// shows a checked row: a notifying level collapses to the most permissive
+// offered option, 'hush' (muted) is always available. Purely presentational —
+// the stored value only changes when the user taps.
+//
+// 'default' is the "inherit from parent/base" sentinel, not an explicit level,
+// so it is left unnormalized rather than collapsed (which would misrepresent
+// an inherited setting as a stronger explicit override). Callers should
+// resolve 'default' to the effective inherited level before normalizing.
 export function normalizeLevelToOptions(
   level: ub.NotificationLevel | null | undefined,
   options: RadioInputOption<ub.NotificationLevel>[]
 ): ub.NotificationLevel | null | undefined {
-  if (!level || options.some((option) => option.value === level)) {
+  if (
+    !level ||
+    level === 'default' ||
+    options.some((option) => option.value === level)
+  ) {
     return level;
   }
   const fallback = options.find((option) => option.value !== 'hush');

--- a/packages/app/ui/contexts/chatOptions/index.ts
+++ b/packages/app/ui/contexts/chatOptions/index.ts
@@ -1,2 +1,3 @@
 export * from './chatOptions';
 export * from './useChatOptions';
+export * from './useChatVolumeOptions';

--- a/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
+++ b/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
@@ -1,0 +1,31 @@
+import * as store from '@tloncorp/shared/store';
+
+import {
+  getNotificationLevelContext,
+  useNotificationLevelOptions,
+} from '../../components/NotificationLevelSelector';
+import { useChatOptions } from './useChatOptions';
+
+// Builds the notification-volume radio options for the chat currently in the
+// ChatOptions context, along with its current level and the volume setter.
+// Shared by the notifications action sheet (ChatOptionsSheet) and the
+// full-screen volume menu (ChatVolumeScreen) so they stay in sync.
+export function useChatVolumeOptions() {
+  const { updateVolume, group, channel } = useChatOptions();
+
+  const { data: currentChannelVolume } = store.useChannelVolumeLevel(
+    channel?.id ?? ''
+  );
+  const { data: currentGroupVolume } = store.useGroupVolumeLevel(
+    group?.id ?? ''
+  );
+  const currentLevel = channel?.id ? currentChannelVolume : currentGroupVolume;
+
+  const options = useNotificationLevelOptions({
+    includeLoud: true,
+    shortDescriptions: true,
+    context: getNotificationLevelContext(channel),
+  });
+
+  return { currentLevel, options, updateVolume };
+}

--- a/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
+++ b/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
@@ -1,4 +1,6 @@
+import type * as ub from '@tloncorp/api/urbit';
 import * as store from '@tloncorp/shared/store';
+import { useCallback } from 'react';
 
 import {
   getNotificationLevelContext,
@@ -33,8 +35,22 @@ export function useChatVolumeOptions() {
   // the effective base level before matching. A remaining level not offered by
   // this menu (e.g. a legacy/inherited 'soft' on a DM) would otherwise leave no
   // row checked.
-  const effectiveLevel = rawLevel === 'default' ? baseVolume : rawLevel;
+  const isInheriting = rawLevel === 'default';
+  const effectiveLevel = isInheriting ? baseVolume : rawLevel;
   const currentLevel = normalizeLevelToOptions(effectiveLevel, options);
 
-  return { currentLevel, options, updateVolume };
+  // While inheriting, the checked row only reflects the inherited default.
+  // Re-tapping it must keep inheriting rather than pin a concrete override —
+  // otherwise future app-default changes would stop applying to this chat.
+  const setVolume = useCallback(
+    (level: ub.NotificationLevel | null) => {
+      if (isInheriting && level === currentLevel) {
+        return;
+      }
+      updateVolume(level);
+    },
+    [isInheriting, currentLevel, updateVolume]
+  );
+
+  return { currentLevel, options, updateVolume: setVolume };
 }

--- a/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
+++ b/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
@@ -20,6 +20,7 @@ export function useChatVolumeOptions() {
   const { data: currentGroupVolume } = store.useGroupVolumeLevel(
     group?.id ?? ''
   );
+  const baseVolume = store.useBaseVolumeLevel();
   const rawLevel = channel?.id ? currentChannelVolume : currentGroupVolume;
 
   const options = useNotificationLevelOptions({
@@ -28,9 +29,12 @@ export function useChatVolumeOptions() {
     context: getNotificationLevelContext(channel),
   });
 
-  // A stored level not offered by this menu (e.g. a legacy/inherited 'soft' on
-  // a DM) would otherwise leave no row checked.
-  const currentLevel = normalizeLevelToOptions(rawLevel, options);
+  // 'default' means "inherit from base" (e.g. after unmuting), so resolve it to
+  // the effective base level before matching. A remaining level not offered by
+  // this menu (e.g. a legacy/inherited 'soft' on a DM) would otherwise leave no
+  // row checked.
+  const effectiveLevel = rawLevel === 'default' ? baseVolume : rawLevel;
+  const currentLevel = normalizeLevelToOptions(effectiveLevel, options);
 
   return { currentLevel, options, updateVolume };
 }

--- a/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
+++ b/packages/app/ui/contexts/chatOptions/useChatVolumeOptions.ts
@@ -2,6 +2,7 @@ import * as store from '@tloncorp/shared/store';
 
 import {
   getNotificationLevelContext,
+  normalizeLevelToOptions,
   useNotificationLevelOptions,
 } from '../../components/NotificationLevelSelector';
 import { useChatOptions } from './useChatOptions';
@@ -19,13 +20,17 @@ export function useChatVolumeOptions() {
   const { data: currentGroupVolume } = store.useGroupVolumeLevel(
     group?.id ?? ''
   );
-  const currentLevel = channel?.id ? currentChannelVolume : currentGroupVolume;
+  const rawLevel = channel?.id ? currentChannelVolume : currentGroupVolume;
 
   const options = useNotificationLevelOptions({
     includeLoud: true,
     shortDescriptions: true,
     context: getNotificationLevelContext(channel),
   });
+
+  // A stored level not offered by this menu (e.g. a legacy/inherited 'soft' on
+  // a DM) would otherwise leave no row checked.
+  const currentLevel = normalizeLevelToOptions(rawLevel, options);
 
   return { currentLevel, options, updateVolume };
 }


### PR DESCRIPTION
## Summary

Group and channel notification "volume" menus listed DMs as an option, which is nonsensical since a per-group/channel volume override never affects DMs (TLON-5912). This contextualizes the option labels per group / channel / DM and simplifies the DM menu to a true all-or-nothing choice.

## Changes

- `NotificationLevelSelector.tsx`: added a `context` (`base | group | channel | dm`) to `useNotificationLevelOptions`, plus a `getNotificationLevelContext(channel)` helper that derives it. Labels are now data-driven via `CONTEXT_LEVELS` / `LEVEL_TITLES` / `LEVEL_DESCRIPTIONS` tables and pure resolvers instead of inline ternaries.
  - Group: "All group activity", "Group posts, mentions, and replies", "Mentions and replies", "Nothing"
  - Channel: same with "Channel" wording
  - DM / group DM: "All messages" (→ `medium`, the default) and "Nothing" (→ `hush`)
  - Base (app-wide) settings keep their DM-inclusive labels, unchanged.
- Added `useChatVolumeOptions()` hook (`ui/contexts/chatOptions/`) bundling the current-level lookup + option building + `updateVolume`, shared by both surfaces.
- `ChatOptionsSheet.tsx` (notifications action sheet) and `ChatVolumeScreen.tsx` (full-screen menu) now consume the shared hook, eliminating duplicated store lookups and context logic.

### Stored level vs. displayed options

Because the DM menu only offers `medium`/`hush`, a stored level outside that set would otherwise leave no row checked. `normalizeLevelToOptions` resolves this purely for display (it never writes on render):

- An explicit notifying level not offered by the menu (e.g. a legacy/inherited `soft`/`loud` on a DM) collapses to the most permissive offered option so a row is always checked.
- `'default'` is the "inherit from base" sentinel (e.g. `unmuteChat` writes it), not an explicit level. `useChatVolumeOptions` resolves `'default'` to the effective base level (`store.useBaseVolumeLevel()`) before matching, and the normalizer refuses to collapse `'default'` — so an inherited setting can never masquerade as a stronger explicit override, and tapping the checked row can't silently write a custom one.

## How did I test?

- `pnpm -r tsc`, prettier, and eslint clean on all touched files.
- Updated the `setGroupNotifications` e2e helper + `group-channel-management.spec.ts` caller to the new group-context labels.
- Manually verified labels in the simulator across a group, a group channel, and a DM (action sheet + full-screen ChatInfo menu); base push-notification settings unchanged. Confirmed an inherited/unmuted DM shows the correct base-derived row checked rather than a false "All messages" override.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

Pure UI/label change with no schema, API, or persisted-state impact — revert the commit. Stored volume levels are unaffected (only their display labels and which row renders checked changed).

## Screenshots / videos

| Type | Long-press menu | Dedicated volume screen |
|------|-----------------|-------------------------|
| DM | <img alt="Screenshot 2026-06-22 at 1 18 21 PM" src="https://github.com/user-attachments/assets/7999da38-af32-4e21-a114-6d4cb1b78cca" /> | N/A |
| Channel | <img alt="Screenshot 2026-06-22 at 1 10 16 PM" src="https://github.com/user-attachments/assets/a45775e7-fc70-4f67-bef2-1360cad09fdd" /> | <img alt="Screenshot 2026-06-22 at 1 22 00 PM" src="https://github.com/user-attachments/assets/8e6a5c67-bb41-4fee-afca-f9584add6063" /> |
| Group | <img alt="Screenshot 2026-06-22 at 1 10 08 PM" src="https://github.com/user-attachments/assets/adb0243a-ab2e-4870-b582-e7b63a78f905" /> | <img alt="Screenshot 2026-06-22 at 1 21 52 PM" src="https://github.com/user-attachments/assets/a0cfb8e7-f063-4190-b0fd-90eace4fe536" /> |
| Global | N/A | <img alt="Screenshot 2026-06-22 at 1 22 23 PM" src="https://github.com/user-attachments/assets/08939a6d-c6c2-4af4-be32-8511d489b7f7" /> |
