### PR TITLE
feat(steward/lens): explicit trusted-bots %entry gate + retry/retention hardening

### DIFF
--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -213,6 +213,13 @@
   ::  state-0 migration). No time-based expiry — lens runs are durable
   ::  memory of agent activity, not transient logs.
   ::
+  ::  payloads are opaque to %steward, but a sponsored moon could send
+  ::  arbitrarily large cords. cap incoming bytes so a misbehaving (or
+  ::  compromised) gateway can't blow up loom usage with a single poke.
+  ::  the gateway-side truncates to ~50KB; this is a hard ceiling.
+  ::
+  ++  max-payload-bytes  ^-  @ud  524.288
+  ::
   ++  le-handle-configure
     |=  cap=@ud
     ^+  cor
@@ -267,6 +274,12 @@
   ++  le-handle-entry
     |=  [=id:lens:s =payload:lens:s final=?]
     ^+  cor
+    ::  drop oversized payloads to keep loom usage bounded; a sponsored
+    ::  moon misbehaving (or compromised) can't force unbounded growth.
+    ::
+    ?:  (gth (met 3 payload) max-payload-bytes)
+      %-  (slog leaf+"steward: lens payload oversized, dropping" ~)
+      cor
     ?:  =(src.bowl our.bowl)
       (le-fan-out id payload final)
     (le-store src.bowl id payload final)

--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -161,6 +161,13 @@
       ((slog 'steward: lens run fan-out nacked' u.p.sign) cor)
     ==
   ::
+      [%lens %retry *]
+    ?+  -.sign  cor
+        %poke-ack
+      ?~  p.sign  cor
+      ((slog 'steward: lens retry relay nacked' u.p.sign) cor)
+    ==
+  ::
       [%activity ~]
     ?+    -.sign  cor
         %fact
@@ -214,12 +221,17 @@
     ::
     le-prune-all
   ::
