### PR TITLE
enable React Compiler on web and mobile

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,7 +26,7 @@ module.exports = {
     },
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'import-x'],
+  plugins: ['@typescript-eslint', 'import-x', 'react-compiler'],
   ignorePatterns: ['dist', 'node_modules', '*.md'],
   overrides: [
     {
@@ -115,6 +115,9 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'react/display-name': 'warn',
+    // Surfaces Rules-of-React violations and components the React Compiler
+    // can't optimize. Warn-level during rollout; does not fail lint/CI.
+    'react-compiler/react-compiler': 'warn',
     'no-useless-escape': 'warn',
     'no-restricted-imports': [
       'error',

--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -26,6 +26,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   buildCacheProvider:
     process.env.TLON_EAS_CACHE_DISABLED === '1' ? undefined : 'eas',
+  experiments: {
+    reactCompiler: true,
+  },
   extra: {
     eas: {
       projectId,

--- a/apps/tlon-mobile/babel.config.js
+++ b/apps/tlon-mobile/babel.config.js
@@ -32,7 +32,7 @@ module.exports = function (api) {
               reactCompilerEnvironment !== 'production',
           },
           panicThreshold:
-            reactCompilerEnvironment === 'production' ? 'NONE' : undefined,
+            reactCompilerEnvironment === 'production' ? 'none' : undefined,
           customOptOutDirectives: ['widget', 'use no memo', 'use no forget'],
         },
       ],

--- a/apps/tlon-mobile/babel.config.js
+++ b/apps/tlon-mobile/babel.config.js
@@ -1,8 +1,41 @@
 module.exports = function (api) {
-  api.cache(true);
+  const reactCompilerEnvironment = api.caller((caller) => {
+    if (
+      !caller?.supportsReactCompiler ||
+      caller.isNodeModule ||
+      caller.isServer ||
+      caller.isReactServer
+    ) {
+      return 'disabled';
+    }
+    return caller.isDev === false ? 'production' : 'development';
+  });
+
   return {
-    presets: [['babel-preset-expo', { unstable_transformImportMeta: true }]],
+    presets: [
+      [
+        'babel-preset-expo',
+        {
+          unstable_transformImportMeta: true,
+          // The compiler is configured first below so it sees original source.
+          'react-compiler': false,
+        },
+      ],
+    ],
     plugins: [
+      reactCompilerEnvironment !== 'disabled' && [
+        'babel-plugin-react-compiler',
+        {
+          target: '19',
+          environment: {
+            enableResetCacheOnSourceFileChanges:
+              reactCompilerEnvironment !== 'production',
+          },
+          panicThreshold:
+            reactCompilerEnvironment === 'production' ? 'NONE' : undefined,
+          customOptOutDirectives: ['widget', 'use no memo', 'use no forget'],
+        },
+      ],
       // Allow sql imports so that we can bundle drizzle migrations.
       [
         'inline-import',
@@ -19,6 +52,6 @@ module.exports = function (api) {
         },
       ],
       'react-native-worklets/plugin',
-    ],
+    ].filter(Boolean),
   };
 };

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -172,6 +172,7 @@
     "@types/seedrandom": "^3.0.5",
     "@types/tmp": "^0.2.6",
     "babel-plugin-inline-import": "^3.0.0",
+    "babel-plugin-react-compiler": "1.0.0",
     "babel-preset-expo": "~57.0.0",
     "better-sqlite3": "11.8.1",
     "concurrently": "^8.0.1",

--- a/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/PasteInviteLinkScreen.tsx
@@ -19,7 +19,7 @@ import { checkInputForInvite, createDevLogger } from '@tloncorp/shared';
 import * as Clipboard from 'expo-clipboard';
 import { debounce } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import { Keyboard } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -46,7 +46,6 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
     control,
     formState: { errors },
     setValue,
-    watch,
   } = useForm<FormData>({
     defaultValues: {
       inviteLink: DEFAULT_INVITE_LINK_URL,
@@ -96,7 +95,7 @@ export const PasteInviteLinkScreen = ({ navigation }: Props) => {
   );
 
   // watch for changes to the input & check for valid invite links
-  const inviteLinkValue = watch('inviteLink');
+  const inviteLinkValue = useWatch({ control, name: 'inviteLink' });
   useEffect(() => {
     debouncedInputHandler(inviteLinkValue);
   }, [inviteLinkValue, debouncedInputHandler]);

--- a/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/SignupScreen.tsx
@@ -28,7 +28,7 @@ import {
 } from '@tloncorp/shared';
 import { Button } from '@tloncorp/ui';
 import { useCallback, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useFormState } from 'react-hook-form';
 import { Platform } from 'react-native';
 
 import { PhoneNumberInput } from '../../components/OnboardingInputs';
@@ -76,6 +76,12 @@ export const SignupScreen = ({ navigation }: Props) => {
     defaultValues: {
       email: DEFAULT_ONBOARDING_TLON_EMAIL ? genDefaultEmail() : '',
     },
+  });
+  const { isValid: isPhoneValid } = useFormState({
+    control: phoneForm.control,
+  });
+  const { errors: emailErrors, isValid: isEmailValid } = useFormState({
+    control: emailForm.control,
   });
 
   const handlePressEula = useCallback(() => {
@@ -224,10 +230,7 @@ export const SignupScreen = ({ navigation }: Props) => {
                   },
                 }}
                 render={({ field: { onChange, onBlur, value } }) => (
-                  <Field
-                    label="Email"
-                    error={emailForm.formState.errors.email?.message}
-                  >
+                  <Field label="Email" error={emailErrors.email?.message}>
                     <TextInput
                       placeholder="Email Address"
                       onBlur={() => {
@@ -239,15 +242,9 @@ export const SignupScreen = ({ navigation }: Props) => {
                       keyboardType="email-address"
                       autoCapitalize="none"
                       autoCorrect={false}
-                      returnKeyType={
-                        emailForm.formState.isValid ? 'next' : 'default'
-                      }
-                      enablesReturnKeyAutomatically={
-                        emailForm.formState.isValid
-                      }
-                      onSubmitEditing={
-                        emailForm.formState.isValid ? onSubmit : undefined
-                      }
+                      returnKeyType={isEmailValid ? 'next' : 'default'}
+                      enablesReturnKeyAutomatically={isEmailValid}
+                      onSubmitEditing={isEmailValid ? onSubmit : undefined}
                       autoFocus
                     />
                   </Field>
@@ -261,9 +258,7 @@ export const SignupScreen = ({ navigation }: Props) => {
               loading={isSubmitting}
               disabled={
                 isSubmitting ||
-                (otpMethod === 'phone'
-                  ? !phoneForm.formState.isValid
-                  : !emailForm.formState.isValid)
+                (otpMethod === 'phone' ? !isPhoneValid : !isEmailValid)
               }
               label="Sign up"
               centered

--- a/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
+++ b/apps/tlon-mobile/src/screens/Onboarding/TlonLogin.tsx
@@ -20,7 +20,7 @@ import {
 import { createDevLogger } from '@tloncorp/shared';
 import { Button } from '@tloncorp/ui';
 import { useCallback, useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, useForm, useFormState } from 'react-hook-form';
 
 import { PhoneNumberInput } from '../../components/OnboardingInputs';
 import { useRecaptcha } from '../../hooks/useRecaptcha';
@@ -77,6 +77,12 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
     defaultValues: {
       email: DEFAULT_TLON_LOGIN_EMAIL ?? '',
     },
+  });
+  const { isValid: isPhoneValid } = useFormState({
+    control: phoneForm.control,
+  });
+  const { errors: emailErrors, isValid: isEmailValid } = useFormState({
+    control: emailForm.control,
   });
 
   const onSubmit = useCallback(async () => {
@@ -207,10 +213,7 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
                   },
                 }}
                 render={({ field: { onChange, onBlur, value } }) => (
-                  <Field
-                    label="Email"
-                    error={emailForm.formState.errors.email?.message}
-                  >
+                  <Field label="Email" error={emailErrors.email?.message}>
                     <TextInput
                       placeholder="Email Address"
                       onBlur={() => {
@@ -238,9 +241,7 @@ export const TlonLoginScreen = ({ navigation, route }: Props) => {
               loading={isSubmitting}
               disabled={
                 isSubmitting ||
-                (otpMethod === 'phone'
-                  ? !phoneForm.formState.isValid
-                  : !emailForm.formState.isValid)
+                (otpMethod === 'phone' ? !isPhoneValid : !isEmailValid)
               }
               label="Send code to log in"
               centered

--- a/apps/tlon-web/package.json
+++ b/apps/tlon-web/package.json
@@ -172,6 +172,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@welldone-software/why-did-you-render": "^7.0.1",
     "autoprefixer": "^10.4.4",
+    "babel-plugin-react-compiler": "1.0.0",
     "concurrently": "^8.0.1",
     "cross-env": "^7.0.3",
     "flow-remove-types": "^2.241.0",

--- a/apps/tlon-web/vite.config.mts
+++ b/apps/tlon-web/vite.config.mts
@@ -85,6 +85,7 @@ export default ({ mode }: { mode: string }) => {
         react({
           babel: {
             plugins: [
+              'babel-plugin-react-compiler',
               '@babel/plugin-proposal-export-namespace-from',
               'react-native-worklets/plugin',
             ],
@@ -117,6 +118,7 @@ export default ({ mode }: { mode: string }) => {
           // adding these per instructions here:
           // https://docs.swmansion.com/react-native-reanimated/docs/guides/web-support/
           plugins: [
+            'babel-plugin-react-compiler',
             '@babel/plugin-proposal-export-namespace-from',
             'react-native-worklets/plugin',
           ],

--- a/apps/tlon-web/vite.config.mts
+++ b/apps/tlon-web/vite.config.mts
@@ -73,6 +73,9 @@ export default ({ mode }: { mode: string }) => {
       return [
         basicSsl() as Plugin,
         react({
+          babel: {
+            plugins: ['babel-plugin-react-compiler'],
+          },
           jsxImportSource: wdyrJsxImportSource,
         }) as PluginOption[],
       ];

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "lint-staged": "^15.0.0",
     "prettierignore-monorepo": "^1.0.5",

--- a/packages/app/features/groups/EditChannelPrivacyScreen.tsx
+++ b/packages/app/features/groups/EditChannelPrivacyScreen.tsx
@@ -5,7 +5,7 @@ import {
 } from '@tloncorp/shared/logic/notesPermissionsCompat';
 import { Text } from '@tloncorp/ui';
 import { useCallback, useEffect, useRef } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { ScrollView, View, YStack } from 'tamagui';
 
 import { useChannelEditScreen } from '../../hooks/useChannelEditScreen';
@@ -50,7 +50,7 @@ export function EditChannelPrivacyScreen(props: Props) {
     },
   });
 
-  const isPrivate = form.watch('isPrivate');
+  const isPrivate = useWatch({ control: form.control, name: 'isPrivate' });
   const usesNotesPermissionsCompat = notesPermissionsCompatActive(
     channel?.type
   );

--- a/packages/app/fixtures/PhoneNumberInput.fixture.tsx
+++ b/packages/app/fixtures/PhoneNumberInput.fixture.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@tloncorp/ui';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { YStack } from 'tamagui';
 
 import { PhoneNumberInput } from '../ui/components/Form/PhoneNumberInput';
@@ -10,7 +10,7 @@ function PhoneNumberInputFixture() {
     mode: 'onChange',
     defaultValues: { phoneNumber: '' },
   });
-  const value = form.watch('phoneNumber');
+  const value = useWatch({ control: form.control, name: 'phoneNumber' });
 
   return (
     <FixtureWrapper fillWidth safeArea>

--- a/packages/app/ui/components/EditProfileScreenView.tsx
+++ b/packages/app/ui/components/EditProfileScreenView.tsx
@@ -11,7 +11,7 @@ import {
 } from '@tloncorp/ui';
 import { ConfirmDialog } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, XStack, useTheme } from 'tamagui';
 
@@ -96,7 +96,6 @@ export function EditProfileScreenView(props: Props) {
     control,
     handleSubmit,
     reset,
-    watch,
     formState: { isDirty, isValid },
   } = useForm({
     mode: 'onChange',
@@ -109,7 +108,7 @@ export function EditProfileScreenView(props: Props) {
     },
   });
 
-  const currentSigilColor = watch('sigilColor');
+  const currentSigilColor = useWatch({ control, name: 'sigilColor' });
 
   useEffect(() => {
     reset({

--- a/packages/app/ui/components/Form/PhoneNumberInput.tsx
+++ b/packages/app/ui/components/Form/PhoneNumberInput.tsx
@@ -1,7 +1,7 @@
 import { getLocales } from 'expo-localization';
 import { isValidPhoneNumber } from 'libphonenumber-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Controller, UseFormReturn } from 'react-hook-form';
+import { Controller, UseFormReturn, useFormState } from 'react-hook-form';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { CountryPicker } from 'react-native-country-codes-picker';
 import {
@@ -35,6 +35,7 @@ export function PhoneNumberInput({ form, shouldFocus = true }: Props) {
   const [country, setCountry] = useState(defaultCountry);
   const inputRef = useRef<TransformerTextInputInstance>(null);
   const theme = useTheme();
+  const { errors } = useFormState({ control: form.control });
 
   // One international transformer: the calling code is part of the editable
   // text and the country is detected from it as the user types.
@@ -63,7 +64,7 @@ export function PhoneNumberInput({ form, shouldFocus = true }: Props) {
           <Field
             width={'100%'}
             label="Phone Number"
-            error={form.formState.errors.phoneNumber?.message}
+            error={errors.phoneNumber?.message}
           >
             <View
               style={{

--- a/packages/app/ui/components/ManageChannels/ChannelPermissions.tsx
+++ b/packages/app/ui/components/ManageChannels/ChannelPermissions.tsx
@@ -2,7 +2,7 @@ import * as db from '@tloncorp/shared/db';
 import { notesPermissionsCompatActive } from '@tloncorp/shared/logic/notesPermissionsCompat';
 import { Icon, IconButton, Pressable, Text } from '@tloncorp/ui';
 import { useCallback, useMemo } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { Platform, Switch } from 'react-native';
 import { View, XStack, YStack } from 'tamagui';
 
@@ -107,10 +107,10 @@ export function PermissionTable({
   groupRoles: db.GroupRole[];
   channelType?: string;
 }) {
-  const { watch, setValue } = useFormContext<ChannelPrivacyFormSchema>();
-  const isPrivate = watch('isPrivate');
-  const readers = watch('readers');
-  const writers = watch('writers');
+  const { control, setValue } = useFormContext<ChannelPrivacyFormSchema>();
+  const isPrivate = useWatch({ control, name: 'isPrivate' });
+  const readers = useWatch({ control, name: 'readers' });
+  const writers = useWatch({ control, name: 'writers' });
   const hasUnifiedPermissions = notesPermissionsCompatActive(channelType);
 
   const displayedRoles = useMemo(() => {

--- a/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
+++ b/packages/app/ui/components/ManageChannels/CreateChannelSheet.tsx
@@ -4,7 +4,7 @@ import { createChannel, useNotesDeskAvailable } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import { Button } from '@tloncorp/ui';
 import { useCallback, useMemo } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { YStack } from 'tamagui';
 
 import { useCurrentUserId } from '../../../hooks/useCurrentUser';
@@ -93,7 +93,7 @@ export function CreateChannelSheet({
     [notesAvailable]
   );
 
-  const isPrivate = watch('isPrivate');
+  const isPrivate = useWatch({ control, name: 'isPrivate' });
 
   // Only toggles isPrivate without setting readers/writers because:
   // - If private: the user proceeds to CreateChannelPermissionsScreen to configure permissions

--- a/packages/app/ui/components/PhoneAttestationPane.tsx
+++ b/packages/app/ui/components/PhoneAttestationPane.tsx
@@ -4,7 +4,7 @@ import * as domain from '@tloncorp/shared/domain';
 import { Button, LoadingSpinner, Text, triggerHaptic } from '@tloncorp/ui';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
 import { useCallback, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useFormState } from 'react-hook-form';
 import { View, YStack } from 'tamagui';
 
 import { useStore } from '../contexts/storeContext';
@@ -79,6 +79,7 @@ function SubmitPhoneNumPane(props: { attestation: db.Attestation | null }) {
       phoneNumber: '',
     },
   });
+  const { isValid } = useFormState({ control: phoneForm.control });
 
   const onSubmit = useCallback(async () => {
     try {
@@ -133,7 +134,7 @@ function SubmitPhoneNumPane(props: { attestation: db.Attestation | null }) {
       <Button
         onPress={onSubmit}
         loading={isSubmitting}
-        disabled={isSubmitting || !phoneForm.formState.isValid}
+        disabled={isSubmitting || !isValid}
         marginTop="$2xl"
         label="Connect Phone Number"
         centered

--- a/packages/app/ui/components/draftInputs/LinkInput.tsx
+++ b/packages/app/ui/components/draftInputs/LinkInput.tsx
@@ -17,7 +17,7 @@ import {
 } from '@tloncorp/ui';
 import { KeyboardAvoidingView, LoadingSpinner } from '@tloncorp/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, useTheme } from 'tamagui';
@@ -99,7 +99,6 @@ export function LinkInput({
 
   const {
     control,
-    watch,
     handleSubmit,
     setValue,
     formState: { isDirty, isValid },
@@ -112,7 +111,17 @@ export function LinkInput({
     },
   });
 
-  const form = watch();
+  const urlValue = useWatch({ control, name: 'url' });
+  const titleValue = useWatch({ control, name: 'title' });
+  const descriptionValue = useWatch({ control, name: 'description' });
+  const form = useMemo(
+    () => ({
+      url: urlValue,
+      title: titleValue,
+      description: descriptionValue,
+    }),
+    [urlValue, titleValue, descriptionValue]
+  );
   const url = useDebouncedValue(form.url, 500);
   // We need to track debounce dirty state to appropriately disable the send button. useLinkGrabber's
   // loading state will not be set until the debounce fires.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "@vitejs/plugin-react": "^4.2.1",
+    "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^8.50.0",
     "eslint-plugin-prettier": "^5.0.0",
     "typescript": "^5.1.3",

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -16,7 +16,14 @@ export default defineConfig({
       },
     ],
   },
-  plugins: [react(), viteSingleFile()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ['babel-plugin-react-compiler'],
+      },
+    }),
+    viteSingleFile(),
+  ],
   server: {
     port: 3000,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,6 +1085,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@5.1.6(@types/node@25.9.3)(lightningcss@1.32.0)(terser@5.46.0))
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       eslint:
         specifier: ^8.50.0
         version: 8.57.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,6 +479,9 @@ importers:
       babel-plugin-inline-import:
         specifier: ^3.0.0
         version: 3.0.0
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       babel-preset-expo:
         specifier: ~57.0.0
         version: 57.0.2(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@57.0.7(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.0)(@react-native/metro-config@0.86.0)(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@react-native/jest-preset@0.86.0(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.86.0)(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-refresh@0.14.2)
@@ -885,6 +888,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.4
         version: 10.4.21(postcss@8.5.15)
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       concurrently:
         specifier: ^8.0.1
         version: 8.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.34.1
         version: 7.34.1(eslint@8.57.0)
+      eslint-plugin-react-compiler:
+        specifier: 19.1.0-rc.2
+        version: 19.1.0-rc.2(eslint@8.57.0)
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.0(eslint@8.57.0)
@@ -1918,6 +1921,13 @@ packages:
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -8000,6 +8010,12 @@ packages:
       eslint-config-prettier:
         optional: true
 
+  eslint-plugin-react-compiler@19.1.0-rc.2:
+    resolution: {integrity: sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
+
   eslint-plugin-react-hooks@4.6.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
@@ -8928,6 +8944,9 @@ packages:
   hermes-estree@0.23.1:
     resolution: {integrity: sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==}
 
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
   hermes-estree@0.35.0:
     resolution: {integrity: sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==}
 
@@ -8939,6 +8958,9 @@ packages:
 
   hermes-parser@0.23.1:
     resolution: {integrity: sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
@@ -13698,6 +13720,12 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod-validation-error@3.5.4:
+    resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -14721,6 +14749,14 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.29.0)
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
     dependencies:
@@ -22329,6 +22365,18 @@ snapshots:
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
 
+  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@8.57.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
+      eslint: 8.57.0
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 3.5.4(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react-hooks@4.6.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
@@ -23499,6 +23547,8 @@ snapshots:
 
   hermes-estree@0.23.1: {}
 
+  hermes-estree@0.25.1: {}
+
   hermes-estree@0.35.0: {}
 
   hermes-estree@0.36.0: {}
@@ -23508,6 +23558,10 @@ snapshots:
   hermes-parser@0.23.1:
     dependencies:
       hermes-estree: 0.23.1
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hermes-parser@0.35.0:
     dependencies:
@@ -29194,6 +29248,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod-validation-error@3.5.4(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Turns on the [React Compiler](https://react.dev/learn/react-compiler) (stable `babel-plugin-react-compiler@1.0.0`) for the web (Vite) and mobile (Expo) builds. The compiler auto-memoizes components and hooks at build time, so we get memoization without hand-written `useMemo`/`useCallback`/`memo`. It runs in global mode — every component is compiled, not just annotated ones. Everything here is on React 19, so no separate compiler-runtime package is needed.

## Changes

- **Web** (`apps/tlon-web/vite.config.mts`): add `babel-plugin-react-compiler` as the first Babel plugin in the `@vitejs/plugin-react` config across all build modes — default/`dev`, electron, and mock/staging.
- **Mobile** (`apps/tlon-mobile/app.config.ts`): set `experiments.reactCompiler: true`. Expo threads this through Metro into `babel-preset-expo`, which enables the compiler.
- **Editor** (`packages/editor`): the tentap web editor builds as its own single-file bundle (loaded in a webview) and isn't covered by the app builds, so the compiler is added to its Vite config too.
- **react-hook-form compatibility** (`packages/app`): migrate render-time `watch(name)` reads to `useWatch({ control, name })` in the 6 components that used it (see below).
- **Lint** (`.eslintrc.cjs`): add `eslint-plugin-react-compiler` at `warn` level to surface Rules-of-React violations going forward.
- Add `babel-plugin-react-compiler@1.0.0` as a devDependency of the two apps and the editor package, and update the lockfile.

## react-hook-form compatibility

The compiler and react-hook-form's `watch()` are [a known incompatibility](https://github.com/react-hook-form/react-hook-form/issues/11910). `watch(name)` is a plain function call that returns different values across renders for the same arguments — so the compiler memoizes its result keyed on the stable `watch` reference and serves a **stale** value forever after the first render. The compiler reports `CompileSuccess` on these components (no diagnostic), so an ESLint rule would not have caught it.

This surfaced as a real failure: the `channel-permissions-members` e2e test — enabling Custom Permissions never rendered the Members row, because `PermissionTable` read stale `readers`/`writers` form state.

Fix per react-hook-form's [official guidance](https://github.com/orgs/react-hook-form/discussions/12524): replace render-time `watch(name)` with `useWatch({ control, name })` (a real hook — the compiler re-runs it every render and can't wrongly memoize its return). Event-time `watch()` reads inside callbacks (e.g. `CreateChannelSheet`'s `handlePressNext`) are left as-is — they run at invocation and are never memoized.

Verified by compiling `ChannelPermissions.tsx` before/after: `watch("readers")` went from a value cached on the stable `watch` reference to `useWatch(...)` called live each render.

I also audited the rest of the react-hook-form surface by inspecting compiled output. Render-time `formState` reads (`isDirty`/`isValid`/`errors`, ~10 components) are **safe**: they're destructured directly from the fresh `useForm()` hook return each render (`const { isValid } = t6`), so the proxy getter fires every render and the value isn't cached — unlike `watch()`, whose result flowed into a memoized `useMemo`/`Set`. The couple accessed via `try/finally` or behind an eslint-disable bail out of compilation entirely (also safe). `getValues()` is only used imperatively in effects/callbacks. So `watch()` was the only broken pattern.

### ESLint rule caveat

`eslint-plugin-react-compiler` is added at `warn` (non-blocking; ~94 findings in `packages/app` today, a triage backlog; #6114, stacked on this PR, removes the runtime store-injection pattern behind most of them, 94 → 28). It would **not** have caught this bug — the compiler reports `CompileSuccess` on the `watch()` components, so the rule emits nothing for them. It's worth having for the Rules-of-React violations it does catch, but it isn't a safety net for this class. The rule ships properly in `eslint-plugin-react-hooks` v5+; adopting that is a separate major-bump follow-up (this repo is on v4 + legacy `.eslintrc`), so the standalone plugin is a stopgap.

## How did I test?

- Compiled the affected components through `babel-plugin-react-compiler` and confirmed the stale-memoization pattern is gone (hook calls are no longer cached).
- Built the editor bundle and confirmed the compiler ran in the output (`react/compiler-runtime` import + `useMemoCache`).
- `packages/app` typechecks clean; the 6 changed files lint clean.
- The `channel-permissions-members` e2e (which failed on the compiler commits and is green on `develop`) **now passes** with the migration — full CI run green.

**Still worth a smoke pass before merge.** The react-hook-form surface is audited (above) and I believe it's covered, but only `ChannelPermissions` has e2e coverage, and other referential-impurity patterns outside RHF (e.g. some external-store selectors) could fail the same way silently under global compilation.

## Risks and impact

- Safe to rollback without consulting PR author? Yes — revert the config + dep changes, the `useWatch` migration, and the lint rule; no persisted state or data changes.
- Affects important code area:
  - [x] State / providers
  - [x] Channel display
  - [x] Other: build-time transform applied to every component across web, mobile, and the editor bundle

Blast radius is the whole app. The compiler bails out safely on components it can't prove are safe, so worst case is an isolated stale-render regression — with a clean, self-contained revert.

## Rollback plan

Revert this PR (or remove the config changes, the devDependencies, and the `useWatch` migration). No migrations or state to unwind.

## Screenshots / videos

N/A — no visual changes; this is a build-time optimization plus a form-reactivity fix.


