### PR TITLE
hermes: accept lens blob/sent-at kwargs in attention test mocks

### DIFF
--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -218,11 +218,13 @@ class RecordingCLI(FakeCLI):
             message_id="post-id",
         )
 
-    async def send_message(self, chat_id, text):
+    async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
         self.sends.append((chat_id, text))
         return self._next_result()
 
-    async def send_reply(self, chat_id, post_id, text, *, parent_author=None):
+    async def send_reply(
+        self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None
+    ):
         self.thread_replies.append((chat_id, post_id, text, parent_author))
         result = self._next_result()
         if result.command == ():
@@ -867,7 +869,7 @@ class AdapterAttentionTests(unittest.TestCase):
         sent = []
 
         class BlockingCLI(FakeCLI):
-            async def send_message(self, chat_id, text):
+            async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
                 sent.append((chat_id, text))
                 await release
                 return tlon_api.TlonSendResult(


### PR DESCRIPTION
## Summary

develop's `test-build` is currently red: #6033 (hermes-lens) made `adapter.py` pass `blob=`/`sent_at=` to the CLI send paths, while #6094 (bot-loop protection) added attention-test CLI mocks without those kwargs. Each PR was green against the develop it branched from, but their merge fails 8 tests in `test_adapter_attention.py` with `TypeError: RecordingCLI.send_message() got an unexpected keyword argument 'blob'`. This surfaces on every open PR's merge ref (e.g. #6096).

## Changes

- Add `*, blob=None, sent_at=None` to `RecordingCLI.send_message`/`send_reply` and the local `BlockingCLI.send_message`, matching the base `FakeCLI` signatures. Recorded tuples are unchanged, so no assertions move.

## How did I test?

- `./dev/test.sh` in `packages/hermes-tlon-adapter`: 522 tests, OK (was: FAILED errors=8)

## Risks and impact

- Safe to rollback without consulting PR author? Yes (test-only)

## Rollback plan

Revert; only test mocks are touched.