### PR TITLE
fix: guard voice memo recorder stop methods on mount

### DIFF
--- a/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/app/ui/components/AudioRecorder/AudioRecorder.tsx
@@ -124,6 +124,11 @@ export const AudioRecorder = forwardRef<
   const waveformRef = useRef<IWaveformRef>(null);
   const extractWaveformData = useExtractWaveformDataCallback();
 
+  // Tracks whether a native recording is in progress. `state.recorderState`
+  // lags the native recorder (it updates via an async event), so a synchronous
+  // ref is needed to decide whether `stopRecord()` should run.
+  const isRecordingRef = useRef(false);
+
   const refApi = useMemo(
     () => ({
       enterRecordingMode() {
@@ -158,8 +163,10 @@ export const AudioRecorder = forwardRef<
             return;
           }
 
+          isRecordingRef.current = true;
           await waveformRef.current?.startRecord();
         } catch (error) {
+          isRecordingRef.current = false;
           // cancel to avoid trapping user (user can't exit recording mode
           // without stopping record)
           Alert.alert('Failed to start recording');
@@ -167,6 +174,10 @@ export const AudioRecorder = forwardRef<
         }
       },
       async stopRecording() {
+        // Only stop a recording we actually started. `stopRecord` rejects
+        // when nothing is recording (e.g. closing the sheet on mount).
+        if (!isRecordingRef.current) return;
+        isRecordingRef.current = false;
         const uri = await waveformRef.current?.stopRecord();
         if (uri == null) {
           console.warn('No uri returned from stopRecord');
@@ -193,6 +204,9 @@ export const AudioRecorder = forwardRef<
         });
       },
       async stopPlayback() {
+        // `stopPlayer` is only valid in playback mode; the waveform library
+        // rejects with "mode is not static" if called while recording.
+        if (state.live) return;
         await waveformRef.current?.stopPlayer();
       },
       async pausePlayback() {
@@ -202,7 +216,7 @@ export const AudioRecorder = forwardRef<
         await waveformRef.current?.resumePlayer();
       },
     }),
-    [onCancel]
+    [onCancel, state.live]
   );
 
   useImperativeHandle(ref, () => refApi);


### PR DESCRIPTION
## Summary

On mobile, the voice memo recorder fires **two** unhandled promise rejections on mount (the "Log 1 of 2" LogBox):

- `Error: error in stopping player: mode is not static`
- `Error: Failed to stop recording` / `Error: Recording resources not properly initialized`

Both come from `AudioRecorder`'s imperative stop methods being called when there's nothing to stop. This guards both so they no-op in that case.

## Changes

`AudioRecorderSheet` renders closed (mounted inside the composer's attachment flow — `AttachmentSheet` → `AddGalleryPost`), and its mount effect calls the open-change handler with `open = false`, which unconditionally runs both `stopRecording()` and `stopPlayback()`. The recorder is still in its initial recording mode with nothing recording, so:

- `stopPlayback()` → `stopPlayer()` hits the `@simform_solutions/react-native-audio-waveform` guard that rejects when `mode !== 'static'`.
- `stopRecording()` → `stopRecord()` rejects from the native module because no recording is in progress.

Neither call is awaited/caught by the sheet, so both surface as unhandled rejections on mount.

The fix guards each method at the source:
- `stopPlayback()` returns early while `state.live` (recording mode); `state.live` is added to `refApi`'s memo deps so the guard reads the current mode.
- `stopRecording()` returns early unless a recording is in progress, tracked with a synchronous `isRecordingRef` (set before `startRecord()`, cleared on stop/failure). A React-state guard can't be used here because `state.recorderState` lags the native recorder — it updates via an async event, so a quick open→close right after recording starts would skip `stopRecord()` and leave the recorder running.

This is the native counterpart of the web-only fix in [`d44fb1b30`](https://github.com/tloncorp/tlon-apps/commit/d44fb1b303cf79634589f147e0cfeeed2faae16f), which neutralized the same two calls on web by making the shim's ref null so the `?.` guards short-circuit. On native the ref is real, so the calls run and reject.

## How did I test?

Verified on the iOS simulator with the app's own dev build, watching the Metro/device logs across a full reload + composer mount:

- Before: `mode is not static` **and** `Failed to stop recording` / `Recording resources not properly initialized` both fire on mount.
- After both guards: **0 occurrences** of all three strings on mount.

Recording → playback → closing the sheet still stops playback normally. Typecheck + lint pass.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes** — one file, trivial revert.
- Affects important code area:
  - [x] Other: voice memo recorder (mobile only; web path already handled)

## Rollback plan

Revert this commit.

## Screenshots / videos

N/A — removes LogBox errors; no visual change.
