### PR TITLE
hermes: merge co-existing post-blob entries on hermes outbound sends

### DIFF
--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -19,7 +19,7 @@ import uuid
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -42,13 +42,13 @@ from .approval import (
     approval_ship,
     approval_type,
     build_approval_card,
+    build_pending_approvals_response,
     create_pending_approval,
     find_approval,
     find_duplicate,
     format_approval_request,
     format_blocked_list,
     format_confirmation,
-    format_pending_list,
     parse_approval_command,
     parse_dm_allowlist,
     parse_foreigns,
@@ -77,7 +77,12 @@ from .history import (
     fetch_channel_history,
     fetch_thread_context,
 )
-from .media import PreparedMedia, prepare_inbound_media, render_content_with_blob
+from .media import (
+    PreparedMedia,
+    combine_blob_fields,
+    prepare_inbound_media,
+    render_content_with_blob,
+)
 from .mention import (
     BotMentionMatcher,
     build_bot_mention_terms,
@@ -631,6 +636,9 @@ class TlonAdapter(BasePlatformAdapter):
         self._known_bot_ships: set[str] = set()
         self._known_bot_consecutive_by_channel: dict[str, int] = {}
         self._pending_bot_cap_addendum: dict[str, tuple[str, str]] = {}
+        # Lens output IDs derive from --sent-at. Reserve strictly increasing
+        # values so quick consecutive sends cannot collide on the same post ID.
+        self._last_lens_sent_at = 0
         self._owner_listen = self._owner_listen_env_defaults()
         self._settings_group_channels: set[str] = set()
         self._settings_loaded = False
@@ -1207,9 +1215,17 @@ class TlonAdapter(BasePlatformAdapter):
             self._pending_approvals, time.time() * 1000.0
         )
         pruned = len(self._pending_approvals) != before
+        if pruned:
+            await self._persist_pending_approvals()
 
+        blob_fields: tuple[str | None, ...] = ()
         if action == "pending":
-            reply = format_pending_list(self._pending_approvals)
+            reply, pending_blob = build_pending_approvals_response(
+                self._pending_approvals,
+                is_dm=_is_dm_chat_id(reply_chat_id),
+            )
+            if pending_blob is not None:
+                blob_fields = (pending_blob,)
         elif action == "banned":
             reply = format_blocked_list(await self._blocked_ships_list())
         elif action == "unban":
@@ -1225,9 +1241,9 @@ class TlonAdapter(BasePlatformAdapter):
             else:
                 reply = await self._execute_approval_action(approval, action)
 
-        if pruned:
-            await self._persist_pending_approvals()
-        await self._send_control_reply(reply_chat_id, reply_parent_id, reply)
+        await self._send_control_reply(
+            reply_chat_id, reply_parent_id, reply, blob_fields=blob_fields
+        )
 
     async def _execute_approval_action(
         self, approval: dict[str, Any], action: str
@@ -1668,12 +1684,22 @@ class TlonAdapter(BasePlatformAdapter):
         chat_id: str,
         parent_id: Optional[str],
         text: str,
+        *,
+        blob_fields: Sequence[str | None] = (),
     ) -> None:
+        # Control commands are consumed before normal dispatch, so they never
+        # have a lens run. Retain their existing routing rule: channel control
+        # replies may thread, while direct-message control replies stay linear.
+        text = str(text or "")[:MAX_MESSAGE_LENGTH]
+        thread_parent = parent_id if parent_id and not _is_dm_chat_id(chat_id) else None
         with cli_context("control_plane"):
-            if parent_id and not _is_dm_chat_id(chat_id):
-                result = await self._cli.send_reply(chat_id, parent_id, text)
-            else:
-                result = await self._cli.send_message(chat_id, text)
+            result, _ = await self._deliver_post(
+                chat_id,
+                text,
+                parent_id=thread_parent,
+                blob_fields=blob_fields,
+                lens_blob=None,
+            )
         if not result.success:
             logger.warning("[tlon] control command reply failed: %s", result.error)
 
@@ -2406,6 +2432,46 @@ class TlonAdapter(BasePlatformAdapter):
             self._seen_ids.discard(old)
         return True
 
+    def _next_lens_sent_at(self) -> int:
+        """Allocate the post ID timestamp for one lens-stamped output."""
+        sent_at_ms = max(int(time.time() * 1000), self._last_lens_sent_at + 1)
+        self._last_lens_sent_at = sent_at_ms
+        return sent_at_ms
+
+    async def _deliver_post(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        parent_id: Optional[str] = None,
+        parent_author: Optional[str] = None,
+        blob_fields: Sequence[str | None] = (),
+        lens_blob: Optional[str] = None,
+    ) -> tuple[Any, Optional[int]]:
+        """Deliver one post after composing every applicable blob source.
+
+        ``blob_fields`` is the adapter-facing producer seam: callers pass
+        complete serialized post-blob arrays, which are ordered before the
+        internal lens reference. A caller-provided blob must ride non-empty
+        content (the published CLI has no blob-only send transport).
+        """
+        blob = combine_blob_fields(*blob_fields, lens_blob)
+        sent_at_ms = self._next_lens_sent_at() if lens_blob is not None else None
+        if parent_id:
+            result = await self._cli.send_reply(
+                chat_id,
+                parent_id,
+                content,
+                parent_author=parent_author,
+                blob=blob,
+                sent_at=sent_at_ms,
+            )
+        else:
+            result = await self._cli.send_message(
+                chat_id, content, blob=blob, sent_at=sent_at_ms
+            )
+        return result, sent_at_ms
+
     async def send(
         self,
         chat_id: str,
@@ -2413,6 +2479,13 @@ class TlonAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        """Send a model reply.
+
+        Adapter callers may provide ``metadata["blob"]`` as a complete,
+        serialized post-blob entry array. It is composed before the internal
+        context-lens reference and must accompany non-empty content because
+        the deployed CLI does not support blob-only posts.
+        """
         pending = self._pending_bot_cap_addendum.get(chat_id)
         addendum = ""
         if pending and reply_to and str(reply_to) == pending[1]:
@@ -2423,6 +2496,22 @@ class TlonAdapter(BasePlatformAdapter):
             )
         content = (content or "")[: self.MAX_MESSAGE_LENGTH - len(addendum)] + addendum
         metadata = metadata or {}
+        caller_blob = metadata.get("blob")
+        if not (isinstance(caller_blob, str) and caller_blob.strip()):
+            # A whitespace-only string is treated as ABSENT, same as None:
+            # it never fires the blob-requires-content guard below.
+            caller_blob = None
+        if caller_blob is not None and not content.strip():
+            blob_error = "metadata['blob'] requires non-empty content (no blob-only CLI transport)"
+            self._telemetry.record_delivery(chat_id, content=content, success=False)
+            self._lens.record_delivery_failure(chat_id, error=blob_error)
+            return SendResult(
+                success=False,
+                message_id=None,
+                error=blob_error,
+                raw_response={},
+                retryable=False,
+            )
         # Core anchors every reply to the triggering message (reply_to), but
         # Tlon conversations are linear: reply top-level unless the
         # conversation is already a thread (metadata.thread_id carries the
@@ -2437,30 +2526,18 @@ class TlonAdapter(BasePlatformAdapter):
         # the run from the message (badge / message actions), matching
         # OpenClaw. Only when a run is active for this conversation.
         lens_blob = self._lens_reference_blob(chat_id)
-        # Only override the send time — and derive the lens output id from it
-        # (~author/<@da of sent>, how the client resolves outputs) — when we're
-        # actually stamping a lens output. Passing --sent-at on every send
-        # would let an older `tlon` binary (which doesn't know the flag) fold
-        # it into the message body; gate it exactly like --blob above.
-        sent_at_ms = int(time.time() * 1000) if lens_blob is not None else None
         with cli_context("delivery", conversation=chat_id):
-            if is_thread_reply:
-                # parentAuthor: honor what Hermes passes; otherwise the CLI
-                # attributes the reference to the bot. (We don't assume a DM
-                # partner authored the thread root.)
-                parent_author = metadata.get("parent_author") or None
-                result = await self._cli.send_reply(
-                    chat_id,
-                    thread_parent,
-                    content,
-                    parent_author=parent_author,
-                    blob=lens_blob,
-                    sent_at=sent_at_ms,
-                )
-            else:
-                result = await self._cli.send_message(
-                    chat_id, content, blob=lens_blob, sent_at=sent_at_ms
-                )
+            # parentAuthor: honor what Hermes passes; otherwise the CLI
+            # attributes the reference to the bot. (We don't assume a DM
+            # partner authored the thread root.)
+            result, sent_at_ms = await self._deliver_post(
+                chat_id,
+                content,
+                parent_id=thread_parent if is_thread_reply else None,
+                parent_author=metadata.get("parent_author") or None,
+                blob_fields=(caller_blob,) if caller_blob is not None else (),
+                lens_blob=lens_blob,
+            )
         self._telemetry.record_delivery(chat_id, content=content, success=result.success)
         if result.success:
             # sent_at_ms is set iff there's an active run to stamp (see above).

--- a/packages/hermes-tlon-adapter/approval.py
+++ b/packages/hermes-tlon-adapter/approval.py
@@ -17,6 +17,7 @@ text notification.
 from __future__ import annotations
 
 import json
+import math
 import re
 import uuid
 from typing import Any, Iterable, Mapping, Optional
@@ -32,6 +33,20 @@ SETTINGS_KEY_AUTO_ACCEPT_DM_INVITES = "autoAcceptDmInvites"
 APPROVAL_TTL_MS = 48 * 60 * 60 * 1000
 DM_INVITE_PREVIEW = "(DM invite - no message yet)"
 PREVIEW_MAX_CHARS = 100
+# Derived from the client's component budget, not a taste choice: each
+# pending item with a preview line costs ~9 components (row + title +
+# context + preview + actions row + 3 buttons + divider), so 4 items already
+# renders a 43-component card and a 5th would push it past 50 — the a2ui
+# validator's maxComponents (packages/api/src/client/a2ui.ts LIMITS).
+MAX_PENDING_APPROVALS_A2UI = 4
+MAX_PENDING_APPROVALS_TEXT = 25
+
+_MAX_DISPLAY_SHIP_CHARS = 60
+_MAX_DISPLAY_NEST_CHARS = 80
+_MAX_DISPLAY_GROUP_CHARS = 80
+_MAX_DISPLAY_TITLE_CHARS = 80
+_MAX_DISPLAY_PREVIEW_CHARS = 100
+_APPROVAL_ID_RE = re.compile(r"^[a-z0-9]{1,16}$")
 
 A2UI_CATALOG_ID = "tlon.a2ui.basic.v1"
 A2UI_MESSAGE_VERSION = "v0.9"
@@ -337,24 +352,102 @@ def format_approval_request(approval: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _bounded_display_text(value: Any, max_chars: int, fallback: str = "") -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    return truncate(text, max_chars)
+
+
+def approval_id_is_actionable(approval: Mapping[str, Any]) -> bool:
+    """Whether an approval ID can round-trip through the owner command parser."""
+    return bool(_APPROVAL_ID_RE.fullmatch(approval_id(approval)))
+
+
+def _pending_approval_type(approval: Mapping[str, Any]) -> str:
+    kind = approval_type(approval)
+    return kind if kind in {"dm", "channel", "group"} else "unknown"
+
+
+def _pending_approval_descriptor(approval: Mapping[str, Any]) -> str:
+    return {
+        "dm": "DM request",
+        "channel": "channel request",
+        "group": "group invite",
+    }.get(_pending_approval_type(approval), "request")
+
+
+def _pending_display_id(approval: Mapping[str, Any]) -> str:
+    if approval_id_is_actionable(approval):
+        return f"#{approval_id(approval)}"
+    return "[unactionable approval ID]"
+
+
+def _pending_display_ship(approval: Mapping[str, Any]) -> str:
+    value = _bounded_display_text(
+        approval.get("requestingShip"), _MAX_DISPLAY_SHIP_CHARS
+    )
+    return normalize_ship(value) if value else "[unknown ship]"
+
+
+def _pending_display_nest(approval: Mapping[str, Any]) -> str:
+    return _bounded_display_text(approval.get("channelNest"), _MAX_DISPLAY_NEST_CHARS)
+
+
+def _pending_display_group_flag(approval: Mapping[str, Any]) -> str:
+    return _bounded_display_text(approval.get("groupFlag"), _MAX_DISPLAY_GROUP_CHARS)
+
+
+def _pending_group_label(approval: Mapping[str, Any]) -> str:
+    return _bounded_display_text(
+        approval.get("groupTitle"), _MAX_DISPLAY_TITLE_CHARS
+    ) or _pending_display_group_flag(approval) or "[unknown group]"
+
+
+def _pending_display_preview(approval: Mapping[str, Any]) -> str:
+    return _bounded_display_text(
+        approval.get("messagePreview"), _MAX_DISPLAY_PREVIEW_CHARS
+    )
+
+
 def format_pending_list(approvals: Iterable[Mapping[str, Any]]) -> str:
+    """Render a bounded, actionable fallback for persisted approval data.
+
+    Pending approvals are stored as untrusted JSON in %settings. Never let a
+    corrupt record crowd the owner-facing command guidance out of the reply;
+    malformed IDs are deliberately labeled rather than truncated into commands
+    that could not resolve to the stored record.
+    """
     entries = list(approvals)
     if not entries:
         return "No pending approvals."
     lines = [f"{len(entries)} pending approval(s):"]
-    for approval in entries:
-        descriptor = _approval_descriptor(approval)
-        if approval_type(approval) == "group":
-            detail = f" {_group_label(approval)} (from {approval_ship(approval)})"
-            lines.append(f"• #{approval_id(approval)} {descriptor}:{detail}")
+    for approval in entries[:MAX_PENDING_APPROVALS_TEXT]:
+        descriptor = _pending_approval_descriptor(approval)
+        request_id = _pending_display_id(approval)
+        # An unactionable ID can never resolve via /allow, /reject, or /ban;
+        # tell the owner it will still self-clear once its TTL elapses.
+        expiry_hint = (
+            "" if approval_id_is_actionable(approval) else "; expires automatically"
+        )
+        if _pending_approval_type(approval) == "group":
+            detail = (
+                f" {_pending_group_label(approval)} "
+                f"(from {_pending_display_ship(approval)})"
+            )
+            lines.append(f"• {request_id} {descriptor}:{detail}{expiry_hint}")
             continue
-        nest = approval_nest(approval)
+        nest = _pending_display_nest(approval)
         where = f" in {nest}" if nest else ""
-        preview = str(approval.get("messagePreview") or "")
+        preview = _pending_display_preview(approval)
         suffix = f' — "{truncate(preview, 60)}"' if preview else ""
         lines.append(
-            f"• #{approval_id(approval)} {descriptor} from {approval_ship(approval)}{where}{suffix}"
+            f"• {request_id} {descriptor} from {_pending_display_ship(approval)}"
+            f"{where}{suffix}{expiry_hint}"
         )
+    remaining = len(entries) - MAX_PENDING_APPROVALS_TEXT
+    if remaining > 0:
+        lines.append(f"• … {remaining} more pending approval(s) not shown.")
     lines.append("")
     lines.append("Reply /allow <id> · /reject <id> · /ban <id>")
     return "\n".join(lines)
@@ -476,12 +569,16 @@ def _approval_nav_target(approval: Mapping[str, Any]) -> Optional[dict[str, Any]
 
 
 def _approval_card_title(approval: Mapping[str, Any]) -> str:
-    ship = approval_ship(approval)
+    # Pending approvals are untrusted persisted JSON (see module docstring);
+    # bound every field the same way the pending-list card does so a
+    # corrupted/oversized channelNest or groupTitle can't blow the a2ui
+    # validator's per-card size limits and knock the card back to plain text.
+    ship = _pending_display_ship(approval)
     kind = approval_type(approval)
     if kind == "channel":
-        return f"Let the bot reply to {ship} in {approval_nest(approval) or 'this channel'}?"
+        return f"Let the bot reply to {ship} in {_pending_display_nest(approval) or 'this channel'}?"
     if kind == "group":
-        return f"Let the bot join {truncate(_group_label(approval), 60)}?"
+        return f"Let the bot join {truncate(_pending_group_label(approval), 60)}?"
     return f"Allow {ship} to DM the bot?"
 
 
@@ -506,11 +603,11 @@ def _approval_card_allow_note(approval: Mapping[str, Any]) -> str:
 def _approval_card_context_lines(approval: Mapping[str, Any]) -> list[str]:
     if approval_type(approval) == "group":
         return [
-            f"Inviter: {approval_ship(approval)}",
-            f"Group: {_group_label(approval)}",
+            f"Inviter: {_pending_display_ship(approval)}",
+            f"Group: {_pending_group_label(approval)}",
         ]
-    lines = [f"Sender: {approval_ship(approval)}"]
-    nest = approval_nest(approval)
+    lines = [f"Sender: {_pending_display_ship(approval)}"]
+    nest = _pending_display_nest(approval)
     if nest:
         lines.append(f"Channel: {nest}")
     return lines
@@ -612,3 +709,360 @@ def build_approval_card(approval: Mapping[str, Any]) -> dict[str, Any]:
     )
 
     return make_a2ui_blob_entry(f"approval-{request_id}", "root", components)
+
+
+# ── Pending approvals A2UI ──────────────────────────────────────────────
+
+
+def _pending_item_fields(approval: Mapping[str, Any]) -> tuple[str, str, Optional[str]]:
+    """Return bounded display fields for one persisted pending approval."""
+    kind = _pending_approval_type(approval)
+    ship = _pending_display_ship(approval)
+    preview = _pending_display_preview(approval)
+    preview_line = f'Message: "{preview}"' if preview else None
+    if kind == "dm":
+        return f"DM from {ship}", f"Sender: {ship}", preview_line
+    if kind == "channel":
+        return (
+            f"Channel access for {ship}",
+            f"Channel: {_pending_display_nest(approval) or 'this channel'}",
+            preview_line,
+        )
+    return f"Group invite from {ship}", f"Group: {_pending_group_label(approval)}", None
+
+
+def _pending_text_component(
+    component_id: str, text: str, *, variant: Optional[str] = None
+) -> dict[str, Any]:
+    component: dict[str, Any] = {"id": component_id, "component": "Text", "text": text}
+    if variant is not None:
+        component["variant"] = variant
+    return component
+
+
+def _pending_button(
+    component_id: str,
+    label_id: str,
+    command: str,
+    *,
+    variant: Optional[str] = None,
+) -> dict[str, Any]:
+    component: dict[str, Any] = {
+        "id": component_id,
+        "component": "Button",
+        "child": label_id,
+        "action": {
+            "event": {
+                "name": A2UI_ACTION_SEND_MESSAGE,
+                "context": {"text": command},
+            }
+        },
+    }
+    if variant is not None:
+        component["variant"] = variant
+    return component
+
+
+def build_pending_approvals_card(
+    approvals: Iterable[Mapping[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """Build the bounded pending-approvals card from OpenClaw #5939.
+
+    Action IDs are intentionally strict: a malformed persisted ID is shown in
+    the text fallback as unactionable instead of being shortened into a button
+    command that could address a different record.
+    """
+    active = list(approvals)
+    if not 0 < len(active) <= MAX_PENDING_APPROVALS_A2UI:
+        return None
+    if any(
+        not approval_id_is_actionable(approval)
+        or _pending_approval_type(approval) == "unknown"
+        for approval in active
+    ):
+        return None
+
+    body_children = ["eyebrow", "title", "titleDivider"]
+    components: list[dict[str, Any]] = [
+        {"id": "root", "component": "Card", "child": "body"},
+        {"id": "body", "component": "Column", "children": body_children},
+        _pending_text_component("eyebrow", "Pending requests", variant="caption"),
+        _pending_text_component(
+            "title",
+            f"{len(active)} approval {'request' if len(active) == 1 else 'requests'}",
+            variant="h3",
+        ),
+        {"id": "titleDivider", "component": "Divider"},
+        _pending_text_component("allowLabel", "Allow"),
+        _pending_text_component("rejectLabel", "Reject"),
+        _pending_text_component("blockLabel", "Block"),
+    ]
+
+    for index, approval in enumerate(active):
+        prefix = f"item{index}"
+        title, context, preview = _pending_item_fields(approval)
+        request_id = approval_id(approval)
+        if index:
+            divider_id = f"{prefix}Divider"
+            body_children.append(divider_id)
+            components.append({"id": divider_id, "component": "Divider"})
+        body_children.append(prefix)
+        item_children = [f"{prefix}Title", f"{prefix}Context"]
+        if preview:
+            item_children.append(f"{prefix}Preview")
+        item_children.append(f"{prefix}Actions")
+        components.extend(
+            [
+                {"id": prefix, "component": "Column", "children": item_children},
+                _pending_text_component(f"{prefix}Title", title, variant="h4"),
+                _pending_text_component(f"{prefix}Context", context, variant="caption"),
+                *(
+                    [_pending_text_component(f"{prefix}Preview", preview, variant="caption")]
+                    if preview
+                    else []
+                ),
+                {
+                    "id": f"{prefix}Actions",
+                    "component": "Row",
+                    "children": [
+                        f"{prefix}Allow",
+                        f"{prefix}Reject",
+                        f"{prefix}Block",
+                    ],
+                },
+                _pending_button(
+                    f"{prefix}Allow",
+                    "allowLabel",
+                    f"/allow {request_id}",
+                    variant="primary",
+                ),
+                _pending_button(
+                    f"{prefix}Reject", "rejectLabel", f"/reject {request_id}"
+                ),
+                _pending_button(
+                    f"{prefix}Block",
+                    "blockLabel",
+                    f"/ban {request_id}",
+                    variant="borderless",
+                ),
+            ]
+        )
+
+    return make_a2ui_blob_entry("pending-approvals", "root", components)
+
+
+def _is_plain_object(value: Any) -> bool:
+    return isinstance(value, Mapping)
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _is_valid_target_id(value: Any) -> bool:
+    return _is_non_empty_string(value) and len(value) <= 500
+
+
+def _is_valid_navigation_target(target: Any) -> bool:
+    if not _is_plain_object(target):
+        return False
+    target_type = target.get("type")
+
+    def optional_id(name: str) -> bool:
+        return name not in target or _is_valid_target_id(target.get(name))
+
+    if target_type == "message":
+        return (
+            _is_valid_target_id(target.get("channelId"))
+            and _is_valid_target_id(target.get("postId"))
+            and all(optional_id(name) for name in ("parentId", "parentAuthorId", "authorId", "groupId"))
+        )
+    if target_type == "channel":
+        return _is_valid_target_id(target.get("channelId")) and all(
+            optional_id(name) for name in ("groupId", "selectedPostId")
+        )
+    if target_type == "group":
+        return _is_valid_target_id(target.get("groupId"))
+    if target_type == "profile":
+        return _is_valid_target_id(target.get("userId")) and all(
+            optional_id(name) for name in ("groupId", "channelId")
+        )
+    if target_type in {"chatDetails", "chatVolume"}:
+        return (
+            target.get("chatType") in {"group", "channel"}
+            and _is_valid_target_id(target.get("chatId"))
+            and optional_id("groupId")
+        )
+    return False
+
+
+def _is_valid_button_action(action: Any) -> bool:
+    if not _is_plain_object(action) or not _is_plain_object(action.get("event")):
+        return False
+    event = action["event"]
+    context = event.get("context")
+    if event.get("name") == A2UI_ACTION_SEND_MESSAGE:
+        return (
+            _is_plain_object(context)
+            and _is_non_empty_string(context.get("text"))
+            and len(context["text"]) <= 1000
+        )
+    if event.get("name") == A2UI_ACTION_NAVIGATE:
+        return _is_plain_object(context) and _is_valid_navigation_target(context.get("target"))
+    return False
+
+
+def _is_valid_a2ui_component(component: Any) -> bool:
+    if not _is_plain_object(component) or not _is_non_empty_string(component.get("id")):
+        return False
+    weight = component.get("weight")
+    if "weight" in component and (not _is_finite_number(weight) or not 0 <= weight <= 12):
+        return False
+    kind = component.get("component")
+    if kind == "Text":
+        return (
+            isinstance(component.get("text"), str)
+            and len(component["text"]) <= 1000
+            and component.get("variant") in {None, "body", "caption", "h1", "h2", "h3", "h4", "h5"}
+        )
+    if kind in {"Row", "Column"}:
+        children = component.get("children")
+        return (
+            isinstance(children, list)
+            and len(children) <= 12
+            and all(_is_non_empty_string(child) for child in children)
+            and len(set(children)) == len(children)
+            and component.get("justify") in {None, "start", "center", "end", "spaceBetween", "spaceAround"}
+            and component.get("align") in {None, "start", "center", "end", "stretch"}
+        )
+    if kind == "Card":
+        return _is_non_empty_string(component.get("child"))
+    if kind == "Divider":
+        return True
+    if kind == "Button":
+        return (
+            _is_non_empty_string(component.get("child"))
+            and ("disabled" not in component or isinstance(component["disabled"], bool))
+            and component.get("variant") in {None, "default", "primary", "secondary", "borderless"}
+            and _is_valid_button_action(component.get("action"))
+        )
+    return False
+
+
+def validate_a2ui_card(entry: Any) -> bool:
+    """Conservative Python port of ``A2UI.validateBlobEntry``.
+
+    This keeps a malformed card from replacing the plain-text `/pending`
+    response. It covers the client envelope, component, and reachable-tree
+    invariants without accepting a shape the renderer would reject.
+    """
+    if not _is_plain_object(entry) or entry.get("type") != "a2ui" or entry.get("version") != 1:
+        return False
+    try:
+        # ASCII escaping is intentionally conservative for the browser's
+        # JSON.stringify length budget and also catches non-serializable data.
+        if len(json.dumps(entry, ensure_ascii=True, separators=(",", ":")).encode("ascii")) > 32 * 1024:
+            return False
+    except (TypeError, ValueError):
+        return False
+
+    messages = entry.get("messages")
+    if not isinstance(messages, list):
+        return False
+    create_message = next(
+        (message for message in messages if _is_plain_object(message) and "createSurface" in message),
+        None,
+    )
+    update_message = next(
+        (message for message in messages if _is_plain_object(message) and "updateComponents" in message),
+        None,
+    )
+    if (
+        not _is_plain_object(create_message)
+        or not _is_plain_object(update_message)
+        or create_message.get("version") != A2UI_MESSAGE_VERSION
+        or update_message.get("version") != A2UI_MESSAGE_VERSION
+        or not _is_plain_object(create_message.get("createSurface"))
+        or not _is_plain_object(update_message.get("updateComponents"))
+    ):
+        return False
+    create_surface = create_message["createSurface"]
+    update = update_message["updateComponents"]
+    components = update.get("components")
+    if (
+        not _is_non_empty_string(create_surface.get("surfaceId"))
+        or create_surface.get("surfaceId") != update.get("surfaceId")
+        or not _is_non_empty_string(create_surface.get("catalogId"))
+        or not isinstance(components, list)
+        or not 0 < len(components) <= 50
+        or not all(_is_valid_a2ui_component(component) for component in components)
+    ):
+        return False
+
+    by_id: dict[str, Mapping[str, Any]] = {}
+    total_text = 0
+    for component in components:
+        component_id = component["id"]
+        if component_id in by_id:
+            return False
+        by_id[component_id] = component
+        if component["component"] == "Text":
+            total_text += len(component["text"])
+        elif component["component"] == "Button":
+            action = component["action"]
+            event = action["event"]
+            if event["name"] == A2UI_ACTION_SEND_MESSAGE:
+                total_text += len(event["context"]["text"])
+    if total_text > 8000:
+        return False
+
+    root = update.get("root", components[0]["id"])
+    if not _is_non_empty_string(root) or root not in by_id:
+        return False
+    visiting: set[str] = set()
+    expanded = 0
+
+    def visit(component_id: str, depth: int) -> bool:
+        nonlocal expanded
+        if depth > 8 or component_id in visiting:
+            return False
+        expanded += 1
+        if expanded > 50 * 12:
+            return False
+        component = by_id.get(component_id)
+        if component is None:
+            return False
+        visiting.add(component_id)
+        if component["component"] in {"Row", "Column"}:
+            children = component["children"]
+        elif component["component"] in {"Card", "Button"}:
+            children = [component["child"]]
+        else:
+            children = []
+        if len(children) > 12 or not all(visit(child, depth + 1) for child in children):
+            return False
+        visiting.remove(component_id)
+        return True
+
+    return visit(root, 1)
+
+
+def build_pending_approvals_response(
+    approvals: Iterable[Mapping[str, Any]], *, is_dm: bool
+) -> tuple[str, Optional[str]]:
+    """Return the self-sufficient text fallback and optional pending-card blob."""
+    active = list(approvals)
+    text = format_pending_list(active)
+    if not is_dm:
+        return text, None
+    card = build_pending_approvals_card(active)
+    if card is None or not validate_a2ui_card(card):
+        return text, None
+    try:
+        return text, serialize_blob(card)
+    except (TypeError, ValueError):
+        return text, None

--- a/packages/hermes-tlon-adapter/media.py
+++ b/packages/hermes-tlon-adapter/media.py
@@ -11,9 +11,11 @@ import inspect
 import ipaddress
 import json
 import logging
+import math
 import mimetypes
 import os
 import socket
+import sys
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Sequence
 from urllib.parse import ParseResult, unquote, urljoin, urlparse
@@ -22,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 MAX_BLOB_DOWNLOAD_BYTES = 100 * 1024 * 1024
 MAX_REDIRECTS = 5
+_MAX_INT_LITERAL_DIGITS = 4_000
 
 
 @dataclass(frozen=True)
@@ -94,6 +97,85 @@ class MediaTooLargeError(MediaDownloadError):
 
 class UnsafeMediaUrlError(MediaDownloadError):
     pass
+
+
+def _reject_json_constant(_value: str) -> Any:
+    """Make ``json.loads`` reject constants that ``JSON.parse`` rejects."""
+    raise ValueError("non-standard JSON constant")
+
+
+def _normalize_json_float(value: str) -> Any:
+    """Match JSON.parse + JSON.stringify for overflowing float literals."""
+    result = float(value)
+    return result if math.isfinite(result) else None
+
+
+def _int_literal_digit_limit() -> int:
+    """Return a safe conversion band for CPython's configurable int limit."""
+    runtime = getattr(sys, "get_int_max_str_digits", lambda: 0)()
+    if runtime == 0:
+        return _MAX_INT_LITERAL_DIGITS
+    return min(_MAX_INT_LITERAL_DIGITS, runtime - 1)
+
+
+def _bounded_parse_int(value: str) -> Any:
+    """Normalize integer literals that cannot survive JavaScript's Number path.
+
+    Python 3.11 may reject a very large literal before we can merge the other
+    entries in its field. JavaScript instead parses that literal as a Number,
+    and JSON.stringify emits ``null`` when it overflows. Keep fields intact by
+    converting both Python-unsafe and JS-overflowing literals to ``None``.
+    """
+    if len(value.lstrip("-")) > _int_literal_digit_limit():
+        return None
+    result = int(value)
+    try:
+        float(result)
+    except OverflowError:
+        return None
+    return result
+
+
+def combine_blob_fields(*fields: str | None) -> str | None:
+    """Merge serialized post-blob arrays without losing a valid co-field.
+
+    This mirrors OpenClaw's ``combineBlobFields``: falsy, malformed, and
+    non-array fields are skipped; surviving entries retain argument order.
+    Strict constants and numeric hooks preserve the JSON.parse /
+    JSON.stringify behaviour used by the reference implementation. The result
+    is ASCII-escaped so it is safe to hand directly to the ``tlon`` subprocess
+    even when an input contains an unpaired surrogate.
+
+    Nesting depth is deliberately unbounded, like the reference (JSON.parse
+    imposes no depth limit): a very deep field is preserved wherever this
+    runtime's json parser can decode it (CPython >= 3.14, iterative). On
+    recursive parsers (<= 3.13, including the 3.11 dev-image runtime) the
+    ``RecursionError`` catches below act as a safety net: such a field is
+    skipped — the co-fields and the message itself always survive.
+    """
+    entries: list[Any] = []
+    for field in fields:
+        if not field:
+            continue
+        try:
+            parsed = json.loads(
+                field,
+                parse_constant=_reject_json_constant,
+                parse_float=_normalize_json_float,
+                parse_int=_bounded_parse_int,
+            )
+        except (TypeError, ValueError, RecursionError):
+            continue
+        if isinstance(parsed, list):
+            entries.extend(parsed)
+    if not entries:
+        return None
+    try:
+        return json.dumps(entries, ensure_ascii=True, allow_nan=False, separators=(",", ":"))
+    except (TypeError, ValueError, RecursionError):
+        # A parsed structure too deep to re-serialize must drop the blob,
+        # never abort message delivery.
+        return None
 
 
 def parse_blob_data(blob: str | None) -> list[BlobEntry]:

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -3,6 +3,7 @@ import importlib.util
 import json
 import os
 import sys
+import time
 import types
 import unittest
 from pathlib import Path
@@ -131,6 +132,7 @@ def channel_event(
     author="~ten",
     nest="chat/~pen/general",
     post_id="170.141",
+    parent_id=None,
     blob=None,
     content=None,
 ):
@@ -142,15 +144,16 @@ def channel_event(
     }
     if blob is not None:
         essay["blob"] = blob
+    set_payload = {"essay": essay}
+    if parent_id:
+        set_payload["seal"] = {"parent-id": parent_id}
     return {
         "nest": nest,
         "response": {
             "post": {
                 "id": post_id,
                 "r-post": {
-                    "set": {
-                        "essay": essay
-                    }
+                    "set": set_payload
                 },
             }
         },
@@ -237,7 +240,9 @@ class FakeSSE:
 class FakeCLI:
     def __init__(self):
         self.messages = []
+        self.message_blobs = []
         self.replies = []
+        self.reply_blobs = []
         self.commands = []
 
     async def run_command(self, args):
@@ -248,12 +253,14 @@ class FakeCLI:
 
     async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
         self.messages.append((chat_id, text))
+        self.message_blobs.append((blob, sent_at))
         return tlon_api.TlonSendResult(
             success=True, command=("tlon-test", "posts", "send"), message_id="post-id"
         )
 
     async def send_reply(self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None):
         self.replies.append((chat_id, post_id, text, parent_author))
+        self.reply_blobs.append((blob, sent_at))
         return tlon_api.TlonSendResult(
             success=True, command=("tlon-test", "posts", "reply"), message_id="reply-id"
         )
@@ -1133,6 +1140,122 @@ class AdapterApprovalTests(unittest.TestCase):
             dm=True,
         )
         self.assertIn("• ~bus", adapter._cli.messages[-1][1])
+
+    def test_pending_dm_reply_sends_card_with_full_text_fallback(self):
+        adapter = self.make_adapter()
+        first_id = self.queue_dm_request(adapter)
+        self.dispatches(
+            adapter,
+            dm_event("second request", author="~bus", whom="~bus", msg_id="dm-2"),
+            dm=True,
+        )
+        second_id = adapter._pending_approvals[1]["id"]
+
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-1"),
+            dm=True,
+        )
+
+        text = adapter._cli.messages[-1][1]
+        blob, sent_at = adapter._cli.message_blobs[-1]
+        self.assertIn(f"#{first_id}", text)
+        self.assertIn(f"#{second_id}", text)
+        self.assertIn("/allow <id> · /reject <id> · /ban <id>", text)
+        self.assertIsNone(sent_at)
+        entry = json.loads(blob)[0]
+        self.assertEqual(entry["type"], "a2ui")
+        self.assertIn(f"/allow {first_id}", blob)
+        self.assertIn(f"/reject {second_id}", blob)
+
+    def test_pending_channel_reply_and_out_of_budget_reply_have_no_card(self):
+        adapter = self.make_adapter()
+        self.queue_dm_request(adapter)
+        self.dispatches(
+            adapter,
+            channel_event(
+                "/pending", author="~mug", post_id="pending-1", parent_id="170.0"
+            ),
+        )
+        self.assertEqual(len(adapter._cli.replies), 1)
+        self.assertIsNone(adapter._cli.reply_blobs[-1][0])
+
+        adapter = self.make_adapter()
+        adapter._pending_approvals = [
+            {
+                "id": f"d{index}",
+                "type": "dm",
+                "requestingShip": f"~ship{index}",
+                "timestamp": int(time.time() * 1000),
+            }
+            for index in range(5)
+        ]
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-2"),
+            dm=True,
+        )
+        self.assertIsNone(adapter._cli.message_blobs[-1][0])
+
+    def test_pending_zero_items_replies_with_text_only_no_blob(self):
+        adapter = self.make_adapter()
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-1"),
+            dm=True,
+        )
+        text = adapter._cli.messages[-1][1]
+        blob, _sent_at = adapter._cli.message_blobs[-1]
+        self.assertIn("No pending approvals", text)
+        self.assertIsNone(blob)
+
+    def test_pending_card_falls_back_to_text_when_validator_forced_false(self):
+        approval_mod = sys.modules[f"{PACKAGE_NAME}.approval"]
+        adapter = self.make_adapter()
+        first_id = self.queue_dm_request(adapter, "hi bot")
+        self.dispatches(
+            adapter,
+            dm_event("second request", author="~bus", whom="~bus", msg_id="dm-2"),
+            dm=True,
+        )
+        second_id = adapter._pending_approvals[1]["id"]
+
+        original = approval_mod.validate_a2ui_card
+        approval_mod.validate_a2ui_card = lambda _card: False
+        self.addCleanup(setattr, approval_mod, "validate_a2ui_card", original)
+
+        self.dispatches(
+            adapter,
+            dm_event("/pending", author="~mug", whom="~mug", msg_id="cmd-1"),
+            dm=True,
+        )
+
+        text = adapter._cli.messages[-1][1]
+        blob, _sent_at = adapter._cli.message_blobs[-1]
+        self.assertIn(f"#{first_id}", text)
+        self.assertIn(f"#{second_id}", text)
+        self.assertIsNone(blob)
+
+    def test_control_reply_truncates_to_max_message_length(self):
+        adapter = self.make_adapter()
+        long_text = "x" * (tlon_api.MAX_MESSAGE_LENGTH + 500)
+
+        asyncio.run(adapter._send_control_reply("~mug", None, long_text))
+
+        sent_text = adapter._cli.messages[-1][1]
+        self.assertEqual(len(sent_text), tlon_api.MAX_MESSAGE_LENGTH)
+
+    def test_dm_control_reply_with_parent_id_still_uses_posts_send(self):
+        # DMs are linear; a control reply must never thread even when a
+        # parent_id is passed in, unlike the channel side (which does thread
+        # — see test_pending_channel_reply_and_out_of_budget_reply_have_no_card).
+        adapter = self.make_adapter()
+
+        asyncio.run(adapter._send_control_reply("~mug", "170.0", "some reply"))
+
+        self.assertEqual(adapter._cli.replies, [])
+        self.assertEqual(len(adapter._cli.messages), 1)
+        self.assertEqual(adapter._cli.messages[-1], ("~mug", "some reply"))
 
     def test_allow_unknown_id_reports_not_found(self):
         adapter = self.make_adapter()

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -206,7 +206,9 @@ def loop_cap_addendum(ship="~bot"):
 class RecordingCLI(FakeCLI):
     def __init__(self, results=None):
         self.sends = []
+        self.send_blobs = []
         self.thread_replies = []
+        self.reply_blobs = []
         self.results = list(results or [])
 
     def _next_result(self):
@@ -220,12 +222,14 @@ class RecordingCLI(FakeCLI):
 
     async def send_message(self, chat_id, text, *, blob=None, sent_at=None):
         self.sends.append((chat_id, text))
+        self.send_blobs.append((blob, sent_at))
         return self._next_result()
 
     async def send_reply(
         self, chat_id, post_id, text, *, parent_author=None, blob=None, sent_at=None
     ):
         self.thread_replies.append((chat_id, post_id, text, parent_author))
+        self.reply_blobs.append((blob, sent_at))
         result = self._next_result()
         if result.command == ():
             return tlon_api.TlonSendResult(
@@ -1161,6 +1165,151 @@ class AdapterAttentionTests(unittest.TestCase):
         # No lens output to stamp → no --sent-at override (keeps older `tlon`
         # binaries from folding an unknown flag into the message body).
         self.assertIsNone(captured["sent_at"])
+
+    def test_send_composes_caller_blob_with_active_lens_reference(self):
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
+        )
+        adapter._lens_sync._ready = True
+        adapter._lens.begin(
+            "chat/~pen/general",
+            adapter_mod.LensRun(
+                lens_id="L42",
+                message_id="m",
+                chat_type="channel",
+                trigger="mention",
+                conversation_kind="channel",
+            ),
+        )
+        adapter._cli = RecordingCLI()
+        caller_blob = json.dumps([{"type": "a2ui", "version": 1, "messages": []}])
+
+        result = asyncio.run(
+            adapter.send("chat/~pen/general", "reply", metadata={"blob": caller_blob})
+        )
+
+        self.assertTrue(result.success)
+        blob, sent_at = adapter._cli.send_blobs[-1]
+        entries = json.loads(blob)
+        self.assertEqual([entry["type"] for entry in entries], ["a2ui", "tlon-context-lens"])
+        self.assertEqual(entries[1]["lensId"], "L42")
+        self.assertIsNotNone(sent_at)
+        output = adapter._lens.get("chat/~pen/general").outputs[-1]
+        self.assertEqual(output.message_id, tlon_api.format_post_id("~pen", sent_at))
+
+    def test_caller_blob_routes_without_lens_and_malformed_blob_fails_closed(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        adapter._cli = RecordingCLI()
+        caller_blob = json.dumps([{"type": "a2ui", "version": 1, "messages": []}])
+
+        asyncio.run(adapter.send("chat/~pen/general", "reply", metadata={"blob": caller_blob}))
+        blob, sent_at = adapter._cli.send_blobs[-1]
+        self.assertEqual(json.loads(blob), json.loads(caller_blob))
+        self.assertIsNone(sent_at)
+
+        asyncio.run(adapter.send("chat/~pen/general", "plain", metadata={"blob": 7}))
+        self.assertIsNone(adapter._cli.send_blobs[-1][0])
+
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
+        )
+        adapter._lens_sync._ready = True
+        adapter._lens.begin(
+            "chat/~pen/general",
+            adapter_mod.LensRun(
+                lens_id="L43",
+                message_id="m",
+                chat_type="channel",
+                trigger="mention",
+                conversation_kind="channel",
+            ),
+        )
+        adapter._cli = RecordingCLI()
+        asyncio.run(adapter.send("chat/~pen/general", "reply", metadata={"blob": "not json"}))
+        entries = json.loads(adapter._cli.send_blobs[-1][0])
+        self.assertEqual([entry["type"] for entry in entries], ["tlon-context-lens"])
+
+    def test_lens_sent_at_allocator_is_monotonic_under_a_frozen_clock(self):
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
+        )
+        adapter._lens_sync._ready = True
+        adapter._lens.begin(
+            "chat/~pen/general",
+            adapter_mod.LensRun(
+                lens_id="L44",
+                message_id="m",
+                chat_type="channel",
+                trigger="mention",
+                conversation_kind="channel",
+            ),
+        )
+        adapter._cli = RecordingCLI()
+
+        with patch.object(adapter_mod.time, "time", return_value=1_700_000_000.0):
+            asyncio.run(adapter.send("chat/~pen/general", "first"))
+            asyncio.run(adapter.send("chat/~pen/general", "second"))
+
+        first_sent_at = adapter._cli.send_blobs[-2][1]
+        second_sent_at = adapter._cli.send_blobs[-1][1]
+        self.assertLess(first_sent_at, second_sent_at)
+        outputs = adapter._lens.get("chat/~pen/general").outputs
+        self.assertEqual(outputs[-2].message_id, tlon_api.format_post_id("~pen", first_sent_at))
+        self.assertEqual(outputs[-1].message_id, tlon_api.format_post_id("~pen", second_sent_at))
+
+    def test_caller_blob_requires_non_empty_content(self):
+        adapter = self.make_adapter({"allowed_users": ["~mug"]})
+        adapter._cli = RecordingCLI()
+        caller_blob = json.dumps([{"type": "a2ui", "version": 1, "messages": []}])
+
+        result = asyncio.run(
+            adapter.send("chat/~pen/general", "  ", metadata={"blob": caller_blob})
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("metadata['blob'] requires non-empty content", result.error)
+        self.assertEqual(adapter._cli.sends, [])
+
+        result = asyncio.run(adapter.send("chat/~pen/general", ""))
+        self.assertTrue(result.success)
+        self.assertEqual(adapter._cli.sends[-1][1], "")
+
+    def test_caller_blob_guard_with_active_lens_run_fails_delivery_not_no_reply(self):
+        adapter = self.make_adapter(
+            {"allowed_users": ["~mug"], "context_lens": True, "context_lens_owner": "~zod"}
+        )
+        adapter._lens_sync._ready = True
+        adapter._lens.begin(
+            "chat/~pen/general",
+            adapter_mod.LensRun(
+                lens_id="L50",
+                message_id="m",
+                chat_type="channel",
+                trigger="mention",
+                conversation_kind="channel",
+            ),
+        )
+        adapter._cli = RecordingCLI()
+        caller_blob = json.dumps([{"type": "a2ui", "version": 1, "messages": []}])
+
+        result = asyncio.run(
+            adapter.send("chat/~pen/general", "  ", metadata={"blob": caller_blob})
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("metadata['blob'] requires non-empty content", result.error)
+        # The guard must fail closed before ever reaching the CLI.
+        self.assertEqual(adapter._cli.sends, [])
+        self.assertEqual(adapter._cli.thread_replies, [])
+
+        run = adapter._lens.get("chat/~pen/general")
+        # No LensOutput recorded for the rejected send...
+        self.assertEqual(run.outputs, [])
+        # ...but the run must finalize as a delivery error, not a silent
+        # no_reply: the guard now runs through the same failure lifecycle
+        # as a CLI-level send failure.
+        self.assertTrue(run.delivery_failed)
+        self.assertIn("metadata['blob'] requires non-empty content", run.error)
 
     def test_nickname_fetch_failure_keeps_ship_and_alias_wakes(self):
         adapter = self.make_adapter({"allowed_users": ["~mug"], "bot_mentions": ["arvo"]})

--- a/packages/hermes-tlon-adapter/test_approval.py
+++ b/packages/hermes-tlon-adapter/test_approval.py
@@ -391,6 +391,146 @@ class A2UICardTests(unittest.TestCase):
             components["allow"]["action"]["event"]["context"]["text"], "/allow g9f3a"
         )
 
+    def test_card_survives_oversized_persisted_fields(self):
+        """Pending approvals are untrusted persisted JSON; a corrupted
+        groupTitle or channelNest must not blow the a2ui validator's size
+        limits — every button command must still resolve to its approval."""
+        oversized_group = make_approval(
+            id="g1a2b",
+            type="group",
+            requestingShip="~ten",
+            groupFlag="~host/projects",
+            groupTitle="x" * 50_000,
+        )
+        oversized_channel = make_approval(
+            id="c3d4e",
+            type="channel",
+            requestingShip="~pen",
+            channelNest="y" * 50_000,
+        )
+        store = [oversized_group, oversized_channel]
+        for item in store:
+            card = approval.build_approval_card(item)
+            self.assertTrue(approval.validate_a2ui_card(card))
+            components, _ = self.card_components(card)
+            for component in components.values():
+                if component.get("component") != "Button":
+                    continue
+                command_text = component["action"]["event"]["context"]["text"]
+                parsed = approval.parse_approval_command(command_text)
+                self.assertIsNotNone(parsed)
+                _action, arg = parsed
+                resolved = approval.find_approval(store, arg)
+                self.assertIsNotNone(resolved)
+                self.assertEqual(resolved["id"], item["id"])
+
+
+class PendingApprovalsA2UITests(unittest.TestCase):
+    def approvals(self, count):
+        return [
+            make_approval(
+                id=f"d{index}",
+                messagePreview=f"request {index}",
+                requestingShip=f"~ship{index}",
+            )
+            for index in range(count)
+        ]
+
+    @staticmethod
+    def components(card):
+        return card["messages"][1]["updateComponents"]["components"]
+
+    def test_pending_card_is_valid_for_one_and_four_items(self):
+        for count in (1, 4):
+            card = approval.build_pending_approvals_card(self.approvals(count))
+            self.assertTrue(approval.validate_a2ui_card(card))
+            components = self.components(card)
+            ids = [component["id"] for component in components]
+            self.assertEqual(len(ids), len(set(ids)))
+            self.assertLessEqual(len(components), 50)
+            self.assertIn(f"/allow d{count - 1}", json.dumps(card))
+            self.assertIn(f"/reject d{count - 1}", json.dumps(card))
+            self.assertIn(f"/ban d{count - 1}", json.dumps(card))
+
+    def test_pending_card_falls_back_outside_dm_card_budget_or_with_bad_id(self):
+        self.assertIsNone(approval.build_pending_approvals_card([]))
+        self.assertIsNone(approval.build_pending_approvals_card(self.approvals(5)))
+        malformed = self.approvals(1)
+        malformed[0]["id"] = "bad id"
+        self.assertIsNone(approval.build_pending_approvals_card(malformed))
+
+        text, blob = approval.build_pending_approvals_response(malformed, is_dm=True)
+        self.assertIsNone(blob)
+        self.assertIn("[unactionable approval ID]", text)
+        self.assertIn("/allow <id>", text)
+
+    def test_pending_response_keeps_full_text_fallback_beneath_card(self):
+        approvals = self.approvals(2)
+        text, blob = approval.build_pending_approvals_response(approvals, is_dm=True)
+
+        self.assertEqual(text, approval.format_pending_list(approvals))
+        self.assertIn("#d0", text)
+        self.assertIn("#d1", text)
+        self.assertIn("/allow <id> · /reject <id> · /ban <id>", text)
+        self.assertIsNotNone(blob)
+        self.assertTrue(approval.validate_a2ui_card(json.loads(blob)[0]))
+
+        channel_text, channel_blob = approval.build_pending_approvals_response(
+            approvals, is_dm=False
+        )
+        self.assertEqual(channel_text, text)
+        self.assertIsNone(channel_blob)
+
+    def test_pending_response_falls_back_when_validation_rejects_card(self):
+        approvals = self.approvals(2)
+        original = approval.validate_a2ui_card
+        approval.validate_a2ui_card = lambda _card: False
+        self.addCleanup(setattr, approval, "validate_a2ui_card", original)
+
+        text, blob = approval.build_pending_approvals_response(approvals, is_dm=True)
+        self.assertEqual(text, approval.format_pending_list(approvals))
+        self.assertIsNone(blob)
+
+    def test_validator_rejects_duplicate_dangling_and_cyclic_components(self):
+        card = approval.build_pending_approvals_card(self.approvals(1))
+        components = self.components(card)
+        components.append(dict(components[0]))
+        self.assertFalse(approval.validate_a2ui_card(card))
+
+        card = approval.build_pending_approvals_card(self.approvals(1))
+        components = self.components(card)
+        next(component for component in components if component["id"] == "body")["children"].append(
+            "missing"
+        )
+        self.assertFalse(approval.validate_a2ui_card(card))
+
+        card = approval.build_pending_approvals_card(self.approvals(1))
+        next(component for component in self.components(card) if component["id"] == "body")[
+            "children"
+        ].append("root")
+        self.assertFalse(approval.validate_a2ui_card(card))
+
+    def test_pending_text_is_bounded_for_hostile_persisted_data(self):
+        approvals = [
+            make_approval(
+                id=" " * 50_000,
+                type="not-a-real-kind" * 5_000,
+                requestingShip="~" + "s" * 50_000,
+                channelNest="n" * 50_000,
+                groupFlag="g" * 50_000,
+                groupTitle="t" * 50_000,
+                messagePreview="p" * 50_000,
+            )
+            for _ in range(30)
+        ]
+        text, blob = approval.build_pending_approvals_response(approvals, is_dm=True)
+
+        self.assertIsNone(blob)
+        self.assertLessEqual(len(text), 10_000)
+        self.assertIn("[unactionable approval ID]", text)
+        self.assertIn("5 more pending approval(s) not shown.", text)
+        self.assertIn("/allow <id> · /reject <id> · /ban <id>", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/hermes-tlon-adapter/test_media.py
+++ b/packages/hermes-tlon-adapter/test_media.py
@@ -102,6 +102,166 @@ class MediaParsingTests(unittest.TestCase):
         )
 
 
+class BlobCompositionTests(unittest.TestCase):
+    def test_merges_arrays_in_order_and_skips_bad_fields(self):
+        merged = media.combine_blob_fields(
+            json.dumps([{"type": "a2ui", "version": 1}]),
+            "not json",
+            json.dumps({"not": "an array"}),
+            json.dumps([{"type": "tlon-context-lens", "version": 1}]),
+        )
+
+        self.assertEqual(
+            json.loads(merged),
+            [
+                {"type": "a2ui", "version": 1},
+                {"type": "tlon-context-lens", "version": 1},
+            ],
+        )
+        self.assertIsNone(media.combine_blob_fields("", "not json", "{}"))
+
+    def test_strict_constants_do_not_drop_valid_cofield(self):
+        valid = json.dumps([{"type": "a2ui", "version": 1}])
+        merged = media.combine_blob_fields(
+            "[NaN]",
+            "[Infinity]",
+            "[-Infinity]",
+            valid,
+        )
+
+        self.assertEqual(json.loads(merged), [{"type": "a2ui", "version": 1}])
+
+    def test_very_deep_field_outcome_matches_runtime_parser(self):
+        # No adapter-imposed depth policy exists (the reference JSON.parse has
+        # none): a very deep field is preserved when this runtime's json
+        # parser decodes it (CPython >= 3.14, iterative — the reference
+        # behavior) and skipped when it cannot (recursive parsers <= 3.13,
+        # including the deployed 3.11 runtime, via the RecursionError safety
+        # net). Probe the runtime, then assert that runtime's deterministic
+        # outcome. Assertions avoid comparing the deep structure wholesale so
+        # a failure never recurses in unittest's repr.
+        deep = "[" * 5_000 + "]" * 5_000
+        try:
+            json.loads(deep)
+            parser_handles_depth = True
+        except RecursionError:
+            parser_handles_depth = False
+
+        valid = json.dumps([{"type": "a2ui", "version": 1}])
+        merged = media.combine_blob_fields(deep, valid)
+        entries = json.loads(merged)
+        if parser_handles_depth:
+            self.assertEqual(len(entries), 2)
+            self.assertIsInstance(entries[0], list)
+            self.assertEqual(entries[1], {"type": "a2ui", "version": 1})
+        else:
+            self.assertEqual(entries, [{"type": "a2ui", "version": 1}])
+
+    def test_moderately_deep_field_is_no_longer_dropped_by_the_removed_cap(self):
+        # 300 levels comfortably cleared the old 256-level depth cap but is
+        # nowhere near Python's own json recursion limit (~1000); it must
+        # merge fine now that the cap is gone entirely.
+        moderately_nested = "[" * 300 + "]" * 300
+        valid = json.dumps([{"type": "a2ui", "version": 1}])
+        merged = media.combine_blob_fields(moderately_nested, valid)
+
+        entries = json.loads(merged)
+        self.assertEqual(len(entries), 2)
+        depth = 0
+        node = entries[0]
+        while isinstance(node, list) and node:
+            depth += 1
+            node = node[0]
+        self.assertEqual(depth, 298)
+        self.assertEqual(entries[1], {"type": "a2ui", "version": 1})
+
+    def test_deep_a2ui_recipe_survives_alongside_lens_reference(self):
+        # A structurally valid a2ui entry whose recipe happens to be a deeply
+        # nested array (257 levels — past the removed cap) must round-trip
+        # intact, and a co-field must not be crowded out by it.
+        recipe = []
+        for _ in range(257):
+            recipe = [recipe]
+        a2ui_field = json.dumps(
+            [{"type": "a2ui", "version": 1, "messages": [], "recipe": recipe}]
+        )
+        lens_field = json.dumps([{"type": "tlon-context-lens", "version": 1}])
+        merged = media.combine_blob_fields(a2ui_field, lens_field)
+
+        entries = json.loads(merged)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["type"], "a2ui")
+        self.assertEqual(entries[0]["recipe"], recipe)
+        self.assertEqual(entries[1]["type"], "tlon-context-lens")
+
+    def test_default_band_five_thousand_digit_integer_emits_null(self):
+        # No sys.set_int_max_str_digits manipulation here (unlike
+        # test_runtime_integer_limit_does_not_drop_coexisting_entry): this
+        # exercises our own _MAX_INT_LITERAL_DIGITS band under CPython's
+        # default int/str conversion limit.
+        field = f'[{json.dumps({"type": "a2ui", "version": 1})},{"9" * 5_000}]'
+        merged = media.combine_blob_fields(field)
+
+        entries = json.loads(merged)
+        self.assertEqual(entries[0]["type"], "a2ui")
+        self.assertIsNone(entries[1])
+
+    def test_numeric_normalization_preserves_entries_in_the_same_field(self):
+        a2ui = {
+            "type": "a2ui",
+            "version": 1,
+            "messages": [],
+            "recipe": int("9" * 100),
+        }
+        field = f'[{json.dumps(a2ui, separators=(",", ":"))},{{"value":1e400}},{{"finite":1.5}}]'
+        merged = media.combine_blob_fields(
+            field,
+            json.dumps([{"type": "tlon-context-lens", "version": 1}]),
+        )
+
+        entries = json.loads(merged)
+        self.assertEqual(entries[0]["recipe"], int("9" * 100))
+        self.assertIsNone(entries[1]["value"])
+        self.assertEqual(entries[2]["finite"], 1.5)
+        self.assertEqual(entries[3]["type"], "tlon-context-lens")
+
+    def test_js_overflowing_integers_normalize_to_null_without_losing_a2ui(self):
+        a2ui = {"type": "a2ui", "version": 1, "messages": [], "recipe": 0}
+        a2ui_prefix = json.dumps(a2ui, separators=(",", ":"))[:-2]
+        field = "[" + a2ui_prefix + "9" * 400 + "}]"
+        merged = media.combine_blob_fields(
+            field,
+            json.dumps([{"type": "tlon-context-lens", "version": 1}]),
+        )
+
+        entries = json.loads(merged)
+        self.assertIsNone(entries[0]["recipe"])
+        self.assertEqual(entries[1]["type"], "tlon-context-lens")
+
+    def test_runtime_integer_limit_does_not_drop_coexisting_entry(self):
+        if not hasattr(sys, "set_int_max_str_digits"):
+            self.skipTest("CPython integer limit unavailable")
+        old_limit = sys.get_int_max_str_digits()
+        self.addCleanup(sys.set_int_max_str_digits, old_limit)
+        sys.set_int_max_str_digits(640)
+        field = f'[{json.dumps({"type": "a2ui", "version": 1})},{"9" * 1000}]'
+        merged = media.combine_blob_fields(field)
+        sys.set_int_max_str_digits(old_limit)
+
+        entries = json.loads(merged)
+        self.assertEqual(entries[0]["type"], "a2ui")
+        self.assertIsNone(entries[1])
+
+    def test_very_large_field_and_lone_surrogate_are_safe_to_forward(self):
+        large = json.dumps([{"type": "x", "version": 1, "value": "x" * (65 * 1024)}])
+        surrogate = '[{"type":"y","value":"\\ud800"}]'
+        merged = media.combine_blob_fields(large, surrogate)
+
+        self.assertGreater(len(merged), 64 * 1024)
+        self.assertEqual(len(json.loads(merged)), 2)
+        merged.encode("utf-8")
+
+
 class MediaPreparationTests(unittest.TestCase):
     def cache(self, kind):
         def fake_cache(data, *, filename="", mime_type="", default_kind=None):


### PR DESCRIPTION
## Summary

Adds blob co-existence to the hermes-tlon-adapter so multiple producers (e.g. a lens ref and an a2ui card) can ride one reply. Post blobs are JSON arrays, but each producer previously serialized a complete single-entry field, so two sources on one post were last-writer-wins. Ports OpenClaw's `combineBlobFields` and uses it as the composition seam for all outbound posts. Fixes TLON-6091.

## Changes

-   `media.py`: `combine_blob_fields()`, a JS-dialect-faithful port (rejects NaN/Infinity tokens, non-finite floats become null, runtime-aware integer band with null past the JS-double boundary; ASCII-escaped output for subprocess argv). No depth/size caps, matching the reference; deep-field behavior is runtime-dependent and documented (preserved on CPython >= 3.14, RecursionError-skipped on <= 3.13, including the deployed 3.11).
-   `adapter.py`: `_deliver_post()` delivery seam where all blob sources compose (caller fields first, lens ref last); monotonic per-adapter `--sent-at` allocator (sent-at derives ship post ids and lens output ids, so same-millisecond stamps collide); `send()` gains a documented `metadata["blob"]` contract (type-checked, requires non-empty content, guard failures go through the normal telemetry/lens delivery-failure lifecycle); `_send_control_reply` gains `blob_fields` plus `MAX_MESSAGE_LENGTH` truncation, keeping the DM no-thread routing contract.
-   `approval.py`: `/pending` answers with an actionable a2ui card (1-4 pending, DM contexts) riding the full pending-list text. Deliberate deviation from OpenClaw #5939: it sends empty text with the card, but our CLI requires content and the full list keeps non-a2ui clients functional. Includes `validate_a2ui_card()` (mini-port of the client's `validateBlobEntry`; failure falls back to text) and display sanitation for untrusted %settings data (strict id gate for card-vs-text, bounded formatter inputs, 25-entry list cap).
-   Tests: ~30 new across four modules, including a JSON-dialect matrix, adversarial persisted-approval data, two-source coexistence through public `send()`, frozen-clock allocator monotonicity, and producer-to-CLI card tests.

Scope note: no production caller pairs both blob sources on one post yet; this PR provides the composition mechanism and the first card producer, and the pairing route through `send()` metadata is contract-tested.

Follow-ups: #6059's chunked send will take a small known conflict in `send()` (one-shot blob fields ride the first chunk).

## How did I test?

-   `./dev/test.sh` in `packages/hermes-tlon-adapter`: 550 tests, OK
-   Verified on Python 3.11, 3.12, 3.13, and 3.14 (dialect tests probe runtime behavior)
-   Both `SendResult` constructions in `send()` verified against the real pinned core (`hermes-agent@v2026.6.19` `gateway/platforms/base.py`): field names/required-ness match, and the test stubs faithfully model them

## Risks and impact

-   Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert.