### PR TITLE
chore(mobile): disable dev menu floating action button by default

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     </intent>
   </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
+    <meta-data android:name="EXDevMenuShowFloatingActionButton" android:value="false"/>
     <meta-data android:name="expo.modules.notifications.default_notification_icon" android:resource="@drawable/notification_icon"/>
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
     <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -37,6 +37,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>EXDevMenuShowFloatingActionButton</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
## Summary

Since the Expo SDK 56 upgrade, dev builds show expo-dev-menu's floating gear button overlaying the app UI. This disables it by default on both platforms; it can still be re-enabled per device from the dev menu's settings.

## Changes

- Add `EXDevMenuShowFloatingActionButton: false` to the iOS Info.plist and as `<meta-data>` in the AndroidManifest — the keys expo-dev-menu reads for the FAB default ([iOS](https://github.com/expo/expo/blob/f5d56c05565e8dbb0cdc4bb5390f712f0ca620d4/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift#L29-L49), [Android](https://github.com/expo/expo/blob/f5d56c05565e8dbb0cdc4bb5390f712f0ca620d4/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt#L68)). An explicit per-device toggle still wins over this default, and the dev menu itself stays reachable via shake / three-finger long press / Cmd+D.

## How did I test?

Checked on a fresh sim / emu that the button doesn't show up by default.

Also verified the toggle still works: writing `EXDevMenuShowFloatingActionButton = YES` to the app's UserDefaults (what the dev menu settings toggle does) and relaunching makes the FAB reappear; deleting it hides it again. Dev menu still opens via shake / Cmd+D (iOS) and menu key (Android).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: dev-only tooling config — expo-dev-menu ships only in debug builds, so no production impact

## Rollback plan

Revert the commit; it only adds two config entries.

## Screenshots / videos

| iOS default (no FAB) | iOS with toggle re-enabled | Android default (no FAB) |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/3eb0a821-8a8d-4134-900a-cc9e3cebed64" width="240" /> | <img src="https://github.com/user-attachments/assets/73dcf85c-1ca8-4415-bd24-2e84bac09b8d" width="240" /> | <img src="https://github.com/user-attachments/assets/c291bf95-2ddf-4935-90d6-bac0cd5b9996" width="240" /> |

