### PR TITLE
openclaw: subscription retries and status observability

### DIFF
--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -411,6 +411,7 @@ export async function monitorTlonProvider(
     extra?: {
       errorKind?: string | null;
       attempt?: number | null;
+      downMs?: number | null;
     }
   ) => {
     telemetry?.capturePluginError({
@@ -422,6 +423,7 @@ export async function monitorTlonProvider(
       errorKind: extra?.errorKind ?? classifyPluginError(error),
       errorText: formatTlonTelemetryErrorText(error),
       attempt: extra?.attempt ?? null,
+      downMs: extra?.downMs ?? null,
     });
   };
   runtime.log?.(`[tlon] Starting monitor for ${botShipName}`);
@@ -472,6 +474,30 @@ export async function monitorTlonProvider(
     }
   }
 
+  // Map a subscription's gall app (+ path where one app carries several
+  // subscriptions) onto the telemetry error-source vocabulary.
+  const subscriptionErrorSource = (
+    app: string,
+    path: string
+  ): TlonPluginErrorSource => {
+    switch (app) {
+      case 'chat':
+        return 'chat_firehose';
+      case 'channels':
+        return 'channels_firehose';
+      case 'contacts':
+        return 'contacts_subscription';
+      case 'steward':
+        return 'steward_subscription';
+      case 'groups':
+        return path === '/v1/foreigns'
+          ? 'foreigns_subscription'
+          : 'groups_ui_subscription';
+      default:
+        return 'settings_refresh';
+    }
+  };
+
   let api: UrbitSSEClient | null = null;
   let cookie: string;
   try {
@@ -489,6 +515,73 @@ export async function monitorTlonProvider(
         const newCookie = await authenticateWithRetry(5, 're_auth');
         client.updateCookie(newCookie);
         runtime.log?.('[tlon] Re-authentication successful');
+      },
+      // A dead inbound subscription means silently lost messages (incident
+      // 2026-07-07: chat firehose died for 5.5h with zero telemetry), so
+      // surface recovery progress to PostHog. Sampled: first failure, then
+      // every 5th, plus a marker event once the subscription recovers.
+      onSubscriptionRecovery: (event) => {
+        const source = subscriptionErrorSource(event.app, event.path);
+        if (event.phase === 'retrying') {
+          if (event.attempt === 1 || event.attempt % 5 === 0) {
+            capturePluginError(source, event.error ?? 'resubscribe failed', {
+              errorKind: 'resubscribe_failed',
+              attempt: event.attempt,
+              downMs: event.downMs,
+            });
+          }
+          return;
+        }
+        runtime.log?.(
+          `[tlon] Subscription ${event.app}${event.path} ${event.phase} after ${event.attempt} failed attempt(s), down ${event.downMs}ms`
+        );
+        if (event.attempt > 0) {
+          capturePluginError(
+            source,
+            `subscription recovered (${event.phase}) after ${event.attempt} failed attempt(s)`,
+            {
+              errorKind: 'resubscribe_recovered',
+              attempt: event.attempt,
+              downMs: event.downMs,
+            }
+          );
+        }
+      },
+      // Stream-level drops/stalls/reconnects. Distinct from per-subscription
+      // recovery above: this is the whole SSE channel going down. Without it,
+      // a stream that drops and cleanly reconnects (or a watchdog-detected
+      // hung socket) is invisible in PostHog — only stdout.
+      onStreamRecovery: (event) => {
+        if (event.phase === 'reconnected') {
+          if (event.attempt > 0 || (event.downtimeMs ?? 0) > 0) {
+            capturePluginError(
+              'sse_stream',
+              `SSE stream reconnected after ${event.attempt} attempt(s)`,
+              {
+                errorKind: 'stream_reconnected',
+                attempt: event.attempt,
+                downMs: event.downtimeMs ?? null,
+              }
+            );
+          }
+          return;
+        }
+        if (event.phase === 'watchdog_stale') {
+          capturePluginError(
+            'sse_stream',
+            `SSE stream stale (${event.idleMs}ms idle); forcing reconnect`,
+            { errorKind: 'stream_stale', downMs: event.idleMs ?? null }
+          );
+          return;
+        }
+        // reconnect_failed — sample like the subscription retries.
+        if (event.attempt === 1 || event.attempt % 5 === 0) {
+          capturePluginError(
+            'sse_stream',
+            event.error ?? 'stream reconnect failed',
+            { errorKind: 'stream_reconnect_failed', attempt: event.attempt }
+          );
+        }
       },
     });
   } catch (error) {
@@ -719,6 +812,7 @@ export async function monitorTlonProvider(
             errorKind: report.event.errorKind ?? null,
             errorText: report.event.errorText,
             attempt: report.event.attempt ?? null,
+            downMs: report.event.downMs ?? null,
           });
           break;
         case 'telemetry':
