### PR TITLE
hermes: track bot nickname/avatar live via contacts /v1/news subscription

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -108,7 +108,7 @@ TLON_GATEWAY_STATUS_OWNER=~friend # optional override; defaults to TLON_OWNER_SH
 
 The adapter also accepts the older `TLON_SHIP_*`, `TLON_URL/TLON_SHIP/TLON_CODE`, and `URBIT_*` aliases and passes them through to the CLI, so it works with the credential resolver in `@tloncorp/tlon-skill`.
 
-Group attention is deterministic and happens before the model runs. Messages from allowed users dispatch when they mention the node id, bare node id, an alias in `TLON_BOT_MENTIONS`, or the node profile nickname fetched at startup. Nickname lookup failures are non-fatal; the adapter falls back to node id, bare node id, and configured aliases.
+Group attention is deterministic and happens before the model runs. Messages from allowed users dispatch when they mention the node id, bare node id, an alias in `TLON_BOT_MENTIONS`, or the node profile nickname. The nickname is fetched at startup and tracked live via a `contacts /v1/news` subscription: renaming the bot (including during onboarding) updates the wake terms without a restart, clearing the nickname drops that term, and the profile is re-synced after each SSE reconnect. Nickname lookup failures are non-fatal; the adapter falls back to node id, bare node id, and configured aliases.
 
 `TLON_FREE_RESPONSE_CHANNELS` and `TLON_REQUIRE_MENTION=false` allow unmentioned group messages to dispatch for the owner, explicitly allowed users, or all users when `TLON_ALLOW_ALL_USERS=true`. `TLON_DM_ALLOWLIST` is additive for DMs and does not grant group-channel access.
 

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -75,6 +75,7 @@ from .media import PreparedMedia, prepare_inbound_media, render_content_with_blo
 from .mention import (
     BotMentionMatcher,
     build_bot_mention_terms,
+    extract_profile_avatar,
     extract_profile_nickname,
 )
 from .owner_listen import (
@@ -542,6 +543,8 @@ class TlonAdapter(BasePlatformAdapter):
         self._seen_order: list[str] = []
         self._monitored_channels = set(self.tlon_config.channels)
         self._mention_matcher = self._build_mention_matcher()
+        self._bot_nickname: str = ""
+        self._bot_avatar: str = ""
         self._participated_threads: set[str] = set()
         self._known_bot_consecutive_by_channel: dict[str, int] = {}
         self._owner_listen = self._owner_listen_env_defaults()
@@ -587,7 +590,7 @@ class TlonAdapter(BasePlatformAdapter):
                 {"adapterVersion": adapter_version, "adapterFingerprint": fingerprint}
             )
             set_active_telemetry(self._telemetry)
-            await self._load_bot_nickname()
+            await self._load_bot_profile()
             await self._load_settings_state()
             await self._process_pending_dm_invites()
             await self._process_pending_group_invites()
@@ -1526,20 +1529,49 @@ class TlonAdapter(BasePlatformAdapter):
         if not result.success:
             logger.warning("[tlon] control command reply failed: %s", result.error)
 
-    async def _load_bot_nickname(self) -> None:
+    async def _load_bot_profile(self) -> None:
         if self._sse is None:
             return
         try:
             profile = await self._sse.scry("/contacts/v1/self.json")
-            nickname = extract_profile_nickname(profile)
         except Exception as exc:
-            logger.debug("[tlon] could not fetch self profile nickname: %s", exc)
+            logger.debug("[tlon] could not fetch self profile: %s", exc)
             return
-        if not nickname:
-            logger.debug("[tlon] self profile nickname is empty")
+        if not isinstance(profile, dict):
             return
-        self._mention_matcher = self._build_mention_matcher(nickname=nickname)
-        logger.info("[tlon] loaded bot nickname for wake detection: %s", nickname)
+        self._apply_self_contact(profile)
+
+    def _apply_self_contact(self, contact: Any) -> None:
+        """Reconcile bot nickname/avatar state from a self contact map.
+
+        Shared by the boot/reconnect scry and live `contacts /v1/news` %self
+        facts. Both carry the full contact map, so an absent nickname means the
+        nickname is cleared — rebuild the matcher to drop the stale wake term."""
+        nickname = extract_profile_nickname(contact)
+        avatar = extract_profile_avatar(contact)
+        if nickname != self._bot_nickname:
+            self._bot_nickname = nickname
+            self._mention_matcher = self._build_mention_matcher(nickname=nickname)
+            if nickname:
+                logger.info("[tlon] bot nickname for wake detection: %s", nickname)
+            else:
+                logger.info(
+                    "[tlon] bot nickname cleared; waking on ship id and aliases only"
+                )
+        if avatar != self._bot_avatar:
+            self._bot_avatar = avatar
+            logger.info("[tlon] bot avatar %s", "updated" if avatar else "cleared")
+
+    def _handle_contacts_event(self, raw: Any) -> None:
+        if not isinstance(raw, dict):
+            return
+        self_update = raw.get("self")
+        if not isinstance(self_update, dict):
+            return
+        contact = self_update.get("contact")
+        if not isinstance(contact, dict):
+            return
+        self._apply_self_contact(contact)
 
     async def _start_gateway_status(self) -> None:
         try:
