### PR TITLE
openclaw: telemetry for session lifecycle and harness diagnostics

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineChannelPluginEntry } from 'openclaw/plugin-sdk/core';
+import { onDiagnosticEvent } from 'openclaw/plugin-sdk/diagnostic-runtime';
 
 import { tlonPlugin } from './src/channel.js';
 import { sendGatewayStop } from './src/gateway-status.js';
@@ -16,7 +17,13 @@ import { handleOwnerListenCommand } from './src/owner-listen-command.js';
 import { setTlonRuntime } from './src/runtime.js';
 import { getSessionRole } from './src/session-roles.js';
 import { parseTlonTarget } from './src/targets.js';
-import { recordToolCall, reportOutboundRoute } from './src/telemetry.js';
+import {
+  type TlonSessionDiagnosticReportInput,
+  recordToolCall,
+  reportOutboundRoute,
+  reportSessionDiagnostic,
+  reportSessionLifecycle,
+} from './src/telemetry.js';
 import { resolveTlonBinary } from './src/tlon-binary.js';
 import { checkBlockedSendOperation } from './src/tlon-tool-guard.js';
 import {
@@ -218,6 +225,17 @@ async function readTlonSkillVersion(binary: string): Promise<string> {
   } catch (error) {
     return `unavailable (${summarizeError(error)})`;
   }
+}
+
+function isTlonSessionDiagnosticEvent(event: {
+  type: string;
+}): event is TlonSessionDiagnosticReportInput {
+  return (
+    event.type === 'session.stalled' ||
+    event.type === 'session.stuck' ||
+    event.type === 'session.recovery.requested' ||
+    event.type === 'session.recovery.completed'
+  );
 }
 
 export default defineChannelPluginEntry({
@@ -504,6 +522,49 @@ export default defineChannelPluginEntry({
         error: event.error,
       });
     });
+
+    // ── Session lifecycle / watchdog telemetry ─────────────────────────
+    // These hooks are global to OpenClaw, so telemetry.ts filters them through
+    // session keys remembered from Tlon inbound replies before emitting.
+    api.on('session_start', (event, ctx) => {
+      reportSessionLifecycle({
+        lifecycleEvent: 'session_start',
+        sessionKey: event.sessionKey ?? ctx.sessionKey,
+        sessionId: event.sessionId ?? ctx.sessionId,
+        agentId: ctx.agentId,
+        hasNextSession: false,
+      });
+    });
+
+    api.on('session_end', (event, ctx) => {
+      reportSessionLifecycle({
+        lifecycleEvent: 'session_end',
+        sessionKey: event.sessionKey ?? ctx.sessionKey,
+        sessionId: event.sessionId ?? ctx.sessionId,
+        agentId: ctx.agentId,
+        reason: event.reason ?? null,
+        messageCount: event.messageCount,
+        durationMs: event.durationMs ?? null,
+        transcriptArchived: event.transcriptArchived ?? null,
+        hasNextSession: Boolean(event.nextSessionId ?? event.nextSessionKey),
+      });
+    });
+
+    let diagnosticEventsUnsubscribed = false;
+    const unsubscribeDiagnosticEvents = onDiagnosticEvent((event) => {
+      const candidate = event as unknown as { type: string };
+      if (isTlonSessionDiagnosticEvent(candidate)) {
+        reportSessionDiagnostic(candidate);
+      }
+    });
+    const unsubscribeDiagnosticEventsOnce = () => {
+      if (diagnosticEventsUnsubscribed) {
+        return;
+      }
+      diagnosticEventsUnsubscribed = true;
+      unsubscribeDiagnosticEvents();
+    };
+    api.on('gateway_stop', unsubscribeDiagnosticEventsOnce);
 
     // ── Route diagnostics ───────────────────────────────────────────────
     // Fires for every outbound send OpenClaw routes — the primary streamed

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -3,7 +3,10 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineChannelPluginEntry } from 'openclaw/plugin-sdk/core';
-import { onDiagnosticEvent } from 'openclaw/plugin-sdk/diagnostic-runtime';
+import {
+  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
+} from 'openclaw/plugin-sdk/diagnostic-runtime';
 
 import { tlonPlugin } from './src/channel.js';
 import { sendGatewayStop } from './src/gateway-status.js';
@@ -19,10 +22,15 @@ import { getSessionRole } from './src/session-roles.js';
 import { parseTlonTarget } from './src/targets.js';
 import {
   type TlonSessionDiagnosticReportInput,
+  formatTlonTelemetryErrorText,
   recordToolCall,
+  reportHarnessError,
   reportOutboundRoute,
+  reportPluginError,
   reportSessionDiagnostic,
   reportSessionLifecycle,
+  reportSessionTurnCreated,
+  reportTelemetryError,
 } from './src/telemetry.js';
 import { resolveTlonBinary } from './src/tlon-binary.js';
 import { checkBlockedSendOperation } from './src/tlon-tool-guard.js';
@@ -238,6 +246,158 @@ function isTlonSessionDiagnosticEvent(event: {
   );
 }
 
+type DiagnosticCandidate = Record<string, unknown> & { type?: unknown };
+
+function stringField(event: DiagnosticCandidate, key: string): string | null {
+  const value = event[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function numberField(event: DiagnosticCandidate, key: string): number | null {
+  const value = event[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function diagnosticErrorText(event: DiagnosticCandidate): string | null {
+  return stringField(event, 'error') ?? stringField(event, 'message');
+}
+
+function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
+  const type = stringField(event, 'type');
+  if (!type) {
+    return;
+  }
+
+  if (type === 'session.turn.created') {
+    reportSessionTurnCreated({
+      type,
+      sessionKey: stringField(event, 'sessionKey'),
+      sessionId: stringField(event, 'sessionId'),
+      runId: stringField(event, 'runId'),
+      agentId: stringField(event, 'agentId'),
+    });
+    return;
+  }
+
+  const common = {
+    harnessEventType: type,
+    sessionKey: stringField(event, 'sessionKey'),
+    sessionId: stringField(event, 'sessionId'),
+    runId: stringField(event, 'runId'),
+    agentId: stringField(event, 'agentId'),
+    provider: stringField(event, 'provider'),
+    model: stringField(event, 'model'),
+    phase: stringField(event, 'phase'),
+    outcome: stringField(event, 'outcome'),
+    errorCategory: stringField(event, 'errorCategory'),
+    failureKind: stringField(event, 'failureKind'),
+    durationMs: numberField(event, 'durationMs'),
+    errorText: diagnosticErrorText(event),
+  };
+
+  switch (type) {
+    case 'harness.run.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'harness',
+      });
+      return;
+    case 'harness.run.completed':
+      if (common.outcome === 'completed') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'harness',
+      });
+      return;
+    case 'model.call.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'model',
+      });
+      return;
+    case 'tool.execution.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'tool',
+        toolName: stringField(event, 'toolName'),
+      });
+      return;
+    case 'run.completed':
+      if (common.outcome === 'completed') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'run',
+      });
+      return;
+    case 'message.delivery.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'message_delivery',
+        phase: stringField(event, 'deliveryKind'),
+      });
+      return;
+    case 'message.dispatch.completed':
+      if (common.outcome !== 'error') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'message_dispatch',
+        phase: stringField(event, 'source'),
+      });
+      return;
+    case 'message.processed':
+      if (common.outcome !== 'error') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'message_processing',
+        phase: stringField(event, 'channel'),
+      });
+      return;
+  }
+}
+
+function safeTelemetryObserver(params: {
+  logger: { warn: (message: string) => void };
+  telemetrySource: string;
+  sourceEventName?: string | null;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+  run: () => void;
+}): void {
+  try {
+    params.run();
+  } catch (error) {
+    params.logger.warn(
+      `[tlon] Telemetry observer failed (${params.telemetrySource}${params.sourceEventName ? `:${params.sourceEventName}` : ''}): ${String(error)}`
+    );
+    try {
+      reportTelemetryError({
+        telemetrySource: params.telemetrySource,
+        sourceEventName: params.sourceEventName,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        runId: params.runId,
+        agentId: params.agentId,
+        errorKind: error instanceof Error ? error.name : typeof error,
+        errorText: formatTlonTelemetryErrorText(error),
+      });
+    } catch (reportError) {
+      params.logger.warn(
+        `[tlon] Telemetry error reporting failed: ${String(reportError)}`
+      );
+    }
+  }
+}
+
 export default defineChannelPluginEntry({
   id: 'tlon',
   name: 'Tlon',
@@ -273,7 +433,14 @@ export default defineChannelPluginEntry({
       const gsManager = createGatewayStatusManager({
         logger: {
           log: (m) => api.logger.info(m),
-          error: (m) => api.logger.warn(m),
+          error: (m) => {
+            reportPluginError({
+              pluginErrorSource: 'gateway_status_heartbeat',
+              errorKind: 'heartbeat',
+              errorText: m,
+            });
+            api.logger.warn(m);
+          },
         },
       });
       setGatewayStatusManager(gsManager);
@@ -515,11 +682,19 @@ export default defineChannelPluginEntry({
         );
       }
 
-      recordToolCall({
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'after_tool_call',
+        sourceEventName: event.toolName,
         sessionKey: ctx.sessionKey,
-        toolName: event.toolName,
-        durationMs: event.durationMs,
-        error: event.error,
+        run: () => {
+          recordToolCall({
+            sessionKey: ctx.sessionKey,
+            toolName: event.toolName,
+            durationMs: event.durationMs,
+            error: event.error,
+          });
+        },
       });
     });
 
@@ -527,42 +702,92 @@ export default defineChannelPluginEntry({
     // These hooks are global to OpenClaw, so telemetry.ts filters them through
     // session keys remembered from Tlon inbound replies before emitting.
     api.on('session_start', (event, ctx) => {
-      reportSessionLifecycle({
-        lifecycleEvent: 'session_start',
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'session_start',
+        sourceEventName: 'session_start',
         sessionKey: event.sessionKey ?? ctx.sessionKey,
         sessionId: event.sessionId ?? ctx.sessionId,
         agentId: ctx.agentId,
-        hasNextSession: false,
+        run: () => {
+          reportSessionLifecycle({
+            lifecycleEvent: 'session_start',
+            sessionKey: event.sessionKey ?? ctx.sessionKey,
+            sessionId: event.sessionId ?? ctx.sessionId,
+            agentId: ctx.agentId,
+            hasNextSession: false,
+          });
+        },
       });
     });
 
     api.on('session_end', (event, ctx) => {
-      reportSessionLifecycle({
-        lifecycleEvent: 'session_end',
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'session_end',
+        sourceEventName: 'session_end',
         sessionKey: event.sessionKey ?? ctx.sessionKey,
         sessionId: event.sessionId ?? ctx.sessionId,
         agentId: ctx.agentId,
-        reason: event.reason ?? null,
-        messageCount: event.messageCount,
-        durationMs: event.durationMs ?? null,
-        transcriptArchived: event.transcriptArchived ?? null,
-        hasNextSession: Boolean(event.nextSessionId ?? event.nextSessionKey),
+        run: () => {
+          reportSessionLifecycle({
+            lifecycleEvent: 'session_end',
+            sessionKey: event.sessionKey ?? ctx.sessionKey,
+            sessionId: event.sessionId ?? ctx.sessionId,
+            agentId: ctx.agentId,
+            reason: event.reason ?? null,
+            messageCount: event.messageCount,
+            durationMs: event.durationMs ?? null,
+            transcriptArchived: event.transcriptArchived ?? null,
+            hasNextSession: Boolean(
+              event.nextSessionId ?? event.nextSessionKey
+            ),
+          });
+        },
       });
     });
 
     let diagnosticEventsUnsubscribed = false;
     const unsubscribeDiagnosticEvents = onDiagnosticEvent((event) => {
       const candidate = event as unknown as { type: string };
-      if (isTlonSessionDiagnosticEvent(candidate)) {
-        reportSessionDiagnostic(candidate);
-      }
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'diagnostic_session',
+        sourceEventName: candidate.type,
+        sessionKey: (candidate as { sessionKey?: string }).sessionKey,
+        sessionId: (candidate as { sessionId?: string }).sessionId,
+        run: () => {
+          if (isTlonSessionDiagnosticEvent(candidate)) {
+            reportSessionDiagnostic(candidate);
+          }
+        },
+      });
     });
+    const unsubscribeInternalDiagnosticEvents = onInternalDiagnosticEvent(
+      (event) => {
+        const candidate = event as DiagnosticCandidate;
+        safeTelemetryObserver({
+          logger: api.logger,
+          telemetrySource: 'diagnostic_internal',
+          sourceEventName: stringField(candidate, 'type'),
+          sessionKey: stringField(candidate, 'sessionKey'),
+          sessionId: stringField(candidate, 'sessionId'),
+          runId: stringField(candidate, 'runId'),
+          agentId: stringField(candidate, 'agentId'),
+          run: () => reportHarnessDiagnostic(candidate),
+        });
+      }
+    );
+    const unsubscribeAllDiagnosticEvents = () => {
+      unsubscribeDiagnosticEvents();
+      unsubscribeInternalDiagnosticEvents();
+    };
     const unsubscribeDiagnosticEventsOnce = () => {
       if (diagnosticEventsUnsubscribed) {
         return;
       }
       diagnosticEventsUnsubscribed = true;
-      unsubscribeDiagnosticEvents();
+      unsubscribeAllDiagnosticEvents();
     };
     api.on('gateway_stop', unsubscribeDiagnosticEventsOnce);
 
@@ -578,34 +803,66 @@ export default defineChannelPluginEntry({
     // sends land off-Tlon; and a debug-gated local log for single-gateway
     // triage.
     api.on('message_sending', (event, ctx) => {
-      const resolvedChannel = ctx.channelId;
-      const routedToTlon = resolvedChannel === 'tlon';
-      // Only infer target kind for Tlon targets; a webchat target id is not a
-      // Tlon target and must not be misclassified.
-      const parsedTarget = routedToTlon ? parseTlonTarget(event.to) : null;
-      const targetKind =
-        parsedTarget?.kind === 'dm'
-          ? 'dm'
-          : parsedTarget?.kind === 'channel'
-            ? 'group'
-            : 'unknown';
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'message_sending',
+        sourceEventName: 'message_sending',
+        sessionKey: ctx.sessionKey,
+        runId: ctx.runId,
+        run: () => {
+          const resolvedChannel = ctx.channelId;
+          const routedToTlon = resolvedChannel === 'tlon';
+          // Only infer target kind for Tlon targets; a webchat target id is not
+          // a Tlon target and must not be misclassified.
+          const parsedTarget = routedToTlon ? parseTlonTarget(event.to) : null;
+          const targetKind =
+            parsedTarget?.kind === 'dm'
+              ? 'dm'
+              : parsedTarget?.kind === 'channel'
+                ? 'group'
+                : 'unknown';
 
-      reportOutboundRoute({ resolvedChannel, routedToTlon, targetKind });
+          reportOutboundRoute({ resolvedChannel, routedToTlon, targetKind });
 
-      if (isRouteDebugEnabled()) {
-        api.logger.info(
-          `[tlon][route-debug] message_sending ${JSON.stringify({
-            channelId: ctx.channelId,
-            to: event.to,
-            routedToTlon,
-            targetKind,
-            sessionKey: ctx.sessionKey ?? null,
-            conversationId: ctx.conversationId ?? null,
-            messageId: ctx.messageId ?? null,
-            threadId: event.threadId ?? null,
-          })}`
-        );
-      }
+          if (isRouteDebugEnabled()) {
+            api.logger.info(
+              `[tlon][route-debug] message_sending ${JSON.stringify({
+                channelId: ctx.channelId,
+                to: event.to,
+                routedToTlon,
+                targetKind,
+                sessionKey: ctx.sessionKey ?? null,
+                conversationId: ctx.conversationId ?? null,
+                messageId: ctx.messageId ?? null,
+                threadId: event.threadId ?? null,
+              })}`
+            );
+          }
+        },
+      });
+    });
+
+    api.on('message_sent', (event, ctx) => {
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'message_sent',
+        sourceEventName: 'message_sent',
+        sessionKey: event.sessionKey ?? ctx.sessionKey,
+        runId: event.runId ?? ctx.runId,
+        run: () => {
+          if (event.success !== false) {
+            return;
+          }
+          reportHarnessError({
+            harnessEventType: 'message_sent',
+            errorScope: 'message_delivery',
+            sessionKey: event.sessionKey ?? ctx.sessionKey,
+            runId: event.runId ?? ctx.runId,
+            errorText: event.error ?? null,
+            outcome: 'error',
+          });
+        },
+      });
     });
 
     // ── Slash commands for approval & admin ────────────────────────────

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -2,13 +2,20 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineChannelPluginEntry } from 'openclaw/plugin-sdk/core';
+import {
+  type OpenClawPluginApi,
+  defineChannelPluginEntry,
+} from 'openclaw/plugin-sdk/core';
 import {
   onDiagnosticEvent,
   onInternalDiagnosticEvent,
 } from 'openclaw/plugin-sdk/diagnostic-runtime';
 
 import { tlonPlugin } from './src/channel.js';
