### PR TITLE
openclaw: capture more internal debug logs

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -506,16 +506,39 @@ function reportHarnessDebugDiagnostic(
       numberAttribute(attributes, 'durationMs'),
     toolName:
       stringField(event, 'toolName') ?? stringAttribute(attributes, 'toolName'),
+    toolCallId:
+      stringField(event, 'toolCallId') ??
+      stringAttribute(attributes, 'toolCallId'),
+    toolSource:
+      stringField(event, 'toolSource') ??
+      stringAttribute(attributes, 'toolSource'),
+    toolOwner:
+      stringField(event, 'toolOwner') ??
+      stringAttribute(attributes, 'toolOwner'),
     pluginId:
       stringField(event, 'pluginId') ?? stringAttribute(attributes, 'pluginId'),
     harnessId:
       stringField(event, 'harnessId') ??
       stringAttribute(attributes, 'harnessId'),
+    modelCallId:
+      stringField(event, 'modelCallId') ??
+      stringField(event, 'callId') ??
+      stringAttribute(attributes, 'modelCallId') ??
+      stringAttribute(attributes, 'callId'),
     modelApi:
       stringField(event, 'modelApi') ?? stringAttribute(attributes, 'modelApi'),
     modelTransport:
       stringField(event, 'modelTransport') ??
       stringAttribute(attributes, 'modelTransport'),
+    requestPayloadBytes:
+      numberField(event, 'requestPayloadBytes') ??
+      numberAttribute(attributes, 'requestPayloadBytes'),
+    responseStreamBytes:
+      numberField(event, 'responseStreamBytes') ??
+      numberAttribute(attributes, 'responseStreamBytes'),
+    timeToFirstByteMs:
+      numberField(event, 'timeToFirstByteMs') ??
+      numberAttribute(attributes, 'timeToFirstByteMs'),
     logLevel: stringField(event, 'level'),
     loggerName: stringField(event, 'loggerName'),
     codeFunctionName,
@@ -559,6 +582,16 @@ function reportHarnessDebugDiagnostic(
     reserveTokens:
       numberField(event, 'reserveTokens') ??
       numberAttribute(attributes, 'reserveTokens'),
+    contextChannel:
+      stringField(event, 'contextChannel') ??
+      stringField(event, 'channel') ??
+      stringAttribute(attributes, 'contextChannel') ??
+      stringAttribute(attributes, 'channel'),
+    contextTrigger:
+      stringField(event, 'contextTrigger') ??
+      stringField(event, 'trigger') ??
+      stringAttribute(attributes, 'contextTrigger') ??
+      stringAttribute(attributes, 'trigger'),
   });
 }
 

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -28,9 +28,11 @@ import { setTlonRuntime } from './src/runtime.js';
 import { getSessionRole } from './src/session-roles.js';
 import { parseTlonTarget } from './src/targets.js';
 import {
+  type TlonDiagnosticLogAttributes,
   type TlonSessionDiagnosticReportInput,
   formatTlonTelemetryErrorText,
   recordToolCall,
+  reportHarnessDebug,
   reportHarnessError,
   reportOutboundRoute,
   reportPluginError,
@@ -265,6 +267,59 @@ function numberField(event: DiagnosticCandidate, key: string): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function objectField(
+  event: DiagnosticCandidate,
+  key: string
+): Record<string, unknown> | null {
+  const value = event[key];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function diagnosticLogAttributes(
+  event: DiagnosticCandidate
+): TlonDiagnosticLogAttributes | null {
+  const attributes = objectField(event, 'attributes');
+  if (!attributes) {
+    return null;
+  }
+
+  const normalized = Object.create(null) as TlonDiagnosticLogAttributes;
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value === 'string') {
+      normalized[key] = value;
+      continue;
+    }
+    if (typeof value === 'boolean') {
+      normalized[key] = value;
+      continue;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      normalized[key] = value;
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function stringAttribute(
+  attributes: TlonDiagnosticLogAttributes | null,
+  key: string
+): string | null {
+  const value = attributes?.[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function numberAttribute(
+  attributes: TlonDiagnosticLogAttributes | null,
+  key: string
+): number | null {
+  const value = attributes?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 function diagnosticErrorText(event: DiagnosticCandidate): string | null {
   return stringField(event, 'error') ?? stringField(event, 'message');
 }
@@ -290,6 +345,223 @@ function diagnosticSummary(
     .join(' ');
 }
 
+const HARNESS_DEBUG_EVENT_TYPES = new Set([
+  'session.turn.created',
+  'run.started',
+  'run.completed',
+  'context.assembled',
+  'model.call.started',
+  'model.call.completed',
+  'model.call.error',
+  'harness.run.started',
+  'harness.run.completed',
+  'harness.run.error',
+  'tool.execution.started',
+  'tool.execution.completed',
+  'tool.execution.error',
+  'tool.execution.blocked',
+]);
+
+const HARNESS_DEBUG_LOG_PATTERNS = [
+  '[context-engine]',
+  '[lcm]',
+  '[trace:embedded-run]',
+  'context engine',
+  'lossless-claw',
+];
+
+function debugEventKind(type: string): string {
+  if (type === 'session.turn.created') {
+    return 'turn';
+  }
+  if (type === 'context.assembled') {
+    return 'context';
+  }
+  if (type.startsWith('model.call.')) {
+    return 'model';
+  }
+  if (type.startsWith('harness.run.')) {
+    return 'harness';
+  }
+  if (type.startsWith('tool.execution.')) {
+    return 'tool';
+  }
+  if (type.startsWith('run.')) {
+    return 'run';
+  }
+  if (type === 'log.record') {
+    return 'log';
+  }
+  return 'diagnostic';
+}
+
+function isContextEngineDebugMessage(message: string | null): boolean {
+  const normalized = message?.toLowerCase() ?? '';
+  return HARNESS_DEBUG_LOG_PATTERNS.some((pattern) =>
+    normalized.includes(pattern)
+  );
+}
+
+function extractContextEngineTaskId(message: string | null): string | null {
+  return extractDiagnosticKeyValue(message, 'taskId');
+}
+
+function extractDiagnosticKeyValue(
+  message: string | null,
+  key: string
+): string | null {
+  if (!message) {
+    return null;
+  }
+  return new RegExp(`\\b${key}=([^\\s]+)`).exec(message)?.[1] ?? null;
+}
+
+function extractDiagnosticSessionKey(message: string | null): string | null {
+  if (!message) {
+    return null;
+  }
+  return /\bsessionKey=([^\s]+)/.exec(message)?.[1] ?? null;
+}
+
+function shouldReportHarnessDebug(event: DiagnosticCandidate, type: string) {
+  if (HARNESS_DEBUG_EVENT_TYPES.has(type)) {
+    return true;
+  }
+  if (type !== 'log.record') {
+    return false;
+  }
+
+  const message = stringField(event, 'message');
+  if (isContextEngineDebugMessage(message)) {
+    return true;
+  }
+
+  const level = stringField(event, 'level')?.toLowerCase();
+  const attributes = diagnosticLogAttributes(event);
+  return (
+    Boolean(
+      stringField(event, 'sessionKey') ??
+        stringAttribute(attributes, 'sessionKey')
+    ) &&
+    (level === 'warn' || level === 'warning' || level === 'error')
+  );
+}
+
+function reportHarnessDebugDiagnostic(
+  event: DiagnosticCandidate,
+  type: string
+) {
+  if (!shouldReportHarnessDebug(event, type)) {
+    return;
+  }
+
+  const message = stringField(event, 'message');
+  const attributes = diagnosticLogAttributes(event);
+  const code = objectField(event, 'code');
+  const codeFunctionName =
+    typeof code?.functionName === 'string' && code.functionName.trim()
+      ? code.functionName
+      : null;
+  const codeLine =
+    typeof code?.line === 'number' && Number.isFinite(code.line)
+      ? code.line
+      : null;
+  const isContextEngineEvent = isContextEngineDebugMessage(message);
+  const contextEngineTaskId =
+    stringField(event, 'contextEngineTaskId') ??
+    stringAttribute(attributes, 'contextEngineTaskId') ??
+    stringAttribute(attributes, 'taskId') ??
+    extractContextEngineTaskId(message);
+  const contextEngineOperation =
+    stringField(event, 'contextEngineOperation') ??
+    stringAttribute(attributes, 'contextEngineOperation') ??
+    stringAttribute(attributes, 'operation') ??
+    extractDiagnosticKeyValue(message, 'operation');
+  const contextEngineLane =
+    stringField(event, 'contextEngineLane') ??
+    stringAttribute(attributes, 'contextEngineLane') ??
+    stringAttribute(attributes, 'lane') ??
+    extractDiagnosticKeyValue(message, 'lane');
+  reportHarnessDebug({
+    harnessEventType: type,
+    debugEventKind: debugEventKind(type),
+    sessionKey:
+      stringField(event, 'sessionKey') ??
+      stringAttribute(attributes, 'sessionKey') ??
+      extractDiagnosticSessionKey(message),
+    sessionId:
+      stringField(event, 'sessionId') ??
+      stringAttribute(attributes, 'sessionId'),
+    runId: stringField(event, 'runId') ?? stringAttribute(attributes, 'runId'),
+    agentId:
+      stringField(event, 'agentId') ?? stringAttribute(attributes, 'agentId'),
+    provider:
+      stringField(event, 'provider') ?? stringAttribute(attributes, 'provider'),
+    model: stringField(event, 'model') ?? stringAttribute(attributes, 'model'),
+    phase: stringField(event, 'phase') ?? stringAttribute(attributes, 'phase'),
+    outcome:
+      stringField(event, 'outcome') ?? stringAttribute(attributes, 'outcome'),
+    durationMs:
+      numberField(event, 'durationMs') ??
+      numberAttribute(attributes, 'durationMs'),
+    toolName:
+      stringField(event, 'toolName') ?? stringAttribute(attributes, 'toolName'),
+    pluginId:
+      stringField(event, 'pluginId') ?? stringAttribute(attributes, 'pluginId'),
+    harnessId:
+      stringField(event, 'harnessId') ??
+      stringAttribute(attributes, 'harnessId'),
+    modelApi:
+      stringField(event, 'modelApi') ?? stringAttribute(attributes, 'modelApi'),
+    modelTransport:
+      stringField(event, 'modelTransport') ??
+      stringAttribute(attributes, 'modelTransport'),
+    logLevel: stringField(event, 'level'),
+    loggerName: stringField(event, 'loggerName'),
+    codeFunctionName,
+    codeLine,
+    logAttributes: attributes,
+    message,
+    contextEngineEvent: isContextEngineEvent ? type : null,
+    contextEngineTaskId,
+    contextEngineOperation,
+    contextEngineLane,
+    errorName:
+      stringField(event, 'errorName') ??
+      stringAttribute(attributes, 'errorName'),
+    errorCode:
+      stringField(event, 'errorCode') ??
+      stringAttribute(attributes, 'errorCode'),
+    messageCount:
+      numberField(event, 'messageCount') ??
+      numberAttribute(attributes, 'messageCount'),
+    historyTextChars:
+      numberField(event, 'historyTextChars') ??
+      numberAttribute(attributes, 'historyTextChars'),
+    historyImageBlocks:
+      numberField(event, 'historyImageBlocks') ??
+      numberAttribute(attributes, 'historyImageBlocks'),
+    maxMessageTextChars:
+      numberField(event, 'maxMessageTextChars') ??
+      numberAttribute(attributes, 'maxMessageTextChars'),
+    systemPromptChars:
+      numberField(event, 'systemPromptChars') ??
+      numberAttribute(attributes, 'systemPromptChars'),
+    promptChars:
+      numberField(event, 'promptChars') ??
+      numberAttribute(attributes, 'promptChars'),
+    promptImages:
+      numberField(event, 'promptImages') ??
+      numberAttribute(attributes, 'promptImages'),
+    contextTokenBudget:
+      numberField(event, 'contextTokenBudget') ??
+      numberAttribute(attributes, 'contextTokenBudget'),
+    reserveTokens:
+      numberField(event, 'reserveTokens') ??
+      numberAttribute(attributes, 'reserveTokens'),
+  });
+}
+
 function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
   const type = stringField(event, 'type');
   if (!type) {
@@ -304,8 +576,11 @@ function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
       runId: stringField(event, 'runId'),
       agentId: stringField(event, 'agentId'),
     });
+    reportHarnessDebugDiagnostic(event, type);
     return;
   }
+
+  reportHarnessDebugDiagnostic(event, type);
 
   const common = {
     harnessEventType: type,

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -48,6 +48,7 @@ import {
   type TlonPluginErrorSource,
   createTlonTelemetry,
   formatTlonTelemetryErrorText,
+  setDebugTelemetryReporter,
   setErrorTelemetryReporter,
   setOutboundRouteReporter,
   setSessionTelemetryReporter,
@@ -631,6 +632,14 @@ export async function monitorTlonProvider(
           telemetry?.captureSessionRecovery(report.event);
           break;
       }
+    });
+    setDebugTelemetryReporter((event) => {
+      telemetry?.captureHarnessDebug({
+        ...event,
+        accountId: event.accountId ?? account.accountId,
+        ownerShip: event.ownerShip ?? currentTelemetryOwnerShip(),
+        botShip: event.botShip || botShipName,
+      });
     });
     setErrorTelemetryReporter((report) => {
       switch (report.kind) {
@@ -4285,6 +4294,7 @@ export async function monitorTlonProvider(
       clearShadowsForAccount(account.accountId);
       setOutboundRouteReporter(null);
       setSessionTelemetryReporter(null);
+      setDebugTelemetryReporter(null);
       setErrorTelemetryReporter(null);
       await telemetry?.close();
       try {

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -945,6 +945,8 @@ describe('telemetry tool tracking', () => {
       promptChars: 7890,
       contextTokenBudget: 200000,
       reserveTokens: 20000,
+      contextChannel: 'tlon',
+      contextTrigger: 'message',
     });
 
     const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
@@ -967,6 +969,8 @@ describe('telemetry tool tracking', () => {
       promptChars: 7890,
       contextTokenBudget: 200000,
       reserveTokens: 20000,
+      contextChannel: 'tlon',
+      contextTrigger: 'message',
       harnessDebugSequence: 1,
       contextAssembledSeen: true,
       runStartedSeen: false,
@@ -1015,6 +1019,63 @@ describe('telemetry tool tracking', () => {
       modelCallStartedSeen: false,
       harnessRunStartedSeen: false,
       toolExecutionStartedSeen: false,
+    });
+  });
+
+  it('captures tool and model call identifiers on harness debug events', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'tool.execution.completed',
+      debugEventKind: 'tool',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      toolName: 'read',
+      toolCallId: 'call-read-1',
+      toolSource: 'core',
+      toolOwner: 'openclaw',
+      durationMs: 42,
+    });
+
+    let call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'tool.execution.completed',
+      debugEventKind: 'tool',
+      toolName: 'read',
+      toolCallId: 'call-read-1',
+      toolSource: 'core',
+      toolOwner: 'openclaw',
+      durationMs: 42,
+    });
+
+    reportHarnessDebug({
+      harnessEventType: 'model.call.completed',
+      debugEventKind: 'model',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      provider: 'openrouter',
+      model: 'anthropic/claude-haiku-4.5',
+      modelCallId: 'model-call-1',
+      durationMs: 2997,
+      requestPayloadBytes: 12345,
+      responseStreamBytes: 6789,
+      timeToFirstByteMs: 321,
+    });
+
+    call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'model.call.completed',
+      debugEventKind: 'model',
+      modelCallId: 'model-call-1',
+      durationMs: 2997,
+      requestPayloadBytes: 12345,
+      responseStreamBytes: 6789,
+      timeToFirstByteMs: 321,
     });
   });
 

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -4,6 +4,7 @@ import {
   _testing,
   createTlonTelemetry,
   recordToolCall,
+  reportHarnessDebug,
   reportHarnessError,
   reportOutboundRoute,
   reportPluginError,
@@ -11,6 +12,7 @@ import {
   reportSessionLifecycle,
   reportSessionTurnCreated,
   reportTelemetryError,
+  setDebugTelemetryReporter,
   setErrorTelemetryReporter,
   setOutboundRouteReporter,
   setSessionTelemetryReporter,
@@ -42,7 +44,9 @@ describe('telemetry tool tracking', () => {
   beforeEach(() => {
     _testing.clearToolCalls();
     _testing.clearSessionContexts();
+    _testing.clearHarnessDebugSnapshots();
     setSessionTelemetryReporter(null);
+    setDebugTelemetryReporter(null);
     setErrorTelemetryReporter(null);
     postHogMocks.identify.mockClear();
     postHogMocks.capture.mockClear();
@@ -803,6 +807,19 @@ describe('telemetry tool tracking', () => {
     });
   }
 
+  function bindDebugReporter(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    setDebugTelemetryReporter((event) =>
+      telemetry.captureHarnessDebug({
+        ...event,
+        accountId: event.accountId ?? 'default',
+        ownerShip: event.ownerShip ?? '~zod',
+        botShip: event.botShip || '~nec',
+      })
+    );
+  }
+
   it('reports lifecycle hooks only for remembered Tlon sessions', async () => {
     const telemetry = createEnabledTelemetry()!;
     bindSessionReporter(telemetry);
@@ -909,6 +926,239 @@ describe('telemetry tool tracking', () => {
     });
   });
 
+  it('captures harness debug breadcrumbs for remembered Tlon sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'context.assembled',
+      debugEventKind: 'context',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      agentId: 'agent-main',
+      provider: 'anthropic',
+      model: 'claude-test',
+      messageCount: 12,
+      historyTextChars: 3456,
+      promptChars: 7890,
+      contextTokenBudget: 200000,
+      reserveTokens: 20000,
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      harnessEventType: 'context.assembled',
+      debugEventKind: 'context',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      provider: 'anthropic',
+      model: 'claude-test',
+      messageCount: 12,
+      historyTextChars: 3456,
+      promptChars: 7890,
+      contextTokenBudget: 200000,
+      reserveTokens: 20000,
+      harnessDebugSequence: 1,
+      contextAssembledSeen: true,
+      runStartedSeen: false,
+      modelCallStartedSeen: false,
+    });
+    expect(Object.hasOwn(call.properties, 'message')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'logAttributes')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'contextEngineTaskId')).toBe(false);
+  });
+
+  it('resets harness debug breadcrumbs when a reused session starts a new run', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'harness.run.started',
+      debugEventKind: 'harness',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-1',
+    });
+    reportHarnessDebug({
+      harnessEventType: 'context.assembled',
+      debugEventKind: 'context',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-1',
+    });
+    reportHarnessDebug({
+      harnessEventType: 'run.started',
+      debugEventKind: 'run',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'run.started',
+      runId: 'run-2',
+      harnessDebugSequence: 1,
+      runStartedSeen: true,
+      contextAssembledSeen: false,
+      modelCallStartedSeen: false,
+      harnessRunStartedSeen: false,
+      toolExecutionStartedSeen: false,
+    });
+  });
+
+  it('captures selected log attributes on harness debug events', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'log.record',
+      debugEventKind: 'log',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      logLevel: 'WARN',
+      loggerName: 'context-engine',
+      codeFunctionName: 'runContextTask',
+      codeLine: 42,
+      message:
+        '[context-engine] deferred turn maintenance queued taskId=abc123 lane=context-engine-turn-maintenance:session-1 operation=assemble',
+      logAttributes: {
+        taskId: 'abc123',
+        lane: 'context-engine-turn-maintenance:session-1',
+        operation: 'assemble',
+        pluginId: 'lossless-claw',
+        durationMs: 123,
+        retryable: true,
+        'bad key': 'dropped',
+      },
+      contextEngineEvent: 'log.record',
+      contextEngineTaskId: 'abc123',
+      contextEngineOperation: 'assemble',
+      contextEngineLane: 'context-engine-turn-maintenance:session-1',
+      pluginId: 'lossless-claw',
+      durationMs: 123,
+      errorName: 'TimeoutError',
+      errorCode: 'ETIMEDOUT',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'log.record',
+      debugEventKind: 'log',
+      logLevel: 'WARN',
+      loggerName: 'context-engine',
+      codeFunctionName: 'runContextTask',
+      codeLine: 42,
+      pluginId: 'lossless-claw',
+      durationMs: 123,
+      contextEngineTaskId: 'abc123',
+      contextEngineOperation: 'assemble',
+      contextEngineLane: 'context-engine-turn-maintenance:session-1',
+      errorName: 'TimeoutError',
+      errorCode: 'ETIMEDOUT',
+      lastContextEngineTaskId: 'abc123',
+      lastContextEngineOperation: 'assemble',
+      lastContextEngineLane: 'context-engine-turn-maintenance:session-1',
+    });
+    expect(call.properties.logAttributes).toMatchObject({
+      taskId: 'abc123',
+      lane: 'context-engine-turn-maintenance:session-1',
+      operation: 'assemble',
+      pluginId: 'lossless-claw',
+      durationMs: 123,
+      retryable: true,
+    });
+    expect(call.properties.logAttributes['bad key']).toBeUndefined();
+  });
+
+  it('enriches watchdog diagnostics with the last harness debug snapshot', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindSessionReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+    const longContextEngineMessage =
+      '[context-engine] deferred turn maintenance queued taskId=abc123 sessionKey=session-1 lane=context-engine-turn-maintenance:session-1 ' +
+      `detail=${'x'.repeat(320)}`;
+
+    reportHarnessDebug({
+      harnessEventType: 'run.started',
+      debugEventKind: 'run',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      agentId: 'agent-main',
+      provider: 'anthropic',
+      model: 'claude-test',
+    });
+    reportHarnessDebug({
+      harnessEventType: 'log.record',
+      debugEventKind: 'log',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      logLevel: 'INFO',
+      message: longContextEngineMessage,
+      contextEngineEvent: 'log.record',
+      contextEngineTaskId: 'abc123',
+      contextEngineOperation: 'maintenance',
+      contextEngineLane: 'context-engine-turn-maintenance:session-1',
+    });
+    postHogMocks.capture.mockClear();
+
+    reportSessionDiagnostic({
+      type: 'session.stalled',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      state: 'processing',
+      ageMs: 360_000,
+      queueDepth: 2,
+      reason: 'active_work_without_progress',
+      classification: 'stalled_agent_run',
+      activeWorkKind: 'embedded_run',
+      lastProgressAgeMs: 300_000,
+      lastProgressReason: 'embedded_run:started',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Watchdog');
+    expect(call.properties).toMatchObject({
+      reason: 'active_work_without_progress',
+      classification: 'stalled_agent_run',
+      activeWorkKind: 'embedded_run',
+      lastProgressReason: 'embedded_run:started',
+      harnessDebugSequence: 2,
+      lastHarnessEventType: 'log.record',
+      lastHarnessEventRunId: 'run-2',
+      lastHarnessProvider: 'anthropic',
+      lastHarnessModel: 'claude-test',
+      runStartedSeen: true,
+      contextAssembledSeen: false,
+      modelCallStartedSeen: false,
+      lastContextEngineEvent: 'log.record',
+      lastContextEngineTaskId: 'abc123',
+      lastContextEngineOperation: 'maintenance',
+      lastContextEngineLane: 'context-engine-turn-maintenance:session-1',
+      lastContextEngineMessage: longContextEngineMessage,
+    });
+    expect(call.properties.lastHarnessEventAgeMs).toEqual(expect.any(Number));
+    expect(call.properties.lastContextEngineEventAgeMs).toEqual(
+      expect.any(Number)
+    );
+  });
+
   it('reports harness errors only for remembered Tlon sessions', async () => {
     const telemetry = createEnabledTelemetry()!;
     bindErrorReporter(telemetry);
@@ -990,20 +1240,20 @@ describe('telemetry tool tracking', () => {
       harness: 'openclaw',
       harnessEventType: 'diagnostic.liveness.warning',
       errorScope: 'runtime',
-      sessionKey: null,
-      sessionId: null,
-      runId: null,
       accountId: 'default',
-      agentId: null,
       ownerShip: '~zod',
       botShip: '~nec',
-      destinationKind: null,
       outcome: 'warning',
       errorCategory: 'liveness_warning',
       failureKind: 'event_loop_delay',
       durationMs: 30_000,
       errorText: 'reasons=event_loop_delay eventLoopDelayP99Ms=250',
     });
+    expect(Object.hasOwn(call.properties, 'sessionKey')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'sessionId')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'runId')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'agentId')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'destinationKind')).toBe(false);
   });
 
   it('captures plugin errors without throttling or truncating error text', () => {
@@ -1034,8 +1284,8 @@ describe('telemetry tool tracking', () => {
       botShip: '~nec',
       errorKind: 'Error',
       errorText: 'first full error\nwith details',
-      attempt: null,
     });
+    expect(Object.hasOwn(calls[0].properties, 'attempt')).toBe(false);
     expect(calls[1].properties.errorText).toBe(
       'second full error\nwith details'
     );
@@ -1072,10 +1322,12 @@ describe('telemetry tool tracking', () => {
 describe('outbound route telemetry', () => {
   beforeEach(() => {
     _testing.clearSessionContexts();
+    _testing.clearHarnessDebugSnapshots();
     postHogMocks.identify.mockClear();
     postHogMocks.capture.mockClear();
     setOutboundRouteReporter(null);
     setSessionTelemetryReporter(null);
+    setDebugTelemetryReporter(null);
     setErrorTelemetryReporter(null);
   });
 

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -372,10 +372,17 @@ export type TlonHarnessDebugEvent = TlonHarnessDebugSnapshotFields & {
   outcome: string | null;
   durationMs: number | null;
   toolName: string | null;
+  toolCallId: string | null;
+  toolSource: string | null;
+  toolOwner: string | null;
   pluginId: string | null;
   harnessId: string | null;
+  modelCallId: string | null;
   modelApi: string | null;
   modelTransport: string | null;
+  requestPayloadBytes: number | null;
+  responseStreamBytes: number | null;
+  timeToFirstByteMs: number | null;
   logLevel: string | null;
   message: string | null;
   loggerName: string | null;
@@ -397,6 +404,8 @@ export type TlonHarnessDebugEvent = TlonHarnessDebugSnapshotFields & {
   promptImages: number | null;
   contextTokenBudget: number | null;
   reserveTokens: number | null;
+  contextChannel: string | null;
+  contextTrigger: string | null;
 };
 
 export type TlonPluginErrorSource =
@@ -1482,10 +1491,17 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           outcome: event.outcome,
           durationMs: event.durationMs,
           toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          toolSource: event.toolSource,
+          toolOwner: event.toolOwner,
           pluginId: event.pluginId,
           harnessId: event.harnessId,
+          modelCallId: event.modelCallId,
           modelApi: event.modelApi,
           modelTransport: event.modelTransport,
+          requestPayloadBytes: event.requestPayloadBytes,
+          responseStreamBytes: event.responseStreamBytes,
+          timeToFirstByteMs: event.timeToFirstByteMs,
           logLevel: event.logLevel,
           message: event.message,
           loggerName: event.loggerName,
@@ -1507,6 +1523,8 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           promptImages: event.promptImages,
           contextTokenBudget: event.contextTokenBudget,
           reserveTokens: event.reserveTokens,
+          contextChannel: event.contextChannel,
+          contextTrigger: event.contextTrigger,
           harnessDebugSequence: event.harnessDebugSequence,
           lastHarnessEventType: event.lastHarnessEventType,
           lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
@@ -1817,10 +1835,17 @@ export type TlonHarnessDebugReportInput = {
   outcome?: string | null;
   durationMs?: number | null;
   toolName?: string | null;
+  toolCallId?: string | null;
+  toolSource?: string | null;
+  toolOwner?: string | null;
   pluginId?: string | null;
   harnessId?: string | null;
+  modelCallId?: string | null;
   modelApi?: string | null;
   modelTransport?: string | null;
+  requestPayloadBytes?: number | null;
+  responseStreamBytes?: number | null;
+  timeToFirstByteMs?: number | null;
   logLevel?: string | null;
   message?: string | null;
   loggerName?: string | null;
@@ -1842,6 +1867,8 @@ export type TlonHarnessDebugReportInput = {
   promptImages?: number | null;
   contextTokenBudget?: number | null;
   reserveTokens?: number | null;
+  contextChannel?: string | null;
+  contextTrigger?: string | null;
 };
 
 export type TlonPluginErrorReportInput = {
@@ -2078,10 +2105,17 @@ export function reportHarnessDebug(event: TlonHarnessDebugReportInput): void {
     outcome: optionalString(event.outcome),
     durationMs: optionalNumber(event.durationMs),
     toolName: optionalString(event.toolName),
+    toolCallId: optionalString(event.toolCallId),
+    toolSource: optionalString(event.toolSource),
+    toolOwner: optionalString(event.toolOwner),
     pluginId: optionalString(event.pluginId),
     harnessId: optionalString(event.harnessId),
+    modelCallId: optionalString(event.modelCallId),
     modelApi: optionalString(event.modelApi),
     modelTransport: optionalString(event.modelTransport),
+    requestPayloadBytes: optionalNumber(event.requestPayloadBytes),
+    responseStreamBytes: optionalNumber(event.responseStreamBytes),
+    timeToFirstByteMs: optionalNumber(event.timeToFirstByteMs),
     logLevel: optionalString(event.logLevel),
     message: optionalString(event.message),
     loggerName: optionalString(event.loggerName),
@@ -2103,6 +2137,8 @@ export function reportHarnessDebug(event: TlonHarnessDebugReportInput): void {
     promptImages: optionalNumber(event.promptImages),
     contextTokenBudget: optionalNumber(event.contextTokenBudget),
     reserveTokens: optionalNumber(event.reserveTokens),
+    contextChannel: optionalString(event.contextChannel),
+    contextTrigger: optionalString(event.contextTrigger),
     ...snapshot,
   });
 }

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -17,6 +17,29 @@ type ToolSessionTrace = {
   calls: ToolCallRecord[];
 };
 
+type HarnessDebugSnapshotRecord = {
+  updatedAt: number;
+  debugSequence: number;
+  lastHarnessEventType: string | null;
+  lastHarnessEventAt: number | null;
+  lastHarnessEventRunId: string | null;
+  lastHarnessEventPhase: string | null;
+  lastHarnessEventOutcome: string | null;
+  lastHarnessProvider: string | null;
+  lastHarnessModel: string | null;
+  runStartedSeen: boolean;
+  contextAssembledSeen: boolean;
+  modelCallStartedSeen: boolean;
+  harnessRunStartedSeen: boolean;
+  toolExecutionStartedSeen: boolean;
+  lastContextEngineEvent: string | null;
+  lastContextEngineEventAt: number | null;
+  lastContextEngineTaskId: string | null;
+  lastContextEngineOperation: string | null;
+  lastContextEngineLane: string | null;
+  lastContextEngineMessage: string | null;
+};
+
 export type TlonHarnessName = 'openclaw' | 'hermes';
 type ReplyDispatchKind = 'tool' | 'block' | 'final';
 type ReplyDispatchCounts = Partial<Record<ReplyDispatchKind, number>>;
@@ -219,7 +242,34 @@ export type TlonSessionLifecycleEvent = {
   hasNextSession: boolean;
 };
 
-export type TlonSessionWatchdogEvent = {
+export type TlonHarnessDebugSnapshotFields = {
+  harnessDebugSequence: number | null;
+  lastHarnessEventType: string | null;
+  lastHarnessEventAgeMs: number | null;
+  lastHarnessEventRunId: string | null;
+  lastHarnessEventPhase: string | null;
+  lastHarnessEventOutcome: string | null;
+  lastHarnessProvider: string | null;
+  lastHarnessModel: string | null;
+  runStartedSeen: boolean;
+  contextAssembledSeen: boolean;
+  modelCallStartedSeen: boolean;
+  harnessRunStartedSeen: boolean;
+  toolExecutionStartedSeen: boolean;
+  lastContextEngineEvent: string | null;
+  lastContextEngineEventAgeMs: number | null;
+  lastContextEngineTaskId: string | null;
+  lastContextEngineOperation: string | null;
+  lastContextEngineLane: string | null;
+  lastContextEngineMessage: string | null;
+};
+
+export type TlonDiagnosticLogAttributes = Record<
+  string,
+  string | number | boolean
+>;
+
+export type TlonSessionWatchdogEvent = TlonHarnessDebugSnapshotFields & {
   diagnosticType: 'session.stalled' | 'session.stuck';
   sessionKey: string;
   sessionId: string | null;
@@ -241,7 +291,7 @@ export type TlonSessionWatchdogEvent = {
   terminalProgressStale: boolean;
 };
 
-export type TlonSessionRecoveryEvent = {
+export type TlonSessionRecoveryEvent = TlonHarnessDebugSnapshotFields & {
   diagnosticType: 'session.recovery.requested' | 'session.recovery.completed';
   sessionKey: string;
   sessionId: string | null;
@@ -304,6 +354,51 @@ export type TlonHarnessErrorEvent = {
   errorText: string | null;
 };
 
+export type TlonHarnessDebugEvent = TlonHarnessDebugSnapshotFields & {
+  harness: TlonHarnessName;
+  harnessEventType: string;
+  debugEventKind: string;
+  sessionKey: string;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  provider: string | null;
+  model: string | null;
+  phase: string | null;
+  outcome: string | null;
+  durationMs: number | null;
+  toolName: string | null;
+  pluginId: string | null;
+  harnessId: string | null;
+  modelApi: string | null;
+  modelTransport: string | null;
+  logLevel: string | null;
+  message: string | null;
+  loggerName: string | null;
+  codeFunctionName: string | null;
+  codeLine: number | null;
+  logAttributes: TlonDiagnosticLogAttributes | null;
+  contextEngineEvent: string | null;
+  contextEngineTaskId: string | null;
+  contextEngineOperation: string | null;
+  contextEngineLane: string | null;
+  errorName: string | null;
+  errorCode: string | null;
+  messageCount: number | null;
+  historyTextChars: number | null;
+  historyImageBlocks: number | null;
+  maxMessageTextChars: number | null;
+  systemPromptChars: number | null;
+  promptChars: number | null;
+  promptImages: number | null;
+  contextTokenBudget: number | null;
+  reserveTokens: number | null;
+};
+
 export type TlonPluginErrorSource =
   | 'auth'
   | 're_auth'
@@ -351,6 +446,7 @@ export interface TlonTelemetryClient {
   captureSessionWatchdog(event: TlonSessionWatchdogEvent): void;
   captureSessionRecovery(event: TlonSessionRecoveryEvent): void;
   captureHarnessError(event: TlonHarnessErrorEvent): void;
+  captureHarnessDebug(event: TlonHarnessDebugEvent): void;
   capturePluginError(event: TlonPluginErrorEvent): void;
   captureTelemetryError(event: TlonTelemetryErrorEvent): void;
   captureOutboundRoute(
@@ -369,6 +465,7 @@ const TLON_SESSION_LIFECYCLE_EVENT = 'TlonBot Session Lifecycle';
 const TLON_SESSION_WATCHDOG_EVENT = 'TlonBot Session Watchdog';
 const TLON_SESSION_RECOVERY_EVENT = 'TlonBot Session Recovery';
 const TLON_HARNESS_ERROR_EVENT = 'TlonBot Harness Error';
+const TLON_HARNESS_DEBUG_EVENT = 'TlonBot Harness Debug';
 const TLON_PLUGIN_ERROR_EVENT = 'TlonBot Plugin Error';
 const TLON_TELEMETRY_ERROR_EVENT = 'TlonBot Telemetry Error';
 const TLON_HEARTBEAT_NUDGE_EVENT = 'TlonBot Heartbeat Nudge Sent';
@@ -380,6 +477,8 @@ const REPLY_TRACE_TTL_MS = 60 * 60 * 1000;
 const MAX_ACTIVE_REPLY_TRACES = 50;
 const SESSION_CONTEXT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_SESSION_CONTEXTS = 5_000;
+const HARNESS_DEBUG_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
+const MAX_HARNESS_DEBUG_SNAPSHOTS = 5_000;
 const toolCallsBySession = sharedMap<string, ToolSessionTrace>(
   'telemetry.toolCallsBySession'
 );
@@ -387,6 +486,10 @@ const sessionContextsBySessionKey = sharedMap<
   string,
   TlonSessionTelemetryContext
 >('telemetry.sessionContextsBySessionKey');
+const harnessDebugSnapshotsBySessionKey = sharedMap<
+  string,
+  HarnessDebugSnapshotRecord
+>('telemetry.harnessDebugSnapshotsBySessionKey');
 
 function cleanupToolCalls(now = Date.now()): void {
   for (const [sessionKey, trace] of toolCallsBySession) {
@@ -480,6 +583,171 @@ function cleanupSessionContexts(now = Date.now()): void {
     }
     sessionContextsBySessionKey.delete(oldestKey);
   }
+}
+
+function cleanupHarnessDebugSnapshots(now = Date.now()): void {
+  for (const [sessionKey, snapshot] of harnessDebugSnapshotsBySessionKey) {
+    if (now - snapshot.updatedAt > HARNESS_DEBUG_SNAPSHOT_TTL_MS) {
+      harnessDebugSnapshotsBySessionKey.delete(sessionKey);
+    }
+  }
+
+  while (harnessDebugSnapshotsBySessionKey.size > MAX_HARNESS_DEBUG_SNAPSHOTS) {
+    const oldestKey = [...harnessDebugSnapshotsBySessionKey.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    )[0]?.[0];
+    if (!oldestKey) {
+      break;
+    }
+    harnessDebugSnapshotsBySessionKey.delete(oldestKey);
+  }
+}
+
+function createEmptyHarnessDebugSnapshot(
+  now = Date.now()
+): HarnessDebugSnapshotRecord {
+  return {
+    updatedAt: now,
+    debugSequence: 0,
+    lastHarnessEventType: null,
+    lastHarnessEventAt: null,
+    lastHarnessEventRunId: null,
+    lastHarnessEventPhase: null,
+    lastHarnessEventOutcome: null,
+    lastHarnessProvider: null,
+    lastHarnessModel: null,
+    runStartedSeen: false,
+    contextAssembledSeen: false,
+    modelCallStartedSeen: false,
+    harnessRunStartedSeen: false,
+    toolExecutionStartedSeen: false,
+    lastContextEngineEvent: null,
+    lastContextEngineEventAt: null,
+    lastContextEngineTaskId: null,
+    lastContextEngineOperation: null,
+    lastContextEngineLane: null,
+    lastContextEngineMessage: null,
+  };
+}
+
+function harnessDebugSnapshotFields(
+  snapshot: HarnessDebugSnapshotRecord | null,
+  now = Date.now()
+): TlonHarnessDebugSnapshotFields {
+  return {
+    harnessDebugSequence: snapshot?.debugSequence ?? null,
+    lastHarnessEventType: snapshot?.lastHarnessEventType ?? null,
+    lastHarnessEventAgeMs:
+      snapshot?.lastHarnessEventAt !== null &&
+      snapshot?.lastHarnessEventAt !== undefined
+        ? Math.max(0, now - snapshot.lastHarnessEventAt)
+        : null,
+    lastHarnessEventRunId: snapshot?.lastHarnessEventRunId ?? null,
+    lastHarnessEventPhase: snapshot?.lastHarnessEventPhase ?? null,
+    lastHarnessEventOutcome: snapshot?.lastHarnessEventOutcome ?? null,
+    lastHarnessProvider: snapshot?.lastHarnessProvider ?? null,
+    lastHarnessModel: snapshot?.lastHarnessModel ?? null,
+    runStartedSeen: snapshot?.runStartedSeen === true,
+    contextAssembledSeen: snapshot?.contextAssembledSeen === true,
+    modelCallStartedSeen: snapshot?.modelCallStartedSeen === true,
+    harnessRunStartedSeen: snapshot?.harnessRunStartedSeen === true,
+    toolExecutionStartedSeen: snapshot?.toolExecutionStartedSeen === true,
+    lastContextEngineEvent: snapshot?.lastContextEngineEvent ?? null,
+    lastContextEngineEventAgeMs:
+      snapshot?.lastContextEngineEventAt !== null &&
+      snapshot?.lastContextEngineEventAt !== undefined
+        ? Math.max(0, now - snapshot.lastContextEngineEventAt)
+        : null,
+    lastContextEngineTaskId: snapshot?.lastContextEngineTaskId ?? null,
+    lastContextEngineOperation: snapshot?.lastContextEngineOperation ?? null,
+    lastContextEngineLane: snapshot?.lastContextEngineLane ?? null,
+    lastContextEngineMessage: snapshot?.lastContextEngineMessage ?? null,
+  };
+}
+
+function lookupHarnessDebugSnapshotFields(
+  sessionKey?: string | null
+): TlonHarnessDebugSnapshotFields {
+  const normalized = sessionKey?.trim();
+  if (!normalized) {
+    return harnessDebugSnapshotFields(null);
+  }
+
+  cleanupHarnessDebugSnapshots();
+  return harnessDebugSnapshotFields(
+    harnessDebugSnapshotsBySessionKey.get(normalized) ?? null
+  );
+}
+
+function updateHarnessDebugSnapshot(
+  sessionKey: string,
+  event: TlonHarnessDebugReportInput,
+  now = Date.now()
+): TlonHarnessDebugSnapshotFields {
+  cleanupHarnessDebugSnapshots(now);
+  const previous = harnessDebugSnapshotsBySessionKey.get(sessionKey);
+  const eventRunId = optionalString(event.runId);
+  const resetForNewRun =
+    previous &&
+    eventRunId &&
+    previous.lastHarnessEventRunId &&
+    previous.lastHarnessEventRunId !== eventRunId;
+  const existing = resetForNewRun
+    ? createEmptyHarnessDebugSnapshot(now)
+    : previous ?? createEmptyHarnessDebugSnapshot(now);
+  const contextEngineEvent = optionalString(event.contextEngineEvent);
+  const contextEngineTaskId = optionalString(event.contextEngineTaskId);
+  const contextEngineOperation = optionalString(event.contextEngineOperation);
+  const contextEngineLane = optionalString(event.contextEngineLane);
+  const message = optionalString(event.message);
+
+  const updated: HarnessDebugSnapshotRecord = {
+    ...existing,
+    updatedAt: now,
+    debugSequence: existing.debugSequence + 1,
+    lastHarnessEventType:
+      optionalString(event.harnessEventType) ?? existing.lastHarnessEventType,
+    lastHarnessEventAt: now,
+    lastHarnessEventRunId: eventRunId ?? existing.lastHarnessEventRunId,
+    lastHarnessEventPhase:
+      optionalString(event.phase) ?? existing.lastHarnessEventPhase,
+    lastHarnessEventOutcome:
+      optionalString(event.outcome) ?? existing.lastHarnessEventOutcome,
+    lastHarnessProvider:
+      optionalString(event.provider) ?? existing.lastHarnessProvider,
+    lastHarnessModel: optionalString(event.model) ?? existing.lastHarnessModel,
+    runStartedSeen:
+      existing.runStartedSeen || event.harnessEventType === 'run.started',
+    contextAssembledSeen:
+      existing.contextAssembledSeen ||
+      event.harnessEventType === 'context.assembled',
+    modelCallStartedSeen:
+      existing.modelCallStartedSeen ||
+      event.harnessEventType === 'model.call.started',
+    harnessRunStartedSeen:
+      existing.harnessRunStartedSeen ||
+      event.harnessEventType === 'harness.run.started',
+    toolExecutionStartedSeen:
+      existing.toolExecutionStartedSeen ||
+      event.harnessEventType === 'tool.execution.started',
+    lastContextEngineEvent:
+      contextEngineEvent ?? existing.lastContextEngineEvent,
+    lastContextEngineEventAt: contextEngineEvent
+      ? now
+      : existing.lastContextEngineEventAt,
+    lastContextEngineTaskId:
+      contextEngineTaskId ?? existing.lastContextEngineTaskId,
+    lastContextEngineOperation:
+      contextEngineOperation ?? existing.lastContextEngineOperation,
+    lastContextEngineLane: contextEngineLane ?? existing.lastContextEngineLane,
+    lastContextEngineMessage:
+      contextEngineEvent && message
+        ? message
+        : existing.lastContextEngineMessage,
+  };
+
+  harnessDebugSnapshotsBySessionKey.set(sessionKey, updated);
+  return harnessDebugSnapshotFields(updated, now);
 }
 
 function rememberTlonSessionContext(params: {
@@ -685,12 +953,21 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     });
   }
 
-  private properties<T extends Record<string, unknown>>(props: T): T {
-    return {
+  private properties<T extends Record<string, unknown>>(
+    props: T,
+    options?: { omitNullish?: boolean }
+  ): Record<string, unknown> {
+    const properties = {
       logSource: TLON_TELEMETRY_LOG_SOURCE,
       ...this.versionIdentity,
       ...props,
     };
+    if (options?.omitNullish !== true) {
+      return properties;
+    }
+    return Object.fromEntries(
+      Object.entries(properties).filter(([, value]) => value != null)
+    );
   }
 
   captureGatewayConnected(event: TlonGatewayConnectedEvent): void {
@@ -1014,27 +1291,49 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: ownerShip,
       event: TLON_SESSION_WATCHDOG_EVENT,
-      properties: this.properties({
-        botShip: event.botShip,
-        ownerShip: event.ownerShip,
-        accountId: event.accountId,
-        agentId: event.agentId,
-        sessionKey: event.sessionKey,
-        sessionId: event.sessionId,
-        diagnosticType: event.diagnosticType,
-        destinationKind: event.destinationKind,
-        state: event.state,
-        ageMs: event.ageMs,
-        queueDepth: event.queueDepth,
-        reason: event.reason,
-        classification: event.classification,
-        activeWorkKind: event.activeWorkKind,
-        lastProgressAgeMs: event.lastProgressAgeMs,
-        lastProgressReason: event.lastProgressReason,
-        activeToolName: event.activeToolName,
-        activeToolAgeMs: event.activeToolAgeMs,
-        terminalProgressStale: event.terminalProgressStale,
-      }),
+      properties: this.properties(
+        {
+          botShip: event.botShip,
+          ownerShip: event.ownerShip,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          diagnosticType: event.diagnosticType,
+          destinationKind: event.destinationKind,
+          state: event.state,
+          ageMs: event.ageMs,
+          queueDepth: event.queueDepth,
+          reason: event.reason,
+          classification: event.classification,
+          activeWorkKind: event.activeWorkKind,
+          lastProgressAgeMs: event.lastProgressAgeMs,
+          lastProgressReason: event.lastProgressReason,
+          activeToolName: event.activeToolName,
+          activeToolAgeMs: event.activeToolAgeMs,
+          terminalProgressStale: event.terminalProgressStale,
+          harnessDebugSequence: event.harnessDebugSequence,
+          lastHarnessEventType: event.lastHarnessEventType,
+          lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
+          lastHarnessEventRunId: event.lastHarnessEventRunId,
+          lastHarnessEventPhase: event.lastHarnessEventPhase,
+          lastHarnessEventOutcome: event.lastHarnessEventOutcome,
+          lastHarnessProvider: event.lastHarnessProvider,
+          lastHarnessModel: event.lastHarnessModel,
+          runStartedSeen: event.runStartedSeen,
+          contextAssembledSeen: event.contextAssembledSeen,
+          modelCallStartedSeen: event.modelCallStartedSeen,
+          harnessRunStartedSeen: event.harnessRunStartedSeen,
+          toolExecutionStartedSeen: event.toolExecutionStartedSeen,
+          lastContextEngineEvent: event.lastContextEngineEvent,
+          lastContextEngineEventAgeMs: event.lastContextEngineEventAgeMs,
+          lastContextEngineTaskId: event.lastContextEngineTaskId,
+          lastContextEngineOperation: event.lastContextEngineOperation,
+          lastContextEngineLane: event.lastContextEngineLane,
+          lastContextEngineMessage: event.lastContextEngineMessage,
+        },
+        { omitNullish: true }
+      ),
     });
   }
 
@@ -1047,28 +1346,50 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: ownerShip,
       event: TLON_SESSION_RECOVERY_EVENT,
-      properties: this.properties({
-        botShip: event.botShip,
-        ownerShip: event.ownerShip,
-        accountId: event.accountId,
-        agentId: event.agentId,
-        sessionKey: event.sessionKey,
-        sessionId: event.sessionId,
-        diagnosticType: event.diagnosticType,
-        destinationKind: event.destinationKind,
-        state: event.state,
-        stateGeneration: event.stateGeneration,
-        ageMs: event.ageMs,
-        queueDepth: event.queueDepth,
-        reason: event.reason,
-        activeWorkKind: event.activeWorkKind,
-        allowActiveAbort: event.allowActiveAbort,
-        status: event.status,
-        action: event.action,
-        outcomeReason: event.outcomeReason,
-        released: event.released,
-        stale: event.stale,
-      }),
+      properties: this.properties(
+        {
+          botShip: event.botShip,
+          ownerShip: event.ownerShip,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          diagnosticType: event.diagnosticType,
+          destinationKind: event.destinationKind,
+          state: event.state,
+          stateGeneration: event.stateGeneration,
+          ageMs: event.ageMs,
+          queueDepth: event.queueDepth,
+          reason: event.reason,
+          activeWorkKind: event.activeWorkKind,
+          allowActiveAbort: event.allowActiveAbort,
+          status: event.status,
+          action: event.action,
+          outcomeReason: event.outcomeReason,
+          released: event.released,
+          stale: event.stale,
+          harnessDebugSequence: event.harnessDebugSequence,
+          lastHarnessEventType: event.lastHarnessEventType,
+          lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
+          lastHarnessEventRunId: event.lastHarnessEventRunId,
+          lastHarnessEventPhase: event.lastHarnessEventPhase,
+          lastHarnessEventOutcome: event.lastHarnessEventOutcome,
+          lastHarnessProvider: event.lastHarnessProvider,
+          lastHarnessModel: event.lastHarnessModel,
+          runStartedSeen: event.runStartedSeen,
+          contextAssembledSeen: event.contextAssembledSeen,
+          modelCallStartedSeen: event.modelCallStartedSeen,
+          harnessRunStartedSeen: event.harnessRunStartedSeen,
+          toolExecutionStartedSeen: event.toolExecutionStartedSeen,
+          lastContextEngineEvent: event.lastContextEngineEvent,
+          lastContextEngineEventAgeMs: event.lastContextEngineEventAgeMs,
+          lastContextEngineTaskId: event.lastContextEngineTaskId,
+          lastContextEngineOperation: event.lastContextEngineOperation,
+          lastContextEngineLane: event.lastContextEngineLane,
+          lastContextEngineMessage: event.lastContextEngineMessage,
+        },
+        { omitNullish: true }
+      ),
     });
   }
 
@@ -1105,28 +1426,109 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: ownerShip,
       event: TLON_HARNESS_ERROR_EVENT,
-      properties: this.properties({
-        harness: event.harness,
-        harnessEventType: event.harnessEventType,
-        errorScope: event.errorScope,
-        sessionKey: event.sessionKey,
-        sessionId: event.sessionId,
-        runId: event.runId,
-        accountId: event.accountId,
-        agentId: event.agentId,
-        ownerShip: event.ownerShip,
-        botShip: event.botShip,
-        destinationKind: event.destinationKind,
-        provider: event.provider,
-        model: event.model,
-        toolName: event.toolName,
-        phase: event.phase,
-        outcome: event.outcome,
-        errorCategory: event.errorCategory,
-        failureKind: event.failureKind,
-        durationMs: event.durationMs,
-        errorText: event.errorText,
-      }),
+      properties: this.properties(
+        {
+          harness: event.harness,
+          harnessEventType: event.harnessEventType,
+          errorScope: event.errorScope,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          runId: event.runId,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          destinationKind: event.destinationKind,
+          provider: event.provider,
+          model: event.model,
+          toolName: event.toolName,
+          phase: event.phase,
+          outcome: event.outcome,
+          errorCategory: event.errorCategory,
+          failureKind: event.failureKind,
+          durationMs: event.durationMs,
+          errorText: event.errorText,
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  captureHarnessDebug(event: TlonHarnessDebugEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_HARNESS_DEBUG_EVENT,
+      properties: this.properties(
+        {
+          harness: event.harness,
+          harnessEventType: event.harnessEventType,
+          debugEventKind: event.debugEventKind,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          runId: event.runId,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          destinationKind: event.destinationKind,
+          provider: event.provider,
+          model: event.model,
+          phase: event.phase,
+          outcome: event.outcome,
+          durationMs: event.durationMs,
+          toolName: event.toolName,
+          pluginId: event.pluginId,
+          harnessId: event.harnessId,
+          modelApi: event.modelApi,
+          modelTransport: event.modelTransport,
+          logLevel: event.logLevel,
+          message: event.message,
+          loggerName: event.loggerName,
+          codeFunctionName: event.codeFunctionName,
+          codeLine: event.codeLine,
+          logAttributes: event.logAttributes,
+          contextEngineEvent: event.contextEngineEvent,
+          contextEngineTaskId: event.contextEngineTaskId,
+          contextEngineOperation: event.contextEngineOperation,
+          contextEngineLane: event.contextEngineLane,
+          errorName: event.errorName,
+          errorCode: event.errorCode,
+          messageCount: event.messageCount,
+          historyTextChars: event.historyTextChars,
+          historyImageBlocks: event.historyImageBlocks,
+          maxMessageTextChars: event.maxMessageTextChars,
+          systemPromptChars: event.systemPromptChars,
+          promptChars: event.promptChars,
+          promptImages: event.promptImages,
+          contextTokenBudget: event.contextTokenBudget,
+          reserveTokens: event.reserveTokens,
+          harnessDebugSequence: event.harnessDebugSequence,
+          lastHarnessEventType: event.lastHarnessEventType,
+          lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
+          lastHarnessEventRunId: event.lastHarnessEventRunId,
+          lastHarnessEventPhase: event.lastHarnessEventPhase,
+          lastHarnessEventOutcome: event.lastHarnessEventOutcome,
+          lastHarnessProvider: event.lastHarnessProvider,
+          lastHarnessModel: event.lastHarnessModel,
+          runStartedSeen: event.runStartedSeen,
+          contextAssembledSeen: event.contextAssembledSeen,
+          modelCallStartedSeen: event.modelCallStartedSeen,
+          harnessRunStartedSeen: event.harnessRunStartedSeen,
+          toolExecutionStartedSeen: event.toolExecutionStartedSeen,
+          lastContextEngineEvent: event.lastContextEngineEvent,
+          lastContextEngineEventAgeMs: event.lastContextEngineEventAgeMs,
+          lastContextEngineTaskId: event.lastContextEngineTaskId,
+          lastContextEngineOperation: event.lastContextEngineOperation,
+          lastContextEngineLane: event.lastContextEngineLane,
+          lastContextEngineMessage: event.lastContextEngineMessage,
+        },
+        { omitNullish: true }
+      ),
     });
   }
 
@@ -1139,16 +1541,19 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: ownerShip,
       event: TLON_PLUGIN_ERROR_EVENT,
-      properties: this.properties({
-        harness: event.harness,
-        pluginErrorSource: event.pluginErrorSource,
-        accountId: event.accountId,
-        ownerShip: event.ownerShip,
-        botShip: event.botShip,
-        errorKind: event.errorKind,
-        errorText: event.errorText,
-        attempt: event.attempt,
-      }),
+      properties: this.properties(
+        {
+          harness: event.harness,
+          pluginErrorSource: event.pluginErrorSource,
+          accountId: event.accountId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          errorKind: event.errorKind,
+          errorText: event.errorText,
+          attempt: event.attempt,
+        },
+        { omitNullish: true }
+      ),
     });
   }
 
@@ -1161,20 +1566,23 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: ownerShip,
       event: TLON_TELEMETRY_ERROR_EVENT,
-      properties: this.properties({
-        harness: event.harness,
-        telemetrySource: event.telemetrySource,
-        sourceEventName: event.sourceEventName,
-        sessionKey: event.sessionKey,
-        sessionId: event.sessionId,
-        runId: event.runId,
-        accountId: event.accountId,
-        agentId: event.agentId,
-        ownerShip: event.ownerShip,
-        botShip: event.botShip,
-        errorKind: event.errorKind,
-        errorText: event.errorText,
-      }),
+      properties: this.properties(
+        {
+          harness: event.harness,
+          telemetrySource: event.telemetrySource,
+          sourceEventName: event.sourceEventName,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          runId: event.runId,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          errorKind: event.errorKind,
+          errorText: event.errorText,
+        },
+        { omitNullish: true }
+      ),
     });
   }
 
@@ -1313,6 +1721,7 @@ export type ErrorTelemetryReporter = (
     | { kind: 'plugin'; event: TlonPluginErrorReportInput }
     | { kind: 'telemetry'; event: TlonTelemetryErrorReportInput }
 ) => void;
+export type DebugTelemetryReporter = (event: TlonHarnessDebugEvent) => void;
 
 export type TlonSessionLifecycleReportInput = {
   lifecycleEvent: 'session_start' | 'session_end';
@@ -1391,6 +1800,50 @@ export type TlonHarnessErrorReportInput = {
   errorText?: string | null;
 };
 
+export type TlonHarnessDebugReportInput = {
+  harnessEventType: string;
+  debugEventKind: string;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  accountId?: string | null;
+  agentId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  destinationKind?: TlonDestinationKind | null;
+  provider?: string | null;
+  model?: string | null;
+  phase?: string | null;
+  outcome?: string | null;
+  durationMs?: number | null;
+  toolName?: string | null;
+  pluginId?: string | null;
+  harnessId?: string | null;
+  modelApi?: string | null;
+  modelTransport?: string | null;
+  logLevel?: string | null;
+  message?: string | null;
+  loggerName?: string | null;
+  codeFunctionName?: string | null;
+  codeLine?: number | null;
+  logAttributes?: TlonDiagnosticLogAttributes | null;
+  contextEngineEvent?: string | null;
+  contextEngineTaskId?: string | null;
+  contextEngineOperation?: string | null;
+  contextEngineLane?: string | null;
+  errorName?: string | null;
+  errorCode?: string | null;
+  messageCount?: number | null;
+  historyTextChars?: number | null;
+  historyImageBlocks?: number | null;
+  maxMessageTextChars?: number | null;
+  systemPromptChars?: number | null;
+  promptChars?: number | null;
+  promptImages?: number | null;
+  contextTokenBudget?: number | null;
+  reserveTokens?: number | null;
+};
+
 export type TlonPluginErrorReportInput = {
   pluginErrorSource: TlonPluginErrorSource;
   accountId?: string | null;
@@ -1424,6 +1877,9 @@ const sessionTelemetryReporterSlot = sharedSlot<SessionTelemetryReporter>(
 const errorTelemetryReporterSlot = sharedSlot<ErrorTelemetryReporter>(
   'telemetry.errorTelemetryReporter'
 );
+const debugTelemetryReporterSlot = sharedSlot<DebugTelemetryReporter>(
+  'telemetry.debugTelemetryReporter'
+);
 
 export function setOutboundRouteReporter(
   reporter: OutboundRouteReporter | null
@@ -1447,6 +1903,12 @@ export function setErrorTelemetryReporter(
   errorTelemetryReporterSlot.set(reporter);
 }
 
+export function setDebugTelemetryReporter(
+  reporter: DebugTelemetryReporter | null
+): void {
+  debugTelemetryReporterSlot.set(reporter);
+}
+
 function optionalString(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   return normalized ? normalized : null;
@@ -1458,6 +1920,44 @@ function optionalErrorText(value: string | null | undefined): string | null {
 
 function optionalNumber(value: number | null | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
+const BLOCKED_DIAGNOSTIC_LOG_ATTRIBUTE_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+function normalizeLogAttributes(
+  value: TlonDiagnosticLogAttributes | null | undefined
+): TlonDiagnosticLogAttributes | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const normalized = Object.create(null) as TlonDiagnosticLogAttributes;
+  for (const [key, attributeValue] of Object.entries(value)) {
+    if (
+      BLOCKED_DIAGNOSTIC_LOG_ATTRIBUTE_KEYS.has(key) ||
+      !DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE.test(key)
+    ) {
+      continue;
+    }
+    if (typeof attributeValue === 'string') {
+      normalized[key] = attributeValue;
+      continue;
+    }
+    if (typeof attributeValue === 'boolean') {
+      normalized[key] = attributeValue;
+      continue;
+    }
+    if (typeof attributeValue === 'number' && Number.isFinite(attributeValue)) {
+      normalized[key] = attributeValue;
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
 }
 
 export function formatTlonTelemetryErrorText(error: unknown): string {
@@ -1545,6 +2045,68 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
   });
 }
 
+export function reportHarnessDebug(event: TlonHarnessDebugReportInput): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextRuntime(rememberedContext, {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        agentId: event.agentId,
+      })
+    : null;
+  if (!context) {
+    return;
+  }
+
+  const logAttributes = normalizeLogAttributes(event.logAttributes);
+  const snapshot = updateHarnessDebugSnapshot(context.sessionKey, event);
+  debugTelemetryReporterSlot.get()?.({
+    harness: 'openclaw',
+    harnessEventType: event.harnessEventType,
+    debugEventKind: event.debugEventKind,
+    sessionKey: context.sessionKey,
+    sessionId: context.sessionId,
+    runId: optionalString(event.runId) ?? context.runId,
+    accountId: context.accountId ?? optionalString(event.accountId),
+    agentId: optionalString(event.agentId) ?? context.agentId,
+    ownerShip: context.ownerShip ?? optionalString(event.ownerShip),
+    botShip: context.botShip ?? optionalString(event.botShip) ?? '',
+    destinationKind: context.destinationKind ?? event.destinationKind ?? 'dm',
+    provider: optionalString(event.provider),
+    model: optionalString(event.model),
+    phase: optionalString(event.phase),
+    outcome: optionalString(event.outcome),
+    durationMs: optionalNumber(event.durationMs),
+    toolName: optionalString(event.toolName),
+    pluginId: optionalString(event.pluginId),
+    harnessId: optionalString(event.harnessId),
+    modelApi: optionalString(event.modelApi),
+    modelTransport: optionalString(event.modelTransport),
+    logLevel: optionalString(event.logLevel),
+    message: optionalString(event.message),
+    loggerName: optionalString(event.loggerName),
+    codeFunctionName: optionalString(event.codeFunctionName),
+    codeLine: optionalNumber(event.codeLine),
+    logAttributes,
+    contextEngineEvent: optionalString(event.contextEngineEvent),
+    contextEngineTaskId: optionalString(event.contextEngineTaskId),
+    contextEngineOperation: optionalString(event.contextEngineOperation),
+    contextEngineLane: optionalString(event.contextEngineLane),
+    errorName: optionalString(event.errorName),
+    errorCode: optionalString(event.errorCode),
+    messageCount: optionalNumber(event.messageCount),
+    historyTextChars: optionalNumber(event.historyTextChars),
+    historyImageBlocks: optionalNumber(event.historyImageBlocks),
+    maxMessageTextChars: optionalNumber(event.maxMessageTextChars),
+    systemPromptChars: optionalNumber(event.systemPromptChars),
+    promptChars: optionalNumber(event.promptChars),
+    promptImages: optionalNumber(event.promptImages),
+    contextTokenBudget: optionalNumber(event.contextTokenBudget),
+    reserveTokens: optionalNumber(event.reserveTokens),
+    ...snapshot,
+  });
+}
+
 export function reportPluginError(event: TlonPluginErrorReportInput): void {
   errorTelemetryReporterSlot.get()?.({
     kind: 'plugin',
@@ -1625,6 +2187,9 @@ export function reportSessionDiagnostic(
   if (!context) {
     return;
   }
+  const harnessDebugSnapshot = lookupHarnessDebugSnapshotFields(
+    context.sessionKey
+  );
 
   if (event.type === 'session.stalled' || event.type === 'session.stuck') {
     sessionTelemetryReporterSlot.get()?.({
@@ -1649,6 +2214,7 @@ export function reportSessionDiagnostic(
         activeToolName: optionalString(event.activeToolName),
         activeToolAgeMs: optionalNumber(event.activeToolAgeMs),
         terminalProgressStale: event.terminalProgressStale === true,
+        ...harnessDebugSnapshot,
       },
     });
     return;
@@ -1684,6 +2250,7 @@ export function reportSessionDiagnostic(
       outcomeReason: optionalString(recoveryEvent.outcomeReason),
       released: optionalNumber(recoveryEvent.released),
       stale: recoveryEvent.stale === true,
+      ...harnessDebugSnapshot,
     },
   });
 }
@@ -1691,6 +2258,7 @@ export function reportSessionDiagnostic(
 export const _testing = {
   clearToolCalls: () => toolCallsBySession.clear(),
   clearSessionContexts: () => sessionContextsBySessionKey.clear(),
+  clearHarnessDebugSnapshots: () => harnessDebugSnapshotsBySessionKey.clear(),
   getReplyTraceTtlMs: () => REPLY_TRACE_TTL_MS,
   getToolTraceTtlMs: () => TOOL_TRACE_TTL_MS,
 };


### PR DESCRIPTION
## Summary

Adds additional log capture from OpenClaw's internal internal diagnostic event stream. This should provide us with more context for understanding where the stalled sessions are hanging up (per TLON-5756).

## Changes

- adds *TlonBot Harness Debug* telemetry event for capturing more granular turn-level diagnostics
- augments existing session events with per-session state breadcrumbs
- captured richer debug details: tool names, tool call IDs, tool source/owner, model call IDs, model timing/byte metrics, context size/token fields, and sanitized logAttributes 

## How did I test?

Locally using Docker dev setup. Confirmed events show up in PostHog

## Risks and impact

- Safe to rollback without consulting PR author? Yes