-  ::  lens-action auth: per-variant, since %entry and %retry take pokes from
-  ::  different src shapes.
-  ::    %entry: src=our (bot's own gateway) or src is a moon we sponsor (a
-  ::            bot we own fanning a run to us as its owner).
-  ::    %retry: src=our (local client) or src is the configured owner (an
-  ::            owner planet poking its bot moon).
+  ::  lens-action auth: per-variant, since each shape has a different src
+  ::  expectation.
+  ::    %entry: src=our (bot's own gateway pokes locally) or src is a moon we
+  ::            sponsor (a bot we own fanning a run to us as its owner).
+  ::            data flow: bot → owner.
+  ::    %retry: src=our (local client OR an owner-side relay forwarding to
+  ::            its own bot when bot == our) or src is the configured owner
+  ::            (an owner planet relaying a retry to its bot moon).
+  ::            data flow: owner → bot, with the owner's steward acting as
+  ::            the cross-ship relay if bot != our.
+  ::    %configure: src=our only.
   ::
   ++  le-poke-action
     |=  =action:lens:s
@@ -239,7 +251,7 @@
                   =(src.bowl u.owner.state)
               ==
           ==
-      (le-handle-retry id.action src.bowl)
+      (le-handle-retry bot.action id.action src.bowl)
     ::
         %configure
       ?>  =(src.bowl our.bowl)
@@ -259,18 +271,36 @@
       (le-fan-out id payload final)
     (le-store src.bowl id payload final)
   ::
-  ::  retry: emit a fact on /v1/lens that the local gateway picks up and
-  ::  re-dispatches. retry doesn't mutate stored state — the gateway will
-  ::  create a new lens run with a fresh id and poke us back with %entry.
+  ::  retry: route based on whether we are the targeted bot or just the
+  ::  owner-side relay.
+  ::    bot == our: we run the bot's gateway locally; emit the retry fact
+  ::                on /v1/lens for the gateway to pick up. .requester is
+  ::                whoever first poked (the local client, or the cross-
+  ::                ship owner if we received this via fan-out).
+  ::    bot != our: we are the owner forwarding a retry to a bot moon we
+  ::                own. cross-ship poke that bot's steward with the same
+  ::                action; the bot will recognize bot == our.bowl there
+  ::                and emit the fact for its local gateway.
+  ::  retry never mutates stored state — the gateway will create a new
+  ::  lens run with a fresh id and poke us back via %entry.
   ::
   ++  le-handle-retry
-    |=  [=id:lens:s requester=ship]
+    |=  [bot=ship =id:lens:s requester=ship]
     ^+  cor
-    %+  give  %fact
-    :*  ~[/v1/lens]
-        %steward-update-1
-        !>(`update:v1:s`[%lens %retry-requested id requester])
-    ==
+    ?:  =(bot our.bowl)
+      %+  give  %fact
+      :*  ~[/v1/lens]
+          %steward-update-1
+          !>(`update:v1:s`[%lens %retry-requested id requester])
+      ==
+    %-  emit
+    :^    %pass
+        /lens/retry/(scot %p bot)/(scot %t id)
+      %agent
+    :+  [bot %steward]
+      %poke
+    :-  %steward-action-1
+    !>(`action:v1:s`[%lens %retry bot id])
   ::
   ++  le-watch
     |=  =path

--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -79,28 +79,32 @@
 ++  emit  |=(=card cor(cards [card cards]))
 ++  give  |=(=gift:agent:gall (emit %give gift))
 ::
-::  %steward-action-1 is accepted from ourselves, or from a moon we
-::  sponsor. a bot is typically a moon of the owner planet; the owner
-::  accepts lens runs from itself and from its own moons. a moon's
-::  sponsor is its low 32 bits and is immutable, so we derive it
-::  directly rather than scrying jael ((end 5) for any non-moon equals
-::  the ship itself, so the inequality excludes galaxies/stars/planets).
+::  %steward-action-1 auth is per-variant rather than blanket-gated, since
+::  the lens module accepts two distinct inbound shapes:
+::    %entry: data flowing in from the bot's gateway (src=our) or fanning
+::            in from a moon we sponsor (src is a bot we own).
+::    %retry: an owner-initiated retry request, which cross-ship from the
+::            owner planet to the bot moon — owner is not a moon we sponsor,
+::            so the entry gate would reject it.
+::  gateway and top-level %configure remain self-only.
 ::
 ++  poke
   |=  [=mark =vase]
   ^+  cor
   ?+  mark  ~|(bad-poke-mark+mark !!)
       %steward-action-1
-    ?>  ?|  =(src.bowl our.bowl)
-            ?&  !=(src.bowl (end 5 src.bowl))
-                =(our.bowl (end 5 src.bowl))
-            ==
-        ==
     =+  !<(=action:v1:s vase)
     ?-  -.action
-      %configure  cor(owner.state `owner.action)
-      %lens       (le-poke-action:le-core action.action)
-      %gateway    (ga-poke-action:ga-core action.action)
+        %configure
+      ?>  =(src.bowl our.bowl)
+      cor(owner.state `owner.action)
+    ::
+        %lens
+      (le-poke-action:le-core action.action)
+    ::
+        %gateway
+      ?>  =(src.bowl our.bowl)
+      (ga-poke-action:ga-core action.action)
     ==
   ==
 ::
@@ -191,19 +195,59 @@
     ^-  ?
     (lth received.run (sub now.bowl max-run-age))
   ::
-  ::  the same action arrives in two roles (the ownership gate in +poke
-  ::  has already vetted src as ourselves or a moon we sponsor):
+  ::  lens-action auth: per-variant, since %entry and %retry take pokes from
+  ::  different src shapes.
+  ::    %entry: src=our (bot's own gateway) or src is a moon we sponsor (a
+  ::            bot we own fanning a run to us as its owner).
+  ::    %retry: src=our (local client) or src is the configured owner (an
+  ::            owner planet poking its bot moon).
+  ::
+  ++  le-poke-action
+    |=  =action:lens:s
+    ^+  cor
+    ?-  -.action
+        %entry
+      ?>  ?|  =(src.bowl our.bowl)
+              ?&  !=(src.bowl (end 5 src.bowl))
+                  =(our.bowl (end 5 src.bowl))
+              ==
+          ==
+      (le-handle-entry id.action payload.action final.action)
+    ::
+        %retry
+      ?>  ?|  =(src.bowl our.bowl)
+              ?&  ?=(^ owner.state)
+                  =(src.bowl u.owner.state)
+              ==
+          ==
+      (le-handle-retry id.action src.bowl)
+    ==
+  ::
+  ::  the same %entry action arrives in two roles:
   ::    - bot role (src==our): our own gateway poked us; fan the run out
   ::      to our configured owner.
   ::    - owner role (src is a sponsored moon): one of our bots sent us
   ::      its run; store it keyed by src.bowl so we can serve it to clients.
   ::
-  ++  le-poke-action
-    |=  =action:lens:s
+  ++  le-handle-entry
+    |=  [=id:lens:s =payload:lens:s final=?]
     ^+  cor
     ?:  =(src.bowl our.bowl)
-      (le-fan-out id.action payload.action final.action)
-    (le-store src.bowl id.action payload.action final.action)
+      (le-fan-out id payload final)
+    (le-store src.bowl id payload final)
+  ::
+  ::  retry: emit a fact on /v1/lens that the local gateway picks up and
+  ::  re-dispatches. retry doesn't mutate stored state — the gateway will
+  ::  create a new lens run with a fresh id and poke us back with %entry.
+  ::
+  ++  le-handle-retry
+    |=  [=id:lens:s requester=ship]
+    ^+  cor
+    %+  give  %fact
+    :*  ~[/v1/lens]
+        %steward-update-1
+        !>(`update:v1:s`[%lens %retry-requested id requester])
+    ==
   ::
   ++  le-watch
     |=  =path
@@ -225,7 +269,7 @@
       =/  =id:lens:s  i.t.t.t.path
       ?~  r=(~(get by lens.state) [bot id])  [~ ~]
       ?:  (le-expired u.r)  [~ ~]
-      ``steward-update-1+!>(`update:v1:s`[%lens bot id u.r])
+      ``steward-update-1+!>(`update:v1:s`[%lens %entry bot id u.r])
     ==
   ::
   ++  le-fan-out
@@ -235,7 +279,7 @@
     ?:  =(u.owner.state our.bowl)
       ::  self-owned bot: store directly, no network hop
       (le-store our.bowl id payload final)
-    =/  =action:lens:s  [id payload final]
+    =/  =action:lens:s  [%entry id payload final]
     %-  emit
     :^    %pass
         /lens/fanout/(scot %p u.owner.state)/(scot %t id)
@@ -257,7 +301,7 @@
     %+  give  %fact
     :*  ~[/v1/lens]
         %steward-update-1
-        !>(`update:v1:s`[%lens bot id run])
+        !>(`update:v1:s`[%lens %entry bot id run])
     ==
   ::
   ++  le-prune
@@ -310,7 +354,7 @@
       (gth received.run.a received.run.b)
     %+  turn  (scag 50 sorted)
     |=  [[bot=ship =id:lens:s] =run:lens:s]
-    [bot id run]
+    `update:lens:s`[%entry bot id run]
   --
 ::
 ++  ga-core

--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -10,15 +10,28 @@
 /+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
+::  legacy steward state (lens was a bare map, no time-cap-free retention
+::  config). on-load migrates this into state-1 with a default cap.
+::
 +$  state-0
   $:  %0
+      owner=(unit ship)
+      lens=state-0:lens:s
+      gateway=state:gateway:s
+  ==
++$  state-1
+  $:  %1
       owner=(unit ship)
       lens=state:lens:s
       gateway=state:gateway:s
   ==
+::  default cap on first install or on state-0 → state-1 migration. set
+::  generously: at ~20KB/run that's ~200MB per bot, well within modern
+::  loom budgets. ships that want more (or less) can poke %lens %configure.
 ::
+++  default-max-runs-per-bot  ^-  @ud  10.000
 --
-=|  state-0
+=|  state-1
 =*  state  -
 %-  agent:dbug
 %^  verb  |  %warn
@@ -30,16 +43,29 @@
       cor   ~(. +> [bowl ~])
   ++  on-init
     ^-  (quip card _this)
-    [~[wait-prune:le-core:cor watch-activity:cor] this]
+    =.  max-runs-per-bot.lens.state  default-max-runs-per-bot
+    [~[watch-activity:cor] this]
   ++  on-save  !>(state)
   ++  on-load
     |=  ole=vase
     ^-  (quip card _this)
-    =/  attempt  (mule |.(!<(state-0 ole)))
-    ?:  ?=(%& -.attempt)
-      [~ this(state p.attempt)]
+    ::  try current state-1 first, then state-0 with migration, then bunt.
+    ::
+    =/  one  (mule |.(!<(state-1 ole)))
+    ?:  ?=(%& -.one)
+      [~ this(state p.one)]
+    =/  zero  (mule |.(!<(state-0 ole)))
+    ?:  ?=(%& -.zero)
+      =/  upgraded=state-1
+        :*  %1
+            owner.p.zero
+            [lens.p.zero default-max-runs-per-bot]
+            gateway.p.zero
+        ==
+      [~ this(state upgraded)]
     %-  (slog 'steward: on-load state mismatch, resetting to bunt' ~)
-    [~[wait-prune:le-core:cor watch-activity:cor] this]
+    =.  max-runs-per-bot.lens.state  default-max-runs-per-bot
+    [~[watch-activity:cor] this]
   ++  on-poke
     |=  [=mark =vase]
     ^-  (quip card _this)
@@ -164,13 +190,6 @@
   |=  [=wire sign=sign-arvo]
   ^+  cor
   ?+  wire  cor
-      [%lens %prune ~]
-    ?.  ?=([%behn %wake *] sign)  cor
-    =?  cor  ?=(^ error.sign)
-      ((slog 'steward: lens prune wake failed' u.error.sign) cor)
-    =.  cor  le-prune-all:le-core
-    (emit wait-prune:le-core)
-  ::
       [%gateway %lease-check ~]
     ?.  ?=([%behn %wake *] sign)  cor
     ga-lease-check:ga-core
@@ -182,18 +201,18 @@
 ::
 ++  le-core
   |%
-  ++  max-runs-per-bot  ^-  @ud  1.000
-  ++  max-run-age       ^-  @dr  ~d90
-  ++  prune-interval    ^-  @dr  ~d1
+  ::  retention is count-bounded only; the cap lives in state and is set
+  ::  by %lens %configure (default in default-max-runs-per-bot on init /
+  ::  state-0 migration). No time-based expiry — lens runs are durable
+  ::  memory of agent activity, not transient logs.
   ::
-  ++  wait-prune
-    ^-  card
-    [%pass /lens/prune %arvo %b %wait (add now.bowl prune-interval)]
-  ::
-  ++  le-expired
-    |=  =run:lens:s
-    ^-  ?
-    (lth received.run (sub now.bowl max-run-age))
+  ++  le-handle-configure
+    |=  cap=@ud
+    ^+  cor
+    =.  max-runs-per-bot.lens.state  cap
+    ::  the new cap takes effect on every bot immediately.
+    ::
+    le-prune-all
   ::
   ::  lens-action auth: per-variant, since %entry and %retry take pokes from
   ::  different src shapes.
@@ -221,6 +240,10 @@
               ==
           ==
       (le-handle-retry id.action src.bowl)
+    ::
+        %configure
+      ?>  =(src.bowl our.bowl)
+      (le-handle-configure max-runs-per-bot.action)
     ==
   ::
   ::  the same %entry action arrives in two roles:
@@ -262,14 +285,24 @@
     ^-  (unit (unit cage))
     ?+  path  [~ ~]
         [%v1 %recent ~]
-      ``noun+!>(le-recent)
+      ``noun+!>((le-recent 50))
+    ::
+        [%v1 %recent @ ~]
+      =/  parsed  (slaw %ud i.t.t.path)
+      ?~  parsed  [~ ~]
+      ``noun+!>((le-recent u.parsed))
+    ::
+        [%v1 %since @ ~]
+      =/  parsed  (slaw %da i.t.t.path)
+      ?~  parsed  [~ ~]
+      ``noun+!>((le-since u.parsed))
     ::
         [%v1 %run @ @ ~]
-      =/  bot  (slav %p i.t.t.path)
+      =/  parsed-bot  (slaw %p i.t.t.path)
+      ?~  parsed-bot  [~ ~]
       =/  =id:lens:s  i.t.t.t.path
-      ?~  r=(~(get by lens.state) [bot id])  [~ ~]
-      ?:  (le-expired u.r)  [~ ~]
-      ``steward-update-1+!>(`update:v1:s`[%lens %entry bot id u.r])
+      ?~  r=(~(get by runs.lens.state) [u.parsed-bot id])  [~ ~]
+      ``steward-update-1+!>(`update:v1:s`[%lens %entry u.parsed-bot id u.r])
     ==
   ::
   ++  le-fan-out
@@ -292,11 +325,11 @@
     ::  drop late partials once a run is finalized: overwriting would
     ::  pair complete=& with a stale partial payload (and fact it out)
     ::
-    =/  prev  (~(get by lens.state) [bot id])
+    =/  prev  (~(get by runs.lens.state) [bot id])
     ?:  &(?=(^ prev) complete.u.prev !final)
       cor
     =/  =run:lens:s  [final now.bowl payload]
-    =.  lens.state  (~(put by lens.state) [bot id] run)
+    =.  runs.lens.state  (~(put by runs.lens.state) [bot id] run)
     =.  cor  (le-prune bot)
     %+  give  %fact
     :*  ~[/v1/lens]
@@ -304,31 +337,29 @@
         !>(`update:v1:s`[%lens %entry bot id run])
     ==
   ::
+  ::  trim a single bot's records to .max-runs-per-bot, dropping the
+  ::  oldest by .received first. invoked on every insert (bounds that
+  ::  bot's tail) and on %configure (applies a new cap to every bot).
+  ::
   ++  le-prune
     |=  for=ship
     ^+  cor
     =/  mine
-      %+  skim  ~(tap by lens.state)
+      %+  skim  ~(tap by runs.lens.state)
       |=  [[bot=ship *] *]
       =(bot for)
-    =/  dead
-      %+  skim  mine
-      |=  [* =run:lens:s]
-      (le-expired run)
-    =/  live
-      %+  skip  mine
-      |=  [* =run:lens:s]
-      (le-expired run)
-    =?  dead  (gth (lent live) max-runs-per-bot)
-      =/  sorted
-        %+  sort  live
-        |=  [a=[* =run:lens:s] b=[* =run:lens:s]]
-        (lth received.run.a received.run.b)
-      (weld dead (scag (sub (lent live) max-runs-per-bot) sorted))
-    =/  keys  (turn dead |=([k=[bot=ship =id:lens:s] *] k))
+    ?:  (lte (lent mine) max-runs-per-bot.lens.state)
+      cor
+    =/  sorted
+      %+  sort  mine
+      |=  [a=[* =run:lens:s] b=[* =run:lens:s]]
+      (lth received.run.a received.run.b)
+    =/  to-drop
+      (scag (sub (lent mine) max-runs-per-bot.lens.state) sorted)
+    =/  keys  (turn to-drop |=([k=[bot=ship =id:lens:s] *] k))
     |-  ^+  cor
     ?~  keys  cor
-    =.  lens.state  (~(del by lens.state) i.keys)
+    =.  runs.lens.state  (~(del by runs.lens.state) i.keys)
     $(keys t.keys)
   ::
   ++  le-prune-all
@@ -336,23 +367,40 @@
     =/  bots=(list ship)
       %~  tap  in
       %-  ~(gas in *(set ship))
-      (turn ~(tap by lens.state) |=([[bot=ship *] *] bot))
+      (turn ~(tap by runs.lens.state) |=([[bot=ship *] *] bot))
     |-  ^+  cor
     ?~  bots  cor
     =.  cor  (le-prune i.bots)
     $(bots t.bots)
   ::
+  ::  newest .count runs across all bots, as %entry updates.
+  ::
   ++  le-recent
+    |=  count=@ud
+    ^-  (list update:lens:s)
+    =/  sorted
+      %+  sort  ~(tap by runs.lens.state)
+      |=  [a=[* =run:lens:s] b=[* =run:lens:s]]
+      (gth received.run.a received.run.b)
+    %+  turn  (scag count sorted)
+    |=  [[bot=ship =id:lens:s] =run:lens:s]
+    `update:lens:s`[%entry bot id run]
+  ::
+  ::  every entry with .received >= cutoff, newest first. paginate
+  ::  history by passing the oldest .received from the last page.
+  ::
+  ++  le-since
+    |=  cutoff=@da
     ^-  (list update:lens:s)
     =/  fresh
-      %+  skip  ~(tap by lens.state)
+      %+  skim  ~(tap by runs.lens.state)
       |=  [* =run:lens:s]
-      (le-expired run)
+      (gte received.run cutoff)
     =/  sorted
       %+  sort  fresh
       |=  [a=[* =run:lens:s] b=[* =run:lens:s]]
       (gth received.run.a received.run.b)
-    %+  turn  (scag 50 sorted)
+    %+  turn  sorted
     |=  [[bot=ship =id:lens:s] =run:lens:s]
     `update:lens:s`[%entry bot id run]
   --

--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -315,17 +315,17 @@
     ^-  (unit (unit cage))
     ?+  path  [~ ~]
         [%v1 %recent ~]
-      ``noun+!>((le-recent 50))
+      ``steward-update-1+!>(`update:v1:s`[%lens %recent (le-recent 50)])
     ::
         [%v1 %recent @ ~]
       =/  parsed  (slaw %ud i.t.t.path)
       ?~  parsed  [~ ~]
-      ``noun+!>((le-recent u.parsed))
+      ``steward-update-1+!>(`update:v1:s`[%lens %recent (le-recent u.parsed)])
     ::
         [%v1 %since @ ~]
       =/  parsed  (slaw %da i.t.t.path)
       ?~  parsed  [~ ~]
-      ``noun+!>((le-since u.parsed))
+      ``steward-update-1+!>(`update:v1:s`[%lens %recent (le-since u.parsed)])
     ::
         [%v1 %run @ @ ~]
       =/  parsed-bot  (slaw %p i.t.t.path)
@@ -403,25 +403,25 @@
     =.  cor  (le-prune i.bots)
     $(bots t.bots)
   ::
-  ::  newest .count runs across all bots, as %entry updates.
+  ::  newest .count entries across all bots.
   ::
   ++  le-recent
     |=  count=@ud
-    ^-  (list update:lens:s)
+    ^-  (list entry:lens:s)
     =/  sorted
       %+  sort  ~(tap by runs.lens.state)
       |=  [a=[* =run:lens:s] b=[* =run:lens:s]]
       (gth received.run.a received.run.b)
     %+  turn  (scag count sorted)
     |=  [[bot=ship =id:lens:s] =run:lens:s]
-    `update:lens:s`[%entry bot id run]
+    `entry:lens:s`[bot id run]
   ::
   ::  every entry with .received >= cutoff, newest first. paginate
   ::  history by passing the oldest .received from the last page.
   ::
   ++  le-since
     |=  cutoff=@da
-    ^-  (list update:lens:s)
+    ^-  (list entry:lens:s)
     =/  fresh
       %+  skim  ~(tap by runs.lens.state)
       |=  [* =run:lens:s]
@@ -432,7 +432,7 @@
       (gth received.run.a received.run.b)
     %+  turn  sorted
     |=  [[bot=ship =id:lens:s] =run:lens:s]
-    `update:lens:s`[%entry bot id run]
+    `entry:lens:s`[bot id run]
   --
 ::
 ++  ga-core

--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -10,8 +10,9 @@
 /+  default-agent, verb, dbug
 |%
 +$  card  card:agent:gall
-::  legacy steward state (lens was a bare map, no time-cap-free retention
-::  config). on-load migrates this into state-1 with a default cap.
+::  legacy steward state (lens was a bare map, no retention config).
+::  on-load migrates this into state-2 with a default cap and an empty
+::  trusted-bots set.
 ::
 +$  state-0
   $:  %0
@@ -19,19 +20,41 @@
       lens=state-0:lens:s
       gateway=state:gateway:s
   ==
+::  state-1: post-cap, pre-trust-bots. accepted lens %entry pokes either
+::  from self or from moons sponsored by this ship. on-load migrates
+::  this into state-2 by initializing an empty trusted-bots set —
+::  operators must explicitly re-grant trust post-upgrade for cross-
+::  ship fan-out to resume (the prior moon-sponsor auto-trust path is
+::  removed; trust is now ship-class-agnostic and explicit).
+::
 +$  state-1
   $:  %1
       owner=(unit ship)
       lens=state:lens:s
       gateway=state:gateway:s
   ==
-::  default cap on first install or on state-0 → state-1 migration. set
+::  state-2: ships we (as the owner) accept lens %entry fan-outs from
+::  live in `.bots`. populated by [%trust-bot ship]; checked in the
+::  lens %entry gate. empty set means "no remote bot trusted" — only
+::  local pokes accepted. trust is explicit and ship-class-agnostic:
+::  a bot may be a planet, moon, comet, star, or galaxy. moon
+::  sponsorship is NOT an auto-trust — even a moon we sponsor must
+::  be trusted with %trust-bot to fan-out runs to us.
+::
++$  state-2
+  $:  %2
+      owner=(unit ship)
+      bots=(set ship)
+      lens=state:lens:s
+      gateway=state:gateway:s
+  ==
+::  default cap on first install or on state-0 → state-2 migration. set
 ::  generously: at ~20KB/run that's ~200MB per bot, well within modern
 ::  loom budgets. ships that want more (or less) can poke %lens %configure.
 ::
 ++  default-max-runs-per-bot  ^-  @ud  10.000
 --
-=|  state-1
+=|  state-2
 =*  state  -
 %-  agent:dbug
 %^  verb  |  %warn
@@ -49,16 +72,29 @@
   ++  on-load
     |=  ole=vase
     ^-  (quip card _this)
-    ::  try current state-1 first, then state-0 with migration, then bunt.
+    ::  try current state-2 first, then state-1 with migration (add
+    ::  empty bots set), then state-0 with migration (add default cap
+    ::  and empty bots set), then bunt.
     ::
+    =/  two  (mule |.(!<(state-2 ole)))
+    ?:  ?=(%& -.two)
+      [~ this(state p.two)]
     =/  one  (mule |.(!<(state-1 ole)))
     ?:  ?=(%& -.one)
-      [~ this(state p.one)]
+      =/  upgraded=state-2
+        :*  %2
+            owner.p.one
+            ~
+            lens.p.one
+            gateway.p.one
+        ==
+      [~ this(state upgraded)]
     =/  zero  (mule |.(!<(state-0 ole)))
     ?:  ?=(%& -.zero)
-      =/  upgraded=state-1
-        :*  %1
+      =/  upgraded=state-2
+        :*  %2
             owner.p.zero
+            ~
             [lens.p.zero default-max-runs-per-bot]
             gateway.p.zero
         ==
@@ -108,11 +144,12 @@
 ::  %steward-action-1 auth is per-variant rather than blanket-gated, since
 ::  the lens module accepts two distinct inbound shapes:
 ::    %entry: data flowing in from the bot's gateway (src=our) or fanning
-::            in from a moon we sponsor (src is a bot we own).
-::    %retry: an owner-initiated retry request, which cross-ship from the
-::            owner planet to the bot moon — owner is not a moon we sponsor,
-::            so the entry gate would reject it.
-::  gateway and top-level %configure remain self-only.
+::            in from a remote bot we have explicitly trusted via
+::            [%trust-bot ship].
+::    %retry: an owner-initiated retry request, which cross-ships from
+::            the owner planet to the bot — owner is not in our trusted
+::            bots set, so the entry gate would reject it.
+::  gateway, %configure, %trust-bot and %untrust-bot remain self-only.
 ::
 ++  poke
   |=  [=mark =vase]
@@ -124,6 +161,14 @@
         %configure
       ?>  =(src.bowl our.bowl)
       cor(owner.state `owner.action)
+    ::
+        %trust-bot
+      ?>  =(src.bowl our.bowl)
+      cor(bots.state (~(put in bots.state) ship.action))
+    ::
+        %untrust-bot
+      ?>  =(src.bowl our.bowl)
+      cor(bots.state (~(del in bots.state) ship.action))
     ::
         %lens
       (le-poke-action:le-core action.action)
@@ -210,10 +255,10 @@
   |%
   ::  retention is count-bounded only; the cap lives in state and is set
   ::  by %lens %configure (default in default-max-runs-per-bot on init /
-  ::  state-0 migration). No time-based expiry — lens runs are durable
-  ::  memory of agent activity, not transient logs.
+  ::  state-0 → state-2 migration). No time-based expiry — lens runs are
+  ::  durable memory of agent activity, not transient logs.
   ::
-  ::  payloads are opaque to %steward, but a sponsored moon could send
+  ::  payloads are opaque to %steward, but a trusted bot could send
   ::  arbitrarily large cords. cap incoming bytes so a misbehaving (or
   ::  compromised) gateway can't blow up loom usage with a single poke.
   ::  the gateway-side truncates to ~50KB; this is a hard ceiling.
@@ -230,14 +275,16 @@
   ::
   ::  lens-action auth: per-variant, since each shape has a different src
   ::  expectation.
-  ::    %entry: src=our (bot's own gateway pokes locally) or src is a moon we
-  ::            sponsor (a bot we own fanning a run to us as its owner).
-  ::            data flow: bot → owner.
+  ::    %entry: src=our (bot's own gateway pokes locally) or src is a bot
+  ::            we explicitly trust via [%trust-bot ship] (a remote bot
+  ::            fanning a run to us as its owner). data flow: bot → owner.
+  ::            ship class is irrelevant — bots may be planets, moons,
+  ::            comets, stars, or galaxies. trust is the only gate.
   ::    %retry: src=our (local client OR an owner-side relay forwarding to
   ::            its own bot when bot == our) or src is the configured owner
-  ::            (an owner planet relaying a retry to its bot moon).
-  ::            data flow: owner → bot, with the owner's steward acting as
-  ::            the cross-ship relay if bot != our.
+  ::            (an owner ship relaying a retry to its bot). data flow:
+  ::            owner → bot, with the owner's steward acting as the cross-
+  ::            ship relay if bot != our.
   ::    %configure: src=our only.
   ::
   ++  le-poke-action
@@ -246,9 +293,7 @@
     ?-  -.action
         %entry
       ?>  ?|  =(src.bowl our.bowl)
-              ?&  !=(src.bowl (end 5 src.bowl))
-                  =(our.bowl (end 5 src.bowl))
-              ==
+              (~(has in bots.state) src.bowl)
           ==
       (le-handle-entry id.action payload.action final.action)
     ::
@@ -268,14 +313,14 @@
   ::  the same %entry action arrives in two roles:
   ::    - bot role (src==our): our own gateway poked us; fan the run out
   ::      to our configured owner.
-  ::    - owner role (src is a sponsored moon): one of our bots sent us
-  ::      its run; store it keyed by src.bowl so we can serve it to clients.
+  ::    - owner role (src is a trusted bot): one of our bots sent us its
+  ::      run; store it keyed by src.bowl so we can serve it to clients.
   ::
   ++  le-handle-entry
     |=  [=id:lens:s =payload:lens:s final=?]
     ^+  cor
-    ::  drop oversized payloads to keep loom usage bounded; a sponsored
-    ::  moon misbehaving (or compromised) can't force unbounded growth.
+    ::  drop oversized payloads to keep loom usage bounded; a trusted
+    ::  bot misbehaving (or compromised) can't force unbounded growth.
     ::
     ?:  (gth (met 3 payload) max-payload-bytes)
       %-  (slog leaf+"steward: lens payload oversized, dropping" ~)
@@ -290,8 +335,8 @@
   ::                on /v1/lens for the gateway to pick up. .requester is
   ::                whoever first poked (the local client, or the cross-
   ::                ship owner if we received this via fan-out).
-  ::    bot != our: we are the owner forwarding a retry to a bot moon we
-  ::                own. cross-ship poke that bot's steward with the same
+  ::    bot != our: we are the owner forwarding a retry to a bot we own.
+  ::                cross-ship poke that bot's steward with the same
   ::                action; the bot will recognize bot == our.bowl there
   ::                and emit the fact for its local gateway.
   ::  retry never mutates stored state — the gateway will create a new

--- a/desk/mar/steward/action-1.hoon
+++ b/desk/mar/steward/action-1.hoon
@@ -120,26 +120,13 @@
     |=  jon=^json
     ^-  action:v1:s
     =,  dejs:format
-    ?.  ?=([%o *] jon)  ~|(bad-steward-action-json+jon !!)
-    =/  kv  ~(tap by p.jon)
-    ?~  kv  ~|(empty-steward-action-json+jon !!)
-    =/  key=@t  p.i.kv
-    =/  val=^json  q.i.kv
-    ?+  key  ~|(unknown-steward-action-key+key !!)
-        'configure'
-      [%configure ((ot ~[owner+(se %p)]) val)]
-    ::
-        'trust-bot'
-      [%trust-bot ((ot ~[ship+(se %p)]) val)]
-    ::
-        'untrust-bot'
-      [%untrust-bot ((ot ~[ship+(se %p)]) val)]
-    ::
-        'lens'
-      [%lens (lens-grab val)]
-    ::
-        'gateway'
-      [%gateway (gateway-grab val)]
+    %.  jon
+    %-  of
+    :~  [%configure (ot ~[owner+(se %p)])]
+        [%trust-bot (ot ~[ship+(se %p)])]
+        [%untrust-bot (ot ~[ship+(se %p)])]
+        [%lens lens-grab]
+        [%gateway gateway-grab]
     ==
   ++  lens-grab
     |=  jon=^json

--- a/desk/mar/steward/action-1.hoon
+++ b/desk/mar/steward/action-1.hoon
@@ -11,8 +11,11 @@
 ::    lens variants:
 ::      {"entry": {"id":..., "payload":..., "final":...}}
 ::          gateway pushes a run record. local-only path (src=our or moon).
-::      {"retry": {"id":...}}
-::          owner-initiated retry of a finalized run. cross-ship from owner.
+::      {"retry": {"bot":"~ship", "id":...}}
+::          owner-initiated retry of a finalized run. routed via the
+::          owner's steward to the bot's steward (cross-ship).
+::      {"configure": {"max-runs-per-bot":N}}
+::          per-ship retention cap; applied to every bot immediately.
 ::
 ::    NOTE: the %gateway configure maps offline-reply-cooldown → reply-cooldown
 ::    in the gateway sub-grab, mirroring gateway-status.
@@ -55,8 +58,10 @@
     ::
         %retry
       %-  frond  :-  'retry'
-      %-  frond  :-  'id'
-      s+id.act
+      %-  pairs
+      :~  ['bot' s+(scot %p bot.act)]
+          ['id' s+id.act]
+      ==
     ::
         %configure
       %-  frond  :-  'configure'
@@ -123,7 +128,7 @@
     %.  jon
     %-  of
     :~  [%entry (ot ~[id+so payload+so final+bo])]
-        [%retry (ot ~[id+so])]
+        [%retry (ot ~[bot+(se %p) id+so])]
         [%configure (ot ~[max-runs-per-bot+ni])]
     ==
   ++  gateway-grab

--- a/desk/mar/steward/action-1.hoon
+++ b/desk/mar/steward/action-1.hoon
@@ -1,12 +1,18 @@
-::  steward-action-1: mark for steward inbound actions (LOCAL ONLY)
+::  steward-action-1: mark for steward inbound actions.
 ::
-::    dispatched by module key: {"configure": {...}} or {"lens": {...}}
-::      or {"gateway": {...}}
+::    dispatched by module key: {"configure": {...}}, {"lens": {...}}, or
+::    {"gateway": {...}}.
 ::    %configure sets the owner (top-level, not module-scoped).
-::    %lens wraps a single run action {id, payload, final}.
+::    %lens wraps a lens-module action — see lens variants below.
 ::    %gateway wraps a gateway lifecycle action (configure/start/heartbeat/stop).
 ::    adding a future module means adding a variant to $action in sur/steward,
 ::    not a new mark file.
+::
+::    lens variants:
+::      {"entry": {"id":..., "payload":..., "final":...}}
+::          gateway pushes a run record. local-only path (src=our or moon).
+::      {"retry": {"id":...}}
+::          owner-initiated retry of a finalized run. cross-ship from owner.
 ::
 ::    NOTE: the %gateway configure maps offline-reply-cooldown → reply-cooldown
 ::    in the gateway sub-grab, mirroring gateway-status.
@@ -28,15 +34,29 @@
     ::
         %lens
       %-  frond  :-  'lens'
-      %-  pairs
-      :~  ['id' s+id.action.action]
-          ['payload' s+payload.action.action]
-          ['final' b+final.action.action]
-      ==
+      (lens-grow action.action)
     ::
         %gateway
       %-  frond  :-  'gateway'
       (gateway-grow action.action)
+    ==
+  ++  lens-grow
+    |=  act=action:lens:s
+    ^-  ^json
+    =,  enjs:format
+    ?-  -.act
+        %entry
+      %-  frond  :-  'entry'
+      %-  pairs
+      :~  ['id' s+id.act]
+          ['payload' s+payload.act]
+          ['final' b+final.act]
+      ==
+    ::
+        %retry
+      %-  frond  :-  'retry'
+      %-  frond  :-  'id'
+      s+id.act
     ==
   ++  gateway-grow
     |=  act=action:gateway:s
@@ -86,10 +106,19 @@
       [%configure ((ot ~[owner+(se %p)]) val)]
     ::
         'lens'
-      [%lens ((ot ~[id+so payload+so final+bo]) val)]
+      [%lens (lens-grab val)]
     ::
         'gateway'
       [%gateway (gateway-grab val)]
+    ==
+  ++  lens-grab
+    |=  jon=^json
+    ^-  action:lens:v1:s
+    =,  dejs:format
+    %.  jon
+    %-  of
+    :~  [%entry (ot ~[id+so payload+so final+bo])]
+        [%retry (ot ~[id+so])]
     ==
   ++  gateway-grab
     |=  jon=^json

--- a/desk/mar/steward/action-1.hoon
+++ b/desk/mar/steward/action-1.hoon
@@ -1,8 +1,11 @@
 ::  steward-action-1: mark for steward inbound actions.
 ::
-::    dispatched by module key: {"configure": {...}}, {"lens": {...}}, or
+::    dispatched by module key: {"configure": {...}}, {"trust-bot":
+::    {...}}, {"untrust-bot": {...}}, {"lens": {...}}, or
 ::    {"gateway": {...}}.
 ::    %configure sets the owner (top-level, not module-scoped).
+::    %trust-bot/%untrust-bot add/remove a ship from the set of bots
+::    whose lens %entry fan-out we accept (owner-side trust list).
 ::    %lens wraps a lens-module action — see lens variants below.
 ::    %gateway wraps a gateway lifecycle action (configure/start/heartbeat/stop).
 ::    adding a future module means adding a variant to $action in sur/steward,
@@ -10,7 +13,8 @@
 ::
 ::    lens variants:
 ::      {"entry": {"id":..., "payload":..., "final":...}}
-::          gateway pushes a run record. local-only path (src=our or moon).
+::          gateway pushes a run record. local-only path (src=our) or
+::          fan-out from a trusted remote bot (src in bots).
 ::      {"retry": {"bot":"~ship", "id":...}}
 ::          owner-initiated retry of a finalized run. routed via the
 ::          owner's steward to the bot's steward (cross-ship).
@@ -34,6 +38,16 @@
       %-  frond  :-  'configure'
       %-  frond  :-  'owner'
       s+(scot %p owner.action)
+    ::
+        %trust-bot
+      %-  frond  :-  'trust-bot'
+      %-  frond  :-  'ship'
+      s+(scot %p ship.action)
+    ::
+        %untrust-bot
+      %-  frond  :-  'untrust-bot'
+      %-  frond  :-  'ship'
+      s+(scot %p ship.action)
     ::
         %lens
       %-  frond  :-  'lens'
@@ -114,6 +128,12 @@
     ?+  key  ~|(unknown-steward-action-key+key !!)
         'configure'
       [%configure ((ot ~[owner+(se %p)]) val)]
+    ::
+        'trust-bot'
+      [%trust-bot ((ot ~[ship+(se %p)]) val)]
+    ::
+        'untrust-bot'
+      [%untrust-bot ((ot ~[ship+(se %p)]) val)]
     ::
         'lens'
       [%lens (lens-grab val)]

--- a/desk/mar/steward/action-1.hoon
+++ b/desk/mar/steward/action-1.hoon
@@ -57,6 +57,11 @@
       %-  frond  :-  'retry'
       %-  frond  :-  'id'
       s+id.act
+    ::
+        %configure
+      %-  frond  :-  'configure'
+      %-  frond  :-  'max-runs-per-bot'
+      (numb max-runs-per-bot.act)
     ==
   ++  gateway-grow
     |=  act=action:gateway:s
@@ -119,6 +124,7 @@
     %-  of
     :~  [%entry (ot ~[id+so payload+so final+bo])]
         [%retry (ot ~[id+so])]
+        [%configure (ot ~[max-runs-per-bot+ni])]
     ==
   ++  gateway-grab
     |=  jon=^json

--- a/desk/mar/steward/update-1.hoon
+++ b/desk/mar/steward/update-1.hoon
@@ -1,7 +1,9 @@
 ::  steward-update-1: mark for steward outbound updates and scry results
 ::
-::    lens update is now a single entry (bot + id + run), not a union.
-::    dispatched by module key: {"lens": {...lens-entry...}}
+::    dispatched by module key: {"lens": {...}} or {"gateway": {...}}.
+::    lens variants:
+::      {"entry": {bot, id, complete, received, payload}} — a run record
+::      {"retry-requested": {id, requester}} — owner asked for a re-dispatch
 ::    adding a future module means adding a variant to $update in sur/steward,
 ::    not a new mark file.
 ::
@@ -18,14 +20,30 @@
     ?-  -.update
         %lens
       %-  frond  :-  'lens'
-      (entry update.update)
+      (lens-update update.update)
     ::
         %gateway
       %-  frond  :-  'gateway'
       (gateway-update update.update)
     ==
+    ++  lens-update
+      |=  upd=update:lens:v1:s
+      ^-  ^json
+      =,  enjs:format
+      ?-  -.upd
+          %entry
+        %-  frond  :-  'entry'
+        (entry entry.upd)
+      ::
+          %retry-requested
+        %-  frond  :-  'retry-requested'
+        %-  pairs
+        :~  ['id' s+id.upd]
+            ['requester' s+(scot %p requester.upd)]
+        ==
+      ==
     ++  entry
-      |=  e=update:lens:v1:s
+      |=  e=entry:lens:v1:s
       ^-  ^json
       =,  enjs:format
       %-  pairs

--- a/desk/mar/steward/update-1.hoon
+++ b/desk/mar/steward/update-1.hoon
@@ -41,6 +41,10 @@
         :~  ['id' s+id.upd]
             ['requester' s+(scot %p requester.upd)]
         ==
+      ::
+          %recent
+        %-  frond  :-  'recent'
+        a+(turn entries.upd entry)
       ==
     ++  entry
       |=  e=entry:lens:v1:s

--- a/desk/mar/steward/update-1.hoon
+++ b/desk/mar/steward/update-1.hoon
@@ -66,10 +66,7 @@
         %-  frond  :-  'status'
         %-  pairs
         :~  ['status' s+(crip (trip -.upd))]
-            ['lease-until'
-              ?~  lease-until.upd  ~
-              s+(scot %da u.lease-until.upd)
-            ]
+            ['lease-until' ?~(lease-until.upd ~ s+(scot %da u.lease-until.upd))]
         ==
       ::
           %owner-activity

--- a/desk/sur/steward.hoon
+++ b/desk/sur/steward.hoon
@@ -83,10 +83,15 @@
   ::                      the local gateway should re-dispatch. Only emitted
   ::                      on the bot ship (the owner-side relay forwards the
   ::                      poke to the bot, which then emits this fact).
+  ::    %recent: a batch of entries, returned by the /recent and /since
+  ::             scries. The scry path returns this in a steward-update-1
+  ::             cage so HTTP clients can scry as .json; the fact/sub
+  ::             channel never carries this variant.
   ::
   +$  update
     $%  [%entry =entry]
         [%retry-requested =id requester=ship]
+        [%recent entries=(list entry)]
     ==
   --
 ::  gateway module types

--- a/desk/sur/steward.hoon
+++ b/desk/sur/steward.hoon
@@ -43,12 +43,31 @@
   ::
   +$  entry  [bot=ship =id =run]
   ::
-  ::  $action: add new lens run
+  ::  $action: lens module inbound actions.
   ::
-  +$  action  [=id payload=@t final=?]
-  ::  $update: lens subscription update, currently only a single run update
+  ::    %entry: gateway pushes a run record (partial or final). authoritative
+  ::            data flow into the store; src is self (gateway local poke) or
+  ::            a moon we sponsor (cross-ship fan-out from a bot to its owner).
+  ::    %retry: owner-initiated request to re-dispatch a finalized run that
+  ::            failed or aborted. src must be the configured owner (a cross-
+  ::            ship poke from the owner's mobile/web client to the bot ship)
+  ::            or self. emits a %retry-requested fact on /v1/lens for the
+  ::            bot's local gateway to pick up and dispatch.
   ::
-  +$  update  entry
+  +$  action
+    $%  [%entry =id payload=@t final=?]
+        [%retry =id]
+    ==
+  ::  $update: lens subscription update.
+  ::
+  ::    %entry: a stored run record (insert or update).
+  ::    %retry-requested: a retry was requested for run .id by .requester;
+  ::                      the local gateway should re-dispatch.
+  ::
+  +$  update
+    $%  [%entry =entry]
+        [%retry-requested =id requester=ship]
+    ==
   --
 ::  gateway module types
 ::

--- a/desk/sur/steward.hoon
+++ b/desk/sur/steward.hoon
@@ -2,8 +2,20 @@
 ::  steward: shared protocol types for the umbrella harness agent
 ::
 |%
+::  $action: top-level inbound actions for the steward umbrella agent.
+::
+::    %configure: set the bot's owner (self-only).
+::    %trust-bot / %untrust-bot: add/remove a ship from the owner-side
+::            trusted-bots set. only ships in this set may fan in lens
+::            %entry pokes cross-ship; trust is explicit and ship-class-
+::            agnostic (planet/moon/star/comet/galaxy all eligible).
+::            self-only.
+::    %lens / %gateway: forwarded to the named module's action handler.
+::
 +$  action
   $%  [%configure owner=ship]
+      [%trust-bot ship=ship]
+      [%untrust-bot ship=ship]
       [%lens =action:lens]
       [%gateway =action:gateway]
   ==
@@ -59,7 +71,9 @@
   ::
   ::    %entry: gateway pushes a run record (partial or final). authoritative
   ::            data flow into the store; src is self (gateway local poke) or
-  ::            a moon we sponsor (cross-ship fan-out from a bot to its owner).
+  ::            a remote bot we've explicitly trusted via [%trust-bot ship]
+  ::            (cross-ship fan-out from a bot to its owner). trust is
+  ::            ship-class-agnostic — bots may be planets, moons, comets, etc.
   ::    %retry: owner-initiated request to re-dispatch a finalized run that
   ::            failed or aborted. carries .bot so the agent can route it:
   ::            received locally (src=our) and bot == our, emit a fact for

--- a/desk/sur/steward.hoon
+++ b/desk/sur/steward.hoon
@@ -61,24 +61,28 @@
   ::            data flow into the store; src is self (gateway local poke) or
   ::            a moon we sponsor (cross-ship fan-out from a bot to its owner).
   ::    %retry: owner-initiated request to re-dispatch a finalized run that
-  ::            failed or aborted. src must be the configured owner (a cross-
-  ::            ship poke from the owner's mobile/web client to the bot ship)
-  ::            or self. emits a %retry-requested fact on /v1/lens for the
-  ::            bot's local gateway to pick up and dispatch.
+  ::            failed or aborted. carries .bot so the agent can route it:
+  ::            received locally (src=our) and bot == our, emit a fact for
+  ::            the local gateway; received locally but bot != our, cross-
+  ::            ship poke the bot's steward; received cross-ship from the
+  ::            configured owner with bot == our, emit a fact. (the symmetric
+  ::            case to %entry, which is bot → owner; %retry is owner → bot.)
   ::    %configure: set the per-ship lens config. Currently the only knob is
   ::            .max-runs-per-bot. Local only (src=our). On set, applies the
   ::            new cap immediately by pruning every bot to size.
   ::
   +$  action
     $%  [%entry =id payload=@t final=?]
-        [%retry =id]
+        [%retry bot=ship =id]
         [%configure max-runs-per-bot=@ud]
     ==
   ::  $update: lens subscription update.
   ::
   ::    %entry: a stored run record (insert or update).
   ::    %retry-requested: a retry was requested for run .id by .requester;
-  ::                      the local gateway should re-dispatch.
+  ::                      the local gateway should re-dispatch. Only emitted
+  ::                      on the bot ship (the owner-side relay forwards the
+  ::                      poke to the bot, which then emits this fact).
   ::
   +$  update
     $%  [%entry =entry]

--- a/desk/sur/steward.hoon
+++ b/desk/sur/steward.hoon
@@ -15,9 +15,21 @@
 ::
 ++  lens
   |%
-  ::  $state: lens tracked bot runs
+  ::  $state-0: legacy lens state (steward state-0). Plain map of runs.
   ::
-  +$  state  (map [bot=ship =id] run)
+  +$  state-0  (map [bot=ship =id] run)
+  ::  $state: lens module state.
+  ::
+  ::    .runs is the durable store of finalized + partial run records,
+  ::    keyed by [bot id].
+  ::    .max-runs-per-bot caps the count per bot (oldest beyond the cap
+  ::    are pruned on next insert or %configure). No time-based expiry —
+  ::    lens runs are durable memory, not transient logs.
+  ::
+  +$  state
+    $:  runs=(map [bot=ship =id] run)
+        max-runs-per-bot=@ud
+    ==
   ::  $id: gateway-assigned run identifier (the lensId stamped on posts)
   ::
   +$  id  @t
@@ -53,10 +65,14 @@
   ::            ship poke from the owner's mobile/web client to the bot ship)
   ::            or self. emits a %retry-requested fact on /v1/lens for the
   ::            bot's local gateway to pick up and dispatch.
+  ::    %configure: set the per-ship lens config. Currently the only knob is
+  ::            .max-runs-per-bot. Local only (src=our). On set, applies the
+  ::            new cap immediately by pruning every bot to size.
   ::
   +$  action
     $%  [%entry =id payload=@t final=?]
         [%retry =id]
+        [%configure max-runs-per-bot=@ud]
     ==
   ::  $update: lens subscription update.
   ::

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -5,10 +5,19 @@
 /=  agent  /app/steward
 |%
 ++  dap  %steward
++$  state-1
+  $:  %1
+      owner=(unit ship)
+      lens=state:lens:s
+      gateway=state:gateway:s
+  ==
+::  state-0 is the legacy shape; the agent migrates it forward on-load.
+::  kept here only for the migration test.
+::
 +$  state-0
   $:  %0
       owner=(unit ship)
-      lens=state:lens:s
+      lens=state-0:lens:s
       gateway=state:gateway:s
   ==
 ++  payload  ^-  @t  '{"schemaVersion":1,"summary":"run-record"}'
@@ -74,7 +83,7 @@
     (do-poke %steward-action-1 !>(`action:v1:s`[%configure ~bus]))
   ;<  ~  bind:m  (ex-cards caz ~)
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   (ex-equal !>(owner.st) !>(`(unit ship)``~bus))
 ::
 ::  a completely foreign ship (not ourselves, not our moon) must crash
@@ -218,77 +227,182 @@
   ?>  ?=(%entry -.update.update)
   (ex-equal !>(run.entry.update.update) !>(`run:lens:s`[& ~2024.1.1 payload]))
 ::
-::  runs older than max-run-age (90d) are pruned on the next store
+::  on-init seeds the lens config (default max-runs-per-bot) and subscribes
+::  to %activity. there is no prune timer — pruning is count-based and runs
+::  on every insert and every %configure.
 ::
-++  test-old-runs-pruned-by-age
-  %-  eval-mare
-  =/  m  (mare ,~)
-  ^-  form:m
-  ;<  ~  bind:m  setup
-  ;<  *  bind:m
-    %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'old-run' payload &]))
-  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
-  ;<  *  bind:m
-    %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'new-run' payload &]))
-  ;<  res=cage  bind:m  (got-peek /x/v1/lens/recent)
-  =+  !<(entries=(list update:lens:s) q.res)
-  ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(1))
-  ?>  ?=(^ entries)
-  ?>  ?=(%entry -.i.entries)
-  (ex-equal !>(id.entry.i.entries) !>('new-run'))
-::
-::  on-init arms the prune timer AND the activity subscription
-::
-++  test-init-arms-prune-timer-and-activity
+++  test-init-seeds-config-and-activity
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  *  bind:m  (set-scry-gate scries)
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(our ~dev, src ~dev)))
   ;<  caz=(list card)  bind:m  (do-init dap agent)
