### PR TITLE
fix(openclaw): de-flake integration CI — pin vere/pier (rube-27 + v4.5) and kill cross-test session history tag bleed

### DIFF
--- a/packages/openclaw/dev/docker-compose.test.yml
+++ b/packages/openclaw/dev/docker-compose.test.yml
@@ -21,26 +21,33 @@ services:
         apt-get update && apt-get install -y curl xz-utils
         cd /data
 
+        # Pin both halves of the runtime/snapshot pair so the version skew that
+        # crashed serf replay (stale snapshot -> downgrade runtime to replay ->
+        # serf unexpectedly shut down) cannot silently return when `latest`
+        # advances past the snapshot kelvin. rube-27 is the archive generation
+        # the tlon-web e2e suite runs; vere-v4.5 is the matching runtime.
+        echo "==> vere pin: vere-v4.5  pier gen: 27"
+
         echo "==> Downloading zod..."
-        curl -fSL https://bootstrap.urbit.org/rube-zod25.tgz -o rube-zod25.tgz || { echo "Failed to download zod"; exit 1; }
-        ls -la rube-zod25.tgz
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-zod27.tgz -o rube-zod27.tgz || { echo "Failed to download zod"; exit 1; }
+        ls -la rube-zod27.tgz
         echo "==> Extracting zod..."
-        tar xzf rube-zod25.tgz || { echo "Failed to extract zod"; exit 1; }
+        tar xzf rube-zod27.tgz || { echo "Failed to extract zod"; exit 1; }
 
         echo "==> Downloading ten..."
-        curl -fSL https://bootstrap.urbit.org/rube-ten25.tgz -o rube-ten25.tgz || { echo "Failed to download ten"; exit 1; }
-        ls -la rube-ten25.tgz
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-ten27.tgz -o rube-ten27.tgz || { echo "Failed to download ten"; exit 1; }
+        ls -la rube-ten27.tgz
         echo "==> Extracting ten..."
-        tar xzf rube-ten25.tgz || { echo "Failed to extract ten"; exit 1; }
+        tar xzf rube-ten27.tgz || { echo "Failed to extract ten"; exit 1; }
 
         echo "==> Downloading mug..."
-        curl -fSL https://bootstrap.urbit.org/rube-mug25.tgz -o rube-mug25.tgz || { echo "Failed to download mug"; exit 1; }
-        ls -la rube-mug25.tgz
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-mug27.tgz -o rube-mug27.tgz || { echo "Failed to download mug"; exit 1; }
+        ls -la rube-mug27.tgz
         echo "==> Extracting mug..."
-        tar xzf rube-mug25.tgz || { echo "Failed to extract mug"; exit 1; }
+        tar xzf rube-mug27.tgz || { echo "Failed to extract mug"; exit 1; }
 
         echo "==> Downloading vere..."
-        curl -fSL https://urbit.org/install/linux-x86_64/latest | tar xz || { echo "Failed to download vere"; exit 1; }
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/urbit/vere/releases/download/vere-v4.5/linux-x86_64.tgz | tar xz || { echo "Failed to download vere"; exit 1; }
         VERE=$$(ls -1 vere-*-linux-x86_64 | head -1)
         chmod +x $$VERE
         echo "==> Using vere: $$VERE"

--- a/packages/openclaw/test/cases/01-messages.test.ts
+++ b/packages/openclaw/test/cases/01-messages.test.ts
@@ -18,6 +18,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import {
   type TestFixtures,
   getFixtures,
+  registerEngagingTurn,
   requireFixtureGroup,
   waitFor,
 } from '../lib/index.js';
