### PR TITLE
openclaw: emit cron-run failures to PostHog

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -42,6 +42,7 @@ import {
   type TlonSessionDiagnosticReportInput,
   formatTlonTelemetryErrorText,
   recordToolCall,
+  reportCronRun,
   reportHarnessDebug,
   reportHarnessError,
   reportOutboundRoute,
@@ -1485,8 +1486,35 @@ export default defineChannelPluginEntry({
         publishContextLensEvent('created', background.lens);
       }
     };
-    api.on('agent_turn_prepare', (_event, ctx) => ensureCronContextLens(ctx));
-    api.on('model_call_started', (_event, ctx) => ensureCronContextLens(ctx));
+    // Record the run as cron for telemetry even when the context lens is
+    // disabled, so a harness error during this run can be attributed — and
+    // surfaced — as a cron failure (see reportCronRun / the `isCron` flag on
+    // `TlonBot Harness Error`). The agent-level hook context is the only place
+    // the gateway exposes the cron trigger.
+    const onCronAgentHook = (ctx: {
+      sessionKey?: string;
+      trigger?: string;
+      jobId?: string;
+      runId?: string;
+    }) => {
+      if (ctx.trigger === 'cron') {
+        safeTelemetryObserver({
+          logger: api.logger,
+          telemetrySource: 'cron_run',
+          sessionKey: ctx.sessionKey,
+          runId: ctx.runId,
+          run: () =>
+            reportCronRun({
+              sessionKey: ctx.sessionKey,
+              runId: ctx.runId,
+              jobId: ctx.jobId,
+            }),
+        });
+      }
+      ensureCronContextLens(ctx);
+    };
+    api.on('agent_turn_prepare', (_event, ctx) => onCronAgentHook(ctx));
+    api.on('model_call_started', (_event, ctx) => onCronAgentHook(ctx));
 
     // Background lenses normally finalize on tool-result idle; agent_end
     // re-arms the window so runs that end with model output (no trailing

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1525,6 +1525,30 @@ describe('telemetry tool tracking', () => {
     expect(Object.hasOwn(call.properties, 'cronJobId')).toBe(false);
   });
 
+  it('attributes a runId-less cron failure in a remembered session, ignoring the stale context runId', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+    // Session was remembered from a prior inbound reply (context.runId='run-1').
+    await rememberSessionForDiagnostics(telemetry);
+
+    // A cron run reuses that session; both the cron hook and the failing
+    // diagnostic omit a runId. The lookup must use the diagnostic's own
+    // (absent) runId and match the runId-less cron signal — not the stale
+    // interactive runId carried on the remembered context.
+    reportCronRun({ sessionKey: 'session-1', jobId: 'job-7' });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      errorText: 'model unresponsive',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties.isCron).toBe(true);
+    expect(call.properties.cronJobId).toBe('job-7');
+  });
+
   it("does not bleed another cron run's job id into a matched run with no job id", () => {
     const telemetry = createEnabledTelemetry()!;
     bindErrorReporter(telemetry);

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1525,13 +1525,17 @@ describe('telemetry tool tracking', () => {
     expect(Object.hasOwn(call.properties, 'cronJobId')).toBe(false);
   });
 
-  it('does not bleed another cron run\'s job id into a matched run with no job id', () => {
+  it("does not bleed another cron run's job id into a matched run with no job id", () => {
     const telemetry = createEnabledTelemetry()!;
     bindErrorReporter(telemetry);
 
     // run-a recorded with a runId but no job id; a later run sets a different one.
     reportCronRun({ sessionKey: 'cron-session', runId: 'run-a' });
-    reportCronRun({ sessionKey: 'cron-session', runId: 'run-b', jobId: 'job-b' });
+    reportCronRun({
+      sessionKey: 'cron-session',
+      runId: 'run-b',
+      jobId: 'job-b',
+    });
     reportHarnessError({
       harnessEventType: 'model.call.error',
       errorScope: 'model',

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1549,6 +1549,27 @@ describe('telemetry tool tracking', () => {
     expect(call.properties.cronJobId).toBe('job-7');
   });
 
+  it('does not bleed a previous cron run\'s job id into a later runId-less signal that omits one', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    // Earlier cron run in this session recorded a job id...
+    reportCronRun({ sessionKey: 'cron-session', runId: 'cron-1', jobId: 'job-a' });
+    // ...then a later runId-less cron signal for the same session omits one.
+    reportCronRun({ sessionKey: 'cron-session' });
+    reportHarnessError({
+      harnessEventType: 'harness.run.error',
+      errorScope: 'harness',
+      sessionKey: 'cron-session',
+      errorText: 'run failed',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties.isCron).toBe(true);
+    // The runId-less failure must not inherit 'job-a' from the earlier run.
+    expect(Object.hasOwn(call.properties, 'cronJobId')).toBe(false);
+  });
+
   it("does not bleed another cron run's job id into a matched run with no job id", () => {
     const telemetry = createEnabledTelemetry()!;
     bindErrorReporter(telemetry);

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -4,6 +4,7 @@ import {
   _testing,
   createTlonTelemetry,
   recordToolCall,
+  reportCronRun,
   reportHarnessDebug,
   reportHarnessError,
   reportOutboundRoute,
@@ -46,6 +47,7 @@ describe('telemetry tool tracking', () => {
     _testing.clearToolCalls();
     _testing.clearSessionContexts();
     _testing.clearHarnessDebugSnapshots();
+    _testing.clearCronRuns();
     setSessionTelemetryReporter(null);
     setDebugTelemetryReporter(null);
     setErrorTelemetryReporter(null);
@@ -1396,6 +1398,152 @@ describe('telemetry tool tracking', () => {
       durationMs: 1234,
       errorText: 'full\nmodel\nerror',
     });
+  });
+
+  it('attributes a cron run failure as isCron, bypassing the remembered-session gate', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    // No inbound reply ever remembered this session — a scheduled cron run.
+    reportCronRun({
+      sessionKey: 'cron-session',
+      runId: 'cron-run',
+      jobId: 'job-7',
+    });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'cron-session',
+      runId: 'cron-run',
+      provider: 'anthropic',
+      model: 'claude-test',
+      errorCategory: 'network',
+      failureKind: 'connection_reset',
+      errorText: 'model unresponsive',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties).toMatchObject({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'cron-session',
+      runId: 'cron-run',
+      isCron: true,
+      cronJobId: 'job-7',
+    });
+  });
+
+  it('attributes a runId-less cron failure best-effort', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    reportCronRun({ sessionKey: 'cron-session', jobId: 'job-9' });
+    reportHarnessError({
+      harnessEventType: 'harness.run.error',
+      errorScope: 'harness',
+      sessionKey: 'cron-session',
+      errorText: 'run failed',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties).toMatchObject({
+      errorScope: 'harness',
+      isCron: true,
+      cronJobId: 'job-9',
+    });
+  });
+
+  it('does not attribute a different run reusing the cron session key', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportCronRun({
+      sessionKey: 'session-1',
+      runId: 'cron-run',
+      jobId: 'job-7',
+    });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      runId: 'interactive-run',
+      errorText: 'model unresponsive',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties.isCron).toBe(false);
+    expect(Object.hasOwn(call.properties, 'cronJobId')).toBe(false);
+  });
+
+  it('does not attribute non-gateway scopes (tool errors) during a cron run', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    reportCronRun({
+      sessionKey: 'session-1',
+      runId: 'cron-run',
+      jobId: 'job-7',
+    });
+    reportHarnessError({
+      harnessEventType: 'tool.execution.error',
+      errorScope: 'tool',
+      sessionKey: 'session-1',
+      runId: 'cron-run',
+      toolName: 'tlon',
+      errorText: 'tool blew up',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties.errorScope).toBe('tool');
+    expect(call.properties.isCron).toBe(false);
+  });
+
+  it('does not mis-attribute an interactive run after a runId-less cron hook in the same session', async () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+    await rememberSessionForDiagnostics(telemetry);
+
+    // Cron hook fired before a runId was assigned (the documented main-session
+    // topology): records sawCronWithoutRunId, no runId. This must NOT poison
+    // later interactive runs that reuse the same session key.
+    reportCronRun({ sessionKey: 'session-1', jobId: 'job-7' });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'session-1',
+      runId: 'interactive-run',
+      errorText: 'model unresponsive',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.event).toBe('TlonBot Harness Error');
+    expect(call.properties.isCron).toBe(false);
+    expect(Object.hasOwn(call.properties, 'cronJobId')).toBe(false);
+  });
+
+  it('does not bleed another cron run\'s job id into a matched run with no job id', () => {
+    const telemetry = createEnabledTelemetry()!;
+    bindErrorReporter(telemetry);
+
+    // run-a recorded with a runId but no job id; a later run sets a different one.
+    reportCronRun({ sessionKey: 'cron-session', runId: 'run-a' });
+    reportCronRun({ sessionKey: 'cron-session', runId: 'run-b', jobId: 'job-b' });
+    reportHarnessError({
+      harnessEventType: 'model.call.error',
+      errorScope: 'model',
+      sessionKey: 'cron-session',
+      runId: 'run-a',
+      errorText: 'model unresponsive',
+    });
+
+    const call = postHogMocks.capture.mock.calls.at(-1)?.[0];
+    expect(call.properties.isCron).toBe(true);
+    // run-a carried no job id; it must not inherit run-b's 'job-b'.
+    expect(Object.hasOwn(call.properties, 'cronJobId')).toBe(false);
   });
 
   it('reports process-level harness diagnostics without a session key', () => {

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -1549,12 +1549,16 @@ describe('telemetry tool tracking', () => {
     expect(call.properties.cronJobId).toBe('job-7');
   });
 
-  it('does not bleed a previous cron run\'s job id into a later runId-less signal that omits one', () => {
+  it("does not bleed a previous cron run's job id into a later runId-less signal that omits one", () => {
     const telemetry = createEnabledTelemetry()!;
     bindErrorReporter(telemetry);
 
     // Earlier cron run in this session recorded a job id...
-    reportCronRun({ sessionKey: 'cron-session', runId: 'cron-1', jobId: 'job-a' });
+    reportCronRun({
+      sessionKey: 'cron-session',
+      runId: 'cron-1',
+      jobId: 'job-a',
+    });
     // ...then a later runId-less cron signal for the same session omits one.
     reportCronRun({ sessionKey: 'cron-session' });
     reportHarnessError({

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -2243,9 +2243,16 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
     : null;
 
   const sessionKey = context?.sessionKey ?? optionalString(event.sessionKey);
-  const runId = optionalString(event.runId) ?? context?.runId ?? null;
+  // Cron correlation uses the diagnostic's OWN runId, kept separate from the
+  // emitted `runId` below. The emitted value falls back to a remembered
+  // interactive runId from a prior reply — but when a cron run reuses that
+  // session and both the cron hook and this diagnostic omit a runId, feeding
+  // that stale id into lookupCronRun would force the exact-match branch and
+  // miss the runId-less cron signal reportCronRun recorded for this run.
+  const eventRunId = optionalString(event.runId);
+  const runId = eventRunId ?? context?.runId ?? null;
   const cronAttribution = CRON_GATEWAY_ERROR_SCOPES.has(event.errorScope)
-    ? lookupCronRun(sessionKey, runId)
+    ? lookupCronRun(sessionKey, eventRunId)
     : null;
 
   // Harness errors are normally filtered to runs we remember from inbound Tlon

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -55,7 +55,10 @@ type CronRunRecord = {
   // A cron hook fired before a runId was assigned. Lets a runId-less failure
   // in the same session still be attributed best-effort.
   sawCronWithoutRunId: boolean;
-  lastJobId: string | null;
+  // Job id of the most-recent runId-less cron signal (null when that signal
+  // carried none). Reset on every runId-less hook so a runId-less failure is
+  // attributed to its own run's job id, never inheriting a previous run's.
+  runlessJobId: string | null;
   updatedAt: number;
 };
 
@@ -723,16 +726,12 @@ export function reportCronRun(params: {
   const record = cronRunsBySessionKey.get(sessionKey) ?? {
     runIds: new Map<string, string | null>(),
     sawCronWithoutRunId: false,
-    lastJobId: null,
+    runlessJobId: null,
     updatedAt: now,
   };
   record.updatedAt = now;
 
   const jobId = optionalString(params.jobId);
-  if (jobId) {
-    record.lastJobId = jobId;
-  }
-
   const runId = optionalString(params.runId);
   if (runId) {
     record.runIds.set(runId, jobId ?? record.runIds.get(runId) ?? null);
@@ -745,6 +744,10 @@ export function reportCronRun(params: {
     }
   } else {
     record.sawCronWithoutRunId = true;
+    // Record THIS signal's own job id (null when absent), overwriting any
+    // prior, so a runId-less failure is never tagged with an earlier cron
+    // run's job id.
+    record.runlessJobId = jobId;
   }
 
   cronRunsBySessionKey.set(sessionKey, record);
@@ -776,7 +779,7 @@ function lookupCronRun(
     // when a runId-less cron signal exists for the session, we can't prove this
     // run is the cron one, and mislabeling an interactive failure is worse than
     // missing one (these feed unattended-failure alerts). Use the run's own job
-    // id; never borrow another run's via lastJobId.
+    // id; never borrow another run's.
     return record.runIds.has(runId)
       ? { cronJobId: record.runIds.get(runId) ?? null }
       : null;
@@ -785,7 +788,9 @@ function lookupCronRun(
   // The failing event carries no runId: attribute only when a cron signal in
   // this session also lacked one (symmetric), so a runId-bearing interactive
   // failure can never reach this best-effort path.
-  return record.sawCronWithoutRunId ? { cronJobId: record.lastJobId } : null;
+  return record.sawCronWithoutRunId
+    ? { cronJobId: record.runlessJobId }
+    : null;
 }
 
 function cleanupHarnessDebugSnapshots(now = Date.now()): void {

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -788,9 +788,7 @@ function lookupCronRun(
   // The failing event carries no runId: attribute only when a cron signal in
   // this session also lacked one (symmetric), so a runId-bearing interactive
   // failure can never reach this best-effort path.
-  return record.sawCronWithoutRunId
-    ? { cronJobId: record.runlessJobId }
-    : null;
+  return record.sawCronWithoutRunId ? { cronJobId: record.runlessJobId } : null;
 }
 
 function cleanupHarnessDebugSnapshots(now = Date.now()): void {

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -46,6 +46,21 @@ type HarnessDebugSnapshotRecord = {
   lastContextEngineMessage: string | null;
 };
 
+type CronRunRecord = {
+  // runIds observed to belong to a cron run in this session, mapped to their
+  // cron job id (null when the gateway didn't expose one). A failing run is
+  // matched by runId so a later interactive run that reuses the same (main)
+  // session key is never mis-attributed to cron.
+  runIds: Map<string, string | null>;
+  // A cron hook fired before a runId was assigned. Lets a runId-less failure
+  // in the same session still be attributed best-effort.
+  sawCronWithoutRunId: boolean;
+  lastJobId: string | null;
+  updatedAt: number;
+};
+
+type CronRunAttribution = { cronJobId: string | null };
+
 export type TlonHarnessName = 'openclaw' | 'hermes';
 type ReplyDispatchKind = 'tool' | 'block' | 'final';
 type ReplyDispatchCounts = Partial<Record<ReplyDispatchKind, number>>;
@@ -365,6 +380,11 @@ export type TlonHarnessErrorEvent = {
   failureKind: string | null;
   durationMs: number | null;
   errorText: string | null;
+  // True when this error belongs to a confirmed cron run (gateway-error scopes
+  // only). Cron runs are unattended, so these are the failures worth alerting
+  // on. `cronJobId` is the gateway's cron job id when it exposed one.
+  isCron: boolean;
+  cronJobId: string | null;
 };
 
 export type TlonHarnessDebugEvent = TlonHarnessDebugSnapshotFields & {
@@ -501,6 +521,18 @@ const SESSION_CONTEXT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_SESSION_CONTEXTS = 5_000;
 const HARNESS_DEBUG_SNAPSHOT_TTL_MS = 60 * 60 * 1000;
 const MAX_HARNESS_DEBUG_SNAPSHOTS = 5_000;
+const CRON_RUN_TTL_MS = 60 * 60 * 1000;
+const MAX_CRON_RUN_SESSIONS = 5_000;
+const MAX_CRON_RUN_IDS_PER_SESSION = 50;
+// Harness error scopes that represent the gateway returning an actual error
+// result for a run (a model/provider failure, an unresponsive model, a failed
+// run) — as opposed to plugin/tool/runtime noise. Only these get cron
+// attribution, matching "a cron failed and the gateway told us why".
+const CRON_GATEWAY_ERROR_SCOPES = new Set<TlonHarnessErrorScope>([
+  'model',
+  'harness',
+  'run',
+]);
 const toolCallsBySession = sharedMap<string, ToolSessionTrace>(
   'telemetry.toolCallsBySession'
 );
@@ -512,6 +544,9 @@ const harnessDebugSnapshotsBySessionKey = sharedMap<
   string,
   HarnessDebugSnapshotRecord
 >('telemetry.harnessDebugSnapshotsBySessionKey');
+const cronRunsBySessionKey = sharedMap<string, CronRunRecord>(
+  'telemetry.cronRunsBySessionKey'
+);
 
 function cleanupToolCalls(now = Date.now()): void {
   for (const [sessionKey, trace] of toolCallsBySession) {
@@ -645,6 +680,112 @@ function cleanupSessionContexts(now = Date.now()): void {
     }
     sessionContextsBySessionKey.delete(oldestKey);
   }
+}
+
+function cleanupCronRuns(now = Date.now()): void {
+  for (const [sessionKey, record] of cronRunsBySessionKey) {
+    if (now - record.updatedAt > CRON_RUN_TTL_MS) {
+      cronRunsBySessionKey.delete(sessionKey);
+    }
+  }
+
+  while (cronRunsBySessionKey.size > MAX_CRON_RUN_SESSIONS) {
+    const oldestKey = [...cronRunsBySessionKey.entries()].sort(
+      (a, b) => a[1].updatedAt - b[1].updatedAt
+    )[0]?.[0];
+    if (!oldestKey) {
+      break;
+    }
+    cronRunsBySessionKey.delete(oldestKey);
+  }
+}
+
+/**
+ * Record that a run in `sessionKey` was triggered by cron. Populated from the
+ * agent-level hooks (`agent_turn_prepare` / `model_call_started`) — the only
+ * place the gateway exposes the cron trigger, since cron jobs can run inside
+ * the main session whose key has no `:cron:` marker. Idempotent; safe to call
+ * on every cron hook for the same run.
+ */
+export function reportCronRun(params: {
+  sessionKey?: string | null;
+  runId?: string | null;
+  jobId?: string | null;
+}): void {
+  const sessionKey = optionalString(params.sessionKey);
+  if (!sessionKey) {
+    return;
+  }
+
+  const now = Date.now();
+  cleanupCronRuns(now);
+
+  const record = cronRunsBySessionKey.get(sessionKey) ?? {
+    runIds: new Map<string, string | null>(),
+    sawCronWithoutRunId: false,
+    lastJobId: null,
+    updatedAt: now,
+  };
+  record.updatedAt = now;
+
+  const jobId = optionalString(params.jobId);
+  if (jobId) {
+    record.lastJobId = jobId;
+  }
+
+  const runId = optionalString(params.runId);
+  if (runId) {
+    record.runIds.set(runId, jobId ?? record.runIds.get(runId) ?? null);
+    while (record.runIds.size > MAX_CRON_RUN_IDS_PER_SESSION) {
+      const oldestRunId = record.runIds.keys().next().value;
+      if (oldestRunId === undefined) {
+        break;
+      }
+      record.runIds.delete(oldestRunId);
+    }
+  } else {
+    record.sawCronWithoutRunId = true;
+  }
+
+  cronRunsBySessionKey.set(sessionKey, record);
+}
+
+function lookupCronRun(
+  sessionKey: string | null,
+  runId: string | null
+): CronRunAttribution | null {
+  const normalized = optionalString(sessionKey);
+  if (!normalized) {
+    return null;
+  }
+
+  cleanupCronRuns();
+  const record = cronRunsBySessionKey.get(normalized);
+  if (!record) {
+    return null;
+  }
+  // Deliberately do NOT refresh `updatedAt` on read: the TTL is the window
+  // during which a cron run's failure is expected, measured from the last cron
+  // hook (a write). A busy session that keeps emitting harness errors would
+  // otherwise refresh this record forever and keep mis-matching long after the
+  // cron run ended.
+
+  if (runId) {
+    // A run is cron only if we positively recorded THIS exact runId as cron. A
+    // different runId reusing the same (main) session key is not cron — even
+    // when a runId-less cron signal exists for the session, we can't prove this
+    // run is the cron one, and mislabeling an interactive failure is worse than
+    // missing one (these feed unattended-failure alerts). Use the run's own job
+    // id; never borrow another run's via lastJobId.
+    return record.runIds.has(runId)
+      ? { cronJobId: record.runIds.get(runId) ?? null }
+      : null;
+  }
+
+  // The failing event carries no runId: attribute only when a cron signal in
+  // this session also lacked one (symmetric), so a runId-bearing interactive
+  // failure can never reach this best-effort path.
+  return record.sawCronWithoutRunId ? { cronJobId: record.lastJobId } : null;
 }
 
 function cleanupHarnessDebugSnapshots(now = Date.now()): void {
@@ -1515,6 +1656,8 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           failureKind: event.failureKind,
           durationMs: event.durationMs,
           errorText: event.errorText,
+          isCron: event.isCron,
+          cronJobId: event.cronJobId,
         },
         { omitNullish: true }
       ),
@@ -2098,7 +2241,18 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
         agentId: event.agentId,
       })
     : null;
-  if (!context && event.sessionKey) {
+
+  const sessionKey = context?.sessionKey ?? optionalString(event.sessionKey);
+  const runId = optionalString(event.runId) ?? context?.runId ?? null;
+  const cronAttribution = CRON_GATEWAY_ERROR_SCOPES.has(event.errorScope)
+    ? lookupCronRun(sessionKey, runId)
+    : null;
+
+  // Harness errors are normally filtered to runs we remember from inbound Tlon
+  // replies. Cron runs are scheduled and never have an inbound reply, so no
+  // remembered context exists — but a confirmed cron failure is exactly what we
+  // want to surface, so it bypasses the remembered-context gate.
+  if (!context && event.sessionKey && !cronAttribution) {
     return;
   }
 
@@ -2108,9 +2262,9 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
       harness: 'openclaw',
       harnessEventType: event.harnessEventType,
       errorScope: event.errorScope,
-      sessionKey: context?.sessionKey ?? null,
+      sessionKey,
       sessionId: context?.sessionId ?? optionalString(event.sessionId),
-      runId: optionalString(event.runId) ?? context?.runId ?? null,
+      runId,
       accountId: context?.accountId ?? optionalString(event.accountId),
       agentId: optionalString(event.agentId) ?? context?.agentId ?? null,
       ownerShip: context?.ownerShip ?? optionalString(event.ownerShip),
@@ -2126,6 +2280,8 @@ export function reportHarnessError(event: TlonHarnessErrorReportInput): void {
       failureKind: optionalString(event.failureKind),
       durationMs: optionalNumber(event.durationMs),
       errorText: optionalErrorText(event.errorText),
+      isCron: cronAttribution != null,
+      cronJobId: cronAttribution?.cronJobId ?? null,
     },
   });
 }
@@ -2353,6 +2509,7 @@ export const _testing = {
   clearToolCalls: () => toolCallsBySession.clear(),
   clearSessionContexts: () => sessionContextsBySessionKey.clear(),
   clearHarnessDebugSnapshots: () => harnessDebugSnapshotsBySessionKey.clear(),
+  clearCronRuns: () => cronRunsBySessionKey.clear(),
   getReplyTraceTtlMs: () => REPLY_TRACE_TTL_MS,
   getToolTraceTtlMs: () => TOOL_TRACE_TTL_MS,
 };


### PR DESCRIPTION
## Summary

Tag `TlonBot Harness Error` events with `isCron`/`cronJobId` when a scheduled cron run fails and the gateway returns an actual error result (model/harness/run scopes — provider issue, unresponsive model, failed run). Cron runs are unattended, so these are the failures worth alerting on, and they were previously dropped: harness errors are filtered to sessions remembered from inbound Tlon replies, which a scheduled cron run never has, so a confirmed cron failure now bypasses that gate.

The cron trigger is only exposed on the agent-level hooks (`agent_turn_prepare`/`model_call_started`), so cron runs are recorded into a shared-state tracker there (independent of the context lens) and correlated to the failing run in `reportHarnessError`.

Attribution is by exact runId match so a later interactive run reusing the main session key is never mislabeled; a runId-less failure is only attributed when the cron signal was also runId-less. Job ids are per-run (no cross-run bleed), and the tracker TTL is write-oriented.

## Changes

- **`packages/openclaw/src/telemetry.ts`**
  - New cron-run tracker: `reportCronRun()` records cron runs into a shared-state map keyed by `sessionKey` (mapping each `runId → jobId`, plus a `sawCronWithoutRunId` flag), with a 1h write-oriented TTL and session/per-runId caps. `lookupCronRun()` resolves whether a failing run was cron.
  - `TlonHarnessErrorEvent` gains `isCron` / `cronJobId`; `captureHarnessError` emits them (`omitNullish` keeps `isCron: false`, strips `cronJobId: null`).
  - `reportHarnessError` computes cron attribution for **gateway-error scopes only** (`model`, `harness`, `run`) and lets a confirmed cron failure bypass the "remembered inbound-reply session" gate that otherwise drops scheduled-run errors.
  - `_testing.clearCronRuns()` added.
- **`packages/openclaw/index.ts`**
  - `onCronAgentHook` records the cron run from `agent_turn_prepare` / `model_call_started` (the only hooks that expose the cron trigger), independent of the context lens, wrapped in `safeTelemetryObserver`.
- **`packages/openclaw/src/telemetry.test.ts`**
  - Cases for attribution, runId-less best-effort, reused-session non-attribution, tool-scope exclusion, the interactive-run false-positive guard, and jobId no-bleed.

## How did I test?

- `pnpm vitest run src/telemetry.test.ts` — **39/39 pass**, including 6 cron cases (two are regression guards that fail under the pre-fix logic).
- `pnpm tsc --noEmit` — no new type errors (only the pre-existing `openclaw/plugin-sdk` + `posthog-node` module-not-found, since the SDK isn't installed in this checkout; resolves in CI).
- `pnpm exec eslint` clean on the changed files.
- A multi-angle code review caught and fixed three issues before merge: a false-positive attribution (interactive run mislabeled cron when a cron hook lacked a runId), a cron-`jobId` cross-run bleed, and a read-refreshed TTL — each now covered by tests.

**Open verification item:** whether `ctx.runId` is present on `agent_turn_prepare`/`model_call_started` in the installed OpenClaw SDK. Attribution is precise either way; if `runId` is absent on those hooks, recall drops for cron reuse of the main session (conservative — no false alerts), and a different join key would be the follow-up. To validate end-to-end: trigger a cron run against an unreachable/erroring model and confirm a `TlonBot Harness Error` with `isCron = true` lands in PostHog.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — purely additive telemetry/observability. No schema, state, or migration changes; reverting just removes the cron attribution and restores prior behavior.
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: OpenClaw (tlonbot) plugin telemetry → PostHog

## Rollback plan

`git revert`. No data backfill or cleanup needed — events stop carrying `isCron`/`cronJobId`, and cron-only harness errors return to being dropped as before. Any PostHog insight/alert built on `isCron = true` simply stops receiving new matches.

## Screenshots / videos

N/A — backend/telemetry only. Verify via the `TlonBot Harness Error` event in PostHog, filtered on `isCron = true` (and `cronJobId` when the gateway exposed a job id).

