### PR TITLE
hermes: add notes to hermes tlon tool allowlist

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -12,7 +12,7 @@ This first pass keeps the integration deliberately small:
 -   group dispatches carry recent channel/thread history as context
 -   DMs dispatch directly, deny-by-default: unknown senders queue for owner approval with rich A2UI approve/deny cards
 
-The model-visible `tlon` tool is not a delivery path. It blocks `posts send`, `posts reply`, `dms send`, `dms reply`, and `notebook` so normal replies stay inside Hermes' platform delivery path (`TlonAdapter.send()`).
+The model-visible `tlon` tool is not a delivery path. It blocks text `posts send`, `posts reply`, `dms send`, and `dms reply` when they target the current conversation, so normal replies stay inside Hermes' platform delivery path (`TlonAdapter.send()`); proactive sends to other channels/DMs and `--image` sends anywhere remain allowed. It separately blocks `notebook`, since the `%diary` backend is removed — use `tlon notes` for `%notes` notebooks.
 
 When this package can find `@tloncorp/tlon-skill/SKILL.md`, it registers that file as the explicit plugin skill `tlon-platform:tlon`. The model-facing tool and platform hint point at `skill_view("tlon-platform:tlon")`, which works the same way in dev and production because the skill registration travels with the plugin. Set `TLON_SKILL_PATH` when the skill file lives somewhere non-standard.
 

--- a/packages/hermes-tlon-adapter/prompts/hermes/.hermes.md
+++ b/packages/hermes-tlon-adapter/prompts/hermes/.hermes.md
@@ -6,9 +6,9 @@
 
 ## Hermes Delivery Rules
 
-For normal replies in the current Tlon conversation, reply with normal assistant text and let Hermes deliver it through the Tlon platform adapter. Do not use `tlon posts send`, `tlon posts reply`, `tlon dms send`, `tlon dms reply`, or `tlon notebook` for normal chat replies.
+For normal replies in the current Tlon conversation, reply with normal assistant text and let Hermes deliver it through the Tlon platform adapter. Do not use `tlon posts send`, `tlon posts reply`, `tlon dms send`, or `tlon dms reply` for normal chat replies.
 
-The `tlon` tool is for reads, administration, profile updates, uploads, and management. If the user asks for a proactive cross-platform send and Hermes has a `send_message` tool available, use that tool so delivery still routes through Hermes.
+The `tlon` tool is for reads, administration, profile updates, uploads, %notes notebooks, and management. If the user asks for a proactive cross-platform send and Hermes has a `send_message` tool available, use that tool so delivery still routes through Hermes.
 
 Hermes session context shows the platform user id, chat id, channel id, and thread id when available. Use those exact ids for Tlon operations. Compare the session user id with `{{TLON_OWNER_SHIP}}` when deciding whether the sender is the owner.
 

--- a/packages/hermes-tlon-adapter/prompts/shared/tool-discipline.md
+++ b/packages/hermes-tlon-adapter/prompts/shared/tool-discipline.md
@@ -1,6 +1,6 @@
 ## Tool Discipline
 
-Use the `tlon` tool for Tlon reads, profile management, group/channel administration, contacts, settings, uploads, exposes, hooks, and message history.
+Use the `tlon` tool for Tlon reads, profile management, group/channel administration, contacts, settings, uploads, exposes, hooks, %notes notebooks, and message history.
 
 Do not guess `tlon` command syntax. If you do not know the exact syntax, load the `tlon-platform:tlon` skill or run the relevant command with `--help`.
 

--- a/packages/hermes-tlon-adapter/test_tlon_tool.py
+++ b/packages/hermes-tlon-adapter/test_tlon_tool.py
@@ -18,6 +18,30 @@ package.__path__ = [str(PACKAGE_DIR)]
 sys.modules[PACKAGE_NAME] = package
 
 
+# Minimal stand-ins for the gateway package so ``adapter`` imports at module
+# load. Only the names ``adapter`` binds are needed; ``block_tlon_session_tool``
+# never instantiates the adapter, so trivial classes suffice.
+class _StubBasePlatformAdapter:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+gateway = types.ModuleType("gateway")
+gateway_config = types.ModuleType("gateway.config")
+gateway_config.Platform = type("Platform", (), {})
+gateway_config.PlatformConfig = type("PlatformConfig", (), {})
+gateway_platforms = types.ModuleType("gateway.platforms")
+gateway_base = types.ModuleType("gateway.platforms.base")
+gateway_base.BasePlatformAdapter = _StubBasePlatformAdapter
+gateway_base.MessageEvent = type("MessageEvent", (), {})
+gateway_base.MessageType = type("MessageType", (), {"TEXT": "text"})
+gateway_base.SendResult = type("SendResult", (), {})
+sys.modules["gateway"] = gateway
+sys.modules["gateway.config"] = gateway_config
+sys.modules["gateway.platforms"] = gateway_platforms
+sys.modules["gateway.platforms.base"] = gateway_base
+
+
 def load_module(name):
     module_name = f"{PACKAGE_NAME}.{name}"
     spec = importlib.util.spec_from_file_location(module_name, PACKAGE_DIR / f"{name}.py")
@@ -29,6 +53,7 @@ def load_module(name):
 
 tlon_api = load_module("tlon_api")
 tlon_tool = load_module("tlon_tool")
+adapter_mod = load_module("adapter")
 
 
 class TlonToolGuardTests(unittest.TestCase):
@@ -120,6 +145,34 @@ class TlonToolGuardTests(unittest.TestCase):
         blocked = tlon_tool.check_tlon_tool_command(args)
         self.assertIsNotNone(blocked)
         self.assertIn("notebook", blocked.lower())
+        # The redirect must point at the replacement, not the removed backend.
+        self.assertIn("notes", blocked.lower())
+
+    def test_allows_notes_read_and_write_commands(self):
+        # %notes replaced the removed %diary/notebook backend; reads and writes
+        # both pass the tool guard (owner gating happens at the session level).
+        for command in (
+            "notes list",
+            "notes note notes/~zod/docs 12",
+            'notes note-create notes/~zod/docs root "Title" --markdown post.md',
+            "notes note-update notes/~zod/docs 12 --body new.md",
+            "notes note-delete notes/~zod/docs 12",
+        ):
+            with self.subTest(command=command):
+                args, error = tlon_tool.split_tlon_command(command)
+                self.assertIsNone(error)
+                self.assertIsNone(tlon_tool.check_tlon_tool_command(args))
+
+    def test_notes_writes_not_caught_by_current_conversation_block(self):
+        # notes never targets a chat conversation, so the send block (which
+        # protects the current chat) must not fire even when a chat is active.
+        args, error = tlon_tool.split_tlon_command(
+            'notes note-create notes/~zod/docs root "Title" --stdin'
+        )
+        self.assertIsNone(error)
+        self.assertIsNone(
+            tlon_tool.check_tlon_tool_command(args, session_chat_id="chat/~zod/general")
+        )
 
     def test_allows_read_and_admin_commands(self):
         for command in (
@@ -200,6 +253,9 @@ class TlonToolGuardTests(unittest.TestCase):
         blocked = tlon_tool.check_tlon_tool_command(args)
         self.assertIsNotNone(blocked)
         self.assertIn("Unknown tlon subcommand", blocked)
+        # The block advertises the allowlist, which now includes notes.
+        self.assertIn("Allowed:", blocked)
+        self.assertIn("notes", blocked)
 
     def test_normalizes_global_help_and_version_aliases(self):
         self.assertEqual(tlon_tool.normalize_global_command_args(["help"]), ["--help"])
@@ -237,6 +293,33 @@ class TlonToolExecutionTests(unittest.TestCase):
         self.assertEqual(payload["stdout"], "~zod\n")
         self.assertEqual(calls[0][0], ("tlon-test", "contacts", "self"))
         self.assertEqual(calls[0][1]["TLON_NODE_URL"], "https://zod.tlon.network")
+
+    def test_execute_tlon_tool_runs_notes_command(self):
+        calls = []
+        cfg = tlon_api.TlonConfig.from_env(
+            env={
+                "TLON_NODE_URL": "https://zod.tlon.network",
+                "TLON_NODE_ID": "~zod",
+                "TLON_ACCESS_CODE": "code",
+                "TLON_CLI": "tlon-test",
+            }
+        )
+
+        async def runner(command, env, timeout):
+            calls.append(tuple(command))
+            return tlon_api.TlonProcessResult(returncode=0, stdout="[]\n")
+
+        async def run():
+            return await tlon_tool.execute_tlon_tool(
+                {"command": "notes list"},
+                config=cfg,
+                runner=runner,
+            )
+
+        payload = json.loads(asyncio.run(run()))
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(calls[0], ("tlon-test", "notes", "list"))
 
     def test_execute_tlon_tool_does_not_run_blocked_command(self):
         async def runner(command, env, timeout):
@@ -353,6 +436,48 @@ class TlonSkillPathTests(unittest.TestCase):
                 tlon_tool.resolve_tlon_skill_path({"TLON_SKILL_DIR": str(skill_dir)}),
                 skill,
             )
