### PR TITLE
openclaw: capture web plugin error on gateway start

### DIFF
--- a/packages/openclaw/dev/entrypoint.sh
+++ b/packages/openclaw/dev/entrypoint.sh
@@ -128,7 +128,7 @@ if [ -f "$CONFIG_PATH" ]; then
     .plugins.load.paths |= map(
       if . == "/workspace/openclaw-tlon" then "/workspace/tlon" else . end
     )
-    | .plugins.allow = (.plugins.allow // []) + ["@tloncorp/openclaw"]
+    | .plugins.allow = (.plugins.allow // []) + ["tlon"]
     | .plugins.allow |= unique
   ' "$CONFIG_PATH" > "$CONFIG_PATH.tmp" && mv "$CONFIG_PATH.tmp" "$CONFIG_PATH"
 

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -145,7 +145,6 @@ import {
   tlonDeliveryContext,
 } from './session-routing.js';
 import { resolveSettingsMirrorSync } from './settings-sync.js';
-import { probeWebSearchBootStatus } from './web-search-status.js';
 import {
   type ParsedCite,
   extractCites,
@@ -159,6 +158,7 @@ import {
   shouldEngageInGroup,
   stripBotMention,
 } from './utils.js';
+import { probeWebSearchBootStatus } from './web-search-status.js';
 
 // Local structural types — @tloncorp/api defines these internally but
 // does not export them from its public entrypoint.

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -145,6 +145,7 @@ import {
   tlonDeliveryContext,
 } from './session-routing.js';
 import { resolveSettingsMirrorSync } from './settings-sync.js';
+import { probeWebSearchBootStatus } from './web-search-status.js';
 import {
   type ParsedCite,
   extractCites,
@@ -4842,6 +4843,23 @@ export async function monitorTlonProvider(
       );
       await api.connect();
       runtime.log?.('[tlon] Connected! Firehose subscriptions active');
+      const webSearchRuntime = core.webSearch;
+      const webSearchStatus = probeWebSearchBootStatus({
+        searchConfig: cfg.tools?.web?.search,
+        listProviders:
+          typeof webSearchRuntime?.listProviders === 'function'
+            ? () => webSearchRuntime.listProviders()
+            : undefined,
+      });
+      if (!webSearchStatus.webSearchAvailable) {
+        runtime.error?.(
+          `[tlon] web_search unavailable at gateway boot: enabled=${webSearchStatus.webSearchEnabled}, providers=[${webSearchStatus.webSearchProviders.join(', ')}]${
+            webSearchStatus.webSearchProbeError
+              ? `, probeError=${webSearchStatus.webSearchProbeError}`
+              : ''
+          }`
+        );
+      }
       telemetry?.captureGatewayConnected({
         ownerShip: effectiveOwnerShip,
         botShip: botShipName,
@@ -4857,6 +4875,7 @@ export async function monitorTlonProvider(
         pendingApprovalCount: pendingApprovals.length,
         autoDiscoverChannels: effectiveAutoDiscoverChannels,
         ownerListenEnabled: effectiveOwnerListenEnabled,
+        ...webSearchStatus,
       });
 
       // Periodically refresh channel discovery

--- a/packages/openclaw/src/monitor/web-search-status.test.ts
+++ b/packages/openclaw/src/monitor/web-search-status.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { probeWebSearchBootStatus } from './web-search-status.js';
+
+describe('probeWebSearchBootStatus', () => {
+  it('reports available when enabled and a provider is registered', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: { provider: 'brave' },
+      listProviders: () => [{ id: 'brave' }],
+    });
+
+    expect(status).toEqual({
+      webSearchEnabled: true,
+      webSearchConfiguredProvider: 'brave',
+      webSearchProviders: ['brave'],
+      webSearchProviderCount: 1,
+      webSearchAvailable: true,
+      webSearchProbeError: null,
+    });
+  });
+
+  it('reports unavailable when the registry has no providers', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: { provider: 'brave' },
+      listProviders: () => [],
+    });
+
+    expect(status.webSearchAvailable).toBe(false);
+    expect(status.webSearchProviderCount).toBe(0);
+    expect(status.webSearchProbeError).toBeNull();
+  });
+
+  it('defaults enabled to true and configured provider to null when config is absent', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: undefined,
+      listProviders: () => [{ id: 'perplexity' }],
+    });
+
+    expect(status.webSearchEnabled).toBe(true);
+    expect(status.webSearchConfiguredProvider).toBeNull();
+    expect(status.webSearchAvailable).toBe(true);
+  });
+
+  it('reports unavailable when web search is explicitly disabled', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: { enabled: false },
+      listProviders: () => [{ id: 'brave' }],
+    });
+
+    expect(status.webSearchEnabled).toBe(false);
+    expect(status.webSearchAvailable).toBe(false);
+    expect(status.webSearchProviders).toEqual(['brave']);
+  });
+
+  it('dedupes and sorts registered provider ids', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: undefined,
+      listProviders: () => [
+        { id: 'perplexity' },
+        { id: 'brave' },
+        { id: 'brave' },
+      ],
+    });
+
+    expect(status.webSearchProviders).toEqual(['brave', 'perplexity']);
+    expect(status.webSearchProviderCount).toBe(2);
+  });
+
+  it('captures a probe error when listProviders throws', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: undefined,
+      listProviders: () => {
+        throw new Error('registry not loaded');
+      },
+    });
+
+    expect(status.webSearchAvailable).toBe(false);
+    expect(status.webSearchProviders).toEqual([]);
+    expect(status.webSearchProbeError).toBe('registry not loaded');
+  });
+
+  it('captures a probe error when the runtime lacks listProviders', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: undefined,
+      listProviders: undefined,
+    });
+
+    expect(status.webSearchAvailable).toBe(false);
+    expect(status.webSearchProbeError).toMatch(/listProviders missing/);
+  });
+
+  it('normalizes the configured provider id', () => {
+    const status = probeWebSearchBootStatus({
+      searchConfig: { provider: ' Brave ' },
+      listProviders: () => [],
+    });
+
+    expect(status.webSearchConfiguredProvider).toBe('brave');
+  });
+});

