### PR TITLE
openclaw: let presence keepalive self-heal instead of tripping permanently

### DIFF
--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -2940,10 +2940,17 @@ export async function monitorTlonProvider(
             // callbacks, killing the thinking indicator for the rest of long
             // runs. stopRun is already wired to deliver/idle/cleanup.
             maxDurationMs: 0,
-            // The SDK default (2) trips the keepalive permanently after two
-            // transient poke failures, which lets the ship-side presence expire
-            // mid-run. Failures are already logged via onStartError.
-            maxConsecutiveFailures: 5,
+            // Any positive value permanently trips the keepalive guard after N
+            // consecutive poke failures — with no mid-run reset, that seals the
+            // indicator for the rest of the run. Long tool chains self-DoS the
+            // bot ship's Eyre (CLI pokes, scries, uploads, lens partials all on
+            // the same event loop as the 20s keepalive), and refresh failures
+            // cluster in exactly those runs. Setting 0 disables the trip: the
+            // loop keeps attempting every 20s, and the first successful poke
+            // after Eyre recovers re-publishes the full status — which
+            // re-creates the ship-side %computing entry even if the 90s TTL
+            // already expired it. Failures are still logged via onStartError.
+            maxConsecutiveFailures: 0,
           })
         : undefined;
 


### PR DESCRIPTION
## What this fixes

The "thinking..." indicator disappears mid-work on long tool-chain runs, and users assume the bot is broken. Traced to the SDK's typing-start guard: after N consecutive keepalive poke failures (currently 5) it sets a permanent trip flag and never resets it until the run ends. The ship-side \`%computing\` entry then expires at its 90s TTL and stays gone for the rest of the run — even after Eyre recovers.

Long runs cause exactly this because the gateway self-DoSes its own ship: CLI pokes, context scries, uploads, lens partials, and the 20s keepalive all contend on the same event loop. Refresh failures cluster in bursts precisely during heavy runs.

## The change

One line: \`maxConsecutiveFailures: 5\` → \`0\` in \`packages/openclaw/src/monitor/index.ts\`.

The SDK bundle at \`node_modules/openclaw/dist/typing-start-guard-*.js\` gates the trip in two places:
- constructor: \`typeof params.maxConsecutiveFailures === "number" && params.maxConsecutiveFailures > 0 ? Math.floor(...) : void 0\`
- trip branch: \`if (maxConsecutiveFailures && consecutiveFailures >= max) { tripped = true; ... }\`

Both are bypassed by \`0\` — the loop keeps attempting every 20s. Failures still log through the existing \`onStartError\`. The first successful poke after Eyre recovers re-publishes the full computing status, which **re-creates the entry even if the ship already expired it** — the indicator flickers instead of dying, and recovers on its own.

## What doesn't change

- Happy path: still one poke per 20s per active run.
- Stop semantics: delivery/idle/cleanup still stop the loop; stopped-run tombstones still prevent late-refresh resurrection.
- In-flight guard: hung pokes still can't stack concurrent ticks.

## The one downside

If failures are permanent (e.g. \`%presence\` uninstalled, every poke nacks forever), the old code silenced itself after 5. The new code logs one doomed poke every 20s for the run's duration (~3/min). If that noise matters we can demote repeat failures to debug after the first per-run, but it's arguably useful signal.

## Test plan

- [ ] \`pnpm --filter @tloncorp/openclaw tsc\` (CI)
- [ ] \`pnpm --filter @tloncorp/openclaw test src/monitor\` (CI)
- [ ] Live: run a \`~malmur-halmex\` / \`~sitrul-nacwyl\` deployment through a long tool chain (5+ min) under induced Eyre pressure and confirm the indicator survives or self-recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)