### PR TITLE
fix: gallery 'Media or File' sheet dismisses before you can pick media

### DIFF
--- a/packages/app/ui/components/BottomSheetWrapper.native.tsx
+++ b/packages/app/ui/components/BottomSheetWrapper.native.tsx
@@ -159,6 +159,14 @@ export const BottomSheetWrapper = forwardRef<
      * sheet transitions.
      */
     const isProgrammaticChange = useRef(false);
+    /**
+     * Whether `handleSheetChanges` already observed the closed state (index -1)
+     * for the current dismissal. `handleModalDismiss` is only a fallback for the
+     * case where gorhom skips `onChange(-1)`; if that callback already ran, it
+     * made the open/skip decision and `handleModalDismiss` must not report the
+     * close a second time.
+     */
+    const reachedClosedIndex = useRef(false);
     // Default-path callers (unmountOnClose=false) start mounted=true regardless
     // of `open`, mirroring today's render-immediately behavior. Opt-in callers
     // start mounted === open.
@@ -348,6 +356,7 @@ export const BottomSheetWrapper = forwardRef<
       (index: number) => {
         // When sheet is closed (index -1), handle cleanup and callbacks
         if (index === -1) {
+          reachedClosedIndex.current = true;
           // Only notify parent if dismissOnSnapToBottom is true and it's user-initiated
           if (dismissOnSnapToBottom && !isProgrammaticChange.current) {
             onOpenChange(false);
@@ -355,6 +364,7 @@ export const BottomSheetWrapper = forwardRef<
           // Reset flag when reaching closed state
           isProgrammaticChange.current = false;
         } else if (index >= 0) {
+          reachedClosedIndex.current = false;
           // Reset flag when sheet reaches any open snap point
           // This ensures the flag only protects the specific operation that set it
           isProgrammaticChange.current = false;
@@ -369,6 +379,21 @@ export const BottomSheetWrapper = forwardRef<
     // on every modal dismissal path; if the parent still thinks the sheet is
     // open at that point, sync it so the next open isn't a no-op.
     const handleModalDismiss = useCallback(() => {
+      // If handleSheetChanges already saw index -1 for this dismissal, it has
+      // already decided whether to report the close (respecting the
+      // programmatic-change flag). Reporting again here would double-fire
+      // onOpenChange(false) for programmatic dismissals and, since the flag was
+      // consumed by handleSheetChanges, this fallback can no longer tell such a
+      // dismissal apart — spuriously closing the parent (e.g. clobbering a
+      // nested-sheet handoff).
+      if (reachedClosedIndex.current) {
+        reachedClosedIndex.current = false;
+        return;
+      }
+      // Fallback for when gorhom skips onChange(-1) (dismiss mid-open-animation).
+      // A programmatic close sets `open` false first, so it no-ops here; only a
+      // user dismiss reaches this with the parent still open, and we sync it so
+      // the sheet can reopen.
       if (open) {
         onOpenChange(false);
       }


### PR DESCRIPTION
Fixes TLON-6142

## Summary

Opening a gallery post (**Pictures channel → New → "Media or File"**) flashes the second sheet ("Media Library / Capture / Upload a File / Voice Memo") open and immediately closes it, so you can't get to the media picker. The chat composer's single-level `+` sheet is unaffected — this only bites the two-sheet handoff in `AddGalleryPost`.

## Changes

Root cause is in the shared `BottomSheetWrapper` (native). A gorhom modal dismissal fires **both** `onChange(-1)` and `onDismiss`. `handleSheetChanges` handles `onChange(-1)` — it respects the `isProgrammaticChange` flag (skipping the callback for programmatic closes) and then resets the flag. `handleModalDismiss` then ran with the flag already consumed, so it could no longer tell a programmatic dismissal from a user one and reported the close upward a second time.

For the gallery handoff, that spurious `onOpenChange(false)` runs the parent's `onClose`, which resets `route` back to `'gallery'` — canceling the `setTimeout`-driven transition to `'add-attachment'`.

This is a latent bug that only recently detonated:

- **Planted** in #6039 (`fix: bottom sheet modals fail to reopen after being dismissed`), which added `handleModalDismiss` as an `onDismiss` fallback without the `isProgrammaticChange` guard that `handleSheetChanges` uses. Harmless at first — the spurious close landed *before* the 300ms handoff (`gallery → gallery → add-attachment`, a no-op).
- **Triggered** by #6072 (native portals via react-native-teleport), which slowed the modal close enough that the spurious close now lands *after* the handoff (`gallery → add-attachment → gallery`), clobbering it. Confirmed by bisect: the flow works on a pre-#6072 build and breaks once #6072 is in.

`handleModalDismiss` is only a fallback for the case where gorhom **skips** `onChange(-1)` (dismiss mid-open-animation), so it's now gated on whether `onChange(-1)` already ran for this dismissal.

## How did I test?

iOS simulator, dev build, Pictures channel → New → Media or File:

- **Before:** second sheet opens then instantly dismisses; can't reach the picker.
- **After:** second sheet stays open → Media Library → system picker → pick → post goes live in the gallery.
- Verified user-initiated dismiss still works (backdrop tap and picking a photo both close the sheet correctly — no stuck-open regression).

Before/after screen recordings below.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: shared bottom-sheet primitive (all native `ActionSheet` / modal sheets)

This touches the shared `BottomSheetWrapper` used by every native modal sheet, so the blast radius is wide. The change only *removes* a redundant close signal — the real close is still driven by `handleSheetChanges(-1)`, unchanged — so it can't prevent a sheet from closing; worst case is the opposite (a sheet that gorhom dismisses without firing `onChange(-1)` fails to notify the parent), which the retained `!reachedClosedIndex` fallback path still handles. Worth a quick sanity pass on a couple of other sheets (channel actions, message long-press) during review.

## Rollback plan

Revert the PR — single-file change, no native/config/schema changes.

## Screenshots / videos

Before

https://github.com/user-attachments/assets/7041987c-df02-4fd2-9118-547e023c017b

After

https://github.com/user-attachments/assets/42dfbec6-55e5-40b4-a247-886d882c1a3c

