### PR TITLE
fix(lens/api): repoint client at %steward umbrella module

### DIFF
--- a/packages/api/src/client/lensApi.ts
+++ b/packages/api/src/client/lensApi.ts
@@ -22,29 +22,44 @@ export const toLensRun = (entry: ub.LensRunEntry): LensRun => {
     lensId: entry.id,
     complete: entry.complete,
     receivedAt: parseReceived(entry.received),
-    // %steward relays the run record as structured JSON, not a cord — pass
-    // it through unchanged.
-    payload: entry.payload,
+    payload: parsePayload(entry.payload),
   };
 };
 
-export const getRecentLensRuns = async (count?: number): Promise<LensRun[]> => {
+// The agent relays payloads as opaque serialized-JSON cords; parse once at
+// the API edge so the rest of the client sees structured data.
+function parsePayload(payload: string): unknown {
+  try {
+    return JSON.parse(payload);
+  } catch {
+    logger.log('failed to parse lens payload', payload.slice(0, 100));
+    return null;
+  }
+}
+
+// %steward emits three lens-update variants on the wire. %entry / %recent
+// carry data; %retry-requested is a signal for the gateway, not the client.
+function isLensEntryUpdate(
+  update: ub.LensModuleUpdate
+): update is { entry: ub.LensRunEntry } {
+  return 'entry' in update;
+}
+
+export const getRecentLensRuns = async (
+  count?: number
+): Promise<LensRun[]> => {
   const path =
     count && count > 0 ? `/v1/lens/recent/${count}` : '/v1/lens/recent';
   const response = await scry<ub.LensRecentScry>({ app: 'steward', path });
-
-  return response.recent.map(toLensRun);
+  return response.lens.recent.map(toLensRun);
 };
 
-// Paginate run history backwards: pass the oldest receivedAt (@da string)
-// from the last page to fetch everything at or after that cutoff.
 export const getLensRunsSince = async (cutoff: string): Promise<LensRun[]> => {
   const response = await scry<ub.LensRecentScry>({
     app: 'steward',
     path: `/v1/lens/since/${cutoff}`,
   });
-
-  return response.recent.map(toLensRun);
+  return response.lens.recent.map(toLensRun);
 };
 
 export const getLensRun = async (
@@ -52,12 +67,14 @@ export const getLensRun = async (
   lensId: string
 ): Promise<LensRun | null> => {
   try {
-    const response = await scry<{ entry: ub.LensRunEntry }>({
+    const response = await scry<{ lens: ub.LensModuleUpdate }>({
       app: 'steward',
       path: `/v1/lens/run/${botShip}/${lensId}`,
     });
-
-    return toLensRun(response.entry);
+    if (!isLensEntryUpdate(response.lens)) {
+      return null;
+    }
+    return toLensRun(response.lens.entry);
   } catch (error) {
     if (error instanceof BadResponseError && error.status === 404) {
       return null;
@@ -68,9 +85,11 @@ export const getLensRun = async (
 };
 
 /**
- * Ask the bot to re-run a failed lens run. Pokes our own %steward agent,
- * which relays the request to the bot ship; the bot's gateway re-dispatches
- * and the retry shows up as a new run.
+ * Ask the bot to re-run a failed lens run. Pokes our own (local) %steward
+ * with the bot ship and lensId; %steward routes it to the bot — if the bot
+ * is us, it emits a %retry-requested fact for the local gateway; if the
+ * bot is a different ship, %steward cross-ship pokes that ship's %steward,
+ * which then emits the fact for its own local gateway.
  */
 export const retryLensRun = ({
   botShip,
@@ -81,15 +100,15 @@ export const retryLensRun = ({
 }) =>
   poke({
     app: 'steward',
-    mark: 'steward-lens-action-1',
-    json: { retry: { bot: botShip, id: lensId } },
+    mark: 'steward-action-1',
+    json: { lens: { retry: { bot: botShip, id: lensId } } },
   });
 
 export const subscribeToLensUpdates = async (
   handler: (runs: LensRun[]) => void
 ) => {
-  // Older ships don't have the %steward agent; probe with a scry so a missing
-  // agent skips the subscription instead of wedging sync.
+  // Older ships don't have %steward; probe with a scry so a missing agent
+  // skips the subscription instead of wedging sync.
   try {
     await scry<ub.LensRecentScry>({
       app: 'steward',
@@ -98,25 +117,25 @@ export const subscribeToLensUpdates = async (
   } catch (error) {
     if (error instanceof BadResponseError && error.status === 404) {
       logger.trackEvent('%steward agent missing');
-      logger.warn('lens agent unavailable, skipping lens subscription');
+      logger.warn('steward agent unavailable, skipping lens subscription');
       return null;
     }
 
     throw error;
   }
 
-  return subscribe<ub.LensUpdate>(
+  return subscribe<{ lens: ub.LensModuleUpdate }>(
     {
       app: 'steward',
       path: '/v1/lens',
     },
     (event) => {
-      logger.log('raw lens event', event);
-      // /v1/lens carries %entry (a stored run, for us) and %retry-requested
-      // (for the bot's own gateway); only the former concerns the client.
-      if ('entry' in event) {
-        handler([toLensRun(event.entry)]);
+      logger.log('raw steward lens event', event);
+      if (!isLensEntryUpdate(event.lens)) {
+        // %retry-requested signals are for the gateway, not run data.
+        return;
       }
+      handler([toLensRun(event.lens.entry)]);
     }
   );
 };

--- a/packages/api/src/urbit/lens.ts
+++ b/packages/api/src/urbit/lens.ts
@@ -1,6 +1,9 @@
 /**
  * Wire types for the %steward agent's lens module (per-run bot introspection).
- * See desk/sur/steward/lens.hoon and docs/steward.md.
+ * See desk/sur/steward.hoon and docs/steward.md.
+ *
+ * The agent stores run records keyed by [bot id]; clients subscribe to
+ * /v1/lens for live updates and scry /x/v1/lens/* for backfill.
  */
 
 export interface LensRunEntry {
@@ -8,28 +11,44 @@ export interface LensRunEntry {
   bot: string;
   /** lensId stamped into the channel post pointer blob */
   id: string;
-  /** whether a %run-final has been received for this id */
+  /** whether a final (final=true) record has been received for this id */
   complete: boolean;
   /** @da string of when the latest record arrived on the owner ship */
   received: string;
-  /** the run record, relayed as structured JSON with an inner schemaVersion */
-  payload: unknown;
+  /** opaque serialized-JSON run record with an inner schemaVersion */
+  payload: string;
 }
 
 /**
- * The lens update (steward-lens-update-1), a tagged union:
- *   - `entry`: a single run, facted on /v1/lens and returned by the /run scry
- *   - `recent`: a batch, returned by the /recent and /since scries
- *   - `retry-requested`: emitted on the bot ship for its gateway; the
- *     owner-side client ignores it
+ * %steward lens-module update variants. Subscribers on /v1/lens see
+ * `%entry` (a stored run record) and `%retry-requested` (a signal for the
+ * local gateway). The `%recent` variant only appears in scry responses
+ * for the /recent and /since paths — it carries a batch of entries.
  */
-export type LensUpdate =
+export type LensModuleUpdate =
   | { entry: LensRunEntry }
-  | { recent: LensRunEntry[] }
-  | { 'retry-requested': { id: string; requester: string } };
+  | { 'retry-requested': { id: string; requester: string } }
+  | { recent: LensRunEntry[] };
+
+export type StewardUpdate =
+  | { lens: LensModuleUpdate }
+  | { gateway: unknown };
+
+/**
+ * Lens-module actions poked into %steward. The wire shape always nests
+ * under the top-level { lens: ... } module tag.
+ *
+ *   { entry: { id, payload, final } }   — gateway pushes a run milestone
+ *   { retry: { bot, id } }              — owner asks to re-dispatch
+ *   { configure: { 'max-runs-per-bot' } } — set the retention cap
+ */
+export type LensModuleAction =
+  | { entry: { id: string; payload: string; final: boolean } }
+  | { retry: { bot: string; id: string } }
+  | { configure: { 'max-runs-per-bot': number } };
 
 /**
  * Scry response for /x/v1/lens/recent[/<count>] and /x/v1/lens/since/<da>:
- * the %recent update variant, carrying a batch of entries.
+ * a steward-update-1 cage carrying a %recent update with the entry batch.
  */
-export type LensRecentScry = { recent: LensRunEntry[] };
+export type LensRecentScry = { lens: { recent: LensRunEntry[] } };


### PR DESCRIPTION
Stacks on Hunter's #6007 (`hm/lens-1-api`) as a single delta. Aligns the lens **client** API with the module-nested `%steward` agent (#5971), which #6007's client still addresses with the old flat lens-only protocol.

## The gap this closes
The agent (#5971) moved lens under a `{ lens: ... }` umbrella module. #6007's client still speaks the pre-umbrella protocol, so its lens traffic wouldn't match the current agent:
- retry poke mark `steward-lens-action-1` → **`steward-action-1`** with `{ lens: { retry: { bot, id } } }`
- scry/response shape `response.recent` → **`response.lens.recent`** (`LensRecentScry = { lens: { recent } }`)
- payload is now a serialized-JSON CORD parsed at the API edge (`parsePayload`)
- adds `LensModuleUpdate` / `StewardUpdate` / `LensModuleAction` types + `isLensEntryUpdate` guard

Only `packages/api/src/client/lensApi.ts` and `urbit/lens.ts` change (~120 lines). This is the missing glue between #5971 (agent) and the #6007→#6010 client stack.

## Test plan
- [x] `pnpm --dir packages/api tsc` clean against current `hm/lens-1-api`
- [ ] Manual: client lens recent/retry round-trips against a ship running the umbrella `%steward`

🤖 Generated with [Claude Code](https://claude.com/claude-code)