--- a/packages/openclaw/src/monitor/web-search-status.ts
+++ b/packages/openclaw/src/monitor/web-search-status.ts
@@ -1,0 +1,70 @@
+/**
+ * Boot-time web_search availability probe.
+ *
+ * The gateway resolves web_search from provider plugins loaded into its
+ * registry. When a provider plugin fails to install (e.g. a broken npm cache
+ * during provisioning), the registry comes up empty and the gateway disables
+ * web_search without any error — the tool is simply absent, so nothing fires
+ * until a user happens to ask the bot to search. Probing at gateway-connect
+ * time and reporting the result on `TlonBot Gateway Connected` makes that
+ * failure observable fleet-wide at provision time.
+ */
+
+export type WebSearchBootStatus = {
+  /** `tools.web.search.enabled` — defaults to true when unset. */
+  webSearchEnabled: boolean;
+  /** `tools.web.search.provider`, or null when auto-detecting. */
+  webSearchConfiguredProvider: string | null;
+  /** Provider ids registered in the gateway's plugin registry, sorted. */
+  webSearchProviders: string[];
+  webSearchProviderCount: number;
+  /**
+   * True when web_search is enabled and at least one provider is registered.
+   * False also covers probe failures — alert on false, filter expected
+   * `webSearchEnabled: false` deployments via that field.
+   */
+  webSearchAvailable: boolean;
+  /** Non-null when the probe itself failed (couldn't read the registry). */
+  webSearchProbeError: string | null;
+};
+
+type WebSearchConfigSlice = {
+  enabled?: boolean;
+  provider?: string;
+};
+
+export function probeWebSearchBootStatus(params: {
+  searchConfig: WebSearchConfigSlice | undefined;
+  listProviders: (() => Array<{ id: string }>) | undefined;
+}): WebSearchBootStatus {
+  const webSearchEnabled = params.searchConfig?.enabled !== false;
+  const configuredProvider =
+    params.searchConfig?.provider?.trim().toLowerCase() || null;
+
+  let providers: string[] = [];
+  let probeError: string | null = null;
+  if (typeof params.listProviders !== 'function') {
+    probeError = 'webSearch runtime unavailable (listProviders missing)';
+  } else {
+    try {
+      providers = [
+        ...new Set(params.listProviders().map((provider) => provider.id)),
+      ].sort();
+    } catch (error) {
+      probeError =
+        error instanceof Error
+          ? error.message || String(error)
+          : String(error);
+    }
+  }
+
+  return {
+    webSearchEnabled,
+    webSearchConfiguredProvider: configuredProvider,
+    webSearchProviders: providers,
+    webSearchProviderCount: providers.length,
+    webSearchAvailable:
+      probeError == null && webSearchEnabled && providers.length > 0,
+    webSearchProbeError: probeError,
+  };
+}

