### PR TITLE
fix: unread queries return undefined and throw in React Query

### DIFF
--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -2523,9 +2523,11 @@ export const getGroupUnread = createReadQuery(
   'getGroupUnread',
   async ({ groupId }: { groupId: string }, ctx: QueryCtx) => {
     if (!groupId) return Promise.resolve(null);
-    return ctx.db.query.groupUnreads.findFirst({
-      where: and(eq($groupUnreads.groupId, groupId)),
-    });
+    return (
+      (await ctx.db.query.groupUnreads.findFirst({
+        where: and(eq($groupUnreads.groupId, groupId)),
+      })) ?? null
+    );
   },
   ['groupUnreads']
 );
@@ -2533,9 +2535,11 @@ export const getGroupUnread = createReadQuery(
 export const getBaseUnread = createReadQuery(
   'getBaseUnread',
   async (ctx: QueryCtx) => {
-    return ctx.db.query.baseUnreads.findFirst({
-      where: eq($baseUnreads.id, BASE_UNREADS_SINGLETON_KEY),
-    });
+    return (
+      (await ctx.db.query.baseUnreads.findFirst({
+        where: eq($baseUnreads.id, BASE_UNREADS_SINGLETON_KEY),
+      })) ?? null
+    );
   },
   ['baseUnreads']
 );


### PR DESCRIPTION
## Summary

On mobile, a red error toast — `Query data cannot be undefined … Affected query key: ["baseUnreads",{}]` — fires repeatedly on the home screen and in channels for logged-in users. `getBaseUnread` returns Drizzle's `findFirst()` directly, which resolves to `undefined` when the singleton `base_unreads` row doesn't exist yet (it's only written on the first activity update, never seeded). React Query v5 rejects an `undefined` query result, so `useBaseUnread` — mounted app-wide by `useSyncAppBadge` — throws until that row first appears.

## Changes

Coerce the possibly-`undefined` result to `null` in `getBaseUnread`, and in its sibling `getGroupUnread`, which has the same `findFirst`→`undefined` hazard.

## How did I test?

Reproduced the recurring error toast on a logged-in mobile build (the `baseUnreads` query mounts unconditionally via `useSyncAppBadge` in `AuthenticatedApp`). The failure is a RQ-v5 invariant (`queryFn` must not return `undefined`), so the `?? null` removes the throw. No behavior change for consumers — `useSyncAppBadge` already guards on `!baseUnread?.notifTimestamp`, so `null` is handled identically to a missing row.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] State / providers

Tiny, contained: a `?? null` on two local read queries. Worst case is nil — the consumers already treat "no data" as null.

## Rollback plan

Revert this PR.

## Screenshots / videos

N/A — removes an error toast; no intended visual change.