@@ -161,10 +162,26 @@ describe('messages', () => {
     test('processes a DM thread reply', async () => {
       // Owner sends a parent DM, then replies to it. The plugin should
       // hand the reply to the agent loop — verify via _received.
+      //
+      // The parent gets its OWN script key (not the reply's). Owner DMs always
+      // engage the model, so an *untagged* parent would inherit the last
+      // [tlon-test:KEY] still sitting in the shared ~ten DM session history
+      // (e.g. the previous test's `post-channel-basic`) and misroute. Tagging
+      // the parent with a distinct key keeps the *reply* assertion clean
+      // (still keyed on `dm-thread-reply`) while removing that bleed.
+      // registerEngagingTurn defaults to allowExtraCalls: 1 because these
+      // engaging DM flows make one trailing model turn beyond their text reply.
+      const parentKey = 'dm-thread-parent';
       const parentToken = `it-dm-parent-${Date.now().toString(36)}`;
+      // Give the parent a UNIQUE reply text so we can wait for the bot to
+      // actually deliver it (i.e. the parent run completed), not merely started.
+      const parentAck = `parent-ack-${parentToken}`;
+      const parentTag = await registerEngagingTurn(parentKey, [
+        { kind: 'text', content: parentAck },
+      ]);
       await fixtures.userState.sendPost({
         channelId: fixtures.botShip,
-        content: story(`parent ${parentToken}`),
+        content: story(`${parentTag} parent ${parentToken}`),
       });
 
       // Poll for the parent post to land on the BOT'S view of the DM channel.
@@ -187,8 +204,28 @@ describe('messages', () => {
         return found?.id ? found : undefined;
       }, 30_000);
 
+      // Wait for the parent RUN to fully settle — the bot has DELIVERED its
+      // reply — before sending the thread reply. Waiting only on the first
+      // recorded model call proves the run started, not that it finished, so
+      // the reply could still race a mid-flight parent run. Serializing on
+      // delivery keeps this a harness-correctness test, not an I2 concurrency
+      // test.
+      await waitFor(async () => {
+        const posts = await fixtures.botState.channelPosts(
+          fixtures.userShip,
+          10
+        );
+        const delivered = (posts ?? []).some((p) => {
+          const pp = p as PostLike;
+          return (
+            pp.authorId === fixtures.botShip && postText(pp).includes(parentAck)
+          );
+        });
+        return delivered ? true : undefined;
+      }, 30_000);
+
       const key = 'dm-thread-reply';
-      await fakeModel.script(key, [
+      const replyTag = await registerEngagingTurn(key, [
         { kind: 'text', content: 'Got your thread reply' },
       ]);
 
@@ -196,7 +233,7 @@ describe('messages', () => {
         channelId: fixtures.botShip,
         parentId: String(parent.id),
         parentAuthor: fixtures.userShip,
-        content: story(`[tlon-test:${key}] reply body`),
+        content: story(`${replyTag} reply body`),
       });
 
       const calls = await waitFor(async () => {

--- a/packages/openclaw/test/cases/03-heartbeat.test.ts
+++ b/packages/openclaw/test/cases/03-heartbeat.test.ts
@@ -16,6 +16,7 @@ import {
   type StateClient,
   createStateClient,
   getTestConfig,
+  registerEngagingTurn,
   waitFor,
 } from '../lib/index.js';
 import {
@@ -187,7 +188,11 @@ describe('re-engagement nudges', () => {
     // Phase 2: owner replies. The plugin's owner-reply handler should clear
     // `lastNudgeStage` so the next inactivity cycle can re-send stage 1.
     const { markdownToStory } = await import('../../src/urbit/story.js');
-    const replyText = `heartbeat-reply-${Date.now()}`;
+    // Owner DMs always engage the model; tag this reply with its own key so it
+    // can't inherit a stale [tlon-test:KEY] from the shared owner DM session
+    // history. The assertion below is on lastNudgeStage state, not this reply.
+    const replyTag = await registerEngagingTurn('heartbeat-owner-reply');
+    const replyText = `${replyTag} heartbeat-reply-${Date.now()}`;
     await ownerState.sendPost({
       channelId: botShip,
       content: markdownToStory(replyText),

--- a/packages/openclaw/test/cases/07-blobs.test.ts
+++ b/packages/openclaw/test/cases/07-blobs.test.ts
@@ -102,7 +102,8 @@ describe('blobs', () => {
     viewer: TestFixtures['userState'],
     channelId: string,
     authorId: string,
-    bodySubstring: string
+    bodySubstring: string,
+    timeoutMs = 10_000
   ): Promise<{ id: string }> {
     return waitFor(async () => {
       const posts = await viewer.channelPosts(channelId, 10);
@@ -118,7 +119,7 @@ describe('blobs', () => {
         );
       }) as { id?: string } | undefined;
       return found?.id ? { id: found.id } : undefined;
-    }, 10_000);
+    }, timeoutMs);
   }
 
   // ── DM tests ─────────────────────────────────────────────────────────
@@ -185,12 +186,15 @@ describe('blobs', () => {
     );
     // Wait for the parent RUN to fully settle (bot delivered its reply) before
     // sending the thread reply, so this stays a harness-correctness test rather
-    // than an I2 concurrency test.
+    // than an I2 concurrency test. Use a 30s budget (not findParentPost's 10s
+    // default) — this is a full model round-trip delivery, matching the DM-thread
+    // test's parent-settle wait, and 10s can be too tight under CI load.
     await findParentPost(
       fixtures.userState,
       fixtures.botShip,
       fixtures.botShip,
-      parentAck
+      parentAck,
+      30_000
     );
 
     await fixtures.userState.sendReply({

--- a/packages/openclaw/test/cases/07-blobs.test.ts
+++ b/packages/openclaw/test/cases/07-blobs.test.ts
@@ -22,6 +22,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import {
   type TestFixtures,
   getFixtures,
+  registerEngagingTurn,
   requireFixtureGroup,
   waitFor,
 } from '../lib/index.js';
@@ -160,21 +161,36 @@ describe('blobs', () => {
     const parentMarker = `parent-${transcriptionToken}`;
     await fakeModel.script(key, [{ kind: 'text', content: 'got the reply' }]);
 
-    // Parent post is a thread anchor only — UNTAGGED and NO blob. The
-    // bot will still process it (owner DMs always engage) but that call
-    // hits the fake-model without a [tlon-test:KEY] tag and is recorded
-    // under key=null, so it can't satisfy fakeModel.received(key) below.
-    // This guarantees the assertion is about the REPLY path, not the
-    // parent path.
+    // Parent post is a thread anchor only (NO blob). Owner DMs always engage
+    // the model, so the parent gets its OWN key — otherwise it would inherit
+    // the last [tlon-test:KEY] still in the shared ~ten DM session history and
+    // misroute. A distinct key keeps the assertion about the REPLY path
+    // (`fakeModel.received(key)` below) while not bleeding a foreign key.
+    const parentKey = 'blob-dm-reply-parent';
+    // Unique reply text so we can wait for the bot to actually DELIVER the
+    // parent reply (run completed), not merely start it.
+    const parentAck = `blob-parent-ack-${Date.now().toString(36)}`;
+    const parentTag = await registerEngagingTurn(parentKey, [
+      { kind: 'text', content: parentAck },
+    ]);
     await fixtures.userState.sendPost({
       channelId: fixtures.botShip,
-      content: storyText(parentMarker),
+      content: storyText(`${parentTag} ${parentMarker}`),
     });
     const parent = await findParentPost(
       fixtures.userState,
       fixtures.botShip,
       fixtures.userShip,
       parentMarker
+    );
+    // Wait for the parent RUN to fully settle (bot delivered its reply) before
+    // sending the thread reply, so this stays a harness-correctness test rather
+    // than an I2 concurrency test.
+    await findParentPost(
+      fixtures.userState,
+      fixtures.botShip,
+      fixtures.botShip,
+      parentAck
     );
 
     await fixtures.userState.sendReply({

--- a/packages/openclaw/test/lib/client.ts
+++ b/packages/openclaw/test/lib/client.ts
@@ -145,16 +145,21 @@ export function createTlonClient(config: TlonClientConfig): TestClient {
     throw new Error(`Failed to send DM after 3 attempts: ${lastSendError}`);
   };
 
-  /** Best-effort `/stop` to drain the bot after a timeout. */
+  /**
+   * Timeout cleanup hook. Deliberately does NOT send an in-band `/stop`.
+   *
+   * `/stop` rides the same `processMessage()` DM path as any other message
+   * (the monitor has no out-of-band `/stop` escape hatch), so on a timeout —
+   * exactly when the session is stuck or draining — it just queues behind the
+   * run we're failing on and becomes another stale message that bleeds into a
+   * later test. The fake-model's provenance-aware routing already neutralizes a
+   * stale tag carried over on session history, so the old in-band `/stop` + 3s
+   * sleep only added contamination.
+   */
   const bestEffortStopAfterTimeout = async (): Promise<void> => {
-    try {
-      console.log(`[timeout cleanup] sending /stop to ${bot.shipName}`);
-      await sendDmWithRetry('/stop');
-      await sleep(3000);
-      console.log(`[timeout cleanup] /stop sent; gave it 3s to drain`);
-    } catch (err) {
-      console.log(`[timeout cleanup] failed to send /stop: ${String(err)}`);
-    }
+    console.log(
+      `[timeout cleanup] not sending /stop (in-band; would poison the session)`
+    );
   };
 
   return {
@@ -301,7 +306,7 @@ export function createTlonClient(config: TlonClientConfig): TestClient {
           `Timeout waiting for bot response after ${timeoutMs}ms ` +
           `(attempts=${attempts}, baselineSequence=${baselineSequence}` +
           (lastPollError ? `, lastPollError=${lastPollError}` : '') +
-          `; sent /stop for cleanup)`;
+          `)`;
         console.log(`[TEST] Response success: false`);
         console.log(
           `[TEST] Response text: ${JSON.stringify(timeoutError.slice(0, 500))}`

--- a/packages/openclaw/test/lib/fixtures.ts
+++ b/packages/openclaw/test/lib/fixtures.ts
@@ -10,6 +10,7 @@ import {
   createTlonClient,
 } from './client.js';
 import { getTestConfig } from './config.js';
+import { registerEngagingTurn } from './scripted.js';
 import { type StateClient, createStateClient } from './state.js';
 
 export interface TestFixtures {
@@ -317,9 +318,13 @@ export async function ensureThirdPartyDmAccess(
     return;
   }
 
+  // Tag the probe with its own key. This is a model-engaging owner-style DM,
+  // so an untagged version would inherit the last [tlon-test:KEY] in the
+  // third-party DM session history and misroute (the bleed Bucket 2 removes).
   const probeToken = `fixture-dm-check-${Date.now().toString(36)}`;
+  const probeTag = await registerEngagingTurn('fixture-thirdparty-probe');
   const probeResponse = await thirdPartyClient.prompt(
-    `Hello, this is a DM access check for integration tests. Reply with "${probeToken}".`,
+    `${probeTag} Hello, this is a DM access check for integration tests. Reply with "${probeToken}".`,
     { timeoutMs: 45_000 }
   );
 
@@ -355,8 +360,9 @@ export async function ensureThirdPartyDmAccess(
   );
 
   const confirmToken = `fixture-dm-confirm-${Date.now().toString(36)}`;
+  const confirmTag = await registerEngagingTurn('fixture-thirdparty-confirm');
   const confirmResponse = await thirdPartyClient.prompt(
-    `Hello again, this is a DM access confirmation. Reply with "${confirmToken}".`,
+    `${confirmTag} Hello again, this is a DM access confirmation. Reply with "${confirmToken}".`,
     { timeoutMs: 60_000 }
   );
 

--- a/packages/openclaw/test/lib/index.ts
+++ b/packages/openclaw/test/lib/index.ts
@@ -22,6 +22,8 @@ export {
 
 export { getTestConfig, type TestEnvConfig } from './config.js';
 
+export { registerEngagingTurn } from './scripted.js';
+
 export {
   waitFor,
   getFixtures,

--- a/packages/openclaw/test/lib/scripted.ts
+++ b/packages/openclaw/test/lib/scripted.ts
@@ -1,0 +1,40 @@
+/**
+ * Helpers for model-engaging test turns.
+ *
+ * Any message that engages the bot's agent loop (owner DMs always do; @mentions
+ * and thread replies in watched channels do) becomes a model call. openclaw
+ * re-sends the whole conversation history on every call and DMs share one
+ * long-lived per-peer session, so an *untagged* engaging turn inherits the last
+ * `[tlon-test:KEY]` tag still sitting in history — typically a prior test's key
+ * — and misroutes (see bucket2-redesign.md).
+ *
+ * The durable fix is server-side (provenance-aware key selection + benign
+ * handling of stale prior-epoch tags). This helper is the front-line fix: give
+ * every engaging setup turn (thread-anchor parents, probes) its OWN key so it
+ * never inherits a foreign one. A grep for raw `sendPost` / `sendReply` /
+ * `sendDm` / `prompt` then becomes a review tool for the intentional, knowingly
+ * non-engaging exceptions, rather than the audit itself.
+ */
+import {
+  type ScriptOptions,
+  type Step,
+  fakeModel,
+} from '../support/fake-model/client.js';
+
+const DEFAULT_ACK: Step[] = [{ kind: 'text', content: 'ack' }];
+
+/**
+ * Register a (benign by default) script for `key` and return the
+ * `[tlon-test:KEY]` tag to embed in the engaging turn's content.
+ *
+ * Defaults to `allowExtraCalls: 1` because these engaging flows make one
+ * trailing model turn beyond their single text response.
+ */
+export async function registerEngagingTurn(
+  key: string,
+  steps: Step[] = DEFAULT_ACK,
+  opts: ScriptOptions = { allowExtraCalls: 1 }
+): Promise<string> {
+  await fakeModel.script(key, steps, opts);
+  return `[tlon-test:${key}]`;
+}

--- a/packages/openclaw/test/support/fake-model/client.ts
+++ b/packages/openclaw/test/support/fake-model/client.ts
@@ -20,11 +20,37 @@
  *   await fixtures.client.prompt(
  *     `[tlon-test:post-channel-basic] post something into the channel`,
  *   );
+ *
+ * Trailing / extra model calls: some flows make ONE more model turn than they
+ * have logical responses (e.g. a DM reply that emits its text and then makes a
+ * trailing turn). By default an extra call past the last scripted step is a
+ * loud 400 (it usually means a test under-specified its flow). A flow that
+ * legitimately makes a bounded number of extra turns opts in explicitly:
+ *
+ *   await fakeModel.script(key, [{ kind: "text", content: "ack" }], {
+ *     allowExtraCalls: 1,
+ *   });
+ *
+ * Stale-history bleed is handled server-side: openclaw re-sends conversation
+ * history and DMs share one per-peer session, so an old `[tlon-test:KEY]` tag
+ * can ride into a later, untagged engaging turn. The server selects the script
+ * by the tag on the *latest user turn* first, and treats a prior-epoch tag that
+ * is no longer registered as a benign no-op (flagged `stale`) rather than a
+ * 400. See bucket2-redesign.md §4.
  */
 
 export type Step =
   | { kind: 'text'; content: string }
   | { kind: 'tool_call'; name: string; args: Record<string, unknown> };
+
+export interface ScriptOptions {
+  /**
+   * Number of model calls past the last scripted step to tolerate, returning
+   * benign filler (200) instead of a 400. Use for a flow that legitimately
+   * makes a trailing model turn. Default 0 (exhaustion is a loud 400).
+   */
+  allowExtraCalls?: number;
+}
 
 const baseUrl = (() => {
   const fromEnv = process.env.FAKE_MODEL_BASE_URL;
@@ -34,11 +60,19 @@ const baseUrl = (() => {
   return 'http://localhost:4000';
 })();
 
-async function postScript(key: string, steps: Step[]): Promise<void> {
+async function postScript(
+  key: string,
+  steps: Step[],
+  opts: ScriptOptions = {}
+): Promise<void> {
   const res = await fetch(`${baseUrl}/v1/_scripts`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ key, steps }),
+    body: JSON.stringify({
+      key,
+      steps,
+      allowExtraCalls: opts.allowExtraCalls ?? 0,
+    }),
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');
@@ -57,7 +91,7 @@ async function deleteScripts(): Promise<void> {
 }
 
 export interface ReceivedCall {
-  /** [tlon-test:KEY] tag found in the request, or null if no tag. */
+  /** [tlon-test:KEY] tag selected for the request, or null if none. */
   key: string | null;
   /** Server-side timestamp (ms) when the call arrived. */
   at: number;
@@ -75,9 +109,28 @@ export interface ReceivedCall {
    * replied with something".
    */
   userText: string;
+  /** Epoch (reset generation) the server was in when the call arrived. */
+  epoch: number;
+  /** Epoch in which this call's key was last registered, or null if never. */
+  registeredEpoch: number | null;
+  /**
+   * True when `epoch > registeredEpoch` — a reset() ran between the key's
+   * registration and this call's arrival, so the tag rode in on re-sent
+   * session history from a prior test. A DIAGNOSTIC classification only: the
+   * server serves such calls benignly (it does not 400 on them).
+   */
+  stale: boolean;
+  /**
+   * How the key was selected: 'latest-user' (tag on the newest user turn),
+   * 'history-active' (continuation; last historical tag still registered),
+   * 'history-inactive' (last historical tag no longer registered), or 'none'.
+   */
+  provenance: 'latest-user' | 'history-active' | 'history-inactive' | 'none';
 }
 
-async function getReceivedCalls(key?: string): Promise<ReceivedCall[]> {
+async function getReceived(
+  key?: string
+): Promise<{ calls: ReceivedCall[]; epoch: number }> {
   const url = key
     ? `${baseUrl}/v1/_received?key=${encodeURIComponent(key)}`
     : `${baseUrl}/v1/_received`;
@@ -86,8 +139,22 @@ async function getReceivedCalls(key?: string): Promise<ReceivedCall[]> {
     const detail = await res.text().catch(() => '');
     throw new Error(`fakeModel.received failed: ${res.status} ${detail}`);
   }
-  const body = (await res.json()) as { calls?: ReceivedCall[] };
-  return body.calls ?? [];
+  const body = (await res.json()) as { calls?: ReceivedCall[]; epoch?: number };
+  return { calls: body.calls ?? [], epoch: body.epoch ?? 0 };
+}
+
+async function getReceivedCalls(key?: string): Promise<ReceivedCall[]> {
+  return (await getReceived(key)).calls;
+}
+
+/**
+ * All cross-epoch (stale) calls recorded since the last reset. Use to REPORT
+ * stale-history bleed by class in verification — not as a hard assertion, since
+ * a stale call is served benignly and is an inherent (harmless) consequence of
+ * untagged engaging turns + persistent session history.
+ */
+async function getStaleCalls(): Promise<ReceivedCall[]> {
+  return (await getReceivedCalls()).filter((c) => c.stale);
 }
 
 export const fakeModel = {
@@ -95,4 +162,5 @@ export const fakeModel = {
   script: postScript,
   reset: deleteScripts,
   received: getReceivedCalls,
+  staleCalls: getStaleCalls,
 };

--- a/packages/openclaw/test/support/fake-model/server.mjs
+++ b/packages/openclaw/test/support/fake-model/server.mjs
@@ -1,5 +1,5 @@
-import crypto from "node:crypto";
-import http from "node:http";
+import crypto from 'node:crypto';
+import http from 'node:http';
 
 // Force unbuffered stdout/stderr so logs surface immediately under
 // `docker compose logs` instead of waiting on the pipe buffer to flush.
@@ -11,7 +11,9 @@ if (process.stderr._handle?.setBlocking) {
 }
 
 const port = Number(process.env.PORT ?? 4000);
-console.log(`[fake-model] starting (pid ${process.pid}, node ${process.version})`);
+console.log(
+  `[fake-model] starting (pid ${process.pid}, node ${process.version})`
+);
 
 const TLON_TEST_KEY_RE = /\[tlon-test:([a-zA-Z0-9_.:-]+)\]/g;
 
@@ -27,76 +29,162 @@ const TLON_TEST_KEY_RE = /\[tlon-test:([a-zA-Z0-9_.:-]+)\]/g;
  */
 const scripts = new Map();
 const callCounts = new Map();
+// Per-script bounded tolerance for "extra" model calls beyond the scripted
+// steps. Some flows legitimately make one more model turn than they have
+// logical responses (e.g. a DM reply that emits its text and then makes a
+// trailing turn). A script opts in with `allowExtraCalls: N`; up to N calls
+// past the last step return benign filler (200) instead of a hard 400. This
+// is deliberately per-script — global leniency would hide real
+// under-specification regressions (see bucket2-redesign.md §4c).
+const allowExtraCalls = new Map();
 // All /v1/chat/completions calls seen since last reset, in arrival order.
 // Tests use this for negative assertions: "no model call for [tlon-test:X]
 // arrived after the prompt was sent" — much faster than waiting on a
 // silence timeout in the test client.
 const receivedCalls = [];
 
+// Monotonic epoch counter, bumped on every reset() (DELETE /v1/_scripts).
+// Lets us attribute a late model call to the test generation that was active
+// when it arrived, vs the generation that registered its key.
+let epoch = 0;
+
+// key -> { epoch } registration history. CRITICALLY this is NOT cleared by
+// reset(), so a stale call arriving after a different test reset the server
+// can still be attributed to the last owner + registration epoch for its key.
+// Bounded FIFO so a long suite can't grow it without limit.
+const lastRegistration = new Map();
+const MAX_REGISTRATION_HISTORY = 500;
+
+function recordRegistration(key) {
+  // Re-registering an existing key updates in place (keeps FIFO position);
+  // a brand-new key may need to evict the oldest entry to stay bounded.
+  if (
+    !lastRegistration.has(key) &&
+    lastRegistration.size >= MAX_REGISTRATION_HISTORY
+  ) {
+    const oldest = lastRegistration.keys().next().value;
+    if (oldest !== undefined) {
+      lastRegistration.delete(oldest);
+    }
+  }
+  lastRegistration.set(key, { epoch });
+}
+
 const server = http.createServer(async (req, res) => {
   try {
-    if (req.method === "GET" && req.url === "/health") {
+    if (req.method === 'GET' && req.url === '/health') {
       sendJson(res, 200, { ok: true });
       return;
     }
 
-    if (req.method === "GET" && req.url === "/v1/models") {
+    if (req.method === 'GET' && req.url === '/v1/models') {
       sendJson(res, 200, {
-        object: "list",
-        data: [{ id: "tlon-test-scripted", object: "model", owned_by: "tlon-tests" }],
+        object: 'list',
+        data: [
+          { id: 'tlon-test-scripted', object: 'model', owned_by: 'tlon-tests' },
+        ],
       });
       return;
     }
 
-    if (req.method === "POST" && req.url === "/v1/_scripts") {
+    if (req.method === 'POST' && req.url === '/v1/_scripts') {
       const body = await readJson(req);
       const { key, steps } = body ?? {};
-      const validation = validateScript(key, steps);
+      const extra = body?.allowExtraCalls ?? 0;
+      const validation = validateScript(key, steps, extra);
       if (validation) {
         sendJson(res, 400, { error: { message: validation } });
         return;
       }
       scripts.set(key, steps);
       callCounts.set(key, 0);
-      console.log(`[fake-model] registered script "${key}" with ${steps.length} step(s)`);
+      allowExtraCalls.set(key, extra);
+      recordRegistration(key);
+      console.log(
+        `[fake-model] registered script "${key}" with ${steps.length} step(s)` +
+          (extra > 0 ? ` (+${extra} extra)` : '') +
+          ` (epoch ${epoch})`
+      );
       sendJson(res, 200, { ok: true });
       return;
     }
 
-    if (req.method === "DELETE" && req.url === "/v1/_scripts") {
+    if (req.method === 'DELETE' && req.url === '/v1/_scripts') {
       scripts.clear();
       callCounts.clear();
+      allowExtraCalls.clear();
       receivedCalls.length = 0;
-      console.log(`[fake-model] cleared all scripts and received-call log`);
-      sendJson(res, 200, { ok: true });
+      // Bump the epoch but keep `lastRegistration` so a stale call arriving
+      // after this reset can still be attributed to the test that owned its
+      // key in a previous epoch.
+      epoch += 1;
+      console.log(
+        `[fake-model] cleared all scripts and received-call log (epoch -> ${epoch})`
+      );
+      sendJson(res, 200, { ok: true, epoch });
       return;
     }
 
-    if (req.method === "GET" && req.url.startsWith("/v1/_received")) {
-      const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
-      const filterKey = url.searchParams.get("key");
+    if (req.method === 'GET' && req.url.startsWith('/v1/_received')) {
+      const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+      const filterKey = url.searchParams.get('key');
       const calls = filterKey
         ? receivedCalls.filter((c) => c.key === filterKey)
         : receivedCalls.slice();
-      sendJson(res, 200, { calls, count: calls.length });
+      sendJson(res, 200, { calls, count: calls.length, epoch });
       return;
     }
 
-    if (req.method === "POST" && req.url === "/v1/chat/completions") {
+    if (req.method === 'POST' && req.url === '/v1/chat/completions') {
       const body = await readJson(req);
       const messages = Array.isArray(body.messages) ? body.messages : [];
-      const key = extractLatestScriptKey(messages);
-      const streamFlag = body.stream === true ? " stream=true" : "";
+      const streamFlag = body.stream === true ? ' stream=true' : '';
 
       // Flatten user-role message text so tests can assert that specific
       // content (e.g. blob transcriptions, filenames) actually reached the
       // model request. We only record user-role messages (not system or
       // assistant) to keep the payload small and the contract clear.
       const userText = messages
-        .filter((m) => m?.role === "user")
+        .filter((m) => m?.role === 'user')
         .map((m) => extractText(m?.content))
         .filter(Boolean)
-        .join("\n");
+        .join('\n');
+
+      // ── Provenance-aware key selection ────────────────────────────────
+      // openclaw re-sends the whole conversation history on every turn, and
+      // DMs share one long-lived per-peer session. So a flat "last tag across
+      // all messages" lets a PREVIOUS test's tag, still sitting in history,
+      // capture an untagged engaging turn (e.g. a thread parent) → stale
+      // misroute. Prefer the tag on the LATEST user turn (a genuinely new
+      // tagged prompt is authoritative); fall back to the last historical tag
+      // only to serve legitimate continuation turns (an untagged tool-result
+      // turn whose run was kicked off by an earlier tagged prompt). See
+      // bucket2-redesign.md §4b.
+      const latestUserKey = extractTagFromLastUserTurn(messages);
+      const historicalKey = extractLatestScriptKey(messages);
+      let key = null;
+      let provenance = 'none';
+      if (latestUserKey) {
+        key = latestUserKey;
+        provenance = 'latest-user';
+      } else if (historicalKey && scripts.has(historicalKey)) {
+        key = historicalKey;
+        provenance = 'history-active';
+      } else if (historicalKey) {
+        key = historicalKey;
+        provenance = 'history-inactive';
+      }
+
+      // Attribute this call to the epoch that registered its key. If the
+      // registration epoch is older than the current epoch, a reset() ran
+      // between registration and arrival — a different test owns the current
+      // epoch and this is cross-epoch (stale) bleed. Kept as a DIAGNOSTIC
+      // classification, never a hard failure (see bucket2-findings.md).
+      const registeredEpoch =
+        key && lastRegistration.has(key)
+          ? lastRegistration.get(key).epoch
+          : null;
+      const stale = registeredEpoch !== null && epoch > registeredEpoch;
 
       receivedCalls.push({
         key,
@@ -105,25 +193,50 @@ const server = http.createServer(async (req, res) => {
         stream: body.stream === true,
         messageCount: messages.length,
         userText,
+        epoch,
+        registeredEpoch,
+        stale,
+        provenance,
       });
 
+      // No tag anywhere → loud 400 (preserve negative-path strictness).
       if (!key) {
         console.log(
-          `[fake-model] POST /v1/chat/completions model=${body.model}${streamFlag} → 400 (no [tlon-test:KEY] tag)`,
+          `[fake-model] POST /v1/chat/completions model=${body.model}${streamFlag} → 400 (no [tlon-test:KEY] tag)`
         );
         sendJson(res, 400, {
           error: {
             message:
-              "no [tlon-test:KEY] tag found in messages; register a script and tag the prompt before sending",
+              'no [tlon-test:KEY] tag found in messages; register a script and tag the prompt before sending',
           },
         });
         return;
       }
 
       const steps = scripts.get(key);
+
+      // Key is not registered in the CURRENT epoch.
       if (!steps) {
+        // Stale-history bleed is benign ONLY when the key was inherited from
+        // re-sent history (`history-inactive`), not when the newest user turn
+        // explicitly carries it. A `latest-user` key with no current script is
+        // a real under-specification (the test tagged a turn but forgot to
+        // register it) — keep it a loud 400 even if the name matches a prior
+        // epoch, so the strict oracle still catches that mistake.
+        if (stale && provenance === 'history-inactive') {
+          // A prior test's tag rode in on re-sent history for an untagged turn
+          // this epoch never scripted. Make it harmless (benign 200) so it
+          // can't error a run or wedge the session — but keep it visible as a
+          // diagnostic. THIS is the core durability fix.
+          console.log(
+            `[fake-model] key="${key}"${streamFlag} → 200 STALE-BENIGN (registeredEpoch=${registeredEpoch} arrivedEpoch=${epoch}, provenance=${provenance})`
+          );
+          respondScripted(res, body, benignFiller());
+          return;
+        }
+        // Genuinely unknown / never-registered key → loud 400.
         console.log(
-          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (no script registered)`,
+          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (no script registered)`
         );
         sendJson(res, 400, {
           error: { message: `no fake-model script registered for "${key}"` },
@@ -133,8 +246,23 @@ const server = http.createServer(async (req, res) => {
 
       const n = callCounts.get(key) ?? 0;
       if (n >= steps.length) {
+        const extra = allowExtraCalls.get(key) ?? 0;
+        if (n < steps.length + extra) {
+          // Bounded, opted-in extra call — a flow that legitimately makes one
+          // more model turn than it has scripted responses. Return benign
+          // filler so the run completes cleanly instead of erroring.
+          console.log(
+            `[fake-model] key="${key}"${streamFlag} → 200 EXTRA call ${n + 1} (of ${steps.length}+${extra})`
+          );
+          callCounts.set(key, n + 1);
+          respondScripted(res, body, benignFiller());
+          return;
+        }
+        // Exhausted current-epoch script → loud 400. This is one of the best
+        // signals that a test under-specified its model flow; do not soften it
+        // globally (opt in per script via allowExtraCalls instead).
         console.log(
-          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (script exhausted: call ${n + 1} of ${steps.length})`,
+          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (script exhausted: call ${n + 1} of ${steps.length})`
         );
         sendJson(res, 400, {
           error: {
@@ -147,70 +275,74 @@ const server = http.createServer(async (req, res) => {
 
       const step = steps[n];
       const scripted =
-        step.kind === "tool_call"
+        step.kind === 'tool_call'
           ? toolCallResponse({ name: step.name, args: step.args })
           : textResponse(step.content);
 
       console.log(
-        `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 200 step ${n + 1}/${steps.length} (${step.kind})`,
+        `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 200 step ${n + 1}/${steps.length} (${step.kind}) [${provenance}]`
       );
 
-      const payload = completionPayload({ model: body.model, scripted });
-
-      if (body.stream === true) {
-        sendSseCompletion(res, payload);
-      } else {
-        sendJson(res, 200, payload);
-      }
+      respondScripted(res, body, scripted);
       return;
     }
 
     sendJson(res, 404, {
-      error: { message: `Unhandled fake model route: ${req.method} ${req.url}` },
+      error: {
+        message: `Unhandled fake model route: ${req.method} ${req.url}`,
+      },
     });
   } catch (error) {
     sendJson(res, 500, {
-      error: { message: error instanceof Error ? error.message : String(error) },
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+      },
     });
   }
 });
 
-server.on("error", (err) => {
+server.on('error', (err) => {
   console.error(`[fake-model] server error:`, err);
 });
 
-process.on("uncaughtException", (err) => {
+process.on('uncaughtException', (err) => {
   console.error(`[fake-model] uncaughtException:`, err);
 });
-process.on("unhandledRejection", (reason) => {
+process.on('unhandledRejection', (reason) => {
   console.error(`[fake-model] unhandledRejection:`, reason);
 });
 
-server.listen(port, "0.0.0.0", () => {
+server.listen(port, '0.0.0.0', () => {
   console.log(`[fake-model] listening on :${port}`);
 });
 
-function validateScript(key, steps) {
-  if (typeof key !== "string" || key.length === 0) {
+function validateScript(key, steps, extra) {
+  if (typeof key !== 'string' || key.length === 0) {
     return "missing or invalid 'key' (must be non-empty string)";
   }
   if (!Array.isArray(steps) || steps.length === 0) {
     return "missing or invalid 'steps' (must be non-empty array)";
   }
+  if (
+    extra !== undefined &&
+    (typeof extra !== 'number' || !Number.isInteger(extra) || extra < 0)
+  ) {
+    return "invalid 'allowExtraCalls' (must be a non-negative integer)";
+  }
   for (let i = 0; i < steps.length; i += 1) {
     const s = steps[i];
-    if (!s || typeof s !== "object") {
+    if (!s || typeof s !== 'object') {
       return `step ${i}: not an object`;
     }
-    if (s.kind === "text") {
-      if (typeof s.content !== "string") {
+    if (s.kind === 'text') {
+      if (typeof s.content !== 'string') {
         return `step ${i}: text step requires string 'content'`;
       }
-    } else if (s.kind === "tool_call") {
-      if (typeof s.name !== "string" || s.name.length === 0) {
+    } else if (s.kind === 'tool_call') {
+      if (typeof s.name !== 'string' || s.name.length === 0) {
         return `step ${i}: tool_call step requires non-empty string 'name'`;
       }
-      if (!s.args || typeof s.args !== "object" || Array.isArray(s.args)) {
+      if (!s.args || typeof s.args !== 'object' || Array.isArray(s.args)) {
         return `step ${i}: tool_call step requires object 'args'`;
       }
     } else {
@@ -224,7 +356,7 @@ function extractLatestScriptKey(messages) {
   const text = messages
     .map((message) => extractText(message?.content))
     .filter(Boolean)
-    .join("\n");
+    .join('\n');
   let latest = null;
   for (const match of text.matchAll(TLON_TEST_KEY_RE)) {
     latest = match[1];
@@ -232,50 +364,93 @@ function extractLatestScriptKey(messages) {
   return latest;
 }
 
+// The tag on the LATEST user-role turn only (the genuinely new inbound),
+// distinct from extractLatestScriptKey which scans the whole re-sent history.
+// This is what lets a new tagged prompt take precedence over a stale tag still
+// sitting in conversation history (bucket2-redesign.md §4b).
+function extractTagFromLastUserTurn(messages) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role !== 'user') {
+      continue;
+    }
+    const text = extractText(messages[i]?.content);
+    let latest = null;
+    for (const match of text.matchAll(TLON_TEST_KEY_RE)) {
+      latest = match[1];
+    }
+    return latest;
+  }
+  return null;
+}
+
+// A harmless 200 completion used when we deliberately don't want a model call
+// to error a run: stale-history bleed (prior-epoch key) and opted-in bounded
+// extra calls. The text is NON-EMPTY on purpose: openclaw treats an empty
+// terminal assistant message as an "incomplete terminal response" and fails the
+// run via model-fallback, which would defeat the point of serving these calls
+// benignly. A minimal "ok" terminates the agent loop cleanly.
+function benignFiller() {
+  return textResponse('ok');
+}
+
+// Send a scripted completion, honoring the request's streaming preference.
+function respondScripted(res, body, scripted) {
+  const payload = completionPayload({ model: body.model, scripted });
+  if (body.stream === true) {
+    sendSseCompletion(res, payload);
+  } else {
+    sendJson(res, 200, payload);
+  }
+}
+
 function extractText(content) {
-  if (typeof content === "string") {
+  if (typeof content === 'string') {
     return content;
   }
   if (Array.isArray(content)) {
     return content
       .map((part) => {
-        if (typeof part === "string") {
+        if (typeof part === 'string') {
           return part;
         }
-        if (part && typeof part === "object") {
-          if (typeof part.text === "string") {
+        if (part && typeof part === 'object') {
+          if (typeof part.text === 'string') {
             return part.text;
           }
-          if (typeof part.content === "string") {
+          if (typeof part.content === 'string') {
             return part.content;
           }
         }
-        return "";
+        return '';
       })
-      .join("\n");
+      .join('\n');
   }
-  if (content && typeof content === "object" && typeof content.text === "string") {
+  if (
+    content &&
+    typeof content === 'object' &&
+    typeof content.text === 'string'
+  ) {
     return content.text;
   }
-  return "";
+  return '';
 }
 
 function textResponse(content) {
   return {
-    message: { role: "assistant", content },
-    finish_reason: "stop",
+    message: { role: 'assistant', content },
+    finish_reason: 'stop',
   };
 }
 
 function toolCallResponse({ name, args }) {
   return {
     message: {
-      role: "assistant",
+      role: 'assistant',
       content: null,
       tool_calls: [
         {
-          id: `call_${crypto.randomUUID().replace(/-/g, "")}`,
-          type: "function",
+          id: `call_${crypto.randomUUID().replace(/-/g, '')}`,
+          type: 'function',
           function: {
             name,
             arguments: JSON.stringify(args),
@@ -283,16 +458,16 @@ function toolCallResponse({ name, args }) {
         },
       ],
     },
-    finish_reason: "tool_calls",
+    finish_reason: 'tool_calls',
   };
 }
 
 function completionPayload({ model, scripted }) {
   return {
     id: `chatcmpl-fake-${Date.now()}`,
-    object: "chat.completion",
+    object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
-    model: model ?? "tlon-test-scripted",
+    model: model ?? 'tlon-test-scripted',
     choices: [
       {
         index: 0,
@@ -306,15 +481,15 @@ function completionPayload({ model, scripted }) {
 
 function sendSseCompletion(res, payload) {
   res.writeHead(200, {
-    "content-type": "text/event-stream; charset=utf-8",
-    "cache-control": "no-cache",
-    connection: "keep-alive",
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
   });
 
   const choice = payload.choices[0];
   const base = {
     id: payload.id,
-    object: "chat.completion.chunk",
+    object: 'chat.completion.chunk',
     created: payload.created,
     model: payload.model,
   };
@@ -326,11 +501,11 @@ function sendSseCompletion(res, payload) {
         choices: [
           {
             index: 0,
-            delta: { role: "assistant", tool_calls: choice.message.tool_calls },
+            delta: { role: 'assistant', tool_calls: choice.message.tool_calls },
             finish_reason: null,
           },
         ],
-      })}\n\n`,
+      })}\n\n`
     );
   } else {
     res.write(
@@ -339,11 +514,11 @@ function sendSseCompletion(res, payload) {
         choices: [
           {
             index: 0,
-            delta: { role: "assistant", content: choice.message.content ?? "" },
+            delta: { role: 'assistant', content: choice.message.content ?? '' },
             finish_reason: null,
           },
         ],
-      })}\n\n`,
+      })}\n\n`
     );
   }
 
@@ -351,14 +526,14 @@ function sendSseCompletion(res, payload) {
     `data: ${JSON.stringify({
       ...base,
       choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason }],
-    })}\n\n`,
+    })}\n\n`
   );
-  res.write("data: [DONE]\n\n");
+  res.write('data: [DONE]\n\n');
   res.end();
 }
 
 function sendJson(res, status, payload) {
-  res.writeHead(status, { "content-type": "application/json" });
+  res.writeHead(status, { 'content-type': 'application/json' });
   res.end(JSON.stringify(payload));
 }
 
@@ -367,6 +542,6 @@ async function readJson(req) {
   for await (const chunk of req) {
     chunks.push(chunk);
   }
-  const raw = Buffer.concat(chunks).toString("utf8");
+  const raw = Buffer.concat(chunks).toString('utf8');
   return raw ? JSON.parse(raw) : {};
 }


### PR DESCRIPTION
## Summary

fixes TLON-6040

Fixes two distinct, frequently-recurring flakes in the `OpenClaw Plugin CI` "Integration Tests" job, which runs `packages/openclaw`'s ephemeral-fakezod integration suite. The first is a `~zod` startup crash caused by vere/pier version skew; the second is a 60s timeout in the DM-thread-reply test caused by stale session-history tags bleeding between tests.

## Changes

Bucket 1, `~zod` startup crash (vere/pier version skew):

- In `dev/docker-compose.test.yml`, bumped the pier archives from `rube-*25` to the `rube-*27` generation (the generation the tlon-web e2e suite runs) and pinned vere to a versioned GitHub release asset (`vere-v4.5`) instead of the unpinned `latest`. Previously a `latest` runtime that drifted newer than the kelvin-25 snapshot triggered `stale snapshot, downgrade runtime to replay`, and the replay serf crashed (`pier: serf unexpectedly shut down`), surfacing as a `~zod` readiness timeout (the first readiness gate in `run.sh`).
- Added `--retry`/`--retry-delay`/`--retry-all-errors` to all pier and vere downloads, plus a version-echo line so a future skew is obvious.

Bucket 2, DM-thread-reply 60s timeout (session-history tag bleed):

- DMs route to one long-lived per-peer OpenClaw session and every inbound re-sends the full conversation history. The scripted fake-model previously picked its script from the last `[tlon-test:KEY]` tag across all messages, so an untagged model-engaging turn (e.g. a thread-anchor parent DM) inherited a previous test's tag still sitting in history, misrouted to a stale 400, and lost the intended `dm-thread-reply` dispatch.
- Added provenance-aware key selection in `test/support/fake-model/server.mjs`: prefer the tag on the latest user turn, and only fall back to a historical tag if it is still registered in the current epoch.
- Added epoch and `lastRegistration` ownership history (surviving `reset()`) in `server.mjs` and `client.ts`. Cross-epoch ("stale") calls are classified as a diagnostic; a stale prior-epoch key that is history-inactive is served a benign 200 rather than a hard 400, so inherited tags can't error a run. Strictness is preserved: latest-user keys with no script, genuinely-unknown keys, and current-epoch script exhaustion all stay loud 400s.
- Added a per-script `allowExtraCalls` opt-in for flows that legitimately make one trailing model turn, and made `benignFiller` return a minimal non-empty `'ok'` (empty text was treated by OpenClaw as an incomplete terminal response and failed runs).
- Added `test/lib/scripted.ts` with a `registerEngagingTurn` helper, exported via `test/lib/index.ts`, and used it to tag every model-engaging test turn: the `dm-thread-reply` parent (`01-messages`), the thread-anchor parent (`07-blobs`), the `ensureThirdPartyDmAccess` probe and confirm prompts (`fixtures.ts`), and the owner reply (`03-heartbeat`).
- Strengthened parent-settle waits in `01-messages` and `07-blobs`: the test now waits for the bot to actually deliver the parent's reply (unique ack text) before sending the thread reply, serializing parent-then-reply so the test checks harness correctness rather than concurrency.
- Removed the in-band `/stop` from `bestEffortStopAfterTimeout` (`client.ts`). `/stop` rides the same DM path and only added session contamination on timeout.

## How did I test?

- Bucket 1: confirmed live. Ships boot cleanly (`Using vere: vere-v4.5`, normal `disk: loaded epoch`, no `stale snapshot`/`serf` lines), and all three piers pass the real `/~/login` readiness gate.
- Bucket 2: ran `01-messages` 7 consecutive times green (a 6-run loop plus 1 standalone), with `dm-thread-reply` settling in roughly 24 to 27s versus the previous 60s timeout.
- Ran the full suite: green except for a separate, pre-existing cross-ship Ames reaction-relay flake in `04-security` (a reaction-approval test that fails each run, unrelated to and untouched by this work; to be tracked separately).
- Verified fake-model behavior across the full suite: stale calls were all benign and history-inactive-only, no untagged-engaging 400s, and roughly 37 total model calls with no runaway.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: OpenClaw plugin CI / integration test harness

## Rollback plan

Revert

