### PR TITLE
feat(steward): explicit trusted-bots %entry gate

### DIFF
--- a/desk/app/steward.hoon
+++ b/desk/app/steward.hoon
@@ -18,9 +18,15 @@
 ::  %steward is greenfield (unreleased), so it has a single state version and
 ::  no migration — an unreadable state just resets to bunt.
 ::
+::    .owner: shared owner ship (lens send target, gateway owner-DM tracking)
+::    .bots:  owner-side trusted bots — ships allowed to send lens %entry
+::            pokes cross-ship. explicit and ship-class-agnostic; an empty
+::            set means only local pokes are accepted.
+::
 +$  state-0
   $:  %0
       owner=(unit ship)
+      bots=(set ship)
       lens=state:v1:sl
       gateway=state:v1:sg
   ==
@@ -98,13 +104,15 @@
   ^+  cor
   ?+  mark  ~|(bad-poke-mark+mark !!)
   ::
-  ::  steward-core config: local only.
+  ::  steward-core config + trusted-bots management: local only.
   ::
       %steward-action-1
     ?>  =(src.bowl our.bowl)
     =+  !<(=action:v1:s vase)
     ?-  -.action
-      %configure  cor(owner.state `owner.action)
+      %configure    cor(owner.state `owner.action)
+      %trust-bot    cor(bots.state (~(put in bots.state) ship.action))
+      %untrust-bot  cor(bots.state (~(del in bots.state) ship.action))
     ==
   ::
   ::  lens module actions. auth is per-variant (each shape expects a
@@ -209,9 +217,10 @@
   ::
   ::  lens-action auth is per-variant, since each shape expects a different
   ::  src:
-  ::    %entry: src=our (the bot's own gateway pokes locally) or a moon we
-  ::            sponsor (a bot we own fanning a run to us as its owner); jael
-  ::            is the authority, via +sein:title.
+  ::    %entry: src=our (the bot's own gateway pokes locally) or a ship in the
+  ::            owner-side trusted-bots set (a bot we've explicitly trusted via
+  ::            %trust-bot, fanning a run to us as its owner). ship-class-
+  ::            agnostic — moon sponsorship is NOT an auto-trust.
   ::    %retry: src=our (a local client, or an owner-side relay forwarding to
   ::            its own bot when bot==our) or the configured owner (relaying a
   ::            retry to its bot moon).
@@ -223,7 +232,7 @@
     ?-  -.action
         %entry
       ?>  ?|  =(src.bowl our.bowl)
-              =(our.bowl (sein:title our.bowl now.bowl src.bowl))
+              (~(has in bots.state) src.bowl)
           ==
       (le-handle-entry id.action payload.action final.action)
     ::

--- a/desk/mar/steward/action-1.hoon
+++ b/desk/mar/steward/action-1.hoon
@@ -16,6 +16,16 @@
       %-  frond  :-  'configure'
       %-  frond  :-  'owner'
       s+(scot %p owner.action)
+    ::
+        %trust-bot
+      %-  frond  :-  'trust-bot'
+      %-  frond  :-  'ship'
+      s+(scot %p ship.action)
+    ::
+        %untrust-bot
+      %-  frond  :-  'untrust-bot'
+      %-  frond  :-  'ship'
+      s+(scot %p ship.action)
     ==
   --
 ++  grab
@@ -25,6 +35,8 @@
     =,  dejs:format
     %-  of
     :~  [%configure (ot ~[owner+(se %p)])]
+        [%trust-bot (ot ~[ship+(se %p)])]
+        [%untrust-bot (ot ~[ship+(se %p)])]
     ==
   --
 --

--- a/desk/sur/steward.hoon
+++ b/desk/sur/steward.hoon
@@ -4,9 +4,20 @@
 ::    files: sur/steward/lens.hoon, sur/steward/gateway.hoon.
 ::
 |%
-::  $action: set the shared owner — the bot's owner ship, used across
-::  modules (lens fan-out target, gateway owner-DM tracking).
+::  $action: cross-cutting (non-module) inbound actions. all self-only.
 ::
-+$  action  [%configure owner=ship]
+::    %configure: set the shared owner — the bot's owner ship, used across
+::            modules (lens send target, gateway owner-DM tracking).
+::    %trust-bot / %untrust-bot: add/remove a ship from the owner-side
+::            trusted-bots set. only ships in this set may send lens %entry
+::            pokes cross-ship. trust is explicit and ship-class-agnostic
+::            (planet/moon/star/comet/galaxy all eligible) — moon
+::            sponsorship is NOT an auto-trust.
+::
++$  action
+  $%  [%configure owner=ship]
+      [%trust-bot ship=ship]
+      [%untrust-bot ship=ship]
+  ==
 ++  v1  .
 --

--- a/desk/tests/app/steward.hoon
+++ b/desk/tests/app/steward.hoon
@@ -7,11 +7,13 @@
 /=  agent  /app/steward
 |%
 ++  dap  %steward
-::  agent state — single version (greenfield, no migration)
+::  agent state — single version (greenfield, no migration). `bots` is the
+::  owner-side trusted set.
 ::
 +$  state-0
   $:  %0
       owner=(unit ship)
+      bots=(set ship)
       lens=state:v1:l
       gateway=state:v1:g
   ==
@@ -20,10 +22,9 @@
 ++  payload   ^-  json  s+'run-record'
 ++  payload2  ^-  json  s+'partial'
 ::
-::  our ship in tests is ~dev (a galaxy; set via +setup below).  a moon's
-::  sponsor is its low 32 bits, so any ship >= 2^32 whose low 32 bits equal
-::  ~dev is a moon ~dev sponsors.  (add ~dev (bex 32)) is the simplest such
-::  moon and passes the ownership gate ((sein ...) == ~dev via the mock).
+::  our ship in tests is ~dev (set via +setup below). +moon stands in for a
+::  remote bot ship; the %entry gate is now an explicit trusted-bots set
+::  (not sponsorship), so tests that fan in from it call +trust-moon first.
 ::
 ++  moon  ^-  ship  (add ~dev (bex 32))
 ::
@@ -32,12 +33,6 @@
   ^-  (unit vase)
   ?+  path  ~
     [%gu @ %activity @ %$ ~]  `!>(&)
-  ::  mock jael +sein for the %steward-lens-action-1 ownership gate. a moon's
-  ::  sponsor is its low 32 bits; a galaxy (e.g. ~zod) sponsors itself —
-  ::  both reproduced by (end 5 who) for the ships these tests use.
-  ::
-      [%j @ %sein @ @ ~]
-    `!>(`@p`(end 5 (slav %p i.t.t.t.t.path)))
   ==
 ::
 ++  setup
@@ -56,6 +51,20 @@
   ^-  form:m
   ;<  *  bind:m
     (do-poke %steward-action-1 !>(`action:v1:s`[%configure owner]))
+  (pure:m ~)
+::
+++  trust
+  |=  bot=ship
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot bot]))
+  (pure:m ~)
+::
+++  trust-moon
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  (trust moon)
   (pure:m ~)
 ::
 ++  ga-configure
