### PR TITLE
hermes: resolve inbound cites

### DIFF
--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -71,6 +71,7 @@ from .channel_access import (
     is_channel_open,
     parse_channel_rules,
 )
+from .cite import resolve_cites
 from .history import (
     build_channel_context,
     build_thread_context,
@@ -167,6 +168,7 @@ from .tlon_tool import (
 logger = logging.getLogger(__name__)
 
 RECONNECT_BACKOFF_SECONDS = (2, 5, 10, 30, 60)
+CITE_RESOLUTION_BUDGET_SECONDS = 5.0
 RENOTIFY_COOLDOWN_MS = 10 * 60 * 1000
 REQUIRED_ENV = [
     "TLON_NODE_URL",
@@ -2131,6 +2133,20 @@ class TlonAdapter(BasePlatformAdapter):
         message: TlonIncomingMessage,
         text: str,
     ) -> tuple[str, PreparedMedia]:
+        cite_block = ""
+        if self._sse is not None and message.content:
+            try:
+                cite_block = await asyncio.wait_for(
+                    resolve_cites(self._sse.scry, message.content),
+                    CITE_RESOLUTION_BUDGET_SECONDS,
+                )
+            except (Exception, asyncio.TimeoutError) as exc:
+                logger.debug(
+                    "[tlon] cite resolution failed for %s: %s",
+                    message.message_id,
+                    exc,
+                )
+                self._telemetry.error("cite_resolve", exc)
         try:
             prepared = await prepare_inbound_media(message.content, message.blob)
         except Exception as exc:
@@ -2140,13 +2156,16 @@ class TlonAdapter(BasePlatformAdapter):
                 exc,
             )
             self._telemetry.error("media_prepare", exc)
-            return text, PreparedMedia()
+            prepared = PreparedMedia()
         if not prepared.text_prefix:
-            return text, prepared
-        body = str(text or "").strip()
-        dispatch_text = (
-            f"{prepared.text_prefix}\n{body}" if body else prepared.text_prefix
-        )
+            dispatch_text = text
+        else:
+            body = str(text or "").strip()
+            dispatch_text = (
+                f"{prepared.text_prefix}\n{body}" if body else prepared.text_prefix
+            )
+        if cite_block:
+            dispatch_text = f"{cite_block}\n\n{dispatch_text}"
         return dispatch_text, prepared
 
     async def _with_group_context(

--- a/packages/hermes-tlon-adapter/cite.py
+++ b/packages/hermes-tlon-adapter/cite.py
@@ -1,0 +1,154 @@
+"""Inbound channel-cite resolution for Hermes Tlon messages.
+
+Ports OpenClaw's cite enrichment while using Hermes' existing ``/channels/v4``
+history parsing and rendering helpers. Cites are parsed synchronously from the
+story, then resolved through an injected scry function so callers can bound
+the work and tests can provide small fakes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .history import (
+    ScryFn,
+    format_ud,
+    parse_parent_post,
+    render_history_content,
+    sanitize_context_text,
+)
+
+logger = logging.getLogger(__name__)
+
+_NEST_RE = re.compile(r"(?:chat|heap|diary)/~[a-z-]+/[a-z0-9-]+")
+_UD_RE = re.compile(r"[0-9]+(?:\.[0-9]+)*")
+_WHERE_RE = re.compile(r"^/(?:msg|note|curio)/([^/]+)(?:/([^/]+))?$")
+_LEGACY_WHERE_RE = re.compile(r"^/msg/(~[a-z-]+)/([^/]+)$")
+
+
+@dataclass(frozen=True)
+class ParsedCite:
+    type: str
+    nest: Optional[str] = None
+    where: Optional[str] = None
+    post_id: Optional[str] = None
+    reply_id: Optional[str] = None
+    legacy_author: Optional[str] = None
+
+
+def extract_cites(content: Any) -> list[ParsedCite]:
+    """Return cite blocks from a Story without rejecting malformed siblings."""
+    if not isinstance(content, list):
+        return []
+
+    cites: list[ParsedCite] = []
+    for verse in content:
+        if not isinstance(verse, dict):
+            continue
+        block = verse.get("block")
+        if not isinstance(block, dict):
+            continue
+        raw_cite = block.get("cite")
+        if not isinstance(raw_cite, dict):
+            continue
+
+        for cite_type in ("chan", "group", "desk", "bait"):
+            if cite_type not in raw_cite:
+                continue
+            if cite_type != "chan":
+                cites.append(ParsedCite(type=cite_type))
+                break
+
+            chan = raw_cite.get("chan")
+            nest = chan.get("nest") if isinstance(chan, dict) else None
+            where = chan.get("where") if isinstance(chan, dict) else None
+            post_id, reply_id, legacy_author = _parse_channel_where(where)
+            cites.append(
+                ParsedCite(
+                    type="chan",
+                    nest=nest if isinstance(nest, str) else None,
+                    where=where if isinstance(where, str) else None,
+                    post_id=post_id,
+                    reply_id=reply_id,
+                    legacy_author=legacy_author,
+                )
+            )
+            break
+    return cites
+
+
+def _parse_channel_where(
+    where: Any,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    if not isinstance(where, str):
+        return None, None, None
+    legacy = _LEGACY_WHERE_RE.fullmatch(where)
+    if legacy is not None:
+        return legacy.group(2), None, legacy.group(1)
+    current = _WHERE_RE.fullmatch(where)
+    if current is None:
+        return None, None, None
+    return current.group(1), current.group(2), None
+
+
+def _validated_scry_path(cite: ParsedCite) -> Optional[str]:
+    """Build a channels-v4 route only from route-safe cite components."""
+    if cite.type != "chan" or not _valid_nest(cite.nest) or not _valid_ud(cite.post_id):
+        return None
+
+    post_ud = format_ud(cite.post_id)
+    if cite.reply_id is None:
+        return f"/channels/v4/{cite.nest}/posts/post/{post_ud}"
+    if not _valid_ud(cite.reply_id):
+        return None
+    reply_ud = format_ud(cite.reply_id)
+    return (
+        f"/channels/v4/{cite.nest}/posts/post/id/{post_ud}/"
+        f"replies/reply/id/{reply_ud}"
+    )
+
+
+def _valid_nest(nest: Optional[str]) -> bool:
+    return isinstance(nest, str) and _NEST_RE.fullmatch(nest) is not None
+
+
+def _valid_ud(value: Optional[str]) -> bool:
+    if not isinstance(value, str) or _UD_RE.fullmatch(value) is None:
+        return False
+    return "." not in value or format_ud(value) == value
+
+
+async def resolve_cites(scry: ScryFn, content: Any, *, max_attempts: int = 3) -> str:
+    """Resolve up to ``max_attempts`` valid channel cites in story order.
+
+    A failed scry is an expected miss and does not consume a replacement from
+    later cites. Cancellation intentionally propagates to the caller's budget.
+    """
+    if max_attempts <= 0:
+        return ""
+
+    attempts: list[tuple[ParsedCite, str]] = []
+    for cite in extract_cites(content):
+        path = _validated_scry_path(cite)
+        if path is None:
+            continue
+        attempts.append((cite, path))
+        if len(attempts) == max_attempts:
+            break
+
+    lines: list[str] = []
+    for cite, path in attempts:
+        try:
+            payload = await scry(path)
+            entry = parse_parent_post(payload, cite.post_id or "")
+            if entry is None:
+                continue
+            text = sanitize_context_text(render_history_content(entry))
+            if text.strip():
+                lines.append(f"> {entry.author} wrote: {text}")
+        except Exception as exc:
+            logger.debug("[tlon] cite resolution failed for %s: %s", path, exc)
+    return "\n".join(lines)

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -1169,6 +1169,45 @@ class AdapterApprovalTests(unittest.TestCase):
         )
         self.assertEqual(len(follow_up), 1)
 
+    def test_channel_approval_replay_resolves_queued_cite(self):
+        adapter = self.make_adapter({"context_messages": 0})
+        path = "/channels/v4/chat/~host/quoted/posts/post/123"
+        adapter._sse.payloads[path] = {
+            "essay": {
+                "author": "~quoted-author",
+                "sent": 1000,
+                "content": [{"inline": ["quoted text"]}],
+            },
+            "seal": {"id": "123"},
+        }
+        content = [
+            {
+                "block": {
+                    "cite": {
+                        "chan": {
+                            "nest": "chat/~host/quoted",
+                            "where": "/msg/123",
+                        }
+                    }
+                }
+            },
+            {"inline": ["~pen please answer"]},
+        ]
+
+        self.dispatches(adapter, channel_event("", content=content))
+        request_id = adapter._pending_approvals[0]["id"]
+        events = self.dispatches(
+            adapter,
+            dm_event(f"/allow {request_id}", author="~mug", whom="~mug"),
+            dm=True,
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0].text,
+            "> ~quoted-author wrote: quoted text\n\n[quoted message] ~pen please answer",
+        )
+
     def test_channel_bot_approval_replay_counts_loop_safety(self):
         adapter = self.make_adapter({"max_consecutive_bot_responses": 1})
 

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -5,6 +5,7 @@ import os
 import sys
 import types
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -159,6 +160,22 @@ def channel_event(
                 "r-post": {
                     "set": set_payload,
                 },
+            }
+        },
+    }
+
+
+def dm_event(text, *, author="~mug", whom="~mug", msg_id="dm-1", content=None):
+    return {
+        "whom": whom,
+        "id": msg_id,
+        "response": {
+            "add": {
+                "essay": {
+                    "author": author,
+                    "sent": 1000,
+                    "content": [{"inline": [text]}] if content is None else content,
+                }
             }
         },
     }
@@ -1621,6 +1638,314 @@ class LensTriggerMapTests(unittest.TestCase):
         t = adapter_mod._lens_trigger
         self.assertEqual(t("approved", is_dm=True), "dm")
         self.assertEqual(t("approved", is_dm=False), "mention")
+
+
+class CitationDispatchTests(unittest.TestCase):
+    def make_adapter(self, extra=None):
+        base = {
+            "node_url": "https://pen.tlon.network",
+            "node_id": "~pen",
+            "access_code": "code",
+            "channels": ["chat/~pen/general"],
+            "allowed_users": ["~mug"],
+            "require_mention": False,
+            "context_messages": 0,
+        }
+        base.update(extra or {})
+        with patch.dict(os.environ, {}, clear=True):
+            return adapter_mod.TlonAdapter(PlatformConfig(extra=base))
+
+    async def dispatches(self, adapter, raw, *, dm=False):
+        events = []
+
+        async def record(event):
+            events.append(event)
+
+        adapter.handle_message = record
+        if dm:
+            await adapter._handle_dm_event(raw)
+        else:
+            await adapter._handle_channel_event(raw)
+        return events
+
+    @staticmethod
+    def cite_block(where, *, nest="chat/~host/quoted"):
+        return {"block": {"cite": {"chan": {"nest": nest, "where": where}}}}
+
+    @staticmethod
+    def cited_payload(text, *, author="~quoted-author"):
+        return {
+            "essay": {
+                "author": author,
+                "sent": 1000,
+                "content": [{"inline": [text]}],
+            },
+            "seal": {"id": "123"},
+        }
+
+    class RecordingSSE:
+        def __init__(self, payloads=None):
+            self.payloads = payloads or {}
+            self.scries = []
+
+        async def scry(self, path):
+            self.scries.append(path)
+            payload = self.payloads.get(path)
+            if isinstance(payload, BaseException):
+                raise payload
+            if payload is None:
+                raise ConnectionError(f"no payload for {path}")
+            return payload
+
+    class RecordingTelemetry:
+        def __init__(self):
+            self.errors = []
+
+        def error(self, component, exc, **context):
+            self.errors.append((component, exc, context))
+
+        def start_reply(self, *args, **kwargs):
+            pass
+
+    def test_channel_cite_prepends_resolved_text(self):
+        adapter = self.make_adapter()
+        path = "/channels/v4/chat/~host/quoted/posts/post/123"
+        adapter._sse = self.RecordingSSE({path: self.cited_payload("quoted")})
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0].text,
+            "> ~quoted-author wrote: quoted\n\n[quoted message] body",
+        )
+
+    def test_multiple_cites_join_with_one_newline(self):
+        adapter = self.make_adapter()
+        adapter._sse = self.RecordingSSE(
+            {
+                "/channels/v4/chat/~host/quoted/posts/post/123": self.cited_payload("one"),
+                "/channels/v4/chat/~host/quoted/posts/post/456": self.cited_payload("two"),
+            }
+        )
+        content = [
+            self.cite_block("/msg/123"),
+            self.cite_block("/msg/456"),
+            {"inline": ["body"]},
+        ]
+
+        events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(
+            events[0].text,
+            "> ~quoted-author wrote: one\n> ~quoted-author wrote: two\n\n"
+            "[quoted message] [quoted message] body",
+        )
+
+    def test_cite_media_prefix_and_body_have_the_required_order(self):
+        adapter = self.make_adapter()
+        path = "/channels/v4/chat/~host/quoted/posts/post/123"
+        adapter._sse = self.RecordingSSE({path: self.cited_payload("quoted")})
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        async def fake_prepare(story_content, blob):
+            return adapter_mod.PreparedMedia(text_prefix="[attachment]")
+
+        with patch.object(adapter_mod, "prepare_inbound_media", fake_prepare):
+            events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(
+            events[0].text,
+            "> ~quoted-author wrote: quoted\n\n[attachment]\n[quoted message] body",
+        )
+
+    def test_zero_cite_payloads_keep_existing_text_and_media_composition(self):
+        adapter = self.make_adapter()
+        message = tlon_api.TlonIncomingMessage(
+            chat_id="chat/~pen/general",
+            chat_name="general",
+            chat_type="group",
+            user_id="~mug",
+            user_name="~mug",
+            text="  body  ",
+            message_id="no-cite",
+            reply_to_message_id=None,
+            sent_at=datetime.now(),
+            raw={},
+            content=[{"inline": ["body"]}],
+        )
+
+        text, _ = asyncio.run(adapter._prepare_dispatch_payload(message, "  body  "))
+        self.assertEqual(text, "  body  ")
+
+        async def fake_prepare(story_content, blob):
+            return adapter_mod.PreparedMedia(text_prefix="[attachment]")
+
+        with patch.object(adapter_mod, "prepare_inbound_media", fake_prepare):
+            text, _ = asyncio.run(adapter._prepare_dispatch_payload(message, "  body  "))
+        self.assertEqual(text, "[attachment]\nbody")
+
+    def test_dm_cross_channel_cite_resolves(self):
+        # Cite resolution is a deliberate "resolve everything" policy for any
+        # authorized wake-capable sender, not an owner-only carve-out. Use a
+        # different owner (~pen) and have ~mug dispatch merely as a
+        # config-allowlisted (non-owner) sender to prove that.
+        adapter = self.make_adapter({"owner_ship": "~pen"})
+        self.assertFalse(adapter._is_owner("~mug"))
+        path = "/channels/v4/chat/~other/private/posts/post/123"
+        adapter._sse = self.RecordingSSE({path: self.cited_payload("cross-channel")})
+        content = [
+            self.cite_block("/msg/123", nest="chat/~other/private"),
+            {"inline": ["dm body"]},
+        ]
+
+        events = asyncio.run(
+            self.dispatches(adapter, dm_event("", author="~mug", whom="~mug", content=content), dm=True)
+        )
+
+        self.assertEqual(
+            events[0].text,
+            "> ~quoted-author wrote: cross-channel\n\n[quoted message] dm body",
+        )
+        self.assertEqual(adapter._sse.scries, [path])
+
+    def test_unmentioned_channel_cite_does_not_scry(self):
+        adapter = self.make_adapter({"require_mention": True})
+        adapter._sse = self.RecordingSSE()
+        content = [self.cite_block("/msg/123"), {"inline": ["ordinary chatter"]}]
+
+        events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(events, [])
+        self.assertEqual(adapter._sse.scries, [])
+
+    def test_hanging_scry_times_out_and_later_event_still_dispatches(self):
+        adapter = self.make_adapter()
+
+        class HangingSSE:
+            def __init__(self):
+                self.scries = []
+
+            async def scry(self, path):
+                self.scries.append(path)
+                await asyncio.Event().wait()
+
+        adapter._sse = HangingSSE()
+        cited_content = [self.cite_block("/msg/123"), {"inline": ["first"]}]
+
+        async def run():
+            with patch.object(adapter_mod, "CITE_RESOLUTION_BUDGET_SECONDS", 0.05):
+                first = await self.dispatches(adapter, channel_event("", content=cited_content))
+                second = await self.dispatches(adapter, channel_event("second", post_id="2"))
+            return first, second
+
+        # An outer timeout comfortably above the patched budget (0.05s) but
+        # far below the 5s module default proves dispatch actually honored
+        # the patched budget rather than an import-time-captured constant.
+        first, second = asyncio.run(asyncio.wait_for(run(), timeout=1.0))
+
+        self.assertEqual(first[0].text, "[quoted message] first")
+        self.assertEqual(second[0].text, "second")
+
+    def test_per_cite_scry_failure_does_not_emit_cite_telemetry(self):
+        adapter = self.make_adapter()
+        adapter._telemetry = self.RecordingTelemetry()
+        adapter._sse = self.RecordingSSE(
+            {"/channels/v4/chat/~host/quoted/posts/post/123": ConnectionError("deleted")}
+        )
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(events[0].text, "[quoted message] body")
+        self.assertEqual([item for item in adapter._telemetry.errors if item[0] == "cite_resolve"], [])
+
+    def test_timeout_emits_one_cite_telemetry_error(self):
+        adapter = self.make_adapter()
+        adapter._telemetry = self.RecordingTelemetry()
+
+        class HangingSSE:
+            async def scry(self, path):
+                await asyncio.Event().wait()
+
+        adapter._sse = HangingSSE()
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        with patch.object(adapter_mod, "CITE_RESOLUTION_BUDGET_SECONDS", 0.01):
+            events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        cite_errors = [item for item in adapter._telemetry.errors if item[0] == "cite_resolve"]
+        self.assertEqual(events[0].text, "[quoted message] body")
+        self.assertEqual(len(cite_errors), 1)
+
+    def test_resolver_phase_exception_emits_one_error_and_dispatches(self):
+        adapter = self.make_adapter()
+        adapter._telemetry = self.RecordingTelemetry()
+        adapter._sse = self.RecordingSSE()
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        async def explode(scry, story_content, *, max_attempts=3):
+            raise RuntimeError("unexpected resolver failure")
+
+        with patch.object(adapter_mod, "resolve_cites", explode):
+            events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        cite_errors = [item for item in adapter._telemetry.errors if item[0] == "cite_resolve"]
+        self.assertEqual(events[0].text, "[quoted message] body")
+        self.assertEqual(len(cite_errors), 1)
+
+    def test_resolver_cancelled_error_propagates_and_emits_no_telemetry(self):
+        # CancelledError must escape _prepare_dispatch_payload rather than
+        # being caught by the ``(Exception, asyncio.TimeoutError)`` phase
+        # guard, and must not be recorded as a cite_resolve telemetry error.
+        adapter = self.make_adapter()
+        adapter._telemetry = self.RecordingTelemetry()
+        adapter._sse = self.RecordingSSE()
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        async def cancel(scry, story_content, *, max_attempts=3):
+            raise asyncio.CancelledError()
+
+        async def attempt():
+            with patch.object(adapter_mod, "resolve_cites", cancel):
+                try:
+                    await self.dispatches(adapter, channel_event("", content=content))
+                    return "no-error"
+                except asyncio.CancelledError:
+                    return "cancelled"
+
+        result = asyncio.run(attempt())
+
+        self.assertEqual(result, "cancelled")
+        self.assertEqual(
+            [item for item in adapter._telemetry.errors if item[0] == "cite_resolve"], []
+        )
+
+    def test_media_failure_keeps_resolved_cite_block(self):
+        adapter = self.make_adapter()
+        path = "/channels/v4/chat/~host/quoted/posts/post/123"
+        adapter._sse = self.RecordingSSE({path: self.cited_payload("quoted")})
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        async def explode(story_content, blob):
+            raise RuntimeError("media unavailable")
+
+        with patch.object(adapter_mod, "prepare_inbound_media", explode):
+            events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(
+            events[0].text,
+            "> ~quoted-author wrote: quoted\n\n[quoted message] body",
+        )
+
+    def test_missing_sse_keeps_placeholder_without_crashing(self):
+        adapter = self.make_adapter()
+        content = [self.cite_block("/msg/123"), {"inline": ["body"]}]
+
+        events = asyncio.run(self.dispatches(adapter, channel_event("", content=content)))
+
+        self.assertEqual(events[0].text, "[quoted message] body")
 
 
 if __name__ == "__main__":

--- a/packages/hermes-tlon-adapter/test_cite.py
+++ b/packages/hermes-tlon-adapter/test_cite.py
@@ -1,0 +1,330 @@
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+PACKAGE_DIR = Path(__file__).parent
+PACKAGE_NAME = "hermes_tlon_adapter_cite_testpkg"
+
+package = types.ModuleType(PACKAGE_NAME)
+package.__path__ = [str(PACKAGE_DIR)]
+sys.modules[PACKAGE_NAME] = package
+
+
+def load_module(name):
+    module_name = f"{PACKAGE_NAME}.{name}"
+    spec = importlib.util.spec_from_file_location(module_name, PACKAGE_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+load_module("tlon_api")
+load_module("media")
+load_module("history")
+cite = load_module("cite")
+
+
+POST_ID = "170141184506536961460817141626482720768"
+REPLY_ID = "170141184506537047334633492345058754560"
+NEST = "chat/~host/chan"
+
+
+def chan_cite(where, *, nest=NEST):
+    return {"block": {"cite": {"chan": {"nest": nest, "where": where}}}}
+
+
+def essay_payload(author="~real-author", text="hello", *, blob=None):
+    essay = {
+        "author": author,
+        "sent": 1000,
+        "content": [{"inline": [text]}],
+    }
+    if blob is not None:
+        essay["blob"] = blob
+    return {"essay": essay, "seal": {"id": POST_ID}}
+
+
+def reply_payload(author="~real-author", text="reply"):
+    return {
+        "seal": {"id": REPLY_ID},
+        "revision": 1,
+        "memo": {
+            "author": author,
+            "sent": 1000,
+            "content": [{"inline": [text]}],
+        },
+    }
+
+
+def recording_scry(payload=None, *, errors=()):
+    calls = []
+    remaining_errors = list(errors)
+
+    async def scry(path):
+        calls.append(path)
+        if remaining_errors:
+            raise remaining_errors.pop(0)
+        return payload if payload is not None else essay_payload()
+
+    scry.calls = calls
+    return scry
+
+
+class ExtractCitesTests(unittest.TestCase):
+    def test_current_client_top_level_form(self):
+        parsed = cite.extract_cites([chan_cite(f"/msg/{POST_ID}")])
+
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0].type, "chan")
+        self.assertEqual(parsed[0].post_id, POST_ID)
+        self.assertIsNone(parsed[0].reply_id)
+        self.assertIsNone(parsed[0].legacy_author)
+
+    def test_current_client_reply_form(self):
+        # This is the current-client reply shape in channelPosts.json:1036.
+        parsed = cite.extract_cites([chan_cite(f"/msg/{POST_ID}/{REPLY_ID}")])
+
+        self.assertEqual(parsed[0].post_id, POST_ID)
+        self.assertEqual(parsed[0].reply_id, REPLY_ID)
+
+    def test_note_curio_and_note_reply_forms(self):
+        parsed = cite.extract_cites(
+            [
+                chan_cite("/note/123456"),
+                chan_cite("/curio/456789"),
+                chan_cite("/note/123456/789012"),
+            ]
+        )
+
+        self.assertEqual(
+            [(item.post_id, item.reply_id) for item in parsed],
+            [("123456", None), ("456789", None), ("123456", "789012")],
+        )
+
+    def test_legacy_authored_form(self):
+        parsed = cite.extract_cites([chan_cite("/msg/~legacy-author/170.141.184.505")])
+
+        self.assertEqual(parsed[0].post_id, "170.141.184.505")
+        self.assertEqual(parsed[0].legacy_author, "~legacy-author")
+        self.assertIsNone(parsed[0].reply_id)
+
+    def test_non_channel_variants_are_classified(self):
+        content = [
+            {"block": {"cite": {"group": "~host/group"}}},
+            {"block": {"cite": {"desk": "base"}}},
+            {"block": {"cite": {"bait": {"foo": "bar"}}}},
+        ]
+
+        self.assertEqual([item.type for item in cite.extract_cites(content)], ["group", "desk", "bait"])
+
+    def test_malformed_content_is_tolerated_and_multiple_cites_keep_order(self):
+        content = [
+            "not a verse",
+            {"block": {"cite": "not a cite"}},
+            chan_cite("/not-a-pointer"),
+            chan_cite("/msg/123"),
+            {"block": {"cite": {"group": "~host/group"}}},
+        ]
+
+        parsed = cite.extract_cites(content)
+
+        self.assertEqual([item.type for item in parsed], ["chan", "chan", "group"])
+        self.assertIsNone(parsed[0].post_id)
+        self.assertEqual(parsed[1].post_id, "123")
+        self.assertEqual(cite.extract_cites({"not": "a story"}), [])
+
+
+class CiteValidationTests(unittest.TestCase):
+    def _resolve(self, content):
+        scry = recording_scry()
+        result = asyncio.run(cite.resolve_cites(scry, content))
+        self.assertEqual(result, "")
+        self.assertEqual(scry.calls, [])
+
+    def test_invalid_nests_never_scry(self):
+        for nest in ("club/~host/chan", "chat/host/chan", "chat/~host/chan/extra"):
+            with self.subTest(nest=nest):
+                self._resolve([chan_cite("/msg/123", nest=nest)])
+
+    def test_invalid_ids_never_scry(self):
+        for where in (
+            "/msg/123/456/extra",
+            "/msg/123?query",
+            "/msg/123#fragment",
+            "/msg/letters",
+            "/msg/-1",
+            "/msg/",
+        ):
+            with self.subTest(where=where):
+                self._resolve([chan_cite(where)])
+
+    def test_malformed_dotted_ids_never_scry(self):
+        for post_id in (".123", "123.", "1..234", "1.23"):
+            with self.subTest(post_id=post_id):
+                self._resolve([chan_cite(f"/msg/{post_id}")])
+
+    def test_malformed_reply_ids_never_scry(self):
+        for where in (
+            "/msg/123/letters",
+            "/msg/123/1..2",
+            "/msg/123/.123",
+            "/msg/123/1/2",
+        ):
+            with self.subTest(where=where):
+                self._resolve([chan_cite(where)])
+
+    def test_undotted_and_canonical_dotted_ids_scry(self):
+        scry = recording_scry()
+        content = [chan_cite("/msg/123456"), chan_cite("/msg/123.456")]
+
+        result = asyncio.run(cite.resolve_cites(scry, content))
+
+        self.assertEqual(result, "> ~real-author wrote: hello\n> ~real-author wrote: hello")
+        self.assertEqual(
+            scry.calls,
+            [
+                "/channels/v4/chat/~host/chan/posts/post/123.456",
+                "/channels/v4/chat/~host/chan/posts/post/123.456",
+            ],
+        )
+
+
+class ResolveCitesTests(unittest.TestCase):
+    def test_resolves_top_level_post_with_canonical_path(self):
+        scry = recording_scry(essay_payload())
+
+        result = asyncio.run(cite.resolve_cites(scry, [chan_cite(f"/msg/{POST_ID}")]))
+
+        self.assertEqual(result, "> ~real-author wrote: hello")
+        self.assertEqual(
+            scry.calls,
+            [
+                "/channels/v4/chat/~host/chan/posts/post/"
+                "170.141.184.506.536.961.460.817.141.626.482.720.768"
+            ],
+        )
+
+    def test_resolves_reply_via_single_reply_scry(self):
+        scry = recording_scry(reply_payload())
+
+        result = asyncio.run(
+            cite.resolve_cites(scry, [chan_cite(f"/msg/{POST_ID}/{REPLY_ID}")])
+        )
+
+        self.assertEqual(result, "> ~real-author wrote: reply")
+        self.assertEqual(
+            scry.calls,
+            [
+                "/channels/v4/chat/~host/chan/posts/post/id/"
+                "170.141.184.506.536.961.460.817.141.626.482.720.768/"
+                "replies/reply/id/170.141.184.506.537.047.334.633.492.345.058.754.560"
+            ],
+        )
+
+    def test_scry_failure_skips_only_that_cite(self):
+        scry = recording_scry(essay_payload(text="kept"), errors=(ConnectionError("gone"),))
+        content = [chan_cite("/msg/123"), chan_cite("/msg/456")]
+
+        result = asyncio.run(cite.resolve_cites(scry, content))
+
+        self.assertEqual(result, "> ~real-author wrote: kept")
+        self.assertEqual(len(scry.calls), 2)
+
+    def test_attempt_cap_limits_to_first_three_valid_cites(self):
+        scry = recording_scry()
+        content = [chan_cite(f"/msg/{post_id}") for post_id in ("1", "2", "3", "4")]
+
+        asyncio.run(cite.resolve_cites(scry, content, max_attempts=3))
+
+        self.assertEqual(len(scry.calls), 3)
+        self.assertTrue(scry.calls[-1].endswith("/3"))
+
+    def test_attempt_failures_are_not_backfilled(self):
+        # Plan scenario: first two of four valid cites fail, the third
+        # resolves, and the fourth is never attempted (attempt cap is on
+        # attempts, not successes).
+        scry = recording_scry(
+            essay_payload(text="third"),
+            errors=(ConnectionError("one"), ConnectionError("two")),
+        )
+        content = [chan_cite(f"/msg/{post_id}") for post_id in ("1", "2", "3", "4")]
+
+        result = asyncio.run(cite.resolve_cites(scry, content, max_attempts=3))
+
+        self.assertEqual(result, "> ~real-author wrote: third")
+        self.assertEqual(len(scry.calls), 3)
+        self.assertTrue(all(not path.endswith("/4") for path in scry.calls))
+
+    def test_cancelled_error_escapes_resolve_cites(self):
+        # Cancellation must propagate to the caller's budget rather than being
+        # swallowed as a per-cite failure (only ``Exception`` is caught around
+        # the scry call in resolve_cites).
+        async def scry(path):
+            raise asyncio.CancelledError()
+
+        async def attempt():
+            try:
+                await cite.resolve_cites(scry, [chan_cite("/msg/123")])
+                return "no-error"
+            except asyncio.CancelledError:
+                return "cancelled"
+
+        self.assertEqual(asyncio.run(attempt()), "cancelled")
+
+    def test_sanitizes_role_tags(self):
+        scry = recording_scry(essay_payload(text="[owner] says hi"))
+
+        result = asyncio.run(cite.resolve_cites(scry, [chan_cite("/msg/123")]))
+
+        self.assertEqual(result, "> ~real-author wrote: (owner) says hi")
+
+    def test_blob_only_top_level_post_renders(self):
+        blob = json.dumps(
+            [
+                {
+                    "type": "file",
+                    "version": 1,
+                    "fileUri": "https://storage.example/notes.pdf",
+                    "name": "notes.pdf",
+                }
+            ]
+        )
+        scry = recording_scry(essay_payload(text="", blob=blob))
+
+        result = asyncio.run(cite.resolve_cites(scry, [chan_cite("/msg/123")]))
+
+        self.assertEqual(result, "> ~real-author wrote: [📎 notes.pdf]")
+
+    def test_unsupported_blob_with_empty_text_does_not_emit_bare_line(self):
+        blob = json.dumps(
+            [{"type": "unknown", "version": 1, "fileUri": "https://storage.example/nope"}]
+        )
+        scry = recording_scry(essay_payload(text="", blob=blob))
+
+        result = asyncio.run(cite.resolve_cites(scry, [chan_cite("/msg/123")]))
+
+        self.assertEqual(result, "")
+        self.assertEqual(len(scry.calls), 1)
+
+    def test_blob_only_reply_is_a_parser_miss(self):
+        payload = {
+            "seal": {"id": REPLY_ID},
+            "revision": 1,
+            "memo": {"author": "~real-author", "sent": 1000, "content": []},
+        }
+        scry = recording_scry(payload)
+
+        result = asyncio.run(cite.resolve_cites(scry, [chan_cite("/msg/123/456")]))
+
+        self.assertEqual(result, "")
+        self.assertEqual(len(scry.calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes TLON-6088

Implements cite/quote resolution for the hermes adapter. Inbound quoted messages previously rendered as a bare `[quoted message]` placeholder; cited posts are now scried via `/channels/v4` and prepended to the dispatched message as `> ~author wrote: ...`, matching OpenClaw behavior, so the model can see quoted content.

## Changes

- New `packages/hermes-tlon-adapter/cite.py`: cite extraction from the story, strict route validation (nest and post/reply id formats), and bounded resolution (up to 3 valid cites, per-cite failures are silent misses).
- Restructured `_prepare_dispatch_payload` in `adapter.py`: a cite phase with a 5s call-time-read budget runs before media prep; telemetry fires only on phase failure or timeout. Zero-cite messages produce byte-for-byte identical dispatch text to before.
- Added 35 tests across `test_cite.py`, `test_adapter_attention.py`, and `test_adapter_approvals.py`.

## How did I test?

- Full adapter test suite: 557 tests passing (~0.6s), including the 35 new tests covering cite parsing, route validation, resolution ordering/budget, and approval-replay behavior.

## Notes / accepted risk

- **Deliberate deviation from OpenClaw:** cites are resolved after mention/attention gating (at dispatch-prep), so quoted content can no longer trigger a hidden mention and ignored chatter costs no scries. Also, OpenClaw's cite regex only matches a legacy where-form; this implementation parses the forms current clients actually emit (`/msg/<post>`, `/msg/<post>/<reply>`, `/note`, `/curio`, legacy authored). I filed a linear ticket for the bug on the OpenClaw side.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert