### PR TITLE
feat(hermes-lens): emit context lens to %steward from the Hermes adapter

### DIFF
--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -509,8 +509,17 @@ def _lens_run_kind(dispatch_reason: str) -> str:
     return "owner_listen" if dispatch_reason == "owner-listen" else "conversation"
 
 
-def _lens_final_status(processing_outcome: Optional[str], *, delivered: bool) -> str:
+def _lens_final_status(
+    processing_outcome: Optional[str],
+    *,
+    delivered: bool,
+    delivery_failed: bool = False,
+) -> str:
     """Map (outcome, delivery) onto the terminal ContextLensStatus."""
+    # A send that Hermes produced but the CLI failed to deliver is an error,
+    # even if the processing outcome itself was a "success".
+    if delivery_failed:
+        return "error"
     if delivered:
         return "completed"
     if processing_outcome == "failure":
@@ -2145,9 +2154,14 @@ class TlonAdapter(BasePlatformAdapter):
         )
         existing = self._lens.get(event.source.chat_id)
         delivered = bool(existing and existing.delivered_message_count > 0)
+        delivery_failed = bool(existing and existing.delivery_failed)
         await self._lens.finish(
             event.source.chat_id,
-            status=_lens_final_status(processing_outcome, delivered=delivered),
+            status=_lens_final_status(
+                processing_outcome,
+                delivered=delivered,
+                delivery_failed=delivery_failed,
+            ),
         )
 
     @staticmethod
@@ -2217,6 +2231,12 @@ class TlonAdapter(BasePlatformAdapter):
                     preview=content or None,
                     chunk_index=None,
                 ),
+            )
+        else:
+            # A produced-but-undelivered reply is a delivery failure, not a
+            # no_reply; record it so the run finalizes as an error.
+            self._lens.record_delivery_failure(
+                chat_id, error=(result.stderr or "").strip() or "delivery failed"
             )
 
         raw_response = {

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import time
+import uuid
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -2123,7 +2123,7 @@ class TlonAdapter(BasePlatformAdapter):
         is_dm: bool,
         dispatch_reason: str,
     ) -> None:
-        if not self._lens.enabled:
+        if not self._lens.active:
             return
         # The lens is a non-essential observability sink; a bug in its
         # accounting must never break message dispatch. Poke failures are
@@ -2152,7 +2152,7 @@ class TlonAdapter(BasePlatformAdapter):
             self._telemetry.error("context_lens", exc, operation="begin")
 
     def _lens_reference_blob(self, conversation_id: str) -> Optional[str]:
-        if not self._lens.enabled:
+        if not self._lens.active:
             return None
         run = self._lens.get(conversation_id)
         if run is None:
@@ -2162,7 +2162,7 @@ class TlonAdapter(BasePlatformAdapter):
         )
 
     async def _finish_lens_run_on_error(self, conversation_id: str) -> None:
-        if not self._lens.enabled:
+        if not self._lens.active:
             return
         try:
             # finish() no-ops if the run already reached a terminal state and

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -2065,41 +2065,49 @@ class TlonAdapter(BasePlatformAdapter):
             dispatch_reason=dispatch_reason,
         )
         await self._begin_lens_run(message, is_dm=is_dm, dispatch_reason=dispatch_reason)
-        # Thread context flows for DMs too, so the bot replies inside a DM
-        # thread instead of the main conversation.
-        reply_context = message.reply_to_message_id
-        source = self.build_source(
-            chat_id=message.chat_id,
-            chat_name=message.chat_name,
-            chat_type=message.chat_type,
-            user_id=message.user_id,
-            user_name=message.user_name,
-            thread_id=reply_context,
-            message_id=message.message_id,
-        )
-        prepared = prepared_media or PreparedMedia()
-        event_kwargs = {
-            "text": message.text,
-            "message_type": _message_type_member(prepared.message_type),
-            "source": source,
-            "raw_message": message.raw,
-            "message_id": message.message_id,
-            "reply_to_message_id": reply_context,
-            "timestamp": message.sent_at,
-            "media_urls": list(prepared.media_urls),
-            "media_types": list(prepared.media_types),
-        }
         try:
-            event = MessageEvent(**event_kwargs)
-        except TypeError:
-            # Keeps older Hermes test doubles and runtimes from failing before
-            # they pick up the native media fields.
-            media_urls = event_kwargs.pop("media_urls")
-            media_types = event_kwargs.pop("media_types")
-            event = MessageEvent(**event_kwargs)
-            setattr(event, "media_urls", media_urls)
-            setattr(event, "media_types", media_types)
-        await self.handle_message(event)
+            # Thread context flows for DMs too, so the bot replies inside a DM
+            # thread instead of the main conversation.
+            reply_context = message.reply_to_message_id
+            source = self.build_source(
+                chat_id=message.chat_id,
+                chat_name=message.chat_name,
+                chat_type=message.chat_type,
+                user_id=message.user_id,
+                user_name=message.user_name,
+                thread_id=reply_context,
+                message_id=message.message_id,
+            )
+            prepared = prepared_media or PreparedMedia()
+            event_kwargs = {
+                "text": message.text,
+                "message_type": _message_type_member(prepared.message_type),
+                "source": source,
+                "raw_message": message.raw,
+                "message_id": message.message_id,
+                "reply_to_message_id": reply_context,
+                "timestamp": message.sent_at,
+                "media_urls": list(prepared.media_urls),
+                "media_types": list(prepared.media_types),
+            }
+            try:
+                event = MessageEvent(**event_kwargs)
+            except TypeError:
+                # Keeps older Hermes test doubles and runtimes from failing
+                # before they pick up the native media fields.
+                media_urls = event_kwargs.pop("media_urls")
+                media_types = event_kwargs.pop("media_types")
+                event = MessageEvent(**event_kwargs)
+                setattr(event, "media_urls", media_urls)
+                setattr(event, "media_types", media_types)
+            await self.handle_message(event)
+        except Exception:
+            # Dispatch raised before on_processing_complete could finalize the
+            # run (e.g. _route_stream_event catches and skips handle_message
+            # errors). Close it out as an error so the lens UI shows a terminal
+            # state and the run doesn't leak until the next prune.
+            await self._finish_lens_run_on_error(message.chat_id)
+            raise
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         await self._computing_presence.refresh_run(
@@ -2141,6 +2149,16 @@ class TlonAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[tlon] context-lens begin failed: %s", exc)
             self._telemetry.error("context_lens", exc, operation="begin")
+
+    async def _finish_lens_run_on_error(self, conversation_id: str) -> None:
+        if not self._lens.enabled:
+            return
+        try:
+            # finish() no-ops if the run already reached a terminal state and
+            # was popped (e.g. on_processing_complete ran before the raise).
+            await self._lens.finish(conversation_id, status="error")
+        except Exception as exc:
+            logger.warning("[tlon] context-lens error-finish failed: %s", exc)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: Any) -> None:
         await self._computing_presence.stop_run(

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -109,6 +109,17 @@ from .telemetry import (
     handle_post_tool_call_telemetry,
     set_active_telemetry,
 )
+from .lens import (
+    LensOutput,
+    LensRun,
+    TlonLensRecorder,
+    TlonLensSync,
+    clear_active_recorder,
+    handle_post_api_request_lens,
+    handle_post_tool_call_lens,
+    handle_pre_tool_call_lens,
+    set_active_recorder,
+)
 from .version import (
     content_fingerprint,
     format_version_reply,
@@ -478,6 +489,46 @@ def _processing_outcome_value(outcome: Any) -> Optional[str]:
     return None
 
 
+# Maps the adapter's dispatch_reason (attention.py / approval flow) onto the
+# ContextLensTrigger union the client renders (context-lens.ts).
+_LENS_TRIGGER_MAP = {
+    "dm": "dm",
+    "mention": "mention",
+    "owner-listen": "owner-listen",
+    "participated-thread": "thread",
+    "approved": "dm",
+}
+
+
+def _lens_trigger(dispatch_reason: str) -> str:
+    return _LENS_TRIGGER_MAP.get(dispatch_reason, "unknown")
+
+
+def _lens_run_kind(dispatch_reason: str) -> str:
+    return "owner_listen" if dispatch_reason == "owner-listen" else "conversation"
+
+
+def _lens_final_status(processing_outcome: Optional[str], *, delivered: bool) -> str:
+    """Map (outcome, delivery) onto the terminal ContextLensStatus."""
+    if delivered:
+        return "completed"
+    if processing_outcome == "failure":
+        return "error"
+    if processing_outcome == "cancelled":
+        return "aborted"
+    return "no_reply"
+
+
+def _epoch_ms(value: Any) -> Optional[int]:
+    ts = getattr(value, "timestamp", None)
+    if callable(ts):
+        try:
+            return int(value.timestamp() * 1000)
+        except Exception:
+            return None
+    return None
+
+
 def _cli_available(cli: str | None = None) -> bool:
     candidate = cli or os.getenv("TLON_CLI", "tlon")
     if not candidate:
@@ -532,6 +583,13 @@ class TlonAdapter(BasePlatformAdapter):
                 "gateway_status", exc, operation=operation
             ),
         )
+        self._lens_sync = TlonLensSync(
+            self.tlon_config,
+            on_error=lambda operation, exc: self._telemetry.error(
+                "context_lens", exc, operation=operation
+            ),
+        )
+        self._lens = TlonLensRecorder(self._lens_sync)
         self._computing_presence = TlonComputingPresenceTracker(
             reporter=TlonComputingPresenceReporter(self.tlon_config),
             on_error=lambda action, exc: self._telemetry.error(
@@ -592,6 +650,7 @@ class TlonAdapter(BasePlatformAdapter):
             await self._process_pending_dm_invites()
             await self._process_pending_group_invites()
             await self._start_gateway_status()
+            await self._start_lens()
             self._stream_task = asyncio.create_task(self._run_stream())
             self._computing_presence.bind_loop(asyncio.get_running_loop())
             set_active_computing_presence_tracker(self._computing_presence)
@@ -647,8 +706,10 @@ class TlonAdapter(BasePlatformAdapter):
             self._connected_at = 0.0
         clear_active_telemetry(self._telemetry)
         clear_active_computing_presence_tracker(self._computing_presence)
+        clear_active_recorder(self._lens)
         await self._computing_presence.close()
         await self._stop_gateway_status("shutdown")
+        await self._stop_lens()
         if self._stream_task is not None:
             self._stream_task.cancel()
             try:
@@ -1554,6 +1615,22 @@ class TlonAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[tlon] gateway-status shutdown failed: %s", exc)
 
+    async def _start_lens(self) -> None:
+        try:
+            started = await self._lens_sync.start()
+        except Exception as exc:
+            logger.warning("[tlon] context-lens activation failed: %s", exc)
+            self._telemetry.error("context_lens", exc, operation="start")
+            return
+        if started:
+            set_active_recorder(self._lens)
+
+    async def _stop_lens(self) -> None:
+        try:
+            await self._lens_sync.stop()
+        except Exception as exc:
+            logger.warning("[tlon] context-lens shutdown failed: %s", exc)
+
     async def _connect_sse(self) -> None:
         await self._close_sse()
         self._sse = TlonSSEClient(self.tlon_config)
@@ -1977,6 +2054,7 @@ class TlonAdapter(BasePlatformAdapter):
             sender_role="owner" if self._is_owner(message.user_id) else "user",
             dispatch_reason=dispatch_reason,
         )
+        await self._begin_lens_run(message, is_dm=is_dm, dispatch_reason=dispatch_reason)
         # Thread context flows for DMs too, so the bot replies inside a DM
         # thread instead of the main conversation.
         reply_context = message.reply_to_message_id
@@ -2019,14 +2097,49 @@ class TlonAdapter(BasePlatformAdapter):
             run_id=self._presence_run_id(event),
         )
 
+    async def _begin_lens_run(
+        self,
+        message: TlonIncomingMessage,
+        *,
+        is_dm: bool,
+        dispatch_reason: str,
+    ) -> None:
+        if not self._lens.enabled:
+            return
+        conversation_kind = "dm" if is_dm else "channel"
+        run = LensRun(
+            lens_id=str(uuid.uuid4()),
+            message_id=message.message_id,
+            chat_type=conversation_kind,
+            trigger=_lens_trigger(dispatch_reason),
+            conversation_kind=conversation_kind,
+            run_kind=_lens_run_kind(dispatch_reason),
+            author_ship=normalize_ship(message.user_id) or None,
+            conversation_id=message.chat_id,
+            received_at=_epoch_ms(message.sent_at),
+            preview=message.text or None,
+            thread_messages=1 if message.reply_to_message_id else 0,
+            emits_telemetry=self._telemetry.enabled,
+        )
+        run.set_status("dispatching")
+        self._lens.begin(message.chat_id, run)
+        await self._lens.push(message.chat_id)
+
     async def on_processing_complete(self, event: MessageEvent, outcome: Any) -> None:
         await self._computing_presence.stop_run(
             conversation_id=event.source.chat_id,
             run_id=self._presence_run_id(event),
         )
+        processing_outcome = _processing_outcome_value(outcome)
         self._telemetry.finish_reply(
             event.source.chat_id,
-            processing_outcome=_processing_outcome_value(outcome),
+            processing_outcome=processing_outcome,
+        )
+        existing = self._lens.get(event.source.chat_id)
+        delivered = bool(existing and existing.delivered_message_count > 0)
+        await self._lens.finish(
+            event.source.chat_id,
+            status=_lens_final_status(processing_outcome, delivered=delivered),
         )
 
     @staticmethod
@@ -2085,6 +2198,18 @@ class TlonAdapter(BasePlatformAdapter):
             else:
                 result = await self._cli.send_message(chat_id, content)
         self._telemetry.record_delivery(chat_id, content=content, success=result.success)
