### PR TITLE
fix(ios): native crash when attaching a video (SDK 56 image-manipulator)

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -195,6 +195,13 @@ container, and we confirm the Android repro no longer needs the local fix.
 
 ## expo-image-manipulator@56.0.19
 
+This patch carries two independent iOS hunks.
+
+Local patch:
+`patches/expo-image-manipulator@56.0.19.patch`
+
+### Orientation normalization (HDR HEIC uploads)
+
 Why:
 Expo's iOS orientation transformer normalizes images by manually creating a
 `CGContext` with the source image's bit depth and color space, but with a
@@ -209,9 +216,6 @@ Skips orientation normalization when `UIImage.imageOrientation` is already
 UIKit choose a supported backing context while still applying orientation and
 mirroring before the requested resize runs.
 
-Local patch:
-`patches/expo-image-manipulator@56.0.19.patch`
-
 Upstream:
 - no matching Expo upstream fix found as of June 2026
 - related public reports: `Expensify/App#81702`,
@@ -225,9 +229,40 @@ Validation:
 - Confirm ordinary JPEG and HEIC uploads still resize and upload
 
 Removal:
-Remove this patch once `expo-image-manipulator` ships an equivalent orientation
+Remove this hunk once `expo-image-manipulator` ships an equivalent orientation
 normalization fix, or once we replace upload resizing with a lower-level ImageIO
 thumbnail path.
