### PR TITLE
fix(openclaw/lens): attribute message-tool replies to foreground runs

### DIFF
--- a/packages/openclaw/src/channel.runtime.ts
+++ b/packages/openclaw/src/channel.runtime.ts
@@ -8,7 +8,9 @@ import type {
 } from 'openclaw/plugin-sdk/core';
 
 import {
+  type ContextLensRegistry,
   getActiveBackgroundContextLens,
+  getActiveForegroundContextLensForConversation,
   recordBackgroundContextLensOutput,
 } from './context-lens.js';
 import { monitorTlonProvider } from './monitor/index.js';
@@ -103,48 +105,87 @@ function resolveReplyId(
   return replyToId ?? threadId ? String(replyToId ?? threadId) : undefined;
 }
 
+type OutboundLensTarget = {
+  // Foreground runs hold their own registry instance; background sends route
+  // through the shared module-level background registry (registry === null).
+  registry: ContextLensRegistry | null;
+  lensId: string;
+  blob: string;
+  foreground: boolean;
+};
+
 /**
- * Gateway-delivered sends (cron announcements, CLI sends) carry no session
- * context, so messages produced by background runs would otherwise land
- * without a lens pointer. Stamp them with the currently active background
- * lens — best-effort correlation, bounded by the lens's short post-run
- * finalize window.
+ * Resolve the context lens an outbound send should attach to.
+ *
+ * Prefers the foreground run that is mid-dispatch for this conversation, so a
+ * reply the model issues by calling the `message` tool itself (instead of
+ * emitting a normal final reply) is recorded against that run — otherwise the
+ * run finalizes as `no_reply` despite having posted. Falls back to the most
+ * recent background lens for gateway/cron/CLI sends that carry no session
+ * context (best-effort, bounded by the lens's short post-run finalize window).
+ *
+ * Attribution is keyed on conversationId, which keeps concurrent runs in
+ * different conversations separated. Two foreground runs overlapping in the
+ * same conversation cannot be told apart here (the outbound adapter has no run
+ * identity), so a tool post may land on the most recently bound of them — a
+ * best-effort tradeoff matching the background-stamp heuristic.
  */
-function resolveBackgroundLensStamp(
-  cfg: OpenClawConfig,
-  botShip: string
-): { lensId: string; blob: string } | null {
-  if (!resolveTlonAccount(cfg).contextLens.enabled) {
+function resolveOutboundLensTarget(
+  account: ConfiguredTlonAccount,
+  botShip: string,
+  conversationId: string
+): OutboundLensTarget | null {
+  if (!account.contextLens.enabled) {
     return null;
   }
-  const lens = getActiveBackgroundContextLens();
-  if (!lens) {
+  const foreground =
+    getActiveForegroundContextLensForConversation(conversationId);
+  if (foreground) {
+    return {
+      registry: foreground.registry,
+      lensId: foreground.lensId,
+      blob: serializeContextLensReferenceBlob(foreground.lensId, botShip),
+      foreground: true,
+    };
+  }
+  const background = getActiveBackgroundContextLens();
+  if (!background) {
     return null;
   }
   return {
-    lensId: lens.lensId,
-    blob: serializeContextLensReferenceBlob(lens.lensId, botShip),
+    registry: null,
+    lensId: background.lensId,
+    blob: serializeContextLensReferenceBlob(background.lensId, botShip),
+    foreground: false,
   };
 }
 
-function recordBackgroundLensDelivery(params: {
-  stamp: { lensId: string } | null;
-  messageId: string;
-  conversationId: string;
-  kind: 'dm' | 'channel';
-  sentAt?: number;
-  text?: string;
-}) {
-  if (!params.stamp) {
+function recordOutboundLensDelivery(
+  target: OutboundLensTarget | null,
+  params: {
+    messageId: string;
+    conversationId: string;
+    kind: 'dm' | 'channel';
+    sentAt?: number;
+    text?: string;
+  }
+) {
+  if (!target) {
     return;
   }
-  recordBackgroundContextLensOutput(params.stamp.lensId, {
+  const output = {
     messageId: params.messageId,
     conversationId: params.conversationId,
     kind: params.kind,
     sentAt: params.sentAt ?? Date.now(),
     preview: params.text ? params.text.slice(0, 140) : undefined,
-  });
+  };
+  if (target.foreground && target.registry) {
+    target.registry.recordOutput(target.lensId, output);
+    target.registry.recordPersistence(target.lensId, { postsReply: true });
+    return;
+  }
+  recordBackgroundContextLensOutput(target.lensId, output);
 }
 
 export const tlonRuntimeOutbound: Pick<
@@ -164,36 +205,40 @@ export const tlonRuntimeOutbound: Pick<
         const fromShip = normalizeShip(account.ship);
         const replyId = resolveReplyId(replyToId, threadId);
         const botProfile = await getBotProfile(fromShip);
-        const stamp = resolveBackgroundLensStamp(cfg, fromShip);
         if (parsed.kind === 'dm') {
+          const conversationId = normalizeShip(parsed.ship);
+          const target = resolveOutboundLensTarget(
+            account,
+            fromShip,
+            conversationId
+          );
           const result = await sendDm({
             fromShip,
             toShip: parsed.ship,
             text,
-            blob: stamp?.blob,
+            blob: target?.blob,
             replyToId: replyId,
             botProfile,
           });
-          recordBackgroundLensDelivery({
-            stamp,
+          recordOutboundLensDelivery(target, {
             messageId: result.messageId,
-            conversationId: parsed.ship,
+            conversationId,
             kind: 'dm',
             sentAt: result.sentAt,
             text,
           });
           return result;
         }
+        const target = resolveOutboundLensTarget(account, fromShip, parsed.nest);
         const result = await sendChannelPost({
           fromShip,
           nest: parsed.nest,
           story: markdownToStory(text),
-          blob: stamp?.blob,
+          blob: target?.blob,
           replyToId: replyId,
           botProfile,
         });
-        recordBackgroundLensDelivery({
-          stamp,
+        recordOutboundLensDelivery(target, {
           messageId: result.messageId,
           conversationId: parsed.nest,
           kind: 'channel',
@@ -228,36 +273,40 @@ export const tlonRuntimeOutbound: Pick<
         const story = buildMediaStory(text, uploadedUrl);
         const replyId = resolveReplyId(replyToId, threadId);
         const botProfile = await getBotProfile(fromShip);
-        const stamp = resolveBackgroundLensStamp(cfg, fromShip);
         if (parsed.kind === 'dm') {
+          const conversationId = normalizeShip(parsed.ship);
+          const target = resolveOutboundLensTarget(
+            account,
+            fromShip,
+            conversationId
+          );
           const result = await sendDmWithStory({
             fromShip,
             toShip: parsed.ship,
             story,
-            blob: stamp?.blob,
+            blob: target?.blob,
             replyToId: replyId,
             botProfile,
           });
-          recordBackgroundLensDelivery({
-            stamp,
+          recordOutboundLensDelivery(target, {
             messageId: result.messageId,
-            conversationId: parsed.ship,
+            conversationId,
             kind: 'dm',
             sentAt: result.sentAt,
             text,
           });
           return result;
         }
+        const target = resolveOutboundLensTarget(account, fromShip, parsed.nest);
         const result = await sendChannelPost({
           fromShip,
           nest: parsed.nest,
           story,
-          blob: stamp?.blob,
+          blob: target?.blob,
           replyToId: replyId,
           botProfile,
         });
-        recordBackgroundLensDelivery({
-          stamp,
+        recordOutboundLensDelivery(target, {
           messageId: result.messageId,
           conversationId: parsed.nest,
           kind: 'channel',

--- a/packages/openclaw/src/channel.runtime.ts
+++ b/packages/openclaw/src/channel.runtime.ts
@@ -229,7 +229,11 @@ export const tlonRuntimeOutbound: Pick<
           });
           return result;
         }
-        const target = resolveOutboundLensTarget(account, fromShip, parsed.nest);
+        const target = resolveOutboundLensTarget(
+          account,
+          fromShip,
+          parsed.nest
+        );
         const result = await sendChannelPost({
           fromShip,
           nest: parsed.nest,
@@ -297,7 +301,11 @@ export const tlonRuntimeOutbound: Pick<
           });
           return result;
         }
-        const target = resolveOutboundLensTarget(account, fromShip, parsed.nest);
+        const target = resolveOutboundLensTarget(
+          account,
+          fromShip,
+          parsed.nest
+        );
         const result = await sendChannelPost({
           fromShip,
           nest: parsed.nest,

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -520,9 +520,7 @@ describe('context lens registry', () => {
       expect(resolved?.registry).toBe(registry);
 
       // Conversations without an active foreground run resolve to null.
-      expect(
-        getActiveForegroundContextLensForConversation('~zod')
-      ).toBeNull();
+      expect(getActiveForegroundContextLensForConversation('~zod')).toBeNull();
       expect(getActiveForegroundContextLensForConversation('')).toBeNull();
 
       // The resolved registry records the tool-driven post as a run output.

--- a/packages/openclaw/src/context-lens.test.ts
+++ b/packages/openclaw/src/context-lens.test.ts
@@ -13,6 +13,7 @@ import {
   ensureBackgroundContextLensForSession,
   finalizeBackgroundContextLensForSession,
   getActiveBackgroundContextLens,
+  getActiveForegroundContextLensForConversation,
   hashSessionKey,
   recordBackgroundContextLensOutput,
   recordContextLensToolResultForSession,
@@ -488,6 +489,59 @@ describe('context lens registry', () => {
       finalizeBackgroundContextLensForSession('session-active-bg-a');
       finalizeBackgroundContextLensForSession('session-active-bg-b');
       unbindContextLensFromSession(conversationKey, conversation.lensId);
+    }
+  });
+
+  it('resolves the foreground dispatch lens for a conversation so message-tool posts attribute correctly', () => {
+    const registry = createContextLensRegistry();
+    const sessionKey = 'session-fg-dm';
+    const lens = registry.create({
+      messageId: 'message-fg-dm',
+      chatType: 'dm',
+      sessionKey,
+      conversationId: '~ten',
+    });
+    bindContextLensToSession(sessionKey, registry, lens.lensId);
+
+    // A concurrent background run for an unrelated conversation must not match.
+    const background = ensureBackgroundContextLensForSession('session-fg-bg', {
+      runKind: 'cron',
+      trigger: 'cron',
+    });
+
+    try {
+      // Foreground bindings are not background-stamp candidates.
+      expect(getActiveBackgroundContextLens()?.lensId).toBe(
+        background?.lens.lensId
+      );
+
+      const resolved = getActiveForegroundContextLensForConversation('~ten');
+      expect(resolved?.lensId).toBe(lens.lensId);
+      expect(resolved?.registry).toBe(registry);
+
+      // Conversations without an active foreground run resolve to null.
+      expect(
+        getActiveForegroundContextLensForConversation('~zod')
+      ).toBeNull();
+      expect(getActiveForegroundContextLensForConversation('')).toBeNull();
+
+      // The resolved registry records the tool-driven post as a run output.
+      resolved?.registry.recordOutput(resolved.lensId, {
+        messageId: '~zod/170.141.184',
+        conversationId: '~ten',
+        kind: 'dm',
+        sentAt: 456,
+        preview: 'cat from the internet',
+      });
+      expect(registry.get(lens.lensId)?.outputs).toEqual([
+        expect.objectContaining({
+          messageId: '~zod/170.141.184',
+          preview: 'cat from the internet',
+        }),
+      ]);
+    } finally {
+      finalizeBackgroundContextLensForSession('session-fg-bg');
+      unbindContextLensFromSession(sessionKey, lens.lensId);
     }
   });
 

--- a/packages/openclaw/src/context-lens.ts
+++ b/packages/openclaw/src/context-lens.ts
@@ -985,6 +985,46 @@ export function getActiveBackgroundContextLens(): ContextLens | null {
   return best;
 }
 
+/**
+ * Active foreground (in-session) dispatch lens for a given conversation, if a
+ * run is mid-dispatch for it. The outbound send path uses this to attribute
+ * message-tool posts — replies the model issues by calling the `message` tool
+ * itself, instead of emitting a normal final reply — to the run that produced
+ * them, so a tool-only answer is not mislabeled `no_reply`. Matched on
+ * conversationId (not recency) so concurrent runs in different conversations
+ * stay correctly separated.
+ */
+export function getActiveForegroundContextLensForConversation(
+  conversationId: string | null | undefined
+): { registry: ContextLensRegistry; lensId: string } | null {
+  const target = conversationId?.trim();
+  if (!target) {
+    return null;
+  }
+  let best: {
+    registry: ContextLensRegistry;
+    lensId: string;
+    updatedAt: number;
+  } | null = null;
+  for (const binding of activeLensesBySession.values()) {
+    if (binding.background) {
+      continue;
+    }
+    const lens = binding.registry.get(binding.lensId);
+    if (!lens || lens.triggerDetails.conversationId?.trim() !== target) {
+      continue;
+    }
+    if (!best || lens.updatedAt > best.updatedAt) {
+      best = {
+        registry: binding.registry,
+        lensId: binding.lensId,
+        updatedAt: lens.updatedAt,
+      };
+    }
+  }
+  return best ? { registry: best.registry, lensId: best.lensId } : null;
+}
+
 export function recordBackgroundContextLensOutput(
   lensId: string,
   output: ContextLensOutput

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -3400,11 +3400,21 @@ export async function monitorTlonProvider(
           dispatchError
         );
         unbindContextLensFromSession(lensSessionKeys, lens.lensId);
+        // A reply the model issued by calling the `message` tool itself lands
+        // through the outbound adapter, which records it on the lens but never
+        // touches this closure's `deliveredMessageCount`. Count the lens's own
+        // recorded outputs so a tool-only answer isn't finalized as no_reply.
+        const recordedOutputCount =
+          contextLenses.get(lens.lensId)?.outputs.length ?? 0;
+        const effectiveDeliveredCount = Math.max(
+          deliveredMessageCount,
+          recordedOutputCount
+        );
         contextLenses.recordLifecycle(lens.lensId, {
           completedAt: Date.now(),
           durationMs: dispatchDurationMs,
           timedOut: dispatchTimedOut,
-          deliveredMessageCount,
+          deliveredMessageCount: effectiveDeliveredCount,
           queuedFinal: dispatchResult?.queuedFinal ?? false,
           queuedFinalCount: dispatchResult?.counts.final ?? 0,
           queuedBlockCount: dispatchResult?.counts.block ?? 0,
@@ -3413,7 +3423,7 @@ export async function monitorTlonProvider(
           sendAttemptCount,
           sendErrorCount,
           sendErrorKind,
-          deliveredMessageCount,
+          deliveredMessageCount: effectiveDeliveredCount,
           replyCharCount,
           replyWordCount,
           replyMediaCount,
@@ -3434,7 +3444,7 @@ export async function monitorTlonProvider(
         if (!dispatchError) {
           contextLenses.setStatus(
             lens.lensId,
-            deliveredMessageCount > 0 ? 'completed' : 'no_reply'
+            effectiveDeliveredCount > 0 ? 'completed' : 'no_reply'
           );
         }
         const finalLens = contextLenses.get(lens.lensId);


### PR DESCRIPTION
## What changed

- resolve active foreground Context Lens runs by conversation before falling back to background attribution
- stamp Tlon messages sent through the shared message tool with the foreground lens id
- record those posts as lens outputs and count them when finalizing run status
- cover foreground resolution and concurrent background isolation

## Why

OpenClaw 2026.6.11 treats message-tool sends as valid source-visible replies. Tlon delivered those messages successfully, but Context Lens only incremented delivery state inside the buffered final-reply dispatcher. Tool-only replies therefore finalized as no_reply with no outputs.

This is a Tlon adapter attribution gap exposed by the 6.11 reply path, not a Tlon or Context Lens schema change.

## Verification

- pnpm test -- src/context-lens.test.ts: 46 files, 785 tests passed
- pnpm tsc --noEmit
- pnpm lint: 0 errors; existing warnings only
- pnpm build
- live Bearclawd gateway loaded adapter source 6990907be8 and reconnected the Tlon firehose