+        if result.success:
+            self._lens.record_output(
+                chat_id,
+                LensOutput(
+                    message_id=str(result.message_id or ""),
+                    conversation_id=chat_id,
+                    kind="dm" if normalize_ship(chat_id) == chat_id else "channel",
+                    sent_at=int(time.time() * 1000),
+                    preview=content or None,
+                    chunk_index=None,
+                ),
+            )
 
         raw_response = {
             "stdout": result.stdout,
@@ -2265,10 +2390,13 @@ async def _standalone_send(
 
 def register(ctx) -> None:
     ctx.register_hook("pre_tool_call", handle_pre_tool_call)
+    ctx.register_hook("pre_tool_call", handle_pre_tool_call_lens)
     ctx.register_hook("pre_tool_call", block_tlon_session_tool)
     ctx.register_hook("post_api_request", handle_post_api_request)
     ctx.register_hook("post_api_request", handle_post_api_request_telemetry)
+    ctx.register_hook("post_api_request", handle_post_api_request_lens)
     ctx.register_hook("post_tool_call", handle_post_tool_call_telemetry)
+    ctx.register_hook("post_tool_call", handle_post_tool_call_lens)
 
     ctx.register_tool(
         name="tlon",

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -116,6 +116,7 @@ from .lens import (
     TlonLensRecorder,
     TlonLensSync,
     clear_active_recorder,
+    context_lens_reference_blob,
     handle_post_api_request_lens,
     handle_post_tool_call_lens,
     handle_pre_tool_call_lens,
@@ -2150,6 +2151,16 @@ class TlonAdapter(BasePlatformAdapter):
             logger.warning("[tlon] context-lens begin failed: %s", exc)
             self._telemetry.error("context_lens", exc, operation="begin")
 
+    def _lens_reference_blob(self, conversation_id: str) -> Optional[str]:
+        if not self._lens.enabled:
+            return None
+        run = self._lens.get(conversation_id)
+        if run is None:
+            return None
+        return context_lens_reference_blob(
+            run.lens_id, normalize_ship(self.tlon_config.ship_name) or None
+        )
+
     async def _finish_lens_run_on_error(self, conversation_id: str) -> None:
         if not self._lens.enabled:
             return
@@ -2223,6 +2234,10 @@ class TlonAdapter(BasePlatformAdapter):
         if thread_parent is None and self.tlon_config.reply_in_thread:
             thread_parent = reply_to
         is_thread_reply = bool(thread_parent)
+        # Stamp the reply with a pointer to its lens run so the client can open
+        # the run from the message (badge / message actions), matching
+        # OpenClaw. Only when a run is active for this conversation.
+        lens_blob = self._lens_reference_blob(chat_id)
         with cli_context("delivery", conversation=chat_id):
             if is_thread_reply:
                 # parentAuthor: honor what Hermes passes; otherwise the CLI
@@ -2234,9 +2249,12 @@ class TlonAdapter(BasePlatformAdapter):
                     thread_parent,
                     content,
                     parent_author=parent_author,
+                    blob=lens_blob,
                 )
             else:
-                result = await self._cli.send_message(chat_id, content)
+                result = await self._cli.send_message(
+                    chat_id, content, blob=lens_blob
+                )
         self._telemetry.record_delivery(chat_id, content=content, success=result.success)
         if result.success:
             self._lens.record_output(

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -2107,24 +2107,31 @@ class TlonAdapter(BasePlatformAdapter):
     ) -> None:
         if not self._lens.enabled:
             return
-        conversation_kind = "dm" if is_dm else "channel"
-        run = LensRun(
-            lens_id=str(uuid.uuid4()),
-            message_id=message.message_id,
-            chat_type=conversation_kind,
-            trigger=_lens_trigger(dispatch_reason),
-            conversation_kind=conversation_kind,
-            run_kind=_lens_run_kind(dispatch_reason),
-            author_ship=normalize_ship(message.user_id) or None,
-            conversation_id=message.chat_id,
-            received_at=_epoch_ms(message.sent_at),
-            preview=message.text or None,
-            thread_messages=1 if message.reply_to_message_id else 0,
-            emits_telemetry=self._telemetry.enabled,
-        )
-        run.set_status("dispatching")
-        self._lens.begin(message.chat_id, run)
-        await self._lens.push(message.chat_id)
+        # The lens is a non-essential observability sink; a bug in its
+        # accounting must never break message dispatch. Poke failures are
+        # already swallowed by TlonLensSync.push — this guards the rest.
+        try:
+            conversation_kind = "dm" if is_dm else "channel"
+            run = LensRun(
+                lens_id=str(uuid.uuid4()),
+                message_id=message.message_id,
+                chat_type=conversation_kind,
+                trigger=_lens_trigger(dispatch_reason),
+                conversation_kind=conversation_kind,
+                run_kind=_lens_run_kind(dispatch_reason),
+                author_ship=normalize_ship(message.user_id) or None,
+                conversation_id=message.chat_id,
+                received_at=_epoch_ms(message.sent_at),
+                preview=message.text or None,
+                thread_messages=1 if message.reply_to_message_id else 0,
+                emits_telemetry=self._telemetry.enabled,
+            )
+            run.set_status("dispatching")
+            self._lens.begin(message.chat_id, run)
+            await self._lens.push(message.chat_id)
+        except Exception as exc:
+            logger.warning("[tlon] context-lens begin failed: %s", exc)
+            self._telemetry.error("context_lens", exc, operation="begin")
 
     async def on_processing_complete(self, event: MessageEvent, outcome: Any) -> None:
         await self._computing_presence.stop_run(

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -137,6 +137,7 @@ from .tlon_api import (
     TlonGatewayStatus,
     TlonIncomingMessage,
     TlonSSEClient,
+    format_post_id,
     normalize_ship,
     parse_channel_message,
     parse_dm_message,
@@ -498,11 +499,18 @@ _LENS_TRIGGER_MAP = {
     "mention": "mention",
     "owner-listen": "owner-listen",
     "participated-thread": "thread",
-    "approved": "dm",
+    # A free (unprompted) channel response has no dedicated trigger in the
+    # shared taxonomy; OpenClaw's channel path likewise falls through to
+    # "unknown". Mapped explicitly so it reads as intentional, not an omission.
+    "free-response": "unknown",
 }
 
 
-def _lens_trigger(dispatch_reason: str) -> str:
+def _lens_trigger(dispatch_reason: str, *, is_dm: bool) -> str:
+    # Approvals replay either a DM request or a group post, so resolve by
+    # conversation kind rather than assuming DM.
+    if dispatch_reason == "approved":
+        return "dm" if is_dm else "mention"
     return _LENS_TRIGGER_MAP.get(dispatch_reason, "unknown")
 
 
@@ -2134,7 +2142,7 @@ class TlonAdapter(BasePlatformAdapter):
                 lens_id=str(uuid.uuid4()),
                 message_id=message.message_id,
                 chat_type=conversation_kind,
-                trigger=_lens_trigger(dispatch_reason),
+                trigger=_lens_trigger(dispatch_reason, is_dm=is_dm),
                 conversation_kind=conversation_kind,
                 run_kind=_lens_run_kind(dispatch_reason),
                 author_ship=normalize_ship(message.user_id) or None,
@@ -2238,6 +2246,10 @@ class TlonAdapter(BasePlatformAdapter):
         # the run from the message (badge / message actions), matching
         # OpenClaw. Only when a run is active for this conversation.
         lens_blob = self._lens_reference_blob(chat_id)
+        # Own the send timestamp so we can derive the post id (~author/<@da of
+        # sent>) ourselves — the client resolves lens outputs by author + sent
+        # time, and only the value we hand the CLI is knowable here.
+        sent_at_ms = int(time.time() * 1000)
         with cli_context("delivery", conversation=chat_id):
             if is_thread_reply:
                 # parentAuthor: honor what Hermes passes; otherwise the CLI
@@ -2250,20 +2262,21 @@ class TlonAdapter(BasePlatformAdapter):
                     content,
                     parent_author=parent_author,
                     blob=lens_blob,
+                    sent_at=sent_at_ms,
                 )
             else:
                 result = await self._cli.send_message(
-                    chat_id, content, blob=lens_blob
+                    chat_id, content, blob=lens_blob, sent_at=sent_at_ms
                 )
         self._telemetry.record_delivery(chat_id, content=content, success=result.success)
         if result.success:
             self._lens.record_output(
                 chat_id,
                 LensOutput(
-                    message_id=str(result.message_id or ""),
+                    message_id=format_post_id(self.tlon_config.ship_name, sent_at_ms),
                     conversation_id=chat_id,
                     kind="dm" if normalize_ship(chat_id) == chat_id else "channel",
-                    sent_at=int(time.time() * 1000),
+                    sent_at=sent_at_ms,
                     preview=content or None,
                     chunk_index=None,
                 ),

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -2246,10 +2246,12 @@ class TlonAdapter(BasePlatformAdapter):
         # the run from the message (badge / message actions), matching
         # OpenClaw. Only when a run is active for this conversation.
         lens_blob = self._lens_reference_blob(chat_id)
-        # Own the send timestamp so we can derive the post id (~author/<@da of
-        # sent>) ourselves — the client resolves lens outputs by author + sent
-        # time, and only the value we hand the CLI is knowable here.
-        sent_at_ms = int(time.time() * 1000)
+        # Only override the send time — and derive the lens output id from it
+        # (~author/<@da of sent>, how the client resolves outputs) — when we're
+        # actually stamping a lens output. Passing --sent-at on every send
+        # would let an older `tlon` binary (which doesn't know the flag) fold
+        # it into the message body; gate it exactly like --blob above.
+        sent_at_ms = int(time.time() * 1000) if lens_blob is not None else None
         with cli_context("delivery", conversation=chat_id):
             if is_thread_reply:
                 # parentAuthor: honor what Hermes passes; otherwise the CLI
@@ -2270,17 +2272,19 @@ class TlonAdapter(BasePlatformAdapter):
                 )
         self._telemetry.record_delivery(chat_id, content=content, success=result.success)
         if result.success:
-            self._lens.record_output(
-                chat_id,
-                LensOutput(
-                    message_id=format_post_id(self.tlon_config.ship_name, sent_at_ms),
-                    conversation_id=chat_id,
-                    kind="dm" if normalize_ship(chat_id) == chat_id else "channel",
-                    sent_at=sent_at_ms,
-                    preview=content or None,
-                    chunk_index=None,
-                ),
-            )
+            # sent_at_ms is set iff there's an active run to stamp (see above).
+            if sent_at_ms is not None:
+                self._lens.record_output(
+                    chat_id,
+                    LensOutput(
+                        message_id=format_post_id(self.tlon_config.ship_name, sent_at_ms),
+                        conversation_id=chat_id,
+                        kind="dm" if normalize_ship(chat_id) == chat_id else "channel",
+                        sent_at=sent_at_ms,
+                        preview=content or None,
+                        chunk_index=None,
+                    ),
+                )
         else:
             # A produced-but-undelivered reply is a delivery failure, not a
             # no_reply; record it so the run finalizes as an error.

--- a/packages/hermes-tlon-adapter/lens.py
+++ b/packages/hermes-tlon-adapter/lens.py
@@ -249,6 +249,7 @@ class LensRun:
     timeout_ms: Optional[int] = None
     timed_out: bool = False
     delivered_message_count: int = 0
+    delivery_failed: bool = False
 
     def touch(self) -> None:
         self.updated_at = _now_ms()
@@ -626,6 +627,16 @@ class TlonLensRecorder:
         if run is not None:
             run.record_output(output)
             run.delivered_message_count += 1
+
+    def record_delivery_failure(
+        self, conversation_id: str, error: Optional[str] = None
+    ) -> None:
+        run = self._runs.get(conversation_id)
+        if run is not None:
+            run.delivery_failed = True
+            if error and not run.error:
+                run.error = error
+            run.touch()
 
     def set_status(
         self, conversation_id: str, status: str, error: Optional[str] = None

--- a/packages/hermes-tlon-adapter/lens.py
+++ b/packages/hermes-tlon-adapter/lens.py
@@ -1,0 +1,775 @@
+"""Context-lens ship sync for the Hermes Tlon adapter.
+
+The context lens is per-run bot introspection: for each message-handling run
+the adapter records a lifecycle (created -> dispatching -> tool_running ->
+delivering -> terminal), the tool calls made, the model output, the assembled
+context, and where the run persisted state. Runs are poked to the bot ship's
+``%steward`` agent (lens module), which stores them and fans them out to the
+configured owner ship, where a client renders them.
+
+This module is the emitter side. It mirrors the OpenClaw gateway's
+``context-lens-ship-sync.ts`` so both bot backends feed the SAME on-ship agent
+and the SAME client UI:
+
+  * payload shape == the gateway's ``ContextLens`` object, wrapped as
+    ``{schemaVersion, lens, truncated?}`` (see ``build_lens_payload``);
+  * poke shape == ``steward`` / ``steward-lens-action-1`` with
+    ``{entry: {id, payload, final}}``, preceded once by a
+    ``steward-action-1`` / ``{configure: {owner}}`` poke.
+
+The recorder accumulates a run purely in memory (fed synchronously by the same
+hooks that feed PostHog telemetry) and the sink pushes snapshots to the ship
+from the adapter's async dispatch path. It is independent of PostHog: the lens
+is the on-ship UI and must work whether or not cloud telemetry is enabled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional
+
+from .tlon_api import ClientFactory, TlonConfig, TlonSSEClient
+
+logger = logging.getLogger(__name__)
+
+# Kept in lockstep with packages/openclaw/src/context-lens-ship-sync.ts so the
+# on-ship store and client render both backends identically.
+PAYLOAD_SCHEMA_VERSION = 1
+MAX_SUMMARY_CHARS = 4_096
+MAX_PAYLOAD_CHARS = 50 * 1_024
+# The steward lens module has no time-based expiry (count-capped instead), but
+# the client ContextLens carries expiresAt; mirror the gateway's DEFAULT_TTL_MS
+# (context-lens.ts) so both backends age entries out identically.
+DEFAULT_TTL_MS = 30 * 60 * 1_000
+# Bound in-memory runs so a leaked/never-finalized run can't grow unbounded.
+MAX_TRACKED_RUNS = 256
+RUN_TTL_SECONDS = 30 * 60
+
+TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"completed", "no_reply", "timed_out", "aborted", "error"}
+)
+
+_STEWARD_APP = "steward"
+_CONFIGURE_MARK = "steward-action-1"
+_LENS_MARK = "steward-lens-action-1"
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1_000)
+
+
+def _truncate(value: Optional[str]) -> Optional[str]:
+    if value is None or len(value) <= MAX_SUMMARY_CHARS:
+        return value
+    return f"{value[:MAX_SUMMARY_CHARS]}… [truncated]"
+
+
+@dataclass
+class LensToolRun:
+    id: str
+    name: str
+    call_index: int
+    started_at: int
+    tool_call_id: Optional[str] = None
+    phase: Optional[str] = None
+    completed_at: Optional[int] = None
+    duration_ms: Optional[int] = None
+    status: str = "running"  # running | completed | error | blocked
+    argument_summary: Optional[str] = None
+    argument_detail: Optional[str] = None
+    result_summary: Optional[str] = None
+    error: Optional[str] = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "id": self.id,
+            "callIndex": self.call_index,
+            "name": self.name,
+            "startedAt": self.started_at,
+            "completedAt": self.completed_at,
+            "durationMs": self.duration_ms,
+            "status": self.status,
+        }
+        if self.tool_call_id is not None:
+            out["toolCallId"] = self.tool_call_id
+        if self.phase is not None:
+            out["phase"] = self.phase
+        if self.argument_summary is not None:
+            out["argumentSummary"] = _truncate(self.argument_summary)
+        if self.argument_detail is not None:
+            out["argumentDetail"] = _truncate(self.argument_detail)
+        if self.result_summary is not None:
+            out["resultSummary"] = _truncate(self.result_summary)
+        if self.error is not None:
+            out["error"] = self.error
+        return out
+
+
+@dataclass
+class LensSource:
+    kind: str  # message | memory | identity | system | tool_result | other
+    label: str
+    included: bool = True
+    source_id: Optional[str] = None
+    reason: Optional[str] = None
+    token_estimate: Optional[int] = None
+    preview: Optional[str] = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "kind": self.kind,
+            "label": self.label,
+            "included": self.included,
+        }
+        if self.source_id is not None:
+            out["sourceId"] = self.source_id
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.token_estimate is not None:
+            out["tokenEstimate"] = self.token_estimate
+        if self.preview is not None:
+            out["preview"] = _truncate(self.preview)
+        return out
+
+
+@dataclass
+class LensPersistenceEvent:
+    kind: str  # memory | conversation_state | tool_cache | artifact | other
+    action: str  # read | created | updated | skipped | deleted
+    location: str  # openclaw | urbit | tlon-desk | external
+    status: str  # ok | failed | skipped
+    at: int
+    key: Optional[str] = None
+    reason: Optional[str] = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "kind": self.kind,
+            "action": self.action,
+            "location": self.location,
+            "status": self.status,
+            "at": self.at,
+        }
+        if self.key is not None:
+            out["key"] = self.key
+        if self.reason is not None:
+            out["reason"] = self.reason
+        return out
+
+
+@dataclass
+class LensOutput:
+    message_id: str
+    conversation_id: str
+    kind: str  # dm | channel
+    sent_at: int
+    preview: Optional[str] = None
+    chunk_index: Optional[int] = None
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "messageId": self.message_id,
+            "conversationId": self.conversation_id,
+            "kind": self.kind,
+            "sentAt": self.sent_at,
+        }
+        if self.preview is not None:
+            out["preview"] = _truncate(self.preview)
+        if self.chunk_index is not None:
+            out["chunkIndex"] = self.chunk_index
+        return out
+
+
+@dataclass
+class LensRun:
+    """In-memory accumulator for a single run, rendered to a ContextLens dict.
+
+    Field names mirror ``ContextLens`` (context-lens.ts): Python attributes are
+    snake_case, the emitted JSON keys are camelCase via ``to_context_lens``.
+    """
+
+    lens_id: str
+    message_id: str
+    chat_type: str  # dm | channel | internal
+    trigger: str
+    conversation_kind: str  # dm | channel | internal
+    run_kind: str = "conversation"
+    visibility: str = "owner"
+    session_key_hash: Optional[str] = None
+    author_ship: Optional[str] = None
+    conversation_id: Optional[str] = None
+    received_at: Optional[int] = None
+    preview: Optional[str] = None
+    retry_of: Optional[str] = None
+
+    model: Optional[str] = None
+    provider: Optional[str] = None
+
+    status: str = "assembling"
+    error: Optional[str] = None
+
+    created_at: int = field(default_factory=_now_ms)
+    updated_at: int = field(default_factory=_now_ms)
+
+    # context
+    current_message: bool = True
+    thread_messages: int = 0
+    channel_messages: int = 0
+    cited_posts: int = 0
+    attachments: int = 0
+    pending_nudge: bool = False
+    sources: list[LensSource] = field(default_factory=list)
+
+    # persistence
+    posts_reply: bool = False
+    updates_settings: bool = False
+    writes_media: bool = False
+    emits_telemetry: bool = False
+    caches_history: bool = False
+    persistence_events: list[LensPersistenceEvent] = field(default_factory=list)
+
+    # tools
+    owner_only_available: list[str] = field(default_factory=list)
+    tool_runs: list[LensToolRun] = field(default_factory=list)
+
+    outputs: list[LensOutput] = field(default_factory=list)
+
+    # lifecycle
+    queued_at: Optional[int] = None
+    dispatch_started_at: Optional[int] = None
+    first_tool_started_at: Optional[int] = None
+    completed_at: Optional[int] = None
+    duration_ms: Optional[int] = None
+    timeout_ms: Optional[int] = None
+    timed_out: bool = False
+    delivered_message_count: int = 0
+
+    def touch(self) -> None:
+        self.updated_at = _now_ms()
+
+    def set_status(self, status: str, error: Optional[str] = None) -> None:
+        self.status = status
+        if error:
+            self.error = error
+        if status in TERMINAL_STATUSES and self.completed_at is None:
+            self.completed_at = _now_ms()
+            start = self.dispatch_started_at or self.created_at
+            self.duration_ms = max(0, self.completed_at - start)
+            self.timed_out = self.timed_out or status == "timed_out"
+        self.touch()
+
+    def start_tool(
+        self,
+        name: str,
+        *,
+        tool_call_id: Optional[str] = None,
+        argument_summary: Optional[str] = None,
+        argument_detail: Optional[str] = None,
+        phase: Optional[str] = None,
+    ) -> LensToolRun:
+        now = _now_ms()
+        run = LensToolRun(
+            id=str(uuid.uuid4()),
+            name=name,
+            call_index=len(self.tool_runs) + 1,
+            started_at=now,
+            tool_call_id=tool_call_id,
+            argument_summary=argument_summary,
+            argument_detail=argument_detail,
+            phase=phase,
+        )
+        self.tool_runs.append(run)
+        if self.first_tool_started_at is None:
+            self.first_tool_started_at = now
+        self.touch()
+        return run
+
+    def _find_open_tool(
+        self, name: str, tool_call_id: Optional[str]
+    ) -> Optional[LensToolRun]:
+        for run in reversed(self.tool_runs):
+            if run.status != "running":
+                continue
+            if tool_call_id is not None and run.tool_call_id == tool_call_id:
+                return run
+            if tool_call_id is None and run.name == name:
+                return run
+        return None
+
+    def complete_tool(
+        self,
+        name: str,
+        *,
+        tool_call_id: Optional[str] = None,
+        duration_ms: Optional[int] = None,
+        result_summary: Optional[str] = None,
+        error: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        run = self._find_open_tool(name, tool_call_id)
+        if run is None:
+            # A completion with no matching start (result-only hook): synthesize
+            # a closed run so the tool still appears in the lens.
+            run = self.start_tool(name, tool_call_id=tool_call_id)
+        now = _now_ms()
+        run.completed_at = now
+        run.duration_ms = (
+            duration_ms if duration_ms is not None else max(0, now - run.started_at)
+        )
+        if result_summary is not None:
+            run.result_summary = result_summary
+        if error:
+            run.error = error
+            run.status = status or "error"
+        else:
+            run.status = status or "completed"
+        self.touch()
+
+    def close_open_tools(self, status: str = "error") -> None:
+        # ContextLensToolRun.status is 'running'|'completed'|'error'|'blocked'
+        # (context-lens.ts) — a dangling tool at run end is reported as 'error',
+        # never the run-level 'aborted' status.
+        now = _now_ms()
+        for run in self.tool_runs:
+            if run.status == "running":
+                run.completed_at = now
+                run.duration_ms = max(0, now - run.started_at)
+                run.status = status
+        self.touch()
+
+    def record_output(self, output: LensOutput) -> None:
+        self.outputs.append(output)
+        self.posts_reply = True
+        self.touch()
+
+    def record_source(self, source: LensSource) -> None:
+        self.sources.append(source)
+        self.touch()
+
+    def record_persistence_event(self, event: LensPersistenceEvent) -> None:
+        self.persistence_events.append(event)
+        self.touch()
+
+    @property
+    def called_tools(self) -> list[str]:
+        seen: list[str] = []
+        for run in self.tool_runs:
+            if run.name not in seen:
+                seen.append(run.name)
+        return seen
+
+    @property
+    def last_tool_started_at(self) -> Optional[int]:
+        return self.tool_runs[-1].started_at if self.tool_runs else None
+
+    def to_context_lens(self) -> dict[str, Any]:
+        lens: dict[str, Any] = {
+            "lensId": self.lens_id,
+            "messageId": self.message_id,
+            "sessionKeyHash": self.session_key_hash,
+            "chatType": self.chat_type,
+            "runKind": self.run_kind,
+            "visibility": self.visibility,
+            "trigger": self.trigger,
+            "triggerDetails": {
+                "type": self.trigger,
+                "messageId": self.message_id,
+                "conversationKind": self.conversation_kind,
+                **({"authorShip": self.author_ship} if self.author_ship else {}),
+                **(
+                    {"conversationId": self.conversation_id}
+                    if self.conversation_id
+                    else {}
+                ),
+                **({"receivedAt": self.received_at} if self.received_at else {}),
+                **({"preview": _truncate(self.preview)} if self.preview else {}),
+            },
+            "model": self.model,
+            "provider": self.provider,
+            "context": {
+                "currentMessage": self.current_message,
+                "threadMessages": self.thread_messages,
+                "channelMessages": self.channel_messages,
+                "citedPosts": self.cited_posts,
+                "attachments": self.attachments,
+                "pendingNudge": self.pending_nudge,
+                "sources": [s.to_json() for s in self.sources],
+            },
+            "persistence": {
+                "postsReply": self.posts_reply,
+                "updatesSettings": self.updates_settings,
+                "writesMedia": self.writes_media,
+                "emitsTelemetry": self.emits_telemetry,
+                "cachesHistory": self.caches_history,
+                "events": [e.to_json() for e in self.persistence_events],
+            },
+            "tools": {
+                "ownerOnlyAvailable": list(self.owner_only_available),
+                "called": self.called_tools,
+                "callCount": len(self.tool_runs),
+                "lastStartedAt": self.last_tool_started_at,
+                "runs": [r.to_json() for r in self.tool_runs],
+            },
+            "outputs": [o.to_json() for o in self.outputs],
+            "lifecycle": {
+                "queuedAt": self.queued_at,
+                "queuedMs": max(0, (self.dispatch_started_at or self.created_at) - (self.queued_at or self.created_at)),
+                "dispatchStartedAt": self.dispatch_started_at,
+                "firstToolStartedAt": self.first_tool_started_at,
+                "completedAt": self.completed_at,
+                "durationMs": self.duration_ms,
+                "timeoutMs": self.timeout_ms,
+                "timedOut": self.timed_out,
+                "deliveredMessageCount": self.delivered_message_count,
+                "queuedFinal": False,
+                "queuedFinalCount": 0,
+                "queuedBlockCount": 0,
+            },
+            "status": self.status,
+            "error": self.error,
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+            "expiresAt": self.created_at + DEFAULT_TTL_MS,
+        }
+        if self.retry_of is not None:
+            lens["retryOf"] = self.retry_of
+        return lens
+
+
+def build_lens_payload(lens: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a ContextLens dict as the steward run payload.
+
+    Mirrors ``buildLensRunPayload`` (context-lens-ship-sync.ts): per-field
+    truncation happens as the dict is built (``to_context_lens`` /
+    ``_truncate``); here we enforce the total size cap, dropping the bulky
+    arrays but keeping run identity and status when a run is oversized.
+    """
+    payload: dict[str, Any] = {"schemaVersion": PAYLOAD_SCHEMA_VERSION, "lens": lens}
+    if len(json.dumps(payload, separators=(",", ":"))) <= MAX_PAYLOAD_CHARS:
+        return payload
+    skeleton = dict(lens)
+    skeleton["context"] = {**lens["context"], "sources": []}
+    skeleton["persistence"] = {**lens["persistence"], "events": []}
+    skeleton["tools"] = {**lens["tools"], "runs": []}
+    skeleton["outputs"] = []
+    return {
+        "schemaVersion": PAYLOAD_SCHEMA_VERSION,
+        "lens": skeleton,
+        "truncated": True,
+    }
+
+
+class TlonLensSync:
+    """Pokes lens run records to the bot ship's ``%steward`` agent.
+
+    Owns its own SSE client (like ``TlonGatewayStatus``) so lens traffic does
+    not contend with the main event subscription. Gated on an owner ship being
+    resolvable and ``TLON_CONTEXT_LENS`` being enabled; a no-op otherwise.
+    """
+
+    def __init__(
+        self,
+        config: TlonConfig,
+        *,
+        client_factory: ClientFactory = TlonSSEClient,
+        on_error: Callable[[str, BaseException], None] | None = None,
+    ) -> None:
+        self.config = config
+        self.owner = config.context_lens_owner_ship()
+        self._client_factory = client_factory
+        self._client: Optional[TlonSSEClient] = None
+        self._configured = False
+        self._on_error = on_error
+        # Serialize pokes so a run's partial/final ordering is preserved.
+        self._queue: asyncio.Lock = asyncio.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.config.context_lens_enabled and self.owner)
+
+    def _report_error(self, operation: str, exc: BaseException) -> None:
+        if self._on_error is None:
+            return
+        try:
+            self._on_error(operation, exc)
+        except Exception as report_exc:
+            logger.debug("[tlon] context-lens error reporter failed: %s", report_exc)
+
+    async def start(self) -> bool:
+        if not self.config.context_lens_enabled:
+            logger.info("[tlon] context-lens disabled")
+            return False
+        if not self.owner:
+            logger.info("[tlon] context-lens skipped: no owner configured")
+            return False
+        client = self._client_factory(self.config)
+        self._client = client
+        try:
+            await client.authenticate()
+            await client.open()
+        except Exception:
+            await self._safe_close_client()
+            self._client = None
+            raise
+        logger.info("[tlon] context-lens sync active (owner=%s)", self.owner)
+        return True
+
+    async def stop(self) -> None:
+        self._configured = False
+        await self._safe_close_client()
+        self._client = None
+
+    async def push(self, run: LensRun, *, final: bool) -> None:
+        if not self.enabled or self._client is None:
+            return
+        if run.visibility == "internal":
+            return
+        payload = build_lens_payload(run.to_context_lens())
+        try:
+            async with self._queue:
+                await self._ensure_configured()
+                await self._client.poke(
+                    _STEWARD_APP,
+                    _LENS_MARK,
+                    {"entry": {"id": run.lens_id, "payload": payload, "final": final}},
+                )
+        except Exception as exc:
+            # A failed %configure must re-run before the next entry poke.
+            self._configured = False
+            logger.warning("[tlon] context-lens push failed (%s): %s", run.lens_id, exc)
+            self._report_error("push", exc)
+
+    async def _ensure_configured(self) -> None:
+        if self._configured or self._client is None:
+            return
+        await self._client.poke(
+            _STEWARD_APP, _CONFIGURE_MARK, {"configure": {"owner": self.owner}}
+        )
+        self._configured = True
+
+    async def _safe_close_client(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.close()
+            except Exception:
+                pass
+
+
+class TlonLensRecorder:
+    """Per-conversation run accumulator + sink, held as a process singleton.
+
+    The adapter drives lifecycle transitions (``begin`` / ``dispatching`` /
+    ``delivering`` / ``finish``) from its async path and awaits pokes there;
+    the sync tool/model hooks only mutate the in-memory run.
+    """
+
+    def __init__(self, sync: TlonLensSync) -> None:
+        self._sync = sync
+        self._runs: dict[str, LensRun] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._sync.enabled
+
+    def get(self, conversation_id: str) -> Optional[LensRun]:
+        return self._runs.get(conversation_id)
+
+    def _prune(self) -> None:
+        if len(self._runs) <= MAX_TRACKED_RUNS:
+            return
+        cutoff = _now_ms() - RUN_TTL_SECONDS * 1_000
+        stale = [k for k, r in self._runs.items() if r.updated_at < cutoff]
+        for key in stale:
+            self._runs.pop(key, None)
+
+    def begin(self, conversation_id: str, run: LensRun) -> LensRun:
+        if not self.enabled or not conversation_id:
+            return run
+        self._prune()
+        self._runs[conversation_id] = run
+        return run
+
+    def record_tool_start(self, conversation_id: str, name: str, **kwargs: Any) -> None:
+        run = self._runs.get(conversation_id)
+        if run is not None:
+            run.start_tool(name, **kwargs)
+
+    def record_tool_complete(
+        self, conversation_id: str, name: str, **kwargs: Any
+    ) -> None:
+        run = self._runs.get(conversation_id)
+        if run is not None:
+            run.complete_tool(name, **kwargs)
+
+    def record_model(
+        self,
+        conversation_id: str,
+        *,
+        model: Optional[str],
+        provider: Optional[str],
+    ) -> None:
+        run = self._runs.get(conversation_id)
+        if run is None:
+            return
+        run.model = model or run.model
+        run.provider = provider or run.provider
+        run.touch()
+
+    def record_output(self, conversation_id: str, output: LensOutput) -> None:
+        run = self._runs.get(conversation_id)
+        if run is not None:
+            run.record_output(output)
+            run.delivered_message_count += 1
+
+    def set_status(
+        self, conversation_id: str, status: str, error: Optional[str] = None
+    ) -> None:
+        run = self._runs.get(conversation_id)
+        if run is not None:
+            run.set_status(status, error)
+
+    async def push(self, conversation_id: str) -> None:
+        run = self._runs.get(conversation_id)
+        if run is not None:
+            await self._sync.push(run, final=False)
+
+    async def finish(
+        self, conversation_id: str, *, status: Optional[str] = None
+    ) -> None:
+        run = self._runs.pop(conversation_id, None)
+        if run is None:
+            return
+        run.close_open_tools(status="error")
+        if status is not None:
+            run.set_status(status)
+        elif run.status not in TERMINAL_STATUSES:
+            run.set_status("no_reply")
+        await self._sync.push(run, final=True)
+
+
+_active_recorder: Optional[TlonLensRecorder] = None
+
+
+def set_active_recorder(recorder: TlonLensRecorder) -> None:
+    global _active_recorder
+    _active_recorder = recorder
+
+
+def clear_active_recorder(recorder: TlonLensRecorder) -> None:
+    global _active_recorder
+    if _active_recorder is recorder:
+        _active_recorder = None
+
+
+def get_active_recorder() -> Optional[TlonLensRecorder]:
+    return _active_recorder
+
+
+# ── Hermes hook handlers ────────────────────────────────────────────────────
+#
+# These mirror the telemetry/presence hooks: they resolve the active run from
+# the per-run session env (set by the gateway when it invokes Hermes for a Tlon
+# conversation) and mutate the in-memory ``LensRun`` synchronously. The ship
+# poke happens later from the adapter's async dispatch path.
+
+
+def _session_env(name: str, default: str = "") -> str:
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return os.getenv(name, default)
+    return get_session_env(name, default)
+
+
+def _lens_conversation(kwargs: Mapping[str, Any]) -> Optional[str]:
+    platform = str(
+        kwargs.get("platform") or _session_env("HERMES_SESSION_PLATFORM", "")
+    ).lower()
+    if platform != "tlon":
+        return None
+    conversation = str(_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+    return conversation or None
+
+
+def _summarize_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, separators=(",", ":"), default=str, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _argument_summary(tool_name: str, args: Any) -> Optional[str]:
+    if isinstance(args, Mapping):
+        keys = ", ".join(sorted(str(k) for k in args.keys()))
+        return f"{tool_name}({keys})" if keys else f"{tool_name}()"
+    if args is None:
+        return None
+    return f"{tool_name}(…)"
+
+
+def _active_run(kwargs: Mapping[str, Any]) -> tuple[Optional[TlonLensRecorder], Optional[str]]:
+    recorder = get_active_recorder()
+    if recorder is None or not recorder.enabled:
+        return None, None
+    conversation = _lens_conversation(kwargs)
+    if conversation is None:
+        return None, None
+    return recorder, conversation
+
+
+def handle_pre_tool_call_lens(**kwargs: Any) -> None:
+    recorder, conversation = _active_run(kwargs)
+    if recorder is None or conversation is None:
+        return
+    tool_name = str(kwargs.get("tool_name") or "").strip() or "unknown"
+    args = kwargs.get("args")
+    recorder.record_tool_start(
+        conversation,
+        tool_name,
+        tool_call_id=str(kwargs.get("tool_call_id") or "") or None,
+        argument_summary=_argument_summary(tool_name, args),
+        argument_detail=_summarize_value(args),
+    )
+
+
+def handle_post_tool_call_lens(**kwargs: Any) -> None:
+    recorder, conversation = _active_run(kwargs)
+    if recorder is None or conversation is None:
+        return
+    tool_name = str(kwargs.get("tool_name") or "").strip() or "unknown"
+    status = str(kwargs.get("status") or "").lower()
+    error = str(kwargs.get("error_type") or "") if status not in ("", "ok") else ""
+    try:
+        duration_ms: Optional[int] = int(kwargs.get("duration_ms") or 0) or None
+    except (TypeError, ValueError):
+        duration_ms = None
+    recorder.record_tool_complete(
+        conversation,
+        tool_name,
+        tool_call_id=str(kwargs.get("tool_call_id") or "") or None,
+        duration_ms=duration_ms,
+        result_summary=_summarize_value(kwargs.get("result")),
+        error=error or None,
+        status="error" if error else "completed",
+    )
+
+
+def handle_post_api_request_lens(**kwargs: Any) -> None:
+    recorder, conversation = _active_run(kwargs)
+    if recorder is None or conversation is None:
+        return
+    recorder.record_model(
+        conversation,
+        model=str(kwargs.get("model") or "") or None,
+        provider=str(kwargs.get("provider") or "") or None,
+    )

--- a/packages/hermes-tlon-adapter/lens.py
+++ b/packages/hermes-tlon-adapter/lens.py
@@ -748,7 +748,10 @@ def handle_post_tool_call_lens(**kwargs: Any) -> None:
         return
     tool_name = str(kwargs.get("tool_name") or "").strip() or "unknown"
     status = str(kwargs.get("status") or "").lower()
-    error = str(kwargs.get("error_type") or "") if status not in ("", "ok") else ""
+    # A non-ok status is a failure even if Hermes gives us no error_type, so key
+    # the terminal tool status off `status`, not just the presence of an error.
+    failed = status not in ("", "ok")
+    error = str(kwargs.get("error_type") or "") if failed else ""
     try:
         duration_ms: Optional[int] = int(kwargs.get("duration_ms") or 0) or None
     except (TypeError, ValueError):
@@ -760,7 +763,7 @@ def handle_post_tool_call_lens(**kwargs: Any) -> None:
         duration_ms=duration_ms,
         result_summary=_summarize_value(kwargs.get("result")),
         error=error or None,
-        status="error" if error else "completed",
+        status="error" if failed else "completed",
     )
 
 

--- a/packages/hermes-tlon-adapter/lens.py
+++ b/packages/hermes-tlon-adapter/lens.py
@@ -58,6 +58,9 @@ TERMINAL_STATUSES: frozenset[str] = frozenset(
 _STEWARD_APP = "steward"
 _CONFIGURE_MARK = "steward-action-1"
 _LENS_MARK = "steward-lens-action-1"
+# Existence probe: a %steward lens scry that any installed agent answers (and
+# our own ship is always allowed to peek). A ship without %steward nacks it.
+_STEWARD_PROBE_PATH = "/steward/v1/lens/recent"
 
 
 def _now_ms() -> int:
@@ -506,6 +509,10 @@ class TlonLensSync:
         self._client_factory = client_factory
         self._client: Optional[TlonSSEClient] = None
         self._configured = False
+        # Set once start() confirms %steward is installed; gates begin/stamp so
+        # we never poke into the void or stamp replies with lens IDs whose runs
+        # were never stored (a badge the client can't load).
+        self._ready = False
         self._on_error = on_error
         # Serialize pokes so a run's partial/final ordering is preserved.
         self._queue: asyncio.Lock = asyncio.Lock()
@@ -513,6 +520,11 @@ class TlonLensSync:
     @property
     def enabled(self) -> bool:
         return bool(self.config.context_lens_enabled and self.owner)
+
+    @property
+    def active(self) -> bool:
+        """Enabled AND a live sync that verified %steward at startup."""
+        return self.enabled and self._ready
 
     def _report_error(self, operation: str, exc: BaseException) -> None:
         if self._on_error is None:
@@ -538,11 +550,31 @@ class TlonLensSync:
             await self._safe_close_client()
             self._client = None
             raise
+        # Verify %steward is installed before trusting pokes or stamping
+        # replies (mirrors OpenClaw gating the lens on the /v1/lens subscribe,
+        # which a ship without the agent nacks).
+        if not await self._steward_installed(client):
+            logger.info(
+                "[tlon] context-lens skipped: steward agent not reachable"
+            )
+            await self._safe_close_client()
+            self._client = None
+            return False
+        self._ready = True
         logger.info("[tlon] context-lens sync active (owner=%s)", self.owner)
         return True
 
+    async def _steward_installed(self, client: TlonSSEClient) -> bool:
+        try:
+            await client.scry(_STEWARD_PROBE_PATH)
+            return True
+        except Exception as exc:
+            logger.debug("[tlon] context-lens steward probe failed: %s", exc)
+            return False
+
     async def stop(self) -> None:
         self._configured = False
+        self._ready = False
         await self._safe_close_client()
         self._client = None
 
@@ -597,6 +629,10 @@ class TlonLensRecorder:
     @property
     def enabled(self) -> bool:
         return self._sync.enabled
+
+    @property
+    def active(self) -> bool:
+        return self._sync.active
 
     def get(self, conversation_id: str) -> Optional[LensRun]:
         return self._runs.get(conversation_id)

--- a/packages/hermes-tlon-adapter/lens.py
+++ b/packages/hermes-tlon-adapter/lens.py
@@ -466,6 +466,26 @@ def build_lens_payload(lens: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def context_lens_reference_blob(
+    lens_id: str, bot_ship: Optional[str] = None
+) -> str:
+    """Post-blob field pointing a delivered reply at its lens run.
+
+    Mirrors ``serializeContextLensReferenceBlob`` (openclaw/urbit/blob.ts): a
+    JSON array with a single ``tlon-context-lens`` entry. The client's
+    ``getContextLensStamp`` reads this off ``post.blob`` to surface the
+    per-message lens entry point (badge / message actions).
+    """
+    entry: dict[str, Any] = {
+        "type": "tlon-context-lens",
+        "version": 1,
+        "lensId": lens_id,
+    }
+    if bot_ship:
+        entry["botShip"] = bot_ship
+    return json.dumps([entry], separators=(",", ":"))
+
+
 class TlonLensSync:
     """Pokes lens run records to the bot ship's ``%steward`` agent.
 

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -242,13 +242,13 @@ class FakeCLI:
             success=True, command=("tlon-test", *args), stdout="ok\n"
         )
 
-    async def send_message(self, chat_id, text):
+    async def send_message(self, chat_id, text, *, blob=None):
         self.messages.append((chat_id, text))
         return tlon_api.TlonSendResult(
             success=True, command=("tlon-test", "posts", "send"), message_id="post-id"
         )
 
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None):
+    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
         self.replies.append((chat_id, post_id, text, parent_author))
         return tlon_api.TlonSendResult(
             success=True, command=("tlon-test", "posts", "reply"), message_id="reply-id"

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -242,13 +242,13 @@ class FakeCLI:
             success=True, command=("tlon-test", *args), stdout="ok\n"
         )
 
-    async def send_message(self, chat_id, text, *, blob=None):
+    async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
         self.messages.append((chat_id, text))
         return tlon_api.TlonSendResult(
             success=True, command=("tlon-test", "posts", "send"), message_id="post-id"
         )
 
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
+    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
         self.replies.append((chat_id, post_id, text, parent_author))
         return tlon_api.TlonSendResult(
             success=True, command=("tlon-test", "posts", "reply"), message_id="reply-id"

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -176,14 +176,14 @@ class FakeSSE:
 
 
 class FakeCLI:
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
+    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
         return tlon_api.TlonSendResult(
             success=True,
             command=("tlon-test", "posts", "reply"),
             message_id="reply-id",
         )
 
-    async def send_message(self, chat_id, text, *, blob=None):
+    async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
         return tlon_api.TlonSendResult(
             success=True,
             command=("tlon-test", "posts", "send"),
@@ -670,11 +670,11 @@ class AdapterAttentionTests(unittest.TestCase):
                 self.sends = []
                 self.thread_replies = []
 
-            async def send_message(self, chat_id, text, *, blob=None):
+            async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
                 self.sends.append((chat_id, text))
                 return await super().send_message(chat_id, text)
 
-            async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
+            async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
                 self.thread_replies.append((chat_id, post_id, text))
                 return await super().send_reply(
                     chat_id, post_id, text, parent_author=parent_author
@@ -713,7 +713,7 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter._cli = FakeCLI()
         recorded = []
 
-        async def record_reply(chat_id, post_id, text, *, parent_author=None, blob=None):
+        async def record_reply(chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
             recorded.append(post_id)
             return tlon_api.TlonSendResult(
                 success=True, command=("tlon-test",), message_id="reply-id"
@@ -732,8 +732,9 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter._lens_sync._ready = True
         captured = {}
 
-        async def record_message(chat_id, text, *, blob=None):
+        async def record_message(chat_id, text, *, blob=None, sent_at=None):
             captured["blob"] = blob
+            captured["sent_at"] = sent_at
             return tlon_api.TlonSendResult(
                 success=True, command=("tlon-test",), message_id="post-id"
             )
@@ -755,6 +756,15 @@ class AdapterAttentionTests(unittest.TestCase):
         self.assertEqual(entry["type"], "tlon-context-lens")
         self.assertEqual(entry["lensId"], "L42")
         self.assertEqual(entry["botShip"], "~pen")
+        # The adapter owns the send time and derives the output id from it —
+        # the same value it hands the CLI, so both agree.
+        self.assertIsNotNone(captured["sent_at"])
+        output = adapter._lens.get("chat/~pen/general").outputs[0]
+        self.assertEqual(
+            output.message_id,
+            tlon_api.format_post_id("~pen", captured["sent_at"]),
+        )
+        self.assertEqual(output.sent_at, captured["sent_at"])
 
     def test_send_without_active_lens_run_omits_blob(self):
         adapter = self.make_adapter(
@@ -764,7 +774,7 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter._lens_sync._ready = True
         captured = {"blob": "unset"}
 
-        async def record_message(chat_id, text, *, blob=None):
+        async def record_message(chat_id, text, *, blob=None, sent_at=None):
             captured["blob"] = blob
             return tlon_api.TlonSendResult(
                 success=True, command=("tlon-test",), message_id="post-id"
@@ -1013,6 +1023,22 @@ class AdapterAttentionTests(unittest.TestCase):
         self.assertIsNotNone(block)
         self.assertEqual(block["action"], "block")
         self.assertIn("owner-only", block["message"])
+
+
+class LensTriggerMapTests(unittest.TestCase):
+    def test_maps_dispatch_reasons_to_valid_triggers(self):
+        t = adapter_mod._lens_trigger
+        self.assertEqual(t("dm", is_dm=True), "dm")
+        self.assertEqual(t("mention", is_dm=False), "mention")
+        self.assertEqual(t("participated-thread", is_dm=False), "thread")
+        self.assertEqual(t("owner-listen", is_dm=False), "owner-listen")
+        # free-response is a real dispatch reason with no dedicated trigger.
+        self.assertEqual(t("free-response", is_dm=False), "unknown")
+
+    def test_approved_resolves_by_conversation_kind(self):
+        t = adapter_mod._lens_trigger
+        self.assertEqual(t("approved", is_dm=True), "dm")
+        self.assertEqual(t("approved", is_dm=False), "mention")
 
 
 if __name__ == "__main__":

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -728,6 +728,8 @@ class AdapterAttentionTests(unittest.TestCase):
             {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
         )
         self.assertTrue(adapter._lens.enabled)
+        # Simulate a started sync that verified %steward at startup.
+        adapter._lens_sync._ready = True
         captured = {}
 
         async def record_message(chat_id, text, *, blob=None):
@@ -758,6 +760,8 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter = self.make_adapter(
             {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
         )
+        # Active sync, but no run began for this conversation → no stamp.
+        adapter._lens_sync._ready = True
         captured = {"blob": "unset"}
 
         async def record_message(chat_id, text, *, blob=None):

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -776,6 +776,7 @@ class AdapterAttentionTests(unittest.TestCase):
 
         async def record_message(chat_id, text, *, blob=None, sent_at=None):
             captured["blob"] = blob
+            captured["sent_at"] = sent_at
             return tlon_api.TlonSendResult(
                 success=True, command=("tlon-test",), message_id="post-id"
             )
@@ -784,6 +785,9 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter._cli.send_message = record_message
         asyncio.run(adapter.send("chat/~pen/general", "hi"))
         self.assertIsNone(captured["blob"])
+        # No lens output to stamp → no --sent-at override (keeps older `tlon`
+        # binaries from folding an unknown flag into the message body).
+        self.assertIsNone(captured["sent_at"])
 
     def test_nickname_fetch_failure_keeps_ship_and_alias_wakes(self):
         adapter = self.make_adapter({"allowed_users": ["~mug"], "bot_mentions": ["arvo"]})

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -176,14 +176,14 @@ class FakeSSE:
 
 
 class FakeCLI:
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None):
+    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
         return tlon_api.TlonSendResult(
             success=True,
             command=("tlon-test", "posts", "reply"),
             message_id="reply-id",
         )
 
-    async def send_message(self, chat_id, text):
+    async def send_message(self, chat_id, text, *, blob=None):
         return tlon_api.TlonSendResult(
             success=True,
             command=("tlon-test", "posts", "send"),
@@ -670,11 +670,11 @@ class AdapterAttentionTests(unittest.TestCase):
                 self.sends = []
                 self.thread_replies = []
 
-            async def send_message(self, chat_id, text):
+            async def send_message(self, chat_id, text, *, blob=None):
                 self.sends.append((chat_id, text))
                 return await super().send_message(chat_id, text)
 
-            async def send_reply(self, chat_id, post_id, text, *, parent_author=None):
+            async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
                 self.thread_replies.append((chat_id, post_id, text))
                 return await super().send_reply(
                     chat_id, post_id, text, parent_author=parent_author
@@ -713,7 +713,7 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter._cli = FakeCLI()
         recorded = []
 
-        async def record_reply(chat_id, post_id, text, *, parent_author=None):
+        async def record_reply(chat_id, post_id, text, *, parent_author=None, blob=None):
             recorded.append(post_id)
             return tlon_api.TlonSendResult(
                 success=True, command=("tlon-test",), message_id="reply-id"
@@ -722,6 +722,54 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter._cli.send_reply = record_reply
         asyncio.run(adapter.send("chat/~pen/general", "reply", reply_to="170.141"))
         self.assertEqual(recorded, ["170.141"])
+
+    def test_send_stamps_active_lens_run(self):
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
+        )
+        self.assertTrue(adapter._lens.enabled)
+        captured = {}
+
+        async def record_message(chat_id, text, *, blob=None):
+            captured["blob"] = blob
+            return tlon_api.TlonSendResult(
+                success=True, command=("tlon-test",), message_id="post-id"
+            )
+
+        adapter._cli = FakeCLI()
+        adapter._cli.send_message = record_message
+        adapter._lens.begin(
+            "chat/~pen/general",
+            adapter_mod.LensRun(
+                lens_id="L42",
+                message_id="m",
+                chat_type="channel",
+                trigger="mention",
+                conversation_kind="channel",
+            ),
+        )
+        asyncio.run(adapter.send("chat/~pen/general", "hi"))
+        entry = json.loads(captured["blob"])[0]
+        self.assertEqual(entry["type"], "tlon-context-lens")
+        self.assertEqual(entry["lensId"], "L42")
+        self.assertEqual(entry["botShip"], "~pen")
+
+    def test_send_without_active_lens_run_omits_blob(self):
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
+        )
+        captured = {"blob": "unset"}
+
+        async def record_message(chat_id, text, *, blob=None):
+            captured["blob"] = blob
+            return tlon_api.TlonSendResult(
+                success=True, command=("tlon-test",), message_id="post-id"
+            )
+
+        adapter._cli = FakeCLI()
+        adapter._cli.send_message = record_message
+        asyncio.run(adapter.send("chat/~pen/general", "hi"))
+        self.assertIsNone(captured["blob"])
 
     def test_nickname_fetch_failure_keeps_ship_and_alias_wakes(self):
         adapter = self.make_adapter({"allowed_users": ["~mug"], "bot_mentions": ["arvo"]})

--- a/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
+++ b/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
@@ -249,7 +249,7 @@ class FakeCLI:
             stdout=self.version_stdout,
         )
 
-    async def send_message(self, chat_id, text):
+    async def send_message(self, chat_id, text, *, blob=None):
         self.messages.append((chat_id, text))
         return tlon_api.TlonSendResult(
             success=True,
@@ -257,7 +257,7 @@ class FakeCLI:
             message_id="post-id",
         )
 
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None):
+    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
         self.replies.append((chat_id, post_id, text, parent_author))
         return tlon_api.TlonSendResult(
             success=True,
@@ -540,7 +540,7 @@ class AdapterOwnerListenTests(unittest.TestCase):
                 self.replies = []
                 self.instances.append(self)
 
-            async def send_message(self, chat_id, text):
+            async def send_message(self, chat_id, text, *, blob=None):
                 self.messages.append((chat_id, text))
                 return tlon_api.TlonSendResult(
                     success=True,
@@ -548,7 +548,7 @@ class AdapterOwnerListenTests(unittest.TestCase):
                     message_id="top-id",
                 )
 
-            async def send_reply(self, chat_id, post_id, text, *, parent_author=None):
+            async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
                 self.replies.append((chat_id, post_id, text, parent_author))
                 return tlon_api.TlonSendResult(
                     success=True,

--- a/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
+++ b/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
@@ -249,7 +249,7 @@ class FakeCLI:
             stdout=self.version_stdout,
         )
 
-    async def send_message(self, chat_id, text, *, blob=None):
+    async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
         self.messages.append((chat_id, text))
         return tlon_api.TlonSendResult(
             success=True,
@@ -257,7 +257,7 @@ class FakeCLI:
             message_id="post-id",
         )
 
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
+    async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
         self.replies.append((chat_id, post_id, text, parent_author))
         return tlon_api.TlonSendResult(
             success=True,
@@ -540,7 +540,7 @@ class AdapterOwnerListenTests(unittest.TestCase):
                 self.replies = []
                 self.instances.append(self)
 
-            async def send_message(self, chat_id, text, *, blob=None):
+            async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
                 self.messages.append((chat_id, text))
                 return tlon_api.TlonSendResult(
                     success=True,
@@ -548,7 +548,7 @@ class AdapterOwnerListenTests(unittest.TestCase):
                     message_id="top-id",
                 )
 
-            async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None):
+            async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
                 self.replies.append((chat_id, post_id, text, parent_author))
                 return tlon_api.TlonSendResult(
                     success=True,

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -251,6 +251,16 @@ class SyncSequencingTests(unittest.TestCase):
         self.assertEqual(client.entries()[-1]["entry"]["payload"]["lens"]["status"], "completed")
         self.assertTrue(client.closed)
 
+    def test_delivery_failure_flags_run(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        rec = lens.TlonLensRecorder(lens.TlonLensSync(cfg, client_factory=FakeClient))
+        rec.begin("~alice", make_run())
+        rec.record_delivery_failure("~alice", error="boom")
+        r = rec.get("~alice")
+        self.assertTrue(r.delivery_failed)
+        self.assertEqual(r.delivered_message_count, 0)
+        self.assertEqual(r.error, "boom")
+
     def test_configure_poked_once(self):
         cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
         sync = lens.TlonLensSync(cfg, client_factory=FakeClient)

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -261,6 +261,25 @@ class SyncSequencingTests(unittest.TestCase):
         self.assertEqual(r.delivered_message_count, 0)
         self.assertEqual(r.error, "boom")
 
+    def test_finish_as_error_pushes_final_once(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+        rec = lens.TlonLensRecorder(sync)
+
+        async def scenario():
+            await sync.start()
+            rec.begin("~alice", make_run())
+            await rec.finish("~alice", status="error")
+            # A second finish (e.g. dispatch raised after a normal finish) is a
+            # no-op — the run was already popped.
+            await rec.finish("~alice", status="error")
+
+        run(scenario())
+        entries = FakeClient.instances[0].entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["entry"]["payload"]["lens"]["status"], "error")
+        self.assertTrue(entries[0]["entry"]["final"])
+
     def test_configure_poked_once(self):
         cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
         sync = lens.TlonLensSync(cfg, client_factory=FakeClient)

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -53,6 +53,8 @@ class FakeClient:
         self.opened = False
         self.closed = False
         self.fail_on_mark = None
+        self.scries = []
+        self.steward_missing = False
         FakeClient.instances.append(self)
 
     async def authenticate(self):
@@ -68,6 +70,12 @@ class FakeClient:
         if self.fail_on_mark == mark:
             raise RuntimeError(f"poke {mark} failed")
         self.pokes.append((app, mark, payload))
+
+    async def scry(self, path):
+        self.scries.append(path)
+        if self.steward_missing:
+            raise ConnectionError(f"scry {path} failed: no such agent")
+        return {"recent": []}
 
     def marks(self):
         return [mark for _app, mark, _payload in self.pokes]
@@ -233,6 +241,42 @@ class TruncationTests(unittest.TestCase):
 class SyncSequencingTests(unittest.TestCase):
     def setUp(self):
         FakeClient.instances.clear()
+
+    def test_start_probes_steward_and_activates(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+
+        async def scenario():
+            self.assertTrue(await sync.start())
+            self.assertTrue(sync.active)
+
+        run(scenario())
+        client = FakeClient.instances[-1]
+        self.assertIn(lens._STEWARD_PROBE_PATH, client.scries)
+
+    def test_start_returns_false_when_steward_missing(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+
+        def factory(config):
+            client = FakeClient(config)
+            client.steward_missing = True
+            return client
+
+        sync = lens.TlonLensSync(cfg, client_factory=factory)
+        rec = lens.TlonLensRecorder(sync)
+
+        async def scenario():
+            self.assertFalse(await sync.start())
+            self.assertFalse(sync.active)
+            # Inactive sync: begin stores nothing and a push is a no-op.
+            rec.begin("~alice", make_run())
+            await rec.push("~alice")
+
+        run(scenario())
+        client = FakeClient.instances[-1]
+        self.assertIn(lens._STEWARD_PROBE_PATH, client.scries)
+        self.assertTrue(client.closed)
+        self.assertEqual(client.entries(), [])
 
     def test_configure_precedes_entry_and_final_last(self):
         cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -1,0 +1,411 @@
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+PACKAGE_DIR = Path(__file__).parent
+PACKAGE_NAME = "hermes_tlon_adapter_lens_testpkg"
+
+package = types.ModuleType(PACKAGE_NAME)
+package.__path__ = [str(PACKAGE_DIR)]
+sys.modules[PACKAGE_NAME] = package
+
+
+def load_module(name):
+    module_name = f"{PACKAGE_NAME}.{name}"
+    spec = importlib.util.spec_from_file_location(module_name, PACKAGE_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tlon_api = load_module("tlon_api")
+lens = load_module("lens")
+
+TlonConfig = tlon_api.TlonConfig
+
+
+def make_config(**overrides):
+    env = {
+        "TLON_NODE_URL": "https://bot.tlon.network",
+        "TLON_NODE_ID": "~bot",
+        "TLON_ACCESS_CODE": "code",
+    }
+    env.update(overrides)
+    return TlonConfig.from_env(env=env)
+
+
+class FakeClient:
+    """Stands in for TlonSSEClient; records pokes instead of hitting a ship."""
+
+    instances = []
+
+    def __init__(self, config):
+        self.config = config
+        self.pokes = []
+        self.authenticated = False
+        self.opened = False
+        self.closed = False
+        self.fail_on_mark = None
+        FakeClient.instances.append(self)
+
+    async def authenticate(self):
+        self.authenticated = True
+
+    async def open(self):
+        self.opened = True
+
+    async def close(self):
+        self.closed = True
+
+    async def poke(self, app, mark, payload):
+        if self.fail_on_mark == mark:
+            raise RuntimeError(f"poke {mark} failed")
+        self.pokes.append((app, mark, payload))
+
+    def marks(self):
+        return [mark for _app, mark, _payload in self.pokes]
+
+    def entries(self):
+        return [p for _a, m, p in self.pokes if m == lens._LENS_MARK]
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_run(**overrides):
+    kwargs = dict(
+        lens_id="L1",
+        message_id="m1",
+        chat_type="dm",
+        trigger="dm",
+        conversation_kind="dm",
+        conversation_id="~alice",
+    )
+    kwargs.update(overrides)
+    return lens.LensRun(**kwargs)
+
+
+class PayloadMappingTests(unittest.TestCase):
+    def test_context_lens_shape_and_camel_case(self):
+        r = make_run(model="hermes-3", provider="nous", author_ship="~alice")
+        r.start_tool("search", tool_call_id="t1", argument_detail='{"q":"hi"}')
+        r.complete_tool("search", tool_call_id="t1", result_summary="ok", duration_ms=12)
+        r.record_output(
+            lens.LensOutput(
+                message_id="o1", conversation_id="~alice", kind="dm", sent_at=5
+            )
+        )
+        r.set_status("completed")
+
+        doc = r.to_context_lens()
+        self.assertEqual(doc["lensId"], "L1")
+        self.assertEqual(doc["chatType"], "dm")
+        self.assertEqual(doc["model"], "hermes-3")
+        self.assertEqual(doc["triggerDetails"]["conversationKind"], "dm")
+        self.assertEqual(doc["triggerDetails"]["authorShip"], "~alice")
+        self.assertEqual(doc["tools"]["callCount"], 1)
+        self.assertEqual(doc["tools"]["runs"][0]["status"], "completed")
+        self.assertEqual(doc["tools"]["runs"][0]["resultSummary"], "ok")
+        self.assertEqual(doc["tools"]["called"], ["search"])
+        self.assertEqual(len(doc["outputs"]), 1)
+        self.assertTrue(doc["persistence"]["postsReply"])
+        self.assertEqual(doc["status"], "completed")
+        self.assertIsNotNone(doc["lifecycle"]["completedAt"])
+        self.assertGreater(doc["expiresAt"], doc["createdAt"])
+
+    def test_terminal_status_sets_duration_and_timeout(self):
+        r = make_run()
+        r.set_status("timed_out")
+        doc = r.to_context_lens()
+        self.assertTrue(doc["lifecycle"]["timedOut"])
+        self.assertIsNotNone(doc["lifecycle"]["durationMs"])
+
+    def test_retry_of_included_only_when_set(self):
+        self.assertNotIn("retryOf", make_run().to_context_lens())
+        self.assertEqual(make_run(retry_of="L0").to_context_lens()["retryOf"], "L0")
+
+
+class ToolMatchingTests(unittest.TestCase):
+    def test_complete_matches_open_by_tool_call_id(self):
+        r = make_run()
+        r.start_tool("a", tool_call_id="1")
+        r.start_tool("b", tool_call_id="2")
+        r.complete_tool("b", tool_call_id="2", result_summary="rb")
+        r.complete_tool("a", tool_call_id="1", result_summary="ra")
+        by_id = {run.tool_call_id: run for run in r.tool_runs}
+        self.assertEqual(by_id["1"].result_summary, "ra")
+        self.assertEqual(by_id["2"].result_summary, "rb")
+        self.assertEqual(len(r.tool_runs), 2)
+
+    def test_complete_without_start_synthesizes_run(self):
+        r = make_run()
+        r.complete_tool("orphan", result_summary="x", status="completed")
+        self.assertEqual(len(r.tool_runs), 1)
+        self.assertEqual(r.tool_runs[0].result_summary, "x")
+
+    def test_error_status_and_close_open_tools(self):
+        r = make_run()
+        r.start_tool("boom", tool_call_id="9")
+        r.complete_tool("boom", tool_call_id="9", error="kaboom")
+        self.assertEqual(r.tool_runs[0].status, "error")
+        r.start_tool("dangling", tool_call_id="10")
+        r.close_open_tools()
+        # Dangling tools close as 'error' (a valid ContextLensToolRun status),
+        # not the run-level 'aborted'.
+        self.assertEqual(r.tool_runs[1].status, "error")
+
+    def test_call_index_is_one_based(self):
+        r = make_run()
+        r.start_tool("a", tool_call_id="1")
+        r.start_tool("b", tool_call_id="2")
+        self.assertEqual([run.call_index for run in r.tool_runs], [1, 2])
+        self.assertEqual(r.to_context_lens()["tools"]["callCount"], 2)
+
+    def test_tool_run_statuses_are_contract_valid(self):
+        valid = {"running", "completed", "error", "blocked"}
+        r = make_run()
+        r.start_tool("open", tool_call_id="1")
+        r.start_tool("done", tool_call_id="2")
+        r.complete_tool("done", tool_call_id="2")
+        r.start_tool("failed", tool_call_id="3")
+        r.complete_tool("failed", tool_call_id="3", error="x")
+        r.close_open_tools()
+        for run in r.to_context_lens()["tools"]["runs"]:
+            self.assertIn(run["status"], valid)
+
+
+class TruncationTests(unittest.TestCase):
+    def test_summary_truncation(self):
+        big = "x" * (lens.MAX_SUMMARY_CHARS + 500)
+        r = make_run()
+        r.start_tool("t", tool_call_id="1", argument_detail=big)
+        r.complete_tool("t", tool_call_id="1", result_summary=big)
+        detail = r.to_context_lens()["tools"]["runs"][0]["argumentDetail"]
+        self.assertLess(len(detail), len(big))
+        self.assertTrue(detail.endswith("[truncated]"))
+
+    def test_payload_cap_drops_arrays(self):
+        r = make_run()
+        # Force oversize by stuffing many tool runs with large results.
+        for i in range(400):
+            r.start_tool(f"t{i}", tool_call_id=str(i))
+            r.complete_tool(f"t{i}", tool_call_id=str(i), result_summary="y" * 500)
+        r.set_status("completed")
+        payload = lens.build_lens_payload(r.to_context_lens())
+        self.assertTrue(payload.get("truncated"))
+        self.assertEqual(payload["lens"]["tools"]["runs"], [])
+        self.assertEqual(payload["lens"]["outputs"], [])
+        # Identity + status survive the drop.
+        self.assertEqual(payload["lens"]["lensId"], "L1")
+        self.assertEqual(payload["lens"]["status"], "completed")
+        self.assertLessEqual(
+            len(json.dumps(payload, separators=(",", ":"))), lens.MAX_PAYLOAD_CHARS
+        )
+
+    def test_small_payload_not_truncated(self):
+        payload = lens.build_lens_payload(make_run().to_context_lens())
+        self.assertNotIn("truncated", payload)
+        self.assertEqual(payload["schemaVersion"], lens.PAYLOAD_SCHEMA_VERSION)
+
+
+class SyncSequencingTests(unittest.TestCase):
+    def setUp(self):
+        FakeClient.instances.clear()
+
+    def test_configure_precedes_entry_and_final_last(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+        rec = lens.TlonLensRecorder(sync)
+
+        async def scenario():
+            self.assertTrue(await sync.start())
+            r = make_run()
+            r.set_status("dispatching")
+            rec.begin("~alice", r)
+            await rec.push("~alice")
+            rec.record_output(
+                "~alice",
+                lens.LensOutput(
+                    message_id="o1", conversation_id="~alice", kind="dm", sent_at=1
+                ),
+            )
+            await rec.finish("~alice", status="completed")
+            await sync.stop()
+
+        run(scenario())
+        client = FakeClient.instances[0]
+        self.assertEqual(
+            client.marks(),
+            [lens._CONFIGURE_MARK, lens._LENS_MARK, lens._LENS_MARK],
+        )
+        finals = [e["entry"]["final"] for e in client.entries()]
+        self.assertEqual(finals, [False, True])
+        self.assertEqual(client.entries()[-1]["entry"]["payload"]["lens"]["status"], "completed")
+        self.assertTrue(client.closed)
+
+    def test_configure_poked_once(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+
+        async def scenario():
+            await sync.start()
+            await sync.push(make_run(lens_id="a"), final=True)
+            await sync.push(make_run(lens_id="b"), final=True)
+
+        run(scenario())
+        client = FakeClient.instances[0]
+        self.assertEqual(client.marks().count(lens._CONFIGURE_MARK), 1)
+
+    def test_configure_retried_after_failure(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        errors = []
+        sync = lens.TlonLensSync(
+            cfg,
+            client_factory=FakeClient,
+            on_error=lambda op, exc: errors.append((op, str(exc))),
+        )
+
+        async def scenario():
+            await sync.start()
+            sync._client.fail_on_mark = lens._CONFIGURE_MARK
+            await sync.push(make_run(), final=True)  # configure fails
+            sync._client.fail_on_mark = None
+            await sync.push(make_run(), final=True)  # should re-configure + entry
+
+        run(scenario())
+        client = FakeClient.instances[0]
+        self.assertTrue(errors)
+        # First attempt only got the (failed, unrecorded) configure; the retry
+        # re-runs configure and lands the entry.
+        self.assertEqual(client.marks(), [lens._CONFIGURE_MARK, lens._LENS_MARK])
+
+    def test_internal_visibility_not_pushed(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+
+        async def scenario():
+            await sync.start()
+            await sync.push(make_run(visibility="internal"), final=True)
+
+        run(scenario())
+        client = FakeClient.instances[0]
+        self.assertEqual(client.entries(), [])
+
+
+class GatingTests(unittest.TestCase):
+    def setUp(self):
+        FakeClient.instances.clear()
+
+    def test_disabled_when_flag_off(self):
+        cfg = make_config(TLON_OWNER_SHIP="~zod")  # flag not set
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+        self.assertFalse(sync.enabled)
+
+        async def scenario():
+            self.assertFalse(await sync.start())
+            await sync.push(make_run(), final=True)
+
+        run(scenario())
+        self.assertEqual(FakeClient.instances, [])
+
+    def test_disabled_when_no_owner(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true")  # no owner anywhere
+        sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+        self.assertFalse(sync.enabled)
+
+        async def scenario():
+            self.assertFalse(await sync.start())
+
+        run(scenario())
+
+    def test_context_lens_owner_overrides_owner_ship(self):
+        cfg = make_config(
+            TLON_CONTEXT_LENS="true",
+            TLON_OWNER_SHIP="~zod",
+            TLON_CONTEXT_LENS_OWNER="~nec",
+        )
+        self.assertEqual(cfg.context_lens_owner_ship(), "~nec")
+
+    def test_owner_falls_back_to_owner_ship(self):
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        self.assertEqual(cfg.context_lens_owner_ship(), "~zod")
+
+    def test_recorder_begin_noop_when_disabled(self):
+        cfg = make_config(TLON_OWNER_SHIP="~zod")
+        rec = lens.TlonLensRecorder(lens.TlonLensSync(cfg, client_factory=FakeClient))
+        rec.begin("~alice", make_run())
+        self.assertIsNone(rec.get("~alice"))
+
+
+class HookTests(unittest.TestCase):
+    def setUp(self):
+        FakeClient.instances.clear()
+        cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
+        self.sync = lens.TlonLensSync(cfg, client_factory=FakeClient)
+        self.rec = lens.TlonLensRecorder(self.sync)
+        lens.set_active_recorder(self.rec)
+        self.addCleanup(lambda: lens.clear_active_recorder(self.rec))
+        env = patch.dict(
+            os.environ,
+            {"HERMES_SESSION_PLATFORM": "tlon", "HERMES_SESSION_CHAT_ID": "~alice"},
+        )
+        env.start()
+        self.addCleanup(env.stop)
+        self.rec.begin("~alice", make_run())
+
+    def _kwargs(self, **extra):
+        base = {"platform": "tlon"}
+        base.update(extra)
+        return base
+
+    def test_pre_tool_call_captures_args(self):
+        lens.handle_pre_tool_call_lens(
+            **self._kwargs(tool_name="search", args={"q": "hi"}, tool_call_id="t1")
+        )
+        r = self.rec.get("~alice")
+        self.assertEqual(r.tool_runs[0].argument_detail, '{"q":"hi"}')
+        self.assertEqual(r.tool_runs[0].argument_summary, "search(q)")
+
+    def test_post_tool_call_captures_result_and_error(self):
+        lens.handle_pre_tool_call_lens(
+            **self._kwargs(tool_name="t", args={}, tool_call_id="x")
+        )
+        lens.handle_post_tool_call_lens(
+            **self._kwargs(
+                tool_name="t", tool_call_id="x", result={"n": 1}, status="ok", duration_ms=7
+            )
+        )
+        r = self.rec.get("~alice")
+        self.assertEqual(r.tool_runs[0].status, "completed")
+        self.assertEqual(r.tool_runs[0].result_summary, '{"n":1}')
+        self.assertEqual(r.tool_runs[0].duration_ms, 7)
+
+    def test_post_tool_call_error_status(self):
+        lens.handle_post_tool_call_lens(
+            **self._kwargs(tool_name="t", tool_call_id="x", status="error", error_type="Boom")
+        )
+        self.assertEqual(self.rec.get("~alice").tool_runs[0].status, "error")
+
+    def test_post_api_request_captures_model(self):
+        lens.handle_post_api_request_lens(
+            **self._kwargs(model="hermes-3", provider="nous")
+        )
+        r = self.rec.get("~alice")
+        self.assertEqual(r.model, "hermes-3")
+        self.assertEqual(r.provider, "nous")
+
+    def test_hooks_ignore_non_tlon_platform(self):
+        lens.handle_pre_tool_call_lens(platform="discord", tool_name="x", args={})
+        self.assertEqual(self.rec.get("~alice").tool_runs, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -394,6 +394,14 @@ class HookTests(unittest.TestCase):
         )
         self.assertEqual(self.rec.get("~alice").tool_runs[0].status, "error")
 
+    def test_post_tool_call_failure_without_error_type_is_error(self):
+        # A non-ok status must record as 'error' even when Hermes omits an
+        # error_type, not fall through to 'completed'.
+        lens.handle_post_tool_call_lens(
+            **self._kwargs(tool_name="t", tool_call_id="x", status="error")
+        )
+        self.assertEqual(self.rec.get("~alice").tool_runs[0].status, "error")
+
     def test_post_api_request_captures_model(self):
         lens.handle_post_api_request_lens(
             **self._kwargs(model="hermes-3", provider="nous")

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -210,6 +210,20 @@ class TruncationTests(unittest.TestCase):
             len(json.dumps(payload, separators=(",", ":"))), lens.MAX_PAYLOAD_CHARS
         )
 
+    def test_reference_blob_shape(self):
+        # Mirrors serializeContextLensReferenceBlob (openclaw/urbit/blob.ts):
+        # a JSON array with a single tlon-context-lens entry.
+        blob = json.loads(lens.context_lens_reference_blob("L9", "~bot"))
+        self.assertEqual(
+            blob,
+            [{"type": "tlon-context-lens", "version": 1, "lensId": "L9", "botShip": "~bot"}],
+        )
+
+    def test_reference_blob_omits_bot_ship_when_absent(self):
+        blob = json.loads(lens.context_lens_reference_blob("L9"))
+        self.assertNotIn("botShip", blob[0])
+        self.assertEqual(blob[0]["lensId"], "L9")
+
     def test_small_payload_not_truncated(self):
         payload = lens.build_lens_payload(make_run().to_context_lens())
         self.assertNotIn("truncated", payload)

--- a/packages/hermes-tlon-adapter/test_tlon_api.py
+++ b/packages/hermes-tlon-adapter/test_tlon_api.py
@@ -561,6 +561,30 @@ class TlonCLITests(unittest.TestCase):
         self.assertEqual(calls[0][1]["TLON_ACCESS_CODE"], "code")
         self.assertEqual(calls[0][1]["TLON_URL"], "https://zod.tlon.network")
 
+    def test_send_extracts_post_id_from_stdout(self):
+        cfg = tlon_api.TlonConfig.from_env(
+            env={
+                "TLON_NODE_URL": "https://zod.tlon.network",
+                "TLON_NODE_ID": "~zod",
+                "TLON_ACCESS_CODE": "code",
+                "TLON_CLI": "tlon-test",
+            }
+        )
+
+        async def runner(command, env, timeout):
+            return tlon_api.TlonProcessResult(
+                returncode=0,
+                stdout="✓ Message sent\npostId=~zod/170.141.184.503.808\n",
+            )
+
+        async def run():
+            cli = tlon_api.TlonCLI(cfg, runner=runner)
+            return await cli.send_message("chat/~zod/general", "hi")
+
+        result = asyncio.run(run())
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "~zod/170.141.184.503.808")
+
     def test_run_command_uses_same_runner_and_env(self):
         calls = []
         cfg = tlon_api.TlonConfig.from_env(

--- a/packages/hermes-tlon-adapter/test_tlon_api.py
+++ b/packages/hermes-tlon-adapter/test_tlon_api.py
@@ -561,7 +561,8 @@ class TlonCLITests(unittest.TestCase):
         self.assertEqual(calls[0][1]["TLON_ACCESS_CODE"], "code")
         self.assertEqual(calls[0][1]["TLON_URL"], "https://zod.tlon.network")
 
-    def test_send_extracts_post_id_from_stdout(self):
+    def test_send_and_reply_forward_sent_at(self):
+        calls = []
         cfg = tlon_api.TlonConfig.from_env(
             env={
                 "TLON_NODE_URL": "https://zod.tlon.network",
@@ -572,18 +573,29 @@ class TlonCLITests(unittest.TestCase):
         )
 
         async def runner(command, env, timeout):
-            return tlon_api.TlonProcessResult(
-                returncode=0,
-                stdout="✓ Message sent\npostId=~zod/170.141.184.503.808\n",
-            )
+            calls.append(tuple(command))
+            return tlon_api.TlonProcessResult(returncode=0, stdout="✓ Message sent\n")
 
         async def run():
             cli = tlon_api.TlonCLI(cfg, runner=runner)
-            return await cli.send_message("chat/~zod/general", "hi")
+            await cli.send_message("chat/~zod/general", "hi", sent_at=1234)
+            await cli.send_reply("~nec", "170.141", "hi", sent_at=5678)
 
-        result = asyncio.run(run())
-        self.assertTrue(result.success)
-        self.assertEqual(result.message_id, "~zod/170.141.184.503.808")
+        asyncio.run(run())
+        self.assertEqual(calls[0][-2:], ("--sent-at", "1234"))
+        self.assertEqual(calls[1][-2:], ("--sent-at", "5678"))
+
+    def test_format_post_id_round_trips_through_da(self):
+        # da.fromUnix round-trips via aura's da.toUnix; the id is
+        # ~author/<dotted @ud>.
+        pid = tlon_api.format_post_id("bot", 1_700_000_000_000)
+        ship, _, ud = pid.partition("/")
+        self.assertEqual(ship, "~bot")
+        self.assertIn(".", ud)
+        da = int(ud.replace(".", ""))
+        offset = (1 << 64) // 2000
+        back = round((offset + (da - tlon_api._DA_UNIX_EPOCH)) * 1000 / (1 << 64))
+        self.assertEqual(back, 1_700_000_000_000)
 
     def test_run_command_uses_same_runner_and_env(self):
         calls = []

--- a/packages/hermes-tlon-adapter/tlon_api.py
+++ b/packages/hermes-tlon-adapter/tlon_api.py
@@ -657,8 +657,13 @@ class TlonCLI:
         self._runner = runner or self._run_subprocess
         self._observer = observer
 
-    async def send_message(self, chat_id: str, text: str) -> TlonSendResult:
-        return await self._run(("posts", "send", chat_id, text))
+    async def send_message(
+        self, chat_id: str, text: str, *, blob: str | None = None
+    ) -> TlonSendResult:
+        args: list[str] = ["posts", "send", chat_id, text]
+        if blob:
+            args.extend(["--blob", blob])
+        return await self._run(tuple(args))
 
     async def send_reply(
         self,
@@ -667,10 +672,13 @@ class TlonCLI:
         text: str,
         *,
         parent_author: str | None = None,
+        blob: str | None = None,
     ) -> TlonSendResult:
         args: list[str] = ["posts", "reply", chat_id, post_id, text]
         if parent_author:
             args.extend(["--author", normalize_ship(parent_author)])
+        if blob:
+            args.extend(["--blob", blob])
         return await self._run(tuple(args))
 
     async def run_command(self, args: Sequence[str]) -> TlonSendResult:

--- a/packages/hermes-tlon-adapter/tlon_api.py
+++ b/packages/hermes-tlon-adapter/tlon_api.py
@@ -191,6 +191,8 @@ class TlonConfig:
     gateway_status_lease_seconds: float = DEFAULT_GATEWAY_LEASE_SECONDS
     gateway_status_active_window_seconds: int = DEFAULT_GATEWAY_ACTIVE_WINDOW_SECONDS
     gateway_status_reply_cooldown_seconds: int = DEFAULT_GATEWAY_OFFLINE_REPLY_COOLDOWN_SECONDS
+    context_lens_enabled: bool = False
+    context_lens_owner: str = ""
     sse_read_timeout_seconds: float = DEFAULT_SSE_READ_TIMEOUT_SECONDS
     # Force the hosted (memex) image-upload path. Opt-in: only true when the
     # operator sets TLON_HOSTING. Read once where the env is reliably present
@@ -470,6 +472,22 @@ class TlonConfig:
             ),
             DEFAULT_GATEWAY_OFFLINE_REPLY_COOLDOWN_SECONDS,
         )
+        context_lens_enabled = parse_bool(
+            _env_or_extra(
+                env,
+                ("TLON_CONTEXT_LENS", "TLON_CONTEXT_LENS_ENABLED"),
+                extra,
+                ("context_lens", "context_lens_enabled"),
+            )
+        )
+        context_lens_owner = normalize_ship(
+            _env_first(
+                env,
+                ("TLON_CONTEXT_LENS_OWNER",),
+                extra,
+                ("context_lens_owner",),
+            )
+        )
         sse_read_timeout_seconds = _parse_float(
             _env_or_extra(
                 env,
@@ -530,6 +548,8 @@ class TlonConfig:
             gateway_status_lease_seconds=gateway_status_lease_seconds,
             gateway_status_active_window_seconds=gateway_status_active_window_seconds,
             gateway_status_reply_cooldown_seconds=gateway_status_reply_cooldown_seconds,
+            context_lens_enabled=context_lens_enabled,
+            context_lens_owner=context_lens_owner,
             sse_read_timeout_seconds=sse_read_timeout_seconds,
         )
 
@@ -594,6 +614,9 @@ class TlonConfig:
 
     def gateway_status_owner_ship(self) -> str:
         return self.gateway_status_owner or self.owner_ship
+
+    def context_lens_owner_ship(self) -> str:
+        return self.context_lens_owner or self.owner_ship
 
 
 @dataclass(frozen=True)

--- a/packages/hermes-tlon-adapter/tlon_api.py
+++ b/packages/hermes-tlon-adapter/tlon_api.py
@@ -44,6 +44,36 @@ def bare_ship(ship: str) -> str:
     return normalize_ship(ship).lstrip("~")
 
 
+# @da (Urbit date) conversion, matching @urbit/aura's da.fromUnix so a post id
+# we compute here round-trips through the client's da.toUnix.
+_DA_UNIX_EPOCH = 170_141_184_475_152_167_957_503_069_145_530_368_000  # @ud ~1970.1.1
+_DA_SECOND = 1 << 64  # @ud ~s1
+
+
+def unix_ms_to_da(ms: int) -> int:
+    return _DA_UNIX_EPOCH + (int(ms) * _DA_SECOND) // 1000
+
+
+def _dotted_ud(value: int) -> str:
+    """Render a bare @ud as Hoon's dotted decimal (groups of 3 from the right)."""
+    digits = str(value)
+    groups: list[str] = []
+    while len(digits) > 3:
+        groups.insert(0, digits[-3:])
+        digits = digits[:-3]
+    groups.insert(0, digits)
+    return ".".join(groups)
+
+
+def format_post_id(ship: str, sent_at_ms: int) -> str:
+    """A post's id: ``~author/<@ud of da.fromUnix(sent)>``.
+
+    Mirrors how the api stamps a post id and how the client resolves a message
+    (by author + send time), computed from the exact ``sent`` the CLI used.
+    """
+    return f"{normalize_ship(ship)}/{_dotted_ud(unix_ms_to_da(sent_at_ms))}"
+
+
 def parse_bool(value: Any) -> bool:
     return str(value or "").strip().lower() in TRUE_VALUES
 
@@ -658,11 +688,18 @@ class TlonCLI:
         self._observer = observer
 
     async def send_message(
-        self, chat_id: str, text: str, *, blob: str | None = None
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        blob: str | None = None,
+        sent_at: int | None = None,
     ) -> TlonSendResult:
         args: list[str] = ["posts", "send", chat_id, text]
         if blob:
             args.extend(["--blob", blob])
+        if sent_at is not None:
+            args.extend(["--sent-at", str(sent_at)])
         return await self._run(tuple(args))
 
     async def send_reply(
@@ -673,12 +710,15 @@ class TlonCLI:
         *,
         parent_author: str | None = None,
         blob: str | None = None,
+        sent_at: int | None = None,
     ) -> TlonSendResult:
         args: list[str] = ["posts", "reply", chat_id, post_id, text]
         if parent_author:
             args.extend(["--author", normalize_ship(parent_author)])
         if blob:
             args.extend(["--blob", blob])
+        if sent_at is not None:
+            args.extend(["--sent-at", str(sent_at)])
         return await self._run(tuple(args))
 
     async def run_command(self, args: Sequence[str]) -> TlonSendResult:

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -280,7 +280,7 @@ describe('posts send', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(context.stdout()).toMatch(/^✓ Message sent\npostId=~nec\/[\d.]+\n$/);
+    expect(context.stdout()).toBe('✓ Message sent\n');
     expect(context.stderr()).toBe('');
     expect(context.calls.authenticateApps).toEqual([['channels']]);
     expect(context.calls.sendPost).toEqual([
@@ -344,6 +344,27 @@ describe('posts send', () => {
     expect(context.calls.sendPost[0].blob).toBe('[{"type":"a2ui"}]');
   });
 
+  it('honors --sent-at over the clock', async () => {
+    const context = makeDeps({ now: 999 });
+    await run(
+      ['send', 'chat/~host/channel', 'hi', '--sent-at', '1234'],
+      context.deps
+    );
+    expect(context.calls.sendPost[0].sentAt).toBe(1234);
+    // and it does not leak into the message text
+    expect(context.calls.sendPost[0].content).toEqual([{ inline: ['hi'] }]);
+  });
+
+  it('rejects a non-positive --sent-at', async () => {
+    const context = makeDeps();
+    const exitCode = await run(
+      ['send', 'chat/~host/channel', 'hi', '--sent-at', 'nope'],
+      context.deps
+    );
+    expect(exitCode).toBe(1);
+    expect(context.calls.sendPost).toEqual([]);
+  });
+
   it('wraps image fetch failures as a stable command error after auth', async () => {
     const context = makeDeps({
       buildImageVerse: async () => {
@@ -404,7 +425,7 @@ describe('posts reply', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(context.stdout()).toMatch(/^✓ Reply sent\npostId=~nec\/[\d.]+\n$/);
+    expect(context.stdout()).toBe('✓ Reply sent\n');
     expect(context.calls.authenticateApps).toEqual([['channels']]);
     expect(context.calls.sendReply).toEqual([
       {

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -280,7 +280,7 @@ describe('posts send', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(context.stdout()).toBe('✓ Message sent\n');
+    expect(context.stdout()).toMatch(/^✓ Message sent\npostId=~nec\/[\d.]+\n$/);
     expect(context.stderr()).toBe('');
     expect(context.calls.authenticateApps).toEqual([['channels']]);
     expect(context.calls.sendPost).toEqual([
@@ -404,7 +404,7 @@ describe('posts reply', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(context.stdout()).toBe('✓ Reply sent\n');
+    expect(context.stdout()).toMatch(/^✓ Reply sent\npostId=~nec\/[\d.]+\n$/);
     expect(context.calls.authenticateApps).toEqual([['channels']]);
     expect(context.calls.sendReply).toEqual([
       {

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -428,6 +428,40 @@ describe('posts reply', () => {
     expect(context.calls.sendReply[0].parentAuthor).toBe('~bus');
   });
 
+  it('stamps a validated --blob without folding it into the message', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      [
+        'reply',
+        'chat/~host/channel',
+        '170.141',
+        'hello there',
+        '--blob',
+        '[{"type":"tlon-context-lens","lensId":"L1"}]',
+      ],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.sendReply[0].content).toEqual([
+      { inline: ['hello there'] },
+    ]);
+    expect(context.calls.sendReply[0].blob).toBe(
+      '[{"type":"tlon-context-lens","lensId":"L1"}]'
+    );
+  });
+
+  it('rejects a malformed reply --blob', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      ['reply', 'chat/~host/channel', '170.141', 'hi', '--blob', '{"a":1}'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.calls.sendReply).toEqual([]);
+  });
+
   it('defaults the parent author to a one-to-one DM target', async () => {
     const context = makeDeps({ currentUserId: '~nec' });
     await run(['reply', '~sampel-palnet', '170.141', 'hi'], context.deps);

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -1,5 +1,3 @@
-import { da } from '@urbit/aura';
-
 import {
   DIARY_REMOVED,
   NOTES_CHANNEL_CONTENT_UNSUPPORTED,
@@ -33,6 +31,8 @@ Send options:
   --blob <json>        Attach a post-blob JSON array (e.g. an a2ui entry)
   --image <url>        Attach an image (direct png/jpeg/gif/webp URL, e.g. from
                        'tlon upload'); message becomes an optional caption
+  --sent-at <ms>       Override the send timestamp (unix ms); the post id
+                       derives from it. Applies to send and reply.
 
 Examples:
   tlon posts send chat/~host/channel "Hello from tlon"
@@ -44,9 +44,9 @@ Channel format: chat/~host/channel-name, heap/~host/name
 Use 'tlon messages channel <nest> --limit N' to see post IDs.`;
 
 export const POSTS_COMMAND_HELP: Record<string, string> = {
-  send: 'Usage: tlon posts send <channel> [message] [--blob <json>] [--image <url>] (message optional with --image)',
+  send: 'Usage: tlon posts send <channel> [message] [--blob <json>] [--image <url>] [--sent-at <ms>] (message optional with --image)',
   reply:
-    'Usage: tlon posts reply <channel> <post-id> <message> [--author ~ship] [--blob <json>]',
+    'Usage: tlon posts reply <channel> <post-id> <message> [--author ~ship] [--blob <json>] [--sent-at <ms>]',
   react: 'Usage: tlon posts react <channel> <post-id> <emoji>',
   unreact: 'Usage: tlon posts unreact <channel> <post-id>',
   edit: 'Usage: tlon posts edit <channel> <post-id> <message>',
@@ -65,8 +65,8 @@ export const POSTS_REACT_HELP = POSTS_COMMAND_HELP.react;
 const POSTS_EDIT_REMOVED_FLAGS_MESSAGE =
   'tlon posts edit no longer supports --title/--image/--content (notebook-only affordances). Edit the message text directly; use `tlon notes` for %notes content.';
 
-const POST_REPLY_OPTION_FLAGS = ['author', 'blob'] as const;
-const POST_SEND_OPTION_FLAGS = ['blob', 'image'] as const;
+const POST_REPLY_OPTION_FLAGS = ['author', 'blob', 'sent-at'] as const;
+const POST_SEND_OPTION_FLAGS = ['blob', 'image', 'sent-at'] as const;
 
 export interface PostReactionInput {
   channelId: string;
@@ -173,6 +173,7 @@ type ParsedPostsArgs =
       message: string;
       imageUrl?: string;
       blob?: string;
+      sentAt?: number;
     }
   | {
       kind: 'reply';
@@ -181,6 +182,7 @@ type ParsedPostsArgs =
       message: string;
       parentAuthor?: string;
       blob?: string;
+      sentAt?: number;
     }
   | { kind: 'react'; channelId: string; postId: string; emoji: string }
   | { kind: 'unreact'; channelId: string; postId: string }
@@ -205,12 +207,20 @@ function formatPostId(postId: string): string {
   return formatUd(extractNumericId(postId));
 }
 
-// The lens/consumer-facing id for a just-sent post: `~author/<@ud of the send
-// @da>`. This matches how the api stamps the post id and how the client
-// resolves a reply (by author + sent time), so callers scraping stdout can
-// navigate to it. Compute from the same sentAt handed to the send call.
-function referenceId(authorId: string, sentAt: number): string {
-  return `${authorId}/${formatUd(da.fromUnix(sentAt).toString())}`;
+// Optional `--sent-at <unix-ms>`: overrides the send timestamp so a caller
+// (e.g. the Hermes adapter) controls the post's `sent` — and can therefore
+// derive the post id (~author/<@da of sent>) itself without scraping output.
+function validatedSentAt(args: string[], help: string): number | undefined {
+  const idx = args.indexOf('--sent-at');
+  if (idx === -1) {
+    return undefined;
+  }
+  const raw = args[idx + 1];
+  const ms = Number(raw);
+  if (!raw || !Number.isInteger(ms) || ms <= 0) {
+    throw usageError(help);
+  }
+  return ms;
 }
 
 function wantsHelp(args: string[]): boolean {
@@ -410,7 +420,15 @@ function parseArgs(args: string[]): ParsedPostsArgs {
         throw usageError(POSTS_COMMAND_HELP.send);
       }
       const blob = validatedBlobFlag(args);
-      return { kind: 'send', channelId: args[1], message, imageUrl, blob };
+      const sentAt = validatedSentAt(args, POSTS_COMMAND_HELP.send);
+      return {
+        kind: 'send',
+        channelId: args[1],
+        message,
+        imageUrl,
+        blob,
+        sentAt,
+      };
     }
     case 'reply': {
       const channelId = args[1];
@@ -425,7 +443,16 @@ function parseArgs(args: string[]): ParsedPostsArgs {
       }
       const parentAuthor = authorIdx !== -1 ? args[authorIdx + 1] : undefined;
       const blob = validatedBlobFlag(args, POSTS_COMMAND_HELP.reply);
-      return { kind: 'reply', channelId, postId, message, parentAuthor, blob };
+      const sentAt = validatedSentAt(args, POSTS_COMMAND_HELP.reply);
+      return {
+        kind: 'reply',
+        channelId,
+        postId,
+        message,
+        parentAuthor,
+        blob,
+        sentAt,
+      };
     }
     case 'react': {
       const [, channelId, postId, emoji] = args;
@@ -524,9 +551,10 @@ async function sendPost(
     message: string;
     imageUrl?: string;
     blob?: string;
+    sentAt?: number;
   },
   deps: PostsDeps
-): Promise<string> {
+): Promise<void> {
   // Image block first, caption after — matches how the apps compose
   // attachment posts.
   const imageVerse = parsed.imageUrl
@@ -537,16 +565,13 @@ async function sendPost(
     ...(parsed.message ? markdownToStory(parsed.message) : []),
   ];
 
-  const authorId = deps.getCurrentUserId();
-  const sentAt = deps.now();
   await deps.postsApi.sendPost({
     channelId: parsed.channelId,
-    authorId,
-    sentAt,
+    authorId: deps.getCurrentUserId(),
+    sentAt: parsed.sentAt ?? deps.now(),
     content,
     blob: parsed.blob,
   });
-  return referenceId(authorId, sentAt);
 }
 
 async function sendReply(
@@ -556,11 +581,11 @@ async function sendReply(
     message: string;
     parentAuthor?: string;
     blob?: string;
+    sentAt?: number;
   },
   deps: PostsDeps
-): Promise<string> {
+): Promise<void> {
   const authorId = deps.getCurrentUserId();
-  const sentAt = deps.now();
   await deps.postsApi.sendReply({
     channelId: parsed.channelId,
     parentId: formatPostId(parsed.postId),
@@ -570,11 +595,10 @@ async function sendReply(
       parsed.parentAuthor
     ),
     content: markdownToStory(parsed.message),
-    sentAt,
+    sentAt: parsed.sentAt ?? deps.now(),
     authorId,
     blob: parsed.blob,
   });
-  return referenceId(authorId, sentAt);
 }
 
 // Fetch existing post to preserve metadata during edits. Returns null on any
@@ -643,18 +667,14 @@ export async function run(args: string[], deps: PostsDeps): Promise<number> {
     await deps.authenticate(postTargetApps(parsed.kind, parsed.channelId));
 
     switch (parsed.kind) {
-      case 'send': {
-        const id = await sendPost(parsed, deps);
+      case 'send':
+        await sendPost(parsed, deps);
         writeLine(deps.stdout, '✓ Message sent');
-        writeLine(deps.stdout, `postId=${id}`);
         return 0;
-      }
-      case 'reply': {
-        const id = await sendReply(parsed, deps);
+      case 'reply':
+        await sendReply(parsed, deps);
         writeLine(deps.stdout, '✓ Reply sent');
-        writeLine(deps.stdout, `postId=${id}`);
         return 0;
-      }
       case 'react':
         await reactToPost(parsed, deps);
         writeLine(deps.stdout, '✓ Reaction added');

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -21,7 +21,7 @@ export const POSTS_HELP = `Usage: tlon posts <command>
 
 Commands:
   send <channel> [message]                 Send a message to a channel [--blob <json>] [--image <url>]
-  reply <channel> <post-id> <message>      Reply to a channel post [--author ~ship]
+  reply <channel> <post-id> <message>      Reply to a channel post [--author ~ship] [--blob <json>]
   react <channel> <post-id> <emoji>     React to a post with an emoji
   unreact <channel> <post-id>           Remove your reaction from a post
   edit <channel> <post-id> <message>    Edit a post's message text
@@ -44,7 +44,7 @@ Use 'tlon messages channel <nest> --limit N' to see post IDs.`;
 export const POSTS_COMMAND_HELP: Record<string, string> = {
   send: 'Usage: tlon posts send <channel> [message] [--blob <json>] [--image <url>] (message optional with --image)',
   reply:
-    'Usage: tlon posts reply <channel> <post-id> <message> [--author ~ship]',
+    'Usage: tlon posts reply <channel> <post-id> <message> [--author ~ship] [--blob <json>]',
   react: 'Usage: tlon posts react <channel> <post-id> <emoji>',
   unreact: 'Usage: tlon posts unreact <channel> <post-id>',
   edit: 'Usage: tlon posts edit <channel> <post-id> <message>',
@@ -63,7 +63,7 @@ export const POSTS_REACT_HELP = POSTS_COMMAND_HELP.react;
 const POSTS_EDIT_REMOVED_FLAGS_MESSAGE =
   'tlon posts edit no longer supports --title/--image/--content (notebook-only affordances). Edit the message text directly; use `tlon notes` for %notes content.';
 
-const POST_REPLY_OPTION_FLAGS = ['author'] as const;
+const POST_REPLY_OPTION_FLAGS = ['author', 'blob'] as const;
 const POST_SEND_OPTION_FLAGS = ['blob', 'image'] as const;
 
 export interface PostReactionInput {
@@ -118,6 +118,7 @@ export interface PostReplyInput {
   content: Story;
   sentAt: number;
   authorId: string;
+  blob?: string;
 }
 
 export interface PostLookupQuery {
@@ -177,6 +178,7 @@ type ParsedPostsArgs =
       postId: string;
       message: string;
       parentAuthor?: string;
+      blob?: string;
     }
   | { kind: 'react'; channelId: string; postId: string; emoji: string }
   | { kind: 'unreact'; channelId: string; postId: string }
@@ -250,14 +252,17 @@ function validatedImageFlag(args: string[], usage: string): string | undefined {
   return url;
 }
 
-function validatedSendBlob(args: string[]): string | undefined {
+function validatedBlobFlag(
+  args: string[],
+  help: string = POSTS_COMMAND_HELP.send
+): string | undefined {
   const blobIdx = args.indexOf('--blob');
   if (blobIdx === -1) {
     return undefined;
   }
   const blob = args[blobIdx + 1];
   if (!blob) {
-    throw usageError(POSTS_COMMAND_HELP.send);
+    throw usageError(help);
   }
   try {
     if (!Array.isArray(JSON.parse(blob))) {
@@ -394,7 +399,7 @@ function parseArgs(args: string[]): ParsedPostsArgs {
       if (!args[1] || (!message && !imageUrl)) {
         throw usageError(POSTS_COMMAND_HELP.send);
       }
-      const blob = validatedSendBlob(args);
+      const blob = validatedBlobFlag(args);
       return { kind: 'send', channelId: args[1], message, imageUrl, blob };
     }
     case 'reply': {
@@ -409,7 +414,8 @@ function parseArgs(args: string[]): ParsedPostsArgs {
         throw usageError(POSTS_COMMAND_HELP.reply);
       }
       const parentAuthor = authorIdx !== -1 ? args[authorIdx + 1] : undefined;
-      return { kind: 'reply', channelId, postId, message, parentAuthor };
+      const blob = validatedBlobFlag(args, POSTS_COMMAND_HELP.reply);
+      return { kind: 'reply', channelId, postId, message, parentAuthor, blob };
     }
     case 'react': {
       const [, channelId, postId, emoji] = args;
@@ -536,6 +542,7 @@ async function sendReply(
     postId: string;
     message: string;
     parentAuthor?: string;
+    blob?: string;
   },
   deps: PostsDeps
 ): Promise<void> {
@@ -551,6 +558,7 @@ async function sendReply(
     content: markdownToStory(parsed.message),
     sentAt: deps.now(),
     authorId,
+    blob: parsed.blob,
   });
 }
 

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -1,3 +1,5 @@
+import { da } from '@urbit/aura';
+
 import {
   DIARY_REMOVED,
   NOTES_CHANNEL_CONTENT_UNSUPPORTED,
@@ -201,6 +203,14 @@ function formatUd(id: string): string {
 
 function formatPostId(postId: string): string {
   return formatUd(extractNumericId(postId));
+}
+
+// The lens/consumer-facing id for a just-sent post: `~author/<@ud of the send
+// @da>`. This matches how the api stamps the post id and how the client
+// resolves a reply (by author + sent time), so callers scraping stdout can
+// navigate to it. Compute from the same sentAt handed to the send call.
+function referenceId(authorId: string, sentAt: number): string {
+  return `${authorId}/${formatUd(da.fromUnix(sentAt).toString())}`;
 }
 
 function wantsHelp(args: string[]): boolean {
@@ -516,7 +526,7 @@ async function sendPost(
     blob?: string;
   },
   deps: PostsDeps
-): Promise<void> {
+): Promise<string> {
   // Image block first, caption after — matches how the apps compose
   // attachment posts.
   const imageVerse = parsed.imageUrl
@@ -527,13 +537,16 @@ async function sendPost(
     ...(parsed.message ? markdownToStory(parsed.message) : []),
   ];
 
+  const authorId = deps.getCurrentUserId();
+  const sentAt = deps.now();
   await deps.postsApi.sendPost({
     channelId: parsed.channelId,
-    authorId: deps.getCurrentUserId(),
-    sentAt: deps.now(),
+    authorId,
+    sentAt,
     content,
     blob: parsed.blob,
   });
+  return referenceId(authorId, sentAt);
 }
 
 async function sendReply(
@@ -545,8 +558,9 @@ async function sendReply(
     blob?: string;
   },
   deps: PostsDeps
-): Promise<void> {
+): Promise<string> {
   const authorId = deps.getCurrentUserId();
+  const sentAt = deps.now();
   await deps.postsApi.sendReply({
     channelId: parsed.channelId,
     parentId: formatPostId(parsed.postId),
@@ -556,10 +570,11 @@ async function sendReply(
       parsed.parentAuthor
     ),
     content: markdownToStory(parsed.message),
-    sentAt: deps.now(),
+    sentAt,
     authorId,
     blob: parsed.blob,
   });
+  return referenceId(authorId, sentAt);
 }
 
 // Fetch existing post to preserve metadata during edits. Returns null on any
@@ -628,14 +643,18 @@ export async function run(args: string[], deps: PostsDeps): Promise<number> {
     await deps.authenticate(postTargetApps(parsed.kind, parsed.channelId));
 
     switch (parsed.kind) {
-      case 'send':
-        await sendPost(parsed, deps);
+      case 'send': {
+        const id = await sendPost(parsed, deps);
         writeLine(deps.stdout, '✓ Message sent');
+        writeLine(deps.stdout, `postId=${id}`);
         return 0;
-      case 'reply':
-        await sendReply(parsed, deps);
+      }
+      case 'reply': {
+        const id = await sendReply(parsed, deps);
         writeLine(deps.stdout, '✓ Reply sent');
+        writeLine(deps.stdout, `postId=${id}`);
         return 0;
+      }
       case 'react':
         await reactToPost(parsed, deps);
         writeLine(deps.stdout, '✓ Reaction added');


### PR DESCRIPTION
## Summary

Ports the OpenClaw **context lens** (per-run bot introspection: lifecycle, tool calls, model output, context, persistence, outputs) to the Python **Hermes Tlon adapter**, so Hermes bots report into the same on-ship `%steward` agent and the same client lens UI as OpenClaw bots.

This is **PR1 — the emitter**. Owner-requested **retry** (subscribe to the bot ship's `%retry-requested` and re-dispatch) is a deliberate follow-up.

## What's here

- **`lens.py` (new)**
  - `LensRun` accumulator + `to_context_lens()` producing the camelCase `ContextLens` JSON (mirrors `packages/openclaw/src/context-lens.ts`).
  - `build_lens_payload()` — `{ schemaVersion: 1, lens }` wrapper, per-field truncation, and the ~50KB cap with array-dropping skeleton fallback (mirrors `buildLensRunPayload` in `context-lens-ship-sync.ts`).
  - `TlonLensSync` — owns its own SSE client (like `TlonGatewayStatus`); pokes the **bot ship's** `%steward`: `steward-action-1` `{configure:{owner}}` once, then `steward-lens-action-1` `{entry:{id,payload,final}}` per snapshot. Re-configures if a poke fails.
  - `TlonLensRecorder` — per-conversation run store (keyed like `telemetry.py`'s reply traces).
  - Hermes hook handlers: `pre_tool_call` (args), `post_tool_call` (result/status/duration/error), `post_api_request` (model/provider). Conversation resolved from `HERMES_SESSION_CHAT_ID`, same as the telemetry/presence hooks.
- **`tlon_api.py`** — `context_lens_enabled` / `context_lens_owner` config, `TLON_CONTEXT_LENS[_ENABLED]` / `TLON_CONTEXT_LENS_OWNER` env parsing, `context_lens_owner_ship()`.
- **`adapter.py`** — start/stop the sink in `connect`/`disconnect`, register the three hooks, begin a run + push a `dispatching` partial in `_dispatch_message`, record outputs in `send`, and finish (outcome→terminal-status mapping) in `on_processing_complete`.
- **`test_lens.py` (new)** — payload mapping, truncation + 50KB fallback, poke sequencing (configure once → partials → one final), gating on/off, hook capture, contract-valid tool statuses.

Gated off by default (needs an owner ship + `TLON_CONTEXT_LENS`). **PostHog telemetry is unchanged** and runs alongside the lens as a second sink.

## Reviewed

Sequential Codex review caught and fixed 3 contract-fidelity bugs (verified against `context-lens.ts`):
- dangling tool runs closed as invalid `aborted` → now `error` (valid `ContextLensToolRun.status`);
- `callIndex` was 0-based → 1-based (`callCount + 1`);
- `expiresAt` used a 90d TTL → matches TS `DEFAULT_TTL_MS` (30 min).

## Known limitation (follow-up)

Only `dispatching` (partial) and the terminal state (final) are poked. Intermediate `tool_running`/`delivering` milestones aren't live-pushed — all tool/model/output data still lands in the final poke, but the live UI won't show mid-run progress. Live milestones need cross-thread loop scheduling (like the presence tracker); deferred to keep PR1 focused.

## Test plan

- [x] `python3 -m unittest test_lens` — 25 tests pass
- [x] Full adapter suite (`test_tlon_api`, `test_telemetry`, `test_adapter_*`) — 183 pass, no regressions
- [ ] Integration: run the adapter against a dev/fakezod ship with `%steward` installed; DM the bot; scry the bot ship's `%steward` for the `entry`; confirm a dev-build client lens UI renders the run (dispatching → final, tool runs, output)
- [ ] E2E on `~malmur-halmex` / `~sitrul-nacwyl`: verify fan-out to the owner ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)