-  %+  ex-cards  caz
-  :~  (ex-arvo /lens/prune %b %wait (add *@da ~d1))
-      (ex-task /activity [~dev %activity] %watch /v5)
-  ==
-::
-::  a prune wake runs prune-all and re-arms the timer
-::
-++  test-prune-wake-reclaims-and-rearms
-  %-  eval-mare
-  =/  m  (mare ,~)
-  ^-  form:m
-  ;<  ~  bind:m  setup
-  ;<  *  bind:m
-    %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'old-run' payload &]))
-  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
-  ;<  caz=(list card)  bind:m  (do-arvo /lens/prune [%behn %wake ~])
   ;<  ~  bind:m
     %+  ex-cards  caz
-    :~  (ex-arvo /lens/prune %b %wait (add (add ~2024.1.1 ~d91) ~d1))
+    :~  (ex-task /activity [~dev %activity] %watch /v5)
     ==
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
-  (ex-equal !>(~(wyt by lens.st)) !>(0))
+  =/  st  !<(state-1 !<(vase q.res))
+  (ex-equal !>(max-runs-per-bot.lens.st) !>(`@ud`10.000))
 ::
-::  even with no timer fire or new store, expired runs must not be
-::  served by /x/v1/lens/recent or /x/v1/lens/run
+::  on-load migrates a legacy state-0 (lens as bare map, no cap) into
+::  state-1 with the default cap, preserving the stored runs.
 ::