@@ -1563,6 +1595,7 @@ class TlonAdapter(BasePlatformAdapter):
         await self._sse.subscribe("chat", "/v3")
         await self._sse.subscribe("settings", f"/desk/{SETTINGS_DESK}")
         await self._sse.subscribe("groups", "/v1/foreigns")
+        await self._sse.subscribe("contacts", "/v1/news")
 
     async def _close_sse(self, *, graceful: bool = True) -> None:
         if self._sse is not None:
@@ -1580,6 +1613,9 @@ class TlonAdapter(BasePlatformAdapter):
                     # Settings events do not replay, so re-sync owner-listen
                     # state after every reconnect.
                     await self._load_settings_state()
+                    # Contacts facts do not replay either; catch up on renames
+                    # (or clears) missed while disconnected.
+                    await self._load_bot_profile()
                 assert self._sse is not None
                 async for event in self._sse.events():
                     if not self._running:
@@ -1613,6 +1649,8 @@ class TlonAdapter(BasePlatformAdapter):
                 self._handle_settings_event(event.json)
             elif event.app == "groups":
                 await self._handle_foreigns(event.json)
+            elif event.app == "contacts":
+                self._handle_contacts_event(event.json)
         except asyncio.CancelledError:
             raise
         except Exception as exc:

--- a/packages/hermes-tlon-adapter/mention.py
+++ b/packages/hermes-tlon-adapter/mention.py
@@ -33,15 +33,23 @@ def build_bot_mention_terms(
     return tuple(result)
 
 
-def extract_profile_nickname(profile: Any) -> str:
+def _extract_profile_value(profile: Any, key: str) -> str:
     if not isinstance(profile, dict):
         return ""
-    nickname = profile.get("nickname")
-    if isinstance(nickname, dict):
-        value = nickname.get("value")
+    field = profile.get(key)
+    if isinstance(field, dict):
+        value = field.get("value")
     else:
-        value = nickname
+        value = field
     return str(value or "").strip()
+
+
+def extract_profile_nickname(profile: Any) -> str:
+    return _extract_profile_value(profile, "nickname")
+
+
+def extract_profile_avatar(profile: Any) -> str:
+    return _extract_profile_value(profile, "avatar")
 
 
 class BotMentionMatcher:

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -727,7 +727,7 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter = self.make_adapter({"allowed_users": ["~mug"], "bot_mentions": ["arvo"]})
         adapter._sse = FakeSSE(error=RuntimeError("not ready"))
 
-        asyncio.run(adapter._load_bot_nickname())
+        asyncio.run(adapter._load_bot_profile())
 
         self.assertTrue(adapter._mention_matcher.mentioned("~pen hello"))
         self.assertTrue(adapter._mention_matcher.mentioned("arvo hello"))
@@ -736,11 +736,216 @@ class AdapterAttentionTests(unittest.TestCase):
         adapter = self.make_adapter({"allowed_users": ["~mug"]})
         adapter._sse = FakeSSE(payload={"nickname": {"value": "Jon"}})
 
-        asyncio.run(adapter._load_bot_nickname())
+        asyncio.run(adapter._load_bot_profile())
         events = asyncio.run(self.dispatches(adapter, channel_event("jon, hello")))
 
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].text, "hello")
+
+    # ── contacts tracking (live nickname/avatar via /v1/news) ────────────
+
+    @staticmethod
+    def _self_fact(contact):
+        return {"self": {"contact": contact}}
+
+    def test_contacts_self_fact_adds_nickname_wake(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+        )
+        events = asyncio.run(self.dispatches(adapter, channel_event("jon, hello")))
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].text, "hello")
+
+    def test_contacts_self_fact_rename_replaces_old_term(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+        )
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Arvo"}})
+        )
+
+        new_wake = asyncio.run(
+            self.dispatches(adapter, channel_event("arvo, hello", post_id="170.142"))
+        )
+        self.assertEqual(len(new_wake), 1)
+
+        old_wake = asyncio.run(
+            self.dispatches(adapter, channel_event("jon, hello", post_id="170.143"))
+        )
+        self.assertEqual(len(old_wake), 0)
+
+        ship_wake = asyncio.run(
+            self.dispatches(adapter, channel_event("~pen hello", post_id="170.144"))
+        )
+        self.assertEqual(len(ship_wake), 1)
+
+    def test_contacts_self_fact_clear_removes_nickname_term(self):
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "bot_mentions": ["arvo"]}
+        )
+
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+        )
+        # Full contact map with no nickname key == nickname cleared.
+        adapter._handle_contacts_event(self._self_fact({}))
+
+        old_wake = asyncio.run(
+            self.dispatches(adapter, channel_event("jon, hello", post_id="170.142"))
+        )
+        self.assertEqual(len(old_wake), 0)
+
+        alias_wake = asyncio.run(
+            self.dispatches(adapter, channel_event("arvo, hello", post_id="170.143"))
+        )
+        self.assertEqual(len(alias_wake), 1)
+
+        ship_wake = asyncio.run(
+            self.dispatches(adapter, channel_event("~pen hello", post_id="170.144"))
+        )
+        self.assertEqual(len(ship_wake), 1)
+
+    def test_contacts_non_self_and_malformed_facts_are_inert(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+        )
+        matcher = adapter._mention_matcher
+
+        for raw in (
+            {"peer": {"who": "~zod", "contact": {"nickname": {"value": "Zod"}}}},
+            {"page": {"kip": "~zod", "contact": {}, "mod": {}}},
+            {"wipe": {"kip": "~zod"}},
+            "not-a-dict",
+            {"self": {}},
+            {"self": {"contact": "bogus"}},
+        ):
+            adapter._handle_contacts_event(raw)
+            self.assertIs(adapter._mention_matcher, matcher)
+
+    def test_contacts_self_fact_avatar_only_change(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+        )
+        matcher = adapter._mention_matcher
+
+        # Full map: unchanged nickname + new avatar. Nickname must stay set,
+        # so the matcher object is untouched while _bot_avatar updates.
+        adapter._handle_contacts_event(
+            self._self_fact(
+                {
+                    "nickname": {"type": "text", "value": "Jon"},
+                    "avatar": {"type": "look", "value": "https://example/a.png"},
+                }
+            )
+        )
+        self.assertIs(adapter._mention_matcher, matcher)
+        self.assertEqual(adapter._bot_avatar, "https://example/a.png")
+
+        # A second identical fact is a no-op.
+        adapter._handle_contacts_event(
+            self._self_fact(
+                {
+                    "nickname": {"type": "text", "value": "Jon"},
+                    "avatar": {"type": "look", "value": "https://example/a.png"},
+                }
+            )
+        )
+        self.assertIs(adapter._mention_matcher, matcher)
+        self.assertEqual(adapter._bot_avatar, "https://example/a.png")
+
+    def test_route_stream_event_dispatches_contacts_app(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        payload = self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+
+        asyncio.run(
+            adapter._route_stream_event(
+                types.SimpleNamespace(app="contacts", json=payload)
+            )
+        )
+
+        events = asyncio.run(self.dispatches(adapter, channel_event("jon, hello")))
+        self.assertEqual(len(events), 1)
+
+    def test_load_bot_profile_clears_stale_nickname(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        adapter._handle_contacts_event(
+            self._self_fact({"nickname": {"type": "text", "value": "Jon"}})
+        )
+
+        # Reconnect catch-up: an empty (but present) contact map clears.
+        adapter._sse = FakeSSE(payload={})
+        asyncio.run(adapter._load_bot_profile())
+
+        old_wake = asyncio.run(self.dispatches(adapter, channel_event("jon, hello")))
+        self.assertEqual(len(old_wake), 0)
+
+    def test_connect_sse_subscribes_contacts_news(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        subscriptions = []
+
+        class RecordingSSE:
+            def __init__(self, config):
+                pass
+
+            async def authenticate(self):
+                return "cookie"
+
+            async def open(self):
+                return None
+
+            async def subscribe(self, app, path):
+                subscriptions.append((app, path))
+                return len(subscriptions)
+
+        with patch.object(adapter_mod, "TlonSSEClient", RecordingSSE):
+            asyncio.run(adapter._connect_sse())
+
+        # The contacts subscription is added alongside — not in place of — the
+        # pre-existing four.
+        self.assertEqual(
+            subscriptions,
+            [
+                ("channels", "/v2"),
+                ("chat", "/v3"),
+                ("settings", f"/desk/{adapter_mod.SETTINGS_DESK}"),
+                ("groups", "/v1/foreigns"),
+                ("contacts", "/v1/news"),
+            ],
+        )
+
+    def test_stream_resync_branch_reloads_profile(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        adapter._sse = None
+        calls = []
+
+        class ResyncSSE:
+            async def events(self):
+                adapter._running = False
+                if False:  # pragma: no cover - makes events() an async generator
+                    yield None
+
+        async def fake_connect():
+            adapter._sse = ResyncSSE()
+
+        async def record_settings():
+            calls.append("settings")
+
+        async def record_profile():
+            calls.append("profile")
+
+        with patch.object(adapter, "_connect_sse", fake_connect), patch.object(
+            adapter, "_load_settings_state", record_settings
+        ), patch.object(adapter, "_load_bot_profile", record_profile):
+            asyncio.run(adapter._run_stream())
+
+        self.assertEqual(calls, ["settings", "profile"])
 
     def test_env_enablement_seeds_owner_dm_as_home_channel(self):
         with patch.dict(

--- a/packages/hermes-tlon-adapter/test_mention.py
+++ b/packages/hermes-tlon-adapter/test_mention.py
@@ -81,6 +81,21 @@ class BotMentionMatcherTests(unittest.TestCase):
         self.assertEqual(mention.extract_profile_nickname({"nickname": "Mr Arvo"}), "Mr Arvo")
         self.assertEqual(mention.extract_profile_nickname({"nickname": {"value": ""}}), "")
 
+    def test_extract_profile_avatar(self):
+        self.assertEqual(
+            mention.extract_profile_avatar(
+                {"avatar": {"type": "look", "value": "https://example/a.png"}}
+            ),
+            "https://example/a.png",
+        )
+        self.assertEqual(
+            mention.extract_profile_avatar({"avatar": "https://example/a.png"}),
+            "https://example/a.png",
+        )
+        self.assertEqual(mention.extract_profile_avatar({}), "")
+        self.assertEqual(mention.extract_profile_avatar({"avatar": {"type": "null"}}), "")
+        self.assertEqual(mention.extract_profile_avatar("not-a-dict"), "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes TLON-6089

Tracks the Hermes Tlon bot's own nickname (and avatar) live via a `contacts /v1/news` subscription, so renaming the bot updates its group-channel wake terms without a gateway restart. Previously the nickname was scried once at connect, so any post-boot rename (including the name a user sets during onboarding) was invisible until a full restart.

## Changes

- In `adapter.py`, subscribed the existing Eyre SSE channel to `contacts /v1/news` in `_connect_sse`, alongside the existing four subscriptions.
- Renamed `_load_bot_nickname` to `_load_bot_profile` (scry + delegate) and added `_apply_self_contact`, shared by the boot scry, reconnect re-scry, and live `%self` facts. It rebuilds the wake-term matcher on any nickname change, including clearing (an absent nickname in the full contact map drops the stale term rather than early-returning), and tracks/logs avatar changes.
- Added `_handle_contacts_event` (acts on `%self` facts only; ignores peer, page, and wipe) and routed `contacts` events in `_route_stream_event`.
- Re-run `_load_bot_profile` in the `_run_stream` reconnect branch, since contacts facts do not replay (same pattern as the existing settings re-sync).
- In `mention.py`, factored `extract_profile_nickname` onto a shared `_extract_profile_value` and added `extract_profile_avatar`.
- Updated the adapter README to describe live nickname tracking.

## How did I test?

- Added unit coverage for `extract_profile_avatar` in `test_mention.py`.
- Added a contacts-tracking section in `test_adapter_attention.py` covering live rename, replace, and clear; inert peer and malformed facts; avatar-only change; route dispatch; reconnect clear; the subscription wiring; and the reconnect-branch re-sync.
- Ran the full adapter suite: `cd packages/hermes-tlon-adapter && pnpm test` (415 tests passing).

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Other: Hermes adapter

Note: this also resolves an onboarding name-ordering risk (a bot that would not answer to the name just given). Live tracking makes provisioning order moot. Behavior is additive and confined to the Hermes adapter; a rollback returns to fetch-once-at-connect behavior.

## Rollback plan

Revert