### PR TITLE
add notes publish actions

### DIFF
--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -29,6 +29,7 @@ import {
   BadResponseError,
   poke,
   requestJson,
+  scry,
   subscribe,
   unsubscribe,
 } from './urbit';
@@ -40,6 +41,7 @@ vi.mock('./urbit', async () => {
     ...actual,
     poke: vi.fn(),
     requestJson: vi.fn(),
+    scry: vi.fn(),
     subscribe: vi.fn(),
     unsubscribe: vi.fn(),
   };
@@ -47,6 +49,7 @@ vi.mock('./urbit', async () => {
 
 const pokeMock = poke as unknown as Mock;
 const requestJsonMock = requestJson as unknown as Mock;
+const scryMock = scry as unknown as Mock;
 const subscribeMock = subscribe as unknown as Mock;
 const unsubscribeMock = unsubscribe as unknown as Mock;
 
@@ -72,6 +75,7 @@ function pendingErrorStrings(error: NotesV1PendingWriteError): string {
 beforeEach(() => {
   requestJsonMock.mockResolvedValue(undefined);
   pokeMock.mockResolvedValue(undefined);
+  scryMock.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -759,6 +763,57 @@ describe('notebook delete helpers', () => {
     await expect(
       deleteNotesNotebookBestEffort('~zod/blog')
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('publish helpers', () => {
+  test('notes facade lists and updates published notes through %notes', async () => {
+    scryMock.mockResolvedValue([{ host: '~zod', flagName: 'blog', noteId: 3 }]);
+
+    await expect(notes.listPublished()).resolves.toEqual([
+      { host: '~zod', flagName: 'blog', noteId: 3 },
+    ]);
+    expect(scryMock).toHaveBeenCalledWith({
+      app: 'notes',
+      path: '/v0/published',
+    });
+
+    await notes.publishNote({
+      flag: 'notes/~zod/blog',
+      noteId: 3,
+      html: '<p>Hello</p>',
+    });
+    expect(pokeMock).toHaveBeenLastCalledWith({
+      app: 'notes',
+      mark: 'notes-action',
+      json: {
+        type: 'notebook',
+        flag: '~zod/blog',
+        action: {
+          type: 'note',
+          id: 3,
+          action: { type: 'publish', html: '<p>Hello</p>' },
+        },
+      },
+    });
+
+    await notes.unpublishNote({
+      flag: { host: 'zod', name: 'blog' },
+      noteId: 3,
+    });
+    expect(pokeMock).toHaveBeenLastCalledWith({
+      app: 'notes',
+      mark: 'notes-action',
+      json: {
+        type: 'notebook',
+        flag: '~zod/blog',
+        action: {
+          type: 'note',
+          id: 3,
+          action: { type: 'unpublish' },
+        },
+      },
+    });
   });
 });
 

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -1,6 +1,6 @@
 import { createDevLogger } from '../lib/logger';
 import type * as models from '../types/models';
-import { poke, requestJson, subscribe, unsubscribe } from './urbit';
+import { poke, requestJson, scry, subscribe, unsubscribe } from './urbit';
 
 const logger = createDevLogger('notesApi', false);
 
@@ -22,6 +22,12 @@ export type NotesNote = models.NotesNote;
 export type NotesMember = models.NotesMember;
 export type NotesNoteRevision = models.NotesNoteRevision;
 
+export interface NotesPublishedRecord {
+  host: string;
+  flagName: string;
+  noteId: number;
+}
+
 export interface NotesFlag {
   host: string;
   name: string;
@@ -40,7 +46,13 @@ export type NotesStreamEvent = {
   flagName: string;
 };
 
-type NotesNotebookAction = { type: 'delete' };
+type NotesNoteAction =
+  | { type: 'publish'; html: string }
+  | { type: 'unpublish' };
+
+type NotesNotebookAction =
+  | { type: 'delete' }
+  | { type: 'note'; id: number; action: NotesNoteAction };
 type NotesJoinAction = { type: 'join'; ship: string; name: string };
 type NotesLeaveAction = { type: 'leave'; ship: string; name: string };
 
@@ -120,6 +132,14 @@ async function notesAction(action: NotesAction) {
   });
 }
 
+function notebookAction(target: NotesTarget, action: NotesNotebookAction) {
+  return notesAction({
+    type: 'notebook',
+    flag: formatNotesFlag(normalizeNotesTarget(target)),
+    action,
+  });
+}
+
 export async function joinNotesNotebook(target: NotesTarget) {
   const flag = normalizeNotesTarget(target);
   return notesAction({
@@ -170,11 +190,7 @@ export async function unsubscribeFromNotesNotebook(subscriptionId: number) {
 }
 
 function deleteNotesNotebook(flag: NotesFlag) {
-  return notesAction({
-    type: 'notebook',
-    flag: formatNotesFlag(flag),
-    action: { type: 'delete' },
-  });
+  return notebookAction(flag, { type: 'delete' });
 }
 
 export async function deleteNotesNotebookStrict(target: NotesTarget) {
@@ -453,6 +469,18 @@ function normalizeMemberV1(raw: any): NotesV1MemberRecord {
       ? [raw.role]
       : [];
   return { ship: req(raw.ship, 'member.ship'), roles };
+}
+
+function normalizePublishedRecord(raw: any): NotesPublishedRecord {
+  const noteId = req(raw.noteId, 'published.noteId');
+  if (typeof noteId !== 'number') {
+    throw new Error('%notes published record is missing noteId');
+  }
+  return {
+    host: reqString(raw.host, 'published.host'),
+    flagName: reqString(raw.flagName, 'published.flagName'),
+    noteId,
+  };
 }
 
 function maybe<T>(value: T | null | undefined): T | null {
@@ -1045,6 +1073,44 @@ async function listMembers(target: NotesTarget): Promise<NotesMember[]> {
   return rawMembers.flatMap((member) => toClientNotesMembers(target, member));
 }
 
+async function listPublished(): Promise<NotesPublishedRecord[]> {
+  const rawPublished = await scry({
+    app: 'notes',
+    path: '/v0/published',
+  });
+  return requireArray(rawPublished, normalizePublishedRecord);
+}
+
+async function publishNote({
+  flag,
+  noteId,
+  html,
+}: {
+  flag: NotesTarget;
+  noteId: number;
+  html: string;
+}) {
+  return notebookAction(flag, {
+    type: 'note',
+    id: noteId,
+    action: { type: 'publish', html },
+  });
+}
+
+async function unpublishNote({
+  flag,
+  noteId,
+}: {
+  flag: NotesTarget;
+  noteId: number;
+}) {
+  return notebookAction(flag, {
+    type: 'note',
+    id: noteId,
+    action: { type: 'unpublish' },
+  });
+}
+
 export type NotesV1Api = {
   getRequest: typeof getRequestV1;
   listNotebooks: typeof listNotebooksV1;
@@ -1089,6 +1155,9 @@ export type NotesApi = {
   moveFolder: typeof moveFolderV1;
   deleteFolder: typeof deleteFolderV1;
   listMembers: typeof listMembers;
+  listPublished: typeof listPublished;
+  publishNote: typeof publishNote;
+  unpublishNote: typeof unpublishNote;
 };
 
 export const notesV1: NotesV1Api = {
@@ -1135,4 +1204,7 @@ export const notes: NotesApi = {
   moveFolder: moveFolderV1,
   deleteFolder: deleteFolderV1,
   listMembers,
+  listPublished,
+  publishNote,
+  unpublishNote,
 };

--- a/packages/app/fixtures/NotesChannel.fixture.tsx
+++ b/packages/app/fixtures/NotesChannel.fixture.tsx
@@ -312,7 +312,6 @@ function NotebookContentsListFixture() {
             isNotePublished={(noteId) => publishedNoteIds.has(noteId)}
             layout={usePhoneViewport ? 'stack' : 'takeover'}
             publishDisabled={false}
-            publishingAction={null}
             selectedNoteId={selectedNoteId}
             treeRows={treeRows}
             onCreateFolderInFolder={() => {}}
@@ -379,7 +378,6 @@ function NotesTreeFixture() {
             isDeletingFolder={false}
             layout="takeover"
             publishDisabled={false}
-            publishingAction={null}
             selectedNoteId={1}
             treeRows={treeRows}
             onCreateFolderInFolder={() => {}}

--- a/packages/app/fixtures/NotesChannel.fixture.tsx
+++ b/packages/app/fixtures/NotesChannel.fixture.tsx
@@ -161,6 +161,13 @@ function seedNotesQueries() {
     ['notesNotes', new Set(['notesNotes']), notebookFlag],
     notes
   );
+  queryClient.setQueryData(
+    ['notesPublished', notebookFlag],
+    [
+      { host: '~zod', flagName: 'native-notes-fixture', noteId: 4 },
+      { host: '~zod', flagName: 'native-notes-fixture', noteId: 5 },
+    ]
+  );
 }
 
 function useSeedNotesFixtureData() {
@@ -243,6 +250,7 @@ function NotebookContentsListFixture() {
   const [selectedNoteId, setSelectedNoteId] = useState<number | null>(
     initialSelection.noteId
   );
+  const publishedNoteIds = useMemo(() => new Set([4, 5]), []);
 
   useEffect(() => {
     setActiveFolderId(initialSelection.activeFolderId);
@@ -297,8 +305,14 @@ function NotebookContentsListFixture() {
           ) : null}
           <NotesTreePane
             canEdit={canEdit}
+            getPublishedNoteUrl={(note) =>
+              `https://test.tlon.app/notes/native-notes-fixture/${note.noteId}`
+            }
             isDeletingFolder={false}
+            isNotePublished={(noteId) => publishedNoteIds.has(noteId)}
             layout={usePhoneViewport ? 'stack' : 'takeover'}
+            publishDisabled={false}
+            publishingAction={null}
             selectedNoteId={selectedNoteId}
             treeRows={treeRows}
             onCreateFolderInFolder={() => {}}
@@ -309,8 +323,11 @@ function NotebookContentsListFixture() {
             onMoveNote={() => {}}
             onOpenNote={openNote}
             onOpenFolder={openFolder}
+            onPublishNote={() => {}}
             onRenameFolder={() => {}}
             onRenameNote={() => {}}
+            onUnpublishNote={() => {}}
+            onViewPublishedNote={() => {}}
           />
         </YStack>
       </ChannelHeaderItemsProvider>
@@ -358,8 +375,11 @@ function NotesTreeFixture() {
         >
           <NotesTreePane
             canEdit
+            isNotePublished={() => false}
             isDeletingFolder={false}
             layout="takeover"
+            publishDisabled={false}
+            publishingAction={null}
             selectedNoteId={1}
             treeRows={treeRows}
             onCreateFolderInFolder={() => {}}
@@ -370,8 +390,10 @@ function NotesTreeFixture() {
             onMoveNote={() => {}}
             onOpenNote={() => {}}
             onOpenFolder={(folder) => setActiveFolderId(folder.folderId)}
+            onPublishNote={() => {}}
             onRenameFolder={() => {}}
             onRenameNote={() => {}}
+            onUnpublishNote={() => {}}
           />
         </YStack>
         <YStack flex={1} backgroundColor="$background" />

--- a/packages/app/ui/components/NotesChannel/NotesActions.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesActions.tsx
@@ -13,6 +13,7 @@ export function NotesActionMenu({
   onAction,
   open,
   onOpenChange,
+  bottomContent,
   trigger,
 }: {
   groups: ActionGroup[];
@@ -24,6 +25,9 @@ export function NotesActionMenu({
   onAction?: (action?: () => void) => void;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  // Rendered below the action list, outside the dismiss-on-press wrapper —
+  // for rows that must keep the sheet open, e.g. inline toggles.
+  bottomContent?: ReactNode;
   trigger: ReactNode;
 }) {
   const isWindowNarrow = useIsWindowNarrow();
@@ -63,6 +67,7 @@ export function NotesActionMenu({
       ) : null}
       <ActionSheet.Content>
         <NotesActionGroupList groups={groups} onAction={handleAction} />
+        {bottomContent}
       </ActionSheet.Content>
     </ActionSheet>
   );

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -11,16 +11,24 @@ import {
   deleteNotebookNote,
   moveNotebookFolder,
   moveNotebookNote,
+  noteIsPublished,
+  publishNotebookNote,
+  publishedNotePath,
+  publishedNoteUrl,
   renameNotebookFolder,
+  unpublishNotebookNote,
   useMutableCallback,
+  usePublishedNotesForNotebook,
 } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { collectDescendantFolderIds } from '@tloncorp/shared/logic/notesTree';
 import { useIsWindowNarrow, useToast } from '@tloncorp/ui';
-import { useEffect, useMemo, useState } from 'react';
-import { Platform } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Linking, Platform } from 'react-native';
 import { YStack } from 'tamagui';
 
+import { useShip } from '../../../contexts/ship';
 import type { RootStackParamList } from '../../../navigation/types';
 import { useNotebookSidebarRegistration } from '../../contexts/notebookSidebar';
 import { ActionSheet } from '../ActionSheet';
@@ -44,7 +52,11 @@ import {
   createNotesNewNoteAction,
 } from './NotesHeaderActions';
 import { MoveNoteSheet } from './NotesMoveSheets';
-import { NotesNoteDetail } from './NotesNoteDetail';
+import {
+  NotesNoteDetail,
+  type NotesNoteDraftSnapshot,
+  getNotesNoteDraftSnapshot,
+} from './NotesNoteDetail';
 import { NotesEmptyDetailPane, NotesTreePane } from './NotesTreePane';
 import { canSelectNotesImportSources } from './notesImport';
 import { trackNotesActionError } from './notesTelemetry';
@@ -90,6 +102,8 @@ function withMoveOperationTimeout(operation: Promise<void>): Promise<void> {
   });
 }
 
+type PublishingAction = 'publish' | 'unpublish' | null;
+
 export function NotesNativeChannel({
   channelId,
   channelTitle,
@@ -105,6 +119,7 @@ export function NotesNativeChannel({
 }) {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const isFocused = useIsFocused();
+  const { shipUrl } = useShip();
   const isWindowNarrow = useIsWindowNarrow();
   const showToast = useToast();
   const useDesktopSplit = Platform.OS === 'web' && !isWindowNarrow;
@@ -120,6 +135,8 @@ export function NotesNativeChannel({
   const [isCreatingNote, setIsCreatingNote] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [newActionSheetOpen, setNewActionSheetOpen] = useState(false);
+  const [publishingAction, setPublishingAction] =
+    useState<PublishingAction>(null);
   const [renameFolderName, setRenameFolderName] = useState('');
   const [isDeletingFolder, setIsDeletingFolder] = useState(false);
   const {
@@ -148,11 +165,17 @@ export function NotesNativeChannel({
   } = useEntityDialog<db.NotesFolder>();
   const [focusTitleNoteId, setFocusTitleNoteId] = useState<number | null>(null);
   const [startEditNoteId, setStartEditNoteId] = useState<number | null>(null);
+  const activeNoteDraftRef = useRef<NotesNoteDraftSnapshot | null>(null);
 
   const { folders, notes, canEdit, rootFolderId, gate } = useNotebookData(
     notebookFlag,
     { syncEnabled: isFocused }
   );
+  const { data: publishedNotes, refetch: refetchPublishedNotes } =
+    usePublishedNotesForNotebook({
+      notebookFlag,
+      enabled: Boolean(notebookFlag),
+    });
 
   const canImportFiles = canEdit && canSelectNotesImportSources('files');
   const canImportFolder = canEdit && canSelectNotesImportSources('folder');
@@ -178,6 +201,56 @@ export function NotesNativeChannel({
       }),
     [activeFolderId, folderNoteCounts, folders, notes, rootFolderId]
   );
+  const isNotePublished = useMemo(
+    () => (noteId: number) => noteIsPublished(publishedNotes, noteId),
+    [publishedNotes]
+  );
+  const getPublishedNoteUrl = useMemo(
+    () => (note: db.NotesNote) => {
+      if (!notebookFlag) {
+        return null;
+      }
+
+      return publishedNoteUrl(
+        publishedNotePath(notebookFlag, note.noteId),
+        shipUrl
+      );
+    },
+    [notebookFlag, shipUrl]
+  );
+  const getPublishedNoteShareUrl = useMemo(
+    () => (publishedPath: string) => {
+      return publishedNoteUrl(publishedPath, shipUrl);
+    },
+    [shipUrl]
+  );
+  const handleNoteDraftChange = useMutableCallback(
+    (draft: NotesNoteDraftSnapshot | null) => {
+      activeNoteDraftRef.current = draft;
+    }
+  );
+  const getNotePublishContent = useMutableCallback((note: db.NotesNote) => {
+    const activeDraft = activeNoteDraftRef.current;
+    const draft =
+      activeDraft &&
+      activeDraft.notebookFlag === notebookFlag &&
+      activeDraft.noteId === note.noteId
+        ? activeDraft
+        : notebookFlag
+          ? getNotesNoteDraftSnapshot(notebookFlag, note.noteId)
+          : null;
+    if (draft) {
+      return {
+        title: draft.title,
+        body: draft.body,
+      };
+    }
+
+    return {
+      title: note.title,
+      body: note.bodyMd,
+    };
+  });
   const selectNoteInPane = useMutableCallback((noteId: number | null) => {
     setSelectedNoteId(noteId);
     const note =
@@ -341,7 +414,7 @@ export function NotesNativeChannel({
     notebookFlag,
     notes,
     rootFolderId,
-    selectedFolderId,
+    selectedFolderId: selectedFolderId ?? activeFolderId,
     setError,
   });
 
@@ -412,6 +485,81 @@ export function NotesNativeChannel({
   const handleRenameNote = useMutableCallback((note: db.NotesNote) => {
     if (!canEdit) return;
     openNote(note, { focusTitle: true });
+  });
+
+  const openPublishedUrl = useMutableCallback(async (url: string) => {
+    if (Platform.OS === 'web') {
+      window.open(url, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    await Linking.openURL(url);
+  });
+
+  const handleViewPublishedNote = useMutableCallback((note: db.NotesNote) => {
+    const publishedUrl = getPublishedNoteUrl(note);
+    if (!publishedUrl) return;
+    void openPublishedUrl(publishedUrl).catch((e) => {
+      const message = errorMessage(e, 'Failed to open published note');
+      trackNotesActionError('view published note', e, message);
+      setError(message);
+    });
+  });
+
+  const handlePublishNote = useMutableCallback(async (note: db.NotesNote) => {
+    if (!notebookFlag || !canEdit || publishingAction) return;
+
+    setPublishingAction('publish');
+    try {
+      let publishedUrl: string | null = null;
+      await runAction('Failed to publish note', async () => {
+        const content = getNotePublishContent(note);
+        const publishedPath = await publishNotebookNote({
+          notebookFlag,
+          noteId: note.noteId,
+          title: content.title,
+          body: content.body,
+        });
+        await refetchPublishedNotes();
+        publishedUrl = getPublishedNoteShareUrl(publishedPath);
+      });
+
+      if (publishedUrl) {
+        try {
+          await Clipboard.setStringAsync(publishedUrl);
+          showToast({
+            message: 'Published note. Link copied to clipboard.',
+            duration: 2000,
+          });
+        } catch (e) {
+          const message = errorMessage(
+            e,
+            'Published note, but failed to copy link'
+          );
+          trackNotesActionError('copy published note link', e, message);
+          setError(message);
+        }
+      }
+    } finally {
+      setPublishingAction(null);
+    }
+  });
+
+  const handleUnpublishNote = useMutableCallback(async (note: db.NotesNote) => {
+    if (!notebookFlag || !canEdit || publishingAction) return;
+
+    setPublishingAction('unpublish');
+    try {
+      await runAction('Failed to unpublish note', async () => {
+        await unpublishNotebookNote({
+          notebookFlag,
+          noteId: note.noteId,
+        });
+        await refetchPublishedNotes();
+      });
+    } finally {
+      setPublishingAction(null);
+    }
   });
 
   const handleOpenRenameFolder = useMutableCallback(
@@ -643,8 +791,12 @@ export function NotesNativeChannel({
   const notesTreePane = (
     <NotesTreePane
       canEdit={canEdit}
+      getPublishedNoteUrl={getPublishedNoteUrl}
       isDeletingFolder={isDeletingFolder}
+      isNotePublished={isNotePublished}
       layout={useDesktopSplit ? 'takeover' : 'stack'}
+      publishDisabled={publishingAction !== null}
+      publishingAction={publishingAction}
       selectedNoteId={useDesktopSplit ? selectedNoteId : null}
       treeRows={treeRows}
       onDeleteFolder={handleDeleteFolder}
@@ -652,11 +804,14 @@ export function NotesNativeChannel({
       onMoveFolder={openMoveFolderDialog}
       onMoveNote={openMoveNoteDialog}
       onOpenNote={openNote}
+      onPublishNote={handlePublishNote}
       onCreateFolderInFolder={(folder) => openAddFolderDialog(folder.folderId)}
       onCreateNoteInFolder={(folder) => void handleCreateNote(folder.folderId)}
       onRenameFolder={handleOpenRenameFolder}
       onRenameNote={handleRenameNote}
       onOpenFolder={openFolder}
+      onUnpublishNote={handleUnpublishNote}
+      onViewPublishedNote={handleViewPublishedNote}
     />
   );
 
@@ -697,6 +852,7 @@ export function NotesNativeChannel({
           headerActionsPlacement="inline"
           noteId={selectedNoteId}
           notebookFlag={notebookFlag}
+          onDraftChange={handleNoteDraftChange}
           onTitleAutoFocused={handleTitleAutoFocused}
           startInEdit={startEditNoteId === selectedNoteId}
           // This embedded pane shares the shell's notebook; syncing here too

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -796,7 +796,6 @@ export function NotesNativeChannel({
       isNotePublished={isNotePublished}
       layout={useDesktopSplit ? 'takeover' : 'stack'}
       publishDisabled={publishingAction !== null}
-      publishingAction={publishingAction}
       selectedNoteId={useDesktopSplit ? selectedNoteId : null}
       treeRows={treeRows}
       onDeleteFolder={handleDeleteFolder}

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -47,17 +47,68 @@ const BODY_FONT_SIZE = 14;
 const BODY_LINE_HEIGHT = 22;
 const BODY_MONO_CHAR_WIDTH = BODY_FONT_SIZE * 0.62;
 const SAVE_STATUS_SLOT_WIDTH = 88;
+const DRAFT_SNAPSHOT_TTL_MS = 120_000;
 
 export type NotesNoteDraftSnapshot = {
+  notebookFlag: string;
   noteId: number;
   title: string;
   body: string;
   isDirty: boolean;
+  updatedAt: number;
 };
 
 const draftStashKey = (notebookFlag: string, noteId: number) =>
   `${notebookFlag}/${noteId}`;
+const draftSnapshotKey = (notebookFlag: string, noteId: number) =>
+  `${notebookFlag}/${noteId}`;
 const notePreviewModes = new Map<string, boolean>();
+const notesNoteDraftSnapshots = new Map<string, NotesNoteDraftSnapshot>();
+
+function rememberNotesNoteDraftSnapshot(snapshot: NotesNoteDraftSnapshot) {
+  notesNoteDraftSnapshots.set(
+    draftSnapshotKey(snapshot.notebookFlag, snapshot.noteId),
+    snapshot
+  );
+}
+
+function clearNotesNoteDraftSnapshot(notebookFlag: string, noteId: number) {
+  notesNoteDraftSnapshots.delete(draftSnapshotKey(notebookFlag, noteId));
+}
+
+function clearMatchingNotesNoteDraftSnapshot({
+  notebookFlag,
+  noteId,
+  title,
+  body,
+}: {
+  notebookFlag: string;
+  noteId: number;
+  title: string;
+  body: string;
+}) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  const snapshot = notesNoteDraftSnapshots.get(key);
+  if (!snapshot || snapshot.title !== title || snapshot.body !== body) {
+    return;
+  }
+
+  notesNoteDraftSnapshots.delete(key);
+}
+
+export function getNotesNoteDraftSnapshot(
+  notebookFlag: string,
+  noteId: number
+) {
+  const key = draftSnapshotKey(notebookFlag, noteId);
+  const snapshot = notesNoteDraftSnapshots.get(key);
+  if (!snapshot) return null;
+  if (Date.now() - snapshot.updatedAt > DRAFT_SNAPSHOT_TTL_MS) {
+    notesNoteDraftSnapshots.delete(key);
+    return null;
+  }
+  return snapshot;
+}
 
 function getNotePreviewModeKey(
   notebookFlag: string | null | undefined,
@@ -260,26 +311,65 @@ export function NotesNoteDetail({
     return () => onDraftChange?.(null);
   }, [onDraftChange]);
 
+  const publishDraftSnapshot = useCallback(
+    (body: string) => {
+      if (
+        !notebookFlag ||
+        !selectedNote ||
+        !draftBase ||
+        !draftsMatchSelectedNote
+      ) {
+        if (notebookFlag && selectedNote) {
+          clearNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId);
+        }
+        onDraftChange?.(null);
+        return;
+      }
+
+      const dirty =
+        normalizeNotebookNoteTitle(titleDraft) !== draftBase.title ||
+        body !== draftBase.bodyMd;
+      const snapshot: NotesNoteDraftSnapshot = {
+        notebookFlag,
+        noteId: selectedNote.noteId,
+        title: titleDraft,
+        body,
+        isDirty: dirty,
+        updatedAt: Date.now(),
+      };
+
+      if (dirty) {
+        rememberNotesNoteDraftSnapshot(snapshot);
+      } else {
+        clearNotesNoteDraftSnapshot(notebookFlag, selectedNote.noteId);
+      }
+      onDraftChange?.(snapshot);
+    },
+    [
+      draftBase,
+      draftsMatchSelectedNote,
+      notebookFlag,
+      onDraftChange,
+      selectedNote,
+      titleDraft,
+    ]
+  );
+
   useEffect(() => {
-    if (!onDraftChange) return;
+    if (!onDraftChange && !notebookFlag) return;
     if (!selectedNote || !draftsMatchSelectedNote) {
-      onDraftChange(null);
+      onDraftChange?.(null);
       return;
     }
 
-    onDraftChange({
-      noteId: selectedNote.noteId,
-      title: titleDraft,
-      body: bodyDraft,
-      isDirty,
-    });
+    publishDraftSnapshot(bodyDraft);
   }, [
     bodyDraft,
     draftsMatchSelectedNote,
-    isDirty,
+    notebookFlag,
     onDraftChange,
+    publishDraftSnapshot,
     selectedNote,
-    titleDraft,
   ]);
 
   useEffect(() => {
@@ -391,6 +481,14 @@ export function NotesNoteDetail({
     preserveScrollOffset();
     setSaveState('saving');
     setError(null);
+    rememberNotesNoteDraftSnapshot({
+      notebookFlag,
+      noteId: draftBase.noteId,
+      title: titleDraft,
+      body: bodyToSave,
+      isDirty: true,
+      updatedAt: Date.now(),
+    });
     try {
       const updated = await runSave(
         notebookFlag,
@@ -404,6 +502,12 @@ export function NotesNoteDetail({
         setDraftBase(updated);
       }
       clearDraftStash(notebookFlag, draftBase.noteId, {
+        title: titleDraft,
+        body: bodyToSave,
+      });
+      clearMatchingNotesNoteDraftSnapshot({
+        notebookFlag,
+        noteId: draftBase.noteId,
         title: titleDraft,
         body: bodyToSave,
       });
@@ -465,9 +569,23 @@ export function NotesNoteDetail({
     if (!dirty) return;
     const { flag, base } = ctx;
     preserveScrollOffset();
+    rememberNotesNoteDraftSnapshot({
+      notebookFlag: flag,
+      noteId: base.noteId,
+      title: titleToSave,
+      body: bodyToSave,
+      isDirty: true,
+      updatedAt: Date.now(),
+    });
     runSave(flag, base, titleToSave, bodyToSave)
       .then((updated) => {
         clearDraftStash(flag, base.noteId, {
+          title: titleToSave,
+          body: bodyToSave,
+        });
+        clearMatchingNotesNoteDraftSnapshot({
+          notebookFlag: flag,
+          noteId: base.noteId,
           title: titleToSave,
           body: bodyToSave,
         });

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -48,6 +48,13 @@ const BODY_LINE_HEIGHT = 22;
 const BODY_MONO_CHAR_WIDTH = BODY_FONT_SIZE * 0.62;
 const SAVE_STATUS_SLOT_WIDTH = 88;
 
+export type NotesNoteDraftSnapshot = {
+  noteId: number;
+  title: string;
+  body: string;
+  isDirty: boolean;
+};
+
 const draftStashKey = (notebookFlag: string, noteId: number) =>
   `${notebookFlag}/${noteId}`;
 const notePreviewModes = new Map<string, boolean>();
@@ -150,6 +157,7 @@ export function NotesNoteDetail({
   headerActionsPlacement = 'channel-header',
   noteId,
   notebookFlag,
+  onDraftChange,
   onTitleAutoFocused,
   startInEdit = false,
   syncEnabled = true,
@@ -158,6 +166,7 @@ export function NotesNoteDetail({
   headerActionsPlacement?: 'channel-header' | 'inline' | 'none';
   noteId: number | null;
   notebookFlag: string | null | undefined;
+  onDraftChange?: (draft: NotesNoteDraftSnapshot | null) => void;
   onTitleAutoFocused?: () => void;
   startInEdit?: boolean;
   syncEnabled?: boolean;
@@ -246,6 +255,32 @@ export function NotesNoteDetail({
   useEffect(() => {
     bodyDraftRef.current = bodyDraft;
   }, [bodyDraft]);
+
+  useEffect(() => {
+    return () => onDraftChange?.(null);
+  }, [onDraftChange]);
+
+  useEffect(() => {
+    if (!onDraftChange) return;
+    if (!selectedNote || !draftsMatchSelectedNote) {
+      onDraftChange(null);
+      return;
+    }
+
+    onDraftChange({
+      noteId: selectedNote.noteId,
+      title: titleDraft,
+      body: bodyDraft,
+      isDirty,
+    });
+  }, [
+    bodyDraft,
+    draftsMatchSelectedNote,
+    isDirty,
+    onDraftChange,
+    selectedNote,
+    titleDraft,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/packages/app/ui/components/NotesChannel/NotesTreePane.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreePane.tsx
@@ -8,8 +8,12 @@ import type { NotesTreeRow } from './notesTree';
 
 export function NotesTreePane({
   canEdit,
+  getPublishedNoteUrl,
   isDeletingFolder,
+  isNotePublished,
   layout,
+  publishDisabled,
+  publishingAction,
   selectedNoteId,
   treeRows,
   onCreateFolderInFolder,
@@ -19,13 +23,20 @@ export function NotesTreePane({
   onMoveFolder,
   onMoveNote,
   onOpenNote,
+  onPublishNote,
   onRenameFolder,
   onRenameNote,
   onOpenFolder,
+  onUnpublishNote,
+  onViewPublishedNote,
 }: {
   canEdit: boolean;
+  getPublishedNoteUrl?: (note: db.NotesNote) => string | null;
   isDeletingFolder: boolean;
+  isNotePublished: (noteId: number) => boolean;
   layout: 'stack' | 'takeover';
+  publishDisabled: boolean;
+  publishingAction: 'publish' | 'unpublish' | null;
   selectedNoteId: number | null;
   treeRows: NotesTreeRow[];
   onCreateFolderInFolder: (folder: db.NotesFolder) => void;
@@ -35,9 +46,12 @@ export function NotesTreePane({
   onMoveFolder: (folder: db.NotesFolder) => void;
   onMoveNote: (note: db.NotesNote) => void;
   onOpenNote: (note: db.NotesNote) => void;
+  onPublishNote: (note: db.NotesNote) => void;
   onRenameFolder: (folder: db.NotesFolder) => void;
   onRenameNote: (note: db.NotesNote) => void;
   onOpenFolder: (folder: db.NotesFolder) => void;
+  onUnpublishNote: (note: db.NotesNote) => void;
+  onViewPublishedNote?: (note: db.NotesNote) => void;
 }) {
   if (treeRows.length === 0) {
     return (
@@ -75,12 +89,27 @@ export function NotesTreePane({
           <NoteRow
             key={row.note.id}
             canEdit={canEdit}
+            isPublished={isNotePublished(row.note.noteId)}
             note={row.note}
+            publishDisabled={publishDisabled}
+            publishedUrl={
+              isNotePublished(row.note.noteId)
+                ? getPublishedNoteUrl?.(row.note) ?? null
+                : null
+            }
+            publishingAction={publishingAction}
             selected={selectedNoteId === row.note.noteId}
             onDelete={() => onDeleteNote(row.note)}
             onMove={() => onMoveNote(row.note)}
             onPress={() => onOpenNote(row.note)}
+            onPublish={() => onPublishNote(row.note)}
             onRename={() => onRenameNote(row.note)}
+            onUnpublish={() => onUnpublishNote(row.note)}
+            onViewPublished={
+              onViewPublishedNote
+                ? () => onViewPublishedNote(row.note)
+                : undefined
+            }
           />
         )
       )}

--- a/packages/app/ui/components/NotesChannel/NotesTreePane.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreePane.tsx
@@ -13,7 +13,6 @@ export function NotesTreePane({
   isNotePublished,
   layout,
   publishDisabled,
-  publishingAction,
   selectedNoteId,
   treeRows,
   onCreateFolderInFolder,
@@ -36,7 +35,6 @@ export function NotesTreePane({
   isNotePublished: (noteId: number) => boolean;
   layout: 'stack' | 'takeover';
   publishDisabled: boolean;
-  publishingAction: 'publish' | 'unpublish' | null;
   selectedNoteId: number | null;
   treeRows: NotesTreeRow[];
   onCreateFolderInFolder: (folder: db.NotesFolder) => void;
@@ -97,7 +95,6 @@ export function NotesTreePane({
                 ? getPublishedNoteUrl?.(row.note) ?? null
                 : null
             }
-            publishingAction={publishingAction}
             selected={selectedNoteId === row.note.noteId}
             onDelete={() => onDeleteNote(row.note)}
             onMove={() => onMoveNote(row.note)}

--- a/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
@@ -14,6 +14,8 @@ import { OverflowTriggerButton } from '../OverflowMenuButton';
 import { NotesActionMenu } from './NotesActions';
 import { noteTimestampMs } from './notesTree';
 
+type PublishingAction = 'publish' | 'unpublish' | null;
+
 export function FolderTreeRow({
   canEdit,
   folder,
@@ -122,20 +124,34 @@ export function FolderTreeRow({
 
 export function NoteRow({
   canEdit,
+  isPublished,
   note,
+  publishDisabled,
+  publishedUrl,
+  publishingAction,
   selected = false,
   onDelete,
   onMove,
   onPress,
+  onPublish,
   onRename,
+  onUnpublish,
+  onViewPublished,
 }: {
   canEdit: boolean;
+  isPublished: boolean;
   note: db.NotesNote;
+  publishDisabled: boolean;
+  publishedUrl?: string | null;
+  publishingAction: PublishingAction;
   selected?: boolean;
   onDelete: () => void;
   onMove: () => void;
   onPress: () => void;
+  onPublish: () => void;
   onRename: () => void;
+  onUnpublish: () => void;
+  onViewPublished?: () => void;
 }) {
   const updatedAt = noteTimestampMs(note.updatedAt ?? note.createdAt);
   const bodyPreview = getNoteBodyPreview(note.bodyMd);
@@ -156,8 +172,34 @@ export function NoteRow({
         testID: `NotesMoveNoteAction-${note.noteId}`,
       },
     ],
+    [
+      'neutral',
+      {
+        title: isPublished ? 'Update published note' : 'Publish to web',
+        description: isPublished ? publishedUrl ?? undefined : undefined,
+        startIcon: 'EyeOpen',
+        action: onPublish,
+        disabled: publishDisabled,
+        testID: `NotesPublishNoteAction-${note.noteId}`,
+      },
+      isPublished && publishedUrl && onViewPublished
+        ? {
+            title: 'View published note',
+            startIcon: 'Link',
+            action: onViewPublished,
+            testID: `NotesViewPublishedNoteAction-${note.noteId}`,
+          }
+        : null,
+    ],
     canEdit && [
       'negative',
+      isPublished && {
+        title: 'Unpublish note',
+        startIcon: 'EyeClosed',
+        action: onUnpublish,
+        disabled: publishDisabled || publishingAction === 'unpublish',
+        testID: `NotesUnpublishNoteAction-${note.noteId}`,
+      },
       {
         title: 'Delete note',
         startIcon: 'Trash',

--- a/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
@@ -3,18 +3,16 @@ import { Icon, Pressable } from '@tloncorp/ui';
 import type { IconType } from '@tloncorp/ui';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Platform } from 'react-native';
-import { TamaguiWebElement, XStack } from 'tamagui';
+import { Platform, Switch } from 'react-native';
+import { TamaguiWebElement, View, XStack } from 'tamagui';
 
 import { useSheetCloseAfterAnimation } from '../../hooks/useSheetCloseAfterAnimation';
 import type { ActionGroup } from '../ActionSheet';
-import { createActionGroups } from '../ActionSheet';
+import { ActionSheet, createActionGroups } from '../ActionSheet';
 import { ListItem } from '../ListItem';
 import { OverflowTriggerButton } from '../OverflowMenuButton';
 import { NotesActionMenu } from './NotesActions';
 import { noteTimestampMs } from './notesTree';
-
-type PublishingAction = 'publish' | 'unpublish' | null;
 
 export function FolderTreeRow({
   canEdit,
@@ -128,7 +126,6 @@ export function NoteRow({
   note,
   publishDisabled,
   publishedUrl,
-  publishingAction,
   selected = false,
   onDelete,
   onMove,
@@ -143,7 +140,6 @@ export function NoteRow({
   note: db.NotesNote;
   publishDisabled: boolean;
   publishedUrl?: string | null;
-  publishingAction: PublishingAction;
   selected?: boolean;
   onDelete: () => void;
   onMove: () => void;
@@ -172,34 +168,8 @@ export function NoteRow({
         testID: `NotesMoveNoteAction-${note.noteId}`,
       },
     ],
-    [
-      'neutral',
-      {
-        title: isPublished ? 'Update published note' : 'Publish to web',
-        description: isPublished ? publishedUrl ?? undefined : undefined,
-        startIcon: 'EyeOpen',
-        action: onPublish,
-        disabled: publishDisabled,
-        testID: `NotesPublishNoteAction-${note.noteId}`,
-      },
-      isPublished && publishedUrl && onViewPublished
-        ? {
-            title: 'View published note',
-            startIcon: 'Link',
-            action: onViewPublished,
-            testID: `NotesViewPublishedNoteAction-${note.noteId}`,
-          }
-        : null,
-    ],
     canEdit && [
       'negative',
-      isPublished && {
-        title: 'Unpublish note',
-        startIcon: 'EyeClosed',
-        action: onUnpublish,
-        disabled: publishDisabled || publishingAction === 'unpublish',
-        testID: `NotesUnpublishNoteAction-${note.noteId}`,
-      },
       {
         title: 'Delete note',
         startIcon: 'Trash',
@@ -207,6 +177,60 @@ export function NoteRow({
         testID: `NotesDeleteNoteAction-${note.noteId}`,
       },
     ]
+  );
+  // Rendered outside NotesActionGroupList's dismiss-on-press wrapper: the
+  // sheet stays open, so the switch flips and the published-note actions
+  // appear in place instead of the sheet vanishing mid-operation.
+  const publishSection = (
+    <ActionSheet.ActionGroup accent="neutral">
+      <ActionSheet.Action
+        action={{
+          title: 'Publish to web',
+          description: isPublished ? publishedUrl ?? undefined : undefined,
+          startIcon: 'EyeOpen',
+          // Visual-only: the row press drives the toggle. Letting the Switch
+          // handle taps double-fires with the row action, and its taps get
+          // eaten by the sheet's pan gesture on Android (see
+          // ChannelPermissions.tsx for the same workaround).
+          endIcon: (
+            <View pointerEvents="none">
+              <Switch value={isPublished} disabled={publishDisabled} />
+            </View>
+          ),
+          action: isPublished ? onUnpublish : onPublish,
+          disabled: publishDisabled,
+        }}
+        testID={`NotesPublishToggleAction-${note.noteId}`}
+      />
+      {isPublished ? (
+        <ActionSheet.Action
+          action={{
+            title: 'Update published note',
+            startIcon: 'Refresh',
+            action: onPublish,
+            disabled: publishDisabled,
+          }}
+          testID={`NotesPublishNoteAction-${note.noteId}`}
+        />
+      ) : null}
+      {isPublished && publishedUrl ? (
+        <ActionSheet.CopyAction
+          action={{ title: 'Copy link', startIcon: 'Copy' }}
+          copyText={publishedUrl}
+          testID={`NotesCopyPublishedNoteAction-${note.noteId}`}
+        />
+      ) : null}
+      {isPublished && publishedUrl && onViewPublished ? (
+        <ActionSheet.Action
+          action={{
+            title: 'View published note',
+            startIcon: 'Link',
+            action: onViewPublished,
+          }}
+          testID={`NotesViewPublishedNoteAction-${note.noteId}`}
+        />
+      ) : null}
+    </ActionSheet.ActionGroup>
   );
   const { actionsMenu, rowActionProps } = useRowActions({
     actionGroups,
@@ -216,6 +240,7 @@ export function NoteRow({
       title: note.title || 'Untitled',
       subtitle: bodyPreview || 'Note',
     },
+    bottomContent: publishSection,
   });
 
   return (
@@ -257,6 +282,7 @@ function useRowActions({
   actionGroups,
   canEdit,
   header,
+  bottomContent,
 }: {
   actionGroups: ActionGroup[];
   canEdit: boolean;
@@ -265,6 +291,7 @@ function useRowActions({
     subtitle?: string;
     title: string;
   };
+  bottomContent?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -327,6 +354,7 @@ function useRowActions({
           open={open}
           onAction={handleAction}
           onOpenChange={handleOpenChange}
+          bottomContent={bottomContent}
           trigger={actionsTrigger}
         />
       ) : null,

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -3,6 +3,7 @@ export * from './contextLens';
 export * from './embed';
 export * from './semver';
 export * from './reactionSupport';
+export * from './notesPublish';
 export * from '@tloncorp/api/lib/types';
 export * from '@tloncorp/api/lib/utils';
 export * as featureFlags from '@tloncorp/api/lib/featureFlags';

--- a/packages/shared/src/logic/notesPublish.test.ts
+++ b/packages/shared/src/logic/notesPublish.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+
+import { renderPublishedNoteHtml } from './notesPublish';
+
+test('renderPublishedNoteHtml renders markdown list children as list items', () => {
+  const html = renderPublishedNoteHtml({
+    title: 'List note',
+    body: '- first\n- second',
+  });
+
+  expect(html).toContain('<ul><li>first</li><li>second</li></ul>');
+  expect(html).not.toContain('<ul><li><ul>');
+});

--- a/packages/shared/src/logic/notesPublish.ts
+++ b/packages/shared/src/logic/notesPublish.ts
@@ -1,0 +1,207 @@
+import { markdownToStory } from '@tloncorp/api/client/markdown';
+import {
+  type BlockData,
+  type InlineData,
+  type ListData,
+  type PostContent,
+  type TableRowData,
+  convertContent,
+} from '@tloncorp/api/client/postContent';
+
+export function publishedNotePath(notebookFlag: string, noteId: number) {
+  return `/notes/pub/${notebookFlag}/${noteId}`;
+}
+
+const publishedNoteCss = `body{margin:0;padding:48px 24px;background:#111;color:#f4f4f4;font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}main{max-width:720px;margin:0 auto}h1,h2,h3,h4,h5,h6{line-height:1.2;color:#fff;margin:1.4em 0 .45em}main>h1:first-child{margin-top:0}p,blockquote,pre,ul,ol,table{margin:1em 0}a{color:#8f84ff}code,pre{font-family:"SFMono-Regular","JetBrains Mono",monospace;background:#1d1d1d}code{padding:2px 5px;border-radius:4px}pre{padding:16px;border:1px solid #333;border-radius:8px;overflow:auto}pre code{padding:0;background:transparent}blockquote{border-left:3px solid #8f84ff;padding-left:16px;color:#c2c2c2}hr{border:0;border-top:1px solid #333;margin:2em 0}img,video{max-width:100%;border-radius:8px}table{border-collapse:collapse;width:100%}th,td{border:1px solid #333;padding:8px 10px}th{background:#1d1d1d}.tlon-published-footer{margin-top:48px;padding-top:16px;border-top:1px solid #333;color:#8a8a8a;font-size:12px}`;
+const inlineStyleTags = {
+  bold: 'strong',
+  code: 'code',
+  italic: 'em',
+  strikethrough: 's',
+} as const;
+
+export function renderPublishedNoteHtml({
+  title,
+  body,
+}: {
+  title: string;
+  body: string;
+}) {
+  const safeTitle = title.trim() || 'Untitled';
+  const bodyHtml = renderMarkdownBodyHtml(body);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(safeTitle)}</title>
+<style>${publishedNoteCss}</style>
+</head>
+<body>
+<main>
+<h1>${escapeHtml(safeTitle)}</h1>
+${bodyHtml || '<p></p>'}
+<div class="tlon-published-footer">Published from Tlon</div>
+</main>
+</body>
+</html>`;
+}
+
+function renderMarkdownBodyHtml(body: string) {
+  try {
+    return renderBlocksToHtml(convertContent(markdownToStory(body), null));
+  } catch {
+    return renderPlainTextHtml(body);
+  }
+}
+
+function renderPlainTextHtml(text: string) {
+  return text
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean)
+    .map(
+      (paragraph) => `<p>${escapeHtml(paragraph).replace(/\n/g, '<br>')}</p>`
+    )
+    .join('\n');
+}
+
+function renderBlocksToHtml(blocks: PostContent) {
+  return blocks.map(renderBlockToHtml).filter(Boolean).join('\n');
+}
+
+function renderBlockToHtml(block: BlockData): string {
+  switch (block.type) {
+    case 'paragraph':
+      return `<p>${renderInlinesToHtml(block.content)}</p>`;
+    case 'blockquote':
+      return `<blockquote>${renderInlinesToHtml(block.content)}</blockquote>`;
+    case 'bigEmoji':
+      return `<p>${escapeHtml(block.emoji)}</p>`;
+    case 'header': {
+      const level = block.level.replace('h', '');
+      return `<h${level}>${renderInlinesToHtml(block.children)}</h${level}>`;
+    }
+    case 'code':
+      return `<pre><code>${escapeHtml(block.content)}</code></pre>`;
+    case 'image':
+      return `<img src="${safeUrlAttr(block.src)}" alt="${escapeAttr(block.alt)}">`;
+    case 'video':
+      return `<video controls src="${safeUrlAttr(block.video.src)}">${escapeHtml(block.video.alt)}</video>`;
+    case 'link':
+      return `<p><a href="${safeUrlAttr(block.url)}">${escapeHtml(block.title || block.url)}</a></p>`;
+    case 'rule':
+      return '<hr>';
+    case 'list':
+      return renderListToHtml(block.list);
+    case 'table':
+      return renderTableToHtml(block);
+    case 'reference':
+      return `<p>${escapeHtml(referenceLabel(block))}</p>`;
+    case 'file':
+    case 'voicememo':
+    case 'a2ui':
+      return '';
+  }
+}
+
+function renderInlinesToHtml(inlines: InlineData[]) {
+  return inlines.map(renderInlineToHtml).join('');
+}
+
+function renderInlineToHtml(inline: InlineData): string {
+  switch (inline.type) {
+    case 'text':
+      return escapeHtml(inline.text);
+    case 'mention':
+      return escapeHtml(inline.contactId);
+    case 'groupMention':
+      return escapeHtml(`@${inline.group}`);
+    case 'lineBreak':
+      return '<br>';
+    case 'link':
+      return `<a href="${safeUrlAttr(inline.href)}">${escapeHtml(inline.text || inline.href)}</a>`;
+    case 'task':
+      return `${inline.checked ? '[x]' : '[ ]'} ${renderInlinesToHtml(inline.children)}`;
+    case 'style': {
+      const children = renderInlinesToHtml(inline.children);
+      const tag = inlineStyleTags[inline.style];
+      return `<${tag}>${children}</${tag}>`;
+    }
+  }
+}
+
+function renderListToHtml(list: ListData) {
+  const tag = list.type === 'ordered' ? 'ol' : 'ul';
+  return `<${tag}>${renderListItemToHtml(list)}</${tag}>`;
+}
+
+function renderListItemToHtml(item: ListData): string {
+  const children = item.children?.map(renderListItemToHtml).join('') ?? '';
+  return `<li>${renderInlinesToHtml(item.content)}${
+    children ? `<ul>${children}</ul>` : ''
+  }</li>`;
+}
+
+function renderTableToHtml(block: Extract<BlockData, { type: 'table' }>) {
+  const header = renderTableRowToHtml(block.header, block.align, 'th');
+  const rows = block.rows
+    .map((row) => renderTableRowToHtml(row, block.align, 'td'))
+    .join('');
+  return `<table><thead>${header}</thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderTableRowToHtml(
+  row: TableRowData,
+  align: Extract<BlockData, { type: 'table' }>['align'],
+  cellTag: 'td' | 'th'
+) {
+  const cells = row.cells
+    .map((cell, index) => {
+      const textAlign = align[index]
+        ? ` style="text-align:${align[index]}"`
+        : '';
+      return `<${cellTag}${textAlign}>${renderInlinesToHtml(cell.content)}</${cellTag}>`;
+    })
+    .join('');
+  return `<tr>${cells}</tr>`;
+}
+
+function referenceLabel(block: Extract<BlockData, { type: 'reference' }>) {
+  switch (block.referenceType) {
+    case 'channel':
+      return block.replyId
+        ? `Reply in ${block.channelId}`
+        : `Post in ${block.channelId}`;
+    case 'group':
+      return `Group ${block.groupId}`;
+    case 'app':
+      return `${block.userId}/${block.appId}`;
+  }
+}
+
+function safeUrlAttr(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? '';
+  if (!trimmed) return '#';
+  if (trimmed.startsWith('/') || trimmed.startsWith('#'))
+    return escapeAttr(trimmed);
+  try {
+    const url = new URL(trimmed);
+    if (['http:', 'https:', 'mailto:'].includes(url.protocol))
+      return escapeAttr(trimmed);
+  } catch {
+    return '#';
+  }
+  return '#';
+}
+
+function escapeAttr(value: string | null | undefined) {
+  return escapeHtml(value ?? '').replace(/"/g, '&quot;');
+}
+
+function escapeHtml(value: string | null | undefined) {
+  return (value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/packages/shared/src/logic/notesPublish.ts
+++ b/packages/shared/src/logic/notesPublish.ts
@@ -12,6 +12,10 @@ export function publishedNotePath(notebookFlag: string, noteId: number) {
   return `/notes/pub/${notebookFlag}/${noteId}`;
 }
 
+export function publishedNoteUrl(path: string, shipUrl?: string | null) {
+  return shipUrl ? new URL(path, shipUrl).toString() : null;
+}
+
 const publishedNoteCss = `body{margin:0;padding:48px 24px;background:#111;color:#f4f4f4;font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}main{max-width:720px;margin:0 auto}h1,h2,h3,h4,h5,h6{line-height:1.2;color:#fff;margin:1.4em 0 .45em}main>h1:first-child{margin-top:0}p,blockquote,pre,ul,ol,table{margin:1em 0}a{color:#8f84ff}code,pre{font-family:"SFMono-Regular","JetBrains Mono",monospace;background:#1d1d1d}code{padding:2px 5px;border-radius:4px}pre{padding:16px;border:1px solid #333;border-radius:8px;overflow:auto}pre code{padding:0;background:transparent}blockquote{border-left:3px solid #8f84ff;padding-left:16px;color:#c2c2c2}hr{border:0;border-top:1px solid #333;margin:2em 0}img,video{max-width:100%;border-radius:8px}table{border-collapse:collapse;width:100%}th,td{border:1px solid #333;padding:8px 10px}th{background:#1d1d1d}.tlon-published-footer{margin-top:48px;padding-top:16px;border-top:1px solid #333;color:#8a8a8a;font-size:12px}`;
 const inlineStyleTags = {
   bold: 'strong',

--- a/packages/shared/src/logic/notesPublish.ts
+++ b/packages/shared/src/logic/notesPublish.ts
@@ -136,15 +136,25 @@ function renderInlineToHtml(inline: InlineData): string {
 }
 
 function renderListToHtml(list: ListData) {
-  const tag = list.type === 'ordered' ? 'ol' : 'ul';
-  return `<${tag}>${renderListItemToHtml(list)}</${tag}>`;
+  const tag = listTag(list);
+  const items = [
+    ...(list.content.length > 0
+      ? [`<li>${renderInlinesToHtml(list.content)}</li>`]
+      : []),
+    ...(list.children?.map(renderListItemToHtml) ?? []),
+  ];
+  return `<${tag}>${items.join('')}</${tag}>`;
 }
 
 function renderListItemToHtml(item: ListData): string {
   const children = item.children?.map(renderListItemToHtml).join('') ?? '';
   return `<li>${renderInlinesToHtml(item.content)}${
-    children ? `<ul>${children}</ul>` : ''
+    children ? `<${listTag(item)}>${children}</${listTag(item)}>` : ''
   }</li>`;
+}
+
+function listTag(list: ListData) {
+  return list.type === 'ordered' ? 'ol' : 'ul';
 }
 
 function renderTableToHtml(block: Extract<BlockData, { type: 'table' }>) {

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -2,6 +2,7 @@ import * as api from '@tloncorp/api';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import * as db from '../db';
+import { publishedNotePath } from '../logic';
 import { setupDatabaseTestSuite } from '../test/helpers';
 import {
   makeApiNotesFolder,
@@ -14,8 +15,11 @@ import {
 import {
   createNotebookNote,
   deleteNotebookNote,
+  noteIsPublished,
+  publishNotebookNote,
   saveNotebookNote,
   syncNotesNotebook,
+  unpublishNotebookNote,
 } from './notesActions';
 
 setupDatabaseTestSuite();
@@ -401,4 +405,51 @@ test('deleteNotebookNote keeps the local delete when sync stays stale', async ()
   await expect(
     db.getNotesNote({ notebookFlag, noteId: note.noteId })
   ).resolves.toBeNull();
+});
+
+test('publishNotebookNote renders current markdown and marks note published', async () => {
+  const publishNotesNote = vi
+    .spyOn(api, 'publishNotesNote')
+    .mockResolvedValue(1);
+  vi.spyOn(api, 'listPublishedNotes').mockResolvedValue([
+    { host: '~zod', flagName: 'native-notes', noteId: 3 },
+  ]);
+
+  const path = await publishNotebookNote({
+    notebookFlag,
+    noteId: 3,
+    title: 'Public & safe',
+    body: 'Hello **world**',
+  });
+
+  expect(path).toBe(publishedNotePath(notebookFlag, 3));
+  expect(publishNotesNote).toHaveBeenCalledWith({
+    flag: notebookFlag,
+    noteId: 3,
+    html: expect.stringContaining('<strong>world</strong>'),
+  });
+  expect(publishNotesNote.mock.calls[0]?.[0].html).toContain(
+    '<title>Public &amp; safe</title>'
+  );
+});
+
+test('unpublishNotebookNote waits for the note to leave published records', async () => {
+  const unpublishNotesNote = vi
+    .spyOn(api, 'unpublishNotesNote')
+    .mockResolvedValue(1);
+  vi.spyOn(api, 'listPublishedNotes').mockResolvedValue([]);
+
+  await unpublishNotebookNote({ notebookFlag, noteId: 3 });
+
+  expect(unpublishNotesNote).toHaveBeenCalledWith({
+    flag: notebookFlag,
+    noteId: 3,
+  });
+});
+
+test('noteIsPublished matches published records by note id', () => {
+  const published = [{ host: '~zod', flagName: 'native-notes', noteId: 3 }];
+
+  expect(noteIsPublished(published, 3)).toBe(true);
+  expect(noteIsPublished(published, 4)).toBe(false);
 });

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -2,7 +2,7 @@ import * as api from '@tloncorp/api';
 import { afterEach, expect, test, vi } from 'vitest';
 
 import * as db from '../db';
-import { publishedNotePath } from '../logic';
+import { publishedNotePath, publishedNoteUrl } from '../logic';
 import { setupDatabaseTestSuite } from '../test/helpers';
 import {
   makeApiNotesFolder,
@@ -431,6 +431,15 @@ test('publishNotebookNote renders current markdown and marks note published', as
   expect(publishNotesNote.mock.calls[0]?.[0].html).toContain(
     '<title>Public &amp; safe</title>'
   );
+});
+
+test('publishedNoteUrl builds links from the ship URL', () => {
+  expect(
+    publishedNoteUrl(
+      publishedNotePath(notebookFlag, 3),
+      'https://zod.tlon.network'
+    )
+  ).toBe('https://zod.tlon.network/notes/pub/~zod/native-notes/3');
 });
 
 test('unpublishNotebookNote waits for the note to leave published records', async () => {

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -442,6 +442,20 @@ test('publishedNoteUrl builds links from the ship URL', () => {
   ).toBe('https://zod.tlon.network/notes/pub/~zod/native-notes/3');
 });
 
+test('publishNotebookNote fails loudly when the publish never confirms', async () => {
+  vi.spyOn(api.notes, 'publishNote').mockResolvedValue(1);
+  vi.spyOn(api.notes, 'listPublished').mockResolvedValue([]);
+
+  await expect(
+    publishNotebookNote({
+      notebookFlag,
+      noteId: 3,
+      title: 'Unconfirmed',
+      body: 'body',
+    })
+  ).rejects.toThrow('publish is not yet confirmed');
+});
+
 test('unpublishNotebookNote waits for the note to leave published records', async () => {
   const unpublishNotesNote = vi
     .spyOn(api.notes, 'unpublishNote')

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -409,9 +409,9 @@ test('deleteNotebookNote keeps the local delete when sync stays stale', async ()
 
 test('publishNotebookNote renders current markdown and marks note published', async () => {
   const publishNotesNote = vi
-    .spyOn(api, 'publishNotesNote')
+    .spyOn(api.notes, 'publishNote')
     .mockResolvedValue(1);
-  vi.spyOn(api, 'listPublishedNotes').mockResolvedValue([
+  vi.spyOn(api.notes, 'listPublished').mockResolvedValue([
     { host: '~zod', flagName: 'native-notes', noteId: 3 },
   ]);
 
@@ -444,9 +444,9 @@ test('publishedNoteUrl builds links from the ship URL', () => {
 
 test('unpublishNotebookNote waits for the note to leave published records', async () => {
   const unpublishNotesNote = vi
-    .spyOn(api, 'unpublishNotesNote')
+    .spyOn(api.notes, 'unpublishNote')
     .mockResolvedValue(1);
-  vi.spyOn(api, 'listPublishedNotes').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'listPublished').mockResolvedValue([]);
 
   await unpublishNotebookNote({ notebookFlag, noteId: 3 });
 

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -6,13 +6,18 @@ import { useEffect, useMemo } from 'react';
 import * as db from '../db';
 import type { WrappedQuery } from '../db/query';
 import { createDevLogger } from '../debug';
-import { withRetry } from '../logic';
+import {
+  publishedNotePath,
+  renderPublishedNoteHtml,
+  withRetry,
+} from '../logic';
 import { collectDescendantFolderIds } from '../logic/notesTree';
 import { useKeyFromQueryDeps } from './useKeyFromQueryDeps';
 
 const logger = createDevLogger('notesActions', false);
 
 const NOTES_SYNC_STALE_TIME = 15_000;
+const NOTES_PUBLISHED_STALE_TIME = 15_000;
 
 type SyncNotesNotebookOptions = {
   hydrateNoteIds?: readonly number[];
@@ -267,6 +272,38 @@ export const useNotesNotes = createNotebookQueryHook(
   db.getNotesNotes
 );
 
+export function usePublishedNotesForNotebook({
+  notebookFlag,
+  enabled = true,
+}: {
+  notebookFlag: string | null | undefined;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: ['notesPublished', notebookFlag],
+    queryFn: () => listPublishedNotesForNotebook(notebookFlag!),
+    enabled: enabled && Boolean(notebookFlag),
+    staleTime: NOTES_PUBLISHED_STALE_TIME,
+  });
+}
+
+async function listPublishedNotesForNotebook(notebookFlag: string) {
+  const { parsed } = requireNotesNotebookFlag(notebookFlag);
+  const published = await api.listPublishedNotes();
+  return published.filter(
+    (record) => record.host === parsed.host && record.flagName === parsed.name
+  );
+}
+
+export function noteIsPublished(
+  published: api.NotesPublishedRecord[] | null | undefined,
+  noteId: number | null | undefined
+) {
+  return noteId != null
+    ? Boolean(published?.some((record) => record.noteId === noteId))
+    : false;
+}
+
 async function createAndFindNewItem<T>({
   notebookFlag,
   getItems,
@@ -413,6 +450,40 @@ export async function saveNotebookNote({
       : undefined
   );
   return db.getNotesNote({ notebookFlag, noteId: note.noteId });
+}
+
+export async function publishNotebookNote({
+  notebookFlag,
+  noteId,
+  title,
+  body,
+}: {
+  notebookFlag: string;
+  noteId: number;
+  title: string;
+  body: string;
+}) {
+  await api.publishNotesNote({
+    flag: notebookFlag,
+    noteId,
+    html: renderPublishedNoteHtml({ title, body }),
+  });
+  await waitForPublishedNoteState(notebookFlag, noteId, true);
+  return publishedNotePath(notebookFlag, noteId);
+}
+
+export async function unpublishNotebookNote({
+  notebookFlag,
+  noteId,
+}: {
+  notebookFlag: string;
+  noteId: number;
+}) {
+  await api.unpublishNotesNote({
+    flag: notebookFlag,
+    noteId,
+  });
+  await waitForPublishedNoteState(notebookFlag, noteId, false);
 }
 
 export async function moveNotebookNote({
@@ -603,6 +674,25 @@ async function syncNotesNotebookUntil<T>(
     await db.saveNotesNotebookSnapshot(readySnapshot);
   }
   return readyValue;
+}
+
+async function waitForPublishedNoteState(
+  notebookFlag: string,
+  noteId: number,
+  expected: boolean
+) {
+  try {
+    await withRetry(async () => {
+      const published = await listPublishedNotesForNotebook(notebookFlag);
+      if (noteIsPublished(published, noteId) !== expected) {
+        throw notYetSynced;
+      }
+    }, notesRetryOptions);
+  } catch (e) {
+    if (e !== notYetSynced) {
+      throw e;
+    }
+  }
 }
 
 async function hydrateNotesForSnapshot(

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -289,7 +289,7 @@ export function usePublishedNotesForNotebook({
 
 async function listPublishedNotesForNotebook(notebookFlag: string) {
   const { parsed } = requireNotesNotebookFlag(notebookFlag);
-  const published = await api.listPublishedNotes();
+  const published = await api.notes.listPublished();
   return published.filter(
     (record) => record.host === parsed.host && record.flagName === parsed.name
   );
@@ -463,7 +463,7 @@ export async function publishNotebookNote({
   title: string;
   body: string;
 }) {
-  await api.publishNotesNote({
+  await api.notes.publishNote({
     flag: notebookFlag,
     noteId,
     html: renderPublishedNoteHtml({ title, body }),
@@ -479,7 +479,7 @@ export async function unpublishNotebookNote({
   notebookFlag: string;
   noteId: number;
 }) {
-  await api.unpublishNotesNote({
+  await api.notes.unpublishNote({
     flag: notebookFlag,
     noteId,
   });

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -692,6 +692,14 @@ async function waitForPublishedNoteState(
     if (e !== notYetSynced) {
       throw e;
     }
+    // Unlike snapshot polls, this confirmation gates a user-facing success
+    // signal (link copied, toast) — an unconfirmed publish must fail loudly
+    // rather than report success for a state the backend never reached.
+    throw new Error(
+      `%notes write request is still pending; the ${
+        expected ? 'publish' : 'unpublish'
+      } is not yet confirmed and may still complete. Check the note's published state before retrying.`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Adds publish and unpublish actions for native notes. This is PR 4 of the native notes stack and is stacked on #5992.

Stack:

1. #5990 data foundation
2. #5991 native shell
3. #5992 import flow
4. #5993 publish actions

## Changes

- Added a small published-note HTML renderer with escaping and URL handling.
- Added store actions for publish, unpublish, published-state polling, and published URL creation.
- Added note detail menu actions for publish, view published note, and unpublish.
- Built published-note links from the configured ship URL instead of the app host.
- Added tests for publish rendering, publish URLs, publish state, and unpublish behavior.

## How did I test?

Tested on device


## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] State / providers
  - [x] Channel display
  - [ ] Navigation
  - [ ] Notifications

## Rollback plan

Revert this PR to remove publish actions. Native notes, import, and local editing remain available through the lower stack PRs.
