### PR TITLE
context lens: ownership guard

### DIFF
--- a/packages/app/ui/components/Channel/ContextLens/ContextLensBadge.tsx
+++ b/packages/app/ui/components/Channel/ContextLens/ContextLensBadge.tsx
@@ -1,9 +1,9 @@
 import * as db from '@tloncorp/shared/db';
+import * as store from '@tloncorp/shared/store';
 import { Pressable } from '@tloncorp/ui';
 import { useMemo } from 'react';
 import { SizableText, XStack } from 'tamagui';
 
-import { useCurrentUserId } from '../../../contexts/appDataContext';
 import { getOwnContextLensStamp } from './lensPost';
 import { useContextLensAvailable } from './useContextLensStore';
 
@@ -15,10 +15,10 @@ export function ContextLensBadge({
   onPress?: (post: db.Post) => void;
 }) {
   const available = useContextLensAvailable();
-  const currentUserId = useCurrentUserId();
+  const { data: ownedBotShips } = store.useContextLensBotShips();
   const stamp = useMemo(
-    () => getOwnContextLensStamp(post, currentUserId),
-    [currentUserId, post]
+    () => getOwnContextLensStamp(post, ownedBotShips ?? []),
+    [ownedBotShips, post]
   );
 
   if (!available || !stamp) {

--- a/packages/app/ui/components/Channel/ContextLens/ContextLensBadge.tsx
+++ b/packages/app/ui/components/Channel/ContextLens/ContextLensBadge.tsx
@@ -3,7 +3,8 @@ import { Pressable } from '@tloncorp/ui';
 import { useMemo } from 'react';
 import { SizableText, XStack } from 'tamagui';
 
-import { getContextLensStamp } from './lensPost';
+import { useCurrentUserId } from '../../../contexts/appDataContext';
+import { getOwnContextLensStamp } from './lensPost';
 import { useContextLensAvailable } from './useContextLensStore';
 
 export function ContextLensBadge({
@@ -14,7 +15,11 @@ export function ContextLensBadge({
   onPress?: (post: db.Post) => void;
 }) {
   const available = useContextLensAvailable();
-  const stamp = useMemo(() => getContextLensStamp(post), [post]);
+  const currentUserId = useCurrentUserId();
+  const stamp = useMemo(
+    () => getOwnContextLensStamp(post, currentUserId),
+    [currentUserId, post]
+  );
 
   if (!available || !stamp) {
     return null;

--- a/packages/app/ui/components/Channel/ContextLens/lensPost.test.ts
+++ b/packages/app/ui/components/Channel/ContextLens/lensPost.test.ts
@@ -39,24 +39,35 @@ describe('getOwnContextLensStamp', () => {
     },
   ]);
 
-  it('returns lens metadata for a post authored by the current ship', () => {
+  it('returns lens metadata for a post authored by an owned hosted bot', () => {
     expect(
       getOwnContextLensStamp(
         { authorId: '~zod', blob } as Parameters<
           typeof getOwnContextLensStamp
         >[0],
-        '~zod'
+        ['~zod']
       )
     ).toEqual({ lensId: 'lens-123', botShip: '~zod' });
   });
 
-  it('rejects lens metadata on a post authored by another ship', () => {
+  it('rejects lens metadata from a bot the user does not own', () => {
+    expect(
+      getOwnContextLensStamp(
+        { authorId: '~zod', blob } as Parameters<
+          typeof getOwnContextLensStamp
+        >[0],
+        ['~nec']
+      )
+    ).toBeNull();
+  });
+
+  it('rejects lens metadata stamped onto another author\'s post', () => {
     expect(
       getOwnContextLensStamp(
         { authorId: '~nec', blob } as Parameters<
           typeof getOwnContextLensStamp
         >[0],
-        '~zod'
+        ['~zod']
       )
     ).toBeNull();
   });

--- a/packages/app/ui/components/Channel/ContextLens/lensPost.test.ts
+++ b/packages/app/ui/components/Channel/ContextLens/lensPost.test.ts
@@ -1,7 +1,7 @@
 import { da, scot } from '@urbit/aura';
 import { describe, expect, it } from 'vitest';
 
-import { parseLensMessageId } from './lensPost';
+import { getOwnContextLensStamp, parseLensMessageId } from './lensPost';
 
 // mirrors the gateway's formatSentAt (src/urbit/send.ts)
 function gatewayMessageId(ship: string, sentAt: number) {
@@ -26,5 +26,38 @@ describe('parseLensMessageId', () => {
     expect(parseLensMessageId('~malmur-halmex/')).toBeNull();
     expect(parseLensMessageId('~malmur-halmex/not-a-number')).toBeNull();
     expect(parseLensMessageId('~malmur-halmex/0')).toBeNull();
+  });
+});
+
+describe('getOwnContextLensStamp', () => {
+  const blob = JSON.stringify([
+    {
+      type: 'tlon-context-lens',
+      version: 1,
+      lensId: 'lens-123',
+      botShip: '~zod',
+    },
+  ]);
+
+  it('returns lens metadata for a post authored by the current ship', () => {
+    expect(
+      getOwnContextLensStamp(
+        { authorId: '~zod', blob } as Parameters<
+          typeof getOwnContextLensStamp
+        >[0],
+        '~zod'
+      )
+    ).toEqual({ lensId: 'lens-123', botShip: '~zod' });
+  });
+
+  it('rejects lens metadata on a post authored by another ship', () => {
+    expect(
+      getOwnContextLensStamp(
+        { authorId: '~nec', blob } as Parameters<
+          typeof getOwnContextLensStamp
+        >[0],
+        '~zod'
+      )
+    ).toBeNull();
   });
 });

--- a/packages/app/ui/components/Channel/ContextLens/lensPost.test.ts
+++ b/packages/app/ui/components/Channel/ContextLens/lensPost.test.ts
@@ -61,7 +61,7 @@ describe('getOwnContextLensStamp', () => {
     ).toBeNull();
   });
 
-  it('rejects lens metadata stamped onto another author\'s post', () => {
+  it("rejects lens metadata stamped onto another author's post", () => {
     expect(
       getOwnContextLensStamp(
         { authorId: '~nec', blob } as Parameters<

--- a/packages/app/ui/components/Channel/ContextLens/lensPost.ts
+++ b/packages/app/ui/components/Channel/ContextLens/lensPost.ts
@@ -50,3 +50,13 @@ export function getContextLensStamp(post: db.Post): ContextLensStamp | null {
     botShip: entry.botShip ?? post.authorId ?? null,
   };
 }
+
+export function getOwnContextLensStamp(
+  post: db.Post,
+  currentUserId: string
+): ContextLensStamp | null {
+  if (post.authorId !== currentUserId) {
+    return null;
+  }
+  return getContextLensStamp(post);
+}

--- a/packages/app/ui/components/Channel/ContextLens/lensPost.ts
+++ b/packages/app/ui/components/Channel/ContextLens/lensPost.ts
@@ -1,3 +1,4 @@
+import { preSig } from '@tloncorp/api/lib/urbit';
 import * as db from '@tloncorp/shared/db';
 import * as logic from '@tloncorp/shared/logic';
 import { da, parse } from '@urbit/aura';
@@ -53,10 +54,15 @@ export function getContextLensStamp(post: db.Post): ContextLensStamp | null {
 
 export function getOwnContextLensStamp(
   post: db.Post,
-  currentUserId: string
+  ownedBotShips: readonly string[]
 ): ContextLensStamp | null {
-  if (post.authorId !== currentUserId) {
+  const stamp = getContextLensStamp(post);
+  if (!stamp?.botShip || !post.authorId) {
     return null;
   }
-  return getContextLensStamp(post);
+
+  const botShip = preSig(stamp.botShip);
+  const authorId = preSig(post.authorId);
+  const isOwnedBot = ownedBotShips.some((ship) => preSig(ship) === botShip);
+  return isOwnedBot && authorId === botShip ? stamp : null;
 }

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -16,7 +16,7 @@ import { useAttachmentContext } from '../../../contexts/attachment';
 import { useChannelContext } from '../../../contexts/channel';
 import { triggerHaptic, useIsAdmin } from '../../../utils';
 import ActionList from '../../ActionList';
-import { getContextLensStamp } from '../../Channel/ContextLens/lensPost';
+import { getOwnContextLensStamp } from '../../Channel/ContextLens/lensPost';
 import { useContextLensAvailable } from '../../Channel/ContextLens/useContextLensStore';
 import { useForwardPostSheet } from '../../ForwardPostSheet';
 import {
@@ -49,12 +49,15 @@ export default function MessageActions({
   postActionIds: ChannelAction.Id[];
 }) {
   const contextLensAvailable = useContextLensAvailable();
+  const currentUserId = useCurrentUserId();
   const showViewBotRun = useMemo(
     () =>
       Boolean(
-        contextLensAvailable && onViewBotRun && getContextLensStamp(post)
+        contextLensAvailable &&
+          onViewBotRun &&
+          getOwnContextLensStamp(post, currentUserId)
       ),
-    [contextLensAvailable, onViewBotRun, post]
+    [contextLensAvailable, currentUserId, onViewBotRun, post]
   );
 
   // arbitrary width that looks reasonable given labels

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -49,15 +49,15 @@ export default function MessageActions({
   postActionIds: ChannelAction.Id[];
 }) {
   const contextLensAvailable = useContextLensAvailable();
-  const currentUserId = useCurrentUserId();
+  const { data: ownedBotShips } = store.useContextLensBotShips();
   const showViewBotRun = useMemo(
     () =>
       Boolean(
         contextLensAvailable &&
           onViewBotRun &&
-          getOwnContextLensStamp(post, currentUserId)
+          getOwnContextLensStamp(post, ownedBotShips ?? [])
       ),
-    [contextLensAvailable, currentUserId, onViewBotRun, post]
+    [contextLensAvailable, onViewBotRun, ownedBotShips, post]
   );
 
   // arbitrary width that looks reasonable given labels


### PR DESCRIPTION
## Summary

Fixes TLON-6121 by adding an ownership guard to the "bot run" badge and the context lens.

## Changes

- Matches a bot-post author/owner to the current user
- Hides the button if the above check is false

## How did I test?

Tested on web, cannot see others' bot runs and can see mine. Also adds a test for this logic

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

git revert