### PR TITLE
fix: save media to photos broken by expo-media-library deprecation throw

### DIFF
--- a/packages/app/features/top/MediaViewerScreen.tsx
+++ b/packages/app/features/top/MediaViewerScreen.tsx
@@ -233,7 +233,7 @@ async function downloadMedia({
         const fileUri = localUri.startsWith('file://')
           ? localUri
           : `file://${localUri}`;
-        await MediaLibrary.saveToLibraryAsync(fileUri);
+        await MediaLibrary.Asset.create(fileUri);
         Alert.alert('Success', `${Noun} saved to your photos!`);
       } catch (saveError) {
         logger.trackError(`Failed to save ${noun} to library`, {

--- a/packages/app/features/top/mediaLibrary.web.ts
+++ b/packages/app/features/top/mediaLibrary.web.ts
@@ -6,6 +6,8 @@ export async function requestPermissionsAsync(): Promise<never> {
   throw new Error('expo-media-library is not available on web');
 }
 
-export async function saveToLibraryAsync(_uri: string): Promise<never> {
-  throw new Error('expo-media-library is not available on web');
-}
+export const Asset = {
+  create(_filePath: string): Promise<never> {
+    throw new Error('expo-media-library is not available on web');
+  },
+};


### PR DESCRIPTION
## Summary

In SDK 56, `saveToLibraryAsync` imported from the main `expo-media-library` entry throws at runtime (the legacy methods now throw from the main entry; they moved behind `expo-media-library/legacy`). This breaks save-to-photos in the media viewer: every save shows the "Failed to save image to photos" alert.

## Changes

- `MediaViewerScreen`: `MediaLibrary.saveToLibraryAsync(fileUri)` → `MediaLibrary.Asset.create(fileUri)` (expo's replacement, same behavior).
- `mediaLibrary.web.ts`: web stub mirrors the new import shape (`Asset.create`); still never invoked on web.

## How did I test?

- iOS simulator, dev build: saving an image from the full-screen media viewer.
  - Before: "Failed to save image to photos" alert, console shows the deprecation throw from `saveToLibraryAsync`.
  - After: "Image saved to your photos!" alert.
- Android emulator: same flow verified — "Image saved to your photos!" (screenshot below).

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: media viewer save-to-photos

## Rollback plan

Revert the PR — no native or config changes.

## Screenshots / videos

Save-to-photos from the media viewer, before the fix (deprecation throw surfaces as the failure alert):

https://github.com/user-attachments/assets/633b1cb7-9309-4c9e-8369-7ee51d55cbe4

Same flow with `Asset.create`:

https://github.com/user-attachments/assets/f9b4013a-fe79-40fd-a838-3c77378a5e6c

Android (emulator, same fix):

<img src="https://github.com/user-attachments/assets/65cc6233-9f47-4229-90ce-875830b17ccd" width="300" />


