### PR TITLE
deps: bump expo-share-intent to 7.0.0 for Expo SDK 56

### DIFF
--- a/apps/tlon-mobile/ios/Podfile.lock
+++ b/apps/tlon-mobile/ios/Podfile.lock
@@ -281,7 +281,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSensors (56.0.6):
     - ExpoModulesCore
-  - ExpoShareIntentModule (5.1.1):
+  - ExpoShareIntentModule (7.0.0):
     - ExpoModulesCore
   - ExpoSMS (56.0.3):
     - ExpoModulesCore
@@ -3399,7 +3399,7 @@ SPEC CHECKSUMS:
   ExpoNotifications: 87875dae0faded5284004bc1204990947d3f64e0
   ExpoSecureStore: f1bd083c1b7b8d4142013ffcc0082d377d9f49f4
   ExpoSensors: d34558ddf1f1d61c7a22180d1d40d8bd89d67d7b
-  ExpoShareIntentModule: 928ff229dd5e577561944786f0de08be339f640b
+  ExpoShareIntentModule: ca4400482299e779d77b93a722ee79146c108c35
   ExpoSMS: 2cebfd889706da39a397d20c8a68abb0ce7f185d
   ExpoSpeechRecognition: 119acf84448579e53f841d040aad76982f945e2d
   ExpoSplashScreen: 3fe3a57d56d7242a9109d9714a6f9fa1e256538b

--- a/apps/tlon-mobile/ios/ShareExtension/ShareViewController.swift
+++ b/apps/tlon-mobile/ios/ShareExtension/ShareViewController.swift
@@ -26,6 +26,7 @@ class ShareViewController: UIViewController {
     "\(shareProtocol)ShareKey"
   }
 
+  let hideView: Bool = false
   private let loadingIndicator = UIActivityIndicatorView(style: .large)
   var sharedMedia: [SharedMediaFile] = []
   var sharedWebUrl: [WebUrl] = []
@@ -36,17 +37,31 @@ class ShareViewController: UIViewController {
   let urlContentType: String = UTType.url.identifier
   let propertyListType: String = UTType.propertyList.identifier
   let fileURLType: String = UTType.fileURL.identifier
+  let pkpassContentType: String = "com.apple.pkpass"
   let pdfContentType: String = UTType.pdf.identifier
+  let vcardContentType: String = "public.vcard"
   private let maxVideoSizeBytes = 150 * 1024 * 1024
   private let maxVideoSizeLabel = "150 MB"
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    setupLoadingIndicator()
+    if hideView {
+      view.backgroundColor = .clear
+      view.isOpaque = false
+      handleViewLoad()
+    } else {
+      setupLoadingIndicator()
+    }
   }
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
+    if !hideView {
+      handleViewLoad()
+    }
+  }
+
+  private func handleViewLoad() {
     Task {
       guard let extensionContext = self.extensionContext,
         let content = extensionContext.inputItems.first as? NSExtensionItem,
@@ -60,8 +75,12 @@ class ShareViewController: UIViewController {
           await handleImages(content: content, attachment: attachment, index: index)
         } else if attachment.hasItemConformingToTypeIdentifier(videoContentType) {
           await handleVideos(content: content, attachment: attachment, index: index)
+        } else if attachment.hasItemConformingToTypeIdentifier(vcardContentType) {
+          await handleVCard(content: content, attachment: attachment, index: index)
         } else if attachment.hasItemConformingToTypeIdentifier(fileURLType) {
           await handleFiles(content: content, attachment: attachment, index: index)
+        } else if attachment.hasItemConformingToTypeIdentifier(pkpassContentType) {
+          await handlePkPass(content: content, attachment: attachment, index: index)
         } else if attachment.hasItemConformingToTypeIdentifier(pdfContentType) {
           await handlePdf(content: content, attachment: attachment, index: index)
         } else if attachment.hasItemConformingToTypeIdentifier(propertyListType) {
@@ -74,6 +93,40 @@ class ShareViewController: UIViewController {
           NSLog("[ERROR] content type not handle !\(String(describing: content))")
           dismissWithError(message: "content type not handle \(String(describing: content)))")
         }
+      }
+    }
+  }
+
+  private func handleVCard(content: NSExtensionItem, attachment: NSItemProvider, index: Int) async {
+    Task.detached {
+      do {
+        if let url = try? await attachment.loadItem(forTypeIdentifier: self.vcardContentType)
+          as? URL
+        {
+          // ensure a .vcf file extension so mime resolves properly
+          let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString + ".vcf")
+          _ = Self.copyFile(at: url, to: tmp)
+          Task { @MainActor in
+            await self.handleFileURL(content: content, url: tmp, index: index)
+          }
+        } else if let data = try? await attachment.loadItem(
+          forTypeIdentifier: self.vcardContentType) as? Data
+        {
+          let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString + ".vcf")
+          try data.write(to: tmp)
+          Task { @MainActor in
+            await self.handleFileURL(content: content, url: tmp, index: index)
+          }
+        } else {
+          NSLog("[ERROR] Cannot load vcard content !\(String(describing: content))")
+          await self.dismissWithError(
+            message: "Cannot load vCard content \(String(describing: content))")
+        }
+      } catch {
+        NSLog("[ERROR] handleVCard exception: \(error.localizedDescription)")
+        await self.dismissWithError(message: "vCard error: \(error.localizedDescription)")
       }
     }
   }
