### PR TITLE
Web notebook editor and sidebar fixes

### DIFF
--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -120,6 +120,14 @@ export function NotesNativeChannel({
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const isFocused = useIsFocused();
   const { shipUrl } = useShip();
+  // Browser web never sets shipUrl in the ship context (only the native and
+  // desktop login flows do). The web app is served by the ship itself, so
+  // published paths resolve against the current origin.
+  const publishedUrlBase =
+    shipUrl ||
+    (Platform.OS === 'web' && typeof window !== 'undefined'
+      ? window.location.origin
+      : null);
   const isWindowNarrow = useIsWindowNarrow();
   const showToast = useToast();
   const useDesktopSplit = Platform.OS === 'web' && !isWindowNarrow;
@@ -213,16 +221,16 @@ export function NotesNativeChannel({
 
       return publishedNoteUrl(
         publishedNotePath(notebookFlag, note.noteId),
-        shipUrl
+        publishedUrlBase
       );
     },
-    [notebookFlag, shipUrl]
+    [notebookFlag, publishedUrlBase]
   );
   const getPublishedNoteShareUrl = useMemo(
     () => (publishedPath: string) => {
-      return publishedNoteUrl(publishedPath, shipUrl);
+      return publishedNoteUrl(publishedPath, publishedUrlBase);
     },
-    [shipUrl]
+    [publishedUrlBase]
   );
   const handleNoteDraftChange = useMutableCallback(
     (draft: NotesNoteDraftSnapshot | null) => {
@@ -512,6 +520,7 @@ export function NotesNativeChannel({
     setPublishingAction('publish');
     try {
       let publishedUrl: string | null = null;
+      let published = false;
       await runAction('Failed to publish note', async () => {
         const content = getNotePublishContent(note);
         const publishedPath = await publishNotebookNote({
@@ -522,6 +531,7 @@ export function NotesNativeChannel({
         });
         await refetchPublishedNotes();
         publishedUrl = getPublishedNoteShareUrl(publishedPath);
+        published = true;
       });
 
       if (publishedUrl) {
@@ -539,6 +549,10 @@ export function NotesNativeChannel({
           trackNotesActionError('copy published note link', e, message);
           setError(message);
         }
+      } else if (published) {
+        // No share URL could be built; the publish itself still succeeded,
+        // so don't leave the user without feedback.
+        showToast({ message: 'Published note.', duration: 2000 });
       }
     } finally {
       setPublishingAction(null);
@@ -550,13 +564,18 @@ export function NotesNativeChannel({
 
     setPublishingAction('unpublish');
     try {
+      let unpublished = false;
       await runAction('Failed to unpublish note', async () => {
         await unpublishNotebookNote({
           notebookFlag,
           noteId: note.noteId,
         });
         await refetchPublishedNotes();
+        unpublished = true;
       });
+      if (unpublished) {
+        showToast({ message: 'Unpublished note.', duration: 2000 });
+      }
     } finally {
       setPublishingAction(null);
     }

--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -848,7 +848,7 @@ export function NotesNativeChannel({
       ) : (
         <NotesNoteDetail
           autoFocusTitle={focusTitleNoteId === selectedNoteId}
-          headerActionsPlacement="inline"
+          headerActionsPlacement="channel-header"
           noteId={selectedNoteId}
           notebookFlag={notebookFlag}
           onDraftChange={handleNoteDraftChange}

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -437,12 +437,26 @@ export function NotesNoteDetail({
 
   useEffect(() => {
     if (!autoFocusTitle || !selectedNoteRowId || !canEdit) return;
+    if (isPreviewing) {
+      // The title is a locked display field in preview mode, so renaming
+      // needs the editor. Leaving preview re-runs this effect with the
+      // editable input mounted, and the focus below can land.
+      setPreviewMode(false);
+      return;
+    }
     const timeout = setTimeout(() => {
       titleInputRef.current?.focus();
       onTitleAutoFocused?.();
     });
     return () => clearTimeout(timeout);
-  }, [autoFocusTitle, canEdit, onTitleAutoFocused, selectedNoteRowId]);
+  }, [
+    autoFocusTitle,
+    canEdit,
+    isPreviewing,
+    onTitleAutoFocused,
+    selectedNoteRowId,
+    setPreviewMode,
+  ]);
 
   // All saves go through one chain so each rebases onto the revision the
   // previous save produced instead of racing the backend revision check.

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -20,12 +20,21 @@ import {
   NativeScrollEvent,
   NativeSyntheticEvent,
 } from 'react-native';
-import { Input, ScrollView, TextArea, XStack, YStack } from 'tamagui';
+import {
+  Input,
+  ScrollView,
+  TextArea,
+  XStack,
+  YStack,
+  getTokenValue,
+  isWeb,
+} from 'tamagui';
 
 import {
   useRegisterChannelHeaderItem,
   useRegisterChannelHeaderLoadingSubtitle,
 } from '../Channel/ChannelHeader';
+import { TextInput, type TextInputRef } from '../Form';
 import { NotebookContentRenderer } from '../NotebookPost/NotebookPost';
 import { ScreenHeader } from '../ScreenHeader';
 import {
@@ -43,6 +52,7 @@ type SaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
 // covered by the flush paths and the draft stash either way.
 const AUTOSAVE_DEBOUNCE_MS = 10_000;
 const MIN_BODY_INPUT_HEIGHT = 360;
+const NOTE_COLUMN_MAX_WIDTH = 760;
 const BODY_FONT_SIZE = 14;
 const BODY_LINE_HEIGHT = 22;
 const BODY_MONO_CHAR_WIDTH = BODY_FONT_SIZE * 0.62;
@@ -238,11 +248,7 @@ export function NotesNoteDetail({
   );
   const titleDraftRef = useRef(titleDraft);
   const bodyDraftRef = useRef(bodyDraft);
-  const pendingBodyDraftRef = useRef<string | null>(null);
-  const bodyDraftUpdateTimeoutRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  const titleInputRef = useRef<ElementRef<typeof Input>>(null);
+  const titleInputRef = useRef<TextInputRef>(null);
   const bodyInputRef = useRef<ElementRef<typeof TextArea>>(null);
   const scrollViewRef = useRef<ElementRef<typeof ScrollView>>(null);
   const scrollOffsetYRef = useRef(0);
@@ -269,6 +275,11 @@ export function NotesNoteDetail({
         bodyDraft !== draftBase.bodyMd)
   );
   const previewState = useMemo(() => {
+    // Markdown conversion is too expensive to run per keystroke; only
+    // compute it when the preview pane is actually visible.
+    if (!isPreviewing) {
+      return { content: [], error: null };
+    }
     try {
       return {
         content: convertContent(markdownToStory(bodyDraft), null),
@@ -280,11 +291,24 @@ export function NotesNoteDetail({
         error: errorMessage(e, 'Unable to render Markdown preview'),
       };
     }
-  }, [bodyDraft]);
+  }, [bodyDraft, isPreviewing]);
+  // On web the editor pane is pinned to the viewport and the textarea
+  // scrolls its own content, so the body input spans the full pane and
+  // fakes the centered note column with horizontal padding. Native keeps
+  // the grow-to-content textarea inside the page scroll.
+  const useWebEditorPane = isWeb && !isPreviewing;
   const bodyInputHeight = useMemo(
-    () => estimateBodyInputHeight(bodyDraft, bodyInputWidth),
-    [bodyDraft, bodyInputWidth]
+    () =>
+      useWebEditorPane ? 0 : estimateBodyInputHeight(bodyDraft, bodyInputWidth),
+    [bodyDraft, bodyInputWidth, useWebEditorPane]
   );
+  const bodyEditorPadding = useMemo(() => {
+    const basePadding = getTokenValue('$xl', 'space');
+    if (!bodyInputWidth) return basePadding;
+    return (
+      Math.max((bodyInputWidth - NOTE_COLUMN_MAX_WIDTH) / 2, 0) + basePadding
+    );
+  }, [bodyInputWidth]);
   const folderPath = useMemo(
     () =>
       selectedNote
@@ -372,31 +396,6 @@ export function NotesNoteDetail({
     selectedNote,
   ]);
 
-  useEffect(() => {
-    return () => {
-      if (bodyDraftUpdateTimeoutRef.current !== null) {
-        clearTimeout(bodyDraftUpdateTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const flushPendingBodyDraft = useCallback(() => {
-    if (bodyDraftUpdateTimeoutRef.current !== null) {
-      clearTimeout(bodyDraftUpdateTimeoutRef.current);
-      bodyDraftUpdateTimeoutRef.current = null;
-    }
-
-    const pendingBody = pendingBodyDraftRef.current;
-    pendingBodyDraftRef.current = null;
-    if (pendingBody === null || bodyDraftRef.current === pendingBody) {
-      return bodyDraftRef.current;
-    }
-
-    bodyDraftRef.current = pendingBody;
-    setBodyDraft(pendingBody);
-    return pendingBody;
-  }, []);
-
   const preserveScrollOffset = useCallback(() => {
     if (isPreviewing) return;
     pendingScrollRestoreYRef.current = Math.max(
@@ -473,7 +472,7 @@ export function NotesNoteDetail({
 
   const saveSelectedNote = useCallback(async () => {
     if (!notebookFlag || !draftBase || !canEdit) return false;
-    const bodyToSave = flushPendingBodyDraft();
+    const bodyToSave = bodyDraftRef.current;
     const dirty =
       normalizeNotebookNoteTitle(titleDraft) !== draftBase.title ||
       bodyToSave !== draftBase.bodyMd;
@@ -525,7 +524,6 @@ export function NotesNoteDetail({
   }, [
     canEdit,
     draftBase,
-    flushPendingBodyDraft,
     notebookFlag,
     preserveScrollOffset,
     runSave,
@@ -533,7 +531,15 @@ export function NotesNoteDetail({
   ]);
 
   useEffect(() => {
-    if (!isDirty || !canEdit || saveState === 'saving') return;
+    if (!canEdit || saveState === 'saving') return;
+    if (!isDirty) {
+      // Edits were reverted back to the saved content; there's nothing to
+      // save, so don't leave a stale "Not synced" showing.
+      if (saveState === 'dirty') {
+        setSaveState('idle');
+      }
+      return;
+    }
     setSaveState('dirty');
     const timeout = setTimeout(() => {
       saveSelectedNote();
@@ -559,7 +565,7 @@ export function NotesNoteDetail({
   });
 
   const flushPendingSave = useCallback(() => {
-    const bodyToSave = flushPendingBodyDraft();
+    const bodyToSave = bodyDraftRef.current;
     const titleToSave = titleDraftRef.current;
     const ctx = flushCtxRef.current;
     if (!ctx || !ctx.flag || !ctx.base || !ctx.canEdit) return;
@@ -597,7 +603,7 @@ export function NotesNoteDetail({
         setSaveState('saved');
       })
       .catch(() => {});
-  }, [flushPendingBodyDraft, preserveScrollOffset, runSave]);
+  }, [preserveScrollOffset, runSave]);
 
   // Flush unsaved work when switching notes or unmounting — the poke
   // outlives the component.
@@ -615,12 +621,30 @@ export function NotesNoteDetail({
     return () => subscription.remove();
   }, [flushPendingSave]);
 
+  // Guard so the stash restore below runs once per loaded note revision.
+  // Without it, any edit that brings the content back to the saved state
+  // (type a char, then delete it) flips the editor clean again and the
+  // restore effect re-applies the stash — resurrecting the deleted edit
+  // and destroying the caret position.
+  const stashRestoreCheckedRef = useRef<string | null>(null);
+  const stashRestoreKey =
+    notebookFlag && draftBase
+      ? `${draftStashKey(notebookFlag, draftBase.noteId)}/${draftBase.revision}`
+      : null;
+
   // Stash drafts as crash insurance between autosave cycles. Stashes are
-  // cleared by the save paths above once their content lands, never just
-  // because the editor is clean — a fresh mount is clean too, and must not
-  // destroy a stash before the restore effect below has read it.
+  // cleared by the save paths above once their content lands, or — once the
+  // restore pass has run — when the editor returns to a clean state, which
+  // means the user reverted the stashed edits themselves. A fresh mount is
+  // clean too, but its restore pass hasn't run yet, so its stash survives.
   useEffect(() => {
-    if (!notebookFlag || !draftBase || !isDirty) return;
+    if (!notebookFlag || !draftBase) return;
+    if (!isDirty) {
+      if (stashRestoreCheckedRef.current === stashRestoreKey) {
+        clearDraftStash(notebookFlag, draftBase.noteId);
+      }
+      return;
+    }
     void db.notesNoteDrafts.setValue((stashes) => ({
       ...stashes,
       [draftStashKey(notebookFlag, draftBase.noteId)]: {
@@ -630,14 +654,23 @@ export function NotesNoteDetail({
         stashedAt: Date.now(),
       },
     }));
-  }, [bodyDraft, draftBase, isDirty, notebookFlag, titleDraft]);
+  }, [
+    bodyDraft,
+    draftBase,
+    isDirty,
+    notebookFlag,
+    stashRestoreKey,
+    titleDraft,
+  ]);
 
   // Restore a stashed draft after a crash/kill. Only restore while the
   // editor is clean and the row is still at the stash's base revision —
   // then pushing the restored draft can't clobber anyone's newer work. A
   // stash from an older revision is superseded; drop it.
   useEffect(() => {
-    if (!notebookFlag || !draftBase || isDirty) return;
+    if (!notebookFlag || !draftBase || isDirty || !stashRestoreKey) return;
+    if (stashRestoreCheckedRef.current === stashRestoreKey) return;
+    stashRestoreCheckedRef.current = stashRestoreKey;
     let cancelled = false;
     void db.notesNoteDrafts.getValue().then((stashes) => {
       const stash = stashes[draftStashKey(notebookFlag, draftBase.noteId)];
@@ -654,7 +687,7 @@ export function NotesNoteDetail({
     return () => {
       cancelled = true;
     };
-  }, [draftBase, isDirty, notebookFlag]);
+  }, [draftBase, isDirty, notebookFlag, stashRestoreKey]);
 
   const togglePreview = useCallback(() => {
     setPreviewMode(!isPreviewing);
@@ -697,23 +730,19 @@ export function NotesNoteDetail({
     setTitleDraft(nextTitle);
   }, []);
 
+  // The body input is controlled, so the state update must be synchronous:
+  // deferring it makes React revert the DOM to the stale draft after each
+  // keystroke, which destroys the caret position.
   const handleBodyDraftChange = useCallback(
     (nextBody: string) => {
-      if (
-        bodyDraftRef.current === nextBody ||
-        pendingBodyDraftRef.current === nextBody
-      ) {
+      if (bodyDraftRef.current === nextBody) {
         return;
       }
       preserveScrollOffset();
-      pendingBodyDraftRef.current = nextBody;
-      if (bodyDraftUpdateTimeoutRef.current !== null) return;
-
-      bodyDraftUpdateTimeoutRef.current = setTimeout(() => {
-        flushPendingBodyDraft();
-      }, 0);
+      bodyDraftRef.current = nextBody;
+      setBodyDraft(nextBody);
     },
-    [flushPendingBodyDraft, preserveScrollOffset]
+    [preserveScrollOffset]
   );
 
   const handleBodyInputFocus = useCallback(() => {
@@ -782,7 +811,12 @@ export function NotesNoteDetail({
         automaticallyAdjustKeyboardInsets
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ flexGrow: 1 }}
+        scrollEnabled={!useWebEditorPane}
+        contentContainerStyle={
+          useWebEditorPane
+            ? { flexGrow: 1, height: '100%' }
+            : { flexGrow: 1 }
+        }
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
         onScrollEndDrag={handleScrollEnd}
@@ -793,7 +827,7 @@ export function NotesNoteDetail({
         <YStack
           flexGrow={1}
           width="100%"
-          maxWidth={760}
+          maxWidth={useWebEditorPane ? undefined : NOTE_COLUMN_MAX_WIDTH}
           marginHorizontal="auto"
         >
           <YStack
@@ -801,6 +835,9 @@ export function NotesNoteDetail({
             paddingTop="$l"
             paddingBottom="$l"
             gap="$l"
+            width="100%"
+            maxWidth={NOTE_COLUMN_MAX_WIDTH}
+            marginHorizontal="auto"
           >
             {folderPath || noteDate || saveStatusLabel ? (
               <XStack alignItems="center" gap="$m" minHeight={18}>
@@ -843,34 +880,50 @@ export function NotesNoteDetail({
               </XStack>
             ) : null}
             <XStack alignItems="center" gap="$s">
-              <Input
-                ref={titleInputRef}
-                flex={1}
-                width="100%"
-                value={titleDraft}
-                onChangeText={handleTitleDraftChange}
-                onSubmitEditing={focusBodyInput}
-                placeholder="Untitled"
-                placeholderTextColor="$tertiaryText"
-                returnKeyType="next"
-                blurOnSubmit={false}
-                fontSize={24}
-                height={34}
-                minHeight={34}
-                fontWeight="400"
-                borderColor="transparent"
-                borderWidth={0}
-                backgroundColor="transparent"
-                paddingHorizontal={0}
-                paddingVertical={0}
-                disabled={!canEdit}
-              />
+              {isPreviewing ? (
+                <Input
+                  flex={1}
+                  width="100%"
+                  value={titleDraft}
+                  placeholder="Untitled"
+                  placeholderTextColor="$tertiaryText"
+                  fontSize={24}
+                  height={34}
+                  minHeight={34}
+                  fontWeight="400"
+                  borderColor="transparent"
+                  borderWidth={0}
+                  backgroundColor="transparent"
+                  paddingHorizontal={0}
+                  paddingVertical={0}
+                  disabled
+                  testID="NotesTitleDisplay"
+                />
+              ) : (
+                <TextInput
+                  ref={titleInputRef}
+                  value={titleDraft}
+                  onChangeText={handleTitleDraftChange}
+                  onSubmitEditing={focusBodyInput}
+                  placeholder="Untitled"
+                  returnKeyType="next"
+                  blurOnSubmit={false}
+                  editable={canEdit}
+                  frameStyle={{
+                    flex: 1,
+                    // Bleed the frame left by its own padding + border so
+                    // the text inside aligns with the note text column.
+                    marginLeft: -(getTokenValue('$xl', 'space') + 1),
+                  }}
+                  testID="NotesTitleInput"
+                />
+              )}
               {inlineActions}
             </XStack>
           </YStack>
           <YStack
             flexGrow={1}
-            minHeight={MIN_BODY_INPUT_HEIGHT}
+            minHeight={useWebEditorPane ? 0 : MIN_BODY_INPUT_HEIGHT}
             position="relative"
           >
             {isPreviewing ? (
@@ -901,17 +954,18 @@ export function NotesNoteDetail({
             ) : (
               <YStack
                 flexGrow={1}
-                minHeight={MIN_BODY_INPUT_HEIGHT}
-                paddingHorizontal="$xl"
+                minHeight={useWebEditorPane ? 0 : MIN_BODY_INPUT_HEIGHT}
+                paddingHorizontal={useWebEditorPane ? 0 : '$xl'}
                 paddingTop={0}
-                paddingBottom="$xl"
+                paddingBottom={useWebEditorPane ? 0 : '$xl'}
                 testID="NotesBodyScrollView"
               >
                 <TextArea
                   ref={bodyInputRef}
                   width="100%"
-                  minHeight={MIN_BODY_INPUT_HEIGHT}
-                  height={bodyInputHeight}
+                  flex={useWebEditorPane ? 1 : undefined}
+                  minHeight={useWebEditorPane ? 0 : MIN_BODY_INPUT_HEIGHT}
+                  height={useWebEditorPane ? undefined : bodyInputHeight}
                   value={bodyDraft}
                   onChangeText={handleBodyDraftChange}
                   onFocus={handleBodyInputFocus}
@@ -923,12 +977,19 @@ export function NotesNoteDetail({
                   color="$primaryText"
                   backgroundColor="$background"
                   borderWidth={0}
-                  paddingHorizontal={0}
-                  paddingVertical={0}
+                  paddingLeft={useWebEditorPane ? bodyEditorPadding : 0}
+                  paddingRight={
+                    useWebEditorPane
+                      ? bodyEditorPadding + getTokenValue('$l', 'space')
+                      : 0
+                  }
+                  paddingTop={0}
+                  paddingBottom={useWebEditorPane ? '$xl' : 0}
                   disabled={!canEdit}
                   rejectResponderTermination={false}
-                  scrollEnabled={false}
+                  scrollEnabled={useWebEditorPane}
                   textAlignVertical="top"
+                  focusVisibleStyle={{ outlineWidth: 0 }}
                   style={{ lineHeight: BODY_LINE_HEIGHT }}
                   testID="NotesBodyInput"
                 />

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -827,9 +827,7 @@ export function NotesNoteDetail({
         keyboardShouldPersistTaps="handled"
         scrollEnabled={!useWebEditorPane}
         contentContainerStyle={
-          useWebEditorPane
-            ? { flexGrow: 1, height: '100%' }
-            : { flexGrow: 1 }
+          useWebEditorPane ? { flexGrow: 1, height: '100%' } : { flexGrow: 1 }
         }
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}

--- a/packages/app/ui/components/NotesChannel/NotesTreePane.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreePane.tsx
@@ -117,7 +117,7 @@ export function NotesTreePane({
     return (
       <YStack flex={1} minHeight={0} backgroundColor="$background">
         <ScrollView flex={1}>
-          <YStack paddingTop="$s" paddingBottom="$m">
+          <YStack paddingTop="$l" paddingHorizontal="$l" paddingBottom="$m">
             {treeList}
           </YStack>
         </ScrollView>
@@ -131,8 +131,8 @@ export function NotesTreePane({
         width="100%"
         maxWidth={760}
         marginHorizontal="auto"
-        paddingLeft="$s"
-        paddingRight="$s"
+        paddingLeft="$l"
+        paddingRight="$l"
         paddingTop="$m"
         paddingBottom="$m"
       >

--- a/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesTreeRows.tsx
@@ -1,5 +1,5 @@
 import * as db from '@tloncorp/shared/db';
-import { Icon, Pressable } from '@tloncorp/ui';
+import { Icon, Pressable, useIsWindowNarrow } from '@tloncorp/ui';
 import type { IconType } from '@tloncorp/ui';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -186,7 +186,6 @@ export function NoteRow({
       <ActionSheet.Action
         action={{
           title: 'Publish to web',
-          description: isPublished ? publishedUrl ?? undefined : undefined,
           startIcon: 'EyeOpen',
           // Visual-only: the row press drives the toggle. Letting the Switch
           // handle taps double-fires with the row action, and its taps get
@@ -303,6 +302,7 @@ function useRowActions({
       setOpen(true);
     }
   };
+  const isWindowNarrow = useIsWindowNarrow();
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
       if (nextOpen) {
@@ -338,9 +338,16 @@ function useRowActions({
         paddingHorizontal="$xs"
         paddingVertical="$xs"
         marginRight="$-xs"
+        role="button"
+        testID="NotesRowOverflowTrigger"
         onPress={(event) => {
           event.stopPropagation();
-          setOpen((currentOpen) => !currentOpen);
+          // In popover mode (wide web) the menu's Popover.Trigger wrapper
+          // toggles the open state itself; toggling here too would cancel
+          // it out. In sheet mode the trigger renders bare, so it's on us.
+          if (isWindowNarrow) {
+            setOpen((currentOpen) => !currentOpen);
+          }
         }}
       />
     ) : null;


### PR DESCRIPTION
Fixes TLON-6111

## Summary

Fixes a set of web notebook (notes channel) bugs: the body editor's caret jumping on every keystroke, deleted edits resurrecting from the draft stash, the sidebar overflow "…" button doing nothing on click, and "Publish to web" giving no feedback and no way to retrieve the URL on web. Also reworks the web editor layout into a viewport-bounded, internally-scrolling pane and standardizes the title field.

## Changes

- **Caret fix**: the body textarea is controlled, but its state update was deferred through a `setTimeout`, so React reverted the DOM to the stale draft after each `input` event and destroyed the caret. State now updates synchronously; the markdown preview conversion is skipped while the preview pane is hidden so keystrokes stay cheap.
- **Stash resurrection fix**: the crash-stash restore effect re-ran whenever the editor returned to a clean state, re-applying the stash (type a char, delete it → it came back with the caret thrown to the end). The restore pass now runs once per loaded note revision, and a clean editor after that point clears the stale stash. Save status also resets from "Not synced" when edits are reverted to the saved content.
- **Web editor pane** (web only): edit mode pins the pane to the viewport — the body textarea is full pane width, bounded at the bottom of the window, and scrolls its own content. The centered 760px note column is preserved via computed horizontal padding, and the focus ring is removed. Native keeps the grow-to-content textarea inside the page scroll.
- **Title field**: renders as the standard bordered `TextInput` while editing (bled left so its text aligns with the note column) and as a locked plain title in preview mode. The Preview/Edit toggle moved into the channel header on the desktop split view.
- **Overflow "…" button**: its `onPress` toggled open state on top of the menu's `Popover.Trigger` doing the same, so the two cancelled out (right-click worked because it bypasses the trigger). It now only self-toggles in sheet mode, where the trigger renders bare, and is exposed with `role="button"` + a testID (it wasn't in the accessibility tree).
- **Publish to web feedback**: browser web never populates `shipUrl` in the ship context (only native/desktop login flows do), so the share URL was always null there — no toast, no clipboard copy, and no Copy link / View published note rows. The URL base now falls back to `window.location.origin` on web (the app is served by the ship), publish/unpublish always toast, and the raw URL is no longer displayed in the menu.
- **Notes tree spacing**: the folder/note listing container now matches the group channel list's `$l` horizontal padding (rows no longer bleed to the pane edge).

## How did I test?

Drove every change live in Chrome against a dev ship (`pnpm dev:web`): instrumented the textarea's `value` setter and caret per frame to confirm the stale-revert cycle before and its absence after; typed/deleted characters mid-note to confirm caret stability and no stash resurrection (including across a cold reload); verified the editor pane geometry (no page scroll, textarea bottom = viewport bottom, internal scroll, text column aligned at the same x as before); confirmed the "…" button opens/closes the menu via real clicks and traced the double-toggle in console logs; verified the publish menu now shows Copy link / View published note and caught the "Published note. Link copied to clipboard." toast with a MutationObserver. `pnpm tsc` passes in `packages/app`.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: notes channel editor, draft persistence, and web publish flow

## Rollback plan

Revert the branch commits (`69ee1f4d5`, `b99d17618`); no migrations, schema changes, or backend changes involved. The draft-stash format is unchanged, so reverting cannot strand or corrupt stashed drafts.

## Screenshots / videos

### Editor view

<img width="1312" height="1080" alt="Screenshot 2026-07-08 at 11 35 34 AM" src="https://github.com/user-attachments/assets/87fcd550-65a7-41bc-980e-08d6189ef7ac" />

### Preview view

<img width="1312" height="1080" alt="Screenshot 2026-07-08 at 11 35 42 AM" src="https://github.com/user-attachments/assets/6b31d877-3c88-40fe-9a64-68bac18f1ff9" />

### Context menu (from sidebar)

<img width="1312" height="1080" alt="Screenshot 2026-07-08 at 11 35 57 AM" src="https://github.com/user-attachments/assets/864afeed-b27d-4305-9ab7-5e1c8d1c801e" />
