### PR TITLE
steward: code style improvements

### DIFF
--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -11,16 +11,15 @@
 ::    only cross-cutting config (the shared owner).
 ::
 /-  s=steward, a=activity, av=activity-ver, cv=chat-ver, st=story
-/-  l=steward-lens
-/-  g=steward-gateway
+/-  sl=steward-lens, sg=steward-gateway
 /+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
 +$  state-0
   $:  %0
       owner=(unit ship)
-      lens=state:v1:l
-      gateway=state:v1:g
+      lens=state:v1:sl
+      gateway=state:v1:sg
   ==
 ::
 --
@@ -109,12 +108,12 @@
     ?>  ?|  =(src.bowl our.bowl)
             =(our.bowl (sein:title our.bowl now.bowl src.bowl))
         ==
-    (le-poke-action:le-core !<(action:v1:l vase))
+    (le-poke-action:le-core !<(action:v1:sl vase))
   ::
   ::  gateway liveness: local only (enforced in ga-poke-action).
   ::
       %steward-gateway-action-1
-    (ga-poke-action:ga-core !<(action:v1:g vase))
+    (ga-poke-action:ga-core !<(action:v1:sg vase))
   ==
 ::
 ++  watch
@@ -137,7 +136,7 @@
   |=  [=wire =sign:agent:gall]
   ^+  cor
   ?+  wire  cor
-      [%lens %fanout *]
+      [%lens %send *]
     ?+  -.sign  cor
         %poke-ack
       ?~  p.sign  cor
@@ -154,6 +153,7 @@
       (ga-handle-activity-add:ga-core source.update event.update)
     ::
         %kick
+      ::TODO resubscription loop
       (emit watch-activity)
     ::
         %watch-ack
@@ -188,34 +188,38 @@
 ++  watch-activity
   ^-  card
   [%pass /activity %agent [our.bowl %activity] %watch /v5]
+::  |le-core: lens module
 ::
 ++  le-core
   |%
-  ++  max-runs-per-bot  ^-  @ud  1.000
-  ++  max-run-age       ^-  @dr  ~d90
-  ++  prune-interval    ^-  @dr  ~d1
+  ++  max-runs-per-bot  1.000
+  ++  max-run-age       ~d90
+  ++  prune-interval    ~d1
+  ++  recent-count      50
   ::
   ++  wait-prune
     ^-  card
     [%pass /lens/prune %arvo %b %wait (add now.bowl prune-interval)]
   ::
   ++  le-expired
-    |=  =run:v1:l
+    |=  =run:v1:sl
     ^-  ?
     (lth received.run (sub now.bowl max-run-age))
+  ::  +le-poke-action: handle lens poke
   ::
   ::  the same action arrives in two roles (the ownership gate in +poke has
   ::  already vetted src as ourselves or a moon we sponsor):
-  ::    - bot role (src==our): our own gateway poked us; fan the run out
+  ::    - bot role (src==our): our own gateway poked us; send the run out
   ::      to our configured owner.
   ::    - owner role (src is a sponsored moon): one of our bots sent us its
   ::      run; store it keyed by src.bowl so we can serve it to clients.
   ::
+  ::
   ++  le-poke-action
-    |=  =action:v1:l
+    |=  =action:v1:sl
     ^+  cor
     ?:  =(src.bowl our.bowl)
-      (le-fan-out id.action payload.action final.action)
+      (le-send id.action payload.action final.action)
     (le-store src.bowl id.action payload.action final.action)
   ::
   ++  le-watch
@@ -235,28 +239,28 @@
     ::
         [%v1 %run @ @ ~]
       =/  bot  (slav %p i.t.t.path)
-      =/  =id:v1:l  i.t.t.t.path
+      =/  =id:v1:sl  i.t.t.t.path
       ?~  r=(~(get by lens.state) [bot id])  [~ ~]
       ?:  (le-expired u.r)  [~ ~]
