### PR TITLE
fix(openclaw/lens): per-account global services + route telemetry

### DIFF
--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -82,9 +82,11 @@ channels:
 
 ## Telemetry
 
-Telemetry is disabled by default. The plugin only sends tlemetry events when `channels.tlon.telemetry.enabled` is set to `true` and an API key is configured.
+Telemetry is disabled by default. The plugin only sends telemetry events when `channels.tlon.telemetry.enabled` is set to `true` and an API key is configured.
 
-When enabled, the plugin captures a single `TlonBot Reply Handled` event each time it enters the OpenClaw reply flow. The event summarizes OpenClaw usage (tools used, character count, etc.), but does not log message content.
+Every event carries content-free version identity: `harness: "openclaw"`, `pluginVersion`, `pluginCommit`, `pluginFingerprint`, plus Hermes-compatible `adapterVersion` and `adapterFingerprint` fields for shared PostHog charts.
+
+When enabled, the plugin captures `TlonBot Gateway Connected` after subscriptions are active, `TlonBot Reply Handled` after each OpenClaw reply flow, `TlonBot Outbound Routed` for route-dependent sends, and heartbeat nudge events. `TlonBot Gateway Connected` also includes the resolved `tlon` CLI version as `tlonSkillVersion`. These summarize counts, routing, model/tool usage, and delivery status, but do not log message content.
 
 The plugin does not enable telemetry automatically just because an API key is present. `enabled: true` is required so open-source installs do not phone home by default.
 
@@ -115,11 +117,23 @@ Reply "approve", "deny", or "block" (ID: dm-1234567890-abc)
 
 The owner can send these commands via DM:
 
-| Command         | Description                    |
-| --------------- | ------------------------------ |
-| `blocked`       | List all blocked ships         |
-| `pending`       | List pending approval requests |
-| `unblock ~ship` | Unblock a ship                 |
+| Command        | Description                                |
+| -------------- | ------------------------------------------ |
+| `tlon version` | Show OpenClaw Tlon plugin version identity |
+| `tlon-version` | Legacy alias for `tlon version`            |
+| `banned`       | List all blocked ships                     |
+| `pending`      | List pending approval requests             |
+| `unban ~ship`  | Unblock a ship                             |
+
+`/tlon version` and the legacy `/tlon-version` alias report the same field-per-line summary as Hermes:
+
+```
+Harness: OpenClaw
+Adapter Version: 0.4.3
+Tlon Skill: 0.3.2
+Fingerprint: fp1:8aa23ca2bc8d
+Source: no git checkout
+```
 
 ## Bundled Skill
 
@@ -129,6 +143,7 @@ This plugin bundles [@tloncorp/tlon-skill](https://www.npmjs.com/package/@tlonco
 -   Channel listing and history
 -   Group administration
 -   Message posting and reactions
+-   Notes channel management and note CRUD
 -   Settings management
 
 The skill is automatically available to your agent. For standalone usage, see the [tlon-skill repo](https://github.com/tloncorp/tlon-skill).

--- a/packages/openclaw/dev/build-local-skill-override.sh
+++ b/packages/openclaw/dev/build-local-skill-override.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-PLUGIN_DIR="${PLUGIN_DIR:-/workspace/openclaw-tlon}"
-TLON_SKILL_DIR="${TLON_SKILL_DIR:-/workspace/tlon-skill}"
+# /workspace/tlon is the container-local plugin copy openclaw actually loads
+# (the entrypoint installs there); link the override into it, matching
+# build-local-api-override.sh. The bind-mounted /workspace/openclaw-tlon is
+# not on plugins.load.paths, so linking there would be a no-op.
+PLUGIN_DIR="${PLUGIN_DIR:-/workspace/tlon}"
+# Build from the in-monorepo package so workspace/hoisted deps resolve
+# (@tloncorp/api symlink + @urbit/* at the monorepo root). Compose sets this
+# explicitly; the default mirrors it for standalone invocations.
+TLON_SKILL_DIR="${TLON_SKILL_DIR:-/workspace/tlon-apps/packages/tlon-skill}"
 
 if [ ! -f "$TLON_SKILL_DIR/package.json" ]; then
   echo "==> No local tlon-skill checkout found at $TLON_SKILL_DIR; using published @tloncorp/tlon-skill"
@@ -37,19 +44,27 @@ ln -s "$TLON_SKILL_DIR" "$TARGET"
 # After symlinking, the fallback resolves from the realpath ($TLON_SKILL_DIR/bin/)
 # walking up via the local checkout's node_modules — which on a darwin host won't
 # have the linux binary package installed. So we always produce $TLON_SKILL_DIR/bin/tlon
-# inside the container, either by rebuilding from source (preferred — picks up local
-# edits) or by hydrating the matching platform-arch binary from openclaw-tlon's npm
-# install (fallback when no source is present).
+# inside the container, either by hydrating the matching platform-arch binary from
+# the plugin's npm install (the default — works on any Docker backend) or, when
+# opted in, by rebuilding from source to pick up local edits.
 # bin/tlon is gitignored in tlon-skill, so writing it through the bind mount won't
 # pollute the host working tree.
+#
+# Why the source build is opt-in: `bun build --compile` writes a temp file and
+# renames it onto --outfile. On VirtioFS bind mounts (Docker Desktop) the temp
+# lands at the host realpath while --outfile is the mount path, and the
+# cross-namespace rename fails with ENOENT. The npm-installed skill already
+# ships a working prebuilt binary, so source-from-build is only needed when
+# actively editing tlon-skill — set TLON_SKILL_FROM_SOURCE=1 for that.
 ARCH_KEY=$(node -e 'console.log(process.platform + "-" + process.arch)')
 echo "==> Container platform-arch: $ARCH_KEY"
 
-if [ -f "$TLON_SKILL_DIR/scripts/main.ts" ] && command -v bun >/dev/null 2>&1; then
+if [ -n "${TLON_SKILL_FROM_SOURCE:-}" ] && [ -f "$TLON_SKILL_DIR/scripts/main.ts" ] && command -v bun >/dev/null 2>&1; then
   # Build from source so local edits to tlon-skill scripts/*.ts show up in the CLI.
   # bun --compile bundles all deps into the binary; the host's node_modules (bind
-  # mounted) is reused since tlon-skill's deps are pure JS.
-  echo "==> Rebuilding tlon-skill from source for $ARCH_KEY..."
+  # mounted) is reused since tlon-skill's deps are pure JS. Note: may fail on
+  # VirtioFS (see above) — fall back by unsetting TLON_SKILL_FROM_SOURCE.
+  echo "==> Rebuilding tlon-skill from source for $ARCH_KEY (TLON_SKILL_FROM_SOURCE set)..."
   if [ ! -d "$TLON_SKILL_DIR/node_modules" ]; then
     echo "==> Installing tlon-skill deps (bun install)..."
     (cd "$TLON_SKILL_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)
@@ -65,8 +80,7 @@ if [ -f "$TLON_SKILL_DIR/scripts/main.ts" ] && command -v bun >/dev/null 2>&1; t
   echo "==> Built $TLON_SKILL_DIR/bin/tlon from source"
 else
   if [ -f "$TLON_SKILL_DIR/scripts/main.ts" ]; then
-    echo "==> Source present but bun not installed; falling back to npm-installed binary."
-    echo "==> Add bun to dev/Dockerfile to rebuild from source on container start."
+    echo "==> Using prebuilt tlon-skill binary (set TLON_SKILL_FROM_SOURCE=1 to rebuild from local source)."
   fi
   # Always overwrite bin/tlon — never trust whatever is already there. The local
   # checkout may carry a host-built darwin binary (e.g. from `pnpm dev:link`),

--- a/packages/openclaw/dev/docker-compose.test.yml
+++ b/packages/openclaw/dev/docker-compose.test.yml
@@ -21,26 +21,33 @@ services:
         apt-get update && apt-get install -y curl xz-utils
         cd /data
 
+        # Pin both halves of the runtime/snapshot pair so the version skew that
+        # crashed serf replay (stale snapshot -> downgrade runtime to replay ->
+        # serf unexpectedly shut down) cannot silently return when `latest`
+        # advances past the snapshot kelvin. rube-27 is the archive generation
+        # the tlon-web e2e suite runs; vere-v4.5 is the matching runtime.
+        echo "==> vere pin: vere-v4.5  pier gen: 27"
+
         echo "==> Downloading zod..."
-        curl -fSL https://bootstrap.urbit.org/rube-zod25.tgz -o rube-zod25.tgz || { echo "Failed to download zod"; exit 1; }
-        ls -la rube-zod25.tgz
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-zod27.tgz -o rube-zod27.tgz || { echo "Failed to download zod"; exit 1; }
+        ls -la rube-zod27.tgz
         echo "==> Extracting zod..."
-        tar xzf rube-zod25.tgz || { echo "Failed to extract zod"; exit 1; }
+        tar xzf rube-zod27.tgz || { echo "Failed to extract zod"; exit 1; }
 
         echo "==> Downloading ten..."
-        curl -fSL https://bootstrap.urbit.org/rube-ten25.tgz -o rube-ten25.tgz || { echo "Failed to download ten"; exit 1; }
-        ls -la rube-ten25.tgz
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-ten27.tgz -o rube-ten27.tgz || { echo "Failed to download ten"; exit 1; }
+        ls -la rube-ten27.tgz
         echo "==> Extracting ten..."
-        tar xzf rube-ten25.tgz || { echo "Failed to extract ten"; exit 1; }
+        tar xzf rube-ten27.tgz || { echo "Failed to extract ten"; exit 1; }
 
         echo "==> Downloading mug..."
-        curl -fSL https://bootstrap.urbit.org/rube-mug25.tgz -o rube-mug25.tgz || { echo "Failed to download mug"; exit 1; }
-        ls -la rube-mug25.tgz
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-mug27.tgz -o rube-mug27.tgz || { echo "Failed to download mug"; exit 1; }
+        ls -la rube-mug27.tgz
         echo "==> Extracting mug..."
-        tar xzf rube-mug25.tgz || { echo "Failed to extract mug"; exit 1; }
+        tar xzf rube-mug27.tgz || { echo "Failed to extract mug"; exit 1; }
 
         echo "==> Downloading vere..."
-        curl -fSL https://urbit.org/install/linux-x86_64/latest | tar xz || { echo "Failed to download vere"; exit 1; }
+        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/urbit/vere/releases/download/vere-v4.5/linux-x86_64.tgz | tar xz || { echo "Failed to download vere"; exit 1; }
         VERE=$$(ls -1 vere-*-linux-x86_64 | head -1)
         chmod +x $$VERE
         echo "==> Using vere: $$VERE"

--- a/packages/openclaw/dev/docker-compose.yml
+++ b/packages/openclaw/dev/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       # Inside the container, the local tlon-apps/homestead checkout is always mounted here.
       # This must not use the host absolute path from .env.
       - TLON_APPS_DIR=/workspace/tlon-apps
-      # Inside the container, the local tlon-skill checkout is always mounted here.
-      # This must not use the host absolute path from .env.
-      - TLON_SKILL_DIR=/workspace/tlon-skill
+      # The tlon-skill override builds from the in-monorepo package so its
+      # workspace deps resolve: @tloncorp/api via the symlink into
+      # packages/api, and @urbit/* hoisted to the monorepo root node_modules.
+      # Must point inside the /workspace/tlon-apps mount, not a standalone one.
+      - TLON_SKILL_DIR=/workspace/tlon-apps/packages/tlon-skill
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     volumes:
@@ -27,12 +29,10 @@ services:
       # Mount tlonbot for config and prompts. Defaults to a checkout sitting
       # next to the tlon-apps monorepo root; override with TLONBOT_DIR.
       - ${TLONBOT_DIR:-../../../../tlonbot}:/workspace/tlonbot
-      # The containing tlon-apps monorepo, for dev-only @tloncorp/api override
-      # builds. Defaults to the repo this package lives in.
+      # The containing tlon-apps monorepo, for dev-only @tloncorp/api and
+      # @tloncorp/tlon-skill override builds. Both override scripts build from
+      # packages/* inside this mount so workspace/hoisted deps resolve.
       - ${TLON_APPS_DIR:-../../..}:/workspace/tlon-apps
-      # The in-monorepo tlon-skill package, for the dev-only
-      # @tloncorp/tlon-skill override (built from source in the container).
-      - ${TLON_SKILL_DIR:-../../tlon-skill}:/workspace/tlon-skill
       # Persist OpenClaw state
       - openclaw-state:/root/.openclaw
       # Config from tlonbot (copied + patched by entrypoint, not mounted directly)

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -1474,7 +1474,12 @@ export default defineChannelPluginEntry({
                 ? 'group'
                 : 'unknown';
 
-          reportOutboundRoute({ resolvedChannel, routedToTlon, targetKind });
+          reportOutboundRoute({
+            resolvedChannel,
+            routedToTlon,
+            targetKind,
+            accountId: ctx.accountId ?? null,
+          });
 
           if (isRouteDebugEnabled()) {
             api.logger.info(

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -2,7 +2,14 @@ import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineChannelPluginEntry } from 'openclaw/plugin-sdk/core';
+import {
+  type OpenClawPluginApi,
+  defineChannelPluginEntry,
+} from 'openclaw/plugin-sdk/core';
+import {
+  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
+} from 'openclaw/plugin-sdk/diagnostic-runtime';
 
 import { tlonPlugin } from './src/channel.js';
 import { publishContextLensEvent } from './src/context-lens-events.js';
@@ -15,25 +22,52 @@ import {
   recordContextLensToolStartForSession,
   scheduleBackgroundContextLensFinalization,
 } from './src/context-lens.js';
+import {
+  installTlonDiagnosticSubscriptions,
+  shouldInstallTlonDiagnosticSubscriptions,
+} from './src/diagnostic-subscriptions.js';
 import { sendGatewayStop } from './src/gateway-status.js';
 import {
   createGatewayStatusManager,
   setGatewayStatusManager,
 } from './src/gateway-status.js';
 import { resolveBridgeForCommand } from './src/monitor/command-auth.js';
+import { isRouteDebugEnabled } from './src/monitor/session-routing.js';
 import { handleOwnerListenCommand } from './src/owner-listen-command.js';
 import { setTlonRuntime } from './src/runtime.js';
 import { getSessionRole } from './src/session-roles.js';
-import { recordToolCall } from './src/telemetry.js';
+import { parseTlonTarget } from './src/targets.js';
+import {
+  type TlonDiagnosticLogAttributes,
+  type TlonSessionDiagnosticReportInput,
+  formatTlonTelemetryErrorText,
+  recordToolCall,
+  reportHarnessDebug,
+  reportHarnessError,
+  reportOutboundRoute,
+  reportPluginError,
+  reportSessionDiagnostic,
+  reportSessionLifecycle,
+  reportSessionTurnCreated,
+  reportTelemetryError,
+} from './src/telemetry.js';
 import { resolveTlonBinary } from './src/tlon-binary.js';
-import { checkBlockedSendOperation } from './src/tlon-tool-guard.js';
+import {
+  checkBlockedSendOperation,
+  formatAllowedTlonSubcommands,
+  isAllowedTlonSubcommand,
+} from './src/tlon-tool-guard.js';
 import {
   formatToolTraceEvent,
   liveToolTraceContentsEnabled,
   shouldLogAfterToolTrace,
 } from './src/tool-trace.js';
 import { listTlonAccountIds, resolveTlonAccount } from './src/types.js';
-import { PLUGIN_COMMIT, PLUGIN_VERSION } from './src/version.generated.js';
+import {
+  formatTlonVersionIdentity,
+  resolveTlonSkillVersion,
+  setTlonSkillVersionResolver,
+} from './src/version.js';
 
 export { tlonPlugin } from './src/channel.js';
 export { setTlonRuntime } from './src/runtime.js';
@@ -57,24 +91,6 @@ function readToolCallId(event: unknown): string | undefined {
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 const require = createRequire(import.meta.url);
-
-// Whitelist of allowed tlon subcommands
-const ALLOWED_TLON_COMMANDS = new Set([
-  'activity',
-  'channels',
-  'contacts',
-  'dms',
-  'expose',
-  'groups',
-  'hooks',
-  'messages',
-  'notebook',
-  'posts',
-  'settings',
-  'upload',
-  'help',
-  'version',
-]);
 
 /** Credential flags that the tlon skill binary accepts before the subcommand. */
 const CREDENTIAL_FLAGS_WITH_VALUE = new Set([
@@ -203,7 +219,7 @@ function runTlonCommand(
   binary: string,
   args: string[],
   credentials?: { url: string; ship: string; code: string },
-  timeoutMs = DEFAULT_TLON_CLI_TIMEOUT_MS
+  options?: { timeoutMs?: number }
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const env = { ...process.env };
@@ -214,20 +230,18 @@ function runTlonCommand(
     }
 
     const child = spawn(binary, args, { env });
-    let settled = false;
-    let killTimer: NodeJS.Timeout | null = null;
-    const timeout = setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      child.kill('SIGTERM');
-      killTimer = setTimeout(() => child.kill('SIGKILL'), 2_000);
-      reject(new Error(`tlon command timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
     let stdout = '';
     let stderr = '';
+    let timedOut = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutMs = options?.timeoutMs;
+
+    const cleanup = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+    };
 
     child.stdout.on('data', (data) => {
       stdout += data.toString();
@@ -238,32 +252,735 @@ function runTlonCommand(
     });
 
     child.on('error', (err) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      if (killTimer) {
-        clearTimeout(killTimer);
-      }
+      cleanup();
       reject(new Error(`Failed to run tlon: ${err.message}`));
     });
 
+    if (timeoutMs) {
+      timeout = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+      }, timeoutMs);
+    }
+
     child.on('close', (code) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      if (killTimer) {
-        clearTimeout(killTimer);
-      }
-      if (code !== 0) {
+      cleanup();
+      if (timedOut) {
+        reject(new Error(`tlon timed out after ${timeoutMs}ms`));
+      } else if (code !== 0) {
         reject(new Error(stderr || `tlon exited with code ${code}`));
       } else {
         resolve(stdout);
       }
     });
+  });
+}
+
+function firstLine(value: string): string {
+  return value.trim().split(/\r?\n/)[0]?.trim() || 'unknown';
+}
+
+function summarizeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return firstLine(message).slice(0, 180);
+}
+
+async function readTlonSkillVersion(binary: string): Promise<string> {
+  try {
+    return firstLine(
+      await runTlonCommand(binary, ['--version'], undefined, {
+        timeoutMs: 5_000,
+      })
+    );
+  } catch (error) {
+    return `unavailable (${summarizeError(error)})`;
+  }
+}
+
+function isTlonSessionDiagnosticEvent(event: {
+  type: string;
+}): event is TlonSessionDiagnosticReportInput {
+  return (
+    event.type === 'session.stalled' ||
+    event.type === 'session.stuck' ||
+    event.type === 'session.recovery.requested' ||
+    event.type === 'session.recovery.completed'
+  );
+}
+
+type DiagnosticCandidate = Record<string, unknown> & { type?: unknown };
+
+function stringField(event: DiagnosticCandidate, key: string): string | null {
+  const value = event[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function numberField(event: DiagnosticCandidate, key: string): number | null {
+  const value = event[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function objectField(
+  event: DiagnosticCandidate,
+  key: string
+): Record<string, unknown> | null {
+  const value = event[key];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function diagnosticLogAttributes(
+  event: DiagnosticCandidate
+): TlonDiagnosticLogAttributes | null {
+  const attributes = objectField(event, 'attributes');
+  if (!attributes) {
+    return null;
+  }
+
+  const normalized = Object.create(null) as TlonDiagnosticLogAttributes;
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value === 'string') {
+      normalized[key] = value;
+      continue;
+    }
+    if (typeof value === 'boolean') {
+      normalized[key] = value;
+      continue;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      normalized[key] = value;
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function stringAttribute(
+  attributes: TlonDiagnosticLogAttributes | null,
+  key: string
+): string | null {
+  const value = attributes?.[key];
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function numberAttribute(
+  attributes: TlonDiagnosticLogAttributes | null,
+  key: string
+): number | null {
+  const value = attributes?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function diagnosticErrorText(event: DiagnosticCandidate): string | null {
+  return stringField(event, 'error') ?? stringField(event, 'message');
+}
+
+function stringListField(event: DiagnosticCandidate, key: string): string[] {
+  const value = event[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter(Boolean);
+}
+
+function diagnosticSummary(
+  parts: Array<[string, string | number | boolean | null | undefined]>
+): string {
+  return parts
+    .filter(
+      ([, value]) => value !== null && value !== undefined && value !== ''
+    )
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(' ');
+}
+
+const HARNESS_DEBUG_EVENT_TYPES = new Set([
+  'session.turn.created',
+  'run.started',
+  'run.completed',
+  'context.assembled',
+  'model.call.started',
+  'model.call.completed',
+  'model.call.error',
+  'harness.run.started',
+  'harness.run.completed',
+  'harness.run.error',
+  'tool.execution.started',
+  'tool.execution.completed',
+  'tool.execution.error',
+  'tool.execution.blocked',
+]);
+
+const HARNESS_DEBUG_LOG_PATTERNS = [
+  '[context-engine]',
+  '[lcm]',
+  '[trace:embedded-run]',
+  'context engine',
+  'lossless-claw',
+];
+
+function debugEventKind(type: string): string {
+  if (type === 'session.turn.created') {
+    return 'turn';
+  }
+  if (type === 'context.assembled') {
+    return 'context';
+  }
+  if (type.startsWith('model.call.')) {
+    return 'model';
+  }
+  if (type.startsWith('harness.run.')) {
+    return 'harness';
+  }
+  if (type.startsWith('tool.execution.')) {
+    return 'tool';
+  }
+  if (type.startsWith('run.')) {
+    return 'run';
+  }
+  if (type === 'log.record') {
+    return 'log';
+  }
+  return 'diagnostic';
+}
+
+function isContextEngineDebugMessage(message: string | null): boolean {
+  const normalized = message?.toLowerCase() ?? '';
+  return HARNESS_DEBUG_LOG_PATTERNS.some((pattern) =>
+    normalized.includes(pattern)
+  );
+}
+
+function extractContextEngineTaskId(message: string | null): string | null {
+  return extractDiagnosticKeyValue(message, 'taskId');
+}
+
+function extractDiagnosticKeyValue(
+  message: string | null,
+  key: string
+): string | null {
+  if (!message) {
+    return null;
+  }
+  return new RegExp(`\\b${key}=([^\\s]+)`).exec(message)?.[1] ?? null;
+}
+
+function extractDiagnosticSessionKey(message: string | null): string | null {
+  if (!message) {
+    return null;
+  }
+  return /\bsessionKey=([^\s]+)/.exec(message)?.[1] ?? null;
+}
+
+function shouldReportHarnessDebug(event: DiagnosticCandidate, type: string) {
+  if (HARNESS_DEBUG_EVENT_TYPES.has(type)) {
+    return true;
+  }
+  if (type !== 'log.record') {
+    return false;
+  }
+
+  const message = stringField(event, 'message');
+  if (isContextEngineDebugMessage(message)) {
+    return true;
+  }
+
+  const level = stringField(event, 'level')?.toLowerCase();
+  const attributes = diagnosticLogAttributes(event);
+  return (
+    Boolean(
+      stringField(event, 'sessionKey') ??
+        stringAttribute(attributes, 'sessionKey')
+    ) &&
+    (level === 'warn' || level === 'warning' || level === 'error')
+  );
+}
+
+function reportHarnessDebugDiagnostic(
+  event: DiagnosticCandidate,
+  type: string
+) {
+  if (!shouldReportHarnessDebug(event, type)) {
+    return;
+  }
+
+  const message = stringField(event, 'message');
+  const attributes = diagnosticLogAttributes(event);
+  const code = objectField(event, 'code');
+  const codeFunctionName =
+    typeof code?.functionName === 'string' && code.functionName.trim()
+      ? code.functionName
+      : null;
+  const codeLine =
+    typeof code?.line === 'number' && Number.isFinite(code.line)
+      ? code.line
+      : null;
+  const isContextEngineEvent = isContextEngineDebugMessage(message);
+  const contextEngineTaskId =
+    stringField(event, 'contextEngineTaskId') ??
+    stringAttribute(attributes, 'contextEngineTaskId') ??
+    stringAttribute(attributes, 'taskId') ??
+    extractContextEngineTaskId(message);
+  const contextEngineOperation =
+    stringField(event, 'contextEngineOperation') ??
+    stringAttribute(attributes, 'contextEngineOperation') ??
+    stringAttribute(attributes, 'operation') ??
+    extractDiagnosticKeyValue(message, 'operation');
+  const contextEngineLane =
+    stringField(event, 'contextEngineLane') ??
+    stringAttribute(attributes, 'contextEngineLane') ??
+    stringAttribute(attributes, 'lane') ??
+    extractDiagnosticKeyValue(message, 'lane');
+  reportHarnessDebug({
+    harnessEventType: type,
+    debugEventKind: debugEventKind(type),
+    sessionKey:
+      stringField(event, 'sessionKey') ??
+      stringAttribute(attributes, 'sessionKey') ??
+      extractDiagnosticSessionKey(message),
+    sessionId:
+      stringField(event, 'sessionId') ??
+      stringAttribute(attributes, 'sessionId'),
+    runId: stringField(event, 'runId') ?? stringAttribute(attributes, 'runId'),
+    agentId:
+      stringField(event, 'agentId') ?? stringAttribute(attributes, 'agentId'),
+    provider:
+      stringField(event, 'provider') ?? stringAttribute(attributes, 'provider'),
+    model: stringField(event, 'model') ?? stringAttribute(attributes, 'model'),
+    phase: stringField(event, 'phase') ?? stringAttribute(attributes, 'phase'),
+    outcome:
+      stringField(event, 'outcome') ?? stringAttribute(attributes, 'outcome'),
+    durationMs:
+      numberField(event, 'durationMs') ??
+      numberAttribute(attributes, 'durationMs'),
+    toolName:
+      stringField(event, 'toolName') ?? stringAttribute(attributes, 'toolName'),
+    toolCallId:
+      stringField(event, 'toolCallId') ??
+      stringAttribute(attributes, 'toolCallId'),
+    toolSource:
+      stringField(event, 'toolSource') ??
+      stringAttribute(attributes, 'toolSource'),
+    toolOwner:
+      stringField(event, 'toolOwner') ??
+      stringAttribute(attributes, 'toolOwner'),
+    pluginId:
+      stringField(event, 'pluginId') ?? stringAttribute(attributes, 'pluginId'),
+    harnessId:
+      stringField(event, 'harnessId') ??
+      stringAttribute(attributes, 'harnessId'),
+    modelCallId:
+      stringField(event, 'modelCallId') ??
+      stringField(event, 'callId') ??
+      stringAttribute(attributes, 'modelCallId') ??
+      stringAttribute(attributes, 'callId'),
+    modelApi:
+      stringField(event, 'modelApi') ?? stringAttribute(attributes, 'modelApi'),
+    modelTransport:
+      stringField(event, 'modelTransport') ??
+      stringAttribute(attributes, 'modelTransport'),
+    requestPayloadBytes:
+      numberField(event, 'requestPayloadBytes') ??
+      numberAttribute(attributes, 'requestPayloadBytes'),
+    responseStreamBytes:
+      numberField(event, 'responseStreamBytes') ??
+      numberAttribute(attributes, 'responseStreamBytes'),
+    timeToFirstByteMs:
+      numberField(event, 'timeToFirstByteMs') ??
+      numberAttribute(attributes, 'timeToFirstByteMs'),
+    logLevel: stringField(event, 'level'),
+    loggerName: stringField(event, 'loggerName'),
+    codeFunctionName,
+    codeLine,
+    logAttributes: attributes,
+    message,
+    contextEngineEvent: isContextEngineEvent ? type : null,
+    contextEngineTaskId,
+    contextEngineOperation,
+    contextEngineLane,
+    errorName:
+      stringField(event, 'errorName') ??
+      stringAttribute(attributes, 'errorName'),
+    errorCode:
+      stringField(event, 'errorCode') ??
+      stringAttribute(attributes, 'errorCode'),
+    messageCount:
+      numberField(event, 'messageCount') ??
+      numberAttribute(attributes, 'messageCount'),
+    historyTextChars:
+      numberField(event, 'historyTextChars') ??
+      numberAttribute(attributes, 'historyTextChars'),
+    historyImageBlocks:
+      numberField(event, 'historyImageBlocks') ??
+      numberAttribute(attributes, 'historyImageBlocks'),
+    maxMessageTextChars:
+      numberField(event, 'maxMessageTextChars') ??
+      numberAttribute(attributes, 'maxMessageTextChars'),
+    systemPromptChars:
+      numberField(event, 'systemPromptChars') ??
+      numberAttribute(attributes, 'systemPromptChars'),
+    promptChars:
+      numberField(event, 'promptChars') ??
+      numberAttribute(attributes, 'promptChars'),
+    promptImages:
+      numberField(event, 'promptImages') ??
+      numberAttribute(attributes, 'promptImages'),
+    contextTokenBudget:
+      numberField(event, 'contextTokenBudget') ??
+      numberAttribute(attributes, 'contextTokenBudget'),
+    reserveTokens:
+      numberField(event, 'reserveTokens') ??
+      numberAttribute(attributes, 'reserveTokens'),
+    contextChannel:
+      stringField(event, 'contextChannel') ??
+      stringField(event, 'channel') ??
+      stringAttribute(attributes, 'contextChannel') ??
+      stringAttribute(attributes, 'channel'),
+    contextTrigger:
+      stringField(event, 'contextTrigger') ??
+      stringField(event, 'trigger') ??
+      stringAttribute(attributes, 'contextTrigger') ??
+      stringAttribute(attributes, 'trigger'),
+  });
+}
+
+function reportHarnessDiagnostic(event: DiagnosticCandidate): void {
+  const type = stringField(event, 'type');
+  if (!type) {
+    return;
+  }
+
+  if (type === 'session.turn.created') {
+    reportSessionTurnCreated({
+      type,
+      sessionKey: stringField(event, 'sessionKey'),
+      sessionId: stringField(event, 'sessionId'),
+      runId: stringField(event, 'runId'),
+      agentId: stringField(event, 'agentId'),
+    });
+    reportHarnessDebugDiagnostic(event, type);
+    return;
+  }
+
+  reportHarnessDebugDiagnostic(event, type);
+
+  const common = {
+    harnessEventType: type,
+    sessionKey: stringField(event, 'sessionKey'),
+    sessionId: stringField(event, 'sessionId'),
+    runId: stringField(event, 'runId'),
+    agentId: stringField(event, 'agentId'),
+    provider: stringField(event, 'provider'),
+    model: stringField(event, 'model'),
+    phase: stringField(event, 'phase'),
+    outcome: stringField(event, 'outcome'),
+    errorCategory: stringField(event, 'errorCategory'),
+    failureKind: stringField(event, 'failureKind'),
+    durationMs: numberField(event, 'durationMs'),
+    errorText: diagnosticErrorText(event),
+  };
+
+  switch (type) {
+    case 'harness.run.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'harness',
+      });
+      return;
+    case 'harness.run.completed':
+      if (common.outcome === 'completed') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'harness',
+      });
+      return;
+    case 'model.call.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'model',
+      });
+      return;
+    case 'model.failover': {
+      const reason = stringField(event, 'reason');
+      const fromProvider = stringField(event, 'fromProvider');
+      const fromModel = stringField(event, 'fromModel');
+      const toProvider = stringField(event, 'toProvider');
+      const toModel = stringField(event, 'toModel');
+      reportHarnessError({
+        ...common,
+        errorScope: 'model',
+        provider: fromProvider,
+        model: fromModel,
+        phase: stringField(event, 'lane'),
+        outcome: 'failover',
+        errorCategory: 'model_failover',
+        failureKind: reason,
+        errorText: diagnosticSummary([
+          ['fromProvider', fromProvider],
+          ['fromModel', fromModel],
+          ['toProvider', toProvider],
+          ['toModel', toModel],
+          ['reason', reason],
+          ['cascadeDepth', numberField(event, 'cascadeDepth')],
+        ]),
+      });
+      return;
+    }
+    case 'tool.execution.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'tool',
+        toolName: stringField(event, 'toolName'),
+      });
+      return;
+    case 'tool.execution.blocked': {
+      const deniedReason = stringField(event, 'deniedReason');
+      const reason = stringField(event, 'reason');
+      reportHarnessError({
+        ...common,
+        errorScope: 'tool',
+        toolName: stringField(event, 'toolName'),
+        phase: stringField(event, 'toolSource'),
+        outcome: 'blocked',
+        errorCategory: 'tool_blocked',
+        failureKind: deniedReason,
+        errorText: reason ?? deniedReason,
+      });
+      return;
+    }
+    case 'tool.loop': {
+      const level = stringField(event, 'level');
+      const action = stringField(event, 'action');
+      if (level !== 'critical' && action !== 'block') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'tool',
+        toolName: stringField(event, 'toolName'),
+        phase: level,
+        outcome: action,
+        errorCategory: 'tool_loop',
+        failureKind: stringField(event, 'detector'),
+        errorText:
+          stringField(event, 'message') ??
+          diagnosticSummary([
+            ['level', level],
+            ['action', action],
+            ['detector', stringField(event, 'detector')],
+            ['count', numberField(event, 'count')],
+          ]),
+      });
+      return;
+    }
+    case 'run.completed':
+      if (common.outcome === 'completed') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'run',
+      });
+      return;
+    case 'message.delivery.error':
+      reportHarnessError({
+        ...common,
+        errorScope: 'message_delivery',
+        phase: stringField(event, 'deliveryKind'),
+      });
+      return;
+    case 'message.dispatch.completed':
+      if (common.outcome !== 'error') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'message_dispatch',
+        phase: stringField(event, 'source'),
+      });
+      return;
+    case 'message.processed':
+      if (common.outcome !== 'error') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'message_processing',
+        phase: stringField(event, 'channel'),
+      });
+      return;
+    case 'diagnostic.async_queue.dropped':
+      reportHarnessError({
+        ...common,
+        errorScope: 'diagnostics',
+        outcome: 'dropped',
+        errorCategory: 'diagnostic_async_queue_dropped',
+        failureKind: 'queue_full',
+        errorText: diagnosticSummary([
+          ['droppedEvents', numberField(event, 'droppedEvents')],
+          ['droppedTrustedEvents', numberField(event, 'droppedTrustedEvents')],
+          [
+            'droppedUntrustedEvents',
+            numberField(event, 'droppedUntrustedEvents'),
+          ],
+          ['queueLength', numberField(event, 'queueLength')],
+          ['maxQueueLength', numberField(event, 'maxQueueLength')],
+        ]),
+      });
+      return;
+    case 'diagnostic.liveness.warning': {
+      const reasons = stringListField(event, 'reasons');
+      reportHarnessError({
+        ...common,
+        errorScope: 'runtime',
+        phase: stringField(event, 'phase'),
+        outcome: 'warning',
+        errorCategory: 'liveness_warning',
+        failureKind: reasons.join(',') || null,
+        durationMs: numberField(event, 'intervalMs'),
+        errorText: diagnosticSummary([
+          ['reasons', reasons.join(',')],
+          ['eventLoopDelayP99Ms', numberField(event, 'eventLoopDelayP99Ms')],
+          ['eventLoopDelayMaxMs', numberField(event, 'eventLoopDelayMaxMs')],
+          ['cpuCoreRatio', numberField(event, 'cpuCoreRatio')],
+          ['active', numberField(event, 'active')],
+          ['waiting', numberField(event, 'waiting')],
+          ['queued', numberField(event, 'queued')],
+        ]),
+      });
+      return;
+    }
+    case 'diagnostic.memory.pressure': {
+      const memory = event.memory as Record<string, unknown> | undefined;
+      const memoryNumber = (key: string) => {
+        const value = memory?.[key];
+        return typeof value === 'number' && Number.isFinite(value)
+          ? value
+          : null;
+      };
+      reportHarnessError({
+        ...common,
+        errorScope: 'runtime',
+        outcome: stringField(event, 'level'),
+        errorCategory: 'memory_pressure',
+        failureKind: stringField(event, 'reason'),
+        durationMs: numberField(event, 'windowMs'),
+        errorText: diagnosticSummary([
+          ['level', stringField(event, 'level')],
+          ['reason', stringField(event, 'reason')],
+          ['rssBytes', memoryNumber('rssBytes')],
+          ['heapUsedBytes', memoryNumber('heapUsedBytes')],
+          ['thresholdBytes', numberField(event, 'thresholdBytes')],
+          ['rssGrowthBytes', numberField(event, 'rssGrowthBytes')],
+        ]),
+      });
+      return;
+    }
+    case 'payload.large':
+      if (stringField(event, 'action') !== 'rejected') {
+        return;
+      }
+      reportHarnessError({
+        ...common,
+        errorScope: 'payload',
+        phase: stringField(event, 'surface'),
+        outcome: 'rejected',
+        errorCategory: 'payload_large',
+        failureKind: stringField(event, 'reason'),
+        errorText: diagnosticSummary([
+          ['surface', stringField(event, 'surface')],
+          ['channel', stringField(event, 'channel')],
+          ['pluginId', stringField(event, 'pluginId')],
+          ['bytes', numberField(event, 'bytes')],
+          ['limitBytes', numberField(event, 'limitBytes')],
+          ['count', numberField(event, 'count')],
+          ['reason', stringField(event, 'reason')],
+        ]),
+      });
+      return;
+  }
+}
+
+function safeTelemetryObserver(params: {
+  logger: { warn: (message: string) => void };
+  telemetrySource: string;
+  sourceEventName?: string | null;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+  run: () => void;
+}): void {
+  try {
+    params.run();
+  } catch (error) {
+    params.logger.warn(
+      `[tlon] Telemetry observer failed (${params.telemetrySource}${params.sourceEventName ? `:${params.sourceEventName}` : ''}): ${String(error)}`
+    );
+    try {
+      reportTelemetryError({
+        telemetrySource: params.telemetrySource,
+        sourceEventName: params.sourceEventName,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        runId: params.runId,
+        agentId: params.agentId,
+        errorKind: error instanceof Error ? error.name : typeof error,
+        errorText: formatTlonTelemetryErrorText(error),
+      });
+    } catch (reportError) {
+      params.logger.warn(
+        `[tlon] Telemetry error reporting failed: ${String(reportError)}`
+      );
+    }
+  }
+}
+
+function installTelemetryDiagnosticObservers(
+  api: OpenClawPluginApi
+): () => void {
+  return installTlonDiagnosticSubscriptions(() => {
+    const unsubscribeDiagnosticEvents = onDiagnosticEvent((event) => {
+      const candidate = event as unknown as { type: string };
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'diagnostic_session',
+        sourceEventName: candidate.type,
+        sessionKey: (candidate as { sessionKey?: string }).sessionKey,
+        sessionId: (candidate as { sessionId?: string }).sessionId,
+        run: () => {
+          if (isTlonSessionDiagnosticEvent(candidate)) {
+            reportSessionDiagnostic(candidate);
+          }
+        },
+      });
+    });
+    const unsubscribeInternalDiagnosticEvents = onInternalDiagnosticEvent(
+      (event) => {
+        const candidate = event as DiagnosticCandidate;
+        safeTelemetryObserver({
+          logger: api.logger,
+          telemetrySource: 'diagnostic_internal',
+          sourceEventName: stringField(candidate, 'type'),
+          sessionKey: stringField(candidate, 'sessionKey'),
+          sessionId: stringField(candidate, 'sessionId'),
+          runId: stringField(candidate, 'runId'),
+          agentId: stringField(candidate, 'agentId'),
+          run: () => reportHarnessDiagnostic(candidate),
+        });
+      }
+    );
+
+    return () => {
+      unsubscribeDiagnosticEvents();
+      unsubscribeInternalDiagnosticEvents();
+    };
   });
 }
 
@@ -302,7 +1019,14 @@ export default defineChannelPluginEntry({
       const gsManager = createGatewayStatusManager({
         logger: {
           log: (m) => api.logger.info(m),
-          error: (m) => api.logger.warn(m),
+          error: (m) => {
+            reportPluginError({
+              pluginErrorSource: 'gateway_status_heartbeat',
+              errorKind: 'heartbeat',
+              errorText: m,
+            });
+            api.logger.warn(m);
+          },
         },
       });
       setGatewayStatusManager(gsManager);
@@ -351,15 +1075,6 @@ export default defineChannelPluginEntry({
     }
     // else: zero accounts configured — nothing to do
 
-    // Register /tlon-version command
-    api.registerCommand({
-      name: 'tlon-version',
-      description: 'Show Tlon plugin version.',
-      handler: async () => {
-        return { text: `Tlon plugin v${PLUGIN_VERSION} (${PLUGIN_COMMIT})` };
-      },
-    });
-
     const contextLensRoutesEnabled = registerContextLensRoutes(api);
     const contextLensShipSyncEnabled = initContextLensShipSync(api);
     // Recording and the disk store run when at least one reader path is
@@ -370,7 +1085,9 @@ export default defineChannelPluginEntry({
       initContextLensStore(api);
     }
 
-    // Register the tlon tool
+    // Resolve the tlon tool binary once. The tool itself and version
+    // diagnostics share this path so telemetry reports what OpenClaw will
+    // actually execute.
     const tlonBinary = resolveTlonBinary({
       moduleDir: __dirname,
       resolveModule: require.resolve,
@@ -378,6 +1095,44 @@ export default defineChannelPluginEntry({
     });
     api.logger.info(`[tlon] Registering tlon tool, binary: ${tlonBinary}`);
 
+    setTlonSkillVersionResolver(() => readTlonSkillVersion(tlonBinary));
+    const renderTlonVersion = async () => ({
+      text: formatTlonVersionIdentity({
+        tlonSkillVersion: await resolveTlonSkillVersion(),
+      }),
+    });
+    void resolveTlonSkillVersion().then((version) => {
+      api.logger.info(`[tlon] Tlon skill version: ${version}`);
+    });
+
+    // Register /tlon-version command
+    api.registerCommand({
+      name: 'tlon-version',
+      description: 'Show Tlon plugin version.',
+      handler: async () => {
+        return renderTlonVersion();
+      },
+    });
+
+    api.registerCommand({
+      name: 'tlon',
+      description: 'Tlon plugin diagnostics. Usage: /tlon version',
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        const args = (ctx.args ?? '').trim().toLowerCase();
+        if (args !== 'version') {
+          return { text: 'Usage: /tlon version' };
+        }
+
+        const result = resolveBridgeForCommand(ctx);
+        if ('error' in result) {
+          return { text: result.error };
+        }
+        return renderTlonVersion();
+      },
+    });
+
+    // Register the tlon tool
     // Capture credentials from config at registration time
     const account = resolveTlonAccount(api.config);
     const credentials =
@@ -399,9 +1154,9 @@ export default defineChannelPluginEntry({
       name: 'tlon',
       label: 'Tlon CLI',
       description:
-        'Tlon/Urbit API for reading data and administration: activity, channels, contacts, groups, messages, posts, settings, upload, expose, hooks. ' +
+        'Tlon/Urbit API for reading data and administration: activity, channels, contacts, groups, messages, notes, posts, settings, upload, expose, hooks. ' +
         'DO NOT use this tool to send messages — use the `message` tool instead. ' +
-        "Examples: 'activity mentions --limit 10', 'channels groups', 'contacts self', 'groups list'",
+        "Examples: 'activity mentions --limit 10', 'channels groups', 'contacts self', 'groups list', 'notes list'",
       parameters: {
         type: 'object',
         properties: {
@@ -410,7 +1165,7 @@ export default defineChannelPluginEntry({
             description:
               'The tlon command and arguments (read/admin operations). ' +
               'To send messages, use the `message` tool, not this tool. ' +
-              "Examples: 'activity mentions --limit 10', 'contacts get ~sampel-palnet', 'groups list', 'messages dm ~ship --limit 20'",
+              "Examples: 'activity mentions --limit 10', 'contacts get ~sampel-palnet', 'groups list', 'messages dm ~ship --limit 20', 'notes list'",
           },
         },
         required: ['command'],
@@ -421,12 +1176,12 @@ export default defineChannelPluginEntry({
 
           const subIdx = findSubcommandIndex(args);
           const subcommand = subIdx >= 0 ? args[subIdx] : undefined;
-          if (!subcommand || !ALLOWED_TLON_COMMANDS.has(subcommand)) {
+          if (!isAllowedTlonSubcommand(subcommand)) {
             return {
               content: [
                 {
                   type: 'text' as const,
-                  text: `Error: Unknown tlon subcommand '${subcommand ?? '(none)'}'. Allowed: ${[...ALLOWED_TLON_COMMANDS].join(', ')}`,
+                  text: `Error: Unknown tlon subcommand '${subcommand ?? '(none)'}'. Allowed: ${formatAllowedTlonSubcommands()}`,
                 },
               ],
               details: { error: true },
@@ -442,12 +1197,9 @@ export default defineChannelPluginEntry({
             };
           }
 
-          const output = await runTlonCommand(
-            tlonBinary,
-            args,
-            credentials,
-            toolTimeoutMs
-          );
+          const output = await runTlonCommand(tlonBinary, args, credentials, {
+            timeoutMs: toolTimeoutMs,
+          });
           return {
             content: [{ type: 'text' as const, text: output }],
             details: undefined,
@@ -594,12 +1346,21 @@ export default defineChannelPluginEntry({
         );
       }
 
-      recordToolCall({
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'after_tool_call',
+        sourceEventName: event.toolName,
         sessionKey: ctx.sessionKey,
-        toolName: event.toolName,
-        durationMs: event.durationMs,
-        error: event.error,
+        run: () => {
+          recordToolCall({
+            sessionKey: ctx.sessionKey,
+            toolName: event.toolName,
+            durationMs: event.durationMs,
+            error: event.error,
+          });
+        },
       });
+
       if (contextLensEnabled) {
         const lens = recordContextLensToolResultForSession(
           ctx.sessionKey,
@@ -625,6 +1386,135 @@ export default defineChannelPluginEntry({
           );
         }
       }
+    });
+
+    // ── Session lifecycle / watchdog telemetry ─────────────────────────
+    // These hooks are global to OpenClaw, so telemetry.ts filters them through
+    // session keys remembered from Tlon inbound replies before emitting.
+    api.on('session_start', (event, ctx) => {
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'session_start',
+        sourceEventName: 'session_start',
+        sessionKey: event.sessionKey ?? ctx.sessionKey,
+        sessionId: event.sessionId ?? ctx.sessionId,
+        agentId: ctx.agentId,
+        run: () => {
+          reportSessionLifecycle({
+            lifecycleEvent: 'session_start',
+            sessionKey: event.sessionKey ?? ctx.sessionKey,
+            sessionId: event.sessionId ?? ctx.sessionId,
+            agentId: ctx.agentId,
+            hasNextSession: false,
+          });
+        },
+      });
+    });
+
+    api.on('session_end', (event, ctx) => {
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'session_end',
+        sourceEventName: 'session_end',
+        sessionKey: event.sessionKey ?? ctx.sessionKey,
+        sessionId: event.sessionId ?? ctx.sessionId,
+        agentId: ctx.agentId,
+        run: () => {
+          reportSessionLifecycle({
+            lifecycleEvent: 'session_end',
+            sessionKey: event.sessionKey ?? ctx.sessionKey,
+            sessionId: event.sessionId ?? ctx.sessionId,
+            agentId: ctx.agentId,
+            reason: event.reason ?? null,
+            messageCount: event.messageCount,
+            durationMs: event.durationMs ?? null,
+            transcriptArchived: event.transcriptArchived ?? null,
+            hasNextSession: Boolean(
+              event.nextSessionId ?? event.nextSessionKey
+            ),
+          });
+        },
+      });
+    });
+
+    if (shouldInstallTlonDiagnosticSubscriptions(api.registrationMode)) {
+      const unsubscribeDiagnosticEvents =
+        installTelemetryDiagnosticObservers(api);
+      api.on('gateway_stop', unsubscribeDiagnosticEvents);
+    }
+
+    // ── Route diagnostics ───────────────────────────────────────────────
+    // Fires for every outbound send OpenClaw routes — the primary streamed
+    // reply (resolves to `tlon`) and route-dependent sends (the shared
+    // `message` tool, subagents, which can resolve elsewhere). `ctx.channelId`
+    // is where the send resolved; `routedToTlon: false` (e.g. `webchat`) is the
+    // leak this work targets. Read-only; never alters delivery.
+    //
+    // Two sinks: a PostHog event (the primary, fleet-wide signal — gated by the
+    // existing telemetry config, on in hosted prod) so we can count how often
+    // sends land off-Tlon; and a debug-gated local log for single-gateway
+    // triage.
+    api.on('message_sending', (event, ctx) => {
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'message_sending',
+        sourceEventName: 'message_sending',
+        sessionKey: ctx.sessionKey,
+        runId: ctx.runId,
+        run: () => {
+          const resolvedChannel = ctx.channelId;
+          const routedToTlon = resolvedChannel === 'tlon';
+          // Only infer target kind for Tlon targets; a webchat target id is not
+          // a Tlon target and must not be misclassified.
+          const parsedTarget = routedToTlon ? parseTlonTarget(event.to) : null;
+          const targetKind =
+            parsedTarget?.kind === 'dm'
+              ? 'dm'
+              : parsedTarget?.kind === 'channel'
+                ? 'group'
+                : 'unknown';
+
+          reportOutboundRoute({ resolvedChannel, routedToTlon, targetKind });
+
+          if (isRouteDebugEnabled()) {
+            api.logger.info(
+              `[tlon][route-debug] message_sending ${JSON.stringify({
+                channelId: ctx.channelId,
+                to: event.to,
+                routedToTlon,
+                targetKind,
+                sessionKey: ctx.sessionKey ?? null,
+                conversationId: ctx.conversationId ?? null,
+                messageId: ctx.messageId ?? null,
+                threadId: event.threadId ?? null,
+              })}`
+            );
+          }
+        },
+      });
+    });
+
+    api.on('message_sent', (event, ctx) => {
+      safeTelemetryObserver({
+        logger: api.logger,
+        telemetrySource: 'message_sent',
+        sourceEventName: 'message_sent',
+        sessionKey: event.sessionKey ?? ctx.sessionKey,
+        runId: event.runId ?? ctx.runId,
+        run: () => {
+          if (event.success !== false) {
+            return;
+          }
+          reportHarnessError({
+            harnessEventType: 'message_sent',
+            errorScope: 'message_delivery',
+            sessionKey: event.sessionKey ?? ctx.sessionKey,
+            runId: event.runId ?? ctx.runId,
+            errorText: event.error ?? null,
+            outcome: 'error',
+          });
+        },
+      });
     });
 
     // Cron jobs can run inside the main session, where the session key has

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.4.3",
+  "version": "0.7.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -15,6 +15,7 @@ import {
 
 import { tlonMessageActions } from './actions.js';
 import { tlonChannelConfigSchema } from './config-schema.js';
+import { resolveTlonOutboundSessionRoute } from './session-route.js';
 import {
   applyTlonSetupConfig,
   createTlonSetupWizardBase,
@@ -115,6 +116,7 @@ export const tlonPlugin = createChatChannelPlugin({
         }),
     },
     messaging: {
+      targetPrefixes: ['tlon'],
       normalizeTarget: (target) => {
         const parsed = parseTlonTarget(target);
         if (!parsed) {
@@ -125,10 +127,21 @@ export const tlonPlugin = createChatChannelPlugin({
         }
         return parsed.nest;
       },
+      parseExplicitTarget: ({ raw }) => {
+        const parsed = parseTlonTarget(raw);
+        if (!parsed) {
+          return null;
+        }
+        return parsed.kind === 'dm'
+          ? { to: parsed.ship, chatType: 'direct' }
+          : { to: parsed.nest, chatType: 'group' };
+      },
       targetResolver: {
         looksLikeId: (target) => Boolean(parseTlonTarget(target)),
         hint: formatTargetHint(),
       },
+      resolveOutboundSessionRoute: (params) =>
+        resolveTlonOutboundSessionRoute(params),
     },
     actions: tlonMessageActions,
     agentPrompt: {

--- a/packages/openclaw/src/config-schema.ts
+++ b/packages/openclaw/src/config-schema.ts
@@ -52,8 +52,10 @@ export const TlonContextLensSchema = z.object({
   visibilityDefault: z.enum(['owner', 'participants', 'internal']).optional(),
   authToken: z.string().min(16).optional(),
   allowedOrigins: z.array(z.string().min(1)).optional(),
-  // Owner ships that receive run records via the %context-lens agent (ship sync).
-  // Falls back to `ownerShip` when empty.
+  // Owner ships that receive run records via the %steward agent (ship sync).
+  // %steward stores a singular owner; if multiple are configured, only the
+  // first is used (the rest are logged and ignored). Falls back to
+  // `ownerShip` when empty.
   owners: z.array(ShipSchema).optional(),
   // Durable on-disk history of finalized runs (default on when the lens is
   // enabled). Hosted deployments with ephemeral disks can point `path` at a

--- a/packages/openclaw/src/context-lens-routes.ts
+++ b/packages/openclaw/src/context-lens-routes.ts
@@ -9,7 +9,11 @@ import {
   subscribeToContextLensEvents,
 } from './context-lens-events.js';
 import { getContextLensStore } from './context-lens-store.js';
-import { type TlonContextLensConfig, resolveTlonAccount } from './types.js';
+import {
+  type TlonContextLensConfig,
+  resolveLensAccountId,
+  resolveTlonAccount,
+} from './types.js';
 
 export const CONTEXT_LENS_RECENT_ROUTE = '/tlon/context-lens/recent';
 export const CONTEXT_LENS_EVENTS_ROUTE = '/tlon/context-lens/events';
@@ -145,7 +149,10 @@ function readLastEventId(req: IncomingMessage): number | null {
 }
 
 export function registerContextLensRoutes(api: ContextLensRouteApi): boolean {
-  const lensConfig = resolveTlonAccount(api.config).contextLens;
+  const lensConfig = resolveTlonAccount(
+    api.config,
+    resolveLensAccountId(api.config)
+  ).contextLens;
   if (!lensConfig.enabled) {
     api.logger.debug?.('[tlon] Context lens disabled; routes not registered');
     return false;

--- a/packages/openclaw/src/context-lens-ship-sync.test.ts
+++ b/packages/openclaw/src/context-lens-ship-sync.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
 import { describe, expect, it } from 'vitest';
 
@@ -10,8 +13,13 @@ import {
   createContextLensShipSync,
   initContextLensShipSync,
   isContextLensEffectivelyEnabled,
+  loadSyncedLensIds,
+  recordSyncedLensId,
+  replayUnsyncedFinalRuns,
   resolveLensOwners,
+  syncedLensIdsPath,
 } from './context-lens-ship-sync.js';
+import { createContextLensStore } from './context-lens-store.js';
 import { type ContextLens, createContextLensRegistry } from './context-lens.js';
 import {
   API_CLIENT_PARAMS_SLOT,
@@ -178,14 +186,90 @@ describe('buildLensRunPayload', () => {
     expect(payload.lens.status).toBe(lens.status);
     expect(raw.length).toBeLessThan(50 * 1_024);
   });
+
+  it('includes retrySeed in the run payload and keeps retryOf', () => {
+    const lens = makeLens();
+    lens.retryOf = 'lens-original';
+    lens.retrySeed = {
+      messageText: 'secret original message body',
+      blobField: '{"k":"v"}',
+    };
+    const payload = JSON.parse(buildLensRunPayload(lens)) as {
+      lens: ContextLens;
+    };
+    expect(payload.lens.retrySeed).toEqual({
+      messageText: 'secret original message body',
+      blobField: '{"k":"v"}',
+    });
+    expect(payload.lens.retryOf).toBe('lens-original');
+    expect(JSON.stringify(payload)).toContain('secret original message body');
+  });
+
+  it('keeps retrySeed when oversized payloads are skeletonized', () => {
+    const registry = createContextLensRegistry({ ttlMs: 60_000 });
+    const blobField = JSON.stringify({ body: 'b'.repeat(7_500) });
+    const lens = registry.create({
+      messageId: 'msg-oversized-retry',
+      chatType: 'channel',
+      trigger: 'mention',
+      senderShip: '~ten',
+      conversationId: 'chat/~ten/test',
+      retrySeed: {
+        messageText: 'm'.repeat(20_000),
+        blobField,
+        parentId: '170.1',
+        isThreadReply: true,
+        replyParentId: '170.2',
+        cachesHistory: true,
+      },
+    });
+    lens.tools.runs = Array.from({ length: 100 }, (_, i) => ({
+      id: `t-${i}`,
+      callIndex: i + 1,
+      name: 'browser',
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+      durationMs: 5,
+      status: 'completed' as const,
+      argumentSummary: 'y'.repeat(4_000),
+      resultSummary: 'z'.repeat(4_000),
+    }));
+
+    const raw = buildLensRunPayload(lens);
+    const payload = JSON.parse(raw) as {
+      truncated?: boolean;
+      lens: ContextLens;
+    };
+
+    expect(payload.truncated).toBe(true);
+    expect(payload.lens.tools.runs).toEqual([]);
+    expect(payload.lens.context.sources).toEqual([]);
+    expect(payload.lens.outputs).toEqual([]);
+    expect(payload.lens.retrySeed).toEqual(lens.retrySeed);
+    expect(payload.lens.retrySeed?.messageText).toHaveLength(16_384);
+    expect(payload.lens.retrySeed?.blobField).toBe(blobField);
+    expect(raw.length).toBeLessThan(50 * 1_024);
+    expect(raw.length).toBeLessThan(512 * 1_024);
+  });
 });
+
+const labelPoke = (poke: RecordedPoke): string => {
+  const json = poke.json as {
+    configure?: unknown;
+    lens?: { entry?: { final?: boolean } };
+  };
+  if (json.configure) return 'configure';
+  const entry = json.lens?.entry;
+  if (!entry) return 'unknown';
+  return entry.final ? 'entry-final' : 'entry-partial';
+};
 
 describe('createContextLensShipSync', () => {
   it('configures owners once, then pokes run milestones and finals', async () => {
     const pokes: RecordedPoke[] = [];
     const params = makeParams(pokes);
     const sync = createContextLensShipSync({
-      owners: ['~bus'],
+      owner: '~bus',
       logger: silentLogger,
       getParams: () => params,
     });
@@ -196,29 +280,39 @@ describe('createContextLensShipSync', () => {
     sync.handleEvent(makeEvent({ ...lens, status: 'completed' }));
     await sync.flush();
 
-    expect(pokes.map((p) => Object.keys(p.json as object)[0])).toEqual([
+    expect(pokes.map(labelPoke)).toEqual([
       'configure',
-      'run-event',
-      'run-event',
-      'run-final',
+      'entry-partial',
+      'entry-partial',
+      'entry-final',
     ]);
     expect(
-      pokes.every(
-        (p) => p.app === 'context-lens' && p.mark === 'context-lens-action-1'
-      )
+      pokes.every((p) => p.app === 'steward' && p.mark === 'steward-action-1')
     ).toBe(true);
-    expect(pokes[0].json).toEqual({ configure: { owners: ['~bus'] } });
-    const final = pokes[3].json as {
-      'run-final': { id: string; payload: unknown };
+    expect(pokes[0].json).toEqual({ configure: { owner: '~bus' } });
+    // partial entry assertions: same lensId, non-empty payload, final=false.
+    const partialPoke = pokes[1].json as {
+      lens: { entry: { id: string; payload: unknown; final: boolean } };
     };
-    expect(final['run-final'].id).toBe(lens.lensId);
+    expect(partialPoke.lens.entry.id).toBe(lens.lensId);
+    expect(typeof partialPoke.lens.entry.payload).toBe('string');
+    expect((partialPoke.lens.entry.payload as string).length).toBeGreaterThan(
+      0
+    );
+    expect(partialPoke.lens.entry.final).toBe(false);
+    // final entry assertions: same lensId, final=true.
+    const finalPoke = pokes[3].json as {
+      lens: { entry: { id: string; payload: unknown; final: boolean } };
+    };
+    expect(finalPoke.lens.entry.id).toBe(lens.lensId);
+    expect(finalPoke.lens.entry.final).toBe(true);
   });
 
   it('skips repeat events with an unchanged status', async () => {
     const pokes: RecordedPoke[] = [];
     const params = makeParams(pokes);
     const sync = createContextLensShipSync({
-      owners: ['~bus'],
+      owner: '~bus',
       logger: silentLogger,
       getParams: () => params,
     });
@@ -229,14 +323,14 @@ describe('createContextLensShipSync', () => {
     sync.handleEvent(makeEvent(lens));
     await sync.flush();
 
-    expect(pokes).toHaveLength(2); // configure + one run-event
+    expect(pokes).toHaveLength(2); // configure + one entry-partial
   });
 
   it('ignores internal-visibility runs', async () => {
     const pokes: RecordedPoke[] = [];
     const params = makeParams(pokes);
     const sync = createContextLensShipSync({
-      owners: ['~bus'],
+      owner: '~bus',
       logger: silentLogger,
       getParams: () => params,
     });
@@ -254,7 +348,7 @@ describe('createContextLensShipSync', () => {
     const params = makeParams(pokes);
     let connected = false;
     const sync = createContextLensShipSync({
-      owners: ['~bus'],
+      owner: '~bus',
       logger: silentLogger,
       getParams: () => (connected ? params : null),
     });
@@ -266,10 +360,7 @@ describe('createContextLensShipSync', () => {
     connected = true;
     sync.handleEvent(makeEvent(makeLens({ status: 'completed' })));
     await sync.flush();
-    expect(pokes.map((p) => Object.keys(p.json as object)[0])).toEqual([
-      'configure',
-      'run-final',
-    ]);
+    expect(pokes.map(labelPoke)).toEqual(['configure', 'entry-final']);
   });
 
   it('re-configures after a poke failure and on params instance change', async () => {
@@ -290,7 +381,7 @@ describe('createContextLensShipSync', () => {
     let current = flaky;
     const warnings: string[] = [];
     const sync = createContextLensShipSync({
-      owners: ['~bus'],
+      owner: '~bus',
       logger: { info: () => {}, warn: (m) => warnings.push(m) },
       getParams: () => current,
     });
@@ -304,21 +395,120 @@ describe('createContextLensShipSync', () => {
     // Second final: configure retried (now succeeding), then the run poke.
     sync.handleEvent(makeEvent(makeLens({ status: 'completed' })));
     await sync.flush();
-    expect(pokes.map((p) => Object.keys(p.json as object)[0])).toEqual([
-      'configure',
-      'run-final',
-    ]);
+    expect(pokes.map(labelPoke)).toEqual(['configure', 'entry-final']);
 
     // New params instance (monitor restart): configure re-asserted.
     current = makeParams(pokes);
     sync.handleEvent(makeEvent(makeLens({ status: 'completed' })));
     await sync.flush();
-    expect(pokes.map((p) => Object.keys(p.json as object)[0])).toEqual([
+    expect(pokes.map(labelPoke)).toEqual([
       'configure',
-      'run-final',
+      'entry-final',
       'configure',
-      'run-final',
+      'entry-final',
     ]);
+  });
+});
+
+describe('synced lens id bookkeeping', () => {
+  it('round-trips ids and survives a missing or garbage file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lens-synced-'));
+    const file = syncedLensIdsPath(path.join(dir, 'runs.jsonl'));
+    try {
+      expect(loadSyncedLensIds(file).size).toBe(0);
+
+      recordSyncedLensId(file, 'a');
+      recordSyncedLensId(file, 'b');
+      recordSyncedLensId(file, 'a');
+      expect([...loadSyncedLensIds(file)]).toEqual(['b', 'a']);
+
+      fs.writeFileSync(file, 'not json');
+      expect(loadSyncedLensIds(file).size).toBe(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports run finals via onRunFinal only after a successful poke', async () => {
+    const pokes: RecordedPoke[] = [];
+    const params = makeParams(pokes);
+    let connected = false;
+    const finals: string[] = [];
+    const sync = createContextLensShipSync({
+      owner: '~bus',
+      logger: silentLogger,
+      getParams: () => (connected ? params : null),
+      onRunFinal: (lens) => finals.push(lens.lensId),
+    });
+
+    // Dropped (no params): poke never sent, so no bookkeeping.
+    sync.handleEvent(makeEvent(makeLens({ status: 'completed' })));
+    await sync.flush();
+    expect(finals).toHaveLength(0);
+
+    connected = true;
+    // Milestone events are not tracked, only finals.
+    const lens = makeLens({ status: 'tool_running' });
+    sync.handleEvent(makeEvent(lens));
+    sync.handleEvent(makeEvent({ ...lens, status: 'aborted' }));
+    await sync.flush();
+    expect(finals).toEqual([lens.lensId]);
+  });
+});
+
+describe('replayUnsyncedFinalRuns', () => {
+  function makeFinalLens(
+    overrides: Partial<ContextLens> & { completedAt?: number }
+  ): ContextLens {
+    const { completedAt, ...rest } = overrides;
+    const lens = makeLens({ status: 'completed', ...rest });
+    return {
+      ...lens,
+      lifecycle: { ...lens.lifecycle, completedAt: completedAt ?? Date.now() },
+    };
+  }
+
+  it('re-pokes only unsynced, recent, non-internal terminal runs', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lens-replay-'));
+    const filePath = path.join(dir, 'runs.jsonl');
+    try {
+      const store = createContextLensStore({ filePath });
+      const missed = makeFinalLens({ status: 'aborted' });
+      const alreadySynced = makeFinalLens({});
+      const internal = makeFinalLens({ visibility: 'internal' });
+      const stale = makeFinalLens({
+        completedAt: Date.now() - 25 * 60 * 60 * 1_000,
+      });
+      for (const lens of [missed, alreadySynced, internal]) {
+        store.save(lens);
+      }
+      // Bypass save()'s own retention so the stale lens is present in memory.
+      fs.appendFileSync(filePath, `${JSON.stringify(stale)}\n`);
+      const reloaded = createContextLensStore({ filePath });
+      recordSyncedLensId(syncedLensIdsPath(filePath), alreadySynced.lensId);
+
+      const pokes: RecordedPoke[] = [];
+      const params = makeParams(pokes);
+      const finals: string[] = [];
+      const sync = createContextLensShipSync({
+        owner: '~bus',
+        logger: silentLogger,
+        getParams: () => params,
+        onRunFinal: (lens) => {
+          finals.push(lens.lensId);
+          recordSyncedLensId(syncedLensIdsPath(filePath), lens.lensId);
+        },
+      });
+
+      expect(replayUnsyncedFinalRuns(reloaded, sync, silentLogger)).toBe(1);
+      await sync.flush();
+      expect(finals).toEqual([missed.lensId]);
+
+      // Second boot: the replayed run is now recorded as synced.
+      expect(replayUnsyncedFinalRuns(reloaded, sync, silentLogger)).toBe(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -353,10 +543,7 @@ describe('initContextLensShipSync', () => {
       publishContextLensEvent('final', makeLens({ status: 'completed' }));
       await new Promise((resolve) => setTimeout(resolve, 20));
 
-      expect(pokes.map((p) => Object.keys(p.json as object)[0])).toEqual([
-        'configure',
-        'run-final',
-      ]);
+      expect(pokes.map(labelPoke)).toEqual(['configure', 'entry-final']);
     } finally {
       slot.set(previousParams);
     }

--- a/packages/openclaw/src/context-lens-ship-sync.ts
+++ b/packages/openclaw/src/context-lens-ship-sync.ts
@@ -17,7 +17,7 @@ import {
 } from './gateway-status.js';
 import { sharedSlot } from './shared-state.js';
 import { normalizeShip } from './targets.js';
-import { resolveTlonAccount } from './types.js';
+import { resolveLensAccountId, resolveTlonAccount } from './types.js';
 
 const PAYLOAD_SCHEMA_VERSION = 1;
 const MAX_SUMMARY_CHARS = 4_096;
@@ -416,11 +416,12 @@ export function initContextLensShipSync(api: {
     replayCancelSlot.get()?.();
     replayCancelSlot.set(null);
   };
-  if (!resolveTlonAccount(api.config).contextLens.enabled) {
+  const lensAccountId = resolveLensAccountId(api.config);
+  if (!resolveTlonAccount(api.config, lensAccountId).contextLens.enabled) {
     teardown();
     return false;
   }
-  const owner = resolveLensOwner(api.config);
+  const owner = resolveLensOwner(api.config, lensAccountId);
   if (!owner) {
     teardown();
     api.logger.info(
@@ -428,7 +429,7 @@ export function initContextLensShipSync(api: {
     );
     return false;
   }
-  const owners = resolveLensOwners(api.config);
+  const owners = resolveLensOwners(api.config, lensAccountId);
   if (owners.length > 1) {
     api.logger.warn(
       `[tlon] Context lens ship sync: %steward stores a single owner; using ${owner}, ignoring ${owners.slice(1).join(', ')}`

--- a/packages/openclaw/src/context-lens-ship-sync.ts
+++ b/packages/openclaw/src/context-lens-ship-sync.ts
@@ -1,9 +1,15 @@
+import fs from 'node:fs';
 import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
 
 import {
   type ContextLensEvent,
   subscribeToContextLensEvents,
 } from './context-lens-events.js';
+import {
+  type ContextLensStore,
+  getContextLensStore,
+  lensFinalizedAt,
+} from './context-lens-store.js';
 import type { ContextLens, ContextLensStatus } from './context-lens.js';
 import {
   API_CLIENT_PARAMS_SLOT,
@@ -17,11 +23,17 @@ const PAYLOAD_SCHEMA_VERSION = 1;
 const MAX_SUMMARY_CHARS = 4_096;
 const MAX_PAYLOAD_CHARS = 50 * 1_024;
 const MAX_TRACKED_RUNS = 1_000;
+const MAX_SYNCED_IDS = 1_000;
+const REPLAY_POLL_MS = 2_000;
+const REPLAY_GIVE_UP_MS = 10 * 60_000;
+const REPLAY_WINDOW_MS = 24 * 60 * 60 * 1_000;
+const REPLAY_MAX_RUNS = 50;
 
 const TERMINAL_STATUSES: ReadonlySet<ContextLensStatus> = new Set([
   'completed',
   'no_reply',
   'timed_out',
+  'aborted',
   'error',
 ]);
 
@@ -41,6 +53,33 @@ const apiClientParamsSlot = sharedSlot<SharedApiClientParams>(
 const shipSyncUnsubscribeSlot = sharedSlot<() => void>(
   'contextLens.shipSync.unsubscribe'
 );
+const replayCancelSlot = sharedSlot<() => void>(
+  'contextLens.shipSync.replayCancel'
+);
+
+export function syncedLensIdsPath(storeFilePath: string): string {
+  return `${storeFilePath}.synced.json`;
+}
+
+export function loadSyncedLensIds(filePath: string): Set<string> {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    if (!Array.isArray(parsed)) {
+      return new Set();
+    }
+    return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+export function recordSyncedLensId(filePath: string, lensId: string): void {
+  const ids = loadSyncedLensIds(filePath);
+  ids.delete(lensId);
+  ids.add(lensId);
+  const trimmed = [...ids].slice(-MAX_SYNCED_IDS);
+  fs.writeFileSync(filePath, JSON.stringify(trimmed), { mode: 0o600 });
+}
 
 function truncateSummary(value: string | undefined): string | undefined {
   if (value === undefined || value.length <= MAX_SUMMARY_CHARS) {
@@ -50,7 +89,7 @@ function truncateSummary(value: string | undefined): string | undefined {
 }
 
 /**
- * Build the opaque run payload poked to %context-lens, serialized to a JSON
+ * Build the opaque run payload poked to %steward, serialized to a JSON
  * string (the agent stores payloads as cords — embedding $json in Hoon mark
  * sample types breaks ford tube builds). The lens snapshot is passed
  * through with per-field truncation (tool args/results, previews) and a
@@ -58,6 +97,12 @@ function truncateSummary(value: string | undefined): string | undefined {
  * stay small. Full untruncated runs remain on gateway disk (Phase 2 store).
  */
 export function buildLensRunPayload(lens: ContextLens): string {
+  // retrySeed (raw chat text + blob field) is included so the agent is the
+  // durable source of truth for retry: any gateway, current or future, can
+  // replay a run by scrying %steward for the payload regardless of local cache
+  // state. Message text is already on the ship in the original DM/channel, so
+  // mirroring it here does not introduce new exposure; it does grow per-poke
+  // Ames traffic by roughly 1-10KB.
   const slim: ContextLens = {
     ...lens,
     context: {
@@ -84,8 +129,9 @@ export function buildLensRunPayload(lens: ContextLens): string {
   if (payload.length <= MAX_PAYLOAD_CHARS) {
     return payload;
   }
-  // Still oversized (e.g. hundreds of tool runs): drop the bulky arrays but
-  // keep the run's identity, status, and timings inspectable.
+  // Still oversized (e.g. hundreds of tool runs or a giant message): drop
+  // the bulky arrays but keep run identity, retrySeed, and status; retry
+  // remains possible because retrySeed survives the skeletonization.
   const skeleton: ContextLens = {
     ...slim,
     context: { ...slim.context, sources: [] },
@@ -116,6 +162,20 @@ export function resolveLensOwners(
 }
 
 /**
+ * %steward's lens module stores a single owner ship (`unit ship`). If the
+ * config lists multiple `contextLens.owners`, we pick the first and ignore
+ * the rest — multi-owner fan-out is no longer supported on the agent side.
+ * Returns null when no owner is configured (sync stays inert).
+ */
+export function resolveLensOwner(
+  config: OpenClawConfig,
+  accountId?: string | null
+): string | null {
+  const owners = resolveLensOwners(config, accountId);
+  return owners[0] ?? null;
+}
+
+/**
  * True when at least one context-lens consumer can read recorded runs: the
  * HTTP routes (need authToken) or the ship sync (needs resolvable owners).
  * The monitor must record runs whenever either path is live — gating the
@@ -142,30 +202,38 @@ export type ContextLensShipSync = {
 };
 
 /**
- * Mirror context-lens runs to the bot ship's %context-lens agent, which fans them
- * out to owner ships for durable, mobile-reachable history.
+ * Mirror context-lens runs to the bot ship's %steward agent (lens module),
+ * which fans them out to the configured owner ship for durable, mobile-
+ * reachable history.
  *
- * - terminal status → `%run-final`
- * - non-terminal status transitions → `%run-event` milestones
+ * - terminal status → `[%entry id payload final=true]`
+ * - non-terminal status transitions → `[%entry id payload final=false]`
  *
  * Pokes ride the monitor-published api-client params (the same slot the
- * gateway-status heartbeat uses). The agent's `owners` set is configured
- * lazily: once per params-slot instance, ordered before any run poke via a
- * serial queue, so monitor restarts re-assert the config.
+ * gateway-status heartbeat uses). The agent's owner is configured lazily
+ * (once per params-slot instance, ordered before any run poke via a serial
+ * queue) so monitor restarts re-assert the config.
  */
 export function createContextLensShipSync(opts: {
-  owners: string[];
+  /** The single configured owner ship (%steward stores `unit ship`). */
+  owner: string;
   logger: SyncLogger;
   getParams?: () => SharedApiClientParams | null;
+  /** Called after a final entry poke is acked — basis for boot-time replay. */
+  onRunFinal?: (lens: ContextLens) => void;
 }): ContextLensShipSync {
-  const { owners, logger } = opts;
+  const { owner, logger, onRunFinal } = opts;
   const getParams = opts.getParams ?? (() => apiClientParamsSlot.get() ?? null);
 
   const lastStatusByLensId = new Map<string, ContextLensStatus>();
   let configuredFor: SharedApiClientParams | null = null;
   let queue: Promise<void> = Promise.resolve();
 
-  const enqueuePoke = (label: string, json: unknown) => {
+  const enqueuePoke = (
+    label: string,
+    json: unknown,
+    onSuccess?: () => void
+  ) => {
     queue = queue
       .then(async () => {
         const params = getParams();
@@ -176,18 +244,30 @@ export function createContextLensShipSync(opts: {
           return;
         }
         if (params !== configuredFor) {
+          // %steward's top-level %configure is per-ship (sets the singular
+          // owner); the lens module's own configure sub-action sets the
+          // retention cap. We only assert the owner here; retention is left
+          // at the steward default unless an operator pokes %lens
+          // %configure separately.
           await params.poke({
-            app: 'context-lens',
-            mark: 'context-lens-action-1',
-            json: { configure: { owners } },
+            app: 'steward',
+            mark: 'steward-action-1',
+            json: { configure: { owner } },
           });
           configuredFor = params;
         }
         await params.poke({
-          app: 'context-lens',
-          mark: 'context-lens-action-1',
+          app: 'steward',
+          mark: 'steward-action-1',
           json,
         });
+        try {
+          onSuccess?.();
+        } catch (error) {
+          logger.warn(
+            `[tlon] Context lens ship sync bookkeeping failed (${label}): ${String(error)}`
+          );
+        }
       })
       .catch((error) => {
         // A failed %configure must retry before the next run poke.
@@ -205,9 +285,19 @@ export function createContextLensShipSync(opts: {
     }
     if (TERMINAL_STATUSES.has(lens.status)) {
       lastStatusByLensId.delete(lens.lensId);
-      enqueuePoke(`run-final ${lens.lensId}`, {
-        'run-final': { id: lens.lensId, payload: buildLensRunPayload(lens) },
-      });
+      enqueuePoke(
+        `entry-final ${lens.lensId}`,
+        {
+          lens: {
+            entry: {
+              id: lens.lensId,
+              payload: buildLensRunPayload(lens),
+              final: true,
+            },
+          },
+        },
+        onRunFinal ? () => onRunFinal(lens) : undefined
+      );
       return;
     }
     if (lens.status === lastStatusByLensId.get(lens.lensId)) {
@@ -222,8 +312,14 @@ export function createContextLensShipSync(opts: {
       }
       lastStatusByLensId.delete(oldest);
     }
-    enqueuePoke(`run-event ${lens.lensId}`, {
-      'run-event': { id: lens.lensId, payload: buildLensRunPayload(lens) },
+    enqueuePoke(`entry-partial ${lens.lensId}`, {
+      lens: {
+        entry: {
+          id: lens.lensId,
+          payload: buildLensRunPayload(lens),
+          final: false,
+        },
+      },
     });
   };
 
@@ -231,6 +327,75 @@ export function createContextLensShipSync(opts: {
     handleEvent,
     flush: () => queue,
   };
+}
+
+/**
+ * Re-poke terminal runs whose final %entry never reached the ship — e.g. runs
+ * finalized during a SIGTERM shutdown, where the store write (sync fs)
+ * landed but the poke died with the process. Without this the ship copy
+ * stays frozen at the last in-flight status forever. Idempotent ship-side
+ * (last write wins per run id); bounded by a recency window and a count cap
+ * so a first boot without a synced-ids file cannot flood the ship.
+ */
+export function replayUnsyncedFinalRuns(
+  store: ContextLensStore,
+  sync: ContextLensShipSync,
+  logger: SyncLogger,
+  now = Date.now()
+): number {
+  const synced = loadSyncedLensIds(syncedLensIdsPath(store.filePath));
+  const cutoff = now - REPLAY_WINDOW_MS;
+  const missed = store
+    .list()
+    .filter(
+      (lens) =>
+        TERMINAL_STATUSES.has(lens.status) &&
+        lens.visibility !== 'internal' &&
+        !synced.has(lens.lensId) &&
+        lensFinalizedAt(lens) > cutoff
+    )
+    .slice(-REPLAY_MAX_RUNS);
+  if (missed.length === 0) {
+    return 0;
+  }
+  logger.info(
+    `[tlon] Context lens ship sync replaying ${missed.length} unsynced terminal run(s)`
+  );
+  for (const lens of missed) {
+    sync.handleEvent({ seq: 0, at: now, phase: 'replay', lens });
+  }
+  return missed.length;
+}
+
+function startShipSyncReplay(
+  sync: ContextLensShipSync,
+  logger: SyncLogger
+): void {
+  replayCancelSlot.get()?.();
+  const startedAt = Date.now();
+  // Poll: at init time neither the api-client params (monitor not connected)
+  // nor the disk store (initialized after ship sync) exist yet.
+  const timer = setInterval(() => {
+    if (Date.now() - startedAt > REPLAY_GIVE_UP_MS) {
+      stop();
+      return;
+    }
+    const store = getContextLensStore();
+    if (!store || !apiClientParamsSlot.get()) {
+      return;
+    }
+    stop();
+    try {
+      replayUnsyncedFinalRuns(store, sync, logger);
+    } catch (error) {
+      logger.warn(
+        `[tlon] Context lens ship sync replay failed: ${String(error)}`
+      );
+    }
+  }, REPLAY_POLL_MS);
+  timer.unref?.();
+  const stop = () => clearInterval(timer);
+  replayCancelSlot.set(stop);
 }
 
 /**
@@ -242,21 +407,49 @@ export function initContextLensShipSync(api: {
   config: OpenClawConfig;
   logger: SyncLogger;
 }): boolean {
+  // Tear down any prior subscription/replay first: a config reload that
+  // disables the lens or empties owners must not leak the previous
+  // subscriber, which would keep fanning runs to the former owner list.
+  const teardown = () => {
+    shipSyncUnsubscribeSlot.get()?.();
+    shipSyncUnsubscribeSlot.set(null);
+    replayCancelSlot.get()?.();
+    replayCancelSlot.set(null);
+  };
   if (!resolveTlonAccount(api.config).contextLens.enabled) {
+    teardown();
     return false;
   }
-  const owners = resolveLensOwners(api.config);
-  if (owners.length === 0) {
+  const owner = resolveLensOwner(api.config);
+  if (!owner) {
+    teardown();
     api.logger.info(
-      '[tlon] Context lens ship sync disabled: no owners configured (set contextLens.owners or ownerShip)'
+      '[tlon] Context lens ship sync disabled: no owner configured (set contextLens.owners or ownerShip)'
     );
     return false;
   }
-  const sync = createContextLensShipSync({ owners, logger: api.logger });
+  const owners = resolveLensOwners(api.config);
+  if (owners.length > 1) {
+    api.logger.warn(
+      `[tlon] Context lens ship sync: %steward stores a single owner; using ${owner}, ignoring ${owners.slice(1).join(', ')}`
+    );
+  }
+  const sync = createContextLensShipSync({
+    owner,
+    logger: api.logger,
+    onRunFinal: (lens) => {
+      const store = getContextLensStore();
+      if (!store) {
+        return;
+      }
+      recordSyncedLensId(syncedLensIdsPath(store.filePath), lens.lensId);
+    },
+  });
   shipSyncUnsubscribeSlot.get()?.();
   shipSyncUnsubscribeSlot.set(subscribeToContextLensEvents(sync.handleEvent));
+  startShipSyncReplay(sync, api.logger);
   api.logger.info(
-    `[tlon] Context lens ship sync enabled, fanning out to ${owners.join(', ')}`
+    `[tlon] Context lens ship sync enabled, fanning out to ${owner}`
   );
   return true;
 }

--- a/packages/openclaw/src/context-lens-store.test.ts
+++ b/packages/openclaw/src/context-lens-store.test.ts
@@ -7,11 +7,20 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { publishContextLensEvent } from './context-lens-events.js';
 import {
   createContextLensStore,
+  createInflightCheckpoint,
   getContextLensStore,
+  inflightCheckpointPath,
   initContextLensStore,
+  markLensAborted,
+  recoverInterruptedRuns,
   setContextLensStore,
 } from './context-lens-store.js';
-import { type ContextLens, createContextLensRegistry } from './context-lens.js';
+import {
+  type ContextLens,
+  type ContextLensStatus,
+  createContextLensRegistry,
+} from './context-lens.js';
+import { sharedSlot } from './shared-state.js';
 
 let tmpDir: string;
 let filePath: string;
@@ -41,6 +50,18 @@ function makeLens(
     status: 'completed',
     lifecycle: { ...lens.lifecycle, completedAt },
   };
+}
+
+function makeInflightLens(
+  overrides: { messageId?: string; status?: ContextLensStatus } = {}
+): ContextLens {
+  const registry = createContextLensRegistry({ ttlMs: 60_000 });
+  const lens = registry.create({
+    messageId: overrides.messageId ?? 'inflight-1',
+    chatType: 'dm',
+    trigger: 'dm',
+  });
+  return { ...lens, status: overrides.status ?? 'dispatching' };
 }
 
 describe('createContextLensStore', () => {
@@ -154,6 +175,173 @@ describe('createContextLensStore', () => {
   });
 });
 
+describe('createInflightCheckpoint', () => {
+  it('upserts, removes, and survives reload', () => {
+    const checkpointPath = inflightCheckpointPath(filePath);
+    const checkpoint = createInflightCheckpoint({ filePath: checkpointPath });
+    const a = makeInflightLens({ messageId: 'ckpt-a' });
+    const b = makeInflightLens({ messageId: 'ckpt-b' });
+
+    checkpoint.upsert(a);
+    checkpoint.upsert(b);
+    expect(
+      checkpoint
+        .list()
+        .map((l) => l.lensId)
+        .sort()
+    ).toEqual([a.lensId, b.lensId].sort());
+
+    checkpoint.remove(a.lensId);
+    const reloaded = createInflightCheckpoint({ filePath: checkpointPath });
+    expect(reloaded.list().map((l) => l.lensId)).toEqual([b.lensId]);
+  });
+
+  it('keeps the latest snapshot per lensId', () => {
+    const checkpoint = createInflightCheckpoint({
+      filePath: inflightCheckpointPath(filePath),
+    });
+    const lens = makeInflightLens({
+      messageId: 'ckpt-dup',
+      status: 'assembling',
+    });
+    checkpoint.upsert(lens);
+    checkpoint.upsert({ ...lens, status: 'tool_running' });
+    expect(checkpoint.list()).toHaveLength(1);
+    expect(checkpoint.list()[0].status).toBe('tool_running');
+  });
+
+  it('clear empties the file', () => {
+    const checkpointPath = inflightCheckpointPath(filePath);
+    const checkpoint = createInflightCheckpoint({ filePath: checkpointPath });
+    checkpoint.upsert(makeInflightLens());
+    checkpoint.clear();
+    expect(checkpoint.list()).toHaveLength(0);
+    expect(fs.readFileSync(checkpointPath, 'utf8')).toBe('');
+  });
+
+  it('evicts the oldest entry past maxInflight', () => {
+    const checkpoint = createInflightCheckpoint({
+      filePath: inflightCheckpointPath(filePath),
+      maxInflight: 2,
+    });
+    const a = makeInflightLens({ messageId: 'evict-a' });
+    const b = makeInflightLens({ messageId: 'evict-b' });
+    const c = makeInflightLens({ messageId: 'evict-c' });
+    checkpoint.upsert(a);
+    checkpoint.upsert(b);
+    checkpoint.upsert(c);
+    expect(checkpoint.list().map((l) => l.lensId)).toEqual([
+      b.lensId,
+      c.lensId,
+    ]);
+  });
+});
+
+describe('markLensAborted', () => {
+  it('finalizes status, timings, and open tool runs', () => {
+    const now = 10_000;
+    const base = makeInflightLens({ status: 'tool_running' });
+    const lens: ContextLens = {
+      ...base,
+      createdAt: now - 5_000,
+      tools: {
+        ...base.tools,
+        runs: [
+          {
+            id: 't1',
+            callIndex: 1,
+            name: 'search',
+            startedAt: now - 3_000,
+            completedAt: null,
+            durationMs: null,
+            status: 'running',
+          },
+          {
+            id: 't2',
+            callIndex: 2,
+            name: 'fetch',
+            startedAt: now - 8_000,
+            completedAt: now - 7_000,
+            durationMs: 1_000,
+            status: 'completed',
+          },
+        ],
+      },
+    };
+
+    const aborted = markLensAborted(lens, now);
+
+    expect(aborted.status).toBe('aborted');
+    expect(aborted.error).toContain('Gateway stopped');
+    expect(aborted.lifecycle.completedAt).toBe(now);
+    expect(aborted.lifecycle.durationMs).toBe(5_000);
+    expect(aborted.tools.runs[0]).toMatchObject({
+      status: 'error',
+      completedAt: now,
+      durationMs: 3_000,
+    });
+    // A tool run that already finished is left untouched.
+    expect(aborted.tools.runs[1]).toMatchObject({
+      status: 'completed',
+      durationMs: 1_000,
+    });
+  });
+
+  it('preserves an existing terminal timestamp and error', () => {
+    const base = makeInflightLens();
+    const lens: ContextLens = {
+      ...base,
+      error: 'original error',
+      lifecycle: { ...base.lifecycle, completedAt: 42, durationMs: 7 },
+    };
+    const aborted = markLensAborted(lens, 99);
+    expect(aborted.lifecycle.completedAt).toBe(42);
+    expect(aborted.lifecycle.durationMs).toBe(7);
+    expect(aborted.error).toBe('original error');
+  });
+});
+
+describe('recoverInterruptedRuns', () => {
+  it('aborts leftover in-flight runs into the store and clears the checkpoint', () => {
+    const store = createContextLensStore({ filePath });
+    const checkpoint = createInflightCheckpoint({
+      filePath: inflightCheckpointPath(filePath),
+    });
+    const lens = makeInflightLens({ messageId: 'killed' });
+    checkpoint.upsert(lens);
+
+    const recovered = recoverInterruptedRuns({ store, checkpoint });
+
+    expect(recovered).toBe(1);
+    expect(store.get(lens.lensId)?.status).toBe('aborted');
+    expect(checkpoint.list()).toHaveLength(0);
+  });
+
+  it('skips runs already terminal on disk (stale checkpoint line)', () => {
+    const store = createContextLensStore({ filePath });
+    const finished = makeLens({ messageId: 'finished' });
+    store.save(finished);
+    const checkpoint = createInflightCheckpoint({
+      filePath: inflightCheckpointPath(filePath),
+    });
+    // Same lensId, but the checkpoint still holds the pre-terminal snapshot.
+    checkpoint.upsert({ ...finished, status: 'dispatching' });
+
+    const recovered = recoverInterruptedRuns({ store, checkpoint });
+
+    expect(recovered).toBe(0);
+    expect(store.get(finished.lensId)?.status).toBe('completed');
+  });
+
+  it('does no work when the checkpoint is empty', () => {
+    const store = createContextLensStore({ filePath });
+    const checkpoint = createInflightCheckpoint({
+      filePath: inflightCheckpointPath(filePath),
+    });
+    expect(recoverInterruptedRuns({ store, checkpoint })).toBe(0);
+  });
+});
+
 // Keep this block last: initContextLensStore subscribes to the global lens
 // event stream, and that subscription persists for the rest of the file.
 describe('initContextLensStore', () => {
@@ -199,8 +387,13 @@ describe('initContextLensStore', () => {
     publishContextLensEvent('final', finalized);
     expect(store?.get(finalized.lensId)?.messageId).toBe('finalized');
 
+    const aborted = makeLens({ messageId: 'aborted-run' });
+    publishContextLensEvent('final', { ...aborted, status: 'aborted' });
+    expect(store?.get(aborted.lensId)?.messageId).toBe('aborted-run');
+
     const reloaded = createContextLensStore({ filePath });
     expect(reloaded.get(finalized.lensId)?.messageId).toBe('finalized');
+    expect(reloaded.get(aborted.lensId)?.status).toBe('aborted');
   });
 
   it('replaces the event subscription on re-init instead of stacking writers', () => {
@@ -228,5 +421,91 @@ describe('initContextLensStore', () => {
       ? fs.readFileSync(stalePath, 'utf8')
       : '';
     expect(staleContents).not.toContain(finalized.lensId);
+  });
+
+  it('tears down the store and writer when persistence is disabled on re-init', () => {
+    const store = initContextLensStore(
+      makeApi({
+        enabled: true,
+        authToken: 'a-token-of-sufficient-length',
+        store: { path: filePath },
+      })
+    );
+    expect(store).not.toBeNull();
+    expect(getContextLensStore()).toBe(store);
+
+    // Leave a run in flight so a checkpoint sidecar exists at teardown.
+    const inFlight = makeInflightLens({ messageId: 'still-running' });
+    publishContextLensEvent('created', { ...inFlight, status: 'dispatching' });
+    const checkpointPath = inflightCheckpointPath(filePath);
+    expect(fs.readFileSync(checkpointPath, 'utf8')).toContain(inFlight.lensId);
+
+    // Re-init with the store disabled (lens itself still enabled).
+    expect(
+      initContextLensStore(
+        makeApi({
+          enabled: true,
+          authToken: 'a-token-of-sufficient-length',
+          store: { enabled: false },
+        })
+      )
+    ).toBeNull();
+    expect(getContextLensStore()).toBeNull();
+
+    // The checkpoint sidecar must be cleared so a later re-enable/restart
+    // doesn't recover a run that may have finished while persistence was off.
+    expect(fs.readFileSync(checkpointPath, 'utf8')).toBe('');
+
+    // A terminal event after disabling must not reach the old JSONL file.
+    const finalized = makeLens({ messageId: 'after-disable' });
+    publishContextLensEvent('final', finalized);
+    const contents = fs.existsSync(filePath)
+      ? fs.readFileSync(filePath, 'utf8')
+      : '';
+    expect(contents).not.toContain(finalized.lensId);
+  });
+
+  it('checkpoints in-flight events and clears them on terminal', () => {
+    initContextLensStore(
+      makeApi({
+        enabled: true,
+        authToken: 'a-token-of-sufficient-length',
+        store: { path: filePath },
+      })
+    );
+    const checkpointPath = inflightCheckpointPath(filePath);
+
+    const lens = makeInflightLens({ messageId: 'checkpointed' });
+    publishContextLensEvent('created', { ...lens, status: 'dispatching' });
+    expect(fs.readFileSync(checkpointPath, 'utf8')).toContain(lens.lensId);
+
+    publishContextLensEvent('final', { ...lens, status: 'completed' });
+    expect(fs.readFileSync(checkpointPath, 'utf8')).not.toContain(lens.lensId);
+  });
+
+  it('recovers an interrupted run as aborted on boot', () => {
+    // Simulate a prior process that died mid-run: a checkpoint entry exists
+    // with no terminal record in the store.
+    const stranded = makeInflightLens({
+      messageId: 'stranded',
+      status: 'tool_running',
+    });
+    fs.writeFileSync(
+      inflightCheckpointPath(filePath),
+      `${JSON.stringify(stranded)}\n`
+    );
+    // Recovery is once-per-process; reset the guard so this boot runs it.
+    sharedSlot<boolean>('contextLens.inflight.recovered').set(false);
+
+    const store = initContextLensStore(
+      makeApi({
+        enabled: true,
+        authToken: 'a-token-of-sufficient-length',
+        store: { path: filePath },
+      })
+    );
+
+    expect(store?.get(stranded.lensId)?.status).toBe('aborted');
+    expect(fs.readFileSync(inflightCheckpointPath(filePath), 'utf8')).toBe('');
   });
 });

--- a/packages/openclaw/src/context-lens-store.ts
+++ b/packages/openclaw/src/context-lens-store.ts
@@ -6,7 +6,7 @@ import { resolveStateDir } from 'openclaw/plugin-sdk/state-paths';
 import { subscribeToContextLensEvents } from './context-lens-events.js';
 import type { ContextLens, ContextLensStatus } from './context-lens.js';
 import { sharedSlot } from './shared-state.js';
-import { resolveTlonAccount } from './types.js';
+import { resolveLensAccountId, resolveTlonAccount } from './types.js';
 
 export const DEFAULT_STORE_RETAIN_DAYS = 30;
 export const DEFAULT_STORE_MAX_STORED = 500;
@@ -404,7 +404,10 @@ export function initContextLensStore(api: {
   config: OpenClawConfig;
   logger: StoreLogger;
 }): ContextLensStore | null {
-  const lensConfig = resolveTlonAccount(api.config).contextLens;
+  const lensConfig = resolveTlonAccount(
+    api.config,
+    resolveLensAccountId(api.config)
+  ).contextLens;
   if (!lensConfig.enabled || !lensConfig.store.enabled) {
     // A re-init that disables the store (or the whole lens) must tear down any
     // store + writer left over from a prior init, or terminal events would keep

--- a/packages/openclaw/src/context-lens-store.ts
+++ b/packages/openclaw/src/context-lens-store.ts
@@ -10,19 +10,25 @@ import { resolveTlonAccount } from './types.js';
 
 export const DEFAULT_STORE_RETAIN_DAYS = 30;
 export const DEFAULT_STORE_MAX_STORED = 500;
+export const DEFAULT_MAX_INFLIGHT = 200;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+const ABORTED_BY_RECOVERY_ERROR = 'Gateway stopped before this run finished';
 
 const TERMINAL_STATUSES: ReadonlySet<ContextLensStatus> = new Set([
   'completed',
   'no_reply',
   'timed_out',
+  'aborted',
   'error',
 ]);
 
 export type ContextLensStore = {
   save: (lens: ContextLens) => void;
   get: (lensId: string) => ContextLens | null;
+  /** Retained runs, oldest→newest by finalization time. */
+  list: () => ContextLens[];
   size: () => number;
   filePath: string;
 };
@@ -40,6 +46,11 @@ const storeUnsubscribeSlot = sharedSlot<() => void>(
   'contextLens.store.unsubscribe'
 );
 
+// Recovery of interrupted runs is a once-per-process boot operation: a plugin
+// re-init mid-run must not re-read the checkpoint and abort runs that are
+// still live in the current process.
+const recoveredSlot = sharedSlot<boolean>('contextLens.inflight.recovered');
+
 export function getContextLensStore(): ContextLensStore | null {
   return storeSlot.get();
 }
@@ -52,7 +63,7 @@ export function defaultContextLensStorePath(): string {
   return path.join(resolveStateDir(), 'tlon', 'context-lens-runs.jsonl');
 }
 
-function lensFinalizedAt(lens: ContextLens): number {
+export function lensFinalizedAt(lens: ContextLens): number {
   return lens.lifecycle.completedAt ?? lens.updatedAt ?? lens.createdAt;
 }
 
@@ -175,14 +186,217 @@ export function createContextLensStore(opts: {
       }
       return lens;
     },
+    list: () => {
+      const now = Date.now();
+      return [...runs.values()].filter((lens) => isRetained(lens, now));
+    },
     size: () => runs.size,
   };
+}
+
+export function inflightCheckpointPath(storeFilePath: string): string {
+  return `${storeFilePath}.inflight.jsonl`;
+}
+
+/**
+ * Sidecar checkpoint of runs that are currently in flight. A run only reaches
+ * the durable store on a terminal event, so a SIGKILL/crash mid-run (or a
+ * SIGTERM that abandons the run without finalizing) would otherwise leave no
+ * trace on the gateway and a frozen in-flight copy on the ship. This file
+ * keeps the latest non-terminal snapshot per run; on the next boot
+ * `recoverInterruptedRuns` finalizes whatever is left as `aborted`.
+ *
+ * Backed by an in-memory map with whole-file atomic rewrites — the file only
+ * ever holds concurrently-running runs (terminal events remove them), so it
+ * stays tiny.
+ */
+export type InflightCheckpoint = {
+  upsert: (lens: ContextLens) => void;
+  remove: (lensId: string) => void;
+  list: () => ContextLens[];
+  clear: () => void;
+  filePath: string;
+};
+
+export function createInflightCheckpoint(opts: {
+  filePath: string;
+  maxInflight?: number | null;
+  logger?: StoreLogger;
+}): InflightCheckpoint {
+  const filePath = opts.filePath;
+  const maxInflight = opts.maxInflight ?? DEFAULT_MAX_INFLIGHT;
+  const logger = opts.logger;
+  const pending = new Map<string, ContextLens>();
+
+  const flush = () => {
+    const lines = [...pending.values()]
+      .map((lens) => JSON.stringify(lens))
+      .join('\n');
+    const tmpPath = `${filePath}.tmp`;
+    fs.writeFileSync(tmpPath, lines.length > 0 ? `${lines}\n` : '', {
+      mode: 0o600,
+    });
+    fs.renameSync(tmpPath, filePath);
+  };
+
+  const load = () => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    if (!fs.existsSync(filePath)) {
+      return;
+    }
+    const raw = fs.readFileSync(filePath, 'utf8');
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        const lens = JSON.parse(trimmed) as ContextLens;
+        if (typeof lens?.lensId === 'string' && lens.lensId) {
+          pending.delete(lens.lensId);
+          pending.set(lens.lensId, lens);
+        }
+      } catch {
+        // Drop malformed checkpoint lines; a partial run record is not worth
+        // failing boot over.
+      }
+    }
+  };
+
+  try {
+    load();
+  } catch (error) {
+    logger?.warn(
+      `[tlon] Context lens in-flight checkpoint load failed: ${String(error)}`
+    );
+  }
+
+  return {
+    filePath,
+    upsert: (lens) => {
+      pending.delete(lens.lensId);
+      pending.set(lens.lensId, lens);
+      while (pending.size > maxInflight) {
+        const oldest = pending.keys().next().value;
+        if (!oldest) {
+          break;
+        }
+        pending.delete(oldest);
+      }
+      flush();
+    },
+    remove: (lensId) => {
+      if (pending.delete(lensId)) {
+        flush();
+      }
+    },
+    list: () => [...pending.values()],
+    clear: () => {
+      if (pending.size === 0 && !fs.existsSync(filePath)) {
+        return;
+      }
+      pending.clear();
+      flush();
+    },
+  };
+}
+
+/**
+ * Finalize an interrupted run as `aborted`: stamp completion timings and close
+ * any tool runs left open when the process died, so the inspector shows a
+ * coherent terminal record rather than a run frozen mid-flight.
+ */
+export function markLensAborted(
+  lens: ContextLens,
+  now = Date.now()
+): ContextLens {
+  const completedAt = lens.lifecycle.completedAt ?? now;
+  return {
+    ...lens,
+    status: 'aborted',
+    error: lens.error ?? ABORTED_BY_RECOVERY_ERROR,
+    tools: {
+      ...lens.tools,
+      runs: lens.tools.runs.map((run) =>
+        run.completedAt
+          ? run
+          : {
+              ...run,
+              completedAt: now,
+              durationMs: now - run.startedAt,
+              status: 'error' as const,
+              error: run.error ?? ABORTED_BY_RECOVERY_ERROR,
+            }
+      ),
+    },
+    lifecycle: {
+      ...lens.lifecycle,
+      completedAt,
+      durationMs: lens.lifecycle.durationMs ?? completedAt - lens.createdAt,
+    },
+    updatedAt: now,
+  };
+}
+
+/**
+ * On boot, finalize runs that a previous process left in flight: each leftover
+ * checkpoint snapshot is marked `aborted` and saved to the durable store,
+ * where ship-sync's boot replay picks it up and overwrites the ship's frozen
+ * in-flight copy. Skips runs already terminal on disk (a stale checkpoint line
+ * whose terminal removal was lost to the crash). Clears the checkpoint after.
+ */
+export function recoverInterruptedRuns(opts: {
+  store: ContextLensStore;
+  checkpoint: InflightCheckpoint;
+  logger?: StoreLogger;
+  now?: number;
+}): number {
+  const { store, checkpoint, logger } = opts;
+  const now = opts.now ?? Date.now();
+  const pending = checkpoint.list();
+  if (pending.length === 0) {
+    return 0;
+  }
+  let recovered = 0;
+  let failed = 0;
+  for (const lens of pending) {
+    if (TERMINAL_STATUSES.has(lens.status)) {
+      continue;
+    }
+    const existing = store.get(lens.lensId);
+    if (existing && TERMINAL_STATUSES.has(existing.status)) {
+      continue;
+    }
+    try {
+      store.save(markLensAborted(lens, now));
+      recovered += 1;
+    } catch (error) {
+      failed += 1;
+      logger?.warn(
+        `[tlon] Context lens recovery failed for ${lens.lensId}: ${String(error)}`
+      );
+    }
+  }
+  // Keep the checkpoint when any save failed so the next boot can retry —
+  // a transient write hiccup must not permanently drop the only inflight
+  // snapshot.
+  if (failed === 0) {
+    checkpoint.clear();
+  }
+  if (recovered > 0) {
+    logger?.info(
+      `[tlon] Context lens recovered ${recovered} interrupted run(s) as aborted`
+    );
+  }
+  return recovered;
 }
 
 /**
  * Wire the disk store to the lens event stream: every event whose lens has
  * reached a terminal status is persisted (last write wins, so a later
- * "final" snapshot for the same lensId replaces the earlier one).
+ * "final" snapshot for the same lensId replaces the earlier one). Non-terminal
+ * events are checkpointed to a sidecar so an interrupted run can be recovered
+ * as `aborted` on the next boot.
  *
  * Returns the store, or null when the lens or its store is disabled.
  */
@@ -192,6 +406,29 @@ export function initContextLensStore(api: {
 }): ContextLensStore | null {
   const lensConfig = resolveTlonAccount(api.config).contextLens;
   if (!lensConfig.enabled || !lensConfig.store.enabled) {
+    // A re-init that disables the store (or the whole lens) must tear down any
+    // store + writer left over from a prior init, or terminal events would keep
+    // landing in the old JSONL despite persistence being off.
+    const previousStore = getContextLensStore();
+    storeUnsubscribeSlot.get()?.();
+    storeUnsubscribeSlot.set(null);
+    setContextLensStore(null);
+    // Clearing the writer can't run the terminal `checkpoint.remove` for any
+    // run still in flight, so a leftover sidecar would make a later re-enable
+    // (or restart on the same path) recover a run that actually finished while
+    // persistence was off. Drop the checkpoint along with the store.
+    if (previousStore) {
+      try {
+        createInflightCheckpoint({
+          filePath: inflightCheckpointPath(previousStore.filePath),
+          logger: api.logger,
+        }).clear();
+      } catch (error) {
+        api.logger.warn(
+          `[tlon] Context lens checkpoint teardown failed: ${String(error)}`
+        );
+      }
+    }
     return null;
   }
   let store: ContextLensStore;
@@ -209,17 +446,48 @@ export function initContextLensStore(api: {
     return null;
   }
   setContextLensStore(store);
+
+  const checkpoint = createInflightCheckpoint({
+    filePath: inflightCheckpointPath(store.filePath),
+    logger: api.logger,
+  });
+  // Once per process: a mid-run re-init must not re-read the checkpoint and
+  // abort runs still live in this process.
+  if (!recoveredSlot.get()) {
+    recoveredSlot.set(true);
+    try {
+      recoverInterruptedRuns({ store, checkpoint, logger: api.logger });
+    } catch (error) {
+      api.logger.warn(`[tlon] Context lens recovery failed: ${String(error)}`);
+    }
+  }
+
   storeUnsubscribeSlot.get()?.();
   storeUnsubscribeSlot.set(
     subscribeToContextLensEvents((event) => {
-      if (!TERMINAL_STATUSES.has(event.lens.status)) {
+      const lens = event.lens;
+      if (TERMINAL_STATUSES.has(lens.status)) {
+        try {
+          checkpoint.remove(lens.lensId);
+        } catch (error) {
+          api.logger.warn(
+            `[tlon] Context lens checkpoint clear failed for ${lens.lensId}: ${String(error)}`
+          );
+        }
+        try {
+          store.save(lens);
+        } catch (error) {
+          api.logger.warn(
+            `[tlon] Context lens store write failed for ${lens.lensId}: ${String(error)}`
+          );
+        }
         return;
       }
       try {
-        store.save(event.lens);
+        checkpoint.upsert(lens);
       } catch (error) {
         api.logger.warn(
-          `[tlon] Context lens store write failed for ${event.lens.lensId}: ${String(error)}`
+          `[tlon] Context lens checkpoint write failed for ${lens.lensId}: ${String(error)}`
         );
       }
     })

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -8,6 +8,7 @@ import {
 } from './context-lens-events.js';
 import {
   bindContextLensToSession,
+  buildRetryDispatch,
   createContextLensRegistry,
   ensureBackgroundContextLensForSession,
   finalizeBackgroundContextLensForSession,
@@ -731,6 +732,178 @@ describe('context lens event bus', () => {
     expect(duplicateBus.findRecentContextLensById(lens.lensId)).toMatchObject({
       lensId: lens.lensId,
       messageId: 'message-global-bus',
+    });
+  });
+});
+
+describe('retry seed and dispatch', () => {
+  it('captures retryOf and retrySeed on create and preserves them through clones', () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-1',
+      chatType: 'channel',
+      trigger: 'retry',
+      sessionKey: 'session-retry-1',
+      senderShip: '~ten',
+      conversationId: 'chat/~ten/test',
+      retryOf: 'lens-original',
+      retrySeed: {
+        messageText: 'hello again',
+        blobField: '{"k":"v"}',
+        parentId: '170.1',
+        isThreadReply: true,
+        replyParentId: '170.2',
+        cachesHistory: true,
+      },
+    });
+
+    expect(lens.retryOf).toBe('lens-original');
+    expect(lens.retrySeed).toEqual({
+      messageText: 'hello again',
+      blobField: '{"k":"v"}',
+      parentId: '170.1',
+      isThreadReply: true,
+      replyParentId: '170.2',
+      cachesHistory: true,
+    });
+
+    const fetched = registry.get(lens.lensId);
+    expect(fetched?.retrySeed).toEqual(lens.retrySeed);
+    // Clones are independent copies, not shared references.
+    expect(fetched?.retrySeed).not.toBe(lens.retrySeed);
+  });
+
+  it('caps oversized retry seed text and drops oversized blobs', () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-2',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-2',
+      senderShip: '~ten',
+      retrySeed: {
+        messageText: 'x'.repeat(20_000),
+        blobField: 'y'.repeat(10_000),
+      },
+    });
+
+    expect(lens.retrySeed?.messageText.length).toBe(16_384);
+    expect(lens.retrySeed?.blobField).toBeUndefined();
+  });
+
+  it("builds a retry dispatch from a failed run's seed", () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-3',
+      chatType: 'channel',
+      trigger: 'mention',
+      sessionKey: 'session-retry-3',
+      senderShip: '~ten',
+      conversationId: 'chat/~ten/test',
+      preview: 'preview text',
+      retrySeed: {
+        messageText: 'full original text',
+        blobField: null,
+        parentId: '170.5',
+        isThreadReply: true,
+        replyParentId: null,
+        cachesHistory: true,
+      },
+    });
+    const aborted = registry.setStatus(lens.lensId, 'aborted');
+    expect(aborted).not.toBeNull();
+
+    const result = buildRetryDispatch(aborted!);
+    expect(result).toEqual({
+      ok: true,
+      dispatch: {
+        messageId: 'message-retry-3',
+        senderShip: '~ten',
+        messageText: 'full original text',
+        blobField: null,
+        isGroup: true,
+        channelNest: 'chat/~ten/test',
+        parentId: '170.5',
+        isThreadReply: true,
+        replyParentId: null,
+        cachesHistory: true,
+        degraded: false,
+      },
+    });
+  });
+
+  it('falls back to the preview as degraded when the run predates retrySeed', () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-4',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-4',
+      senderShip: '~ten',
+      preview: 'truncated preview',
+    });
+    const failed = registry.setStatus(lens.lensId, 'error', new Error('boom'));
+
+    const result = buildRetryDispatch(failed!);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.dispatch.messageText).toBe('truncated preview');
+      expect(result.dispatch.degraded).toBe(true);
+      expect(result.dispatch.isGroup).toBe(false);
+    }
+  });
+
+  it('refuses non-retryable, internal, and incomplete runs', () => {
+    const registry = createContextLensRegistry();
+
+    const completed = registry.create({
+      messageId: 'message-retry-5',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-5',
+      senderShip: '~ten',
+      preview: 'done',
+    });
+    const completedLens = registry.setStatus(completed.lensId, 'completed');
+    expect(buildRetryDispatch(completedLens!)).toEqual({
+      ok: false,
+      reason: 'status completed is not retryable',
+    });
+
+    const internal = registry.create({
+      messageId: 'message-retry-6',
+      chatType: 'internal',
+      trigger: 'cron',
+      sessionKey: 'session-retry-6',
+      preview: 'cron run',
+    });
+    const internalLens = registry.setStatus(internal.lensId, 'error');
+    expect(buildRetryDispatch(internalLens!).ok).toBe(false);
+
+    const noAuthor = registry.create({
+      messageId: 'message-retry-7',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-7',
+      preview: 'anonymous',
+    });
+    const noAuthorLens = registry.setStatus(noAuthor.lensId, 'timed_out');
+    expect(buildRetryDispatch(noAuthorLens!)).toEqual({
+      ok: false,
+      reason: 'original run has no author ship',
+    });
+
+    const noText = registry.create({
+      messageId: 'message-retry-8',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-8',
+      senderShip: '~ten',
+    });
+    const noTextLens = registry.setStatus(noText.lensId, 'no_reply');
+    expect(buildRetryDispatch(noTextLens!)).toEqual({
+      ok: false,
+      reason: 'no message text available to retry',
     });
   });
 });

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -12,6 +12,7 @@ export type ContextLensTrigger =
   | 'owner-blob'
   | 'summarization'
   | 'tool'
+  | 'retry'
   | 'unknown';
 
 export type ContextLensRunKind =
@@ -32,6 +33,7 @@ export type ContextLensStatus =
   | 'completed'
   | 'no_reply'
   | 'timed_out'
+  | 'aborted'
   | 'error';
 
 export type ContextLensTriggerDetails = {
@@ -42,6 +44,23 @@ export type ContextLensTriggerDetails = {
   conversationKind: 'dm' | 'channel' | 'internal';
   receivedAt?: number;
   preview?: string;
+};
+
+/**
+ * Snapshot of the original dispatch inputs, captured at lens creation so an
+ * owner-requested retry can re-dispatch the message faithfully. The seed is
+ * capped at capture, persisted in the JSONL store, and included in ship-sync
+ * payloads so the owner ship can retry runs even if gateway-local cache state
+ * is gone. Message text and blob JSON already originate from the DM/channel
+ * visible to the owner.
+ */
+export type ContextLensRetrySeed = {
+  messageText: string;
+  blobField?: string | null;
+  parentId?: string | null;
+  isThreadReply?: boolean;
+  replyParentId?: string | null;
+  cachesHistory?: boolean;
 };
 
 export type ContextLensSourceKind =
@@ -106,6 +125,9 @@ export type ContextLens = {
   visibility: ContextLensVisibility;
   trigger: ContextLensTrigger;
   triggerDetails: ContextLensTriggerDetails;
+  /** lensId of the run this one retries, when trigger is "retry". */
+  retryOf?: string;
+  retrySeed?: ContextLensRetrySeed;
   model: string | null;
   provider: string | null;
   context: {
@@ -165,6 +187,8 @@ export type CreateContextLensInput = {
   conversationId?: string;
   receivedAt?: number;
   preview?: string;
+  retryOf?: string;
+  retrySeed?: ContextLensRetrySeed;
   now?: number;
   ttlMs?: number;
 };
@@ -198,6 +222,8 @@ type ActiveContextLensBinding = {
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const MAX_LENSES = 200;
+const MAX_RETRY_SEED_TEXT_CHARS = 16_384;
+const MAX_RETRY_SEED_BLOB_CHARS = 8_192;
 // Long enough for the gateway to deliver the run's reply (cron DMs etc.)
 // after the last tool result, so the outbound stamp/output land on the lens
 // before it finalizes.
@@ -253,6 +279,94 @@ function cloneLens(lens: ContextLens): ContextLens {
     outputs: lens.outputs.map((output) => ({ ...output })),
     lifecycle: { ...lens.lifecycle },
     triggerDetails: { ...lens.triggerDetails },
+    ...(lens.retrySeed ? { retrySeed: { ...lens.retrySeed } } : {}),
+  };
+}
+
+function capRetrySeed(seed: ContextLensRetrySeed): ContextLensRetrySeed {
+  const capped: ContextLensRetrySeed = {
+    ...seed,
+    messageText: seed.messageText.slice(0, MAX_RETRY_SEED_TEXT_CHARS),
+  };
+  // A truncated blob would be unparseable JSON — drop it instead.
+  if (
+    typeof seed.blobField === 'string' &&
+    seed.blobField.length > MAX_RETRY_SEED_BLOB_CHARS
+  ) {
+    delete capped.blobField;
+  }
+  return capped;
+}
+
+export const RETRYABLE_STATUSES: ReadonlySet<ContextLensStatus> = new Set([
+  'no_reply',
+  'timed_out',
+  'aborted',
+  'error',
+]);
+
+export type RetryDispatch = {
+  messageId: string;
+  senderShip: string;
+  messageText: string;
+  blobField?: string | null;
+  isGroup: boolean;
+  channelNest?: string;
+  parentId?: string | null;
+  isThreadReply?: boolean;
+  replyParentId?: string | null;
+  cachesHistory?: boolean;
+  /** True when dispatching from the truncated preview because the run predates retrySeed. */
+  degraded: boolean;
+};
+
+export type RetryDispatchResult =
+  | { ok: true; dispatch: RetryDispatch }
+  | { ok: false; reason: string };
+
+/**
+ * Reconstruct processMessage params from a finalized lens so an owner can
+ * re-run it. Pure eligibility + mapping; the caller owns dedup and dispatch.
+ */
+export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
+  if (!RETRYABLE_STATUSES.has(lens.status)) {
+    return { ok: false, reason: `status ${lens.status} is not retryable` };
+  }
+  if (
+    lens.triggerDetails.conversationKind === 'internal' ||
+    lens.runKind === 'internal'
+  ) {
+    return { ok: false, reason: 'internal runs cannot be retried' };
+  }
+  const senderShip = lens.triggerDetails.authorShip;
+  if (!senderShip) {
+    return { ok: false, reason: 'original run has no author ship' };
+  }
+  const isGroup = lens.triggerDetails.conversationKind === 'channel';
+  const conversationId = lens.triggerDetails.conversationId;
+  if (isGroup && !conversationId) {
+    return { ok: false, reason: 'channel run has no conversation id' };
+  }
+  const seed = lens.retrySeed;
+  const messageText = seed?.messageText ?? lens.triggerDetails.preview ?? '';
+  if (!messageText.trim()) {
+    return { ok: false, reason: 'no message text available to retry' };
+  }
+  return {
+    ok: true,
+    dispatch: {
+      messageId: lens.messageId,
+      senderShip,
+      messageText,
+      blobField: seed?.blobField ?? null,
+      isGroup,
+      ...(isGroup && conversationId ? { channelNest: conversationId } : {}),
+      parentId: seed?.parentId ?? null,
+      isThreadReply: seed?.isThreadReply ?? false,
+      replyParentId: seed?.replyParentId ?? null,
+      cachesHistory: seed?.cachesHistory ?? true,
+      degraded: !seed,
+    },
   };
 }
 
@@ -318,6 +432,8 @@ export function createContextLensRegistry(
         ...(input.receivedAt ? { receivedAt: input.receivedAt } : {}),
         ...(input.preview ? { preview: input.preview } : {}),
       },
+      ...(input.retryOf ? { retryOf: input.retryOf } : {}),
+      ...(input.retrySeed ? { retrySeed: capRetrySeed(input.retrySeed) } : {}),
       model: null,
       provider: null,
       context: {
@@ -858,7 +974,24 @@ export function recordBackgroundContextLensOutput(
   lensId: string,
   output: ContextLensOutput
 ): ContextLens | null {
-  return getBackgroundContextLensRegistry().recordOutput(lensId, output);
+  const registry = getBackgroundContextLensRegistry();
+  const lens = registry.recordOutput(lensId, output);
+  if (!lens) {
+    return null;
+  }
+  // Mirror the dispatch deliver path: without these the run inspector shows
+  // "Persistence: none" for background runs that did post messages.
+  registry.recordPersistence(lensId, { postsReply: true });
+  return (
+    registry.recordPersistenceEvent(lensId, {
+      kind: 'conversation_state',
+      action: 'created',
+      location: 'urbit',
+      status: 'ok',
+      key: 'reply',
+      reason: 'posted gateway-delivered message',
+    }) ?? lens
+  );
 }
 
 export function recordContextLensToolStartForSession(

--- a/packages/openclaw/src/diagnostic-subscriptions.test.ts
+++ b/packages/openclaw/src/diagnostic-subscriptions.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearTlonDiagnosticSubscriptionsForTest,
+  installTlonDiagnosticSubscriptions,
+  shouldInstallTlonDiagnosticSubscriptions,
+} from './diagnostic-subscriptions.js';
+
+describe('diagnostic subscriptions', () => {
+  afterEach(() => {
+    clearTlonDiagnosticSubscriptionsForTest();
+  });
+
+  it('installs only during full registration', () => {
+    expect(shouldInstallTlonDiagnosticSubscriptions('full')).toBe(true);
+    expect(shouldInstallTlonDiagnosticSubscriptions('tool-discovery')).toBe(
+      false
+    );
+    expect(shouldInstallTlonDiagnosticSubscriptions('discovery')).toBe(false);
+    expect(shouldInstallTlonDiagnosticSubscriptions('cli-metadata')).toBe(
+      false
+    );
+    expect(shouldInstallTlonDiagnosticSubscriptions(undefined)).toBe(false);
+  });
+
+  it('replaces an existing process-global subscription instead of stacking', () => {
+    const firstUnsubscribe = vi.fn();
+    const secondUnsubscribe = vi.fn();
+
+    const cleanupFirst = installTlonDiagnosticSubscriptions(
+      () => firstUnsubscribe
+    );
+    const cleanupSecond = installTlonDiagnosticSubscriptions(
+      () => secondUnsubscribe
+    );
+
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(secondUnsubscribe).not.toHaveBeenCalled();
+
+    cleanupFirst();
+    expect(secondUnsubscribe).not.toHaveBeenCalled();
+
+    cleanupSecond();
+    expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps cleanup idempotent', () => {
+    const unsubscribe = vi.fn();
+    const cleanup = installTlonDiagnosticSubscriptions(() => unsubscribe);
+
+    cleanup();
+    cleanup();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/openclaw/src/diagnostic-subscriptions.ts
+++ b/packages/openclaw/src/diagnostic-subscriptions.ts
@@ -1,0 +1,69 @@
+import { sharedSlot } from './shared-state.js';
+
+export type TlonDiagnosticSubscriptionInstaller = () => () => void;
+
+type TlonDiagnosticSubscription = {
+  id: number;
+  unsubscribe: () => void;
+};
+
+const diagnosticSubscriptionSlot = sharedSlot<TlonDiagnosticSubscription>(
+  'telemetry.diagnosticEventsSubscription'
+);
+const diagnosticSubscriptionIdSlot = sharedSlot<number>(
+  'telemetry.diagnosticEventsSubscription.nextId'
+);
+
+function nextDiagnosticSubscriptionId(): number {
+  const nextId = (diagnosticSubscriptionIdSlot.get() ?? 0) + 1;
+  diagnosticSubscriptionIdSlot.set(nextId);
+  return nextId;
+}
+
+export function shouldInstallTlonDiagnosticSubscriptions(
+  registrationMode: string | null | undefined
+): boolean {
+  return registrationMode === 'full';
+}
+
+export function installTlonDiagnosticSubscriptions(
+  install: TlonDiagnosticSubscriptionInstaller
+): () => void {
+  diagnosticSubscriptionSlot.get()?.unsubscribe();
+
+  const id = nextDiagnosticSubscriptionId();
+  let unsubscribed = false;
+  let installedUnsubscribe: () => void;
+  try {
+    installedUnsubscribe = install();
+  } catch (error) {
+    diagnosticSubscriptionSlot.set(null);
+    throw error;
+  }
+  const unsubscribe = () => {
+    if (unsubscribed) {
+      return;
+    }
+    unsubscribed = true;
+    installedUnsubscribe();
+  };
+
+  diagnosticSubscriptionSlot.set({ id, unsubscribe });
+
+  return () => {
+    if (diagnosticSubscriptionSlot.get()?.id !== id) {
+      return;
+    }
+    try {
+      unsubscribe();
+    } finally {
+      diagnosticSubscriptionSlot.set(null);
+    }
+  };
+}
+
+export function clearTlonDiagnosticSubscriptionsForTest(): void {
+  diagnosticSubscriptionSlot.get()?.unsubscribe();
+  diagnosticSubscriptionSlot.set(null);
+  diagnosticSubscriptionIdSlot.set(null);
+}

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1,18 +1,25 @@
 import type { Story } from '@tloncorp/api';
 import { configureGatewayStatus, gatewayStart } from '@tloncorp/api';
+import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import { createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
 import type { OpenClawConfig, ReplyPayload } from 'openclaw/plugin-sdk/core';
 import type { RuntimeEnv } from 'openclaw/plugin-sdk/runtime';
 
 import {
+  findRecentContextLensById,
   publishContextLensEvent,
   setContextLensEventCapacity,
 } from '../context-lens-events.js';
-import { isContextLensEffectivelyEnabled } from '../context-lens-ship-sync.js';
+import {
+  isContextLensEffectivelyEnabled,
+  resolveLensOwner,
+} from '../context-lens-ship-sync.js';
+import { getContextLensStore } from '../context-lens-store.js';
 import {
   type ContextLensTrigger,
   bindContextLensToSession,
+  buildRetryDispatch,
   createContextLensRegistry,
   unbindContextLensFromSession,
 } from '../context-lens.js';
@@ -53,7 +60,16 @@ import {
   normalizeShip,
   parseChannelNest,
 } from '../targets.js';
-import { createTlonTelemetry } from '../telemetry.js';
+import {
+  type TlonDeliverySkipReason,
+  type TlonPluginErrorSource,
+  createTlonTelemetry,
+  formatTlonTelemetryErrorText,
+  setDebugTelemetryReporter,
+  setErrorTelemetryReporter,
+  setOutboundRouteReporter,
+  setSessionTelemetryReporter,
+} from '../telemetry.js';
 import { resolveTlonAccount } from '../types.js';
 import { configureTlonApiWithPoke } from '../urbit/api-client.js';
 import { authenticate } from '../urbit/auth.js';
@@ -64,6 +80,10 @@ import type { DmInvite, Foreigns } from '../urbit/foreigns.js';
 import { type BotProfile, sendChannelPost, sendDm } from '../urbit/send.js';
 import { UrbitSSEClient } from '../urbit/sse-client.js';
 import { markdownToStory } from '../urbit/story.js';
+import {
+  formatTlonVersionIdentity,
+  resolveTlonSkillVersion,
+} from '../version.js';
 import {
   type DisplayContext,
   type PendingApproval,
@@ -113,6 +133,13 @@ import {
 import { createOwnerReplyPersistenceQueue } from './owner-reply-persistence.js';
 import { createPendingNudgePersistenceQueue } from './pending-nudge-persistence.js';
 import { createProcessedMessageTracker } from './processed-messages.js';
+import {
+  type TlonInboundRouteRecord,
+  isRouteDebugEnabled,
+  recordTlonRouteAndDispatch,
+  routeUpdateWillSkipByPin,
+  tlonDeliveryContext,
+} from './session-routing.js';
 import { resolveSettingsMirrorSync } from './settings-sync.js';
 import {
   type ParsedCite,
@@ -183,12 +210,15 @@ type WritResponseDelta =
       'add-react'?: never;
     };
 type WritResponse = { whom: string; id: string; response: WritResponseDelta };
-const DEFAULT_CONTEXT_LENS_RUN_TIMEOUT_MS = 120_000;
-
-function normalizeRunTimeoutMs(value: number | null | undefined): number {
+// Returns the configured run timeout, or null when unset. A null result means
+// "don't override the agent's own turn timeout" — we must not impose a default
+// here, or every reply would be capped regardless of the agent's config.
+function normalizeRunTimeoutMs(
+  value: number | null | undefined
+): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value >= 1_000
     ? Math.floor(value)
-    : DEFAULT_CONTEXT_LENS_RUN_TIMEOUT_MS;
+    : null;
 }
 
 // Holds the data needed for any module-loader context to (re)configure its
@@ -227,6 +257,13 @@ const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
 const GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS = 15_000;
 const GATEWAY_STATUS_ACTIVATION_RETRY_MS = 30_000;
+
+function classifyPluginError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name || 'Error';
+  }
+  return typeof error;
+}
 
 // Bound an activation poke so a silently-hung promise surfaces as a
 // retryable error instead of leaving gateway-status dead for the process
@@ -356,14 +393,53 @@ export async function monitorTlonProvider(
   const accountCode = account.code;
 
   const botShipName = normalizeShip(account.ship);
+  const tlonSkillVersion = await resolveTlonSkillVersion();
+  let effectiveOwnerShip: string | null = account.ownerShip
+    ? normalizeShip(account.ownerShip)
+    : null;
+  setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
+  const telemetry = createTlonTelemetry({
+    config: account.telemetry,
+    runtime,
+  });
+  const currentTelemetryOwnerShip = () =>
+    getEffectiveOwnerShip(account.accountId) ?? effectiveOwnerShip;
+  const capturePluginError = (
+    pluginErrorSource: TlonPluginErrorSource,
+    error: unknown,
+    extra?: {
+      errorKind?: string | null;
+      attempt?: number | null;
+    }
+  ) => {
+    telemetry?.capturePluginError({
+      harness: 'openclaw',
+      pluginErrorSource,
+      accountId: account.accountId,
+      ownerShip: currentTelemetryOwnerShip(),
+      botShip: botShipName,
+      errorKind: extra?.errorKind ?? classifyPluginError(error),
+      errorText: formatTlonTelemetryErrorText(error),
+      attempt: extra?.attempt ?? null,
+    });
+  };
   runtime.log?.(`[tlon] Starting monitor for ${botShipName}`);
+  runtime.log?.(
+    `[tlon] version: ${formatTlonVersionIdentity({
+      markdown: false,
+      tlonSkillVersion,
+    }).replace(/\n/g, ' | ')}`
+  );
 
   const ssrfPolicy = ssrfPolicyFromAllowPrivateNetwork(
     account.allowPrivateNetwork
   );
 
   // Helper to authenticate with retry logic
-  async function authenticateWithRetry(maxAttempts = 10): Promise<string> {
+  async function authenticateWithRetry(
+    maxAttempts = 10,
+    source: 'auth' | 're_auth' = 'auth'
+  ): Promise<string> {
     for (let attempt = 1; ; attempt++) {
       if (opts.abortSignal?.aborted) {
         throw new Error('Aborted while waiting to authenticate');
@@ -372,6 +448,7 @@ export async function monitorTlonProvider(
         runtime.log?.(`[tlon] Attempting authentication to ${accountUrl}...`);
         return await authenticate(accountUrl, accountCode, { ssrfPolicy });
       } catch (error: any) {
+        capturePluginError(source, error, { attempt });
         runtime.error?.(
           `[tlon] Failed to authenticate (attempt ${attempt}): ${error?.message ?? String(error)}`
         );
@@ -395,22 +472,28 @@ export async function monitorTlonProvider(
   }
 
   let api: UrbitSSEClient | null = null;
-  const cookie = await authenticateWithRetry();
-  api = new UrbitSSEClient(account.url, cookie, {
-    ship: botShipName,
-    ssrfPolicy,
-    logger: {
-      log: (message) => runtime.log?.(message),
-      error: (message) => runtime.error?.(message),
-    },
-    // Re-authenticate on reconnect in case the session expired
-    onReconnect: async (client) => {
-      runtime.log?.('[tlon] Re-authenticating on SSE reconnect...');
-      const newCookie = await authenticateWithRetry(5);
-      client.updateCookie(newCookie);
-      runtime.log?.('[tlon] Re-authentication successful');
-    },
-  });
+  let cookie: string;
+  try {
+    cookie = await authenticateWithRetry();
+    api = new UrbitSSEClient(account.url, cookie, {
+      ship: botShipName,
+      ssrfPolicy,
+      logger: {
+        log: (message) => runtime.log?.(message),
+        error: (message) => runtime.error?.(message),
+      },
+      // Re-authenticate on reconnect in case the session expired
+      onReconnect: async (client) => {
+        runtime.log?.('[tlon] Re-authenticating on SSE reconnect...');
+        const newCookie = await authenticateWithRetry(5, 're_auth');
+        client.updateCookie(newCookie);
+        runtime.log?.('[tlon] Re-authentication successful');
+      },
+    });
+  } catch (error) {
+    await telemetry?.close();
+    throw error;
+  }
 
   // Configure @tloncorp/api's global client to use the SSE client's poke for all send operations
   configureTlonApiWithPoke(api.poke.bind(api), botShipName, account.url);
@@ -485,11 +568,11 @@ export async function monitorTlonProvider(
   });
 
   // Outer try/finally wraps everything from slot publication onward.
-  // The reviewer's P2: a synchronous throw between slot publication and
-  // the inner try at ~line 2719 (constructor, queue setup, bridge
-  // setup, channel discovery, future edits in this large pre-try
-  // region) would leave the shared slot orphaned. This outer finally
-  // catches all of those and runs cleanup unconditionally.
+  // A synchronous throw between slot publication and the inner try
+  // (constructor, queue setup, bridge setup, channel discovery, future
+  // edits in this large pre-try region) would leave the shared slot
+  // orphaned. This outer finally catches all of those and runs cleanup
+  // unconditionally.
   try {
     const computingPresence = createComputingPresenceTracker({ runtime });
     const contextLensConfig = account.contextLens;
@@ -546,10 +629,6 @@ export async function monitorTlonProvider(
     let effectiveGroupInviteAllowlist: string[] = account.groupInviteAllowlist;
     let effectiveAutoDiscoverChannels: boolean =
       account.autoDiscoverChannels ?? false;
-    let effectiveOwnerShip: string | null = account.ownerShip
-      ? normalizeShip(account.ownerShip)
-      : null;
-    setEffectiveOwnerShip(account.accountId, effectiveOwnerShip);
     let effectiveOwnerListenEnabled: boolean =
       account.ownerListenEnabled ?? true;
     // Canonicalize on every read so an entry stored from a slightly-off user
@@ -587,9 +666,77 @@ export async function monitorTlonProvider(
       pendingNudgeRehydrated = true;
     };
 
-    const telemetry = createTlonTelemetry({
-      config: account.telemetry,
-      runtime,
+    // Bridge route-resolution telemetry from the global `message_sending` hook
+    // to this account's telemetry client. Reports every route-dependent send so
+    // we can measure how often a reply lands on webchat instead of Tlon.
+    setOutboundRouteReporter((event) =>
+      telemetry?.captureOutboundRoute({
+        ...event,
+        ownerShip:
+          getEffectiveOwnerShip(account.accountId) ?? effectiveOwnerShip,
+        botShip: botShipName,
+      })
+    );
+    setSessionTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'lifecycle':
+          telemetry?.captureSessionLifecycle(report.event);
+          break;
+        case 'watchdog':
+          telemetry?.captureSessionWatchdog(report.event);
+          break;
+        case 'recovery':
+          telemetry?.captureSessionRecovery(report.event);
+          break;
+      }
+    });
+    setDebugTelemetryReporter((event) => {
+      telemetry?.captureHarnessDebug({
+        ...event,
+        accountId: event.accountId ?? account.accountId,
+        ownerShip: event.ownerShip ?? currentTelemetryOwnerShip(),
+        botShip: event.botShip || botShipName,
+      });
+    });
+    setErrorTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'harness':
+          telemetry?.captureHarnessError({
+            ...report.event,
+            accountId: report.event.accountId ?? account.accountId,
+            ownerShip: report.event.ownerShip ?? currentTelemetryOwnerShip(),
+            botShip: report.event.botShip || botShipName,
+          });
+          break;
+        case 'plugin':
+          telemetry?.capturePluginError({
+            harness: 'openclaw',
+            pluginErrorSource: report.event.pluginErrorSource,
+            accountId: report.event.accountId ?? account.accountId,
+            ownerShip: report.event.ownerShip ?? currentTelemetryOwnerShip(),
+            botShip: report.event.botShip ?? botShipName,
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+            attempt: report.event.attempt ?? null,
+          });
+          break;
+        case 'telemetry':
+          telemetry?.captureTelemetryError({
+            harness: 'openclaw',
+            telemetrySource: report.event.telemetrySource,
+            sourceEventName: report.event.sourceEventName ?? null,
+            sessionKey: report.event.sessionKey ?? null,
+            sessionId: report.event.sessionId ?? null,
+            runId: report.event.runId ?? null,
+            accountId: report.event.accountId ?? account.accountId,
+            agentId: report.event.agentId ?? null,
+            ownerShip: report.event.ownerShip ?? currentTelemetryOwnerShip(),
+            botShip: report.event.botShip ?? botShipName,
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+          });
+          break;
+      }
     });
 
     // Track threads we've participated in (by parentId) - respond without mention requirement
@@ -1087,6 +1234,9 @@ export async function monitorTlonProvider(
               );
               return;
             } catch (err) {
+              capturePluginError('gateway_status_activation', err, {
+                attempt,
+              });
               runtime.error?.(
                 `[gateway-status] activation attempt ${attempt} failed: ${String(err)} — retrying in ${GATEWAY_STATUS_ACTIVATION_RETRY_MS / 1000}s`
               );
@@ -1094,6 +1244,7 @@ export async function monitorTlonProvider(
             await abortableDelay(GATEWAY_STATUS_ACTIVATION_RETRY_MS, signal);
           }
         } catch (err) {
+          capturePluginError('gateway_status_activation', err);
           runtime.error?.(`[gateway-status] start failed: ${String(err)}`);
         }
       })();
@@ -1869,6 +2020,7 @@ export async function monitorTlonProvider(
       parentId?: string | null;
       isThreadReply?: boolean;
       replyParentId?: string | null; // Override parentId for delivery only (not in ctx payload)
+      retryOf?: string; // lensId of the failed run this dispatch retries
     }) => {
       const {
         messageId,
@@ -1950,6 +2102,15 @@ export async function monitorTlonProvider(
         conversationId: isGroup ? groupChannel ?? '' : senderShip,
         receivedAt: timestamp,
         preview: previewText(messageText),
+        ...(params.retryOf ? { retryOf: params.retryOf } : {}),
+        retrySeed: {
+          messageText: rawMessageText,
+          blobField: params.blobField ?? null,
+          parentId: parentId ?? null,
+          isThreadReply: Boolean(isThreadReply),
+          replyParentId: params.replyParentId ?? null,
+          cachesHistory: Boolean(params.cachesHistory),
+        },
       });
       contextLenses.recordPersistence(lens.lensId, {
         cachesHistory: Boolean(params.cachesHistory),
@@ -2581,7 +2742,17 @@ export async function monitorTlonProvider(
         CommandSource: 'text' as const,
         Provider: 'tlon',
         Surface: 'tlon',
-        MessageSid: messageId,
+        // The SDK's inbound dedupe keys off {sessionScope, routeKey, MessageSid}
+        // with a 20m TTL, and a failed run commits that entry — so a manual retry
+        // reusing the original message id would be silently dropped. Suffix the
+        // dedupe-facing MessageSid per retry to bust that, but keep MessageSidFull
+        // pointing at the real provider id (the field exists exactly for "MessageSid
+        // is a shortened alias") so downstream consumers that resolve the canonical
+        // message id don't see the synthetic token.
+        MessageSid: params.retryOf
+          ? `${messageId}#retry:${lens.lensId}`
+          : messageId,
+        MessageSidFull: messageId,
         // Include downloaded media attachments (MediaPaths/MediaUrls/MediaTypes for OpenClaw media pipeline)
         ...(attachments.length > 0 && {
           MediaPaths: attachments.map((a) => a.path),
@@ -2597,15 +2768,59 @@ export async function monitorTlonProvider(
         }),
       });
 
+      // ── Durable session-route persistence ───────────────────────
+      // The streamed reply below goes out through our own `deliver` callback
+      // and does not consult session metadata. But later route-dependent sends
+      // (the shared `message` tool, subagents, system-event turns) resolve
+      // their destination from the session store; without a persisted Tlon
+      // route they fall back to webchat. recordTlonRouteAndDispatch (below)
+      // records the route before dispatch and fails open — never blocks the
+      // reply.
+      const routeDebug: ((rec: TlonInboundRouteRecord) => void) | undefined =
+        isRouteDebugEnabled()
+          ? (rec) =>
+              runtime.log?.(
+                `[tlon][route-debug] inbound ${JSON.stringify({
+                  messageId,
+                  agentId: route.agentId,
+                  sessionKey: route.sessionKey,
+                  mainSessionKey: route.mainSessionKey,
+                  lastRoutePolicy: route.lastRoutePolicy,
+                  matchedBy: route.matchedBy,
+                  provider: ctxPayload.Provider,
+                  surface: ctxPayload.Surface,
+                  originatingChannel: ctxPayload.OriginatingChannel,
+                  originatingTo: ctxPayload.OriginatingTo,
+                  ctxSessionKey: ctxPayload.SessionKey,
+                  isGroup,
+                  groupChannel: groupChannel ?? null,
+                  senderShip,
+                  parentId: parentId ?? null,
+                  deliverParentId: deliverParentId ?? null,
+                  recordSessionKey: rec.recordSessionKey,
+                  lastRouteSessionKey: rec.lastRouteSessionKey,
+                  target: rec.target,
+                  hadUpdateLastRoute: Boolean(rec.updateLastRoute),
+                  pinWillSkip: routeUpdateWillSkipByPin(rec.updateLastRoute),
+                  skippedReason: rec.skippedReason ?? null,
+                })}`
+              )
+          : undefined;
+
       const dispatchStartTime = Date.now();
+      const runId = randomUUID();
       const dispatchTimeoutMs = normalizeRunTimeoutMs(
         account.lifecycle.runTimeoutMs
       );
       const replyTelemetry = telemetry?.startReply({
         sessionKey: route.sessionKey,
+        runId,
+        accountId: account.accountId,
+        agentId: route.agentId,
         ownerShip: effectiveOwnerShip,
         botShip: botShipName,
         chatType: isGroup ? 'groupChannel' : 'dm',
+        destinationKind: isGroup ? 'groupChannel' : 'dm',
         isThreadReply: Boolean(isThreadReply),
         senderRole,
         attachmentCount,
@@ -2614,9 +2829,16 @@ export async function monitorTlonProvider(
       let selectedModel: string | null = null;
       let selectedThinkLevel: string | null = null;
       let deliveredMessageCount = 0;
+      let sendAttemptCount = 0;
+      let sendErrorCount = 0;
+      let sendErrorKind: string | null = null;
       let replyCharCount = 0;
       let replyWordCount = 0;
       let replyMediaCount = 0;
+      let deliverySkipReason: TlonDeliverySkipReason | null = null;
+      const recordDeliverySkip = (reason: TlonDeliverySkipReason) => {
+        deliverySkipReason ??= reason;
+      };
       let dispatchTimedOut = false;
       const dispatchAbortController = new AbortController();
       const abortFromMonitor = () => {
@@ -2694,9 +2916,12 @@ export async function monitorTlonProvider(
           typeof core.channel.reply.dispatchReplyWithBufferedBlockDispatcher
         >[0]['replyOptions']
       > = {
+        runId,
         abortSignal: dispatchAbortController.signal,
         ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
-        timeoutOverrideSeconds: Math.ceil(dispatchTimeoutMs / 1000),
+        ...(dispatchTimeoutMs !== null
+          ? { timeoutOverrideSeconds: Math.ceil(dispatchTimeoutMs / 1000) }
+          : {}),
         onModelSelected: ({ provider, model, thinkLevel }) => {
           selectedProvider = provider;
           selectedModel = model;
@@ -2731,170 +2956,235 @@ export async function monitorTlonProvider(
         | {
             queuedFinal: boolean;
             counts: Record<string, number>;
+            failedCounts?: Partial<Record<string, number>>;
+            sourceReplyDeliveryMode?: string;
+            beforeAgentRunBlocked?: boolean;
           }
         | undefined;
       let dispatchError: unknown;
 
       try {
-        let timeoutId: NodeJS.Timeout | null = null;
-        try {
-          contextLenses.setStatus(lens.lensId, 'dispatching');
-          contextLenses.recordLifecycle(lens.lensId, {
-            dispatchStartedAt: Date.now(),
-            timeoutMs: dispatchTimeoutMs,
-          });
-          bindContextLensToSession(lensSessionKeys, contextLenses, lens.lensId);
-          logContextLens(lens.lensId, 'dispatching');
-          timeoutId = setTimeout(() => {
-            dispatchTimedOut = true;
-            if (!dispatchAbortController.signal.aborted) {
-              dispatchAbortController.abort(
-                new Error(
-                  `Tlon dispatch timed out after ${dispatchTimeoutMs}ms`
-                )
+        dispatchResult = await recordTlonRouteAndDispatch({
+          session: core.channel.session,
+          cfg,
+          route,
+          ctxPayload,
+          ctxSessionKey: ctxPayload.SessionKey,
+          isGroup,
+          groupChannel,
+          senderShip,
+          parentId,
+          deliverParentId,
+          effectiveOwnerShip,
+          effectiveDmAllowlist,
+          messageId,
+          sessionStore: cfg.session?.store,
+          logError: (msg) => runtime.error?.(msg),
+          // Routine skip / pin-skip diagnostics are debug-gated to avoid
+          // high-volume logs for expected policy cases.
+          logDebug: isRouteDebugEnabled()
+            ? (msg) => runtime.log?.(msg)
+            : undefined,
+          onRecord: routeDebug,
+          dispatch: async () => {
+            let timeoutId: NodeJS.Timeout | null = null;
+            try {
+              contextLenses.setStatus(lens.lensId, 'dispatching');
+              contextLenses.recordLifecycle(lens.lensId, {
+                dispatchStartedAt: Date.now(),
+                timeoutMs: dispatchTimeoutMs,
+              });
+              bindContextLensToSession(
+                lensSessionKeys,
+                contextLenses,
+                lens.lensId
               );
-            }
-          }, dispatchTimeoutMs);
-          dispatchResult =
-            await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-              ctx: ctxPayload,
-              cfg,
-              replyOptions,
-              dispatcherOptions: {
-                responsePrefix,
-                humanDelay,
-                typingCallbacks,
-                deliver: async (payload: ReplyPayload) => {
-                  contextLenses.setStatus(lens.lensId, 'delivering');
-                  let replyText = payload.text;
-                  if (!replyText) {
-                    return;
+              logContextLens(lens.lensId, 'dispatching');
+              if (dispatchTimeoutMs !== null) {
+                timeoutId = setTimeout(() => {
+                  dispatchTimedOut = true;
+                  if (!dispatchAbortController.signal.aborted) {
+                    dispatchAbortController.abort(
+                      new Error(
+                        `Tlon dispatch timed out after ${dispatchTimeoutMs}ms`
+                      )
+                    );
                   }
+                }, dispatchTimeoutMs);
+              }
+              return await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher(
+                {
+                  ctx: ctxPayload,
+                  cfg,
+                  replyOptions,
+                  dispatcherOptions: {
+                    responsePrefix,
+                    humanDelay,
+                    typingCallbacks,
+                    onSkip: (_payload, info) => {
+                      recordDeliverySkip(info.reason);
+                    },
+                    deliver: async (payload: ReplyPayload) => {
+                      contextLenses.setStatus(lens.lensId, 'delivering');
+                      let replyText = payload.text;
+                      if (!replyText) {
+                        const hasMedia = Array.isArray(payload.mediaUrls)
+                          ? payload.mediaUrls.length > 0
+                          : Boolean(payload.mediaUrl);
+                        recordDeliverySkip(
+                          hasMedia
+                            ? 'media_only_payload_not_sent'
+                            : 'empty_payload_text'
+                        );
+                        return;
+                      }
 
-                  // Process any block directives in the response (strips them from text)
-                  replyText = await processBlockDirectives(
-                    replyText,
-                    senderShip
-                  );
-                  if (!replyText) {
-                    return;
-                  } // Response was only a directive
-
-                  // Use settings store value if set, otherwise fall back to file config
-                  const showSignature = effectiveShowModelSig;
-                  if (showSignature) {
-                    const modelCfg = cfg.agents?.defaults?.model;
-                    const modelInfo =
-                      selectedModel ||
-                      (payload as { metadata?: { model?: string } }).metadata
-                        ?.model ||
-                      (payload as { model?: string }).model ||
-                      (route as { model?: string }).model ||
-                      (typeof modelCfg === 'string'
-                        ? modelCfg
-                        : modelCfg?.primary);
-                    replyText = `${replyText}\n\n_[Generated by ${formatModelName(modelInfo)}]_`;
-                  }
-
-                  // Add addendum if this is the last response before bot rate limit
-                  if (
-                    isGroup &&
-                    groupChannel &&
-                    knownBotShips.has(senderShip)
-                  ) {
-                    const count = consecutiveBotMessages.get(groupChannel) ?? 0;
-                    if (maxBotResponses > 0 && count === maxBotResponses) {
-                      const otherBot = formatShipWithNickname(senderShip);
-                      replyText += `\n\n---\n_This is my last response to ${otherBot} for now. To continue our conversation, someone will need to mention me._`;
-                    }
-                  }
-
-                  let outputMessageId: string | null = null;
-                  const contextLensBlob = buildContextLensReferenceBlobField(
-                    lens.lensId
-                  );
-                  if (isGroup && groupChannel) {
-                    // Send to any channel type (chat, heap, diary) using the nest directly
-                    const result = await sendChannelPost({
-                      botProfile: getBotProfile(),
-                      fromShip: botShipName,
-                      nest: groupChannel,
-                      story: markdownToStory(replyText),
-                      replyToId: deliverParentId ?? undefined,
-                      blob: contextLensBlob,
-                    });
-                    outputMessageId = result.messageId;
-                    // Track thread participation for future replies without mention
-                    if (deliverParentId) {
-                      participatedThreads.add(deliverParentId);
-                      runtime.log?.(
-                        `[tlon] Now tracking thread for future replies: ${deliverParentId}`
+                      // Process any block directives in the response (strips them from text)
+                      replyText = await processBlockDirectives(
+                        replyText,
+                        senderShip
                       );
-                    }
-                  } else {
-                    const result = await sendDm({
-                      botProfile: getBotProfile(),
-                      fromShip: botShipName,
-                      toShip: senderShip,
-                      text: replyText,
-                      replyToId: deliverParentId ?? undefined,
-                      blob: contextLensBlob,
-                    });
-                    outputMessageId = result.messageId;
-                  }
+                      if (!replyText) {
+                        recordDeliverySkip('block_directive_only');
+                        return;
+                      } // Response was only a directive
 
-                  if (presenceConversationId) {
-                    await computingPresence.stopRun({
-                      conversationId: presenceConversationId,
-                      runId: presenceRunId,
-                    });
-                  }
+                      // Use settings store value if set, otherwise fall back to file config
+                      const showSignature = effectiveShowModelSig;
+                      if (showSignature) {
+                        const modelCfg = cfg.agents?.defaults?.model;
+                        const modelInfo =
+                          selectedModel ||
+                          (payload as { metadata?: { model?: string } })
+                            .metadata?.model ||
+                          (payload as { model?: string }).model ||
+                          (route as { model?: string }).model ||
+                          (typeof modelCfg === 'string'
+                            ? modelCfg
+                            : modelCfg?.primary);
+                        replyText = `${replyText}\n\n_[Generated by ${formatModelName(modelInfo)}]_`;
+                      }
 
-                  deliveredMessageCount += 1;
-                  contextLenses.recordPersistence(lens.lensId, {
-                    postsReply: true,
-                  });
-                  if (outputMessageId) {
-                    contextLenses.recordOutput(lens.lensId, {
-                      messageId: outputMessageId,
-                      conversationId: isGroup ? groupChannel ?? '' : senderShip,
-                      kind: isGroup ? 'channel' : 'dm',
-                      sentAt: Date.now(),
-                      preview: previewText(replyText),
-                      chunkIndex: deliveredMessageCount - 1,
-                    });
-                  }
-                  contextLenses.recordPersistenceEvent(lens.lensId, {
-                    kind: 'conversation_state',
-                    action: 'created',
-                    location: 'urbit',
-                    status: 'ok',
-                    key: 'reply',
-                    reason: 'posted bot response',
-                  });
-                  replyCharCount += replyText.length;
-                  replyWordCount += replyText.trim()
-                    ? replyText.trim().split(/\s+/).length
-                    : 0;
-                  replyMediaCount += Array.isArray(payload.mediaUrls)
-                    ? payload.mediaUrls.length
-                    : payload.mediaUrl
-                      ? 1
-                      : 0;
-                },
-                onError: (err, info) => {
-                  const dispatchDuration = Date.now() - dispatchStartTime;
-                  runtime.error?.(
-                    `[tlon] ${info.kind} reply failed after ${dispatchDuration}ms: ${String(err)}`
-                  );
-                },
-              },
-            });
-        } finally {
-          if (timeoutId) {
-            clearTimeout(timeoutId);
-          }
-        }
+                      // Add addendum if this is the last response before bot rate limit
+                      if (
+                        isGroup &&
+                        groupChannel &&
+                        knownBotShips.has(senderShip)
+                      ) {
+                        const count =
+                          consecutiveBotMessages.get(groupChannel) ?? 0;
+                        if (maxBotResponses > 0 && count === maxBotResponses) {
+                          const otherBot = formatShipWithNickname(senderShip);
+                          replyText += `\n\n---\n_This is my last response to ${otherBot} for now. To continue our conversation, someone will need to mention me._`;
+                        }
+                      }
+
+                      if (isRouteDebugEnabled()) {
+                        runtime.log?.(
+                          `[tlon][route-debug] deliver ${JSON.stringify({
+                            messageId,
+                            isGroup,
+                            destination: isGroup
+                              ? groupChannel ?? null
+                              : senderShip,
+                            deliverParentId: deliverParentId ?? null,
+                          })}`
+                        );
+                      }
+
+                      sendAttemptCount += 1;
+                      let outputMessageId: string | null = null;
+                      const contextLensBlob =
+                        buildContextLensReferenceBlobField(lens.lensId);
+                      if (isGroup && groupChannel) {
+                        // Send to any channel type (chat, heap, diary) using the nest directly
+                        const result = await sendChannelPost({
+                          botProfile: getBotProfile(),
+                          fromShip: botShipName,
+                          nest: groupChannel,
+                          story: markdownToStory(replyText),
+                          replyToId: deliverParentId ?? undefined,
+                          blob: contextLensBlob,
+                        });
+                        outputMessageId = result.messageId;
+                        // Track thread participation for future replies without mention
+                        if (deliverParentId) {
+                          participatedThreads.add(String(deliverParentId));
+                          runtime.log?.(
+                            `[tlon] Now tracking thread for future replies: ${deliverParentId}`
+                          );
+                        }
+                      } else {
+                        const result = await sendDm({
+                          botProfile: getBotProfile(),
+                          fromShip: botShipName,
+                          toShip: senderShip,
+                          text: replyText,
+                          replyToId: deliverParentId ?? undefined,
+                          blob: contextLensBlob,
+                        });
+                        outputMessageId = result.messageId;
+                      }
+
+                      if (presenceConversationId) {
+                        await computingPresence.stopRun({
+                          conversationId: presenceConversationId,
+                          runId: presenceRunId,
+                        });
+                      }
+
+                      deliveredMessageCount += 1;
+                      contextLenses.recordPersistence(lens.lensId, {
+                        postsReply: true,
+                      });
+                      if (outputMessageId) {
+                        contextLenses.recordOutput(lens.lensId, {
+                          messageId: outputMessageId,
+                          conversationId: isGroup
+                            ? groupChannel ?? ''
+                            : senderShip,
+                          kind: isGroup ? 'channel' : 'dm',
+                          sentAt: Date.now(),
+                          preview: previewText(replyText),
+                          chunkIndex: deliveredMessageCount - 1,
+                        });
+                      }
+                      contextLenses.recordPersistenceEvent(lens.lensId, {
+                        kind: 'conversation_state',
+                        action: 'created',
+                        location: 'urbit',
+                        status: 'ok',
+                        key: 'reply',
+                        reason: 'posted bot response',
+                      });
+                      replyCharCount += replyText.length;
+                      replyWordCount += replyText.trim()
+                        ? replyText.trim().split(/\s+/).length
+                        : 0;
+                      replyMediaCount += Array.isArray(payload.mediaUrls)
+                        ? payload.mediaUrls.length
+                        : payload.mediaUrl
+                          ? 1
+                          : 0;
+                    },
+                    onError: (err, info) => {
+                      const dispatchDuration = Date.now() - dispatchStartTime;
+                      sendErrorCount += 1;
+                      sendErrorKind = info.kind;
+                      runtime.error?.(
+                        `[tlon] ${info.kind} reply failed after ${dispatchDuration}ms: ${String(err)}`
+                      );
+                    },
+                  },
+                }
+              );
+            } finally {
+              if (timeoutId) {
+                clearTimeout(timeoutId);
+              }
+            }
+          },
+        });
       } catch (error) {
         dispatchError = error;
         if (dispatchTimedOut) {
@@ -2922,6 +3212,9 @@ export async function monitorTlonProvider(
           queuedBlockCount: dispatchResult?.counts.block ?? 0,
         });
         await replyTelemetry?.capture({
+          sendAttemptCount,
+          sendErrorCount,
+          sendErrorKind,
           deliveredMessageCount,
           replyCharCount,
           replyWordCount,
@@ -2930,6 +3223,11 @@ export async function monitorTlonProvider(
           queuedFinal: dispatchResult?.queuedFinal ?? false,
           queuedFinalCount: dispatchResult?.counts.final ?? 0,
           queuedBlockCount: dispatchResult?.counts.block ?? 0,
+          failedCounts: dispatchResult?.failedCounts,
+          deliverySkipReason,
+          sourceReplyDeliveryMode:
+            dispatchResult?.sourceReplyDeliveryMode ?? null,
+          beforeAgentRunBlocked: dispatchResult?.beforeAgentRunBlocked === true,
           provider: selectedProvider,
           model: selectedModel,
           thinkLevel: selectedThinkLevel,
@@ -3055,6 +3353,11 @@ export async function monitorTlonProvider(
                 core.system.enqueueSystemEvent(eventText, {
                   sessionKey: route.sessionKey,
                   contextKey: `tlon:reaction:${nest}:${postId}:${reactEmoji}:${ship}`,
+                  // Route any resulting system/heartbeat turn back to Tlon.
+                  deliveryContext: tlonDeliveryContext(
+                    `tlon:${nest}`,
+                    route.accountId
+                  ),
                 });
               }
             } catch (err: any) {
@@ -3489,6 +3792,11 @@ export async function monitorTlonProvider(
                 core.system.enqueueSystemEvent(eventText, {
                   sessionKey: route.sessionKey,
                   contextKey: `tlon:dm-reaction:${messageId}:${reactEmoji}:${reactAuthor}:${action}`,
+                  // Route any resulting system/heartbeat turn back to Tlon.
+                  deliveryContext: tlonDeliveryContext(
+                    `tlon:${partnerShip || reactAuthor}`,
+                    route.accountId
+                  ),
                 });
                 runtime.log?.(`[tlon] DM_REACTION: ${eventText}`);
               }
@@ -3649,6 +3957,7 @@ export async function monitorTlonProvider(
         path: '/v4',
         event: (data) => handleChannelsFirehose(data as ChannelFirehoseEvent),
         err: (error) => {
+          capturePluginError('channels_firehose', error);
           runtime.error?.(`[tlon] Channels firehose error: ${String(error)}`);
         },
         quit: () => {
@@ -3665,6 +3974,7 @@ export async function monitorTlonProvider(
         path: '/v4',
         event: (data) => handleChatFirehose(data as ChatFirehoseEvent),
         err: (error) => {
+          capturePluginError('chat_firehose', error);
           runtime.error?.(`[tlon] Chat firehose error: ${String(error)}`);
         },
         quit: () => {
@@ -3733,6 +4043,7 @@ export async function monitorTlonProvider(
           }
         },
         err: (error) => {
+          capturePluginError('contacts_subscription', error);
           runtime.error?.(
             `[tlon] Contacts subscription error: ${String(error)}`
           );
@@ -3744,6 +4055,146 @@ export async function monitorTlonProvider(
         },
       });
       runtime.log?.('[tlon] Subscribed to contacts updates (/v1/news)');
+
+      // Subscribe to the bot ship's %steward lens module for owner-initiated
+      // retries. The agent verifies the requester before emitting the fact;
+      // the checks here are defense-in-depth. /v1/lens carries both %entry
+      // and %retry-requested updates — we ignore entries (they're echoes of
+      // our own pokes) and act only on the retry signal.
+      if (contextLensEnabled) {
+        const recentRetryDispatches = new Map<string, number>();
+        const RETRY_DEDUP_MS = 60_000;
+        const handleLensRetryFact = async (data: unknown) => {
+          const update = (
+            data as {
+              lens?: {
+                'retry-requested'?: { id?: unknown; requester?: unknown };
+              };
+            } | null
+          )?.lens?.['retry-requested'];
+          if (!update) {
+            // %entry updates (our own pokes echoing back) — ignore.
+            return;
+          }
+          const lensId = typeof update.id === 'string' ? update.id : '';
+          const requester =
+            typeof update.requester === 'string'
+              ? normalizeShip(update.requester)
+              : '';
+          if (!lensId || !requester) {
+            return;
+          }
+          // Align with the singular owner the agent actually stores; any
+          // "extra" configured owners are ignored at sync-configure time too,
+          // so accepting their retries here would be inconsistent.
+          const owner = resolveLensOwner(cfg, opts.accountId ?? undefined);
+          if (!owner || owner !== requester) {
+            runtime.log?.(
+              `[tlon] Context lens retry refused for ${lensId}: requester ${requester} is not the configured owner`
+            );
+            return;
+          }
+          const now = Date.now();
+          for (const [id, ts] of recentRetryDispatches) {
+            if (now - ts > RETRY_DEDUP_MS) {
+              recentRetryDispatches.delete(id);
+            }
+          }
+          if (recentRetryDispatches.has(lensId)) {
+            runtime.log?.(
+              `[tlon] Context lens retry ignored for ${lensId}: recently dispatched`
+            );
+            return;
+          }
+          // Reserve the dedup slot before the first await so two concurrent
+          // retry facts for the same lensId can't both pass the check above.
+          recentRetryDispatches.set(lensId, now);
+          const lens =
+            contextLenses.get(lensId) ??
+            findRecentContextLensById(lensId) ??
+            getContextLensStore()?.get(lensId);
+          if (!lens) {
+            recentRetryDispatches.delete(lensId);
+            runtime.log?.(
+              `[tlon] Context lens retry refused: run ${lensId} not found`
+            );
+            return;
+          }
+          const result = buildRetryDispatch(lens);
+          if (!result.ok) {
+            recentRetryDispatches.delete(lensId);
+            runtime.log?.(
+              `[tlon] Context lens retry refused for ${lensId}: ${result.reason}`
+            );
+            return;
+          }
+          const dispatch = result.dispatch;
+          if (await isShipBlocked(dispatch.senderShip)) {
+            recentRetryDispatches.delete(lensId);
+            runtime.log?.(
+              `[tlon] Context lens retry refused for ${lensId}: original sender ${dispatch.senderShip} is blocked`
+            );
+            return;
+          }
+          runtime.log?.(
+            `[tlon] Context lens retry dispatching for ${lensId} (requested by ${requester})${
+              dispatch.degraded
+                ? ' [degraded: no retry seed, using preview]'
+                : ''
+            }`
+          );
+          await processMessage({
+            messageId: lens.messageId,
+            senderShip: dispatch.senderShip,
+            messageText: dispatch.messageText,
+            blobField: dispatch.blobField,
+            isGroup: dispatch.isGroup,
+            ...(dispatch.channelNest
+              ? { channelNest: dispatch.channelNest }
+              : {}),
+            timestamp: Date.now(),
+            parentId: dispatch.parentId,
+            isThreadReply: dispatch.isThreadReply,
+            replyParentId: dispatch.replyParentId,
+            cachesHistory: dispatch.cachesHistory,
+            trigger: 'retry',
+            retryOf: lensId,
+          });
+        };
+        try {
+          await api.subscribe({
+            app: 'steward',
+            path: '/v1/lens',
+            event: (data) => {
+              handleLensRetryFact(data).catch((error: any) => {
+                runtime.error?.(
+                  `[tlon] Steward lens retry handler error: ${error?.message ?? String(error)}`
+                );
+              });
+            },
+            err: (error) => {
+              runtime.error?.(
+                `[tlon] Steward lens subscription error: ${String(error)}`
+              );
+            },
+            quit: () => {
+              runtime.log?.(
+                '[tlon] Steward lens quit received, SSE client will resubscribe'
+              );
+            },
+          });
+          runtime.log?.(
+            '[tlon] Subscribed to steward lens facts (/v1/lens) for retry signals'
+          );
+        } catch (error: any) {
+          // Ships without %steward (or older context-lens-only ships) nack
+          // the subscribe; retries are unavailable but everything else keeps
+          // working.
+          runtime.log?.(
+            `[tlon] Steward lens subscription unavailable: ${error?.message ?? String(error)}`
+          );
+        }
+      }
 
       // Subscribe to settings store for hot-reloading config
       const applySettingsSnapshot = (
@@ -3997,7 +4448,14 @@ export async function monitorTlonProvider(
                             const memberDisplay = formatShipWithNickname(ship);
                             core.system.enqueueSystemEvent(
                               `[${memberDisplay} joined group ${groupFlag}]`,
-                              { sessionKey: route.sessionKey }
+                              {
+                                sessionKey: route.sessionKey,
+                                // Route any resulting system turn back to Tlon.
+                                deliveryContext: tlonDeliveryContext(
+                                  `tlon:${nest}`,
+                                  route.accountId
+                                ),
+                              }
                             );
                             runtime.log?.(
                               `[tlon] Member joined: ${ship} → ${groupFlag}`
@@ -4138,6 +4596,7 @@ export async function monitorTlonProvider(
             }
           },
           err: (error) => {
+            capturePluginError('groups_ui_subscription', error);
             runtime.error?.(
               `[tlon] Groups-ui subscription error: ${String(error)}`
             );
@@ -4153,6 +4612,7 @@ export async function monitorTlonProvider(
         );
       } catch (err) {
         // Groups-ui subscription is optional - channel discovery will still work via polling
+        capturePluginError('groups_ui_subscription', err);
         runtime.log?.(
           `[tlon] Groups-ui subscription failed (will rely on polling): ${String(err)}`
         );
@@ -4301,6 +4761,7 @@ export async function monitorTlonProvider(
               })();
             },
             err: (error) => {
+              capturePluginError('foreigns_subscription', error);
               runtime.error?.(
                 `[tlon] Foreigns subscription error: ${String(error)}`
               );
@@ -4315,6 +4776,7 @@ export async function monitorTlonProvider(
             '[tlon] Subscribed to foreigns (/v1/foreigns) for auto-accepting group invites'
           );
         } catch (err) {
+          capturePluginError('foreigns_subscription', err);
           runtime.log?.(`[tlon] Foreigns subscription failed: ${String(err)}`);
         }
       }
@@ -4338,6 +4800,22 @@ export async function monitorTlonProvider(
       );
       await api.connect();
       runtime.log?.('[tlon] Connected! Firehose subscriptions active');
+      telemetry?.captureGatewayConnected({
+        ownerShip: effectiveOwnerShip,
+        botShip: botShipName,
+        tlonSkillVersion: await resolveTlonSkillVersion(),
+        accountId: account.accountId,
+        configured: account.configured,
+        watchedChannelCount: watchedChannels.size,
+        dmAllowlistCount: effectiveDmAllowlist.length,
+        defaultAuthorizedShipsCount: (
+          currentSettings.defaultAuthorizedShips ??
+          account.defaultAuthorizedShips
+        ).length,
+        pendingApprovalCount: pendingApprovals.length,
+        autoDiscoverChannels: effectiveAutoDiscoverChannels,
+        ownerListenEnabled: effectiveOwnerListenEnabled,
+      });
 
       // Periodically refresh channel discovery
       const pollInterval = setInterval(
@@ -4378,6 +4856,7 @@ export async function monitorTlonProvider(
             fresh: refreshResult.fresh,
           });
         } catch (err) {
+          capturePluginError('settings_refresh', err);
           runtime.error?.(`[tlon] Settings refresh failed: ${String(err)}`);
         }
       }, SETTINGS_REFRESH_INTERVAL_MS);
@@ -4471,6 +4950,10 @@ export async function monitorTlonProvider(
       await ownerReplyPersistence.flush();
       await pendingNudgePersistence.flush();
       clearShadowsForAccount(account.accountId);
+      setOutboundRouteReporter(null);
+      setSessionTelemetryReporter(null);
+      setDebugTelemetryReporter(null);
+      setErrorTelemetryReporter(null);
       await telemetry?.close();
       try {
         await api?.close();

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -669,14 +669,22 @@ export async function monitorTlonProvider(
     // Bridge route-resolution telemetry from the global `message_sending` hook
     // to this account's telemetry client. Reports every route-dependent send so
     // we can measure how often a reply lands on webchat instead of Tlon.
-    setOutboundRouteReporter((event) =>
+    setOutboundRouteReporter((event) => {
+      // The reporter slot is process-global, so a send from a sibling account
+      // can arrive here; resolve owner/bot from the event's account rather than
+      // this monitor's closure (matching the debug/error reporters below).
+      const routeAccountId = event.accountId ?? account.accountId;
+      const routeShip =
+        routeAccountId === account.accountId
+          ? account.ship
+          : resolveTlonAccount(cfg, routeAccountId).ship;
+      const routeBotShip = routeShip ? normalizeShip(routeShip) : botShipName;
       telemetry?.captureOutboundRoute({
         ...event,
-        ownerShip:
-          getEffectiveOwnerShip(account.accountId) ?? effectiveOwnerShip,
-        botShip: botShipName,
-      })
-    );
+        ownerShip: getEffectiveOwnerShip(routeAccountId) ?? effectiveOwnerShip,
+        botShip: routeBotShip || botShipName,
+      });
+    });
     setSessionTelemetryReporter((report) => {
       switch (report.kind) {
         case 'lifecycle':

--- a/packages/openclaw/src/monitor/session-routing.persistence.test.ts
+++ b/packages/openclaw/src/monitor/session-routing.persistence.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadSessionStore } from 'openclaw/plugin-sdk/config-runtime';
+import { recordInboundSession } from 'openclaw/plugin-sdk/conversation-runtime';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import type { ResolvedAgentRoute } from 'openclaw/plugin-sdk/routing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildTlonInboundRouteRecord } from './session-routing.js';
+
+// Proves the durable route written by buildTlonInboundRouteRecord + the real
+// SDK `recordInboundSession` lands under `lastRouteSessionKey` where the
+// delivery consumer reads it — i.e. a later route-dependent send resolves Tlon
+// instead of falling back to webchat.
+
+function makeRoute(
+  overrides: Partial<ResolvedAgentRoute> = {}
+): ResolvedAgentRoute {
+  return {
+    agentId: 'default',
+    channel: 'tlon',
+    accountId: 'default',
+    sessionKey: 'tlon:main',
+    mainSessionKey: 'tlon:main',
+    lastRoutePolicy: 'main',
+    matchedBy: 'default',
+    ...overrides,
+  };
+}
+
+const cfg = { session: { dmScope: 'main' } } as unknown as OpenClawConfig;
+
+let dir: string;
+let storePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'tlon-route-'));
+  storePath = join(dir, 'sessions.json');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function persist(record: ReturnType<typeof buildTlonInboundRouteRecord>) {
+  const tasks: Array<Promise<unknown>> = [];
+  const errors: unknown[] = [];
+  await recordInboundSession({
+    storePath,
+    sessionKey: record.recordSessionKey,
+    ctx: {
+      SessionKey: record.recordSessionKey,
+      Provider: 'tlon',
+      Surface: 'tlon',
+      OriginatingChannel: 'tlon',
+      OriginatingTo: record.target ?? undefined,
+      ChatType: 'direct',
+      SenderId: '~zod',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    updateLastRoute: record.updateLastRoute,
+    onRecordError: (err) => errors.push(err),
+    trackSessionMetaTask: (task) => tasks.push(task),
+  });
+  await Promise.all(tasks);
+  expect(errors).toEqual([]);
+}
+
+describe('Tlon route persistence (real SDK store)', () => {
+  it('persists a DM route under lastRouteSessionKey for the consumer to resolve', async () => {
+    const record = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+    });
+
+    await persist(record);
+
+    const entry = loadSessionStore(storePath)[record.lastRouteSessionKey];
+    expect(entry).toBeDefined();
+    expect(entry?.deliveryContext?.channel).toBe('tlon');
+    expect(entry?.deliveryContext?.to).toBe('tlon:~zod');
+    expect(entry?.lastChannel).toBe('tlon');
+    expect(entry?.lastTo).toBe('tlon:~zod');
+  });
+
+  it('persists a group/channel route under a session-specific key', async () => {
+    const record = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute({
+        sessionKey: 'tlon:group:chat/~host/general',
+        lastRoutePolicy: 'session',
+      }),
+      isGroup: true,
+      groupChannel: 'chat/~host/general',
+      senderShip: '~nec',
+    });
+
+    await persist(record);
+
+    const entry = loadSessionStore(storePath)[record.lastRouteSessionKey];
+    expect(entry).toBeDefined();
+    expect(entry?.lastChannel).toBe('tlon');
+    expect(entry?.lastTo).toBe('tlon:chat/~host/general');
+  });
+
+  it('clears stale thread state when a later unthreaded route is recorded', async () => {
+    const threaded = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+      deliverParentId: 'thread-1',
+    });
+    await persist(threaded);
+    expect(
+      loadSessionStore(storePath)[threaded.lastRouteSessionKey]?.lastThreadId
+    ).toBe('thread-1');
+
+    const unthreaded = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+    });
+    await persist(unthreaded);
+    expect(
+      loadSessionStore(storePath)[unthreaded.lastRouteSessionKey]?.lastThreadId
+    ).toBeUndefined();
+  });
+
+  it('owner pin blocks a non-owner DM from overwriting the main route and fires onSkip', async () => {
+    // Owner establishes the durable main-session route (owner === sender, no skip).
+    const owner = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~zod',
+      effectiveOwnerShip: '~zod',
+    });
+    await persist(owner);
+    expect(loadSessionStore(storePath)[owner.lastRouteSessionKey]?.lastTo).toBe(
+      'tlon:~zod'
+    );
+
+    // A non-owner DM resolves to the same main session but must not clobber it.
+    const intruder = buildTlonInboundRouteRecord({
+      cfg,
+      route: makeRoute(),
+      isGroup: false,
+      senderShip: '~nec',
+      effectiveOwnerShip: '~zod',
+    });
+    const update = intruder.updateLastRoute;
+    if (!update?.mainDmOwnerPin) {
+      throw new Error('expected a mainDmOwnerPin for a non-owner main DM');
+    }
+
+    const skips: Array<{ ownerRecipient: string; senderRecipient: string }> =
+      [];
+    await recordInboundSession({
+      storePath,
+      sessionKey: intruder.recordSessionKey,
+      ctx: {
+        SessionKey: intruder.recordSessionKey,
+        Provider: 'tlon',
+        ChatType: 'direct',
+        SenderId: '~nec',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      updateLastRoute: {
+        ...update,
+        mainDmOwnerPin: {
+          ...update.mainDmOwnerPin,
+          onSkip: (p) => skips.push(p),
+        },
+      },
+      onRecordError: (err) => {
+        throw err;
+      },
+    });
+
+    // Route unchanged, and the skip was observable rather than silent.
+    expect(
+      loadSessionStore(storePath)[intruder.lastRouteSessionKey]?.lastTo
+    ).toBe('tlon:~zod');
+    expect(skips).toEqual([
+      { ownerRecipient: '~zod', senderRecipient: '~nec' },
+    ]);
+  });
+});

--- a/packages/openclaw/src/monitor/session-routing.test.ts
+++ b/packages/openclaw/src/monitor/session-routing.test.ts
@@ -1,0 +1,530 @@
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import type { ResolvedAgentRoute } from 'openclaw/plugin-sdk/routing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type TlonInboundRouteInput,
+  buildTlonInboundRouteRecord,
+  recordRouteThenDispatch,
+  recordTlonInboundRoute,
+  recordTlonRouteAndDispatch,
+  routeUpdateWillSkipByPin,
+  tlonDeliveryContext,
+} from './session-routing.js';
+
+function makeRoute(
+  overrides: Partial<ResolvedAgentRoute> = {}
+): ResolvedAgentRoute {
+  return {
+    agentId: 'default',
+    channel: 'tlon',
+    accountId: 'default',
+    sessionKey: 'tlon:main',
+    mainSessionKey: 'tlon:main',
+    lastRoutePolicy: 'main',
+    matchedBy: 'default',
+    ...overrides,
+  };
+}
+
+function cfgWithDmScope(dmScope?: string): OpenClawConfig {
+  return { session: dmScope ? { dmScope } : {} } as unknown as OpenClawConfig;
+}
+
+function dmInput(
+  overrides: Partial<TlonInboundRouteInput> = {}
+): TlonInboundRouteInput {
+  return {
+    cfg: cfgWithDmScope('main'),
+    route: makeRoute(),
+    isGroup: false,
+    senderShip: '~zod',
+    ...overrides,
+  };
+}
+
+function groupInput(
+  overrides: Partial<TlonInboundRouteInput> = {}
+): TlonInboundRouteInput {
+  return {
+    cfg: cfgWithDmScope('main'),
+    // group peers resolve to a session-specific route, not the main session
+    route: makeRoute({
+      sessionKey: 'tlon:group:chat/~host/general',
+      lastRoutePolicy: 'session',
+    }),
+    isGroup: true,
+    groupChannel: 'chat/~host/general',
+    senderShip: '~nec',
+    ...overrides,
+  };
+}
+
+describe('buildTlonInboundRouteRecord — DM', () => {
+  it('records channel tlon, provider-qualified to, and no thread id', () => {
+    const r = buildTlonInboundRouteRecord(dmInput({ senderShip: '~zod' }));
+    expect(r.target).toBe('tlon:~zod');
+    expect(r.updateLastRoute?.channel).toBe('tlon');
+    expect(r.updateLastRoute?.to).toBe('tlon:~zod');
+    expect(r.updateLastRoute?.threadId).toBeUndefined();
+  });
+
+  it('records threadId from deliverParentId', () => {
+    const r = buildTlonInboundRouteRecord(dmInput({ deliverParentId: '123' }));
+    expect(r.updateLastRoute?.threadId).toBe('123');
+  });
+
+  it('records threadId from parentId when no deliverParentId', () => {
+    const r = buildTlonInboundRouteRecord(dmInput({ parentId: '456' }));
+    expect(r.updateLastRoute?.threadId).toBe('456');
+  });
+
+  it('omits threadId for an unthreaded DM (lets SDK clear stale thread state)', () => {
+    const r = buildTlonInboundRouteRecord(dmInput());
+    expect(r.updateLastRoute).toBeDefined();
+    expect('threadId' in (r.updateLastRoute ?? {})).toBe(false);
+  });
+
+  it('writes updateLastRoute.sessionKey as lastRouteSessionKey even when it differs from recordSessionKey', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({
+        route: makeRoute({
+          sessionKey: 'tlon:peer',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+        ctxSessionKey: 'tlon:ctx',
+      })
+    );
+    // policy 'main' => last-route key collapses to mainSessionKey
+    expect(r.lastRouteSessionKey).toBe('tlon:main');
+    expect(r.recordSessionKey).toBe('tlon:ctx');
+    expect(r.updateLastRoute?.sessionKey).toBe('tlon:main');
+  });
+});
+
+describe('buildTlonInboundRouteRecord — DM main-session pinning', () => {
+  it('pins the configured owner against a different sender', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveOwnerShip: '~zod' })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin).toEqual({
+      ownerRecipient: '~zod',
+      senderRecipient: '~nec',
+    });
+  });
+
+  it('prefers the configured owner over a single allowlist entry', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({
+        senderShip: '~nec',
+        effectiveOwnerShip: '~zod',
+        effectiveDmAllowlist: ['~bus'],
+      })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin?.ownerRecipient).toBe('~zod');
+  });
+
+  it('pins a single-owner allowlist when no owner is configured', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveDmAllowlist: ['~bus'] })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin?.ownerRecipient).toBe('~bus');
+  });
+
+  it('does not pin a wildcard allowlist', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveDmAllowlist: ['*'] })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
+  it('does not pin a multi-entry allowlist with no configured owner', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveDmAllowlist: ['~bus', '~rch'] })
+    );
+    expect(r.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
+  it('does not pin an isolated per-channel-peer session', () => {
+    const r = buildTlonInboundRouteRecord(
+      dmInput({
+        cfg: cfgWithDmScope('per-channel-peer'),
+        route: makeRoute({
+          sessionKey: 'tlon:peer:~nec',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'session',
+        }),
+        senderShip: '~nec',
+        effectiveOwnerShip: '~zod',
+      })
+    );
+    expect(r.updateLastRoute).toBeDefined();
+    expect(r.updateLastRoute?.sessionKey).toBe('tlon:peer:~nec');
+    expect(r.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+});
+
+describe('buildTlonInboundRouteRecord — group/channel', () => {
+  it('records a provider-qualified channel nest target for a session-specific route', () => {
+    const r = buildTlonInboundRouteRecord(groupInput());
+    expect(r.target).toBe('tlon:chat/~host/general');
+    expect(r.updateLastRoute?.to).toBe('tlon:chat/~host/general');
+    expect(r.updateLastRoute?.sessionKey).toBe('tlon:group:chat/~host/general');
+  });
+
+  it('records group thread id from deliverParentId ?? parentId', () => {
+    const r = buildTlonInboundRouteRecord(groupInput({ parentId: 't1' }));
+    expect(r.updateLastRoute?.threadId).toBe('t1');
+  });
+
+  it('skips updateLastRoute (but not origin metadata) when groupChannel is missing', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: undefined })
+    );
+    expect(r.updateLastRoute).toBeUndefined();
+    expect(r.target).toBeNull();
+    expect(r.skippedReason).toBe('group-missing-channel');
+  });
+
+  it('skips updateLastRoute when the group route resolves to the main session', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({
+        route: makeRoute({
+          sessionKey: 'tlon:main',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+      })
+    );
+    expect(r.updateLastRoute).toBeUndefined();
+    expect(r.target).toBe('tlon:chat/~host/general');
+    expect(r.skippedReason).toBe('group-route-targets-main-session');
+  });
+
+  it('skips updateLastRoute for a malformed group nest', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: 'not-a-valid-nest' })
+    );
+    expect(r.updateLastRoute).toBeUndefined();
+    expect(r.target).toBeNull();
+    expect(r.skippedReason).toBe('group-invalid-channel');
+  });
+
+  it('canonicalizes the group nest before storing it', () => {
+    const r = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: 'CHAT/~ZOD/General' })
+    );
+    expect(r.updateLastRoute?.to).toBe('tlon:chat/~zod/General');
+  });
+});
+
+describe('recordTlonInboundRoute', () => {
+  it('records under recordSessionKey with the durable route under lastRouteSessionKey', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const record = buildTlonInboundRouteRecord(
+      dmInput({
+        route: makeRoute({
+          sessionKey: 'tlon:peer',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+        ctxSessionKey: 'tlon:ctx',
+        senderShip: '~zod',
+      })
+    );
+
+    await recordTlonInboundRoute({
+      session: { recordInboundSession },
+      storePath: '/tmp/store.json',
+      ctxPayload: { SessionKey: 'tlon:ctx' },
+      record,
+    });
+
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    const arg = recordInboundSession.mock.calls[0][0];
+    expect(arg.sessionKey).toBe('tlon:ctx');
+    expect(arg.updateLastRoute.sessionKey).toBe('tlon:main');
+    expect(arg.updateLastRoute.to).toBe('tlon:~zod');
+  });
+
+  it('fails open and logs when recordInboundSession throws', async () => {
+    const recordInboundSession = vi.fn().mockRejectedValue(new Error('boom'));
+    const logError = vi.fn();
+    const record = buildTlonInboundRouteRecord(dmInput());
+
+    await expect(
+      recordTlonInboundRoute({
+        session: { recordInboundSession },
+        storePath: '/tmp/store.json',
+        ctxPayload: {},
+        record,
+        logError,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError.mock.calls[0][0]).toContain(
+      'failed recording inbound session route'
+    );
+  });
+
+  it('records origin metadata and warns (logError) for a missing-channel group route', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const logError = vi.fn();
+    const logDebug = vi.fn();
+    const record = buildTlonInboundRouteRecord(
+      groupInput({ groupChannel: undefined })
+    );
+
+    await recordTlonInboundRoute({
+      session: { recordInboundSession },
+      storePath: '/tmp/store.json',
+      ctxPayload: {},
+      record,
+      logError,
+      logDebug,
+    });
+
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(
+      recordInboundSession.mock.calls[0][0].updateLastRoute
+    ).toBeUndefined();
+    // Anomalous case is visible outside debug; routine debug log is not used.
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError.mock.calls[0][0]).toContain('group-missing-channel');
+    expect(logDebug).not.toHaveBeenCalled();
+  });
+
+  it('debug-logs (logDebug, not logError) a routine main-session group skip', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const logError = vi.fn();
+    const logDebug = vi.fn();
+    const record = buildTlonInboundRouteRecord(
+      groupInput({
+        route: makeRoute({
+          sessionKey: 'tlon:main',
+          mainSessionKey: 'tlon:main',
+          lastRoutePolicy: 'main',
+        }),
+      })
+    );
+    expect(record.skippedReason).toBe('group-route-targets-main-session');
+
+    await recordTlonInboundRoute({
+      session: { recordInboundSession },
+      storePath: '/tmp/store.json',
+      ctxPayload: {},
+      record,
+      logError,
+      logDebug,
+    });
+
+    expect(logDebug).toHaveBeenCalledTimes(1);
+    expect(logError).not.toHaveBeenCalled();
+  });
+});
+
+describe('tlonDeliveryContext', () => {
+  it('builds a Tlon delivery context for a channel nest target', () => {
+    expect(tlonDeliveryContext('tlon:chat/~host/general', 'acct-1')).toEqual({
+      channel: 'tlon',
+      to: 'tlon:chat/~host/general',
+      accountId: 'acct-1',
+    });
+  });
+
+  it('omits accountId when not provided', () => {
+    expect(tlonDeliveryContext('tlon:~zod')).toEqual({
+      channel: 'tlon',
+      to: 'tlon:~zod',
+    });
+  });
+});
+
+describe('routeUpdateWillSkipByPin', () => {
+  it('is true when a pin owner differs from the sender', () => {
+    const record = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~nec', effectiveOwnerShip: '~zod' })
+    );
+    expect(routeUpdateWillSkipByPin(record.updateLastRoute)).toBe(true);
+  });
+
+  it('is false when the pinned owner is the sender', () => {
+    const record = buildTlonInboundRouteRecord(
+      dmInput({ senderShip: '~zod', effectiveOwnerShip: '~zod' })
+    );
+    expect(routeUpdateWillSkipByPin(record.updateLastRoute)).toBe(false);
+  });
+
+  it('is false when there is no pin', () => {
+    const record = buildTlonInboundRouteRecord(dmInput({ senderShip: '~zod' }));
+    expect(routeUpdateWillSkipByPin(record.updateLastRoute)).toBe(false);
+    expect(routeUpdateWillSkipByPin(undefined)).toBe(false);
+  });
+});
+
+describe('recordRouteThenDispatch', () => {
+  it('records before dispatching and returns the dispatch result', async () => {
+    const calls: string[] = [];
+    const result = await recordRouteThenDispatch({
+      record: async () => {
+        calls.push('record');
+      },
+      dispatch: async () => {
+        calls.push('dispatch');
+        return 'dispatched';
+      },
+    });
+    expect(calls).toEqual(['record', 'dispatch']);
+    expect(result).toBe('dispatched');
+  });
+
+  it('does not dispatch if the record step rejects', async () => {
+    const dispatch = vi.fn();
+    await expect(
+      recordRouteThenDispatch({
+        record: async () => {
+          throw new Error('record failed');
+        },
+        dispatch,
+      })
+    ).rejects.toThrow('record failed');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordTlonRouteAndDispatch (monitor boundary)', () => {
+  function mockSession() {
+    const order: string[] = [];
+    const recordInboundSession = vi.fn().mockImplementation(async () => {
+      order.push('record');
+    });
+    const resolveStorePath = vi.fn().mockReturnValue('/tmp/store.json');
+    return { order, recordInboundSession, resolveStorePath };
+  }
+
+  it('records the route before dispatching for a DM', async () => {
+    const { order, recordInboundSession, resolveStorePath } = mockSession();
+    const dispatch = vi.fn().mockImplementation(async () => {
+      order.push('dispatch');
+      return 'ok';
+    });
+
+    const result = await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: { SessionKey: 'tlon:main' } as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      dispatch,
+    });
+
+    expect(result).toBe('ok');
+    expect(order).toEqual(['record', 'dispatch']);
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession.mock.calls[0][0].updateLastRoute.to).toBe(
+      'tlon:~zod'
+    );
+  });
+
+  it('records the route before dispatching for a group message', async () => {
+    const { order, recordInboundSession, resolveStorePath } = mockSession();
+    const dispatch = vi.fn().mockImplementation(async () => {
+      order.push('dispatch');
+    });
+
+    await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute({
+        sessionKey: 'tlon:group:chat/~host/general',
+        lastRoutePolicy: 'session',
+      }),
+      ctxPayload: { SessionKey: 'tlon:group:chat/~host/general' } as never,
+      ctxSessionKey: 'tlon:group:chat/~host/general',
+      isGroup: true,
+      groupChannel: 'chat/~host/general',
+      senderShip: '~nec',
+      dispatch,
+    });
+
+    expect(order).toEqual(['record', 'dispatch']);
+    expect(recordInboundSession.mock.calls[0][0].updateLastRoute.to).toBe(
+      'tlon:chat/~host/general'
+    );
+  });
+
+  it('passes the built record to onRecord', async () => {
+    const { recordInboundSession, resolveStorePath } = mockSession();
+    const onRecord = vi.fn();
+
+    await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: {} as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      onRecord,
+      dispatch: async () => undefined,
+    });
+
+    expect(onRecord).toHaveBeenCalledTimes(1);
+    expect(onRecord.mock.calls[0][0].target).toBe('tlon:~zod');
+  });
+
+  it('still dispatches when recording fails (fail open)', async () => {
+    const recordInboundSession = vi.fn().mockRejectedValue(new Error('boom'));
+    const resolveStorePath = vi.fn().mockReturnValue('/tmp/store.json');
+    const dispatch = vi.fn().mockResolvedValue('ok');
+    const logError = vi.fn();
+
+    const result = await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: {} as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      logError,
+      dispatch,
+    });
+
+    expect(result).toBe('ok');
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalled();
+  });
+
+  it('still dispatches when resolveStorePath throws (fail open)', async () => {
+    const recordInboundSession = vi.fn().mockResolvedValue(undefined);
+    const resolveStorePath = vi.fn().mockImplementation(() => {
+      throw new Error('bad store config');
+    });
+    const dispatch = vi.fn().mockResolvedValue('ok');
+    const logError = vi.fn();
+
+    const result = await recordTlonRouteAndDispatch({
+      session: { recordInboundSession, resolveStorePath },
+      cfg: cfgWithDmScope('main'),
+      route: makeRoute(),
+      ctxPayload: {} as never,
+      ctxSessionKey: 'tlon:main',
+      isGroup: false,
+      senderShip: '~zod',
+      logError,
+      dispatch,
+    });
+
+    expect(result).toBe('ok');
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(logError.mock.calls[0][0]).toContain(
+      'failed resolving session store path'
+    );
+  });
+});

--- a/packages/openclaw/src/monitor/session-routing.ts
+++ b/packages/openclaw/src/monitor/session-routing.ts
@@ -1,0 +1,441 @@
+import { resolvePinnedMainDmOwnerFromAllowlist } from 'openclaw/plugin-sdk/conversation-runtime';
+import type { OpenClawConfig, PluginRuntime } from 'openclaw/plugin-sdk/core';
+import {
+  type ResolvedAgentRoute,
+  resolveInboundLastRouteSessionKey,
+} from 'openclaw/plugin-sdk/routing';
+
+import { canonicalizeNest, normalizeShip } from '../targets.js';
+
+/**
+ * Durable last-route update for a Tlon inbound turn. Mirrors the SDK's
+ * `InboundLastRouteUpdate` shape; the monitor's record call site passes this
+ * straight to `core.channel.session.recordInboundSession`, which type-checks it against the
+ * real SDK type. We keep a local alias here so the pure helper has no dependency
+ * on internal SDK type paths.
+ *
+ * NOTE: `sessionKey` here is the *last-route* session key (where the consumer
+ * reads delivery state from), which is NOT necessarily the same as the
+ * top-level `sessionKey` used for origin metadata. `recordInboundSession`
+ * writes durable delivery state under `update.sessionKey`.
+ */
+export type TlonUpdateLastRoute = {
+  sessionKey: string;
+  channel: 'tlon';
+  to: string;
+  accountId?: string;
+  threadId?: string | number;
+  mainDmOwnerPin?: {
+    ownerRecipient: string;
+    senderRecipient: string;
+    onSkip?: (params: {
+      ownerRecipient: string;
+      senderRecipient: string;
+    }) => void;
+  };
+};
+
+export type TlonInboundRouteInput = {
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  /** The finalized inbound ctx; only `SessionKey` is read. */
+  ctxSessionKey?: string | null;
+  isGroup: boolean;
+  groupChannel?: string | null;
+  senderShip: string;
+  parentId?: string | number | null;
+  deliverParentId?: string | number | null;
+  effectiveOwnerShip?: string | null;
+  effectiveDmAllowlist?: string[];
+};
+
+export type TlonInboundRouteRecord = {
+  /** Session key for origin-metadata recording (`recordSessionMetaFromInbound`). */
+  recordSessionKey: string;
+  /** Session key the durable delivery route is written under (and read from). */
+  lastRouteSessionKey: string;
+  /** Provider-qualified delivery target, or null when it cannot be built. */
+  target: string | null;
+  /**
+   * The durable route update, or `undefined` when route persistence is
+   * intentionally skipped (origin metadata is still recorded by the caller).
+   */
+  updateLastRoute?: TlonUpdateLastRoute;
+  /** Set when `updateLastRoute` is omitted, for a distinctive caller log. */
+  skippedReason?:
+    | 'group-missing-channel'
+    | 'group-invalid-channel'
+    | 'group-route-targets-main-session';
+};
+
+/**
+ * Build the parameters for persisting a Tlon inbound turn's durable session
+ * route. Pure: no I/O, no SDK store access. The caller passes the result to
+ * `recordInboundSession` (see `recordTlonInboundRoute`).
+ *
+ * Routing rules:
+ * - DM: persist `tlon:<senderShip>`. When the last-route session is the agent
+ *   main session and a single owner is pinned, attach `mainDmOwnerPin` so a
+ *   non-owner DM cannot silently overwrite the owner/main route.
+ * - Group/channel: persist `tlon:<groupChannel>` only when the last-route
+ *   session is NOT the main session (avoid clobbering a broad shared session).
+ *   Skip — but still record origin metadata — when `groupChannel` is missing.
+ */
+export function buildTlonInboundRouteRecord(
+  input: TlonInboundRouteInput
+): TlonInboundRouteRecord {
+  const {
+    cfg,
+    route,
+    ctxSessionKey,
+    isGroup,
+    groupChannel,
+    senderShip,
+    parentId,
+    deliverParentId,
+    effectiveOwnerShip,
+    effectiveDmAllowlist,
+  } = input;
+
+  const recordSessionKey = ctxSessionKey ?? route.sessionKey;
+  const lastRouteSessionKey = resolveInboundLastRouteSessionKey({
+    route,
+    sessionKey: recordSessionKey,
+  });
+
+  const rawThread = deliverParentId ?? parentId;
+  const threadId =
+    rawThread != null && rawThread !== '' ? String(rawThread) : undefined;
+
+  const base = { recordSessionKey, lastRouteSessionKey };
+
+  if (isGroup) {
+    const nest = groupChannel?.trim();
+    if (!nest) {
+      return { ...base, target: null, skippedReason: 'group-missing-channel' };
+    }
+    // Validate/canonicalize the nest before storing. Firehose nests are already
+    // canonical, but config/settings-watched values can be malformed; a bad
+    // nest would otherwise persist an unusable `lastTo`.
+    const canonicalNest = canonicalizeNest(nest);
+    if (!canonicalNest) {
+      return { ...base, target: null, skippedReason: 'group-invalid-channel' };
+    }
+    const target = `tlon:${canonicalNest}`;
+    // Don't overwrite a broad shared main session with a per-group route.
+    if (lastRouteSessionKey === route.mainSessionKey) {
+      return {
+        ...base,
+        target,
+        skippedReason: 'group-route-targets-main-session',
+      };
+    }
+    return {
+      ...base,
+      target,
+      updateLastRoute: {
+        sessionKey: lastRouteSessionKey,
+        channel: 'tlon',
+        to: target,
+        ...(route.accountId ? { accountId: route.accountId } : {}),
+        ...(threadId !== undefined ? { threadId } : {}),
+      },
+    };
+  }
+
+  // DM
+  const target = `tlon:${senderShip}`;
+  const mainDmOwnerPin = resolveMainDmOwnerPin({
+    cfg,
+    route,
+    lastRouteSessionKey,
+    senderShip,
+    effectiveOwnerShip,
+    effectiveDmAllowlist,
+  });
+
+  return {
+    ...base,
+    target,
+    updateLastRoute: {
+      sessionKey: lastRouteSessionKey,
+      channel: 'tlon',
+      to: target,
+      ...(route.accountId ? { accountId: route.accountId } : {}),
+      ...(threadId !== undefined ? { threadId } : {}),
+      ...(mainDmOwnerPin ? { mainDmOwnerPin } : {}),
+    },
+  };
+}
+
+function resolveMainDmOwnerPin(params: {
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  lastRouteSessionKey: string;
+  senderShip: string;
+  effectiveOwnerShip?: string | null;
+  effectiveDmAllowlist?: string[];
+}): TlonUpdateLastRoute['mainDmOwnerPin'] | undefined {
+  const {
+    cfg,
+    route,
+    lastRouteSessionKey,
+    senderShip,
+    effectiveOwnerShip,
+    effectiveDmAllowlist,
+  } = params;
+
+  // Only the main session can be clobbered by another DM sender; isolated
+  // per-peer sessions need no pin.
+  if (lastRouteSessionKey !== route.mainSessionKey) {
+    return undefined;
+  }
+
+  const sender = senderShip.trim();
+  if (!sender) {
+    return undefined;
+  }
+
+  // Tlon's configured owner (`ownerShip`) is separate from `dmAllowlist`, and
+  // owner DMs are valid even when the owner isn't allowlisted. Prefer pinning
+  // the configured owner; otherwise fall back to the SDK's allowlist semantics
+  // (which only pin when there is exactly one allowed sender).
+  const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
+    dmScope: cfg.session?.dmScope,
+    allowFrom: effectiveOwnerShip ? [effectiveOwnerShip] : effectiveDmAllowlist,
+    normalizeEntry: normalizeShip,
+  });
+  if (!pinnedOwner) {
+    return undefined;
+  }
+
+  return {
+    ownerRecipient: pinnedOwner,
+    senderRecipient: normalizeShip(sender),
+  };
+}
+
+/**
+ * The slice of `core.channel.session` used by `recordTlonInboundRoute`. Typed
+ * from the SDK runtime so the call site validates our `updateLastRoute` shape
+ * against the real `InboundLastRouteUpdate` (e.g. that `channel: 'tlon'` and the
+ * pin shape are accepted).
+ */
+type SessionRecorder = Pick<
+  PluginRuntime['channel']['session'],
+  'recordInboundSession'
+>;
+type RecordInboundCtx = Parameters<
+  SessionRecorder['recordInboundSession']
+>[0]['ctx'];
+
+/**
+ * Persist a Tlon inbound turn's session route. Always records origin metadata
+ * (even when `record.updateLastRoute` is omitted) and fails open: a persistence
+ * failure is logged but never blocks the live reply.
+ */
+export async function recordTlonInboundRoute(deps: {
+  session: SessionRecorder;
+  storePath: string;
+  ctxPayload: RecordInboundCtx;
+  record: TlonInboundRouteRecord;
+  messageId?: string;
+  accountId?: string;
+  logError?: (msg: string) => void;
+  logDebug?: (msg: string) => void;
+}): Promise<void> {
+  const { session, storePath, ctxPayload, record, messageId, accountId } = deps;
+
+  if (
+    record.skippedReason === 'group-missing-channel' ||
+    record.skippedReason === 'group-invalid-channel'
+  ) {
+    // Anomalous (a group turn with no/malformed channel nest); surface outside
+    // debug too.
+    deps.logError?.(
+      `[tlon] route persistence skipped (${record.skippedReason}): ` +
+        `messageId=${messageId ?? '?'} lastRouteSessionKey=${record.lastRouteSessionKey}`
+    );
+  } else if (record.skippedReason) {
+    // Normal policy outcome (e.g. a group route that targets the shared main
+    // session); debug-only to avoid high-volume logs for an expected case.
+    deps.logDebug?.(
+      `[tlon] route persistence skipped (${record.skippedReason}): ` +
+        `messageId=${messageId ?? '?'} lastRouteSessionKey=${record.lastRouteSessionKey} ` +
+        `target=${record.target ?? '(none)'}`
+    );
+  }
+
+  // When a main-session DM is pinned to an owner, the SDK skips the durable
+  // route update for a non-owner sender. Wire an onSkip so that decision is
+  // observable instead of silently looking like a successful write.
+  const pin = record.updateLastRoute?.mainDmOwnerPin;
+  const updateLastRoute: TlonUpdateLastRoute | undefined =
+    record.updateLastRoute
+      ? {
+          ...record.updateLastRoute,
+          ...(pin
+            ? {
+                mainDmOwnerPin: {
+                  ...pin,
+                  onSkip: ({ ownerRecipient, senderRecipient }) =>
+                    deps.logDebug?.(
+                      `[tlon] durable route update skipped by owner pin: ` +
+                        `messageId=${messageId ?? '?'} owner=${ownerRecipient} ` +
+                        `sender=${senderRecipient} lastRouteSessionKey=${record.lastRouteSessionKey}`
+                    ),
+                },
+              }
+            : {}),
+        }
+      : undefined;
+
+  try {
+    await session.recordInboundSession({
+      storePath,
+      sessionKey: record.recordSessionKey,
+      ctx: ctxPayload,
+      updateLastRoute,
+      onRecordError: (err) => {
+        deps.logError?.(`[tlon] failed updating session meta: ${String(err)}`);
+      },
+    });
+  } catch (err) {
+    deps.logError?.(
+      `[tlon] failed recording inbound session route: ${String(err)} ` +
+        `(messageId=${messageId ?? '?'} storePath=${storePath} ` +
+        `recordSessionKey=${record.recordSessionKey} ` +
+        `lastRouteSessionKey=${record.lastRouteSessionKey} ` +
+        `target=${record.target ?? '(none)'} accountId=${accountId ?? '(none)'} ` +
+        `hadUpdateLastRoute=${Boolean(record.updateLastRoute)})`
+    );
+  }
+}
+
+/**
+ * Whether the SDK will skip the durable route update because a main-session DM
+ * is pinned to an owner different from the sender. A built `updateLastRoute`
+ * does not guarantee a write, so diagnostics should report this rather than
+ * imply the route was persisted.
+ */
+export function routeUpdateWillSkipByPin(
+  update?: TlonUpdateLastRoute
+): boolean {
+  const pin = update?.mainDmOwnerPin;
+  if (!pin) {
+    return false;
+  }
+  return pin.ownerRecipient !== pin.senderRecipient;
+}
+
+/**
+ * Run the durable route-record step before reply dispatch. The bug this fixes
+ * lives at exactly this boundary: route-dependent sends that happen during
+ * dispatch must observe the persisted route, so recording must complete first.
+ * Keeping this ordering in one place gives the monitor a testable guard.
+ */
+export async function recordRouteThenDispatch<T>(steps: {
+  record: () => Promise<void>;
+  dispatch: () => Promise<T>;
+}): Promise<T> {
+  await steps.record();
+  return steps.dispatch();
+}
+
+/**
+ * The monitor's "build ctx → record route → dispatch" boundary, as a single
+ * testable unit (this is where the original webchat-leak bug lived). Builds the
+ * Tlon route record, persists it, and only then runs `dispatch`. The monitor
+ * delegates its entire record+dispatch to this so the ordering is covered by a
+ * unit test rather than only by the monitor's structure.
+ */
+export async function recordTlonRouteAndDispatch<T>(params: {
+  session: Pick<
+    PluginRuntime['channel']['session'],
+    'recordInboundSession' | 'resolveStorePath'
+  >;
+  cfg: OpenClawConfig;
+  route: ResolvedAgentRoute;
+  ctxPayload: RecordInboundCtx;
+  ctxSessionKey?: string | null;
+  isGroup: boolean;
+  groupChannel?: string | null;
+  senderShip: string;
+  parentId?: string | number | null;
+  deliverParentId?: string | number | null;
+  effectiveOwnerShip?: string | null;
+  effectiveDmAllowlist?: string[];
+  messageId?: string;
+  sessionStore?: string;
+  logError?: (msg: string) => void;
+  logDebug?: (msg: string) => void;
+  /** Called with the built record, before persistence (used for debug logging). */
+  onRecord?: (record: TlonInboundRouteRecord) => void;
+  dispatch: () => Promise<T>;
+}): Promise<T> {
+  const record = buildTlonInboundRouteRecord({
+    cfg: params.cfg,
+    route: params.route,
+    ctxSessionKey: params.ctxSessionKey,
+    isGroup: params.isGroup,
+    groupChannel: params.groupChannel,
+    senderShip: params.senderShip,
+    parentId: params.parentId,
+    deliverParentId: params.deliverParentId,
+    effectiveOwnerShip: params.effectiveOwnerShip,
+    effectiveDmAllowlist: params.effectiveDmAllowlist,
+  });
+  params.onRecord?.(record);
+
+  return recordRouteThenDispatch({
+    // Fail open across the *entire* persistence step — including
+    // resolveStorePath, which can throw on bad session-store config — so a
+    // persistence failure never suppresses the live Tlon reply.
+    record: async () => {
+      let storePath: string;
+      try {
+        storePath = params.session.resolveStorePath(params.sessionStore, {
+          agentId: params.route.agentId,
+        });
+      } catch (err) {
+        params.logError?.(
+          `[tlon] failed resolving session store path: ${String(err)} ` +
+            `(messageId=${params.messageId ?? '?'})`
+        );
+        return;
+      }
+      await recordTlonInboundRoute({
+        session: params.session,
+        storePath,
+        ctxPayload: params.ctxPayload,
+        record,
+        messageId: params.messageId,
+        accountId: params.route.accountId,
+        logError: params.logError,
+        logDebug: params.logDebug,
+      });
+    },
+    dispatch: params.dispatch,
+  });
+}
+
+/**
+ * Build a Tlon `deliveryContext` for an enqueued system event (reactions,
+ * group-join notices). System-event turns resolve delivery from the event's
+ * `deliveryContext` or the session store; attaching this ensures a later
+ * system/heartbeat turn driven by the event routes to Tlon instead of falling
+ * back to webchat, even on a session that hasn't persisted an inbound route yet.
+ * `to` is the provider-qualified target (`tlon:~ship` for DMs, `tlon:<nest>` for
+ * channels), matching `OriginatingTo` and the durable route.
+ */
+export function tlonDeliveryContext(
+  to: string,
+  accountId?: string
+): { channel: 'tlon'; to: string; accountId?: string } {
+  return { channel: 'tlon', to, ...(accountId ? { accountId } : {}) };
+}
+
+/** Route-debug gate: enabled via `TLON_OPENCLAW_ROUTE_DEBUG=1`. */
+export function isRouteDebugEnabled(): boolean {
+  return process.env.TLON_OPENCLAW_ROUTE_DEBUG === '1';
+}

--- a/packages/openclaw/src/session-route.test.ts
+++ b/packages/openclaw/src/session-route.test.ts
@@ -1,0 +1,103 @@
+import type { ChannelOutboundSessionRouteParams } from 'openclaw/plugin-sdk/core';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+import { describe, expect, it } from 'vitest';
+
+import { tlonPlugin } from './channel.js';
+import { resolveTlonOutboundSessionRoute } from './session-route.js';
+
+const cfg = {} as unknown as OpenClawConfig;
+
+function params(
+  overrides: Partial<ChannelOutboundSessionRouteParams> & { target: string }
+): ChannelOutboundSessionRouteParams {
+  return {
+    cfg,
+    agentId: 'default',
+    accountId: 'default',
+    ...overrides,
+  } as ChannelOutboundSessionRouteParams;
+}
+
+describe('resolveTlonOutboundSessionRoute', () => {
+  it.each(['dm/~sampel-palnet', '~sampel-palnet', 'tlon:~sampel-palnet'])(
+    'resolves %s to a direct Tlon route',
+    (target) => {
+      const route = resolveTlonOutboundSessionRoute(params({ target }));
+      expect(route).not.toBeNull();
+      expect(route?.chatType).toBe('direct');
+      expect(route?.peer).toEqual({ kind: 'direct', id: '~sampel-palnet' });
+      expect(route?.to).toBe('tlon:~sampel-palnet');
+      expect(route?.from).toBe('tlon:~sampel-palnet');
+    }
+  );
+
+  it.each([
+    'chat/~host/general',
+    'group:~host/general',
+    'tlon:chat/~host/general',
+  ])('resolves %s to a group Tlon route', (target) => {
+    const route = resolveTlonOutboundSessionRoute(params({ target }));
+    expect(route).not.toBeNull();
+    expect(route?.chatType).toBe('group');
+    expect(route?.peer).toEqual({ kind: 'group', id: 'chat/~host/general' });
+    expect(route?.to).toBe('tlon:chat/~host/general');
+    expect(route?.from).toBe('tlon:group:chat/~host/general');
+  });
+
+  it('preserves account id in the route', () => {
+    const route = resolveTlonOutboundSessionRoute(
+      params({ target: '~zod', accountId: 'acct-2' })
+    );
+    expect(route).not.toBeNull();
+  });
+
+  it('preserves thread id', () => {
+    const route = resolveTlonOutboundSessionRoute(
+      params({ target: '~zod', threadId: 'thr-1' })
+    );
+    expect(route?.threadId).toBe('thr-1');
+  });
+
+  it('omits thread id when not provided', () => {
+    const route = resolveTlonOutboundSessionRoute(params({ target: '~zod' }));
+    expect(route?.threadId).toBeUndefined();
+  });
+
+  it('returns null for invalid targets', () => {
+    expect(
+      resolveTlonOutboundSessionRoute(params({ target: 'not a target!!' }))
+    ).toBeNull();
+    expect(resolveTlonOutboundSessionRoute(params({ target: '' }))).toBeNull();
+  });
+});
+
+describe('tlonPlugin messaging surface (explicit-target wiring)', () => {
+  const messaging = tlonPlugin.messaging;
+
+  it('declares tlon as an explicit target prefix', () => {
+    expect(messaging?.targetPrefixes).toContain('tlon');
+  });
+
+  it('parseExplicitTarget returns a canonical DM target', () => {
+    expect(messaging?.parseExplicitTarget?.({ raw: 'tlon:~ship' })).toEqual({
+      to: '~ship',
+      chatType: 'direct',
+    });
+  });
+
+  it('parseExplicitTarget returns a canonical group target', () => {
+    expect(
+      messaging?.parseExplicitTarget?.({ raw: 'tlon:chat/~host/general' })
+    ).toEqual({ to: 'chat/~host/general', chatType: 'group' });
+  });
+
+  it('parseExplicitTarget returns null for a non-Tlon target', () => {
+    expect(
+      messaging?.parseExplicitTarget?.({ raw: 'not a target!!' })
+    ).toBeNull();
+  });
+
+  it('wires resolveOutboundSessionRoute', () => {
+    expect(typeof messaging?.resolveOutboundSessionRoute).toBe('function');
+  });
+});

--- a/packages/openclaw/src/session-route.ts
+++ b/packages/openclaw/src/session-route.ts
@@ -1,0 +1,54 @@
+import {
+  type ChannelOutboundSessionRouteParams,
+  buildChannelOutboundSessionRoute,
+} from 'openclaw/plugin-sdk/core';
+
+import { parseTlonTarget } from './targets.js';
+
+/**
+ * Channel-native outbound session-route builder for Tlon.
+ *
+ * Lets explicit outbound sends to a Tlon target (e.g. the shared `message` tool
+ * with `to: tlon:~ship`) derive a stable Tlon session route, so they resolve
+ * to Tlon even when the current turn's surface is something else. Returns
+ * `null` for non-Tlon / unparseable targets so core can fall through.
+ */
+export function resolveTlonOutboundSessionRoute(
+  params: ChannelOutboundSessionRouteParams
+) {
+  const parsed = parseTlonTarget(params.target);
+  if (!parsed) {
+    return null;
+  }
+
+  const threadId =
+    params.threadId != null && params.threadId !== ''
+      ? params.threadId
+      : undefined;
+
+  if (parsed.kind === 'dm') {
+    return buildChannelOutboundSessionRoute({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      channel: 'tlon',
+      accountId: params.accountId,
+      peer: { kind: 'direct', id: parsed.ship },
+      chatType: 'direct',
+      from: `tlon:${parsed.ship}`,
+      to: `tlon:${parsed.ship}`,
+      ...(threadId !== undefined ? { threadId } : {}),
+    });
+  }
+
+  return buildChannelOutboundSessionRoute({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: 'tlon',
+    accountId: params.accountId,
+    peer: { kind: 'group', id: parsed.nest },
+    chatType: 'group',
+    from: `tlon:group:${parsed.nest}`,
+    to: `tlon:${parsed.nest}`,
+    ...(threadId !== undefined ? { threadId } : {}),
+  });
+}

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1,6 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { _testing, createTlonTelemetry, recordToolCall } from './telemetry.js';
+import {
+  _testing,
+  createTlonTelemetry,
+  recordToolCall,
+  reportHarnessDebug,
+  reportHarnessError,
+  reportOutboundRoute,
+  reportPluginError,
+  reportSessionDiagnostic,
+  reportSessionLifecycle,
+  reportSessionTurnCreated,
+  reportTelemetryError,
+  setDebugTelemetryReporter,
+  setErrorTelemetryReporter,
+  setOutboundRouteReporter,
+  setSessionTelemetryReporter,
+} from './telemetry.js';
 
 const postHogMocks = vi.hoisted(() => ({
   identify: vi.fn(),
@@ -10,22 +26,36 @@ const postHogMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('posthog-node', () => ({
-  PostHog: vi.fn(
-    class MockPostHog {
-      constructor() {
-        return postHogMocks;
-      }
-    }
-  ),
+  PostHog: vi.fn(function MockPostHog() {
+    return postHogMocks;
+  }),
 }));
+
+const VERSION_IDENTITY_MATCH = {
+  harness: 'openclaw',
+  pluginVersion: expect.any(String),
+  pluginCommit: expect.any(String),
+  pluginFingerprint: expect.stringMatching(/^fp1:[a-f0-9]{12}$/),
+  adapterVersion: expect.any(String),
+  adapterFingerprint: expect.stringMatching(/^fp1:[a-f0-9]{12}$/),
+};
 
 describe('telemetry tool tracking', () => {
   beforeEach(() => {
     _testing.clearToolCalls();
+    _testing.clearSessionContexts();
+    _testing.clearHarnessDebugSnapshots();
+    setSessionTelemetryReporter(null);
+    setDebugTelemetryReporter(null);
+    setErrorTelemetryReporter(null);
     postHogMocks.identify.mockClear();
     postHogMocks.capture.mockClear();
     postHogMocks.flush.mockClear();
     postHogMocks.shutdown.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   function createEnabledTelemetry() {
@@ -42,10 +72,15 @@ describe('telemetry tool tracking', () => {
     sessionKey?: string;
     deliveredMessageCount?: number;
     dispatchError?: unknown;
+    deliverySkipReason?: 'empty' | 'silent' | 'heartbeat';
+    sourceReplyDeliveryMode?: string | null;
   }) {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
       sessionKey: params?.sessionKey ?? 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
       ownerShip: '~zod',
       botShip: '~nec',
       chatType: 'dm',
@@ -63,6 +98,10 @@ describe('telemetry tool tracking', () => {
       queuedFinal: false,
       queuedFinalCount: 1,
       queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 0 },
+      deliverySkipReason: params?.deliverySkipReason ?? null,
+      sourceReplyDeliveryMode: params?.sourceReplyDeliveryMode ?? 'automatic',
+      beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
       thinkLevel: null,
@@ -83,6 +122,9 @@ describe('telemetry tool tracking', () => {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
       sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
       ownerShip: '~zod',
       botShip: '~nec',
       chatType: 'dm',
@@ -111,6 +153,9 @@ describe('telemetry tool tracking', () => {
       queuedFinal: false,
       queuedFinalCount: 1,
       queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
       thinkLevel: null,
@@ -178,10 +223,120 @@ describe('telemetry tool tracking', () => {
     ).toBe('error');
   });
 
-  it('captures camelCase telemetry properties without routing metadata', async () => {
+  it('captures delivery skip reason only for no-reply outcomes', async () => {
+    await captureReply({
+      deliveredMessageCount: 0,
+      deliverySkipReason: 'silent',
+    });
+    expect(
+      postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.deliverySkipReason
+    ).toBe('silent');
+
+    await captureReply({
+      deliveredMessageCount: 1,
+      deliverySkipReason: 'silent',
+    });
+    expect(
+      postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.deliverySkipReason
+    ).toBeNull();
+
+    await captureReply({
+      deliveredMessageCount: 0,
+      sourceReplyDeliveryMode: 'message_tool_only',
+    });
+    expect(
+      postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties.deliverySkipReason
+    ).toBe('source_reply_delivery_mode_message_tool_only');
+  });
+
+  it('classifies direct send and dispatcher failures as errors', async () => {
     const telemetry = createEnabledTelemetry();
     const replyTelemetry = telemetry?.startReply({
       sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'groupChannel',
+      destinationKind: 'groupChannel',
+      isThreadReply: true,
+      senderRole: 'user',
+      attachmentCount: 0,
+    });
+
+    await replyTelemetry?.capture({
+      sendAttemptCount: 1,
+      sendErrorCount: 1,
+      sendErrorKind: 'final',
+      deliveredMessageCount: 0,
+      replyCharCount: 0,
+      replyWordCount: 0,
+      replyMediaCount: 0,
+      dispatchDurationMs: 750,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 1 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: true,
+      provider: 'anthropic',
+      model: 'claude-test',
+      thinkLevel: 'medium',
+    });
+
+    const props = postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties;
+    expect(props).toMatchObject({
+      outcome: 'error',
+      destinationKind: 'groupChannel',
+      sendAttemptCount: 1,
+      sendError: true,
+      sendErrorCount: 1,
+      sendErrorKind: 'final',
+      failedFinalCount: 1,
+      failedReplyCount: 1,
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: true,
+    });
+  });
+
+  it('emits abandoned reply telemetry for stale traces', () => {
+    vi.useFakeTimers();
+
+    const telemetry = createEnabledTelemetry();
+    telemetry?.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'dm',
+      isThreadReply: false,
+      senderRole: 'owner',
+      attachmentCount: 0,
+    });
+
+    vi.advanceTimersByTime(_testing.getReplyTraceTtlMs());
+
+    const props = postHogMocks.capture.mock.calls.at(-1)?.[0]?.properties;
+    expect(props).toMatchObject({
+      outcome: 'abandoned',
+      abandonedReason: 'stale',
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      deliveredMessageCount: 0,
+      sendAttemptCount: 0,
+    });
+  });
+
+  it('captures camelCase reply telemetry properties with turn context', async () => {
+    const telemetry = createEnabledTelemetry();
+    const replyTelemetry = telemetry?.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
       ownerShip: '~zod',
       botShip: '~nec',
       chatType: 'dm',
@@ -205,6 +360,9 @@ describe('telemetry tool tracking', () => {
       queuedFinal: false,
       queuedFinalCount: 1,
       queuedBlockCount: 0,
+      failedCounts: { tool: 0, block: 0, final: 0 },
+      sourceReplyDeliveryMode: 'automatic',
+      beforeAgentRunBlocked: false,
       provider: 'anthropic',
       model: 'claude-test',
       thinkLevel: null,
@@ -212,26 +370,45 @@ describe('telemetry tool tracking', () => {
 
     expect(postHogMocks.identify).toHaveBeenCalledWith({
       distinctId: '~zod',
-      properties: {
+      properties: expect.objectContaining({
         logSource: 'openclawPlugin',
         tlonOwnerShip: '~zod',
         tlonBotShip: '~nec',
-      },
+        harness: 'openclaw',
+        pluginVersion: expect.any(String),
+        pluginFingerprint: expect.stringMatching(/^fp1:[a-f0-9]{12}$/),
+      }),
     });
 
     expect(postHogMocks.capture).toHaveBeenCalledWith({
       distinctId: '~zod',
       event: 'TlonBot Reply Handled',
-      properties: {
+      properties: expect.objectContaining({
         logSource: 'openclawPlugin',
+        harness: 'openclaw',
+        pluginVersion: expect.any(String),
+        pluginCommit: expect.any(String),
+        pluginFingerprint: expect.stringMatching(/^fp1:[a-f0-9]{12}$/),
+        adapterVersion: expect.any(String),
+        adapterFingerprint: expect.stringMatching(/^fp1:[a-f0-9]{12}$/),
         botShip: '~nec',
         ownerShip: '~zod',
+        sessionKey: 'session-1',
+        sessionId: null,
+        runId: 'run-1',
+        accountId: 'default',
+        agentId: 'agent-main',
         outcome: 'responded',
         chatType: 'dm',
+        destinationKind: 'dm',
         isThreadReply: false,
         senderRole: 'owner',
         attachmentCount: 1,
         hasAttachments: true,
+        sendAttemptCount: 0,
+        sendError: false,
+        sendErrorCount: 0,
+        sendErrorKind: null,
         deliveredMessageCount: 1,
         replyCharCount: 42,
         replyWordCount: 7,
@@ -240,6 +417,16 @@ describe('telemetry tool tracking', () => {
         queuedFinal: false,
         queuedFinalCount: 1,
         queuedBlockCount: 0,
+        failedToolCount: 0,
+        failedBlockCount: 0,
+        failedFinalCount: 0,
+        failedReplyCount: 0,
+        deliverySkipReason: null,
+        sourceReplyDeliveryMode: 'automatic',
+        beforeAgentRunBlocked: false,
+        dispatchError: false,
+        dispatchErrorKind: null,
+        abandonedReason: null,
         provider: 'anthropic',
         model: 'claude-test',
         thinkLevel: null,
@@ -254,18 +441,102 @@ describe('telemetry tool tracking', () => {
             error: null,
           },
         ],
-      },
+      }),
     });
 
     const capturedEvent = postHogMocks.capture.mock.calls[0]?.[0];
-    expect(capturedEvent?.properties).not.toHaveProperty('accountId');
-    expect(capturedEvent?.properties).not.toHaveProperty('agentId');
     expect(capturedEvent?.properties).not.toHaveProperty('channel');
+    expect(capturedEvent?.properties).not.toHaveProperty('messageId');
+    expect(capturedEvent?.properties).not.toHaveProperty('messageIds');
+    expect(capturedEvent?.properties).not.toHaveProperty('inboundMessageId');
+    expect(capturedEvent?.properties).not.toHaveProperty('outboundMessageIds');
 
     await telemetry?.close();
 
     expect(postHogMocks.flush).toHaveBeenCalledTimes(1);
     expect(postHogMocks.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('threads OpenClaw sessionId from lifecycle into reply telemetry', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    const replyTelemetry = telemetry.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'dm',
+      isThreadReply: false,
+      senderRole: 'owner',
+      attachmentCount: 0,
+    });
+
+    reportSessionLifecycle({
+      lifecycleEvent: 'session_start',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      agentId: 'agent-main',
+    });
+
+    await replyTelemetry.capture({
+      deliveredMessageCount: 1,
+      replyCharCount: 12,
+      replyWordCount: 2,
+      replyMediaCount: 0,
+      dispatchDurationMs: 150,
+      queuedFinal: true,
+      queuedFinalCount: 1,
+      queuedBlockCount: 0,
+      provider: null,
+      model: null,
+      thinkLevel: null,
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Reply Handled');
+    expect(call.properties).toMatchObject({
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-1',
+    });
+  });
+
+  it('captures gateway connected with version identity', () => {
+    const telemetry = createEnabledTelemetry()!;
+    telemetry.captureGatewayConnected({
+      ownerShip: '~zod',
+      botShip: '~nec',
+      tlonSkillVersion: '0.3.2',
+      accountId: 'default',
+      configured: true,
+      watchedChannelCount: 3,
+      dmAllowlistCount: 2,
+      defaultAuthorizedShipsCount: 1,
+      pendingApprovalCount: 4,
+      autoDiscoverChannels: true,
+      ownerListenEnabled: true,
+    });
+
+    expect(postHogMocks.capture).toHaveBeenCalledWith({
+      distinctId: '~zod',
+      event: 'TlonBot Gateway Connected',
+      properties: expect.objectContaining({
+        logSource: 'openclawPlugin',
+        ...VERSION_IDENTITY_MATCH,
+        botShip: '~nec',
+        ownerShip: '~zod',
+        tlonSkillVersion: '0.3.2',
+        accountId: 'default',
+        configured: true,
+        watchedChannelCount: 3,
+        dmAllowlistCount: 2,
+        defaultAuthorizedShipsCount: 1,
+        pendingApprovalCount: 4,
+        autoDiscoverChannels: true,
+        ownerListenEnabled: true,
+      }),
+    });
   });
 
   describe('captureHeartbeatNudge', () => {
@@ -286,7 +557,7 @@ describe('telemetry tool tracking', () => {
       expect(postHogMocks.capture).toHaveBeenCalledWith({
         distinctId: '~zod',
         event: 'TlonBot Heartbeat Nudge Sent',
-        properties: {
+        properties: expect.objectContaining({
           logSource: 'openclawPlugin',
           botShip: '~nec',
           ownerShip: '~zod',
@@ -298,7 +569,7 @@ describe('telemetry tool tracking', () => {
           accountId: 'default',
           messageId: '~nec/170.141.184.506.511.632.882.809.306.892.730.368.000',
           nudgeSentAtMs: 1700000000000,
-        },
+        }),
       });
     });
 
@@ -338,11 +609,11 @@ describe('telemetry tool tracking', () => {
 
       expect(postHogMocks.identify).toHaveBeenCalledWith({
         distinctId: '~zod',
-        properties: {
+        properties: expect.objectContaining({
           logSource: 'openclawPlugin',
           tlonOwnerShip: '~zod',
           tlonBotShip: '~nec',
-        },
+        }),
       });
     });
 
@@ -381,7 +652,7 @@ describe('telemetry tool tracking', () => {
       expect(postHogMocks.capture).toHaveBeenCalledWith({
         distinctId: '~zod',
         event: 'TlonBot Heartbeat Nudge Reengaged',
-        properties: {
+        properties: expect.objectContaining({
           logSource: 'openclawPlugin',
           botShip: '~nec',
           ownerShip: '~zod',
@@ -391,7 +662,7 @@ describe('telemetry tool tracking', () => {
           reengagementDelayMs: 4000,
           channel: 'tlon',
           accountId: 'default',
-        },
+        }),
       });
     });
 
@@ -410,11 +681,11 @@ describe('telemetry tool tracking', () => {
 
       expect(postHogMocks.identify).toHaveBeenCalledWith({
         distinctId: '~zod',
-        properties: {
+        properties: expect.objectContaining({
           logSource: 'openclawPlugin',
           tlonOwnerShip: '~zod',
           tlonBotShip: '~nec',
-        },
+        }),
       });
     });
 
@@ -439,5 +710,755 @@ describe('telemetry tool tracking', () => {
     const capturedEvent = await captureReply();
     expect(capturedEvent?.event).toBe('TlonBot Reply Handled');
     expect(capturedEvent?.properties.outcome).toBe('responded');
+  });
+
+  async function rememberSessionForDiagnostics(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    const replyTelemetry = telemetry.startReply({
+      sessionKey: 'session-1',
+      runId: 'run-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      chatType: 'dm',
+      isThreadReply: false,
+      senderRole: 'owner',
+      attachmentCount: 0,
+    });
+
+    await replyTelemetry.capture({
+      deliveredMessageCount: 1,
+      replyCharCount: 10,
+      replyWordCount: 2,
+      replyMediaCount: 0,
+      dispatchDurationMs: 100,
+      queuedFinal: true,
+      queuedFinalCount: 1,
+      queuedBlockCount: 0,
+      provider: null,
+      model: null,
+      thinkLevel: null,
+    });
+    postHogMocks.capture.mockClear();
+  }
+
+  function bindSessionReporter(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    setSessionTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'lifecycle':
+          telemetry.captureSessionLifecycle(report.event);
+          break;
+        case 'watchdog':
+          telemetry.captureSessionWatchdog(report.event);
+          break;
+        case 'recovery':
+          telemetry.captureSessionRecovery(report.event);
+          break;
+      }
+    });
+  }
+
+  function bindErrorReporter(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    setErrorTelemetryReporter((report) => {
+      switch (report.kind) {
+        case 'harness':
+          telemetry.captureHarnessError({
+            ...report.event,
+            accountId: report.event.accountId ?? 'default',
+            ownerShip: report.event.ownerShip ?? '~zod',
+            botShip: report.event.botShip || '~nec',
+          });
+          break;
+        case 'plugin':
+          telemetry.capturePluginError({
+            harness: 'openclaw',
+            pluginErrorSource: report.event.pluginErrorSource,
+            accountId: report.event.accountId ?? 'default',
+            ownerShip: report.event.ownerShip ?? '~zod',
+            botShip: report.event.botShip ?? '~nec',
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+            attempt: report.event.attempt ?? null,
+          });
+          break;
+        case 'telemetry':
+          telemetry.captureTelemetryError({
+            harness: 'openclaw',
+            telemetrySource: report.event.telemetrySource,
+            sourceEventName: report.event.sourceEventName ?? null,
+            sessionKey: report.event.sessionKey ?? null,
+            sessionId: report.event.sessionId ?? null,
+            runId: report.event.runId ?? null,
+            accountId: report.event.accountId ?? 'default',
+            agentId: report.event.agentId ?? null,
+            ownerShip: report.event.ownerShip ?? '~zod',
+            botShip: report.event.botShip ?? '~nec',
+            errorKind: report.event.errorKind ?? null,
+            errorText: report.event.errorText,
+          });
+          break;
+      }
+    });
+  }
+
+  function bindDebugReporter(
+    telemetry: NonNullable<ReturnType<typeof createEnabledTelemetry>>
+  ) {
+    setDebugTelemetryReporter((event) =>
+      telemetry.captureHarnessDebug({
+        ...event,
+        accountId: event.accountId ?? 'default',
+        ownerShip: event.ownerShip ?? '~zod',
+        botShip: event.botShip || '~nec',
+      })
+    );
+  }
+
+  it('reports lifecycle hooks only for remembered Tlon sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindSessionReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportSessionLifecycle({
+      lifecycleEvent: 'session_start',
+      sessionKey: 'unknown-session',
+      sessionId: 'ignored',
+    });
+    expect(postHogMocks.capture).not.toHaveBeenCalled();
+
+    reportSessionLifecycle({
+      lifecycleEvent: 'session_end',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      agentId: 'agent-main',
+      reason: 'idle',
+      messageCount: 3,
+      durationMs: 1200,
+      transcriptArchived: true,
+      hasNextSession: true,
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Lifecycle');
+    expect(call.properties).toMatchObject({
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      destinationKind: 'dm',
+      lifecycleEvent: 'session_end',
+      reason: 'idle',
+      messageCount: 3,
+      durationMs: 1200,
+      transcriptArchived: true,
+      hasNextSession: true,
+    });
+  });
+
+  it('reports high-signal watchdog and recovery diagnostics for remembered sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindSessionReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportSessionDiagnostic({
+      type: 'session.stalled',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      state: 'processing',
+      ageMs: 60_000,
+      queueDepth: 1,
+      reason: 'tool_call_stalled',
+      classification: 'blocked_tool_call',
+      activeWorkKind: 'tool_call',
+      activeToolName: 'tlon',
+      activeToolAgeMs: 55_000,
+      lastProgressAgeMs: 56_000,
+      lastProgressReason: 'tool:tlon:started',
+      terminalProgressStale: true,
+    });
+
+    let call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Watchdog');
+    expect(call.properties).toMatchObject({
+      diagnosticType: 'session.stalled',
+      sessionKey: 'session-1',
+      classification: 'blocked_tool_call',
+      activeWorkKind: 'tool_call',
+      activeToolName: 'tlon',
+      terminalProgressStale: true,
+    });
+
+    reportSessionDiagnostic({
+      type: 'session.recovery.completed',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      state: 'processing',
+      stateGeneration: 7,
+      ageMs: 90_000,
+      queueDepth: 1,
+      activeWorkKind: 'tool_call',
+      status: 'released',
+      action: 'release_lane',
+      outcomeReason: 'stale_session_state',
+      released: 1,
+      stale: true,
+    });
+
+    call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Recovery');
+    expect(call.properties).toMatchObject({
+      diagnosticType: 'session.recovery.completed',
+      sessionKey: 'session-1',
+      stateGeneration: 7,
+      status: 'released',
+      action: 'release_lane',
+      outcomeReason: 'stale_session_state',
+      released: 1,
+      stale: true,
+    });
+  });
+
+  it('captures harness debug breadcrumbs for remembered Tlon sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'context.assembled',
+      debugEventKind: 'context',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      agentId: 'agent-main',
+      provider: 'anthropic',
+      model: 'claude-test',
+      messageCount: 12,
+      historyTextChars: 3456,
+      promptChars: 7890,
+      contextTokenBudget: 200000,
+      reserveTokens: 20000,
+      contextChannel: 'tlon',
+      contextTrigger: 'message',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      harnessEventType: 'context.assembled',
+      debugEventKind: 'context',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      provider: 'anthropic',
+      model: 'claude-test',
+      messageCount: 12,
+      historyTextChars: 3456,
+      promptChars: 7890,
+      contextTokenBudget: 200000,
+      reserveTokens: 20000,
+      contextChannel: 'tlon',
+      contextTrigger: 'message',
+      harnessDebugSequence: 1,
+      contextAssembledSeen: true,
+      runStartedSeen: false,
+      modelCallStartedSeen: false,
+    });
+    expect(Object.hasOwn(call.properties, 'message')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'logAttributes')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'contextEngineTaskId')).toBe(false);
+  });
+
+  it('resets harness debug breadcrumbs when a reused session starts a new run', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'harness.run.started',
+      debugEventKind: 'harness',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-1',
+    });
+    reportHarnessDebug({
+      harnessEventType: 'context.assembled',
+      debugEventKind: 'context',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-1',
+    });
+    reportHarnessDebug({
+      harnessEventType: 'run.started',
+      debugEventKind: 'run',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'run.started',
+      runId: 'run-2',
+      harnessDebugSequence: 1,
+      runStartedSeen: true,
+      contextAssembledSeen: false,
+      modelCallStartedSeen: false,
+      harnessRunStartedSeen: false,
+      toolExecutionStartedSeen: false,
+    });
+  });
+
+  it('captures tool and model call identifiers on harness debug events', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'tool.execution.completed',
+      debugEventKind: 'tool',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      toolName: 'read',
+      toolCallId: 'call-read-1',
+      toolSource: 'core',
+      toolOwner: 'openclaw',
+      durationMs: 42,
+    });
+
+    let call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'tool.execution.completed',
+      debugEventKind: 'tool',
+      toolName: 'read',
+      toolCallId: 'call-read-1',
+      toolSource: 'core',
+      toolOwner: 'openclaw',
+      durationMs: 42,
+    });
+
+    reportHarnessDebug({
+      harnessEventType: 'model.call.completed',
+      debugEventKind: 'model',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      provider: 'openrouter',
+      model: 'anthropic/claude-haiku-4.5',
+      modelCallId: 'model-call-1',
+      durationMs: 2997,
+      requestPayloadBytes: 12345,
+      responseStreamBytes: 6789,
+      timeToFirstByteMs: 321,
+    });
+
+    call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'model.call.completed',
+      debugEventKind: 'model',
+      modelCallId: 'model-call-1',
+      durationMs: 2997,
+      requestPayloadBytes: 12345,
+      responseStreamBytes: 6789,
+      timeToFirstByteMs: 321,
+    });
+  });
+
+  it('captures selected log attributes on harness debug events', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindDebugReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessDebug({
+      harnessEventType: 'log.record',
+      debugEventKind: 'log',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      logLevel: 'WARN',
+      loggerName: 'context-engine',
+      codeFunctionName: 'runContextTask',
+      codeLine: 42,
+      message:
+        '[context-engine] deferred turn maintenance queued taskId=abc123 lane=context-engine-turn-maintenance:session-1 operation=assemble',
+      logAttributes: {
+        taskId: 'abc123',
+        lane: 'context-engine-turn-maintenance:session-1',
+        operation: 'assemble',
+        pluginId: 'lossless-claw',
+        durationMs: 123,
+        retryable: true,
+        'bad key': 'dropped',
+      },
+      contextEngineEvent: 'log.record',
+      contextEngineTaskId: 'abc123',
+      contextEngineOperation: 'assemble',
+      contextEngineLane: 'context-engine-turn-maintenance:session-1',
+      pluginId: 'lossless-claw',
+      durationMs: 123,
+      errorName: 'TimeoutError',
+      errorCode: 'ETIMEDOUT',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Debug');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'log.record',
+      debugEventKind: 'log',
+      logLevel: 'WARN',
+      loggerName: 'context-engine',
+      codeFunctionName: 'runContextTask',
+      codeLine: 42,
+      pluginId: 'lossless-claw',
+      durationMs: 123,
+      contextEngineTaskId: 'abc123',
+      contextEngineOperation: 'assemble',
+      contextEngineLane: 'context-engine-turn-maintenance:session-1',
+      errorName: 'TimeoutError',
+      errorCode: 'ETIMEDOUT',
+      lastContextEngineTaskId: 'abc123',
+      lastContextEngineOperation: 'assemble',
+      lastContextEngineLane: 'context-engine-turn-maintenance:session-1',
+    });
+    expect(call.properties.logAttributes).toMatchObject({
+      taskId: 'abc123',
+      lane: 'context-engine-turn-maintenance:session-1',
+      operation: 'assemble',
+      pluginId: 'lossless-claw',
+      durationMs: 123,
+      retryable: true,
+    });
+    expect(call.properties.logAttributes['bad key']).toBeUndefined();
+  });
+
+  it('enriches watchdog diagnostics with the last harness debug snapshot', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindSessionReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+    const longContextEngineMessage =
+      '[context-engine] deferred turn maintenance queued taskId=abc123 sessionKey=session-1 lane=context-engine-turn-maintenance:session-1 ' +
+      `detail=${'x'.repeat(320)}`;
+
+    reportHarnessDebug({
+      harnessEventType: 'run.started',
+      debugEventKind: 'run',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      agentId: 'agent-main',
+      provider: 'anthropic',
+      model: 'claude-test',
+    });
+    reportHarnessDebug({
+      harnessEventType: 'log.record',
+      debugEventKind: 'log',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      logLevel: 'INFO',
+      message: longContextEngineMessage,
+      contextEngineEvent: 'log.record',
+      contextEngineTaskId: 'abc123',
+      contextEngineOperation: 'maintenance',
+      contextEngineLane: 'context-engine-turn-maintenance:session-1',
+    });
+    postHogMocks.capture.mockClear();
+
+    reportSessionDiagnostic({
+      type: 'session.stalled',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      state: 'processing',
+      ageMs: 360_000,
+      queueDepth: 2,
+      reason: 'active_work_without_progress',
+      classification: 'stalled_agent_run',
+      activeWorkKind: 'embedded_run',
+      lastProgressAgeMs: 300_000,
+      lastProgressReason: 'embedded_run:started',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Session Watchdog');
+    expect(call.properties).toMatchObject({
+      reason: 'active_work_without_progress',
+      classification: 'stalled_agent_run',
+      activeWorkKind: 'embedded_run',
+      lastProgressReason: 'embedded_run:started',
+      harnessDebugSequence: 2,
+      lastHarnessEventType: 'log.record',
+      lastHarnessEventRunId: 'run-2',
+      lastHarnessProvider: 'anthropic',
+      lastHarnessModel: 'claude-test',
+      runStartedSeen: true,
+      contextAssembledSeen: false,
+      modelCallStartedSeen: false,
+      lastContextEngineEvent: 'log.record',
+      lastContextEngineTaskId: 'abc123',
+      lastContextEngineOperation: 'maintenance',
+      lastContextEngineLane: 'context-engine-turn-maintenance:session-1',
+      lastContextEngineMessage: longContextEngineMessage,
+    });
+    expect(call.properties.lastHarnessEventAgeMs).toEqual(expect.any(Number));
+    expect(call.properties.lastContextEngineEventAgeMs).toEqual(
+      expect.any(Number)
+    );
+  });
+
+  it('reports harness errors only for remembered Tlon sessions', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'unknown-session',
+      runId: 'ignored-run',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      durationMs: 1234,
+      errorText: 'full\nmodel\nerror',
+    });
+    expect(postHogMocks.capture).not.toHaveBeenCalled();
+
+    reportSessionTurnCreated({
+      type: 'session.turn.created',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      agentId: 'agent-main',
+    });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      durationMs: 1234,
+      errorText: 'full\nmodel\nerror',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      sessionId: 'openclaw-session-1',
+      runId: 'run-2',
+      accountId: 'default',
+      agentId: 'agent-main',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      destinationKind: 'dm',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      durationMs: 1234,
+      errorText: 'full\nmodel\nerror',
+    });
+  });
+
+  it('reports process-level harness diagnostics without a session key', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportHarnessError({
+      harnessEventType: 'diagnostic.liveness.warning',
+      errorScope: 'runtime',
+      outcome: 'warning',
+      errorCategory: 'liveness_warning',
+      failureKind: 'event_loop_delay',
+      durationMs: 30_000,
+      errorText: 'reasons=event_loop_delay eventLoopDelayP99Ms=250',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      harnessEventType: 'diagnostic.liveness.warning',
+      errorScope: 'runtime',
+      accountId: 'default',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      outcome: 'warning',
+      errorCategory: 'liveness_warning',
+      failureKind: 'event_loop_delay',
+      durationMs: 30_000,
+      errorText: 'reasons=event_loop_delay eventLoopDelayP99Ms=250',
+    });
+    expect(Object.hasOwn(call.properties, 'sessionKey')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'sessionId')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'runId')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'agentId')).toBe(false);
+    expect(Object.hasOwn(call.properties, 'destinationKind')).toBe(false);
+  });
+
+  it('captures plugin errors without throttling or truncating error text', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportPluginError({
+      pluginErrorSource: 'chat_firehose',
+      errorKind: 'Error',
+      errorText: 'first full error\nwith details',
+      attempt: null,
+    });
+    reportPluginError({
+      pluginErrorSource: 'chat_firehose',
+      errorKind: 'Error',
+      errorText: 'second full error\nwith details',
+      attempt: null,
+    });
+
+    const calls = postHogMocks.capture.mock.calls.map((call) => call[0]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].event).toBe('TlonBot Plugin Error');
+    expect(calls[0].properties).toMatchObject({
+      harness: 'openclaw',
+      pluginErrorSource: 'chat_firehose',
+      accountId: 'default',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      errorKind: 'Error',
+      errorText: 'first full error\nwith details',
+    });
+    expect(Object.hasOwn(calls[0].properties, 'attempt')).toBe(false);
+    expect(calls[1].properties.errorText).toBe(
+      'second full error\nwith details'
+    );
+  });
+
+  it('captures telemetry observer failures', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportTelemetryError({
+      telemetrySource: 'diagnostic_internal',
+      sourceEventName: 'model.call.error',
+      sessionKey: 'session-1',
+      errorKind: 'TypeError',
+      errorText: 'observer exploded\nwith details',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Telemetry Error');
+    expect(call.properties).toMatchObject({
+      harness: 'openclaw',
+      telemetrySource: 'diagnostic_internal',
+      sourceEventName: 'model.call.error',
+      sessionKey: 'session-1',
+      accountId: 'default',
+      ownerShip: '~zod',
+      botShip: '~nec',
+      errorKind: 'TypeError',
+      errorText: 'observer exploded\nwith details',
+    });
+  });
+});
+
+describe('outbound route telemetry', () => {
+  beforeEach(() => {
+    _testing.clearSessionContexts();
+    _testing.clearHarnessDebugSnapshots();
+    postHogMocks.identify.mockClear();
+    postHogMocks.capture.mockClear();
+    setOutboundRouteReporter(null);
+    setSessionTelemetryReporter(null);
+    setDebugTelemetryReporter(null);
+    setErrorTelemetryReporter(null);
+  });
+
+  function createEnabledTelemetry() {
+    return createTlonTelemetry({
+      config: { enabled: true, apiKey: 'phc_test', host: null },
+    });
+  }
+
+  it('captures a webchat (off-Tlon) send as the tracked leak', () => {
+    const telemetry = createEnabledTelemetry();
+    telemetry?.captureOutboundRoute({
+      ownerShip: '~zod',
+      botShip: '~nec',
+      resolvedChannel: 'webchat',
+      routedToTlon: false,
+      targetKind: 'unknown',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Outbound Routed');
+    expect(call.distinctId).toBe('~zod');
+    expect(call.properties.resolvedChannel).toBe('webchat');
+    expect(call.properties.routedToTlon).toBe(false);
+  });
+
+  it('captures a healthy Tlon send', () => {
+    const telemetry = createEnabledTelemetry();
+    telemetry?.captureOutboundRoute({
+      ownerShip: '~zod',
+      botShip: '~nec',
+      resolvedChannel: 'tlon',
+      routedToTlon: true,
+      targetKind: 'dm',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties.routedToTlon).toBe(true);
+    expect(call.properties.targetKind).toBe('dm');
+  });
+
+  it('skips capture when ownerShip is not configured', () => {
+    const telemetry = createEnabledTelemetry();
+    telemetry?.captureOutboundRoute({
+      ownerShip: null,
+      botShip: '~nec',
+      resolvedChannel: 'webchat',
+      routedToTlon: false,
+      targetKind: 'unknown',
+    });
+    expect(postHogMocks.capture).not.toHaveBeenCalled();
+  });
+
+  it('reportOutboundRoute forwards to the registered reporter, and null clears it', () => {
+    const reporter = vi.fn();
+    setOutboundRouteReporter(reporter);
+    reportOutboundRoute({
+      resolvedChannel: 'webchat',
+      routedToTlon: false,
+      targetKind: 'unknown',
+    });
+    expect(reporter).toHaveBeenCalledTimes(1);
+    expect(reporter.mock.calls[0][0].routedToTlon).toBe(false);
+
+    setOutboundRouteReporter(null);
+    reportOutboundRoute({
+      resolvedChannel: 'tlon',
+      routedToTlon: true,
+      targetKind: 'dm',
+    });
+    expect(reporter).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -1,8 +1,9 @@
 import type { RuntimeEnv } from 'openclaw/plugin-sdk/runtime';
 import { PostHog } from 'posthog-node';
 
-import { sharedMap } from './shared-state.js';
+import { sharedMap, sharedSlot } from './shared-state.js';
 import type { TlonTelemetryConfig } from './types.js';
+import { getTlonVersionIdentity } from './version.js';
 
 type ToolCallRecord = {
   toolName: string;
@@ -14,6 +15,46 @@ type ToolCallRecord = {
 type ToolSessionTrace = {
   updatedAt: number;
   calls: ToolCallRecord[];
+};
+
+type HarnessDebugSnapshotRecord = {
+  updatedAt: number;
+  debugSequence: number;
+  lastHarnessEventType: string | null;
+  lastHarnessEventAt: number | null;
+  lastHarnessEventRunId: string | null;
+  lastHarnessEventPhase: string | null;
+  lastHarnessEventOutcome: string | null;
+  lastHarnessProvider: string | null;
+  lastHarnessModel: string | null;
+  runStartedSeen: boolean;
+  contextAssembledSeen: boolean;
+  modelCallStartedSeen: boolean;
+  harnessRunStartedSeen: boolean;
+  toolExecutionStartedSeen: boolean;
+  lastContextEngineEvent: string | null;
+  lastContextEngineEventAt: number | null;
+  lastContextEngineTaskId: string | null;
+  lastContextEngineOperation: string | null;
+  lastContextEngineLane: string | null;
+  lastContextEngineMessage: string | null;
+};
+
+export type TlonHarnessName = 'openclaw' | 'hermes';
+type ReplyDispatchKind = 'tool' | 'block' | 'final';
+type ReplyDispatchCounts = Partial<Record<ReplyDispatchKind, number>>;
+type TlonDestinationKind = 'dm' | 'groupChannel';
+
+type TlonSessionTelemetryContext = {
+  sessionKey: string;
+  sessionId: string | null;
+  runId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  accountId: string | null;
+  agentId: string | null;
+  destinationKind: TlonDestinationKind;
+  updatedAt: number;
 };
 
 export type ToolUsageSummary = {
@@ -63,16 +104,34 @@ export type TlonHeartbeatReengagementEvent = {
   accountId: string | null;
 };
 
-export type TlonReplyOutcome = 'responded' | 'no_reply' | 'error';
+export type TlonReplyOutcome = 'responded' | 'no_reply' | 'error' | 'abandoned';
+export type TlonDeliverySkipReason =
+  | 'empty'
+  | 'silent'
+  | 'heartbeat'
+  | 'empty_payload_text'
+  | 'block_directive_only'
+  | 'media_only_payload_not_sent'
+  | 'source_reply_delivery_mode_message_tool_only';
 
 export type TlonReplyOutcomeEvent = {
+  sessionKey: string;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
   ownerShip: string | null;
   botShip: string;
   outcome: TlonReplyOutcome;
   chatType: 'dm' | 'groupChannel';
+  destinationKind: TlonDestinationKind;
   isThreadReply: boolean;
   senderRole: 'owner' | 'user';
   attachmentCount: number;
+  sendAttemptCount: number;
+  sendError: boolean;
+  sendErrorCount: number;
+  sendErrorKind: string | null;
   deliveredMessageCount: number;
   replyCharCount: number;
   replyWordCount: number;
@@ -81,6 +140,16 @@ export type TlonReplyOutcomeEvent = {
   queuedFinal: boolean;
   queuedFinalCount: number;
   queuedBlockCount: number;
+  failedToolCount: number;
+  failedBlockCount: number;
+  failedFinalCount: number;
+  failedReplyCount: number;
+  deliverySkipReason: TlonDeliverySkipReason | null;
+  sourceReplyDeliveryMode: string | null;
+  beforeAgentRunBlocked: boolean;
+  dispatchError: boolean;
+  dispatchErrorKind: string | null;
+  abandonedReason: string | null;
   provider: string | null;
   model: string | null;
   thinkLevel: string | null;
@@ -89,15 +158,37 @@ export type TlonReplyOutcomeEvent = {
 
 export type TlonReplyTelemetryStart = {
   sessionKey: string;
+  sessionId?: string | null;
+  runId?: string | null;
+  accountId?: string | null;
+  agentId?: string | null;
   ownerShip: string | null;
   botShip: string;
   chatType: 'dm' | 'groupChannel';
+  destinationKind?: TlonDestinationKind;
   isThreadReply: boolean;
   senderRole: 'owner' | 'user';
   attachmentCount: number;
 };
 
+export type TlonGatewayConnectedEvent = {
+  ownerShip: string | null;
+  botShip: string;
+  tlonSkillVersion: string;
+  accountId: string | null;
+  configured: boolean;
+  watchedChannelCount: number;
+  dmAllowlistCount: number;
+  defaultAuthorizedShipsCount: number;
+  pendingApprovalCount: number;
+  autoDiscoverChannels: boolean;
+  ownerListenEnabled: boolean;
+};
+
 export type TlonReplyTelemetryResult = {
+  sendAttemptCount?: number;
+  sendErrorCount?: number;
+  sendErrorKind?: string | null;
   deliveredMessageCount: number;
   replyCharCount: number;
   replyWordCount: number;
@@ -106,6 +197,10 @@ export type TlonReplyTelemetryResult = {
   queuedFinal: boolean;
   queuedFinalCount: number;
   queuedBlockCount: number;
+  failedCounts?: ReplyDispatchCounts;
+  deliverySkipReason?: TlonDeliverySkipReason | null;
+  sourceReplyDeliveryMode?: string | null;
+  beforeAgentRunBlocked?: boolean;
   provider: string | null;
   model: string | null;
   thinkLevel: string | null;
@@ -116,22 +211,294 @@ export interface TlonReplyTelemetrySession {
   capture(result: TlonReplyTelemetryResult): Promise<void>;
 }
 
+/**
+ * One outbound send seen by OpenClaw's `message_sending` hook, tagged with which
+ * channel it resolved to. This fires for both the primary streamed reply (which
+ * resolves to `tlon`, so `routedToTlon: true`) and route-dependent sends (the
+ * shared `message` tool, subagents — which can resolve elsewhere). So
+ * `routedToTlon: false` is the meaningful signal: a send that went somewhere
+ * users can't see (e.g. webchat) — the bug this tracks. The `true` events
+ * include healthy primary replies, so prefer the off-Tlon count over a raw rate.
+ */
+export type TlonOutboundRouteEvent = {
+  resolvedChannel: string;
+  routedToTlon: boolean;
+  targetKind: 'dm' | 'group' | 'unknown';
+};
+
+export type TlonSessionLifecycleEvent = {
+  lifecycleEvent: 'session_start' | 'session_end';
+  sessionKey: string;
+  sessionId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  reason: string | null;
+  messageCount: number | null;
+  durationMs: number | null;
+  transcriptArchived: boolean | null;
+  hasNextSession: boolean;
+};
+
+export type TlonHarnessDebugSnapshotFields = {
+  harnessDebugSequence: number | null;
+  lastHarnessEventType: string | null;
+  lastHarnessEventAgeMs: number | null;
+  lastHarnessEventRunId: string | null;
+  lastHarnessEventPhase: string | null;
+  lastHarnessEventOutcome: string | null;
+  lastHarnessProvider: string | null;
+  lastHarnessModel: string | null;
+  runStartedSeen: boolean;
+  contextAssembledSeen: boolean;
+  modelCallStartedSeen: boolean;
+  harnessRunStartedSeen: boolean;
+  toolExecutionStartedSeen: boolean;
+  lastContextEngineEvent: string | null;
+  lastContextEngineEventAgeMs: number | null;
+  lastContextEngineTaskId: string | null;
+  lastContextEngineOperation: string | null;
+  lastContextEngineLane: string | null;
+  lastContextEngineMessage: string | null;
+};
+
+export type TlonDiagnosticLogAttributes = Record<
+  string,
+  string | number | boolean
+>;
+
+export type TlonSessionWatchdogEvent = TlonHarnessDebugSnapshotFields & {
+  diagnosticType: 'session.stalled' | 'session.stuck';
+  sessionKey: string;
+  sessionId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  state: string;
+  ageMs: number;
+  queueDepth: number | null;
+  reason: string | null;
+  classification: string;
+  activeWorkKind: string | null;
+  lastProgressAgeMs: number | null;
+  lastProgressReason: string | null;
+  activeToolName: string | null;
+  activeToolAgeMs: number | null;
+  terminalProgressStale: boolean;
+};
+
+export type TlonSessionRecoveryEvent = TlonHarnessDebugSnapshotFields & {
+  diagnosticType: 'session.recovery.requested' | 'session.recovery.completed';
+  sessionKey: string;
+  sessionId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  state: string;
+  stateGeneration: number | null;
+  ageMs: number;
+  queueDepth: number | null;
+  reason: string | null;
+  activeWorkKind: string | null;
+  allowActiveAbort: boolean;
+  status: string | null;
+  action: string | null;
+  outcomeReason: string | null;
+  released: number | null;
+  stale: boolean;
+};
+
+export type TlonSessionTelemetryReport =
+  | { kind: 'lifecycle'; event: TlonSessionLifecycleEvent }
+  | { kind: 'watchdog'; event: TlonSessionWatchdogEvent }
+  | { kind: 'recovery'; event: TlonSessionRecoveryEvent };
+
+export type TlonHarnessErrorScope =
+  | 'harness'
+  | 'model'
+  | 'tool'
+  | 'run'
+  | 'runtime'
+  | 'diagnostics'
+  | 'payload'
+  | 'message_delivery'
+  | 'message_dispatch'
+  | 'message_processing';
+
+export type TlonHarnessErrorEvent = {
+  harness: TlonHarnessName;
+  harnessEventType: string;
+  errorScope: TlonHarnessErrorScope;
+  sessionKey: string | null;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind | null;
+  provider: string | null;
+  model: string | null;
+  toolName: string | null;
+  phase: string | null;
+  outcome: string | null;
+  errorCategory: string | null;
+  failureKind: string | null;
+  durationMs: number | null;
+  errorText: string | null;
+};
+
+export type TlonHarnessDebugEvent = TlonHarnessDebugSnapshotFields & {
+  harness: TlonHarnessName;
+  harnessEventType: string;
+  debugEventKind: string;
+  sessionKey: string;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  destinationKind: TlonDestinationKind;
+  provider: string | null;
+  model: string | null;
+  phase: string | null;
+  outcome: string | null;
+  durationMs: number | null;
+  toolName: string | null;
+  toolCallId: string | null;
+  toolSource: string | null;
+  toolOwner: string | null;
+  pluginId: string | null;
+  harnessId: string | null;
+  modelCallId: string | null;
+  modelApi: string | null;
+  modelTransport: string | null;
+  requestPayloadBytes: number | null;
+  responseStreamBytes: number | null;
+  timeToFirstByteMs: number | null;
+  logLevel: string | null;
+  message: string | null;
+  loggerName: string | null;
+  codeFunctionName: string | null;
+  codeLine: number | null;
+  logAttributes: TlonDiagnosticLogAttributes | null;
+  contextEngineEvent: string | null;
+  contextEngineTaskId: string | null;
+  contextEngineOperation: string | null;
+  contextEngineLane: string | null;
+  errorName: string | null;
+  errorCode: string | null;
+  messageCount: number | null;
+  historyTextChars: number | null;
+  historyImageBlocks: number | null;
+  maxMessageTextChars: number | null;
+  systemPromptChars: number | null;
+  promptChars: number | null;
+  promptImages: number | null;
+  contextTokenBudget: number | null;
+  reserveTokens: number | null;
+  contextChannel: string | null;
+  contextTrigger: string | null;
+};
+
+export type TlonPluginErrorSource =
+  | 'auth'
+  | 're_auth'
+  | 'gateway_status_activation'
+  | 'gateway_status_heartbeat'
+  | 'channels_firehose'
+  | 'chat_firehose'
+  | 'contacts_subscription'
+  | 'groups_ui_subscription'
+  | 'foreigns_subscription'
+  | 'settings_refresh';
+
+export type TlonPluginErrorEvent = {
+  harness: TlonHarnessName;
+  pluginErrorSource: TlonPluginErrorSource;
+  accountId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  errorKind: string | null;
+  errorText: string;
+  attempt: number | null;
+};
+
+export type TlonTelemetryErrorEvent = {
+  harness: TlonHarnessName;
+  telemetrySource: string;
+  sourceEventName: string | null;
+  sessionKey: string | null;
+  sessionId: string | null;
+  runId: string | null;
+  accountId: string | null;
+  agentId: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  errorKind: string | null;
+  errorText: string;
+};
+
 export interface TlonTelemetryClient {
+  captureGatewayConnected(event: TlonGatewayConnectedEvent): void;
   startReply(params: TlonReplyTelemetryStart): TlonReplyTelemetrySession;
   captureHeartbeatNudge(event: TlonHeartbeatNudgeEvent): void;
   captureHeartbeatReengagement(event: TlonHeartbeatReengagementEvent): void;
+  captureSessionLifecycle(event: TlonSessionLifecycleEvent): void;
+  captureSessionWatchdog(event: TlonSessionWatchdogEvent): void;
+  captureSessionRecovery(event: TlonSessionRecoveryEvent): void;
+  captureHarnessError(event: TlonHarnessErrorEvent): void;
+  captureHarnessDebug(event: TlonHarnessDebugEvent): void;
+  capturePluginError(event: TlonPluginErrorEvent): void;
+  captureTelemetryError(event: TlonTelemetryErrorEvent): void;
+  captureOutboundRoute(
+    event: TlonOutboundRouteEvent & {
+      ownerShip?: string | null;
+      botShip: string;
+    }
+  ): void;
   close(): Promise<void>;
 }
 
 const TLON_TELEMETRY_EVENT_NAME = 'TlonBot Reply Handled';
+const TLON_GATEWAY_CONNECTED_EVENT = 'TlonBot Gateway Connected';
+const TLON_OUTBOUND_ROUTED_EVENT = 'TlonBot Outbound Routed';
+const TLON_SESSION_LIFECYCLE_EVENT = 'TlonBot Session Lifecycle';
+const TLON_SESSION_WATCHDOG_EVENT = 'TlonBot Session Watchdog';
+const TLON_SESSION_RECOVERY_EVENT = 'TlonBot Session Recovery';
+const TLON_HARNESS_ERROR_EVENT = 'TlonBot Harness Error';
+const TLON_HARNESS_DEBUG_EVENT = 'TlonBot Harness Debug';
+const TLON_PLUGIN_ERROR_EVENT = 'TlonBot Plugin Error';
+const TLON_TELEMETRY_ERROR_EVENT = 'TlonBot Telemetry Error';
 const TLON_HEARTBEAT_NUDGE_EVENT = 'TlonBot Heartbeat Nudge Sent';
 const TLON_HEARTBEAT_REENGAGED_EVENT = 'TlonBot Heartbeat Nudge Reengaged';
 const TLON_TELEMETRY_LOG_SOURCE = 'openclawPlugin';
 const TOOL_TRACE_TTL_MS = 60 * 60 * 1000;
 const MAX_TOOL_CALLS_PER_SESSION = 200;
+const REPLY_TRACE_TTL_MS = 60 * 60 * 1000;
+const MAX_ACTIVE_REPLY_TRACES = 50;
+const SESSION_CONTEXT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_SESSION_CONTEXTS = 5_000;
+const HARNESS_DEBUG_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
+const MAX_HARNESS_DEBUG_SNAPSHOTS = 5_000;
 const toolCallsBySession = sharedMap<string, ToolSessionTrace>(
   'telemetry.toolCallsBySession'
 );
+const sessionContextsBySessionKey = sharedMap<
+  string,
+  TlonSessionTelemetryContext
+>('telemetry.sessionContextsBySessionKey');
+const harnessDebugSnapshotsBySessionKey = sharedMap<
+  string,
+  HarnessDebugSnapshotRecord
+>('telemetry.harnessDebugSnapshotsBySessionKey');
 
 function cleanupToolCalls(now = Date.now()): void {
   for (const [sessionKey, trace] of toolCallsBySession) {
@@ -209,21 +576,374 @@ function collectToolUsageSince(
   };
 }
 
+function cleanupSessionContexts(now = Date.now()): void {
+  for (const [sessionKey, context] of sessionContextsBySessionKey) {
+    if (now - context.updatedAt > SESSION_CONTEXT_TTL_MS) {
+      sessionContextsBySessionKey.delete(sessionKey);
+    }
+  }
+
+  while (sessionContextsBySessionKey.size > MAX_SESSION_CONTEXTS) {
+    const oldestKey = [...sessionContextsBySessionKey.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    )[0]?.[0];
+    if (!oldestKey) {
+      break;
+    }
+    sessionContextsBySessionKey.delete(oldestKey);
+  }
+}
+
+function cleanupHarnessDebugSnapshots(now = Date.now()): void {
+  for (const [sessionKey, snapshot] of harnessDebugSnapshotsBySessionKey) {
+    if (now - snapshot.updatedAt > HARNESS_DEBUG_SNAPSHOT_TTL_MS) {
+      harnessDebugSnapshotsBySessionKey.delete(sessionKey);
+    }
+  }
+
+  while (harnessDebugSnapshotsBySessionKey.size > MAX_HARNESS_DEBUG_SNAPSHOTS) {
+    const oldestKey = [...harnessDebugSnapshotsBySessionKey.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    )[0]?.[0];
+    if (!oldestKey) {
+      break;
+    }
+    harnessDebugSnapshotsBySessionKey.delete(oldestKey);
+  }
+}
+
+function createEmptyHarnessDebugSnapshot(
+  now = Date.now()
+): HarnessDebugSnapshotRecord {
+  return {
+    updatedAt: now,
+    debugSequence: 0,
+    lastHarnessEventType: null,
+    lastHarnessEventAt: null,
+    lastHarnessEventRunId: null,
+    lastHarnessEventPhase: null,
+    lastHarnessEventOutcome: null,
+    lastHarnessProvider: null,
+    lastHarnessModel: null,
+    runStartedSeen: false,
+    contextAssembledSeen: false,
+    modelCallStartedSeen: false,
+    harnessRunStartedSeen: false,
+    toolExecutionStartedSeen: false,
+    lastContextEngineEvent: null,
+    lastContextEngineEventAt: null,
+    lastContextEngineTaskId: null,
+    lastContextEngineOperation: null,
+    lastContextEngineLane: null,
+    lastContextEngineMessage: null,
+  };
+}
+
+function harnessDebugSnapshotFields(
+  snapshot: HarnessDebugSnapshotRecord | null,
+  now = Date.now()
+): TlonHarnessDebugSnapshotFields {
+  return {
+    harnessDebugSequence: snapshot?.debugSequence ?? null,
+    lastHarnessEventType: snapshot?.lastHarnessEventType ?? null,
+    lastHarnessEventAgeMs:
+      snapshot?.lastHarnessEventAt !== null &&
+      snapshot?.lastHarnessEventAt !== undefined
+        ? Math.max(0, now - snapshot.lastHarnessEventAt)
+        : null,
+    lastHarnessEventRunId: snapshot?.lastHarnessEventRunId ?? null,
+    lastHarnessEventPhase: snapshot?.lastHarnessEventPhase ?? null,
+    lastHarnessEventOutcome: snapshot?.lastHarnessEventOutcome ?? null,
+    lastHarnessProvider: snapshot?.lastHarnessProvider ?? null,
+    lastHarnessModel: snapshot?.lastHarnessModel ?? null,
+    runStartedSeen: snapshot?.runStartedSeen === true,
+    contextAssembledSeen: snapshot?.contextAssembledSeen === true,
+    modelCallStartedSeen: snapshot?.modelCallStartedSeen === true,
+    harnessRunStartedSeen: snapshot?.harnessRunStartedSeen === true,
+    toolExecutionStartedSeen: snapshot?.toolExecutionStartedSeen === true,
+    lastContextEngineEvent: snapshot?.lastContextEngineEvent ?? null,
+    lastContextEngineEventAgeMs:
+      snapshot?.lastContextEngineEventAt !== null &&
+      snapshot?.lastContextEngineEventAt !== undefined
+        ? Math.max(0, now - snapshot.lastContextEngineEventAt)
+        : null,
+    lastContextEngineTaskId: snapshot?.lastContextEngineTaskId ?? null,
+    lastContextEngineOperation: snapshot?.lastContextEngineOperation ?? null,
+    lastContextEngineLane: snapshot?.lastContextEngineLane ?? null,
+    lastContextEngineMessage: snapshot?.lastContextEngineMessage ?? null,
+  };
+}
+
+function lookupHarnessDebugSnapshotFields(
+  sessionKey?: string | null
+): TlonHarnessDebugSnapshotFields {
+  const normalized = sessionKey?.trim();
+  if (!normalized) {
+    return harnessDebugSnapshotFields(null);
+  }
+
+  cleanupHarnessDebugSnapshots();
+  return harnessDebugSnapshotFields(
+    harnessDebugSnapshotsBySessionKey.get(normalized) ?? null
+  );
+}
+
+function updateHarnessDebugSnapshot(
+  sessionKey: string,
+  event: TlonHarnessDebugReportInput,
+  now = Date.now()
+): TlonHarnessDebugSnapshotFields {
+  cleanupHarnessDebugSnapshots(now);
+  const previous = harnessDebugSnapshotsBySessionKey.get(sessionKey);
+  const eventRunId = optionalString(event.runId);
+  const resetForNewRun =
+    previous &&
+    eventRunId &&
+    previous.lastHarnessEventRunId &&
+    previous.lastHarnessEventRunId !== eventRunId;
+  const existing = resetForNewRun
+    ? createEmptyHarnessDebugSnapshot(now)
+    : previous ?? createEmptyHarnessDebugSnapshot(now);
+  const contextEngineEvent = optionalString(event.contextEngineEvent);
+  const contextEngineTaskId = optionalString(event.contextEngineTaskId);
+  const contextEngineOperation = optionalString(event.contextEngineOperation);
+  const contextEngineLane = optionalString(event.contextEngineLane);
+  const message = optionalString(event.message);
+
+  const updated: HarnessDebugSnapshotRecord = {
+    ...existing,
+    updatedAt: now,
+    debugSequence: existing.debugSequence + 1,
+    lastHarnessEventType:
+      optionalString(event.harnessEventType) ?? existing.lastHarnessEventType,
+    lastHarnessEventAt: now,
+    lastHarnessEventRunId: eventRunId ?? existing.lastHarnessEventRunId,
+    lastHarnessEventPhase:
+      optionalString(event.phase) ?? existing.lastHarnessEventPhase,
+    lastHarnessEventOutcome:
+      optionalString(event.outcome) ?? existing.lastHarnessEventOutcome,
+    lastHarnessProvider:
+      optionalString(event.provider) ?? existing.lastHarnessProvider,
+    lastHarnessModel: optionalString(event.model) ?? existing.lastHarnessModel,
+    runStartedSeen:
+      existing.runStartedSeen || event.harnessEventType === 'run.started',
+    contextAssembledSeen:
+      existing.contextAssembledSeen ||
+      event.harnessEventType === 'context.assembled',
+    modelCallStartedSeen:
+      existing.modelCallStartedSeen ||
+      event.harnessEventType === 'model.call.started',
+    harnessRunStartedSeen:
+      existing.harnessRunStartedSeen ||
+      event.harnessEventType === 'harness.run.started',
+    toolExecutionStartedSeen:
+      existing.toolExecutionStartedSeen ||
+      event.harnessEventType === 'tool.execution.started',
+    lastContextEngineEvent:
+      contextEngineEvent ?? existing.lastContextEngineEvent,
+    lastContextEngineEventAt: contextEngineEvent
+      ? now
+      : existing.lastContextEngineEventAt,
+    lastContextEngineTaskId:
+      contextEngineTaskId ?? existing.lastContextEngineTaskId,
+    lastContextEngineOperation:
+      contextEngineOperation ?? existing.lastContextEngineOperation,
+    lastContextEngineLane: contextEngineLane ?? existing.lastContextEngineLane,
+    lastContextEngineMessage:
+      contextEngineEvent && message
+        ? message
+        : existing.lastContextEngineMessage,
+  };
+
+  harnessDebugSnapshotsBySessionKey.set(sessionKey, updated);
+  return harnessDebugSnapshotFields(updated, now);
+}
+
+function rememberTlonSessionContext(params: {
+  sessionKey: string;
+  sessionId?: string | null;
+  runId?: string | null;
+  ownerShip: string | null;
+  botShip: string;
+  accountId?: string | null;
+  agentId?: string | null;
+  destinationKind: TlonDestinationKind;
+}): void {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return;
+  }
+
+  const now = Date.now();
+  cleanupSessionContexts(now);
+  const existing = sessionContextsBySessionKey.get(sessionKey);
+  sessionContextsBySessionKey.set(sessionKey, {
+    sessionKey,
+    sessionId: optionalString(params.sessionId) ?? existing?.sessionId ?? null,
+    runId: optionalString(params.runId) ?? existing?.runId ?? null,
+    ownerShip: params.ownerShip,
+    botShip: params.botShip,
+    accountId: params.accountId ?? null,
+    agentId: params.agentId ?? null,
+    destinationKind: params.destinationKind,
+    updatedAt: now,
+  });
+}
+
+function lookupTlonSessionContext(
+  sessionKey?: string | null
+): TlonSessionTelemetryContext | null {
+  const normalized = sessionKey?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  cleanupSessionContexts();
+  const context = sessionContextsBySessionKey.get(normalized);
+  if (!context) {
+    return null;
+  }
+
+  context.updatedAt = Date.now();
+  sessionContextsBySessionKey.set(normalized, context);
+  return context;
+}
+
+function updateTlonSessionContextSessionId(
+  context: TlonSessionTelemetryContext,
+  sessionId?: string | null
+): TlonSessionTelemetryContext {
+  const normalizedSessionId = optionalString(sessionId);
+  if (!normalizedSessionId || context.sessionId === normalizedSessionId) {
+    return context;
+  }
+
+  const updated = {
+    ...context,
+    sessionId: normalizedSessionId,
+    updatedAt: Date.now(),
+  };
+  sessionContextsBySessionKey.set(updated.sessionKey, updated);
+  return updated;
+}
+
+function updateTlonSessionContextRuntime(
+  context: TlonSessionTelemetryContext,
+  params: {
+    sessionId?: string | null;
+    runId?: string | null;
+    agentId?: string | null;
+  }
+): TlonSessionTelemetryContext {
+  const normalizedSessionId = optionalString(params.sessionId);
+  const normalizedRunId = optionalString(params.runId);
+  const normalizedAgentId = optionalString(params.agentId);
+  if (
+    (!normalizedSessionId || context.sessionId === normalizedSessionId) &&
+    (!normalizedRunId || context.runId === normalizedRunId) &&
+    (!normalizedAgentId || context.agentId === normalizedAgentId)
+  ) {
+    return context;
+  }
+
+  const updated = {
+    ...context,
+    sessionId: normalizedSessionId ?? context.sessionId,
+    runId: normalizedRunId ?? context.runId,
+    agentId: normalizedAgentId ?? context.agentId,
+    updatedAt: Date.now(),
+  };
+  sessionContextsBySessionKey.set(updated.sessionKey, updated);
+  return updated;
+}
+
+function countDispatchFailures(
+  counts: ReplyDispatchCounts | undefined,
+  kind: ReplyDispatchKind
+): number {
+  const value = counts?.[kind];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, value)
+    : 0;
+}
+
+function classifyError(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+  if (error instanceof Error) {
+    return error.name || 'Error';
+  }
+  if (typeof error === 'object' && error !== null) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === 'string' && code.trim()) {
+      return code.trim().slice(0, 80);
+    }
+    const name = (error as { name?: unknown }).name;
+    if (typeof name === 'string' && name.trim()) {
+      return name.trim().slice(0, 80);
+    }
+    return 'object';
+  }
+  return typeof error;
+}
+
 function resolveReplyOutcome(params: {
   deliveredMessageCount: number;
+  sendError?: boolean;
+  failedCounts?: ReplyDispatchCounts;
   dispatchError?: unknown;
 }): TlonReplyOutcome {
   if (params.deliveredMessageCount > 0) {
     return 'responded';
   }
 
-  return params.dispatchError ? 'error' : 'no_reply';
+  const failedReplyCount =
+    countDispatchFailures(params.failedCounts, 'tool') +
+    countDispatchFailures(params.failedCounts, 'block') +
+    countDispatchFailures(params.failedCounts, 'final');
+
+  return params.dispatchError || params.sendError || failedReplyCount > 0
+    ? 'error'
+    : 'no_reply';
 }
+
+function resolveDeliverySkipReason(params: {
+  outcome: TlonReplyOutcome;
+  deliverySkipReason?: TlonDeliverySkipReason | null;
+  sourceReplyDeliveryMode?: string | null;
+}): TlonDeliverySkipReason | null {
+  if (params.outcome !== 'no_reply') {
+    return null;
+  }
+  if (params.deliverySkipReason) {
+    return params.deliverySkipReason;
+  }
+  if (params.sourceReplyDeliveryMode === 'message_tool_only') {
+    return 'source_reply_delivery_mode_message_tool_only';
+  }
+  return null;
+}
+
+type ActiveReplyTrace = {
+  params: TlonReplyTelemetryStart & {
+    sessionId: string | null;
+    runId: string | null;
+    accountId: string | null;
+    agentId: string | null;
+    destinationKind: TlonDestinationKind;
+  };
+  startedAt: number;
+  toolTraceCursor: number;
+  timeout: ReturnType<typeof setTimeout>;
+};
 
 class PostHogTlonTelemetry implements TlonTelemetryClient {
   private readonly client: PostHog;
   private readonly runtime?: RuntimeEnv;
+  private readonly versionIdentity = getTlonVersionIdentity();
   private readonly identifiedOwners = new Set<string>();
+  private readonly activeReplyTraces = new Map<symbol, ActiveReplyTrace>();
   private missingOwnerWarningLogged = false;
 
   constructor(params: {
@@ -242,25 +962,138 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     });
   }
 
+  private properties<T extends Record<string, unknown>>(
+    props: T,
+    options?: { omitNullish?: boolean }
+  ): Record<string, unknown> {
+    const properties = {
+      logSource: TLON_TELEMETRY_LOG_SOURCE,
+      ...this.versionIdentity,
+      ...props,
+    };
+    if (options?.omitNullish !== true) {
+      return properties;
+    }
+    return Object.fromEntries(
+      Object.entries(properties).filter(([, value]) => value != null)
+    );
+  }
+
+  captureGatewayConnected(event: TlonGatewayConnectedEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_GATEWAY_CONNECTED_EVENT,
+      properties: this.properties({
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        tlonSkillVersion: event.tlonSkillVersion,
+        accountId: event.accountId,
+        configured: event.configured,
+        watchedChannelCount: event.watchedChannelCount,
+        dmAllowlistCount: event.dmAllowlistCount,
+        defaultAuthorizedShipsCount: event.defaultAuthorizedShipsCount,
+        pendingApprovalCount: event.pendingApprovalCount,
+        autoDiscoverChannels: event.autoDiscoverChannels,
+        ownerListenEnabled: event.ownerListenEnabled,
+      }),
+    });
+  }
+
   startReply(params: TlonReplyTelemetryStart): TlonReplyTelemetrySession {
+    const normalizedParams: ActiveReplyTrace['params'] = {
+      ...params,
+      sessionId: optionalString(params.sessionId),
+      runId: params.runId ?? null,
+      accountId: params.accountId ?? null,
+      agentId: params.agentId ?? null,
+      destinationKind: params.destinationKind ?? params.chatType,
+    };
     const toolTraceCursor = createToolTraceCursor(params.sessionKey);
+    rememberTlonSessionContext({
+      sessionKey: normalizedParams.sessionKey,
+      sessionId: normalizedParams.sessionId,
+      runId: normalizedParams.runId,
+      ownerShip: normalizedParams.ownerShip,
+      botShip: normalizedParams.botShip,
+      accountId: normalizedParams.accountId,
+      agentId: normalizedParams.agentId,
+      destinationKind: normalizedParams.destinationKind,
+    });
+
+    this.pruneActiveReplyTraces();
+    const token = Symbol(normalizedParams.sessionKey);
+    const trace: ActiveReplyTrace = {
+      params: normalizedParams,
+      startedAt: Date.now(),
+      toolTraceCursor,
+      timeout: setTimeout(() => {
+        this.captureAbandonedReplyTrace(token, 'stale');
+      }, REPLY_TRACE_TTL_MS),
+    };
+    trace.timeout.unref?.();
+    this.activeReplyTraces.set(token, trace);
+    this.pruneActiveReplyTraces();
 
     return {
       capture: async (result) => {
+        const activeTrace = this.activeReplyTraces.get(token);
+        if (!activeTrace) {
+          return;
+        }
+        this.activeReplyTraces.delete(token);
+        clearTimeout(activeTrace.timeout);
+
         // Yield once so after_tool_call hooks for the just-finished reply have time to run.
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
+        const failedToolCount = countDispatchFailures(
+          result.failedCounts,
+          'tool'
+        );
+        const failedBlockCount = countDispatchFailures(
+          result.failedCounts,
+          'block'
+        );
+        const failedFinalCount = countDispatchFailures(
+          result.failedCounts,
+          'final'
+        );
+        const sendErrorCount = Math.max(0, result.sendErrorCount ?? 0);
+        const sessionContext = lookupTlonSessionContext(
+          activeTrace.params.sessionKey
+        );
+
+        const outcome = resolveReplyOutcome({
+          deliveredMessageCount: result.deliveredMessageCount,
+          sendError: sendErrorCount > 0,
+          failedCounts: result.failedCounts,
+          dispatchError: result.dispatchError,
+        });
+        const sourceReplyDeliveryMode = result.sourceReplyDeliveryMode ?? null;
+
         this.captureReplyOutcome({
-          ownerShip: params.ownerShip,
-          botShip: params.botShip,
-          outcome: resolveReplyOutcome({
-            deliveredMessageCount: result.deliveredMessageCount,
-            dispatchError: result.dispatchError,
-          }),
-          chatType: params.chatType,
-          isThreadReply: params.isThreadReply,
-          senderRole: params.senderRole,
-          attachmentCount: params.attachmentCount,
+          sessionKey: activeTrace.params.sessionKey,
+          sessionId: sessionContext?.sessionId ?? activeTrace.params.sessionId,
+          runId: activeTrace.params.runId,
+          accountId: activeTrace.params.accountId,
+          agentId: activeTrace.params.agentId,
+          ownerShip: activeTrace.params.ownerShip,
+          botShip: activeTrace.params.botShip,
+          outcome,
+          chatType: activeTrace.params.chatType,
+          destinationKind: activeTrace.params.destinationKind,
+          isThreadReply: activeTrace.params.isThreadReply,
+          senderRole: activeTrace.params.senderRole,
+          attachmentCount: activeTrace.params.attachmentCount,
+          sendAttemptCount: Math.max(0, result.sendAttemptCount ?? 0),
+          sendError: sendErrorCount > 0,
+          sendErrorCount,
+          sendErrorKind: result.sendErrorKind ?? null,
           deliveredMessageCount: result.deliveredMessageCount,
           replyCharCount: result.replyCharCount,
           replyWordCount: result.replyWordCount,
@@ -269,13 +1102,104 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           queuedFinal: result.queuedFinal,
           queuedFinalCount: result.queuedFinalCount,
           queuedBlockCount: result.queuedBlockCount,
+          failedToolCount,
+          failedBlockCount,
+          failedFinalCount,
+          failedReplyCount:
+            failedToolCount + failedBlockCount + failedFinalCount,
+          deliverySkipReason: resolveDeliverySkipReason({
+            outcome,
+            deliverySkipReason: result.deliverySkipReason,
+            sourceReplyDeliveryMode,
+          }),
+          sourceReplyDeliveryMode,
+          beforeAgentRunBlocked: result.beforeAgentRunBlocked === true,
+          dispatchError: Boolean(result.dispatchError),
+          dispatchErrorKind: classifyError(result.dispatchError),
+          abandonedReason: null,
           provider: result.provider,
           model: result.model,
           thinkLevel: result.thinkLevel,
-          toolUsage: collectToolUsageSince(params.sessionKey, toolTraceCursor),
+          toolUsage: collectToolUsageSince(
+            activeTrace.params.sessionKey,
+            activeTrace.toolTraceCursor
+          ),
         });
       },
     };
+  }
+
+  private captureAbandonedReplyTrace(token: symbol, reason: string): void {
+    const trace = this.activeReplyTraces.get(token);
+    if (!trace) {
+      return;
+    }
+    this.activeReplyTraces.delete(token);
+    clearTimeout(trace.timeout);
+    const sessionContext = lookupTlonSessionContext(trace.params.sessionKey);
+
+    this.captureReplyOutcome({
+      sessionKey: trace.params.sessionKey,
+      sessionId: sessionContext?.sessionId ?? trace.params.sessionId,
+      runId: trace.params.runId,
+      accountId: trace.params.accountId,
+      agentId: trace.params.agentId,
+      ownerShip: trace.params.ownerShip,
+      botShip: trace.params.botShip,
+      outcome: 'abandoned',
+      chatType: trace.params.chatType,
+      destinationKind: trace.params.destinationKind,
+      isThreadReply: trace.params.isThreadReply,
+      senderRole: trace.params.senderRole,
+      attachmentCount: trace.params.attachmentCount,
+      sendAttemptCount: 0,
+      sendError: false,
+      sendErrorCount: 0,
+      sendErrorKind: null,
+      deliveredMessageCount: 0,
+      replyCharCount: 0,
+      replyWordCount: 0,
+      replyMediaCount: 0,
+      dispatchDurationMs: Date.now() - trace.startedAt,
+      queuedFinal: false,
+      queuedFinalCount: 0,
+      queuedBlockCount: 0,
+      failedToolCount: 0,
+      failedBlockCount: 0,
+      failedFinalCount: 0,
+      failedReplyCount: 0,
+      deliverySkipReason: null,
+      sourceReplyDeliveryMode: null,
+      beforeAgentRunBlocked: false,
+      dispatchError: false,
+      dispatchErrorKind: null,
+      abandonedReason: reason,
+      provider: null,
+      model: null,
+      thinkLevel: null,
+      toolUsage: collectToolUsageSince(
+        trace.params.sessionKey,
+        trace.toolTraceCursor
+      ),
+    });
+  }
+
+  private pruneActiveReplyTraces(now = Date.now()): void {
+    for (const [token, trace] of this.activeReplyTraces) {
+      if (now - trace.startedAt > REPLY_TRACE_TTL_MS) {
+        this.captureAbandonedReplyTrace(token, 'stale');
+      }
+    }
+
+    while (this.activeReplyTraces.size > MAX_ACTIVE_REPLY_TRACES) {
+      const oldest = [...this.activeReplyTraces.entries()].sort(
+        (a, b) => a[1].startedAt - b[1].startedAt
+      )[0];
+      if (!oldest) {
+        break;
+      }
+      this.captureAbandonedReplyTrace(oldest[0], 'max_traces');
+    }
   }
 
   private captureReplyOutcome(event: TlonReplyOutcomeEvent): void {
@@ -287,16 +1211,25 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: ownerShip,
       event: TLON_TELEMETRY_EVENT_NAME,
-      properties: {
-        logSource: TLON_TELEMETRY_LOG_SOURCE,
+      properties: this.properties({
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        runId: event.runId,
+        accountId: event.accountId,
+        agentId: event.agentId,
         botShip: event.botShip,
         ownerShip: event.ownerShip,
         outcome: event.outcome,
         chatType: event.chatType,
+        destinationKind: event.destinationKind,
         isThreadReply: event.isThreadReply,
         senderRole: event.senderRole,
         attachmentCount: event.attachmentCount,
         hasAttachments: event.attachmentCount > 0,
+        sendAttemptCount: event.sendAttemptCount,
+        sendError: event.sendError,
+        sendErrorCount: event.sendErrorCount,
+        sendErrorKind: event.sendErrorKind,
         deliveredMessageCount: event.deliveredMessageCount,
         replyCharCount: event.replyCharCount,
         replyWordCount: event.replyWordCount,
@@ -305,6 +1238,16 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         queuedFinal: event.queuedFinal,
         queuedFinalCount: event.queuedFinalCount,
         queuedBlockCount: event.queuedBlockCount,
+        failedToolCount: event.failedToolCount,
+        failedBlockCount: event.failedBlockCount,
+        failedFinalCount: event.failedFinalCount,
+        failedReplyCount: event.failedReplyCount,
+        deliverySkipReason: event.deliverySkipReason,
+        sourceReplyDeliveryMode: event.sourceReplyDeliveryMode,
+        beforeAgentRunBlocked: event.beforeAgentRunBlocked,
+        dispatchError: event.dispatchError,
+        dispatchErrorKind: event.dispatchErrorKind,
+        abandonedReason: event.abandonedReason,
         provider: event.provider,
         model: event.model,
         thinkLevel: event.thinkLevel,
@@ -317,7 +1260,347 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           durationMs: call.durationMs,
           error: call.error,
         })),
-      },
+      }),
+    });
+  }
+
+  captureSessionLifecycle(event: TlonSessionLifecycleEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_SESSION_LIFECYCLE_EVENT,
+      properties: this.properties({
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        accountId: event.accountId,
+        agentId: event.agentId,
+        sessionKey: event.sessionKey,
+        sessionId: event.sessionId,
+        lifecycleEvent: event.lifecycleEvent,
+        destinationKind: event.destinationKind,
+        reason: event.reason,
+        messageCount: event.messageCount,
+        durationMs: event.durationMs,
+        transcriptArchived: event.transcriptArchived,
+        hasNextSession: event.hasNextSession,
+      }),
+    });
+  }
+
+  captureSessionWatchdog(event: TlonSessionWatchdogEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_SESSION_WATCHDOG_EVENT,
+      properties: this.properties(
+        {
+          botShip: event.botShip,
+          ownerShip: event.ownerShip,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          diagnosticType: event.diagnosticType,
+          destinationKind: event.destinationKind,
+          state: event.state,
+          ageMs: event.ageMs,
+          queueDepth: event.queueDepth,
+          reason: event.reason,
+          classification: event.classification,
+          activeWorkKind: event.activeWorkKind,
+          lastProgressAgeMs: event.lastProgressAgeMs,
+          lastProgressReason: event.lastProgressReason,
+          activeToolName: event.activeToolName,
+          activeToolAgeMs: event.activeToolAgeMs,
+          terminalProgressStale: event.terminalProgressStale,
+          harnessDebugSequence: event.harnessDebugSequence,
+          lastHarnessEventType: event.lastHarnessEventType,
+          lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
+          lastHarnessEventRunId: event.lastHarnessEventRunId,
+          lastHarnessEventPhase: event.lastHarnessEventPhase,
+          lastHarnessEventOutcome: event.lastHarnessEventOutcome,
+          lastHarnessProvider: event.lastHarnessProvider,
+          lastHarnessModel: event.lastHarnessModel,
+          runStartedSeen: event.runStartedSeen,
+          contextAssembledSeen: event.contextAssembledSeen,
+          modelCallStartedSeen: event.modelCallStartedSeen,
+          harnessRunStartedSeen: event.harnessRunStartedSeen,
+          toolExecutionStartedSeen: event.toolExecutionStartedSeen,
+          lastContextEngineEvent: event.lastContextEngineEvent,
+          lastContextEngineEventAgeMs: event.lastContextEngineEventAgeMs,
+          lastContextEngineTaskId: event.lastContextEngineTaskId,
+          lastContextEngineOperation: event.lastContextEngineOperation,
+          lastContextEngineLane: event.lastContextEngineLane,
+          lastContextEngineMessage: event.lastContextEngineMessage,
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  captureSessionRecovery(event: TlonSessionRecoveryEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_SESSION_RECOVERY_EVENT,
+      properties: this.properties(
+        {
+          botShip: event.botShip,
+          ownerShip: event.ownerShip,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          diagnosticType: event.diagnosticType,
+          destinationKind: event.destinationKind,
+          state: event.state,
+          stateGeneration: event.stateGeneration,
+          ageMs: event.ageMs,
+          queueDepth: event.queueDepth,
+          reason: event.reason,
+          activeWorkKind: event.activeWorkKind,
+          allowActiveAbort: event.allowActiveAbort,
+          status: event.status,
+          action: event.action,
+          outcomeReason: event.outcomeReason,
+          released: event.released,
+          stale: event.stale,
+          harnessDebugSequence: event.harnessDebugSequence,
+          lastHarnessEventType: event.lastHarnessEventType,
+          lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
+          lastHarnessEventRunId: event.lastHarnessEventRunId,
+          lastHarnessEventPhase: event.lastHarnessEventPhase,
+          lastHarnessEventOutcome: event.lastHarnessEventOutcome,
+          lastHarnessProvider: event.lastHarnessProvider,
+          lastHarnessModel: event.lastHarnessModel,
+          runStartedSeen: event.runStartedSeen,
+          contextAssembledSeen: event.contextAssembledSeen,
+          modelCallStartedSeen: event.modelCallStartedSeen,
+          harnessRunStartedSeen: event.harnessRunStartedSeen,
+          toolExecutionStartedSeen: event.toolExecutionStartedSeen,
+          lastContextEngineEvent: event.lastContextEngineEvent,
+          lastContextEngineEventAgeMs: event.lastContextEngineEventAgeMs,
+          lastContextEngineTaskId: event.lastContextEngineTaskId,
+          lastContextEngineOperation: event.lastContextEngineOperation,
+          lastContextEngineLane: event.lastContextEngineLane,
+          lastContextEngineMessage: event.lastContextEngineMessage,
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  captureOutboundRoute(
+    event: TlonOutboundRouteEvent & {
+      ownerShip?: string | null;
+      botShip: string;
+    }
+  ): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_OUTBOUND_ROUTED_EVENT,
+      properties: this.properties({
+        botShip: event.botShip,
+        ownerShip: event.ownerShip,
+        resolvedChannel: event.resolvedChannel,
+        routedToTlon: event.routedToTlon,
+        targetKind: event.targetKind,
+      }),
+    });
+  }
+
+  captureHarnessError(event: TlonHarnessErrorEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_HARNESS_ERROR_EVENT,
+      properties: this.properties(
+        {
+          harness: event.harness,
+          harnessEventType: event.harnessEventType,
+          errorScope: event.errorScope,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          runId: event.runId,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          destinationKind: event.destinationKind,
+          provider: event.provider,
+          model: event.model,
+          toolName: event.toolName,
+          phase: event.phase,
+          outcome: event.outcome,
+          errorCategory: event.errorCategory,
+          failureKind: event.failureKind,
+          durationMs: event.durationMs,
+          errorText: event.errorText,
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  captureHarnessDebug(event: TlonHarnessDebugEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_HARNESS_DEBUG_EVENT,
+      properties: this.properties(
+        {
+          harness: event.harness,
+          harnessEventType: event.harnessEventType,
+          debugEventKind: event.debugEventKind,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          runId: event.runId,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          destinationKind: event.destinationKind,
+          provider: event.provider,
+          model: event.model,
+          phase: event.phase,
+          outcome: event.outcome,
+          durationMs: event.durationMs,
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          toolSource: event.toolSource,
+          toolOwner: event.toolOwner,
+          pluginId: event.pluginId,
+          harnessId: event.harnessId,
+          modelCallId: event.modelCallId,
+          modelApi: event.modelApi,
+          modelTransport: event.modelTransport,
+          requestPayloadBytes: event.requestPayloadBytes,
+          responseStreamBytes: event.responseStreamBytes,
+          timeToFirstByteMs: event.timeToFirstByteMs,
+          logLevel: event.logLevel,
+          message: event.message,
+          loggerName: event.loggerName,
+          codeFunctionName: event.codeFunctionName,
+          codeLine: event.codeLine,
+          logAttributes: event.logAttributes,
+          contextEngineEvent: event.contextEngineEvent,
+          contextEngineTaskId: event.contextEngineTaskId,
+          contextEngineOperation: event.contextEngineOperation,
+          contextEngineLane: event.contextEngineLane,
+          errorName: event.errorName,
+          errorCode: event.errorCode,
+          messageCount: event.messageCount,
+          historyTextChars: event.historyTextChars,
+          historyImageBlocks: event.historyImageBlocks,
+          maxMessageTextChars: event.maxMessageTextChars,
+          systemPromptChars: event.systemPromptChars,
+          promptChars: event.promptChars,
+          promptImages: event.promptImages,
+          contextTokenBudget: event.contextTokenBudget,
+          reserveTokens: event.reserveTokens,
+          contextChannel: event.contextChannel,
+          contextTrigger: event.contextTrigger,
+          harnessDebugSequence: event.harnessDebugSequence,
+          lastHarnessEventType: event.lastHarnessEventType,
+          lastHarnessEventAgeMs: event.lastHarnessEventAgeMs,
+          lastHarnessEventRunId: event.lastHarnessEventRunId,
+          lastHarnessEventPhase: event.lastHarnessEventPhase,
+          lastHarnessEventOutcome: event.lastHarnessEventOutcome,
+          lastHarnessProvider: event.lastHarnessProvider,
+          lastHarnessModel: event.lastHarnessModel,
+          runStartedSeen: event.runStartedSeen,
+          contextAssembledSeen: event.contextAssembledSeen,
+          modelCallStartedSeen: event.modelCallStartedSeen,
+          harnessRunStartedSeen: event.harnessRunStartedSeen,
+          toolExecutionStartedSeen: event.toolExecutionStartedSeen,
+          lastContextEngineEvent: event.lastContextEngineEvent,
+          lastContextEngineEventAgeMs: event.lastContextEngineEventAgeMs,
+          lastContextEngineTaskId: event.lastContextEngineTaskId,
+          lastContextEngineOperation: event.lastContextEngineOperation,
+          lastContextEngineLane: event.lastContextEngineLane,
+          lastContextEngineMessage: event.lastContextEngineMessage,
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  capturePluginError(event: TlonPluginErrorEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_PLUGIN_ERROR_EVENT,
+      properties: this.properties(
+        {
+          harness: event.harness,
+          pluginErrorSource: event.pluginErrorSource,
+          accountId: event.accountId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          errorKind: event.errorKind,
+          errorText: event.errorText,
+          attempt: event.attempt,
+        },
+        { omitNullish: true }
+      ),
+    });
+  }
+
+  captureTelemetryError(event: TlonTelemetryErrorEvent): void {
+    const ownerShip = event.ownerShip ?? '';
+    if (!this.ensureIdentified(ownerShip, event.botShip)) {
+      return;
+    }
+
+    this.client.capture({
+      distinctId: ownerShip,
+      event: TLON_TELEMETRY_ERROR_EVENT,
+      properties: this.properties(
+        {
+          harness: event.harness,
+          telemetrySource: event.telemetrySource,
+          sourceEventName: event.sourceEventName,
+          sessionKey: event.sessionKey,
+          sessionId: event.sessionId,
+          runId: event.runId,
+          accountId: event.accountId,
+          agentId: event.agentId,
+          ownerShip: event.ownerShip,
+          botShip: event.botShip,
+          errorKind: event.errorKind,
+          errorText: event.errorText,
+        },
+        { omitNullish: true }
+      ),
     });
   }
 
@@ -338,6 +1621,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         distinctId: ownerShip,
         properties: {
           logSource: TLON_TELEMETRY_LOG_SOURCE,
+          ...this.versionIdentity,
           tlonOwnerShip: ownerShip,
           tlonBotShip: botShip,
         },
@@ -354,8 +1638,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: event.ownerShip,
       event: TLON_HEARTBEAT_NUDGE_EVENT,
-      properties: {
-        logSource: TLON_TELEMETRY_LOG_SOURCE,
+      properties: this.properties({
         botShip: event.botShip,
         ownerShip: event.ownerShip,
         trigger: 'heartbeat',
@@ -366,7 +1649,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         accountId: event.accountId,
         messageId: event.messageId,
         nudgeSentAtMs: event.nudgeSentAtMs,
-      },
+      }),
     });
   }
 
@@ -378,8 +1661,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
     this.client.capture({
       distinctId: event.ownerShip,
       event: TLON_HEARTBEAT_REENGAGED_EVENT,
-      properties: {
-        logSource: TLON_TELEMETRY_LOG_SOURCE,
+      properties: this.properties({
         botShip: event.botShip,
         ownerShip: event.ownerShip,
         nudgeStage: event.nudgeStage,
@@ -388,11 +1670,15 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         reengagementDelayMs: event.reengagementDelayMs,
         channel: event.channel,
         accountId: event.accountId,
-      },
+      }),
     });
   }
 
   async close(): Promise<void> {
+    for (const token of [...this.activeReplyTraces.keys()]) {
+      this.captureAbandonedReplyTrace(token, 'telemetry_close');
+    }
+
     try {
       await this.client.flush();
     } catch (error) {
@@ -435,7 +1721,580 @@ export function createTlonTelemetry(params: {
   });
 }
 
+/**
+ * Bridge so the global `message_sending` hook (registered in the extension
+ * entry) can report route resolutions to the per-account telemetry client
+ * (created in the monitor's runtime context). The two run in separate plugin
+ * module contexts, so this must go through the shared-state slot, not a plain
+ * module singleton. The monitor publishes a reporter bound to its telemetry
+ * client + owner/bot ships; the hook calls `reportOutboundRoute`.
+ */
+export type OutboundRouteReporter = (event: TlonOutboundRouteEvent) => void;
+export type SessionTelemetryReporter = (
+  report: TlonSessionTelemetryReport
+) => void;
+export type ErrorTelemetryReporter = (
+  report:
+    | { kind: 'harness'; event: TlonHarnessErrorEvent }
+    | { kind: 'plugin'; event: TlonPluginErrorReportInput }
+    | { kind: 'telemetry'; event: TlonTelemetryErrorReportInput }
+) => void;
+export type DebugTelemetryReporter = (event: TlonHarnessDebugEvent) => void;
+
+export type TlonSessionLifecycleReportInput = {
+  lifecycleEvent: 'session_start' | 'session_end';
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  agentId?: string | null;
+  reason?: string | null;
+  messageCount?: number | null;
+  durationMs?: number | null;
+  transcriptArchived?: boolean | null;
+  hasNextSession?: boolean;
+};
+
+export type TlonSessionDiagnosticReportInput =
+  | {
+      type: 'session.stalled' | 'session.stuck';
+      sessionKey?: string | null;
+      sessionId?: string | null;
+      state: string;
+      ageMs: number;
+      queueDepth?: number;
+      reason?: string;
+      classification: string;
+      activeWorkKind?: string;
+      lastProgressAgeMs?: number;
+      lastProgressReason?: string;
+      activeToolName?: string;
+      activeToolAgeMs?: number;
+      terminalProgressStale?: boolean;
+    }
+  | {
+      type: 'session.recovery.requested' | 'session.recovery.completed';
+      sessionKey?: string | null;
+      sessionId?: string | null;
+      state: string;
+      stateGeneration?: number;
+      ageMs: number;
+      queueDepth?: number;
+      reason?: string;
+      activeWorkKind?: string;
+      allowActiveAbort?: boolean;
+      status?: string;
+      action?: string;
+      outcomeReason?: string;
+      released?: number;
+      stale?: boolean;
+    };
+
+export type TlonSessionTurnCreatedReportInput = {
+  type: 'session.turn.created';
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+};
+
+export type TlonHarnessErrorReportInput = {
+  harnessEventType: string;
+  errorScope: TlonHarnessErrorScope;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  accountId?: string | null;
+  agentId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  destinationKind?: TlonDestinationKind | null;
+  provider?: string | null;
+  model?: string | null;
+  toolName?: string | null;
+  phase?: string | null;
+  outcome?: string | null;
+  errorCategory?: string | null;
+  failureKind?: string | null;
+  durationMs?: number | null;
+  errorText?: string | null;
+};
+
+export type TlonHarnessDebugReportInput = {
+  harnessEventType: string;
+  debugEventKind: string;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  accountId?: string | null;
+  agentId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  destinationKind?: TlonDestinationKind | null;
+  provider?: string | null;
+  model?: string | null;
+  phase?: string | null;
+  outcome?: string | null;
+  durationMs?: number | null;
+  toolName?: string | null;
+  toolCallId?: string | null;
+  toolSource?: string | null;
+  toolOwner?: string | null;
+  pluginId?: string | null;
+  harnessId?: string | null;
+  modelCallId?: string | null;
+  modelApi?: string | null;
+  modelTransport?: string | null;
+  requestPayloadBytes?: number | null;
+  responseStreamBytes?: number | null;
+  timeToFirstByteMs?: number | null;
+  logLevel?: string | null;
+  message?: string | null;
+  loggerName?: string | null;
+  codeFunctionName?: string | null;
+  codeLine?: number | null;
+  logAttributes?: TlonDiagnosticLogAttributes | null;
+  contextEngineEvent?: string | null;
+  contextEngineTaskId?: string | null;
+  contextEngineOperation?: string | null;
+  contextEngineLane?: string | null;
+  errorName?: string | null;
+  errorCode?: string | null;
+  messageCount?: number | null;
+  historyTextChars?: number | null;
+  historyImageBlocks?: number | null;
+  maxMessageTextChars?: number | null;
+  systemPromptChars?: number | null;
+  promptChars?: number | null;
+  promptImages?: number | null;
+  contextTokenBudget?: number | null;
+  reserveTokens?: number | null;
+  contextChannel?: string | null;
+  contextTrigger?: string | null;
+};
+
+export type TlonPluginErrorReportInput = {
+  pluginErrorSource: TlonPluginErrorSource;
+  accountId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  errorKind?: string | null;
+  errorText: string;
+  attempt?: number | null;
+};
+
+export type TlonTelemetryErrorReportInput = {
+  telemetrySource: string;
+  sourceEventName?: string | null;
+  sessionKey?: string | null;
+  sessionId?: string | null;
+  runId?: string | null;
+  agentId?: string | null;
+  accountId?: string | null;
+  ownerShip?: string | null;
+  botShip?: string | null;
+  errorKind?: string | null;
+  errorText: string;
+};
+
+const outboundRouteReporterSlot = sharedSlot<OutboundRouteReporter>(
+  'telemetry.outboundRouteReporter'
+);
+const sessionTelemetryReporterSlot = sharedSlot<SessionTelemetryReporter>(
+  'telemetry.sessionTelemetryReporter'
+);
+const errorTelemetryReporterSlot = sharedSlot<ErrorTelemetryReporter>(
+  'telemetry.errorTelemetryReporter'
+);
+const debugTelemetryReporterSlot = sharedSlot<DebugTelemetryReporter>(
+  'telemetry.debugTelemetryReporter'
+);
+
+export function setOutboundRouteReporter(
+  reporter: OutboundRouteReporter | null
+): void {
+  outboundRouteReporterSlot.set(reporter);
+}
+
+export function reportOutboundRoute(event: TlonOutboundRouteEvent): void {
+  outboundRouteReporterSlot.get()?.(event);
+}
+
+export function setSessionTelemetryReporter(
+  reporter: SessionTelemetryReporter | null
+): void {
+  sessionTelemetryReporterSlot.set(reporter);
+}
+
+export function setErrorTelemetryReporter(
+  reporter: ErrorTelemetryReporter | null
+): void {
+  errorTelemetryReporterSlot.set(reporter);
+}
+
+export function setDebugTelemetryReporter(
+  reporter: DebugTelemetryReporter | null
+): void {
+  debugTelemetryReporterSlot.set(reporter);
+}
+
+function optionalString(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function optionalErrorText(value: string | null | undefined): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function optionalNumber(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
+const BLOCKED_DIAGNOSTIC_LOG_ATTRIBUTE_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+function normalizeLogAttributes(
+  value: TlonDiagnosticLogAttributes | null | undefined
+): TlonDiagnosticLogAttributes | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const normalized = Object.create(null) as TlonDiagnosticLogAttributes;
+  for (const [key, attributeValue] of Object.entries(value)) {
+    if (
+      BLOCKED_DIAGNOSTIC_LOG_ATTRIBUTE_KEYS.has(key) ||
+      !DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE.test(key)
+    ) {
+      continue;
+    }
+    if (typeof attributeValue === 'string') {
+      normalized[key] = attributeValue;
+      continue;
+    }
+    if (typeof attributeValue === 'boolean') {
+      normalized[key] = attributeValue;
+      continue;
+    }
+    if (typeof attributeValue === 'number' && Number.isFinite(attributeValue)) {
+      normalized[key] = attributeValue;
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+export function formatTlonTelemetryErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message || String(error);
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error === null) {
+    return 'null';
+  }
+
+  if (error === undefined) {
+    return 'undefined';
+  }
+
+  try {
+    const json = JSON.stringify(error);
+    if (json) {
+      return json;
+    }
+  } catch {
+    // Fall through to String(error).
+  }
+
+  return String(error);
+}
+
+export function reportSessionTurnCreated(
+  event: TlonSessionTurnCreatedReportInput
+): void {
+  const context = lookupTlonSessionContext(event.sessionKey);
+  if (!context) {
+    return;
+  }
+
+  updateTlonSessionContextRuntime(context, {
+    sessionId: event.sessionId,
+    runId: event.runId,
+    agentId: event.agentId,
+  });
+}
+
+export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextRuntime(rememberedContext, {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        agentId: event.agentId,
+      })
+    : null;
+  if (!context && event.sessionKey) {
+    return;
+  }
+
+  errorTelemetryReporterSlot.get()?.({
+    kind: 'harness',
+    event: {
+      harness: 'openclaw',
+      harnessEventType: event.harnessEventType,
+      errorScope: event.errorScope,
+      sessionKey: context?.sessionKey ?? null,
+      sessionId: context?.sessionId ?? optionalString(event.sessionId),
+      runId: optionalString(event.runId) ?? context?.runId ?? null,
+      accountId: context?.accountId ?? optionalString(event.accountId),
+      agentId: optionalString(event.agentId) ?? context?.agentId ?? null,
+      ownerShip: context?.ownerShip ?? optionalString(event.ownerShip),
+      botShip: context?.botShip ?? optionalString(event.botShip) ?? '',
+      destinationKind:
+        context?.destinationKind ?? event.destinationKind ?? null,
+      provider: optionalString(event.provider),
+      model: optionalString(event.model),
+      toolName: optionalString(event.toolName),
+      phase: optionalString(event.phase),
+      outcome: optionalString(event.outcome),
+      errorCategory: optionalString(event.errorCategory),
+      failureKind: optionalString(event.failureKind),
+      durationMs: optionalNumber(event.durationMs),
+      errorText: optionalErrorText(event.errorText),
+    },
+  });
+}
+
+export function reportHarnessDebug(event: TlonHarnessDebugReportInput): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextRuntime(rememberedContext, {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        agentId: event.agentId,
+      })
+    : null;
+  if (!context) {
+    return;
+  }
+
+  const logAttributes = normalizeLogAttributes(event.logAttributes);
+  const snapshot = updateHarnessDebugSnapshot(context.sessionKey, event);
+  debugTelemetryReporterSlot.get()?.({
+    harness: 'openclaw',
+    harnessEventType: event.harnessEventType,
+    debugEventKind: event.debugEventKind,
+    sessionKey: context.sessionKey,
+    sessionId: context.sessionId,
+    runId: optionalString(event.runId) ?? context.runId,
+    accountId: context.accountId ?? optionalString(event.accountId),
+    agentId: optionalString(event.agentId) ?? context.agentId,
+    ownerShip: context.ownerShip ?? optionalString(event.ownerShip),
+    botShip: context.botShip ?? optionalString(event.botShip) ?? '',
+    destinationKind: context.destinationKind ?? event.destinationKind ?? 'dm',
+    provider: optionalString(event.provider),
+    model: optionalString(event.model),
+    phase: optionalString(event.phase),
+    outcome: optionalString(event.outcome),
+    durationMs: optionalNumber(event.durationMs),
+    toolName: optionalString(event.toolName),
+    toolCallId: optionalString(event.toolCallId),
+    toolSource: optionalString(event.toolSource),
+    toolOwner: optionalString(event.toolOwner),
+    pluginId: optionalString(event.pluginId),
+    harnessId: optionalString(event.harnessId),
+    modelCallId: optionalString(event.modelCallId),
+    modelApi: optionalString(event.modelApi),
+    modelTransport: optionalString(event.modelTransport),
+    requestPayloadBytes: optionalNumber(event.requestPayloadBytes),
+    responseStreamBytes: optionalNumber(event.responseStreamBytes),
+    timeToFirstByteMs: optionalNumber(event.timeToFirstByteMs),
+    logLevel: optionalString(event.logLevel),
+    message: optionalString(event.message),
+    loggerName: optionalString(event.loggerName),
+    codeFunctionName: optionalString(event.codeFunctionName),
+    codeLine: optionalNumber(event.codeLine),
+    logAttributes,
+    contextEngineEvent: optionalString(event.contextEngineEvent),
+    contextEngineTaskId: optionalString(event.contextEngineTaskId),
+    contextEngineOperation: optionalString(event.contextEngineOperation),
+    contextEngineLane: optionalString(event.contextEngineLane),
+    errorName: optionalString(event.errorName),
+    errorCode: optionalString(event.errorCode),
+    messageCount: optionalNumber(event.messageCount),
+    historyTextChars: optionalNumber(event.historyTextChars),
+    historyImageBlocks: optionalNumber(event.historyImageBlocks),
+    maxMessageTextChars: optionalNumber(event.maxMessageTextChars),
+    systemPromptChars: optionalNumber(event.systemPromptChars),
+    promptChars: optionalNumber(event.promptChars),
+    promptImages: optionalNumber(event.promptImages),
+    contextTokenBudget: optionalNumber(event.contextTokenBudget),
+    reserveTokens: optionalNumber(event.reserveTokens),
+    contextChannel: optionalString(event.contextChannel),
+    contextTrigger: optionalString(event.contextTrigger),
+    ...snapshot,
+  });
+}
+
+export function reportPluginError(event: TlonPluginErrorReportInput): void {
+  errorTelemetryReporterSlot.get()?.({
+    kind: 'plugin',
+    event,
+  });
+}
+
+export function reportTelemetryError(
+  event: TlonTelemetryErrorReportInput
+): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextRuntime(rememberedContext, {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        agentId: event.agentId,
+      })
+    : null;
+
+  errorTelemetryReporterSlot.get()?.({
+    kind: 'telemetry',
+    event: {
+      ...event,
+      sessionKey: context?.sessionKey ?? optionalString(event.sessionKey),
+      sessionId: context?.sessionId ?? optionalString(event.sessionId),
+      runId: optionalString(event.runId) ?? context?.runId ?? null,
+      agentId: optionalString(event.agentId) ?? context?.agentId ?? null,
+      accountId: event.accountId ?? context?.accountId ?? null,
+      ownerShip: event.ownerShip ?? context?.ownerShip ?? null,
+      botShip: event.botShip ?? context?.botShip ?? null,
+      sourceEventName: optionalString(event.sourceEventName),
+      errorKind: optionalString(event.errorKind),
+    },
+  });
+}
+
+export function reportSessionLifecycle(
+  event: TlonSessionLifecycleReportInput
+): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextSessionId(rememberedContext, event.sessionId)
+    : null;
+  if (!context) {
+    return;
+  }
+
+  sessionTelemetryReporterSlot.get()?.({
+    kind: 'lifecycle',
+    event: {
+      lifecycleEvent: event.lifecycleEvent,
+      sessionKey: context.sessionKey,
+      sessionId: context.sessionId,
+      accountId: context.accountId,
+      agentId: optionalString(event.agentId) ?? context.agentId,
+      ownerShip: context.ownerShip,
+      botShip: context.botShip,
+      destinationKind: context.destinationKind,
+      reason: optionalString(event.reason),
+      messageCount: optionalNumber(event.messageCount),
+      durationMs: optionalNumber(event.durationMs),
+      transcriptArchived:
+        typeof event.transcriptArchived === 'boolean'
+          ? event.transcriptArchived
+          : null,
+      hasNextSession: event.hasNextSession === true,
+    },
+  });
+}
+
+export function reportSessionDiagnostic(
+  event: TlonSessionDiagnosticReportInput
+): void {
+  const rememberedContext = lookupTlonSessionContext(event.sessionKey);
+  const context = rememberedContext
+    ? updateTlonSessionContextSessionId(rememberedContext, event.sessionId)
+    : null;
+  if (!context) {
+    return;
+  }
+  const harnessDebugSnapshot = lookupHarnessDebugSnapshotFields(
+    context.sessionKey
+  );
+
+  if (event.type === 'session.stalled' || event.type === 'session.stuck') {
+    sessionTelemetryReporterSlot.get()?.({
+      kind: 'watchdog',
+      event: {
+        diagnosticType: event.type,
+        sessionKey: context.sessionKey,
+        sessionId: context.sessionId,
+        accountId: context.accountId,
+        agentId: context.agentId,
+        ownerShip: context.ownerShip,
+        botShip: context.botShip,
+        destinationKind: context.destinationKind,
+        state: event.state,
+        ageMs: event.ageMs,
+        queueDepth: optionalNumber(event.queueDepth),
+        reason: optionalString(event.reason),
+        classification: event.classification,
+        activeWorkKind: optionalString(event.activeWorkKind),
+        lastProgressAgeMs: optionalNumber(event.lastProgressAgeMs),
+        lastProgressReason: optionalString(event.lastProgressReason),
+        activeToolName: optionalString(event.activeToolName),
+        activeToolAgeMs: optionalNumber(event.activeToolAgeMs),
+        terminalProgressStale: event.terminalProgressStale === true,
+        ...harnessDebugSnapshot,
+      },
+    });
+    return;
+  }
+
+  const recoveryEvent = event as Extract<
+    TlonSessionDiagnosticReportInput,
+    {
+      type: 'session.recovery.requested' | 'session.recovery.completed';
+    }
+  >;
+
+  sessionTelemetryReporterSlot.get()?.({
+    kind: 'recovery',
+    event: {
+      diagnosticType: recoveryEvent.type,
+      sessionKey: context.sessionKey,
+      sessionId: context.sessionId,
+      accountId: context.accountId,
+      agentId: context.agentId,
+      ownerShip: context.ownerShip,
+      botShip: context.botShip,
+      destinationKind: context.destinationKind,
+      state: recoveryEvent.state,
+      stateGeneration: optionalNumber(recoveryEvent.stateGeneration),
+      ageMs: recoveryEvent.ageMs,
+      queueDepth: optionalNumber(recoveryEvent.queueDepth),
+      reason: optionalString(recoveryEvent.reason),
+      activeWorkKind: optionalString(recoveryEvent.activeWorkKind),
+      allowActiveAbort: recoveryEvent.allowActiveAbort === true,
+      status: optionalString(recoveryEvent.status),
+      action: optionalString(recoveryEvent.action),
+      outcomeReason: optionalString(recoveryEvent.outcomeReason),
+      released: optionalNumber(recoveryEvent.released),
+      stale: recoveryEvent.stale === true,
+      ...harnessDebugSnapshot,
+    },
+  });
+}
+
 export const _testing = {
   clearToolCalls: () => toolCallsBySession.clear(),
+  clearSessionContexts: () => sessionContextsBySessionKey.clear(),
+  clearHarnessDebugSnapshots: () => harnessDebugSnapshotsBySessionKey.clear(),
+  getReplyTraceTtlMs: () => REPLY_TRACE_TTL_MS,
   getToolTraceTtlMs: () => TOOL_TRACE_TTL_MS,
 };

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -224,6 +224,14 @@ export type TlonOutboundRouteEvent = {
   resolvedChannel: string;
   routedToTlon: boolean;
   targetKind: 'dm' | 'group' | 'unknown';
+  /**
+   * Which Tlon account produced the send, from the `message_sending` hook
+   * context. The reporter slot is process-global (one slot, last registrar
+   * wins), so the owner/bot ship must be resolved from this rather than the
+   * registering monitor's closure, or every account's routes get attributed
+   * to whichever monitor registered last.
+   */
+  accountId?: string | null;
 };
 
 export type TlonSessionLifecycleEvent = {

--- a/packages/openclaw/src/tlon-tool-guard.test.ts
+++ b/packages/openclaw/src/tlon-tool-guard.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
-import { checkBlockedSendOperation } from './tlon-tool-guard.js';
+import {
+  checkBlockedSendOperation,
+  formatAllowedTlonSubcommands,
+  isAllowedTlonSubcommand,
+} from './tlon-tool-guard.js';
 
 describe('tlon tool guard', () => {
+  describe('allowed subcommands', () => {
+    it('allows notes commands through the tlon tool gate', () => {
+      expect(isAllowedTlonSubcommand('notes')).toBe(true);
+      expect(formatAllowedTlonSubcommands()).toContain('notes');
+    });
+
+    it('keeps notebook allowed for skill-level removal guidance', () => {
+      expect(isAllowedTlonSubcommand('notebook')).toBe(true);
+    });
+  });
+
   describe('blocks non-club dms send/reply', () => {
     it('blocks dms send with a ship target', () => {
       const result = checkBlockedSendOperation([
@@ -109,6 +124,12 @@ describe('tlon tool guard', () => {
   });
 
   describe('allows other subcommands', () => {
+    it('allows notes', () => {
+      expect(
+        checkBlockedSendOperation(['notes', 'list', 'notes/~host/slug'])
+      ).toBeNull();
+    });
+
     it('allows notebook', () => {
       expect(
         checkBlockedSendOperation(['notebook', 'diary/~host/slug', 'Title'])

--- a/packages/openclaw/src/tlon-tool-guard.ts
+++ b/packages/openclaw/src/tlon-tool-guard.ts
@@ -6,6 +6,36 @@
  * compatibility — clubs are deprecated and slated for removal audit.
  */
 
+export const ALLOWED_TLON_COMMANDS = [
+  'activity',
+  'channels',
+  'contacts',
+  'dms',
+  'expose',
+  'groups',
+  'hooks',
+  'messages',
+  'notes',
+  'notebook',
+  'posts',
+  'settings',
+  'upload',
+  'help',
+  'version',
+] as const;
+
+const ALLOWED_TLON_COMMAND_SET = new Set<string>(ALLOWED_TLON_COMMANDS);
+
+export function isAllowedTlonSubcommand(
+  subcommand: string | undefined
+): boolean {
+  return subcommand != null && ALLOWED_TLON_COMMAND_SET.has(subcommand);
+}
+
+export function formatAllowedTlonSubcommands(): string {
+  return ALLOWED_TLON_COMMANDS.join(', ');
+}
+
 /** DM sub-operations that are send actions (not management). */
 const DM_SEND_ACTIONS = new Set(['send', 'reply']);
 

--- a/packages/openclaw/src/types.test.ts
+++ b/packages/openclaw/src/types.test.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
 import { describe, expect, it } from 'vitest';
 
-import { resolveTlonAccount } from './types.js';
+import { resolveLensAccountId, resolveTlonAccount } from './types.js';
 
 describe('resolveTlonAccount telemetry', () => {
   it('defaults telemetry to disabled', () => {
@@ -278,5 +278,71 @@ describe('resolveTlonAccount contextLens', () => {
       owners: [],
       store: { enabled: true, path: null, retainDays: null, maxStored: null },
     });
+  });
+});
+
+describe('resolveLensAccountId', () => {
+  it('returns null when no account enables the lens', () => {
+    expect(
+      resolveLensAccountId({
+        channels: {
+          tlon: { ship: '~zod', url: 'https://example.com', code: 'code-123' },
+        },
+      } as OpenClawConfig)
+    ).toBeNull();
+  });
+
+  it('prefers the default account when it enables the lens', () => {
+    expect(
+      resolveLensAccountId({
+        channels: {
+          tlon: {
+            ship: '~zod',
+            url: 'https://example.com',
+            code: 'code-123',
+            contextLens: {
+              enabled: true,
+              authToken: 'a-token-of-sufficient-length',
+            },
+            accounts: {
+              hosted: {
+                ship: '~bus',
+                url: 'https://hosted.example.com',
+                code: 'code-456',
+                contextLens: {
+                  enabled: true,
+                  authToken: 'another-token-of-sufficient-length',
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig)
+    ).toBe('default');
+  });
+
+  it('finds a named account when the lens is configured only there', () => {
+    expect(
+      resolveLensAccountId({
+        channels: {
+          tlon: {
+            ship: '~zod',
+            url: 'https://example.com',
+            code: 'code-123',
+            accounts: {
+              hosted: {
+                ship: '~bus',
+                url: 'https://hosted.example.com',
+                code: 'code-456',
+                contextLens: {
+                  enabled: true,
+                  authToken: 'a-token-of-sufficient-length',
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig)
+    ).toBe('hosted');
   });
 });

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -27,7 +27,7 @@ export type TlonContextLensConfig = {
   visibilityDefault: TlonContextLensVisibility;
   authToken: string | null;
   allowedOrigins: string[];
-  /** Owner ships receiving run records via %context-lens ship sync; empty falls back to ownerShip. */
+  /** Owner ships receiving run records via %steward ship sync; empty falls back to ownerShip. %steward stores a singular owner, so only the first entry is used (others are logged and ignored). */
   owners: string[];
   store: TlonContextLensStoreConfig;
 };
@@ -326,7 +326,7 @@ export function resolveTlonAccount(
 /**
  * Context lens is effectively on only when enabled AND at least one reader
  * path exists: an auth token (gateway HTTP/SSE routes) or owner ships
- * (%context-lens ship sync). Without either, recording and blob stamping would
+ * (%steward ship sync). Without either, recording and blob stamping would
  * produce data nothing can read.
  */
 export function isContextLensEnabled(

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -345,6 +345,24 @@ export function isContextLensEnabled(
   );
 }
 
+/**
+ * Context-lens global services (HTTP routes, disk store, %steward ship sync)
+ * are process-global and single-config-shaped: one server, one JSONL, one
+ * owner. They must resolve against the account that actually turns the lens
+ * on, which is not necessarily `default` — a config can enable the lens under
+ * a named account with no top-level block.
+ *
+ * Returns the id of the first effectively-enabled lens account, preferring
+ * `default`, or null when no account enables the lens.
+ */
+export function resolveLensAccountId(cfg: OpenClawConfig): string | null {
+  const ids = listTlonAccountIds(cfg);
+  if (ids.includes('default') && isContextLensEnabled(cfg, 'default')) {
+    return 'default';
+  }
+  return ids.find((id) => isContextLensEnabled(cfg, id)) ?? null;
+}
+
 export function listTlonAccountIds(cfg: OpenClawConfig): string[] {
   const base = cfg.channels?.tlon as
     | { ship?: string; accounts?: Record<string, Record<string, unknown>> }

--- a/packages/openclaw/src/version.ts
+++ b/packages/openclaw/src/version.ts
@@ -1,0 +1,191 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { sharedSlot } from './shared-state.js';
+import { PLUGIN_COMMIT, PLUGIN_VERSION } from './version.generated.js';
+
+const HARNESS = 'openclaw' as const;
+const FINGERPRINT_RULE = 'fp1';
+const FINGERPRINT_HEX_CHARS = 12;
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+export type TlonVersionIdentity = {
+  harness: typeof HARNESS;
+  pluginVersion: string;
+  pluginCommit: string;
+  pluginFingerprint: string;
+  adapterVersion: string;
+  adapterFingerprint: string;
+};
+
+type TlonSkillVersionResolver = () => Promise<string>;
+
+const tlonSkillVersionResolverSlot = sharedSlot<TlonSkillVersionResolver>(
+  'version.tlonSkillVersionResolver'
+);
+const tlonSkillVersionSlot = sharedSlot<string>('version.tlonSkillVersion');
+
+function findPackageRoot(startDir = moduleDir): string {
+  let dir = startDir;
+  for (let i = 0; i < 6; i += 1) {
+    if (existsSync(join(dir, 'package.json'))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return startDir;
+}
+
+function walkFiles(
+  dir: string,
+  predicate: (path: string) => boolean
+): string[] {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, predicate));
+    } else if (entry.isFile() && predicate(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function sourceRuntimeFiles(packageRoot: string): string[] {
+  const roots = ['index.ts', 'setup-entry.ts', 'setup-api.ts']
+    .map((name) => join(packageRoot, name))
+    .filter(existsSync);
+  const srcFiles = walkFiles(
+    join(packageRoot, 'src'),
+    (path) =>
+      path.endsWith('.ts') &&
+      !path.endsWith('.test.ts') &&
+      basename(path) !== 'version.generated.ts'
+  );
+  return [...roots, ...srcFiles].sort();
+}
+
+function distRuntimeFiles(packageRoot: string): string[] {
+  return walkFiles(
+    join(packageRoot, 'dist'),
+    (path) => path.endsWith('.js') && basename(path) !== 'version.generated.js'
+  ).sort();
+}
+
+function isWithin(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function runtimeFiles(
+  packageRoot: string,
+  currentModuleDir = moduleDir
+): string[] {
+  const distFiles = distRuntimeFiles(packageRoot);
+  if (
+    distFiles.length > 0 &&
+    isWithin(join(packageRoot, 'dist'), currentModuleDir)
+  ) {
+    return distFiles;
+  }
+
+  const sourceFiles = sourceRuntimeFiles(packageRoot);
+  return sourceFiles.length > 0 ? sourceFiles : distFiles;
+}
+
+function contentFingerprint(packageRoot = findPackageRoot()): string {
+  const digest = createHash('sha256');
+  const files = runtimeFiles(packageRoot);
+
+  for (const file of files) {
+    digest.update(relative(packageRoot, file).replaceAll('\\', '/'));
+    digest.update('\0');
+    try {
+      digest.update(readFileSync(file));
+    } catch {
+      digest.update('<unreadable>');
+    }
+    digest.update('\0');
+  }
+
+  return `${FINGERPRINT_RULE}:${digest.digest('hex').slice(0, FINGERPRINT_HEX_CHARS)}`;
+}
+
+const pluginFingerprint = contentFingerprint();
+
+const VERSION_IDENTITY: TlonVersionIdentity = {
+  harness: HARNESS,
+  pluginVersion: PLUGIN_VERSION || 'unknown',
+  pluginCommit: PLUGIN_COMMIT || 'unknown',
+  pluginFingerprint,
+  // Hermes uses adapter* names. Keep the same fields on OpenClaw events so
+  // shared PostHog charts can group both harnesses without special casing.
+  adapterVersion: PLUGIN_VERSION || 'unknown',
+  adapterFingerprint: pluginFingerprint,
+};
+
+export function getTlonVersionIdentity(): TlonVersionIdentity {
+  return VERSION_IDENTITY;
+}
+
+export function setTlonSkillVersionResolver(
+  resolver: TlonSkillVersionResolver | null
+): void {
+  tlonSkillVersionResolverSlot.set(resolver);
+  tlonSkillVersionSlot.set(null);
+}
+
+export function getKnownTlonSkillVersion(): string {
+  return tlonSkillVersionSlot.get() ?? 'unknown';
+}
+
+export async function resolveTlonSkillVersion(): Promise<string> {
+  const cached = tlonSkillVersionSlot.get();
+  if (cached) {
+    return cached;
+  }
+
+  const resolver = tlonSkillVersionResolverSlot.get();
+  if (!resolver) {
+    return 'unknown';
+  }
+
+  const version = await resolver();
+  tlonSkillVersionSlot.set(version || 'unknown');
+  return tlonSkillVersionSlot.get() ?? 'unknown';
+}
+
+export function formatTlonVersionIdentity(options?: {
+  markdown?: boolean;
+  tlonSkillVersion?: string | null;
+}): string {
+  const markdown = options?.markdown ?? true;
+  const identity = getTlonVersionIdentity();
+  const tlonSkillVersion =
+    options?.tlonSkillVersion?.trim() || getKnownTlonSkillVersion();
+  const source =
+    identity.pluginCommit === 'unknown'
+      ? 'no git checkout'
+      : identity.pluginCommit;
+  const row = (label: string, value: string) =>
+    markdown ? `*${label}*: **${value}**` : `${label}: ${value}`;
+
+  return [
+    row('Harness', 'OpenClaw'),
+    row('Adapter Version', identity.pluginVersion),
+    row('Tlon Skill', tlonSkillVersion),
+    row('Fingerprint', identity.pluginFingerprint),
+    row('Source', source),
+  ].join('\n');
+}

--- a/packages/openclaw/test/cases/01-messages.test.ts
+++ b/packages/openclaw/test/cases/01-messages.test.ts
@@ -18,6 +18,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import {
   type TestFixtures,
   getFixtures,
+  registerEngagingTurn,
   requireFixtureGroup,
   waitFor,
 } from '../lib/index.js';
@@ -161,10 +162,26 @@ describe('messages', () => {
     test('processes a DM thread reply', async () => {
       // Owner sends a parent DM, then replies to it. The plugin should
       // hand the reply to the agent loop — verify via _received.
+      //
+      // The parent gets its OWN script key (not the reply's). Owner DMs always
+      // engage the model, so an *untagged* parent would inherit the last
+      // [tlon-test:KEY] still sitting in the shared ~ten DM session history
+      // (e.g. the previous test's `post-channel-basic`) and misroute. Tagging
+      // the parent with a distinct key keeps the *reply* assertion clean
+      // (still keyed on `dm-thread-reply`) while removing that bleed.
+      // registerEngagingTurn defaults to allowExtraCalls: 1 because these
+      // engaging DM flows make one trailing model turn beyond their text reply.
+      const parentKey = 'dm-thread-parent';
       const parentToken = `it-dm-parent-${Date.now().toString(36)}`;
+      // Give the parent a UNIQUE reply text so we can wait for the bot to
+      // actually deliver it (i.e. the parent run completed), not merely started.
+      const parentAck = `parent-ack-${parentToken}`;
+      const parentTag = await registerEngagingTurn(parentKey, [
+        { kind: 'text', content: parentAck },
+      ]);
       await fixtures.userState.sendPost({
         channelId: fixtures.botShip,
-        content: story(`parent ${parentToken}`),
+        content: story(`${parentTag} parent ${parentToken}`),
       });
 
       // Poll for the parent post to land on the BOT'S view of the DM channel.
@@ -187,8 +204,28 @@ describe('messages', () => {
         return found?.id ? found : undefined;
       }, 30_000);
 
+      // Wait for the parent RUN to fully settle — the bot has DELIVERED its
+      // reply — before sending the thread reply. Waiting only on the first
+      // recorded model call proves the run started, not that it finished, so
+      // the reply could still race a mid-flight parent run. Serializing on
+      // delivery keeps this a harness-correctness test, not an I2 concurrency
+      // test.
+      await waitFor(async () => {
+        const posts = await fixtures.botState.channelPosts(
+          fixtures.userShip,
+          10
+        );
+        const delivered = (posts ?? []).some((p) => {
+          const pp = p as PostLike;
+          return (
+            pp.authorId === fixtures.botShip && postText(pp).includes(parentAck)
+          );
+        });
+        return delivered ? true : undefined;
+      }, 30_000);
+
       const key = 'dm-thread-reply';
-      await fakeModel.script(key, [
+      const replyTag = await registerEngagingTurn(key, [
         { kind: 'text', content: 'Got your thread reply' },
       ]);
 
@@ -196,7 +233,7 @@ describe('messages', () => {
         channelId: fixtures.botShip,
         parentId: String(parent.id),
         parentAuthor: fixtures.userShip,
-        content: story(`[tlon-test:${key}] reply body`),
+        content: story(`${replyTag} reply body`),
       });
 
       const calls = await waitFor(async () => {

--- a/packages/openclaw/test/cases/03-heartbeat.test.ts
+++ b/packages/openclaw/test/cases/03-heartbeat.test.ts
@@ -16,6 +16,7 @@ import {
   type StateClient,
   createStateClient,
   getTestConfig,
+  registerEngagingTurn,
   waitFor,
 } from '../lib/index.js';
 import {
@@ -187,7 +188,11 @@ describe('re-engagement nudges', () => {
     // Phase 2: owner replies. The plugin's owner-reply handler should clear
     // `lastNudgeStage` so the next inactivity cycle can re-send stage 1.
     const { markdownToStory } = await import('../../src/urbit/story.js');
-    const replyText = `heartbeat-reply-${Date.now()}`;
+    // Owner DMs always engage the model; tag this reply with its own key so it
+    // can't inherit a stale [tlon-test:KEY] from the shared owner DM session
+    // history. The assertion below is on lastNudgeStage state, not this reply.
+    const replyTag = await registerEngagingTurn('heartbeat-owner-reply');
+    const replyText = `${replyTag} heartbeat-reply-${Date.now()}`;
     await ownerState.sendPost({
       channelId: botShip,
       content: markdownToStory(replyText),

--- a/packages/openclaw/test/cases/07-blobs.test.ts
+++ b/packages/openclaw/test/cases/07-blobs.test.ts
@@ -22,6 +22,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 import {
   type TestFixtures,
   getFixtures,
+  registerEngagingTurn,
   requireFixtureGroup,
   waitFor,
 } from '../lib/index.js';
@@ -101,7 +102,8 @@ describe('blobs', () => {
     viewer: TestFixtures['userState'],
     channelId: string,
     authorId: string,
-    bodySubstring: string
+    bodySubstring: string,
+    timeoutMs = 10_000
   ): Promise<{ id: string }> {
     return waitFor(async () => {
       const posts = await viewer.channelPosts(channelId, 10);
@@ -117,7 +119,7 @@ describe('blobs', () => {
         );
       }) as { id?: string } | undefined;
       return found?.id ? { id: found.id } : undefined;
-    }, 10_000);
+    }, timeoutMs);
   }
 
   // ── DM tests ─────────────────────────────────────────────────────────
@@ -160,21 +162,39 @@ describe('blobs', () => {
     const parentMarker = `parent-${transcriptionToken}`;
     await fakeModel.script(key, [{ kind: 'text', content: 'got the reply' }]);
 
-    // Parent post is a thread anchor only — UNTAGGED and NO blob. The
-    // bot will still process it (owner DMs always engage) but that call
-    // hits the fake-model without a [tlon-test:KEY] tag and is recorded
-    // under key=null, so it can't satisfy fakeModel.received(key) below.
-    // This guarantees the assertion is about the REPLY path, not the
-    // parent path.
+    // Parent post is a thread anchor only (NO blob). Owner DMs always engage
+    // the model, so the parent gets its OWN key — otherwise it would inherit
+    // the last [tlon-test:KEY] still in the shared ~ten DM session history and
+    // misroute. A distinct key keeps the assertion about the REPLY path
+    // (`fakeModel.received(key)` below) while not bleeding a foreign key.
+    const parentKey = 'blob-dm-reply-parent';
+    // Unique reply text so we can wait for the bot to actually DELIVER the
+    // parent reply (run completed), not merely start it.
+    const parentAck = `blob-parent-ack-${Date.now().toString(36)}`;
+    const parentTag = await registerEngagingTurn(parentKey, [
+      { kind: 'text', content: parentAck },
+    ]);
     await fixtures.userState.sendPost({
       channelId: fixtures.botShip,
-      content: storyText(parentMarker),
+      content: storyText(`${parentTag} ${parentMarker}`),
     });
     const parent = await findParentPost(
       fixtures.userState,
       fixtures.botShip,
       fixtures.userShip,
       parentMarker
+    );
+    // Wait for the parent RUN to fully settle (bot delivered its reply) before
+    // sending the thread reply, so this stays a harness-correctness test rather
+    // than an I2 concurrency test. Use a 30s budget (not findParentPost's 10s
+    // default) — this is a full model round-trip delivery, matching the DM-thread
+    // test's parent-settle wait, and 10s can be too tight under CI load.
+    await findParentPost(
+      fixtures.userState,
+      fixtures.botShip,
+      fixtures.botShip,
+      parentAck,
+      30_000
     );
 
     await fixtures.userState.sendReply({

--- a/packages/openclaw/test/lib/client.ts
+++ b/packages/openclaw/test/lib/client.ts
@@ -145,16 +145,21 @@ export function createTlonClient(config: TlonClientConfig): TestClient {
     throw new Error(`Failed to send DM after 3 attempts: ${lastSendError}`);
   };
 
-  /** Best-effort `/stop` to drain the bot after a timeout. */
+  /**
+   * Timeout cleanup hook. Deliberately does NOT send an in-band `/stop`.
+   *
+   * `/stop` rides the same `processMessage()` DM path as any other message
+   * (the monitor has no out-of-band `/stop` escape hatch), so on a timeout —
+   * exactly when the session is stuck or draining — it just queues behind the
+   * run we're failing on and becomes another stale message that bleeds into a
+   * later test. The fake-model's provenance-aware routing already neutralizes a
+   * stale tag carried over on session history, so the old in-band `/stop` + 3s
+   * sleep only added contamination.
+   */
   const bestEffortStopAfterTimeout = async (): Promise<void> => {
-    try {
-      console.log(`[timeout cleanup] sending /stop to ${bot.shipName}`);
-      await sendDmWithRetry('/stop');
-      await sleep(3000);
-      console.log(`[timeout cleanup] /stop sent; gave it 3s to drain`);
-    } catch (err) {
-      console.log(`[timeout cleanup] failed to send /stop: ${String(err)}`);
-    }
+    console.log(
+      `[timeout cleanup] not sending /stop (in-band; would poison the session)`
+    );
   };
 
   return {
@@ -301,7 +306,7 @@ export function createTlonClient(config: TlonClientConfig): TestClient {
           `Timeout waiting for bot response after ${timeoutMs}ms ` +
           `(attempts=${attempts}, baselineSequence=${baselineSequence}` +
           (lastPollError ? `, lastPollError=${lastPollError}` : '') +
-          `; sent /stop for cleanup)`;
+          `)`;
         console.log(`[TEST] Response success: false`);
         console.log(
           `[TEST] Response text: ${JSON.stringify(timeoutError.slice(0, 500))}`

--- a/packages/openclaw/test/lib/fixtures.ts
+++ b/packages/openclaw/test/lib/fixtures.ts
@@ -10,6 +10,7 @@ import {
   createTlonClient,
 } from './client.js';
 import { getTestConfig } from './config.js';
+import { registerEngagingTurn } from './scripted.js';
 import { type StateClient, createStateClient } from './state.js';
 
 export interface TestFixtures {
@@ -317,9 +318,13 @@ export async function ensureThirdPartyDmAccess(
     return;
   }
 
+  // Tag the probe with its own key. This is a model-engaging owner-style DM,
+  // so an untagged version would inherit the last [tlon-test:KEY] in the
+  // third-party DM session history and misroute (the bleed Bucket 2 removes).
   const probeToken = `fixture-dm-check-${Date.now().toString(36)}`;
+  const probeTag = await registerEngagingTurn('fixture-thirdparty-probe');
   const probeResponse = await thirdPartyClient.prompt(
-    `Hello, this is a DM access check for integration tests. Reply with "${probeToken}".`,
+    `${probeTag} Hello, this is a DM access check for integration tests. Reply with "${probeToken}".`,
     { timeoutMs: 45_000 }
   );
 
@@ -355,8 +360,9 @@ export async function ensureThirdPartyDmAccess(
   );
 
   const confirmToken = `fixture-dm-confirm-${Date.now().toString(36)}`;
+  const confirmTag = await registerEngagingTurn('fixture-thirdparty-confirm');
   const confirmResponse = await thirdPartyClient.prompt(
-    `Hello again, this is a DM access confirmation. Reply with "${confirmToken}".`,
+    `${confirmTag} Hello again, this is a DM access confirmation. Reply with "${confirmToken}".`,
     { timeoutMs: 60_000 }
   );
 

--- a/packages/openclaw/test/lib/index.ts
+++ b/packages/openclaw/test/lib/index.ts
@@ -22,6 +22,8 @@ export {
 
 export { getTestConfig, type TestEnvConfig } from './config.js';
 
+export { registerEngagingTurn } from './scripted.js';
+
 export {
   waitFor,
   getFixtures,

--- a/packages/openclaw/test/lib/scripted.ts
+++ b/packages/openclaw/test/lib/scripted.ts
@@ -1,0 +1,40 @@
+/**
+ * Helpers for model-engaging test turns.
+ *
+ * Any message that engages the bot's agent loop (owner DMs always do; @mentions
+ * and thread replies in watched channels do) becomes a model call. openclaw
+ * re-sends the whole conversation history on every call and DMs share one
+ * long-lived per-peer session, so an *untagged* engaging turn inherits the last
+ * `[tlon-test:KEY]` tag still sitting in history — typically a prior test's key
+ * — and misroutes (see bucket2-redesign.md).
+ *
+ * The durable fix is server-side (provenance-aware key selection + benign
+ * handling of stale prior-epoch tags). This helper is the front-line fix: give
+ * every engaging setup turn (thread-anchor parents, probes) its OWN key so it
+ * never inherits a foreign one. A grep for raw `sendPost` / `sendReply` /
+ * `sendDm` / `prompt` then becomes a review tool for the intentional, knowingly
+ * non-engaging exceptions, rather than the audit itself.
+ */
+import {
+  type ScriptOptions,
+  type Step,
+  fakeModel,
+} from '../support/fake-model/client.js';
+
+const DEFAULT_ACK: Step[] = [{ kind: 'text', content: 'ack' }];
+
+/**
+ * Register a (benign by default) script for `key` and return the
+ * `[tlon-test:KEY]` tag to embed in the engaging turn's content.
+ *
+ * Defaults to `allowExtraCalls: 1` because these engaging flows make one
+ * trailing model turn beyond their single text response.
+ */
+export async function registerEngagingTurn(
+  key: string,
+  steps: Step[] = DEFAULT_ACK,
+  opts: ScriptOptions = { allowExtraCalls: 1 }
+): Promise<string> {
+  await fakeModel.script(key, steps, opts);
+  return `[tlon-test:${key}]`;
+}

--- a/packages/openclaw/test/support/fake-model/client.ts
+++ b/packages/openclaw/test/support/fake-model/client.ts
@@ -20,11 +20,37 @@
  *   await fixtures.client.prompt(
  *     `[tlon-test:post-channel-basic] post something into the channel`,
  *   );
+ *
+ * Trailing / extra model calls: some flows make ONE more model turn than they
+ * have logical responses (e.g. a DM reply that emits its text and then makes a
+ * trailing turn). By default an extra call past the last scripted step is a
+ * loud 400 (it usually means a test under-specified its flow). A flow that
+ * legitimately makes a bounded number of extra turns opts in explicitly:
+ *
+ *   await fakeModel.script(key, [{ kind: "text", content: "ack" }], {
+ *     allowExtraCalls: 1,
+ *   });
+ *
+ * Stale-history bleed is handled server-side: openclaw re-sends conversation
+ * history and DMs share one per-peer session, so an old `[tlon-test:KEY]` tag
+ * can ride into a later, untagged engaging turn. The server selects the script
+ * by the tag on the *latest user turn* first, and treats a prior-epoch tag that
+ * is no longer registered as a benign no-op (flagged `stale`) rather than a
+ * 400. See bucket2-redesign.md §4.
  */
 
 export type Step =
   | { kind: 'text'; content: string }
   | { kind: 'tool_call'; name: string; args: Record<string, unknown> };
+
+export interface ScriptOptions {
+  /**
+   * Number of model calls past the last scripted step to tolerate, returning
+   * benign filler (200) instead of a 400. Use for a flow that legitimately
+   * makes a trailing model turn. Default 0 (exhaustion is a loud 400).
+   */
+  allowExtraCalls?: number;
+}
 
 const baseUrl = (() => {
   const fromEnv = process.env.FAKE_MODEL_BASE_URL;
@@ -34,11 +60,19 @@ const baseUrl = (() => {
   return 'http://localhost:4000';
 })();
 
-async function postScript(key: string, steps: Step[]): Promise<void> {
+async function postScript(
+  key: string,
+  steps: Step[],
+  opts: ScriptOptions = {}
+): Promise<void> {
   const res = await fetch(`${baseUrl}/v1/_scripts`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ key, steps }),
+    body: JSON.stringify({
+      key,
+      steps,
+      allowExtraCalls: opts.allowExtraCalls ?? 0,
+    }),
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => '');
@@ -57,7 +91,7 @@ async function deleteScripts(): Promise<void> {
 }
 
 export interface ReceivedCall {
-  /** [tlon-test:KEY] tag found in the request, or null if no tag. */
+  /** [tlon-test:KEY] tag selected for the request, or null if none. */
   key: string | null;
   /** Server-side timestamp (ms) when the call arrived. */
   at: number;
@@ -75,9 +109,28 @@ export interface ReceivedCall {
    * replied with something".
    */
   userText: string;
+  /** Epoch (reset generation) the server was in when the call arrived. */
+  epoch: number;
+  /** Epoch in which this call's key was last registered, or null if never. */
+  registeredEpoch: number | null;
+  /**
+   * True when `epoch > registeredEpoch` — a reset() ran between the key's
+   * registration and this call's arrival, so the tag rode in on re-sent
+   * session history from a prior test. A DIAGNOSTIC classification only: the
+   * server serves such calls benignly (it does not 400 on them).
+   */
+  stale: boolean;
+  /**
+   * How the key was selected: 'latest-user' (tag on the newest user turn),
+   * 'history-active' (continuation; last historical tag still registered),
+   * 'history-inactive' (last historical tag no longer registered), or 'none'.
+   */
+  provenance: 'latest-user' | 'history-active' | 'history-inactive' | 'none';
 }
 
-async function getReceivedCalls(key?: string): Promise<ReceivedCall[]> {
+async function getReceived(
+  key?: string
+): Promise<{ calls: ReceivedCall[]; epoch: number }> {
   const url = key
     ? `${baseUrl}/v1/_received?key=${encodeURIComponent(key)}`
     : `${baseUrl}/v1/_received`;
@@ -86,8 +139,22 @@ async function getReceivedCalls(key?: string): Promise<ReceivedCall[]> {
     const detail = await res.text().catch(() => '');
     throw new Error(`fakeModel.received failed: ${res.status} ${detail}`);
   }
-  const body = (await res.json()) as { calls?: ReceivedCall[] };
-  return body.calls ?? [];
+  const body = (await res.json()) as { calls?: ReceivedCall[]; epoch?: number };
+  return { calls: body.calls ?? [], epoch: body.epoch ?? 0 };
+}
+
+async function getReceivedCalls(key?: string): Promise<ReceivedCall[]> {
+  return (await getReceived(key)).calls;
+}
+
+/**
+ * All cross-epoch (stale) calls recorded since the last reset. Use to REPORT
+ * stale-history bleed by class in verification — not as a hard assertion, since
+ * a stale call is served benignly and is an inherent (harmless) consequence of
+ * untagged engaging turns + persistent session history.
+ */
+async function getStaleCalls(): Promise<ReceivedCall[]> {
+  return (await getReceivedCalls()).filter((c) => c.stale);
 }
 
 export const fakeModel = {
@@ -95,4 +162,5 @@ export const fakeModel = {
   script: postScript,
   reset: deleteScripts,
   received: getReceivedCalls,
+  staleCalls: getStaleCalls,
 };

--- a/packages/openclaw/test/support/fake-model/server.mjs
+++ b/packages/openclaw/test/support/fake-model/server.mjs
@@ -1,5 +1,5 @@
-import crypto from "node:crypto";
-import http from "node:http";
+import crypto from 'node:crypto';
+import http from 'node:http';
 
 // Force unbuffered stdout/stderr so logs surface immediately under
 // `docker compose logs` instead of waiting on the pipe buffer to flush.
@@ -11,7 +11,9 @@ if (process.stderr._handle?.setBlocking) {
 }
 
 const port = Number(process.env.PORT ?? 4000);
-console.log(`[fake-model] starting (pid ${process.pid}, node ${process.version})`);
+console.log(
+  `[fake-model] starting (pid ${process.pid}, node ${process.version})`
+);
 
 const TLON_TEST_KEY_RE = /\[tlon-test:([a-zA-Z0-9_.:-]+)\]/g;
 
@@ -27,76 +29,162 @@ const TLON_TEST_KEY_RE = /\[tlon-test:([a-zA-Z0-9_.:-]+)\]/g;
  */
 const scripts = new Map();
 const callCounts = new Map();
+// Per-script bounded tolerance for "extra" model calls beyond the scripted
+// steps. Some flows legitimately make one more model turn than they have
+// logical responses (e.g. a DM reply that emits its text and then makes a
+// trailing turn). A script opts in with `allowExtraCalls: N`; up to N calls
+// past the last step return benign filler (200) instead of a hard 400. This
+// is deliberately per-script — global leniency would hide real
+// under-specification regressions (see bucket2-redesign.md §4c).
+const allowExtraCalls = new Map();
 // All /v1/chat/completions calls seen since last reset, in arrival order.
 // Tests use this for negative assertions: "no model call for [tlon-test:X]
 // arrived after the prompt was sent" — much faster than waiting on a
 // silence timeout in the test client.
 const receivedCalls = [];
 
+// Monotonic epoch counter, bumped on every reset() (DELETE /v1/_scripts).
+// Lets us attribute a late model call to the test generation that was active
+// when it arrived, vs the generation that registered its key.
+let epoch = 0;
+
+// key -> { epoch } registration history. CRITICALLY this is NOT cleared by
+// reset(), so a stale call arriving after a different test reset the server
+// can still be attributed to the last owner + registration epoch for its key.
+// Bounded FIFO so a long suite can't grow it without limit.
+const lastRegistration = new Map();
+const MAX_REGISTRATION_HISTORY = 500;
+
+function recordRegistration(key) {
+  // Re-registering an existing key updates in place (keeps FIFO position);
+  // a brand-new key may need to evict the oldest entry to stay bounded.
+  if (
+    !lastRegistration.has(key) &&
+    lastRegistration.size >= MAX_REGISTRATION_HISTORY
+  ) {
+    const oldest = lastRegistration.keys().next().value;
+    if (oldest !== undefined) {
+      lastRegistration.delete(oldest);
+    }
+  }
+  lastRegistration.set(key, { epoch });
+}
+
 const server = http.createServer(async (req, res) => {
   try {
-    if (req.method === "GET" && req.url === "/health") {
+    if (req.method === 'GET' && req.url === '/health') {
       sendJson(res, 200, { ok: true });
       return;
     }
 
-    if (req.method === "GET" && req.url === "/v1/models") {
+    if (req.method === 'GET' && req.url === '/v1/models') {
       sendJson(res, 200, {
-        object: "list",
-        data: [{ id: "tlon-test-scripted", object: "model", owned_by: "tlon-tests" }],
+        object: 'list',
+        data: [
+          { id: 'tlon-test-scripted', object: 'model', owned_by: 'tlon-tests' },
+        ],
       });
       return;
     }
 
-    if (req.method === "POST" && req.url === "/v1/_scripts") {
+    if (req.method === 'POST' && req.url === '/v1/_scripts') {
       const body = await readJson(req);
       const { key, steps } = body ?? {};
-      const validation = validateScript(key, steps);
+      const extra = body?.allowExtraCalls ?? 0;
+      const validation = validateScript(key, steps, extra);
       if (validation) {
         sendJson(res, 400, { error: { message: validation } });
         return;
       }
       scripts.set(key, steps);
       callCounts.set(key, 0);
-      console.log(`[fake-model] registered script "${key}" with ${steps.length} step(s)`);
+      allowExtraCalls.set(key, extra);
+      recordRegistration(key);
+      console.log(
+        `[fake-model] registered script "${key}" with ${steps.length} step(s)` +
+          (extra > 0 ? ` (+${extra} extra)` : '') +
+          ` (epoch ${epoch})`
+      );
       sendJson(res, 200, { ok: true });
       return;
     }
 
-    if (req.method === "DELETE" && req.url === "/v1/_scripts") {
+    if (req.method === 'DELETE' && req.url === '/v1/_scripts') {
       scripts.clear();
       callCounts.clear();
+      allowExtraCalls.clear();
       receivedCalls.length = 0;
-      console.log(`[fake-model] cleared all scripts and received-call log`);
-      sendJson(res, 200, { ok: true });
+      // Bump the epoch but keep `lastRegistration` so a stale call arriving
+      // after this reset can still be attributed to the test that owned its
+      // key in a previous epoch.
+      epoch += 1;
+      console.log(
+        `[fake-model] cleared all scripts and received-call log (epoch -> ${epoch})`
+      );
+      sendJson(res, 200, { ok: true, epoch });
       return;
     }
 
-    if (req.method === "GET" && req.url.startsWith("/v1/_received")) {
-      const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
-      const filterKey = url.searchParams.get("key");
+    if (req.method === 'GET' && req.url.startsWith('/v1/_received')) {
+      const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+      const filterKey = url.searchParams.get('key');
       const calls = filterKey
         ? receivedCalls.filter((c) => c.key === filterKey)
         : receivedCalls.slice();
-      sendJson(res, 200, { calls, count: calls.length });
+      sendJson(res, 200, { calls, count: calls.length, epoch });
       return;
     }
 
-    if (req.method === "POST" && req.url === "/v1/chat/completions") {
+    if (req.method === 'POST' && req.url === '/v1/chat/completions') {
       const body = await readJson(req);
       const messages = Array.isArray(body.messages) ? body.messages : [];
-      const key = extractLatestScriptKey(messages);
-      const streamFlag = body.stream === true ? " stream=true" : "";
+      const streamFlag = body.stream === true ? ' stream=true' : '';
 
       // Flatten user-role message text so tests can assert that specific
       // content (e.g. blob transcriptions, filenames) actually reached the
       // model request. We only record user-role messages (not system or
       // assistant) to keep the payload small and the contract clear.
       const userText = messages
-        .filter((m) => m?.role === "user")
+        .filter((m) => m?.role === 'user')
         .map((m) => extractText(m?.content))
         .filter(Boolean)
-        .join("\n");
+        .join('\n');
+
+      // ── Provenance-aware key selection ────────────────────────────────
+      // openclaw re-sends the whole conversation history on every turn, and
+      // DMs share one long-lived per-peer session. So a flat "last tag across
+      // all messages" lets a PREVIOUS test's tag, still sitting in history,
+      // capture an untagged engaging turn (e.g. a thread parent) → stale
+      // misroute. Prefer the tag on the LATEST user turn (a genuinely new
+      // tagged prompt is authoritative); fall back to the last historical tag
+      // only to serve legitimate continuation turns (an untagged tool-result
+      // turn whose run was kicked off by an earlier tagged prompt). See
+      // bucket2-redesign.md §4b.
+      const latestUserKey = extractTagFromLastUserTurn(messages);
+      const historicalKey = extractLatestScriptKey(messages);
+      let key = null;
+      let provenance = 'none';
+      if (latestUserKey) {
+        key = latestUserKey;
+        provenance = 'latest-user';
+      } else if (historicalKey && scripts.has(historicalKey)) {
+        key = historicalKey;
+        provenance = 'history-active';
+      } else if (historicalKey) {
+        key = historicalKey;
+        provenance = 'history-inactive';
+      }
+
+      // Attribute this call to the epoch that registered its key. If the
+      // registration epoch is older than the current epoch, a reset() ran
+      // between registration and arrival — a different test owns the current
+      // epoch and this is cross-epoch (stale) bleed. Kept as a DIAGNOSTIC
+      // classification, never a hard failure (see bucket2-findings.md).
+      const registeredEpoch =
+        key && lastRegistration.has(key)
+          ? lastRegistration.get(key).epoch
+          : null;
+      const stale = registeredEpoch !== null && epoch > registeredEpoch;
 
       receivedCalls.push({
         key,
@@ -105,25 +193,50 @@ const server = http.createServer(async (req, res) => {
         stream: body.stream === true,
         messageCount: messages.length,
         userText,
+        epoch,
+        registeredEpoch,
+        stale,
+        provenance,
       });
 
+      // No tag anywhere → loud 400 (preserve negative-path strictness).
       if (!key) {
         console.log(
-          `[fake-model] POST /v1/chat/completions model=${body.model}${streamFlag} → 400 (no [tlon-test:KEY] tag)`,
+          `[fake-model] POST /v1/chat/completions model=${body.model}${streamFlag} → 400 (no [tlon-test:KEY] tag)`
         );
         sendJson(res, 400, {
           error: {
             message:
-              "no [tlon-test:KEY] tag found in messages; register a script and tag the prompt before sending",
+              'no [tlon-test:KEY] tag found in messages; register a script and tag the prompt before sending',
           },
         });
         return;
       }
 
       const steps = scripts.get(key);
+
+      // Key is not registered in the CURRENT epoch.
       if (!steps) {
+        // Stale-history bleed is benign ONLY when the key was inherited from
+        // re-sent history (`history-inactive`), not when the newest user turn
+        // explicitly carries it. A `latest-user` key with no current script is
+        // a real under-specification (the test tagged a turn but forgot to
+        // register it) — keep it a loud 400 even if the name matches a prior
+        // epoch, so the strict oracle still catches that mistake.
+        if (stale && provenance === 'history-inactive') {
+          // A prior test's tag rode in on re-sent history for an untagged turn
+          // this epoch never scripted. Make it harmless (benign 200) so it
+          // can't error a run or wedge the session — but keep it visible as a
+          // diagnostic. THIS is the core durability fix.
+          console.log(
+            `[fake-model] key="${key}"${streamFlag} → 200 STALE-BENIGN (registeredEpoch=${registeredEpoch} arrivedEpoch=${epoch}, provenance=${provenance})`
+          );
+          respondScripted(res, body, benignFiller());
+          return;
+        }
+        // Genuinely unknown / never-registered key → loud 400.
         console.log(
-          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (no script registered)`,
+          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (no script registered)`
         );
         sendJson(res, 400, {
           error: { message: `no fake-model script registered for "${key}"` },
@@ -133,8 +246,23 @@ const server = http.createServer(async (req, res) => {
 
       const n = callCounts.get(key) ?? 0;
       if (n >= steps.length) {
+        const extra = allowExtraCalls.get(key) ?? 0;
+        if (n < steps.length + extra) {
+          // Bounded, opted-in extra call — a flow that legitimately makes one
+          // more model turn than it has scripted responses. Return benign
+          // filler so the run completes cleanly instead of erroring.
+          console.log(
+            `[fake-model] key="${key}"${streamFlag} → 200 EXTRA call ${n + 1} (of ${steps.length}+${extra})`
+          );
+          callCounts.set(key, n + 1);
+          respondScripted(res, body, benignFiller());
+          return;
+        }
+        // Exhausted current-epoch script → loud 400. This is one of the best
+        // signals that a test under-specified its model flow; do not soften it
+        // globally (opt in per script via allowExtraCalls instead).
         console.log(
-          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (script exhausted: call ${n + 1} of ${steps.length})`,
+          `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 400 (script exhausted: call ${n + 1} of ${steps.length})`
         );
         sendJson(res, 400, {
           error: {
@@ -147,70 +275,74 @@ const server = http.createServer(async (req, res) => {
 
       const step = steps[n];
       const scripted =
-        step.kind === "tool_call"
+        step.kind === 'tool_call'
           ? toolCallResponse({ name: step.name, args: step.args })
           : textResponse(step.content);
 
       console.log(
-        `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 200 step ${n + 1}/${steps.length} (${step.kind})`,
+        `[fake-model] POST /v1/chat/completions key="${key}"${streamFlag} → 200 step ${n + 1}/${steps.length} (${step.kind}) [${provenance}]`
       );
 
-      const payload = completionPayload({ model: body.model, scripted });
-
-      if (body.stream === true) {
-        sendSseCompletion(res, payload);
-      } else {
-        sendJson(res, 200, payload);
-      }
+      respondScripted(res, body, scripted);
       return;
     }
 
     sendJson(res, 404, {
-      error: { message: `Unhandled fake model route: ${req.method} ${req.url}` },
+      error: {
+        message: `Unhandled fake model route: ${req.method} ${req.url}`,
+      },
     });
   } catch (error) {
     sendJson(res, 500, {
-      error: { message: error instanceof Error ? error.message : String(error) },
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+      },
     });
   }
 });
 
-server.on("error", (err) => {
+server.on('error', (err) => {
   console.error(`[fake-model] server error:`, err);
 });
 
-process.on("uncaughtException", (err) => {
+process.on('uncaughtException', (err) => {
   console.error(`[fake-model] uncaughtException:`, err);
 });
-process.on("unhandledRejection", (reason) => {
+process.on('unhandledRejection', (reason) => {
   console.error(`[fake-model] unhandledRejection:`, reason);
 });
 
-server.listen(port, "0.0.0.0", () => {
+server.listen(port, '0.0.0.0', () => {
   console.log(`[fake-model] listening on :${port}`);
 });
 
-function validateScript(key, steps) {
-  if (typeof key !== "string" || key.length === 0) {
+function validateScript(key, steps, extra) {
+  if (typeof key !== 'string' || key.length === 0) {
     return "missing or invalid 'key' (must be non-empty string)";
   }
   if (!Array.isArray(steps) || steps.length === 0) {
     return "missing or invalid 'steps' (must be non-empty array)";
   }
+  if (
+    extra !== undefined &&
+    (typeof extra !== 'number' || !Number.isInteger(extra) || extra < 0)
+  ) {
+    return "invalid 'allowExtraCalls' (must be a non-negative integer)";
+  }
   for (let i = 0; i < steps.length; i += 1) {
     const s = steps[i];
-    if (!s || typeof s !== "object") {
+    if (!s || typeof s !== 'object') {
       return `step ${i}: not an object`;
     }
-    if (s.kind === "text") {
-      if (typeof s.content !== "string") {
+    if (s.kind === 'text') {
+      if (typeof s.content !== 'string') {
         return `step ${i}: text step requires string 'content'`;
       }
-    } else if (s.kind === "tool_call") {
-      if (typeof s.name !== "string" || s.name.length === 0) {
+    } else if (s.kind === 'tool_call') {
+      if (typeof s.name !== 'string' || s.name.length === 0) {
         return `step ${i}: tool_call step requires non-empty string 'name'`;
       }
-      if (!s.args || typeof s.args !== "object" || Array.isArray(s.args)) {
+      if (!s.args || typeof s.args !== 'object' || Array.isArray(s.args)) {
         return `step ${i}: tool_call step requires object 'args'`;
       }
     } else {
@@ -224,7 +356,7 @@ function extractLatestScriptKey(messages) {
   const text = messages
     .map((message) => extractText(message?.content))
     .filter(Boolean)
-    .join("\n");
+    .join('\n');
   let latest = null;
   for (const match of text.matchAll(TLON_TEST_KEY_RE)) {
     latest = match[1];
@@ -232,50 +364,93 @@ function extractLatestScriptKey(messages) {
   return latest;
 }
 
+// The tag on the LATEST user-role turn only (the genuinely new inbound),
+// distinct from extractLatestScriptKey which scans the whole re-sent history.
+// This is what lets a new tagged prompt take precedence over a stale tag still
+// sitting in conversation history (bucket2-redesign.md §4b).
+function extractTagFromLastUserTurn(messages) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role !== 'user') {
+      continue;
+    }
+    const text = extractText(messages[i]?.content);
+    let latest = null;
+    for (const match of text.matchAll(TLON_TEST_KEY_RE)) {
+      latest = match[1];
+    }
+    return latest;
+  }
+  return null;
+}
+
+// A harmless 200 completion used when we deliberately don't want a model call
+// to error a run: stale-history bleed (prior-epoch key) and opted-in bounded
+// extra calls. The text is NON-EMPTY on purpose: openclaw treats an empty
+// terminal assistant message as an "incomplete terminal response" and fails the
+// run via model-fallback, which would defeat the point of serving these calls
+// benignly. A minimal "ok" terminates the agent loop cleanly.
+function benignFiller() {
+  return textResponse('ok');
+}
+
+// Send a scripted completion, honoring the request's streaming preference.
+function respondScripted(res, body, scripted) {
+  const payload = completionPayload({ model: body.model, scripted });
+  if (body.stream === true) {
+    sendSseCompletion(res, payload);
+  } else {
+    sendJson(res, 200, payload);
+  }
+}
+
 function extractText(content) {
-  if (typeof content === "string") {
+  if (typeof content === 'string') {
     return content;
   }
   if (Array.isArray(content)) {
     return content
       .map((part) => {
-        if (typeof part === "string") {
+        if (typeof part === 'string') {
           return part;
         }
-        if (part && typeof part === "object") {
-          if (typeof part.text === "string") {
+        if (part && typeof part === 'object') {
+          if (typeof part.text === 'string') {
             return part.text;
           }
-          if (typeof part.content === "string") {
+          if (typeof part.content === 'string') {
             return part.content;
           }
         }
-        return "";
+        return '';
       })
-      .join("\n");
+      .join('\n');
   }
-  if (content && typeof content === "object" && typeof content.text === "string") {
+  if (
+    content &&
+    typeof content === 'object' &&
+    typeof content.text === 'string'
+  ) {
     return content.text;
   }
-  return "";
+  return '';
 }
 
 function textResponse(content) {
   return {
-    message: { role: "assistant", content },
-    finish_reason: "stop",
+    message: { role: 'assistant', content },
+    finish_reason: 'stop',
   };
 }
 
 function toolCallResponse({ name, args }) {
   return {
     message: {
-      role: "assistant",
+      role: 'assistant',
       content: null,
       tool_calls: [
         {
-          id: `call_${crypto.randomUUID().replace(/-/g, "")}`,
-          type: "function",
+          id: `call_${crypto.randomUUID().replace(/-/g, '')}`,
+          type: 'function',
           function: {
             name,
             arguments: JSON.stringify(args),
@@ -283,16 +458,16 @@ function toolCallResponse({ name, args }) {
         },
       ],
     },
-    finish_reason: "tool_calls",
+    finish_reason: 'tool_calls',
   };
 }
 
 function completionPayload({ model, scripted }) {
   return {
     id: `chatcmpl-fake-${Date.now()}`,
-    object: "chat.completion",
+    object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
-    model: model ?? "tlon-test-scripted",
+    model: model ?? 'tlon-test-scripted',
     choices: [
       {
         index: 0,
@@ -306,15 +481,15 @@ function completionPayload({ model, scripted }) {
 
 function sendSseCompletion(res, payload) {
   res.writeHead(200, {
-    "content-type": "text/event-stream; charset=utf-8",
-    "cache-control": "no-cache",
-    connection: "keep-alive",
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
   });
 
   const choice = payload.choices[0];
   const base = {
     id: payload.id,
-    object: "chat.completion.chunk",
+    object: 'chat.completion.chunk',
     created: payload.created,
     model: payload.model,
   };
@@ -326,11 +501,11 @@ function sendSseCompletion(res, payload) {
         choices: [
           {
             index: 0,
-            delta: { role: "assistant", tool_calls: choice.message.tool_calls },
+            delta: { role: 'assistant', tool_calls: choice.message.tool_calls },
             finish_reason: null,
           },
         ],
-      })}\n\n`,
+      })}\n\n`
     );
   } else {
     res.write(
@@ -339,11 +514,11 @@ function sendSseCompletion(res, payload) {
         choices: [
           {
             index: 0,
-            delta: { role: "assistant", content: choice.message.content ?? "" },
+            delta: { role: 'assistant', content: choice.message.content ?? '' },
             finish_reason: null,
           },
         ],
-      })}\n\n`,
+      })}\n\n`
     );
   }
 
@@ -351,14 +526,14 @@ function sendSseCompletion(res, payload) {
     `data: ${JSON.stringify({
       ...base,
       choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason }],
-    })}\n\n`,
+    })}\n\n`
   );
-  res.write("data: [DONE]\n\n");
+  res.write('data: [DONE]\n\n');
   res.end();
 }
 
 function sendJson(res, status, payload) {
-  res.writeHead(status, { "content-type": "application/json" });
+  res.writeHead(status, { 'content-type': 'application/json' });
   res.end(JSON.stringify(payload));
 }
 
@@ -367,6 +542,6 @@ async function readJson(req) {
   for await (const chunk of req) {
     chunks.push(chunk);
   }
-  const raw = Buffer.concat(chunks).toString("utf8");
+  const raw = Buffer.concat(chunks).toString('utf8');
   return raw ? JSON.parse(raw) : {};
 }


### PR DESCRIPTION
Stacks on Pat's context-lens gateway port (#5936, `po/migrate-context-lens`) as a hardening delta. Addresses two correctness gaps in how the process-global lens services resolve config under a multi-account `channels.tlon`.

## Summary
- **Global lens services resolve the right account.** The context-lens HTTP routes, disk store, and %steward ship sync are process-global but previously resolved config against the `default` account only. A lens configured under a named account (with no top-level block) silently stayed off. New `resolveLensAccountId(cfg)` returns the first lens-enabled account, preferring `default`; all three init paths now use it.
- **Outbound-route telemetry attributes the right account.** `setOutboundRouteReporter` lives in a single process-global slot (last monitor to register wins) but hard-bound owner/bot ship to its own closure, mis-attributing sibling accounts' sends. `TlonOutboundRouteEvent` now carries `accountId` (populated from the `message_sending` hook context), and the reporter resolves owner/bot from it — matching the debug/error reporters.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec vitest run src/` — 743/743 pass (added 3 `resolveLensAccountId` cases)
- [x] `prettier --check` clean
- [ ] Manual: verify a named-account-only lens config registers routes + ship sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)