### PR TITLE
skill: add notes request status command

### DIFF
--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -53,6 +53,15 @@ const requestJsonMock = requestJson as unknown as Mock;
 const subscribeMock = subscribe as unknown as Mock;
 const unsubscribeMock = unsubscribe as unknown as Mock;
 
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error('Expected promise to reject');
+}
+
 beforeEach(() => {
   requestJsonMock.mockResolvedValue(undefined);
   pokeMock.mockResolvedValue(undefined);
@@ -244,6 +253,52 @@ describe('notesV1 reads', () => {
       '/notes/~/v1/notebooks/~zod/blog/notes/12/history',
     ]);
   });
+
+  test('getRequest reads a pending request status by id', async () => {
+    requestJsonMock.mockResolvedValue({
+      requestId: '0vabc',
+      body: { type: 'pending', status: 'acked' },
+    });
+
+    await expect(notesV1.getRequest('0vabc')).resolves.toEqual({
+      requestId: '0vabc',
+      body: { type: 'pending', status: 'acked' },
+    });
+    expect(requestJsonMock).toHaveBeenCalledWith(
+      '/notes/~/v1/request/0vabc',
+      'GET'
+    );
+  });
+
+  test('getRequest returns terminal error and notebook bodies', async () => {
+    requestJsonMock.mockResolvedValueOnce({
+      requestId: '0verr',
+      body: { type: 'error', message: 'target ship is unavailable' },
+    });
+    await expect(notesV1.getRequest('0verr')).resolves.toEqual({
+      requestId: '0verr',
+      body: { type: 'error', message: 'target ship is unavailable' },
+    });
+
+    requestJsonMock.mockResolvedValueOnce({
+      requestId: '0vbook',
+      body: {
+        type: 'notebook',
+        notebook: {
+          host: '~zod',
+          flagName: 'blog',
+          notebook: { id: 1, title: 'Blog' },
+        },
+      },
+    });
+    await expect(notesV1.getRequest('0vbook')).resolves.toMatchObject({
+      requestId: '0vbook',
+      body: {
+        type: 'notebook',
+        notebook: { host: '~zod', flagName: 'blog' },
+      },
+    });
+  });
 });
 
 describe('notesV1 normalization variants', () => {
@@ -378,15 +433,32 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     );
   });
 
-  test('createNotebook rejects error/pending/unexpected envelopes', async () => {
+  test('createNotebook rejects error/unexpected envelopes', async () => {
     for (const body of [
       { type: 'error', message: 'no' },
-      { type: 'pending' },
       { type: 'api-key' },
     ]) {
       requestJsonMock.mockResolvedValue({ body });
       await expect(notesV1.createNotebook({ title: 'B' })).rejects.toThrow();
     }
+  });
+
+  test('createNotebook pending includes request status and notebook checks', async () => {
+    requestJsonMock.mockResolvedValue({
+      requestId: '0vabc',
+      body: { type: 'pending' },
+    });
+
+    const message = await rejectionMessage(
+      notesV1.createNotebook({ title: 'B' })
+    );
+
+    expect(message).toContain('%notes write request is still pending');
+    expect(message).toContain('Do not retry automatically');
+    expect(message).toContain('tlon notes request 0vabc');
+    expect(message).toContain('tlon notes list');
+    expect(message).toContain('tlon notes show <notes-nest-from-list>');
+    expect(message).not.toContain('try again');
   });
 
   test('createNotebook reports empty error envelopes with fallback detail', async () => {
@@ -409,6 +481,29 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
       'POST',
       { folder: 3, title: 'T', body: 'B' }
     );
+  });
+
+  test('createNote pending includes request status and note checks', async () => {
+    requestJsonMock.mockResolvedValue({
+      requestId: '0vnote',
+      body: { type: 'pending' },
+    });
+
+    const message = await rejectionMessage(
+      notesV1.createNote({
+        flag: 'notes/~zod/blog',
+        folder: 3,
+        title: 'T',
+        body: 'B',
+      })
+    );
+
+    expect(message).toContain('%notes write request is still pending');
+    expect(message).toContain('Do not retry automatically');
+    expect(message).toContain('tlon notes request 0vnote');
+    expect(message).toContain('tlon notes notes notes/~zod/blog');
+    expect(message).toContain('tlon notes note notes/~zod/blog <id-from-list>');
+    expect(message).not.toContain('try again');
   });
 
   test('updateNoteBody includes expectedRevision only when provided', async () => {
@@ -534,6 +629,26 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
         notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 1, title: 'x' })
       ).rejects.toThrow();
     }