-      ``steward-lens-update-1+!>(`update:v1:l`[bot id u.r])
+      ``steward-lens-update-1+!>(`update:v1:sl`[[bot id] u.r])
     ==
   ::
-  ++  le-fan-out
-    |=  [=id:v1:l payload=json final=?]
+  ++  le-send
+    |=  [=id:v1:sl payload=json final=?]
     ^+  cor
     ?~  owner.state  cor
     ?:  =(u.owner.state our.bowl)
       ::  self-owned bot: store directly, no network hop
       (le-store our.bowl id payload final)
-    =/  =action:v1:l  [id payload final]
+    =/  =action:v1:sl  [id payload final]
     %-  emit
     :^    %pass
-        /lens/fanout/(scot %p u.owner.state)/(scot %t id)
+        /lens/send/(scot %p u.owner.state)/(scot %t id)
       %agent
-    [[u.owner.state %steward] %poke %steward-lens-action-1 !>(`action:v1:l`action)]
+    [[u.owner.state %steward] %poke %steward-lens-action-1 !>(`action:v1:sl`action)]
   ::
   ++  le-store
-    |=  [bot=ship =id:v1:l payload=json final=?]
+    |=  [bot=ship =id:v1:sl payload=json final=?]
     ^+  cor
     ::  drop late partials once a run is finalized: overwriting would pair
     ::  complete=& with a stale partial payload (and fact it out)
@@ -264,33 +268,31 @@
     =/  prev  (~(get by lens.state) [bot id])
     ?:  &(?=(^ prev) complete.u.prev !final)
       cor
-    =/  =run:v1:l  [final now.bowl payload]
+    =/  =run:v1:sl  [final now.bowl payload]
     =.  lens.state  (~(put by lens.state) [bot id] run)
     =.  cor  (le-prune bot)
-    (give %fact ~[/v1/lens] %steward-lens-update-1 !>(`update:v1:l`[bot id run]))
+    (give %fact ~[/v1/lens] %steward-lens-update-1 !>(`update:v1:sl`[[bot id] run]))
   ::
   ++  le-prune
     |=  for=ship
     ^+  cor
-    =/  mine
+    =/  mine=(list entry:sl)
       %+  skim  ~(tap by lens.state)
       |=  [[bot=ship *] *]
       =(bot for)
-    =/  dead
-      %+  skim  mine
-      |=  [* =run:v1:l]
-      (le-expired run)
-    =/  live
-      %+  skip  mine
-      |=  [* =run:v1:l]
-      (le-expired run)
+    =/  [live=(list entry:sl) dead=(list entry:sl)]
+      %+  skid  mine
+      |=  [* =run:v1:sl]
+      !(le-expired run)
+    ::  we mark any live runs above the fixed limit as dead
+    ::
     =?  dead  (gth (lent live) max-runs-per-bot)
       =/  sorted
         %+  sort  live
-        |=  [a=[* =run:v1:l] b=[* =run:v1:l]]
+        |=  [a=[* =run:v1:sl] b=[* =run:v1:sl]]
         (lth received.run.a received.run.b)
       (weld dead (scag (sub (lent live) max-runs-per-bot) sorted))
-    =/  keys  (turn dead |=([k=[bot=ship =id:v1:l] *] k))
+    =/  keys  (turn dead |=([k=[bot=ship =id:v1:sl] *] k))
     |-  ^+  cor
     ?~  keys  cor
     =.  lens.state  (~(del by lens.state) i.keys)
@@ -308,21 +310,22 @@
     $(bots t.bots)
   ::
   ++  le-recent
-    ^-  (list update:v1:l)
-    =/  fresh
+    ^-  (list update:v1:sl)
+    =/  fresh=(list entry:sl)
       %+  skip  ~(tap by lens.state)
-      |=  [* =run:v1:l]
+      |=  [* =run:v1:sl]
       (le-expired run)