-++  test-expired-runs-hidden-from-reads
+++  test-state-0-migrates-to-state-1
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  =/  legacy-run=run:lens:s  [& ~2024.1.1 payload]
+  =/  legacy-lens=state-0:lens:s
+    (malt ~[[[moon 'old-id'] legacy-run]])
+  =/  ole=state-0  [%0 `~bus legacy-lens *state:gateway:s]
+  ;<  *  bind:m  (do-load agent `!>(ole))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-1 !<(vase q.res))
+  ;<  ~  bind:m  (ex-equal !>(owner.st) !>(`(unit ship)``~bus))
+  ;<  ~  bind:m  (ex-equal !>(max-runs-per-bot.lens.st) !>(`@ud`10.000))
+  ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(1))
+  ?~  got=(~(get by runs.lens.st) [moon 'old-id'])
+    |+~['expected migrated run to be present']
+  (ex-equal !>(u.got) !>(legacy-run))
+::
+::  count-based prune: the oldest entries beyond max-runs-per-bot get
+::  dropped on the next insert. configure the cap to 2, store 3 runs from
+::  the same bot in time order, and assert the oldest is gone.
+::
+++  test-count-cap-prunes-oldest-on-insert
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %configure 2]))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'r1' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'r2' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.3)))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'r3' payload &]))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-1 !<(vase q.res))
+  ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(2))
+  ;<  ~  bind:m
+    (ex-equal !>((~(has by runs.lens.st) [moon 'r1'])) !>(|))
+  ;<  ~  bind:m
+    (ex-equal !>((~(has by runs.lens.st) [moon 'r2'])) !>(&))
+  (ex-equal !>((~(has by runs.lens.st) [moon 'r3'])) !>(&))
+::
+::  %configure lowers the cap and the new cap takes effect immediately
+::  across every bot — not lazily on the next per-bot insert.
+::
+++  test-configure-applies-cap-across-all-bots
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'old-run' payload &]))
-  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
-  ;<  res=cage  bind:m  (got-peek /x/v1/lens/recent)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'a1' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'a2' payload &]))
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %configure 1]))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-1 !<(vase q.res))
+  ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(1))
+  ::  the newer entry survives, the older was dropped.
+  ::
+  (ex-equal !>((~(has by runs.lens.st) [moon 'a2'])) !>(&))
+::
+::  /x/v1/lens/recent (no arg) defaults to 50; /x/v1/lens/recent/<n>
+::  caps the returned list to <n> newest. /x/v1/lens/since/<da> returns
+::  every entry with received >= cutoff.
+::
+++  test-recent-windowed-with-count
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'w1' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'w2' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.3)))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'w3' payload &]))
+  ;<  res=cage  bind:m  (got-peek /x/v1/lens/recent/2)
   =+  !<(entries=(list update:lens:s) q.res)
-  ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(0))
-  ;<  run=(unit (unit cage))  bind:m  (get-peek /x/v1/lens/run/(scot %p moon)/old-run)
+  ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(2))
+  ?>  ?=(^ entries)
+  ?>  ?=(%entry -.i.entries)
+  (ex-equal !>(id.entry.i.entries) !>('w3'))
+::
+++  test-since-returns-entries-from-cutoff
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 's1' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.5)))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 's2' payload &]))
+  ;<  res=cage  bind:m  (got-peek /x/v1/lens/since/(scot %da ~2024.1.3))
+  =+  !<(entries=(list update:lens:s) q.res)
+  ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(1))
+  ?>  ?=(^ entries)
+  ?>  ?=(%entry -.i.entries)
+  (ex-equal !>(id.entry.i.entries) !>('s2'))
+::
+::  cap=0 means "store nothing"; the new entry is inserted then pruned
+::  immediately. permitted as a config value (an admin tool to disable
+::  storage without ripping out the agent).
+::
+++  test-configure-cap-zero-drops-everything
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %configure 0]))
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'z1' payload &]))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-1 !<(vase q.res))
+  (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
+::
+::  malformed scry args return [~ ~] (not found) rather than crashing
+::  the agent. covers all paths that take a parsed atom.
+::
+++  test-malformed-scry-args-return-not-found
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  recent=(unit (unit cage))  bind:m
+    (get-peek /x/v1/lens/recent/not-a-number)
+  ;<  ~  bind:m  (ex-equal !>(?=([~ ~] recent)) !>(&))
+  ;<  since=(unit (unit cage))  bind:m
+    (get-peek /x/v1/lens/since/not-a-date)
+  ;<  ~  bind:m  (ex-equal !>(?=([~ ~] since)) !>(&))
+  ;<  run=(unit (unit cage))  bind:m
+    (get-peek /x/v1/lens/run/not-a-ship/some-id)
   (ex-equal !>(?=([~ ~] run)) !>(&))
 ++  test-watch-rejects-foreign-ship
   %-  eval-mare
@@ -397,8 +511,8 @@
     %-  (do-as ~bus)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r5']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
-  (ex-equal !>(~(wyt by lens.st)) !>(0))
+  =/  st  !<(state-1 !<(vase q.res))
+  (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
 ::
 ::  retry against an existing finalized entry must not touch the stored
 ::  record (no overwrite, no demotion, no entry-fact re-emission).
@@ -457,7 +571,7 @@
   ^-  form:m
   ;<  ~  bind:m  setup-gateway
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(active-window.gateway.st) !>(~m5))
   (ex-equal !>(reply-cooldown.gateway.st) !>(~m5))
 ::
@@ -483,7 +597,7 @@
         (ex-fact-paths ~[/v1/gateway])
     ==
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   (ex-equal !>(lease-until.gateway.st) !>(`lease-time))
 ::
