### PR TITLE
refactor: migrate off expo-file-system/legacy

### DIFF
--- a/packages/app/features/top/MediaViewerScreen.tsx
+++ b/packages/app/features/top/MediaViewerScreen.tsx
@@ -3,7 +3,6 @@ import {
   AnalyticsEvent,
   createDevLogger,
   downloadImageForWeb,
-  ensureFileExtension,
 } from '@tloncorp/shared';
 import {
   GestureMediaViewer,
@@ -12,7 +11,7 @@ import {
   Pressable,
   ZStack,
 } from '@tloncorp/ui';
-import * as FileSystem from 'expo-file-system/legacy';
+import { Directory, File, Paths } from 'expo-file-system';
 import { VideoView, useVideoPlayer } from 'expo-video';
 import type {
   PlayingChangeEventPayload,
@@ -186,60 +185,42 @@ async function downloadMedia({
       }
     }
 
-    const baseFilename =
-      uri.split('/').pop()?.split('?')[0] || `downloaded-${noun}`;
     const fallbackExtension = mediaType === 'video' ? '.mp4' : '.jpg';
-    // The URL may be extensionless, so download to a temp path first and
-    // derive the real extension from the response's content-type before
-    // saving. Without this, an extensionless video lands in a .jpg-named file
-    // and fails (or imports incorrectly) in MediaLibrary.
-    const tempUri = `${FileSystem.documentDirectory}tmp-${baseFilename}`;
-    let localUri = tempUri;
 
     try {
-      const downloadResult = await FileSystem.downloadAsync(uri, tempUri);
-
-      if (downloadResult.status !== 200) {
-        logger.trackError(`Failed to download ${noun}`, {
-          status: downloadResult.status,
-          uri,
-        });
-        throw new Error(`Download failed with status ${downloadResult.status}`);
-      }
-
-      const contentType =
-        downloadResult.headers['Content-Type'] ??
-        downloadResult.headers['content-type'];
-      const filename = ensureFileExtension(
-        baseFilename,
-        contentType,
-        fallbackExtension
+      const downloadDirectory = new Directory(Paths.cache, 'media-downloads');
+      downloadDirectory.create({ intermediates: true, idempotent: true });
+      // The URL may be extensionless, so download into a directory: the
+      // filename is then derived from the response headers, giving
+      // MediaLibrary a correctly-typed extension to import.
+      const downloadedFile = await File.downloadFileAsync(
+        uri,
+        downloadDirectory,
+        { idempotent: true }
       );
-      localUri = `${FileSystem.documentDirectory}${filename}`;
-      if (localUri !== tempUri) {
-        await FileSystem.moveAsync({ from: tempUri, to: localUri });
-      }
 
-      const fileInfo = await FileSystem.getInfoAsync(localUri);
-      if (!fileInfo.exists) {
-        logger.trackError('Downloaded file does not exist', {
-          uri,
-          localUri,
-        });
-        throw new Error('Downloaded file does not exist');
+      // When the response has no usable content type, the derived name may
+      // lack an extension (or get Android's generic .bin) — fall back to an
+      // extension based on the media type.
+      if (!downloadedFile.extension || downloadedFile.extension === '.bin') {
+        const baseName = downloadedFile.name.slice(
+          0,
+          downloadedFile.name.length - downloadedFile.extension.length
+        );
+        downloadedFile.moveSync(
+          new File(downloadDirectory, `${baseName}${fallbackExtension}`),
+          { overwrite: true }
+        );
       }
 
       try {
-        const fileUri = localUri.startsWith('file://')
-          ? localUri
-          : `file://${localUri}`;
-        await MediaLibrary.Asset.create(fileUri);
+        await MediaLibrary.Asset.create(downloadedFile.uri);
         Alert.alert('Success', `${Noun} saved to your photos!`);
       } catch (saveError) {
         logger.trackError(`Failed to save ${noun} to library`, {
           error: saveError.message,
           uri,
-          localUri,
+          localUri: downloadedFile.uri,
         });
 
         Alert.alert(
@@ -250,15 +231,14 @@ async function downloadMedia({
       } finally {
         try {
           // Check if file still exists before attempting to delete
-          const fileStillExists = await FileSystem.getInfoAsync(localUri);
-          if (fileStillExists.exists) {
-            await FileSystem.deleteAsync(localUri);
+          if (downloadedFile.exists) {
+            downloadedFile.delete();
           }
         } catch (deleteError) {
           // Silently ignore deletion errors - file may have been moved by MediaLibrary
           logger.trackError(`Failed to delete temporary ${noun} file`, {
             error: deleteError.message,
-            uri: localUri,
+            uri: downloadedFile.uri,
           });
         }
       }

--- a/packages/app/ui/components/NotesChannel/notesImport.test.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.test.ts
@@ -1,6 +1,5 @@
 import * as DocumentPicker from 'expo-document-picker';
 import { Directory as ExpoDirectory } from 'expo-file-system';
-import * as FileSystem from 'expo-file-system/legacy';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
@@ -16,13 +15,20 @@ vi.mock('expo-document-picker', () => ({
   getDocumentAsync: vi.fn(),
 }));
 
-vi.mock('expo-file-system/legacy', () => ({
-  readAsStringAsync: vi.fn(),
-}));
+const readFileText = vi.hoisted(() => vi.fn());
 
 vi.mock('expo-file-system', () => ({
   Directory: {
     pickDirectoryAsync: vi.fn(),
+  },
+  File: class {
+    uri: string;
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+    text() {
+      return readFileText(this.uri);
+    }
   },
 }));
 
@@ -330,7 +336,7 @@ describe('notes import helpers', () => {
         },
       ],
     });
-    vi.mocked(FileSystem.readAsStringAsync).mockImplementation(async (uri) =>
+    readFileText.mockImplementation(async (uri) =>
       uri.endsWith('plan.md') ? '# Plan' : 'Memo body'
     );
 
@@ -341,7 +347,7 @@ describe('notes import helpers', () => {
       multiple: true,
       type: '*/*',
     });
-    expect(FileSystem.readAsStringAsync).toHaveBeenCalledTimes(2);
+    expect(readFileText).toHaveBeenCalledTimes(2);
     expect(sources).toEqual([
       source('Plan.md', '# Plan'),
       source('Memo.txt', 'Memo body'),

--- a/packages/app/ui/components/NotesChannel/notesImport.ts
+++ b/packages/app/ui/components/NotesChannel/notesImport.ts
@@ -1,6 +1,5 @@
 import * as DocumentPicker from 'expo-document-picker';
-import { Directory as ExpoDirectory } from 'expo-file-system';
-import * as FileSystem from 'expo-file-system/legacy';
+import { Directory as ExpoDirectory, File as ExpoFile } from 'expo-file-system';
 
 export type NotesImportSource = {
   relativePath: string;
@@ -474,9 +473,8 @@ async function selectNotesImportSourcesFromNative(
   if (result.assets == null || result.assets.length === 0) return null;
 
   options.onFilesChosen?.();
-  return readNotesImportSourcesFromDocumentPickerAssets(
-    result.assets,
-    FileSystem.readAsStringAsync
+  return readNotesImportSourcesFromDocumentPickerAssets(result.assets, (uri) =>
+    new ExpoFile(uri).text()
   );
 }
 

--- a/packages/shared/src/store/storage/getLocalFileSize.native.ts
+++ b/packages/shared/src/store/storage/getLocalFileSize.native.ts
@@ -1,6 +1,6 @@
-import * as FileSystem from 'expo-file-system/legacy';
+import { File } from 'expo-file-system';
 
 export async function getLocalFileSize(uri: string): Promise<number> {
-  const fileInfo = await FileSystem.getInfoAsync(uri);
-  return fileInfo.exists ? fileInfo.size : 0;
+  // File.size is 0 when the file does not exist or cannot be read.
+  return new File(uri).size;
 }

--- a/packages/shared/src/store/storage/storageActions.ts
+++ b/packages/shared/src/store/storage/storageActions.ts
@@ -4,7 +4,9 @@ import { RNFile, getCurrentUserId } from '@tloncorp/api';
 import { desig } from '@tloncorp/api/lib/urbit';
 import { Attachment } from '@tloncorp/api/types/attachment';
 import { da, render } from '@urbit/aura';
-import * as FileSystem from 'expo-file-system/legacy';
+// Aliased so it doesn't shadow the global web File used elsewhere in this
+// module.
+import { File as ExpoFile } from 'expo-file-system';
 import { SaveFormat, manipulateAsync } from 'expo-image-manipulator';
 
 import * as db from '../../db';
@@ -420,7 +422,7 @@ async function uploadFile(
     }
     return response;
   } else {
-    const response = await FileSystem.uploadAsync(presignedUrl, assetUri, {
+    const response = await new ExpoFile(assetUri).upload(presignedUrl, {
       httpMethod: 'PUT',
       headers,
     });

--- a/packages/shared/src/test/setup.ts
+++ b/packages/shared/src/test/setup.ts
@@ -32,8 +32,10 @@ vi.mock('@react-native-community/netinfo', () => {
   };
 });
 
-vi.mock('expo-file-system/legacy', () => ({
-  uploadAsync: vi.fn(),
+vi.mock('expo-file-system', () => ({
+  File: class {
+    upload = vi.fn().mockResolvedValue({ status: 200, body: '', headers: {} });
+  },
 }));
 
 vi.mock('expo-image-manipulator', () => ({


### PR DESCRIPTION
## Summary

Migrates the remaining call sites off `expo-file-system/legacy` onto the current `File`/`Directory`/`Paths` API, plus the corresponding test mocks. No user-facing behavior change intended.

Stacked on #6057, which independently fixes the save-to-photos deprecation throw.

## Changes

- **Save media to photos** (`MediaViewerScreen.tsx`): `File.downloadFileAsync` into a directory derives the filename from response headers natively, replacing the manual download-to-temp → read `Content-Type` → rename flow. It also rejects on non-2xx, so the manual status/exists checks are gone (same error alerts fire from the catch). Two behavior notes:
  - New fallback: renames to `.mp4`/`.jpg` when the response has no usable content type (extensionless filename, or Android's generic `.bin`).
  - The temp file now lives in the cache directory instead of the document directory.
- **Attachment uploads** (`storageActions.ts`): `FileSystem.uploadAsync(url, uri, ...)` → `new ExpoFile(uri).upload(url, ...)` — same binary-content default and `{ status, body }` result shape. The import is aliased because this module also uses the global web `File` (`params instanceof File`).
- **Notes import** (`notesImport.ts`): the document-picker path reads file contents with `new ExpoFile(uri).text()`.
- **Local file size** (`getLocalFileSize.native.ts`): `getInfoAsync` → `new File(uri).size` (also 0 when the file doesn't exist).

## How did I test?

- Unit tests (notes import, storage) pass with mocks updated to the class API.
- Exercised end-to-end on simulators via agent-device (screenshots below):
  - Save to photos: verified on iOS and Android — the Android pass also covers the header-derived filename path.
  - Attachment upload: posted a gallery image on iOS; the post renders cross-device.
- Notes import from files: unit tests only — the import UI requires a new-style notes channel, which the test ship doesn't have.
- Web: no dedicated QA needed. Every changed call site is native-gated — web uses the `fetch` upload branch, the DOM file-input import path, `getLocalFileSize.ts` (web variant), and `downloadImageForWeb`. The web e2e suite in CI covers the shared upload flow.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: native attachment uploads, save-to-photos

The upload path is the highest-traffic piece — every native attachment upload goes through `uploadFile`. Worst case a failed upload surfaces through the existing error state; no data loss.

## Rollback plan

Revert the PR — no native config or schema changes.

## Screenshots / videos

**Gallery upload** — pick from library → post → post live in gallery (`ExpoFile.upload` + image-manipulator path):

iOS:

https://github.com/user-attachments/assets/58d5f74c-60f9-43e2-aecd-fff987847db8

Android:

https://github.com/user-attachments/assets/24975de1-a263-41a7-9c26-ffaaec0b73fe

**Save to photos** (`File.downloadFileAsync` into cache + `Asset.create`):

| iOS | Android |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ac622692-0afe-42ec-accf-bb8bb5ced888" width="260" /> | <img src="https://github.com/user-attachments/assets/e13fd294-59a1-447f-ab59-7df436174a02" width="260" /> |


