### PR TITLE
fix activity overflow menu trigger

### DIFF
--- a/packages/app/ui/components/Activity/ActivityHeader.tsx
+++ b/packages/app/ui/components/Activity/ActivityHeader.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import { View } from 'tamagui';
 
 import { ActionSheet } from '../ActionSheet';
+import { OverflowTriggerButton } from '../OverflowMenuButton';
 import { ScreenHeader } from '../ScreenHeader';
 import { Tabs } from '../Tabs';
 
@@ -24,7 +25,6 @@ function ActivityHeaderRaw({
 }) {
   const [overflowOpen, setOverflowOpen] = React.useState(false);
   const onOverflowOpenChange = useCallback((open: boolean) => {
-    console.log('Overflow menu open state changed:', open);
     setOverflowOpen(open);
   }, []);
 
@@ -106,8 +106,7 @@ function ActivityOverflowMenu({
       open={open}
       onOpenChange={onOpenChange}
       trigger={
-        <ScreenHeader.IconButton
-          type="Overflow"
+        <OverflowTriggerButton
           onPress={!isWindowNarrow ? undefined : () => onOpenChange(true)}
         />
       }


### PR DESCRIPTION
## Summary

Fixes the Activity header overflow menu on desktop/web. The shared ActionSheet popover trigger now uses `asChild`, so the trigger needs to be a real pressable component rather than a styled icon.

## Changes

- Use the existing `OverflowTriggerButton` for the Activity overflow menu trigger
- Remove a debug log from the Activity menu open handler

## How did I test?

Tested in simulator

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Activity screen header menu

## Rollback plan

Revert the commit.

## Screenshots / videos

N/A
