### PR TITLE
fix(openclaw): run dev brave repair install after config patching

### DIFF
--- a/packages/openclaw/dev/entrypoint.sh
+++ b/packages/openclaw/dev/entrypoint.sh
@@ -70,7 +70,7 @@ if [ -f "/workspace/tlonbot/openclaw.json" ]; then
   if [ -n "$BRAVE_API_KEY" ]; then
     echo "==> Patching Brave web search into config..."
     jq --arg key "$BRAVE_API_KEY" \
-      '.tools.web.search = {"provider": "brave", "apiKey": $key}
+      '.tools.web.search = {"enabled": true, "provider": "brave", "apiKey": $key}
       | .plugins.allow += ["brave"]
       | .plugins.entries.brave = {"enabled": true, "config": {"webSearch": {"apiKey": $key}}}' \
       "$CONFIG_PATH" > "$CONFIG_PATH.tmp" && mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"

--- a/packages/openclaw/dev/entrypoint.sh
+++ b/packages/openclaw/dev/entrypoint.sh
@@ -63,16 +63,11 @@ if [ -f "/workspace/tlonbot/openclaw.json" ]; then
   # Patch in Brave web search if available. openclaw 2026.5.28 only accepts
   # provider "brave" when the plugin is installed, allowed, and enabled, so
   # set provider, allow, and enable together (mirrors the test entrypoint and
-  # production tlonbot flow).
+  # production tlonbot flow). The matching `plugins install` runs later, just
+  # before gateway start — the CLI refuses to install while the config is
+  # invalid, and at this point it can be (load.paths still points at
+  # /workspace/openclaw-tlon until the repoint below).
   if [ -n "$BRAVE_API_KEY" ]; then
-    # The install ledger lives in /root/.openclaw, which is a persisted
-    # volume (openclaw-state) — the image-layer install (Dockerfile) only
-    # seeds brand-new volumes. Repair existing volumes idempotently at
-    # startup, like production does before every gateway start. Tolerate
-    # failure (e.g. offline) the same way; config validation will surface it.
-    echo "==> Ensuring Brave web-search plugin is installed..."
-    openclaw plugins install @openclaw/brave-plugin \
-      || echo "WARN: brave plugin install failed; web_search may be unavailable"
     echo "==> Patching Brave web search into config..."
     jq --arg key "$BRAVE_API_KEY" \
       '.tools.web.search = {"provider": "brave", "apiKey": $key}
@@ -170,6 +165,20 @@ export TLON_RUN_PATH="/workspace/tlonbot/bin/tlon-run"
 if [ -z "$OPENCLAW_GATEWAY_TOKEN" ]; then
   export OPENCLAW_GATEWAY_TOKEN=$(cat /proc/sys/kernel/random/uuid)
   echo "==> Generated gateway token: $OPENCLAW_GATEWAY_TOKEN"
+fi
+
+# Ensure the Brave plugin is actually installed before the gateway starts.
+# The install ledger lives in /root/.openclaw, which is a persisted volume
+# (openclaw-state) — the image-layer install (Dockerfile) only seeds
+# brand-new volumes, so repair existing ones idempotently, like production
+# does before every gateway start. This must run AFTER all config patching
+# above: the CLI refuses to install while the config is invalid, and before
+# the load.paths repoint it can be. Tolerate failure (e.g. offline) like
+# production; gateway config validation will surface it.
+if [ -n "$BRAVE_API_KEY" ]; then
+  echo "==> Ensuring Brave web-search plugin is installed..."
+  openclaw plugins install @openclaw/brave-plugin \
+    || echo "WARN: brave plugin install failed; web_search may be unavailable"
 fi
 
 echo "==> Starting OpenClaw gateway..."

--- a/packages/openclaw/dev/entrypoint.test.sh
+++ b/packages/openclaw/dev/entrypoint.test.sh
@@ -219,7 +219,7 @@ fi
 if [ -n "$BRAVE_API_KEY" ]; then
   echo "==> Patching config: adding Brave search API key..."
   jq --arg key "$BRAVE_API_KEY" \
-    '.tools.web.search = {"provider": "brave", "apiKey": $key}
+    '.tools.web.search = {"enabled": true, "provider": "brave", "apiKey": $key}
     | .plugins.allow += ["brave"]
     | .plugins.entries.brave = {"enabled": true, "config": {"webSearch": {"apiKey": $key}}}' \
     "$CONFIG_DIR/openclaw.json" > "$CONFIG_DIR/openclaw.json.tmp" \


### PR DESCRIPTION
## Summary

Follow-up to #6043. The dev entrypoint's persisted-volume Brave repair (`openclaw plugins install @openclaw/brave-plugin`) ran too early: the openclaw CLI refuses `plugins install` while the config is invalid, and inside the `BRAVE_API_KEY` block the just-copied tlonbot config can still be invalid — `plugins.load.paths` points at `/workspace/openclaw-tlon` until the repoint later in the script, and if the tlon plugin isn't loadable at that moment, `channels.tlon` fails schema validation too. The install then no-ops with a WARN (it's deliberately failure-tolerant, mirroring production), the gateway still boots — 2026.5.28 downgrades a configured-but-missing plugin to a warning when allow/entries evidence exists — and the only symptom is silently dead web_search on reused `openclaw-state` volumes.

## What changed

Moved the install to just before gateway start, after all config patching, keeping the `BRAVE_API_KEY` gate and the failure-tolerant behavior. Comments at both sites explain the ordering constraint.

## How it was found / validated

Caught live in the tlonbot harness (tloncorp/tlonbot#112), which copies the same tlonbot config and hit the exact refusal: `plugins install` failed pre-repoint with "Config invalid outside the plugin recovery path for brave", then succeeded when run from the post-patch state the new placement uses. Also verified there: deleting the ledger from a running container's volume (simulating a pre-#6043 volume) degrades web_search to "provider unavailable" warnings, and the repair install restores brave to enabled.

Not exercised by CI on this repo: Integration Tests use `dev/entrypoint.test.sh`, which needs no startup install (its harness has no persisted state volume — the image-baked ledger is always fresh). This path only runs under local `pnpm dev`.

## Test plan

- [x] `bash -n dev/entrypoint.sh`
- [x] The relocated install command validated live in the equivalent tlonbot harness state (see above)
- [x] No behavior change when `BRAVE_API_KEY` is unset (block is gated identically at both sites)


## Addendum

Also restores `enabled: true` in the Brave `tools.web.search` config in both entrypoints, matching production `tlawn.py` (`{"enabled": True, "provider": "brave", "apiKey": ...}`). 2026.5.28 only disables on `enabled === false` (absent = enabled), so this is prod parity rather than a functional fix. Mirrors the same change in tloncorp/tlonbot#112.
