### PR TITLE
fix(web): unhandled rejections from voice memo recorder on chat mount

### DIFF
--- a/packages/app/ui/components/AudioRecorder/react-native-audio-waveform.web.tsx
+++ b/packages/app/ui/components/AudioRecorder/react-native-audio-waveform.web.tsx
@@ -1,3 +1,4 @@
+import { ComponentProps, forwardRef } from 'react';
 import { NativeModules, View } from 'react-native';
 
 export {
@@ -16,7 +17,13 @@ export const hasRNWaveformNativeModule = NativeModules.AudioWaveform != null;
 // for web, export a dummy component since the native module is not available
 // (even though the Waveform component is JS, it automatically calls into the
 // native module in a way that crashes the web app)
-export const Waveform = View;
+// The ref is intentionally dropped so `ref.current` stays null: it can't
+// implement IWaveformRef, and callers guard their method calls with `?.`.
+export const Waveform = forwardRef<IWaveformRef, ComponentProps<typeof View>>(
+  function Waveform(props, _ref) {
+    return <View {...props} />;
+  }
+);
 
 export function useExtractWaveformDataCallback():
   | ((args: {


### PR DESCRIPTION
## Summary

On web, whenever `AudioRecorderSheet` runs its close path with the recorder mounted, two unhandled promise rejections log: `TypeError: waveformRef.current?.stopRecord is not a function` and the same for `stopPlayer`. This fixes the audio-waveform web shim so `AudioRecorder`'s optional-chaining ref guards short-circuit as intended.

## Changes

The web shim aliased `Waveform` to react-native's `View`, and react-native-web forwards the ref to the underlying DOM element. `AudioRecorder`'s `waveformRef.current` was therefore a non-null `HTMLDivElement` instead of an `IWaveformRef`, so calls like `waveformRef.current?.stopRecord()` didn't short-circuit and threw whenever `AudioRecorderSheet`'s [open/close effect](https://github.com/tloncorp/tlon-apps/blob/1bdb61de47ee0dc58d213b92afa8f20c0124df48/packages/app/ui/components/AudioRecorder/AudioRecorderSheet.tsx#L50-L54) ran its close path with the recorder mounted.

The shim now wraps the stand-in `View` in `forwardRef` and drops the ref, so `waveformRef.current` stays `null` and the existing guards no-op.

One residual on web: the close-path `stopRecording()` now logs a `No uri returned from stopRecord` warning and calls `onCancel(null)` — benign (`Alert.alert` is a no-op in react-native-web, and the sheet is already closed). Fixing that would change native behavior too; out of scope here.

## How did I test?

- **Reproduced and verified in a real browser** against a local dev ship (vite dev server + e2e ~zod pier). Rendering the shim's `Waveform` with a ref through the app bundle: before, `ref.current` is an `HTMLDivElement` and `stopRecord()`/`stopPlayer()` throw exactly the reported TypeErrors; with this fix, `ref.current` is `null` and both calls no-op.
- Full web flows with the fix applied (login → chat channel → notebook composer) run with no waveform errors in the console.
- Typecheck (`@tloncorp/app` tsc) and eslint/prettier pass.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: web-only audio waveform shim; native untouched

## Rollback plan

Revert the commit.

## Screenshots / videos

N/A — console-only change.
