### PR TITLE
presence: re-establish unacked subscriptions

### DIFF
--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -306,7 +306,14 @@
   ::
   +$  versioned-state  $%(state-0 state-1 state-2)
   ::
-  +$  state-1  _%*(. *state-2 - %1)
+  +$  state-1
+    $:  %1
+        =^places
+        want=(set [ship context])
+        subs=(jug context ship)
+        tries=(map [ship context] @ud)
+    ==
+  ::
   +$  state-0
     $:  %0
         =^places

--- a/desk/app/presence.hoon
+++ b/desk/app/presence.hoon
@@ -28,6 +28,12 @@
 ::    timestamps and timeouts as-is, and ignoring any that have expired
 ::    by the time we receive them. if it's in the future, treat it as now.
 ::
+::    we use both /context and /context-2 wire prefixes interchangeably,
+::    because at some point during this agent's lifecycle we needed to
+::    re-establish some subscriptions on a new flow, to work around ames-gall
+::    bugs. we always _send_ the newest wire format, but must check for and
+::    accept either.
+::
 ::TODO  make chat, channels clear %typing whenever we receive a msg?
 ::TODO  discipline
 ::
@@ -39,14 +45,8 @@
 ::      specify the context as it exists _on their end_ (which is relevant for
 ::      the dm case).
 ::      wires only contain the context, because src.bowl indicates the ship.
-+$  state-0
-  $:  %0
-      =places
-      want=(set [ship context])
-      subs=(jug context ship)
-  ==
-+$  state-1
-  $:  %1
++$  state-2
+  $:  %2
       =places
       :: ships=(jug ship context)
     ::
@@ -55,7 +55,6 @@
       tries=(map [ship context] @ud)  ::  consecutive sub nacks
       ::TODO  wack=(set ship)     ::  waiting for acks (load prevention)
   ==
-+$  versioned-state  $%(state-0 state-1)
 ::
 +$  card  card:agent:gall
 ::
@@ -205,14 +204,16 @@
   ::      this will work as long as we're aligned or behind the publisher.
   ::      ⚠️ if we're ahead and ask about a mark they don't know,
   ::      conversion will fail, we will get get kicked!
-  :+  %pass      [%context context]
+  :+  %pass      [%context-2 context]
   :+  %agent     [who %presence]
   :+  %watch-as  %presence-update-1
   [%context (scot %p our) context]
 ::
 ++  leave-context
   |=  [who=ship =context]
-  [%pass [%context context] %agent [who %presence] %leave ~]
+  :~  [%pass [%context context] %agent [who %presence] %leave ~]
+      [%pass [%context-2 context] %agent [who %presence] %leave ~]
+  ==
 ::
 ++  inflate
   |=  [=bowl:gall want=(set [ship context])]
@@ -223,7 +224,7 @@
     %+  murn  ~(tap by wex.bowl)
     |=  [[=wire =ship =term] *]
     ^-  (unit card)
-    ?.  ?=([%context *] wire)  ~
+    ?.  ?=([?(%context %context-2) *] wire)  ~
     =*  context  t.wire
     ?:  (~(has in want) ship context)  ~
     `[%pass wire %agent [ship term] %leave ~]
@@ -234,8 +235,10 @@
     |=  [=ship =context]
     ^-  (unit card)
     ?:  =(ship our.bowl)  ~  ::  don't subscribe to ourselves
-    =/  =wire  [%context context]
-    ?:  (~(has by wex.bowl) wire ship dap.bowl)  ~
+    ?:  ?|  (~(has by wex.bowl) [%context context] ship dap.bowl)
+            (~(has by wex.bowl) [%context-2 context] ship dap.bowl)
+        ==
+      ~
     `(watch-context our.bowl ship context)
   ::
     ::  ensure we have local subs in place
@@ -251,7 +254,7 @@
   ==
 --
 ::
-=|  state-1
+=|  state-2
 =*  state  -
 ::
 %-  agent:dbug
@@ -272,17 +275,45 @@
 ::
 ++  on-load
   |=  ole=vase
-  ^-  (quip card _this)
-  =/  old  !<(versioned-state ole)
-  =/  new=state-1
-    ?-  -.old
-      %0  [%1 places.old want.old subs.old ~]
-      %1  old
+  |^  ^-  (quip card _this)
+      =/  old  !<(versioned-state ole)
+      =?  old  ?=(%0 -.old)  [%1 places.old want.old subs.old ~]
+      =^  caz  old
+        ?.  ?=(%1 -.old)  [~ old]
+        :_  old(- %2)
+        ::  due to a gall-ames bug, if the remote agent wasn't running yet when
+        ::  we first sent out subscription, it blocks the flow indefinitely,
+        ::  even once the agent on the other side is running.
+        ::  now that presence agent is running on all up-to-date ships,
+        ::  re-start unacked subs on a fresh flow, to work around that bug.
+        ::
+        %-  zing
+        %+  turn  ~(tap by wex.bowl)
+        |=  [[=wire =ship =term] acked=? =path]
+        ^-  (list card)
+        ?:  acked                  ~
+        ?.  =(%presence term)      ~
+        ?.  ?=([%context *] wire)  ~
+        :~  [%pass wire %agent [ship term] %leave ~]
+            (watch-context our.bowl ship t.wire)
+        ==
+      ?>  ?=(%2 -.old)
+      :_  this(state old)
+      :*  (tell:log %dbug ~['on-load: scheduling setup' >`@ud`~(wyt in want)< >`@ud`~(wyt by subs)<] ~)
+          (await-setup now.bowl ~)
+          caz
+      ==
+  ::
+  +$  versioned-state  $%(state-0 state-1 state-2)
+  ::
+  +$  state-1  _%*(. *state-2 - %1)
+  +$  state-0
+    $:  %0
+        =^places
+        want=(set [ship context])
+        subs=(jug context ship)
     ==
