### PR TITLE
feat(openclaw/lens): retrySeed + payload skeletonization + steward retry dispatch

### DIFF
--- a/packages/openclaw/src/context-lens-ship-sync.test.ts
+++ b/packages/openclaw/src/context-lens-ship-sync.test.ts
@@ -124,7 +124,7 @@ describe('isContextLensEffectivelyEnabled', () => {
 });
 
 describe('buildLensRunPayload', () => {
-  it('builds a run payload object with a schemaVersion', () => {
+  it('serializes the lens with a schemaVersion', () => {
     const lens = makeLens();
     const payload = buildLensRunPayload(lens);
     expect(payload.schemaVersion).toBe(1);
@@ -169,6 +169,64 @@ describe('buildLensRunPayload', () => {
     expect(payload.truncated).toBe(true);
     expect(payload.lens.tools.runs).toEqual([]);
     expect(payload.lens.status).toBe(lens.status);
+    expect(JSON.stringify(payload).length).toBeLessThan(50 * 1_024);
+  });
+
+  it('includes retrySeed in the run payload and keeps retryOf', () => {
+    const lens = makeLens();
+    lens.retryOf = 'lens-original';
+    lens.retrySeed = {
+      messageText: 'secret original message body',
+      blobField: '{"k":"v"}',
+    };
+    const payload = buildLensRunPayload(lens);
+    expect(payload.lens.retrySeed).toEqual({
+      messageText: 'secret original message body',
+      blobField: '{"k":"v"}',
+    });
+    expect(payload.lens.retryOf).toBe('lens-original');
+    expect(JSON.stringify(payload)).toContain('secret original message body');
+  });
+
+  it('keeps retrySeed when oversized payloads are skeletonized', () => {
+    const registry = createContextLensRegistry({ ttlMs: 60_000 });
+    const blobField = JSON.stringify({ body: 'b'.repeat(7_500) });
+    const lens = registry.create({
+      messageId: 'msg-oversized-retry',
+      chatType: 'channel',
+      trigger: 'mention',
+      senderShip: '~ten',
+      conversationId: 'chat/~ten/test',
+      retrySeed: {
+        messageText: 'm'.repeat(20_000),
+        blobField,
+        parentId: '170.1',
+        isThreadReply: true,
+        replyParentId: '170.2',
+        cachesHistory: true,
+      },
+    });
+    lens.tools.runs = Array.from({ length: 100 }, (_, i) => ({
+      id: `t-${i}`,
+      callIndex: i + 1,
+      name: 'browser',
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+      durationMs: 5,
+      status: 'completed' as const,
+      argumentSummary: 'y'.repeat(4_000),
+      resultSummary: 'z'.repeat(4_000),
+    }));
+
+    const payload = buildLensRunPayload(lens);
+
+    expect(payload.truncated).toBe(true);
+    expect(payload.lens.tools.runs).toEqual([]);
+    expect(payload.lens.context.sources).toEqual([]);
+    expect(payload.lens.outputs).toEqual([]);
+    expect(payload.lens.retrySeed).toEqual(lens.retrySeed);
+    expect(payload.lens.retrySeed?.messageText).toHaveLength(16_384);
+    expect(payload.lens.retrySeed?.blobField).toBe(blobField);
     expect(JSON.stringify(payload).length).toBeLessThan(50 * 1_024);
   });
 });

--- a/packages/openclaw/src/context-lens-ship-sync.ts
+++ b/packages/openclaw/src/context-lens-ship-sync.ts
@@ -22,6 +22,7 @@ const TERMINAL_STATUSES: ReadonlySet<ContextLensStatus> = new Set([
   'completed',
   'no_reply',
   'timed_out',
+  'aborted',
   'error',
 ]);
 
@@ -65,6 +66,12 @@ export type LensRunPayload = {
  * untruncated runs remain on gateway disk (Phase 2 store).
  */
 export function buildLensRunPayload(lens: ContextLens): LensRunPayload {
+  // retrySeed (raw chat text + blob field) rides along on the lens snapshot
+  // so the agent is the durable source of truth for retry: any gateway,
+  // current or future, can replay a run by scrying %steward for the payload
+  // regardless of local cache state. Message text is already on the ship in
+  // the original DM/channel, so mirroring it here does not introduce new
+  // exposure; it does grow per-poke Ames traffic by roughly 1-10KB.
   const slim: ContextLens = {
     ...lens,
     context: {
@@ -91,8 +98,9 @@ export function buildLensRunPayload(lens: ContextLens): LensRunPayload {
   if (JSON.stringify(payload).length <= MAX_PAYLOAD_CHARS) {
     return payload;
   }
-  // Still oversized (e.g. hundreds of tool runs): drop the bulky arrays but
-  // keep the run's identity, status, and timings inspectable.
+  // Still oversized (e.g. hundreds of tool runs or a giant message): drop
+  // the bulky arrays but keep run identity, retrySeed, and status; retry
+  // remains possible because retrySeed survives the skeletonization.
   const skeleton: ContextLens = {
     ...slim,
     context: { ...slim.context, sources: [] },

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -903,7 +903,29 @@ describe('retry seed and dispatch', () => {
     const noTextLens = registry.setStatus(noText.lensId, 'no_reply');
     expect(buildRetryDispatch(noTextLens!)).toEqual({
       ok: false,
-      reason: 'no message text available to retry',
+      reason: 'no message text or blob available to retry',
     });
+  });
+
+  it('retries a blob-only run with no text', () => {
+    const registry = createContextLensRegistry({ ttlMs: 60_000 });
+    const blobOnly = registry.create({
+      messageId: 'message-retry-blob',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-blob',
+      senderShip: '~ten',
+      retrySeed: {
+        messageText: '',
+        blobField: '{"voice":"memo"}',
+      },
+    });
+    const blobOnlyLens = registry.setStatus(blobOnly.lensId, 'no_reply');
+    const result = buildRetryDispatch(blobOnlyLens!);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.dispatch.messageText).toBe('');
+      expect(result.dispatch.blobField).toBe('{"voice":"memo"}');
+    }
   });
 });

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -8,6 +8,7 @@ import {
 } from './context-lens-events.js';
 import {
   bindContextLensToSession,
+  buildRetryDispatch,
   createContextLensRegistry,
   ensureBackgroundContextLensForSession,
   finalizeBackgroundContextLensForSession,
@@ -731,6 +732,178 @@ describe('context lens event bus', () => {
     expect(duplicateBus.findRecentContextLensById(lens.lensId)).toMatchObject({
       lensId: lens.lensId,
       messageId: 'message-global-bus',
+    });
+  });
+});
+
+describe('retry seed and dispatch', () => {
+  it('captures retryOf and retrySeed on create and preserves them through clones', () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-1',
+      chatType: 'channel',
+      trigger: 'retry',
+      sessionKey: 'session-retry-1',
+      senderShip: '~ten',
+      conversationId: 'chat/~ten/test',
+      retryOf: 'lens-original',
+      retrySeed: {
+        messageText: 'hello again',
+        blobField: '{"k":"v"}',
+        parentId: '170.1',
+        isThreadReply: true,
+        replyParentId: '170.2',
+        cachesHistory: true,
+      },
+    });
+
+    expect(lens.retryOf).toBe('lens-original');
+    expect(lens.retrySeed).toEqual({
+      messageText: 'hello again',
+      blobField: '{"k":"v"}',
+      parentId: '170.1',
+      isThreadReply: true,
+      replyParentId: '170.2',
+      cachesHistory: true,
+    });
+
+    const fetched = registry.get(lens.lensId);
+    expect(fetched?.retrySeed).toEqual(lens.retrySeed);
+    // Clones are independent copies, not shared references.
+    expect(fetched?.retrySeed).not.toBe(lens.retrySeed);
+  });
+
+  it('caps oversized retry seed text and drops oversized blobs', () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-2',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-2',
+      senderShip: '~ten',
+      retrySeed: {
+        messageText: 'x'.repeat(20_000),
+        blobField: 'y'.repeat(10_000),
+      },
+    });
+
+    expect(lens.retrySeed?.messageText.length).toBe(16_384);
+    expect(lens.retrySeed?.blobField).toBeUndefined();
+  });
+
+  it("builds a retry dispatch from a failed run's seed", () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-3',
+      chatType: 'channel',
+      trigger: 'mention',
+      sessionKey: 'session-retry-3',
+      senderShip: '~ten',
+      conversationId: 'chat/~ten/test',
+      preview: 'preview text',
+      retrySeed: {
+        messageText: 'full original text',
+        blobField: null,
+        parentId: '170.5',
+        isThreadReply: true,
+        replyParentId: null,
+        cachesHistory: true,
+      },
+    });
+    const aborted = registry.setStatus(lens.lensId, 'aborted');
+    expect(aborted).not.toBeNull();
+
+    const result = buildRetryDispatch(aborted!);
+    expect(result).toEqual({
+      ok: true,
+      dispatch: {
+        messageId: 'message-retry-3',
+        senderShip: '~ten',
+        messageText: 'full original text',
+        blobField: null,
+        isGroup: true,
+        channelNest: 'chat/~ten/test',
+        parentId: '170.5',
+        isThreadReply: true,
+        replyParentId: null,
+        cachesHistory: true,
+        degraded: false,
+      },
+    });
+  });
+
+  it('falls back to the preview as degraded when the run predates retrySeed', () => {
+    const registry = createContextLensRegistry();
+    const lens = registry.create({
+      messageId: 'message-retry-4',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-4',
+      senderShip: '~ten',
+      preview: 'truncated preview',
+    });
+    const failed = registry.setStatus(lens.lensId, 'error', new Error('boom'));
+
+    const result = buildRetryDispatch(failed!);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.dispatch.messageText).toBe('truncated preview');
+      expect(result.dispatch.degraded).toBe(true);
+      expect(result.dispatch.isGroup).toBe(false);
+    }
+  });
+
+  it('refuses non-retryable, internal, and incomplete runs', () => {
+    const registry = createContextLensRegistry();
+
+    const completed = registry.create({
+      messageId: 'message-retry-5',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-5',
+      senderShip: '~ten',
+      preview: 'done',
+    });
+    const completedLens = registry.setStatus(completed.lensId, 'completed');
+    expect(buildRetryDispatch(completedLens!)).toEqual({
+      ok: false,
+      reason: 'status completed is not retryable',
+    });
+
+    const internal = registry.create({
+      messageId: 'message-retry-6',
+      chatType: 'internal',
+      trigger: 'cron',
+      sessionKey: 'session-retry-6',
+      preview: 'cron run',
+    });
+    const internalLens = registry.setStatus(internal.lensId, 'error');
+    expect(buildRetryDispatch(internalLens!).ok).toBe(false);
+
+    const noAuthor = registry.create({
+      messageId: 'message-retry-7',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-7',
+      preview: 'anonymous',
+    });
+    const noAuthorLens = registry.setStatus(noAuthor.lensId, 'timed_out');
+    expect(buildRetryDispatch(noAuthorLens!)).toEqual({
+      ok: false,
+      reason: 'original run has no author ship',
+    });
+
+    const noText = registry.create({
+      messageId: 'message-retry-8',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-8',
+      senderShip: '~ten',
+    });
+    const noTextLens = registry.setStatus(noText.lensId, 'no_reply');
+    expect(buildRetryDispatch(noTextLens!)).toEqual({
+      ok: false,
+      reason: 'no message text available to retry',
     });
   });
 });

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -821,6 +821,7 @@ describe('retry seed and dispatch', () => {
         senderShip: '~ten',
         messageText: 'full original text',
         blobField: null,
+        messageContent: null,
         isGroup: true,
         channelNest: 'chat/~ten/test',
         parentId: '170.5',
@@ -903,7 +904,7 @@ describe('retry seed and dispatch', () => {
     const noTextLens = registry.setStatus(noText.lensId, 'no_reply');
     expect(buildRetryDispatch(noTextLens!)).toEqual({
       ok: false,
-      reason: 'no message text or blob available to retry',
+      reason: 'no message text, blob, or content available to retry',
     });
   });
 
@@ -926,6 +927,32 @@ describe('retry seed and dispatch', () => {
     if (result.ok) {
       expect(result.dispatch.messageText).toBe('');
       expect(result.dispatch.blobField).toBe('{"voice":"memo"}');
+    }
+  });
+
+  it('preserves messageContent so image-block media can be re-attached', () => {
+    const registry = createContextLensRegistry({ ttlMs: 60_000 });
+    const messageContent = [
+      { block: { image: { src: 'https://example.com/cat.png' } } },
+    ];
+    // an image-only message: no text, no blobField, media lives in the Story
+    const imageRun = registry.create({
+      messageId: 'message-retry-image',
+      chatType: 'dm',
+      trigger: 'dm',
+      sessionKey: 'session-retry-image',
+      senderShip: '~ten',
+      retrySeed: {
+        messageText: '',
+        messageContent,
+      },
+    });
+    const imageLens = registry.setStatus(imageRun.lensId, 'error');
+    const result = buildRetryDispatch(imageLens!);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.dispatch.messageText).toBe('');
+      expect(result.dispatch.messageContent).toEqual(messageContent);
     }
   });
 });

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -349,8 +349,12 @@ export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
   }
   const seed = lens.retrySeed;
   const messageText = seed?.messageText ?? lens.triggerDetails.preview ?? '';
