### PR TITLE
feat(lens): sync %steward runs to client db (2/4)

### DIFF
--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -287,6 +287,17 @@ export const featureFlags = createStorageItem<any>({
   defaultValue: null,
 });
 
+export const contextLensGatewayUrl = createStorageItem<string | null>({
+  key: 'contextLensGatewayUrl',
+  defaultValue: null,
+});
+
+export const contextLensGatewayToken = createStorageItem<string | null>({
+  key: 'contextLensGatewayToken',
+  defaultValue: null,
+  isSecure: true,
+});
+
 export const eulaAgreed = createStorageItem<boolean>({
   key: 'eula',
   defaultValue: false,

--- a/packages/shared/src/db/migrations/0001_add_context_lens_runs.sql
+++ b/packages/shared/src/db/migrations/0001_add_context_lens_runs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `context_lens_runs` (
+	`bot_ship` text NOT NULL,
+	`lens_id` text NOT NULL,
+	`complete` integer DEFAULT false NOT NULL,
+	`received_at` integer NOT NULL,
+	`payload` text,
+	PRIMARY KEY(`bot_ship`, `lens_id`)
+);
+--> statement-breakpoint
+CREATE INDEX `context_lens_runs_received_at_index` ON `context_lens_runs` (`received_at`);

--- a/packages/shared/src/db/migrations/meta/0001_snapshot.json
+++ b/packages/shared/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,3087 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "254d90c3-e358-450a-a5bc-9da3c526d95a",
+  "prevId": "b3c5a540-1b40-4dc1-988d-3585a29c43e9",
+  "tables": {
+    "activity_event_contact_group_pins": {
+      "name": "activity_event_contact_group_pins",
+      "columns": {
+        "activity_event_id": {
+          "name": "activity_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_event_contact_groups_activity_event_id_index": {
+          "name": "activity_event_contact_groups_activity_event_id_index",
+          "columns": [
+            "activity_event_id"
+          ],
+          "isUnique": false
+        },
+        "activity_event_contact_groups_group_id_index": {
+          "name": "activity_event_contact_groups_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_event_contact_group_pins_activity_event_id_activity_events_id_fk": {
+          "name": "activity_event_contact_group_pins_activity_event_id_activity_events_id_fk",
+          "tableFrom": "activity_event_contact_group_pins",
+          "tableTo": "activity_events",
+          "columnsFrom": [
+            "activity_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_event_contact_group_pins_group_id_groups_id_fk": {
+          "name": "activity_event_contact_group_pins_group_id_groups_id_fk",
+          "tableFrom": "activity_event_contact_group_pins",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_event_contact_group_pins_activity_event_id_group_id_pk": {
+          "columns": [
+            "activity_event_id",
+            "group_id"
+          ],
+          "name": "activity_event_contact_group_pins_activity_event_id_group_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_events": {
+      "name": "activity_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_author_id": {
+          "name": "parent_author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_mention": {
+          "name": "is_mention",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_notify": {
+          "name": "should_notify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_event_user_id": {
+          "name": "group_event_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_user_id": {
+          "name": "contact_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_update_type": {
+          "name": "contact_update_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_update_value": {
+          "name": "contact_update_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activity_events_id_bucket_id_pk": {
+          "columns": [
+            "id",
+            "bucket_id"
+          ],
+          "name": "activity_events_id_bucket_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attestations": {
+      "name": "attestations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discoverability": {
+          "name": "discoverability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider__url": {
+          "name": "provider__url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proving_tweet_id": {
+          "name": "proving_tweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "attestations_contact_id_index": {
+          "name": "attestations_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "base_unreads": {
+      "name": "base_unreads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'base_unreads'"
+        },
+        "notify": {
+          "name": "notify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notif_timestamp": {
+          "name": "notif_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_readers": {
+      "name": "channel_readers",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_readers_channel_id_index": {
+          "name": "channel_readers_channel_id_index",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "channel_readers_role_id_index": {
+          "name": "channel_readers_role_id_index",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_readers_channel_id_role_id_pk": {
+          "columns": [
+            "channel_id",
+            "role_id"
+          ],
+          "name": "channel_readers_channel_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_unreads": {
+      "name": "channel_unreads",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count_without_threads": {
+          "name": "count_without_threads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_unread_post_id": {
+          "name": "first_unread_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_unread_post_received_at": {
+          "name": "first_unread_post_received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_unreads_channel_id_index": {
+          "name": "channel_unreads_channel_id_index",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_writers": {
+      "name": "channel_writers",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_writers_channel_id_index": {
+          "name": "channel_writers_channel_id_index",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "channel_writers_role_id_index": {
+          "name": "channel_writers_role_id_index",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "channel_writers_channel_id_role_id_pk": {
+          "columns": [
+            "channel_id",
+            "role_id"
+          ],
+          "name": "channel_writers_channel_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image": {
+          "name": "icon_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image_color": {
+          "name": "icon_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image_color": {
+          "name": "cover_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_to_group_at": {
+          "name": "added_to_group_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_user_is_member": {
+          "name": "current_user_is_member",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_user_is_host": {
+          "name": "current_user_is_host",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_count": {
+          "name": "post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_unread_post_id": {
+          "name": "first_unread_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_post_id": {
+          "name": "last_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_post_at": {
+          "name": "last_post_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_post_sequence_num": {
+          "name": "last_post_sequence_num",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_cached_pending_channel": {
+          "name": "is_cached_pending_channel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new_matched_contact": {
+          "name": "is_new_matched_contact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_dm_invite": {
+          "name": "is_dm_invite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_updated_at": {
+          "name": "remote_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_configuration": {
+          "name": "content_configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posts_order": {
+          "name": "posts_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "last_post_id": {
+          "name": "last_post_id",
+          "columns": [
+            "last_post_id"
+          ],
+          "isUnique": false
+        },
+        "last_post_at": {
+          "name": "last_post_at",
+          "columns": [
+            "last_post_at"
+          ],
+          "isUnique": false
+        },
+        "channels_group_id_index": {
+          "name": "channels_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "channels_contact_id_index": {
+          "name": "channels_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_group_id_groups_id_fk": {
+          "name": "channels_group_id_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_member_roles": {
+      "name": "chat_member_roles",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_member_roles_group_id_index": {
+          "name": "chat_member_roles_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "chat_member_roles_contact_id_index": {
+          "name": "chat_member_roles_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        },
+        "chat_member_roles_role_id_index": {
+          "name": "chat_member_roles_role_id_index",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_member_roles_group_id_groups_id_fk": {
+          "name": "chat_member_roles_group_id_groups_id_fk",
+          "tableFrom": "chat_member_roles",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_member_roles_group_id_contact_id_role_id_pk": {
+          "columns": [
+            "group_id",
+            "contact_id",
+            "role_id"
+          ],
+          "name": "chat_member_roles_group_id_contact_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_members": {
+      "name": "group_members",
+      "columns": {
+        "membership_type": {
+          "name": "membership_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_members_chat_id_index": {
+          "name": "group_members_chat_id_index",
+          "columns": [
+            "chat_id"
+          ],
+          "isUnique": false
+        },
+        "group_members_contact_id_index": {
+          "name": "group_members_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "group_members_chat_id_contact_id_pk": {
+          "columns": [
+            "chat_id",
+            "contact_id"
+          ],
+          "name": "group_members_chat_id_contact_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_attestations": {
+      "name": "contact_attestations",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attestation_id": {
+          "name": "attestation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_attestations_contact_id_index": {
+          "name": "contact_attestations_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        },
+        "contact_attestations_attestation_id_index": {
+          "name": "contact_attestations_attestation_id_index",
+          "columns": [
+            "attestation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_attestations_contact_id_contacts_id_fk": {
+          "name": "contact_attestations_contact_id_contacts_id_fk",
+          "tableFrom": "contact_attestations",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_attestations_attestation_id_attestations_id_fk": {
+          "name": "contact_attestations_attestation_id_attestations_id_fk",
+          "tableFrom": "contact_attestations",
+          "tableTo": "attestations",
+          "columnsFrom": [
+            "attestation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contact_attestations_contact_id_attestation_id_pk": {
+          "columns": [
+            "contact_id",
+            "attestation_id"
+          ],
+          "name": "contact_attestations_contact_id_attestation_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_group_pins": {
+      "name": "contact_group_pins",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contact_group_pins_contact_id_index": {
+          "name": "contact_group_pins_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        },
+        "contact_group_pins_group_id_index": {
+          "name": "contact_group_pins_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_group_pins_contact_id_contacts_id_fk": {
+          "name": "contact_group_pins_contact_id_contacts_id_fk",
+          "tableFrom": "contact_group_pins",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_group_pins_group_id_groups_id_fk": {
+          "name": "contact_group_pins_group_id_groups_id_fk",
+          "tableFrom": "contact_group_pins",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contact_group_pins_contact_id_group_id_pk": {
+          "columns": [
+            "contact_id",
+            "group_id"
+          ],
+          "name": "contact_group_pins_contact_id_group_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peerNickname": {
+          "name": "peerNickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customNickname": {
+          "name": "customNickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(COALESCE(\"customNickname\", \"peerNickname\"))",
+            "type": "stored"
+          }
+        },
+        "peerAvatarImage": {
+          "name": "peerAvatarImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customAvatarImage": {
+          "name": "customAvatarImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarImage": {
+          "name": "avatarImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(COALESCE(\"customAvatarImage\", \"peerAvatarImage\"))",
+            "type": "stored"
+          }
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coverImage": {
+          "name": "coverImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isContact": {
+          "name": "isContact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isContactSuggestion": {
+          "name": "isContactSuggestion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "systemContactId": {
+          "name": "systemContactId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_at": {
+          "name": "matched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "contacts_system_contact_id_index": {
+          "name": "contacts_system_contact_id_index",
+          "columns": [
+            "systemContactId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "context_lens_runs": {
+      "name": "context_lens_runs",
+      "columns": {
+        "bot_ship": {
+          "name": "bot_ship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lens_id": {
+          "name": "lens_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "context_lens_runs_received_at_index": {
+          "name": "context_lens_runs_received_at_index",
+          "columns": [
+            "received_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "context_lens_runs_bot_ship_lens_id_pk": {
+          "columns": [
+            "bot_ship",
+            "lens_id"
+          ],
+          "name": "context_lens_runs_bot_ship_lens_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_flagged_posts": {
+      "name": "group_flagged_posts",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flagged_by_contact_id": {
+          "name": "flagged_by_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "flagged_at": {
+          "name": "flagged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_flagged_posts_group_id_index": {
+          "name": "group_flagged_posts_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "group_flagged_posts_post_id_index": {
+          "name": "group_flagged_posts_post_id_index",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        },
+        "group_flagged_posts_channel_id_index": {
+          "name": "group_flagged_posts_channel_id_index",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        },
+        "group_flagged_posts_flagged_by_contact_id_index": {
+          "name": "group_flagged_posts_flagged_by_contact_id_index",
+          "columns": [
+            "flagged_by_contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_flagged_posts_group_id_groups_id_fk": {
+          "name": "group_flagged_posts_group_id_groups_id_fk",
+          "tableFrom": "group_flagged_posts",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_flagged_posts_group_id_post_id_pk": {
+          "columns": [
+            "group_id",
+            "post_id"
+          ],
+          "name": "group_flagged_posts_group_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_join_requests": {
+      "name": "group_join_requests",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_join_requests_group_id_index": {
+          "name": "group_join_requests_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "group_join_requests_contact_id_index": {
+          "name": "group_join_requests_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_join_requests_group_id_groups_id_fk": {
+          "name": "group_join_requests_group_id_groups_id_fk",
+          "tableFrom": "group_join_requests",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_join_requests_group_id_contact_id_pk": {
+          "columns": [
+            "group_id",
+            "contact_id"
+          ],
+          "name": "group_join_requests_group_id_contact_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_member_bans": {
+      "name": "group_member_bans",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_member_bans_group_id_index": {
+          "name": "group_member_bans_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "group_member_bans_contact_id_index": {
+          "name": "group_member_bans_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_member_bans_group_id_groups_id_fk": {
+          "name": "group_member_bans_group_id_groups_id_fk",
+          "tableFrom": "group_member_bans",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_member_bans_group_id_contact_id_pk": {
+          "columns": [
+            "group_id",
+            "contact_id"
+          ],
+          "name": "group_member_bans_group_id_contact_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_member_invites": {
+      "name": "group_member_invites",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_member_invites_group_id_index": {
+          "name": "group_member_invites_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "group_member_invites_contact_id_index": {
+          "name": "group_member_invites_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_member_invites_group_id_groups_id_fk": {
+          "name": "group_member_invites_group_id_groups_id_fk",
+          "tableFrom": "group_member_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_member_invites_group_id_contact_id_pk": {
+          "columns": [
+            "group_id",
+            "contact_id"
+          ],
+          "name": "group_member_invites_group_id_contact_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_nav_section_channels": {
+      "name": "group_nav_section_channels",
+      "columns": {
+        "group_nav_section_id": {
+          "name": "group_nav_section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_index": {
+          "name": "channel_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_nav_section_channels_group_nav_section_id_index": {
+          "name": "group_nav_section_channels_group_nav_section_id_index",
+          "columns": [
+            "group_nav_section_id"
+          ],
+          "isUnique": false
+        },
+        "group_nav_section_channels_channel_id_index": {
+          "name": "group_nav_section_channels_channel_id_index",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_nav_section_channels_group_nav_section_id_group_nav_sections_id_fk": {
+          "name": "group_nav_section_channels_group_nav_section_id_group_nav_sections_id_fk",
+          "tableFrom": "group_nav_section_channels",
+          "tableTo": "group_nav_sections",
+          "columnsFrom": [
+            "group_nav_section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_nav_section_channels_channel_id_channels_id_fk": {
+          "name": "group_nav_section_channels_channel_id_channels_id_fk",
+          "tableFrom": "group_nav_section_channels",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_nav_section_channels_group_nav_section_id_channel_id_pk": {
+          "columns": [
+            "group_nav_section_id",
+            "channel_id"
+          ],
+          "name": "group_nav_section_channels_group_nav_section_id_channel_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_nav_sections": {
+      "name": "group_nav_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image": {
+          "name": "icon_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image_color": {
+          "name": "icon_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image_color": {
+          "name": "cover_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_index": {
+          "name": "section_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_nav_sections_group_id_index": {
+          "name": "group_nav_sections_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_nav_sections_group_id_groups_id_fk": {
+          "name": "group_nav_sections_group_id_groups_id_fk",
+          "tableFrom": "group_nav_sections",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_rank_bans": {
+      "name": "group_rank_bans",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank_id": {
+          "name": "rank_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_rank_bans_group_id_index": {
+          "name": "group_rank_bans_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_rank_bans_group_id_groups_id_fk": {
+          "name": "group_rank_bans_group_id_groups_id_fk",
+          "tableFrom": "group_rank_bans",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_rank_bans_group_id_rank_id_pk": {
+          "columns": [
+            "group_id",
+            "rank_id"
+          ],
+          "name": "group_rank_bans_group_id_rank_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_roles": {
+      "name": "group_roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image": {
+          "name": "icon_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image_color": {
+          "name": "icon_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image_color": {
+          "name": "cover_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_roles_group_id_index": {
+          "name": "group_roles_group_id_index",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "group_roles_group_id_groups_id_fk": {
+          "name": "group_roles_group_id_groups_id_fk",
+          "tableFrom": "group_roles",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_roles_group_id_id_pk": {
+          "columns": [
+            "group_id",
+            "id"
+          ],
+          "name": "group_roles_group_id_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_unreads": {
+      "name": "group_unreads",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_count": {
+          "name": "notify_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "groups": {
+      "name": "groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_image": {
+          "name": "icon_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_image_color": {
+          "name": "icon_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_image_color": {
+          "name": "cover_image_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "privacy": {
+          "name": "privacy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "have_invite": {
+          "name": "have_invite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "have_requested_invite": {
+          "name": "have_requested_invite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_user_is_member": {
+          "name": "current_user_is_member",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_user_is_host": {
+          "name": "current_user_is_host",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_personal_group": {
+          "name": "is_personal_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "join_status": {
+          "name": "join_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_post_id": {
+          "name": "last_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_post_at": {
+          "name": "last_post_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_members_dismissed_at": {
+          "name": "pending_members_dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pins": {
+      "name": "pins",
+      "columns": {
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pin_index": {
+          "name": "pin_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_images": {
+      "name": "post_images",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "src": {
+          "name": "src",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_images_post_id_index": {
+          "name": "post_images_post_id_index",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_images_post_id_posts_id_fk": {
+          "name": "post_images_post_id_posts_id_fk",
+          "tableFrom": "post_images",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_images_post_id_src_pk": {
+          "columns": [
+            "post_id",
+            "src"
+          ],
+          "name": "post_images_post_id_src_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_reactions": {
+      "name": "post_reactions",
+      "columns": {
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_reactions_contact_id_index": {
+          "name": "post_reactions_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        },
+        "post_reactions_post_id_index": {
+          "name": "post_reactions_post_id_index",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_reactions_post_id_posts_id_fk": {
+          "name": "post_reactions_post_id_posts_id_fk",
+          "tableFrom": "post_reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_reactions_contact_id_post_id_pk": {
+          "columns": [
+            "contact_id",
+            "post_id"
+          ],
+          "name": "post_reactions_contact_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_time": {
+          "name": "reply_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_contact_ids": {
+          "name": "reply_contact_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "optimistic_reply_bump_count": {
+          "name": "optimistic_reply_bump_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text_content": {
+          "name": "text_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_app_reference": {
+          "name": "has_app_reference",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_channel_reference": {
+          "name": "has_channel_reference",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_group_reference": {
+          "name": "has_group_reference",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_link": {
+          "name": "has_link",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_image": {
+          "name": "has_image",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_sequence_stub": {
+          "name": "is_sequence_stub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edit_status": {
+          "name": "edit_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_status": {
+          "name": "delete_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_content": {
+          "name": "last_edit_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_title": {
+          "name": "last_edit_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_edit_image": {
+          "name": "last_edit_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backend_time": {
+          "name": "backend_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blob": {
+          "name": "blob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cache_id": {
+          "name": "cache_id",
+          "columns": [
+            "channel_id",
+            "author_id",
+            "sent_at",
+            "sequence_number"
+          ],
+          "isUnique": true
+        },
+        "posts_channel_id": {
+          "name": "posts_channel_id",
+          "columns": [
+            "channel_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "posts_group_id": {
+          "name": "posts_group_id",
+          "columns": [
+            "group_id",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "posts_author_id_index": {
+          "name": "posts_author_id_index",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        },
+        "posts_parent_id_index": {
+          "name": "posts_parent_id_index",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "posts_cached_index": {
+          "name": "posts_cached_index",
+          "columns": [
+            "channel_id",
+            "sent_at",
+            "author_id"
+          ],
+          "isUnique": false,
+          "where": "sequence_number = 0 AND parent_id IS NULL"
+        },
+        "posts_channel_last_preview": {
+          "name": "posts_channel_last_preview",
+          "columns": [
+            "channel_id",
+            "received_at"
+          ],
+          "isUnique": false,
+          "where": "type != 'reply' AND (is_deleted IS NULL OR is_deleted = 0)"
+        },
+        "posts_channel_last_seq": {
+          "name": "posts_channel_last_seq",
+          "columns": [
+            "channel_id",
+            "sequence_number"
+          ],
+          "isUnique": false,
+          "where": "type != 'reply' AND sequence_number IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'settings'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_app_tile_unreads": {
+          "name": "disable_app_tile_unreads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_avatars": {
+          "name": "disable_avatars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_remote_content": {
+          "name": "disable_remote_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_spellcheck": {
+          "name": "disable_spellcheck",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_nicknames": {
+          "name": "disable_nicknames",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ordered_group_pins": {
+          "name": "ordered_group_pins",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side_bar_sort": {
+          "name": "side_bar_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_side_bar_sort": {
+          "name": "group_side_bar_sort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "show_activity_message": {
+          "name": "show_activity_message",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_activity": {
+          "name": "log_activity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_telemetry": {
+          "name": "enable_telemetry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analytics_id": {
+          "name": "analytics_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_welcome_card": {
+          "name": "seen_welcome_card",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_group_flags": {
+          "name": "new_group_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "groups_nav_state": {
+          "name": "groups_nav_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "messages_nav_state": {
+          "name": "messages_nav_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "messages_filter": {
+          "name": "messages_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gallery_settings": {
+          "name": "gallery_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notebook_settings": {
+          "name": "notebook_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activity_seen_timestamp": {
+          "name": "activity_seen_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_wayfinding_splash": {
+          "name": "completed_wayfinding_splash",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_wayfinding_tutorial": {
+          "name": "completed_wayfinding_tutorial",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disable_tlon_infra_enhancement": {
+          "name": "disable_tlon_infra_enhancement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "web_app_splash_dismissed": {
+          "name": "web_app_splash_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_app_promo_dismissed": {
+          "name": "mobile_app_promo_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_contact_sent_invites": {
+      "name": "system_contact_sent_invites",
+      "columns": {
+        "invited_to": {
+          "name": "invited_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_contact_id": {
+          "name": "system_contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "system_contact_sent_invites_system_contact_id_index": {
+          "name": "system_contact_sent_invites_system_contact_id_index",
+          "columns": [
+            "system_contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "system_contact_sent_invites_invited_to_system_contact_id_pk": {
+          "columns": [
+            "invited_to",
+            "system_contact_id"
+          ],
+          "name": "system_contact_sent_invites_invited_to_system_contact_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_contacts": {
+      "name": "system_contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "system_contacts_contact_id_index": {
+          "name": "system_contacts_contact_id_index",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_unreads": {
+      "name": "thread_unreads",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_unread_post_id": {
+          "name": "first_unread_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_unread_post_received_at": {
+          "name": "first_unread_post_received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "thread_unreads_channel_id_thread_id_pk": {
+          "columns": [
+            "channel_id",
+            "thread_id"
+          ],
+          "name": "thread_unreads_channel_id_thread_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "volume_settings": {
+      "name": "volume_settings",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "volume_settings_item_id_index": {
+          "name": "volume_settings_item_id_index",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/shared/src/db/migrations/meta/_journal.json
+++ b/packages/shared/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1780682104236,
       "tag": "0000_real_rhino",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781205968125,
+      "tag": "0001_add_context_lens_runs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/db/migrations/migrations.js
+++ b/packages/shared/src/db/migrations/migrations.js
@@ -2,11 +2,13 @@
 
 import journal from './meta/_journal.json';
 import m0000 from './0000_real_rhino.sql';
+import m0001 from './0001_add_context_lens_runs.sql';
 
   export default {
     journal,
     migrations: {
-      m0000
+      m0000,
+m0001
     }
   }
   

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -1466,12 +1466,15 @@ export const getContextLensRun = createReadQuery(
     { botShip, lensId }: { botShip: string; lensId: string },
     ctx: QueryCtx
   ) => {
-    return ctx.db.query.contextLensRuns.findFirst({
+    const run = await ctx.db.query.contextLensRuns.findFirst({
       where: and(
         eq($contextLensRuns.botShip, botShip),
         eq($contextLensRuns.lensId, lensId)
       ),
     });
+    // findFirst resolves to undefined on a miss; normalize to null so React
+    // Query doesn't treat a not-yet-synced run as a query error.
+    return run ?? null;
   },
   ['contextLensRuns']
 );

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -9,6 +9,7 @@ import {
   interleaveActivityEvents,
   toSourceActivityEvents,
 } from '@tloncorp/api/client/activity';
+import { preSig } from '@tloncorp/api/lib/urbit';
 import { Rank } from '@tloncorp/api/urbit';
 import {
   AnyColumn,
@@ -65,6 +66,7 @@ import {
   contactAttestations as $contactAttestations,
   contactGroups as $contactGroups,
   contacts as $contacts,
+  contextLensRuns as $contextLensRuns,
   groupFlaggedPosts as $groupFlaggedPosts,
   groupJoinRequests as $groupJoinRequests,
   groupMemberBans as $groupMemberBans,
@@ -99,6 +101,7 @@ import {
   ClientMeta,
   Contact,
   ContactAttestation,
+  ContextLensRun,
   Group,
   GroupJoinRequest,
   GroupNavSection,
@@ -1440,6 +1443,88 @@ export const getFlaggedPosts = createReadQuery(
     });
   },
   ['groupFlaggedPosts']
+);
+
+export const insertContextLensRuns = createWriteQuery(
+  'insertContextLensRuns',
+  async (runs: ContextLensRun[], ctx: QueryCtx) => {
+    if (runs.length === 0) return;
+    return ctx.db
+      .insert($contextLensRuns)
+      .values(runs)
+      .onConflictDoUpdate({
+        target: [$contextLensRuns.botShip, $contextLensRuns.lensId],
+        set: conflictUpdateSetAll($contextLensRuns, ['botShip', 'lensId']),
+      });
+  },
+  ['contextLensRuns']
+);
+
+export const getContextLensRun = createReadQuery(
+  'getContextLensRun',
+  async (
+    { botShip, lensId }: { botShip: string; lensId: string },
+    ctx: QueryCtx
+  ) => {
+    return ctx.db.query.contextLensRuns.findFirst({
+      where: and(
+        eq($contextLensRuns.botShip, botShip),
+        eq($contextLensRuns.lensId, lensId)
+      ),
+    });
+  },
+  ['contextLensRuns']
+);
+
+export const getRecentContextLensRuns = createReadQuery(
+  'getRecentContextLensRuns',
+  async ({ count: limit = 50 }: { count?: number }, ctx: QueryCtx) => {
+    return ctx.db.query.contextLensRuns.findMany({
+      orderBy: [desc($contextLensRuns.receivedAt)],
+      limit,
+    });
+  },
+  ['contextLensRuns']
+);
+
+export const getContextLensBotShips = createReadQuery(
+  'getContextLensBotShips',
+  async (ctx: QueryCtx) => {
+    const rows = await ctx.db
+      .selectDistinct({ botShip: $contextLensRuns.botShip })
+      .from($contextLensRuns);
+    return rows.map((row) => preSig(row.botShip));
+  },
+  ['contextLensRuns']
+);
+
+export const getContextLensBotsInChat = createReadQuery(
+  'getContextLensBotsInChat',
+  async ({ chatId }: { chatId: string }, ctx: QueryCtx) => {
+    const [botRows, memberRows] = await Promise.all([
+      ctx.db
+        .selectDistinct({ botShip: $contextLensRuns.botShip })
+        .from($contextLensRuns),
+      ctx.db
+        .select({
+          contactId: $chatMembers.contactId,
+          status: $chatMembers.status,
+        })
+        .from($chatMembers)
+        .where(eq($chatMembers.chatId, chatId)),
+    ]);
+    // chatMembers.status is only set for invite flows; anything but 'invited'
+    // counts as present. Compare sig-normalized since botShip comes from the
+    // gateway and contactId from groups sync.
+    const members = new Set(
+      memberRows
+        .filter((row) => row.status !== 'invited')
+        .map((row) => preSig(row.contactId))
+    );
+    const botShips = new Set(botRows.map((row) => preSig(row.botShip)));
+    return [...botShips].filter((ship) => members.has(ship));
+  },
+  ['contextLensRuns', 'chatMembers']
 );
 
 export const insertChannelPerms = createWriteQuery(
@@ -4363,6 +4448,32 @@ export const getPostWithRelations = createReadQuery(
   // invalidation path would re-stale every cached per-post entry on any
   // posts-table mutation; the targeted path only touches the specific post.
   []
+);
+
+// Resolves a post by the author's send time when the canonical id is
+// unknown — e.g. context lens output ids encode the bot's send time, while
+// channel posts are keyed by host receipt time.
+export const getPostBySentAt = createReadQuery(
+  'getPostBySentAt',
+  async (
+    {
+      channelId,
+      authorId,
+      sentAt,
+    }: { channelId: string; authorId: string; sentAt: number },
+    ctx: QueryCtx
+  ): Promise<Post | null> => {
+    return ctx.db.query.posts
+      .findFirst({
+        where: and(
+          eq($posts.channelId, channelId),
+          eq($posts.authorId, authorId),
+          eq($posts.sentAt, sentAt)
+        ),
+      })
+      .then(returnNullIfUndefined);
+  },
+  ['posts']
 );
 
 export const getPersonalGroup = createReadQuery(

--- a/packages/shared/src/db/schema.ts
+++ b/packages/shared/src/db/schema.ts
@@ -1266,3 +1266,23 @@ export const postReactionsRelations = relations(postReactions, ({ one }) => ({
     references: [contacts.id],
   }),
 }));
+
+// Per-run bot introspection records synced from the %steward agent's lens
+// module. Payload is the gateway's run record as structured JSON (inner
+// schemaVersion); see docs/steward.md.
+export const contextLensRuns = sqliteTable(
+  'context_lens_runs',
+  {
+    botShip: text('bot_ship').notNull(),
+    lensId: text('lens_id').notNull(),
+    complete: boolean('complete').notNull().default(false),
+    receivedAt: timestamp('received_at').notNull(),
+    payload: text('payload', { mode: 'json' }),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.botShip, table.lensId] }),
+    receivedAtIndex: index('context_lens_runs_received_at_index').on(
+      table.receivedAt
+    ),
+  })
+);

--- a/packages/shared/src/db/types.ts
+++ b/packages/shared/src/db/types.ts
@@ -105,6 +105,7 @@ export type AttestationStatus = schema.AttestationStatus;
 export type AttestationDiscoverability = schema.AttestationDiscoverability;
 export type AttestationType = schema.AttestationType;
 export type ContactAttestation = BaseModel<'contactAttestations'>;
+export type ContextLensRun = BaseModel<'contextLensRuns'>;
 
 export type Chat = {
   id: string;

--- a/packages/shared/src/logic/contextLens.test.ts
+++ b/packages/shared/src/logic/contextLens.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractLensConversation, lensRunMatchesChannel } from './contextLens';
+
+function payload(chatType: string, conversationId?: string, schemaVersion = 1) {
+  return {
+    schemaVersion,
+    lens: {
+      chatType,
+      triggerDetails: conversationId ? { conversationId } : undefined,
+    },
+  };
+}
+
+describe('extractLensConversation', () => {
+  it('returns null for missing or malformed payloads', () => {
+    expect(extractLensConversation(null)).toBeNull();
+    expect(extractLensConversation(undefined)).toBeNull();
+    expect(extractLensConversation('garbage')).toBeNull();
+    expect(extractLensConversation({})).toBeNull();
+    expect(extractLensConversation({ schemaVersion: 1 })).toBeNull();
+  });
+
+  it('returns null for unknown schema versions', () => {
+    expect(
+      extractLensConversation(payload('channel', 'chat/~zod/general', 2))
+    ).toBeNull();
+  });
+
+  it('returns null for unknown chat types', () => {
+    expect(extractLensConversation(payload('mystery'))).toBeNull();
+  });
+
+  it('extracts chat type and conversation id', () => {
+    expect(
+      extractLensConversation(payload('channel', 'chat/~zod/general'))
+    ).toEqual({ chatType: 'channel', conversationId: 'chat/~zod/general' });
+    expect(extractLensConversation(payload('dm', '~sampel-palnet'))).toEqual({
+      chatType: 'dm',
+      conversationId: '~sampel-palnet',
+    });
+    expect(extractLensConversation(payload('internal'))).toEqual({
+      chatType: 'internal',
+      conversationId: null,
+    });
+  });
+});
+
+describe('lensRunMatchesChannel', () => {
+  it('matches dm runs against the bot DM channel regardless of sig', () => {
+    const run = { botShip: 'malmur-halmex', payload: payload('dm', '~zod') };
+    expect(lensRunMatchesChannel(run, '~malmur-halmex')).toBe(true);
+    const signedRun = {
+      botShip: '~malmur-halmex',
+      payload: payload('dm', '~zod'),
+    };
+    expect(lensRunMatchesChannel(signedRun, '~malmur-halmex')).toBe(true);
+  });
+
+  it('does not match dm runs against other ships or group channels', () => {
+    const run = { botShip: '~malmur-halmex', payload: payload('dm', '~zod') };
+    expect(lensRunMatchesChannel(run, '~sampel-palnet')).toBe(false);
+    expect(lensRunMatchesChannel(run, 'chat/~zod/general')).toBe(false);
+  });
+
+  it('matches channel runs on the trigger nest', () => {
+    const run = {
+      botShip: '~malmur-halmex',
+      payload: payload('channel', 'chat/~zod/general'),
+    };
+    expect(lensRunMatchesChannel(run, 'chat/~zod/general')).toBe(true);
+    expect(lensRunMatchesChannel(run, 'chat/~zod/other')).toBe(false);
+    expect(lensRunMatchesChannel(run, '~malmur-halmex')).toBe(false);
+  });
+
+  it('excludes internal runs and unparseable payloads', () => {
+    expect(
+      lensRunMatchesChannel(
+        { botShip: '~malmur-halmex', payload: payload('internal') },
+        'chat/~zod/general'
+      )
+    ).toBe(false);
+    expect(
+      lensRunMatchesChannel(
+        { botShip: '~malmur-halmex', payload: null },
+        '~malmur-halmex'
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/logic/contextLens.ts
+++ b/packages/shared/src/logic/contextLens.ts
@@ -1,0 +1,85 @@
+import { preSig } from '@tloncorp/api/lib/urbit';
+
+export interface LensConversation {
+  chatType: 'dm' | 'channel' | 'internal';
+  conversationId: string | null;
+}
+
+/**
+ * Pull the conversation coordinates out of a %context-lens run payload
+ * (`{ schemaVersion: 1, lens }`) without depending on the full lens type.
+ */
+export function extractLensConversation(
+  payload: unknown
+): LensConversation | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as { schemaVersion?: unknown; lens?: unknown };
+  if (record.schemaVersion !== 1 || !record.lens) {
+    return null;
+  }
+  const lens = record.lens as {
+    chatType?: unknown;
+    triggerDetails?: { conversationId?: unknown };
+  };
+  if (
+    lens.chatType !== 'dm' &&
+    lens.chatType !== 'channel' &&
+    lens.chatType !== 'internal'
+  ) {
+    return null;
+  }
+  const conversationId = lens.triggerDetails?.conversationId;
+  return {
+    chatType: lens.chatType,
+    conversationId: typeof conversationId === 'string' ? conversationId : null,
+  };
+}
+
+function isDmChannelId(channelId: string) {
+  return channelId.startsWith('~') && !channelId.includes('/');
+}
+
+/**
+ * Whether a lens conversation belongs to the given channel. DM channel ids
+ * are the counterpart ship, so a bot's dm-triggered runs match its DM channel
+ * (by bot ship); group-channel runs match on the trigger's channel nest.
+ *
+ * Shared by both the synced-run path (payload → conversation) and the live
+ * gateway-event path (parsed lens → conversation), so the two stay in sync.
+ */
+export function conversationMatchesChannel(
+  conversation: LensConversation | null,
+  botShip: string | null | undefined,
+  channelId: string
+): boolean {
+  if (!conversation || conversation.chatType === 'internal') {
+    return false;
+  }
+  if (isDmChannelId(channelId)) {
+    return (
+      conversation.chatType === 'dm' &&
+      !!botShip &&
+      preSig(botShip) === preSig(channelId)
+    );
+  }
+  return (
+    conversation.chatType === 'channel' &&
+    conversation.conversationId === channelId
+  );
+}
+
+/**
+ * Whether a synced lens run belongs to the given channel.
+ */
+export function lensRunMatchesChannel(
+  run: { botShip: string; payload: unknown },
+  channelId: string
+): boolean {
+  return conversationMatchesChannel(
+    extractLensConversation(run.payload),
+    run.botShip,
+    channelId
+  );
+}

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -1,4 +1,5 @@
 export * from './utilHooks';
+export * from './contextLens';
 export * from './embed';
 export * from './semver';
 export * from './reactionSupport';

--- a/packages/shared/src/store/dbHooks.ts
+++ b/packages/shared/src/store/dbHooks.ts
@@ -97,6 +97,49 @@ export const useSettings = () => {
   });
 };
 
+export const useContextLensRun = ({
+  botShip,
+  lensId,
+}: {
+  botShip: string;
+  lensId: string;
+}) => {
+  const deps = useKeyFromQueryDeps(db.getContextLensRun);
+  return useQuery({
+    queryKey: ['contextLensRun', deps, botShip, lensId],
+    queryFn: () => db.getContextLensRun({ botShip, lensId }),
+  });
+};
+
+export const useRecentContextLensRuns = (count?: number) => {
+  const deps = useKeyFromQueryDeps(db.getRecentContextLensRuns);
+  return useQuery({
+    queryKey: ['recentContextLensRuns', deps, count],
+    queryFn: () => db.getRecentContextLensRuns({ count }),
+  });
+};
+
+export const useContextLensBotShips = () => {
+  const deps = useKeyFromQueryDeps(db.getContextLensBotShips);
+  return useQuery({
+    queryKey: ['contextLensBotShips', deps],
+    queryFn: () => db.getContextLensBotShips(),
+  });
+};
+
+export const useContextLensBotsInChat = ({
+  chatId,
+}: {
+  chatId: string | null;
+}) => {
+  const deps = useKeyFromQueryDeps(db.getContextLensBotsInChat);
+  return useQuery({
+    queryKey: ['contextLensBotsInChat', deps, chatId],
+    queryFn: () =>
+      chatId ? db.getContextLensBotsInChat({ chatId }) : Promise.resolve([]),
+  });
+};
+
 export const useCalmSettings = () => {
   const deps = useKeyFromQueryDeps(db.getSettings);
   return useQuery({
@@ -644,6 +687,24 @@ export const usePostWithRelations = (
     gcTime: PER_POST_GC_TIME_MS,
     ...(initialData ? { initialData } : {}),
     queryFn: () => (options == null ? null : db.getPostWithRelations(options)),
+  });
+};
+
+export const usePostBySentAt = (
+  options: { channelId: string; authorId: string; sentAt: number } | null
+) => {
+  const deps = useKeyFromQueryDeps(db.getPostBySentAt);
+  return useQuery({
+    enabled: options != null,
+    queryKey: [
+      'postBySentAt',
+      options?.channelId,
+      options?.authorId,
+      options?.sentAt,
+      deps,
+    ],
+    gcTime: PER_POST_GC_TIME_MS,
+    queryFn: () => (options == null ? null : db.getPostBySentAt(options)),
   });
 };
 

--- a/packages/shared/src/store/index.ts
+++ b/packages/shared/src/store/index.ts
@@ -27,4 +27,5 @@ export * from './settingsActions';
 export * from './systemContactActions';
 export * from './blockingActions';
 export * from './metagrabActions';
+export * from './lensActions';
 export { useChannelContext } from './useChannelContext';

--- a/packages/shared/src/store/lensActions.ts
+++ b/packages/shared/src/store/lensActions.ts
@@ -1,0 +1,53 @@
+import * as api from '@tloncorp/api';
+
+import * as db from '../db';
+import { createDevLogger } from '../debug';
+
+const logger = createDevLogger('lensActions', false);
+
+/**
+ * Resolve a lens run db-first: return the locally synced row if present,
+ * otherwise scry the owner ship's %steward agent (lens module) and cache the result.
+ */
+export async function ensureContextLensRun({
+  botShip,
+  lensId,
+}: {
+  botShip: string;
+  lensId: string;
+}): Promise<db.ContextLensRun | null> {
+  const existing = await db.getContextLensRun({ botShip, lensId });
+  if (existing) {
+    return existing;
+  }
+
+  try {
+    const run = await api.getLensRun(botShip, lensId);
+    if (!run) {
+      return null;
+    }
+    await db.insertContextLensRuns([run]);
+    return run;
+  } catch (error) {
+    // covers ships without the %steward agent as well as transient failures;
+    // callers treat null as "run unavailable"
+    logger.log('lens run scry failed', botShip, lensId, error);
+    return null;
+  }
+}
+
+/**
+ * Request a re-run of a failed lens run. Best-effort: the poke acks when our
+ * ship accepts it; success is observable as a new run (trigger "retry")
+ * arriving via lens sync.
+ */
+export async function retryLensRun({
+  botShip,
+  lensId,
+}: {
+  botShip: string;
+  lensId: string;
+}): Promise<void> {
+  logger.log('requesting lens run retry', botShip, lensId);
+  await api.retryLensRun({ botShip, lensId });
+}

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -2271,6 +2271,16 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
         : setupLowPrioritySubscriptions({
             priority: syncStartPriority.low,
           }).then(() => logger.crumb('subscribed low priority')),
+      // On recovery the live subscription persists across the discontinuity,
+      // so setupLowPrioritySubscriptions (and its post-subscribe lens
+      // backfill) is skipped. Rescry /v1/lens directly to recover any events
+      // missed while the SSE connection was down. No-ops on ships without
+      // %steward (syncLensRuns swallows the 404).
+      alreadySubscribed
+        ? syncLensRuns({ priority: syncStartPriority.low + 1 }).then(() =>
+            logger.crumb('finished recovery lens backfill')
+          )
+        : Promise.resolve(),
       resetActivity({ priority: syncStartPriority.low + 1, retry: true }).then(
         () => logger.crumb(`finished resetting activity`)
       ),

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -937,6 +937,28 @@ export const syncPushNotificationsSetting = async (ctx?: SyncCtx) => {
   await db.pushNotificationSettings.setValue(setting);
 };
 
+export async function handleLensUpdate(runs: api.LensRun[]) {
+  logger.log('received lens update', runs.length);
+  await db.insertContextLensRuns(runs);
+}
+
+export const syncLensRuns = async (ctx?: SyncCtx) => {
+  const runs = await syncQueue.add('lensRuns', ctx, async () => {
+    try {
+      return await api.getRecentLensRuns();
+    } catch (e) {
+      // older ships don't have the %steward agent
+      if (e instanceof api.BadResponseError && e.status === 404) {
+        return null;
+      }
+      throw e;
+    }
+  });
+  if (runs) {
+    await db.insertContextLensRuns(runs);
+  }
+};
+
 async function handleLanyardUpdate(update: api.LanyardUpdate) {
   logger.log('received lanyard update', update.type);
   updateLastActivityTime();
@@ -2321,6 +2343,13 @@ export const setupLowPrioritySubscriptions = async (ctx?: SyncCtx) => {
       api.subscribeToStorageUpdates(createHandler(handleStorageUpdate)),
       api.subscribeToLanyardUpdates(handleLanyardUpdate),
       api.subscribeToSettings(createHandler(handleSettingsUpdate)),
+      // returns null (and skips backfill) when the ship lacks the %steward agent
+      api.subscribeToLensUpdates(handleLensUpdate).then((subscribed) => {
+        if (subscribed === null) {
+          return;
+        }
+        return syncLensRuns();
+      }),
     ]);
   });
 };


### PR DESCRIPTION
**Stack 2/4** (on #6007). Lands bot-run records into local storage from the `%steward` lens module; no UI yet.

- `context_lens_runs` table + migration; queries + db hooks (`useContextLensRun`, `useRecentContextLensRuns`, bot-in-chat lookups).
- store: `lensActions` (db-first ensure-run) + sync wiring that subscribes to `/v1/lens` and scry-backfills, no-op when the agent is absent.
- `logic/contextLens`: channel-scoping matchers shared by the synced and live paths.

Flag-gated; inert until the UI lands. Base is the api layer (#6007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)