@@ -102,8 +111,8 @@
   %-  (do-as ~zod)
   (do-poke %steward-action-1 !>(`action:v1:s`[%configure ~zod]))
 ::
-::  %configure is local-only: a sponsored moon may submit lens runs but
-::  must not be able to repoint the owner
+::  %configure is local-only: a foreign ship must not be able to repoint
+::  the owner
 ::
 ++  test-configure-from-moon-crashes
   %-  eval-mare
@@ -114,8 +123,7 @@
   %-  (do-as moon)
   (do-poke %steward-action-1 !>(`action:v1:s`[%configure ~bus]))
 ::
-::  a lens run from a completely foreign ship (not our moon) crashes the
-::  ownership gate on %steward-lens-action-1
+::  a lens run from an untrusted ship crashes the %entry gate
 ::
 ++  test-lens-from-foreign-ship-crashes
   %-  eval-mare
@@ -126,13 +134,14 @@
   %-  (do-as ~zod)
   (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'lens-x' payload &]))
 ::
-::  a moon we sponsor is accepted; its run is stored keyed by src (the moon)
+::  a trusted bot's run is accepted; stored keyed by src (the bot)
 ::
-++  test-lens-from-sponsored-moon-accepted
+++  test-lens-from-trusted-bot-accepted
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'lens-moon' payload &]))
@@ -147,6 +156,56 @@
   ;<  res=cage  bind:m  (got-peek /x/v1/lens/run/(scot %p moon)/lens-moon)
   =+  !<(=update:v1:l q.res)
   (ex-equal !>(update) !>(`update:v1:l`[%entry [moon 'lens-moon'] [& ~2024.1.1 payload]]))