-  if (!messageText.trim()) {
-    return { ok: false, reason: 'no message text available to retry' };
+  const blobField = seed?.blobField ?? null;
+  // A blob-only run (e.g. a voice memo or file with no text) is dispatchable:
+  // the inbound path accepts hasBlob and processMessage rebuilds the prompt
+  // from blobField. Only reject when there's neither text nor a blob to replay.
+  if (!messageText.trim() && !blobField) {
+    return { ok: false, reason: 'no message text or blob available to retry' };
   }
   return {
     ok: true,
@@ -358,7 +362,7 @@ export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
       messageId: lens.messageId,
       senderShip,
       messageText,
-      blobField: seed?.blobField ?? null,
+      blobField,
       isGroup,
       ...(isGroup && conversationId ? { channelNest: conversationId } : {}),
       parentId: seed?.parentId ?? null,

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -57,6 +57,10 @@ export type ContextLensTriggerDetails = {
 export type ContextLensRetrySeed = {
   messageText: string;
   blobField?: string | null;
+  // Raw Tlon Story content, persisted so a retry can re-attach media that
+  // lives in image blocks (not blobField) — downloadMessageImages rebuilds
+  // MediaPaths from the durable image URLs it carries.
+  messageContent?: unknown;
   parentId?: string | null;
   isThreadReply?: boolean;
   replyParentId?: string | null;
@@ -310,6 +314,7 @@ export type RetryDispatch = {
   senderShip: string;
   messageText: string;
   blobField?: string | null;
+  messageContent?: unknown;
   isGroup: boolean;
   channelNest?: string;
   parentId?: string | null;
@@ -350,11 +355,16 @@ export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
   const seed = lens.retrySeed;
   const messageText = seed?.messageText ?? lens.triggerDetails.preview ?? '';
   const blobField = seed?.blobField ?? null;
-  // A blob-only run (e.g. a voice memo or file with no text) is dispatchable:
-  // the inbound path accepts hasBlob and processMessage rebuilds the prompt
-  // from blobField. Only reject when there's neither text nor a blob to replay.
-  if (!messageText.trim() && !blobField) {
-    return { ok: false, reason: 'no message text or blob available to retry' };
+  const messageContent = seed?.messageContent ?? null;
+  // A run with no text is still dispatchable when it carries media: a blob
+  // attachment (voice memo/file via blobField) or image blocks in the Story
+  // content (downloadMessageImages re-attaches them). Only reject when there's
+  // nothing — no text, blob, or content — to replay.
+  if (!messageText.trim() && !blobField && !messageContent) {
+    return {
+      ok: false,
+      reason: 'no message text, blob, or content available to retry',
+    };
   }
   return {
     ok: true,
@@ -363,6 +373,7 @@ export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
       senderShip,
       messageText,
       blobField,
+      messageContent,
       isGroup,
       ...(isGroup && conversationId ? { channelNest: conversationId } : {}),
       parentId: seed?.parentId ?? null,

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -12,6 +12,7 @@ export type ContextLensTrigger =
   | 'owner-blob'
   | 'summarization'
   | 'tool'
+  | 'retry'
   | 'unknown';
 
 export type ContextLensRunKind =
@@ -32,6 +33,7 @@ export type ContextLensStatus =
   | 'completed'
   | 'no_reply'
   | 'timed_out'
+  | 'aborted'
   | 'error';
 
 export type ContextLensTriggerDetails = {
@@ -42,6 +44,23 @@ export type ContextLensTriggerDetails = {
   conversationKind: 'dm' | 'channel' | 'internal';
   receivedAt?: number;
   preview?: string;
+};
+
+/**
+ * Snapshot of the original dispatch inputs, captured at lens creation so an
+ * owner-requested retry can re-dispatch the message faithfully. The seed is
+ * capped at capture, persisted in the JSONL store, and included in ship-sync
+ * payloads so the owner ship can retry runs even if gateway-local cache state
+ * is gone. Message text and blob JSON already originate from the DM/channel
+ * visible to the owner.
+ */
+export type ContextLensRetrySeed = {
+  messageText: string;
+  blobField?: string | null;
+  parentId?: string | null;
+  isThreadReply?: boolean;
+  replyParentId?: string | null;
+  cachesHistory?: boolean;
 };
 
 export type ContextLensSourceKind =
@@ -106,6 +125,9 @@ export type ContextLens = {
   visibility: ContextLensVisibility;
   trigger: ContextLensTrigger;
   triggerDetails: ContextLensTriggerDetails;
+  /** lensId of the run this one retries, when trigger is "retry". */
+  retryOf?: string;
+  retrySeed?: ContextLensRetrySeed;
   model: string | null;
   provider: string | null;
   context: {
@@ -165,6 +187,8 @@ export type CreateContextLensInput = {
   conversationId?: string;
   receivedAt?: number;
   preview?: string;
+  retryOf?: string;
+  retrySeed?: ContextLensRetrySeed;
   now?: number;
   ttlMs?: number;
 };
@@ -198,6 +222,8 @@ type ActiveContextLensBinding = {
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const MAX_LENSES = 200;
+const MAX_RETRY_SEED_TEXT_CHARS = 16_384;
+export const MAX_RETRY_SEED_BLOB_CHARS = 8_192;
 // Long enough for the gateway to deliver the run's reply (cron DMs etc.)
 // after the last tool result, so the outbound stamp/output land on the lens
 // before it finalizes.
@@ -253,6 +279,94 @@ function cloneLens(lens: ContextLens): ContextLens {
     outputs: lens.outputs.map((output) => ({ ...output })),
     lifecycle: { ...lens.lifecycle },
     triggerDetails: { ...lens.triggerDetails },
+    ...(lens.retrySeed ? { retrySeed: { ...lens.retrySeed } } : {}),
+  };
+}
+
+function capRetrySeed(seed: ContextLensRetrySeed): ContextLensRetrySeed {
+  const capped: ContextLensRetrySeed = {
+    ...seed,
+    messageText: seed.messageText.slice(0, MAX_RETRY_SEED_TEXT_CHARS),
+  };
+  // A truncated blob would be unparseable JSON — drop it instead.
+  if (
+    typeof seed.blobField === 'string' &&
+    seed.blobField.length > MAX_RETRY_SEED_BLOB_CHARS
+  ) {
+    delete capped.blobField;
+  }
+  return capped;
+}
+
+export const RETRYABLE_STATUSES: ReadonlySet<ContextLensStatus> = new Set([
+  'no_reply',
+  'timed_out',
+  'aborted',
+  'error',
+]);
+
+export type RetryDispatch = {
+  messageId: string;
+  senderShip: string;
+  messageText: string;
+  blobField?: string | null;
+  isGroup: boolean;
+  channelNest?: string;
+  parentId?: string | null;
+  isThreadReply?: boolean;
+  replyParentId?: string | null;
+  cachesHistory?: boolean;
+  /** True when dispatching from the truncated preview because the run predates retrySeed. */
+  degraded: boolean;
+};
+
+export type RetryDispatchResult =
+  | { ok: true; dispatch: RetryDispatch }
+  | { ok: false; reason: string };
+
+/**
+ * Reconstruct processMessage params from a finalized lens so an owner can
+ * re-run it. Pure eligibility + mapping; the caller owns dedup and dispatch.
+ */
+export function buildRetryDispatch(lens: ContextLens): RetryDispatchResult {
+  if (!RETRYABLE_STATUSES.has(lens.status)) {
+    return { ok: false, reason: `status ${lens.status} is not retryable` };
+  }
+  if (
+    lens.triggerDetails.conversationKind === 'internal' ||
+    lens.runKind === 'internal'
+  ) {
+    return { ok: false, reason: 'internal runs cannot be retried' };
+  }
+  const senderShip = lens.triggerDetails.authorShip;
+  if (!senderShip) {
+    return { ok: false, reason: 'original run has no author ship' };
+  }
+  const isGroup = lens.triggerDetails.conversationKind === 'channel';
+  const conversationId = lens.triggerDetails.conversationId;
+  if (isGroup && !conversationId) {
+    return { ok: false, reason: 'channel run has no conversation id' };
+  }
+  const seed = lens.retrySeed;
+  const messageText = seed?.messageText ?? lens.triggerDetails.preview ?? '';
+  if (!messageText.trim()) {
+    return { ok: false, reason: 'no message text available to retry' };
+  }
+  return {
+    ok: true,
+    dispatch: {
+      messageId: lens.messageId,
+      senderShip,
+      messageText,
+      blobField: seed?.blobField ?? null,
+      isGroup,
+      ...(isGroup && conversationId ? { channelNest: conversationId } : {}),
+      parentId: seed?.parentId ?? null,
+      isThreadReply: seed?.isThreadReply ?? false,
+      replyParentId: seed?.replyParentId ?? null,
+      cachesHistory: seed?.cachesHistory ?? true,
+      degraded: !seed,
+    },
   };
 }
 
@@ -318,6 +432,8 @@ export function createContextLensRegistry(
         ...(input.receivedAt ? { receivedAt: input.receivedAt } : {}),
         ...(input.preview ? { preview: input.preview } : {}),
       },
+      ...(input.retryOf ? { retryOf: input.retryOf } : {}),
+      ...(input.retrySeed ? { retrySeed: capRetrySeed(input.retrySeed) } : {}),
       model: null,
       provider: null,
       context: {

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -6,13 +6,19 @@ import type { OpenClawConfig, ReplyPayload } from 'openclaw/plugin-sdk/core';
 import type { RuntimeEnv } from 'openclaw/plugin-sdk/runtime';
 
 import {
+  findRecentContextLensById,
   publishContextLensEvent,
   setContextLensEventCapacity,
 } from '../context-lens-events.js';
-import { isContextLensEffectivelyEnabled } from '../context-lens-ship-sync.js';
+import {
+  isContextLensEffectivelyEnabled,
+  resolveLensOwner,
+} from '../context-lens-ship-sync.js';
+import { getContextLensStore } from '../context-lens-store.js';
 import {
   type ContextLensTrigger,
   bindContextLensToSession,
+  buildRetryDispatch,
   createContextLensRegistry,
   unbindContextLensFromSession,
 } from '../context-lens.js';
@@ -1922,6 +1928,7 @@ export async function monitorTlonProvider(
       parentId?: string | null;
       isThreadReply?: boolean;
       replyParentId?: string | null; // Override parentId for delivery only (not in ctx payload)
+      retryOf?: string; // lensId of the failed run this dispatch retries
     }) => {
       const {
         messageId,
@@ -2003,6 +2010,15 @@ export async function monitorTlonProvider(
         conversationId: isGroup ? groupChannel ?? '' : senderShip,
         receivedAt: timestamp,
         preview: previewText(messageText),
+        ...(params.retryOf ? { retryOf: params.retryOf } : {}),
+        retrySeed: {
+          messageText: rawMessageText,
+          blobField: params.blobField ?? null,
+          parentId: parentId ?? null,
+          isThreadReply: Boolean(isThreadReply),
+          replyParentId: params.replyParentId ?? null,
+          cachesHistory: Boolean(params.cachesHistory),
+        },
       });
       contextLenses.recordPersistence(lens.lensId, {
         cachesHistory: Boolean(params.cachesHistory),
@@ -3797,6 +3813,146 @@ export async function monitorTlonProvider(
         },
       });
       runtime.log?.('[tlon] Subscribed to contacts updates (/v1/news)');
+
+      // Subscribe to the bot ship's %steward lens module for owner-initiated
+      // retries. The agent verifies the requester before emitting the fact;
+      // the checks here are defense-in-depth. /v1/lens carries both %entry
+      // and %retry-requested updates — we ignore entries (they're echoes of
+      // our own pokes) and act only on the retry signal.
+      if (contextLensEnabled) {
+        const recentRetryDispatches = new Map<string, number>();
+        const RETRY_DEDUP_MS = 60_000;
+        const handleLensRetryFact = async (data: unknown) => {
+          const update = (
+            data as {
+              lens?: {
+                'retry-requested'?: { id?: unknown; requester?: unknown };
+              };
+            } | null
+          )?.lens?.['retry-requested'];
+          if (!update) {
+            // %entry updates (our own pokes echoing back) — ignore.
+            return;
+          }
+          const lensId = typeof update.id === 'string' ? update.id : '';
+          const requester =
+            typeof update.requester === 'string'
+              ? normalizeShip(update.requester)
+              : '';
+          if (!lensId || !requester) {
+            return;
+          }
+          // Align with the singular owner the agent actually stores; any
+          // "extra" configured owners are ignored at sync-configure time too,
+          // so accepting their retries here would be inconsistent.
+          const owner = resolveLensOwner(cfg, opts.accountId ?? undefined);
+          if (!owner || owner !== requester) {
+            runtime.log?.(
+              `[tlon] Context lens retry refused for ${lensId}: requester ${requester} is not the configured owner`
+            );
+            return;
+          }
+          const now = Date.now();
+          for (const [id, ts] of recentRetryDispatches) {
+            if (now - ts > RETRY_DEDUP_MS) {
+              recentRetryDispatches.delete(id);
+            }
+          }
+          if (recentRetryDispatches.has(lensId)) {
+            runtime.log?.(
+              `[tlon] Context lens retry ignored for ${lensId}: recently dispatched`
+            );
+            return;
+          }
+          // Reserve the dedup slot before the first await so two concurrent
+          // retry facts for the same lensId can't both pass the check above.
+          recentRetryDispatches.set(lensId, now);
+          const lens =
+            contextLenses.get(lensId) ??
+            findRecentContextLensById(lensId) ??
+            getContextLensStore()?.get(lensId);
+          if (!lens) {
+            recentRetryDispatches.delete(lensId);
+            runtime.log?.(
+              `[tlon] Context lens retry refused: run ${lensId} not found`
+            );
+            return;
+          }
+          const result = buildRetryDispatch(lens);
+          if (!result.ok) {
+            recentRetryDispatches.delete(lensId);
+            runtime.log?.(
+              `[tlon] Context lens retry refused for ${lensId}: ${result.reason}`
+            );
+            return;
+          }
+          const dispatch = result.dispatch;
+          if (await isShipBlocked(dispatch.senderShip)) {
+            recentRetryDispatches.delete(lensId);
+            runtime.log?.(
+              `[tlon] Context lens retry refused for ${lensId}: original sender ${dispatch.senderShip} is blocked`
+            );
+            return;
+          }
+          runtime.log?.(
+            `[tlon] Context lens retry dispatching for ${lensId} (requested by ${requester})${
+              dispatch.degraded
+                ? ' [degraded: no retry seed, using preview]'
+                : ''
+            }`
+          );
+          await processMessage({
+            messageId: lens.messageId,
+            senderShip: dispatch.senderShip,
+            messageText: dispatch.messageText,
+            blobField: dispatch.blobField,
+            isGroup: dispatch.isGroup,
+            ...(dispatch.channelNest
+              ? { channelNest: dispatch.channelNest }
+              : {}),
+            timestamp: Date.now(),
+            parentId: dispatch.parentId,
+            isThreadReply: dispatch.isThreadReply,
+            replyParentId: dispatch.replyParentId,
+            cachesHistory: dispatch.cachesHistory,
+            trigger: 'retry',
+            retryOf: lensId,
+          });
+        };
+        try {
+          await api.subscribe({
+            app: 'steward',
+            path: '/v1/lens',
+            event: (data) => {
+              handleLensRetryFact(data).catch((error: any) => {
+                runtime.error?.(
+                  `[tlon] Steward lens retry handler error: ${error?.message ?? String(error)}`
+                );
+              });
+            },
+            err: (error) => {
+              runtime.error?.(
+                `[tlon] Steward lens subscription error: ${String(error)}`
+              );
+            },
+            quit: () => {
+              runtime.log?.(
+                '[tlon] Steward lens quit received, SSE client will resubscribe'
+              );
+            },
+          });
+          runtime.log?.(
+            '[tlon] Subscribed to steward lens facts (/v1/lens) for retry signals'
+          );
+        } catch (error: any) {
+          // Ships without %steward (or older context-lens-only ships) nack
+          // the subscribe; retries are unavailable but everything else keeps
+          // working.
+          runtime.log?.(
+            `[tlon] Steward lens subscription unavailable: ${error?.message ?? String(error)}`
+          );
+        }
+      }
 
       // Subscribe to settings store for hot-reloading config
       const applySettingsSnapshot = (

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -2014,6 +2014,7 @@ export async function monitorTlonProvider(
         retrySeed: {
           messageText: rawMessageText,
           blobField: params.blobField ?? null,
+          messageContent: messageContent ?? null,
           parentId: parentId ?? null,
           isThreadReply: Boolean(isThreadReply),
           replyParentId: params.replyParentId ?? null,
@@ -3906,6 +3907,9 @@ export async function monitorTlonProvider(
             senderShip: dispatch.senderShip,
             messageText: dispatch.messageText,
             blobField: dispatch.blobField,
+            ...(dispatch.messageContent
+              ? { messageContent: dispatch.messageContent }
+              : {}),
             isGroup: dispatch.isGroup,
             ...(dispatch.channelNest
               ? { channelNest: dispatch.channelNest }


### PR DESCRIPTION
Stacks on Pat's context-lens gateway port (#5936, `po/migrate-context-lens`). Extracts **only** the retry-durability vertical from the omnibus #6016 (`wsa/gateway-lens-hardening`) — none of that PR's unrelated session-routing/telemetry/version/diagnostics churn, no `owner→owners[]` widening, no abort-recovery sidecar.

## What this adds
- **retrySeed capture.** Each lens run records a `ContextLensRetrySeed` (raw chat text + blob field, capped), so a failed run can be replayed from data the agent durably holds — not from local gateway cache.
- **retrySeed travels to %steward.** `buildLensRunPayload` carries the seed through to the lens payload. Oversized payloads are **skeletonized** (bulky tool/source/output arrays dropped) while preserving run identity, status, and the retrySeed — so retry survives truncation.
- **Gateway retry dispatch.** `buildRetryDispatch` maps a terminal-failed run + seed into a replay; the monitor subscribes to the bot ship's `%steward` `/v1/lens` facts and, on a `retry-requested` update **from the configured owner**, re-invokes `processMessage`. Dedupes recent dispatches, refuses non-owner requesters and blocked senders, and tolerates ships without `%steward` (subscribe nacks → retries simply unavailable).

This pairs with the steward `%retry` / `%retry-requested` loop (PR #5988): owner requests a retry → steward emits the fact → this gateway replays.

## Payload encoding note
The payload is a **typed JSON object**, matching the `%steward` `steward-lens-action-1` mark (grow `['payload' payload.act]`, grab `payload+same` → stored as `$json`). The omnibus had serialized it to a cord on the premise that `$json` in a Hoon mark sample breaks ford — that was a mark-arm **shadowing** bug, since fixed; this PR keeps the object form base #5936 already uses.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec vitest run src/` — 650/650 pass (adds retrySeed capture/cap, buildRetryDispatch success/degraded/refusal, payload-includes-seed, seed-survives-skeletonization)
- [x] `prettier` clean
- [ ] Manual: owner-initiated retry round-trips through %steward to a re-dispatched run

🤖 Generated with [Claude Code](https://claude.com/claude-code)