### PR TITLE
Fix presence expire timers eating refreshed runs

### DIFF
--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -139,20 +139,6 @@
   ?:  =(~ tos)  (~(del by places) context)
   (~(put by places) context tos)
 ::
-++  cancel-expire
-  |=  [=places key]
-  ^-  (list card)
-  =/  tos  (~(gut by places) context *topics)
-  =/  pes  (~(gut by tos) topic *people)
-  ?~  pre=(~(get by pes) ship)  ~
-  =/  end=@da
-    %+  add  since.u.pre
-    (fall timeout.u.pre (default-timeout topic))
-  :_  ~
-  :+  %pass
-    [%expire (scot %p ship) topic context]
-  [%arvo %b %rest end]
-::
 ++  give-update
   |=  [subs=(jug context ship) disclose=(set ship) upd=update-1]
   ^-  (list card)
@@ -348,7 +334,7 @@
       :+  (give-response %here +>.cmd)
         :+  %pass
           ::TODO  +key-wire
-          [%expire (scot %p ship.key.cmd) topic.key.cmd context.key.cmd]
+          [%expire (scot %da end) (scot %p ship.key.cmd) topic.key.cmd context.key.cmd]
         [%arvo %b %wait end]
       fus
     ::
@@ -356,7 +342,6 @@
       ::TODO  no-op if we didn't have it anyway
       :_  this(places (del-presence places key.cmd))
       ;:  weld
-        (cancel-expire places key.cmd)
         [(give-response %gone key.cmd)]~
         %+  give-update
           (~(del ju subs) context.key.cmd src.bowl)
@@ -557,18 +542,15 @@
             (give-response %here +.upd)
             :+  %pass
               ::TODO  +key-wire
-              [%expire (scot %p ship.key.upd) topic.key.upd context.key.upd]
+              [%expire (scot %da end) (scot %p ship.key.upd) topic.key.upd context.key.upd]
             [%arvo %b %wait end]
         ==
       ::
           %clear
         ::TODO  no-op if we didn't have it anyway
         :_  this(places (del-presence places key.upd))
-        ;:  weld
-          (cancel-expire places key.upd)
-          :~  (tell:log %dbug ~['context fact: %clear applied' >key.upd<] ~)
-              (give-response %gone key.upd)
-          ==
+        :~  (tell:log %dbug ~['context fact: %clear applied' >key.upd<] ~)
+            (give-response %gone key.upd)
         ==
       ==
     ==
@@ -630,14 +612,26 @@
         (watch-context our.bowl ship context)
     ==
   ::
-      [%expire @ topic *]
+      [%expire @ @ topic *]
     ::TODO  +wire-key
-    =/  =ship    (slav %p i.t.wire)
-    =*  topic    i.t.t.wire
-    =*  context  t.t.t.wire
+    =/  end=@da  (slav %da i.t.wire)
+    =/  =ship    (slav %p i.t.t.wire)
+    =*  topic    i.t.t.t.wire
+    =*  context  t.t.t.t.wire
     =*  key      [context ship topic]
-    ::TODO  no-op if we didn't have it anyway
-    =.  places   (del-presence places key)
+    ::  self-validating wake. each %set schedules a fresh timer keyed by its
+    ::  own end, so several may be live on this wire at once. only expire when
+    ::  the stored presence's end matches this wake (i.e. no later %set slid it
+    ::  forward); ignore superseded wakes, and ones whose presence is already
+    ::  gone (cleared, or expired by an earlier wake).
+    =/  tos  (~(gut by places) context *topics)
+    =/  pes  (~(gut by tos) topic *people)
+    ?~  pre=(~(get by pes) ship)  [~ this]
+    =/  cur=@da
+      %+  add  since.u.pre
+      (fall timeout.u.pre (default-timeout topic))
+    ?:  (gth cur end)  [~ this]
+    =.  places  (del-presence places key)
     [[(give-response %gone key)]~ this]
   ==
 ::


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this pull request does in 1-3 sentences. -->

## Changes

- `desk/app/presence.hoon`: embed the timer's `end` date in the `%expire` behn wire (`[%expire (scot %da end) (scot %p ship) topic context]`) at both the host `on-poke %presence-command-1 %set` and subscriber `on-agent %fact %set` scheduling sites.
- `on-arvo` now matches `[%expire @ @ topic *]` and makes the wake **self-validating**: it clears the presence only when the currently-stored presence's end is not later than the fired `end`; superseded wakes (a later `%set` slid the window forward) and wakes for already-gone presences no-op.
- Removed `+cancel-expire` and its two `%clear` call sites — proactive `%rest` is no longer needed now that stale timers validate themselves on fire.

### Why

The old wire was keyed only by `[ship topic context]`, and `%set` never rested the prior timer, so refreshes stacked multiple behn timers on the same wire. `on-arvo` deleted unconditionally, so the earliest timer fired and cleared a still-active presence — the computing/typing indicator flickered off roughly every timeout window during long runs, on both the host-local view and every subscriber. The plugin side (`packages/openclaw`) is designed for a sliding window (90s timeout, re-publish within 30s, 20s keepalive, `maxDurationMs: 0`) and correctly relies on each `%set` extending the ship-side expiry; the bug was entirely backend.

## How did I test?

- Diff reviewed for compile-correctness against `desk/sur/presence.hoon` (wire narrowing, `since.u.pre`/`timeout.u.pre` wing resolution, quip return types, `;: weld` arity). Traced the timer lifecycle by hand across set / refresh / clear / clear-then-reset races.
- ⚠️ Not yet exercised on a running `%groups` ship — needs a manual pass confirming the indicator stays lit through a long multi-tool run and clears promptly on completion.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: `%presence` agent (computing/typing indicators)

## Rollback plan

Revert this commit. The change is confined to `desk/app/presence.hoon`; the `%expire` wire format is internal to the agent (not persisted state or a cross-ship protocol mark), so no migration or coordinated deploy is required.

## Screenshots / videos

<!-- Attach any relevant media. -->