### PR TITLE
fix(onboarding): don't advance signup when no OTP was sent

### DIFF
--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -132,6 +132,10 @@ export const SignupScreen = ({ navigation }: Props) => {
         return;
       }
 
+      // handleSubmit resolves whether or not validation passes; the callback
+      // (which requests the OTP) only runs when the form is valid. Track that so
+      // we don't advance to the OTP screen when no code was actually sent.
+      let otpRequested = false;
       if (otpMethod === 'phone') {
         await phoneForm.handleSubmit(async ({ phoneNumber }) => {
           await hostingApi.requestSignupOtp({
@@ -139,6 +143,7 @@ export const SignupScreen = ({ navigation }: Props) => {
             recaptchaToken,
             platform: selectRecaptchaPlatform(),
           });
+          otpRequested = true;
         })();
       } else {
         await emailForm.handleSubmit(async ({ email }) => {
@@ -147,10 +152,13 @@ export const SignupScreen = ({ navigation }: Props) => {
             recaptchaToken,
             platform: selectRecaptchaPlatform(),
           });
+          otpRequested = true;
         })();
       }
 
-      handleSuccess();
+      if (otpRequested) {
+        handleSuccess();
+      }
     } catch (err) {
       setRemoteError(`Something bad happened. Err: ${err.toString()}`);
       if (err instanceof HostingError) {


### PR DESCRIPTION
## Summary

The signup screen advances to the OTP entry screen even when no verification code was sent. `phoneForm.handleSubmit(cb)()` resolves whether or not the form is valid — it only runs its callback (the OTP request) when valid — but the screen called `handleSuccess()` unconditionally right after, so submitting an invalid phone/email moves the user to the OTP screen with no code on the way. It's currently masked by the submit button's `disabled={!isValid}` gate, but that coupling is fragile: a stale `isValid` re-enables it (e.g. #5966).

## Changes

- `apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx`: set a flag inside the `handleSubmit` callback once the OTP request runs, and only call `handleSuccess()` when it did.

## How did I test?

On an iOS simulator, submitting an invalid `+1`. The bug is gated behind the `disabled={!isValid}` button plus the hosting/recaptcha checks, so to reach the path I temporarily removed those gates (this PR touches none of them); the only difference between the two clips below is the `if (otpRequested)` guard.

- **Without the guard** — advances to the "Confirm Code" OTP screen even though no code was sent (`otpRequested === false`).
- **With the guard** — stays on the signup screen and surfaces the "Please enter a valid phone number" error.

## Risks and impact

- Safe to rollback without consulting PR author? Yes — revert the one-line guard.
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert this PR; the submit handler returns to calling `handleSuccess()` unconditionally.

## Screenshots / videos

**Before** — invalid number advances to the OTP screen with no code sent:

https://github.com/user-attachments/assets/85f0a694-2aa8-44c0-85e9-a55a58c44a0e

**After** — invalid number stays on the signup screen with a validation error:

https://github.com/user-attachments/assets/223cd03c-e1db-4043-9fa1-4941da3c02d7