+import {
+  installTlonDiagnosticSubscriptions,
+  shouldInstallTlonDiagnosticSubscriptions,
+} from './src/diagnostic-subscriptions.js';
 import { sendGatewayStop } from './src/gateway-status.js';
 import {
   createGatewayStatusManager,
@@ -262,6 +269,27 @@ function diagnosticErrorText(event: DiagnosticCandidate): string | null {
   return stringField(event, 'error') ?? stringField(event, 'message');
 }
 
+function stringListField(event: DiagnosticCandidate, key: string): string[] {
+  const value = event[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter(Boolean);
+}
+
+function diagnosticSummary(
+  parts: Array<[string, string | number | boolean | null | undefined]>
+): string {
+  return parts
+    .filter(
+      ([, value]) => value !== null && value !== undefined && value !== ''
+    )
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(' ');
+}
+
 function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
   const type = stringField(event, 'type');
   if (!type) {
@@ -317,6 +345,32 @@ function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
         errorScope: 'model',
       });
       return;
+    case 'model.failover': {
+      const reason = stringField(event, 'reason');
+      const fromProvider = stringField(event, 'fromProvider');
+      const fromModel = stringField(event, 'fromModel');
+      const toProvider = stringField(event, 'toProvider');
+      const toModel = stringField(event, 'toModel');
+      reportHarnessError({
+        ...common,
+        errorScope: 'model',
+        provider: fromProvider,
+        model: fromModel,
+        phase: stringField(event, 'lane'),
+        outcome: 'failover',
+        errorCategory: 'model_failover',
+        failureKind: reason,
+        errorText: diagnosticSummary([
+          ['fromProvider', fromProvider],
+          ['fromModel', fromModel],
+          ['toProvider', toProvider],
+          ['toModel', toModel],
+          ['reason', reason],
+          ['cascadeDepth', numberField(event, 'cascadeDepth')],
+        ]),
+      });
+      return;
+    }
     case 'tool.execution.error':
       reportHarnessError({
         ...common,
@@ -324,6 +378,46 @@ function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
         toolName: stringField(event, 'toolName'),
       });
       return;
+    case 'tool.execution.blocked': {
+      const deniedReason = stringField(event, 'deniedReason');
+      const reason = stringField(event, 'reason');
+      reportHarnessError({
+        ...common,
+        errorScope: 'tool',
+        toolName: stringField(event, 'toolName'),
+        phase: stringField(event, 'toolSource'),
+        outcome: 'blocked',
+        errorCategory: 'tool_blocked',
+        failureKind: deniedReason,
+        errorText: reason ?? deniedReason,
+      });
+      return;
+    }
+    case 'tool.loop': {
+      const level = stringField(event, 'level');
+      const action = stringField(event, 'action');
+      if (level !== 'critical' && action !== 'block') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'tool',
+        toolName: stringField(event, 'toolName'),
+        phase: level,
+        outcome: action,
+        errorCategory: 'tool_loop',
+        failureKind: stringField(event, 'detector'),
+        errorText:
+          stringField(event, 'message') ??
+          diagnosticSummary([
+            ['level', level],
+            ['action', action],
+            ['detector', stringField(event, 'detector')],
+            ['count', numberField(event, 'count')],
+          ]),
+      });
+      return;
+    }
     case 'run.completed':
       if (common.outcome === 'completed') {
         return;
@@ -358,6 +452,95 @@ function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
         ...common,
         errorScope: 'message_processing',
         phase: stringField(event, 'channel'),
+      });
+      return;
+    case 'diagnostic.async_queue.dropped':
+      reportHarnessError({
+        ...common,
+        errorScope: 'diagnostics',
+        outcome: 'dropped',
+        errorCategory: 'diagnostic_async_queue_dropped',
+        failureKind: 'queue_full',
+        errorText: diagnosticSummary([
+          ['droppedEvents', numberField(event, 'droppedEvents')],
+          ['droppedTrustedEvents', numberField(event, 'droppedTrustedEvents')],
+          [
+            'droppedUntrustedEvents',
+            numberField(event, 'droppedUntrustedEvents'),
+          ],
+          ['queueLength', numberField(event, 'queueLength')],
+          ['maxQueueLength', numberField(event, 'maxQueueLength')],
+        ]),
+      });
+      return;
+    case 'diagnostic.liveness.warning': {
+      const reasons = stringListField(event, 'reasons');
+      reportHarnessError({
+        ...common,
+        errorScope: 'runtime',
+        phase: stringField(event, 'phase'),
+        outcome: 'warning',
+        errorCategory: 'liveness_warning',
+        failureKind: reasons.join(',') || null,
+        durationMs: numberField(event, 'intervalMs'),
+        errorText: diagnosticSummary([
+          ['reasons', reasons.join(',')],
+          ['eventLoopDelayP99Ms', numberField(event, 'eventLoopDelayP99Ms')],
+          ['eventLoopDelayMaxMs', numberField(event, 'eventLoopDelayMaxMs')],
+          ['cpuCoreRatio', numberField(event, 'cpuCoreRatio')],
+          ['active', numberField(event, 'active')],
+          ['waiting', numberField(event, 'waiting')],
+          ['queued', numberField(event, 'queued')],
+        ]),
+      });
+      return;
+    }
+    case 'diagnostic.memory.pressure': {
+      const memory = event.memory as Record<string, unknown> | undefined;
+      const memoryNumber = (key: string) => {
+        const value = memory?.[key];
+        return typeof value === 'number' && Number.isFinite(value)
+          ? value
+          : null;
+      };
+      reportHarnessError({
+        ...common,
+        errorScope: 'runtime',
+        outcome: stringField(event, 'level'),
+        errorCategory: 'memory_pressure',
+        failureKind: stringField(event, 'reason'),
+        durationMs: numberField(event, 'windowMs'),
+        errorText: diagnosticSummary([
+          ['level', stringField(event, 'level')],
+          ['reason', stringField(event, 'reason')],
+          ['rssBytes', memoryNumber('rssBytes')],
+          ['heapUsedBytes', memoryNumber('heapUsedBytes')],
+          ['thresholdBytes', numberField(event, 'thresholdBytes')],
+          ['rssGrowthBytes', numberField(event, 'rssGrowthBytes')],
+        ]),
+      });
+      return;
+    }
+    case 'payload.large':
+      if (stringField(event, 'action') !== 'rejected') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'payload',
+        phase: stringField(event, 'surface'),
+        outcome: 'rejected',
+        errorCategory: 'payload_large',
+        failureKind: stringField(event, 'reason'),
+        errorText: diagnosticSummary([
+          ['surface', stringField(event, 'surface')],
+          ['channel', stringField(event, 'channel')],
+          ['pluginId', stringField(event, 'pluginId')],
+          ['bytes', numberField(event, 'bytes')],
+          ['limitBytes', numberField(event, 'limitBytes')],
+          ['count', numberField(event, 'count')],
+          ['reason', stringField(event, 'reason')],
+        ]),
       });
       return;
   }
@@ -396,6 +579,48 @@ function safeTelemetryObserver(params: {
       );
     }
   }
+}
+
+function installTelemetryDiagnosticObservers(
+  api: OpenClawPluginApi
+): () => void {
+  return installTlonDiagnosticSubscriptions(() => {
+    const unsubscribeDiagnosticEvents = onDiagnosticEvent((event) => {
+      const candidate = event as unknown as { type: string };
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'diagnostic_session',
+        sourceEventName: candidate.type,
+        sessionKey: (candidate as { sessionKey?: string }).sessionKey,
+        sessionId: (candidate as { sessionId?: string }).sessionId,
+        run: () => {
+          if (isTlonSessionDiagnosticEvent(candidate)) {
+            reportSessionDiagnostic(candidate);
+          }
+        },
+      });
+    });
+    const unsubscribeInternalDiagnosticEvents = onInternalDiagnosticEvent(
+      (event) => {
+        const candidate = event as DiagnosticCandidate;
+        safeTelemetryObserver({
+          logger: api.logger,
+          telemetrySource: 'diagnostic_internal',
+          sourceEventName: stringField(candidate, 'type'),
+          sessionKey: stringField(candidate, 'sessionKey'),
+          sessionId: stringField(candidate, 'sessionId'),
+          runId: stringField(candidate, 'runId'),
+          agentId: stringField(candidate, 'agentId'),
+          run: () => reportHarnessDiagnostic(candidate),
+        });
+      }
+    );
+
+    return () => {
+      unsubscribeDiagnosticEvents();
+      unsubscribeInternalDiagnosticEvents();
+    };
+  });
 }
 
 export default defineChannelPluginEntry({
@@ -747,49 +972,11 @@ export default defineChannelPluginEntry({
       });
     });
 
