### PR TITLE
bump mobile version to 9.2.0

### DIFF
--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         compileSdk rootProject.ext.compileSdkVersion
         versionCode 108
-        versionName "9.1.0"
+        versionName "9.2.0"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1804,7 +1804,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.1.0;
+				MARKETING_VERSION = 9.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1842,7 +1842,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.1.0;
+				MARKETING_VERSION = 9.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2074,7 +2074,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.1.0;
+				MARKETING_VERSION = 9.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2117,7 +2117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.1.0;
+				MARKETING_VERSION = 9.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tlon-mobile",
-  "version": "9.0.0",
+  "version": "9.2.0",
   "private": true,
   "expo": {
     "autolinking": {


### PR DESCRIPTION
## Summary

Bumps the mobile app version to 9.2.0 so the next production iOS submission is not rejected as an already-submitted 9.1.0 build.

## Changes

- Update the mobile package version to 9.2.0
- Update Android versionName to 9.2.0
- Update iOS marketing versions to 9.2.0

## How did I test?

- Checked the failed Build Tlon Mobile run: iOS submission failed because app version 9.1.0 had already been submitted.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: mobile release metadata

## Rollback plan

Revert this commit.

## Screenshots / videos

N/A