-    =/  sorted
+    =/  sorted=(list entry:sl)
       %+  sort  fresh
-      |=  [a=[* =run:v1:l] b=[* =run:v1:l]]
+      |=  [a=[* =run:v1:sl] b=[* =run:v1:sl]]
       (gth received.run.a received.run.b)
-    %+  turn  (scag 50 sorted)
-    |=  [[bot=ship =id:v1:l] =run:v1:l]
-    [bot id run]
+    %+  turn  (scag recent-count sorted)
+    |=  [[bot=ship =id:v1:sl] =run:v1:sl]
+    [[bot id] run]
   --
+::  |ga-core: gateway module
 ::
-::  gateway module: liveness + offline auto-replies. owner is the shared
+::  liveness + offline auto-replies. owner is the shared
 ::  top-level (unit ship). single-owner: notices/auto-replies target it.
 ::
 ++  ga-core
@@ -354,11 +357,11 @@
     %+  give  %fact
     :*  ~[/v1/gateway]
         %steward-gateway-update-1
-        !>(`update:v1:g`[%status status.gateway.state lease-until.gateway.state])
+        !>(`update:v1:sg`[%status status.gateway.state lease-until.gateway.state])
     ==
   ::
   ++  ga-give-update
-    |=  =update:v1:g
+    |=  =update:v1:sg
     ^+  cor
     (give %fact ~[/v1/gateway] %steward-gateway-update-1 !>(update))
   ::
@@ -379,7 +382,7 @@
     owner.state
   ::
   ++  ga-poke-action
-    |=  =action:v1:g
+    |=  =action:v1:sg
     ^+  cor
     ?>  =(src.bowl our.bowl)
     ?-  -.action

--- a/desk/sur/steward/lens.hoon
+++ b/desk/sur/steward/lens.hoon
@@ -16,9 +16,11 @@
       received=@da
       payload=json
   ==
+::  $run-key: run record identity
++$  run-key  [bot=ship =id]
 ::  $entry: a run plus its identity, as exposed to observers
 ::
-+$  entry  [bot=ship =id =run]
++$  entry  [run-key =run]
 ::  $state: stored runs keyed by bot ship and run id (owner role)
 ::
 +$  state  (map [bot=ship =id] run)

--- a/desk/sur/steward/lens.hoon
+++ b/desk/sur/steward/lens.hoon
@@ -16,11 +16,9 @@
       received=@da
       payload=json
   ==
-::  $run-key: run record identity
-+$  run-key  [bot=ship =id]
 ::  $entry: a run plus its identity, as exposed to observers
 ::
-+$  entry  [run-key =run]
++$  entry  [[bot=ship =id] =run]
 ::  $state: stored runs keyed by bot ship and run id (owner role)
 ::
 +$  state  (map [bot=ship =id] run)

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -139,16 +139,16 @@
     :~  %-  ex-fact
         :*  ~[/v1/lens]
             %steward-lens-update-1
-            !>(`update:v1:l`[moon 'lens-moon' [& ~2024.1.1 payload]])
+            !>(`update:v1:l`[[moon 'lens-moon'] [& ~2024.1.1 payload]])
         ==
     ==
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-moon)
   =+  !<(=update:v1:l q.res)
-  (ex-equal !>(update) !>(`update:v1:l`[moon 'lens-moon' [& ~2024.1.1 payload]]))
+  (ex-equal !>(update) !>(`update:v1:l`[[moon 'lens-moon'] [& ~2024.1.1 payload]]))
 ::
-::  fan-out to a non-self owner emits a %steward-lens-action-1 poke
+::  sending to a non-self owner emits a %steward-lens-action-1 poke
 ::
-++  test-run-final-fans-out-to-owner
+++  test-run-final-sends-to-owner
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
@@ -158,7 +158,7 @@
     (do-poke %steward-lens-action-1 !>(`action:v1:l`['lens-1' payload &]))
   %+  ex-cards  caz
   :~  %-  ex-poke
