### PR TITLE
ChatList: keep reordered pins local during backend rollout

### DIFF
--- a/packages/app/hooks/usePinnedChatOrdering.ts
+++ b/packages/app/hooks/usePinnedChatOrdering.ts
@@ -67,7 +67,7 @@ export function usePinnedChatOrdering({
         // TODO: Remove this override once `%set-order` is deployed fleet-wide.
         // Until then, older groups-ui desks reject the best-effort server poke;
         // the order remains persisted in the local database.
-        keepLocalOrderOnError: true,
+        keepLocalOrderOnUnsupportedBackend: true,
       });
     },
     [fullOrder, visibleIds]

--- a/packages/app/hooks/usePinnedChatOrdering.ts
+++ b/packages/app/hooks/usePinnedChatOrdering.ts
@@ -64,6 +64,10 @@ export function usePinnedChatOrdering({
       return store.reorderPinnedItems({
         optimisticOrder: newFull,
         backendOrder: newVisibleOrder,
+        // TODO: Remove this override once `%set-order` is deployed fleet-wide.
+        // Until then, older groups-ui desks reject the best-effort server poke;
+        // the order remains persisted in the local database.
+        keepLocalOrderOnError: true,
       });
     },
     [fullOrder, visibleIds]

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -34,6 +34,14 @@ export const dismissedPinnedPostBannerIds = createStorageItem<string[]>({
   defaultValue: [],
 });
 
+// TODO: Remove after `%set-order` is deployed fleet-wide. While old groups-ui
+// desks reject pin reorders, this preserves the last local order across stale
+// startup/foreground pin snapshots. Session storage is cleared on logout.
+export const pendingPinnedItemsOrder = createStorageItem<string[] | null>({
+  key: 'pendingPinnedItemsOrder',
+  defaultValue: null,
+});
+
 export const storageConfiguration =
   createStorageItem<StorageConfiguration | null>({
     key: 'storageConfiguration',

--- a/packages/shared/src/db/keyValue.ts
+++ b/packages/shared/src/db/keyValue.ts
@@ -35,10 +35,12 @@ export const dismissedPinnedPostBannerIds = createStorageItem<string[]>({
 });
 
 // TODO: Remove after `%set-order` is deployed fleet-wide. While old groups-ui
-// desks reject pin reorders, this preserves the last local order across stale
-// startup/foreground pin snapshots. Session storage is cleared on logout.
+// desks reject pin reorders, this preserves the locally reordered ids across
+// stale startup/foreground pin snapshots. The v2 key intentionally ignores
+// full-order values written by rollout builds before this stored partial intent.
+// Session storage is cleared on logout.
 export const pendingPinnedItemsOrder = createStorageItem<string[] | null>({
-  key: 'pendingPinnedItemsOrder',
+  key: 'pendingPinnedItemsOrder:v2',
   defaultValue: null,
 });
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -5952,8 +5952,8 @@ export const insertPinnedItems = createWriteQuery(
 );
 
 // Rewrites each pin's index to its position in `orderedItemIds`. Expects the
-// full, unique local pin set (see reorderPinnedItems / normalizeOrder); only
-// rows whose ids appear in the list are updated.
+// full, unique local pin set (see reorderPinnedItems /
+// normalizePinnedItemOrder); only rows whose ids appear in the list are updated.
 export const setPinnedItemsOrder = createWriteQuery(
   'setPinnedItemsOrder',
   async (orderedItemIds: string[], ctx: QueryCtx) => {

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -6008,11 +6008,10 @@ export const deletePinnedItem = createWriteQuery(
 );
 
 // Delete every pinned item. Unlike `insertPinnedItems([])` (a no-op), this is an
-// explicit clear — used by the reorder failure reconcile when the authoritative
-// backend snapshot is empty. Emits the same effects as the single-pin mutators
-// (`insertPinnedItem`/`deletePinnedItem`): some read paths surface pin state via
-// group/channel query deps (e.g. `getGroup` reads `pin`), so clearing pins must
-// invalidate those too, not just `pins`.
+// explicit clear — used when an authoritative pin snapshot is empty. Emits the
+// same effects as the single-pin mutators (`insertPinnedItem`/`deletePinnedItem`):
+// some read paths surface pin state via group/channel query deps (e.g. `getGroup`
+// reads `pin`), so clearing pins must invalidate those too, not just `pins`.
 export const clearPinnedItems = createWriteQuery(
   'clearPinnedItems',
   async (ctx: QueryCtx) => {

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -13,7 +13,10 @@ import { AnalyticsEvent } from '../domain';
 import * as logic from '../logic';
 import { getRandomId } from '../logic';
 import { syncNotesNotebook } from './notesActions';
-import { normalizePinnedItemOrder } from './pinnedItemOrder';
+import {
+  isUnsupportedPinnedItemOrderError,
+  normalizePinnedItemOrder,
+} from './pinnedItemOrder';
 
 const logger = createDevLogger('ChannelActions', false);
 const NOTES_CHANNEL_LISTING_ATTEMPTS = 5;
@@ -558,8 +561,9 @@ export async function unpinItem(pin: db.Pin) {
 // pokes the backend, and re-asserts any order it keeps so a stale in-flight sync
 // can't leave the UI reverted. Returns true when the local order should be kept
 // and false after a failed poke has been reconciled/rolled back. The temporary
-// `keepLocalOrderOnError` option lets callers treat the backend sync as
-// best-effort while `%set-order` rolls out across the fleet.
+// `keepLocalOrderOnUnsupportedBackend` option preserves the local order only
+// for the specific Gall conversion error returned by a pre-`%set-order` desk.
+// Transport failures and unrelated backend errors remain authoritative.
 //
 // The optimistic local write and the backend poke take *different* orders:
 //   - `optimisticOrder` is the full merged pin order (incl. hidden pins in a
@@ -573,11 +577,11 @@ export async function unpinItem(pin: db.Pin) {
 export async function reorderPinnedItems({
   optimisticOrder,
   backendOrder,
-  keepLocalOrderOnError = false,
+  keepLocalOrderOnUnsupportedBackend = false,
 }: {
   optimisticOrder: string[];
   backendOrder: string[];
-  keepLocalOrderOnError?: boolean;
+  keepLocalOrderOnUnsupportedBackend?: boolean;
 }): Promise<boolean> {
   const before = await db.getPinnedItems();
   const previousOrder = [...before]
@@ -589,7 +593,7 @@ export async function reorderPinnedItems({
     return true; // no-op drop
   }
 
-  if (keepLocalOrderOnError) {
+  if (keepLocalOrderOnUnsupportedBackend) {
     // Persist the rollout-era local authority before attempting server sync.
     await db.pendingPinnedItemsOrder.setValue(normalized);
   }
@@ -615,13 +619,16 @@ export async function reorderPinnedItems({
     // stale slot. Only the optimistic write above is the full merged order.
     const after = await db.getPinnedItems();
     const keptOrder = normalizePinnedItemOrder(backendPayload, after);
-    if (keepLocalOrderOnError) {
+    if (keepLocalOrderOnUnsupportedBackend) {
       await db.pendingPinnedItemsOrder.setValue(keptOrder);
     }
     await db.setPinnedItemsOrder(keptOrder);
     return true;
   } catch (e) {
-    if (keepLocalOrderOnError) {
+    if (
+      keepLocalOrderOnUnsupportedBackend &&
+      isUnsupportedPinnedItemOrderError(e)
+    ) {
       // An older groups-ui rejects `%set-order`. Keep the durable local write,
       // but still re-assert the visible reorder in case a pin sync landed while
       // the best-effort poke was in flight.
@@ -630,6 +637,12 @@ export async function reorderPinnedItems({
       await db.pendingPinnedItemsOrder.setValue(keptOrder);
       await db.setPinnedItemsOrder(keptOrder);
       return true;
+    }
+
+    if (keepLocalOrderOnUnsupportedBackend) {
+      // This was not the old-desk conversion failure. Stop treating the local
+      // order as authoritative before reconciling the server snapshot below.
+      await db.pendingPinnedItemsOrder.setValue(null);
     }
 
     console.error('Failed to reorder pinned items', e);

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -13,6 +13,7 @@ import { AnalyticsEvent } from '../domain';
 import * as logic from '../logic';
 import { getRandomId } from '../logic';
 import { syncNotesNotebook } from './notesActions';
+import { normalizePinnedItemOrder } from './pinnedItemOrder';
 
 const logger = createDevLogger('ChannelActions', false);
 const NOTES_CHANNEL_LISTING_ATTEMPTS = 5;
@@ -553,21 +554,6 @@ export async function unpinItem(pin: db.Pin) {
   }
 }
 
-// Slot-preserving reorder, matching the backend %set-order semantics and the
-// frontend mergeVisibleOrderIntoFull: reorder only the ids `desired` names
-// (∩ currently pinned, de-duped) into the slots they currently occupy, leaving
-// any omitted pinned id fixed in place.
-function normalizeOrder(desired: string[], current: db.Pin[]): string[] {
-  const order = [...current]
-    .sort((a, b) => a.index - b.index)
-    .map((p) => p.itemId);
-  const pinnedSet = new Set(order);
-  const wanted = [...new Set(desired)].filter((id) => pinnedSet.has(id));
-  const wantedSet = new Set(wanted);
-  let w = 0;
-  return order.map((id) => (wantedSet.has(id) ? wanted[w++] : id));
-}
-
 // Persist a reorder of the pinned items. Optimistically writes the new order,
 // pokes the backend, and re-asserts any order it keeps so a stale in-flight sync
 // can't leave the UI reverted. Returns true when the local order should be kept
@@ -597,12 +583,16 @@ export async function reorderPinnedItems({
   const previousOrder = [...before]
     .sort((a, b) => a.index - b.index)
     .map((p) => p.itemId);
-  const normalized = normalizeOrder(optimisticOrder, before);
+  const normalized = normalizePinnedItemOrder(optimisticOrder, before);
 
   if (isEqual(previousOrder, normalized)) {
     return true; // no-op drop
   }
 
+  if (keepLocalOrderOnError) {
+    // Persist the rollout-era local authority before attempting server sync.
+    await db.pendingPinnedItemsOrder.setValue(normalized);
+  }
   await db.setPinnedItemsOrder(normalized); // optimistic (full local order)
 
   // Backend payload: only the reordered visible ids, deduped and intersected
@@ -624,7 +614,11 @@ export async function reorderPinnedItems({
     // could drag a hidden pin a mid-poke sync just moved back to this client's
     // stale slot. Only the optimistic write above is the full merged order.
     const after = await db.getPinnedItems();
-    await db.setPinnedItemsOrder(normalizeOrder(backendPayload, after));
+    const keptOrder = normalizePinnedItemOrder(backendPayload, after);
+    if (keepLocalOrderOnError) {
+      await db.pendingPinnedItemsOrder.setValue(keptOrder);
+    }
+    await db.setPinnedItemsOrder(keptOrder);
     return true;
   } catch (e) {
     if (keepLocalOrderOnError) {
@@ -632,7 +626,9 @@ export async function reorderPinnedItems({
       // but still re-assert the visible reorder in case a pin sync landed while
       // the best-effort poke was in flight.
       const after = await db.getPinnedItems();
-      await db.setPinnedItemsOrder(normalizeOrder(backendPayload, after));
+      const keptOrder = normalizePinnedItemOrder(backendPayload, after);
+      await db.pendingPinnedItemsOrder.setValue(keptOrder);
+      await db.setPinnedItemsOrder(keptOrder);
       return true;
     }
 

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -561,8 +561,9 @@ export async function unpinItem(pin: db.Pin) {
 // pokes the backend, and re-asserts any order it keeps so a stale in-flight sync
 // can't leave the UI reverted. Returns true when the local order should be kept
 // and false after a failed poke has been reconciled/rolled back. The temporary
-// `keepLocalOrderOnUnsupportedBackend` option preserves the local order only
-// for the specific Gall conversion error returned by a pre-`%set-order` desk.
+// `keepLocalOrderOnUnsupportedBackend` option tracks only the visible reorder
+// intent until a server snapshot confirms it, and keeps that intent when the
+// specific Gall conversion error from a pre-`%set-order` desk is returned.
 // Transport failures and unrelated backend errors remain authoritative.
 //
 // The optimistic local write and the backend poke take *different* orders:
@@ -593,18 +594,20 @@ export async function reorderPinnedItems({
     return true; // no-op drop
   }
 
-  if (keepLocalOrderOnUnsupportedBackend) {
-    // Persist the rollout-era local authority before attempting server sync.
-    await db.pendingPinnedItemsOrder.setValue(normalized);
-  }
-  await db.setPinnedItemsOrder(normalized); // optimistic (full local order)
-
   // Backend payload: only the reordered visible ids, deduped and intersected
   // with the current pinned set — never expanded back to the full order.
   const pinnedSet = new Set(before.map((p) => p.itemId));
   const backendPayload = [...new Set(backendOrder)].filter((id) =>
     pinnedSet.has(id)
   );
+
+  if (keepLocalOrderOnUnsupportedBackend) {
+    // Persist only the user's visible reorder intent. Keeping it until a server
+    // snapshot confirms the order protects against stale scries that can land
+    // both before and just after the poke resolves without owning hidden pins.
+    await db.pendingPinnedItemsOrder.setValue(backendPayload);
+  }
+  await db.setPinnedItemsOrder(normalized); // optimistic (full local order)
 
   try {
     await api.setPinnedItemOrder(backendPayload);
@@ -619,9 +622,6 @@ export async function reorderPinnedItems({
     // stale slot. Only the optimistic write above is the full merged order.
     const after = await db.getPinnedItems();
     const keptOrder = normalizePinnedItemOrder(backendPayload, after);
-    if (keepLocalOrderOnUnsupportedBackend) {
-      await db.pendingPinnedItemsOrder.setValue(keptOrder);
-    }
     await db.setPinnedItemsOrder(keptOrder);
     return true;
   } catch (e) {
@@ -629,12 +629,12 @@ export async function reorderPinnedItems({
       keepLocalOrderOnUnsupportedBackend &&
       isUnsupportedPinnedItemOrderError(e)
     ) {
-      // An older groups-ui rejects `%set-order`. Keep the durable local write,
-      // but still re-assert the visible reorder in case a pin sync landed while
-      // the best-effort poke was in flight.
+      // An older groups-ui rejects `%set-order`. Preserve only the ids the user
+      // actually reordered, then re-assert them in case a pin sync landed while
+      // the best-effort poke was in flight. Hidden and newly synced pins remain
+      // server-owned and keep their current slots.
       const after = await db.getPinnedItems();
       const keptOrder = normalizePinnedItemOrder(backendPayload, after);
-      await db.pendingPinnedItemsOrder.setValue(keptOrder);
       await db.setPinnedItemsOrder(keptOrder);
       return true;
     }

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -569,10 +569,11 @@ function normalizeOrder(desired: string[], current: db.Pin[]): string[] {
 }
 
 // Persist a reorder of the pinned items. Optimistically writes the new order,
-// pokes the backend, and re-asserts on success so a stale in-flight sync can't
-// leave the UI reverted. Never throws — returns true on success, false on
-// failure (after a best-effort backend reconcile) so drag handlers can roll
-// back their optimistic UI.
+// pokes the backend, and re-asserts any order it keeps so a stale in-flight sync
+// can't leave the UI reverted. Returns true when the local order should be kept
+// and false after a failed poke has been reconciled/rolled back. The temporary
+// `keepLocalOrderOnError` option lets callers treat the backend sync as
+// best-effort while `%set-order` rolls out across the fleet.
 //
 // The optimistic local write and the backend poke take *different* orders:
 //   - `optimisticOrder` is the full merged pin order (incl. hidden pins in a
@@ -586,9 +587,11 @@ function normalizeOrder(desired: string[], current: db.Pin[]): string[] {
 export async function reorderPinnedItems({
   optimisticOrder,
   backendOrder,
+  keepLocalOrderOnError = false,
 }: {
   optimisticOrder: string[];
   backendOrder: string[];
+  keepLocalOrderOnError?: boolean;
 }): Promise<boolean> {
   const before = await db.getPinnedItems();
   const previousOrder = [...before]
@@ -624,6 +627,15 @@ export async function reorderPinnedItems({
     await db.setPinnedItemsOrder(normalizeOrder(backendPayload, after));
     return true;
   } catch (e) {
+    if (keepLocalOrderOnError) {
+      // An older groups-ui rejects `%set-order`. Keep the durable local write,
+      // but still re-assert the visible reorder in case a pin sync landed while
+      // the best-effort poke was in flight.
+      const after = await db.getPinnedItems();
+      await db.setPinnedItemsOrder(normalizeOrder(backendPayload, after));
+      return true;
+    }
+
     console.error('Failed to reorder pinned items', e);
     // Best-effort reconcile to the authoritative backend order. The scry usually
     // fails for the same reason the poke did, so guard it and always return false.

--- a/packages/shared/src/store/pinnedItemOrder.ts
+++ b/packages/shared/src/store/pinnedItemOrder.ts
@@ -1,0 +1,28 @@
+import type { Pin } from '../db';
+
+// Reorder only the pins named by `desired` into the slots they currently
+// occupy. Pins omitted from `desired` keep their slots, which lets a filtered
+// reorder coexist with pins the user could not see and with newly synced pins.
+export function normalizePinnedItemOrder(
+  desired: string[],
+  current: Pin[]
+): string[] {
+  const order = [...current]
+    .sort((a, b) => a.index - b.index)
+    .map((pin) => pin.itemId);
+  const pinnedSet = new Set(order);
+  const wanted = [...new Set(desired)].filter((id) => pinnedSet.has(id));
+  const wantedSet = new Set(wanted);
+  let wantedIndex = 0;
+
+  return order.map((id) => (wantedSet.has(id) ? wanted[wantedIndex++] : id));
+}
+
+export function applyPinnedItemOrder(desired: string[], current: Pin[]): Pin[] {
+  const pinsById = new Map(current.map((pin) => [pin.itemId, pin]));
+
+  return normalizePinnedItemOrder(desired, current).map((itemId, index) => ({
+    ...pinsById.get(itemId)!,
+    index,
+  }));
+}

--- a/packages/shared/src/store/pinnedItemOrder.ts
+++ b/packages/shared/src/store/pinnedItemOrder.ts
@@ -1,5 +1,20 @@
 import type { Pin } from '../db';
 
+// Old groups-ui desks reject `%set-order` while converting the JSON poke to a
+// Hoon noun. Airlock forwards that Gall nack as a raw string. Match the stable
+// conversion frames narrowly so transport errors and unrelated agent crashes
+// still take the normal reconcile/rollback path.
+export function isUnsupportedPinnedItemOrderError(error: unknown): boolean {
+  return (
+    typeof error === 'string' &&
+    error.includes(
+      'gall: poke-as cast fail :groups-ui [a=%json b=%ui-action]'
+    ) &&
+    error.includes("[%bad-key 'set-order']") &&
+    error.includes("[%key 'pins']")
+  );
+}
+
 // Reorder only the pins named by `desired` into the slots they currently
 // occupy. Pins omitted from `desired` keep their slots, which lets a filtered
 // reorder coexist with pins the user could not see and with newly synced pins.

--- a/packages/shared/src/store/reorderPinnedItems.test.ts
+++ b/packages/shared/src/store/reorderPinnedItems.test.ts
@@ -117,11 +117,8 @@ test('reorderPinnedItems reasserts only the visible ids when a sync lands mid-po
 test('reorderPinnedItems keeps the local order for the old-desk conversion failure', async () => {
   await seedPins(['H', 'A', 'B']);
   let orderSeenBeforePoke: string[] = [];
-  let pendingOrderSeenBeforePoke: string[] = [];
+  let pendingOrderSeenBeforePoke: string[] | null = null;
   let storedOrder: string[] | null = null;
-  const getPendingOrder = vi
-    .spyOn(db.pendingPinnedItemsOrder, 'getValue')
-    .mockImplementation(async () => storedOrder);
   const setPendingOrder = vi
     .spyOn(db.pendingPinnedItemsOrder, 'setValue')
     .mockImplementation(async (value) => {
@@ -130,7 +127,7 @@ test('reorderPinnedItems keeps the local order for the old-desk conversion failu
 
   vi.mocked(poke).mockImplementationOnce(async () => {
     orderSeenBeforePoke = await currentOrder();
-    pendingOrderSeenBeforePoke = storedOrder ?? [];
+    pendingOrderSeenBeforePoke = storedOrder;
     // Simulate a stale pin sync landing while the unsupported poke is in flight.
     await db.insertPinnedItems([
       { type: 'group' as const, index: 0, itemId: 'A' },
@@ -146,19 +143,83 @@ test('reorderPinnedItems keeps the local order for the old-desk conversion failu
     keepLocalOrderOnUnsupportedBackend: true,
   });
 
-  // The full order is durably written before the best-effort server poke.
+  // The full order is optimistically written before the best-effort server poke,
+  // while only the visible reorder intent is persisted as local authority.
   expect(orderSeenBeforePoke).toEqual(['H', 'B', 'A']);
-  expect(pendingOrderSeenBeforePoke).toEqual(['H', 'B', 'A']);
+  expect(pendingOrderSeenBeforePoke).toEqual(['B', 'A']);
   // A rejected poke is swallowed, and the visible reorder is re-asserted over
   // the concurrent sync without moving its hidden pin.
   expect(ok).toBe(true);
   expect(await currentOrder()).toEqual(['B', 'H', 'A']);
   expect(lastPokeSetOrder()).toEqual(['B', 'A']);
   expect(scry).not.toHaveBeenCalled();
-  expect(setPendingOrder).toHaveBeenNthCalledWith(1, ['H', 'B', 'A']);
-  expect(setPendingOrder).toHaveBeenLastCalledWith(['B', 'H', 'A']);
-  expect(storedOrder).toEqual(['B', 'H', 'A']);
-  getPendingOrder.mockRestore();
+  expect(setPendingOrder).toHaveBeenCalledTimes(1);
+  expect(setPendingOrder).toHaveBeenCalledWith(['B', 'A']);
+  expect(storedOrder).toEqual(['B', 'A']);
+  setPendingOrder.mockRestore();
+});
+
+test('reorderPinnedItems persists only visible intent after a successful filtered reorder', async () => {
+  await seedPins(['H', 'A', 'B']);
+  let storedOrder: string[] | null = ['A', 'B'];
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
+
+  // A server sync moves hidden H while the supported poke is in flight.
+  vi.mocked(poke).mockImplementationOnce(async () => {
+    await db.insertPinnedItems([
+      { type: 'group' as const, index: 0, itemId: 'A' },
+      { type: 'group' as const, index: 1, itemId: 'B' },
+      { type: 'group' as const, index: 2, itemId: 'H' },
+    ]);
+    return 0;
+  });
+
+  const ok = await reorderPinnedItems({
+    optimisticOrder: ['H', 'B', 'A'],
+    backendOrder: ['B', 'A'],
+    keepLocalOrderOnUnsupportedBackend: true,
+  });
+
+  expect(ok).toBe(true);
+  expect(await currentOrder()).toEqual(['B', 'A', 'H']);
+  expect(setPendingOrder).toHaveBeenCalledTimes(1);
+  expect(setPendingOrder).toHaveBeenCalledWith(['B', 'A']);
+  expect(storedOrder).toEqual(['B', 'A']);
+  setPendingOrder.mockRestore();
+});
+
+test('reorderPinnedItems does not resurrect intent confirmed while the poke is in flight', async () => {
+  await seedPins(['H', 'A', 'B']);
+  let storedOrder: string[] | null = null;
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
+
+  vi.mocked(poke).mockImplementationOnce(async () => {
+    // Model a server snapshot that confirms the partial intent before the poke
+    // acknowledgement arrives. Sync owns the only clearing transition.
+    await db.pendingPinnedItemsOrder.setValue((pendingOrder) => {
+      expect(pendingOrder).toEqual(['B', 'A']);
+      return null;
+    });
+    return 0;
+  });
+
+  const ok = await reorderPinnedItems({
+    optimisticOrder: ['H', 'B', 'A'],
+    backendOrder: ['B', 'A'],
+    keepLocalOrderOnUnsupportedBackend: true,
+  });
+
+  expect(ok).toBe(true);
+  expect(storedOrder).toBeNull();
+  expect(setPendingOrder).toHaveBeenCalledTimes(2);
   setPendingOrder.mockRestore();
 });
 
@@ -181,7 +242,8 @@ test('reorderPinnedItems clears pending state and reconciles transient failures'
 
   expect(ok).toBe(false);
   expect(await currentOrder()).toEqual(['A', 'B', 'C']);
-  expect(setPendingOrder).toHaveBeenNthCalledWith(1, ['C', 'B', 'A']);
+  expect(setPendingOrder).toHaveBeenCalledTimes(2);
+  expect(setPendingOrder).toHaveBeenNthCalledWith(1, ['B', 'A']);
   expect(setPendingOrder).toHaveBeenLastCalledWith(null);
   expect(storedOrder).toBeNull();
   setPendingOrder.mockRestore();

--- a/packages/shared/src/store/reorderPinnedItems.test.ts
+++ b/packages/shared/src/store/reorderPinnedItems.test.ts
@@ -35,12 +35,16 @@ function lastPokeSetOrder(): string[] {
 
 test('reorderPinnedItems writes the full optimistic order locally but pokes only the reordered visible ids', async () => {
   await seedPins(['C', 'A', 'B']);
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockResolvedValue();
 
   // Filtered view: C is hidden; the visible subset [A, B] is reordered to [B, A],
   // which the caller has already merged into the full order [C, B, A].
   const ok = await reorderPinnedItems({
     optimisticOrder: ['C', 'B', 'A'],
     backendOrder: ['B', 'A'],
+    keepLocalOrderOnError: true,
   });
 
   expect(ok).toBe(true);
@@ -49,6 +53,8 @@ test('reorderPinnedItems writes the full optimistic order locally but pokes only
   // The backend poke carries ONLY the visible ids — never the full order — so
   // %set-order leaves the omitted (hidden) pins in their current server slots.
   expect(lastPokeSetOrder()).toEqual(['B', 'A']);
+  expect(setPendingOrder).toHaveBeenLastCalledWith(['C', 'B', 'A']);
+  setPendingOrder.mockRestore();
 });
 
 test('reorderPinnedItems omits hidden pins from the backend payload (stale-hidden-pin safety)', async () => {
@@ -101,9 +107,16 @@ test('reorderPinnedItems reasserts only the visible ids when a sync lands mid-po
 test('reorderPinnedItems can keep the local order when a rollout-era poke fails', async () => {
   await seedPins(['H', 'A', 'B']);
   let orderSeenBeforePoke: string[] = [];
+  let pendingOrderSeenBeforePoke: string[] = [];
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockResolvedValue();
 
   vi.mocked(poke).mockImplementationOnce(async () => {
     orderSeenBeforePoke = await currentOrder();
+    pendingOrderSeenBeforePoke = setPendingOrder.mock.calls.at(
+      -1
+    )?.[0] as string[];
     // Simulate a stale pin sync landing while the unsupported poke is in flight.
     await db.insertPinnedItems([
       { type: 'group' as const, index: 0, itemId: 'A' },
@@ -121,12 +134,16 @@ test('reorderPinnedItems can keep the local order when a rollout-era poke fails'
 
   // The full order is durably written before the best-effort server poke.
   expect(orderSeenBeforePoke).toEqual(['H', 'B', 'A']);
+  expect(pendingOrderSeenBeforePoke).toEqual(['H', 'B', 'A']);
   // A rejected poke is swallowed, and the visible reorder is re-asserted over
   // the concurrent sync without moving its hidden pin.
   expect(ok).toBe(true);
   expect(await currentOrder()).toEqual(['B', 'H', 'A']);
   expect(lastPokeSetOrder()).toEqual(['B', 'A']);
   expect(scry).not.toHaveBeenCalled();
+  expect(setPendingOrder).toHaveBeenNthCalledWith(1, ['H', 'B', 'A']);
+  expect(setPendingOrder).toHaveBeenLastCalledWith(['B', 'H', 'A']);
+  setPendingOrder.mockRestore();
 });
 
 test('reorderPinnedItems is a no-op when the order is unchanged', async () => {

--- a/packages/shared/src/store/reorderPinnedItems.test.ts
+++ b/packages/shared/src/store/reorderPinnedItems.test.ts
@@ -98,6 +98,37 @@ test('reorderPinnedItems reasserts only the visible ids when a sync lands mid-po
   expect(lastPokeSetOrder()).toEqual(['B', 'A']);
 });
 
+test('reorderPinnedItems can keep the local order when a rollout-era poke fails', async () => {
+  await seedPins(['H', 'A', 'B']);
+  let orderSeenBeforePoke: string[] = [];
+
+  vi.mocked(poke).mockImplementationOnce(async () => {
+    orderSeenBeforePoke = await currentOrder();
+    // Simulate a stale pin sync landing while the unsupported poke is in flight.
+    await db.insertPinnedItems([
+      { type: 'group' as const, index: 0, itemId: 'A' },
+      { type: 'group' as const, index: 1, itemId: 'H' },
+      { type: 'group' as const, index: 2, itemId: 'B' },
+    ]);
+    throw new Error('unsupported set-order action');
+  });
+
+  const ok = await reorderPinnedItems({
+    optimisticOrder: ['H', 'B', 'A'],
+    backendOrder: ['B', 'A'],
+    keepLocalOrderOnError: true,
+  });
+
+  // The full order is durably written before the best-effort server poke.
+  expect(orderSeenBeforePoke).toEqual(['H', 'B', 'A']);
+  // A rejected poke is swallowed, and the visible reorder is re-asserted over
+  // the concurrent sync without moving its hidden pin.
+  expect(ok).toBe(true);
+  expect(await currentOrder()).toEqual(['B', 'H', 'A']);
+  expect(lastPokeSetOrder()).toEqual(['B', 'A']);
+  expect(scry).not.toHaveBeenCalled();
+});
+
 test('reorderPinnedItems is a no-op when the order is unchanged', async () => {
   await seedPins(['A', 'B', 'C']);
 

--- a/packages/shared/src/store/reorderPinnedItems.test.ts
+++ b/packages/shared/src/store/reorderPinnedItems.test.ts
@@ -4,6 +4,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import * as db from '../db';
 import { setupDatabaseTestSuite } from '../test/helpers';
 import { reorderPinnedItems } from './channelActions';
+import { isUnsupportedPinnedItemOrderError } from './pinnedItemOrder';
 
 setupDatabaseTestSuite();
 
@@ -33,18 +34,29 @@ function lastPokeSetOrder(): string[] {
   return last.json.pins['set-order'];
 }
 
+const unsupportedSetOrderNack =
+  "gall: poke-as cast fail :groups-ui [a=%json b=%ui-action]\n[%bad-key 'set-order']\n[%key 'pins']\n/sys/vane/gall/hoon:<[1.047 27].[1.047 45]>\n";
+
+test('identifies only the old-desk set-order conversion failure', () => {
+  expect(isUnsupportedPinnedItemOrderError(unsupportedSetOrderNack)).toBe(true);
+  expect(
+    isUnsupportedPinnedItemOrderError(
+      "gall: poke-as cast fail :groups-ui [a=%json b=%ui-action]\n[%bad-key 'other-action']\n[%key 'pins']"
+    )
+  ).toBe(false);
+  expect(isUnsupportedPinnedItemOrderError(new Error('network down'))).toBe(
+    false
+  );
+});
+
 test('reorderPinnedItems writes the full optimistic order locally but pokes only the reordered visible ids', async () => {
   await seedPins(['C', 'A', 'B']);
-  const setPendingOrder = vi
-    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
-    .mockResolvedValue();
 
   // Filtered view: C is hidden; the visible subset [A, B] is reordered to [B, A],
   // which the caller has already merged into the full order [C, B, A].
   const ok = await reorderPinnedItems({
     optimisticOrder: ['C', 'B', 'A'],
     backendOrder: ['B', 'A'],
-    keepLocalOrderOnError: true,
   });
 
   expect(ok).toBe(true);
@@ -53,8 +65,6 @@ test('reorderPinnedItems writes the full optimistic order locally but pokes only
   // The backend poke carries ONLY the visible ids — never the full order — so
   // %set-order leaves the omitted (hidden) pins in their current server slots.
   expect(lastPokeSetOrder()).toEqual(['B', 'A']);
-  expect(setPendingOrder).toHaveBeenLastCalledWith(['C', 'B', 'A']);
-  setPendingOrder.mockRestore();
 });
 
 test('reorderPinnedItems omits hidden pins from the backend payload (stale-hidden-pin safety)', async () => {
@@ -104,32 +114,36 @@ test('reorderPinnedItems reasserts only the visible ids when a sync lands mid-po
   expect(lastPokeSetOrder()).toEqual(['B', 'A']);
 });
 
-test('reorderPinnedItems can keep the local order when a rollout-era poke fails', async () => {
+test('reorderPinnedItems keeps the local order for the old-desk conversion failure', async () => {
   await seedPins(['H', 'A', 'B']);
   let orderSeenBeforePoke: string[] = [];
   let pendingOrderSeenBeforePoke: string[] = [];
+  let storedOrder: string[] | null = null;
+  const getPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'getValue')
+    .mockImplementation(async () => storedOrder);
   const setPendingOrder = vi
     .spyOn(db.pendingPinnedItemsOrder, 'setValue')
-    .mockResolvedValue();
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
 
   vi.mocked(poke).mockImplementationOnce(async () => {
     orderSeenBeforePoke = await currentOrder();
-    pendingOrderSeenBeforePoke = setPendingOrder.mock.calls.at(
-      -1
-    )?.[0] as string[];
+    pendingOrderSeenBeforePoke = storedOrder ?? [];
     // Simulate a stale pin sync landing while the unsupported poke is in flight.
     await db.insertPinnedItems([
       { type: 'group' as const, index: 0, itemId: 'A' },
       { type: 'group' as const, index: 1, itemId: 'H' },
       { type: 'group' as const, index: 2, itemId: 'B' },
     ]);
-    throw new Error('unsupported set-order action');
+    throw unsupportedSetOrderNack;
   });
 
   const ok = await reorderPinnedItems({
     optimisticOrder: ['H', 'B', 'A'],
     backendOrder: ['B', 'A'],
-    keepLocalOrderOnError: true,
+    keepLocalOrderOnUnsupportedBackend: true,
   });
 
   // The full order is durably written before the best-effort server poke.
@@ -143,6 +157,33 @@ test('reorderPinnedItems can keep the local order when a rollout-era poke fails'
   expect(scry).not.toHaveBeenCalled();
   expect(setPendingOrder).toHaveBeenNthCalledWith(1, ['H', 'B', 'A']);
   expect(setPendingOrder).toHaveBeenLastCalledWith(['B', 'H', 'A']);
+  expect(storedOrder).toEqual(['B', 'H', 'A']);
+  getPendingOrder.mockRestore();
+  setPendingOrder.mockRestore();
+});
+
+test('reorderPinnedItems clears pending state and reconciles transient failures', async () => {
+  await seedPins(['C', 'A', 'B']);
+  let storedOrder: string[] | null = null;
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
+  vi.mocked(poke).mockRejectedValueOnce(new Error('network down'));
+  vi.mocked(scry).mockResolvedValueOnce(['A', 'B', 'C']);
+
+  const ok = await reorderPinnedItems({
+    optimisticOrder: ['C', 'B', 'A'],
+    backendOrder: ['B', 'A'],
+    keepLocalOrderOnUnsupportedBackend: true,
+  });
+
+  expect(ok).toBe(false);
+  expect(await currentOrder()).toEqual(['A', 'B', 'C']);
+  expect(setPendingOrder).toHaveBeenNthCalledWith(1, ['C', 'B', 'A']);
+  expect(setPendingOrder).toHaveBeenLastCalledWith(null);
+  expect(storedOrder).toBeNull();
   setPendingOrder.mockRestore();
 });
 

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -81,7 +81,7 @@ vi.mock('../lure', () => ({
   },
 }));
 
-const outputData = [
+const outputData: db.Pin[] = [
   {
     type: 'groupDm',
     index: 0,
@@ -116,6 +116,54 @@ test('syncs pins', async () => {
     (a, b) => a.index - b.index
   );
   expect(savedItems).toEqual(outputData);
+});
+
+test('syncs pin membership without replacing a pending local order', async () => {
+  setScryOutput(inputData);
+  let storedOrder: string[] | null = [inputData[2], inputData[0]];
+  const getPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'getValue')
+    .mockImplementation(async () => storedOrder);
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
+
+  await syncPinnedItems();
+
+  const savedItems = (await db.getPinnedItems()).sort(
+    (a, b) => a.index - b.index
+  );
+  expect(savedItems).toEqual([
+    { ...outputData[2], index: 0 },
+    outputData[1],
+    { ...outputData[0], index: 2 },
+  ]);
+  expect(storedOrder).toEqual([inputData[2], inputData[1], inputData[0]]);
+  getPendingOrder.mockRestore();
+  setPendingOrder.mockRestore();
+});
+
+test('clears pins when a pending local order receives an empty server snapshot', async () => {
+  await db.insertPinnedItems(outputData);
+  setScryOutput([]);
+  let storedOrder: string[] | null = inputData;
+  const getPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'getValue')
+    .mockImplementation(async () => storedOrder);
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
+
+  await syncPinnedItems();
+
+  expect(await db.getPinnedItems()).toEqual([]);
+  expect(storedOrder).toEqual([]);
+  getPendingOrder.mockRestore();
+  setPendingOrder.mockRestore();
 });
 
 // TLON-5606: after a user clears a failed send, `syncChannelWithBackoff`
@@ -554,12 +602,22 @@ const testGroupData: db.Group = {
 // });
 
 test('syncs init data', async () => {
+  let storedOrder: string[] | null = [...rawGroupsInitData.pins].reverse();
+  const getPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'getValue')
+    .mockImplementation(async () => storedOrder);
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
   setScryOutput(rawGroupsInitData);
   await syncInitData();
   const groups = await db.getGroups({});
   expect(groups.length).toEqual(Object.values(groupsInitData.groups).length);
-  const pins = await db.getPinnedItems();
+  const pins = (await db.getPinnedItems()).sort((a, b) => a.index - b.index);
   expect(pins.length).toEqual(groupsInitData.pins.length);
+  expect(pins.map((pin) => pin.itemId)).toEqual(storedOrder);
   const dmsAndClubs = await getClient()
     ?.select({ count: $.count() })
     .from(db.schema.channels)
@@ -573,6 +631,8 @@ test('syncs init data', async () => {
     groupsInitData.chat.dms.length +
       Object.keys(groupsInitData.chat.clubs).length
   );
+  getPendingOrder.mockRestore();
+  setPendingOrder.mockRestore();
 });
 
 test('syncs last posts', async () => {

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -145,6 +145,38 @@ test('syncs pin membership without replacing a pending local order', async () =>
   setPendingOrder.mockRestore();
 });
 
+test('clears a confirmed pending order and accepts later server reorders', async () => {
+  let storedOrder: string[] | null = [...inputData].reverse();
+  const getPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'getValue')
+    .mockImplementation(async () => storedOrder);
+  const setPendingOrder = vi
+    .spyOn(db.pendingPinnedItemsOrder, 'setValue')
+    .mockImplementation(async (value) => {
+      storedOrder = typeof value === 'function' ? value(storedOrder) : value;
+    });
+
+  setScryOutput([...inputData].reverse());
+  await syncPinnedItems();
+  expect(storedOrder).toBeNull();
+  expect(
+    (await db.getPinnedItems())
+      .sort((a, b) => a.index - b.index)
+      .map((pin) => pin.itemId)
+  ).toEqual([...inputData].reverse());
+
+  setScryOutput(inputData);
+  await syncPinnedItems();
+  expect(
+    (await db.getPinnedItems())
+      .sort((a, b) => a.index - b.index)
+      .map((pin) => pin.itemId)
+  ).toEqual(inputData);
+
+  getPendingOrder.mockRestore();
+  setPendingOrder.mockRestore();
+});
+
 test('clears pins when a pending local order receives an empty server snapshot', async () => {
   await db.insertPinnedItems(outputData);
   setScryOutput([]);
@@ -161,7 +193,7 @@ test('clears pins when a pending local order receives an empty server snapshot',
   await syncPinnedItems();
 
   expect(await db.getPinnedItems()).toEqual([]);
-  expect(storedOrder).toEqual([]);
+  expect(storedOrder).toBeNull();
   getPendingOrder.mockRestore();
   setPendingOrder.mockRestore();
 });

--- a/packages/shared/src/store/sync/sync.test.ts
+++ b/packages/shared/src/store/sync/sync.test.ts
@@ -118,7 +118,7 @@ test('syncs pins', async () => {
   expect(savedItems).toEqual(outputData);
 });
 
-test('syncs pin membership without replacing a pending local order', async () => {
+test('syncs pin membership without expanding the pending local intent', async () => {
   setScryOutput(inputData);
   let storedOrder: string[] | null = [inputData[2], inputData[0]];
   const getPendingOrder = vi
@@ -140,13 +140,28 @@ test('syncs pin membership without replacing a pending local order', async () =>
     outputData[1],
     { ...outputData[0], index: 2 },
   ]);
-  expect(storedOrder).toEqual([inputData[2], inputData[1], inputData[0]]);
+  expect(storedOrder).toEqual([inputData[2], inputData[0]]);
+
+  // A later server snapshot moves the pin that was never part of the local
+  // reorder. Its new slot is accepted while the two locally reordered ids keep
+  // their relative order.
+  setScryOutput([inputData[1], inputData[0], inputData[2]]);
+  await syncPinnedItems();
+  const resyncedItems = (await db.getPinnedItems()).sort(
+    (a, b) => a.index - b.index
+  );
+  expect(resyncedItems).toEqual([
+    { ...outputData[1], index: 0 },
+    { ...outputData[2], index: 1 },
+    { ...outputData[0], index: 2 },
+  ]);
+  expect(storedOrder).toEqual([inputData[2], inputData[0]]);
   getPendingOrder.mockRestore();
   setPendingOrder.mockRestore();
 });
 
 test('clears a confirmed pending order and accepts later server reorders', async () => {
-  let storedOrder: string[] | null = [...inputData].reverse();
+  let storedOrder: string[] | null = [inputData[2], inputData[0]];
   const getPendingOrder = vi
     .spyOn(db.pendingPinnedItemsOrder, 'getValue')
     .mockImplementation(async () => storedOrder);
@@ -156,14 +171,14 @@ test('clears a confirmed pending order and accepts later server reorders', async
       storedOrder = typeof value === 'function' ? value(storedOrder) : value;
     });
 
-  setScryOutput([...inputData].reverse());
+  setScryOutput([inputData[2], inputData[1], inputData[0]]);
   await syncPinnedItems();
   expect(storedOrder).toBeNull();
   expect(
     (await db.getPinnedItems())
       .sort((a, b) => a.index - b.index)
       .map((pin) => pin.itemId)
-  ).toEqual([...inputData].reverse());
+  ).toEqual([inputData[2], inputData[1], inputData[0]]);
 
   setScryOutput(inputData);
   await syncPinnedItems();

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -31,6 +31,7 @@ import {
   partitionDiscoveryMatches,
 } from '../lanyardActions';
 import { useLureState } from '../lure';
+import { applyPinnedItemOrder } from '../pinnedItemOrder';
 import { verifyPostDelivery } from '../postActions/verifyPostDelivery';
 import { clearPresenceState, handlePresenceEvent } from '../presence';
 import { getSession, setSession, updateSession } from '../session';
@@ -47,6 +48,34 @@ import { updateLastActivityTime } from './updateLastActivityTime';
 // see something new, we refetch init data. Fallback in case we miss
 // something over %channels or %groups
 const joinedGroupsAndChannels = new Set<string>();
+
+// TODO: Remove with `pendingPinnedItemsOrder` after `%set-order` is deployed
+// fleet-wide. Until then, merge stale server membership into the pending local
+// order instead of allowing startup/foreground sync to undo a failed reorder.
+const persistSyncedPinnedItems = async (
+  pinnedItems: db.Pin[],
+  queryCtx?: QueryCtx
+) => {
+  if ((await db.pendingPinnedItemsOrder.getValue(true)) == null) {
+    return db.insertPinnedItems(pinnedItems, queryCtx);
+  }
+
+  let mergedPinnedItems = pinnedItems;
+  let hasPendingOrder = true;
+  await db.pendingPinnedItemsOrder.setValue((pendingOrder) => {
+    if (pendingOrder == null) {
+      hasPendingOrder = false;
+      return null;
+    }
+    mergedPinnedItems = applyPinnedItemOrder(pendingOrder, pinnedItems);
+    return mergedPinnedItems.map((pin) => pin.itemId);
+  });
+
+  if (hasPendingOrder && mergedPinnedItems.length === 0) {
+    return db.clearPinnedItems(queryCtx);
+  }
+  return db.insertPinnedItems(mergedPinnedItems, queryCtx);
+};
 
 export const syncInitData = async (
   syncCtx?: SyncCtx,
@@ -79,9 +108,9 @@ export const syncInitData = async (
       ctx: queryCtx,
     }).then(() => logger.crumb('persisted unreads'));
 
-    await db
-      .insertPinnedItems(initData.pins, queryCtx)
-      .then(() => logger.crumb('inserted pinned items'));
+    await persistSyncedPinnedItems(initData.pins, queryCtx).then(() =>
+      logger.crumb('inserted pinned items')
+    );
 
     // Store hidden post IDs to apply after posts are synced
     // This avoids the race condition where IDs arrive before posts exist
@@ -720,7 +749,7 @@ export const syncPinnedItems = async (ctx?: SyncCtx) => {
     api.getPinnedItems()
   );
   logger.log('got pinned items from api', pinnedItems.length);
-  await db.insertPinnedItems(pinnedItems);
+  await persistSyncedPinnedItems(pinnedItems);
 };
 
 export const syncGroups = async (ctx?: SyncCtx) => {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -62,13 +62,23 @@ const persistSyncedPinnedItems = async (
 
   let mergedPinnedItems = pinnedItems;
   let hasPendingOrder = true;
+  const incomingOrder = [...pinnedItems]
+    .sort((a, b) => a.index - b.index)
+    .map((pin) => pin.itemId);
   await db.pendingPinnedItemsOrder.setValue((pendingOrder) => {
     if (pendingOrder == null) {
       hasPendingOrder = false;
       return null;
     }
     mergedPinnedItems = applyPinnedItemOrder(pendingOrder, pinnedItems);
-    return mergedPinnedItems.map((pin) => pin.itemId);
+    const mergedOrder = mergedPinnedItems.map((pin) => pin.itemId);
+    if (_.isEqual(incomingOrder, mergedOrder)) {
+      // The backend now reflects the local compatibility order. Retire it so
+      // later snapshots (including reorders from another device) are accepted.
+      mergedPinnedItems = pinnedItems;
+      return null;
+    }
+    return mergedOrder;
   });
 
   if (hasPendingOrder && mergedPinnedItems.length === 0) {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -50,8 +50,8 @@ import { updateLastActivityTime } from './updateLastActivityTime';
 const joinedGroupsAndChannels = new Set<string>();
 
 // TODO: Remove with `pendingPinnedItemsOrder` after `%set-order` is deployed
-// fleet-wide. Until then, merge stale server membership into the pending local
-// order instead of allowing startup/foreground sync to undo a failed reorder.
+// fleet-wide. Until then, apply the pending local reorder intent to each server
+// snapshot without taking authority over hidden or newly added pins.
 const persistSyncedPinnedItems = async (
   pinnedItems: db.Pin[],
   queryCtx?: QueryCtx
@@ -78,7 +78,9 @@ const persistSyncedPinnedItems = async (
       mergedPinnedItems = pinnedItems;
       return null;
     }
-    return mergedOrder;
+    // Keep only the ids the user actually reordered as local intent. Expanding
+    // this to `mergedOrder` would make hidden/new server pins locally owned too.
+    return pendingOrder;
   });
 
   if (hasPendingOrder && mergedPinnedItems.length === 0) {


### PR DESCRIPTION
## Summary

Follow-up to #5904. While `%set-order` rolls out fleet-wide, keep reordered pins persisted on the local device when an older groups-ui desk rejects the action, without letting that compatibility state override hidden or newly synced pins.

## Changes

- Added an opt-in `keepLocalOrderOnUnsupportedBackend` compatibility path for pinned chat-list drag-and-drop, with a fleet-rollout removal TODO.
- Persist only the deduped, visible reorder intent before writing SQLite and attempting the visible-only `%set-order` server poke.
- Keep that partial intent through stale startup/foreground snapshots and clear it once the server confirms the same effective order; successful or unsupported pokes never expand it into a full snapshot.
- Preserve server authority over hidden and newly added pins, including accepting their later cross-device moves while local visible intent remains pending.
- Match only the exact old-desk Gall cast failure; transport, auth, timeout, and unrelated backend errors clear pending intent and take the normal reconcile/rollback path.
- Use a v2 storage key so released full-snapshot values are not reinterpreted as partial intent.
- Extracted the slot-preserving pin-order helper and added focused reorder/sync regression coverage.

## How did I test?

- `pnpm --filter @tloncorp/shared exec vitest run src/store/reorderPinnedItems.test.ts src/store/sync/sync.test.ts --pool=forks --poolOptions.forks.singleFork` (33 tests passed)
- `pnpm --filter @tloncorp/shared tsc`
- `pnpm --filter @tloncorp/app tsc`
- Targeted ESLint on all changed shared files (0 errors; pre-existing warnings only)
- Prettier and `git diff --check`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: pinned chat ordering and pin sync

During the compatibility window, order is intentionally device-local when server sync is unsupported, so pin order can temporarily differ between devices. Pin membership and pins outside the reordered visible subset remain server-owned. The normal server-authoritative failure path remains the default for callers that do not opt in.

## Rollback plan

Revert this PR; there are no database migrations, and the temporary storage keys are harmless if left behind. This restores rollback-on-poke-error and direct server pin-order ingestion. After `%set-order` is deployed fleet-wide, remove the caller override and the clearly marked pending-order compatibility storage/sync path.

## Screenshots / videos

N/A — behavior-only change.