+::
+::  an untrusted ship's %entry is rejected — sponsorship is not auto-trust
+::
+++  test-entry-from-untrusted-rejected
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as moon)
+  (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'no-trust' payload &]))
+::
+::  %untrust-bot revokes trust; a later %entry from that ship is rejected
+::
+++  test-untrust-bot-removes-trust
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
+  ;<  *  bind:m
+    %-  (do-as moon)
+    (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'while-trusted' payload &]))
+  ;<  *  bind:m
+    (do-poke %steward-action-1 !>(`action:v1:s`[%untrust-bot moon]))
+  %-  ex-fail
+  %-  (do-as moon)
+  (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'after-untrust' payload &]))
+::
+::  %trust-bot is self-only — a foreign ship cannot grant itself trust
+::
+++  test-trust-bot-rejects-foreign-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%trust-bot ~zod]))
+::
+::  %untrust-bot is also self-only
+::
+++  test-untrust-bot-rejects-foreign-source
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  %-  ex-fail
+  %-  (do-as ~zod)
+  (do-poke %steward-action-1 !>(`action:v1:s`[%untrust-bot ~zod]))
 ::
 ::  sending to a non-self owner emits a %steward-lens-action-1 poke
 ::
@@ -189,13 +248,14 @@
   =+  !<(=update:v1:l q.res)
   (ex-equal !>(update) !>(`update:v1:l`[%entry [~dev 'lens-1'] [& ~2024.1.1 payload]]))
 ::
-::  a poke from a sponsored moon is stored keyed by src.bowl (the moon)
+::  a poke from a trusted bot is stored keyed by src.bowl (the bot)
 ::
 ++  test-action-stores-keyed-by-source
   %-  eval-mare
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'lens-2' payload |]))
@@ -218,6 +278,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'lens-3' payload |]))
@@ -236,6 +297,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'lens-4' payload &]))
@@ -257,6 +319,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%configure 2]))
   ;<  *  bind:m
@@ -285,6 +348,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'run-a' payload &]))
@@ -306,6 +370,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   ;<  *  bind:m
     %-  (do-as moon)
     (do-poke %steward-lens-action-1 !>(`action:v1:l`[%entry 'run-a' payload &]))
@@ -328,6 +393,7 @@
   =/  m  (mare ,~)
   ^-  form:m
   ;<  ~  bind:m  setup
+  ;<  ~  bind:m  trust-moon
   =/  big=json  [%s `@t`(rap 3 (reap 530.000 'x'))]
   ;<  caz=(list card)  bind:m
     %-  (do-as moon)

