### PR TITLE
chore(mobile): skip dev menu onboarding and disable dev menu at launch

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/tlon-mobile/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,9 @@
     </intent>
   </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
+    <meta-data android:name="EXDevMenuIsOnboardingFinished" android:value="true"/>
     <meta-data android:name="EXDevMenuShowFloatingActionButton" android:value="false"/>
+    <meta-data android:name="EXDevMenuShowsAtLaunch" android:value="false"/>
     <meta-data android:name="expo.modules.notifications.default_notification_icon" android:resource="@drawable/notification_icon"/>
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
     <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>

--- a/apps/tlon-mobile/ios/Landscape/Info-preview.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info-preview.plist
@@ -39,6 +39,12 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>EXDevMenuIsOnboardingFinished</key>
+	<true/>
+	<key>EXDevMenuShowFloatingActionButton</key>
+	<false/>
+	<key>EXDevMenuShowsAtLaunch</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -37,7 +37,11 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>EXDevMenuIsOnboardingFinished</key>
+	<true/>
 	<key>EXDevMenuShowFloatingActionButton</key>
+	<false/>
+	<key>EXDevMenuShowsAtLaunch</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>


### PR DESCRIPTION
## Summary

Dev builds auto-open the expo-dev-menu on every app launch and show its one-time onboarding screen on fresh installs. Since we don't use prebuild/CNG, the `expo-dev-client` plugin options that turn these off (`showMenuAtLaunch: false`, `skipOnboarding: true`) can't be applied from app config — this commits the native entries those options would generate, same approach as #6049.

## Changes

- Add `EXDevMenuIsOnboardingFinished: true` and `EXDevMenuShowsAtLaunch: false` to the iOS Info.plist and as `<meta-data>` in the AndroidManifest — the keys expo-dev-menu reads as seed defaults in debug builds ([iOS](https://github.com/expo/expo/blob/f5d56c05565e8dbb0cdc4bb5390f712f0ca620d4/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift#L29-L49), [Android](https://github.com/expo/expo/blob/f5d56c05565e8dbb0cdc4bb5390f712f0ca620d4/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt#L69-L70)). Per-device toggles in the dev menu settings still override these.
- The iOS preview target's `Info-preview.plist` gets the same two keys plus `EXDevMenuShowFloatingActionButton: false`, which #6049 only added to the main plist — so Debug builds of the preview scheme behave the same. Android needs nothing extra: the preview flavor manifest merges on top of main.
- `launchMode: 'most-recent'` needs no entry — launching the last-opened bundle is already the dev launcher [default](https://github.com/expo/expo/blob/f5d56c05565e8dbb0cdc4bb5390f712f0ca620d4/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt#L340).

## How did I test?

**Not yet verified on a rebuilt dev client** — worth confirming on your next dev build that the menu no longer auto-opens (it stays reachable via shake / three-finger long press / Cmd+D). Key names and default values checked against the SDK 56 sources linked above; all three files lint clean (`plutil -lint`, `xmllint`).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: dev-only tooling config — expo-dev-menu ships only in debug builds, so no production impact

## Rollback plan

Revert the commits; they only add config entries.

## Screenshots / videos

N/A — dev-tooling behavior (dev menu no longer auto-opens on launch).