@@ -501,7 +615,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-heartbeat 'boot-1' new-lease]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   ;<  ~  bind:m  (ex-equal !>(pending-restart.gateway.st) !>(|))
   (ex-equal !>(lease-until.gateway.st) !>(`new-lease))
@@ -517,7 +631,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%down))
   (ex-equal !>(pending-restart.gateway.st) !>(&))
 ::
@@ -532,7 +646,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-stop 'boot-old' 'stale']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   ;<  ~  bind:m  (ex-equal !>(boot-id.gateway.st) !>(`'boot-1'))
   (ex-equal !>(pending-restart.gateway.st) !>(|))
@@ -551,7 +665,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-heartbeat 'boot-1' new-lease]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%down))
   ;<  ~  bind:m  (ex-equal !>(boot-id.gateway.st) !>(~))
   (ex-equal !>(pending-restart.gateway.st) !>(&))
@@ -567,7 +681,7 @@
   ;<  ~  bind:m  (wait ~s91)
   ;<  *  bind:m  (do-arvo /gateway/lease-check [%behn %wake ~])
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%down))
   (ex-equal !>(pending-restart.gateway.st) !>(&))
 ::
@@ -663,13 +777,13 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(pending-restart.gateway.st) !>(&))
   =/  lease-time-2  (add ~2024.1.1 ~m4)
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-start 'boot-2' lease-time-2]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-0 !<(vase q.res))
+  =/  st  !<(state-1 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   (ex-equal !>(pending-restart.gateway.st) !>(|))
 ::

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -434,11 +434,11 @@
 ::  RETRY ACTION TESTS
 ::  ==========================================================
 ::
-::  retry from the configured owner (cross-ship poke from owner planet to
-::  bot moon) emits a %retry-requested fact on /v1/lens for the local
-::  gateway to dispatch. retry doesn't mutate stored state.
+::  retry from the configured owner targeting our.bowl as bot (cross-ship
+::  poke owner → bot) emits a %retry-requested fact on /v1/lens for the
+::  local gateway to dispatch. retry doesn't mutate stored state.
 ::
-++  test-retry-from-owner-emits-fact
+++  test-retry-from-owner-targeting-self-emits-fact
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
@@ -446,7 +446,7 @@
   ;<  ~  bind:m  (configure ~bus)
   ;<  caz=(list card)  bind:m
     %-  (do-as ~bus)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r1']))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r1']))
   %+  ex-cards  caz
   :~  %-  ex-fact
       :*  ~[/v1/lens]
@@ -455,17 +455,17 @@
       ==
   ==
 ::
-::  a local retry (src=our, e.g. self-owned bot whose owner is our ship)
-::  is permitted and tags the requester as our.bowl.
+::  self-poked retry targeting our.bowl (the local-client + self-owned-bot
+::  case) emits the fact with the local ship tagged as requester.
 ::
-++  test-retry-from-self-emits-fact
+++  test-retry-from-self-targeting-self-emits-fact
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  (configure ~dev)
   ;<  caz=(list card)  bind:m
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r2']))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r2']))
   %+  ex-cards  caz
   :~  %-  ex-fact
       :*  ~[/v1/lens]
@@ -474,7 +474,28 @@
       ==
   ==
 ::
-::  retry from a non-owner, non-self ship must crash the auth gate.
+::  self-poked retry targeting a DIFFERENT bot (owner-side relay path):
+::  we forward the same action to the bot's steward over Ames and emit
+::  no local fact. the bot will accept (src=owner) and emit its own fact.
+::
+++  test-retry-self-poked-bot-elsewhere-relays
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  caz=(list card)  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~bus 'lens-r-relay']))
+  %+  ex-cards  caz
+  :~  %-  ex-poke
+      :*  /lens/retry/(scot %p ~bus)/(scot %t 'lens-r-relay')
+          [~bus %steward]
+          %steward-action-1
+          !>(`action:v1:s`[%lens %retry ~bus 'lens-r-relay'])
+      ==
+  ==
+::
+::  retry from a non-owner, non-self ship must crash the auth gate
+::  regardless of bot.
 ::
 ++  test-retry-from-non-owner-rejected
   %-  eval-mare
@@ -484,7 +505,7 @@
   ;<  ~  bind:m  (configure ~bus)
   %-  ex-fail
   %-  (do-as ~zod)
-  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r3']))
+  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r3']))
 ::
 ::  retry when no owner is configured: only self is accepted.
 ::
@@ -495,7 +516,7 @@
   ;<  ~  bind:m  setup
   %-  ex-fail
   %-  (do-as ~bus)
-  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r4']))
+  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r4']))
 ::
 ::  retry does NOT mutate the lens store (no new run record is created;
 ::  no entry fact is emitted). the gateway is expected to dispatch and
@@ -509,7 +530,7 @@
   ;<  ~  bind:m  (configure ~bus)
   ;<  *  bind:m
     %-  (do-as ~bus)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r5']))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r5']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
   =/  st  !<(state-1 !<(vase q.res))
   (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
@@ -529,12 +550,12 @@
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-r6' payload &]))
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
-  ::  retry it from the owner; the entry must remain unchanged and only
-  ::  the retry-requested fact must be emitted (no entry fact).
+  ::  retry it from the owner targeting us; the entry must remain unchanged
+  ::  and only the retry-requested fact must be emitted (no entry fact).
   ::
   ;<  caz=(list card)  bind:m
     %-  (do-as ~bus)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r6']))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r6']))
   ;<  ~  bind:m
     %+  ex-cards  caz
     :~  %-  ex-fact

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -5,15 +5,22 @@
 /=  agent  /app/steward
 |%
 ++  dap  %steward
++$  state-2
+  $:  %2
+      owner=(unit ship)
+      bots=(set ship)
+      lens=state:lens:s
+      gateway=state:gateway:s
+  ==
+::  state-1 / state-0 are legacy shapes; the agent migrates them
+::  forward on-load. kept here only for the migration tests.
+::
 +$  state-1
   $:  %1
       owner=(unit ship)
       lens=state:lens:s
       gateway=state:gateway:s
   ==
-::  state-0 is the legacy shape; the agent migrates it forward on-load.
-::  kept here only for the migration test.
-::
 +$  state-0
   $:  %0
       owner=(unit ship)
@@ -22,10 +29,11 @@
   ==
 ++  payload  ^-  @t  '{"schemaVersion":1,"summary":"run-record"}'
 ::
-::  our ship in tests is ~dev (a galaxy; set via +setup below).  a moon's
-::  sponsor is its low 32 bits, so any ship >= 2^32 whose low 32 bits equal
-::  ~dev is a moon ~dev sponsors.  (add ~dev (bex 32)) is the simplest such
-::  moon and passes the ownership gate ((end 5 moon) == ~dev).
+::  our ship in tests is ~dev (a galaxy; set via +setup below). +moon is
+::  a convenient stand-in for any foreign bot ship — its sponsor relation
+::  to ~dev is incidental, since the lens %entry gate no longer treats
+::  sponsored moons as auto-trusted. tests that want to fan-in from this
+::  ship must call +trust-moon first.
 ::
 ++  moon  ^-  ship  (add ~dev (bex 32))
 ::
@@ -61,6 +69,17 @@
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %configure ~m5 ~m5]))
   (pure:m ~)
 ::
+::  most lens tests fan-in from a remote bot ship (we use +moon as the
+::  representative remote bot, but the gate is ship-class-agnostic). add
+::  it to our trusted-bots set before pretending to receive a fan-out.
+::
+++  trust-moon
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot moon]))
+  (pure:m ~)
+::
 ++  make-dm-fact
   |=  [sender=ship t=@da]
   ^-  [wire gill:gall sign:agent:gall]
