### PR TITLE
feat(lens): wire the bot-run inspector into the app (4/4)

### DIFF
--- a/packages/app/features/lens/ContextLensRunScreen.tsx
+++ b/packages/app/features/lens/ContextLensRunScreen.tsx
@@ -1,0 +1,130 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { getCanonicalPostId } from '@tloncorp/api/client';
+import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useA2UINavigation } from '../../hooks/useA2UINavigation';
+import type { RootStackParamList } from '../../navigation/types';
+import { ScreenHeader, ScrollView, SizableText, YStack } from '../../ui';
+import {
+  type LensMessageTarget,
+  RunInspector,
+} from '../../ui/components/Channel/ContextLens/RunInspector';
+import { RunSummary } from '../../ui/components/Channel/ContextLens/RunSummary';
+import { lensFromRunPayload } from '../../ui/components/Channel/ContextLens/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ContextLensRun'>;
+
+export function ContextLensRunScreen(props: Props) {
+  const { botShip, lensId } = props.route.params;
+
+  const [resolving, setResolving] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    setResolving(true);
+    // db-first; scries the owner ship's %steward agent on a local miss
+    // and caches the result, which re-renders the query below
+    store.ensureContextLensRun({ botShip, lensId }).finally(() => {
+      if (!cancelled) {
+        setResolving(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [botShip, lensId]);
+
+  const runQuery = store.useContextLensRun({ botShip, lensId });
+  const lens = useMemo(
+    () => (runQuery.data ? lensFromRunPayload(runQuery.data.payload) : null),
+    [runQuery.data]
+  );
+  const loading = runQuery.isLoading || (resolving && !lens);
+
+  const navigateFromA2UI = useA2UINavigation();
+  const handlePressMessage = useCallback(
+    async (target: LensMessageTarget) => {
+      // Lens conversation ids are recorded from the bot's perspective: group
+      // channels are nests (contain '/'), but DMs name the counterparty ship
+      // — which on the owner's client is themselves. DM messages live in the
+      // client's DM channel with the bot, whose id is the bot ship.
+      const channelId = target.channelId?.includes('/')
+        ? target.channelId
+        : botShip;
+      if (!channelId) {
+        return;
+      }
+      // Lens payloads don't record thread parents. Output-row clicks supply
+      // parentId from the resolved local post; trigger-row clicks (which
+      // don't pre-resolve) fall back to a db lookup. Without parentId,
+      // threaded replies dead-end in the channel scroller where they aren't
+      // visible.
+      let parentId: string | undefined = target.parentId;
+      if (!parentId) {
+        try {
+          const post = await db.getPost({
+            postId: getCanonicalPostId(target.postId),
+          });
+          parentId = post?.parentId ?? undefined;
+        } catch {
+          // post not cached locally — fall back to channel navigation
+        }
+      }
+      navigateFromA2UI({
+        type: 'message',
+        channelId,
+        postId: target.postId,
+        parentId,
+        authorId: target.authorId,
+      });
+    },
+    [navigateFromA2UI, botShip]
+  );
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <ScreenHeader
+        title="Bot run"
+        backAction={props.navigation.goBack}
+        borderBottom
+      />
+      {lens ? (
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <YStack gap="$m" padding="$l" paddingBottom="$2xl">
+            <RunSummary
+              lens={lens}
+              onRetry={() => store.retryLensRun({ botShip, lensId })}
+            />
+            <RunInspector lens={lens} onPressMessage={handlePressMessage} />
+          </YStack>
+        </ScrollView>
+      ) : (
+        <YStack
+          alignItems="center"
+          justifyContent="center"
+          minHeight={180}
+          gap="$m"
+          margin="$l"
+          borderWidth={1}
+          borderColor="$border"
+          borderRadius="$m"
+          backgroundColor="$secondaryBackground"
+          padding="$m"
+        >
+          <SizableText size="$m" color="$secondaryText" textAlign="center">
+            {loading
+              ? 'Looking for Lens metadata'
+              : 'No Lens metadata for this run'}
+          </SizableText>
+          {!loading ? (
+            <SizableText size="$s" color="$tertiaryText" textAlign="center">
+              Run records sync from your ship and are retained for about 30
+              days. This run is no longer available.
+            </SizableText>
+          ) : null}
+        </YStack>
+      )}
+    </YStack>
+  );
+}

--- a/packages/app/features/lens/ContextLensRunsScreen.tsx
+++ b/packages/app/features/lens/ContextLensRunsScreen.tsx
@@ -1,0 +1,157 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { lensRunMatchesChannel } from '@tloncorp/shared/logic';
+import * as store from '@tloncorp/shared/store';
+import { Pressable } from '@tloncorp/ui';
+import { useCallback, useMemo } from 'react';
+
+import type { RootStackParamList } from '../../navigation/types';
+import {
+  ScreenHeader,
+  ScrollView,
+  SizableText,
+  View,
+  XStack,
+  YStack,
+} from '../../ui';
+import {
+  TONE_COLORS,
+  formatWallTime,
+  runMeta,
+  runPreview,
+  statusLabel,
+  statusTone,
+} from '../../ui/components/Channel/ContextLens/format';
+import {
+  type ContextLens,
+  lensFromRunPayload,
+} from '../../ui/components/Channel/ContextLens/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ContextLensRuns'>;
+
+type RunRow = { botShip: string; lens: ContextLens };
+
+// Channel filtering happens in JS against the synced payload, so widen the
+// fetch when scoped to a channel; otherwise the default-50 page can crop out
+// older channel runs whenever there are more recent runs elsewhere. Runs are
+// retained for ~30 days, so this caps well above any realistic per-user load.
+const CHANNEL_FILTER_RUN_LIMIT = 500;
+
+export function ContextLensRunsScreen(props: Props) {
+  const channelId = props.route.params?.channelId;
+  const recentRunsQuery = store.useRecentContextLensRuns(
+    channelId ? CHANNEL_FILTER_RUN_LIMIT : undefined
+  );
+
+  const rows: RunRow[] = useMemo(
+    () =>
+      (recentRunsQuery.data ?? []).flatMap((row) => {
+        if (channelId && !lensRunMatchesChannel(row, channelId)) {
+          return [];
+        }
+        const lens = lensFromRunPayload(row.payload);
+        return lens ? [{ botShip: row.botShip, lens }] : [];
+      }),
+    [recentRunsQuery.data, channelId]
+  );
+
+  const openRun = useCallback(
+    (row: RunRow) => {
+      props.navigation.push('ContextLensRun', {
+        botShip: row.botShip,
+        lensId: row.lens.lensId,
+        channelId,
+      });
+    },
+    [props.navigation, channelId]
+  );
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <ScreenHeader
+        title={channelId ? 'Bot runs in this channel' : 'Bot runs'}
+        backAction={props.navigation.goBack}
+        borderBottom
+      />
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <YStack gap="$xs" padding="$l" paddingBottom="$2xl">
+          {rows.map((row) => {
+            const tone = TONE_COLORS[statusTone(row.lens.status)];
+            return (
+              <Pressable
+                key={`${row.botShip}/${row.lens.lensId}`}
+                onPress={() => openRun(row)}
+                cursor="pointer"
+                gap="$2xs"
+                minWidth={0}
+                borderWidth={1}
+                borderColor="$border"
+                borderLeftWidth={2}
+                borderLeftColor={tone}
+                borderRadius="$s"
+                paddingHorizontal="$s"
+                paddingVertical="$xs"
+                backgroundColor="$background"
+              >
+                <XStack
+                  alignItems="center"
+                  justifyContent="space-between"
+                  gap="$s"
+                >
+                  <XStack alignItems="center" gap="$xs" flex={1} minWidth={0}>
+                    <View
+                      width={7}
+                      height={7}
+                      borderRadius={999}
+                      backgroundColor={tone}
+                    />
+                    <SizableText
+                      size="$s"
+                      color="$primaryText"
+                      flex={1}
+                      minWidth={0}
+                      numberOfLines={1}
+                    >
+                      {statusLabel(row.lens.status)}
+                    </SizableText>
+                  </XStack>
+                  <SizableText size="$s" color="$tertiaryText" flexShrink={0}>
+                    {formatWallTime(row.lens.updatedAt)}
+                  </SizableText>
+                </XStack>
+                <SizableText size="$s" color="$secondaryText" numberOfLines={2}>
+                  {runPreview(row.lens)}
+                </SizableText>
+                <SizableText size="$s" color="$tertiaryText">
+                  {runMeta(row.lens)}
+                </SizableText>
+              </Pressable>
+            );
+          })}
+          {!rows.length ? (
+            <YStack
+              alignItems="center"
+              justifyContent="center"
+              minHeight={180}
+              gap="$m"
+              borderWidth={1}
+              borderColor="$border"
+              borderRadius="$m"
+              backgroundColor="$secondaryBackground"
+              padding="$m"
+            >
+              <SizableText size="$m" color="$secondaryText" textAlign="center">
+                {recentRunsQuery.isLoading
+                  ? 'Loading bot runs'
+                  : 'No bot runs yet'}
+              </SizableText>
+              <SizableText size="$s" color="$tertiaryText" textAlign="center">
+                Run records sync from your ship and are retained for about 30
+                days.
+              </SizableText>
+            </YStack>
+          ) : null}
+        </YStack>
+      </ScrollView>
+    </YStack>
+  );
+}

--- a/packages/app/features/settings/FeatureFlagScreen.tsx
+++ b/packages/app/features/settings/FeatureFlagScreen.tsx
@@ -23,6 +23,32 @@ export function FeatureFlagScreen({ navigation }: Props) {
     [setEnabled]
   );
 
+  const contextLensGatewayUrl = db.contextLensGatewayUrl.useValue();
+  const contextLensGatewayToken = db.contextLensGatewayToken.useValue();
+  const textSettings = useMemo(() => {
+    if (!flags.contextLens) {
+      return undefined;
+    }
+    return [
+      {
+        key: 'contextLensGatewayUrl',
+        label: 'Context lens gateway URL',
+        value: contextLensGatewayUrl ?? '',
+        placeholder: 'http://localhost:18789',
+        onChange: (value: string) =>
+          db.contextLensGatewayUrl.setValue(value.trim() || null),
+      },
+      {
+        key: 'contextLensGatewayToken',
+        label: 'Context lens gateway token',
+        value: contextLensGatewayToken ?? '',
+        secure: true,
+        onChange: (value: string) =>
+          db.contextLensGatewayToken.setValue(value.trim() || null),
+      },
+    ];
+  }, [flags.contextLens, contextLensGatewayUrl, contextLensGatewayToken]);
+
   const isTlonEmployee = db.isTlonEmployee.useValue();
   const features = useMemo(
     () =>
@@ -44,6 +70,7 @@ export function FeatureFlagScreen({ navigation }: Props) {
   return (
     <FeatureFlagScreenView
       features={features}
+      textSettings={textSettings}
       onBackPressed={handleGoBackPressed}
       onFlagToggled={handleFeatureFlagToggled}
     />

--- a/packages/app/features/top/ChannelScreen.tsx
+++ b/packages/app/features/top/ChannelScreen.tsx
@@ -145,8 +145,14 @@ export default function ChannelScreen(props: Props) {
     }
   }, [currentChannelId, isFocused]);
 
-  const { navigateToImage, navigateToPost, navigateToRef, navigateToSearch } =
-    useChannelNavigation({ channelId: currentChannelId });
+  const {
+    navigateToImage,
+    navigateToPost,
+    navigateToRef,
+    navigateToSearch,
+    navigateToContextLensRuns,
+    navigateToContextLensRun,
+  } = useChannelNavigation({ channelId: currentChannelId });
   const { navigation } = useRootNavigation();
   const navigationRef = useRef(props.navigation);
   const isWindowNarrow = useIsWindowNarrow();
@@ -435,6 +441,8 @@ export default function ChannelScreen(props: Props) {
           goToMediaViewer={navigateToImage}
           goToChatDetails={handleChatDetailsPressed}
           goToSearch={navigateToSearch}
+          goToContextLensRuns={navigateToContextLensRuns}
+          goToContextLensRun={navigateToContextLensRun}
           goToDm={handleGoToDm}
           goToUserProfile={handleGoToUserProfile}
           goToChannelDetails={handleGoToChannelDetails}

--- a/packages/app/features/top/PostScreen.tsx
+++ b/packages/app/features/top/PostScreen.tsx
@@ -72,7 +72,11 @@ function PostScreenContent({
       }),
     });
 
-  const { navigateToImage } = useChannelNavigation({
+  const {
+    navigateToImage,
+    navigateToContextLensRuns,
+    navigateToContextLensRun,
+  } = useChannelNavigation({
     channelId: channelId,
   });
 
@@ -145,6 +149,8 @@ function PostScreenContent({
       onPressRetry={handleRetrySend}
       onGroupAction={performGroupAction}
       goToDm={handleGoToDm}
+      goToContextLensRuns={navigateToContextLensRuns}
+      goToContextLensRun={navigateToContextLensRun}
       negotiationMatch={negotiationStatus.matchedOrPending}
       selectedPostId={selectedPostId}
       // NB: If we're showing posts in a carousel, all carousel items share the

--- a/packages/app/hooks/useChannelNavigation.ts
+++ b/packages/app/hooks/useChannelNavigation.ts
@@ -95,10 +95,23 @@ export const useChannelNavigation = ({ channelId }: { channelId: string }) => {
     });
   }, [navigation, channelQuery.data]);
 
+  const navigateToContextLensRuns = useCallback(() => {
+    navigation.push('ContextLensRuns', { channelId });
+  }, [navigation, channelId]);
+
+  const navigateToContextLensRun = useCallback(
+    ({ botShip, lensId }: { botShip: string; lensId: string }) => {
+      navigation.push('ContextLensRun', { botShip, lensId, channelId });
+    },
+    [navigation, channelId]
+  );
+
   return {
     navigateToPost,
     navigateToRef,
     navigateToImage,
     navigateToSearch,
+    navigateToContextLensRuns,
+    navigateToContextLensRun,
   };
 };

--- a/packages/app/navigation/RootStack.tsx
+++ b/packages/app/navigation/RootStack.tsx
@@ -8,6 +8,8 @@ import { ChannelMetaScreen } from '../features/channels/ChannelMetaScreen';
 import { ChannelTemplateScreen } from '../features/channels/ChannelTemplateScreen';
 import { AddContactsScreen } from '../features/contacts/AddContactsScreen';
 import { InviteSystemContactsScreen } from '../features/contacts/InviteSystemContactsScreen';
+import { ContextLensRunScreen } from '../features/lens/ContextLensRunScreen';
+import { ContextLensRunsScreen } from '../features/lens/ContextLensRunsScreen';
 import { AttestationScreen } from '../features/profile/AttestationScreen';
 import { AppInfoScreen } from '../features/settings/AppInfoScreen';
 import { BlockedUsersScreen } from '../features/settings/BlockedUsersScreen';
@@ -96,6 +98,8 @@ export function RootStack() {
       <Root.Screen name="DM" component={ChannelScreen} />
       <Root.Screen name="GroupDM" component={ChannelScreen} />
       <Root.Screen name="ChannelSearch" component={ChannelSearchScreen} />
+      <Root.Screen name="ContextLensRuns" component={ContextLensRunsScreen} />
+      <Root.Screen name="ContextLensRun" component={ContextLensRunScreen} />
       <Root.Screen name="Post" component={PostScreen} />
       <Root.Screen name="GroupChannels" component={GroupChannelsScreen} />
       <Root.Screen

--- a/packages/app/navigation/linking.ts
+++ b/packages/app/navigation/linking.ts
@@ -28,6 +28,11 @@ export const getMobileLinkingConfig = (
           },
           ChatList: 'ChatList',
           ChannelSearch: { path: 'channel/:channelId/search' },
+          ContextLensRuns: { path: 'lens/runs' },
+          ContextLensRun: {
+            path: 'lens/run/:botShip/:lensId',
+            parse: parsePathParams('botShip', 'lensId'),
+          },
           Post: postScreenConfig(mode),
           MediaViewer: 'media-viewer/:mediaType',
           ChatDetails: {

--- a/packages/app/navigation/types.ts
+++ b/packages/app/navigation/types.ts
@@ -36,6 +36,14 @@ export type RootStackParamList = {
     channelId: string;
     groupId: string;
   };
+  ContextLensRuns: {
+    channelId?: string;
+  };
+  ContextLensRun: {
+    botShip: string;
+    lensId: string;
+    channelId?: string;
+  };
   Post: {
     postId: string;
     channelId: string;

--- a/packages/app/ui/components/Channel/ChannelHeader.tsx
+++ b/packages/app/ui/components/Channel/ChannelHeader.tsx
@@ -90,6 +90,9 @@ export function ChannelHeader({
   goToEdit,
   goToChatDetails,
   goToProfile,
+  onToggleContextLens,
+  contextLensOpen = false,
+  contextLensActive = false,
   showSpinner,
   loadingSubtitle = 'Loading messages…',
   showSearchButton = false,
@@ -106,6 +109,9 @@ export function ChannelHeader({
   goToEdit?: () => void;
   goToChatDetails?: () => void;
   goToProfile?: () => void;
+  onToggleContextLens?: () => void;
+  contextLensOpen?: boolean;
+  contextLensActive?: boolean;
   showSpinner?: boolean;
   loadingSubtitle?: string;
   showSearchButton?: boolean;
@@ -353,6 +359,17 @@ export function ChannelHeader({
             >
               Edit
             </ScreenHeader.TextButton>
+          )}
+          {onToggleContextLens && (
+            <ScreenHeader.IconButton
+              type="RightSidebar"
+              onPress={onToggleContextLens}
+              testID="ContextLensHeaderButton"
+              color={contextLensActive ? '$positiveActionText' : '$primaryText'}
+              backgroundColor={
+                contextLensOpen ? '$secondaryBackground' : 'transparent'
+              }
+            />
           )}
         </>
       }

--- a/packages/app/ui/components/Channel/Scroller.tsx
+++ b/packages/app/ui/components/Channel/Scroller.tsx
@@ -49,6 +49,7 @@ import { ChatMessageActions } from '../ChatMessage/ChatMessageActions/Component'
 import { ViewReactionsSheet } from '../ChatMessage/ViewReactionsSheet';
 import { EmojiPickerSheet } from '../Emoji';
 import { ChannelDivider } from './ChannelDivider';
+import { ContextLensRunSheet } from './ContextLens/ContextLensRunSheet';
 import { PostList, PostListMethods } from './PostList';
 import type { ScrollAnchor } from './scrollerTypes';
 
@@ -99,6 +100,7 @@ const Scroller = forwardRef(
       listHeaderComponent,
       listBottomComponent,
       highlightPostId,
+      onGoToBotRun,
     }: {
       anchor?: ScrollAnchor | null;
       showDividers?: boolean;
@@ -137,6 +139,7 @@ const Scroller = forwardRef(
       listHeaderComponent?: React.ReactElement;
       listBottomComponent?: React.ReactElement;
       highlightPostId?: string | null;
+      onGoToBotRun?: (params: { botShip: string; lensId: string }) => void;
     },
     ref
   ) => {
@@ -175,7 +178,12 @@ const Scroller = forwardRef(
     const [viewReactionsPost, setViewReactionsPost] = useState<null | db.Post>(
       null
     );
+    const [viewBotRunPost, setViewBotRunPost] = useState<null | db.Post>(null);
     const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
+
+    const handlePressBotRun = useCallback((post: db.Post) => {
+      setViewBotRunPost(post);
+    }, []);
 
     const listRef = useRef<PostListMethods>(null);
 
@@ -291,6 +299,7 @@ const Scroller = forwardRef(
             Component={renderItem}
             unreadCount={unreadCount}
             setViewReactionsPost={setViewReactionsPost}
+            onPressBotRun={handlePressBotRun}
             onPressRetry={onPressRetry}
             onPressDelete={onPressDelete}
             showReplies={showReplies}
@@ -333,6 +342,7 @@ const Scroller = forwardRef(
         onPressDelete,
         onPressRetry,
         handlePostLongPressed,
+        handlePressBotRun,
         activeMessage,
         showDividers,
         collectionLayout.dividersEnabled,
@@ -572,6 +582,10 @@ const Scroller = forwardRef(
                 setViewReactionsPost(post);
                 setActiveMessage(null);
               }}
+              onViewBotRun={(post) => {
+                setViewBotRunPost(post);
+                setActiveMessage(null);
+              }}
               mode="immediate"
             />
           </Modal>
@@ -591,6 +605,14 @@ const Scroller = forwardRef(
             post={viewReactionsPost}
             open
             onOpenChange={() => setViewReactionsPost(null)}
+          />
+        ) : null}
+        {viewBotRunPost ? (
+          <ContextLensRunSheet
+            post={viewBotRunPost}
+            open
+            onOpenChange={() => setViewBotRunPost(null)}
+            onExpand={onGoToBotRun}
           />
         ) : null}
       </View>
@@ -624,6 +646,7 @@ const BaseScrollerItem = ({
   unreadCount,
   onLayout,
   setViewReactionsPost,
+  onPressBotRun,
   showReplies,
   onPressImage,
   onPressReplies,
@@ -656,6 +679,7 @@ const BaseScrollerItem = ({
   onPressReplies?: (post: db.Post) => void;
   showReplies?: boolean;
   setViewReactionsPost?: (post: db.Post) => void;
+  onPressBotRun?: (post: db.Post) => void;
   onPressPost?: (post: db.Post) => void;
   onLongPressPost: (post: db.Post) => void;
   onPressRetry?: (post: db.Post) => Promise<void>;
@@ -764,6 +788,7 @@ const BaseScrollerItem = ({
           displayDebugMode={displayDebugMode}
           post={post}
           setViewReactionsPost={setViewReactionsPost}
+          onPressBotRun={onPressBotRun}
           showAuthor={showAuthorLive}
           showReplies={showReplies}
           onPressReplies={post.isDeleted ? undefined : onPressReplies}
@@ -804,6 +829,7 @@ const ScrollerItem = React.memo(BaseScrollerItem, (prev, next) => {
     prev.onPressImage === next.onPressImage &&
     prev.onPressPost === next.onPressPost &&
     prev.onLongPressPost === next.onLongPressPost &&
+    prev.onPressBotRun === next.onPressBotRun &&
     prev.activeMessage === next.activeMessage &&
     prev.itemWidth === next.itemWidth &&
     prev.displayDebugMode === next.displayDebugMode &&

--- a/packages/app/ui/components/Channel/index.tsx
+++ b/packages/app/ui/components/Channel/index.tsx
@@ -28,6 +28,7 @@ import { Alert, Platform } from 'react-native';
 import {
   AnimatePresence,
   View,
+  XStack,
   YStack,
   getVariableValue,
   useTheme,
@@ -61,6 +62,7 @@ import {
   PostCollectionHandle,
 } from '../postCollectionViews/shared';
 import { ChannelHeader, ChannelHeaderItemsProvider } from './ChannelHeader';
+import { ContextLensPanel, useContextLensController } from './ContextLens';
 import { DmInviteOptions } from './DmInviteOptions';
 import { DraftInputView } from './DraftInputView';
 import { PinnedPostBanner } from './PinnedPostBanner';
@@ -270,6 +272,8 @@ interface ChannelProps {
   goToGroupSettings: () => void;
   goToMediaViewer: (post: db.Post, imageUri?: string) => void;
   goToSearch: () => void;
+  goToContextLensRuns?: () => void;
+  goToContextLensRun?: (params: { botShip: string; lensId: string }) => void;
   goToUserProfile: (userId: string) => void;
   goToChannelDetails?: (groupId: string, channelId: string) => void;
   onScrollEndReached?: () => void;
@@ -312,6 +316,8 @@ export function Channel({
   goBack,
   goToChatDetails,
   goToSearch,
+  goToContextLensRuns,
+  goToContextLensRun,
   goToMediaViewer,
   goToPost,
   goToDm,
@@ -675,6 +681,16 @@ export function Channel({
   });
 
   const isNarrow = useIsWindowNarrow();
+  const {
+    contextLensAvailable,
+    contextLensOpen,
+    contextLensActive,
+    contextLensStream,
+    selectedContextLensMessage,
+    toggleContextLens,
+    clearSelectedContextLensMessage,
+    inspectContextLensPost,
+  } = useContextLensController({ channel });
 
   const backgroundColor = getVariableValue(useTheme().background);
 
@@ -748,6 +764,17 @@ export function Channel({
                             goToChatDetails={goToChatDetails}
                             goToProfile={handleGoToProfile}
                             goToSearch={goToSearch}
+                            onToggleContextLens={
+                              contextLensAvailable
+                                ? isNarrow && goToContextLensRuns
+                                  ? goToContextLensRuns
+                                  : toggleContextLens
+                                : undefined
+                            }
+                            contextLensOpen={
+                              contextLensAvailable && contextLensOpen
+                            }
+                            contextLensActive={contextLensActive}
                             showSpinner={showHeaderLoading}
                             showSearchButton={
                               channel.type === 'chat' ||
@@ -762,115 +789,142 @@ export function Channel({
                             onPressPost={goToPost}
                           />
                         )}
-                        <YStack alignItems="stretch" flex={1}>
-                          {includeJoinRequestNotice && (
-                            <SystemNotices.ConnectedJoinRequestNotice
-                              group={group}
-                              onViewRequests={goToGroupSettings}
-                            />
-                          )}
-                          <AnimatePresence>
-                            {draftInputPresentationMode !== 'fullscreen' && (
-                              <View flex={1}>
-                                <PostCollectionContext.Provider
-                                  value={{
-                                    channel,
-                                    collectionConfiguration:
-                                      channel.contentConfiguration == null
-                                        ? undefined
-                                        : ChannelContentConfiguration.defaultPostCollectionRenderer(
-                                            channel.contentConfiguration
-                                          ).configuration,
-                                    editingPost,
-                                    goToMediaViewer,
-                                    goToPost,
-                                    hasNewerPosts,
-                                    hasOlderPosts,
-                                    initialChannelUnread,
-                                    isLoadingPosts: isLoadingPosts ?? false,
-                                    loadPostsError,
-                                    onPressDelete,
-                                    onPressRetrySend,
-                                    onPressRetryLoad,
-                                    onScrollEndReached,
-                                    onScrollStartReached,
-                                    posts: posts ?? undefined,
-                                    scrollToBottom: onPressScrollToBottom,
-                                    selectedPostId,
-                                    setEditingPost,
-                                    LegacyPostView: PostView,
-                                    PostView: ConnectedPostView,
-                                  }}
-                                >
-                                  <PostCollectionView
-                                    collectionRef={collectionRef}
-                                    channel={channel}
-                                  />
-                                </PostCollectionContext.Provider>
-                              </View>
+                        <XStack
+                          alignItems="stretch"
+                          flex={1}
+                          position="relative"
+                        >
+                          <YStack alignItems="stretch" flex={1} minWidth={0}>
+                            {includeJoinRequestNotice && (
+                              <SystemNotices.ConnectedJoinRequestNotice
+                                group={group}
+                                onViewRequests={goToGroupSettings}
+                              />
                             )}
-                          </AnimatePresence>
-
-                          {!canRead ||
-                          !canWrite ||
-                          !negotiationMatch ||
-                          (channel.groupId && !group && !groupIsLoading) ? (
-                            <ReadOnlyNotice
-                              type={
-                                channel.groupId && !group && !groupIsLoading
-                                  ? 'group-deleted'
-                                  : !canRead
-                                    ? 'no-longer-read'
-                                    : !canWrite
-                                      ? 'read-only'
-                                      : isDM
-                                        ? 'dm-mismatch'
-                                        : isGroupDm
-                                          ? 'group-dm-mismatch'
-                                          : 'channel-mismatch'
-                              }
-                            />
-                          ) : channel.contentConfiguration == null ? (
-                            <>
-                              {isChatChannel && !channel.isDmInvite && (
-                                <DraftInputView
-                                  draftInputContext={draftInputContext}
-                                  type={DraftInputId.chat}
-                                />
+                            <AnimatePresence>
+                              {draftInputPresentationMode !== 'fullscreen' && (
+                                <View flex={1}>
+                                  <PostCollectionContext.Provider
+                                    value={{
+                                      channel,
+                                      collectionConfiguration:
+                                        channel.contentConfiguration == null
+                                          ? undefined
+                                          : ChannelContentConfiguration.defaultPostCollectionRenderer(
+                                              channel.contentConfiguration
+                                            ).configuration,
+                                      editingPost,
+                                      goToMediaViewer,
+                                      goToPost,
+                                      inspectContextLensPost:
+                                        contextLensAvailable && contextLensOpen
+                                          ? inspectContextLensPost
+                                          : undefined,
+                                      goToBotRun:
+                                        contextLensAvailable && isNarrow
+                                          ? goToContextLensRun
+                                          : undefined,
+                                      hasNewerPosts,
+                                      hasOlderPosts,
+                                      initialChannelUnread,
+                                      isLoadingPosts: isLoadingPosts ?? false,
+                                      loadPostsError,
+                                      onPressDelete,
+                                      onPressRetrySend,
+                                      onPressRetryLoad,
+                                      onScrollEndReached,
+                                      onScrollStartReached,
+                                      posts: posts ?? undefined,
+                                      scrollToBottom: onPressScrollToBottom,
+                                      selectedPostId,
+                                      setEditingPost,
+                                      LegacyPostView: PostView,
+                                      PostView: ConnectedPostView,
+                                    }}
+                                  >
+                                    <PostCollectionView
+                                      collectionRef={collectionRef}
+                                      channel={channel}
+                                    />
+                                  </PostCollectionContext.Provider>
+                                </View>
                               )}
+                            </AnimatePresence>
 
-                              {channel.type === 'gallery' && (
-                                <DraftInputView
-                                  draftInputContext={draftInputContext}
-                                  type={DraftInputId.gallery}
-                                />
-                              )}
+                            {!canRead ||
+                            !canWrite ||
+                            !negotiationMatch ||
+                            (channel.groupId && !group && !groupIsLoading) ? (
+                              <ReadOnlyNotice
+                                type={
+                                  channel.groupId && !group && !groupIsLoading
+                                    ? 'group-deleted'
+                                    : !canRead
+                                      ? 'no-longer-read'
+                                      : !canWrite
+                                        ? 'read-only'
+                                        : isDM
+                                          ? 'dm-mismatch'
+                                          : isGroupDm
+                                            ? 'group-dm-mismatch'
+                                            : 'channel-mismatch'
+                                }
+                              />
+                            ) : channel.contentConfiguration == null ? (
+                              <>
+                                {isChatChannel && !channel.isDmInvite && (
+                                  <DraftInputView
+                                    draftInputContext={draftInputContext}
+                                    type={DraftInputId.chat}
+                                  />
+                                )}
 
-                              {channel.type === 'notebook' && (
-                                <DraftInputView
-                                  draftInputContext={draftInputContext}
-                                  type={DraftInputId.notebook}
-                                />
-                              )}
-                            </>
-                          ) : (
-                            <DraftInputView
-                              draftInputContext={draftInputContext}
-                              type={
-                                ChannelContentConfiguration.draftInput(
-                                  channel.contentConfiguration
-                                ).id
-                              }
-                            />
-                          )}
+                                {channel.type === 'gallery' && (
+                                  <DraftInputView
+                                    draftInputContext={draftInputContext}
+                                    type={DraftInputId.gallery}
+                                  />
+                                )}
 
-                          {channel.isDmInvite && (
-                            <DmInviteOptions
-                              channel={channel}
-                              goBack={goBack}
-                            />
-                          )}
-                        </YStack>
+                                {channel.type === 'notebook' && (
+                                  <DraftInputView
+                                    draftInputContext={draftInputContext}
+                                    type={DraftInputId.notebook}
+                                  />
+                                )}
+                              </>
+                            ) : (
+                              <DraftInputView
+                                draftInputContext={draftInputContext}
+                                type={
+                                  ChannelContentConfiguration.draftInput(
+                                    channel.contentConfiguration
+                                  ).id
+                                }
+                              />
+                            )}
+
+                            {channel.isDmInvite && (
+                              <DmInviteOptions
+                                channel={channel}
+                                goBack={goBack}
+                              />
+                            )}
+                          </YStack>
+                          {contextLensAvailable &&
+                            contextLensOpen &&
+                            !isNarrow && (
+                              <ContextLensPanel
+                                events={contextLensStream.events}
+                                streamStatus={contextLensStream.status}
+                                selectedMessage={selectedContextLensMessage}
+                                onClearSelectedMessage={
+                                  clearSelectedContextLensMessage
+                                }
+                                channelId={channel.id}
+                              />
+                            )}
+                        </XStack>
                         <GroupPreviewSheet
                           group={groupPreview ?? undefined}
                           open={!!groupPreview}

--- a/packages/app/ui/components/ChatMessage/ChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessage.tsx
@@ -29,6 +29,7 @@ const ChatMessage = ({
   onPress,
   onLongPress,
   onPressRetry,
+  onPressBotRun,
   onShowEmojiPicker,
   onPressEdit,
   showReplies,
@@ -48,6 +49,7 @@ const ChatMessage = ({
   onPress?: (post: db.Post) => void;
   onLongPress?: (post: db.Post) => void;
   onPressRetry?: (post: db.Post) => Promise<void>;
+  onPressBotRun?: (post: db.Post) => void;
   onPressDelete?: (post: db.Post) => void;
   onShowEmojiPicker?: (post: db.Post) => void;
   onPressEdit?: (post: db.Post) => void;
@@ -127,6 +129,7 @@ const ChatMessage = ({
             hideSentAtTimestamp: hideOverflowMenu || !isHovered,
             isHighlighted,
             onLongPress,
+            onPressBotRun,
             onPressImage,
             onPressReplies,
             onPressRetry,
@@ -150,6 +153,7 @@ const ChatMessage = ({
               onReply={handleRepliesPressed}
               onEdit={handleEditPressed}
               onViewReactions={setViewReactionsPost}
+              onViewBotRun={onPressBotRun}
               onShowEmojiPicker={handleEmojiPickerPressed}
               trigger={<OverflowTriggerButton testID="MessageActionsTrigger" />}
               mode="await-trigger"
@@ -172,6 +176,7 @@ export default memo(ChatMessage, (prev, next) => {
     prev.onPressImage === next.onPressImage &&
     prev.onLongPress === next.onLongPress &&
     prev.onPress === next.onPress &&
+    prev.onPressBotRun === next.onPressBotRun &&
     prev.searchQuery === next.searchQuery &&
     prev.displayDebugMode === next.displayDebugMode;
 

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.android.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.android.tsx
@@ -17,6 +17,7 @@ export function ChatMessageActions({
   onReply,
   onEdit,
   onViewReactions,
+  onViewBotRun,
   onShowEmojiPicker,
 }: ChatMessageActionsProps) {
   const [topOffset, setTopOffset] = useState(0);
@@ -71,6 +72,7 @@ export function ChatMessageActions({
             onReply={onReply}
             onEdit={onEdit}
             onViewReactions={onViewReactions}
+            onViewBotRun={onViewBotRun}
           />
         </YStack>
       </View>

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/Component.tsx
@@ -35,6 +35,7 @@ export function ChatMessageActions({
   onReply,
   onEdit,
   onViewReactions,
+  onViewBotRun,
   onShowEmojiPicker,
   trigger,
   onOpenChange,
@@ -176,6 +177,7 @@ export function ChatMessageActions({
                 onReply={onReply}
                 onEdit={onEdit}
                 onViewReactions={onViewReactions}
+                onViewBotRun={onViewBotRun}
               />
             </YStack>
           </Popover.Content>
@@ -208,6 +210,7 @@ export function ChatMessageActions({
                 onReply={onReply}
                 onEdit={onEdit}
                 onViewReactions={onViewReactions}
+                onViewBotRun={onViewBotRun}
               />
             </YStack>
           </View>

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -16,6 +16,8 @@ import { useAttachmentContext } from '../../../contexts/attachment';
 import { useChannelContext } from '../../../contexts/channel';
 import { triggerHaptic, useIsAdmin } from '../../../utils';
 import ActionList from '../../ActionList';
+import { getContextLensStamp } from '../../Channel/ContextLens/lensPost';
+import { useContextLensAvailable } from '../../Channel/ContextLens/useContextLensStore';
 import { useForwardPostSheet } from '../../ForwardPostSheet';
 import {
   DraftInputContext,
@@ -36,14 +38,25 @@ export default function MessageActions({
   postActionIds,
   onEdit,
   onViewReactions,
+  onViewBotRun,
 }: {
   dismiss: () => void;
   onReply?: (post: db.Post) => void;
   onEdit?: () => void;
   onViewReactions?: (post: db.Post) => void;
+  onViewBotRun?: (post: db.Post) => void;
   post: db.Post;
   postActionIds: ChannelAction.Id[];
 }) {
+  const contextLensAvailable = useContextLensAvailable();
+  const showViewBotRun = useMemo(
+    () =>
+      Boolean(
+        contextLensAvailable && onViewBotRun && getContextLensStamp(post)
+      ),
+    [contextLensAvailable, onViewBotRun, post]
+  );
+
   // arbitrary width that looks reasonable given labels
   const width = isWeb ? 'auto' : 220;
   return (
@@ -51,7 +64,7 @@ export default function MessageActions({
       {postActionIds.map((actionId, index, list) => (
         <ConnectedAction
           key={actionId}
-          last={index === list.length - 1 && !__DEV__}
+          last={index === list.length - 1 && !__DEV__ && !showViewBotRun}
           {...{
             dismiss,
             onReply,
@@ -62,6 +75,14 @@ export default function MessageActions({
           }}
         />
       ))}
+      {showViewBotRun && onViewBotRun ? (
+        <ViewBotRunAction
+          post={post}
+          dismiss={dismiss}
+          onViewBotRun={onViewBotRun}
+          last={!__DEV__}
+        />
+      ) : null}
       {ENABLE_COPY_JSON ? <CopyJsonAction post={post} /> : null}
     </ActionList>
   );
@@ -219,6 +240,38 @@ const ConnectedAction = memo(function ConnectedAction({
     </ActionList.Action>
   );
 });
+
+function ViewBotRunAction({
+  post,
+  dismiss,
+  onViewBotRun,
+  last,
+}: {
+  post: db.Post;
+  dismiss: () => void;
+  onViewBotRun: (post: db.Post) => void;
+  last?: boolean;
+}) {
+  return (
+    <ActionList.Action
+      height="auto"
+      last={last}
+      onPress={() => {
+        // On iOS, dismiss the actions modal first to avoid a race between
+        // two modals (see the 'forward' action above)
+        if (Platform.OS === 'ios') {
+          dismiss();
+          setTimeout(() => onViewBotRun(post), 300);
+        } else {
+          onViewBotRun(post);
+          dismiss();
+        }
+      }}
+    >
+      View bot run
+    </ActionList.Action>
+  );
+}
 
 function CopyJsonAction({ post }: { post: db.Post }) {
   const jsonString = useMemo(() => {

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/types.ts
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/types.ts
@@ -15,6 +15,7 @@ export type ChatMessageActionsProps = {
   onReply?: (post: db.Post) => void;
   onEdit?: () => void;
   onViewReactions?: (post: db.Post) => void;
+  onViewBotRun?: (post: db.Post) => void;
   onShowEmojiPicker?: () => void;
   trigger?: React.ReactNode;
   mode: 'await-trigger' | 'immediate';

--- a/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
+++ b/packages/app/ui/components/ChatMessage/StaticChatMessage.tsx
@@ -9,6 +9,7 @@ import { CHAT_REF_LIKE_MAX_WIDTH } from '../../../constants';
 import { useA2UINavigation } from '../../../hooks/useA2UINavigation';
 import { getPostImageViewerId } from '../../../utils/mediaViewer';
 import AuthorRow from '../AuthorRow';
+import { ContextLensBadge } from '../Channel/ContextLens/ContextLensBadge';
 import { A2UIBlock } from '../PostContent/A2UIBlock';
 import { DefaultRendererProps } from '../PostContent/BlockRenderer';
 import { createContentRenderer } from '../PostContent/ContentRenderer';
@@ -34,6 +35,7 @@ export function StaticChatMessage({
   hideSentAtTimestamp,
   isHighlighted,
   onLongPress,
+  onPressBotRun,
   onPressImage,
   onPressReplies,
   onPressRetry,
@@ -49,6 +51,7 @@ export function StaticChatMessage({
   hideSentAtTimestamp?: boolean;
   isHighlighted?: boolean;
   onLongPress?: (post: db.Post) => void;
+  onPressBotRun?: (post: db.Post) => void;
   onPressDelete?: (post: db.Post) => void;
   onPressImage?: (post: db.Post, imageUri?: string) => void;
   onPressReplies?: (post: db.Post) => void;
@@ -240,6 +243,8 @@ export function StaticChatMessage({
           />
         )}
       </View>
+
+      <ContextLensBadge post={post} onPress={onPressBotRun} />
 
       {post.reactions && post.reactions.length > 0 && (
         <View paddingBottom="$l" paddingLeft="$4xl">

--- a/packages/app/ui/components/DetailView.tsx
+++ b/packages/app/ui/components/DetailView.tsx
@@ -20,6 +20,8 @@ export interface DetailViewProps {
   goBack?: () => void;
   onPressRetry?: (post: db.Post) => Promise<void>;
   onPressDelete: (post: db.Post) => void;
+  inspectContextLensPost?: (post: db.Post) => void;
+  onGoToBotRun?: (params: { botShip: string; lensId: string }) => void;
   setActiveMessage: (post: db.Post | null) => void;
   activeMessage: db.Post | null;
   anchor?: ScrollAnchor | null;
@@ -40,6 +42,8 @@ export const DetailView = ({
   onPressImage,
   onPressRetry,
   onPressDelete,
+  inspectContextLensPost,
+  onGoToBotRun,
   setActiveMessage,
   activeMessage,
   anchor,
@@ -109,6 +113,8 @@ export const DetailView = ({
         onPressImage={onPressImage}
         onPressRetry={onPressRetry}
         onPressDelete={onPressDelete}
+        onPressPost={inspectContextLensPost}
+        onGoToBotRun={onGoToBotRun}
         highlightPostId={highlightPostId}
         firstUnreadId={
           initialPostUnread?.count ?? 0 > 0

--- a/packages/app/ui/components/FeatureFlagScreenView.tsx
+++ b/packages/app/ui/components/FeatureFlagScreenView.tsx
@@ -1,16 +1,28 @@
 import { Switch } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ScrollView, SizableText, View, XStack } from 'tamagui';
+import { ScrollView, SizableText, View, XStack, YStack } from 'tamagui';
 
 import { useIsWindowNarrow } from '../utils';
+import { Field, TextInput } from './Form';
 import { ScreenHeader } from './ScreenHeader';
+
+export type FeatureFlagTextSetting = {
+  key: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  secure?: boolean;
+  onChange: (value: string) => void;
+};
 
 export function FeatureFlagScreenView({
   features,
+  textSettings,
   onBackPressed,
   onFlagToggled,
 }: {
   features: { name: string; label: string; enabled: boolean }[];
+  textSettings?: FeatureFlagTextSetting[];
   onBackPressed: () => void;
   onFlagToggled: (flagName: string, enabled: boolean) => void;
 }) {
@@ -58,6 +70,20 @@ export function FeatureFlagScreenView({
             </XStack>
           );
         })}
+        {textSettings?.map((setting) => (
+          <YStack key={setting.key} padding="$l">
+            <Field label={setting.label}>
+              <TextInput
+                value={setting.value}
+                placeholder={setting.placeholder}
+                secureTextEntry={setting.secure}
+                autoCapitalize="none"
+                autoCorrect={false}
+                onChangeText={setting.onChange}
+              />
+            </Field>
+          </YStack>
+        ))}
       </ScrollView>
     </View>
   );

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -26,7 +26,7 @@ import {
 } from 'react';
 import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Text, View, YStack } from 'tamagui';
+import { Text, View, XStack, YStack } from 'tamagui';
 
 import { useChannelNavigation } from '../../hooks/useChannelNavigation';
 import { useIsUserActive } from '../../hooks/useUserActivity';
@@ -42,6 +42,10 @@ import {
   ChannelHeader,
   ChannelHeaderItemsProvider,
 } from './Channel/ChannelHeader';
+import {
+  ContextLensPanel,
+  useContextLensController,
+} from './Channel/ContextLens';
 import { DraftInputView } from './Channel/DraftInputView';
 import { ScrollAnchor } from './Channel/Scroller';
 import { DetailView } from './DetailView';
@@ -178,6 +182,8 @@ export function PostScreenView({
   onPressDelete,
   onGroupAction,
   goToDm,
+  goToContextLensRuns,
+  goToContextLensRun,
   negotiationMatch,
   selectedPostId,
 }: {
@@ -188,6 +194,8 @@ export function PostScreenView({
   handleGoToUserProfile: (userId: string) => void;
   onGroupAction: (action: GroupPreviewAction, group: db.Group) => void;
   goToDm: (participants: string[]) => void;
+  goToContextLensRuns?: () => void;
+  goToContextLensRun?: (params: { botShip: string; lensId: string }) => void;
   selectedPostId?: string | null;
 } & ChannelContext) {
   const isWindowNarrow = utils.useIsWindowNarrow();
@@ -199,6 +207,16 @@ export function PostScreenView({
   // If this screen is a carousel, this is the currently-focused post
   // (`parentPost` does not change when swiping).
   const [focusedPost, setFocusedPost] = useState<db.Post | null>(parentPost);
+  const {
+    contextLensAvailable,
+    contextLensOpen,
+    contextLensActive,
+    contextLensStream,
+    selectedContextLensMessage,
+    toggleContextLens,
+    clearSelectedContextLensMessage,
+    inspectContextLensPost,
+  } = useContextLensController({ channel });
 
   const [galleryEditShouldBlur, setGalleryEditShouldBlur] = useState(false);
 
@@ -366,66 +384,100 @@ export function PostScreenView({
                     goBack={handleGoBack}
                     showEditButton={showEdit}
                     goToEdit={handleEditPress}
+                    onToggleContextLens={
+                      contextLensAvailable
+                        ? isWindowNarrow && goToContextLensRuns
+                          ? goToContextLensRuns
+                          : toggleContextLens
+                        : undefined
+                    }
+                    contextLensOpen={contextLensAvailable && contextLensOpen}
+                    contextLensActive={contextLensActive}
                   />
-                  {parentPost &&
-                    (isEditingParent && channel.type === 'gallery' ? (
-                      <YStack flex={1} backgroundColor="$background">
-                        <GalleryDraftInput
-                          channel={channel}
-                          editingPost={editingPost}
-                          getDraft={
-                            parentEditDraftCallbacks?.getDraft ??
-                            (async () => null)
+                  <XStack alignItems="stretch" flex={1} position="relative">
+                    <YStack flex={1} minWidth={0}>
+                      {parentPost &&
+                        (isEditingParent && channel.type === 'gallery' ? (
+                          <YStack flex={1} backgroundColor="$background">
+                            <GalleryDraftInput
+                              channel={channel}
+                              editingPost={editingPost}
+                              getDraft={
+                                parentEditDraftCallbacks?.getDraft ??
+                                (async () => null)
+                              }
+                              group={group}
+                              clearDraft={
+                                parentEditDraftCallbacks?.clearDraft ??
+                                (async () => {})
+                              }
+                              setEditingPost={setEditingPost}
+                              setShouldBlur={setGalleryEditShouldBlur}
+                              shouldBlur={galleryEditShouldBlur}
+                              storeDraft={
+                                parentEditDraftCallbacks?.storeDraft ??
+                                (async () => {})
+                              }
+                            />
+                          </YStack>
+                        ) : mode === 'single' ? (
+                          <SinglePostView
+                            {...{
+                              channel,
+                              chatThreadHandleRef,
+                              editingPost,
+                              goBack,
+                              group,
+                              handleGoToImage,
+                              inspectContextLensPost:
+                                contextLensAvailable && contextLensOpen
+                                  ? inspectContextLensPost
+                                  : undefined,
+                              onGoToBotRun:
+                                contextLensAvailable && isWindowNarrow
+                                  ? goToContextLensRun
+                                  : undefined,
+                              negotiationMatch,
+                              onPressDelete,
+                              onPressRetry,
+                              parentEditDraftCallbacks,
+                              parentPost,
+                              selectedPostId,
+                              setEditingPost,
+                            }}
+                          />
+                        ) : (
+                          <CarouselPostScreenContent
+                            flex={1}
+                            width="100%"
+                            channelId={channel.id}
+                            initialPostId={parentPost.id}
+                            channelContext={{
+                              editingPost,
+                              group,
+                              negotiationMatch,
+                              onPressDelete,
+                              onPressRetry,
+                              parentEditDraftCallbacks,
+                              setEditingPost,
+                            }}
+                          />
+                        ))}
+                    </YStack>
+                    {contextLensAvailable &&
+                      contextLensOpen &&
+                      !isWindowNarrow && (
+                        <ContextLensPanel
+                          events={contextLensStream.events}
+                          streamStatus={contextLensStream.status}
+                          selectedMessage={selectedContextLensMessage}
+                          onClearSelectedMessage={
+                            clearSelectedContextLensMessage
                           }
-                          group={group}
-                          clearDraft={
-                            parentEditDraftCallbacks?.clearDraft ??
-                            (async () => {})
-                          }
-                          setEditingPost={setEditingPost}
-                          setShouldBlur={setGalleryEditShouldBlur}
-                          shouldBlur={galleryEditShouldBlur}
-                          storeDraft={
-                            parentEditDraftCallbacks?.storeDraft ??
-                            (async () => {})
-                          }
+                          channelId={channel.id}
                         />
-                      </YStack>
-                    ) : mode === 'single' ? (
-                      <SinglePostView
-                        {...{
-                          channel,
-                          chatThreadHandleRef,
-                          editingPost,
-                          goBack,
-                          group,
-                          handleGoToImage,
-                          negotiationMatch,
-                          onPressDelete,
-                          onPressRetry,
-                          parentEditDraftCallbacks,
-                          parentPost,
-                          selectedPostId,
-                          setEditingPost,
-                        }}
-                      />
-                    ) : (
-                      <CarouselPostScreenContent
-                        flex={1}
-                        width="100%"
-                        channelId={channel.id}
-                        initialPostId={parentPost.id}
-                        channelContext={{
-                          editingPost,
-                          group,
-                          negotiationMatch,
-                          onPressDelete,
-                          onPressRetry,
-                          parentEditDraftCallbacks,
-                          setEditingPost,
-                        }}
-                      />
-                    ))}
+                      )}
+                  </XStack>
                   <GroupPreviewSheet
                     group={groupPreview ?? undefined}
                     open={!!groupPreview}
@@ -531,6 +583,8 @@ function SinglePostView({
   editingPost,
   goBack,
   handleGoToImage,
+  inspectContextLensPost,
+  onGoToBotRun,
   negotiationMatch,
   onPressDelete,
   onPressRetry,
@@ -545,6 +599,8 @@ function SinglePostView({
   goBack?: () => void;
   group: db.Group | null;
   handleGoToImage?: (post: db.Post, uri?: string) => void;
+  inspectContextLensPost?: (post: db.Post) => void;
+  onGoToBotRun?: (params: { botShip: string; lensId: string }) => void;
   negotiationMatch: boolean;
   onPressDelete: (post: db.Post) => void;
   onPressRetry?: (post: db.Post) => Promise<void>;
@@ -812,6 +868,8 @@ function SinglePostView({
             setActiveMessage={setActiveMessage}
             highlightPostId={highlightPostId}
             scrollerRef={scrollerRef}
+            inspectContextLensPost={inspectContextLensPost}
+            onGoToBotRun={onGoToBotRun}
           />
         ) : null}
 

--- a/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
+++ b/packages/app/ui/components/postCollectionViews/ListPostCollectionView.tsx
@@ -76,6 +76,16 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
       () => !getIsChatChannel(ctx.channel),
       [ctx.channel]
     );
+    const handlePressPost = useCallback(
+      (post: db.Post) => {
+        if (canDrillIntoPost) {
+          ctx.goToPost(post);
+          return;
+        }
+        ctx.inspectContextLensPost?.(post);
+      },
+      [canDrillIntoPost, ctx.goToPost, ctx.inspectContextLensPost]
+    );
 
     const [highlightPostId, setHighlightPostId] = useState<string | null>(null);
     const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -155,7 +165,11 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
             : null
         }
         unreadCount={ctx.initialChannelUnread?.countWithoutThreads ?? 0}
-        onPressPost={canDrillIntoPost ? ctx.goToPost : undefined}
+        onPressPost={
+          canDrillIntoPost || ctx.inspectContextLensPost
+            ? handlePressPost
+            : undefined
+        }
         onPressReplies={ctx.goToPost}
         onPressImage={ctx.goToMediaViewer}
         onEndReached={ctx.onScrollEndReached}
@@ -167,6 +181,7 @@ export const ListPostCollection: IPostCollectionView = forwardRef(
         ref={scrollerRef}
         isLoading={ctx.isLoadingPosts}
         onPressScrollToBottom={ctx.scrollToBottom}
+        onGoToBotRun={ctx.goToBotRun}
         highlightPostId={highlightPostId}
         listBottomComponent={listBottomComponent}
       />

--- a/packages/app/ui/contexts/componentsKits/componentsKits.tsx
+++ b/packages/app/ui/contexts/componentsKits/componentsKits.tsx
@@ -21,6 +21,7 @@ type RenderItemProps = {
   editing?: boolean;
   setEditingPost?: (post: db.Post | undefined) => void;
   setViewReactionsPost?: (post: db.Post) => void;
+  onPressBotRun?: (post: db.Post) => void;
   editPost?: (post: db.Post, content: Story) => Promise<void>;
   onPressRetry?: (post: db.Post) => Promise<void>;
   onPressDelete: (post: db.Post) => void;

--- a/packages/app/ui/contexts/postCollection.ts
+++ b/packages/app/ui/contexts/postCollection.ts
@@ -10,6 +10,8 @@ export interface PostCollectionContextValue {
   editingPost?: db.Post;
   goToMediaViewer: (post: db.Post, imageUri?: string) => void;
   goToPost: (post: db.Post) => void;
+  inspectContextLensPost?: (post: db.Post) => void;
+  goToBotRun?: (params: { botShip: string; lensId: string }) => void;
   hasNewerPosts?: boolean;
   hasOlderPosts?: boolean;
   initialChannelUnread?: db.ChannelUnread | null;


### PR DESCRIPTION
**Stack 4/4** (on #6009). Mounts the inspector into the app and exposes the feature flag — still **off by default**. With this, the union of 1–4 equals #5987.

- **navigation**: recent-runs + run-inspector screens (`features/lens`), `RootStack`/`linking`/`types`, `useChannelNavigation`.
- **Channel / PostScreenView / ChannelHeader**: sidebar toggle (wide) + controller wiring; `postCollection` context carries inspect / `goToBotRun`.
- **ChatMessage**: inline bot-run badge + long-press message action (incl. Android wrapper), `StaticChatMessage`.
- **settings**: expose `contextLens` (+ gateway URL/token) under experimental features.

## The stack
1. #6007 — api + `tlon-context-lens` blob
2. #6008 — shared run store + sync
3. #6009 — UI components
4. **this** — wire-in + flag

## Verification
- `@tloncorp/app` typechecks (only unrelated pre-existing `expo-av`); lens UI tests pass.
- This branch's tree is identical to #5987 (the original consolidated PR), now decomposed.

Once this stack lands, #5987 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)