+
+
+class TlonSessionGateTests(unittest.TestCase):
+    """The `tlon` tool is owner-only in Tlon chat sessions.
+
+    Enforcement lives in ``block_tlon_session_tool`` and is arg-independent — it
+    gates the whole tool before any command is parsed, so every ``notes``
+    subcommand (read or write) inherits the gate. These cases prove that for a
+    notes write, mirroring the existing send-block coverage.
+    """
+
+    NOTES_WRITE = {"command": 'notes note-create notes/~pen/docs root "T" --stdin'}
+
+    def test_blocks_notes_write_for_non_owner(self):
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "tlon",
+                "HERMES_SESSION_USER_ID": "~mug",
+                "TLON_OWNER_SHIP": "~pen",
+            },
+            clear=True,
+        ):
+            block = adapter_mod.block_tlon_session_tool("tlon", self.NOTES_WRITE)
+
+        self.assertIsNotNone(block)
+        self.assertEqual(block["action"], "block")
+        self.assertIn("owner-only", block["message"])
+
+    def test_allows_notes_write_for_owner(self):
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "tlon",
+                "HERMES_SESSION_USER_ID": "~pen",
+                "TLON_OWNER_SHIP": "~pen",
+            },
+            clear=True,
+        ):
+            block = adapter_mod.block_tlon_session_tool("tlon", self.NOTES_WRITE)
+
+        self.assertIsNone(block)
 
 
 if __name__ == "__main__":

--- a/packages/hermes-tlon-adapter/test_tlon_tool.py
+++ b/packages/hermes-tlon-adapter/test_tlon_tool.py
@@ -187,7 +187,7 @@ class TlonToolGuardTests(unittest.TestCase):
                 blocked = tlon_tool.check_tlon_tool_command(args)
                 self.assertIsNotNone(blocked)
                 self.assertIn("--stdin", blocked)
