### PR TITLE
skill: keep notes pending guidance cli-only

### DIFF
--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'vitest';
 
 import {
+  NotesV1PendingWriteError,
   createNotesNote,
   deleteNotesNotebook,
   deleteNotesNotebookBestEffort,
@@ -53,13 +54,23 @@ const requestJsonMock = requestJson as unknown as Mock;
 const subscribeMock = subscribe as unknown as Mock;
 const unsubscribeMock = unsubscribe as unknown as Mock;
 
-async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+async function rejectionError(promise: Promise<unknown>): Promise<unknown> {
   try {
     await promise;
   } catch (error) {
-    return error instanceof Error ? error.message : String(error);
+    return error;
   }
   throw new Error('Expected promise to reject');
+}
+
+function pendingErrorStrings(error: NotesV1PendingWriteError): string {
+  return [
+    error.name,
+    error.message,
+    error.requestId ?? '',
+    error.status ?? '',
+    JSON.stringify(error.checks),
+  ].join('\n');
 }
 
 beforeEach(() => {
@@ -443,22 +454,24 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     }
   });
 
-  test('createNotebook pending includes request status and notebook checks', async () => {
+  test('createNotebook pending preserves structured request status and notebook checks', async () => {
     requestJsonMock.mockResolvedValue({
       requestId: '0vabc',
-      body: { type: 'pending' },
+      body: { type: 'pending', status: 'acked' },
     });
 
-    const message = await rejectionMessage(
-      notesV1.createNotebook({ title: 'B' })
-    );
+    const error = await rejectionError(notesV1.createNotebook({ title: 'B' }));
 
-    expect(message).toContain('%notes write request is still pending');
-    expect(message).toContain('Do not retry automatically');
-    expect(message).toContain('tlon notes request 0vabc');
-    expect(message).toContain('tlon notes list');
-    expect(message).toContain('tlon notes show <notes-nest-from-list>');
-    expect(message).not.toContain('try again');
+    expect(error).toBeInstanceOf(NotesV1PendingWriteError);
+    const pending = error as NotesV1PendingWriteError;
+    expect(pending.message).toBe('%notes write request is still pending');
+    expect(pending.requestId).toBe('0vabc');
+    expect(pending.status).toBe('acked');
+    expect(pending.checks).toEqual([
+      { type: 'notebook-list' },
+      { type: 'notebook-detail' },
+    ]);
+    expect(pendingErrorStrings(pending)).not.toContain('tlon notes');
   });
 
   test('createNotebook reports empty error envelopes with fallback detail', async () => {
@@ -483,13 +496,13 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     );
   });
 
-  test('createNote pending includes request status and note checks', async () => {
+  test('createNote pending preserves structured request status and note checks', async () => {
     requestJsonMock.mockResolvedValue({
       requestId: '0vnote',
-      body: { type: 'pending' },
+      body: { type: 'pending', status: 'queued' },
     });
 
-    const message = await rejectionMessage(
+    const error = await rejectionError(
       notesV1.createNote({
         flag: 'notes/~zod/blog',
         folder: 3,
@@ -498,12 +511,15 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
       })
     );
 
-    expect(message).toContain('%notes write request is still pending');
-    expect(message).toContain('Do not retry automatically');
-    expect(message).toContain('tlon notes request 0vnote');
-    expect(message).toContain('tlon notes notes notes/~zod/blog');
-    expect(message).toContain('tlon notes note notes/~zod/blog <id-from-list>');
-    expect(message).not.toContain('try again');
+    expect(error).toBeInstanceOf(NotesV1PendingWriteError);
+    const pending = error as NotesV1PendingWriteError;
+    expect(pending.requestId).toBe('0vnote');
+    expect(pending.status).toBe('queued');
+    expect(pending.checks).toEqual([
+      { type: 'note-list', nest: 'notes/~zod/blog' },
+      { type: 'note-detail', nest: 'notes/~zod/blog' },
+    ]);
+    expect(pendingErrorStrings(pending)).not.toContain('tlon notes');
   });
 
   test('updateNoteBody includes expectedRevision only when provided', async () => {
@@ -631,24 +647,33 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     }
   });
 
-  test('pending note and folder writes point at affected objects', async () => {
+  test('pending note and folder writes point at affected objects structurally', async () => {
     requestJsonMock.mockResolvedValue({
       requestId: '0vobj',
       body: { type: 'pending' },
     });
 
-    const noteMessage = await rejectionMessage(
+    const noteError = await rejectionError(
       notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 12, title: 'x' })
     );
-    expect(noteMessage).toContain('tlon notes request 0vobj');
-    expect(noteMessage).toContain('tlon notes note notes/~zod/blog 12');
-    expect(noteMessage).not.toContain('try again');
+    expect(noteError).toBeInstanceOf(NotesV1PendingWriteError);
+    const pendingNote = noteError as NotesV1PendingWriteError;
+    expect(pendingNote.requestId).toBe('0vobj');
+    expect(pendingNote.status).toBeUndefined();
+    expect(pendingNote.checks).toEqual([
+      { type: 'note-detail', nest: 'notes/~zod/blog', noteId: 12 },
+    ]);
+    expect(pendingErrorStrings(pendingNote)).not.toContain('tlon notes');
 
-    const folderMessage = await rejectionMessage(
+    const folderError = await rejectionError(
       notesV1.renameFolder({ flag: 'notes/~zod/blog', folderId: 4, name: 'x' })
     );
-    expect(folderMessage).toContain('tlon notes folder notes/~zod/blog 4');
-    expect(folderMessage).not.toContain('try again');
+    expect(folderError).toBeInstanceOf(NotesV1PendingWriteError);
+    const pendingFolder = folderError as NotesV1PendingWriteError;
+    expect(pendingFolder.checks).toEqual([
+      { type: 'folder-detail', nest: 'notes/~zod/blog', folderId: 4 },
+    ]);
+    expect(pendingErrorStrings(pendingFolder)).not.toContain('tlon notes');
   });
 
   test('void writes report empty error envelopes with fallback detail', async () => {

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -591,6 +591,39 @@ export interface NotesV1RequestStatus {
   body: NotesV1RequestBody;
 }
 
+export type NotesV1PendingWriteCheck =
+  | { type: 'notebook-list' }
+  | { type: 'notebook-detail' }
+  | { type: 'note-list'; nest: string }
+  | { type: 'note-detail'; nest: string; noteId?: number }
+  | { type: 'folder-list'; nest: string }
+  | { type: 'folder-detail'; nest: string; folderId?: number };
+
+export interface NotesV1PendingWriteErrorOptions {
+  requestId?: string;
+  status?: string;
+  checks?: NotesV1PendingWriteCheck[];
+}
+
+export class NotesV1PendingWriteError extends Error {
+  readonly requestId?: string;
+  readonly status?: string;
+  readonly checks: NotesV1PendingWriteCheck[];
+
+  constructor({
+    requestId,
+    status,
+    checks = [],
+  }: NotesV1PendingWriteErrorOptions = {}) {
+    super('%notes write request is still pending');
+    this.name = 'NotesV1PendingWriteError';
+    this.requestId = requestId;
+    this.status = status;
+    this.checks = [...checks];
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 const NOTEBOOKS_V1_PATH = '/notes/~/v1/notebooks';
 const REQUESTS_V1_PATH = '/notes/~/v1/request';
 
@@ -791,48 +824,49 @@ function envelopeRequestId(res: any): string | undefined {
     : undefined;
 }
 
-function pendingWriteMessage(res: any, checkCommands: string[]): string {
-  const requestId = envelopeRequestId(res);
-  const lines = requestId
-    ? [
-        `%notes write request is still pending (request ${requestId}); the outcome is unknown and it may still complete.`,
-        'Do not retry automatically. Check the request before retrying:',
-        `  tlon notes request ${requestId}`,
-        'If the request is still pending, do not issue the write again.',
-        'If the request has completed, inspect whether the write landed:',
-      ]
-    : [
-        '%notes write request is still pending; the outcome is unknown and it may still complete.',
-        'Do not retry automatically. No request id was returned, so inspect whether the write landed:',
-      ];
-  lines.push(
-    ...checkCommands.map((command) => `  ${command}`),
-    'Only retry if the request failed or the requested change is not present.'
-  );
-  return lines.join('\n');
+function envelopePendingStatus(res: any): string | undefined {
+  const status = res?.body?.status;
+  return typeof status === 'string' ? status : undefined;
 }
 
-function notebookWriteChecks(): string[] {
-  return ['tlon notes list', 'tlon notes show <notes-nest-from-list>'];
+function pendingWriteError(
+  res: any,
+  checks: NotesV1PendingWriteCheck[]
+): NotesV1PendingWriteError {
+  return new NotesV1PendingWriteError({
+    requestId: envelopeRequestId(res),
+    status: envelopePendingStatus(res),
+    checks,
+  });
 }
 
-function noteCreateChecks(nest: string): string[] {
-  return [`tlon notes notes ${nest}`, `tlon notes note ${nest} <id-from-list>`];
+function notebookWriteChecks(): NotesV1PendingWriteCheck[] {
+  return [{ type: 'notebook-list' }, { type: 'notebook-detail' }];
 }
 
-function noteChecks(nest: string, noteId: number): string[] {
-  return [`tlon notes note ${nest} ${noteId}`];
-}
-
-function folderCreateChecks(nest: string): string[] {
+function noteCreateChecks(nest: string): NotesV1PendingWriteCheck[] {
   return [
-    `tlon notes folders ${nest}`,
-    `tlon notes folder ${nest} <id-from-list>`,
+    { type: 'note-list', nest },
+    { type: 'note-detail', nest },
   ];
 }
 
-function folderChecks(nest: string, folderId: number): string[] {
-  return [`tlon notes folder ${nest} ${folderId}`];
+function noteChecks(nest: string, noteId: number): NotesV1PendingWriteCheck[] {
+  return [{ type: 'note-detail', nest, noteId }];
+}
+
+function folderCreateChecks(nest: string): NotesV1PendingWriteCheck[] {
+  return [
+    { type: 'folder-list', nest },
+    { type: 'folder-detail', nest },
+  ];
+}
+
+function folderChecks(
+  nest: string,
+  folderId: number
+): NotesV1PendingWriteCheck[] {
+  return [{ type: 'folder-detail', nest, folderId }];
 }
 
 // A *present* envelope body uses the strict whitelist; error/pending/unexpected
@@ -840,7 +874,7 @@ function folderChecks(nest: string, folderId: number): string[] {
 // body and return its normalized summary.
 function unwrapNotebookEnvelope(
   res: any,
-  checkCommands: string[]
+  checks: NotesV1PendingWriteCheck[]
 ): NotesV1NotebookSummary {
   const body = res?.body;
   if (!body || typeof body.type !== 'string') {
@@ -852,7 +886,7 @@ function unwrapNotebookEnvelope(
     case 'error':
       throw new Error(notesEnvelopeErrorMessage(body));
     case 'pending':
-      throw new Error(pendingWriteMessage(res, checkCommands));
+      throw pendingWriteError(res, checks);
     default:
       throw new Error(`Unexpected %notes response type: ${body.type}`);
   }
@@ -862,7 +896,7 @@ function unwrapNotebookEnvelope(
 // error/pending/unexpected throw). A bare/empty non-envelope JSON body (e.g. a
 // folder object from a convenience route) is accepted and ignored —
 // `requestJson` already throws on HTTP failure.
-function assertWriteOk(res: any, checkCommands: string[]): void {
+function assertWriteOk(res: any, checks: NotesV1PendingWriteCheck[]): void {
   const body = res?.body;
   if (!body || typeof body.type !== 'string') {
     return;
@@ -875,7 +909,7 @@ function assertWriteOk(res: any, checkCommands: string[]): void {
     case 'error':
       throw new Error(notesEnvelopeErrorMessage(body));
     case 'pending':
-      throw new Error(pendingWriteMessage(res, checkCommands));
+      throw pendingWriteError(res, checks);
     default:
       throw new Error(`Unexpected %notes response type: ${body.type}`);
   }

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -1,6 +1,7 @@
 import type { NotesV1Api } from '@tloncorp/api';
 import { describe, expect, it } from 'bun:test';
 
+import type { NotesPendingWriteErrorLike } from '../notes-pending-write';
 import { commandError } from './command';
 import {
   NOTES_COMMAND_HELP,
@@ -9,7 +10,6 @@ import {
   parseNotesNest,
   run,
 } from './notes';
-import type { NotesPendingWriteErrorLike } from '../notes-pending-write';
 
 type AnyFn = (...args: unknown[]) => Promise<unknown>;
 

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -6,10 +6,10 @@ import {
   NOTES_COMMAND_HELP,
   NOTES_HELP,
   type NotesDeps,
-  type NotesPendingWriteErrorLike,
   parseNotesNest,
   run,
 } from './notes';
+import type { NotesPendingWriteErrorLike } from '../notes-pending-write';
 
 type AnyFn = (...args: unknown[]) => Promise<unknown>;
 

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -6,6 +6,7 @@ import {
   NOTES_COMMAND_HELP,
   NOTES_HELP,
   type NotesDeps,
+  type NotesPendingWriteErrorLike,
   parseNotesNest,
   run,
 } from './notes';
@@ -45,10 +46,32 @@ interface NotesV1Call {
 interface MakeDepsOptions {
   authenticate?: () => Promise<void>;
   notesV1?: Partial<Record<NotesV1Op, AnyFn>>;
+  isPendingWriteError?: NotesDeps['isPendingWriteError'];
   joinNotesNotebook?: (nest: string) => Promise<void>;
   leaveNotesNotebook?: (nest: string) => Promise<void>;
   readFile?: (path: string) => string;
   readStdin?: () => Promise<string>;
+}
+
+class PendingWriteErrorForTest
+  extends Error
+  implements NotesPendingWriteErrorLike
+{
+  readonly requestId?: string;
+  readonly status?: string;
+  readonly checks: NotesPendingWriteErrorLike['checks'];
+
+  constructor({
+    requestId,
+    status,
+    checks = [],
+  }: Partial<NotesPendingWriteErrorLike> = {}) {
+    super('%notes write request is still pending');
+    this.name = 'NotesV1PendingWriteError';
+    this.requestId = requestId;
+    this.status = status;
+    this.checks = checks;
+  }
 }
 
 function makeDeps(options: MakeDepsOptions = {}) {
@@ -83,6 +106,10 @@ function makeDeps(options: MakeDepsOptions = {}) {
       await options.authenticate?.();
     },
     notesV1: notesV1 as unknown as NotesV1Api,
+    isPendingWriteError:
+      options.isPendingWriteError ??
+      ((error): error is NotesPendingWriteErrorLike =>
+        error instanceof PendingWriteErrorForTest),
     joinNotesNotebook: async (nest) => {
       calls.joinNotesNotebook.push(nest);
       calls.order.push('joinNotesNotebook');
@@ -768,6 +795,187 @@ describe('notes writes call operations with typed args', () => {
     expect(exitCode).toBe(1);
     expect(context.stdout()).toBe('');
     expect(context.stderr()).toContain('%notes error: folder not empty');
+  });
+
+  it('prints pending-write guidance for notebook create', async () => {
+    const context = makeDeps({
+      notesV1: {
+        createNotebook: async () => {
+          throw new PendingWriteErrorForTest({
+            requestId: '0vabc',
+            status: 'acked',
+            checks: [{ type: 'notebook-list' }, { type: 'notebook-detail' }],
+          });
+        },
+      },
+    });
+
+    const exitCode = await run(['create', 'New Notebook'], context.deps);
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toContain(
+      '%notes write request is still pending (request 0vabc)'
+    );
+    expect(context.stderr()).toContain('Do not retry automatically');
+    expect(context.stderr()).toContain('tlon notes request 0vabc');
+    expect(context.stderr()).toContain('tlon notes list');
+    expect(context.stderr()).toContain(
+      'tlon notes show <notes-nest-from-list>'
+    );
+    expect(context.stderr()).toContain(
+      'Only retry if the request failed or the requested change is not present.'
+    );
+    expect(context.stdout()).not.toContain('✓');
+  });
+
+  it('prints pending-write guidance for note create and update checks', async () => {
+    const create = makeDeps({
+      readStdin: async () => 'body',
+      notesV1: {
+        createNote: async () => {
+          throw new PendingWriteErrorForTest({
+            requestId: '0vnote',
+            checks: [
+              { type: 'note-list', nest: 'notes/~zod/blog' },
+              { type: 'note-detail', nest: 'notes/~zod/blog' },
+            ],
+          });
+        },
+      },
+    });
+
+    expect(
+      await run(
+        ['note-create', 'notes/~zod/blog', '7', 'Title', '--stdin'],
+        create.deps
+      )
+    ).toBe(1);
+    expect(create.stdout()).toBe('');
+    expect(create.stderr()).toContain('tlon notes request 0vnote');
+    expect(create.stderr()).toContain('tlon notes notes notes/~zod/blog');
+    expect(create.stderr()).toContain(
+      'tlon notes note notes/~zod/blog <id-from-list>'
+    );
+
+    const update = makeDeps({
+      readStdin: async () => 'updated',
+      notesV1: {
+        updateNoteBody: async () => {
+          throw new PendingWriteErrorForTest({
+            requestId: '0vupdate',
+            checks: [
+              { type: 'note-detail', nest: 'notes/~zod/blog', noteId: 12 },
+            ],
+          });
+        },
+      },
+    });
+
+    expect(
+      await run(
+        ['note-update', 'notes/~zod/blog', '12', '--stdin'],
+        update.deps
+      )
+    ).toBe(1);
+    expect(update.stdout()).toBe('');
+    expect(update.stderr()).toContain('tlon notes request 0vupdate');
+    expect(update.stderr()).toContain('tlon notes note notes/~zod/blog 12');
+  });
+
+  it('prints pending-write guidance for folder create and update checks', async () => {
+    const create = makeDeps({
+      notesV1: {
+        createFolder: async () => {
+          throw new PendingWriteErrorForTest({
+            checks: [
+              { type: 'folder-list', nest: 'notes/~zod/blog' },
+              { type: 'folder-detail', nest: 'notes/~zod/blog' },
+            ],
+          });
+        },
+      },
+    });
+
+    expect(
+      await run(['folder-create', 'notes/~zod/blog', 'Drafts'], create.deps)
+    ).toBe(1);
+    expect(create.stdout()).toBe('');
+    expect(create.stderr()).toContain(
+      'No request id was returned, so inspect whether the write landed'
+    );
+    expect(create.stderr()).not.toContain('tlon notes request');
+    expect(create.stderr()).toContain('tlon notes folders notes/~zod/blog');
+    expect(create.stderr()).toContain(
+      'tlon notes folder notes/~zod/blog <id-from-list>'
+    );
+
+    const rename = makeDeps({
+      notesV1: {
+        renameFolder: async () => {
+          throw new PendingWriteErrorForTest({
+            requestId: '0vfolder',
+            checks: [
+              { type: 'folder-detail', nest: 'notes/~zod/blog', folderId: 4 },
+            ],
+          });
+        },
+      },
+    });
+
+    expect(
+      await run(
+        ['folder-rename', 'notes/~zod/blog', '4', 'Archive'],
+        rename.deps
+      )
+    ).toBe(1);
+    expect(rename.stdout()).toBe('');
+    expect(rename.stderr()).toContain('tlon notes request 0vfolder');
+    expect(rename.stderr()).toContain('tlon notes folder notes/~zod/blog 4');
+  });
+
+  it('prints pending-write guidance for representative delete paths', async () => {
+    const noteDelete = makeDeps({
+      notesV1: {
+        deleteNote: async () => {
+          throw new PendingWriteErrorForTest({
+            requestId: '0vdel-note',
+            checks: [
+              { type: 'note-detail', nest: 'notes/~zod/blog', noteId: 12 },
+            ],
+          });
+        },
+      },
+    });
+
+    expect(
+      await run(['note-delete', 'notes/~zod/blog', '12'], noteDelete.deps)
+    ).toBe(1);
+    expect(noteDelete.stdout()).toBe('');
+    expect(noteDelete.stderr()).toContain('tlon notes request 0vdel-note');
+    expect(noteDelete.stderr()).toContain('tlon notes note notes/~zod/blog 12');
+
+    const folderDelete = makeDeps({
+      notesV1: {
+        deleteFolder: async () => {
+          throw new PendingWriteErrorForTest({
+            requestId: '0vdel-folder',
+            checks: [
+              { type: 'folder-detail', nest: 'notes/~zod/blog', folderId: 4 },
+            ],
+          });
+        },
+      },
+    });
+
+    expect(
+      await run(['folder-delete', 'notes/~zod/blog', '4'], folderDelete.deps)
+    ).toBe(1);
+    expect(folderDelete.stdout()).toBe('');
+    expect(folderDelete.stderr()).toContain('tlon notes request 0vdel-folder');
+    expect(folderDelete.stderr()).toContain(
+      'tlon notes folder notes/~zod/blog 4'
+    );
   });
 });
 

--- a/packages/tlon-skill/scripts/commands/notes.ts
+++ b/packages/tlon-skill/scripts/commands/notes.ts
@@ -5,7 +5,6 @@ import type {
   NotesV1Note,
   NotesV1NoteRevision,
   NotesV1NotebookSummary,
-  NotesV1PendingWriteCheck,
   NotesV1RequestStatus,
 } from '@tloncorp/api';
 
@@ -19,6 +18,10 @@ import {
   writeHelp,
   writeLine,
 } from './command';
+import {
+  formatPendingWriteError,
+  type NotesPendingWriteErrorLike,
+} from '../notes-pending-write';
 
 export const NOTES_HELP = `Usage: tlon notes <command>
 
@@ -115,12 +118,6 @@ export const NOTES_COMMAND_HELP: Record<string, string> = {
 // `root` resolution, pending-write guidance, and human-readable output — it
 // passes typed operations, never string-built paths. Runtime deps identify API
 // error classes, keeping API imports type-only for the command-source contract.
-export interface NotesPendingWriteErrorLike {
-  requestId?: string;
-  status?: string;
-  checks: NotesV1PendingWriteCheck[];
-}
-
 export interface NotesDeps extends CommandDeps {
   authenticate: () => Promise<void>;
   notesV1: NotesV1Api;
@@ -668,49 +665,6 @@ function formatRequestStatus(status: NotesV1RequestStatus): string[] {
       lines.push('Status: api-key');
       break;
   }
-  return lines;
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unhandled pending-write check: ${JSON.stringify(value)}`);
-}
-
-function pendingCheckCommand(check: NotesV1PendingWriteCheck): string {
-  switch (check.type) {
-    case 'notebook-list':
-      return 'tlon notes list';
-    case 'notebook-detail':
-      return 'tlon notes show <notes-nest-from-list>';
-    case 'note-list':
-      return `tlon notes notes ${check.nest}`;
-    case 'note-detail':
-      return `tlon notes note ${check.nest} ${check.noteId ?? '<id-from-list>'}`;
-    case 'folder-list':
-      return `tlon notes folders ${check.nest}`;
-    case 'folder-detail':
-      return `tlon notes folder ${check.nest} ${check.folderId ?? '<id-from-list>'}`;
-  }
-  return assertNever(check);
-}
-
-function formatPendingWriteError(error: NotesPendingWriteErrorLike): string[] {
-  const lines = error.requestId
-    ? [
-        `%notes write request is still pending (request ${error.requestId}); the outcome is unknown and it may still complete.`,
-        'Do not retry automatically. Check the request before retrying:',
-        `  tlon notes request ${error.requestId}`,
-        'If the request is still pending, do not issue the write again.',
-        'If the request has completed, inspect whether the write landed:',
-      ]
-    : [
-        '%notes write request is still pending; the outcome is unknown and it may still complete.',
-        'Do not retry automatically. No request id was returned, so inspect whether the write landed:',
-      ];
-
-  lines.push(
-    ...error.checks.map((check) => `  ${pendingCheckCommand(check)}`),
-    'Only retry if the request failed or the requested change is not present.'
-  );
   return lines;
 }
 

--- a/packages/tlon-skill/scripts/commands/notes.ts
+++ b/packages/tlon-skill/scripts/commands/notes.ts
@@ -9,6 +9,10 @@ import type {
 } from '@tloncorp/api';
 
 import {
+  type NotesPendingWriteErrorLike,
+  formatPendingWriteError,
+} from '../notes-pending-write';
+import {
   type CommandDeps,
   commandError,
   errorMessage,
@@ -18,10 +22,6 @@ import {
   writeHelp,
   writeLine,
 } from './command';
-import {
-  formatPendingWriteError,
-  type NotesPendingWriteErrorLike,
-} from '../notes-pending-write';
 
 export const NOTES_HELP = `Usage: tlon notes <command>
 

--- a/packages/tlon-skill/scripts/commands/notes.ts
+++ b/packages/tlon-skill/scripts/commands/notes.ts
@@ -5,6 +5,7 @@ import type {
   NotesV1Note,
   NotesV1NoteRevision,
   NotesV1NotebookSummary,
+  NotesV1PendingWriteCheck,
   NotesV1RequestStatus,
 } from '@tloncorp/api';
 
@@ -111,12 +112,19 @@ export const NOTES_COMMAND_HELP: Record<string, string> = {
 // The %notes v1 protocol (path construction, request payloads, canonical
 // response shapes, and envelope handling) lives in `@tloncorp/api`'s `notesV1`.
 // This module owns CLI parsing, pre-auth validation, content-source handling,
-// `root` resolution, and human-readable output — it passes typed operations,
-// never string-built paths. (Type-only API import keeps the command-source
-// contract green.)
+// `root` resolution, pending-write guidance, and human-readable output — it
+// passes typed operations, never string-built paths. Runtime deps identify API
+// error classes, keeping API imports type-only for the command-source contract.
+export interface NotesPendingWriteErrorLike {
+  requestId?: string;
+  status?: string;
+  checks: NotesV1PendingWriteCheck[];
+}
+
 export interface NotesDeps extends CommandDeps {
   authenticate: () => Promise<void>;
   notesV1: NotesV1Api;
+  isPendingWriteError: (error: unknown) => error is NotesPendingWriteErrorLike;
   joinNotesNotebook: (nest: string) => Promise<void>;
   leaveNotesNotebook: (nest: string) => Promise<void>;
   readFile: (path: string) => string;
@@ -663,6 +671,49 @@ function formatRequestStatus(status: NotesV1RequestStatus): string[] {
   return lines;
 }
 
+function assertNever(value: never): never {
+  throw new Error(`Unhandled pending-write check: ${JSON.stringify(value)}`);
+}
+
+function pendingCheckCommand(check: NotesV1PendingWriteCheck): string {
+  switch (check.type) {
+    case 'notebook-list':
+      return 'tlon notes list';
+    case 'notebook-detail':
+      return 'tlon notes show <notes-nest-from-list>';
+    case 'note-list':
+      return `tlon notes notes ${check.nest}`;
+    case 'note-detail':
+      return `tlon notes note ${check.nest} ${check.noteId ?? '<id-from-list>'}`;
+    case 'folder-list':
+      return `tlon notes folders ${check.nest}`;
+    case 'folder-detail':
+      return `tlon notes folder ${check.nest} ${check.folderId ?? '<id-from-list>'}`;
+  }
+  return assertNever(check);
+}
+
+function formatPendingWriteError(error: NotesPendingWriteErrorLike): string[] {
+  const lines = error.requestId
+    ? [
+        `%notes write request is still pending (request ${error.requestId}); the outcome is unknown and it may still complete.`,
+        'Do not retry automatically. Check the request before retrying:',
+        `  tlon notes request ${error.requestId}`,
+        'If the request is still pending, do not issue the write again.',
+        'If the request has completed, inspect whether the write landed:',
+      ]
+    : [
+        '%notes write request is still pending; the outcome is unknown and it may still complete.',
+        'Do not retry automatically. No request id was returned, so inspect whether the write landed:',
+      ];
+
+  lines.push(
+    ...error.checks.map((check) => `  ${pendingCheckCommand(check)}`),
+    'Only retry if the request failed or the requested change is not present.'
+  );
+  return lines;
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand handlers
 // ---------------------------------------------------------------------------
@@ -1042,6 +1093,12 @@ export async function run(args: string[], deps: NotesDeps): Promise<number> {
         return await runLeave(parsed.target, deps);
     }
   } catch (error) {
+    if (deps.isPendingWriteError(error)) {
+      for (const line of formatPendingWriteError(error)) {
+        writeLine(deps.stderr, line);
+      }
+      return 1;
+    }
     const handled = handleExpectedCommandError(error, deps);
     if (handled !== null) return handled;
     throw error;

--- a/packages/tlon-skill/scripts/notes-channel-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-channel-runtime.ts
@@ -1,7 +1,13 @@
-import { deleteNotesNotebookStrict, getGroup, notesV1 } from '@tloncorp/api';
+import {
+  NotesV1PendingWriteError,
+  deleteNotesNotebookStrict,
+  getGroup,
+  notesV1,
+} from '@tloncorp/api';
 
 import { commandError, errorMessage } from './commands/command';
 import type { NotesChannelDeps } from './notes-channel';
+import { pendingWriteCommandErrorMessage } from './notes-pending-write';
 
 export function createNotesChannelDeps(): NotesChannelDeps {
   return {
@@ -9,6 +15,9 @@ export function createNotesChannelDeps(): NotesChannelDeps {
       try {
         return await notesV1.createGroupNotebook(input);
       } catch (error) {
+        if (error instanceof NotesV1PendingWriteError) {
+          throw commandError(pendingWriteCommandErrorMessage(error));
+        }
         throw commandError(errorMessage(error));
       }
     },

--- a/packages/tlon-skill/scripts/notes-pending-write.ts
+++ b/packages/tlon-skill/scripts/notes-pending-write.ts
@@ -1,0 +1,58 @@
+import type { NotesV1PendingWriteCheck } from '@tloncorp/api';
+
+export interface NotesPendingWriteErrorLike {
+  requestId?: string;
+  status?: string;
+  checks: NotesV1PendingWriteCheck[];
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled pending-write check: ${JSON.stringify(value)}`);
+}
+
+function pendingCheckCommand(check: NotesV1PendingWriteCheck): string {
+  switch (check.type) {
+    case 'notebook-list':
+      return 'tlon notes list';
+    case 'notebook-detail':
+      return 'tlon notes show <notes-nest-from-list>';
+    case 'note-list':
+      return `tlon notes notes ${check.nest}`;
+    case 'note-detail':
+      return `tlon notes note ${check.nest} ${check.noteId ?? '<id-from-list>'}`;
+    case 'folder-list':
+      return `tlon notes folders ${check.nest}`;
+    case 'folder-detail':
+      return `tlon notes folder ${check.nest} ${check.folderId ?? '<id-from-list>'}`;
+  }
+  return assertNever(check);
+}
+
+export function formatPendingWriteError(
+  error: NotesPendingWriteErrorLike
+): string[] {
+  const lines = error.requestId
+    ? [
+        `%notes write request is still pending (request ${error.requestId}); the outcome is unknown and it may still complete.`,
+        'Do not retry automatically. Check the request before retrying:',
+        `  tlon notes request ${error.requestId}`,
+        'If the request is still pending, do not issue the write again.',
+        'If the request has completed, inspect whether the write landed:',
+      ]
+    : [
+        '%notes write request is still pending; the outcome is unknown and it may still complete.',
+        'Do not retry automatically. No request id was returned, so inspect whether the write landed:',
+      ];
+
+  lines.push(
+    ...error.checks.map((check) => `  ${pendingCheckCommand(check)}`),
+    'Only retry if the request failed or the requested change is not present.'
+  );
+  return lines;
+}
+
+export function pendingWriteCommandErrorMessage(
+  error: NotesPendingWriteErrorLike
+): string {
+  return formatPendingWriteError(error).join('\n');
+}

--- a/packages/tlon-skill/scripts/notes-runtime.test.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.test.ts
@@ -81,9 +81,9 @@ mock.module('@tloncorp/api', () => ({
 }));
 
 let runtimeModule: Promise<typeof import('./notes-runtime')> | null = null;
-let channelRuntimeModule:
-  | Promise<typeof import('./notes-channel-runtime')>
-  | null = null;
+let channelRuntimeModule: Promise<
+  typeof import('./notes-channel-runtime')
+> | null = null;
 
 function loadRuntime() {
   runtimeModule ??= import('./notes-runtime');

--- a/packages/tlon-skill/scripts/notes-runtime.test.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.test.ts
@@ -74,15 +74,25 @@ mock.module('@tloncorp/api', () => ({
   subscribe: async () => 0,
   NotesV1PendingWriteError: MockNotesV1PendingWriteError,
   notesV1: mockedNotesV1,
+  getGroup: async () => ({ channels: [] }),
+  deleteNotesNotebookStrict: async () => undefined,
   joinNotesChannel: async () => undefined,
   leaveNotesChannel: async () => undefined,
 }));
 
 let runtimeModule: Promise<typeof import('./notes-runtime')> | null = null;
+let channelRuntimeModule:
+  | Promise<typeof import('./notes-channel-runtime')>
+  | null = null;
 
 function loadRuntime() {
   runtimeModule ??= import('./notes-runtime');
   return runtimeModule;
+}
+
+function loadChannelRuntime() {
+  channelRuntimeModule ??= import('./notes-channel-runtime');
+  return channelRuntimeModule;
 }
 
 async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
@@ -142,6 +152,73 @@ describe('notes runtime wrapper', () => {
       expect(deps.isPendingWriteError(error)).toBe(false);
     } finally {
       mockedNotesV1.getNotebook = original;
+    }
+  });
+});
+
+describe('notes channel runtime wrapper', () => {
+  it('formats pending createGroupNotebook errors with request guidance', async () => {
+    const pending = new MockNotesV1PendingWriteError({
+      requestId: '0vbook',
+      status: 'acked',
+      checks: [{ type: 'notebook-list' }, { type: 'notebook-detail' }],
+    });
+    const original = mockedNotesV1.createGroupNotebook;
+    mockedNotesV1.createGroupNotebook = async () => {
+      throw pending;
+    };
+
+    try {
+      const { createNotesChannelDeps } = await loadChannelRuntime();
+      const deps = createNotesChannelDeps();
+      const error = await captureRejection(
+        deps.createGroupNotesNotebook({
+          title: 'New',
+          group: { host: '~zod', flagName: 'group' },
+          readers: [],
+        })
+      );
+
+      expect(error).toBeInstanceOf(CommandError);
+      expect((error as CommandError).message).toContain(
+        '%notes write request is still pending (request 0vbook)'
+      );
+      expect((error as CommandError).message).toContain(
+        'Do not retry automatically'
+      );
+      expect((error as CommandError).message).toContain(
+        'tlon notes request 0vbook'
+      );
+      expect((error as CommandError).message).toContain('tlon notes list');
+      expect((error as CommandError).message).toContain(
+        'tlon notes show <notes-nest-from-list>'
+      );
+    } finally {
+      mockedNotesV1.createGroupNotebook = original;
+    }
+  });
+
+  it('continues to wrap ordinary createGroupNotebook errors', async () => {
+    const original = mockedNotesV1.createGroupNotebook;
+    mockedNotesV1.createGroupNotebook = async () => {
+      throw new Error('%notes error: denied');
+    };
+
+    try {
+      const { createNotesChannelDeps } = await loadChannelRuntime();
+      const deps = createNotesChannelDeps();
+      const error = await captureRejection(
+        deps.createGroupNotesNotebook({
+          title: 'New',
+          group: { host: '~zod', flagName: 'group' },
+          readers: [],
+        })
+      );
+
+      expect(error).toBeInstanceOf(CommandError);
+      expect((error as CommandError).message).toBe('%notes error: denied');
+    } finally {
+      mockedNotesV1.createGroupNotebook = original;
     }
   });
 });

--- a/packages/tlon-skill/scripts/notes-runtime.test.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { CommandError } from './commands/command';
+
+const NOTES_V1_OPS = [
+  'getRequest',
+  'listNotebooks',
+  'getNotebook',
+  'createNotebook',
+  'createGroupNotebook',
+  'listNotes',
+  'getNote',
+  'createNote',
+  'updateNoteBody',
+  'renameNote',
+  'moveNote',
+  'deleteNote',
+  'listNoteHistory',
+  'listFolders',
+  'getFolder',
+  'createFolder',
+  'renameFolder',
+  'moveFolder',
+  'deleteFolder',
+  'listMembers',
+] as const;
+
+type NotesV1Op = (typeof NOTES_V1_OPS)[number];
+type MockedNotesV1 = Record<
+  NotesV1Op,
+  (...args: unknown[]) => Promise<unknown>
+>;
+
+class MockNotesV1PendingWriteError extends Error {
+  readonly requestId?: string;
+  readonly status?: string;
+  readonly checks: unknown[];
+
+  constructor({
+    requestId,
+    status,
+    checks = [],
+  }: {
+    requestId?: string;
+    status?: string;
+    checks?: unknown[];
+  } = {}) {
+    super('%notes write request is still pending');
+    this.name = 'NotesV1PendingWriteError';
+    this.requestId = requestId;
+    this.status = status;
+    this.checks = checks;
+  }
+}
+
+const mockedNotesV1 = Object.fromEntries(
+  NOTES_V1_OPS.map((op) => [op, async () => undefined])
+) as MockedNotesV1;
+
+class MockUrbit {
+  cookie = '';
+  nodeId = '';
+
+  constructor(readonly url: string) {}
+}
+
+mock.module('@tloncorp/api', () => ({
+  Urbit: MockUrbit,
+  client: { cookie: '' },
+  configureClient: async () => undefined,
+  internalRemoveClient: () => undefined,
+  preSig: (ship: string) => (ship.startsWith('~') ? ship : `~${ship}`),
+  scry: async () => undefined,
+  subscribe: async () => 0,
+  NotesV1PendingWriteError: MockNotesV1PendingWriteError,
+  notesV1: mockedNotesV1,
+  joinNotesChannel: async () => undefined,
+  leaveNotesChannel: async () => undefined,
+}));
+
+let runtimeModule: Promise<typeof import('./notes-runtime')> | null = null;
+
+function loadRuntime() {
+  runtimeModule ??= import('./notes-runtime');
+  return runtimeModule;
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected promise to reject');
+}
+
+describe('notes runtime wrapper', () => {
+  it('rethrows pending-write errors unchanged from production deps', async () => {
+    const pending = new MockNotesV1PendingWriteError({
+      requestId: '0vabc',
+      status: 'acked',
+      checks: [{ type: 'note-detail', nest: 'notes/~zod/blog', noteId: 12 }],
+    });
+    const original = mockedNotesV1.listNotebooks;
+    mockedNotesV1.listNotebooks = async () => {
+      throw pending;
+    };
+
+    try {
+      const { createNotesDeps } = await loadRuntime();
+      const deps = createNotesDeps();
+      const error = await captureRejection(deps.notesV1.listNotebooks());
+
+      expect(error).toBe(pending);
+      expect(error).toBeInstanceOf(MockNotesV1PendingWriteError);
+      expect(deps.isPendingWriteError(error)).toBe(true);
+      expect((error as MockNotesV1PendingWriteError).requestId).toBe('0vabc');
+      expect((error as MockNotesV1PendingWriteError).status).toBe('acked');
+      expect((error as MockNotesV1PendingWriteError).checks).toEqual([
+        { type: 'note-detail', nest: 'notes/~zod/blog', noteId: 12 },
+      ]);
+    } finally {
+      mockedNotesV1.listNotebooks = original;
+    }
+  });
+
+  it('wraps ordinary API errors as command errors', async () => {
+    const original = mockedNotesV1.getNotebook;
+    mockedNotesV1.getNotebook = async () => {
+      throw new Error('HTTP 500');
+    };
+
+    try {
+      const { createNotesDeps } = await loadRuntime();
+      const deps = createNotesDeps();
+      const error = await captureRejection(
+        deps.notesV1.getNotebook('notes/~zod/blog')
+      );
+
+      expect(error).toBeInstanceOf(CommandError);
+      expect((error as CommandError).message).toBe('HTTP 500');
+      expect(deps.isPendingWriteError(error)).toBe(false);
+    } finally {
+      mockedNotesV1.getNotebook = original;
+    }
+  });
+});

--- a/packages/tlon-skill/scripts/notes-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.ts
@@ -9,7 +9,8 @@ import * as fs from 'fs';
 
 import { ensureClient } from './api-client';
 import { commandError, errorMessage } from './commands/command';
-import type { NotesDeps, NotesPendingWriteErrorLike } from './commands/notes';
+import type { NotesDeps } from './commands/notes';
+import type { NotesPendingWriteErrorLike } from './notes-pending-write';
 
 const STDIN_TIMEOUT_MS = 30_000;
 

--- a/packages/tlon-skill/scripts/notes-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.ts
@@ -1,5 +1,6 @@
 import {
   type NotesV1Api,
+  NotesV1PendingWriteError,
   joinNotesChannel,
   leaveNotesChannel,
   notesV1,
@@ -8,7 +9,7 @@ import * as fs from 'fs';
 
 import { ensureClient } from './api-client';
 import { commandError, errorMessage } from './commands/command';
-import type { NotesDeps } from './commands/notes';
+import type { NotesDeps, NotesPendingWriteErrorLike } from './commands/notes';
 
 const STDIN_TIMEOUT_MS = 30_000;
 
@@ -60,6 +61,9 @@ function wrapNotesV1(): NotesV1Api {
       try {
         return await call(...args);
       } catch (error) {
+        if (error instanceof NotesV1PendingWriteError) {
+          throw error;
+        }
         throw commandError(notesRuntimeErrorMessage(error));
       }
     };
@@ -75,6 +79,8 @@ export function createNotesDeps(): NotesDeps {
       await ensureClient();
     },
     notesV1: wrapNotesV1(),
+    isPendingWriteError: (error): error is NotesPendingWriteErrorLike =>
+      error instanceof NotesV1PendingWriteError,
     // Membership uses the %notes action wrappers (not the v0 app-sync helpers).
     joinNotesNotebook: async (nest: string) => {
       try {


### PR DESCRIPTION
## Summary

Fixes TLON-6068

Fixes `%notes` pending write handling so shared API callers receive structured pending state while CLI notes writes and notes-channel creates render command-specific guidance.

## Changes

- Added `NotesV1PendingWriteError` and semantic pending-write check descriptors in `@tloncorp/api`
- Removed CLI command text from shared `%notes` API pending errors
- Moved pending-write guidance formatting into `tlon-skill` and reused it for `tlon notes ...`, `tlon channels create --kind notes`, and `tlon groups add-channel --kind notes`
- Preserved typed pending errors through `notes-runtime` while continuing to wrap ordinary API errors as command errors
- Preserved pending request guidance for group notes channel creation through `notes-channel-runtime`
- Added API, command, and runtime tests for pending-write behavior and command-source boundaries

## How did I test?

- `pnpm -C packages/api exec vitest run src/client/notesApi.test.ts`
- `pnpm -C packages/tlon-skill exec bun test scripts/notes-runtime.test.ts scripts/commands/notes.test.ts scripts/commands/command-contract.test.ts`
- `pnpm --filter @tloncorp/api tsc`
- `pnpm --filter @tloncorp/tlon-skill typecheck`
- `pnpm --filter @tloncorp/tlon-skill build:smoke`
- `pnpm --filter @tloncorp/tlon-skill test:unit`

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert.

