### PR TITLE
fix(openclaw): deliver Tlon DM source replies

### DIFF
--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -148,6 +148,7 @@ import {
   tlonDeliveryContext,
 } from './session-routing.js';
 import { resolveSettingsMirrorSync } from './settings-sync.js';
+import { resolveTlonSourceReplyDeliveryMode } from './source-reply-delivery.js';
 import {
   type ParsedCite,
   extractCites,
@@ -3139,11 +3140,10 @@ export async function monitorTlonProvider(
           })
         : undefined;
 
-      const hasExplicitVisibleReplyPolicy =
-        cfg.messages?.visibleReplies !== undefined ||
-        cfg.messages?.groupChat?.visibleReplies !== undefined;
-      const sourceReplyDeliveryMode =
-        isGroup && !hasExplicitVisibleReplyPolicy ? 'automatic' : undefined;
+      const sourceReplyDeliveryMode = resolveTlonSourceReplyDeliveryMode({
+        isGroup,
+        messages: cfg.messages,
+      });
 
       const replyOptions: NonNullable<
         Parameters<

--- a/packages/openclaw/src/monitor/source-reply-delivery.test.ts
+++ b/packages/openclaw/src/monitor/source-reply-delivery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTlonSourceReplyDeliveryMode } from './source-reply-delivery.js';
+
+describe('resolveTlonSourceReplyDeliveryMode', () => {
+  it('defaults direct-message source replies to automatic delivery', () => {
+    expect(resolveTlonSourceReplyDeliveryMode({ isGroup: false })).toBe(
+      'automatic'
+    );
+  });
+
+  it('defaults group source replies to automatic delivery', () => {
+    expect(resolveTlonSourceReplyDeliveryMode({ isGroup: true })).toBe(
+      'automatic'
+    );
+  });
+
+  it('lets an explicit global visible-reply policy win', () => {
+    expect(
+      resolveTlonSourceReplyDeliveryMode({
+        isGroup: false,
+        messages: { visibleReplies: 'message_tool_only' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('applies group-only policy only to groups', () => {
+    const messages = {
+      groupChat: { visibleReplies: 'message_tool_only' as const },
+    };
+
+    expect(
+      resolveTlonSourceReplyDeliveryMode({ isGroup: true, messages })
+    ).toBeUndefined();
+    expect(
+      resolveTlonSourceReplyDeliveryMode({ isGroup: false, messages })
+    ).toBe('automatic');
+  });
+});

--- a/packages/openclaw/src/monitor/source-reply-delivery.test.ts
+++ b/packages/openclaw/src/monitor/source-reply-delivery.test.ts
@@ -19,14 +19,14 @@ describe('resolveTlonSourceReplyDeliveryMode', () => {
     expect(
       resolveTlonSourceReplyDeliveryMode({
         isGroup: false,
-        messages: { visibleReplies: 'message_tool_only' },
+        messages: { visibleReplies: 'message_tool' },
       })
     ).toBeUndefined();
   });
 
   it('applies group-only policy only to groups', () => {
     const messages = {
-      groupChat: { visibleReplies: 'message_tool_only' as const },
+      groupChat: { visibleReplies: 'message_tool' as const },
     };
 
     expect(

--- a/packages/openclaw/src/monitor/source-reply-delivery.ts
+++ b/packages/openclaw/src/monitor/source-reply-delivery.ts
@@ -1,0 +1,20 @@
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
+
+export type TlonSourceReplyDeliveryMode = 'automatic' | undefined;
+
+/**
+ * Tlon owns delivery for inbound source turns, so normal assistant finals
+ * should be visible unless the operator explicitly configured otherwise.
+ * Group-only policy must not make direct-message finals private.
+ */
+export function resolveTlonSourceReplyDeliveryMode(params: {
+  isGroup: boolean;
+  messages?: OpenClawConfig['messages'];
+}): TlonSourceReplyDeliveryMode {
+  const hasExplicitPolicy =
+    params.messages?.visibleReplies !== undefined ||
+    (params.isGroup &&
+      params.messages?.groupChat?.visibleReplies !== undefined);
+
+  return hasExplicitPolicy ? undefined : 'automatic';
+}


### PR DESCRIPTION
## Summary

- default Tlon direct-message source replies to automatic delivery
- preserve explicit global visible-reply policy overrides
- keep group-only visible-reply policy scoped to groups
- add focused regression coverage for DM, group, and explicit-policy behavior

## Problem

A genuine Tlon DM is finalized with `ChatType: "direct"`, but the plugin only supplies `sourceReplyDeliveryMode: "automatic"` for group turns. With the Codex harness, the missing DM override becomes `message_tool_only`: the model generates final text, OpenClaw suppresses it, and Context Lens records `no_reply`.

Live reproduction before this fix:

- inbound classified as Tlon DM
- model generated `DM AUTO TEST`
- no tools called
- `queuedFinal=false`, `deliveredMessageCount=0`, status `no_reply`
- the compiled prompt instructed the model that normal final text was private

The same session successfully delivered `message(action=send)` to the correct Tlon DM, confirming that persisted Tlon routing was healthy and isolating the defect to source-reply delivery mode.

## Fix

Resolve Tlon source-reply delivery in a small pure helper:

- DM without explicit global policy: `automatic`
- group without explicit global/group policy: `automatic` (existing behavior)
- explicit global policy: defer to OpenClaw
- explicit group policy: defer only for groups, never DMs

## Validation

- `pnpm test -- src/monitor/source-reply-delivery.test.ts src/context-lens.test.ts` — 48 files, 828 tests passed
- `pnpm tsc` — passed
- targeted Prettier check — passed
- `pnpm build` — passed
- pre-fix live Tlon DM, message-tool DM, and group behavior captured in gateway logs and Context Lens
- post-fix live Tlon DM round-trip passed: no tool call, `queuedFinal=true`, one delivered Tlon DM output, Context Lens `completed`

## Related

Context Lens attribution for successful message-tool replies is separate and already tracked in #6103.
