### PR TITLE
ops: require tag for livenet deploys

### DIFF
--- a/.github/workflows/deploy-livenet.yml
+++ b/.github/workflows/deploy-livenet.yml
@@ -12,6 +12,16 @@ jobs:
     name: "Release to ~sogryp-dister-dozzod-dozzod (livenet)"
     steps:
       - uses: actions/checkout@v3
+      - id: 'tag-validate'
+        env:
+          TAG: ${{inputs.tag}}
+        run: |
+          git fetch origin tag "$TAG" || true
+          if ! git show-ref --verify --quiet refs/tags/"$TAG"
+          then
+            echo "Invalid release tag \"$TAG\""
+            exit 1
+          fi
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:


### PR DESCRIPTION
## Summary

We should require that a proper tag is assigned *before* a release is deployed to livenet.
Misusing the branch name as the tag for livenet deploys makes it quite hard to find out the commit that was actually deployed to ships. (It seems like that might be further muddled by automatic glob update; we will look into that later.)

## Changes

1. Verify that the submitted tag is actually a git tag.

## How did I test?

Tested locally with act. Deploying from `develop` or `staging` fails and aborts the deploy. Deploying from a tag such as `v11.4.0` succeeds.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.