-    let diagnosticEventsUnsubscribed = false;
-    const unsubscribeDiagnosticEvents = onDiagnosticEvent((event) => {
-      const candidate = event as unknown as { type: string };
-      safeTelemetryObserver({
-        logger: api.logger,
-        telemetrySource: 'diagnostic_session',
-        sourceEventName: candidate.type,
-        sessionKey: (candidate as { sessionKey?: string }).sessionKey,
-        sessionId: (candidate as { sessionId?: string }).sessionId,
-        run: () => {
-          if (isTlonSessionDiagnosticEvent(candidate)) {
-            reportSessionDiagnostic(candidate);
-          }
-        },
-      });
-    });
-    const unsubscribeInternalDiagnosticEvents = onInternalDiagnosticEvent(
-      (event) => {
-        const candidate = event as DiagnosticCandidate;
-        safeTelemetryObserver({
-          logger: api.logger,
-          telemetrySource: 'diagnostic_internal',
-          sourceEventName: stringField(candidate, 'type'),
-          sessionKey: stringField(candidate, 'sessionKey'),
-          sessionId: stringField(candidate, 'sessionId'),
-          runId: stringField(candidate, 'runId'),
-          agentId: stringField(candidate, 'agentId'),
-          run: () => reportHarnessDiagnostic(candidate),
-        });
-      }
-    );
-    const unsubscribeAllDiagnosticEvents = () => {
-      unsubscribeDiagnosticEvents();
-      unsubscribeInternalDiagnosticEvents();
-    };
-    const unsubscribeDiagnosticEventsOnce = () => {
-      if (diagnosticEventsUnsubscribed) {
-        return;
-      }
-      diagnosticEventsUnsubscribed = true;
-      unsubscribeAllDiagnosticEvents();
-    };
-    api.on('gateway_stop', unsubscribeDiagnosticEventsOnce);
+    if (shouldInstallTlonDiagnosticSubscriptions(api.registrationMode)) {
+      const unsubscribeDiagnosticEvents =
+        installTelemetryDiagnosticObservers(api);
+      api.on('gateway_stop', unsubscribeDiagnosticEvents);
+    }
 
     // ── Route diagnostics ───────────────────────────────────────────────
     // Fires for every outbound send OpenClaw routes — the primary streamed

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/diagnostic-subscriptions.test.ts
+++ b/packages/openclaw/src/diagnostic-subscriptions.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearTlonDiagnosticSubscriptionsForTest,
+  installTlonDiagnosticSubscriptions,
+  shouldInstallTlonDiagnosticSubscriptions,
+} from './diagnostic-subscriptions.js';
+
+describe('diagnostic subscriptions', () => {
+  afterEach(() => {
+    clearTlonDiagnosticSubscriptionsForTest();
+  });
+
+  it('installs only during full registration', () => {
+    expect(shouldInstallTlonDiagnosticSubscriptions('full')).toBe(true);
+    expect(shouldInstallTlonDiagnosticSubscriptions('tool-discovery')).toBe(
+      false
+    );
+    expect(shouldInstallTlonDiagnosticSubscriptions('discovery')).toBe(false);
+    expect(shouldInstallTlonDiagnosticSubscriptions('cli-metadata')).toBe(
+      false
+    );
+    expect(shouldInstallTlonDiagnosticSubscriptions(undefined)).toBe(false);
+  });
+
+  it('replaces an existing process-global subscription instead of stacking', () => {
+    const firstUnsubscribe = vi.fn();
+    const secondUnsubscribe = vi.fn();
+
+    const cleanupFirst = installTlonDiagnosticSubscriptions(
+      () => firstUnsubscribe
+    );
+    const cleanupSecond = installTlonDiagnosticSubscriptions(
+      () => secondUnsubscribe
+    );
+
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(secondUnsubscribe).not.toHaveBeenCalled();
+
+    cleanupFirst();
+    expect(secondUnsubscribe).not.toHaveBeenCalled();
+
+    cleanupSecond();
+    expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps cleanup idempotent', () => {
+    const unsubscribe = vi.fn();
+    const cleanup = installTlonDiagnosticSubscriptions(() => unsubscribe);
+
+    cleanup();
+    cleanup();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/openclaw/src/diagnostic-subscriptions.ts
+++ b/packages/openclaw/src/diagnostic-subscriptions.ts
@@ -1,0 +1,69 @@
+import { sharedSlot } from './shared-state.js';
+
+export type TlonDiagnosticSubscriptionInstaller = () => () => void;
+
+type TlonDiagnosticSubscription = {
+  id: number;
+  unsubscribe: () => void;
+};
+
+const diagnosticSubscriptionSlot = sharedSlot<TlonDiagnosticSubscription>(
+  'telemetry.diagnosticEventsSubscription'
+);
+const diagnosticSubscriptionIdSlot = sharedSlot<number>(
+  'telemetry.diagnosticEventsSubscription.nextId'
+);
+
+function nextDiagnosticSubscriptionId(): number {
+  const nextId = (diagnosticSubscriptionIdSlot.get() ?? 0) + 1;
+  diagnosticSubscriptionIdSlot.set(nextId);
+  return nextId;
+}
+
+export function shouldInstallTlonDiagnosticSubscriptions(
+  registrationMode: string | null | undefined
+): boolean {
+  return registrationMode === 'full';
+}
+
+export function installTlonDiagnosticSubscriptions(
+  install: TlonDiagnosticSubscriptionInstaller
+): () => void {
+  diagnosticSubscriptionSlot.get()?.unsubscribe();
+
+  const id = nextDiagnosticSubscriptionId();
+  let unsubscribed = false;
+  let installedUnsubscribe: () => void;
+  try {
+    installedUnsubscribe = install();
+  } catch (error) {
+    diagnosticSubscriptionSlot.set(null);
+    throw error;
+  }
+  const unsubscribe = () => {
+    if (unsubscribed) {
+      return;
+    }
+    unsubscribed = true;
+    installedUnsubscribe();
+  };
+
+  diagnosticSubscriptionSlot.set({ id, unsubscribe });
+
+  return () => {
+    if (diagnosticSubscriptionSlot.get()?.id !== id) {
+      return;
+    }
+    try {
+      unsubscribe();
+    } finally {
+      diagnosticSubscriptionSlot.set(null);
+    }
+  };
+}
+
+export function clearTlonDiagnosticSubscriptionsForTest(): void {
+  diagnosticSubscriptionSlot.get()?.unsubscribe();
+  diagnosticSubscriptionSlot.set(null);
+  diagnosticSubscriptionIdSlot.set(null);
+}

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -44,7 +44,10 @@ import {
   parseChannelNest,
 } from '../targets.js';
 import {
+  type TlonPluginErrorSource,
   createTlonTelemetry,
+  formatTlonTelemetryErrorText,
+  setErrorTelemetryReporter,
   setOutboundRouteReporter,
   setSessionTelemetryReporter,
 } from '../telemetry.js';
@@ -225,6 +228,13 @@ const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS = 15_000;
 const GATEWAY_STATUS_ACTIVATION_RETRY_MS = 30_000;
 
+function classifyPluginError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name || 'Error';
+  }
+  return typeof error;
+}
+
 // Bound an activation poke so a silently-hung promise surfaces as a
 // retryable error instead of leaving gateway-status dead for the process
 // lifetime. The underlying poke may still settle after the timeout; the
@@ -354,6 +364,35 @@ export async function monitorTlonProvider(
 
   const botShipName = normalizeShip(account.ship);
   const tlonSkillVersion = await resolveTlonSkillVersion();
+  let effectiveOwnerShip: string | null = account.ownerShip
+    ? normalizeShip(account.ownerShip)
+    : null;
+  setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
+  const telemetry = createTlonTelemetry({
+    config: account.telemetry,
+    runtime,
+  });
+  const currentTelemetryOwnerShip = () =>
+    getEffectiveOwnerShip(account.accountId) ?? effectiveOwnerShip;
+  const capturePluginError = (
+    pluginErrorSource: TlonPluginErrorSource,
+    error: unknown,
+    extra?: {
+      errorKind?: string | null;
+      attempt?: number | null;
+    }
+  ) => {
+    telemetry?.capturePluginError({
+      harness: 'openclaw',
+      pluginErrorSource,
+      accountId: account.accountId,
+      ownerShip: currentTelemetryOwnerShip(),
+      botShip: botShipName,
+      errorKind: extra?.errorKind ?? classifyPluginError(error),
+      errorText: formatTlonTelemetryErrorText(error),
+      attempt: extra?.attempt ?? null,
+    });
+  };
   runtime.log?.(`[tlon] Starting monitor for ${botShipName}`);
   runtime.log?.(
     `[tlon] version: ${formatTlonVersionIdentity({
@@ -367,7 +406,10 @@ export async function monitorTlonProvider(
   );
 
   // Helper to authenticate with retry logic
-  async function authenticateWithRetry(maxAttempts = 10): Promise<string> {
+  async function authenticateWithRetry(
+    maxAttempts = 10,
+    source: 'auth' | 're_auth' = 'auth'
+  ): Promise<string> {
     for (let attempt = 1; ; attempt++) {
       if (opts.abortSignal?.aborted) {
         throw new Error('Aborted while waiting to authenticate');
@@ -376,6 +418,7 @@ export async function monitorTlonProvider(
         runtime.log?.(`[tlon] Attempting authentication to ${accountUrl}...`);
         return await authenticate(accountUrl, accountCode, { ssrfPolicy });
       } catch (error: any) {
+        capturePluginError(source, error, { attempt });
         runtime.error?.(
           `[tlon] Failed to authenticate (attempt ${attempt}): ${error?.message ?? String(error)}`
         );
@@ -399,22 +442,28 @@ export async function monitorTlonProvider(
   }
 
   let api: UrbitSSEClient | null = null;
-  const cookie = await authenticateWithRetry();
-  api = new UrbitSSEClient(account.url, cookie, {
-    ship: botShipName,
-    ssrfPolicy,
-    logger: {
-      log: (message) => runtime.log?.(message),
-      error: (message) => runtime.error?.(message),
-    },
-    // Re-authenticate on reconnect in case the session expired
-    onReconnect: async (client) => {
-      runtime.log?.('[tlon] Re-authenticating on SSE reconnect...');
-      const newCookie = await authenticateWithRetry(5);
-      client.updateCookie(newCookie);
-      runtime.log?.('[tlon] Re-authentication successful');
-    },
-  });
+  let cookie: string;
+  try {
+    cookie = await authenticateWithRetry();
+    api = new UrbitSSEClient(account.url, cookie, {
+      ship: botShipName,
+      ssrfPolicy,
+      logger: {
+        log: (message) => runtime.log?.(message),
+        error: (message) => runtime.error?.(message),
+      },
+      // Re-authenticate on reconnect in case the session expired
+      onReconnect: async (client) => {
+        runtime.log?.('[tlon] Re-authenticating on SSE reconnect...');
+        const newCookie = await authenticateWithRetry(5, 're_auth');
+        client.updateCookie(newCookie);
+        runtime.log?.('[tlon] Re-authentication successful');
+      },
+    });
+  } catch (error) {
+    await telemetry?.close();
+    throw error;
+  }
 
   // Configure @tloncorp/api's global client to use the SSE client's poke for all send operations
   configureTlonApiWithPoke(api.poke.bind(api), botShipName, account.url);
@@ -523,10 +572,6 @@ export async function monitorTlonProvider(
     let effectiveGroupInviteAllowlist: string[] = account.groupInviteAllowlist;
     let effectiveAutoDiscoverChannels: boolean =
       account.autoDiscoverChannels ?? false;
-    let effectiveOwnerShip: string | null = account.ownerShip
-      ? normalizeShip(account.ownerShip)
-      : null;
-    setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
     let effectiveOwnerListenEnabled: boolean =
       account.ownerListenEnabled ?? true;
     // Canonicalize on every read so an entry stored from a slightly-off user
@@ -562,11 +607,6 @@ export async function monitorTlonProvider(
       pendingNudgeRehydrated = true;
     };
 
-    const telemetry = createTlonTelemetry({
-      config: account.telemetry,
-      runtime,
-    });
-
     // Bridge route-resolution telemetry from the global `message_sending` hook
     // to this account's telemetry client. Reports every route-dependent send so
     // we can measure how often a reply lands on webchat instead of Tlon.
@@ -588,6 +628,41 @@ export async function monitorTlonProvider(
           break;
         case 'recovery':
           telemetry?.captureSessionRecovery(report.event);
+          break;
+      }
+    });
+    setErrorTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'harness':
+          telemetry?.captureHarnessError(report.event);
+          break;
+        case 'plugin':
+          telemetry?.capturePluginError({
+            harness: 'openclaw',
+            pluginErrorSource: report.event.pluginErrorSource,
+            accountId: report.event.accountId ?? account.accountId,
+            ownerShip: report.event.ownerShip ?? currentTelemetryOwnerShip(),
+            botShip: report.event.botShip ?? botShipName,
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+            attempt: report.event.attempt ?? null,
+          });
+          break;
+        case 'telemetry':
+          telemetry?.captureTelemetryError({
+            harness: 'openclaw',
+            telemetrySource: report.event.telemetrySource,
+            sourceEventName: report.event.sourceEventName ?? null,
+            sessionKey: report.event.sessionKey ?? null,
+            sessionId: report.event.sessionId ?? null,
+            runId: report.event.runId ?? null,
+            accountId: report.event.accountId ?? account.accountId,
+            agentId: report.event.agentId ?? null,
+            ownerShip: report.event.ownerShip ?? currentTelemetryOwnerShip(),
+            botShip: report.event.botShip ?? botShipName,
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+          });
           break;
       }
     });
@@ -1071,6 +1146,9 @@ export async function monitorTlonProvider(
               );
               return;
             } catch (err) {
+              capturePluginError('gateway_status_activation', err, {
+                attempt,
+              });
               runtime.error?.(
                 `[gateway-status] activation attempt ${attempt} failed: ${String(err)} — retrying in ${GATEWAY_STATUS_ACTIVATION_RETRY_MS / 1000}s`
               );
@@ -1078,6 +1156,7 @@ export async function monitorTlonProvider(
             await abortableDelay(GATEWAY_STATUS_ACTIVATION_RETRY_MS, signal);
           }
         } catch (err) {
+          capturePluginError('gateway_status_activation', err);
           runtime.error?.(`[gateway-status] start failed: ${String(err)}`);
         }
       })();
@@ -3328,6 +3407,7 @@ export async function monitorTlonProvider(
         path: '/v4',
         event: (data) => handleChannelsFirehose(data as ChannelFirehoseEvent),
         err: (error) => {
+          capturePluginError('channels_firehose', error);
           runtime.error?.(`[tlon] Channels firehose error: ${String(error)}`);
         },
         quit: () => {
@@ -3344,6 +3424,7 @@ export async function monitorTlonProvider(
         path: '/v4',
         event: (data) => handleChatFirehose(data as ChatFirehoseEvent),
         err: (error) => {
+          capturePluginError('chat_firehose', error);
           runtime.error?.(`[tlon] Chat firehose error: ${String(error)}`);
         },
         quit: () => {
@@ -3412,6 +3493,7 @@ export async function monitorTlonProvider(
           }
         },
         err: (error) => {
+          capturePluginError('contacts_subscription', error);
           runtime.error?.(
             `[tlon] Contacts subscription error: ${String(error)}`
           );
@@ -3824,6 +3906,7 @@ export async function monitorTlonProvider(
             }
           },
           err: (error) => {
+            capturePluginError('groups_ui_subscription', error);
             runtime.error?.(
               `[tlon] Groups-ui subscription error: ${String(error)}`
             );
@@ -3839,6 +3922,7 @@ export async function monitorTlonProvider(
         );
       } catch (err) {
         // Groups-ui subscription is optional - channel discovery will still work via polling
+        capturePluginError('groups_ui_subscription', err);
         runtime.log?.(
           `[tlon] Groups-ui subscription failed (will rely on polling): ${String(err)}`
         );
@@ -3987,6 +4071,7 @@ export async function monitorTlonProvider(
               })();
             },
             err: (error) => {
+              capturePluginError('foreigns_subscription', error);
               runtime.error?.(
                 `[tlon] Foreigns subscription error: ${String(error)}`
               );
@@ -4001,6 +4086,7 @@ export async function monitorTlonProvider(
             '[tlon] Subscribed to foreigns (/v1/foreigns) for auto-accepting group invites'
           );
         } catch (err) {
+          capturePluginError('foreigns_subscription', err);
           runtime.log?.(`[tlon] Foreigns subscription failed: ${String(err)}`);
         }
       }
@@ -4080,6 +4166,7 @@ export async function monitorTlonProvider(
             fresh: refreshResult.fresh,
           });
         } catch (err) {
+          capturePluginError('settings_refresh', err);
           runtime.error?.(`[tlon] Settings refresh failed: ${String(err)}`);
         }
       }, SETTINGS_REFRESH_INTERVAL_MS);
@@ -4175,6 +4262,7 @@ export async function monitorTlonProvider(
       clearShadowsForAccount(account.accountId);
       setOutboundRouteReporter(null);
       setSessionTelemetryReporter(null);
+      setErrorTelemetryReporter(null);
       await telemetry?.close();
       try {
         await api?.close();

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -635,7 +635,12 @@ export async function monitorTlonProvider(
     setErrorTelemetryReporter((report) => {
       switch (report.kind) {
         case 'harness':
-          telemetry?.captureHarnessError(report.event);
+          telemetry?.captureHarnessError({
+            ...report.event,
+            accountId: report.event.accountId ?? account.accountId,
+            ownerShip: report.event.ownerShip ?? currentTelemetryOwnerShip(),
+            botShip: report.event.botShip || botShipName,
+          });
           break;
         case 'plugin':
           telemetry?.capturePluginError({

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -44,6 +44,7 @@ import {
   parseChannelNest,
 } from '../targets.js';
 import {
+  type TlonDeliverySkipReason,
   type TlonPluginErrorSource,
   createTlonTelemetry,
   formatTlonTelemetryErrorText,
@@ -2446,6 +2447,10 @@ export async function monitorTlonProvider(
       let replyCharCount = 0;
       let replyWordCount = 0;
       let replyMediaCount = 0;
+      let deliverySkipReason: TlonDeliverySkipReason | null = null;
+      const recordDeliverySkip = (reason: TlonDeliverySkipReason) => {
+        deliverySkipReason ??= reason;
+      };
 
       const responsePrefix = core.channel.reply.resolveEffectiveMessagesConfig(
         cfg,
@@ -2573,9 +2578,20 @@ export async function monitorTlonProvider(
                 responsePrefix,
                 humanDelay,
                 typingCallbacks,
+                onSkip: (_payload, info) => {
+                  recordDeliverySkip(info.reason);
+                },
                 deliver: async (payload: ReplyPayload) => {
                   let replyText = payload.text;
                   if (!replyText) {
+                    const hasMedia = Array.isArray(payload.mediaUrls)
+                      ? payload.mediaUrls.length > 0
+                      : Boolean(payload.mediaUrl);
+                    recordDeliverySkip(
+                      hasMedia
+                        ? 'media_only_payload_not_sent'
+                        : 'empty_payload_text'
+                    );
                     return;
                   }
 
@@ -2585,6 +2601,7 @@ export async function monitorTlonProvider(
                     senderShip
                   );
                   if (!replyText) {
+                    recordDeliverySkip('block_directive_only');
                     return;
                   } // Response was only a directive
 
@@ -2705,6 +2722,7 @@ export async function monitorTlonProvider(
           queuedFinalCount: dispatchResult?.counts.final ?? 0,
           queuedBlockCount: dispatchResult?.counts.block ?? 0,
           failedCounts: dispatchResult?.failedCounts,
+          deliverySkipReason,
           sourceReplyDeliveryMode:
             dispatchResult?.sourceReplyDeliveryMode ?? null,
           beforeAgentRunBlocked: dispatchResult?.beforeAgentRunBlocked === true,

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1,5 +1,6 @@
 import type { Story } from '@tloncorp/api';
 import { configureGatewayStatus, gatewayStart } from '@tloncorp/api';
+import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import { createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
 import type { OpenClawConfig, ReplyPayload } from 'openclaw/plugin-sdk/core';
@@ -42,7 +43,11 @@ import {
   normalizeShip,
   parseChannelNest,
 } from '../targets.js';
-import { createTlonTelemetry, setOutboundRouteReporter } from '../telemetry.js';
+import {
+  createTlonTelemetry,
+  setOutboundRouteReporter,
+  setSessionTelemetryReporter,
+} from '../telemetry.js';
 import { resolveTlonAccount } from '../types.js';
 import { configureTlonApiWithPoke } from '../urbit/api-client.js';
 import { authenticate } from '../urbit/auth.js';
@@ -573,6 +578,19 @@ export async function monitorTlonProvider(
         botShip: botShipName,
       })
     );
+    setSessionTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'lifecycle':
+          telemetry?.captureSessionLifecycle(report.event);
+          break;
+        case 'watchdog':
+          telemetry?.captureSessionWatchdog(report.event);
+          break;
+        case 'recovery':
+          telemetry?.captureSessionRecovery(report.event);
+          break;
+      }
+    });
 
     // Track threads we've participated in (by parentId) - respond without mention requirement
     const participatedThreads = new Set<string>();
@@ -2325,11 +2343,16 @@ export async function monitorTlonProvider(
           : undefined;
 
       const dispatchStartTime = Date.now();
+      const runId = randomUUID();
       const replyTelemetry = telemetry?.startReply({
         sessionKey: route.sessionKey,
+        runId,
+        accountId: account.accountId,
+        agentId: route.agentId,
         ownerShip: effectiveOwnerShip,
         botShip: botShipName,
         chatType: isGroup ? 'groupChannel' : 'dm',
+        destinationKind: isGroup ? 'groupChannel' : 'dm',
         isThreadReply: Boolean(isThreadReply),
         senderRole,
         attachmentCount,
@@ -2338,6 +2361,9 @@ export async function monitorTlonProvider(
       let selectedModel: string | null = null;
       let selectedThinkLevel: string | null = null;
       let deliveredMessageCount = 0;
+      let sendAttemptCount = 0;
+      let sendErrorCount = 0;
+      let sendErrorKind: string | null = null;
       let replyCharCount = 0;
       let replyWordCount = 0;
       let replyMediaCount = 0;
@@ -2400,6 +2426,7 @@ export async function monitorTlonProvider(
           typeof core.channel.reply.dispatchReplyWithBufferedBlockDispatcher
         >[0]['replyOptions']
       > = {
+        runId,
         onModelSelected: ({ provider, model, thinkLevel }) => {
           selectedProvider = provider;
           selectedModel = model;
@@ -2428,6 +2455,9 @@ export async function monitorTlonProvider(
         | {
             queuedFinal: boolean;
             counts: Record<string, number>;
+            failedCounts?: Partial<Record<string, number>>;
+            sourceReplyDeliveryMode?: string;
+            beforeAgentRunBlocked?: boolean;
           }
         | undefined;
       let dispatchError: unknown;
@@ -2521,6 +2551,7 @@ export async function monitorTlonProvider(
                     );
                   }
 
+                  sendAttemptCount += 1;
                   if (isGroup && groupChannel) {
                     // Send to any channel type (chat, heap, diary) using the nest directly
                     await sendChannelPost({
@@ -2549,13 +2580,6 @@ export async function monitorTlonProvider(
                     });
                   }
 
-                  if (presenceConversationId) {
-                    await computingPresence.stopRun({
-                      conversationId: presenceConversationId,
-                      runId: presenceRunId,
-                    });
-                  }
-
                   deliveredMessageCount += 1;
                   replyCharCount += replyText.length;
                   replyWordCount += replyText.trim()
@@ -2566,9 +2590,18 @@ export async function monitorTlonProvider(
                     : payload.mediaUrl
                       ? 1
                       : 0;
+
+                  if (presenceConversationId) {
+                    await computingPresence.stopRun({
+                      conversationId: presenceConversationId,
+                      runId: presenceRunId,
+                    });
+                  }
                 },
                 onError: (err, info) => {
                   const dispatchDuration = Date.now() - dispatchStartTime;
+                  sendErrorCount += 1;
+                  sendErrorKind = info.kind;
                   runtime.error?.(
                     `[tlon] ${info.kind} reply failed after ${dispatchDuration}ms: ${String(err)}`
                   );
@@ -2581,6 +2614,9 @@ export async function monitorTlonProvider(
         throw error;
       } finally {
         await replyTelemetry?.capture({
+          sendAttemptCount,
+          sendErrorCount,
+          sendErrorKind,
           deliveredMessageCount,
           replyCharCount,
           replyWordCount,
@@ -2589,6 +2625,10 @@ export async function monitorTlonProvider(
           queuedFinal: dispatchResult?.queuedFinal ?? false,
           queuedFinalCount: dispatchResult?.counts.final ?? 0,
           queuedBlockCount: dispatchResult?.counts.block ?? 0,
+          failedCounts: dispatchResult?.failedCounts,
+          sourceReplyDeliveryMode:
+            dispatchResult?.sourceReplyDeliveryMode ?? null,
+          beforeAgentRunBlocked: dispatchResult?.beforeAgentRunBlocked === true,
           provider: selectedProvider,
           model: selectedModel,
           thinkLevel: selectedThinkLevel,
@@ -4134,6 +4174,7 @@ export async function monitorTlonProvider(
       await pendingNudgePersistence.flush();
       clearShadowsForAccount(account.accountId);
       setOutboundRouteReporter(null);
+      setSessionTelemetryReporter(null);
       await telemetry?.close();
       try {
         await api?.close();

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -764,7 +764,12 @@ describe('telemetry tool tracking', () => {
     setErrorTelemetryReporter((report) => {
       switch (report.kind) {
         case 'harness':
-          telemetry.captureHarnessError(report.event);
+          telemetry.captureHarnessError({
+            ...report.event,
+            accountId: report.event.accountId ?? 'default',
+            ownerShip: report.event.ownerShip ?? '~zod',
+            botShip: report.event.botShip || '~nec',
+          });
           break;
         case 'plugin':
           telemetry.capturePluginError({
@@ -962,6 +967,42 @@ describe('telemetry tool tracking', () => {
       failureKind: 'connection_reset',
       durationMs: 1234,
       errorText: 'full\nmodel\nerror',
+    });
+  });
+
+  it('reports process-level harness diagnostics without a session key', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportHarnessError({
+      harnessEventType: 'diagnostic.liveness.warning',
+      errorScope: 'runtime',
+      outcome: 'warning',
+      errorCategory: 'liveness_warning',
+      failureKind: 'event_loop_delay',
+      durationMs: 30_000,
+      errorText: 'reasons=event_loop_delay eventLoopDelayP99Ms=250',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      harnessEventType: 'diagnostic.liveness.warning',
+      errorScope: 'runtime',
+      sessionKey: null,
+      sessionId: null,
+      runId: null,
+      accountId: 'default',
+      agentId: null,
+      ownerShip: '~zod',
+      botShip: '~nec',
+      destinationKind: null,
+      outcome: 'warning',
+      errorCategory: 'liveness_warning',
+      failureKind: 'event_loop_delay',
+      durationMs: 30_000,
+      errorText: 'reasons=event_loop_delay eventLoopDelayP99Ms=250',
     });
   });
 

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -68,6 +68,8 @@ describe('telemetry tool tracking', () => {
     sessionKey?: string;
     deliveredMessageCount?: number;
     dispatchError?: unknown;
+    deliverySkipReason?: 'empty' | 'silent' | 'heartbeat';
+    sourceReplyDeliveryMode?: string | null;
   }) {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
@@ -93,7 +95,8 @@ describe('telemetry tool tracking', () => {
       queuedFinalCount: 1,
       queuedBlockCount: 0,
       failedCounts: { tool: 0, block: 0, final: 0 },
-      sourceReplyDeliveryMode: 'automatic',
+      deliverySkipReason: params?.deliverySkipReason ?? null,
+      sourceReplyDeliveryMode: params?.sourceReplyDeliveryMode ?? 'automatic',
       beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
@@ -214,6 +217,32 @@ describe('telemetry tool tracking', () => {
     expect(
       postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.outcome
     ).toBe('error');
+  });
+
+  it('captures delivery skip reason only for no-reply outcomes', async () => {
+    await captureReply({
+      deliveredMessageCount: 0,
+      deliverySkipReason: 'silent',
+    });
+    expect(
+      postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.deliverySkipReason
+    ).toBe('silent');
+
+    await captureReply({
+      deliveredMessageCount: 1,
+      deliverySkipReason: 'silent',
+    });
+    expect(
+      postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.deliverySkipReason
+    ).toBeNull();
+
+    await captureReply({
+      deliveredMessageCount: 0,
+      sourceReplyDeliveryMode: 'message_tool_only',
+    });
+    expect(
+      postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.deliverySkipReason
+    ).toBe('source_reply_delivery_mode_message_tool_only');
   });
 
   it('classifies direct send and dispatcher failures as errors', async () => {
@@ -388,6 +417,7 @@ describe('telemetry tool tracking', () => {
         failedBlockCount: 0,
         failedFinalCount: 0,
         failedReplyCount: 0,
+        deliverySkipReason: null,
         sourceReplyDeliveryMode: 'automatic',
         beforeAgentRunBlocked: false,
         dispatchError: false,

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -4,9 +4,14 @@ import {
   _testing,
   createTlonTelemetry,
   recordToolCall,
+  reportHarnessError,
   reportOutboundRoute,
+  reportPluginError,
   reportSessionDiagnostic,
   reportSessionLifecycle,
+  reportSessionTurnCreated,
+  reportTelemetryError,
+  setErrorTelemetryReporter,
   setOutboundRouteReporter,
   setSessionTelemetryReporter,
 } from './telemetry.js';
@@ -38,6 +43,7 @@ describe('telemetry tool tracking', () => {
     _testing.clearToolCalls();
     _testing.clearSessionContexts();
     setSessionTelemetryReporter(null);
+    setErrorTelemetryReporter(null);
     postHogMocks.identify.mockClear();
     postHogMocks.capture.mockClear();
     postHogMocks.flush.mockClear();
@@ -722,6 +728,46 @@ describe('telemetry tool tracking', () => {
     });
   }
 
+  function bindErrorReporter(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    setErrorTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'harness':
+          telemetry.captureHarnessError(report.event);
+          break;
+        case 'plugin':
+          telemetry.capturePluginError({
+            harness: 'openclaw',
+            pluginErrorSource: report.event.pluginErrorSource,
+            accountId: report.event.accountId ?? 'default',
+            ownerShip: report.event.ownerShip ?? '~zod',
+            botShip: report.event.botShip ?? '~nec',
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+            attempt: report.event.attempt ?? null,
+          });
+          break;
+        case 'telemetry':
+          telemetry.captureTelemetryError({
+            harness: 'openclaw',
+            telemetrySource: report.event.telemetrySource,
+            sourceEventName: report.event.sourceEventName ?? null,
+            sessionKey: report.event.sessionKey ?? null,
+            sessionId: report.event.sessionId ?? null,
+            runId: report.event.runId ?? null,
+            accountId: report.event.accountId ?? 'default',
+            agentId: report.event.agentId ?? null,
+            ownerShip: report.event.ownerShip ?? '~zod',
+            botShip: report.event.botShip ?? '~nec',
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+          });
+          break;
+      }
+    });
+  }
+
   it('reports lifecycle hooks only for remembered Tlon sessions', async () => {
     const telemetry = createEnabledTelemetry()!;
     bindSessionReporter(telemetry);
@@ -827,6 +873,129 @@ describe('telemetry tool tracking', () => {
       stale: true,
     });
   });
+
+  it('reports harness errors only for remembered Tlon sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'unknown-session',
+      runId: 'ignored-run',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      durationMs: 1234,
+      errorText: 'full\nmodel\nerror',
+    });
+    expect(postHogMocks.capture).not.toHaveBeenCalled();
+
+    reportSessionTurnCreated({
+      type: 'session.turn.created',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      agentId: 'agent-main',
+    });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      durationMs: 1234,
+      errorText: 'full\nmodel\nerror',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      destinationKind: 'dm',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      durationMs: 1234,
+      errorText: 'full\nmodel\nerror',
+    });
+  });
+
+  it('captures plugin errors without throttling or truncating error text', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportPluginError({
+      pluginErrorSource: 'chat_firehose',
+      errorKind: 'Error',
+      errorText: 'first full error\nwith details',
+      attempt: null,
+    });
+    reportPluginError({
+      pluginErrorSource: 'chat_firehose',
+      errorKind: 'Error',
+      errorText: 'second full error\nwith details',
+      attempt: null,
+    });
+
+    const calls = postHogMocks.capture.mock.calls.map((call) => call[0]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].event).toBe('TlonBot Plugin Error');
+    expect(calls[0].properties).toMatchObject({
+      harness: 'openclaw',
+      pluginErrorSource: 'chat_firehose',
+      accountId: 'default',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      errorKind: 'Error',
+      errorText: 'first full error\nwith details',
+      attempt: null,
+    });
+    expect(calls[1].properties.errorText).toBe(
+      'second full error\nwith details'
+    );
+  });
+
+  it('captures telemetry observer failures', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportTelemetryError({
+      telemetrySource: 'diagnostic_internal',
+      sourceEventName: 'model.call.error',
+      sessionKey: 'session-1',
+      errorKind: 'TypeError',
+      errorText: 'observer exploded\nwith details',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Telemetry Error');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      telemetrySource: 'diagnostic_internal',
+      sourceEventName: 'model.call.error',
+      sessionKey: 'session-1',
+      accountId: 'default',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      errorKind: 'TypeError',
+      errorText: 'observer exploded\nwith details',
+    });
+  });
 });
 
 describe('outbound route telemetry', () => {
@@ -836,6 +1005,7 @@ describe('outbound route telemetry', () => {
     postHogMocks.capture.mockClear();
     setOutboundRouteReporter(null);
     setSessionTelemetryReporter(null);
+    setErrorTelemetryReporter(null);
   });
 
   function createEnabledTelemetry() {

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1,11 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   _testing,
   createTlonTelemetry,
   recordToolCall,
   reportOutboundRoute,
+  reportSessionDiagnostic,
+  reportSessionLifecycle,
   setOutboundRouteReporter,
+  setSessionTelemetryReporter,
 } from './telemetry.js';
 
 const postHogMocks = vi.hoisted(() => ({
@@ -16,13 +19,9 @@ const postHogMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('posthog-node', () => ({
-  PostHog: vi.fn(
-    class MockPostHog {
-      constructor() {
-        return postHogMocks;
-      }
-    }
-  ),
+  PostHog: vi.fn(function MockPostHog() {
+    return postHogMocks;
+  }),
 }));
 
 const VERSION_IDENTITY_MATCH = {
@@ -37,10 +36,16 @@ const VERSION_IDENTITY_MATCH = {
 describe('telemetry tool tracking', () => {
   beforeEach(() => {
     _testing.clearToolCalls();
+    _testing.clearSessionContexts();
+    setSessionTelemetryReporter(null);
     postHogMocks.identify.mockClear();
     postHogMocks.capture.mockClear();
     postHogMocks.flush.mockClear();
     postHogMocks.shutdown.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function createEnabledTelemetry() {
@@ -61,6 +66,9 @@ describe('telemetry tool tracking', () => {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
       sessionKey: params?.sessionKey ?? 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
       ownerShip: '~zod',
       botShip: '~nec',
       chatType: 'dm',
@@ -78,6 +86,9 @@ describe('telemetry tool tracking', () => {
       queuedFinal: false,
       queuedFinalCount: 1,
       queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
       thinkLevel: null,
@@ -98,6 +109,9 @@ describe('telemetry tool tracking', () => {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
       sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
       ownerShip: '~zod',
       botShip: '~nec',
       chatType: 'dm',
@@ -126,6 +140,9 @@ describe('telemetry tool tracking', () => {
       queuedFinal: false,
       queuedFinalCount: 1,
       queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
       thinkLevel: null,
@@ -193,10 +210,94 @@ describe('telemetry tool tracking', () => {
     ).toBe('error');
   });
 
-  it('captures camelCase telemetry properties without routing metadata', async () => {
+  it('classifies direct send and dispatcher failures as errors', async () => {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
       sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'groupChannel',
+      destinationKind: 'groupChannel',
+      isThreadReply: true,
+      senderRole: 'user',
+      attachmentCount: 0,
+    });
+
+    await replyTelemetry?.capture({
+      sendAttemptCount: 1,
+      sendErrorCount: 1,
+      sendErrorKind: 'final',
+      deliveredMessageCount: 0,
+      replyCharCount: 0,
+      replyWordCount: 0,
+      replyMediaCount: 0,
+      dispatchDurationMs: 750,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 1 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: true,
+      provider: 'anthropic',
+      model: 'claude-test',
+      thinkLevel: 'medium',
+    });
+
+    const props = postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties;
+    expect(props).toMatchObject({
+      outcome: 'error',
+      destinationKind: 'groupChannel',
+      sendAttemptCount: 1,
+      sendError: true,
+      sendErrorCount: 1,
+      sendErrorKind: 'final',
+      failedFinalCount: 1,
+      failedReplyCount: 1,
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: true,
+    });
+  });
+
+  it('emits abandoned reply telemetry for stale traces', () => {
+    vi.useFakeTimers();
+
+    const telemetry = createEnabledTelemetry();
+    telemetry?.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'dm',
+      isThreadReply: false,
+      senderRole: 'owner',
+      attachmentCount: 0,
+    });
+
+    vi.advanceTimersByTime(_testing.getReplyTraceTtlMs());
+
+    const props = postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties;
+    expect(props).toMatchObject({
+      outcome: 'abandoned',
+      abandonedReason: 'stale',
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      deliveredMessageCount: 0,
+      sendAttemptCount: 0,
+    });
+  });
+
+  it('captures camelCase reply telemetry properties with turn context', async () => {
+    const telemetry = createEnabledTelemetry();
+    const replyTelemetry = telemetry?.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
       ownerShip: '~zod',
       botShip: '~nec',
       chatType: 'dm',
@@ -220,6 +321,9 @@ describe('telemetry tool tracking', () => {
       queuedFinal: false,
       queuedFinalCount: 1,
       queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
       thinkLevel: null,
@@ -250,12 +354,22 @@ describe('telemetry tool tracking', () => {
         adapterFingerprint: expect.stringMatching(/^fp1:[a-f0-9]{12}$/),
         botShip: '~nec',
         ownerShip: '~zod',
+        sessionKey: 'session-1',
+        sessionId: null,
+        runId: 'run-1',
+        accountId: 'default',
+        agentId: 'agent-main',
         outcome: 'responded',
         chatType: 'dm',
+        destinationKind: 'dm',
         isThreadReply: false,
         senderRole: 'owner',
         attachmentCount: 1,
         hasAttachments: true,
+        sendAttemptCount: 0,
+        sendError: false,
+        sendErrorCount: 0,
+        sendErrorKind: null,
         deliveredMessageCount: 1,
         replyCharCount: 42,
         replyWordCount: 7,
@@ -264,6 +378,15 @@ describe('telemetry tool tracking', () => {
         queuedFinal: false,
         queuedFinalCount: 1,
         queuedBlockCount: 0,
+        failedToolCount: 0,
+        failedBlockCount: 0,
+        failedFinalCount: 0,
+        failedReplyCount: 0,
+        sourceReplyDeliveryMode: 'automatic',
+        beforeAgentRunBlocked: false,
+        dispatchError: false,
+        dispatchErrorKind: null,
+        abandonedReason: null,
         provider: 'anthropic',
         model: 'claude-test',
         thinkLevel: null,
@@ -282,14 +405,61 @@ describe('telemetry tool tracking', () => {
     });
 
     const capturedEvent = postHogMocks.capture.mock.calls[0]?.[0];
-    expect(capturedEvent?.properties).not.toHaveProperty('accountId');
-    expect(capturedEvent?.properties).not.toHaveProperty('agentId');
     expect(capturedEvent?.properties).not.toHaveProperty('channel');
+    expect(capturedEvent?.properties).not.toHaveProperty('messageId');
+    expect(capturedEvent?.properties).not.toHaveProperty('messageIds');
+    expect(capturedEvent?.properties).not.toHaveProperty('inboundMessageId');
+    expect(capturedEvent?.properties).not.toHaveProperty('outboundMessageIds');
 
     await telemetry?.close();
 
     expect(postHogMocks.flush).toHaveBeenCalledTimes(1);
     expect(postHogMocks.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('threads OpenClaw sessionId from lifecycle into reply telemetry', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    const replyTelemetry = telemetry.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'dm',
+      isThreadReply: false,
+      senderRole: 'owner',
+      attachmentCount: 0,
+    });
+
+    reportSessionLifecycle({
+      lifecycleEvent: 'session_start',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      agentId: 'agent-main',
+    });
+
+    await replyTelemetry.capture({
+      deliveredMessageCount: 1,
+      replyCharCount: 12,
+      replyWordCount: 2,
+      replyMediaCount: 0,
+      dispatchDurationMs: 150,
+      queuedFinal: true,
+      queuedFinalCount: 1,
+      queuedBlockCount: 0,
+      provider: null,
+      model: null,
+      thinkLevel: null,
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Reply Handled');
+    expect(call.properties).toMatchObject({
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-1',
+    });
   });
 
   it('captures gateway connected with version identity', () => {
@@ -501,13 +671,171 @@ describe('telemetry tool tracking', () => {
     expect(capturedEvent?.event).toBe('TlonBot Reply Handled');
     expect(capturedEvent?.properties.outcome).toBe('responded');
   });
+
+  async function rememberSessionForDiagnostics(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    const replyTelemetry = telemetry.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'dm',
+      isThreadReply: false,
+      senderRole: 'owner',
+      attachmentCount: 0,
+    });
+
+    await replyTelemetry.capture({
+      deliveredMessageCount: 1,
+      replyCharCount: 10,
+      replyWordCount: 2,
+      replyMediaCount: 0,
+      dispatchDurationMs: 100,
+      queuedFinal: true,
+      queuedFinalCount: 1,
+      queuedBlockCount: 0,
+      provider: null,
+      model: null,
+      thinkLevel: null,
+    });
+    postHogMocks.capture.mockClear();
+  }
+
+  function bindSessionReporter(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    setSessionTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'lifecycle':
+          telemetry.captureSessionLifecycle(report.event);
+          break;
+        case 'watchdog':
+          telemetry.captureSessionWatchdog(report.event);
+          break;
+        case 'recovery':
+          telemetry.captureSessionRecovery(report.event);
+          break;
+      }
+    });
+  }
+
+  it('reports lifecycle hooks only for remembered Tlon sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindSessionReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportSessionLifecycle({
+      lifecycleEvent: 'session_start',
+      sessionKey: 'unknown-session',
+      sessionId: 'ignored',
+    });
+    expect(postHogMocks.capture).not.toHaveBeenCalled();
+
+    reportSessionLifecycle({
+      lifecycleEvent: 'session_end',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      agentId: 'agent-main',
+      reason: 'idle',
+      messageCount: 3,
+      durationMs: 1200,
+      transcriptArchived: true,
+      hasNextSession: true,
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Lifecycle');
+    expect(call.properties).toMatchObject({
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      destinationKind: 'dm',
+      lifecycleEvent: 'session_end',
+      reason: 'idle',
+      messageCount: 3,
+      durationMs: 1200,
+      transcriptArchived: true,
+      hasNextSession: true,
+    });
+  });
+
+  it('reports high-signal watchdog and recovery diagnostics for remembered sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindSessionReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportSessionDiagnostic({
+      type: 'session.stalled',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      state: 'processing',
+      ageMs: 60_000,
+      queueDepth: 1,
+      reason: 'tool_call_stalled',
+      classification: 'blocked_tool_call',
+      activeWorkKind: 'tool_call',
+      activeToolName: 'tlon',
+      activeToolAgeMs: 55_000,
+      lastProgressAgeMs: 56_000,
+      lastProgressReason: 'tool:tlon:started',
+      terminalProgressStale: true,
+    });
+
+    let call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Watchdog');
+    expect(call.properties).toMatchObject({
+      diagnosticType: 'session.stalled',
+      sessionKey: 'session-1',
+      classification: 'blocked_tool_call',
+      activeWorkKind: 'tool_call',
+      activeToolName: 'tlon',
+      terminalProgressStale: true,
+    });
+
+    reportSessionDiagnostic({
+      type: 'session.recovery.completed',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      state: 'processing',
+      stateGeneration: 7,
+      ageMs: 90_000,
+      queueDepth: 1,
+      activeWorkKind: 'tool_call',
+      status: 'released',
+      action: 'release_lane',
+      outcomeReason: 'stale_session_state',
+      released: 1,
+      stale: true,
+    });
+
+    call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Recovery');
+    expect(call.properties).toMatchObject({
+      diagnosticType: 'session.recovery.completed',
+      sessionKey: 'session-1',
+      stateGeneration: 7,
+      status: 'released',
+      action: 'release_lane',
+      outcomeReason: 'stale_session_state',
+      released: 1,
+      stale: true,
+    });
+  });
 });
 
 describe('outbound route telemetry', () => {
   beforeEach(() => {
+    _testing.clearSessionContexts();
     postHogMocks.identify.mockClear();
     postHogMocks.capture.mockClear();
     setOutboundRouteReporter(null);
+    setSessionTelemetryReporter(null);
   });
 
   function createEnabledTelemetry() {

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -274,6 +274,9 @@ export type TlonHarnessErrorScope =
   | 'model'
   | 'tool'
   | 'run'
+  | 'runtime'
+  | 'diagnostics'
+  | 'payload'
   | 'message_delivery'
   | 'message_dispatch'
   | 'message_processing';
@@ -282,14 +285,14 @@ export type TlonHarnessErrorEvent = {
   harness: TlonHarnessName;
   harnessEventType: string;
   errorScope: TlonHarnessErrorScope;
-  sessionKey: string;
+  sessionKey: string | null;
   sessionId: string | null;
   runId: string | null;
   accountId: string | null;
   agentId: string | null;
   ownerShip: string | null;
   botShip: string;
-  destinationKind: TlonDestinationKind;
+  destinationKind: TlonDestinationKind | null;
   provider: string | null;
   model: string | null;
   toolName: string | null;
@@ -1372,7 +1375,11 @@ export type TlonHarnessErrorReportInput = {
   sessionKey?: string | null;
   sessionId?: string | null;
   runId?: string | null;
+  accountId?: string | null;
   agentId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  destinationKind?: TlonDestinationKind | null;
   provider?: string | null;
   model?: string | null;
   toolName?: string | null;
@@ -1506,7 +1513,7 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
         agentId: event.agentId,
       })
     : null;
-  if (!context) {
+  if (!context && event.sessionKey) {
     return;
   }
 
@@ -1516,14 +1523,15 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
       harness: 'openclaw',
       harnessEventType: event.harnessEventType,
       errorScope: event.errorScope,
-      sessionKey: context.sessionKey,
-      sessionId: context.sessionId,
-      runId: optionalString(event.runId) ?? context.runId,
-      accountId: context.accountId,
-      agentId: optionalString(event.agentId) ?? context.agentId,
-      ownerShip: context.ownerShip,
-      botShip: context.botShip,
-      destinationKind: context.destinationKind,
+      sessionKey: context?.sessionKey ?? null,
+      sessionId: context?.sessionId ?? optionalString(event.sessionId),
+      runId: optionalString(event.runId) ?? context?.runId ?? null,
+      accountId: context?.accountId ?? optionalString(event.accountId),
+      agentId: optionalString(event.agentId) ?? context?.agentId ?? null,
+      ownerShip: context?.ownerShip ?? optionalString(event.ownerShip),
+      botShip: context?.botShip ?? optionalString(event.botShip) ?? '',
+      destinationKind:
+        context?.destinationKind ?? event.destinationKind ?? null,
       provider: optionalString(event.provider),
       model: optionalString(event.model),
       toolName: optionalString(event.toolName),

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -17,6 +17,7 @@ type ToolSessionTrace = {
   calls: ToolCallRecord[];
 };
 
+export type TlonHarnessName = 'openclaw' | 'hermes';
 type ReplyDispatchKind = 'tool' | 'block' | 'final';
 type ReplyDispatchCounts = Partial<Record<ReplyDispatchKind, number>>;
 type TlonDestinationKind = 'dm' | 'groupChannel';
@@ -24,6 +25,7 @@ type TlonDestinationKind = 'dm' | 'groupChannel';
 type TlonSessionTelemetryContext = {
   sessionKey: string;
   sessionId: string | null;
+  runId: string | null;
   ownerShip: string | null;
   botShip: string;
   accountId: string | null;
@@ -257,6 +259,76 @@ export type TlonSessionTelemetryReport =
   | { kind: 'watchdog'; event: TlonSessionWatchdogEvent }
   | { kind: 'recovery'; event: TlonSessionRecoveryEvent };
 
+export type TlonHarnessErrorScope =
+  | 'harness'
+  | 'model'
+  | 'tool'
+  | 'run'
+  | 'message_delivery'
+  | 'message_dispatch'
+  | 'message_processing';
+
+export type TlonHarnessErrorEvent = {
+  harness: TlonHarnessName;
+  harnessEventType: string;
+  errorScope: TlonHarnessErrorScope;
+  sessionKey: string;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  provider: string | null;
+  model: string | null;
+  toolName: string | null;
+  phase: string | null;
+  outcome: string | null;
+  errorCategory: string | null;
+  failureKind: string | null;
+  durationMs: number | null;
+  errorText: string | null;
+};
+
+export type TlonPluginErrorSource =
+  | 'auth'
+  | 're_auth'
+  | 'gateway_status_activation'
+  | 'gateway_status_heartbeat'
+  | 'channels_firehose'
+  | 'chat_firehose'
+  | 'contacts_subscription'
+  | 'groups_ui_subscription'
+  | 'foreigns_subscription'
+  | 'settings_refresh';
+
+export type TlonPluginErrorEvent = {
+  harness: TlonHarnessName;
+  pluginErrorSource: TlonPluginErrorSource;
+  accountId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  errorKind: string | null;
+  errorText: string;
+  attempt: number | null;
+};
+
+export type TlonTelemetryErrorEvent = {
+  harness: TlonHarnessName;
+  telemetrySource: string;
+  sourceEventName: string | null;
+  sessionKey: string | null;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  errorKind: string | null;
+  errorText: string;
+};
+
 export interface TlonTelemetryClient {
   captureGatewayConnected(event: TlonGatewayConnectedEvent): void;
   startReply(params: TlonReplyTelemetryStart): TlonReplyTelemetrySession;
@@ -265,6 +337,9 @@ export interface TlonTelemetryClient {
   captureSessionLifecycle(event: TlonSessionLifecycleEvent): void;
   captureSessionWatchdog(event: TlonSessionWatchdogEvent): void;
   captureSessionRecovery(event: TlonSessionRecoveryEvent): void;
+  captureHarnessError(event: TlonHarnessErrorEvent): void;
+  capturePluginError(event: TlonPluginErrorEvent): void;
+  captureTelemetryError(event: TlonTelemetryErrorEvent): void;
   captureOutboundRoute(
     event: TlonOutboundRouteEvent & {
       ownerShip?: string | null;
@@ -280,6 +355,9 @@ const TLON_OUTBOUND_ROUTED_EVENT = 'TlonBot Outbound Routed';
 const TLON_SESSION_LIFECYCLE_EVENT = 'TlonBot Session Lifecycle';
 const TLON_SESSION_WATCHDOG_EVENT = 'TlonBot Session Watchdog';
 const TLON_SESSION_RECOVERY_EVENT = 'TlonBot Session Recovery';
+const TLON_HARNESS_ERROR_EVENT = 'TlonBot Harness Error';
+const TLON_PLUGIN_ERROR_EVENT = 'TlonBot Plugin Error';
+const TLON_TELEMETRY_ERROR_EVENT = 'TlonBot Telemetry Error';
 const TLON_HEARTBEAT_NUDGE_EVENT = 'TlonBot Heartbeat Nudge Sent';
 const TLON_HEARTBEAT_REENGAGED_EVENT = 'TlonBot Heartbeat Nudge Reengaged';
 const TLON_TELEMETRY_LOG_SOURCE = 'openclawPlugin';
@@ -394,6 +472,7 @@ function cleanupSessionContexts(now = Date.now()): void {
 function rememberTlonSessionContext(params: {
   sessionKey: string;
   sessionId?: string | null;
+  runId?: string | null;
   ownerShip: string | null;
   botShip: string;
   accountId?: string | null;
@@ -411,6 +490,7 @@ function rememberTlonSessionContext(params: {
   sessionContextsBySessionKey.set(sessionKey, {
     sessionKey,
     sessionId: optionalString(params.sessionId) ?? existing?.sessionId ?? null,
+    runId: optionalString(params.runId) ?? existing?.runId ?? null,
     ownerShip: params.ownerShip,
     botShip: params.botShip,
     accountId: params.accountId ?? null,
@@ -451,6 +531,36 @@ function updateTlonSessionContextSessionId(
   const updated = {
     ...context,
     sessionId: normalizedSessionId,
+    updatedAt: Date.now(),
+  };
+  sessionContextsBySessionKey.set(updated.sessionKey, updated);
+  return updated;
+}
+
+function updateTlonSessionContextRuntime(
+  context: TlonSessionTelemetryContext,
+  params: {
+    sessionId?: string | null;
+    runId?: string | null;
+    agentId?: string | null;
+  }
+): TlonSessionTelemetryContext {
+  const normalizedSessionId = optionalString(params.sessionId);
+  const normalizedRunId = optionalString(params.runId);
+  const normalizedAgentId = optionalString(params.agentId);
+  if (
+    (!normalizedSessionId || context.sessionId === normalizedSessionId) &&
+    (!normalizedRunId || context.runId === normalizedRunId) &&
+    (!normalizedAgentId || context.agentId === normalizedAgentId)
+  ) {
+    return context;
+  }
+
+  const updated = {
+    ...context,
+    sessionId: normalizedSessionId ?? context.sessionId,
+    runId: normalizedRunId ?? context.runId,
+    agentId: normalizedAgentId ?? context.agentId,
     updatedAt: Date.now(),
   };
   sessionContextsBySessionKey.set(updated.sessionKey, updated);
@@ -591,6 +701,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     rememberTlonSessionContext({
       sessionKey: normalizedParams.sessionKey,
       sessionId: normalizedParams.sessionId,
+      runId: normalizedParams.runId,
       ownerShip: normalizedParams.ownerShip,
       botShip: normalizedParams.botShip,
       accountId: normalizedParams.accountId,
@@ -945,6 +1056,88 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     });
   }
 
+  captureHarnessError(event: TlonHarnessErrorEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_HARNESS_ERROR_EVENT,
+      properties: this.properties({
+        harness: event.harness,
+        harnessEventType: event.harnessEventType,
+        errorScope: event.errorScope,
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        runId: event.runId,
+        accountId: event.accountId,
+        agentId: event.agentId,
+        ownerShip: event.ownerShip,
+        botShip: event.botShip,
+        destinationKind: event.destinationKind,
+        provider: event.provider,
+        model: event.model,
+        toolName: event.toolName,
+        phase: event.phase,
+        outcome: event.outcome,
+        errorCategory: event.errorCategory,
+        failureKind: event.failureKind,
+        durationMs: event.durationMs,
+        errorText: event.errorText,
+      }),
+    });
+  }
+
+  capturePluginError(event: TlonPluginErrorEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_PLUGIN_ERROR_EVENT,
+      properties: this.properties({
+        harness: event.harness,
+        pluginErrorSource: event.pluginErrorSource,
+        accountId: event.accountId,
+        ownerShip: event.ownerShip,
+        botShip: event.botShip,
+        errorKind: event.errorKind,
+        errorText: event.errorText,
+        attempt: event.attempt,
+      }),
+    });
+  }
+
+  captureTelemetryError(event: TlonTelemetryErrorEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_TELEMETRY_ERROR_EVENT,
+      properties: this.properties({
+        harness: event.harness,
+        telemetrySource: event.telemetrySource,
+        sourceEventName: event.sourceEventName,
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        runId: event.runId,
+        accountId: event.accountId,
+        agentId: event.agentId,
+        ownerShip: event.ownerShip,
+        botShip: event.botShip,
+        errorKind: event.errorKind,
+        errorText: event.errorText,
+      }),
+    });
+  }
+
   private ensureIdentified(ownerShip: string, botShip: string): boolean {
     if (!ownerShip) {
       if (!this.missingOwnerWarningLogged) {
@@ -1074,6 +1267,12 @@ export type OutboundRouteReporter = (event: TlonOutboundRouteEvent) => void;
 export type SessionTelemetryReporter = (
   report: TlonSessionTelemetryReport
 ) => void;
+export type ErrorTelemetryReporter = (
+  report:
+    | { kind: 'harness'; event: TlonHarnessErrorEvent }
+    | { kind: 'plugin'; event: TlonPluginErrorReportInput }
+    | { kind: 'telemetry'; event: TlonTelemetryErrorReportInput }
+) => void;
 
 export type TlonSessionLifecycleReportInput = {
   lifecycleEvent: 'session_start' | 'session_end';
@@ -1122,11 +1321,64 @@ export type TlonSessionDiagnosticReportInput =
       stale?: boolean;
     };
 
+export type TlonSessionTurnCreatedReportInput = {
+  type: 'session.turn.created';
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+};
+
+export type TlonHarnessErrorReportInput = {
+  harnessEventType: string;
+  errorScope: TlonHarnessErrorScope;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+  provider?: string | null;
+  model?: string | null;
+  toolName?: string | null;
+  phase?: string | null;
+  outcome?: string | null;
+  errorCategory?: string | null;
+  failureKind?: string | null;
+  durationMs?: number | null;
+  errorText?: string | null;
+};
+
+export type TlonPluginErrorReportInput = {
+  pluginErrorSource: TlonPluginErrorSource;
+  accountId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  errorKind?: string | null;
+  errorText: string;
+  attempt?: number | null;
+};
+
+export type TlonTelemetryErrorReportInput = {
+  telemetrySource: string;
+  sourceEventName?: string | null;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+  accountId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  errorKind?: string | null;
+  errorText: string;
+};
+
 const outboundRouteReporterSlot = sharedSlot<OutboundRouteReporter>(
   'telemetry.outboundRouteReporter'
 );
 const sessionTelemetryReporterSlot = sharedSlot<SessionTelemetryReporter>(
   'telemetry.sessionTelemetryReporter'
+);
+const errorTelemetryReporterSlot = sharedSlot<ErrorTelemetryReporter>(
+  'telemetry.errorTelemetryReporter'
 );
 
 export function setOutboundRouteReporter(
@@ -1145,13 +1397,143 @@ export function setSessionTelemetryReporter(
   sessionTelemetryReporterSlot.set(reporter);
 }
 
+export function setErrorTelemetryReporter(
+  reporter: ErrorTelemetryReporter | null
+): void {
+  errorTelemetryReporterSlot.set(reporter);
+}
+
 function optionalString(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   return normalized ? normalized : null;
 }
 
+function optionalErrorText(value: string | null | undefined): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
 function optionalNumber(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function formatTlonTelemetryErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message || String(error);
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error === null) {
+    return 'null';
+  }
+
+  if (error === undefined) {
+    return 'undefined';
+  }
+
+  try {
+    const json = JSON.stringify(error);
+    if (json) {
+      return json;
+    }
+  } catch {
+    // Fall through to String(error).
+  }
+
+  return String(error);
+}
+
+export function reportSessionTurnCreated(
+  event: TlonSessionTurnCreatedReportInput
+): void {
+  const context = lookupTlonSessionContext(event.sessionKey);
+  if (!context) {
+    return;
+  }
+
+  updateTlonSessionContextRuntime(context, {
+    sessionId: event.sessionId,
+    runId: event.runId,
+    agentId: event.agentId,
+  });
+}
+
+export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextRuntime(rememberedContext, {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        agentId: event.agentId,
+      })
+    : null;
+  if (!context) {
+    return;
+  }
+
+  errorTelemetryReporterSlot.get()?.({
+    kind: 'harness',
+    event: {
+      harness: 'openclaw',
+      harnessEventType: event.harnessEventType,
+      errorScope: event.errorScope,
+      sessionKey: context.sessionKey,
+      sessionId: context.sessionId,
+      runId: optionalString(event.runId) ?? context.runId,
+      accountId: context.accountId,
+      agentId: optionalString(event.agentId) ?? context.agentId,
+      ownerShip: context.ownerShip,
+      botShip: context.botShip,
+      destinationKind: context.destinationKind,
+      provider: optionalString(event.provider),
+      model: optionalString(event.model),
+      toolName: optionalString(event.toolName),
+      phase: optionalString(event.phase),
+      outcome: optionalString(event.outcome),
+      errorCategory: optionalString(event.errorCategory),
+      failureKind: optionalString(event.failureKind),
+      durationMs: optionalNumber(event.durationMs),
+      errorText: optionalErrorText(event.errorText),
+    },
+  });
+}
+
+export function reportPluginError(event: TlonPluginErrorReportInput): void {
+  errorTelemetryReporterSlot.get()?.({
+    kind: 'plugin',
+    event,
+  });
+}
+
+export function reportTelemetryError(
+  event: TlonTelemetryErrorReportInput
+): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextRuntime(rememberedContext, {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        agentId: event.agentId,
+      })
+    : null;
+
+  errorTelemetryReporterSlot.get()?.({
+    kind: 'telemetry',
+    event: {
+      ...event,
+      sessionKey: context?.sessionKey ?? optionalString(event.sessionKey),
+      sessionId: context?.sessionId ?? optionalString(event.sessionId),
+      runId: optionalString(event.runId) ?? context?.runId ?? null,
+      agentId: optionalString(event.agentId) ?? context?.agentId ?? null,
+      accountId: event.accountId ?? context?.accountId ?? null,
+      ownerShip: event.ownerShip ?? context?.ownerShip ?? null,
+      botShip: event.botShip ?? context?.botShip ?? null,
+      sourceEventName: optionalString(event.sourceEventName),
+      errorKind: optionalString(event.errorKind),
+    },
+  });
 }
 
 export function reportSessionLifecycle(

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -82,6 +82,14 @@ export type TlonHeartbeatReengagementEvent = {
 };
 
 export type TlonReplyOutcome = 'responded' | 'no_reply' | 'error' | 'abandoned';
+export type TlonDeliverySkipReason =
+  | 'empty'
+  | 'silent'
+  | 'heartbeat'
+  | 'empty_payload_text'
+  | 'block_directive_only'
+  | 'media_only_payload_not_sent'
+  | 'source_reply_delivery_mode_message_tool_only';
 
 export type TlonReplyOutcomeEvent = {
   sessionKey: string;
@@ -113,6 +121,7 @@ export type TlonReplyOutcomeEvent = {
   failedBlockCount: number;
   failedFinalCount: number;
   failedReplyCount: number;
+  deliverySkipReason: TlonDeliverySkipReason | null;
   sourceReplyDeliveryMode: string | null;
   beforeAgentRunBlocked: boolean;
   dispatchError: boolean;
@@ -166,6 +175,7 @@ export type TlonReplyTelemetryResult = {
   queuedFinalCount: number;
   queuedBlockCount: number;
   failedCounts?: ReplyDispatchCounts;
+  deliverySkipReason?: TlonDeliverySkipReason | null;
   sourceReplyDeliveryMode?: string | null;
   beforeAgentRunBlocked?: boolean;
   provider: string | null;
@@ -618,6 +628,23 @@ function resolveReplyOutcome(params: {
     : 'no_reply';
 }
 
+function resolveDeliverySkipReason(params: {
+  outcome: TlonReplyOutcome;
+  deliverySkipReason?: TlonDeliverySkipReason | null;
+  sourceReplyDeliveryMode?: string | null;
+}): TlonDeliverySkipReason | null {
+  if (params.outcome !== 'no_reply') {
+    return null;
+  }
+  if (params.deliverySkipReason) {
+    return params.deliverySkipReason;
+  }
+  if (params.sourceReplyDeliveryMode === 'message_tool_only') {
+    return 'source_reply_delivery_mode_message_tool_only';
+  }
+  return null;
+}
+
 type ActiveReplyTrace = {
   params: TlonReplyTelemetryStart & {
     sessionId: string | null;
@@ -752,6 +779,14 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           activeTrace.params.sessionKey
         );
 
+        const outcome = resolveReplyOutcome({
+          deliveredMessageCount: result.deliveredMessageCount,
+          sendError: sendErrorCount > 0,
+          failedCounts: result.failedCounts,
+          dispatchError: result.dispatchError,
+        });
+        const sourceReplyDeliveryMode = result.sourceReplyDeliveryMode ?? null;
+
         this.captureReplyOutcome({
           sessionKey: activeTrace.params.sessionKey,
           sessionId: sessionContext?.sessionId ?? activeTrace.params.sessionId,
@@ -760,12 +795,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           agentId: activeTrace.params.agentId,
           ownerShip: activeTrace.params.ownerShip,
           botShip: activeTrace.params.botShip,
-          outcome: resolveReplyOutcome({
-            deliveredMessageCount: result.deliveredMessageCount,
-            sendError: sendErrorCount > 0,
-            failedCounts: result.failedCounts,
-            dispatchError: result.dispatchError,
-          }),
+          outcome,
           chatType: activeTrace.params.chatType,
           destinationKind: activeTrace.params.destinationKind,
           isThreadReply: activeTrace.params.isThreadReply,
@@ -788,7 +818,12 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           failedFinalCount,
           failedReplyCount:
             failedToolCount + failedBlockCount + failedFinalCount,
-          sourceReplyDeliveryMode: result.sourceReplyDeliveryMode ?? null,
+          deliverySkipReason: resolveDeliverySkipReason({
+            outcome,
+            deliverySkipReason: result.deliverySkipReason,
+            sourceReplyDeliveryMode,
+          }),
+          sourceReplyDeliveryMode,
           beforeAgentRunBlocked: result.beforeAgentRunBlocked === true,
           dispatchError: Boolean(result.dispatchError),
           dispatchErrorKind: classifyError(result.dispatchError),
@@ -844,6 +879,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
       failedBlockCount: 0,
       failedFinalCount: 0,
       failedReplyCount: 0,
+      deliverySkipReason: null,
       sourceReplyDeliveryMode: null,
       beforeAgentRunBlocked: false,
       dispatchError: false,
@@ -917,6 +953,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         failedBlockCount: event.failedBlockCount,
         failedFinalCount: event.failedFinalCount,
         failedReplyCount: event.failedReplyCount,
+        deliverySkipReason: event.deliverySkipReason,
         sourceReplyDeliveryMode: event.sourceReplyDeliveryMode,
         beforeAgentRunBlocked: event.beforeAgentRunBlocked,
         dispatchError: event.dispatchError,

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -17,6 +17,21 @@ type ToolSessionTrace = {
   calls: ToolCallRecord[];
 };
 
+type ReplyDispatchKind = 'tool' | 'block' | 'final';
+type ReplyDispatchCounts = Partial<Record<ReplyDispatchKind, number>>;
+type TlonDestinationKind = 'dm' | 'groupChannel';
+
+type TlonSessionTelemetryContext = {
+  sessionKey: string;
+  sessionId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  accountId: string | null;
+  agentId: string | null;
+  destinationKind: TlonDestinationKind;
+  updatedAt: number;
+};
+
 export type ToolUsageSummary = {
   calls: Array<{
     toolName: string;
@@ -64,16 +79,26 @@ export type TlonHeartbeatReengagementEvent = {
   accountId: string | null;
 };
 
-export type TlonReplyOutcome = 'responded' | 'no_reply' | 'error';
+export type TlonReplyOutcome = 'responded' | 'no_reply' | 'error' | 'abandoned';
 
 export type TlonReplyOutcomeEvent = {
+  sessionKey: string;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
   ownerShip: string | null;
   botShip: string;
   outcome: TlonReplyOutcome;
   chatType: 'dm' | 'groupChannel';
+  destinationKind: TlonDestinationKind;
   isThreadReply: boolean;
   senderRole: 'owner' | 'user';
   attachmentCount: number;
+  sendAttemptCount: number;
+  sendError: boolean;
+  sendErrorCount: number;
+  sendErrorKind: string | null;
   deliveredMessageCount: number;
   replyCharCount: number;
   replyWordCount: number;
@@ -82,6 +107,15 @@ export type TlonReplyOutcomeEvent = {
   queuedFinal: boolean;
   queuedFinalCount: number;
   queuedBlockCount: number;
+  failedToolCount: number;
+  failedBlockCount: number;
+  failedFinalCount: number;
+  failedReplyCount: number;
+  sourceReplyDeliveryMode: string | null;
+  beforeAgentRunBlocked: boolean;
+  dispatchError: boolean;
+  dispatchErrorKind: string | null;
+  abandonedReason: string | null;
   provider: string | null;
   model: string | null;
   thinkLevel: string | null;
@@ -90,9 +124,14 @@ export type TlonReplyOutcomeEvent = {
 
 export type TlonReplyTelemetryStart = {
   sessionKey: string;
+  sessionId?: string | null;
+  runId?: string | null;
+  accountId?: string | null;
+  agentId?: string | null;
   ownerShip: string | null;
   botShip: string;
   chatType: 'dm' | 'groupChannel';
+  destinationKind?: TlonDestinationKind;
   isThreadReply: boolean;
   senderRole: 'owner' | 'user';
   attachmentCount: number;
@@ -113,6 +152,9 @@ export type TlonGatewayConnectedEvent = {
 };
 
 export type TlonReplyTelemetryResult = {
+  sendAttemptCount?: number;
+  sendErrorCount?: number;
+  sendErrorKind?: string | null;
   deliveredMessageCount: number;
   replyCharCount: number;
   replyWordCount: number;
@@ -121,6 +163,9 @@ export type TlonReplyTelemetryResult = {
   queuedFinal: boolean;
   queuedFinalCount: number;
   queuedBlockCount: number;
+  failedCounts?: ReplyDispatchCounts;
+  sourceReplyDeliveryMode?: string | null;
+  beforeAgentRunBlocked?: boolean;
   provider: string | null;
   model: string | null;
   thinkLevel: string | null;
@@ -146,11 +191,80 @@ export type TlonOutboundRouteEvent = {
   targetKind: 'dm' | 'group' | 'unknown';
 };
 
+export type TlonSessionLifecycleEvent = {
+  lifecycleEvent: 'session_start' | 'session_end';
+  sessionKey: string;
+  sessionId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  reason: string | null;
+  messageCount: number | null;
+  durationMs: number | null;
+  transcriptArchived: boolean | null;
+  hasNextSession: boolean;
+};
+
+export type TlonSessionWatchdogEvent = {
+  diagnosticType: 'session.stalled' | 'session.stuck';
+  sessionKey: string;
+  sessionId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  state: string;
+  ageMs: number;
+  queueDepth: number | null;
+  reason: string | null;
+  classification: string;
+  activeWorkKind: string | null;
+  lastProgressAgeMs: number | null;
+  lastProgressReason: string | null;
+  activeToolName: string | null;
+  activeToolAgeMs: number | null;
+  terminalProgressStale: boolean;
+};
+
+export type TlonSessionRecoveryEvent = {
+  diagnosticType: 'session.recovery.requested' | 'session.recovery.completed';
+  sessionKey: string;
+  sessionId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  state: string;
+  stateGeneration: number | null;
+  ageMs: number;
+  queueDepth: number | null;
+  reason: string | null;
+  activeWorkKind: string | null;
+  allowActiveAbort: boolean;
+  status: string | null;
+  action: string | null;
+  outcomeReason: string | null;
+  released: number | null;
+  stale: boolean;
+};
+
+export type TlonSessionTelemetryReport =
+  | { kind: 'lifecycle'; event: TlonSessionLifecycleEvent }
+  | { kind: 'watchdog'; event: TlonSessionWatchdogEvent }
+  | { kind: 'recovery'; event: TlonSessionRecoveryEvent };
+
 export interface TlonTelemetryClient {
   captureGatewayConnected(event: TlonGatewayConnectedEvent): void;
   startReply(params: TlonReplyTelemetryStart): TlonReplyTelemetrySession;
   captureHeartbeatNudge(event: TlonHeartbeatNudgeEvent): void;
   captureHeartbeatReengagement(event: TlonHeartbeatReengagementEvent): void;
+  captureSessionLifecycle(event: TlonSessionLifecycleEvent): void;
+  captureSessionWatchdog(event: TlonSessionWatchdogEvent): void;
+  captureSessionRecovery(event: TlonSessionRecoveryEvent): void;
   captureOutboundRoute(
     event: TlonOutboundRouteEvent & {
       ownerShip?: string | null;
@@ -163,14 +277,25 @@ export interface TlonTelemetryClient {
 const TLON_TELEMETRY_EVENT_NAME = 'TlonBot Reply Handled';
 const TLON_GATEWAY_CONNECTED_EVENT = 'TlonBot Gateway Connected';
 const TLON_OUTBOUND_ROUTED_EVENT = 'TlonBot Outbound Routed';
+const TLON_SESSION_LIFECYCLE_EVENT = 'TlonBot Session Lifecycle';
+const TLON_SESSION_WATCHDOG_EVENT = 'TlonBot Session Watchdog';
+const TLON_SESSION_RECOVERY_EVENT = 'TlonBot Session Recovery';
 const TLON_HEARTBEAT_NUDGE_EVENT = 'TlonBot Heartbeat Nudge Sent';
 const TLON_HEARTBEAT_REENGAGED_EVENT = 'TlonBot Heartbeat Nudge Reengaged';
 const TLON_TELEMETRY_LOG_SOURCE = 'openclawPlugin';
 const TOOL_TRACE_TTL_MS = 60 * 60 * 1000;
 const MAX_TOOL_CALLS_PER_SESSION = 200;
+const REPLY_TRACE_TTL_MS = 60 * 60 * 1000;
+const MAX_ACTIVE_REPLY_TRACES = 50;
+const SESSION_CONTEXT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_SESSION_CONTEXTS = 5_000;
 const toolCallsBySession = sharedMap<string, ToolSessionTrace>(
   'telemetry.toolCallsBySession'
 );
+const sessionContextsBySessionKey = sharedMap<
+  string,
+  TlonSessionTelemetryContext
+>('telemetry.sessionContextsBySessionKey');
 
 function cleanupToolCalls(now = Date.now()): void {
   for (const [sessionKey, trace] of toolCallsBySession) {
@@ -248,22 +373,160 @@ function collectToolUsageSince(
   };
 }
 
+function cleanupSessionContexts(now = Date.now()): void {
+  for (const [sessionKey, context] of sessionContextsBySessionKey) {
+    if (now - context.updatedAt > SESSION_CONTEXT_TTL_MS) {
+      sessionContextsBySessionKey.delete(sessionKey);
+    }
+  }
+
+  while (sessionContextsBySessionKey.size > MAX_SESSION_CONTEXTS) {
+    const oldestKey = [...sessionContextsBySessionKey.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    )[0]?.[0];
+    if (!oldestKey) {
+      break;
+    }
+    sessionContextsBySessionKey.delete(oldestKey);
+  }
+}
+
+function rememberTlonSessionContext(params: {
+  sessionKey: string;
+  sessionId?: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  accountId?: string | null;
+  agentId?: string | null;
+  destinationKind: TlonDestinationKind;
+}): void {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return;
+  }
+
+  const now = Date.now();
+  cleanupSessionContexts(now);
+  const existing = sessionContextsBySessionKey.get(sessionKey);
+  sessionContextsBySessionKey.set(sessionKey, {
+    sessionKey,
+    sessionId: optionalString(params.sessionId) ?? existing?.sessionId ?? null,
+    ownerShip: params.ownerShip,
+    botShip: params.botShip,
+    accountId: params.accountId ?? null,
+    agentId: params.agentId ?? null,
+    destinationKind: params.destinationKind,
+    updatedAt: now,
+  });
+}
+
+function lookupTlonSessionContext(
+  sessionKey?: string | null
+): TlonSessionTelemetryContext | null {
+  const normalized = sessionKey?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  cleanupSessionContexts();
+  const context = sessionContextsBySessionKey.get(normalized);
+  if (!context) {
+    return null;
+  }
+
+  context.updatedAt = Date.now();
+  sessionContextsBySessionKey.set(normalized, context);
+  return context;
+}
+
+function updateTlonSessionContextSessionId(
+  context: TlonSessionTelemetryContext,
+  sessionId?: string | null
+): TlonSessionTelemetryContext {
+  const normalizedSessionId = optionalString(sessionId);
+  if (!normalizedSessionId || context.sessionId === normalizedSessionId) {
+    return context;
+  }
+
+  const updated = {
+    ...context,
+    sessionId: normalizedSessionId,
+    updatedAt: Date.now(),
+  };
+  sessionContextsBySessionKey.set(updated.sessionKey, updated);
+  return updated;
+}
+
+function countDispatchFailures(
+  counts: ReplyDispatchCounts | undefined,
+  kind: ReplyDispatchKind
+): number {
+  const value = counts?.[kind];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, value)
+    : 0;
+}
+
+function classifyError(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+  if (error instanceof Error) {
+    return error.name || 'Error';
+  }
+  if (typeof error === 'object' && error !== null) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string' && code.trim()) {
+      return code.trim().slice(0, 80);
+    }
+    const name = (error as { name?: unknown }).name;
+    if (typeof name === 'string' && name.trim()) {
+      return name.trim().slice(0, 80);
+    }
+    return 'object';
+  }
+  return typeof error;
+}
+
 function resolveReplyOutcome(params: {
   deliveredMessageCount: number;
+  sendError?: boolean;
+  failedCounts?: ReplyDispatchCounts;
   dispatchError?: unknown;
 }): TlonReplyOutcome {
   if (params.deliveredMessageCount > 0) {
     return 'responded';
   }
 
-  return params.dispatchError ? 'error' : 'no_reply';
+  const failedReplyCount =
+    countDispatchFailures(params.failedCounts, 'tool') +
+    countDispatchFailures(params.failedCounts, 'block') +
+    countDispatchFailures(params.failedCounts, 'final');
+
+  return params.dispatchError || params.sendError || failedReplyCount > 0
+    ? 'error'
+    : 'no_reply';
 }
+
+type ActiveReplyTrace = {
+  params: TlonReplyTelemetryStart & {
+    sessionId: string | null;
+    runId: string | null;
+    accountId: string | null;
+    agentId: string | null;
+    destinationKind: TlonDestinationKind;
+  };
+  startedAt: number;
+  toolTraceCursor: number;
+  timeout: ReturnType<typeof setTimeout>;
+};
 
 class PostHogTlonTelemetry implements TlonTelemetryClient {
   private readonly client: PostHog;
   private readonly runtime?: RuntimeEnv;
   private readonly versionIdentity = getTlonVersionIdentity();
   private readonly identifiedOwners = new Set<string>();
+  private readonly activeReplyTraces = new Map<symbol, ActiveReplyTrace>();
   private missingOwnerWarningLogged = false;
 
   constructor(params: {
@@ -316,24 +579,91 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
   }
 
   startReply(params: TlonReplyTelemetryStart): TlonReplyTelemetrySession {
+    const normalizedParams: ActiveReplyTrace['params'] = {
+      ...params,
+      sessionId: optionalString(params.sessionId),
+      runId: params.runId ?? null,
+      accountId: params.accountId ?? null,
+      agentId: params.agentId ?? null,
+      destinationKind: params.destinationKind ?? params.chatType,
+    };
     const toolTraceCursor = createToolTraceCursor(params.sessionKey);
+    rememberTlonSessionContext({
+      sessionKey: normalizedParams.sessionKey,
+      sessionId: normalizedParams.sessionId,
+      ownerShip: normalizedParams.ownerShip,
+      botShip: normalizedParams.botShip,
+      accountId: normalizedParams.accountId,
+      agentId: normalizedParams.agentId,
+      destinationKind: normalizedParams.destinationKind,
+    });
+
+    this.pruneActiveReplyTraces();
+    const token = Symbol(normalizedParams.sessionKey);
+    const trace: ActiveReplyTrace = {
+      params: normalizedParams,
+      startedAt: Date.now(),
+      toolTraceCursor,
+      timeout: setTimeout(() => {
+        this.captureAbandonedReplyTrace(token, 'stale');
+      }, REPLY_TRACE_TTL_MS),
+    };
+    trace.timeout.unref?.();
+    this.activeReplyTraces.set(token, trace);
+    this.pruneActiveReplyTraces();
 
     return {
       capture: async (result) => {
+        const activeTrace = this.activeReplyTraces.get(token);
+        if (!activeTrace) {
+          return;
+        }
+        this.activeReplyTraces.delete(token);
+        clearTimeout(activeTrace.timeout);
+
         // Yield once so after_tool_call hooks for the just-finished reply have time to run.
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
+        const failedToolCount = countDispatchFailures(
+          result.failedCounts,
+          'tool'
+        );
+        const failedBlockCount = countDispatchFailures(
+          result.failedCounts,
+          'block'
+        );
+        const failedFinalCount = countDispatchFailures(
+          result.failedCounts,
+          'final'
+        );
+        const sendErrorCount = Math.max(0, result.sendErrorCount ?? 0);
+        const sessionContext = lookupTlonSessionContext(
+          activeTrace.params.sessionKey
+        );
+
         this.captureReplyOutcome({
-          ownerShip: params.ownerShip,
-          botShip: params.botShip,
+          sessionKey: activeTrace.params.sessionKey,
+          sessionId: sessionContext?.sessionId ?? activeTrace.params.sessionId,
+          runId: activeTrace.params.runId,
+          accountId: activeTrace.params.accountId,
+          agentId: activeTrace.params.agentId,
+          ownerShip: activeTrace.params.ownerShip,
+          botShip: activeTrace.params.botShip,
           outcome: resolveReplyOutcome({
             deliveredMessageCount: result.deliveredMessageCount,
+            sendError: sendErrorCount > 0,
+            failedCounts: result.failedCounts,
             dispatchError: result.dispatchError,
           }),
-          chatType: params.chatType,
-          isThreadReply: params.isThreadReply,
-          senderRole: params.senderRole,
-          attachmentCount: params.attachmentCount,
+          chatType: activeTrace.params.chatType,
+          destinationKind: activeTrace.params.destinationKind,
+          isThreadReply: activeTrace.params.isThreadReply,
+          senderRole: activeTrace.params.senderRole,
+          attachmentCount: activeTrace.params.attachmentCount,
+          sendAttemptCount: Math.max(0, result.sendAttemptCount ?? 0),
+          sendError: sendErrorCount > 0,
+          sendErrorCount,
+          sendErrorKind: result.sendErrorKind ?? null,
           deliveredMessageCount: result.deliveredMessageCount,
           replyCharCount: result.replyCharCount,
           replyWordCount: result.replyWordCount,
@@ -342,13 +672,98 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           queuedFinal: result.queuedFinal,
           queuedFinalCount: result.queuedFinalCount,
           queuedBlockCount: result.queuedBlockCount,
+          failedToolCount,
+          failedBlockCount,
+          failedFinalCount,
+          failedReplyCount:
+            failedToolCount + failedBlockCount + failedFinalCount,
+          sourceReplyDeliveryMode: result.sourceReplyDeliveryMode ?? null,
+          beforeAgentRunBlocked: result.beforeAgentRunBlocked === true,
+          dispatchError: Boolean(result.dispatchError),
+          dispatchErrorKind: classifyError(result.dispatchError),
+          abandonedReason: null,
           provider: result.provider,
           model: result.model,
           thinkLevel: result.thinkLevel,
-          toolUsage: collectToolUsageSince(params.sessionKey, toolTraceCursor),
+          toolUsage: collectToolUsageSince(
+            activeTrace.params.sessionKey,
+            activeTrace.toolTraceCursor
+          ),
         });
       },
     };
+  }
+
+  private captureAbandonedReplyTrace(token: symbol, reason: string): void {
+    const trace = this.activeReplyTraces.get(token);
+    if (!trace) {
+      return;
+    }
+    this.activeReplyTraces.delete(token);
+    clearTimeout(trace.timeout);
+    const sessionContext = lookupTlonSessionContext(trace.params.sessionKey);
+
+    this.captureReplyOutcome({
+      sessionKey: trace.params.sessionKey,
+      sessionId: sessionContext?.sessionId ?? trace.params.sessionId,
+      runId: trace.params.runId,
+      accountId: trace.params.accountId,
+      agentId: trace.params.agentId,
+      ownerShip: trace.params.ownerShip,
+      botShip: trace.params.botShip,
+      outcome: 'abandoned',
+      chatType: trace.params.chatType,
+      destinationKind: trace.params.destinationKind,
+      isThreadReply: trace.params.isThreadReply,
+      senderRole: trace.params.senderRole,
+      attachmentCount: trace.params.attachmentCount,
+      sendAttemptCount: 0,
+      sendError: false,
+      sendErrorCount: 0,
+      sendErrorKind: null,
+      deliveredMessageCount: 0,
+      replyCharCount: 0,
+      replyWordCount: 0,
+      replyMediaCount: 0,
+      dispatchDurationMs: Date.now() - trace.startedAt,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+      failedToolCount: 0,
+      failedBlockCount: 0,
+      failedFinalCount: 0,
+      failedReplyCount: 0,
+      sourceReplyDeliveryMode: null,
+      beforeAgentRunBlocked: false,
+      dispatchError: false,
+      dispatchErrorKind: null,
+      abandonedReason: reason,
+      provider: null,
+      model: null,
+      thinkLevel: null,
+      toolUsage: collectToolUsageSince(
+        trace.params.sessionKey,
+        trace.toolTraceCursor
+      ),
+    });
+  }
+
+  private pruneActiveReplyTraces(now = Date.now()): void {
+    for (const [token, trace] of this.activeReplyTraces) {
+      if (now - trace.startedAt > REPLY_TRACE_TTL_MS) {
+        this.captureAbandonedReplyTrace(token, 'stale');
+      }
+    }
+
+    while (this.activeReplyTraces.size > MAX_ACTIVE_REPLY_TRACES) {
+      const oldest = [...this.activeReplyTraces.entries()].sort(
+        (a, b) => a[1].startedAt - b[1].startedAt
+      )[0];
+      if (!oldest) {
+        break;
+      }
+      this.captureAbandonedReplyTrace(oldest[0], 'max_traces');
+    }
   }
 
   private captureReplyOutcome(event: TlonReplyOutcomeEvent): void {
@@ -361,14 +776,24 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
       distinctId: ownerShip,
       event: TLON_TELEMETRY_EVENT_NAME,
       properties: this.properties({
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        runId: event.runId,
+        accountId: event.accountId,
+        agentId: event.agentId,
         botShip: event.botShip,
         ownerShip: event.ownerShip,
         outcome: event.outcome,
         chatType: event.chatType,
+        destinationKind: event.destinationKind,
         isThreadReply: event.isThreadReply,
         senderRole: event.senderRole,
         attachmentCount: event.attachmentCount,
         hasAttachments: event.attachmentCount > 0,
+        sendAttemptCount: event.sendAttemptCount,
+        sendError: event.sendError,
+        sendErrorCount: event.sendErrorCount,
+        sendErrorKind: event.sendErrorKind,
         deliveredMessageCount: event.deliveredMessageCount,
         replyCharCount: event.replyCharCount,
         replyWordCount: event.replyWordCount,
@@ -377,6 +802,15 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         queuedFinal: event.queuedFinal,
         queuedFinalCount: event.queuedFinalCount,
         queuedBlockCount: event.queuedBlockCount,
+        failedToolCount: event.failedToolCount,
+        failedBlockCount: event.failedBlockCount,
+        failedFinalCount: event.failedFinalCount,
+        failedReplyCount: event.failedReplyCount,
+        sourceReplyDeliveryMode: event.sourceReplyDeliveryMode,
+        beforeAgentRunBlocked: event.beforeAgentRunBlocked,
+        dispatchError: event.dispatchError,
+        dispatchErrorKind: event.dispatchErrorKind,
+        abandonedReason: event.abandonedReason,
         provider: event.provider,
         model: event.model,
         thinkLevel: event.thinkLevel,
@@ -389,6 +823,100 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           durationMs: call.durationMs,
           error: call.error,
         })),
+      }),
+    });
+  }
+
+  captureSessionLifecycle(event: TlonSessionLifecycleEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_SESSION_LIFECYCLE_EVENT,
+      properties: this.properties({
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        accountId: event.accountId,
+        agentId: event.agentId,
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        lifecycleEvent: event.lifecycleEvent,
+        destinationKind: event.destinationKind,
+        reason: event.reason,
+        messageCount: event.messageCount,
+        durationMs: event.durationMs,
+        transcriptArchived: event.transcriptArchived,
+        hasNextSession: event.hasNextSession,
+      }),
+    });
+  }
+
+  captureSessionWatchdog(event: TlonSessionWatchdogEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_SESSION_WATCHDOG_EVENT,
+      properties: this.properties({
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        accountId: event.accountId,
+        agentId: event.agentId,
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        diagnosticType: event.diagnosticType,
+        destinationKind: event.destinationKind,
+        state: event.state,
+        ageMs: event.ageMs,
+        queueDepth: event.queueDepth,
+        reason: event.reason,
+        classification: event.classification,
+        activeWorkKind: event.activeWorkKind,
+        lastProgressAgeMs: event.lastProgressAgeMs,
+        lastProgressReason: event.lastProgressReason,
+        activeToolName: event.activeToolName,
+        activeToolAgeMs: event.activeToolAgeMs,
+        terminalProgressStale: event.terminalProgressStale,
+      }),
+    });
+  }
+
+  captureSessionRecovery(event: TlonSessionRecoveryEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_SESSION_RECOVERY_EVENT,
+      properties: this.properties({
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        accountId: event.accountId,
+        agentId: event.agentId,
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        diagnosticType: event.diagnosticType,
+        destinationKind: event.destinationKind,
+        state: event.state,
+        stateGeneration: event.stateGeneration,
+        ageMs: event.ageMs,
+        queueDepth: event.queueDepth,
+        reason: event.reason,
+        activeWorkKind: event.activeWorkKind,
+        allowActiveAbort: event.allowActiveAbort,
+        status: event.status,
+        action: event.action,
+        outcomeReason: event.outcomeReason,
+        released: event.released,
+        stale: event.stale,
       }),
     });
   }
@@ -488,6 +1016,10 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
   }
 
   async close(): Promise<void> {
+    for (const token of [...this.activeReplyTraces.keys()]) {
+      this.captureAbandonedReplyTrace(token, 'telemetry_close');
+    }
+
     try {
       await this.client.flush();
     } catch (error) {
@@ -539,9 +1071,62 @@ export function createTlonTelemetry(params: {
  * client + owner/bot ships; the hook calls `reportOutboundRoute`.
  */
 export type OutboundRouteReporter = (event: TlonOutboundRouteEvent) => void;
+export type SessionTelemetryReporter = (
+  report: TlonSessionTelemetryReport
+) => void;
+
+export type TlonSessionLifecycleReportInput = {
+  lifecycleEvent: 'session_start' | 'session_end';
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  agentId?: string | null;
+  reason?: string | null;
+  messageCount?: number | null;
+  durationMs?: number | null;
+  transcriptArchived?: boolean | null;
+  hasNextSession?: boolean;
+};
+
+export type TlonSessionDiagnosticReportInput =
+  | {
+      type: 'session.stalled' | 'session.stuck';
+      sessionKey?: string | null;
+      sessionId?: string | null;
+      state: string;
+      ageMs: number;
+      queueDepth?: number;
+      reason?: string;
+      classification: string;
+      activeWorkKind?: string;
+      lastProgressAgeMs?: number;
+      lastProgressReason?: string;
+      activeToolName?: string;
+      activeToolAgeMs?: number;
+      terminalProgressStale?: boolean;
+    }
+  | {
+      type: 'session.recovery.requested' | 'session.recovery.completed';
+      sessionKey?: string | null;
+      sessionId?: string | null;
+      state: string;
+      stateGeneration?: number;
+      ageMs: number;
+      queueDepth?: number;
+      reason?: string;
+      activeWorkKind?: string;
+      allowActiveAbort?: boolean;
+      status?: string;
+      action?: string;
+      outcomeReason?: string;
+      released?: number;
+      stale?: boolean;
+    };
 
 const outboundRouteReporterSlot = sharedSlot<OutboundRouteReporter>(
   'telemetry.outboundRouteReporter'
+);
+const sessionTelemetryReporterSlot = sharedSlot<SessionTelemetryReporter>(
+  'telemetry.sessionTelemetryReporter'
 );
 
 export function setOutboundRouteReporter(
@@ -554,7 +1139,131 @@ export function reportOutboundRoute(event: TlonOutboundRouteEvent): void {
   outboundRouteReporterSlot.get()?.(event);
 }
 
+export function setSessionTelemetryReporter(
+  reporter: SessionTelemetryReporter | null
+): void {
+  sessionTelemetryReporterSlot.set(reporter);
+}
+
+function optionalString(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function optionalNumber(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function reportSessionLifecycle(
+  event: TlonSessionLifecycleReportInput
+): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextSessionId(rememberedContext, event.sessionId)
+    : null;
+  if (!context) {
+    return;
+  }
+
+  sessionTelemetryReporterSlot.get()?.({
+    kind: 'lifecycle',
+    event: {
+      lifecycleEvent: event.lifecycleEvent,
+      sessionKey: context.sessionKey,
+      sessionId: context.sessionId,
+      accountId: context.accountId,
+      agentId: optionalString(event.agentId) ?? context.agentId,
+      ownerShip: context.ownerShip,
+      botShip: context.botShip,
+      destinationKind: context.destinationKind,
+      reason: optionalString(event.reason),
+      messageCount: optionalNumber(event.messageCount),
+      durationMs: optionalNumber(event.durationMs),
+      transcriptArchived:
+        typeof event.transcriptArchived === 'boolean'
+          ? event.transcriptArchived
+          : null,
+      hasNextSession: event.hasNextSession === true,
+    },
+  });
+}
+
+export function reportSessionDiagnostic(
+  event: TlonSessionDiagnosticReportInput
+): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextSessionId(rememberedContext, event.sessionId)
+    : null;
+  if (!context) {
+    return;
+  }
+
+  if (event.type === 'session.stalled' || event.type === 'session.stuck') {
+    sessionTelemetryReporterSlot.get()?.({
+      kind: 'watchdog',
+      event: {
+        diagnosticType: event.type,
+        sessionKey: context.sessionKey,
+        sessionId: context.sessionId,
+        accountId: context.accountId,
+        agentId: context.agentId,
+        ownerShip: context.ownerShip,
+        botShip: context.botShip,
+        destinationKind: context.destinationKind,
+        state: event.state,
+        ageMs: event.ageMs,
+        queueDepth: optionalNumber(event.queueDepth),
+        reason: optionalString(event.reason),
+        classification: event.classification,
+        activeWorkKind: optionalString(event.activeWorkKind),
+        lastProgressAgeMs: optionalNumber(event.lastProgressAgeMs),
+        lastProgressReason: optionalString(event.lastProgressReason),
+        activeToolName: optionalString(event.activeToolName),
+        activeToolAgeMs: optionalNumber(event.activeToolAgeMs),
+        terminalProgressStale: event.terminalProgressStale === true,
+      },
+    });
+    return;
+  }
+
+  const recoveryEvent = event as Extract<
+    TlonSessionDiagnosticReportInput,
+    {
+      type: 'session.recovery.requested' | 'session.recovery.completed';
+    }
+  >;
+
+  sessionTelemetryReporterSlot.get()?.({
+    kind: 'recovery',
+    event: {
+      diagnosticType: recoveryEvent.type,
+      sessionKey: context.sessionKey,
+      sessionId: context.sessionId,
+      accountId: context.accountId,
+      agentId: context.agentId,
+      ownerShip: context.ownerShip,
+      botShip: context.botShip,
+      destinationKind: context.destinationKind,
+      state: recoveryEvent.state,
+      stateGeneration: optionalNumber(recoveryEvent.stateGeneration),
+      ageMs: recoveryEvent.ageMs,
+      queueDepth: optionalNumber(recoveryEvent.queueDepth),
+      reason: optionalString(recoveryEvent.reason),
+      activeWorkKind: optionalString(recoveryEvent.activeWorkKind),
+      allowActiveAbort: recoveryEvent.allowActiveAbort === true,
+      status: optionalString(recoveryEvent.status),
+      action: optionalString(recoveryEvent.action),
+      outcomeReason: optionalString(recoveryEvent.outcomeReason),
+      released: optionalNumber(recoveryEvent.released),
+      stale: recoveryEvent.stale === true,
+    },
+  });
+}
+
 export const _testing = {
   clearToolCalls: () => toolCallsBySession.clear(),
+  clearSessionContexts: () => sessionContextsBySessionKey.clear(),
+  getReplyTraceTtlMs: () => REPLY_TRACE_TTL_MS,
   getToolTraceTtlMs: () => TOOL_TRACE_TTL_MS,
 };


### PR DESCRIPTION
## Summary

Adds more comprehensive capture for Openclaw's sessions, built in diagnostics firehose, and errors within our plugin code. This should help us better detect errors and reconstruct what went wrong within PostHog.

## Changes

- Added *TlonBot Session Lifecycle* for normal OpenClaw session_start / session_end boundaries
- Added *TlonBot Session Watchdog* for stuck/stalled sessions
- Added *TlonBot Session Recovery* for OpenClaw builtin recovery requested/completed status
- Added *TlonBot Harness Error* for OpenClaw harness/model/tool/run/message delivery failures via strict internal diagnostic allowlist
- Added *TlonBot Plugin Error* for node integration failures, including auth, re-auth, gateway-status activation/heartbeat, firehose/subscription, and settings refresh errors
- Added *TlonBot Telemetry Error* so failures inside our own telemetry observers are visible without breaking OpenClaw hook execution
- Preserved full available errorText for new error events while avoiding new raw message content, message IDs, tool args/results, or request/response payloads

## How did I test?

Locally using the Docker dev env.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

Just revert on `develop`