-      :*  /lens/fanout/(scot %p ~bus)/(scot %t 'lens-1')
+      :*  /lens/send/(scot %p ~bus)/(scot %t 'lens-1')
           [~bus %steward]
           %steward-lens-action-1
           !>(`action:v1:l`['lens-1' payload &])
@@ -180,12 +180,12 @@
     :~  %-  ex-fact
         :*  ~[/v1/lens]
             %steward-lens-update-1
-            !>(`update:v1:l`[~dev 'lens-1' [& ~2024.1.1 payload]])
+            !>(`update:v1:l`[[~dev 'lens-1'] [& ~2024.1.1 payload]])
         ==
     ==
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p ~dev)/lens-1)
   =+  !<(=update:v1:l q.res)
-  (ex-equal !>(update) !>(`update:v1:l`[~dev 'lens-1' [& ~2024.1.1 payload]]))
+  (ex-equal !>(update) !>(`update:v1:l`[[~dev 'lens-1'] [& ~2024.1.1 payload]]))
 ::
 ::  a poke from a sponsored moon is stored keyed by src.bowl (the moon)
 ::
@@ -202,12 +202,12 @@
     :~  %-  ex-fact
         :*  ~[/v1/lens]
             %steward-lens-update-1
-            !>(`update:v1:l`[moon 'lens-2' [| ~2024.1.1 payload]])
+            !>(`update:v1:l`[[moon 'lens-2'] [| ~2024.1.1 payload]])
         ==
     ==
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-2)
   =+  !<(=update:v1:l q.res)
-  (ex-equal !>(update) !>(`update:v1:l`[moon 'lens-2' [| ~2024.1.1 payload]]))
+  (ex-equal !>(update) !>(`update:v1:l`[[moon 'lens-2'] [| ~2024.1.1 payload]]))
 ::
 ::  final=& marks the run complete
 ::

--- a/docs/steward.md
+++ b/docs/steward.md
@@ -29,12 +29,12 @@ State is `state-0`, defined in the app file. Cross-cutting config is top level; 
 
 ```
 state-0
-  owner    (unit ship)                  shared config: bot fans runs out to it / its DMs are watched; ~ = inert
+  owner    (unit ship)                  shared config: bot sends runs to it / its DMs are watched; ~ = inert
   lens     state:v1:lens                 stored lens run records (owner role)
   gateway  state:v1:gateway              harness liveness + auto-reply bookkeeping
 ```
 
-`owner` is shared: the lens module fans runs out to it, and the gateway module treats its DMs as owner activity worth auto-replying to.
+`owner` is shared: the lens module sends runs to it, and the gateway module treats its DMs as owner activity worth auto-replying to.
 
 `run` (in `sur/steward/lens.hoon`):
 
@@ -52,10 +52,10 @@ Makes a bot's run records — trigger, tool calls, timings, output — durable o
 
 One agent, two roles; the same code runs on every ship, and the role is determined by **who poked it** (the `%steward-lens-action-1` ownership gate has already vetted the source — see below):
 
-- **bot ship role** (`src == our`): the local gateway pokes `%steward-lens-action-1` with a run record. `le-poke-action` fans it out to the configured `owner` as a `%steward-lens-action-1` poke. Ames retries until ack, so owner-ship downtime or gateway restarts don't drop finalized runs once poked.
+- **bot ship role** (`src == our`): the local gateway pokes `%steward-lens-action-1` with a run record. `le-poke-action` sends it to the configured `owner` as a `%steward-lens-action-1` poke. Ames retries until ack, so owner-ship downtime or gateway restarts don't drop finalized runs once poked.
 - **owner ship role** (`src` is a moon we sponsor): a bot sent us its run. `le-poke-action` stores it keyed `[bot=src id]`, gives a fact on `/v1/lens`, and answers scries for clients.
 