@@ -3995,6 +4089,11 @@ export async function monitorTlonProvider(
           runtime.error?.(`[tlon] Channels firehose error: ${String(error)}`);
         },
         quit: () => {
+          capturePluginError(
+            'channels_firehose',
+            'channels firehose quit received; resubscribing',
+            { errorKind: 'quit' }
+          );
           runtime.log?.(
             '[tlon] Channels firehose quit received, SSE client will resubscribe'
           );
@@ -4012,6 +4111,11 @@ export async function monitorTlonProvider(
           runtime.error?.(`[tlon] Chat firehose error: ${String(error)}`);
         },
         quit: () => {
+          capturePluginError(
+            'chat_firehose',
+            'chat firehose quit received; resubscribing',
+            { errorKind: 'quit' }
+          );
           runtime.log?.(
             '[tlon] Chat firehose quit received, SSE client will resubscribe'
           );
@@ -4210,11 +4314,17 @@ export async function monitorTlonProvider(
               });
             },
             err: (error) => {
+              capturePluginError('steward_subscription', error);
               runtime.error?.(
                 `[tlon] Steward lens subscription error: ${String(error)}`
               );
             },
             quit: () => {
+              capturePluginError(
+                'steward_subscription',
+                'steward lens quit received; resubscribing',
+                { errorKind: 'quit' }
+              );
               runtime.log?.(
                 '[tlon] Steward lens quit received, SSE client will resubscribe'
               );

--- a/packages/openclaw/src/telemetry.ts
+++ b/packages/openclaw/src/telemetry.ts
@@ -431,7 +431,9 @@ export type TlonPluginErrorSource =
   | 'contacts_subscription'
   | 'groups_ui_subscription'
   | 'foreigns_subscription'
-  | 'settings_refresh';
+  | 'steward_subscription'
+  | 'settings_refresh'
+  | 'sse_stream';
 
 export type TlonPluginErrorEvent = {
   harness: TlonHarnessName;
@@ -442,6 +444,12 @@ export type TlonPluginErrorEvent = {
   errorKind: string | null;
   errorText: string;
   attempt: number | null;
+  /**
+   * For recoverable subscription/stream failures: how long inbound has been
+   * (or was) down, in ms. Lets PostHog aggregate outage duration rather than
+   * just failure counts.
+   */
+  downMs: number | null;
 };
 
 export type TlonTelemetryErrorEvent = {
@@ -1627,6 +1635,7 @@ class PostHogTlonTelemetry implements TlonTelemetryClient {
           errorKind: event.errorKind,
           errorText: event.errorText,
           attempt: event.attempt,
+          downMs: event.downMs,
         },
         { omitNullish: true }
       ),
@@ -1937,6 +1946,7 @@ export type TlonPluginErrorReportInput = {
   errorKind?: string | null;
   errorText: string;
   attempt?: number | null;
+  downMs?: number | null;
 };
 
 export type TlonTelemetryErrorReportInput = {

--- a/packages/openclaw/src/urbit/sse-client.test.ts
+++ b/packages/openclaw/src/urbit/sse-client.test.ts
@@ -349,4 +349,313 @@ describe('UrbitSSEClient', () => {
       expect(client.maxReconnectDelay).toBe(10000);
     });
   });
+
+  describe('resubscribe resilience', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const okFetchResult = () => ({
+      response: { ok: true, status: 200 },
+      finalUrl: 'https://example.com',
+      release: vi.fn().mockResolvedValue(undefined),
+    });
+
+    it('keeps retrying resubscription beyond five failed attempts', async () => {
+      const { urbitFetch } = await import('./fetch.js');
+      const mockUrbitFetch = vi.mocked(urbitFetch);
+      mockUrbitFetch.mockResolvedValue(okFetchResult());
+
+      const recoverySpy = vi.fn();
+      const client = new UrbitSSEClient(
+        'https://example.com',
+        'urbauth-~zod=123',
+        { onSubscriptionRecovery: recoverySpy }
+      );
+      (client as { isConnected: boolean }).isConnected = true;
+
+      await client.subscribe({
+        app: 'chat',
+        path: '/v4',
+        event: vi.fn(),
+        quit: vi.fn(),
+      });
+      mockUrbitFetch.mockClear();
+      mockUrbitFetch.mockRejectedValue(new Error('node unresponsive'));
+
+      client.processEvent('id: 1\ndata: {"id":1,"response":"quit"}');
+
+      // Backoff waits: 2s, 4s, 8s, 16s, 30s, 30s... The old implementation
+      // gave up permanently after 5 attempts (~62s).
+      await vi.advanceTimersByTimeAsync(125_000);
+      expect(mockUrbitFetch.mock.calls.length).toBeGreaterThanOrEqual(6);
+      expect(recoverySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          app: 'chat',
+          path: '/v4',
+          phase: 'retrying',
+          attempt: 1,
+        })
+      );
+      expect(recoverySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: 'retrying', attempt: 5 })
+      );
+
+      // Node comes back: the next attempt succeeds and reports recovery
+      // with the total downtime so PostHog can aggregate outage duration.
+      mockUrbitFetch.mockResolvedValue(okFetchResult());
+      await vi.advanceTimersByTimeAsync(31_000);
+      const recovered = recoverySpy.mock.calls
+        .map((call) => call[0])
+        .find((event) => event.phase === 'recovered');
+      expect(recovered).toBeDefined();
+      expect(recovered.downMs).toBeGreaterThan(0);
+    });
+
+    it('completes a pending resubscribe via stream reconnect instead of double-subscribing', async () => {
+      const { urbitFetch } = await import('./fetch.js');
+      const mockUrbitFetch = vi.mocked(urbitFetch);
+      mockUrbitFetch.mockResolvedValue(okFetchResult());
+
+      const recoverySpy = vi.fn();
+      const client = new UrbitSSEClient(
+        'https://example.com',
+        'urbauth-~zod=123',
+        { onSubscriptionRecovery: recoverySpy }
+      );
+      (client as { isConnected: boolean }).isConnected = true;
+
+      await client.subscribe({
+        app: 'chat',
+        path: '/v4',
+        event: vi.fn(),
+        quit: vi.fn(),
+      });
+      mockUrbitFetch.mockClear();
+
+      client.processEvent('id: 1\ndata: {"id":1,"response":"quit"}');
+      // Stream drops before the first resubscribe attempt fires.
+      (client as { isConnected: boolean }).isConnected = false;
+
+      await vi.advanceTimersByTimeAsync(4_500);
+      // Disconnected: no subscribe PUTs, but the loop must stay alive
+      // (the old implementation returned here and never recovered).
+      expect(mockUrbitFetch).not.toHaveBeenCalled();
+
+      // Stream reconnects: connect() recreates the channel with the pending
+      // subscription included and bumps the epoch.
+      (client as unknown as { channelEpoch: number }).channelEpoch += 1;
+      (client as { isConnected: boolean }).isConnected = true;
+
+      await vi.advanceTimersByTimeAsync(2_500);
+      expect(mockUrbitFetch).not.toHaveBeenCalled();
+      expect(recoverySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: 'recovered_via_reconnect' })
+      );
+    });
+  });
+
+  describe('stream staleness watchdog', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('notifies handlers and aborts a stale stream', async () => {
+      const streamRecoverySpy = vi.fn();
+      const client = new UrbitSSEClient(
+        'https://example.com',
+        'urbauth-~zod=123',
+        {
+          streamStaleThresholdMs: 1_000,
+          streamWatchdogIntervalMs: 500,
+          onStreamRecovery: streamRecoverySpy,
+        }
+      );
+      const errSpy = vi.fn();
+      await client.subscribe({
+        app: 'chat',
+        path: '/v4',
+        event: vi.fn(),
+        err: errSpy,
+      });
+
+      const abortSpy = vi.fn();
+      (client as { isConnected: boolean }).isConnected = true;
+      (
+        client as unknown as { streamController: { abort: () => void } }
+      ).streamController = { abort: abortSpy };
+      (
+        client as unknown as { startStreamWatchdog: () => void }
+      ).startStreamWatchdog();
+
+      await vi.advanceTimersByTimeAsync(1_600);
+
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+      expect(errSpy).toHaveBeenCalledTimes(1);
+      const staleError = errSpy.mock.calls[0][0] as Error;
+      expect(String(staleError.message)).toContain('stale');
+      // Watchdog fire must reach the stream-recovery hook (→ PostHog),
+      // not just handler err fan-out.
+      expect(streamRecoverySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: 'watchdog_stale',
+          idleMs: expect.any(Number),
+        })
+      );
+
+      // The abort tears the stream down (isConnected flips false) and the
+      // reconnect loop owns recovery; the watchdog must not keep firing.
+      (client as { isConnected: boolean }).isConnected = false;
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+
+      (
+        client as unknown as { stopStreamWatchdog: () => void }
+      ).stopStreamWatchdog();
+    });
+
+    it('does not fire while events are flowing', async () => {
+      const client = new UrbitSSEClient(
+        'https://example.com',
+        'urbauth-~zod=123',
+        { streamStaleThresholdMs: 1_000, streamWatchdogIntervalMs: 500 }
+      );
+      const errSpy = vi.fn();
+      await client.subscribe({
+        app: 'chat',
+        path: '/v4',
+        event: vi.fn(),
+        err: errSpy,
+      });
+
+      const abortSpy = vi.fn();
+      (client as { isConnected: boolean }).isConnected = true;
+      (
+        client as unknown as { streamController: { abort: () => void } }
+      ).streamController = { abort: abortSpy };
+      (
+        client as unknown as { startStreamWatchdog: () => void }
+      ).startStreamWatchdog();
+
+      // Keep traffic flowing (like the 30s heartbeat poke acks in prod).
+      for (let i = 0; i < 5; i += 1) {
+        await vi.advanceTimersByTimeAsync(400);
+        client.processEvent(`id: ${i}\ndata: {"response":"poke","id":${i}}`);
+      }
+
+      expect(abortSpy).not.toHaveBeenCalled();
+      expect(errSpy).not.toHaveBeenCalled();
+
+      (
+        client as unknown as { stopStreamWatchdog: () => void }
+      ).stopStreamWatchdog();
+    });
+  });
+
+  describe('stream reconnect observability', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('reports downtime once the stream reconnects', async () => {
+      const { urbitFetch } = await import('./fetch.js');
+      const mockUrbitFetch = vi.mocked(urbitFetch);
+      // A stream that stays open (like a real SSE connection) so
+      // processStream's for-await blocks instead of hitting the finally and
+      // re-triggering reconnect.
+      const mockStream = new ReadableStream({ start() {} });
+      mockUrbitFetch.mockResolvedValue({
+        response: {
+          ok: true,
+          status: 200,
+          body: mockStream,
+        } as unknown as Response,
+        finalUrl: 'https://example.com',
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const streamRecoverySpy = vi.fn();
+      const client = new UrbitSSEClient(
+        'https://example.com',
+        'urbauth-~zod=123',
+        {
+          streamStaleThresholdMs: 0, // disable watchdog for this test
+          onStreamRecovery: streamRecoverySpy,
+        }
+      );
+      await client.subscribe({ app: 'chat', path: '/v4', event: vi.fn() });
+
+      // Simulate a stream that has been down for a while, then reconnect.
+      (client as unknown as { streamDownSince: number }).streamDownSince =
+        Date.now() - 42_000;
+      client.reconnectAttempts = 2;
+
+      // attemptReconnect awaits an internal backoff timer, so pump timers
+      // while it's in flight rather than awaiting it directly.
+      const reconnectPromise = (
+        client as unknown as { attemptReconnect: () => Promise<void> }
+      ).attemptReconnect();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await reconnectPromise;
+
+      const reconnected = streamRecoverySpy.mock.calls
+        .map((call) => call[0])
+        .find((event) => event.phase === 'reconnected');
+      expect(reconnected).toBeDefined();
+      expect(reconnected.downtimeMs).toBeGreaterThanOrEqual(42_000);
+      // Attempt count is captured before connect() resets it.
+      expect(reconnected.attempt).toBe(3);
+
+      // Stop further reconnects without a full close() — the shared mock
+      // stream is locked by the live reader, so cancel() would throw.
+      client.aborted = true;
+      (
+        client as unknown as { stopStreamWatchdog: () => void }
+      ).stopStreamWatchdog();
+    });
+  });
+
+  describe('reconnect subscription hygiene', () => {
+    it('recreates only handler-backed subscriptions on connect', async () => {
+      const { urbitFetch } = await import('./fetch.js');
+      const { ensureUrbitChannelOpen } = await import('./channel-ops.js');
+      const mockUrbitFetch = vi.mocked(urbitFetch);
+      const mockEnsure = vi.mocked(ensureUrbitChannelOpen);
+      mockUrbitFetch.mockResolvedValue({
+        response: { ok: true, status: 200, body: null },
+        finalUrl: 'https://example.com',
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const client = new UrbitSSEClient(
+        'https://example.com',
+        'urbauth-~zod=123',
+        { streamStaleThresholdMs: 0 }
+      );
+      await client.subscribe({ app: 'chat', path: '/v4', event: vi.fn() });
+      await client.subscribe({ app: 'channels', path: '/v4', event: vi.fn() });
+      // Simulate a quit-kicked subscription whose handlers were removed.
+      client.eventHandlers.delete(1);
+
+      await client.connect();
+
+      const createBody = mockEnsure.mock.calls.at(-1)?.[1]?.createBody as
+        | Array<{ id: number }>
+        | undefined;
+      expect(createBody).toBeDefined();
+      expect(createBody?.map((sub) => sub.id)).toEqual([2]);
+    });
+  });
 });

--- a/packages/openclaw/src/urbit/sse-client.ts
+++ b/packages/openclaw/src/urbit/sse-client.ts
@@ -293,7 +293,9 @@ export class UrbitSSEClient {
         // descriptive error before aborting; don't fan out the raw
         // AbortError too.
         this.suppressNextStreamErrorFanout = false;
-        this.logger.log?.(`[SSE] Stream torn down by watchdog: ${String(error)}`);
+        this.logger.log?.(
+          `[SSE] Stream torn down by watchdog: ${String(error)}`
+        );
         return;
       }
       if (!this.aborted) {

--- a/packages/openclaw/src/urbit/sse-client.ts
+++ b/packages/openclaw/src/urbit/sse-client.ts
@@ -15,6 +15,28 @@ export type UrbitSseLogger = {
   error?: (message: string) => void;
 };
 
+export type SubscriptionRecoveryEvent = {
+  app: string;
+  path: string;
+  phase: 'retrying' | 'recovered' | 'recovered_via_reconnect';
+  /** Failed resubscribe attempts so far (0 on a clean first-try recovery). */
+  attempt: number;
+  /** Elapsed ms since the quit that killed the subscription. */
+  downMs: number;
+  error?: unknown;
+};
+
+export type StreamRecoveryEvent = {
+  phase: 'watchdog_stale' | 'reconnect_failed' | 'reconnected';
+  /** Reconnect attempts so far (0 for watchdog_stale). */
+  attempt: number;
+  /** watchdog_stale: how long the stream had been silent. */
+  idleMs?: number;
+  /** reconnected: how long the stream was down. */
+  downtimeMs?: number;
+  error?: unknown;
+};
+
 type UrbitSseOptions = {
   ship?: string;
   ssrfPolicy?: SsrFPolicy;
@@ -29,6 +51,18 @@ type UrbitSseOptions = {
   reconnectDelay?: number;
   maxReconnectDelay?: number;
   logger?: UrbitSseLogger;
+  /** Observability hook for post-quit resubscribe recovery progress. */
+  onSubscriptionRecovery?: (event: SubscriptionRecoveryEvent) => void;
+  /** Observability hook for stream-level drops, reconnects, and stalls. */
+  onStreamRecovery?: (event: StreamRecoveryEvent) => void;
+  /**
+   * Force a stream reconnect when no SSE event (facts, poke acks, ...) has
+   * arrived for this long. In production the gateway-status heartbeat acks
+   * give the stream a ~30s pulse, so a long silence means the socket is
+   * dead even though no error or EOF was ever surfaced. 0 disables.
+   */
+  streamStaleThresholdMs?: number;
+  streamWatchdogIntervalMs?: number;
 };
 
 export class UrbitSSEClient {
@@ -75,6 +109,22 @@ export class UrbitSSEClient {
   private lastAcknowledgedEventId = -1;
   private readonly ackThreshold = 20;
 
+  /**
+   * Incremented on every successful connect(). A pending post-quit
+   * resubscribe watches this: a bump means the new eyre channel was created
+   * with the full subscription list (see connect), so the pending sub is
+   * already live and sending it again would double-subscribe.
+   */
+  private channelEpoch = 0;
+  private lastEventAt = Date.now();
+  private streamDownSince: number | null = null;
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null;
+  private suppressNextStreamErrorFanout = false;
+  private onSubscriptionRecovery: UrbitSseOptions['onSubscriptionRecovery'];
+  private onStreamRecovery: UrbitSseOptions['onStreamRecovery'];
+  private streamStaleThresholdMs: number;
+  private streamWatchdogIntervalMs: number;
+
   constructor(url: string, cookie: string, options: UrbitSseOptions = {}) {
     const ctx = getUrbitContext(url, options.ship);
     this.url = ctx.baseUrl;
@@ -94,6 +144,10 @@ export class UrbitSSEClient {
     this.ssrfPolicy = options.ssrfPolicy;
     this.lookupFn = options.lookupFn;
     this.fetchImpl = options.fetchImpl;
+    this.onSubscriptionRecovery = options.onSubscriptionRecovery;
+    this.onStreamRecovery = options.onStreamRecovery;
+    this.streamStaleThresholdMs = options.streamStaleThresholdMs ?? 180_000;
+    this.streamWatchdogIntervalMs = options.streamWatchdogIntervalMs ?? 30_000;
   }
 
   async subscribe(params: {
@@ -179,7 +233,12 @@ export class UrbitSSEClient {
         fetchImpl: this.fetchImpl,
       },
       {
-        createBody: this.subscriptions,
+        // Only recreate subscriptions that still have handlers. Entries whose
+        // handlers were removed (e.g. replaced after a gall quit) would
+        // otherwise double-subscribe and double-deliver after a reconnect.
+        createBody: this.subscriptions.filter((sub) =>
+          this.eventHandlers.has(sub.id)
+        ),
         createAuditContext: 'tlon-urbit-channel-create',
       }
     );
@@ -187,6 +246,9 @@ export class UrbitSSEClient {
     await this.openStream();
     this.isConnected = true;
     this.reconnectAttempts = 0;
+    this.channelEpoch += 1;
+    this.lastEventAt = Date.now();
+    this.startStreamWatchdog();
   }
 
   async openStream() {
@@ -226,6 +288,14 @@ export class UrbitSSEClient {
     }
 
     this.processStream(response.body).catch((error) => {
+      if (this.suppressNextStreamErrorFanout) {
+        // The stale-stream watchdog already notified handlers with a
+        // descriptive error before aborting; don't fan out the raw
+        // AbortError too.
+        this.suppressNextStreamErrorFanout = false;
+        this.logger.log?.(`[SSE] Stream torn down by watchdog: ${String(error)}`);
+        return;
+      }
       if (!this.aborted) {
         this.logger.error?.(`Stream error: ${String(error)}`);
         for (const { err } of this.eventHandlers.values()) {
@@ -268,6 +338,7 @@ export class UrbitSSEClient {
       this.streamController = null;
       if (!this.aborted && this.autoReconnect) {
         this.isConnected = false;
+        this.streamDownSince ??= Date.now();
         this.logger.log?.('[SSE] Stream ended, attempting reconnection...');
         await this.attemptReconnect();
       }
@@ -275,6 +346,7 @@ export class UrbitSSEClient {
   }
 
   processEvent(eventData: string) {
+    this.lastEventAt = Date.now();
     const lines = eventData.split('\n');
     let data: string | null = null;
     let eventId: number | null = null;
@@ -474,18 +546,95 @@ export class UrbitSSEClient {
         await this.onReconnect(this);
       }
 
+      // connect() resets the attempt counter on success; capture it first.
+      const attempt = this.reconnectAttempts;
       await this.connect();
       this.logger.log?.('[SSE] Reconnection successful!');
+      const downtimeMs = this.streamDownSince
+        ? Date.now() - this.streamDownSince
+        : undefined;
+      this.streamDownSince = null;
+      this.onStreamRecovery?.({
+        phase: 'reconnected',
+        attempt,
+        downtimeMs,
+      });
     } catch (error) {
       this.logger.error?.(`[SSE] Reconnection failed: ${String(error)}`);
+      this.onStreamRecovery?.({
+        phase: 'reconnect_failed',
+        attempt: this.reconnectAttempts,
+        error,
+      });
       await this.attemptReconnect();
+    }
+  }
+
+  /**
+   * Watchdog for the silent-death failure mode: the socket hangs without an
+   * error or EOF, so processStream blocks forever and no reconnect fires.
+   * When no SSE event has arrived for streamStaleThresholdMs, notify
+   * handlers with a descriptive error and abort the stream, which routes
+   * into the normal auto-reconnect path (fresh channel, all live
+   * subscriptions recreated).
+   */
+  private startStreamWatchdog() {
+    if (
+      this.watchdogTimer ||
+      !this.autoReconnect ||
+      this.streamStaleThresholdMs <= 0
+    ) {
+      return;
+    }
+    this.watchdogTimer = setInterval(() => {
+      if (this.aborted) {
+        this.stopStreamWatchdog();
+        return;
+      }
+      if (!this.isConnected) {
+        // Reconnect loop owns recovery while the stream is down.
+        return;
+      }
+      const idleMs = Date.now() - this.lastEventAt;
+      if (idleMs < this.streamStaleThresholdMs) {
+        return;
+      }
+      this.logger.error?.(
+        `[SSE] Stream stale: no events for ${Math.round(idleMs / 1000)}s (threshold ${Math.round(this.streamStaleThresholdMs / 1000)}s); forcing reconnect`
+      );
+      this.onStreamRecovery?.({ phase: 'watchdog_stale', attempt: 0, idleMs });
+      const staleError = new Error(
+        `SSE stream stale: no events for ${Math.round(idleMs / 1000)}s; forcing reconnect`
+      );
+      for (const { err } of this.eventHandlers.values()) {
+        err?.(staleError);
+      }
+      // Reset so the watchdog doesn't refire while the teardown/reconnect
+      // is still in flight.
+      this.lastEventAt = Date.now();
+      this.streamDownSince ??= Date.now();
+      this.suppressNextStreamErrorFanout = true;
+      this.streamController?.abort();
+    }, this.streamWatchdogIntervalMs);
+    if (typeof this.watchdogTimer === 'object') {
+      this.watchdogTimer.unref?.();
+    }
+  }
+
+  private stopStreamWatchdog() {
+    if (this.watchdogTimer) {
+      clearInterval(this.watchdogTimer);
+      this.watchdogTimer = null;
     }
   }
 
   /**
    * Re-subscribe to an app/path after the Gall agent sends a quit.
    * Creates a new subscription with a fresh ID, transfers event handlers,
-   * and retries with exponential backoff.
+   * and retries with capped exponential backoff until it succeeds, the
+   * client closes, or a stream-level reconnect recreates the channel with
+   * the new subscription already included. A dead inbound subscription is
+   * unrecoverable data loss for the bot, so this never gives up on its own.
    */
   private async resubscribeAfterQuit(oldSubId: number) {
     const oldSub = this.subscriptions.find((s) => s.id === oldSubId);
@@ -494,54 +643,96 @@ export class UrbitSSEClient {
     const handlers = this.eventHandlers.get(oldSubId);
     if (!handlers) return;
 
-    const maxAttempts = 5;
     const baseDelay = 2000;
     const maxDelay = 30000;
 
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      const delay = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+    // Register the replacement once, up front. From this point the sub is
+    // part of this.subscriptions, so any connect() (stream reconnect)
+    // creates it as part of the new channel — tracked via channelEpoch.
+    const newSubId = this.subscriptions.length + 1;
+    const newSub = {
+      id: newSubId,
+      action: 'subscribe' as const,
+      ship: this.ship,
+      app: oldSub.app,
+      path: oldSub.path,
+    };
+    this.subscriptions.push(newSub);
+    this.eventHandlers.set(newSubId, handlers);
+    this.eventHandlers.delete(oldSubId);
+    const epochAtRegistration = this.channelEpoch;
+    const downSince = Date.now();
+
+    let failedAttempts = 0;
+    for (;;) {
+      const delay = Math.min(
+        baseDelay * Math.pow(2, Math.min(failedAttempts, 4)),
+        maxDelay
+      );
       this.logger.log?.(
-        `[SSE] Resubscribing to ${oldSub.app}${oldSub.path} after quit (attempt ${attempt}/${maxAttempts}) in ${delay}ms...`
+        `[SSE] Resubscribing to ${oldSub.app}${oldSub.path} after quit (attempt ${failedAttempts + 1}) in ${delay}ms...`
       );
 
       await new Promise((resolve) => setTimeout(resolve, delay));
 
-      if (this.aborted || !this.isConnected) return;
+      if (this.aborted) return;
 
-      try {
-        const newSubId = this.subscriptions.length + 1;
-        const newSub = {
-          id: newSubId,
-          action: 'subscribe' as const,
-          ship: this.ship,
+      if (this.channelEpoch !== epochAtRegistration) {
+        // A stream reconnect rebuilt the channel with newSub included;
+        // sending it again would double-subscribe.
+        this.logger.log?.(
+          `[SSE] Subscription ${oldSub.app}${oldSub.path} recovered via stream reconnect (id=${newSubId})`
+        );
+        this.onSubscriptionRecovery?.({
           app: oldSub.app,
           path: oldSub.path,
-        };
+          phase: 'recovered_via_reconnect',
+          attempt: failedAttempts,
+          downMs: Date.now() - downSince,
+        });
+        return;
+      }
 
-        this.subscriptions.push(newSub);
-        this.eventHandlers.set(newSubId, handlers);
-        this.eventHandlers.delete(oldSubId);
+      if (!this.isConnected) {
+        // Stream is down; the reconnect loop owns recovery. Keep waiting —
+        // the epoch check above completes this resubscribe when it lands.
+        continue;
+      }
 
+      try {
         await this.sendSubscription(newSub);
         this.logger.log?.(
           `[SSE] Resubscribed to ${oldSub.app}${oldSub.path} successfully (new id=${newSubId})`
         );
+        this.onSubscriptionRecovery?.({
+          app: oldSub.app,
+          path: oldSub.path,
+          phase: 'recovered',
+          attempt: failedAttempts,
+          downMs: Date.now() - downSince,
+        });
         return;
       } catch (error) {
+        failedAttempts += 1;
         this.logger.error?.(
-          `[SSE] Resubscribe failed for ${oldSub.app}${oldSub.path}: ${String(error)}`
+          `[SSE] Resubscribe failed for ${oldSub.app}${oldSub.path} (attempt ${failedAttempts}): ${String(error)}`
         );
+        this.onSubscriptionRecovery?.({
+          app: oldSub.app,
+          path: oldSub.path,
+          phase: 'retrying',
+          attempt: failedAttempts,
+          downMs: Date.now() - downSince,
+          error,
+        });
       }
     }
-
-    this.logger.error?.(
-      `[SSE] Failed to resubscribe to ${oldSub.app}${oldSub.path} after ${maxAttempts} attempts`
-    );
   }
 
   async close() {
     this.aborted = true;
     this.isConnected = false;
+    this.stopStreamWatchdog();
     this.streamController?.abort();
 
     try {


### PR DESCRIPTION
## Summary

Adds telemetry for monitoring SSE connections in the OpenClaw plugin. If subscriptions get disrupted and cause messages to drop, we'll have more context when debugging.

## Changes
- Adds observability hooks for subscription recovery and stream recovery, including retry attempts and downtime
- Makes post-quit subscription recovery much more durable: retries indefinitely with capped backoff instead of giving up after five attempts
- Adds stream-staleness detection: if the SSE stream goes quiet too long, it reports the stale stream, notifies handlers, aborts, and forces reconnect
- Wires the new events into Tlon monitor telemetry
- Expands `sse-client.test.ts` with coverage for infinite retry, reconnect-based recovery, stale stream watchdog behavior, downtime reporting, and reconnect subscription hygiene

## How did I test?

Locally using Docker dev setup

## Risks and impact

- Safe to rollback without consulting PR author? Yes