+
+### manipulate() SharedRef probe order (video attach crash)
+
+Why:
+Passing a shared image ref (expo-video's `VideoThumbnail`, used by the
+video-poster flow in `videoPreviewData.native.ts`) to
+`ImageManipulator.manipulate()` hard-crashes on SDK 56: the `Either<URL,
+SharedRef<UIImage>>` argument probes `URL` first, whose converter runs the JS
+value through the asserting `getAny()`, which hits a Swift `fatalError` on
+shared-object instances before the `SharedRef` branch is tried. The trap is not
+catchable from JS, so attaching a video killed the app.
+
+What it does:
+Swaps the argument to `Either<SharedRef<UIImage>, URL>` so shared refs match
+directly without touching `getAny()`. String/URL sources fail the `SharedRef`
+probe with a catchable exception and fall through to `URL` as before, so
+`manipulateAsync(uri)`-style callers are unchanged.
+
+Upstream:
+- fix submitted: [expo/expo#47432](https://github.com/expo/expo/pull/47432)
+
+Validation:
+- Rebuild the iOS app so the native patch is compiled in
+- Attach a video in a chat: poster generates and the upload completes
+  (previously a hard native crash)
+- Attach an image: resize-on-upload through the same module still works
+
+Removal:
+Remove this hunk once [expo/expo#47432](https://github.com/expo/expo/pull/47432)
+(or an equivalent converter fix in `expo-modules-core`) ships in the Expo SDK
+version we're on.
 
 ## @tamagui/web@2.4.0
 

--- a/patches/expo-image-manipulator@56.0.19.patch
+++ b/patches/expo-image-manipulator@56.0.19.patch
@@ -1,3 +1,19 @@
+diff --git a/ios/ImageManipulatorModule.swift b/ios/ImageManipulatorModule.swift
+index 1f8c73a715d14caa501cc1096310874963ae8685..deddcbf671787eed6970c282ef73ca9d3feb88d6 100644
+--- a/ios/ImageManipulatorModule.swift
++++ b/ios/ImageManipulatorModule.swift
+@@ -10,7 +10,10 @@ public class ImageManipulatorModule: Module {
+   public func definition() -> ModuleDefinition {
+     Name("ExpoImageManipulator")
+ 
+-    Function("manipulate") { (source: Either<URL, SharedRef<UIImage>>) -> ImageManipulatorContext in
++    // SharedRef must be probed before URL: Either tries branches in order, and the
++    // URL branch converts the JS value via the trapping getAny(), which hits a Swift
++    // fatalError on shared-object instances (e.g. expo-video's VideoThumbnail).
++    Function("manipulate") { (source: Either<SharedRef<UIImage>, URL>) -> ImageManipulatorContext in
+       let context = ImageManipulatorContext { [weak appContext] in
+         guard let appContext else {
+           throw Exceptions.AppContextLost()
 diff --git a/ios/Transformers/ImageFixOrientationTransformer.swift b/ios/Transformers/ImageFixOrientationTransformer.swift
 index c3e3b66eb6b5b0ef75431c96bf292d4fae004606..9e9e6503a09771896936c4d823dd28e9d03b51df 100644
 --- a/ios/Transformers/ImageFixOrientationTransformer.swift

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ patchedDependencies:
     hash: e2dvaofo7ridrjocchqzytht3q
     path: patches/expo-background-task@56.0.19.patch
   expo-image-manipulator:
-    hash: dfkb33kreic4nmwomhargjmwmy
+    hash: vrekreoxc43zz3znwmilpjgq4y
     path: patches/expo-image-manipulator@56.0.19.patch
   react-cosmos:
     hash: 3fzdsz7y5qive4fsxr74vllywq
@@ -326,7 +326,7 @@ importers:
         version: 56.0.11(expo@56.0.12)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-image-manipulator:
         specifier: ~56.0.15
-        version: 56.0.19(patch_hash=dfkb33kreic4nmwomhargjmwmy)(expo@56.0.12)
+        version: 56.0.19(patch_hash=vrekreoxc43zz3znwmilpjgq4y)(expo@56.0.12)
       expo-image-picker:
         specifier: ~56.0.14
         version: 56.0.18(expo@56.0.12)
@@ -25352,7 +25352,7 @@ snapshots:
     dependencies:
       expo: 56.0.12(hed2hf4wsztb7pemtxuk4ffjti)
 
-  expo-image-manipulator@56.0.19(patch_hash=dfkb33kreic4nmwomhargjmwmy)(expo@56.0.12):
+  expo-image-manipulator@56.0.19(patch_hash=vrekreoxc43zz3znwmilpjgq4y)(expo@56.0.12):
     dependencies:
       expo: 56.0.12(hed2hf4wsztb7pemtxuk4ffjti)
       expo-image-loader: 56.0.3(expo@56.0.12)


### PR DESCRIPTION
## Summary

Attaching a video hard-crashes the app (native Swift fatalError, not catchable in JS) on SDK 56. The crash happens in the poster-generation flow when the expo-video thumbnail is handed to `ImageManipulator.manipulate()`. One-line ordering fix in our existing `expo-image-manipulator` patch.

## Changes

`videoPreviewData.native.ts` passes a `VideoThumbnail` (a `SharedRef<UIImage>`, per expo-video's API) to `manipulate(source: Either<URL, SharedRef<UIImage>>)`. This is type-correct, but crashes in expo's argument converter:

1. `DynamicEitherType.cast` probes branches in declared order under `try?`, expecting failures to throw
2. The `URL` branch converts the JS value via `getAny()` — a deprecated, *asserting* accessor that recursively walks the object's properties
3. On a shared-object instance that walk hits a function-valued property → `FatalError.unimplemented()` — a Swift **trap**, not a thrown error — so `try?` can't rescue it and the process dies before the `SharedRef` branch is ever tried

The patch swaps the probe order to `Either<SharedRef<UIImage>, URL>`. Shared refs now match directly without touching `getAny()`; string/URL sources fail the SharedRef branch with a *catchable* `NativeSharedObjectNotFoundException` and fall through to `URL` exactly as before, so all existing callers (including legacy `manipulateAsync(uri)`) are unchanged. The function body needs no changes — its `source.get()` lookups are by type, not by position.

Upstream `expo/expo` main still has the same signature and the same trapping converter (checked today); this patch hunk carries us until an upstream fix lands. iOS builds `expo-image-manipulator` from source (`expo.autolinking.ios.buildFromSource`), so the Swift patch takes effect. Android has the same ordering (`EitherOfThree<Uri, ...>`) but a separate converter implementation, no observed crash, and isn't built from source — deliberately left alone.

## How did I test?

- Reproduced on the iOS simulator (real ship): attaching a video crashed with `EXC_BREAKPOINT` in `DynamicEitherType.cast` → `JavaScriptValue.getAny()` (crash report symbolicated, poster flow confirmed as the trigger)
- With the patch: same flow — video attaches, poster/thumbnail generates, upload completes, no crash
- `pnpm install --frozen-lockfile` green (`allowNonAppliedPatches: false`, so the patch is verified to apply strictly); the pre-existing orientation-transformer hunk is intact

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: native image manipulation (resize on upload, video posters) on iOS

Worst case is a regression in the other `manipulate()` callers (string-URI paths); the typed fall-through behavior above is why that's not expected, and image upload (which resizes via the same module) was exercised in testing.

## Rollback plan

Revert the commit and `pnpm install` (restores the previous patch file and lockfile hash). No data or schema impact.

## Screenshots / videos

No UI change — fixes a hard crash on video attach.