-A self-owned bot (`owner` equal to `our`) is stored directly during fan-out with no network hop.
+A self-owned bot (`owner` equal to `our`) is stored directly during send with no network hop.
 
 A lens action is a single shape — `[id=@t payload=json final=?]`. `final=&` marks the run complete; `final=|` is an in-progress milestone that upserts a partial record. A finalized run is never demoted back to partial by a late `final=|` (the late partial is dropped).
 
@@ -126,7 +126,7 @@ Only the local gateway drives liveness, so this requires `src == our`.
 - `/x/v1/gateway/status` → `%noun` `[status:v1:gateway (unit @da)]` — current liveness and lease expiry.
 - `/x/v1/gateway/owner-activity` → `%noun` `@da` — timestamp of the most recent owner DM.
 
-`entry` is `[bot=ship id=@t run]`. The lens update mark grows to JSON for Eyre, embedding the stored payload directly:
+`entry` is `[[bot=ship id=@t] run]`. The lens update mark grows to JSON for Eyre, embedding the stored payload directly:
 
 ```json
 { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": { ... run record ... } }
@@ -136,7 +136,7 @@ Only the local gateway drives liveness, so this requires `src == our`.
 
 - `on-init` arms the daily lens prune timer (`/lens/prune` behn wire) and subscribes to `%activity /v5` for the gateway module. The prune timer is armed once; reloading at `%0` does not stack a second one.
 - `on-load` accepts state `%0` only — `%steward` is greenfield with no prior versions; an unreadable state resets to bunt and re-arms the timers/subscriptions.
-- Wires: lens fan-out on `/lens/fanout/[owner-p]/[id-t]`, lens prune on `/lens/prune`, the gateway lease timer on `/gateway/lease-check`, gateway auto-reply/notice DM sends on `/gateway/dm/send`. The `%activity` subscription is re-watched on `%kick`. Poke/DM nacks are logged and ignored (Ames retries).
+- Wires: lens send on `/lens/send/[owner-p]/[id-t]`, lens prune on `/lens/prune`, the gateway lease timer on `/gateway/lease-check`, gateway auto-reply/notice DM sends on `/gateway/dm/send`. The `%activity` subscription is re-watched on `%kick`. Poke/DM nacks are logged and ignored (Ames retries).
 - `on-watch` and `on-peek` assert `=(src our)` — no cross-ship subscriptions or foreign scries. Only the lens poke is ownership-gated (to admit a bot's runs).
 
 ## integration notes
@@ -144,4 +144,4 @@ Only the local gateway drives liveness, so this requires `src == our`.
 - The gateway (openclaw-tlon / hermes) pokes core `%configure` on monitor activation and `%steward-lens-action-1` run milestones from its run event stream. Lens recording is config-gated on the gateway side (`channels.tlon.contextLens`).
 - Clients store runs locally, subscribe to `/v1/lens` for live updates, and scry on cache miss. The channel post pointer blob carries `botShip` so the client knows which `[bot id]` key to look up.
 - The gateway's HTTP/SSE routes remain an optional desktop enhancement for fine-grained live streaming; `%steward`'s lens module is the durable source of truth.
-- The `%steward-lens-*` marks replace the former `%context-lens-*` marks. There is no separate cross-ship `signal` mark — fan-out reuses `%steward-lens-action-1`, gated by ownership.
+- The `%steward-lens-*` marks replace the former `%context-lens-*` marks. There is no separate cross-ship `signal` mark — sending reuses `%steward-lens-action-1`, gated by ownership.


### PR DESCRIPTION
## Summary

Addresses minor issues in the steward agent.

## Changes
1. Avoid using typical import faces `g` (groups) and `l` (logs). Use `sl` and `sg` (steward-lens, steward-gateway)
2. Modify $entry type to separate out the record key for better ergonomics.
3. Rename "fan-out" to "send". As far as I can tell, we do not actually fan out these records: the consumer is always going to be the owner, so it feels a misnomer.

## How did I test?

Compiled. 

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.