### PR TITLE
Link hosted web users to hosting's bot settings page

### DIFF
--- a/packages/app/features/settings/SettingsScreen.tsx
+++ b/packages/app/features/settings/SettingsScreen.tsx
@@ -12,6 +12,10 @@ import { useHandleLogout } from '../../hooks/useHandleLogout';
 import { useResetDb } from '../../hooks/useResetDb';
 import { RootStackParamList } from '../../navigation/types';
 import { SettingsScreenView, View, openTlonWebApp } from '../../ui';
+import {
+  openExternalBotSettings,
+  useHasExpectedBotDm,
+} from '../../utils/botSettings';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
 
@@ -23,7 +27,14 @@ export default function SettingsScreen(props: Props) {
   const hasHostedAuth = useHasHostedAuth();
   const hostingBotEnabled = db.hostingBotEnabled.useValue();
   const isHostedUser = getCurrentUserIsHosted();
-  const botEnabled = Platform.OS !== 'web' && isHostedUser && hostingBotEnabled;
+  const hasExpectedBotDm = useHasExpectedBotDm(
+    currentUserId,
+    Platform.OS === 'web' && isHostedUser
+  );
+  const botEnabled =
+    Platform.OS === 'web'
+      ? isHostedUser && hasExpectedBotDm
+      : isHostedUser && hostingBotEnabled;
   const navigationRef = useMutableRef(props.navigation);
 
   const onAppInfoPressed = useCallback(() => {
@@ -43,6 +54,10 @@ export default function SettingsScreen(props: Props) {
   }, [navigationRef]);
 
   const onBotSettingsPressed = useCallback(() => {
+    if (Platform.OS === 'web') {
+      openExternalBotSettings();
+      return;
+    }
     navigationRef.current.navigate('BotSettings');
   }, [navigationRef]);
 

--- a/packages/app/features/top/UserProfileScreen.tsx
+++ b/packages/app/features/top/UserProfileScreen.tsx
@@ -21,11 +21,23 @@ import {
   UserProfileScreenView,
   useIsWindowNarrow,
 } from '../../ui';
+import {
+  openExternalBotSettings,
+  useHasExpectedBotDm,
+} from '../../utils/botSettings';
 import { useShipConnectionStatus } from './useShipConnectionStatus';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'UserProfile'>;
 
 const logger = createDevLogger('UserProfileScreen', false);
+
+function getCurrentUserIsHostedSafely() {
+  try {
+    return api.getCurrentUserIsHosted();
+  } catch {
+    return false;
+  }
+}
 
 export function UserProfileScreen({ route, navigation }: Props) {
   const theme = useTheme();
@@ -91,7 +103,20 @@ export function UserProfileScreen({ route, navigation }: Props) {
     return api.isBotUserIdForUser(userId, currentUserId);
   }, [currentUserId, userId]);
 
+  const isHostedUser = isWeb ? getCurrentUserIsHostedSafely() : false;
+  const hasExpectedBotDm = useHasExpectedBotDm(
+    currentUserId,
+    isWeb && isHostedUser
+  );
+  const shouldShowBotSettingsProfileAction = isWeb
+    ? isHostedUser && hasExpectedBotDm && isOwnBotProfile
+    : isOwnBotProfile;
+
   const handlePressBotSettings = useCallback(() => {
+    if (isWeb) {
+      openExternalBotSettings();
+      return;
+    }
     navigateToBotSettings();
   }, [navigateToBotSettings]);
 
@@ -148,7 +173,9 @@ export function UserProfileScreen({ route, navigation }: Props) {
               userId={userId}
               connectionStatus={connectionStatus}
               onPressBotSettings={
-                !isWeb && isOwnBotProfile ? handlePressBotSettings : undefined
+                shouldShowBotSettingsProfileAction
+                  ? handlePressBotSettings
+                  : undefined
               }
               onPressGroup={handlePressGroup}
             />

--- a/packages/app/navigation/desktop/SettingsNavigator.tsx
+++ b/packages/app/navigation/desktop/SettingsNavigator.tsx
@@ -25,6 +25,10 @@ import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import { useHandleLogout } from '../../hooks/useHandleLogout';
 import { useResetDb } from '../../hooks/useResetDb';
 import { DESKTOP_SIDEBAR_WIDTH, SettingsScreenView } from '../../ui';
+import {
+  openExternalBotSettings,
+  useHasExpectedBotDm,
+} from '../../utils/botSettings';
 
 const SettingsDrawer = createDrawerNavigator();
 
@@ -37,7 +41,14 @@ function DrawerContent(props: DrawerContentComponentProps) {
   const hasHostedAuth = useHasHostedAuth();
   const hostingBotEnabled = db.hostingBotEnabled.useValue();
   const isHostedUser = getCurrentUserIsHosted();
-  const botEnabled = Platform.OS !== 'web' && isHostedUser && hostingBotEnabled;
+  const hasExpectedBotDm = useHasExpectedBotDm(
+    currentUserId,
+    Platform.OS === 'web' && isHostedUser
+  );
+  const botEnabled =
+    Platform.OS === 'web'
+      ? isHostedUser && hasExpectedBotDm
+      : isHostedUser && hostingBotEnabled;
   const focusedRoute = props.state.routes[props.state.index];
 
   const onAppInfoPressed = useCallback(() => {
@@ -57,6 +68,10 @@ function DrawerContent(props: DrawerContentComponentProps) {
   }, [navigate]);
 
   const onBotSettingsPressed = useCallback(() => {
+    if (Platform.OS === 'web') {
+      openExternalBotSettings();
+      return;
+    }
     navigate('BotSettings');
   }, [navigate]);
 

--- a/packages/app/utils/botSettings.ts
+++ b/packages/app/utils/botSettings.ts
@@ -1,0 +1,25 @@
+import * as api from '@tloncorp/api';
+import * as store from '@tloncorp/shared/store';
+import { Linking, Platform } from 'react-native';
+
+export const BOT_SETTINGS_URL = 'https://tlon.network/tlonbot';
+
+export function useHasExpectedBotDm(currentUserId: string, enabled: boolean) {
+  const expectedBotId = enabled ? api.getBotUserIdForUser(currentUserId) : '';
+  const { data: botDm } = store.useChannel({ id: expectedBotId });
+
+  return (
+    botDm?.type === 'dm' &&
+    botDm.isPendingChannel !== true &&
+    botDm.isDmInvite !== true
+  );
+}
+
+export function openExternalBotSettings() {
+  if (Platform.OS === 'web') {
+    window.open(BOT_SETTINGS_URL, '_blank', 'noopener,noreferrer');
+    return;
+  }
+
+  Linking.openURL(BOT_SETTINGS_URL);
+}


### PR DESCRIPTION
## Summary

Fixes TLON-6016

Adds web access to bot settings by linking hosted web users out to the central bot settings page at `https://tlon.network/tlonbot`. This is intentionally narrower than an in-app web implementation, since hosted web has ship auth but not central hosting auth, so in-app calls to the hosting and Tlonbot APIs cannot be relied on without a larger auth and CORS project. Native mobile behavior is unchanged and still navigates to the internal `BotSettings` route.

## Changes

- Added `packages/app/utils/botSettings.ts` with the shared link-out behavior:
  - `BOT_SETTINGS_URL` constant pointing at `https://tlon.network/tlonbot`.
  - `openExternalBotSettings()`, which opens a new tab via `window.open(url, '_blank', 'noopener,noreferrer')` on web and falls back to `Linking.openURL` on native.
  - `useHasExpectedBotDm(currentUserId, enabled)`, a hook that returns true when the user has an established (non-pending, non-invite) DM with their expected bot id (`~pinser-botter-<self>`). This is used as a local proxy for "the bot is provisioned", because `hostingBotEnabled` is not available on hosted web.
- Updated `packages/app/features/settings/SettingsScreen.tsx` (mobile) and `packages/app/navigation/desktop/SettingsNavigator.tsx` (desktop/web) so the "Bot Settings" row shows on web for hosted users gated by `useHasExpectedBotDm`, while native keeps the existing `isHostedUser && hostingBotEnabled` gate. Pressing the row opens the external URL on web and navigates to the internal `BotSettings` route on native.
- Updated `packages/app/features/top/UserProfileScreen.tsx` so the own-bot profile "Bot settings" entry also shows on web, gated on hosted status, `useHasExpectedBotDm`, and `isOwnBotProfile`. The hosted check is wrapped in `getCurrentUserIsHostedSafely()` because `getCurrentUserIsHosted()` can throw before the Urbit client is initialized. Pressing the entry opens the external URL on web and navigates internally on native.

Out of scope for this patch: in-app web MCP OAuth, iframing `tlon.network/tlonbot` (it sends `x-frame-options: SAMEORIGIN`), adding hosting auth to the web app, and any hosting-service CORS or auth changes. `BotSettings`, `BotMcpSettings`, and `BotOtherSettings` remain unreachable from web.

## How did I test?

- Manual web verification
- Native smoke check: app settings and own-bot profile still navigate to the internal `BotSettings` route, and `Connect MCP` / `External Services` behavior is unchanged.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: Settings and user-profile bot settings entry points

## Rollback plan

Revert.

## Screenshots / videos

<img width="384" height="684" alt="image" src="https://github.com/user-attachments/assets/a75cdae2-de4d-4a53-a922-83450f0de0f8" />