--- a/packages/openclaw/src/monitor/web-search-status.ts
+++ b/packages/openclaw/src/monitor/web-search-status.ts
@@ -52,9 +52,7 @@ export function probeWebSearchBootStatus(params: {
       ].sort();
     } catch (error) {
       probeError =
-        error instanceof Error
-          ? error.message || String(error)
-          : String(error);
+        error instanceof Error ? error.message || String(error) : String(error);
     }
   }
 

--- a/packages/openclaw/src/telemetry.test.ts
+++ b/packages/openclaw/src/telemetry.test.ts
@@ -532,6 +532,12 @@ describe('telemetry tool tracking', () => {
       pendingApprovalCount: 4,
       autoDiscoverChannels: true,
       ownerListenEnabled: true,
+      webSearchEnabled: true,
+      webSearchConfiguredProvider: 'brave',
+      webSearchProviders: ['brave'],
+      webSearchProviderCount: 1,
+      webSearchAvailable: true,
+      webSearchProbeError: null,
     });
 
     expect(postHogMocks.capture).toHaveBeenCalledWith({
@@ -551,6 +557,12 @@ describe('telemetry tool tracking', () => {
         pendingApprovalCount: 4,
         autoDiscoverChannels: true,
         ownerListenEnabled: true,
+        webSearchEnabled: true,
+        webSearchConfiguredProvider: 'brave',
+        webSearchProviders: ['brave'],
+        webSearchProviderCount: 1,
+        webSearchAvailable: true,
+        webSearchProbeError: null,
       }),
     });
   });

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -196,6 +196,15 @@ export type TlonGatewayConnectedEvent = {
   pendingApprovalCount: number;
   autoDiscoverChannels: boolean;
   ownerListenEnabled: boolean;
+  // Boot-time web_search status (see monitor/web-search-status.ts). Rides on
+  // this event so fleet monitors catch capability loss at provision time —
+  // a failed provider-plugin install disables web_search silently otherwise.
+  webSearchEnabled: boolean;
+  webSearchConfiguredProvider: string | null;
+  webSearchProviders: string[];
+  webSearchProviderCount: number;
+  webSearchAvailable: boolean;
+  webSearchProbeError: string | null;
 };
 
 export type TlonReplyTelemetryResult = {
@@ -1053,6 +1062,12 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
         pendingApprovalCount: event.pendingApprovalCount,
         autoDiscoverChannels: event.autoDiscoverChannels,
         ownerListenEnabled: event.ownerListenEnabled,
+        webSearchEnabled: event.webSearchEnabled,
+        webSearchConfiguredProvider: event.webSearchConfiguredProvider,
+        webSearchProviders: event.webSearchProviders,
+        webSearchProviderCount: event.webSearchProviderCount,
+        webSearchAvailable: event.webSearchAvailable,
+        webSearchProbeError: event.webSearchProbeError,
       }),
     });
   }


### PR DESCRIPTION
## Summary

Adds a check at gateway start to confirm the web search plugin is operable. This gives us enough info in the telemetry event to power an alert.

## Changes

- Adds a boot-time `web_search` availability probe for OpenClaw. Checks enabled state, configured provider, registered, availability, and probe errors
- Threads those fields into the `TlonBot Gateway Connected` telemetry event
- Unit tests covering provider status handling and telemetry capture

## How did I test?

Locally using the OpenClaw dev server.

## Risks and impact

- Safe to rollback without consulting PR author? Yes


Fixes TLON-6114