@@ -83,11 +102,11 @@
     (do-poke %steward-action-1 !>(`action:v1:s`[%configure ~bus]))
   ;<  ~  bind:m  (ex-cards caz ~)
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   (ex-equal !>(owner.st) !>(`(unit ship)``~bus))
 ::
-::  a completely foreign ship (not ourselves, not our moon) must crash
-::  the ownership gate on %steward-action-1
+::  top-level %configure is self-only; a foreign ship must crash the
+::  src.bowl check.
 ::
 ++  test-action-from-foreign-ship-crashes
   %-  eval-mare
@@ -98,17 +117,17 @@
   %-  (do-as ~zod)
   (do-poke %steward-action-1 !>(`action:v1:s`[%configure ~zod]))
 ::
-::  a moon we sponsor must be accepted by the ownership gate
+::  a remote bot we've explicitly trusted via %trust-bot must be accepted
+::  by the lens %entry gate, and its run stored keyed by src.bowl.
+::  the gate is ship-class-agnostic — moon, planet, comet, star, galaxy,
+::  whatever; trust is the only criterion.
 ::
-::  we use ~sampel-dev as the moon (sein of ~sampel-dev is ~dev).
-::  the moon pokes [%lens id payload final] — it should be stored keyed
-::  by src.bowl (the moon itself).
-::
-++  test-action-from-sponsored-moon-accepted
+++  test-action-from-trusted-bot-accepted
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-moon' payload &]))
@@ -123,6 +142,84 @@
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-moon)
   =+  !<(=update:v1:s q.res)
   (ex-equal !>(update) !>(`update:v1:s`[%lens %entry moon 'lens-moon' [& ~2024.1.1 payload]]))
+::
+::  the moon-sponsor relationship is NOT an auto-trust. a moon we sponsor
+::  but have not explicitly trusted must be rejected by the %entry gate.
+::
+++  test-action-from-untrusted-moon-rejected
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as moon)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-no-trust' payload &]))
+::
+::  %trust-bot adds a ship to the trusted set; the same ship's lens
+::  %entry poke must then be accepted (round-trip).
+::
+++  test-trust-bot-adds-to-set-and-accepts-entry
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot ~bus]))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-2 !<(vase q.res))
+  ;<  ~  bind:m  (ex-equal !>((~(has in bots.st) ~bus)) !>(&))
+  ;<  caz=(list card)  bind:m
+    %-  (do-as ~bus)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'trusted-id' payload &]))
+  %+  ex-cards  caz
+  :~  %-  ex-fact
+      :*  ~[/v1/lens]
+          %steward-update-1
+          !>(`update:v1:s`[%lens %entry ~bus 'trusted-id' [& ~2024.1.1 payload]])
+      ==
+  ==
+::
+::  %untrust-bot removes a ship; subsequent %entry from that ship is rejected.
+::
+++  test-untrust-bot-removes-from-set
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot ~bus]))
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%untrust-bot ~bus]))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-2 !<(vase q.res))
+  ;<  ~  bind:m  (ex-equal !>((~(has in bots.st) ~bus)) !>(|))
+  %-  ex-fail
+  %-  (do-as ~bus)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'after-untrust' payload &]))
+::
+::  %trust-bot is self-only; a foreign ship cannot grant itself trust.
+::
+++  test-trust-bot-rejects-foreign-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot ~zod]))
+::
+::  %untrust-bot is also self-only; a foreign ship cannot revoke trust.
+::
+++  test-untrust-bot-rejects-foreign-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot ~bus]))
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%untrust-bot ~bus]))
 ::
 ::  fan-out to a non-self owner emits a %steward-action-1 poke on /lens/fanout/...
 ::
@@ -165,13 +262,14 @@
   =+  !<(=update:v1:s q.res)
   (ex-equal !>(update) !>(`update:v1:s`[%lens %entry ~dev 'lens-1' [& ~2024.1.1 payload]]))
 ::
-::  a poke from a sponsored moon is stored keyed by src.bowl (the moon)
+::  a poke from a trusted bot is stored keyed by src.bowl (the bot)
 ::
 ++  test-action-stores-keyed-by-source
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-2' payload |]))
@@ -194,6 +292,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-3' payload |]))
@@ -213,6 +312,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-4' payload &]))
@@ -243,13 +343,14 @@
     :~  (ex-task /activity [~dev %activity] %watch /v5)
     ==
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   (ex-equal !>(max-runs-per-bot.lens.st) !>(`@ud`10.000))
 ::
 ::  on-load migrates a legacy state-0 (lens as bare map, no cap) into
-::  state-1 with the default cap, preserving the stored runs.
+::  state-2 with the default cap, preserving the stored runs and
+::  initializing an empty trusted-bots set.
 ::
-++  test-state-0-migrates-to-state-1
+++  test-state-0-migrates-to-state-2
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
@@ -260,13 +361,45 @@
   =/  ole=state-0  [%0 `~bus legacy-lens *state:gateway:s]
   ;<  *  bind:m  (do-load agent `!>(ole))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(owner.st) !>(`(unit ship)``~bus))
   ;<  ~  bind:m  (ex-equal !>(max-runs-per-bot.lens.st) !>(`@ud`10.000))
   ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(1))
-  ?~  got=(~(get by runs.lens.st) [moon 'old-id'])
-    |+~['expected migrated run to be present']
-  (ex-equal !>(u.got) !>(legacy-run))
+  ::  the bots set starts empty after migration; trust is explicit and
+  ::  must be re-granted by the operator post-upgrade.
+  ::
+  ;<  ~  bind:m  (ex-equal !>(~(wyt in bots.st)) !>(0))
+  %+  ex-equal
+    !>((~(get by runs.lens.st) [moon 'old-id']))
+  !>(`(unit run:lens:s)``legacy-run)
+::
+::  on-load migrates a deployed state-1 (post-cap, pre-trust-bots) into
+::  state-2 by initializing an empty trusted-bots set. owner, runs, cap,
+::  and gateway state must survive intact — a silent bunt-reset on this
+::  path would drop production data, so the test guards that.
+::
+++  test-state-1-migrates-to-state-2
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  =/  legacy-run=run:lens:s  [& ~2024.1.1 payload]
+  =/  legacy-runs=(map [bot=ship =id:lens:s] run:lens:s)
+    (malt ~[[[moon 'old-id'] legacy-run]])
+  =/  legacy-lens=state:lens:s  [legacy-runs 42]
+  =/  ole=state-1  [%1 `~bus legacy-lens *state:gateway:s]
+  ;<  *  bind:m  (do-load agent `!>(ole))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-2 !<(vase q.res))
+  ;<  ~  bind:m  (ex-equal !>(owner.st) !>(`(unit ship)``~bus))
+  ::  cap is preserved from state-1 (not reset to the default).
+  ::
+  ;<  ~  bind:m  (ex-equal !>(max-runs-per-bot.lens.st) !>(`@ud`42))
+  ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(1))
+  ;<  ~  bind:m  (ex-equal !>(~(wyt in bots.st)) !>(0))
+  %+  ex-equal
+    !>((~(get by runs.lens.st) [moon 'old-id']))
+  !>(`(unit run:lens:s)``legacy-run)
 ::
 ::  count-based prune: the oldest entries beyond max-runs-per-bot get
 ::  dropped on the next insert. configure the cap to 2, store 3 runs from
@@ -277,6 +410,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %configure 2]))
   ;<  *  bind:m
@@ -291,7 +425,7 @@
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'r3' payload &]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(2))
   ;<  ~  bind:m
     (ex-equal !>((~(has by runs.lens.st) [moon 'r1'])) !>(|))
@@ -307,6 +441,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'a1' payload &]))
@@ -317,7 +452,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %configure 1]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(~(wyt by runs.lens.st)) !>(1))
   ::  the newer entry survives, the older was dropped.
   ::
@@ -332,6 +467,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'w1' payload &]))
@@ -356,6 +492,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 's1' payload &]))
@@ -380,13 +517,14 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %configure 0]))
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'z1' payload &]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
 ::
 ::  malformed scry args return [~ ~] (not found) rather than crashing
@@ -534,7 +672,7 @@
     %-  (do-as ~bus)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry ~dev 'lens-r5']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
 ::
 ::  payloads larger than the agent cap (512KB) are dropped without store
@@ -547,6 +685,7 @@
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  (configure ~dev)
+  ;<  ~  bind:m  trust-moon
   ::  build a payload one byte over the cap.
   ::
   =/  big-payload=@t
@@ -556,7 +695,7 @@
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'big' big-payload &]))
   ;<  ~  bind:m  (ex-cards caz ~)
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
 ::
 ::  retry against an existing finalized entry must not touch the stored
@@ -568,7 +707,8 @@
   ^-  form:m
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  (configure ~bus)
-  ::  store a finalized entry as a sponsored moon first.
+  ;<  ~  bind:m  trust-moon
+  ::  store a finalized entry as a trusted bot first.
   ::
   ;<  *  bind:m
     %-  (do-as moon)
@@ -616,7 +756,7 @@
   ^-  form:m
   ;<  ~  bind:m  setup-gateway
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(active-window.gateway.st) !>(~m5))
   (ex-equal !>(reply-cooldown.gateway.st) !>(~m5))
 ::
@@ -642,7 +782,7 @@
         (ex-fact-paths ~[/v1/gateway])
     ==
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   (ex-equal !>(lease-until.gateway.st) !>(`lease-time))
 ::
@@ -660,7 +800,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-heartbeat 'boot-1' new-lease]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   ;<  ~  bind:m  (ex-equal !>(pending-restart.gateway.st) !>(|))
   (ex-equal !>(lease-until.gateway.st) !>(`new-lease))
@@ -676,7 +816,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%down))
   (ex-equal !>(pending-restart.gateway.st) !>(&))
 ::
@@ -691,7 +831,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-stop 'boot-old' 'stale']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   ;<  ~  bind:m  (ex-equal !>(boot-id.gateway.st) !>(`'boot-1'))
   (ex-equal !>(pending-restart.gateway.st) !>(|))
@@ -710,7 +850,7 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-heartbeat 'boot-1' new-lease]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%down))
   ;<  ~  bind:m  (ex-equal !>(boot-id.gateway.st) !>(~))
   (ex-equal !>(pending-restart.gateway.st) !>(&))
@@ -726,7 +866,7 @@
   ;<  ~  bind:m  (wait ~s91)
   ;<  *  bind:m  (do-arvo /gateway/lease-check [%behn %wake ~])
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%down))
   (ex-equal !>(pending-restart.gateway.st) !>(&))
 ::
@@ -822,13 +962,13 @@
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-stop 'boot-1' 'test']))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(pending-restart.gateway.st) !>(&))
   =/  lease-time-2  (add ~2024.1.1 ~m4)
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%gateway %gateway-start 'boot-2' lease-time-2]))
   ;<  res=cage  bind:m  (got-peek /x/dbug/state)
-  =/  st  !<(state-1 !<(vase q.res))
+  =/  st  !<(state-2 !<(vase q.res))
   ;<  ~  bind:m  (ex-equal !>(status.gateway.st) !>(%up))
   (ex-equal !>(pending-restart.gateway.st) !>(|))
 ::

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -344,11 +344,12 @@
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'w3' payload &]))
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/recent/2)
-  =+  !<(entries=(list update:lens:s) q.res)
-  ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(2))
-  ?>  ?=(^ entries)
-  ?>  ?=(%entry -.i.entries)
-  (ex-equal !>(id.entry.i.entries) !>('w3'))
+  =+  !<(=update:v1:s q.res)
+  ?>  ?=(%lens -.update)
+  ?>  ?=(%recent -.update.update)
+  ;<  ~  bind:m  (ex-equal !>((lent entries.update.update)) !>(2))
+  ?>  ?=(^ entries.update.update)
+  (ex-equal !>(id.i.entries.update.update) !>('w3'))
 ::
 ++  test-since-returns-entries-from-cutoff
   %-  eval-mare
@@ -363,11 +364,12 @@
     %-  (do-as moon)
     (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 's2' payload &]))
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/since/(scot %da ~2024.1.3))
-  =+  !<(entries=(list update:lens:s) q.res)
-  ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(1))
-  ?>  ?=(^ entries)
-  ?>  ?=(%entry -.i.entries)
-  (ex-equal !>(id.entry.i.entries) !>('s2'))
+  =+  !<(=update:v1:s q.res)
+  ?>  ?=(%lens -.update)
+  ?>  ?=(%recent -.update.update)
+  ;<  ~  bind:m  (ex-equal !>((lent entries.update.update)) !>(1))
+  ?>  ?=(^ entries.update.update)
+  (ex-equal !>(id.i.entries.update.update) !>('s2'))
 ::
 ::  cap=0 means "store nothing"; the new entry is inserted then pruned
 ::  immediately. permitted as a config value (an admin tool to disable

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -102,18 +102,18 @@
   ;<  ~  bind:m  setup
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-moon' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-moon' payload &]))
   ;<  ~  bind:m
     %+  ex-cards  caz
     :~  %-  ex-fact
         :*  ~[/v1/lens]
             %steward-update-1
-            !>(`update:v1:s`[%lens moon 'lens-moon' [& ~2024.1.1 payload]])
+            !>(`update:v1:s`[%lens %entry moon 'lens-moon' [& ~2024.1.1 payload]])
         ==
     ==
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-moon)
   =+  !<(=update:v1:s q.res)
-  (ex-equal !>(update) !>(`update:v1:s`[%lens moon 'lens-moon' [& ~2024.1.1 payload]]))
+  (ex-equal !>(update) !>(`update:v1:s`[%lens %entry moon 'lens-moon' [& ~2024.1.1 payload]]))
 ::
 ::  fan-out to a non-self owner emits a %steward-action-1 poke on /lens/fanout/...
 ::
@@ -124,13 +124,13 @@
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  (configure ~bus)
   ;<  caz=(list card)  bind:m
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-1' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-1' payload &]))
   %+  ex-cards  caz
   :~  %-  ex-poke
       :*  /lens/fanout/(scot %p ~bus)/(scot %t 'lens-1')
           [~bus %steward]
           %steward-action-1
-          !>(`action:v1:s`[%lens 'lens-1' payload &])
+          !>(`action:v1:s`[%lens %entry 'lens-1' payload &])
       ==
   ==
 ::
@@ -143,18 +143,18 @@
   ;<  ~  bind:m  setup
   ;<  ~  bind:m  (configure ~dev)
   ;<  caz=(list card)  bind:m
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-1' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-1' payload &]))
   ;<  ~  bind:m
     %+  ex-cards  caz
     :~  %-  ex-fact
         :*  ~[/v1/lens]
             %steward-update-1
-            !>(`update:v1:s`[%lens ~dev 'lens-1' [& ~2024.1.1 payload]])
+            !>(`update:v1:s`[%lens %entry ~dev 'lens-1' [& ~2024.1.1 payload]])
         ==
     ==
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p ~dev)/lens-1)
   =+  !<(=update:v1:s q.res)
-  (ex-equal !>(update) !>(`update:v1:s`[%lens ~dev 'lens-1' [& ~2024.1.1 payload]]))
+  (ex-equal !>(update) !>(`update:v1:s`[%lens %entry ~dev 'lens-1' [& ~2024.1.1 payload]]))
 ::
 ::  a poke from a sponsored moon is stored keyed by src.bowl (the moon)
 ::
@@ -165,18 +165,18 @@
   ;<  ~  bind:m  setup
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-2' payload |]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-2' payload |]))
   ;<  ~  bind:m
     %+  ex-cards  caz
     :~  %-  ex-fact
         :*  ~[/v1/lens]
             %steward-update-1
-            !>(`update:v1:s`[%lens moon 'lens-2' [| ~2024.1.1 payload]])
+            !>(`update:v1:s`[%lens %entry moon 'lens-2' [| ~2024.1.1 payload]])
         ==
     ==
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-2)
   =+  !<(=update:v1:s q.res)
-  (ex-equal !>(update) !>(`update:v1:s`[%lens moon 'lens-2' [| ~2024.1.1 payload]]))
+  (ex-equal !>(update) !>(`update:v1:s`[%lens %entry moon 'lens-2' [| ~2024.1.1 payload]]))
 ::
 ::  final=& marks the run complete
 ::
