### PR TITLE
fix: cosmos web renderer fails to boot

### DIFF
--- a/apps/tlon-web/cosmos.config.json
+++ b/apps/tlon-web/cosmos.config.json
@@ -8,6 +8,7 @@
   "dom": {
     "containerQuerySelector": "#app"
   },
+  "globalImports": ["./tamagui.config.ts"],
   "fixturesLocation": "../../packages/app/fixtures",
   "plugins": ["react-cosmos-plugin-vite"]
 }

--- a/apps/tlon-web/vite.cosmos.config.mts
+++ b/apps/tlon-web/vite.cosmos.config.mts
@@ -25,6 +25,13 @@ export default defineConfig(({ mode }) => {
 
   return {
     envPrefix: ['VITE_', 'TAMAGUI_'],
+    // expo 56's runtime (expo/src/async-require/setupHMR) reads process.env.EXPO_OS
+    // to resolve the platform. Metro inlines it via babel-preset-expo; the vite web
+    // build must define it explicitly or expo throws "Missing required parameter
+    // `platform`" at boot.
+    define: {
+      'process.env.EXPO_OS': JSON.stringify('web'),
+    },
     plugins: [
       exportingRawText(/\.sql$/),
       expo52PatchPlugin(),

--- a/apps/tlon-web/vite.cosmos.config.mts
+++ b/apps/tlon-web/vite.cosmos.config.mts
@@ -25,10 +25,6 @@ export default defineConfig(({ mode }) => {
 
   return {
     envPrefix: ['VITE_', 'TAMAGUI_'],
-    // expo 56's runtime (expo/src/async-require/setupHMR) reads process.env.EXPO_OS
-    // to resolve the platform. Metro inlines it via babel-preset-expo; the vite web
-    // build must define it explicitly or expo throws "Missing required parameter
-    // `platform`" at boot.
     define: {
       'process.env.EXPO_OS': JSON.stringify('web'),
     },

--- a/packages/app/fixtures/FixtureWrapper.tsx
+++ b/packages/app/fixtures/FixtureWrapper.tsx
@@ -1,6 +1,9 @@
 // tamagui-ignore
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { NavigationContainer } from '@react-navigation/native';
+import {
+  NavigationContainer,
+  NavigationIndependentTree,
+} from '@react-navigation/native';
 import { internalConfigureClient } from '@tloncorp/api';
 import { QueryClientProvider, queryClient } from '@tloncorp/shared';
 import { type PropsWithChildren, useEffect, useState } from 'react';
@@ -46,11 +49,16 @@ function MockedUrbitClientProvider({ children }: PropsWithChildren<object>) {
 export const FixtureWrapper = (props: FixtureWrapperProps) => {
   return (
     <ToastProvider>
-      <NavigationContainer navigationInChildEnabled>
-        <MockedUrbitClientProvider>
-          <InnerWrapper {...props} />
-        </MockedUrbitClientProvider>
-      </NavigationContainer>
+      {/* The cosmos decorator mounts a NavigationContainer above the
+          PortalProvider; this container must be an independent tree to be
+          nested inside it. */}
+      <NavigationIndependentTree>
+        <NavigationContainer navigationInChildEnabled>
+          <MockedUrbitClientProvider>
+            <InnerWrapper {...props} />
+          </MockedUrbitClientProvider>
+        </NavigationContainer>
+      </NavigationIndependentTree>
     </ToastProvider>
   );
 };

--- a/packages/app/fixtures/FixtureWrapper.tsx
+++ b/packages/app/fixtures/FixtureWrapper.tsx
@@ -49,9 +49,6 @@ function MockedUrbitClientProvider({ children }: PropsWithChildren<object>) {
 export const FixtureWrapper = (props: FixtureWrapperProps) => {
   return (
     <ToastProvider>
-      {/* The cosmos decorator mounts a NavigationContainer above the
-          PortalProvider; this container must be an independent tree to be
-          nested inside it. */}
       <NavigationIndependentTree>
         <NavigationContainer navigationInChildEnabled>
           <MockedUrbitClientProvider>

--- a/packages/app/fixtures/cosmos.decorator.tsx
+++ b/packages/app/fixtures/cosmos.decorator.tsx
@@ -34,9 +34,6 @@ export default ({ children }: { children: React.ReactNode }) => {
         <SafeAreaProvider>
           <ChannelProvider value={{ channel: tlonLocalIntros }}>
             <ComponentsKitProvider>
-              {/* Modal sheets portal their content to this PortalProvider, so
-                  navigation context (e.g. LinkingContext used by Pressable)
-                  must be provided above it. */}
               <NavigationContainer>
                 <PortalProvider>{children}</PortalProvider>
               </NavigationContainer>

--- a/packages/app/fixtures/cosmos.decorator.tsx
+++ b/packages/app/fixtures/cosmos.decorator.tsx
@@ -1,3 +1,4 @@
+import { NavigationContainer } from '@react-navigation/native';
 import { spyOn } from '@tloncorp/shared';
 import React, { useMemo } from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -33,7 +34,12 @@ export default ({ children }: { children: React.ReactNode }) => {
         <SafeAreaProvider>
           <ChannelProvider value={{ channel: tlonLocalIntros }}>
             <ComponentsKitProvider>
-              <PortalProvider>{children}</PortalProvider>
+              {/* Modal sheets portal their content to this PortalProvider, so
+                  navigation context (e.g. LinkingContext used by Pressable)
+                  must be provided above it. */}
+              <NavigationContainer>
+                <PortalProvider>{children}</PortalProvider>
+              </NavigationContainer>
             </ComponentsKitProvider>
           </ChannelProvider>
         </SafeAreaProvider>


### PR DESCRIPTION
## Summary

`pnpm cosmos:web` failed to boot from a clean checkout — the renderer iframe threw ``Missing required parameter `platform` `` and then sat on "WAITING FOR RENDERER…" forever, so no fixtures could be used on web. There were three stacked issues; this fixes all three.

## Changes

- **`vite.cosmos.config.mts`**: define `process.env.EXPO_OS = 'web'`, same as the main [vite.config.mts](https://github.com/tloncorp/tlon-apps/blob/c97a9ac65c98f49ef8bae574393f5ab99c4edbd7/apps/tlon-web/vite.config.mts#L249-L255). Expo 56's runtime reads `EXPO_OS` to resolve the platform at boot — without the define, `HMRClient.setup` throws the reported error.
- **`cosmos.config.json`**: add `"globalImports": ["./tamagui.config.ts"]` so `createTamagui()` runs before any fixture module. Cosmos's generated entry evaluates fixtures before decorators, and some ui components call `getTokenValue()` at module scope (e.g. `InteractableChatListItem`) — that crashed silently before the renderer could connect.
- **`cosmos.decorator.tsx` / `FixtureWrapper.tsx`**: the decorator now mounts a `NavigationContainer` above its `PortalProvider`, and FixtureWrapper's own container becomes a `NavigationIndependentTree` so react-navigation v7 allows the nesting. Modal tamagui sheets portal fixture content to the decorator-level `PortalProvider` — above FixtureWrapper's container — so `Pressable`'s `useLinkProps` threw `Couldn't find a LinkingContext context` (hit by `AudioRecorder.fixture`'s sheet).

## How did I test?

- Fresh worktree: `pnpm install`, `pnpm --filter @tloncorp/editor build` (documented `build:packages` prereq — without it vite errors on `@tloncorp/editor/dist/editorHtml` and the renderer hangs silently), then `pnpm --filter tlon-web cosmos`.
- Verified in the browser: renderer connects, fixture list shows counts, and Button, Channel, ChatOptionsSheet, and AudioRecorder fixtures render — including AudioRecorder's modal sheet content, which previously hit the LinkingContext crash.
- Boot works without `apps/tlon-web/.env.local`.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: dev tooling only — cosmos config and fixture harness, no production code paths
- Not re-verified on cosmos **native**, which shares the decorator/FixtureWrapper changes; they use cross-platform react-navigation v7 APIs and should behave identically there.

## Rollback plan

Revert the commit; no migrations or persisted state.

## Screenshots / videos

n/a (dev tooling)