--- a/docs/steward.md
+++ b/docs/steward.md
@@ -30,11 +30,12 @@ State is a single `state-0`, defined in the app file (the agent is greenfield, s
 ```
 state-0
   owner    (unit ship)                  shared config: bot sends runs to it / its DMs are watched; ~ = inert
+  bots     (set ship)                   owner-side trusted bots: who may send lens %entry pokes cross-ship
   lens     state:v1:lens                 stored lens run records (owner role)
   gateway  state:v1:gateway              harness liveness + auto-reply bookkeeping
 ```
 
-`owner` is shared: the lens module sends runs to it, and the gateway module treats its DMs as owner activity worth auto-replying to.
+`owner` is shared: the lens module sends runs to it, and the gateway module treats its DMs as owner activity worth auto-replying to. `bots` is the owner-side allowlist of ships permitted to fan lens runs in (see the `%entry` gate below); managed via the core `%trust-bot`/`%untrust-bot` pokes.
 
 `run` (in `sur/steward/lens.hoon`):
 
@@ -53,7 +54,7 @@ Makes a bot's run records — trigger, tool calls, timings, output — durable o
 One agent, two roles; the same code runs on every ship, and the role is determined by **who poked it** (the `%steward-lens-action-1` ownership gate has already vetted the source — see below):
 
 - **bot ship role** (`src == our`): the local gateway pokes `%steward-lens-action-1` with a run record. `le-poke-action` sends it to the configured `owner` as a `%steward-lens-action-1` poke. Ames retries until ack, so owner-ship downtime or gateway restarts don't drop finalized runs once poked.
-- **owner ship role** (`src` is a moon we sponsor): a bot sent us its run. `le-poke-action` stores it keyed `[bot=src id]`, gives a fact on `/v1/lens`, and answers scries for clients.
+- **owner ship role** (`src` is a trusted bot — in our `bots` set): a bot sent us its run. `le-poke-action` stores it keyed `[bot=src id]`, gives a fact on `/v1/lens`, and answers scries for clients.
 
 A self-owned bot (`owner` equal to `our`) is stored directly during send with no network hop.
 
@@ -89,13 +90,17 @@ Three inbound marks, each ownership-gated to admit exactly the right source.
 
 ```
 [%configure owner=ship]               top-level: set the shared owner
+[%trust-bot ship=ship]                add a ship to the trusted-bots set
+[%untrust-bot ship=ship]              remove a ship from the trusted-bots set
 ```
+
+`%trust-bot`/`%untrust-bot` manage the owner-side `bots` allowlist that gates lens `%entry` fan-in. Trust is explicit and ship-class-agnostic — a bot may be a planet, moon, comet, star, or galaxy, and moon sponsorship is **not** an auto-trust.
 
 ### `%steward-lens-action-1` (lens)
 
 Auth is **per-variant**, since each shape expects a different `src`:
 
-- `%entry` — accepted iff `src` is `our`, or `src` is a ship `our` sponsors (per jael, via `+sein:title`). A bot is typically a moon of the owner planet, so the owner accepts lens runs from itself and from its own moons; sponsorship rejects comets and unrelated ships. This is the one shape a sponsored moon may submit (its own runs, stored keyed by `src`).
+- `%entry` — accepted iff `src` is `our`, or `src` is in the owner-side trusted-bots set (`bots`, granted via the core `%trust-bot` poke). Ship-class-agnostic: a trusted bot may be a planet, moon, comet, etc. Moon sponsorship is **not** an auto-trust — even a moon the owner sponsors must be explicitly `%trust-bot`'d. This is the one shape a trusted remote ship may submit (its own runs, stored keyed by `src`).
 - `%retry` — accepted iff `src` is `our` (a local client, or an owner-side relay forwarding to its own bot when `bot == our`) or the configured `owner` (relaying a retry to its bot moon).
 - `%configure` — `src == our` only.
 


### PR DESCRIPTION
Stacked on #5988. Ports the **trusted-bots `%entry` gate** from #6014 onto the per-module steward structure.

The lens `%entry` gate was moon-sponsor-only (`+sein:title`), which **rejects a planet→planet** bot/owner setup. Replaced with an explicit, ship-class-agnostic trusted set:
- `state-0` gains `bots=(set ship)`. `%entry` accepted from `our` or any ship in `bots`.
- Core **`%trust-bot` / `%untrust-bot`** pokes (self-only) manage it on `%steward-action-1`.

**Security note:** this removes moon-sponsor auto-trust — after this lands, a moon bot must be explicitly `%trust-bot`'d. The upside is planets/comets/etc. can be bots too. Deliberate policy change, not just a refactor.

Pure trusted-bots diff (5 files) — the single-state/no-migration collapse lives in the base #5988. **41 steward tests pass on zuse 408** (trusted-bot accept/reject, untrust-removes, trust/untrust self-only). Supersedes the trusted-bots portion of #6014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)