@@ -187,14 +187,15 @@
   ;<  ~  bind:m  setup
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-3' payload |]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-3' payload |]))
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-3' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-3' payload &]))
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-3)
   =+  !<(=update:v1:s q.res)
   ?>  ?=(%lens -.update)
-  (ex-equal !>(complete.run.update.update) !>(&))
+  ?>  ?=(%entry -.update.update)
+  (ex-equal !>(complete.run.entry.update.update) !>(&))
 ::
 ::  a late partial (final=|) arriving after a final (final=&) is dropped
 ::
@@ -205,16 +206,17 @@
   ;<  ~  bind:m  setup
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-4' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-4' payload &]))
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'lens-4' '{"partial":true}' |]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-4' '{"partial":true}' |]))
   ;<  ~  bind:m  (ex-cards caz ~)
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-4)
   =+  !<(=update:v1:s q.res)
   ?>  ?=(%lens -.update)
-  (ex-equal !>(run.update.update) !>(`run:lens:s`[& ~2024.1.1 payload]))
+  ?>  ?=(%entry -.update.update)
+  (ex-equal !>(run.entry.update.update) !>(`run:lens:s`[& ~2024.1.1 payload]))
 ::
 ::  runs older than max-run-age (90d) are pruned on the next store
 ::
@@ -225,16 +227,17 @@
   ;<  ~  bind:m  setup
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'old-run' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'old-run' payload &]))
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'new-run' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'new-run' payload &]))
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/recent)
   =+  !<(entries=(list update:lens:s) q.res)
   ;<  ~  bind:m  (ex-equal !>((lent entries)) !>(1))
   ?>  ?=(^ entries)
-  (ex-equal !>(id.i.entries) !>('new-run'))
+  ?>  ?=(%entry -.i.entries)
+  (ex-equal !>(id.entry.i.entries) !>('new-run'))
 ::
 ::  on-init arms the prune timer AND the activity subscription
 ::
@@ -259,7 +262,7 @@
   ;<  ~  bind:m  setup
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'old-run' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'old-run' payload &]))
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
   ;<  caz=(list card)  bind:m  (do-arvo /lens/prune [%behn %wake ~])
   ;<  ~  bind:m
@@ -280,7 +283,7 @@
   ;<  ~  bind:m  setup
   ;<  *  bind:m
     %-  (do-as moon)
-    (do-poke %steward-action-1 !>(`action:v1:s`[%lens 'old-run' payload &]))
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'old-run' payload &]))
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add ~2024.1.1 ~d91))))
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/recent)
   =+  !<(entries=(list update:lens:s) q.res)
@@ -312,6 +315,125 @@
   ?:  ?=(%& -.run)
     |+~['expected foreign /x/v1/lens/run peek to crash']
   &+[~ s]
+::
+::  ==========================================================
+::  RETRY ACTION TESTS
+::  ==========================================================
+::
+::  retry from the configured owner (cross-ship poke from owner planet to
+::  bot moon) emits a %retry-requested fact on /v1/lens for the local
+::  gateway to dispatch. retry doesn't mutate stored state.
+::
+++  test-retry-from-owner-emits-fact
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure ~bus)
+  ;<  caz=(list card)  bind:m
+    %-  (do-as ~bus)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r1']))
+  %+  ex-cards  caz
+  :~  %-  ex-fact
+      :*  ~[/v1/lens]
+          %steward-update-1
+          !>(`update:v1:s`[%lens %retry-requested 'lens-r1' ~bus])
+      ==
+  ==
+::
+::  a local retry (src=our, e.g. self-owned bot whose owner is our ship)
+::  is permitted and tags the requester as our.bowl.
+::
+++  test-retry-from-self-emits-fact
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure ~dev)
+  ;<  caz=(list card)  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r2']))
+  %+  ex-cards  caz
+  :~  %-  ex-fact
+      :*  ~[/v1/lens]
+          %steward-update-1
+          !>(`update:v1:s`[%lens %retry-requested 'lens-r2' ~dev])
+      ==
+  ==
+::
+::  retry from a non-owner, non-self ship must crash the auth gate.
+::
+++  test-retry-from-non-owner-rejected
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure ~bus)
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r3']))
+::
+::  retry when no owner is configured: only self is accepted.
+::
+++  test-retry-without-owner-rejected-from-foreign
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as ~bus)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r4']))
+::
+::  retry does NOT mutate the lens store (no new run record is created;
+::  no entry fact is emitted). the gateway is expected to dispatch and
+::  later push the new run back via %entry.
+::
+++  test-retry-does-not-mutate-store
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure ~bus)
+  ;<  *  bind:m
+    %-  (do-as ~bus)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r5']))
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-0 !<(vase q.res))
+  (ex-equal !>(~(wyt by lens.st)) !>(0))
+::
+::  retry against an existing finalized entry must not touch the stored
+::  record (no overwrite, no demotion, no entry-fact re-emission).
+::
+++  test-retry-preserves-existing-entry
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure ~bus)
+  ::  store a finalized entry as a sponsored moon first.
+  ::
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'lens-r6' payload &]))
+  ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now ~2024.1.2)))
+  ::  retry it from the owner; the entry must remain unchanged and only
+  ::  the retry-requested fact must be emitted (no entry fact).
+  ::
+  ;<  caz=(list card)  bind:m
+    %-  (do-as ~bus)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %retry 'lens-r6']))
+  ;<  ~  bind:m
+    %+  ex-cards  caz
+    :~  %-  ex-fact
+        :*  ~[/v1/lens]
+            %steward-update-1
+            !>(`update:v1:s`[%lens %retry-requested 'lens-r6' ~bus])
+        ==
+    ==
+  ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-r6)
+  =+  !<(=update:v1:s q.res)
+  ?>  ?=(%lens -.update)
+  ?>  ?=(%entry -.update.update)
+  (ex-equal !>(run.entry.update.update) !>(`run:lens:s`[& ~2024.1.1 payload]))
 ::
 ::  ==========================================================
 ::  GATEWAY MODULE TESTS

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -537,6 +537,28 @@
   =/  st  !<(state-1 !<(vase q.res))
   (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
 ::
+::  payloads larger than the agent cap (512KB) are dropped without store
+::  mutation or fact emission — a misbehaving gateway can't force
+::  unbounded growth via a single poke.
+::
+++  test-oversized-entry-payload-dropped
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  (configure ~dev)
+  ::  build a payload one byte over the cap.
+  ::
+  =/  big-payload=@t
+    (crip (reap (add 524.288 1) 'a'))
+  ;<  caz=(list card)  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-action-1 !>(`action:v1:s`[%lens %entry 'big' big-payload &]))
+  ;<  ~  bind:m  (ex-cards caz ~)
+  ;<  res=cage  bind:m  (got-peek /x/dbug/state)
+  =/  st  !<(state-1 !<(vase q.res))
+  (ex-equal !>(~(wyt by runs.lens.st)) !>(0))
+::
 ::  retry against an existing finalized entry must not touch the stored
 ::  record (no overwrite, no demotion, no entry-fact re-emission).
 ::

--- a/docs/steward.md
+++ b/docs/steward.md
@@ -23,14 +23,23 @@ The app helper core keeps each module's logic in its own sub-core: `le-core` for
 
 ## state model
 
-State is `state-0`, defined in the app file. Cross-cutting config is top level; each module owns its own slice:
+State is `state-1`, defined in the app file. Cross-cutting config is top level; each module owns its own slice:
 
 ```
-state-0
-  owner    (unit ship)                 shared config: bot fans runs out to it / its DMs are watched; ~ = inert
-  lens     (map [bot=ship id=@t] run)   stored lens run records (owner role)
+state-1
+  owner    (unit ship)                  shared config: bot fans runs out to it / its DMs are watched; ~ = inert
+  lens     state:lens                   stored lens run records + retention cap (owner role)
   gateway  <gateway state>              harness liveness + auto-reply bookkeeping
 ```
+
+`lens` itself is a record:
+
+```
+runs                (map [bot=ship id=@t] run)   stored lens run records
+max-runs-per-bot    @ud                          retention cap; default 10,000, set by %lens %configure
+```
+
+`state-0` (legacy: `lens` was a bare map, no cap field) is migrated forward by `on-load`.
 
 `owner` is shared: the lens module fans runs out to it, and the gateway module treats its DMs as owner activity worth auto-replying to.
 
@@ -59,11 +68,12 @@ Lens actions form a tagged union: `%entry` carries a run milestone and is the da
 
 ### retention
 
-Bounds, per bot: runs older than 90 days are dropped; at most 1000 live runs per bot (oldest beyond the cap dropped). Enforced in three places:
+Count-bounded per bot, no time-based expiry — lens runs are durable memory of agent activity, not transient logs. The cap is `max-runs-per-bot` in lens state; default is 10,000 (set on init or on state-0 → state-1 migration), and configurable per-ship via the `%lens %configure` action. Enforced in two places:
 
-- **on store**: every incoming run prunes that bot's records.
-- **on a daily timer**: a recurring behn wake on the `/lens/prune` wire prunes all bots and re-arms itself, so storage is reclaimed even when a bot goes quiet.
-- **on read**: `/x/v1/lens/recent` and `/x/v1/lens/run` filter expired runs, so the age bound holds observably regardless of timer cadence (gall scries cannot mutate state, so this is a filter, not a prune).
+- **on store**: every incoming `%entry` prunes that bot's records to the cap (oldest by `received` dropped first).
+- **on `%configure`**: changing the cap applies it to every bot immediately, so a lowered cap takes effect without waiting for the next per-bot insert.
+
+There is no periodic prune timer and no read-time filter — the cap is the only bound, and runs are never silently aged out.
 
 ## module: gateway
 
@@ -89,19 +99,21 @@ JSON poke forms (as sent over Eyre / Ames):
 { "configure": { "owner": "~sampel-palnet" } }
 { "lens": { "entry": { "id": "<lensId>", "payload": "<serialized JSON>", "final": true } } }
 { "lens": { "retry": { "id": "<lensId>" } } }
+{ "lens": { "configure": { "max-runs-per-bot": 25000 } } }
 ```
 
 Hoon types (`sur/steward.hoon`):
 
 ```
 [%configure owner=ship]               top-level: set the shared owner
-[%lens action:lens]                   inner: %entry or %retry, see below
+[%lens action:lens]                   inner: %entry, %retry, or %configure
 [%gateway action:gateway]             gateway lifecycle (configure/start/heartbeat/stop)
 
 ++  lens
   +$  action
     $%  [%entry id=@t payload=@t final=?]  a lens run milestone (final=& finalizes)
         [%retry id=@t]                     owner-initiated re-dispatch request
