### PR TITLE
activity: strip react volume keys from every adjust poke

### DIFF
--- a/packages/api/src/__tests__/activityAction.test.ts
+++ b/packages/api/src/__tests__/activityAction.test.ts
@@ -17,13 +17,17 @@ const adjustAction: ActivityAction = {
 afterEach(() => setActivitySupportsReactions(false));
 
 describe('activityAction mark gating', () => {
-  test('uses the v9 mark and keeps react keys when supported', () => {
+  // react keys are stripped on both marks: the v9 activity-action-1 mark's
+  // dejs falls through to the v8 volume-map parser, which rejects them
+  test('uses the v9 mark and still strips react keys when supported', () => {
     setActivitySupportsReactions(true);
     const action = activityAction(adjustAction);
     expect(action.mark).toBe('activity-action-1');
     const sent = action.json as typeof adjustAction;
-    expect(sent.adjust.volume).toHaveProperty('react');
-    expect(sent.adjust.volume).toHaveProperty('dm-react');
+    expect(sent.adjust.volume).not.toHaveProperty('react');
+    expect(sent.adjust.volume).not.toHaveProperty('dm-react');
+    // non-react keys are preserved
+    expect(sent.adjust.volume).toHaveProperty('post');
   });
 
   test('uses the v8 mark and strips react keys when unsupported', () => {

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -642,10 +642,13 @@ export function subscribeToActivity(
   );
 }
 
-// The v8 activity-action mark's dejs perks over the v8 event-type set and
-// crashes on react/dm-react volume-map keys. When poking an old backend with
-// the v8 mark, strip those keys so the poke parses (reacts aren't configurable
-// on a backend that doesn't support them anyway).
+// No deployed activity-action mark parses react/dm-react volume-map keys: the
+// v8 activity-action mark's dejs perks over the v8 event-type set, and the v9
+// activity-action-1 mark's dejs never overrides adjust/volume-map, so its
+// volume-map parsing falls through to the same v8 event-type set. Either mark
+// crashes on react keys, nacking the poke and rolling back the client's
+// optimistic volume update. Strip the keys from every adjust poke; reacts
+// follow the backend's default react volume instead.
 function stripReactVolumeKeys(action: ub.ActivityAction): ub.ActivityAction {
   if (!('adjust' in action) || !action.adjust.volume) {
     return action;
@@ -657,13 +660,13 @@ function stripReactVolumeKeys(action: ub.ActivityAction): ub.ActivityAction {
 }
 
 export function activityAction(action: ub.ActivityAction) {
-  // activity-action-1 (v9) parses react keys; the agent accepts both marks. Old
-  // backends only have the v8 activity-action mark, so use it and strip reacts.
+  // the agent accepts both marks; old backends only have the v8 activity-action
+  // mark, so gate the mark on backend version
   const supportsReactions = getActivitySupportsReactions();
   return {
     app: 'activity',
     mark: supportsReactions ? 'activity-action-1' : 'activity-action',
-    json: supportsReactions ? action : stripReactVolumeKeys(action),
+    json: stripReactVolumeKeys(action),
   };
 }
 


### PR DESCRIPTION
Fixes [TLON-6071](https://linear.app/tlon/issue/TLON-6071/impossible-to-select-any-global-notification-level)

## Summary

Selecting any global notification level snapped back to "All DMs and group posts" because every volume-adjust poke was nacked by the backend and the client rolled back its optimistic update. The client now strips `react`/`dm-react` volume-map keys from every adjust poke, since no deployed activity-action mark can parse them.

## Changes

- `packages/api/src/client/activityApi.ts`: apply `stripReactVolumeKeys` to every adjust poke instead of only when the backend lacks reaction support. Mark selection (`activity-action-1` vs `activity-action`) is unchanged.
- `packages/api/src/__tests__/activityAction.test.ts`: updated to expect react keys stripped on both marks.

Root cause: `getVolumeMap` emits `react`/`dm-react` keys, and 6cc7a8e71 switched pokes to the v9 `activity-action-1` mark on the assumption its dejs parses those keys — but the v9 dejs core in `desk/lib/activity-json.hoon` never overrides `adjust`/`volume-map`, so volume-map parsing falls through (via `=, v8`) to the v8 parser, whose `event-type` perk rejects react keys. The poke crashes in mark conversion on new backends exactly as it did on old ones, and `setBaseVolumeLevel` reverts; with no stored base row that lands on the `medium` default ("All DMs and group posts").

This is a client-only fix. The backend dejs fallthrough (v9 needs its own `adjust`/`volume-map`/`read-action` arms) should be fixed separately; until then, reacts follow the backend's default react volume and can't be configured per-source (e.g. muting a chat won't silence react notifications).

## How did I test?

- Updated `activityAction.test.ts` covers both marks: react keys stripped, non-react keys preserved, caller's action not mutated.
- Full `packages/api` suite passes (271 tests, 24 files).
- `tsc --noEmit` clean in `packages/api`.
- Traced the round trip: `getLevelFromVolumeMap` already ignores react keys when inferring a level, so maps stored without react entries read back as the correct level (loud/medium/soft/hush all round-trip).

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit. Rolling back restores the current broken behavior on react-supporting backends (volume adjusts nack), but nothing depends on the new behavior — no schema or state changes.

## Screenshots / videos

Repro video in [TLON-6071](https://linear.app/tlon/issue/TLON-6071/impossible-to-select-any-global-notification-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)