-                self.assertIn("--markdown", blocked)
+                self.assertIn("--body", blocked)
 
     def test_allows_read_and_admin_commands(self):
         for command in (

--- a/packages/hermes-tlon-adapter/test_tlon_tool.py
+++ b/packages/hermes-tlon-adapter/test_tlon_tool.py
@@ -167,12 +167,27 @@ class TlonToolGuardTests(unittest.TestCase):
         # notes never targets a chat conversation, so the send block (which
         # protects the current chat) must not fire even when a chat is active.
         args, error = tlon_tool.split_tlon_command(
-            'notes note-create notes/~zod/docs root "Title" --stdin'
+            'notes note-create notes/~zod/docs root "Title" --markdown post.md'
         )
         self.assertIsNone(error)
         self.assertIsNone(
             tlon_tool.check_tlon_tool_command(args, session_chat_id="chat/~zod/general")
         )
+
+    def test_blocks_notes_stdin_content_source(self):
+        # Hermes only passes argv to the tlon subprocess; it cannot stream a
+        # Markdown body on stdin. File-backed notes writes remain allowed.
+        for command in (
+            'notes note-create notes/~zod/docs root "Title" --stdin',
+            "notes note-update notes/~zod/docs 12 --stdin",
+        ):
+            with self.subTest(command=command):
+                args, error = tlon_tool.split_tlon_command(command)
+                self.assertIsNone(error)
+                blocked = tlon_tool.check_tlon_tool_command(args)
+                self.assertIsNotNone(blocked)
+                self.assertIn("--stdin", blocked)
+                self.assertIn("--markdown", blocked)
 
     def test_allows_read_and_admin_commands(self):
         for command in (
@@ -447,7 +462,9 @@ class TlonSessionGateTests(unittest.TestCase):
     notes write, mirroring the existing send-block coverage.
     """
 
-    NOTES_WRITE = {"command": 'notes note-create notes/~pen/docs root "T" --stdin'}
+    NOTES_WRITE = {
+        "command": 'notes note-create notes/~pen/docs root "T" --markdown body.md'
+    }
 
     def test_blocks_notes_write_for_non_owner(self):
         with patch.dict(

--- a/packages/hermes-tlon-adapter/tlon_tool.py
+++ b/packages/hermes-tlon-adapter/tlon_tool.py
@@ -23,6 +23,7 @@ ALLOWED_TLON_COMMANDS = frozenset(
         "hooks",
         "messages",
         "notebook",
+        "notes",
         "posts",
         "settings",
         "upload",
@@ -48,7 +49,9 @@ SEND_OPERATIONS = {
 
 TLON_TOOL_DESCRIPTION = (
     "Tlon/Urbit CLI for reading data and administration: activity, channels, "
-    "contacts, groups, messages, posts, settings, upload, expose, hooks. "
+    "contacts, groups, messages, notes, posts, settings, upload, expose, hooks. "
+    "Use the notes commands to manage %notes notebooks (Markdown notes at "
+    "notes/~host/name nests). "
     "The bot node has its own Tlon profile; when the configured owner asks "
     "to change the bot nickname, avatar, bio, status, or cover image, use "
     "contacts update-profile. For avatars/covers, upload a direct raster "
@@ -100,7 +103,7 @@ TLON_TOOL_SCHEMA = {
                     "instead) EXCEPT image sends: 'posts send <target> "
                     "[caption] --image <uploaded-url>' is allowed anywhere — "
                     "upload first with 'upload <direct-image-url>'. 'notebook' "
-                    "is blocked."
+                    "is removed; use 'notes' commands for %notes notebooks."
                 ),
             }
         },
@@ -274,8 +277,10 @@ def check_tlon_tool_command(
     action = command_args[1] if len(command_args) > 1 else ""
     if subcommand == "notebook":
         return (
-            "Blocked: notebook posting is not available through this tool. Use "
-            "channel posts instead."
+            "Blocked: the notebook command is removed (the %diary backend no "
+            "longer exists). Use the 'tlon notes' commands to manage %notes "
+            "notebooks instead, e.g. 'notes list' or 'notes note-create "
+            'notes/~host/name root "Title" --markdown file.md\'.'
         )
     if (
         (subcommand, action) in SEND_OPERATIONS

--- a/packages/hermes-tlon-adapter/tlon_tool.py
+++ b/packages/hermes-tlon-adapter/tlon_tool.py
@@ -51,7 +51,8 @@ TLON_TOOL_DESCRIPTION = (
     "Tlon/Urbit CLI for reading data and administration: activity, channels, "
     "contacts, groups, messages, notes, posts, settings, upload, expose, hooks. "
     "Use the notes commands to manage %notes notebooks (Markdown notes at "
-    "notes/~host/name nests). "
+    "notes/~host/name nests). For notes bodies, use --body/--markdown files; "
+    "--stdin is blocked because Hermes cannot pipe stdin into the CLI process. "
     "The bot node has its own Tlon profile; when the configured owner asks "
     "to change the bot nickname, avatar, bio, status, or cover image, use "
     "contacts update-profile. For avatars/covers, upload a direct raster "
@@ -103,7 +104,8 @@ TLON_TOOL_SCHEMA = {
                     "instead) EXCEPT image sends: 'posts send <target> "
                     "[caption] --image <uploaded-url>' is allowed anywhere — "
                     "upload first with 'upload <direct-image-url>'. 'notebook' "
-                    "is removed; use 'notes' commands for %notes notebooks."
+                    "is removed; use 'notes' commands for %notes notebooks. "
+                    "For notes bodies, use --body/--markdown files, not --stdin."
                 ),
             }
         },
@@ -236,6 +238,10 @@ def _has_image_flag(args: Sequence[str]) -> bool:
     )
 
 
+def _has_stdin_flag(args: Sequence[str]) -> bool:
+    return any(str(arg) == "--stdin" for arg in args)
+
+
 def _send_targets_current_conversation(
     args: Sequence[str],
     sub_idx: int,
@@ -281,6 +287,12 @@ def check_tlon_tool_command(
             "longer exists). Use the 'tlon notes' commands to manage %notes "
             "notebooks instead, e.g. 'notes list' or 'notes note-create "
             'notes/~host/name root "Title" --markdown file.md\'.'
+        )
+    if subcommand == "notes" and _has_stdin_flag(args[sub_idx:]):
+        return (
+            "Blocked: notes --stdin is not available through this tool because "
+            "Hermes cannot pipe stdin into the tlon CLI process. Write the "
+            "Markdown body to a file and use --body <file> or --markdown <file>."
         )
     if (
         (subcommand, action) in SEND_OPERATIONS

--- a/packages/hermes-tlon-adapter/tlon_tool.py
+++ b/packages/hermes-tlon-adapter/tlon_tool.py
@@ -51,8 +51,9 @@ TLON_TOOL_DESCRIPTION = (
     "Tlon/Urbit CLI for reading data and administration: activity, channels, "
     "contacts, groups, messages, notes, posts, settings, upload, expose, hooks. "
     "Use the notes commands to manage %notes notebooks (Markdown notes at "
-    "notes/~host/name nests). For notes bodies, use --body/--markdown files; "
-    "--stdin is blocked because Hermes cannot pipe stdin into the CLI process. "
+    "notes/~host/name nests). For notes bodies, use --body <file> "
+    "(note-create also accepts --markdown <file>); --stdin is blocked because "
+    "Hermes cannot pipe stdin into the CLI process. "
     "The bot node has its own Tlon profile; when the configured owner asks "
     "to change the bot nickname, avatar, bio, status, or cover image, use "
     "contacts update-profile. For avatars/covers, upload a direct raster "
@@ -105,7 +106,8 @@ TLON_TOOL_SCHEMA = {
                     "[caption] --image <uploaded-url>' is allowed anywhere — "
                     "upload first with 'upload <direct-image-url>'. 'notebook' "
                     "is removed; use 'notes' commands for %notes notebooks. "
-                    "For notes bodies, use --body/--markdown files, not --stdin."
+                    "For notes bodies, use --body <file>; note-create also "
+                    "accepts --markdown <file>. Do not use --stdin."
                 ),
             }
         },
@@ -292,7 +294,7 @@ def check_tlon_tool_command(
         return (
             "Blocked: notes --stdin is not available through this tool because "
             "Hermes cannot pipe stdin into the tlon CLI process. Write the "
-            "Markdown body to a file and use --body <file> or --markdown <file>."
+            "Markdown body to a file and use --body <file>."
         )
     if (
         (subcommand, action) in SEND_OPERATIONS

--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -458,7 +458,8 @@ tlon notes list                                          # List your notebooks
 tlon notes show notes/~host/name                         # Show a notebook
 tlon notes notes notes/~host/name                        # List notes in a notebook
 tlon notes note notes/~host/name 12                      # Show a note (with Markdown body)
-tlon notes note-create notes/~host/name root "Title" --markdown post.md   # New note at the notebook root
+tlon notes note-create notes/~host/name root "Title" --body post.md       # New note at the notebook root
+tlon notes note-create notes/~host/name root "Title" --markdown post.md   # Alias for --body on note-create
 tlon notes note-create notes/~host/name 7 "Title" --stdin                 # New note in folder 7 from stdin
 tlon notes note-update notes/~host/name 12 --body new.md --expected-revision 3
 tlon notes note-rename notes/~host/name 12 "New Title"   # Rename a note
@@ -476,10 +477,12 @@ tlon notes join notes/~host/name                         # Join a notebook
 tlon notes leave notes/~host/name                        # Leave a notebook
 ```
 
-Note bodies come from exactly one of `--body <file>`, `--markdown <file>` (alias),
-or `--stdin`. `note-create` places the note in a folder id, or `root` (resolved to
-the notebook's root folder). `--expected-revision` on `note-update` is optional
-(last-write-wins by default).
+Note bodies come from exactly one content source. `note-create` accepts
+`--body <file>`, `--markdown <file>` (alias), or `--stdin`. `note-update`
+accepts `--body <file>` or `--stdin`; use `--body`, not `--markdown`, for
+file-backed updates. `note-create` places the note in a folder id, or `root`
+(resolved to the notebook's root folder). `--expected-revision` on `note-update`
+is optional (last-write-wins by default).
 
 To create a **group-backed** notes channel for the Tlon app, use `tlon channels
 create ~host/slug "Title" --kind notes` — %notes owns the listing, so


### PR DESCRIPTION
## Summary

Fixes TLON-6094

Adds `notes` to the Hermes `tlon` tool command allowlist so bots can manage `%notes` notebooks, matching the OpenClaw allowlist. The Hermes tool now also blocks stdin-backed notes bodies, since the adapter can only pass argv to the `tlon` CLI and cannot pipe content into `process.stdin`.

## Changes

- Added `notes` to `ALLOWED_TLON_COMMANDS` in `packages/hermes-tlon-adapter/tlon_tool.py` so the model-visible `tlon` tool can run `tlon notes ...` commands.
- Updated the `notebook` block message to explain that the `%diary` backend is removed and redirect to `tlon notes`.
- Refreshed the tool description and schema text to mention notes, steer file-backed note bodies toward `--body <file>`, and explain that `--stdin` is blocked in Hermes.
- Blocked `tlon notes ... --stdin` in the Hermes guard because `execute_tlon_tool` cannot provide stdin to the CLI subprocess.
- Updated the managed prompts (`.hermes.md`, `tool-discipline.md`) and README to mention notes and remove notebook-era wording.
- Updated `packages/tlon-skill/SKILL.md` so the notes guidance matches the actual CLI parser: `note-create` supports `--body`/`--markdown`, while `note-update` uses `--body` for file-backed updates.
- Added unit tests covering: notes reads and writes passing the guard, `notes ... --stdin` being blocked, `notebook` staying blocked with the new redirect, and a session-gate pair showing notes writes inherit the existing owner-only gate (non-owner blocked, owner allowed).

## How did I test?

- `cd packages/hermes-tlon-adapter && python3 -m unittest test_tlon_tool.py`
- `cd packages/hermes-tlon-adapter && ./dev/test.sh`
- Checked the final docs-only `SKILL.md` update with `git diff --check`.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: hermes adapter

## Rollback plan

Revert