-  :_  this(state new)
-  :~  (tell:log %dbug ~['on-load: scheduling setup' >`@ud`~(wyt in want)< >`@ud`~(wyt by subs)<] ~)
-      (await-setup now.bowl ~)
-  ==
+  --
 ::
 ++  on-poke
   |=  [=mark =vase]
@@ -298,7 +329,7 @@
     =;  =cage
       =/  =key     ?-(-.act %set key.act, %clear key.act)
       =/  host=@p  (context-host context.key our.bowl)
-      [[%pass [%context context.key] %agent [host dap.bowl] %poke cage]~ this]
+      [[%pass [%context-2 context.key] %agent [host dap.bowl] %poke cage]~ this]
     :-  %presence-command-1
     !>  ^-  command-1
     ?-  -.act
@@ -460,13 +491,12 @@
       ?:  &(!add.u.news (~(has in want) u.new))
         =.  tries  (~(del by tries) u.new)
         :_  this(want (~(del in want) u.new))
-        :~  (tell:log %dbug ~['channels/all: removing context' >u.new<] ~)
-            (leave-context u.new)
-        ==
+        :-  (tell:log %dbug ~['channels/all: removing context' >u.new<] ~)
+        (leave-context u.new)
       [~ this]
     ==
   ::
-      [%context *]
+      [?(%context %context-2) *]
     =*  context  t.wire
     ?-  -.sign
         %poke-ack
@@ -618,7 +648,9 @@
       =.  tries  (~(del by tries) [ship context])
       :_  this
       [(tell:log %dbug ~['setup(specific): no longer wanted, skipping' >ship< >context<] ~)]~
-    ?:  (~(has by wex.bowl) [%context context] ship dap.bowl)
+    ?:  ?|  (~(has by wex.bowl) [%context context] ship dap.bowl)
+            (~(has by wex.bowl) [%context-2 context] ship dap.bowl)
+        ==
       :_  this
       [(tell:log %dbug ~['setup(specific): already subscribed, skipping' >ship< >context<] ~)]~
     :_  this

--- a/desk/tests/app/presence.hoon
+++ b/desk/tests/app/presence.hoon
@@ -15,7 +15,7 @@
 ::  we are ~zod, in a dm with ~ten. the host (~ten) keys the dm context
 ::  by the subscriber, /dm/~zod; on receipt we translate it to /dm/~ten.
 ::
-++  sub-wire     `wire`/context/dm/(scot %p ~zod)
+++  sub-wire     `wire`/context-2/dm/(scot %p ~zod)
 ++  expire-wire  `wire`/expire/(scot %p host)/computing/dm/(scot %p host)
 ++  key-theirs   `key:p`[/dm/(scot %p ~zod) host %computing]
 ++  key-ours     `key:p`[/dm/(scot %p host) host %computing]
@@ -96,4 +96,26 @@
   ;<  ~  bind:m  (jab-bowl |=(b=bowl b(now (add t0 ~m5))))
   ;<  caz=(list card)  bind:m  do-wake
   (ex-cards caz ~)
+::
+++  test-state-2-resub
+  %-  eval-mare
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  ~  bind:m  setup
+  ;<  ~  bind:m
+    %-  jab-bowl
+    |=  b=bowl
+    =-  b(wex (~(gas by wex.b) -))
+    :~  [[/context/dm/~zod ~fus dap] [| /context/~zod/dm/~zod]]
+        [[/context/dm/~zod ~fun dap] [& /context/~zod/dm/~zod]]
+    ==
+  ;<  caz=(list card)  bind:m
+    %+  do-load  agent
+    %-  some  !>
+    [%1 *places:p want=*(set [ship context:p]) subs=*(jug context:p ship) tries=*(map [ship context:p] @ud)]
+  %+  ex-cards  caz
+  :~  (ex-arvo /setup %b %wait t0)
+      (ex-task /context/dm/~zod [~fus dap] %leave ~)
+      (ex-task /context-2/dm/~zod [~fus dap] %watch-as %presence-update-1 /context/~zod/dm/~zod)
+  ==
 --


### PR DESCRIPTION
## Summary

A gall-ames bug has kept some subscriptions from establishing properly. Leave them, and retry on a new flow.

## Changes

Presence pro-actively opens subscriptions to foreign instances based on the channels and groups we're in. But presence didn't always exist, so on those foreign instances the subscription might have ended up in the agent's "blocked moves" queue, intended to get processed once the agent becomes live.

Due to a gall-ames coordination bug (see urbit/urbit#7391), flows for which moves got queued up in that way will not clear. Instead, the two galls fail to communicate about an agreement on the state of the flow. As a result, none of the communication on that flow (in this case, subscriptions) go through.

To work around the problem, now that up-to-date ships are all running presence agent, we can re-open not-yet-established subscriptions (that is, possibly-affected subscriptions) on new wires, ending up on new flows, giving us a fresh shot at establishing.

(If the presence agent _still_ isn't running on the other side, we'll end up in the same situation. For that scenario, we simply await the kernel-side fix.)

This does mean we have to support two wire formats, /context and /context-2. We always use the latest one for new interactions, but take care to accept the old format on ingress, and check for its presence whenever we're doing a search through the bowl.

Includes a test for the state migration that does the leave-and-rewatch.

## How did I test?

Ran the upgrade on a ship, and wrote a test that confirms both the "needs to be reestablished" and "leave as-is" subscription cases.

## Risks and impact

- Can't trivially roll back due to state version nr bump and changed wires.

## Rollback plan

Coordinate with backend devs as necessary.