+  });
+
+  test('pending note and folder writes point at affected objects', async () => {
+    requestJsonMock.mockResolvedValue({
+      requestId: '0vobj',
+      body: { type: 'pending' },
+    });
+
+    const noteMessage = await rejectionMessage(
+      notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 12, title: 'x' })
+    );
+    expect(noteMessage).toContain('tlon notes request 0vobj');
+    expect(noteMessage).toContain('tlon notes note notes/~zod/blog 12');
+    expect(noteMessage).not.toContain('try again');
+
+    const folderMessage = await rejectionMessage(
+      notesV1.renameFolder({ flag: 'notes/~zod/blog', folderId: 4, name: 'x' })
+    );
+    expect(folderMessage).toContain('tlon notes folder notes/~zod/blog 4');
+    expect(folderMessage).not.toContain('try again');
   });
 
   test('void writes report empty error envelopes with fallback detail', async () => {

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -578,7 +578,21 @@ export interface NotesV1GroupRef {
   flagName: string;
 }
 
+export type NotesV1RequestBody =
+  | { type: 'ok' }
+  | { type: 'no-change' }
+  | { type: 'notebook'; notebook: NotesV1NotebookSummary }
+  | { type: 'error'; message?: string }
+  | { type: 'pending'; status?: string }
+  | { type: 'api-key' };
+
+export interface NotesV1RequestStatus {
+  requestId: string;
+  body: NotesV1RequestBody;
+}
+
 const NOTEBOOKS_V1_PATH = '/notes/~/v1/notebooks';
+const REQUESTS_V1_PATH = '/notes/~/v1/request';
 
 function notebookV1Path(flag: NotesFlag): string {
   return `${NOTEBOOKS_V1_PATH}/${flag.host}/${flag.name}`;
@@ -623,6 +637,13 @@ function requireObject(raw: unknown): any {
 // requires (so the CLI never renders `notes/undefined/undefined`).
 function req<T>(value: T | null | undefined, field: string): T {
   if (value === undefined || value === null) {
+    throw new Error(`%notes response missing required field: ${field}`);
+  }
+  return value;
+}
+
+function reqString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
     throw new Error(`%notes response missing required field: ${field}`);
   }
   return value;
@@ -711,6 +732,45 @@ function normalizeMemberV1(raw: any): NotesV1MemberRecord {
   return { ship: req(raw.ship, 'member.ship'), roles };
 }
 
+function normalizeRequestBodyV1(raw: any): NotesV1RequestBody {
+  const body = requireObject(raw);
+  switch (body.type) {
+    case 'ok':
+      return { type: 'ok' };
+    case 'no-change':
+      return { type: 'no-change' };
+    case 'notebook':
+      return {
+        type: 'notebook',
+        notebook: normalizeNotebookSummaryV1(requireObject(body.notebook)),
+      };
+    case 'error': {
+      const message =
+        body.message === undefined || body.message === null
+          ? undefined
+          : String(body.message);
+      return { type: 'error', message };
+    }
+    case 'pending':
+      return {
+        type: 'pending',
+        status: typeof body.status === 'string' ? body.status : undefined,
+      };
+    case 'api-key':
+      return { type: 'api-key' };
+    default:
+      throw new Error(`Unexpected %notes response type: ${body.type}`);
+  }
+}
+
+function normalizeRequestStatusV1(raw: unknown): NotesV1RequestStatus {
+  const res = requireObject(raw);
+  return {
+    requestId: reqString(res.requestId, 'requestId'),
+    body: normalizeRequestBodyV1(req(res.body, 'body')),
+  };
+}
+
 // --- envelope handling -----------------------------------------------------
 
 function notesEnvelopeErrorMessage(body: any): string {
@@ -724,10 +784,64 @@ function notesEnvelopeErrorMessage(body: any): string {
   return `%notes error: ${detail || 'backend returned an error without details'}`;
 }
 
+function envelopeRequestId(res: any): string | undefined {
+  const requestId = res?.requestId;
+  return typeof requestId === 'string' && requestId.trim()
+    ? requestId.trim()
+    : undefined;
+}
+
+function pendingWriteMessage(res: any, checkCommands: string[]): string {
+  const requestId = envelopeRequestId(res);
+  const lines = requestId
+    ? [
+        `%notes write request is still pending (request ${requestId}); the outcome is unknown and it may still complete.`,
+        'Do not retry automatically. Check the request before retrying:',
+        `  tlon notes request ${requestId}`,
+        'If the request is still pending, do not issue the write again.',
+        'If the request has completed, inspect whether the write landed:',
+      ]
+    : [
+        '%notes write request is still pending; the outcome is unknown and it may still complete.',
+        'Do not retry automatically. No request id was returned, so inspect whether the write landed:',
+      ];
+  lines.push(
+    ...checkCommands.map((command) => `  ${command}`),
+    'Only retry if the request failed or the requested change is not present.'
+  );
+  return lines.join('\n');
+}
+
+function notebookWriteChecks(): string[] {
+  return ['tlon notes list', 'tlon notes show <notes-nest-from-list>'];
+}
+
+function noteCreateChecks(nest: string): string[] {
+  return [`tlon notes notes ${nest}`, `tlon notes note ${nest} <id-from-list>`];
+}
+
+function noteChecks(nest: string, noteId: number): string[] {
+  return [`tlon notes note ${nest} ${noteId}`];
+}
+
+function folderCreateChecks(nest: string): string[] {
+  return [
+    `tlon notes folders ${nest}`,
+    `tlon notes folder ${nest} <id-from-list>`,
+  ];
+}
+
+function folderChecks(nest: string, folderId: number): string[] {
+  return [`tlon notes folder ${nest} ${folderId}`];
+}
+
 // A *present* envelope body uses the strict whitelist; error/pending/unexpected
 // always throw. `createNotebook`/`createGroupNotebook` require a `notebook`
 // body and return its normalized summary.
-function unwrapNotebookEnvelope(res: any): NotesV1NotebookSummary {
+function unwrapNotebookEnvelope(
+  res: any,
+  checkCommands: string[]
+): NotesV1NotebookSummary {
   const body = res?.body;
   if (!body || typeof body.type !== 'string') {
     throw new Error('Unexpected %notes response (missing body).');
@@ -738,9 +852,7 @@ function unwrapNotebookEnvelope(res: any): NotesV1NotebookSummary {
     case 'error':
       throw new Error(notesEnvelopeErrorMessage(body));
     case 'pending':
-      throw new Error(
-        '%notes request is still pending — try again in a moment.'
-      );
+      throw new Error(pendingWriteMessage(res, checkCommands));
     default:
       throw new Error(`Unexpected %notes response type: ${body.type}`);
   }
@@ -750,7 +862,7 @@ function unwrapNotebookEnvelope(res: any): NotesV1NotebookSummary {
 // error/pending/unexpected throw). A bare/empty non-envelope JSON body (e.g. a
 // folder object from a convenience route) is accepted and ignored —
 // `requestJson` already throws on HTTP failure.
-function assertWriteOk(res: any): void {
+function assertWriteOk(res: any, checkCommands: string[]): void {
   const body = res?.body;
   if (!body || typeof body.type !== 'string') {
     return;
@@ -763,14 +875,18 @@ function assertWriteOk(res: any): void {
     case 'error':
       throw new Error(notesEnvelopeErrorMessage(body));
     case 'pending':
-      throw new Error(
-        '%notes request is still pending — try again in a moment.'
-      );
+      throw new Error(pendingWriteMessage(res, checkCommands));
     default:
       throw new Error(`Unexpected %notes response type: ${body.type}`);
   }
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+async function getRequestV1(requestId: string): Promise<NotesV1RequestStatus> {
+  const encoded = encodeURIComponent(requestId);
+  const res = await requestJson(`${REQUESTS_V1_PATH}/${encoded}`, 'GET');
+  return normalizeRequestStatusV1(res);
+}
 
 // --- notebook helpers ------------------------------------------------------
 
@@ -793,7 +909,7 @@ async function createNotebookV1({
   title: string;
 }): Promise<NotesV1NotebookSummary> {
   const res = await requestJson(NOTEBOOKS_V1_PATH, 'POST', { title });
-  return unwrapNotebookEnvelope(res);
+  return unwrapNotebookEnvelope(res, notebookWriteChecks());
 }
 
 async function createGroupNotebookV1({
@@ -810,7 +926,7 @@ async function createGroupNotebookV1({
     group,
     readers,
   });
-  return unwrapNotebookEnvelope(res);
+  return unwrapNotebookEnvelope(res, notebookWriteChecks());
 }
 
 // --- note helpers ----------------------------------------------------------
@@ -850,7 +966,7 @@ async function createNoteV1({
     title,
     body,
   });
-  assertWriteOk(res);
+  assertWriteOk(res, noteCreateChecks(notesChannelId(normalized)));
 }
 
 async function updateNoteBodyV1({
@@ -870,7 +986,7 @@ async function updateNoteBodyV1({
     payload.expectedRevision = expectedRevision;
   }
   const res = await requestJson(noteV1Path(normalized, noteId), 'PUT', payload);
-  assertWriteOk(res);
+  assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
 }
 
 async function renameNoteV1({
@@ -886,7 +1002,7 @@ async function renameNoteV1({
   const res = await requestJson(noteV1Path(normalized, noteId), 'PUT', {
     title,
   });
-  assertWriteOk(res);
+  assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
 }
 
 async function moveNoteV1({
@@ -902,7 +1018,7 @@ async function moveNoteV1({
   const res = await requestJson(noteV1Path(normalized, noteId), 'PUT', {
     folder,
   });
-  assertWriteOk(res);
+  assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
 }
 
 async function deleteNoteV1({
@@ -914,7 +1030,7 @@ async function deleteNoteV1({
 }): Promise<void> {
   const normalized = normalizeNotesTarget(flag);
   const res = await requestJson(noteV1Path(normalized, noteId), 'DELETE');
-  assertWriteOk(res);
+  assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
 }
 
 async function listNoteHistoryV1({
@@ -964,7 +1080,7 @@ async function createFolderV1({
     payload.parent = parent;
   }
   const res = await requestJson(foldersV1Path(normalized), 'POST', payload);
-  assertWriteOk(res);
+  assertWriteOk(res, folderCreateChecks(notesChannelId(normalized)));
 }
 
 async function renameFolderV1({
@@ -980,7 +1096,7 @@ async function renameFolderV1({
   const res = await requestJson(folderV1Path(normalized, folderId), 'PUT', {
     folderName: name,
   });
-  assertWriteOk(res);
+  assertWriteOk(res, folderChecks(notesChannelId(normalized), folderId));
 }
 
 async function moveFolderV1({
@@ -996,7 +1112,7 @@ async function moveFolderV1({
   const res = await requestJson(folderV1Path(normalized, folderId), 'PUT', {
     parent,
   });
-  assertWriteOk(res);
+  assertWriteOk(res, folderChecks(notesChannelId(normalized), folderId));
 }
 
 async function deleteFolderV1({
@@ -1013,7 +1129,7 @@ async function deleteFolderV1({
     `${folderV1Path(normalized, folderId)}?recursive=${recursive ? 'true' : 'false'}`,
     'DELETE'
   );
-  assertWriteOk(res);
+  assertWriteOk(res, folderChecks(notesChannelId(normalized), folderId));
 }
 
 // --- member helpers --------------------------------------------------------
@@ -1027,6 +1143,7 @@ async function listMembersV1(
 }
 
 export type NotesV1Api = {
+  getRequest: typeof getRequestV1;
   listNotebooks: typeof listNotebooksV1;
   getNotebook: typeof getNotebookV1;
   createNotebook: typeof createNotebookV1;
@@ -1049,6 +1166,7 @@ export type NotesV1Api = {
 };
 
 export const notesV1: NotesV1Api = {
+  getRequest: getRequestV1,
   listNotebooks: listNotebooksV1,
   getNotebook: getNotebookV1,
   createNotebook: createNotebookV1,

--- a/packages/tlon-skill/README.md
+++ b/packages/tlon-skill/README.md
@@ -165,7 +165,7 @@ tlon groups reject-invite ~host/group-slug
 - **Messages**: History, search (author nicknames shown)
 - **DMs**: Group DM send/reply, react, accept/decline
 - **Posts**: React, edit, delete
-- **Notes**: %notes notebooks (list, show, create, note-create, note-update, join, leave)
+- **Notes**: %notes notebooks (list, show, request, note-create, note-update, join, leave)
 - **Settings**: Hot-reload plugin config via settings-store
 
 ## Development

--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -453,11 +453,11 @@ Manage %notes notebooks (Markdown-first). Notebooks are nests of the form
 
 ```bash
 tlon notes status                                        # Check %notes reachability
+tlon notes request 0vabc                                 # Check a pending write request
 tlon notes list                                          # List your notebooks
 tlon notes show notes/~host/name                         # Show a notebook
 tlon notes notes notes/~host/name                        # List notes in a notebook
 tlon notes note notes/~host/name 12                      # Show a note (with Markdown body)
-tlon notes create "My Notebook"                          # Create a solo notebook
 tlon notes note-create notes/~host/name root "Title" --markdown post.md   # New note at the notebook root
 tlon notes note-create notes/~host/name 7 "Title" --stdin                 # New note in folder 7 from stdin
 tlon notes note-update notes/~host/name 12 --body new.md --expected-revision 3
@@ -481,10 +481,11 @@ or `--stdin`. `note-create` places the note in a folder id, or `root` (resolved 
 the notebook's root folder). `--expected-revision` on `note-update` is optional
 (last-write-wins by default).
 
-`notes create` makes a **solo** notebook. To create a **group-backed** notes
-channel (so members can read it as a group channel), use `tlon channels create
-~host/slug "Title" --kind notes` — %notes owns the listing, so `--description`
-and writer roles aren't accepted there.
+To create a **group-backed** notes channel for the Tlon app, use `tlon channels
+create ~host/slug "Title" --kind notes` — %notes owns the listing, so
+`--description` and writer roles aren't accepted there. Do not use
+`tlon notes create` for app/group channels; it creates a standalone %notes
+notebook only.
 
 ### Upload
 

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -475,6 +475,11 @@ export const NESTED_HELP_CASES: CliCase[] = [
     'Usage: tlon notes status'
   ),
   helpCase(
+    'notes request --help',
+    ['notes', 'request', '--help'],
+    'Usage: tlon notes request'
+  ),
+  helpCase(
     'notes list --help',
     ['notes', 'list', '--help'],
     'Usage: tlon notes list'
@@ -916,6 +921,17 @@ export const NOTES_FAMILY_CASES: CliCase[] = [
   ),
   authRequiredCase('notes list reaches auth', ['notes', 'list']),
   authRequiredCase('notes status reaches auth', ['notes', 'status']),
+  usageErrorCase(
+    'notes request missing id',
+    ['notes', 'request'],
+    'Usage: tlon notes request'
+  ),
+  usageErrorCase(
+    'notes request rejects path-like id',
+    ['notes', 'request', 'notes/~zod/blog'],
+    'Invalid request id'
+  ),
+  authRequiredCase('notes request reaches auth', ['notes', 'request', '0vabc']),
   authRequiredCase('notes show reaches auth', [
     'notes',
     'show',
@@ -1422,6 +1438,7 @@ export const HOSTILE_HELP_COMMANDS: HostileHelpCommand[] = [
   { name: 'posts delete', args: ['posts', 'delete', '--help'] },
   { name: 'posts edit', args: ['posts', 'edit', '--help'] },
   { name: 'notes status', args: ['notes', 'status', '--help'] },
+  { name: 'notes request', args: ['notes', 'request', '--help'] },
   { name: 'notes list', args: ['notes', 'list', '--help'] },
   { name: 'notes show', args: ['notes', 'show', '--help'] },
   { name: 'notes notes', args: ['notes', 'notes', '--help'] },

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -13,6 +13,7 @@ import {
 type AnyFn = (...args: unknown[]) => Promise<unknown>;
 
 const NOTES_V1_OPS = [
+  'getRequest',
   'listNotebooks',
   'getNotebook',
   'createNotebook',
@@ -153,6 +154,7 @@ describe('notes help and shell', () => {
   it('prints per-subcommand help for a help token after the subcommand', async () => {
     const cases: Array<[string, string]> = [
       ['status', NOTES_COMMAND_HELP.status],
+      ['request', NOTES_COMMAND_HELP.request],
       ['show', NOTES_COMMAND_HELP.show],
       ['note-create', NOTES_COMMAND_HELP['note-create']],
       ['note-update', NOTES_COMMAND_HELP['note-update']],
@@ -201,6 +203,21 @@ describe('notes nest parsing', () => {
       expect(exitCode).toBe(1);
       expect(context.stdout()).toBe('');
       expect(context.stderr()).toContain(`Invalid notes nest: ${nest}`);
+      expectNoAuthOrIo(context);
+    }
+  });
+
+  it('rejects a malformed request id locally before auth', async () => {
+    for (const requestId of ['notes/~zod/blog', '']) {
+      const args = requestId ? ['request', requestId] : ['request'];
+      const context = makeDeps();
+      const exitCode = await run(args, context.deps);
+
+      expect(exitCode).toBe(1);
+      expect(context.stdout()).toBe('');
+      expect(context.stderr()).toContain(
+        requestId ? 'Invalid request id' : NOTES_COMMAND_HELP.request
+      );
       expectNoAuthOrIo(context);
     }
   });
@@ -376,6 +393,68 @@ describe('notes status', () => {
 
     expect(exitCode).toBe(1);
     expect(context.stdout()).toContain('%notes v1 API: unreachable');
+  });
+});
+
+describe('notes request status', () => {
+  it('prints pending request status and exits nonzero', async () => {
+    const context = makeDeps({
+      notesV1: {
+        getRequest: async () => ({
+          requestId: '0vabc',
+          body: { type: 'pending', status: 'acked' },
+        }),
+      },
+    });
+
+    const exitCode = await run(['request', '0vabc'], context.deps);
+
+    expect(exitCode).toBe(1);
+    expect(context.calls.notesV1).toEqual([
+      { op: 'getRequest', args: ['0vabc'] },
+    ]);
+    expect(context.stdout()).toContain('Request: 0vabc');
+    expect(context.stdout()).toContain('Status: pending (acked)');
+    expect(context.stdout()).toContain('Do not issue the write again');
+  });
+
+  it('prints successful and failed terminal request statuses', async () => {
+    const ok = makeDeps({
+      notesV1: {
+        getRequest: async () => ({ requestId: '0vok', body: { type: 'ok' } }),
+      },
+    });
+    expect(await run(['request', '0vok'], ok.deps)).toBe(0);
+    expect(ok.stdout()).toContain('Status: ok');
+
+    const failed = makeDeps({
+      notesV1: {
+        getRequest: async () => ({
+          requestId: '0verr',
+          body: { type: 'error', message: 'target unavailable' },
+        }),
+      },
+    });
+    expect(await run(['request', '0verr'], failed.deps)).toBe(1);
+    expect(failed.stdout()).toContain('Status: error');
+    expect(failed.stdout()).toContain('Message: target unavailable');
+  });
+
+  it('prints notebook request results', async () => {
+    const context = makeDeps({
+      notesV1: {
+        getRequest: async () => ({
+          requestId: '0vbook',
+          body: { type: 'notebook', notebook: NOTEBOOK_SUMMARY },
+        }),
+      },
+    });
+
+    const exitCode = await run(['request', '0vbook'], context.deps);
+
+    expect(exitCode).toBe(0);
+    expect(context.stdout()).toContain('Status: notebook');
+    expect(context.stdout()).toContain('Nest: notes/~zod/blog');
   });
 });
 

--- a/packages/tlon-skill/scripts/commands/notes.ts
+++ b/packages/tlon-skill/scripts/commands/notes.ts
@@ -5,6 +5,7 @@ import type {
   NotesV1Note,
   NotesV1NoteRevision,
   NotesV1NotebookSummary,
+  NotesV1RequestStatus,
 } from '@tloncorp/api';
 
 import {
@@ -23,13 +24,20 @@ export const NOTES_HELP = `Usage: tlon notes <command>
 Manage %notes notebooks (Markdown-first notebooks). Notebooks are addressed as
 nests of the form notes/~host/name. Note bodies are plain Markdown.
 
+For Tlon app/group notebooks, create a notes channel with:
+  tlon channels create ~host/group-slug "Title" --kind notes
+
+The notes create command is for standalone %notes notebooks only; it does not
+create a Tlon app group channel.
+
 Commands:
   status                                  Report %notes reachability
+  request <request-id>                    Check a pending %notes write request
   list                                    List your notebooks
   show <nest>                             Show a notebook
   notes <nest>                            List notes in a notebook
   note <nest> <id>                        Show a note (with its Markdown body)
-  create <title>                          Create a solo notebook
+  create <title>                          Create a standalone %notes notebook (not an app channel)
   note-create <nest> <folder-id|root> <title> (--body <f> | --stdin | --markdown <f>)
   note-update <nest> <id> (--body <f> | --stdin) [--expected-revision <n>]
   note-rename <nest> <id> <title>         Rename a note
@@ -53,19 +61,22 @@ Content sources (Markdown):
 
 Examples:
   tlon notes list
-  tlon notes create "My Notebook"
+  tlon notes request 0vabc
+  tlon channels create ~zod/group "Notes" --kind notes
   tlon notes note-create notes/~zod/blog root "First Note" --markdown post.md
   tlon notes note-update notes/~zod/blog 12 --stdin --expected-revision 3`;
 
 export const NOTES_COMMAND_HELP: Record<string, string> = {
   status: 'Usage: tlon notes status',
+  request:
+    'Usage: tlon notes request <request-id>\nExample: tlon notes request 0vabc',
   list: 'Usage: tlon notes list',
   show: 'Usage: tlon notes show <nest>\nExample: tlon notes show notes/~zod/blog',
   notes:
     'Usage: tlon notes notes <nest>\nExample: tlon notes notes notes/~zod/blog',
   note: 'Usage: tlon notes note <nest> <id>\nExample: tlon notes note notes/~zod/blog 12',
   create:
-    'Usage: tlon notes create <title>\nExample: tlon notes create "My Notebook"',
+    'Usage: tlon notes create <title>\nCreates a standalone %notes notebook only. For Tlon app/group notebooks, use:\n  tlon channels create ~host/group-slug "Title" --kind notes',
   'note-create':
     'Usage: tlon notes note-create <nest> <folder-id|root> <title> (--body <file> | --stdin | --markdown <file>)',
   'note-update':
@@ -119,6 +130,7 @@ type Nest = { nest: string; host: string; name: string };
 type ParsedNotesArgs =
   | { kind: 'help'; help: string }
   | { kind: 'status' }
+  | { kind: 'request'; requestId: string }
   | { kind: 'list' }
   | { kind: 'show'; target: Nest }
   | { kind: 'list-notes'; target: Nest }
@@ -189,6 +201,17 @@ function requireNumericId(id: string, label: string, usage: string): string {
     throw usageError(`Invalid ${label}: ${id}. Expected a number.`, usage);
   }
   return id;
+}
+
+function parseRequestId(requestId: string, usage: string): string {
+  const trimmed = requestId.trim();
+  if (!trimmed || trimmed.includes('/')) {
+    throw usageError(
+      `Invalid request id: ${requestId}. Expected a %notes request id.`,
+      usage
+    );
+  }
+  return trimmed;
 }
 
 const NOTE_CREATE_OPTION_FLAGS = ['body', 'markdown', 'stdin'] as const;
@@ -283,6 +306,13 @@ function parseArgs(args: string[]): ParsedNotesArgs {
   switch (command) {
     case 'status':
       return { kind: 'status' };
+    case 'request': {
+      const requestId = args[1];
+      if (!requestId) {
+        throw usageError(help);
+      }
+      return { kind: 'request', requestId: parseRequestId(requestId, help) };
+    }
     case 'list':
       return { kind: 'list' };
     case 'show': {
@@ -599,6 +629,40 @@ function formatMemberLine(member: NotesV1MemberRecord): string {
   return `${member.ship}${roles}`;
 }
 
+function formatRequestStatus(status: NotesV1RequestStatus): string[] {
+  const lines = [`Request: ${status.requestId}`];
+  switch (status.body.type) {
+    case 'ok':
+      lines.push('Status: ok');
+      break;
+    case 'no-change':
+      lines.push('Status: no-change');
+      break;
+    case 'notebook':
+      lines.push('Status: notebook');
+      lines.push(`Nest: ${notebookNest(status.body.notebook)}`);
+      lines.push(`Title: ${status.body.notebook.notebook.title}`);
+      lines.push(`ID: ${status.body.notebook.notebook.id}`);
+      break;
+    case 'error':
+      lines.push('Status: error');
+      lines.push(
+        `Message: ${status.body.message?.trim() || 'backend returned an error without details'}`
+      );
+      break;
+    case 'pending':
+      lines.push(
+        `Status: pending${status.body.status ? ` (${status.body.status})` : ''}`
+      );
+      lines.push('Do not issue the write again while this request is pending.');
+      break;
+    case 'api-key':
+      lines.push('Status: api-key');
+      break;
+  }
+  return lines;
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand handlers
 // ---------------------------------------------------------------------------
@@ -618,6 +682,14 @@ async function runStatus(deps: NotesDeps): Promise<number> {
   // as unknown rather than guessing.
   writeLine(deps.stdout, 'group-channel mode: unknown (no runtime signal yet)');
   return reachable ? 0 : 1;
+}
+
+async function runRequest(requestId: string, deps: NotesDeps): Promise<number> {
+  const status = await deps.notesV1.getRequest(requestId);
+  for (const line of formatRequestStatus(status)) {
+    writeLine(deps.stdout, line);
+  }
+  return ['ok', 'no-change', 'notebook'].includes(status.body.type) ? 0 : 1;
 }
 
 async function runList(deps: NotesDeps): Promise<number> {
@@ -906,6 +978,8 @@ export async function run(args: string[], deps: NotesDeps): Promise<number> {
     switch (parsed.kind) {
       case 'status':
         return await runStatus(deps);
+      case 'request':
+        return await runRequest(parsed.requestId, deps);
       case 'list':
         return await runList(deps);
       case 'show':

--- a/packages/tlon-skill/scripts/main.ts
+++ b/packages/tlon-skill/scripts/main.ts
@@ -50,7 +50,7 @@ Commands:
   groups       Group management (list, create, info, join, request/accept invites, leave, delete, ...)
   hooks        Channel hooks management (list, add, edit, delete, order, config, cron, rest)
   messages     Message history and search (dm, channel, history, search, context, post)
-  notes        %notes notebooks (list, show, create, note-create, note-update, join, leave)
+  notes        %notes notebooks (list, show, request, note-create, note-update, join, leave)
   posts        Post reactions, edits, deletes (react, unreact, edit, delete)
   settings     OpenClaw settings management (get, set, delete, allow-dm, ...)
   upload       Upload a file from URL, local path, or stdin


### PR DESCRIPTION
## Summary

Fixes TLON-6052

Add a `tlon notes request` command for checking pending %notes write requests and update pending-write errors to guide users/bots toward request inspection instead of retrying. This makes pending write outcomes easier to diagnose from the Tlon skill CLI.

## Changes

- Added `notesV1.getRequest` in `packages/api` for `GET /notes/~/v1/request/<request-id>`, including normalization for pending, ok, no-change, error, api-key, and notebook responses.
- Updated %notes write envelope handling to include request IDs and follow-up read commands when the backend returns a pending write.
- Added `tlon notes request <request-id>` parsing, output formatting, exit codes, help text, and CLI matrix coverage.
- Clarified notes help and docs so app/group notes channels point users to `tlon channels create ... --kind notes`, while `tlon notes create` is described as standalone %notes notebook creation.
- Added API and tlon-skill coverage for request status responses, pending write guidance, and malformed request IDs.

## How did I test?

- `pnpm --filter @tloncorp/api exec vitest run src/client/notesApi.test.ts`
- `pnpm --filter @tloncorp/api tsc`
- `pnpm --filter @tloncorp/tlon-skill exec bun test scripts/commands/notes.test.ts tests/hermetic/cli.test.ts`
- `pnpm --filter @tloncorp/tlon-skill typecheck`
- Live-tested against local `~zod` by creating a test note through the %notes v1 endpoint, checking its returned request ID with `tlon notes request <request-id>`, verifying the note rendered through the CLI, deleting it, and confirming an unknown request ID returns `HTTP 404` with exit code 1.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area: Skill

## Rollback plan

Revert.