@@ -166,17 +219,66 @@ class ShareViewController: UIViewController {
     }
   }
 
+  private func handlePkPass(content: NSExtensionItem, attachment: NSItemProvider, index: Int) async
+  {
+    Task.detached {
+      NSLog("[DEBUG] Attempting to handle pkpass file for item \(index)")
+      NSLog("[DEBUG] Available type identifiers: \(attachment.registeredTypeIdentifiers)")
+
+      do {
+        if let url = try await attachment.loadItem(forTypeIdentifier: self.pkpassContentType)
+          as? URL
+        {
+          NSLog("[DEBUG] Successfully loaded pkpass as URL: \(url.absoluteString)")
+          await self.handleFileURL(content: content, url: url, index: index)
+
+        } else if let data = try await attachment.loadItem(
+          forTypeIdentifier: self.pkpassContentType) as? Data
+        {
+          NSLog("[DEBUG] Successfully loaded pkpass as Data, size: \(data.count) bytes")
+          let tempFileName = UUID().uuidString + ".pkpass"
+          let tempFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            tempFileName)
+
+          // Writing data to a file is I/O, keep it off the main thread.
+          try data.write(to: tempFileURL)
+
+          // Handle the newly created temporary file URL.
+          await self.handleFileURL(content: content, url: tempFileURL, index: index)
+
+        } else {
+          NSLog(
+            "[ERROR] Cannot load pkpass content: Item was neither URL nor Data for type \(self.pkpassContentType). Attachment: \(attachment)"
+          )
+          Task { @MainActor in
+            self.dismissWithError(message: "Cannot load pkpass content (unexpected data type).")
+          }
+        }
+      } catch {
+        NSLog("[ERROR] Exception when handling pkpass: \(error.localizedDescription)")
+        Task { @MainActor in
+          self.dismissWithError(message: "Error processing pkpass: \(error.localizedDescription)")
+        }
+      }
+    }
+  }
+
   private func handleImages(content: NSExtensionItem, attachment: NSItemProvider, index: Int) async
   {
     Task.detached {
-      if let item = try? await attachment.loadItem(forTypeIdentifier: self.imageContentType) {
-        Task { @MainActor in
+      do {
+        let item = try await attachment.loadItem(forTypeIdentifier: self.imageContentType)
 
+        Task { @MainActor in
           var url: URL? = nil
+
           if let dataURL = item as? URL {
             url = dataURL
           } else if let imageData = item as? UIImage {
             url = self.saveScreenshot(imageData)
+            if url == nil {
+              NSLog("[ERROR] handleImages: saveScreenshot returned nil")
+            }
           } else if let imageData = item as? Data {
             guard let imageExtension = self.getImageDataExtension(imageData) else {
               NSLog("[ERROR] Cannot identify image data type !\(String(describing: item))")
@@ -185,17 +287,19 @@ class ShareViewController: UIViewController {
             }
 
             url = self.saveImageData(imageData, fileExtension: imageExtension)
+          } else {
+            NSLog("[ERROR] handleImages: Item is unexpected type: \(type(of: item))")
           }
 
-          guard url != nil else {
-            NSLog("[ERROR] Cannot load image URL content !\(String(describing: item))")
-            self.dismissWithError(message: "Cannot load image URL content")
+          guard let safeURL = url else {
+            NSLog("[ERROR] handleImages: Failed to get URL for image item")
+            self.dismissWithError(message: "Failed to process image")
             return
           }
 
           var pixelWidth: Int? = nil
           var pixelHeight: Int? = nil
-          if let imageSource = CGImageSourceCreateWithURL(url! as CFURL, nil) {
+          if let imageSource = CGImageSourceCreateWithURL(safeURL as CFURL, nil) {
             if let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil)
               as Dictionary?
             {
@@ -216,16 +320,18 @@ class ShareViewController: UIViewController {
           }
 
           // Always copy
-          let fileName = self.getFileName(from: url!, type: .image)
-          let fileExtension = self.getExtension(from: url!, type: .image)
-          let fileSize = self.getFileSize(from: url!)
-          let mimeType = url!.mimeType(ext: fileExtension)
+          let fileName = self.getFileName(from: safeURL, type: .image)
+          let fileExtension = self.getExtension(from: safeURL, type: .image)
+          let fileSize = self.getFileSize(from: safeURL)
+          let mimeType = safeURL.mimeType(ext: fileExtension)
           let newName = "\(UUID().uuidString).\(fileExtension)"
           let newPath = FileManager.default
             .containerURL(
               forSecurityApplicationGroupIdentifier: self.hostAppGroupIdentifier)!
             .appendingPathComponent(newName)
-          let copied = self.copyFile(at: url!, to: newPath)
+
+          let copied = Self.copyFile(at: safeURL, to: newPath)
+
           if copied {
             self.sharedMedia.append(
               SharedMediaFile(
@@ -241,12 +347,11 @@ class ShareViewController: UIViewController {
             userDefaults?.synchronize()
             self.redirectToHostApp(type: .media)
           }
-
         }
-      } else {
-        NSLog("[ERROR] Cannot load image content !\(String(describing: content))")
+      } catch {
+        NSLog("[ERROR] handleImages: Exception loading image item: \(error)")
         await self.dismissWithError(
-          message: "Cannot load image content \(String(describing: content))")
+          message: "Cannot load image content: \(error.localizedDescription)")
       }
     }
   }
@@ -258,7 +363,8 @@ class ShareViewController: UIViewController {
   private func saveScreenshot(_ image: UIImage) -> URL? {
     var screenshotURL: URL? = nil
     if let screenshotData = image.pngData(),
-      let screenshotPath = documentDirectoryPath()?.appendingPathComponent("screenshot.png")
+      let screenshotPath = documentDirectoryPath()?.appendingPathComponent(
+        "screenshot_\(UUID().uuidString).png")
     {
       try? screenshotData.write(to: screenshotPath)
       screenshotURL = screenshotPath
@@ -313,7 +419,7 @@ class ShareViewController: UIViewController {
             .containerURL(
               forSecurityApplicationGroupIdentifier: self.hostAppGroupIdentifier)!
             .appendingPathComponent(newName)
-          let copied = self.copyFile(at: url, to: newPath)
+          let copied = Self.copyFile(at: url, to: newPath)
           if copied {
             let sharedFile = self.getSharedMediaFile(
               forVideo: newPath, fileName: fileName, fileSize: fileSize, mimeType: mimeType)
@@ -386,7 +492,7 @@ class ShareViewController: UIViewController {
       .containerURL(
         forSecurityApplicationGroupIdentifier: self.hostAppGroupIdentifier)!
       .appendingPathComponent(newName)
-    let copied = self.copyFile(at: url, to: newPath)
+    let copied = Self.copyFile(at: url, to: newPath)
     if copied {
       self.sharedMedia.append(
         SharedMediaFile(
@@ -420,7 +526,8 @@ class ShareViewController: UIViewController {
   }
 
   private func redirectToHostApp(type: RedirectType) {
-    let url = URL(string: "\(shareProtocol)://dataUrl=\(sharedKey)#\(type)")!
+    let nonce = UUID().uuidString
+    let url = URL(string: "\(shareProtocol)://dataUrl=\(sharedKey)?nonce=\(nonce)#\(type)")!
     var responder = self as UIResponder?
 
     while responder != nil {
@@ -486,7 +593,7 @@ class ShareViewController: UIViewController {
     }
   }
 
-  func copyFile(at srcURL: URL, to dstURL: URL) -> Bool {
+  nonisolated static func copyFile(at srcURL: URL, to dstURL: URL) -> Bool {
     do {
       if FileManager.default.fileExists(atPath: dstURL.path) {
         try FileManager.default.removeItem(at: dstURL)
@@ -669,6 +776,7 @@ internal let mimeTypes = [
   "cco": "application/x-cocoa",
   "jardiff": "application/x-java-archive-diff",
   "jnlp": "application/x-java-jnlp-file",
+  "pkpass": "application/vnd.apple.pkpass",
   "run": "application/x-makeself",
   "pl": "application/x-perl",
   "pm": "application/x-perl",
@@ -714,6 +822,7 @@ internal let mimeTypes = [
   "asf": "video/x-ms-asf",
   "wmv": "video/x-ms-wmv",
   "avi": "video/x-msvideo",
+  "vcf": "text/vcard",
 ]
 
 extension URL {

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -115,7 +115,7 @@
     "expo-secure-store": "~56.0.4",
     "expo-sensors": "~56.0.5",
     "expo-linking": "~56.0.12",
-    "expo-share-intent": "5.1.1",
+    "expo-share-intent": "7.0.0",
     "expo-sms": "~56.0.3",
     "expo-speech-recognition": "~56.0.0",
     "expo-splash-screen": "~56.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         specifier: ~56.0.5
         version: 56.0.6(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))
       expo-share-intent:
-        specifier: 5.1.1
-        version: 5.1.1(expo-constants@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)))(expo-linking@56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        specifier: 7.0.0
+        version: 7.0.0(expo-constants@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)))(expo-linking@56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       expo-sms:
         specifier: ~56.0.3
         version: 56.0.3(expo@56.0.12)
@@ -2908,9 +2908,6 @@ packages:
 
   '@expo/config-plugins@10.0.3':
     resolution: {integrity: sha512-fjCckkde67pSDf48x7wRuPsgQVIqlDwN7NlOk9/DFgQ1hCH0L5pGqoSmikA1vtAyiA83MOTpkGl3F3wyATyUog==}
-
-  '@expo/config-plugins@10.1.2':
-    resolution: {integrity: sha512-IMYCxBOcnuFStuK0Ay+FzEIBKrwW8OVUMc65+v0+i7YFIIe8aL342l7T4F8lR4oCfhXn7d6M5QPgXvjtc/gAcw==}
 
   '@expo/config-plugins@56.0.9':
     resolution: {integrity: sha512-/6a/S9USwx8OC9tGjHxbviLFiBHyueN3aoNWMLvWDEJoZ1CIVW800ZBzwXq/FYNK2qzcN1LxFmQtzD1zeFQKNA==}
@@ -8587,12 +8584,12 @@ packages:
     resolution: {integrity: sha512-SmM2p2g3Jrktpiazcst+OxhjSzOHXKAY4BPURHYHXvApzzoybMmrNF4IEZ8DKZ145BhSe4ydAmlEFCRTsdtgUQ==}
     engines: {node: '>=20.16.0'}
 
-  expo-share-intent@5.1.1:
-    resolution: {integrity: sha512-0sEf34+4w/ySQd7xZmnog/oOm1q+PUBHFoGU97mxTXIGijY4LNmSX806efrDkYMwCxgRA1iHxG/zBib4zBPmYw==}
+  expo-share-intent@7.0.0:
+    resolution: {integrity: sha512-9fVw0ObAdJMj9YlN/zkBwMKWlQakjP5xa2pf81V44sK+49GJyVT38NBJv+RtEGSK5CH2SUJHHdJ062HZG5a/AQ==}
     peerDependencies:
-      expo: ^54
-      expo-constants: '>=18.0.8'
-      expo-linking: '>=8.0.8'
+      expo: ^56
+      expo-constants: '>=56.0.10'
+      expo-linking: '>=56.0.13'
       react: 19.2.3
       react-native: 0.85.3
 
@@ -16280,25 +16277,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/config-plugins@10.1.2':
-    dependencies:
-      '@expo/config-types': 53.0.5
-      '@expo/json-file': 9.1.5
-      '@expo/plist': 0.3.5
-      '@expo/sdk-runtime-versions': 1.0.0
-      chalk: 4.1.2
-      debug: 4.4.3
-      getenv: 2.0.0
-      glob: 10.5.0
-      resolve-from: 5.0.0
-      semver: 7.7.3
-      slash: 3.0.0
-      slugify: 1.6.6
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@expo/config-plugins@56.0.9(typescript@5.9.3)':
     dependencies:
       '@expo/config-types': 56.0.6
@@ -23793,9 +23771,9 @@ snapshots:
 
   expo-server@56.0.5: {}
 
-  expo-share-intent@5.1.1(expo-constants@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)))(expo-linking@56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  expo-share-intent@7.0.0(expo-constants@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)))(expo-linking@56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
-      '@expo/config-plugins': 10.1.2
+      '@expo/config-plugins': 56.0.9(typescript@5.9.3)
       expo: 56.0.12(hed2hf4wsztb7pemtxuk4ffjti)
       expo-constants: 56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))
       expo-linking: 56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -23803,6 +23781,7 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native-community/cli@13.6.9(encoding@0.1.13))(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.17)(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
+      - typescript
 
   expo-sms@56.0.3(expo@56.0.12):
     dependencies:


### PR DESCRIPTION
## Summary

The Expo SDK 56 upgrade left `expo-share-intent` at 5.1.1, which targets SDK 54 — its config plugin warns on every prebuild ("your Expo SDK version does not match requirements! v5.1.1 needs ^54, found 56.0.0"). v7.0.0 is the library's SDK 56 release. Since our `ios/` directory is committed rather than prebuild-generated, the share-extension Swift file the plugin would normally regenerate is vendored — so this PR also re-bases it on the v7 template.

## Changes

- `expo-share-intent` 5.1.1 → 7.0.0 in tlon-mobile
- Lockfile: its `@expo/config-plugins` dependency now resolves to the shared 56.0.9 instead of a standalone SDK-54-era 10.1.2 copy
- `ios/ShareExtension/ShareViewController.swift`: re-based on the v7.0.0 template (it was forked from the v3.2.3 template), with our customizations re-applied on top
- `ios/Podfile.lock`: regenerated via `pod install` (ExpoShareIntentModule 5.1.1 → 7.0.0; the hermes/React-prebuilt SPEC CHECKSUMS flips are the same environment-dependent drift as the previous regen in a8d13c069)

**The library bump itself is drop-in** ([full 5.1.1 → 7.0.0 diff](https://github.com/achorein/expo-share-intent/compare/v5.1.1...v7.0.0)): the JS API and the config-plugin options we set are untouched; the substantive change is Android's build.gradle migrating from the deprecated legacy `ExpoModulesCorePlugin.gradle` path to the `expo-module-gradle-plugin`. Android runtime code is identical between the two versions — the Android side of this bump is build-time only.

**From the v7 extension template we pick up:**

- a unique nonce per share deeplink — fixes sharing the same content twice in a row (v7's JS side pairs with this)
- vCard and pkpass attachment handling
- `copyFile` as `nonisolated static`

**Customizations preserved:** dynamic app-group/scheme derived from the bundle id (preview/prod variants), the loading-indicator UI (we keep `hideView = false` instead of upstream's new transparent default so users get feedback during long video copies), the 150 MB video cap, the raw-`Data` image path that preserves the original format instead of re-encoding to PNG, and the friendlier error alerts.

## How did I test?

Tested on iOS and Android simulators by sharing a website link and image to the app.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: share-into-app flow (share extension / intent handling)

## Rollback plan

Revert the PR — package.json, lockfiles, and one vendored Swift file.

## Screenshots / videos

N/A