+        [%configure max-runs-per-bot=@ud]  set the per-bot retention cap
     ==
 ```
 
@@ -123,8 +135,10 @@ The gateway action wraps the harness liveness protocol (see the gateway module a
 
 ## scry surface
 
-- `/x/v1/lens/recent` → `%noun` `(list update:lens)` — newest 50 non-expired runs across all bots as `%entry` updates, for backfill.
-- `/x/v1/lens/run/[ship]/[id]` → `%steward-update-1` `[%lens %entry entry]`, or empty (`[~ ~]`) when absent or expired.
+- `/x/v1/lens/recent` → `%noun` `(list update:lens)` — newest 50 runs across all bots as `%entry` updates, for first-page backfill.
+- `/x/v1/lens/recent/[count]` → `%noun` `(list update:lens)` — newest `count` runs across all bots; paginate by varying count.
+- `/x/v1/lens/since/[da]` → `%noun` `(list update:lens)` — every run with `received >= da`, newest first; paginate back through history by passing the oldest `received` from the previous page.
+- `/x/v1/lens/run/[ship]/[id]` → `%steward-update-1` `[%lens %entry entry]`, or empty (`[~ ~]`) when absent.
 - `/x/v1/gateway/status` → `%noun` `[status (unit @da)]` — current liveness and lease expiry.
 - `/x/v1/gateway/owner-activity` → `%noun` `@da` — timestamp of the most recent owner DM.
 
@@ -137,10 +151,10 @@ The gateway action wraps the harness liveness protocol (see the gateway module a
 
 ## lifecycle and invariants
 
-- `on-init` arms the daily lens prune timer (`/lens/prune` behn wire) and subscribes to `%activity /v5` for the gateway module. The prune timer is armed once; reloading at `%0` does not stack a second one.
-- `on-load` accepts state `%0` only — `%steward` is greenfield with no prior versions; an unreadable state resets to bunt and re-arms the timers/subscriptions.
-- Wires: lens fan-out on `/lens/fanout/[owner-p]/[id-t]`, lens prune on `/lens/prune`, the gateway lease timer on `/gateway/lease-check`, gateway auto-reply/notice DM sends on `/gateway/dm/send`. The `%activity` subscription is re-watched on `%kick`. Poke/DM nacks are logged and ignored (Ames retries).
-- `on-watch` and `on-peek` assert `=(src our)` — no cross-ship subscriptions or foreign scries. Only the `%steward-action-1` poke is ownership-gated (to admit a bot's runs).
+- `on-init` seeds the lens config (`max-runs-per-bot` = `default-max-runs-per-bot`) and subscribes to `%activity /v5` for the gateway module. There is no prune timer.
+- `on-load` tries state-1 first, then state-0 with migration (legacy lens map is wrapped into the new record, default cap applied), then bunt on failure.
+- Wires: lens fan-out on `/lens/fanout/[owner-p]/[id-t]`, gateway lease timer on `/gateway/lease-check`, gateway auto-reply/notice DM sends on `/gateway/dm/send`. The `%activity` subscription is re-watched on `%kick`. Poke/DM nacks are logged and ignored (Ames retries).
+- `on-watch` and `on-peek` assert `=(src our)` — no cross-ship subscriptions or foreign scries. The `%steward-action-1` poke is gated per-variant (see "poke surface" above).
 
 ## integration notes
 

--- a/docs/steward.md
+++ b/docs/steward.md
@@ -135,10 +135,12 @@ The gateway action wraps the harness liveness protocol (see the gateway module a
 
 ## scry surface
 
-- `/x/v1/lens/recent` → `%noun` `(list update:lens)` — newest 50 runs across all bots as `%entry` updates, for first-page backfill.
-- `/x/v1/lens/recent/[count]` → `%noun` `(list update:lens)` — newest `count` runs across all bots; paginate by varying count.
-- `/x/v1/lens/since/[da]` → `%noun` `(list update:lens)` — every run with `received >= da`, newest first; paginate back through history by passing the oldest `received` from the previous page.
-- `/x/v1/lens/run/[ship]/[id]` → `%steward-update-1` `[%lens %entry entry]`, or empty (`[~ ~]`) when absent.
+All lens scries return a `%steward-update-1` cage so HTTP clients can scry as `.json` (the mark's grow handles the conversion). List responses are wrapped in the `%recent` update variant.
+
+- `/x/v1/lens/recent` → `[%lens %recent entries]` — newest 50 entries across all bots, for first-page backfill.
+- `/x/v1/lens/recent/[count]` → `[%lens %recent entries]` — newest `count` entries.
+- `/x/v1/lens/since/[da]` → `[%lens %recent entries]` — every entry with `received >= da`, newest first; paginate back through history by passing the oldest `received` from the previous page.
+- `/x/v1/lens/run/[ship]/[id]` → `[%lens %entry entry]`, or empty (`[~ ~]`) when absent.
 - `/x/v1/gateway/status` → `%noun` `[status (unit @da)]` — current liveness and lease expiry.
 - `/x/v1/gateway/owner-activity` → `%noun` `@da` — timestamp of the most recent owner DM.
 
@@ -147,6 +149,7 @@ The gateway action wraps the harness liveness protocol (see the gateway module a
 ```json
 { "lens": { "entry": { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": "<serialized JSON>" } } }
 { "lens": { "retry-requested": { "id": "...", "requester": "~sampel-palnet" } } }
+{ "lens": { "recent": [{ "bot": "~zod", "id": "...", "complete": true, "received": "~...", "payload": "<serialized JSON>" }, ...] } }
 ```
 
 ## lifecycle and invariants

--- a/docs/steward.md
+++ b/docs/steward.md
@@ -64,7 +64,7 @@ One agent, two roles; the same code runs on every ship, and the role is determin
 
 A self-owned bot (`owner` equal to `our`) is stored directly during fan-out with no network hop.
 
-Lens actions form a tagged union: `%entry` carries a run milestone and is the data ingress path; `%retry` is an owner-initiated request to re-dispatch a finalized run. `%entry` is `[%entry id=@t payload=@t final=?]` — `final=&` marks the run complete, `final=|` upserts an in-progress partial, and a finalized run is never demoted by a late `final=|` (the late partial is dropped). `%retry` is `[%retry id=@t]`; it emits a `%retry-requested` fact on `/v1/lens` for the local gateway to pick up and dispatch, but does not mutate stored state — the new run lands later as an `%entry` from the gateway with a fresh `id` (and `retryOf` pointing to the original).
+Lens actions form a tagged union: `%entry` carries a run milestone and is the data ingress path; `%retry` is an owner-initiated request to re-dispatch a finalized run. `%entry` is `[%entry id=@t payload=@t final=?]` — `final=&` marks the run complete, `final=|` upserts an in-progress partial, and a finalized run is never demoted by a late `final=|` (the late partial is dropped). `%retry` is `[%retry bot=ship id=@t]`; the agent routes it by `bot`: if `bot == our.bowl` we emit a `%retry-requested` fact on `/v1/lens` for the local gateway, otherwise we cross-ship poke that bot's steward (which then emits the fact on its own side). Retry doesn't mutate stored state — the new run lands later as an `%entry` from the bot's gateway with a fresh `id` (and `retryOf` pointing to the original).
 
 ### retention
 
@@ -91,14 +91,14 @@ Auth is per-variant rather than blanket-gated:
 
 - `%configure` and `%gateway` require `src == our` (local only).
 - `%lens %entry` requires `src == our` or `src` is a moon `our` sponsors — the data ingress shape, used by the bot's local gateway and by cross-ship fan-out from a moon to its sponsor (a moon's sponsor is its immutable low 32 bits, derived directly — no jael scry).
-- `%lens %retry` requires `src == our` or `src` is the configured `owner` — covers a cross-ship retry poke from an owner planet to a bot moon (the `%entry` gate would reject this direction since the owner isn't a moon the bot sponsors).
+- `%lens %retry` requires `src == our` or `src` is the configured `owner`. Two-hop routing: a client on the owner ship pokes its local steward (src=our), the owner's steward checks `bot.action`; if `bot == our.bowl` it emits the fact directly, else it cross-ship pokes the bot's steward, which then accepts (src=owner, which the bot has configured) and emits the fact.
 
 JSON poke forms (as sent over Eyre / Ames):
 
 ```json
 { "configure": { "owner": "~sampel-palnet" } }
 { "lens": { "entry": { "id": "<lensId>", "payload": "<serialized JSON>", "final": true } } }
-{ "lens": { "retry": { "id": "<lensId>" } } }
+{ "lens": { "retry": { "bot": "~sampel-bot", "id": "<lensId>" } } }
 { "lens": { "configure": { "max-runs-per-bot": 25000 } } }
 ```
 
@@ -111,9 +111,9 @@ Hoon types (`sur/steward.hoon`):
 
 ++  lens
   +$  action
-    $%  [%entry id=@t payload=@t final=?]  a lens run milestone (final=& finalizes)
-        [%retry id=@t]                     owner-initiated re-dispatch request
-        [%configure max-runs-per-bot=@ud]  set the per-bot retention cap
+    $%  [%entry id=@t payload=@t final=?]   a lens run milestone (final=& finalizes)
+        [%retry bot=ship id=@t]             owner-initiated re-dispatch request
+        [%configure max-runs-per-bot=@ud]   set the per-bot retention cap
     ==
 ```
 

--- a/docs/steward.md
+++ b/docs/steward.md
@@ -55,7 +55,7 @@ One agent, two roles; the same code runs on every ship, and the role is determin
 
 A self-owned bot (`owner` equal to `our`) is stored directly during fan-out with no network hop.
 
-A lens action is a single shape — `[id=@t payload=@t final=?]`. `final=&` marks the run complete; `final=|` is an in-progress milestone that upserts a partial record. A finalized run is never demoted back to partial by a late `final=|` (the late partial is dropped).
+Lens actions form a tagged union: `%entry` carries a run milestone and is the data ingress path; `%retry` is an owner-initiated request to re-dispatch a finalized run. `%entry` is `[%entry id=@t payload=@t final=?]` — `final=&` marks the run complete, `final=|` upserts an in-progress partial, and a finalized run is never demoted by a late `final=|` (the late partial is dropped). `%retry` is `[%retry id=@t]`; it emits a `%retry-requested` fact on `/v1/lens` for the local gateway to pick up and dispatch, but does not mutate stored state — the new run lands later as an `%entry` from the gateway with a fresh `id` (and `retryOf` pointing to the original).
 
 ### retention
 
@@ -77,21 +77,32 @@ While the gateway is not live, a DM from the configured `owner` triggers a canne
 
 ## poke surface — `%steward-action-1`
 
-Gated on **ownership**, not strict locality: accepted iff `src` is `our`, or `src` is a moon `our` sponsors (a moon's sponsor is its immutable low 32 bits, derived directly — no jael scry). A bot is typically a moon of the owner planet, so the owner accepts lens runs from itself and from its own moons.
+Auth is per-variant rather than blanket-gated:
+
+- `%configure` and `%gateway` require `src == our` (local only).
+- `%lens %entry` requires `src == our` or `src` is a moon `our` sponsors — the data ingress shape, used by the bot's local gateway and by cross-ship fan-out from a moon to its sponsor (a moon's sponsor is its immutable low 32 bits, derived directly — no jael scry).
+- `%lens %retry` requires `src == our` or `src` is the configured `owner` — covers a cross-ship retry poke from an owner planet to a bot moon (the `%entry` gate would reject this direction since the owner isn't a moon the bot sponsors).
 
 JSON poke forms (as sent over Eyre / Ames):
 
 ```json
 { "configure": { "owner": "~sampel-palnet" } }
-{ "lens": { "id": "<lensId>", "payload": "<serialized JSON>", "final": true } }
+{ "lens": { "entry": { "id": "<lensId>", "payload": "<serialized JSON>", "final": true } } }
+{ "lens": { "retry": { "id": "<lensId>" } } }
 ```
 
 Hoon types (`sur/steward.hoon`):
 
 ```
 [%configure owner=ship]               top-level: set the shared owner
-[%lens id=@t payload=@t final=?]      a lens run milestone (final=& finalizes)
+[%lens action:lens]                   inner: %entry or %retry, see below
 [%gateway action:gateway]             gateway lifecycle (configure/start/heartbeat/stop)
+
+++  lens
+  +$  action
+    $%  [%entry id=@t payload=@t final=?]  a lens run milestone (final=& finalizes)
+        [%retry id=@t]                     owner-initiated re-dispatch request
+    ==
 ```
 
 The gateway action wraps the harness liveness protocol (see the gateway module above):
@@ -105,20 +116,23 @@ The gateway action wraps the harness liveness protocol (see the gateway module a
 
 ## subscription surface
 
-- `/v1/lens` (local only, `?> =(src our)`): `%steward-update-1` `[%lens entry]` facts, one per stored run. No initial backfill fact — clients scry `/x/v1/lens/recent` for backfill.
+- `/v1/lens` (local only, `?> =(src our)`): `%steward-update-1` lens facts. Two variants:
+  - `[%lens %entry entry]` — emitted on every store and on every retry receipt? No: only on entry store. Clients backfill via `/x/v1/lens/recent`.
+  - `[%lens %retry-requested id=@t requester=ship]` — emitted when an owner pokes `%retry`, to signal the local gateway to re-dispatch.
 - `/v1/gateway` (local only): `%steward-update-1` `[%gateway ...]` facts — `%status` (on lifecycle transitions, plus an initial fact on subscribe), `%owner-activity`, and `%auto-reply`.
 
 ## scry surface
 
-- `/x/v1/lens/recent` → `%noun` `(list update:lens)` — newest 50 non-expired runs across all bots, for backfill.
-- `/x/v1/lens/run/[ship]/[id]` → `%steward-update-1` `[%lens entry]`, or empty (`[~ ~]`) when absent or expired.
+- `/x/v1/lens/recent` → `%noun` `(list update:lens)` — newest 50 non-expired runs across all bots as `%entry` updates, for backfill.
+- `/x/v1/lens/run/[ship]/[id]` → `%steward-update-1` `[%lens %entry entry]`, or empty (`[~ ~]`) when absent or expired.
 - `/x/v1/gateway/status` → `%noun` `[status (unit @da)]` — current liveness and lease expiry.
 - `/x/v1/gateway/owner-activity` → `%noun` `@da` — timestamp of the most recent owner DM.
 
 `entry` is `[bot=ship id=@t run]`. The lens update mark grows to JSON for Eyre:
 
 ```json
-{ "lens": { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": "<serialized JSON>" } }
+{ "lens": { "entry": { "bot": "~zod", "id": "...", "complete": true, "received": "~2026.6.10..12.00.00..0000", "payload": "<serialized JSON>" } } }
+{ "lens": { "retry-requested": { "id": "...", "requester": "~sampel-palnet" } } }
 ```
 
 ## lifecycle and invariants


### PR DESCRIPTION
Stacked on `hm/steward` (#5971). Reopens the scope of the now-closed #5975 and adds the trusted-bots auth fix on top. Steward-only diff (app + marks + sur + tests + docs); 7 commits.

## Headline: explicit trusted-bots `%entry` gate (replaces moon-sponsor-only)

#5971 gated lens `%entry` fan-out to **moons sponsored by the owner**. That rejects a planet→planet setup: bot `~sitrul-nacwyl` (planet) fanning runs to owner `~malmur-halmex` (planet) is refused.

This replaces the moon-sponsor check with an explicit, **ship-class-agnostic trusted-bots set**:
- `state-2` adds `bots=(set ship)`. Owner accepts `%entry` from `our` **or** any ship in `bots`.
- Self-only `%trust-bot` / `%untrust-bot` pokes manage the set.
- `on-load` migration is load-bearing: `state-2 → state-1 (+bots=~) → state-0 (+cap +bots=~) → bunt`. In-place mutation of `state-1` would silently bunt-reset live ships (wiping owner/runs/gateway). Trust is **not** auto-granted by moon sponsorship — operators must re-grant with `%trust-bot` post-upgrade.

## Also in this branch (the former #5975 scope)

- **`%retry` action** — owner-initiated re-dispatch of a finalized run; routes via the owner ship when `bot != our`. Emits a `%retry-requested` fact on `/v1/lens` rather than mutating state.
- **Count-only retention** — drops the 90d time cap, the prune timer, and `le-expired`; promotes `max-runs-per-bot` into state, configurable via `[%lens %configure]`, default 10000.
- **Payload cap** — hard 512KB ceiling on incoming `%entry` payloads so a compromised gateway can't blow up loom usage.
- **Scry JSON-friendliness** — `/x/v1/lens/recent`, `/recent/<count>`, `/since/<da>`; malformed args `slaw` to `[~ ~]` instead of crashing the peek.

## Mark build fixes (this session)

- `action-1` grab: manual key dispatch couldn't narrow a bare `@` into the `@p` aura the action union expects — routed through the `of` reparser.
- `update-1` grow: a multiline tall-form `?~` inside a wide `[ ]` cell fails to parse — inlined as `?~(...)`.

Both marks now build (verified against a live 408 kernel).

## Test plan

- [ ] `desk/tests/app/steward.hoon`: entry-union, 6 retry, 5 retention, 2 scry-window, 1 malformed-args robustness.
- [ ] Trusted-bots: `%trust-bot`/`%untrust-bot` self-only; `%entry` accepted from a trusted planet, rejected from an untrusted ship.
- [ ] `state-1 → state-2` migration preserves owner/runs/gateway (no bunt-reset).
- [ ] Marks build on a 408 desk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)