### PR TITLE
add notes import flow

### DIFF
--- a/packages/app/ui/components/NotesChannel/NotesFeedback.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesFeedback.tsx
@@ -3,10 +3,15 @@ import { useEffect, useMemo, useState } from 'react';
 import { Alert, Platform } from 'react-native';
 import { ScrollView, XStack, YStack } from 'tamagui';
 
-const NOTES_PENDING_WRITE_MESSAGE = '%notes write request is still pending';
+export const NOTES_PENDING_WRITE_MESSAGE =
+  '%notes write request is still pending';
 
 export function errorMessage(e: unknown, fallback: string) {
   return e instanceof Error ? e.message : fallback;
+}
+
+export function isNotesPendingWriteError(e: unknown) {
+  return errorMessage(e, '').includes(NOTES_PENDING_WRITE_MESSAGE);
 }
 
 function formatNotesBannerMessage(message: string) {

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -46,6 +46,7 @@ import {
 import { MoveNoteSheet } from './NotesMoveSheets';
 import { NotesNoteDetail } from './NotesNoteDetail';
 import { NotesEmptyDetailPane, NotesTreePane } from './NotesTreePane';
+import { canSelectNotesImportSources } from './notesImport';
 import { trackNotesActionError } from './notesTelemetry';
 import {
   type FolderRow,
@@ -57,6 +58,7 @@ import {
   getNextNoteIdAfterDelete,
   getNextNoteIdAfterFolderDelete,
 } from './notesTree';
+import { useNotesImportController } from './useNotesImportController';
 
 const MOVE_OPERATION_TIMEOUT_MS = 12000;
 const MOVE_OPERATION_TIMEOUT_MESSAGE =
@@ -151,6 +153,9 @@ export function NotesNativeChannel({
     notebookFlag,
     { syncEnabled: isFocused }
   );
+
+  const canImportFiles = canEdit && canSelectNotesImportSources('files');
+  const canImportFolder = canEdit && canSelectNotesImportSources('folder');
 
   const parentFolderRows = useMemo(
     () => buildFolderRows(folders, rootFolderId, { includeRoot: true }),
@@ -318,6 +323,26 @@ export function NotesNativeChannel({
         (currentParentId) => getCreateTargetFolderId(currentParentId) ?? null
       );
     }
+  });
+
+  const canDropImportNotes = canImportFolder && gate !== 'unjoinable';
+  const {
+    dropImportProps,
+    importFiles,
+    importFolder,
+    importNotice,
+    isDragImportActive,
+    isImportingNotes,
+  } = useNotesImportController({
+    canDropImportNotes,
+    canEdit,
+    expandFolder,
+    folders,
+    notebookFlag,
+    notes,
+    rootFolderId,
+    selectedFolderId,
+    setError,
   });
 
   const handleMoveNoteToFolder = useMutableCallback(
@@ -548,11 +573,50 @@ export function NotesNativeChannel({
     }),
   ];
 
+  const importActions = [
+    ...(canImportFiles
+      ? [
+          {
+            title: 'Import files',
+            startIcon: 'ChannelNote' as const,
+            action: () => {
+              setNewActionSheetOpen(false);
+              importFiles();
+            },
+            disabled: isImportingNotes,
+            testID: 'NotesImportFilesAction',
+          },
+        ]
+      : []),
+    ...(canImportFolder
+      ? [
+          {
+            title: 'Import folder',
+            startIcon: 'Folder' as const,
+            action: () => {
+              setNewActionSheetOpen(false);
+              importFolder();
+            },
+            disabled: isImportingNotes,
+            testID: 'NotesImportFolderAction',
+          },
+        ]
+      : []),
+  ];
+
   const newActionGroups = [
     {
       accent: 'neutral' as const,
       actions: createActions,
     },
+    ...(importActions.length > 0
+      ? [
+          {
+            accent: 'neutral' as const,
+            actions: importActions,
+          },
+        ]
+      : []),
   ];
 
   const headerActions = useMemo(() => {
@@ -637,10 +701,30 @@ export function NotesNativeChannel({
   );
 
   return (
-    <YStack flex={1} backgroundColor="$background" position="relative">
+    <YStack
+      flex={1}
+      backgroundColor="$background"
+      position="relative"
+      {...dropImportProps}
+    >
       {error ? <NotesBanner message={error} tone="negative" /> : null}
+      {importNotice ? <NotesBanner message={importNotice} /> : null}
 
       {useDesktopSplit ? noteDetailPane : notesTreePane}
+      {isDragImportActive ? (
+        <YStack
+          pointerEvents="none"
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          left={0}
+          borderColor="$positiveText"
+          borderWidth={2}
+          backgroundColor="$backgroundHover"
+          opacity={0.7}
+        />
+      ) : null}
       <ActionSheet
         open={newActionSheetOpen}
         onOpenChange={setNewActionSheetOpen}
@@ -649,7 +733,7 @@ export function NotesNativeChannel({
       >
         <ActionSheet.SimpleHeader
           title="New"
-          subtitle="Create notes or folders"
+          subtitle="Create or import notes or folders"
         />
         <ActionSheet.Content>
           <NotesActionGroupList

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -554,6 +554,16 @@ export function NotesNativeChannel({
     }
   );
 
+  const runImportAfterSheetCloses = useMutableCallback((action: () => void) => {
+    setNewActionSheetOpen(false);
+    if (Platform.OS === 'web') {
+      action();
+      return;
+    }
+
+    setTimeout(action, 50);
+  });
+
   const createActions = [
     createNotesNewNoteAction({
       action: () => {
@@ -580,8 +590,7 @@ export function NotesNativeChannel({
             title: 'Import files',
             startIcon: 'ChannelNote' as const,
             action: () => {
-              setNewActionSheetOpen(false);
-              importFiles();
+              runImportAfterSheetCloses(importFiles);
             },
             disabled: isImportingNotes,
             testID: 'NotesImportFilesAction',
@@ -594,8 +603,7 @@ export function NotesNativeChannel({
             title: 'Import folder',
             startIcon: 'Folder' as const,
             action: () => {
-              setNewActionSheetOpen(false);
-              importFolder();
+              runImportAfterSheetCloses(importFolder);
             },
             disabled: isImportingNotes,
             testID: 'NotesImportFolderAction',

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -336,7 +336,6 @@ export function NotesNativeChannel({
   } = useNotesImportController({
     canDropImportNotes,
     canEdit,
-    expandFolder,
     folders,
     notebookFlag,
     notes,

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -334,6 +334,7 @@ export function NotesNativeChannel({
     isDragImportActive,
     isImportingNotes,
   } = useNotesImportController({
+    activeFolderId,
     canDropImportNotes,
     canEdit,
     folders,

--- a/packages/app/ui/components/NotesChannel/notesImport.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.test.ts
@@ -262,6 +262,27 @@ describe('notes import helpers', () => {
     expect(unsupportedFile.text).not.toHaveBeenCalled();
   });
 
+  test('strips only the SAF volume prefix, keeping colons in file names', async () => {
+    vi.stubGlobal('document', undefined);
+    vi.mocked(ExpoDirectory.pickDirectoryAsync).mockResolvedValue(
+      makeNativeDirectory(
+        'primary:Research',
+        [
+          makeNativeFile(
+            'primary:Research/Meeting: Q3.md',
+            'Agenda',
+            'content://com.android.externalstorage.documents/tree/primary%3AResearch/document/primary%3AResearch%2FMeeting%3A%20Q3.md'
+          ),
+        ],
+        'content://com.android.externalstorage.documents/tree/primary%3AResearch'
+      ) as never
+    );
+
+    const sources = await selectNotesImportSources('folder');
+
+    expect(sources).toEqual([source('Research/Meeting: Q3.md', 'Agenda')]);
+  });
+
   test('returns null when native folder selection is canceled', async () => {
     vi.stubGlobal('document', undefined);
     vi.mocked(ExpoDirectory.pickDirectoryAsync).mockRejectedValue(

--- a/packages/app/ui/components/NotesChannel/notesImport.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   buildNotesImportItems,
+  getNotesImportTargetFolderId,
   makeUniqueNoteTitle,
   normalizeTitleKey,
   readNotesImportSourcesFromDataTransfer,
@@ -128,6 +129,30 @@ describe('notes import helpers', () => {
     expect(makeUniqueNoteTitle('Plan', existingTitles)).toBe('Plan (2)');
     expect(makeUniqueNoteTitle('Plan', existingTitles)).toBe('Plan (3)');
     expect(makeUniqueNoteTitle('', existingTitles)).toBe('Untitled');
+  });
+
+  test('uses selected folder, active folder, then root for import target', () => {
+    expect(
+      getNotesImportTargetFolderId({
+        selectedFolderId: 9,
+        activeFolderId: 4,
+        rootFolderId: 1,
+      })
+    ).toBe(9);
+    expect(
+      getNotesImportTargetFolderId({
+        selectedFolderId: null,
+        activeFolderId: 4,
+        rootFolderId: 1,
+      })
+    ).toBe(4);
+    expect(
+      getNotesImportTargetFolderId({
+        selectedFolderId: null,
+        activeFolderId: null,
+        rootFolderId: 1,
+      })
+    ).toBe(1);
   });
 
   test('reads dropped files and folders from desktop browsers', async () => {

--- a/packages/app/ui/components/NotesChannel/notesImport.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.test.ts
@@ -5,10 +5,10 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   buildNotesImportItems,
-  readNotesImportSourcesFromDataTransfer,
-  selectNotesImportSources,
   makeUniqueNoteTitle,
   normalizeTitleKey,
+  readNotesImportSourcesFromDataTransfer,
+  selectNotesImportSources,
 } from './notesImport';
 
 vi.mock('expo-document-picker', () => ({

--- a/packages/app/ui/components/NotesChannel/notesImport.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.test.ts
@@ -1,0 +1,248 @@
+import * as DocumentPicker from 'expo-document-picker';
+import { Directory as ExpoDirectory } from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  buildNotesImportItems,
+  readNotesImportSourcesFromDataTransfer,
+  selectNotesImportSources,
+  makeUniqueNoteTitle,
+  normalizeTitleKey,
+} from './notesImport';
+
+vi.mock('expo-document-picker', () => ({
+  getDocumentAsync: vi.fn(),
+}));
+
+vi.mock('expo-file-system/legacy', () => ({
+  readAsStringAsync: vi.fn(),
+}));
+
+vi.mock('expo-file-system', () => ({
+  Directory: {
+    pickDirectoryAsync: vi.fn(),
+  },
+}));
+
+function makeFileEntry(file: File, fullPath: string) {
+  return {
+    fullPath,
+    isDirectory: false,
+    isFile: true,
+    name: file.name,
+    file: (success: (file: File) => void) => success(file),
+  };
+}
+
+function makeDirectoryEntry(
+  name: string,
+  fullPath: string,
+  entries: unknown[]
+) {
+  return {
+    fullPath,
+    isDirectory: true,
+    isFile: false,
+    name,
+    createReader: () => {
+      let hasRead = false;
+      return {
+        readEntries: (success: (entries: unknown[]) => void) => {
+          if (hasRead) {
+            success([]);
+            return;
+          }
+          hasRead = true;
+          success(entries);
+        },
+      };
+    },
+  };
+}
+
+function makeNativeFile(name: string, contents: string, uri?: string) {
+  return {
+    name,
+    text: vi.fn(async () => contents),
+    uri,
+  };
+}
+
+function makeNativeDirectory(name: string, entries: unknown[], uri?: string) {
+  return {
+    list: vi.fn(() => entries),
+    name,
+    uri,
+  };
+}
+
+function source(relativePath: string, contents: string) {
+  return { relativePath, contents };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('notes import helpers', () => {
+  test('builds import items for single markdown and text files', () => {
+    const items = buildNotesImportItems([
+      source('Plan.md', '# Plan'),
+      source('Memo.txt', 'Memo body'),
+    ]);
+
+    expect(items).toMatchObject([
+      {
+        title: 'Plan',
+        body: '# Plan',
+        folderSegments: [],
+      },
+      {
+        title: 'Memo',
+        body: 'Memo body',
+        folderSegments: [],
+      },
+    ]);
+  });
+
+  test('preserves nested folder paths and ignores unsupported files', () => {
+    const items = buildNotesImportItems([
+      source('Research/Trips/Index.markdown', 'Trip notes'),
+      source('Research/image.png', 'not text'),
+      source('Research/.drafts/Secret.md', 'hidden'),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      title: 'Index',
+      folderSegments: ['Research', 'Trips'],
+      body: 'Trip notes',
+    });
+  });
+
+  test('dedupes titles within a folder', () => {
+    const existingTitles = new Set([normalizeTitleKey('Plan')]);
+
+    expect(makeUniqueNoteTitle('Plan', existingTitles)).toBe('Plan (2)');
+    expect(makeUniqueNoteTitle('Plan', existingTitles)).toBe('Plan (3)');
+    expect(makeUniqueNoteTitle('', existingTitles)).toBe('Untitled');
+  });
+
+  test('reads dropped files and folders from desktop browsers', async () => {
+    const fileEntry = makeFileEntry(
+      new File(['# Plan'], 'Plan.md', { type: 'text/markdown' }),
+      '/Research/Plan.md'
+    );
+    const hiddenEntry = makeFileEntry(
+      new File(['hidden'], 'Secret.md', { type: 'text/markdown' }),
+      '/Research/.drafts/Secret.md'
+    );
+    const unsupportedEntry = makeFileEntry(
+      new File(['png'], 'Photo.png', { type: 'image/png' }),
+      '/Research/Photo.png'
+    );
+    const directoryEntry = makeDirectoryEntry('Research', '/Research', [
+      fileEntry,
+      hiddenEntry,
+      unsupportedEntry,
+    ]);
+
+    const sources = await readNotesImportSourcesFromDataTransfer({
+      files: [] as unknown as FileList,
+      items: [
+        {
+          webkitGetAsEntry: () => directoryEntry,
+        },
+      ] as unknown as DataTransferItemList,
+    });
+
+    expect(sources).toEqual([source('Research/Plan.md', '# Plan')]);
+  });
+
+  test('selects native markdown and text files', async () => {
+    vi.stubGlobal('document', undefined);
+    vi.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          name: 'Plan.md',
+          uri: 'file:///plan.md',
+          mimeType: 'text/markdown',
+          lastModified: 0,
+        },
+        {
+          name: 'Memo.txt',
+          uri: 'file:///memo.txt',
+          mimeType: 'text/plain',
+          lastModified: 0,
+        },
+        {
+          name: '.Secret.md',
+          uri: 'file:///secret.md',
+          mimeType: 'text/markdown',
+          lastModified: 0,
+        },
+        {
+          name: 'Photo.png',
+          uri: 'file:///photo.png',
+          mimeType: 'image/png',
+          lastModified: 0,
+        },
+      ],
+    });
+    vi.mocked(FileSystem.readAsStringAsync).mockImplementation(async (uri) =>
+      uri.endsWith('plan.md') ? '# Plan' : 'Memo body'
+    );
+
+    const sources = await selectNotesImportSources('files');
+
+    expect(DocumentPicker.getDocumentAsync).toHaveBeenCalledWith({
+      copyToCacheDirectory: true,
+      multiple: true,
+      type: '*/*',
+    });
+    expect(FileSystem.readAsStringAsync).toHaveBeenCalledTimes(2);
+    expect(sources).toEqual([
+      source('Plan.md', '# Plan'),
+      source('Memo.txt', 'Memo body'),
+    ]);
+  });
+
+  test('selects native folders', async () => {
+    vi.stubGlobal('document', undefined);
+    const hiddenFile = makeNativeFile('Secret.md', 'hidden');
+    const unsupportedFile = makeNativeFile('Photo.png', 'png');
+    vi.mocked(ExpoDirectory.pickDirectoryAsync).mockResolvedValue(
+      makeNativeDirectory('Research', [
+        makeNativeFile('Plan.md', '# Plan'),
+        makeNativeDirectory('Trips', [
+          makeNativeFile('Index.markdown', 'Trip notes'),
+          unsupportedFile,
+        ]),
+        makeNativeDirectory('.drafts', [hiddenFile]),
+      ]) as never
+    );
+
+    const sources = await selectNotesImportSources('folder');
+
+    expect(ExpoDirectory.pickDirectoryAsync).toHaveBeenCalled();
+    expect(DocumentPicker.getDocumentAsync).not.toHaveBeenCalled();
+    expect(sources).toEqual([
+      source('Research/Plan.md', '# Plan'),
+      source('Research/Trips/Index.markdown', 'Trip notes'),
+    ]);
+    expect(hiddenFile.text).not.toHaveBeenCalled();
+    expect(unsupportedFile.text).not.toHaveBeenCalled();
+  });
+
+  test('returns null when native folder selection is canceled', async () => {
+    vi.stubGlobal('document', undefined);
+    vi.mocked(ExpoDirectory.pickDirectoryAsync).mockRejectedValue(
+      new Error('File picking was cancelled by the user')
+    );
+
+    await expect(selectNotesImportSources('folder')).resolves.toBeNull();
+  });
+});

--- a/packages/app/ui/components/NotesChannel/notesImport.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.test.ts
@@ -131,14 +131,14 @@ describe('notes import helpers', () => {
     expect(makeUniqueNoteTitle('', existingTitles)).toBe('Untitled');
   });
 
-  test('uses selected folder, active folder, then root for import target', () => {
+  test('uses active folder, selected folder, then root for import target', () => {
     expect(
       getNotesImportTargetFolderId({
         selectedFolderId: 9,
         activeFolderId: 4,
         rootFolderId: 1,
       })
-    ).toBe(9);
+    ).toBe(4);
     expect(
       getNotesImportTargetFolderId({
         selectedFolderId: null,

--- a/packages/app/ui/components/NotesChannel/notesImport.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.ts
@@ -410,12 +410,16 @@ function isNotesNativeFile(
 
 function getNativeEntryName(entry: NotesNativeEntry) {
   const rawName = entry.name || getNameFromUri(entry.uri) || '';
-  const decodedName = safeDecodeURIComponent(rawName);
+  let decodedName = safeDecodeURIComponent(rawName);
+  // Android SAF entry names decode to full document ids of the form
+  // "<volume>:<path>" (e.g. "primary:Notes/Meeting: Q3.md"). Strip only the
+  // leading volume prefix — any colon after the first path separator belongs
+  // to a real file or folder name and must survive.
+  if (entry.uri?.startsWith('content://')) {
+    decodedName = decodedName.replace(/^[^:/\\]+:/, '');
+  }
   const pathSegments = splitImportPath(decodedName);
   const name = pathSegments[pathSegments.length - 1] ?? decodedName;
-  if (entry.uri?.startsWith('content://') && name.includes(':')) {
-    return name.split(':').pop()?.trim() ?? '';
-  }
   return name.trim();
 }
 

--- a/packages/app/ui/components/NotesChannel/notesImport.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.ts
@@ -7,6 +7,18 @@ export type NotesImportSource = {
   contents: string;
 };
 
+export function getNotesImportTargetFolderId({
+  activeFolderId,
+  rootFolderId,
+  selectedFolderId,
+}: {
+  activeFolderId: number | null | undefined;
+  rootFolderId: number | null | undefined;
+  selectedFolderId: number | null | undefined;
+}) {
+  return selectedFolderId ?? activeFolderId ?? rootFolderId ?? null;
+}
+
 type NotesImportItem = {
   body: string;
   folderSegments: string[];

--- a/packages/app/ui/components/NotesChannel/notesImport.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.ts
@@ -16,7 +16,7 @@ export function getNotesImportTargetFolderId({
   rootFolderId: number | null | undefined;
   selectedFolderId: number | null | undefined;
 }) {
-  return selectedFolderId ?? activeFolderId ?? rootFolderId ?? null;
+  return activeFolderId ?? selectedFolderId ?? rootFolderId ?? null;
 }
 
 type NotesImportItem = {

--- a/packages/app/ui/components/NotesChannel/notesImport.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.ts
@@ -48,9 +48,11 @@ type NotesFileSystemEntry = {
 };
 
 export function canSelectNotesImportSources(mode: NotesImportMode) {
-  return canSelectNotesImportSourcesFromWeb() ||
+  return (
+    canSelectNotesImportSourcesFromWeb() ||
     mode === 'files' ||
-    canSelectNotesImportFolderFromNative();
+    canSelectNotesImportFolderFromNative()
+  );
 }
 
 export async function selectNotesImportSources(
@@ -102,10 +104,12 @@ function selectNotesImportSourcesFromWeb(
 
     input.onchange = () => {
       const files = Array.from(input.files ?? []);
-      readNotesImportSourcesFromFiles(files).then(settle).catch((e) => {
-        cleanup();
-        reject(e);
-      });
+      readNotesImportSourcesFromFiles(files)
+        .then(settle)
+        .catch((e) => {
+          cleanup();
+          reject(e);
+        });
     };
 
     document.body.appendChild(input);
@@ -135,10 +139,15 @@ export async function readNotesImportSourcesFromDataTransfer(
   });
 
   if (entries.length === 0) {
-    return readNotesImportSourcesFromFiles(Array.from(dataTransfer.files ?? []));
+    return readNotesImportSourcesFromFiles(
+      Array.from(dataTransfer.files ?? [])
+    );
   }
 
-  const records = await flatMapAsync(entries, readNotesImportFileRecordsFromEntry);
+  const records = await flatMapAsync(
+    entries,
+    readNotesImportFileRecordsFromEntry
+  );
   return readNotesImportSourcesFromFileRecords(records);
 }
 
@@ -322,8 +331,7 @@ async function readNotesImportFileRecordsFromEntry(
     return [
       {
         relativePath,
-        readText: async () =>
-          (await getFileFromEntry(entry)).text(),
+        readText: async () => (await getFileFromEntry(entry)).text(),
       },
     ];
   }
@@ -404,7 +412,12 @@ function getNameFromUri(uri?: string) {
   try {
     return new URL(uri).pathname.split('/').filter(Boolean).pop() ?? '';
   } catch {
-    return uri.split(/[\\/]+/).filter(Boolean).pop() ?? '';
+    return (
+      uri
+        .split(/[\\/]+/)
+        .filter(Boolean)
+        .pop() ?? ''
+    );
   }
 }
 

--- a/packages/app/ui/components/NotesChannel/notesImport.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.ts
@@ -1,0 +1,461 @@
+import * as DocumentPicker from 'expo-document-picker';
+import { Directory as ExpoDirectory } from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
+
+export type NotesImportSource = {
+  relativePath: string;
+  contents: string;
+};
+
+type NotesImportItem = {
+  body: string;
+  folderSegments: string[];
+  relativePath: string;
+  title: string;
+};
+
+type NotesImportMode = 'files' | 'folder';
+
+const SUPPORTED_IMPORT_EXTENSIONS = ['.markdown', '.md', '.txt'];
+
+type NotesImportFileRecord = {
+  relativePath: string;
+  readText: () => Promise<string>;
+};
+
+type NotesNativeEntry = {
+  name?: string;
+  list?: () => NotesNativeEntry[];
+  text?: () => Promise<string>;
+  uri?: string;
+};
+
+type NotesFileSystemEntry = {
+  fullPath?: string;
+  file?: (
+    success: (file: File) => void,
+    failure?: (error: unknown) => void
+  ) => void;
+  createReader?: () => {
+    readEntries: (
+      success: (entries: NotesFileSystemEntry[]) => void,
+      failure?: (error: unknown) => void
+    ) => void;
+  };
+  isDirectory: boolean;
+  isFile: boolean;
+  name: string;
+};
+
+export function canSelectNotesImportSources(mode: NotesImportMode) {
+  return canSelectNotesImportSourcesFromWeb() ||
+    mode === 'files' ||
+    canSelectNotesImportFolderFromNative();
+}
+
+export async function selectNotesImportSources(
+  mode: NotesImportMode
+): Promise<NotesImportSource[] | null> {
+  return canSelectNotesImportSourcesFromWeb()
+    ? selectNotesImportSourcesFromWeb(mode)
+    : selectNotesImportSourcesFromNative(mode);
+}
+
+function canSelectNotesImportSourcesFromWeb() {
+  return typeof document !== 'undefined';
+}
+
+function selectNotesImportSourcesFromWeb(
+  mode: NotesImportMode
+): Promise<NotesImportSource[] | null> {
+  if (!canSelectNotesImportSourcesFromWeb()) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.md,.markdown,.txt,text/markdown,text/plain';
+    input.multiple = true;
+    if (mode === 'folder') {
+      input.setAttribute('webkitdirectory', '');
+    }
+
+    let settled = false;
+    const cleanup = () => {
+      window.removeEventListener('focus', handleFocus);
+      input.remove();
+    };
+    const settle = (value: NotesImportSource[] | null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const handleFocus = () => {
+      window.setTimeout(() => {
+        if (!input.files || input.files.length === 0) {
+          settle(null);
+        }
+      }, 300);
+    };
+
+    input.onchange = () => {
+      const files = Array.from(input.files ?? []);
+      readNotesImportSourcesFromFiles(files).then(settle).catch((e) => {
+        cleanup();
+        reject(e);
+      });
+    };
+
+    document.body.appendChild(input);
+    window.addEventListener('focus', handleFocus);
+    input.click();
+  });
+}
+
+async function readNotesImportSourcesFromFiles(files: File[]) {
+  return readNotesImportSourcesFromFileRecords(
+    files.map((file) => ({
+      relativePath: getFileRelativePath(file),
+      readText: () => file.text(),
+    }))
+  );
+}
+
+export async function readNotesImportSourcesFromDataTransfer(
+  dataTransfer: Pick<DataTransfer, 'files' | 'items'>
+) {
+  const entries = Array.from(dataTransfer.items ?? []).flatMap((item) => {
+    const maybeEntry = item as DataTransferItem & {
+      webkitGetAsEntry?: () => unknown;
+    };
+    const entry = maybeEntry.webkitGetAsEntry?.();
+    return isNotesFileSystemEntry(entry) ? [entry] : [];
+  });
+
+  if (entries.length === 0) {
+    return readNotesImportSourcesFromFiles(Array.from(dataTransfer.files ?? []));
+  }
+
+  const records = await flatMapAsync(entries, readNotesImportFileRecordsFromEntry);
+  return readNotesImportSourcesFromFileRecords(records);
+}
+
+async function readNotesImportSourcesFromFileRecords(
+  records: NotesImportFileRecord[]
+) {
+  return Promise.all(
+    records
+      .filter((record) => isImportableRelativePath(record.relativePath))
+      .map(async ({ relativePath, readText }) => ({
+        relativePath,
+        contents: await readText(),
+      }))
+  );
+}
+
+async function readNotesImportSourcesFromDocumentPickerAssets(
+  assets: { name: string; uri: string }[],
+  readFileContents: (uri: string) => Promise<string>
+) {
+  return readNotesImportSourcesFromFileRecords(
+    assets.map((asset) => ({
+      relativePath: asset.name,
+      readText: () => readFileContents(asset.uri),
+    }))
+  );
+}
+
+async function readNotesImportSourcesFromNativeDirectory(
+  directory: NotesNativeEntry
+) {
+  if (!isNotesNativeDirectory(directory)) {
+    return [];
+  }
+
+  const rootName = getNativeEntryName(directory);
+  const records = await readNotesImportFileRecordsFromNativeDirectory(
+    directory,
+    rootName ? [rootName] : []
+  );
+  return readNotesImportSourcesFromFileRecords(records);
+}
+
+export function buildNotesImportItems(
+  sources: NotesImportSource[]
+): NotesImportItem[] {
+  return sources.flatMap((source) => {
+    const relativePath = source.relativePath;
+    if (!isImportableRelativePath(relativePath)) {
+      return [];
+    }
+
+    const pathSegments = splitImportPath(relativePath);
+    const fileName = pathSegments[pathSegments.length - 1] ?? relativePath;
+    return [
+      {
+        body: source.contents,
+        folderSegments: pathSegments.slice(0, -1),
+        relativePath,
+        title: titleFromImportFileName(fileName),
+      },
+    ];
+  });
+}
+
+export function makeUniqueNoteTitle(
+  title: string,
+  existingTitles: Set<string>
+) {
+  const baseTitle = title.trim() || 'Untitled';
+  let nextTitle = baseTitle;
+  let index = 2;
+  while (existingTitles.has(normalizeTitleKey(nextTitle))) {
+    nextTitle = `${baseTitle} (${index})`;
+    index += 1;
+  }
+  existingTitles.add(normalizeTitleKey(nextTitle));
+  return nextTitle;
+}
+
+export function normalizeTitleKey(title: string) {
+  return title.trim().toLocaleLowerCase();
+}
+
+function isSupportedNotesImportName(name: string) {
+  const normalizedName = name.toLocaleLowerCase();
+  return SUPPORTED_IMPORT_EXTENSIONS.some((extension) =>
+    normalizedName.endsWith(extension)
+  );
+}
+
+function isImportableRelativePath(relativePath: string) {
+  const pathSegments = splitImportPath(relativePath);
+  const fileName = pathSegments[pathSegments.length - 1] ?? relativePath;
+  return (
+    pathSegments.length > 0 &&
+    !pathSegments.some(isHiddenPathSegment) &&
+    isSupportedNotesImportName(fileName)
+  );
+}
+
+function titleFromImportFileName(name: string) {
+  const extension = SUPPORTED_IMPORT_EXTENSIONS.find((candidate) =>
+    name.toLocaleLowerCase().endsWith(candidate)
+  );
+  return extension ? name.slice(0, -extension.length).trim() : name.trim();
+}
+
+function splitImportPath(relativePath: string) {
+  return relativePath
+    .split(/[\\/]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function getFileRelativePath(file: File) {
+  return (
+    (file as File & { webkitRelativePath?: string }).webkitRelativePath ||
+    file.name
+  );
+}
+
+function isNotesFileSystemEntry(entry: unknown): entry is NotesFileSystemEntry {
+  return (
+    entry != null &&
+    typeof entry === 'object' &&
+    'isDirectory' in entry &&
+    'isFile' in entry &&
+    'name' in entry
+  );
+}
+
+function isHiddenPathSegment(segment: string) {
+  return segment.startsWith('.') || segment === '__MACOSX';
+}
+
+async function readNotesImportFileRecordsFromNativeDirectory(
+  directory: NotesNativeEntry & { list: () => NotesNativeEntry[] },
+  parentSegments: string[]
+): Promise<NotesImportFileRecord[]> {
+  return flatMapAsync(directory.list(), (entry) =>
+    readNotesImportFileRecordsFromNativeEntry(entry, parentSegments)
+  );
+}
+
+async function readNotesImportFileRecordsFromNativeEntry(
+  entry: NotesNativeEntry,
+  parentSegments: string[]
+): Promise<NotesImportFileRecord[]> {
+  const name = getNativeEntryName(entry);
+  if (!name || isHiddenPathSegment(name)) {
+    return [];
+  }
+
+  if (isNotesNativeDirectory(entry)) {
+    return readNotesImportFileRecordsFromNativeDirectory(entry, [
+      ...parentSegments,
+      name,
+    ]);
+  }
+
+  if (!isNotesNativeFile(entry)) {
+    return [];
+  }
+
+  const relativePath = [...parentSegments, name].join('/');
+  return [
+    {
+      relativePath,
+      readText: () => entry.text(),
+    },
+  ];
+}
+
+async function readNotesImportFileRecordsFromEntry(
+  entry: NotesFileSystemEntry
+): Promise<NotesImportFileRecord[]> {
+  if (entry.isFile) {
+    if (!entry.file) return [];
+    const relativePath = normalizeDroppedPath(entry.fullPath || entry.name);
+    return [
+      {
+        relativePath,
+        readText: async () =>
+          (await getFileFromEntry(entry)).text(),
+      },
+    ];
+  }
+
+  if (!entry.isDirectory || !entry.createReader) {
+    return [];
+  }
+
+  const childEntries = await readDirectoryEntries(entry);
+  return flatMapAsync(childEntries, readNotesImportFileRecordsFromEntry);
+}
+
+async function flatMapAsync<T, U>(items: T[], map: (item: T) => Promise<U[]>) {
+  return (await Promise.all(items.map(map))).flat();
+}
+
+function getFileFromEntry(entry: NotesFileSystemEntry) {
+  return new Promise<File>((resolve, reject) => {
+    if (!entry.file) {
+      reject(new Error('File entry is missing a file reader'));
+      return;
+    }
+    entry.file(resolve, reject);
+  });
+}
+
+function readDirectoryEntries(entry: NotesFileSystemEntry) {
+  const reader = entry.createReader?.();
+  if (!reader) return [];
+
+  const entries: NotesFileSystemEntry[] = [];
+
+  return new Promise<NotesFileSystemEntry[]>((resolve, reject) => {
+    const readBatch = () => {
+      reader.readEntries((batch) => {
+        if (batch.length === 0) {
+          resolve(entries);
+          return;
+        }
+        entries.push(...batch);
+        readBatch();
+      }, reject);
+    };
+
+    readBatch();
+  });
+}
+
+function normalizeDroppedPath(path: string) {
+  return path.replace(/^\/+/, '');
+}
+
+function isNotesNativeDirectory(
+  entry: NotesNativeEntry
+): entry is NotesNativeEntry & { list: () => NotesNativeEntry[] } {
+  return typeof entry.list === 'function';
+}
+
+function isNotesNativeFile(
+  entry: NotesNativeEntry
+): entry is NotesNativeEntry & { text: () => Promise<string> } {
+  return typeof entry.text === 'function';
+}
+
+function getNativeEntryName(entry: NotesNativeEntry) {
+  const rawName = entry.name || getNameFromUri(entry.uri) || '';
+  const decodedName = safeDecodeURIComponent(rawName);
+  const pathSegments = splitImportPath(decodedName);
+  const name = pathSegments[pathSegments.length - 1] ?? decodedName;
+  if (entry.uri?.startsWith('content://') && name.includes(':')) {
+    return name.split(':').pop()?.trim() ?? '';
+  }
+  return name.trim();
+}
+
+function getNameFromUri(uri?: string) {
+  if (!uri) return '';
+  try {
+    return new URL(uri).pathname.split('/').filter(Boolean).pop() ?? '';
+  } catch {
+    return uri.split(/[\\/]+/).filter(Boolean).pop() ?? '';
+  }
+}
+
+function safeDecodeURIComponent(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function canSelectNotesImportFolderFromNative() {
+  return typeof ExpoDirectory.pickDirectoryAsync === 'function';
+}
+
+async function selectNotesImportSourcesFromNative(mode: NotesImportMode) {
+  if (mode === 'folder') {
+    return selectNotesImportFolderFromNative();
+  }
+
+  const result = await DocumentPicker.getDocumentAsync({
+    copyToCacheDirectory: true,
+    multiple: true,
+    type: '*/*',
+  });
+
+  if (result.assets == null || result.assets.length === 0) return null;
+
+  return readNotesImportSourcesFromDocumentPickerAssets(
+    result.assets,
+    FileSystem.readAsStringAsync
+  );
+}
+
+async function selectNotesImportFolderFromNative() {
+  if (!canSelectNotesImportFolderFromNative()) return null;
+
+  try {
+    const directory = await ExpoDirectory.pickDirectoryAsync();
+    return readNotesImportSourcesFromNativeDirectory(directory);
+  } catch (e) {
+    if (isPickerCancelError(e)) {
+      return null;
+    }
+    throw e;
+  }
+}
+
+function isPickerCancelError(error: unknown) {
+  return (
+    error instanceof Error &&
+    /pick(?:er|ing).+cancel(?:ed|led)/i.test(error.message)
+  );
+}

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -11,6 +11,7 @@ import { YStack } from 'tamagui';
 import { errorMessage } from './NotesCommon';
 import {
   buildNotesImportItems,
+  getNotesImportTargetFolderId,
   makeUniqueNoteTitle,
   normalizeTitleKey,
   readNotesImportSourcesFromDataTransfer,
@@ -20,6 +21,7 @@ import type { NotesImportSource } from './notesImport';
 import { trackNotesActionError } from './notesTelemetry';
 
 export function useNotesImportController({
+  activeFolderId,
   canDropImportNotes,
   canEdit,
   folders,
@@ -29,6 +31,7 @@ export function useNotesImportController({
   selectedFolderId,
   setError,
 }: {
+  activeFolderId: number | null;
   canDropImportNotes: boolean;
   canEdit: boolean;
   folders: db.NotesFolder[];
@@ -130,7 +133,11 @@ export function useNotesImportController({
 
   const runImport = useMutableCallback(
     async (readSources: () => Promise<NotesImportSource[] | null>) => {
-      const targetRootFolderId = selectedFolderId ?? rootFolderId;
+      const targetRootFolderId = getNotesImportTargetFolderId({
+        activeFolderId,
+        rootFolderId,
+        selectedFolderId,
+      });
 
       if (
         !notebookFlag ||

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -108,12 +108,15 @@ export function useNotesImportController({
           const existingTitles = noteTitlesByFolder.get(folderId) ?? new Set();
           noteTitlesByFolder.set(folderId, existingTitles);
           const title = makeUniqueNoteTitle(item.title, existingTitles);
-          await createNotebookNote({
+          const note = await createNotebookNote({
             notebookFlag: importNotebookFlag,
             folderId,
             title,
             body: item.body,
           });
+          if (!note) {
+            throw new Error(`Failed to create note ${item.relativePath}`);
+          }
           importedCount += 1;
         } catch (e) {
           if (isNotesPendingWriteError(e)) {

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ComponentProps, DragEvent } from 'react';
 import { YStack } from 'tamagui';
 
-import { errorMessage } from './NotesCommon';
+import { errorMessage, isNotesPendingWriteError } from './NotesFeedback';
 import {
   buildNotesImportItems,
   getNotesImportTargetFolderId,
@@ -116,6 +116,9 @@ export function useNotesImportController({
           });
           importedCount += 1;
         } catch (e) {
+          if (isNotesPendingWriteError(e)) {
+            throw e;
+          }
           console.error('Failed to import note', item.relativePath, e);
           failedCount += 1;
         }

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -107,7 +107,6 @@ export function useNotesImportController({
       };
 
       let importedCount = 0;
-      let failedCount = 0;
       for (const item of importItems) {
         try {
           const folderId = await ensureFolderPath(item.folderSegments);
@@ -130,18 +129,14 @@ export function useNotesImportController({
           if (isNotesPendingWriteError(e)) {
             throw e;
           }
-          console.error('Failed to import note', item.relativePath, e);
-          failedCount += 1;
+          const message = errorMessage(e, 'Failed to import note');
+          throw new Error(
+            `${NOTES_PENDING_WRITE_MESSAGE}; the outcome of importing "${item.relativePath}" is unknown and it may still complete. Check whether it was imported before retrying. ${message}`
+          );
         }
       }
 
-      if (importedCount === 0 && failedCount > 0) {
-        throw new Error(
-          `Failed to import ${formatCount(failedCount, 'note')}.`
-        );
-      }
-
-      setImportNotice(formatImportNotice(importedCount, failedCount));
+      setImportNotice(formatImportNotice(importedCount));
     }
   );
 
@@ -271,13 +266,8 @@ function folderCacheKey(name: string, parentFolderId?: number | null) {
   return `${parentFolderId ?? 'root'}:${normalizeTitleKey(name)}`;
 }
 
-function formatImportNotice(importedCount: number, failedCount: number) {
-  return failedCount === 0
-    ? `Imported ${formatCount(importedCount, 'note')}.`
-    : `Imported ${formatCount(importedCount, 'note')}; ${formatCount(
-        failedCount,
-        'note'
-      )} failed.`;
+function formatImportNotice(importedCount: number) {
+  return `Imported ${formatCount(importedCount, 'note')}.`;
 }
 
 function formatCount(count: number, label: string) {

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -1,0 +1,266 @@
+import {
+  createNotebookFolder,
+  createNotebookNote,
+  useMutableCallback,
+} from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ComponentProps, DragEvent } from 'react';
+import { YStack } from 'tamagui';
+
+import { errorMessage } from './NotesCommon';
+import {
+  buildNotesImportItems,
+  makeUniqueNoteTitle,
+  normalizeTitleKey,
+  readNotesImportSourcesFromDataTransfer,
+  selectNotesImportSources,
+} from './notesImport';
+import type { NotesImportSource } from './notesImport';
+
+export function useNotesImportController({
+  canDropImportNotes,
+  canEdit,
+  expandFolder,
+  folders,
+  notebookFlag,
+  notes,
+  rootFolderId,
+  selectedFolderId,
+  setError,
+}: {
+  canDropImportNotes: boolean;
+  canEdit: boolean;
+  expandFolder: (folderId: number) => void;
+  folders: db.NotesFolder[];
+  notebookFlag: string | null | undefined;
+  notes: db.NotesNote[];
+  rootFolderId: number | null;
+  selectedFolderId: number | null;
+  setError: (error: string | null) => void;
+}) {
+  const [importNotice, setImportNotice] = useState<string | null>(null);
+  const [isDragImportActive, setIsDragImportActive] = useState(false);
+  const [isImportingNotes, setIsImportingNotes] = useState(false);
+  const dragImportDepthRef = useRef(0);
+
+  const importNotesFromSources = useMutableCallback(
+    async (
+      sources: NotesImportSource[] | null,
+      targetRootFolderId: number,
+      importNotebookFlag: string
+    ) => {
+      if (!sources) {
+        return;
+      }
+
+      const importItems = buildNotesImportItems(sources);
+      if (importItems.length === 0) {
+        setImportNotice('No markdown or text files found.');
+        return;
+      }
+
+      const foldersByParentAndName = new Map<string, db.NotesFolder>();
+      folders.forEach((folder) => {
+        const key = folderCacheKey(folder.name, folder.parentFolderId);
+        foldersByParentAndName.set(key, folder);
+      });
+
+      const noteTitlesByFolder = new Map<number, Set<string>>();
+      notes.forEach((note) => {
+        const titles = noteTitlesByFolder.get(note.folderId) ?? new Set();
+        titles.add(normalizeTitleKey(note.title));
+        noteTitlesByFolder.set(note.folderId, titles);
+      });
+
+      const expandedFolderIds = new Set<number>([targetRootFolderId]);
+      const ensureFolderPath = async (segments: string[]) => {
+        let parentFolderId = targetRootFolderId;
+        for (const segment of segments) {
+          const key = folderCacheKey(segment, parentFolderId);
+          const existing = foldersByParentAndName.get(key);
+          if (existing) {
+            parentFolderId = existing.folderId;
+            expandedFolderIds.add(parentFolderId);
+            continue;
+          }
+
+          const folder = await createNotebookFolder({
+            notebookFlag: importNotebookFlag,
+            parentFolderId,
+            name: segment,
+          });
+          if (!folder) {
+            throw new Error(`Failed to create folder ${segment}`);
+          }
+
+          foldersByParentAndName.set(key, folder);
+          parentFolderId = folder.folderId;
+          expandedFolderIds.add(parentFolderId);
+        }
+        return parentFolderId;
+      };
+
+      let importedCount = 0;
+      let failedCount = 0;
+      for (const item of importItems) {
+        try {
+          const folderId = await ensureFolderPath(item.folderSegments);
+          const existingTitles = noteTitlesByFolder.get(folderId) ?? new Set();
+          noteTitlesByFolder.set(folderId, existingTitles);
+          const title = makeUniqueNoteTitle(item.title, existingTitles);
+          await createNotebookNote({
+            notebookFlag: importNotebookFlag,
+            folderId,
+            title,
+            body: item.body,
+          });
+          expandedFolderIds.add(folderId);
+          importedCount += 1;
+        } catch (e) {
+          console.error('Failed to import note', item.relativePath, e);
+          failedCount += 1;
+        }
+      }
+
+      expandedFolderIds.forEach(expandFolder);
+      if (importedCount === 0 && failedCount > 0) {
+        throw new Error(
+          `Failed to import ${formatCount(failedCount, 'note')}.`
+        );
+      }
+
+      setImportNotice(formatImportNotice(importedCount, failedCount));
+    }
+  );
+
+  const runImport = useMutableCallback(
+    async (readSources: () => Promise<NotesImportSource[] | null>) => {
+      const targetRootFolderId = selectedFolderId ?? rootFolderId;
+
+      if (
+        !notebookFlag ||
+        targetRootFolderId == null ||
+        !canEdit ||
+        isImportingNotes
+      ) {
+        return;
+      }
+
+      setError(null);
+      setImportNotice(null);
+      setIsImportingNotes(true);
+      try {
+        await importNotesFromSources(
+          await readSources(),
+          targetRootFolderId,
+          notebookFlag
+        );
+      } catch (e) {
+        setError(errorMessage(e, 'Failed to import notes'));
+      } finally {
+        setIsImportingNotes(false);
+      }
+    }
+  );
+
+  const importFiles = useMutableCallback(() => {
+    void runImport(() => selectNotesImportSources('files'));
+  });
+
+  const importFolder = useMutableCallback(() => {
+    void runImport(() => selectNotesImportSources('folder'));
+  });
+
+  const prepareImportDragEvent = useMutableCallback((event: DragEvent) => {
+    if (
+      !canDropImportNotes ||
+      !Array.from(event.dataTransfer.types ?? []).includes('Files')
+    ) {
+      return false;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    return true;
+  });
+
+  const handleImportDragEnter = useMutableCallback((event: DragEvent) => {
+    if (!prepareImportDragEvent(event)) return;
+    dragImportDepthRef.current += 1;
+    setIsDragImportActive(true);
+  });
+
+  const handleImportDragOver = useMutableCallback((event: DragEvent) => {
+    if (!prepareImportDragEvent(event)) return;
+    event.dataTransfer.dropEffect = isImportingNotes ? 'none' : 'copy';
+  });
+
+  const handleImportDragLeave = useMutableCallback((event: DragEvent) => {
+    if (!prepareImportDragEvent(event)) return;
+    dragImportDepthRef.current = Math.max(0, dragImportDepthRef.current - 1);
+    if (dragImportDepthRef.current === 0) {
+      setIsDragImportActive(false);
+    }
+  });
+
+  const handleImportDrop = useMutableCallback((event: DragEvent) => {
+    if (!prepareImportDragEvent(event)) return;
+    dragImportDepthRef.current = 0;
+    setIsDragImportActive(false);
+    void runImport(() =>
+      readNotesImportSourcesFromDataTransfer(event.dataTransfer)
+    );
+  });
+
+  const dropImportProps = useMemo(
+    () =>
+      canDropImportNotes
+        ? ({
+            onDragEnter: handleImportDragEnter,
+            onDragLeave: handleImportDragLeave,
+            onDragOver: handleImportDragOver,
+            onDrop: handleImportDrop,
+          } as unknown as ComponentProps<typeof YStack>)
+        : {},
+    [
+      canDropImportNotes,
+      handleImportDragEnter,
+      handleImportDragLeave,
+      handleImportDragOver,
+      handleImportDrop,
+    ]
+  );
+
+  useEffect(() => {
+    if (!canDropImportNotes) {
+      dragImportDepthRef.current = 0;
+      setIsDragImportActive(false);
+    }
+  }, [canDropImportNotes]);
+
+  return {
+    dropImportProps,
+    importFiles,
+    importFolder,
+    importNotice,
+    isDragImportActive,
+    isImportingNotes,
+  };
+}
+
+function folderCacheKey(name: string, parentFolderId?: number | null) {
+  return `${parentFolderId ?? 'root'}:${normalizeTitleKey(name)}`;
+}
+
+function formatImportNotice(importedCount: number, failedCount: number) {
+  return failedCount === 0
+    ? `Imported ${formatCount(importedCount, 'note')}.`
+    : `Imported ${formatCount(importedCount, 'note')}; ${formatCount(
+        failedCount,
+        'note'
+      )} failed.`;
+}
+
+function formatCount(count: number, label: string) {
+  return `${count} ${label}${count === 1 ? '' : 's'}`;
+}

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -17,6 +17,7 @@ import {
   selectNotesImportSources,
 } from './notesImport';
 import type { NotesImportSource } from './notesImport';
+import { trackNotesActionError } from './notesTelemetry';
 
 export function useNotesImportController({
   canDropImportNotes,
@@ -157,7 +158,11 @@ export function useNotesImportController({
           notebookFlag
         );
       } catch (e) {
-        setError(errorMessage(e, 'Failed to import notes'));
+        const message = errorMessage(e, 'Failed to import notes');
+        trackNotesActionError('import notes', e, message, {
+          targetRootFolderId,
+        });
+        setError(message);
       } finally {
         setIsImportingNotes(false);
       }

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -121,7 +121,9 @@ export function useNotesImportController({
             body: item.body,
           });
           if (!note) {
-            throw new Error(`Failed to create note ${item.relativePath}`);
+            throw new Error(
+              `${NOTES_PENDING_WRITE_MESSAGE}; the outcome is unknown and it may still complete. Check whether note "${title}" was created before retrying.`
+            );
           }
           importedCount += 1;
         } catch (e) {

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -22,7 +22,6 @@ import { trackNotesActionError } from './notesTelemetry';
 export function useNotesImportController({
   canDropImportNotes,
   canEdit,
-  expandFolder,
   folders,
   notebookFlag,
   notes,
@@ -32,7 +31,6 @@ export function useNotesImportController({
 }: {
   canDropImportNotes: boolean;
   canEdit: boolean;
-  expandFolder: (folderId: number) => void;
   folders: db.NotesFolder[];
   notebookFlag: string | null | undefined;
   notes: db.NotesNote[];
@@ -74,7 +72,6 @@ export function useNotesImportController({
         noteTitlesByFolder.set(note.folderId, titles);
       });
 
-      const expandedFolderIds = new Set<number>([targetRootFolderId]);
       const ensureFolderPath = async (segments: string[]) => {
         let parentFolderId = targetRootFolderId;
         for (const segment of segments) {
@@ -82,7 +79,6 @@ export function useNotesImportController({
           const existing = foldersByParentAndName.get(key);
           if (existing) {
             parentFolderId = existing.folderId;
-            expandedFolderIds.add(parentFolderId);
             continue;
           }
 
@@ -97,7 +93,6 @@ export function useNotesImportController({
 
           foldersByParentAndName.set(key, folder);
           parentFolderId = folder.folderId;
-          expandedFolderIds.add(parentFolderId);
         }
         return parentFolderId;
       };
@@ -116,7 +111,6 @@ export function useNotesImportController({
             title,
             body: item.body,
           });
-          expandedFolderIds.add(folderId);
           importedCount += 1;
         } catch (e) {
           console.error('Failed to import note', item.relativePath, e);
@@ -124,7 +118,6 @@ export function useNotesImportController({
         }
       }
 
-      expandedFolderIds.forEach(expandFolder);
       if (importedCount === 0 && failedCount > 0) {
         throw new Error(
           `Failed to import ${formatCount(failedCount, 'note')}.`

--- a/packages/app/ui/components/NotesChannel/useNotesImportController.ts
+++ b/packages/app/ui/components/NotesChannel/useNotesImportController.ts
@@ -8,7 +8,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ComponentProps, DragEvent } from 'react';
 import { YStack } from 'tamagui';
 
-import { errorMessage, isNotesPendingWriteError } from './NotesFeedback';
+import {
+  NOTES_PENDING_WRITE_MESSAGE,
+  errorMessage,
+  isNotesPendingWriteError,
+} from './NotesFeedback';
 import {
   buildNotesImportItems,
   getNotesImportTargetFolderId,
@@ -91,7 +95,9 @@ export function useNotesImportController({
             name: segment,
           });
           if (!folder) {
-            throw new Error(`Failed to create folder ${segment}`);
+            throw new Error(
+              `${NOTES_PENDING_WRITE_MESSAGE}; the outcome is unknown and it may still complete. Check whether folder "${segment}" was created before retrying.`
+            );
           }
 
           foldersByParentAndName.set(key, folder);


### PR DESCRIPTION
## Summary

Adds markdown/text import to the native notes shell. This is PR 3 of the native notes stack and is stacked on #5991.

Stack:

1. #5990 data foundation
2. #5991 native shell
3. #5992 import flow
4. #5993 publish actions

## Changes

- Added file and folder import parsing for markdown, md, and txt files.
- Added import controller wiring for picker selection and drag/drop import.
- Added import actions to the notes header overflow menu.
- Preserved the active folder as the import target when importing from a folder screen.
- Added focused import tests covering file selection, folder paths, title conflicts, unsupported files, and target folder selection.

## How did I test?

Tested on device


## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] State / providers
  - [x] Channel display
  - [ ] Navigation
  - [ ] Notifications

## Rollback plan

Revert this PR to remove import actions and drag/drop import. The native notes shell from #5991 remains usable without import.
