### PR TITLE
hermes: inbound + outbound reactions

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -95,6 +95,7 @@ TLON_OWNER_LISTEN=true
 TLON_OWNER_LISTEN_DISABLED_CHANNELS=
 TLON_OWNER_LISTEN_ENABLED_CHANNELS=
 TLON_CONTEXT_MESSAGES=20
+TLON_REACTION_LEVEL=minimal # off, ack, minimal, or extensive
 TLON_KNOWN_BOT_USERS=~other-bot
 TLON_MAX_CONSECUTIVE_BOT_RESPONSES=3
 TLON_CLI=tlon
@@ -206,7 +207,7 @@ The `autoAcceptDmInvites` gate follows OpenClaw exactly: only the **owner's** in
 The seven keys above are the full "dashboard edit works" set. Everything else Tlon-related is either process env with no settings-store counterpart, or process env that only _seeds_ a settings key's default:
 
 -   **Env that seeds a settings default (edit the settings key to override it at runtime, not just the env):** `TLON_AUTO_DISCOVER` → `autoDiscoverChannels`; `TLON_GROUP_INVITE_ALLOWLIST` → `groupInviteAllowlist`; `TLON_OWNER_LISTEN`/`TLON_OWNER_LISTEN_DEFAULT`/`TLON_OWNER_LISTEN_DISABLED_CHANNELS`/`TLON_OWNER_LISTEN_ENABLED_CHANNELS` → the `ownerListen*` keys; `TLON_CHANNELS` → `groupChannels` (with a limit: a `groupChannels` edit can add or remove settings-managed channels, but can **never remove** a channel that came from `TLON_CHANNELS` — those stay monitored for the life of the process).
--   **Env-only, dashboard-invisible (no settings-store counterpart at all — a dashboard edit here genuinely does nothing):** notably `TLON_FREE_RESPONSE_CHANNELS` (unmentioned-message dispatch in named channels has no settings key on either harness), plus `TLON_ALLOWED_USERS`, `TLON_ALLOW_ALL_USERS`, `TLON_DM_ALLOWLIST` (the env var — distinct from the `dmAllowlist` settings key above), `TLON_REQUIRE_MENTION`, `TLON_BOT_MENTIONS`, `TLON_KNOWN_BOT_USERS`, `TLON_MAX_CONSECUTIVE_BOT_RESPONSES`, `TLON_HOME_CHANNEL`, `TLON_CONTEXT_MESSAGES`, `TLON_REPLY_IN_THREAD`, `TLON_CLI`/`TLON_CLI_TIMEOUT`, `TLON_HOSTING`, `TLON_SKILL_PATH`, `TLON_SSE_READ_TIMEOUT_SECONDS`, `BRAVE_SEARCH_API_KEY`/`BRAVE_API_KEY`, the `TLON_TELEMETRY*` vars, the `TLON_GATEWAY_STATUS*` vars, and the connection credentials (`TLON_NODE_URL`, `TLON_NODE_ID`, `TLON_OWNER_SHIP`, and the `TLON_ACCESS_CODE`/`TLON_COOKIE` auth pair — one of the two is required, not both; each also accepts the older
+-   **Env-only, dashboard-invisible (no settings-store counterpart at all — a dashboard edit here genuinely does nothing):** notably `TLON_FREE_RESPONSE_CHANNELS` (unmentioned-message dispatch in named channels has no settings key on either harness), plus `TLON_ALLOWED_USERS`, `TLON_ALLOW_ALL_USERS`, `TLON_DM_ALLOWLIST` (the env var — distinct from the `dmAllowlist` settings key above), `TLON_REQUIRE_MENTION`, `TLON_BOT_MENTIONS`, `TLON_KNOWN_BOT_USERS`, `TLON_MAX_CONSECUTIVE_BOT_RESPONSES`, `TLON_HOME_CHANNEL`, `TLON_CONTEXT_MESSAGES`, `TLON_REACTION_LEVEL`, `TLON_REPLY_IN_THREAD`, `TLON_CLI`/`TLON_CLI_TIMEOUT`, `TLON_HOSTING`, `TLON_SKILL_PATH`, `TLON_SSE_READ_TIMEOUT_SECONDS`, `BRAVE_SEARCH_API_KEY`/`BRAVE_API_KEY`, the `TLON_TELEMETRY*` vars, the `TLON_GATEWAY_STATUS*` vars, and the connection credentials (`TLON_NODE_URL`, `TLON_NODE_ID`, `TLON_OWNER_SHIP`, and the `TLON_ACCESS_CODE`/`TLON_COOKIE` auth pair — one of the two is required, not both; each also accepts the older
     `TLON_SHIP_*`/`TLON_URL`/`TLON_SHIP`/`TLON_CODE`/`URBIT_*` aliases listed under [Configuration](#configuration)).
 
 ## Debug commands
@@ -269,6 +270,16 @@ When a deployment shows nothing in PostHog, work through the built-in diagnostic
 4. **`TLON_TELEMETRY_DEBUG=true`** — logs every capture/identify enqueue at info level plus the posthog SDK's internal debug output, and elevates repeated delivery failures from debug to warning.
 
 Delivery failures are also surfaced without debug mode: the adapter hooks the SDK's `on_error` callback and warns on the first failed batch (`[tlon] telemetry delivery to PostHog failed …`).
+
+## Reactions
+
+`TLON_REACTION_LEVEL` controls the model-facing reaction affordance. It defaults to `minimal`; `extensive` encourages more frequent natural reactions; `off` and `ack` both hide reaction hints and block `react`/`unreact` (the `ack` tier is retained as a reserved no-op for OpenClaw parity). At `minimal`/`extensive`, dispatched messages expose real wire ids in `[message id: …]` and `[thread root: …]` markers, and recent group context lines include their ids. The model uses `tlon posts react <nest> <post-id> <emoji>` for channels and `tlon dms react <ship> <author/id> <emoji>` for one-to-one DMs; reacting to a thread reply adds `--parent <thread-root-id>` (the DM parent must include its author).
+
+Inbound channel reaction snapshots and DM reaction deltas are deduplicated in bounded in-memory state. An authorized reaction added to one of the bot's own posts wakes the model with the emoji and a cached/scry-fetched content snippet; channel targets that predate the gateway are classified by exact top-level or reply scries. A reaction on another post, and every removal, becomes a bounded passive note that is injected into the next authorized dispatch in that conversation without waking the model. Unauthorized reactions are dropped and never queue approvals. DM removals seen without a prior local add surface once through a tombstone, then deduplicate.
+
+The cache and reaction state are intentionally process-local. After restart or bounded-state eviction, the first channel snapshot for a post can replay its current entries once. This is bounded best-effort observability rather than durable reaction history. The legacy emoji approval path is deliberately not implemented: current A2UI approval cards and `/allow`, `/reject`, and `/ban` replace it.
+
+The `tlon` tool remains owner-only except that non-owner Tlon sessions may use `posts react|unreact` in their current channel or `dms react|unreact` in their current one-to-one DM, when reactions are enabled. They cannot target another conversation, mix the command family, or pass account/credential override flags.
 
 ## Reply Placement
 

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -692,6 +692,24 @@ class ReactionState:
         entries.update(current)
         return transitions
 
+    def forget_entry(
+        self, chat_type: str, chat_id: str, post_id: str, wire_key: str
+    ) -> None:
+        """Drop one committed entry so a later snapshot re-emits it as an add.
+
+        Snapshots commit before their transitions are handled, so when an
+        added reaction's target classification is unresolved (exact scry
+        failure), the entry must be forgotten — otherwise a redelivered or
+        later diff treats it as already-seen and a reaction on the bot's own
+        post is permanently misfiled as a passive note.
+        """
+        posts = self._conversations.get(self._conversation_key(chat_type, chat_id))
+        if not posts:
+            return
+        entries = posts.get(str(post_id))
+        if entries:
+            entries.pop(wire_key, None)
+
     def apply_dm_delta(self, reaction: TlonReaction) -> list[TlonReaction]:
         entries = self._post_entries("dm", reaction.chat_id, reaction.post_id)
         if reaction.added:
@@ -2133,6 +2151,23 @@ class TlonAdapter(BasePlatformAdapter):
                 dispatch_reason="reaction",
             )
             return
+
+        # An unresolved channel classification (scry failed, or the payload
+        # had no decodable author) must stay retryable: the snapshot already
+        # committed this entry, so without forgetting it a later reacts diff
+        # on the post is a no-op and an own-post reaction would be lost as a
+        # passive note forever. Forgetting the entry makes the next diff
+        # re-emit the add and retry exact classification once the scry
+        # recovers. Resolved non-own targets are final — no rollback.
+        if reaction.added and not is_dm:
+            author = str(getattr(target, "author", "") or "")
+            if target is None or not author or author == "unknown":
+                self._reaction_state.forget_entry(
+                    reaction.chat_type,
+                    reaction.chat_id,
+                    reaction.post_id,
+                    reaction.wire_key,
+                )
 
         self._queue_reaction_note(reaction, target)
 

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -15,7 +15,9 @@ import os
 import re
 import shutil
 import time
+import unicodedata
 import uuid
+from collections import OrderedDict, deque
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -72,9 +74,12 @@ from .channel_access import (
     parse_channel_rules,
 )
 from .history import (
+    MessageCache,
     build_channel_context,
     build_thread_context,
     fetch_channel_history,
+    fetch_post,
+    fetch_reply,
     fetch_thread_context,
 )
 from .media import PreparedMedia, prepare_inbound_media, render_content_with_blob
@@ -142,10 +147,14 @@ from .tlon_api import (
     TlonConfig,
     TlonGatewayStatus,
     TlonIncomingMessage,
+    TlonReaction,
     TlonSSEClient,
+    ChannelReactsSnapshot,
     format_post_id,
     normalize_ship,
+    parse_channel_reacts_snapshot,
     parse_channel_message,
+    parse_dm_reaction,
     parse_dm_message,
 )
 from .presence import (
@@ -157,11 +166,13 @@ from .presence import (
     set_active_computing_presence_tracker,
 )
 from .tlon_tool import (
+    CREDENTIAL_FLAGS_WITH_VALUE,
     TLON_TOOL_DESCRIPTION,
     TLON_TOOL_SCHEMA,
     check_tlon_tool_requirements,
     handle_tlon_tool,
     resolve_tlon_skill_path,
+    split_tlon_command,
 )
 
 logger = logging.getLogger(__name__)
@@ -203,6 +214,7 @@ OPTIONAL_ENV = [
     "TLON_OWNER_LISTEN_DISABLED_CHANNELS",
     "TLON_OWNER_LISTEN_ENABLED_CHANNELS",
     "TLON_CONTEXT_MESSAGES",
+    "TLON_REACTION_LEVEL",
     "TLON_TELEMETRY",
     "TLON_TELEMETRY_API_KEY",
     "TLON_TELEMETRY_HOST",
@@ -226,7 +238,9 @@ except ImportError:
 
 def _is_dm_chat_id(chat_id: str) -> bool:
     chat = str(chat_id or "").strip()
-    return bool(chat.startswith("~") and normalize_ship(chat) == chat)
+    return bool(
+        chat.startswith("~") and "/" not in chat and normalize_ship(chat) == chat
+    )
 
 
 # `/tlon ...` debug namespace. Does not match `/tlon-version` (legacy alias)
@@ -502,6 +516,7 @@ def _processing_outcome_value(outcome: Any) -> Optional[str]:
 # ContextLensTrigger union the client renders (context-lens.ts).
 _LENS_TRIGGER_MAP = {
     "dm": "dm",
+    "reaction": "reaction",
     "mention": "mention",
     "owner-listen": "owner-listen",
     "participated-thread": "thread",
@@ -578,6 +593,125 @@ def is_connected(config) -> bool:
     return TlonConfig.from_env(extra).is_complete()
 
 
+def _reaction_state_value(emoji: str) -> str:
+    """Bound comparison value for a wire react, preserving ordinary emojis."""
+    value = str(emoji)
+    if len(value) <= 256:
+        return value
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _reaction_wire_metadata(wire_key: str) -> tuple[str, bool]:
+    """Recover actor metadata from the stable state key for removal events."""
+    if "/" in wire_key:
+        return normalize_ship(wire_key.split("/", 1)[0]), True
+    return normalize_ship(wire_key), False
+
+
+class ReactionState:
+    """Bounded reaction state that turns snapshots/deltas into transitions."""
+
+    def __init__(self, *, posts_per_conversation: int = 200, conversations: int = 64) -> None:
+        self.posts_per_conversation = posts_per_conversation
+        self.conversations = conversations
+        # Values are exact short reacts / digests. None is a DM removal tombstone.
+        self._conversations: OrderedDict[
+            str, OrderedDict[str, dict[str, Optional[str]]]
+        ] = OrderedDict()
+
+    @staticmethod
+    def _conversation_key(chat_type: str, chat_id: str) -> str:
+        return f"{chat_type}:{chat_id}"
+
+    def _post_entries(self, chat_type: str, chat_id: str, post_id: str) -> dict[str, Optional[str]]:
+        key = self._conversation_key(chat_type, chat_id)
+        posts = self._conversations.get(key)
+        if posts is None:
+            posts = OrderedDict()
+            self._conversations[key] = posts
+        self._conversations.move_to_end(key)
+        entries = posts.get(str(post_id))
+        if entries is None:
+            entries = {}
+            posts[str(post_id)] = entries
+        posts.move_to_end(str(post_id))
+        while len(posts) > self.posts_per_conversation:
+            posts.popitem(last=False)
+        while len(self._conversations) > self.conversations:
+            self._conversations.popitem(last=False)
+        return entries
+
+    def apply_channel_snapshot(self, snapshot: ChannelReactsSnapshot) -> list[TlonReaction]:
+        prior = dict(self._post_entries("group", snapshot.chat_id, snapshot.post_id))
+        current = {
+            key: _reaction_state_value(emoji)
+            for key, (emoji, _reactor, _is_bot) in snapshot.entries.items()
+        }
+        transitions: list[TlonReaction] = []
+
+        # A changed map value is a removal followed by a new add, preserving
+        # the state-machine edge instead of treating snapshots as event deltas.
+        for wire_key, prior_emoji in prior.items():
+            if current.get(wire_key) == prior_emoji:
+                continue
+            reactor, reactor_is_bot = _reaction_wire_metadata(wire_key)
+            transitions.append(
+                TlonReaction(
+                    chat_type="group",
+                    chat_id=snapshot.chat_id,
+                    post_id=snapshot.post_id,
+                    parent_id=snapshot.parent_id,
+                    wire_key=wire_key,
+                    reactor=reactor,
+                    reactor_is_bot=reactor_is_bot,
+                    emoji=prior_emoji or "",
+                    added=False,
+                    raw=snapshot.raw,
+                )
+            )
+        for wire_key, (emoji, reactor, reactor_is_bot) in snapshot.entries.items():
+            if prior.get(wire_key) == current[wire_key]:
+                continue
+            transitions.append(
+                TlonReaction(
+                    chat_type="group",
+                    chat_id=snapshot.chat_id,
+                    post_id=snapshot.post_id,
+                    parent_id=snapshot.parent_id,
+                    wire_key=wire_key,
+                    reactor=reactor,
+                    reactor_is_bot=reactor_is_bot,
+                    emoji=emoji,
+                    added=True,
+                    raw=snapshot.raw,
+                )
+            )
+
+        entries = self._post_entries("group", snapshot.chat_id, snapshot.post_id)
+        entries.clear()
+        entries.update(current)
+        return transitions
+
+    def apply_dm_delta(self, reaction: TlonReaction) -> list[TlonReaction]:
+        entries = self._post_entries("dm", reaction.chat_id, reaction.post_id)
+        if reaction.added:
+            value = _reaction_state_value(reaction.emoji)
+            if reaction.wire_key in entries and entries[reaction.wire_key] == value:
+                return []
+            entries[reaction.wire_key] = value
+            return [reaction]
+
+        # An absent remove is real first-observed history, while a None entry
+        # is a tombstone proving this exact delta was already surfaced.
+        if reaction.wire_key in entries and entries[reaction.wire_key] is None:
+            return []
+        entries[reaction.wire_key] = None
+        return [reaction]
+
+    def clear(self) -> None:
+        self._conversations.clear()
+
+
 class TlonAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
 
@@ -623,6 +757,17 @@ class TlonAdapter(BasePlatformAdapter):
         )
         self._seen_ids: set[str] = set()
         self._seen_order: list[str] = []
+        self._reaction_state = ReactionState()
+        self._message_cache = MessageCache()
+        self._pending_reaction_notes: OrderedDict[str, deque[str]] = OrderedDict()
+        # Maps a top-level own-post reaction's synthetic `react/…` dispatch
+        # id to the real reactable post it was about, so send()'s
+        # reply_in_thread fallback (which otherwise threads on the trigger
+        # id) can thread on the actual wire post instead of the synthetic,
+        # nonexistent one. Retained until the bounded cache evicts it or the
+        # adapter disconnects, so retries and additional sends stay anchored
+        # to the real post.
+        self._reaction_reply_targets: OrderedDict[str, str] = OrderedDict()
         self._monitored_channels = set(self.tlon_config.channels)
         self._mention_matcher = self._build_mention_matcher()
         self._bot_nickname: str = ""
@@ -759,6 +904,10 @@ class TlonAdapter(BasePlatformAdapter):
         self._known_bot_ships.clear()
         self._known_bot_consecutive_by_channel.clear()
         self._pending_bot_cap_addendum.clear()
+        self._reaction_state.clear()
+        self._message_cache.clear()
+        self._pending_reaction_notes.clear()
+        self._reaction_reply_targets.clear()
         self._processed_dm_invites.clear()
         self._processed_group_invites.clear()
         self._telemetry.flush()
@@ -1832,6 +1981,191 @@ class TlonAdapter(BasePlatformAdapter):
             logger.exception("[tlon] %s event handler failed", event.app)
             self._telemetry.error("event_handler", exc, app=event.app)
 
+    @staticmethod
+    def _reaction_conversation_key(chat_type: str, chat_id: str) -> str:
+        return f"{chat_type}:{chat_id}"
+
+    @staticmethod
+    def _collapse_reaction_text(value: Any, limit: int, *, structural: bool = False) -> str:
+        # Every Unicode Cc control (C0 *and* C1, e.g. U+009B) collapses to a
+        # space; format/mark characters like ZWJ (Cf) and emoji variation
+        # selectors (Mn) are untouched, so multi-codepoint emoji survive.
+        raw = str(value or "")
+        text = "".join(
+            " " if unicodedata.category(ch) == "Cc" else ch for ch in raw
+        )
+        text = " ".join(text.split())
+        if structural:
+            text = text.replace("[", "(").replace("]", ")")
+        return text[:limit]
+
+    def _encode_reaction_note(self, reaction: TlonReaction, target: Any) -> str:
+        action = "added" if reaction.added else "removed"
+        emoji = self._collapse_reaction_text(reaction.emoji, 32, structural=True)
+        reactor = self._collapse_reaction_text(reaction.reactor, 80, structural=True)
+        post_id = self._collapse_reaction_text(reaction.post_id, 80, structural=True)
+        author = self._collapse_reaction_text(
+            getattr(target, "author", "unknown"), 80, structural=True
+        )
+        snippet = self._collapse_reaction_text(
+            getattr(target, "content", ""), 200, structural=True
+        )
+        kind = "DM " if reaction.chat_type == "dm" else ""
+        note = (
+            f"Tlon {kind}reaction {action}: {emoji or '(unknown)'} by {reactor} "
+            f"on message {post_id} (by {author})"
+        )
+        if snippet:
+            note += f' (message: "{snippet}")'
+        return note[:300]
+
+    def _queue_reaction_note(self, reaction: TlonReaction, target: Any) -> None:
+        key = self._reaction_conversation_key(reaction.chat_type, reaction.chat_id)
+        notes = self._pending_reaction_notes.get(key)
+        if notes is None:
+            notes = deque(maxlen=10)
+            self._pending_reaction_notes[key] = notes
+        self._pending_reaction_notes.move_to_end(key)
+        notes.append(self._encode_reaction_note(reaction, target))
+        while len(self._pending_reaction_notes) > 64:
+            self._pending_reaction_notes.popitem(last=False)
+
+    async def _lookup_reaction_target(
+        self, reaction: TlonReaction, snapshot_cache: Optional[dict] = None
+    ) -> Any:
+        # `snapshot_cache` — when supplied by the caller — memoizes the
+        # lookup (including a failed/None result) for the lifetime of one
+        # SSE event's transitions, so a snapshot with several authorized
+        # entries for the same post makes at most one exact scry instead of
+        # one per transition (a failing scry has a 30s timeout, and the SSE
+        # reader processes events serially). It is never persisted beyond
+        # that one call, so a later event still retries a prior failure.
+        cache_key = (reaction.chat_type, reaction.chat_id, reaction.post_id)
+        if snapshot_cache is not None and cache_key in snapshot_cache:
+            return snapshot_cache[cache_key]
+
+        cached = self._message_cache.lookup(reaction.chat_id, reaction.post_id)
+        if cached is not None or reaction.chat_type != "group" or self._sse is None:
+            if snapshot_cache is not None:
+                snapshot_cache[cache_key] = cached
+            return cached
+        if reaction.parent_id:
+            fetched = await fetch_reply(
+                self._sse.scry,
+                reaction.chat_id,
+                reaction.parent_id,
+                reaction.post_id,
+            )
+        else:
+            fetched = await fetch_post(self._sse.scry, reaction.chat_id, reaction.post_id)
+        # A failed scry, or one that can't identify the author, remains a
+        # cache miss so a later event retries exact classification; only
+        # entries with a decodable author become durable cache knowledge
+        # (an "unknown"-author entry can't classify ownership, so caching it
+        # would permanently misclassify the post — F-3).
+        if fetched is not None and fetched.author and fetched.author != "unknown":
+            self._message_cache.record(
+                reaction.chat_id, fetched.post_id or reaction.post_id, fetched.author, fetched.content
+            )
+        if snapshot_cache is not None:
+            snapshot_cache[cache_key] = fetched
+        return fetched
+
+    def _is_own_reaction_target(self, reaction: TlonReaction, target: Any) -> bool:
+        bot = normalize_ship(self.tlon_config.ship_name)
+        if reaction.chat_type == "dm":
+            author = str(reaction.post_id).split("/", 1)[0]
+            return normalize_ship(author) == bot
+        return normalize_ship(str(getattr(target, "author", ""))) == bot
+
+    async def _handle_reaction(
+        self, reaction: TlonReaction, snapshot_cache: Optional[dict] = None
+    ) -> None:
+        if reaction.reactor == normalize_ship(self.tlon_config.ship_name):
+            return
+        if reaction.reactor_is_bot:
+            self._learn_known_bot_ship(reaction.reactor)
+        is_dm = reaction.chat_type == "dm"
+        if not self._user_authorized(
+            reaction.reactor, is_dm=is_dm, nest="" if is_dm else reaction.chat_id
+        ):
+            logger.info("[tlon] ignoring unauthorized reaction from %s", reaction.reactor)
+            return
+
+        target = await self._lookup_reaction_target(reaction, snapshot_cache)
+        if self._is_own_reaction_target(reaction, target) and reaction.added:
+            emoji = self._collapse_reaction_text(reaction.emoji, 32)
+            snippet = self._collapse_reaction_text(
+                getattr(target, "content", ""), 200
+            )
+            text = f'{emoji} (reacting to: "{snippet}")' if snippet else emoji
+            message = TlonIncomingMessage(
+                chat_id=reaction.chat_id,
+                chat_name=reaction.chat_id,
+                chat_type=reaction.chat_type,
+                user_id=reaction.reactor,
+                user_name=reaction.reactor,
+                text=text,
+                message_id=(
+                    # Event identity only (decision 10) — never shown to the
+                    # model or resolved on the wire. The react component is
+                    # arbitrary `@t`, so it is bounded the same way
+                    # `_reaction_state_value` bounds reaction state (digest
+                    # over 256 chars), keeping this id (which flows into
+                    # LensRun.message_id and presence run ids) from growing
+                    # unbounded while staying deterministic.
+                    f"react/{reaction.post_id}/{reaction.reactor}/"
+                    f"{_reaction_state_value(reaction.emoji)}"
+                ),
+                reply_to_message_id=reaction.parent_id,
+                sent_at=datetime.now(tz=timezone.utc),
+                raw=reaction.raw,
+                author_is_bot=reaction.reactor_is_bot,
+                author_id=reaction.reactor,
+                reactable_target_id=reaction.post_id,
+            )
+            if not is_dm and not self._passes_group_loop_safety(message):
+                return
+            await self._dispatch_message(
+                message,
+                is_dm=is_dm,
+                mark_seen=False,
+                dispatch_reason="reaction",
+            )
+            return
+
+        self._queue_reaction_note(reaction, target)
+
+    async def _dispatch_reaction_transitions(self, transitions: list) -> None:
+        """Handle every transition from one snapshot/delta event.
+
+        Transitions for one event (all naming the same post) share a single
+        target lookup (I1) instead of one exact scry per transition, and a
+        failure handling one transition is logged and does not stop the
+        remaining transitions of the same, already-committed snapshot from
+        being handled (I2) — the SSE reader only ever sees this one event as
+        having succeeded, so a raise here would otherwise lose the rest of
+        the snapshot permanently (redelivery is a no-op diff once state is
+        committed).
+        """
+        if not transitions:
+            return
+        snapshot_cache: dict = {}
+        for reaction in transitions:
+            try:
+                await self._handle_reaction(reaction, snapshot_cache)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.exception(
+                    "[tlon] reaction handler failed for %s in %s",
+                    reaction.post_id,
+                    reaction.chat_id,
+                )
+                self._telemetry.error(
+                    "reaction_handler", exc, chat_type=reaction.chat_type
+                )
+
     async def _handle_channel_event(self, raw: Any) -> None:
         if not isinstance(raw, dict):
             return
@@ -1845,8 +2179,23 @@ class TlonAdapter(BasePlatformAdapter):
             else:
                 return
 
-        message = parse_channel_message(raw, self_ship=self.tlon_config.ship_name)
+        message = parse_channel_message(
+            raw, self_ship=self.tlon_config.ship_name, include_self=True
+        )
         if message is None:
+            snapshot = parse_channel_reacts_snapshot(raw)
+            if snapshot is not None:
+                await self._dispatch_reaction_transitions(
+                    self._reaction_state.apply_channel_snapshot(snapshot)
+                )
+            return
+        self._message_cache.record(
+            message.chat_id,
+            message.message_id,
+            message.author_id or message.user_id,
+            message.text,
+        )
+        if message.author_id == normalize_ship(self.tlon_config.ship_name):
             return
         if message.author_is_bot:
             self._learn_known_bot_ship(message.user_id)
@@ -1914,8 +2263,23 @@ class TlonAdapter(BasePlatformAdapter):
         if isinstance(raw, list):
             await self._handle_dm_invites(raw)
             return
-        message = parse_dm_message(raw, self_ship=self.tlon_config.ship_name)
+        message = parse_dm_message(
+            raw, self_ship=self.tlon_config.ship_name, include_self=True
+        )
         if message is None:
+            reaction = parse_dm_reaction(raw, self_ship=self.tlon_config.ship_name)
+            if reaction is not None:
+                await self._dispatch_reaction_transitions(
+                    self._reaction_state.apply_dm_delta(reaction)
+                )
+            return
+        self._message_cache.record(
+            message.chat_id,
+            message.message_id,
+            message.author_id or message.user_id,
+            message.text,
+        )
+        if message.author_id == normalize_ship(self.tlon_config.ship_name):
             return
         if await self._maybe_handle_control_command(
             message, message.text.strip(), ctx_nest=None
@@ -2170,6 +2534,8 @@ class TlonAdapter(BasePlatformAdapter):
                     current_text=clean_text,
                     current_id=message.message_id,
                     limit=limit,
+                    include_ids=self.tlon_config.reaction_level
+                    in {"minimal", "extensive"},
                 )
             else:
                 entries = await fetch_channel_history(scry, message.chat_id, limit)
@@ -2179,6 +2545,8 @@ class TlonAdapter(BasePlatformAdapter):
                     current_id=message.message_id,
                     is_mention=reason == "mention",
                     limit=limit,
+                    include_ids=self.tlon_config.reaction_level
+                    in {"minimal", "extensive"},
                 )
         except Exception as exc:
             logger.debug("[tlon] context fetch failed for %s: %s", message.chat_id, exc)
@@ -2249,6 +2617,42 @@ class TlonAdapter(BasePlatformAdapter):
         if mark_seen and not self._mark_seen(message):
             return
 
+        if (
+            dispatch_reason == "reaction"
+            and message.reactable_target_id
+            and not message.reply_to_message_id
+        ):
+            # Top-level own-post reaction: there is no thread root, so
+            # source.thread_id will be None and send()'s reply_in_thread
+            # fallback would otherwise thread on message.message_id — the
+            # synthetic `react/…` event id, not a real wire post (I3).
+            # Record the real reactable target so send() can recover it.
+            self._reaction_reply_targets[message.message_id] = message.reactable_target_id
+            self._reaction_reply_targets.move_to_end(message.message_id)
+            while len(self._reaction_reply_targets) > 200:
+                self._reaction_reply_targets.popitem(last=False)
+
+        notes_key = self._reaction_conversation_key(message.chat_type, message.chat_id)
+        pending_notes = tuple(self._pending_reaction_notes.get(notes_key, ()))
+        dispatch_text = message.text
+        if pending_notes:
+            dispatch_text = (
+                "[Recent reactions in this conversation]\n"
+                + "\n".join(pending_notes)
+                + "\n\n"
+                + dispatch_text
+            )
+        if self.tlon_config.reaction_level in {"minimal", "extensive"}:
+            target_id = message.reactable_target_id or message.message_id
+            marker = (
+                "reacted message id"
+                if message.reactable_target_id
+                else "message id"
+            )
+            dispatch_text += f"\n\n[{marker}: {target_id}]"
+            if message.reply_to_message_id:
+                dispatch_text += f"\n[thread root: {message.reply_to_message_id}]"
+
         self._telemetry.start_reply(
             message.chat_id,
             chat_type="dm" if is_dm else "groupChannel",
@@ -2272,7 +2676,7 @@ class TlonAdapter(BasePlatformAdapter):
             )
             prepared = prepared_media or PreparedMedia()
             event_kwargs = {
-                "text": message.text,
+                "text": dispatch_text,
                 "message_type": _message_type_member(prepared.message_type),
                 "source": source,
                 "raw_message": message.raw,
@@ -2293,6 +2697,18 @@ class TlonAdapter(BasePlatformAdapter):
                 setattr(event, "media_urls", media_urls)
                 setattr(event, "media_types", media_types)
             await self.handle_message(event)
+            # Peeked notes are committed only after core accepted the event;
+            # failed/duplicate/unauthorized dispatches leave them untouched.
+            if pending_notes:
+                notes = self._pending_reaction_notes.get(notes_key)
+                if notes is not None:
+                    for note in pending_notes:
+                        if notes and notes[0] == note:
+                            notes.popleft()
+                        else:
+                            break
+                    if not notes:
+                        self._pending_reaction_notes.pop(notes_key, None)
         except Exception:
             # Dispatch raised before on_processing_complete could finalize the
             # run (e.g. _route_stream_event catches and skips handle_message
@@ -2431,7 +2847,17 @@ class TlonAdapter(BasePlatformAdapter):
         # reply_in_thread=true restores always-thread-on-the-trigger.
         thread_parent = str(metadata.get("thread_id") or "") or None
         if thread_parent is None and self.tlon_config.reply_in_thread:
-            thread_parent = reply_to
+            # A top-level own-post reaction's `reply_to` is core's generic
+            # trigger anchor, i.e. the synthetic `react/<post>/<reactor>/
+            # <emoji>` event id — never a real wire post. Recover the actual
+            # reacted post recorded by _dispatch_message (I3) so the fallback
+            # threads onto something that exists; anything else (an ordinary
+            # message's own id) has no entry here and falls through as-is.
+            thread_parent = (
+                self._reaction_reply_targets.get(reply_to)
+                if reply_to
+                else None
+            ) or reply_to
         is_thread_reply = bool(thread_parent)
         # Stamp the reply with a pointer to its lens run so the client can open
         # the run from the message (badge / message actions), matching
@@ -2445,10 +2871,13 @@ class TlonAdapter(BasePlatformAdapter):
         sent_at_ms = int(time.time() * 1000) if lens_blob is not None else None
         with cli_context("delivery", conversation=chat_id):
             if is_thread_reply:
-                # parentAuthor: honor what Hermes passes; otherwise the CLI
-                # attributes the reference to the bot. (We don't assume a DM
-                # partner authored the thread root.)
+                # parentAuthor: honor what Hermes passes. For one-to-one DMs
+                # the writ id itself is author-prefixed, so use that exact
+                # prefix when core did not supply metadata (not the partner
+                # default the CLI would otherwise assume).
                 parent_author = metadata.get("parent_author") or None
+                if not parent_author and _is_dm_chat_id(chat_id) and "/" in thread_parent:
+                    parent_author = normalize_ship(thread_parent.split("/", 1)[0])
                 result = await self._cli.send_reply(
                     chat_id,
                     thread_parent,
@@ -2545,6 +2974,8 @@ def _env_enablement() -> dict | None:
         seed["owner_listen_enabled_channels"] = ",".join(tlon.owner_listen_enabled_channels)
     if tlon.context_messages != DEFAULT_CONTEXT_MESSAGES:
         seed["context_messages"] = tlon.context_messages
+    if tlon.reaction_level != "minimal":
+        seed["reaction_level"] = tlon.reaction_level
     if tlon.telemetry_enabled:
         seed["telemetry"] = True
     if tlon.telemetry_api_key:
@@ -2599,13 +3030,55 @@ def _tool_access_block(message: str) -> dict:
     return {"action": "block", "message": message}
 
 
+def _non_owner_reaction_carveout(args: Optional[dict], config: TlonConfig) -> Optional[str]:
+    """Return None only for a narrowly-scoped current-chat reaction command."""
+    command = str((args or {}).get("command") or "")
+    parsed, parse_error = split_tlon_command(command)
+    if parse_error or len(parsed) < 3:
+        return "Blocked: non-owner Tlon sessions may only react in the current conversation."
+    if any(
+        arg in CREDENTIAL_FLAGS_WITH_VALUE
+        or any(arg.startswith(f"{flag}=") for flag in CREDENTIAL_FLAGS_WITH_VALUE)
+        for arg in parsed
+    ):
+        return (
+            "Blocked: non-owner reactions cannot use credential override flags; "
+            "they must use this bot account in the current conversation."
+        )
+    # Do not use the tool parser's global-flag skipping here: the subcommand
+    # must literally be first, preventing a prefix override from authenticating
+    # the right-looking target as another account.
+    family, action = parsed[0].lower(), parsed[1].lower()
+    if family not in {"posts", "dms"} or action not in {"react", "unreact"}:
+        return "Blocked: non-owner Tlon sessions may only react in the current conversation."
+    if config.reaction_level not in {"minimal", "extensive"}:
+        return (
+            "Blocked: agent reactions are disabled "
+            f'(TLON_REACTION_LEVEL="{config.reaction_level}"). '
+            "Set TLON_REACTION_LEVEL to minimal or extensive to enable."
+        )
+    chat_id = str(_session_env("HERMES_SESSION_CHAT_ID", "")).strip()
+    if not chat_id:
+        return "Blocked: no current Tlon conversation is available for this reaction."
+    expected_family = "dms" if _is_dm_chat_id(chat_id) else "posts"
+    if family != expected_family:
+        return (
+            f"Blocked: use {expected_family} react|unreact for the current "
+            f"{'one-to-one DM' if expected_family == 'dms' else 'channel'} conversation."
+        )
+    target = str(parsed[2] or "").strip()
+    if not target or target.casefold() != chat_id.casefold():
+        return "Blocked: non-owner reactions may target only the current conversation."
+    return None
+
+
 def block_tlon_session_tool(tool_name: str, args: Optional[dict] = None, **_kwargs: Any) -> Optional[dict]:
-    del args
     if _session_env("HERMES_SESSION_PLATFORM", "").lower() != "tlon":
         return None
 
     tool = str(tool_name or "").strip()
-    owner = TlonConfig.from_env().owner_ship
+    tlon = TlonConfig.from_env()
+    owner = tlon.owner_ship
     if not owner:
         return _tool_access_block(
             "Blocked: Tlon owner identity is not configured. Set TLON_OWNER_SHIP "
@@ -2629,6 +3102,21 @@ def block_tlon_session_tool(tool_name: str, args: Optional[dict] = None, **_kwar
             "identity is available."
         )
     if sender != owner:
+        if tool == "tlon":
+            parsed, _parse_error = split_tlon_command(
+                str((args or {}).get("command") or "")
+            )
+            reaction_attempt = any(
+                parsed[index].lower() in {"posts", "dms"}
+                and index + 1 < len(parsed)
+                and parsed[index + 1].lower() in {"react", "unreact"}
+                for index in range(len(parsed))
+            )
+            if reaction_attempt:
+                reaction_block = _non_owner_reaction_carveout(args, tlon)
+                if reaction_block is None:
+                    return None
+                return _tool_access_block(reaction_block)
         return _tool_access_block(f"Blocked: {tool} is owner-only in Tlon chats.")
     return None
 
@@ -2661,6 +3149,31 @@ async def _standalone_send(
         "chat_id": chat_id,
         "message_id": result.message_id,
     }
+
+
+def _reaction_platform_hint(level: str) -> str:
+    if level == "minimal":
+        guidance = (
+            "React ONLY when truly relevant: acknowledge important requests or "
+            "confirmations, and express genuine sentiment sparingly. Avoid routine "
+            "messages and your own replies. Aim for at most one reaction per 5-10 exchanges."
+        )
+    elif level == "extensive":
+        guidance = (
+            "Feel free to react liberally when natural: acknowledge messages, express "
+            "sentiment and personality, react to interesting content or humor, and confirm "
+            "understanding or agreement."
+        )
+    else:
+        return ""
+    return (
+        f" Reactions are enabled for Tlon in {level.upper()} mode. {guidance} "
+        "Message ids and thread roots appear in […] markers. For channels use "
+        "'tlon posts react <nest> <post-id> \"<emoji>\"'; for one-to-one DMs use "
+        "'tlon dms react <ship> <message-id> \"<emoji>\"'. For a thread reply add "
+        "'--parent <thread-root-id>'; use unreact to remove your reaction. Non-owner "
+        "sessions may react only in the current conversation."
+    )
 
 
 def register(ctx) -> None:
@@ -2757,5 +3270,6 @@ def register(ctx) -> None:
             "binary — debug info). Point the owner at those commands when asked "
             "rather than changing configuration yourself. "
             "Use concise plain text and basic markdown."
+            + _reaction_platform_hint(TlonConfig.from_env().reaction_level)
         ),
     )

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -3204,8 +3204,8 @@ def _reaction_platform_hint(level: str) -> str:
     return (
         f" Reactions are enabled for Tlon in {level.upper()} mode. {guidance} "
         "Message ids and thread roots appear in […] markers. For channels use "
-        "'tlon posts react <nest> <post-id> \"<emoji>\"'; for one-to-one DMs use "
-        "'tlon dms react <ship> <message-id> \"<emoji>\"'. For a thread reply add "
+        "'posts react <nest> <post-id> \"<emoji>\"'; for one-to-one DMs use "
+        "'dms react <ship> <message-id> \"<emoji>\"'. For a thread reply add "
         "'--parent <thread-root-id>'; use unreact to remove your reaction. Non-owner "
         "sessions may react only in the current conversation."
     )

--- a/packages/hermes-tlon-adapter/history.py
+++ b/packages/hermes-tlon-adapter/history.py
@@ -185,10 +185,10 @@ def parse_parent_post(payload: Any, parent_id: str) -> Optional[HistoryEntry]:
 
 
 def parse_exact_reply(payload: Any, reply_id: str) -> Optional[HistoryEntry]:
-    """Decode channel-reply-2's one reply object, not a reply collection."""
+    """Decode channel-reply-2's memo or reply-essay object, not a reply collection."""
     if not isinstance(payload, dict):
         return None
-    memo = payload.get("memo")
+    memo = payload.get("memo") or payload.get("reply-essay")
     seal = payload.get("seal")
     return _entry_from_content(memo, seal, fallback_id=reply_id)
 

--- a/packages/hermes-tlon-adapter/history.py
+++ b/packages/hermes-tlon-adapter/history.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Sequence
 
@@ -53,6 +54,47 @@ class HistoryEntry:
     timestamp: float
     post_id: str = ""
     blob: Optional[str] = None
+
+
+class MessageCache:
+    """Small in-memory SSE message cache used to classify reaction targets."""
+
+    def __init__(self, *, per_conversation: int = 100, conversations: int = 64) -> None:
+        self.per_conversation = per_conversation
+        self.conversations = conversations
+        self._entries: OrderedDict[str, OrderedDict[str, HistoryEntry]] = OrderedDict()
+
+    def record(self, chat_key: str, post_id: str, author: str, text: str) -> None:
+        key = str(chat_key or "")
+        item_id = _normalize_id(post_id)
+        if not key or not item_id:
+            return
+        entries = self._entries.get(key)
+        if entries is None:
+            entries = OrderedDict()
+            self._entries[key] = entries
+        self._entries.move_to_end(key)
+        entries[item_id] = HistoryEntry(
+            author=extract_author_ship(author) or str(author or "unknown"),
+            content=str(text or ""),
+            timestamp=0.0,
+            post_id=str(post_id),
+        )
+        entries.move_to_end(item_id)
+        while len(entries) > self.per_conversation:
+            entries.popitem(last=False)
+        while len(self._entries) > self.conversations:
+            self._entries.popitem(last=False)
+
+    def lookup(self, chat_key: str, post_id: str) -> Optional[HistoryEntry]:
+        entries = self._entries.get(str(chat_key or ""))
+        if entries is None:
+            return None
+        self._entries.move_to_end(str(chat_key or ""))
+        return entries.get(_normalize_id(post_id))
+
+    def clear(self) -> None:
+        self._entries.clear()
 
 
 def _entry_from_content(content: Any, seal: Any, fallback_id: Any = None) -> Optional[HistoryEntry]:
@@ -142,9 +184,32 @@ def parse_parent_post(payload: Any, parent_id: str) -> Optional[HistoryEntry]:
     return _entry_from_content(content, seal, fallback_id=parent_id)
 
 
+def parse_exact_reply(payload: Any, reply_id: str) -> Optional[HistoryEntry]:
+    """Decode channel-reply-2's one reply object, not a reply collection."""
+    if not isinstance(payload, dict):
+        return None
+    memo = payload.get("memo")
+    seal = payload.get("seal")
+    return _entry_from_content(memo, seal, fallback_id=reply_id)
+
+
 async def fetch_channel_history(scry: ScryFn, nest: str, count: int) -> list[HistoryEntry]:
     payload = await scry(f"/channels/v4/{nest}/posts/newest/{count}/outline")
     return parse_channel_history(payload)
+
+
+async def fetch_post(
+    scry: ScryFn,
+    nest: str,
+    post_id: str,
+) -> Optional[HistoryEntry]:
+    """Fetch one top-level post through the exact v4 post route."""
+    try:
+        payload = await scry(f"/channels/v4/{nest}/posts/post/{format_ud(post_id)}")
+    except Exception as exc:
+        logger.debug("[tlon] exact post fetch failed for %s: %s", post_id, exc)
+        return None
+    return parse_parent_post(payload, post_id)
 
 
 async def fetch_thread_context(
@@ -190,6 +255,24 @@ async def fetch_thread_context(
     return deduped
 
 
+async def fetch_reply(
+    scry: ScryFn,
+    nest: str,
+    parent_id: str,
+    reply_id: str,
+) -> Optional[HistoryEntry]:
+    """Fetch precisely one channel reply from the v4 reply-id route."""
+    try:
+        payload = await scry(
+            f"/channels/v4/{nest}/posts/post/id/{format_ud(parent_id)}"
+            f"/replies/reply/id/{format_ud(reply_id)}"
+        )
+    except Exception as exc:
+        logger.debug("[tlon] exact reply fetch failed for %s: %s", reply_id, exc)
+        return None
+    return parse_exact_reply(payload, reply_id)
+
+
 def render_history_content(entry: HistoryEntry) -> str:
     return render_content_with_blob(entry.content, entry.blob, compact=True)
 
@@ -203,9 +286,19 @@ def _context_line_items(entries: Sequence[HistoryEntry]) -> list[tuple[HistoryEn
     return items
 
 
-def _context_lines(entries: Sequence[HistoryEntry]) -> str:
+def _context_lines(
+    items: Sequence[tuple[HistoryEntry, str]], *, include_ids: bool = False
+) -> str:
+    """Render pre-filtered (entry, rendered-text) pairs as one line each:
+    `author [id …]: text` when ``include_ids`` and the entry has an id, else
+    `author: text`. Shared by both context builders below."""
     return "\n".join(
-        f"{entry.author}: {rendered}" for entry, rendered in _context_line_items(entries)
+        (
+            f"{entry.author} [id {entry.post_id}]: {rendered}"
+            if include_ids and entry.post_id
+            else f"{entry.author}: {rendered}"
+        )
+        for entry, rendered in items
     )
 
 
@@ -216,6 +309,7 @@ def build_channel_context(
     current_id: str,
     is_mention: bool,
     limit: int,
+    include_ids: bool = False,
 ) -> Optional[str]:
     """Prepend recent channel activity to the current message text."""
     if limit <= 0:
@@ -235,7 +329,7 @@ def build_channel_context(
         "Use this context to understand what's being discussed.]"
     )
     current_label = "[Current message (mentioned you)]" if is_mention else "[Current message]"
-    lines = "\n".join(f"{entry.author}: {rendered}" for entry, rendered in context)
+    lines = _context_lines(context, include_ids=include_ids)
     return f"{note}\n\n{lines}\n\n{current_label}\n{current_text}"
 
 
@@ -245,6 +339,7 @@ def build_thread_context(
     current_text: str,
     current_id: str,
     limit: int,
+    include_ids: bool = False,
 ) -> Optional[str]:
     """Prepend thread history (parent post first) to the current message text."""
     if limit <= 0:
@@ -268,7 +363,7 @@ def build_thread_context(
         "You are participating in this thread. Only respond if relevant or helpful - "
         "you don't need to reply to every message.]"
     )
-    lines = "\n".join(f"{entry.author}: {rendered}" for entry, rendered in context)
+    lines = _context_lines(context, include_ids=include_ids)
     return (
         f"{note}\n\n[Previous messages]\n{lines}\n\n"
         f"[Current message]\n{current_text}"

--- a/packages/hermes-tlon-adapter/plugin.yaml
+++ b/packages/hermes-tlon-adapter/plugin.yaml
@@ -136,6 +136,12 @@ optional_env:
       (default: 20, 0 disables)'
     prompt: 'Group context messages'
     password: false
+  - name: TLON_REACTION_LEVEL
+    description:
+      'Reaction prompt/tool level: off, ack (reserved/off), minimal (default),
+      or extensive'
+    prompt: 'Reaction level'
+    password: false
   - name: TLON_TELEMETRY
     description:
       'Enable opt-in PostHog telemetry (true/false, default false); requires

--- a/packages/hermes-tlon-adapter/test_adapter_approvals.py
+++ b/packages/hermes-tlon-adapter/test_adapter_approvals.py
@@ -270,6 +270,9 @@ class AdapterApprovalTests(unittest.TestCase):
             "access_code": "code",
             "channels": ["chat/~pen/general"],
             "owner_ship": "~mug",
+            # Approval replay assertions are independent of the reaction id
+            # envelope (covered by test_adapter_reactions).
+            "reaction_level": "off",
         }
         base.update(extra or {})
         with patch.dict(os.environ, {}, clear=True):

--- a/packages/hermes-tlon-adapter/test_adapter_attention.py
+++ b/packages/hermes-tlon-adapter/test_adapter_attention.py
@@ -423,6 +423,9 @@ class AdapterAttentionTests(unittest.TestCase):
             "node_id": "~pen",
             "access_code": "code",
             "channels": ["chat/~pen/general"],
+            # Attention assertions focus on wake behavior, not the reaction
+            # envelope (covered in test_adapter_reactions).
+            "reaction_level": "off",
         }
         base.update(extra)
         with patch.dict(os.environ, {}, clear=True):
@@ -1614,6 +1617,10 @@ class LensTriggerMapTests(unittest.TestCase):
         self.assertEqual(t("mention", is_dm=False), "mention")
         self.assertEqual(t("participated-thread", is_dm=False), "thread")
         self.assertEqual(t("owner-listen", is_dm=False), "owner-listen")
+        # reaction dispatches report their own lens trigger (F-4), not
+        # "unknown", regardless of conversation kind.
+        self.assertEqual(t("reaction", is_dm=False), "reaction")
+        self.assertEqual(t("reaction", is_dm=True), "reaction")
         # free-response is a real dispatch reason with no dedicated trigger.
         self.assertEqual(t("free-response", is_dm=False), "unknown")
 

--- a/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
+++ b/packages/hermes-tlon-adapter/test_adapter_owner_listen.py
@@ -274,6 +274,9 @@ class AdapterOwnerListenTests(unittest.TestCase):
             "access_code": "code",
             "channels": ["chat/~pen/general"],
             "owner_ship": "~mug",
+            # Owner-listen/context assertions are independent of reaction id
+            # rendering (covered by test_adapter_reactions).
+            "reaction_level": "off",
         }
         base.update(extra)
         with patch.dict(os.environ, {}, clear=True):

--- a/packages/hermes-tlon-adapter/test_adapter_reactions.py
+++ b/packages/hermes-tlon-adapter/test_adapter_reactions.py
@@ -1,0 +1,567 @@
+import asyncio
+import os
+import re
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Reuse the gateway stubs and adapter loader used by the existing adapter tests.
+from test_adapter_attention import (  # noqa: E402
+    FakeCLI,
+    PlatformConfig,
+    RecordingCLI,
+    adapter_mod,
+    channel_event,
+    tlon_api,
+)
+
+
+def channel_reacts(entries, *, post_id="170.141", parent_id=None):
+    r_post = {"reacts": entries}
+    if parent_id:
+        r_post = {
+            "reply": {"id": post_id, "r-reply": {"reacts": entries}}
+        }
+    return {
+        "nest": "chat/~pen/general",
+        "response": {"post": {"id": parent_id or post_id, "r-post": r_post}},
+    }
+
+
+def dm_react(*, post_id="~pen/170.141", author="~mug", emoji="👍", added=True, parent_id=None):
+    delta = {"add-react": {"author": author, "react": emoji}} if added else {"del-react": author}
+    response = delta
+    if parent_id:
+        response = {"reply": {"id": post_id, "delta": delta}}
+    return {"whom": "~mug", "id": parent_id or post_id, "response": response}
+
+
+# Wire id shapes the CLI parsers accept: a channel post/reply is a bare
+# dotted @ud (`posts.ts`'s formatPostId/extractNumericId round-trip); a DM
+# post/writ id is author-prefixed (`dms.ts`'s parsePostId splits on "/").
+_CHANNEL_ID_RE = re.compile(r"^[0-9.]+$")
+_DM_ID_RE = re.compile(r"^~[a-z0-9-]+/[0-9.]+$")
+
+
+def _extract_marker(text, label):
+    match = re.search(rf"\[{re.escape(label)}: ([^\]]+)\]", text)
+    return match.group(1) if match else None
+
+
+class RecordingSSE:
+    def __init__(self, payload=None, error=None):
+        self.payload = payload
+        self.error = error
+        self.paths = []
+
+    async def scry(self, path):
+        self.paths.append(path)
+        if self.error:
+            raise self.error
+        if callable(self.payload):
+            return self.payload(path)
+        return self.payload
+
+
+class AdapterReactionTests(unittest.TestCase):
+    def make_adapter(self, extra=None):
+        base = {
+            "node_url": "https://pen.tlon.network",
+            "node_id": "~pen",
+            "access_code": "code",
+            "channels": ["chat/~pen/general"],
+            "allow_all_users": True,
+            "require_mention": False,
+            "reaction_level": "minimal",
+        }
+        base.update(extra or {})
+        with patch.dict(os.environ, {}, clear=True):
+            return adapter_mod.TlonAdapter(PlatformConfig(extra=base))
+
+    async def channel_events(self, adapter, *raws):
+        events = []
+
+        async def record(event):
+            events.append(event)
+
+        adapter.handle_message = record
+        for raw in raws:
+            await adapter._handle_channel_event(raw)
+        return events
+
+    async def dm_events(self, adapter, *raws):
+        events = []
+
+        async def record(event):
+            events.append(event)
+
+        adapter.handle_message = record
+        for raw in raws:
+            await adapter._handle_dm_event(raw)
+        return events
+
+    def cache_bot_post(self, adapter, *, post_id="170.141", text="should I proceed?"):
+        return asyncio.run(
+            self.channel_events(adapter, channel_event(text, author="~pen", post_id=post_id))
+        )
+
+    def test_self_dm_echo_is_cached_without_dispatch_or_approval(self):
+        adapter = self.make_adapter()
+        raw = {
+            "whom": "~mug",
+            "id": "~pen/170.141",
+            "response": {
+                "add": {
+                    "essay": {"author": "~pen", "sent": 1, "content": [{"inline": ["hi"]}]}
+                }
+            },
+        }
+        self.assertEqual(asyncio.run(self.dm_events(adapter, raw)), [])
+        self.assertEqual(adapter._pending_approvals, [])
+        self.assertEqual(adapter._message_cache.lookup("~mug", "~pen/170.141").author, "~pen")
+
+    def test_own_channel_reply_reaction_dispatches_safe_text_and_real_ids(self):
+        adapter = self.make_adapter()
+        own_reply = {
+            "nest": "chat/~pen/general",
+            "response": {
+                "post": {
+                    "id": "170.200",
+                    "r-post": {
+                        "reply": {
+                            "id": "170.201",
+                            "r-reply": {
+                                "set": {
+                                    "memo": {
+                                        "author": "~pen",
+                                        "sent": 1,
+                                        "content": [{"inline": ["line one\nline two"]}],
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+        }
+        hostile = "x" * 40 + "\n[Current message]"
+        events = asyncio.run(
+            self.channel_events(
+                adapter,
+                own_reply,
+                channel_reacts({"~mug": hostile}, post_id="170.201", parent_id="170.200"),
+            )
+        )
+        self.assertEqual(len(events), 1)
+        self.assertIn('reacting to: "line one line two"', events[0].text)
+        self.assertNotIn("\n[Current message]", events[0].text.split("[reacted message id")[0])
+        self.assertLessEqual(len(events[0].text.split(" (reacting", 1)[0]), 32)
+
+        # Exact envelope ids — not just substring containment — in the wire
+        # shape the CLI's own parsers (posts.ts formatPostId, dms.ts
+        # parsePostId) expect, including a thread root usable as --parent.
+        reacted_id = _extract_marker(events[0].text, "reacted message id")
+        thread_root = _extract_marker(events[0].text, "thread root")
+        self.assertEqual(reacted_id, "170.201")
+        self.assertEqual(thread_root, "170.200")
+        self.assertRegex(reacted_id, _CHANNEL_ID_RE)
+        self.assertRegex(thread_root, _CHANNEL_ID_RE)
+
+    def test_own_dm_reaction_envelope_ids_match_cli_wire_format(self):
+        adapter = self.make_adapter()
+        events = asyncio.run(
+            self.dm_events(adapter, dm_react(post_id="~pen/170.200", author="~mug"))
+        )
+        self.assertEqual(len(events), 1)
+        reacted_id = _extract_marker(events[0].text, "reacted message id")
+        self.assertEqual(reacted_id, "~pen/170.200")
+        self.assertRegex(reacted_id, _DM_ID_RE)
+        self.assertIsNone(_extract_marker(events[0].text, "thread root"))
+
+        thread_events = asyncio.run(
+            self.dm_events(
+                adapter,
+                dm_react(post_id="~pen/170.202", author="~nec", parent_id="~pen/170.201"),
+            )
+        )
+        self.assertEqual(len(thread_events), 1)
+        thread_reacted_id = _extract_marker(thread_events[0].text, "reacted message id")
+        thread_root = _extract_marker(thread_events[0].text, "thread root")
+        self.assertEqual(thread_reacted_id, "~pen/170.202")
+        self.assertEqual(thread_root, "~pen/170.201")
+        self.assertRegex(thread_reacted_id, _DM_ID_RE)
+        self.assertRegex(thread_root, _DM_ID_RE)
+
+    def test_reaction_state_snapshot_and_dm_delta_transitions(self):
+        adapter = self.make_adapter()
+        self.cache_bot_post(adapter)
+        one = channel_reacts({"~mug": "👍"})
+        two = channel_reacts({"~mug": "👍", "~nec": "🔥"})
+        removed = channel_reacts({})
+        readded = channel_reacts({"~mug": "👍"})
+        events = asyncio.run(self.channel_events(adapter, one, one, two, removed, readded))
+        # initial add, new entry, and a remove-then-re-add (seen-LRU bypassed)
+        self.assertEqual(len(events), 3)
+        # The re-add is the next dispatch, so it drains the two passive removal
+        # notes only after core accepted that event.
+        self.assertIn("[Recent reactions in this conversation]", events[-1].text)
+
+        dm_adapter = self.make_adapter()
+        dm_events = asyncio.run(
+            self.dm_events(
+                dm_adapter,
+                dm_react(),
+                dm_react(),
+                dm_react(added=False),
+                dm_react(added=False),
+            )
+        )
+        self.assertEqual(len(dm_events), 1)
+        self.assertEqual(len(dm_adapter._pending_reaction_notes["dm:~mug"]), 1)
+
+        tombstone = self.make_adapter()
+        asyncio.run(self.dm_events(tombstone, dm_react(added=False), dm_react(added=False)))
+        self.assertEqual(len(tombstone._pending_reaction_notes["dm:~mug"]), 1)
+
+    def test_snapshot_wire_keys_and_bad_snapshot_preserve_state(self):
+        adapter = self.make_adapter()
+        self.cache_bot_post(adapter)
+        bot_entry = {
+            "ship": "~mug",
+            "nickname": "same-ship-bot",
+            "avatar": None,
+            "react": "🔥",
+        }
+        good = channel_reacts({"~mug": "👍", "~mug/bot": bot_entry})
+        malformed = channel_reacts({"~mug": "👍", "~bad": {"unexpected": True}})
+        events = asyncio.run(self.channel_events(adapter, good, malformed, good))
+        self.assertEqual(len(events), 2)
+        # The malformed full snapshot did not create a false removal/re-add.
+        self.assertEqual(len(adapter._pending_reaction_notes), 0)
+
+    def test_authorization_notes_drain_and_failure_retention(self):
+        adapter = self.make_adapter({"allow_all_users": False, "allowed_users": ["~mug"]})
+        asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": "👍"}, post_id="other")))
+        key = "group:chat/~pen/general"
+        self.assertIn(key, adapter._pending_reaction_notes)
+        events = asyncio.run(self.channel_events(adapter, channel_event("hello", author="~mug", post_id="next")))
+        self.assertIn("[Recent reactions in this conversation]", events[0].text)
+        self.assertNotIn(key, adapter._pending_reaction_notes)
+
+        reaction = tlon_api.TlonReaction("group", "chat/~pen/general", "other", None, "~mug", "~mug", False, "👍", True, {})
+        adapter._queue_reaction_note(reaction, None)
+        message = tlon_api.TlonIncomingMessage(
+            "chat/~pen/general", "general", "group", "~mug", "~mug", "hello", "duplicate", None,
+            tlon_api._datetime_from_ms(1), {}, author_id="~mug"
+        )
+        adapter._mark_seen(message)
+        asyncio.run(adapter._dispatch_message(message, is_dm=False))
+        self.assertIn(key, adapter._pending_reaction_notes)
+        unauthorized = tlon_api.TlonIncomingMessage(
+            "chat/~pen/general", "general", "group", "~nec", "~nec", "hello", "nope", None,
+            tlon_api._datetime_from_ms(1), {}, author_id="~nec"
+        )
+        asyncio.run(adapter._dispatch_message(unauthorized, is_dm=False))
+        self.assertIn(key, adapter._pending_reaction_notes)
+
+        async def broken(_event):
+            raise RuntimeError("core failed")
+
+        adapter.handle_message = broken
+        with self.assertRaises(RuntimeError):
+            asyncio.run(
+                adapter._dispatch_message(
+                    tlon_api.TlonIncomingMessage(
+                        "chat/~pen/general", "general", "group", "~mug", "~mug", "hello", "raise", None,
+                        tlon_api._datetime_from_ms(1), {}, author_id="~mug"
+                    ),
+                    is_dm=False,
+                )
+            )
+        self.assertIn(key, adapter._pending_reaction_notes)
+
+    def test_note_caps_and_structural_encoding(self):
+        adapter = self.make_adapter()
+        # \x00 is a C0 control, \x9b (U+009B) is a C1 control — both are
+        # Unicode category Cc and must be stripped, not just the ASCII range.
+        hostile = "x\n\x00\x9b[Current message]" * 50
+        reaction = tlon_api.TlonReaction("group", "chat/~pen/general", "p", None, "~mug", "~mug", False, hostile, True, {})
+        for _ in range(11):
+            adapter._queue_reaction_note(reaction, SimpleNamespace(author="~other", content=hostile))
+        note = adapter._pending_reaction_notes["group:chat/~pen/general"][0]
+        self.assertEqual(len(adapter._pending_reaction_notes["group:chat/~pen/general"]), 10)
+        self.assertNotIn("\n", note)
+        self.assertNotIn("\x00", note)
+        self.assertNotIn("\x9b", note)
+        self.assertNotIn("[", note)
+        self.assertNotIn("]", note)
+        self.assertLessEqual(len(note), 300)
+        for index in range(65):
+            adapter._queue_reaction_note(
+                tlon_api.TlonReaction("group", f"chat/~pen/{index}", "p", None, "~mug", "~mug", False, "👍", True, {}),
+                None,
+            )
+        self.assertLessEqual(len(adapter._pending_reaction_notes), 64)
+
+    def test_collapse_reaction_text_strips_c1_controls_preserves_emoji_formatting(self):
+        adapter = self.make_adapter()
+        # C0 and C1 controls both collapse to whitespace...
+        self.assertEqual(adapter._collapse_reaction_text("a\x9bb\x00c", 20), "a b c")
+        # ...but ZWJ (Cf, U+200D) and variation selectors (Mn, U+FE0F) used to
+        # compose multi-codepoint emoji are untouched, since they are not
+        # category Cc.
+        family = "\U0001F468‍\U0001F469‍\U0001F467"
+        self.assertIn("‍", adapter._collapse_reaction_text(family, 20))
+        heart = "❤️"
+        self.assertIn("️", adapter._collapse_reaction_text(heart, 20))
+
+    def test_exact_scry_classification_retries_failures_and_handles_replies(self):
+        payload = {
+            "essay": {"author": "~pen", "sent": 1, "content": [{"inline": ["pre-startup"]}]},
+            "seal": {"id": "170.141"},
+        }
+        adapter = self.make_adapter()
+        adapter._sse = RecordingSSE(payload)
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": "👍"})))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(adapter._sse.paths, ["/channels/v4/chat/~pen/general/posts/post/170.141"])
+
+        reply_payload = {
+            "seal": {"id": "170.142"},
+            "revision": 1,
+            "memo": {"author": "~pen", "sent": 1, "content": [{"inline": ["reply text"]}]},
+        }
+        reply_adapter = self.make_adapter()
+        reply_adapter._sse = RecordingSSE(reply_payload)
+        reply_events = asyncio.run(
+            self.channel_events(
+                reply_adapter,
+                channel_reacts({"~mug": "👍"}, post_id="170.142", parent_id="170.141"),
+            )
+        )
+        self.assertEqual(len(reply_events), 1)
+        self.assertEqual(
+            reply_adapter._sse.paths,
+            ["/channels/v4/chat/~pen/general/posts/post/id/170.141/replies/reply/id/170.142"],
+        )
+
+        flaky = self.make_adapter()
+        flaky._sse = RecordingSSE(error=RuntimeError("temporary"))
+        asyncio.run(self.channel_events(flaky, channel_reacts({"~mug": "👍"})))
+        flaky._sse.error = None
+        flaky._sse.payload = payload
+        events = asyncio.run(self.channel_events(flaky, channel_reacts({"~nec": "🔥"})))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(len(flaky._sse.paths), 2)
+
+    def test_snapshot_scry_failure_memoized_across_transitions(self):
+        # I1: a failing exact scry for one post is made once per SSE event,
+        # not once per authorized transition sharing that post — otherwise a
+        # multi-entry snapshot repeats the 30s scry timeout per reactor and
+        # stalls the serial SSE loop.
+        adapter = self.make_adapter()
+        adapter._sse = RecordingSSE(error=RuntimeError("boom"))
+        events = asyncio.run(
+            self.channel_events(adapter, channel_reacts({"~mug": "👍", "~nec": "🔥"}))
+        )
+        self.assertEqual(events, [])
+        self.assertEqual(len(adapter._sse.paths), 1)
+        notes = adapter._pending_reaction_notes["group:chat/~pen/general"]
+        self.assertEqual(len(notes), 2)
+
+    def test_snapshot_transition_exception_does_not_abort_remaining_transitions(self):
+        # I2: apply_channel_snapshot() already committed the new map before
+        # returning transitions, so a raise handling the first must not lose
+        # the rest — an SSE redelivery of the same snapshot is a no-op diff
+        # once state is committed, so anything skipped here is lost for good.
+        adapter = self.make_adapter()
+        self.cache_bot_post(adapter)
+        calls = []
+
+        async def flaky(event):
+            calls.append(event)
+            if len(calls) == 1:
+                raise RuntimeError("boom")
+
+        adapter.handle_message = flaky
+        asyncio.run(
+            adapter._handle_channel_event(channel_reacts({"~mug": "👍", "~nec": "🔥"}))
+        )
+        self.assertEqual(len(calls), 2)
+
+    def test_exact_scry_partial_payload_not_cached_negative(self):
+        # M4: an exact scry that has text but no decodable author cannot
+        # classify ownership, so it must not be cached as a durable "not own
+        # post" result — a later reaction on the same post should re-scry.
+        partial_payload = {
+            "essay": {"author": None, "sent": 1, "content": [{"inline": ["partial"]}]},
+            "seal": {"id": "170.141"},
+        }
+        valid_payload = {
+            "essay": {"author": "~pen", "sent": 1, "content": [{"inline": ["now valid"]}]},
+            "seal": {"id": "170.141"},
+        }
+        adapter = self.make_adapter()
+        adapter._sse = RecordingSSE(partial_payload)
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": "👍"})))
+        self.assertEqual(events, [])
+        self.assertIsNone(adapter._message_cache.lookup("chat/~pen/general", "170.141"))
+
+        adapter._sse.payload = valid_payload
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~nec": "🔥"})))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(len(adapter._sse.paths), 2)
+        self.assertIn("[reacted message id: 170.141]", events[0].text)
+
+    def test_synthetic_message_id_caps_hostile_emoji_deterministically(self):
+        # M7: the react component of the synthetic dispatch id is bounded
+        # the same way ReactionState comparison values are (digest over 256
+        # chars), and stays deterministic for the same input.
+        adapter = self.make_adapter()
+        self.cache_bot_post(adapter)
+        hostile = "x" * 500
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": hostile})))
+        self.assertEqual(len(events), 1)
+        message_id = events[0].message_id
+        self.assertTrue(message_id.startswith("react/170.141/~mug/sha256:"))
+        self.assertLess(len(message_id), 150)
+
+        again = self.make_adapter()
+        self.cache_bot_post(again)
+        again_events = asyncio.run(self.channel_events(again, channel_reacts({"~mug": hostile})))
+        self.assertEqual(again_events[0].message_id, message_id)
+
+    def test_reply_in_thread_reaction_fallback_uses_real_target_not_synthetic_id(self):
+        # I3: with TLON_REPLY_IN_THREAD=true, a reply to a top-level own-post
+        # reaction dispatch must thread on the real reacted post, not the
+        # synthetic `react/<post>/<reactor>/<emoji>` trigger id (which is not
+        # a real wire post and cannot be replied to).
+        adapter = self.make_adapter({"reply_in_thread": True})
+        self.cache_bot_post(adapter)
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": "👍"})))
+        self.assertEqual(len(events), 1)
+        message_id = events[0].message_id
+        self.assertTrue(message_id.startswith("react/"))
+
+        adapter._cli = RecordingCLI()
+        asyncio.run(
+            adapter.send("chat/~pen/general", "nice", reply_to=message_id, metadata=None)
+        )
+        self.assertEqual(len(adapter._cli.thread_replies), 1)
+        self.assertEqual(adapter._cli.thread_replies[0][1], "170.141")
+
+    def test_reply_in_thread_reaction_retry_keeps_real_channel_target(self):
+        adapter = self.make_adapter({"reply_in_thread": True})
+        self.cache_bot_post(adapter)
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": "👍"})))
+        self.assertEqual(len(events), 1)
+        message_id = events[0].message_id
+        self.assertTrue(message_id.startswith("react/"))
+
+        timeout = tlon_api.TlonSendResult(
+            success=False,
+            command=("tlon-test", "posts", "reply"),
+            returncode=124,
+            error="timeout",
+        )
+        adapter._cli = RecordingCLI(results=[timeout])
+        first = asyncio.run(
+            adapter.send("chat/~pen/general", "nice", reply_to=message_id, metadata=None)
+        )
+        retry = asyncio.run(
+            adapter.send("chat/~pen/general", "nice", reply_to=message_id, metadata=None)
+        )
+
+        self.assertFalse(first.success)
+        self.assertTrue(first.retryable)
+        self.assertTrue(retry.success)
+        self.assertEqual(
+            [reply[1] for reply in adapter._cli.thread_replies],
+            ["170.141", "170.141"],
+        )
+
+    def test_reply_in_thread_dm_reaction_fallback_uses_real_target_and_parent_author(self):
+        # I3 (DM): same fallback bug additionally corrupted parent_author —
+        # normalize_ship("react") == "~react" — since the synthetic id's
+        # first path segment ("react") was read as the author prefix.
+        adapter = self.make_adapter({"reply_in_thread": True})
+        events = asyncio.run(
+            self.dm_events(adapter, dm_react(post_id="~pen/170.150", author="~mug"))
+        )
+        self.assertEqual(len(events), 1)
+        message_id = events[0].message_id
+        self.assertTrue(message_id.startswith("react/~pen/170.150/~mug/"))
+
+        adapter._cli = RecordingCLI()
+        asyncio.run(adapter.send("~mug", "nice", reply_to=message_id, metadata=None))
+        self.assertEqual(len(adapter._cli.thread_replies), 1)
+        self.assertEqual(adapter._cli.thread_replies[0][1], "~pen/170.150")
+        self.assertEqual(adapter._cli.thread_replies[0][3], "~pen")
+
+    def test_reply_in_thread_dm_reaction_retry_keeps_target_and_parent_author(self):
+        adapter = self.make_adapter({"reply_in_thread": True})
+        events = asyncio.run(
+            self.dm_events(adapter, dm_react(post_id="~pen/170.150", author="~mug"))
+        )
+        self.assertEqual(len(events), 1)
+        message_id = events[0].message_id
+        self.assertTrue(message_id.startswith("react/~pen/170.150/~mug/"))
+
+        timeout = tlon_api.TlonSendResult(
+            success=False,
+            command=("tlon-test", "dms", "reply"),
+            returncode=124,
+            error="timeout",
+        )
+        adapter._cli = RecordingCLI(results=[timeout])
+        first = asyncio.run(adapter.send("~mug", "nice", reply_to=message_id, metadata=None))
+        retry = asyncio.run(adapter.send("~mug", "nice", reply_to=message_id, metadata=None))
+
+        self.assertFalse(first.success)
+        self.assertTrue(first.retryable)
+        self.assertTrue(retry.success)
+        self.assertEqual(
+            [reply[1] for reply in adapter._cli.thread_replies],
+            ["~pen/170.150", "~pen/170.150"],
+        )
+        self.assertEqual(
+            [reply[3] for reply in adapter._cli.thread_replies],
+            ["~pen", "~pen"],
+        )
+
+    def test_bot_loop_envelope_levels_send_parent_author_and_disconnect_cleanup(self):
+        adapter = self.make_adapter({"max_consecutive_bot_responses": 1})
+        self.cache_bot_post(adapter)
+        bot = {"ship": "~other", "nickname": "bot", "avatar": None, "react": "👍"}
+        bot2 = {"ship": "~third", "nickname": "bot", "avatar": None, "react": "🔥"}
+        events = asyncio.run(
+            self.channel_events(adapter, channel_reacts({"~other/bot": bot}), channel_reacts({"~other/bot": bot, "~third/bot": bot2}))
+        )
+        self.assertEqual(len(events), 1)
+        self.assertIn("[reacted message id: 170.141]", events[0].text)
+        self.assertIn("~other", adapter._known_bot_ships)
+
+        dm = self.make_adapter()
+        dm._cli = RecordingCLI()
+        asyncio.run(dm.send("~mug", "reply", reply_to="event", metadata={"thread_id": "~pen/root"}))
+        self.assertEqual(dm._cli.thread_replies[0][3], "~pen")
+
+        for level in ("off", "ack"):
+            plain = self.make_adapter({"reaction_level": level})
+            events = asyncio.run(self.channel_events(plain, channel_event("hello", author="~mug")))
+            self.assertNotIn("[message id:", events[0].text)
+
+        adapter._queue_reaction_note(
+            tlon_api.TlonReaction("group", "chat/~pen/general", "p", None, "~mug", "~mug", False, "👍", True, {}), None
+        )
+        # Sanity: the channel_events() calls above populated ReactionState
+        # for chat/~pen/general's post 170.141 before disconnect clears it.
+        self.assertTrue(len(adapter._reaction_state._conversations) > 0)
+        asyncio.run(adapter.disconnect())
+        self.assertEqual(len(adapter._pending_reaction_notes), 0)
+        self.assertIsNone(adapter._message_cache.lookup("chat/~pen/general", "170.141"))
+        self.assertEqual(len(adapter._reaction_state._conversations), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/hermes-tlon-adapter/test_adapter_reactions.py
+++ b/packages/hermes-tlon-adapter/test_adapter_reactions.py
@@ -600,6 +600,17 @@ class AdapterReactionTests(unittest.TestCase):
         self.assertIsNone(adapter._message_cache.lookup("chat/~pen/general", "170.141"))
         self.assertEqual(len(adapter._reaction_state._conversations), 0)
 
+    def test_reaction_hint_uses_bare_subcommands(self):
+        # The model-facing tlon tool takes the SUBCOMMAND at argument zero; a
+        # leading `tlon` binary token is rejected, so the hint must omit it.
+        for level in ("minimal", "extensive"):
+            hint = adapter_mod._reaction_platform_hint(level)
+            self.assertIn('posts react <nest> <post-id> "<emoji>"', hint)
+            self.assertIn('dms react <ship> <message-id> "<emoji>"', hint)
+            self.assertNotIn("tlon posts react", hint)
+            self.assertNotIn("tlon dms react", hint)
+        self.assertEqual(adapter_mod._reaction_platform_hint("off"), "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/hermes-tlon-adapter/test_adapter_reactions.py
+++ b/packages/hermes-tlon-adapter/test_adapter_reactions.py
@@ -239,6 +239,31 @@ class AdapterReactionTests(unittest.TestCase):
         # The malformed full snapshot did not create a false removal/re-add.
         self.assertEqual(len(adapter._pending_reaction_notes), 0)
 
+    def test_channel_self_reaction_skipped_but_snapshot_state_commits(self):
+        # Reviewer gap (self-reactor skip with state commit): channel
+        # snapshots deliberately KEEP the bot's own entries — the diff
+        # engine needs them for future transitions — so the only guard
+        # against the bot reacting to itself is the `reaction.reactor ==
+        # bot` check inside _handle_reaction, not the snapshot commit.
+        adapter = self.make_adapter()
+        self.cache_bot_post(adapter)
+        snapshot = channel_reacts({"~pen": "👍"})
+        events = asyncio.run(self.channel_events(adapter, snapshot))
+        self.assertEqual(events, [])
+        self.assertEqual(len(adapter._pending_reaction_notes), 0)
+
+        # The self-reaction still committed into ReactionState even though
+        # it produced neither a dispatch nor a passive note.
+        key = "group:chat/~pen/general"
+        entries = adapter._reaction_state._conversations[key]["170.141"]
+        self.assertIn("~pen", entries)
+
+        # Redelivery of the identical snapshot is a no-op diff (no
+        # transitions), so it produces neither events nor notes.
+        events = asyncio.run(self.channel_events(adapter, snapshot))
+        self.assertEqual(events, [])
+        self.assertEqual(len(adapter._pending_reaction_notes), 0)
+
     def test_authorization_notes_drain_and_failure_retention(self):
         adapter = self.make_adapter({"allow_all_users": False, "allowed_users": ["~mug"]})
         asyncio.run(self.channel_events(adapter, channel_reacts({"~mug": "👍"}, post_id="other")))
@@ -279,6 +304,27 @@ class AdapterReactionTests(unittest.TestCase):
                 )
             )
         self.assertIn(key, adapter._pending_reaction_notes)
+
+    def test_unauthorized_reactor_produces_no_events_no_notes_no_approvals(self):
+        # Reviewer gap (unauthorized-reactor drop): an unauthorized reactor
+        # must be fully dropped, not merely undispatched — it must not
+        # become a passive note either, and reactions have no approval
+        # path at all (only messages queue approvals), so the approval
+        # queue must stay untouched.
+        adapter = self.make_adapter({"allow_all_users": False, "allowed_users": ["~mug"]})
+        self.cache_bot_post(adapter)
+        events = asyncio.run(self.channel_events(adapter, channel_reacts({"~nec": "👍"})))
+        self.assertEqual(events, [])
+        self.assertNotIn("group:chat/~pen/general", adapter._pending_reaction_notes)
+        self.assertEqual(adapter._pending_approvals, [])
+
+        # DM side: dm_react()'s default post id ("~pen/170.141") is already
+        # bot-authored by construction (DM ownership is read off the id
+        # prefix, no cached post needed), so the same triple-negative holds.
+        dm_events = asyncio.run(self.dm_events(adapter, dm_react(author="~nec")))
+        self.assertEqual(dm_events, [])
+        self.assertNotIn("dm:~mug", adapter._pending_reaction_notes)
+        self.assertEqual(adapter._pending_approvals, [])
 
     def test_note_caps_and_structural_encoding(self):
         adapter = self.make_adapter()
@@ -368,6 +414,25 @@ class AdapterReactionTests(unittest.TestCase):
         self.assertEqual(len(adapter._sse.paths), 1)
         notes = adapter._pending_reaction_notes["group:chat/~pen/general"]
         self.assertEqual(len(notes), 2)
+
+    def test_snapshot_scry_success_memoized_across_transitions(self):
+        # Reviewer gap (success-path memoization): the existing failure-memo
+        # test above only pins the memo for a scry that raises. A multi-entry
+        # snapshot whose exact scry *succeeds* must still make just one scry
+        # for the whole event — the first transition's successful lookup
+        # populates the message cache, so the second transition must find it
+        # cached instead of re-scrying the same post.
+        payload = {
+            "essay": {"author": "~pen", "sent": 1, "content": [{"inline": ["pre-startup"]}]},
+            "seal": {"id": "170.141"},
+        }
+        adapter = self.make_adapter()
+        adapter._sse = RecordingSSE(payload)
+        events = asyncio.run(
+            self.channel_events(adapter, channel_reacts({"~mug": "👍", "~nec": "🔥"}))
+        )
+        self.assertEqual(len(events), 2)
+        self.assertEqual(len(adapter._sse.paths), 1)
 
     def test_snapshot_transition_exception_does_not_abort_remaining_transitions(self):
         # I2: apply_channel_snapshot() already committed the new map before

--- a/packages/hermes-tlon-adapter/test_adapter_reactions.py
+++ b/packages/hermes-tlon-adapter/test_adapter_reactions.py
@@ -389,6 +389,44 @@ class AdapterReactionTests(unittest.TestCase):
         )
         self.assertEqual(len(calls), 2)
 
+    def test_unresolved_own_post_reaction_retries_after_scry_recovery(self):
+        # Codex PR review P2: the snapshot commits before its transitions are
+        # handled, so an added reaction whose exact scry fails must be
+        # forgotten from state — otherwise redelivery of the same reacts map
+        # is a no-op diff and the own-post reaction is permanently misfiled
+        # as a passive note even after the scry recovers.
+        payload = {
+            "essay": {"author": "~pen", "sent": 1, "content": [{"inline": ["pre-startup"]}]},
+            "seal": {"id": "170.141"},
+        }
+        adapter = self.make_adapter()
+        adapter._sse = RecordingSSE(error=RuntimeError("temporary"))
+        snapshot = channel_reacts({"~mug": "👍"})
+        self.assertEqual(asyncio.run(self.channel_events(adapter, snapshot)), [])
+        self.assertEqual(
+            len(adapter._pending_reaction_notes["group:chat/~pen/general"]), 1
+        )
+
+        adapter._sse.error = None
+        adapter._sse.payload = payload
+        events = asyncio.run(self.channel_events(adapter, snapshot))
+        self.assertEqual(len(events), 1)
+        self.assertIn("👍", events[0].text)
+        self.assertEqual(len(adapter._sse.paths), 2)
+
+        # A resolved non-own target is final: the identical snapshot a third
+        # time must not re-dispatch or re-scry (no rollback for real authors).
+        other_payload = {
+            "essay": {"author": "~mug", "sent": 1, "content": [{"inline": ["hers"]}]},
+            "seal": {"id": "170.150"},
+        }
+        settled = self.make_adapter()
+        settled._sse = RecordingSSE(other_payload)
+        other_snapshot = channel_reacts({"~nec": "🔥"}, post_id="170.150")
+        asyncio.run(self.channel_events(settled, other_snapshot))
+        self.assertEqual(asyncio.run(self.channel_events(settled, other_snapshot)), [])
+        self.assertEqual(len(settled._sse.paths), 1)
+
     def test_exact_scry_partial_payload_not_cached_negative(self):
         # M4: an exact scry that has text but no decodable author cannot
         # classify ownership, so it must not be cached as a durable "not own

--- a/packages/hermes-tlon-adapter/test_history.py
+++ b/packages/hermes-tlon-adapter/test_history.py
@@ -200,6 +200,19 @@ class ParseThreadTests(unittest.TestCase):
             self.assertEqual(entry.content, "root")
             self.assertEqual(entry.post_id, "7")
 
+    def test_exact_reply_accepts_memo_and_reply_essay(self):
+        reply = essay("~mug", "reply", 1000)
+        entries = [
+            history.parse_exact_reply(
+                {"seal": {"id": "8"}, "revision": 1, "memo": reply}, "8"
+            ),
+            history.parse_exact_reply(
+                {"seal": {"id": "8"}, "revision": 1, "reply-essay": reply}, "8"
+            ),
+        ]
+
+        self.assertEqual(entries, [history.HistoryEntry("~mug", "reply", 1000.0, "8")] * 2)
+
     def test_fetch_thread_context_orders_parent_first_and_dedupes(self):
         nest = "chat/~pen/general"
         payloads = {

--- a/packages/hermes-tlon-adapter/test_tlon_api.py
+++ b/packages/hermes-tlon-adapter/test_tlon_api.py
@@ -1084,5 +1084,156 @@ class MessageParsingTests(unittest.TestCase):
         self.assertEqual(message.blob, blob)
 
 
+class ReactionParsingTests(unittest.TestCase):
+    def test_config_reaction_level_defaults_and_invalid_values(self):
+        required = {
+            "TLON_NODE_URL": "https://zod.tlon.network",
+            "TLON_NODE_ID": "~zod",
+            "TLON_ACCESS_CODE": "code",
+        }
+        self.assertEqual(tlon_api.TlonConfig.from_env(env=required).reaction_level, "minimal")
+        self.assertEqual(
+            tlon_api.TlonConfig.from_env(
+                env={**required, "TLON_REACTION_LEVEL": "EXTENSIVE"}
+            ).reaction_level,
+            "extensive",
+        )
+        self.assertEqual(
+            tlon_api.TlonConfig.from_env(
+                env={**required, "TLON_REACTION_LEVEL": "unexpected"}
+            ).reaction_level,
+            "minimal",
+        )
+
+    def test_channel_snapshot_decodes_plain_bot_any_and_reply_entries(self):
+        raw = {
+            "nest": "chat/~zod/general",
+            "response": {
+                "post": {
+                    "id": "170.141",
+                    "r-post": {
+                        "reacts": {
+                            "~mug": "👍",
+                            "~bot/nick": {
+                                "ship": "~bot",
+                                "nickname": "nick",
+                                "avatar": None,
+                                "react": {"any": "🔥"},
+                            },
+                        }
+                    },
+                }
+            },
+        }
+        snapshot = tlon_api.parse_channel_reacts_snapshot(raw)
+        self.assertIsNotNone(snapshot)
+        self.assertEqual(snapshot.post_id, "170.141")
+        self.assertIsNone(snapshot.parent_id)
+        self.assertEqual(snapshot.entries["~mug"], ("👍", "~mug", False))
+        self.assertEqual(snapshot.entries["~bot/nick"], ("🔥", "~bot", True))
+
+        reply_raw = {
+            "nest": "chat/~zod/general",
+            "response": {
+                "post": {
+                    "id": "root",
+                    "r-post": {
+                        "reply": {
+                            "id": "reply",
+                            "r-reply": {"reacts": {"~mug": {"any": ":wave:"}}},
+                        }
+                    },
+                }
+            },
+        }
+        reply = tlon_api.parse_channel_reacts_snapshot(reply_raw)
+        self.assertEqual(reply.post_id, "reply")
+        self.assertEqual(reply.parent_id, "root")
+        self.assertEqual(reply.entries["~mug"], (":wave:", "~mug", False))
+
+    def test_channel_snapshot_rejects_whole_map_on_bad_entry(self):
+        raw = {
+            "nest": "chat/~zod/general",
+            "response": {
+                "post": {
+                    "id": "170.141",
+                    "r-post": {"reacts": {"~mug": "👍", "~bad": {"nope": 1}}},
+                }
+            },
+        }
+        self.assertIsNone(tlon_api.parse_channel_reacts_snapshot(raw))
+
+    def test_dm_reactions_cover_add_remove_reply_bot_any_club_and_self(self):
+        add = {
+            "whom": "~mug",
+            "id": "~zod/170.141",
+            "response": {"add-react": {"author": "~mug", "react": {"any": "👍"}}},
+        }
+        reaction = tlon_api.parse_dm_reaction(add, self_ship="~zod")
+        self.assertEqual((reaction.chat_id, reaction.post_id, reaction.emoji, reaction.added), ("~mug", "~zod/170.141", "👍", True))
+        self.assertEqual(reaction.wire_key, "~mug")
+
+        remove = {
+            "whom": "~mug",
+            "id": "~zod/170.141",
+            "response": {"del-react": {"ship": "~bot", "nickname": "nick", "avatar": None}},
+        }
+        removed = tlon_api.parse_dm_reaction(remove, self_ship="~zod")
+        self.assertFalse(removed.added)
+        self.assertEqual(removed.emoji, "")
+        self.assertEqual((removed.wire_key, removed.reactor, removed.reactor_is_bot), ("~bot/nick", "~bot", True))
+
+        reply = {
+            "whom": "~mug",
+            "id": "~zod/root",
+            "response": {
+                "reply": {
+                    "id": "~zod/reply",
+                    "delta": {"add-react": {"author": "~mug", "react": "🔥"}},
+                }
+            },
+        }
+        reply_reaction = tlon_api.parse_dm_reaction(reply, self_ship="~zod")
+        self.assertEqual((reply_reaction.post_id, reply_reaction.parent_id), ("~zod/reply", "~zod/root"))
+        self.assertIsNone(
+            tlon_api.parse_dm_reaction(
+                {**add, "whom": "0v5.legacy"}, self_ship="~zod"
+            )
+        )
+        self.assertIsNone(
+            tlon_api.parse_dm_reaction(
+                {**add, "response": {"add-react": {"author": "~zod", "react": "👍"}}},
+                self_ship="~zod",
+            )
+        )
+
+    def test_include_self_preserves_author_without_changing_dm_partner(self):
+        channel = tlon_api.parse_channel_message(
+            {
+                "nest": "chat/~zod/general",
+                "response": {
+                    "post": {
+                        "id": "170.141",
+                        "r-post": {"set": {"essay": {"author": "~zod", "sent": 1, "content": [{"inline": ["hi"]}]}}},
+                    }
+                },
+            },
+            self_ship="~zod",
+            include_self=True,
+        )
+        dm = tlon_api.parse_dm_message(
+            {
+                "whom": "~mug",
+                "id": "~zod/170.141",
+                "response": {"add": {"essay": {"author": "~zod", "sent": 1, "content": [{"inline": ["hi"]}]}}},
+            },
+            self_ship="~zod",
+            include_self=True,
+        )
+        self.assertEqual(channel.author_id, "~zod")
+        self.assertEqual(dm.author_id, "~zod")
+        self.assertEqual((dm.chat_id, dm.user_id), ("~mug", "~mug"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/hermes-tlon-adapter/test_tlon_api.py
+++ b/packages/hermes-tlon-adapter/test_tlon_api.py
@@ -1207,6 +1207,49 @@ class ReactionParsingTests(unittest.TestCase):
             )
         )
 
+    def test_bot_reaction_author_allows_null_nickname(self):
+        # nickname is wire type `(unit @t)`: a bot profile without a nickname
+        # serializes null, which must not drop the reaction or reject a snapshot.
+        add = {
+            "whom": "~mug",
+            "id": "~zod/170.141",
+            "response": {
+                "add-react": {
+                    "author": {"ship": "~bot", "nickname": None, "avatar": None},
+                    "react": {"any": "👍"},
+                }
+            },
+        }
+        reaction = tlon_api.parse_dm_reaction(add, self_ship="~zod")
+        self.assertIsNotNone(reaction)
+        self.assertEqual(reaction.reactor, "~bot")
+        self.assertTrue(reaction.reactor_is_bot)
+        self.assertEqual(reaction.emoji, "👍")
+
+        raw = {
+            "nest": "chat/~zod/general",
+            "response": {
+                "post": {
+                    "id": "170.141",
+                    "r-post": {
+                        "reacts": {
+                            "~mug": "👍",
+                            "~bot/": {
+                                "ship": "~bot",
+                                "nickname": None,
+                                "avatar": None,
+                                "react": {"any": "🔥"},
+                            },
+                        }
+                    },
+                }
+            },
+        }
+        snapshot = tlon_api.parse_channel_reacts_snapshot(raw)
+        self.assertIsNotNone(snapshot)
+        self.assertEqual(snapshot.entries["~mug"], ("👍", "~mug", False))
+        self.assertEqual(snapshot.entries["~bot/"], ("🔥", "~bot", True))
+
     def test_include_self_preserves_author_without_changing_dm_partner(self):
         channel = tlon_api.parse_channel_message(
             {

--- a/packages/hermes-tlon-adapter/test_tlon_tool.py
+++ b/packages/hermes-tlon-adapter/test_tlon_tool.py
@@ -497,5 +497,90 @@ class TlonSessionGateTests(unittest.TestCase):
         self.assertIsNone(block)
 
 
+class ReactionToolGateTests(unittest.TestCase):
+    def test_reaction_level_blocks_off_and_ack_but_allows_enabled_levels(self):
+        args, error = tlon_tool.split_tlon_command(
+            'posts react chat/~pen/general 170.141 "👍"'
+        )
+        self.assertIsNone(error)
+        for level in ("off", "ack"):
+            with self.subTest(level=level):
+                blocked = tlon_tool.check_tlon_tool_command(args, reaction_level=level)
+                self.assertIn("TLON_REACTION_LEVEL", blocked)
+        for level in ("minimal", "extensive"):
+            with self.subTest(level=level):
+                self.assertIsNone(
+                    tlon_tool.check_tlon_tool_command(args, reaction_level=level)
+                )
+
+    def _gate(self, command, **env):
+        base = {
+            "HERMES_SESSION_PLATFORM": "tlon",
+            "HERMES_SESSION_USER_ID": "~mug",
+            "HERMES_SESSION_CHAT_ID": "chat/~pen/general",
+            "TLON_OWNER_SHIP": "~pen",
+            "TLON_REACTION_LEVEL": "minimal",
+        }
+        base.update(env)
+        with patch.dict(os.environ, base, clear=True):
+            return adapter_mod.block_tlon_session_tool("tlon", {"command": command})
+
+    def test_non_owner_reaction_carveout_is_bound_to_current_conversation(self):
+        self.assertIsNone(
+            self._gate('posts react chat/~pen/general 170.141 "👍"')
+        )
+        self.assertIn(
+            "use posts",
+            self._gate('dms react ~mug ~pen/170.141 "👍"')["message"],
+        )
+        self.assertIn(
+            "current conversation",
+            self._gate('posts react chat/~pen/else 170.141 "👍"')["message"],
+        )
+        self.assertIn(
+            "owner-only",
+            self._gate('posts delete chat/~pen/general 170.141')["message"],
+        )
+        self.assertIn("owner-only", self._gate('posts "unterminated')["message"])
+
+    def test_non_owner_reaction_blocks_credentials_and_wrong_dm_family(self):
+        for command in (
+            '--ship ~other posts react chat/~pen/general 170.141 "👍"',
+            '--config file posts react chat/~pen/general 170.141 "👍"',
+            '--url=https://other posts react chat/~pen/general 170.141 "👍"',
+        ):
+            with self.subTest(command=command):
+                self.assertIn("credential override", self._gate(command)["message"])
+        self.assertIsNone(
+            self._gate(
+                'dms unreact ~mug ~pen/170.141',
+                HERMES_SESSION_CHAT_ID="~mug",
+            )
+        )
+        self.assertIn(
+            "use dms",
+            self._gate(
+                'posts react ~mug 170.141 "👍"',
+                HERMES_SESSION_CHAT_ID="~mug",
+            )["message"],
+        )
+        self.assertIn(
+            "disabled",
+            self._gate(
+                'posts react chat/~pen/general 170.141 "👍"',
+                TLON_REACTION_LEVEL="ack",
+            )["message"],
+        )
+
+    def test_owner_keeps_unrestricted_tlon_access(self):
+        self.assertIsNone(
+            self._gate(
+                'posts react chat/~other/else 170.141 "👍"',
+                HERMES_SESSION_USER_ID="~pen",
+                TLON_REACTION_LEVEL="off",
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/hermes-tlon-adapter/tlon_api.py
+++ b/packages/hermes-tlon-adapter/tlon_api.py
@@ -30,6 +30,8 @@ DEFAULT_GATEWAY_OFFLINE_REPLY_COOLDOWN_SECONDS = 300
 DEFAULT_SSE_READ_TIMEOUT_SECONDS = 60.0
 DEFAULT_MAX_CONSECUTIVE_BOT_RESPONSES = 3
 DEFAULT_CONTEXT_MESSAGES = 20
+REACTION_LEVELS = frozenset({"off", "ack", "minimal", "extensive"})
+DEFAULT_REACTION_LEVEL = "minimal"
 
 
 def normalize_ship(ship: str) -> str:
@@ -237,6 +239,7 @@ class TlonConfig:
     context_lens_enabled: bool = False
     context_lens_owner: str = ""
     sse_read_timeout_seconds: float = DEFAULT_SSE_READ_TIMEOUT_SECONDS
+    reaction_level: str = DEFAULT_REACTION_LEVEL
     # Force the hosted (memex) image-upload path. Opt-in: only true when the
     # operator sets TLON_HOSTING. Read once where the env is reliably present
     # (the adapter at startup) and carried via this field into CLI invocations,
@@ -541,6 +544,20 @@ class TlonConfig:
             ),
             DEFAULT_SSE_READ_TIMEOUT_SECONDS,
         )
+        reaction_level = _env_first(
+            env,
+            ("TLON_REACTION_LEVEL",),
+            extra,
+            ("reaction_level",),
+            DEFAULT_REACTION_LEVEL,
+        ).lower()
+        if reaction_level not in REACTION_LEVELS:
+            logger.warning(
+                "[tlon] invalid TLON_REACTION_LEVEL=%r; using %s",
+                reaction_level,
+                DEFAULT_REACTION_LEVEL,
+            )
+            reaction_level = DEFAULT_REACTION_LEVEL
 
         auto_discover = parse_bool(
             _env_or_extra(env, ("TLON_AUTO_DISCOVER",), extra, ("auto_discover",))
@@ -594,6 +611,7 @@ class TlonConfig:
             context_lens_enabled=context_lens_enabled,
             context_lens_owner=context_lens_owner,
             sse_read_timeout_seconds=sse_read_timeout_seconds,
+            reaction_level=reaction_level,
         )
 
     def is_complete(self) -> bool:
@@ -1307,6 +1325,42 @@ class TlonIncomingMessage:
     content: Any = None
     blob: Optional[str] = None
     author_is_bot: bool = False
+    # The essay author is distinct from user_id for self echoes in DMs: the
+    # conversation/user remains the partner while this identifies the sender.
+    author_id: str = ""
+    # Set for a synthetic reaction event so its visible id is the actual
+    # reacted post rather than the synthetic event identity.
+    reactable_target_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class TlonReaction:
+    """One decoded reaction transition or snapshot entry.
+
+    ``wire_key`` remains the serialized identity used for state comparisons;
+    ``reactor`` is the ship used for authorization and loop protection.
+    """
+
+    chat_type: str
+    chat_id: str
+    post_id: str
+    parent_id: Optional[str]
+    wire_key: str
+    reactor: str
+    reactor_is_bot: bool
+    emoji: str
+    added: bool
+    raw: Any
+
+
+@dataclass(frozen=True)
+class ChannelReactsSnapshot:
+    chat_id: str
+    post_id: str
+    parent_id: Optional[str]
+    # wire key -> (exact decoded emoji, normalized ship, is bot identity)
+    entries: dict[str, tuple[str, str, bool]]
+    raw: Any
 
 
 def extract_message_text(content: Any) -> str:
@@ -1389,10 +1443,156 @@ def author_is_bot_meta(author: Any) -> bool:
     return isinstance(author, Mapping) and bool(author.get("ship"))
 
 
+def _decode_react_value(value: Any) -> str:
+    """Decode Tlon's ``$react`` JSON without silently accepting bad values."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping) and isinstance(value.get("any"), str):
+        return str(value["any"])
+    raise ValueError("reaction value is not a string or {any: string}")
+
+
+def _reaction_author(author: Any) -> tuple[str, str, bool]:
+    """Return (wire_key, normalized_ship, is_bot) for a reaction author."""
+    if isinstance(author, str) and author.strip():
+        return author, normalize_ship(author), False
+    if isinstance(author, Mapping):
+        ship = normalize_ship(str(author.get("ship") or ""))
+        nickname = author.get("nickname")
+        if not ship or not isinstance(nickname, str):
+            raise ValueError("bot reaction author is missing ship or nickname")
+        return f"{author.get('ship')}/{nickname}", ship, True
+    raise ValueError("reaction author is not a ship or bot identity")
+
+
+def parse_channel_reacts_snapshot(event: Any) -> Optional[ChannelReactsSnapshot]:
+    """Decode a complete channels /v2 reaction map without applying a diff."""
+    if not isinstance(event, dict):
+        return None
+    nest = event.get("nest")
+    response = event.get("response")
+    if not isinstance(nest, str) or not nest or not isinstance(response, dict):
+        return None
+    post = response.get("post")
+    r_post = post.get("r-post") if isinstance(post, dict) else None
+    if not isinstance(post, dict) or not isinstance(r_post, dict):
+        return None
+
+    post_id = post.get("id")
+    parent_id: Optional[str] = None
+    reacts = r_post.get("reacts")
+    reply = r_post.get("reply")
+    if isinstance(reply, dict):
+        r_reply = reply.get("r-reply")
+        if isinstance(r_reply, dict) and "reacts" in r_reply:
+            reacts = r_reply.get("reacts")
+            post_id = reply.get("id")
+            parent_id = str(post.get("id") or "") or None
+
+    if not isinstance(reacts, dict) or not post_id:
+        return None
+
+    try:
+        entries: dict[str, tuple[str, str, bool]] = {}
+        for wire_key, raw_value in reacts.items():
+            if not isinstance(wire_key, str) or not wire_key:
+                raise ValueError("reaction map key is not a non-empty string")
+            if "/" in wire_key:
+                if not isinstance(raw_value, Mapping):
+                    raise ValueError("bot reaction map entry is not an object")
+                reactor = normalize_ship(str(raw_value.get("ship") or ""))
+                if not reactor:
+                    raise ValueError("bot reaction map entry is missing ship")
+                emoji = _decode_react_value(raw_value.get("react"))
+                entries[wire_key] = (emoji, reactor, True)
+            else:
+                reactor = normalize_ship(wire_key)
+                if not reactor:
+                    raise ValueError("reaction map key is not a ship")
+                entries[wire_key] = (_decode_react_value(raw_value), reactor, False)
+    except (TypeError, ValueError) as exc:
+        logger.warning("[tlon] ignoring malformed channel reaction snapshot: %s", exc)
+        return None
+
+    return ChannelReactsSnapshot(
+        chat_id=nest,
+        post_id=str(post_id),
+        parent_id=parent_id,
+        entries=entries,
+        raw=event,
+    )
+
+
+def _is_plain_patp(ship: Any) -> bool:
+    return bool(re.fullmatch(r"~[a-z][a-z-]*", normalize_ship(str(ship or ""))))
+
+
+def parse_dm_reaction(event: Any, *, self_ship: str) -> Optional[TlonReaction]:
+    """Decode one chat /v3 add-react or del-react transition.
+
+    Legacy group-DM events share this subscription but cannot be delivered by
+    the one-to-one DM send path, so they are intentionally excluded here.
+    """
+    if not isinstance(event, dict):
+        return None
+    whom = event.get("whom")
+    response = event.get("response")
+    if not isinstance(whom, str) or not _is_plain_patp(whom) or not isinstance(response, dict):
+        return None
+    root_id = event.get("id")
+    if not root_id:
+        return None
+
+    delta: Any = response
+    post_id: Any = root_id
+    parent_id: Optional[str] = None
+    reply = response.get("reply")
+    if isinstance(reply, dict) and isinstance(reply.get("delta"), dict):
+        delta = reply["delta"]
+        post_id = reply.get("id")
+        parent_id = str(root_id)
+    if not isinstance(delta, dict) or not post_id:
+        return None
+
+    added = "add-react" in delta
+    removed = "del-react" in delta
+    if added == removed:
+        return None
+    try:
+        if added:
+            payload = delta.get("add-react")
+            if not isinstance(payload, Mapping):
+                raise ValueError("add-react is not an object")
+            wire_key, reactor, reactor_is_bot = _reaction_author(payload.get("author"))
+            emoji = _decode_react_value(payload.get("react"))
+        else:
+            wire_key, reactor, reactor_is_bot = _reaction_author(delta.get("del-react"))
+            emoji = ""
+    except (TypeError, ValueError) as exc:
+        logger.warning("[tlon] ignoring malformed DM reaction: %s", exc)
+        return None
+
+    if reactor == normalize_ship(self_ship):
+        return None
+    return TlonReaction(
+        chat_type="dm",
+        chat_id=normalize_ship(whom),
+        post_id=str(post_id),
+        parent_id=parent_id,
+        wire_key=wire_key,
+        reactor=reactor,
+        reactor_is_bot=reactor_is_bot,
+        emoji=emoji,
+        added=added,
+        raw=event,
+    )
+
+
 def parse_channel_message(
     event: Any,
     *,
     self_ship: str,
+    include_self: bool = False,
 ) -> Optional[TlonIncomingMessage]:
     if not isinstance(event, dict):
         return None
@@ -1434,7 +1634,7 @@ def parse_channel_message(
         return None
 
     sender = extract_author_ship(content.get("author"))
-    if not sender or sender == normalize_ship(self_ship):
+    if not sender or (not include_self and sender == normalize_ship(self_ship)):
         return None
 
     story_content = content.get("content")
@@ -1466,6 +1666,7 @@ def parse_channel_message(
         content=story_content,
         blob=blob,
         author_is_bot=author_is_bot_meta(content.get("author")),
+        author_id=sender,
     )
 
 
@@ -1473,6 +1674,7 @@ def parse_dm_message(
     event: Any,
     *,
     self_ship: str,
+    include_self: bool = False,
 ) -> Optional[TlonIncomingMessage]:
     if not isinstance(event, dict):
         return None
@@ -1504,7 +1706,7 @@ def parse_dm_message(
         return None
 
     sender = extract_author_ship(content.get("author"))
-    if not sender or sender == normalize_ship(self_ship):
+    if not sender or (not include_self and sender == normalize_ship(self_ship)):
         return None
 
     partner = normalize_ship(str(whom)) if isinstance(whom, str) else ""
@@ -1531,6 +1733,7 @@ def parse_dm_message(
         content=story_content,
         blob=blob,
         author_is_bot=author_is_bot_meta(content.get("author")),
+        author_id=sender,
     )
 
 

--- a/packages/hermes-tlon-adapter/tlon_api.py
+++ b/packages/hermes-tlon-adapter/tlon_api.py
@@ -1458,10 +1458,13 @@ def _reaction_author(author: Any) -> tuple[str, str, bool]:
         return author, normalize_ship(author), False
     if isinstance(author, Mapping):
         ship = normalize_ship(str(author.get("ship") or ""))
+        if not ship:
+            raise ValueError("bot reaction author is missing ship")
+        # nickname is wire type `(unit @t)`: null/missing is legal for bot
+        # profiles without a nickname, so fall back to an empty suffix.
         nickname = author.get("nickname")
-        if not ship or not isinstance(nickname, str):
-            raise ValueError("bot reaction author is missing ship or nickname")
-        return f"{author.get('ship')}/{nickname}", ship, True
+        suffix = nickname if isinstance(nickname, str) else ""
+        return f"{author.get('ship')}/{suffix}", ship, True
     raise ValueError("reaction author is not a ship or bot identity")
 
 

--- a/packages/hermes-tlon-adapter/tlon_tool.py
+++ b/packages/hermes-tlon-adapter/tlon_tool.py
@@ -270,6 +270,7 @@ def check_tlon_tool_command(
     session_user_id: str = "",
     session_chat_id: str = "",
     owner_ship: str = "",
+    reaction_level: str = "minimal",
 ) -> Optional[str]:
     lowered = [str(arg).lower() for arg in args]
     if lowered in (["--help"], ["--version"]):
@@ -283,6 +284,15 @@ def check_tlon_tool_command(
 
     command_args = [str(arg).lower() for arg in args[sub_idx:]]
     action = command_args[1] if len(command_args) > 1 else ""
+    if (
+        (subcommand, action) in {("posts", "react"), ("posts", "unreact"), ("dms", "react"), ("dms", "unreact")}
+        and str(reaction_level).lower() in {"off", "ack"}
+    ):
+        return (
+            "Blocked: agent reactions are disabled "
+            f'(TLON_REACTION_LEVEL="{str(reaction_level).lower()}"). '
+            "Set TLON_REACTION_LEVEL to minimal or extensive to enable."
+        )
     if subcommand == "notebook":
         return (
             "Blocked: the notebook command is removed (the %diary backend no "
@@ -370,6 +380,7 @@ async def execute_tlon_tool(
         session_user_id=_get_session_env("HERMES_SESSION_USER_ID", ""),
         session_chat_id=_get_session_env("HERMES_SESSION_CHAT_ID", ""),
         owner_ship=cfg.owner_ship,
+        reaction_level=cfg.reaction_level,
     )
     if blocked:
         return _json({"error": blocked, "blocked": True})

--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -394,6 +394,7 @@ Manage direct messages — reactions, invites, and deletions.
 # Management
 tlon dms react ~sampel ~author/170.141... "👍"           # React to a DM
 tlon dms unreact ~sampel ~author/170.141...              # Remove reaction
+tlon dms react ~sampel ~author/reply-id "👍" --parent ~author/root-id  # React to a DM thread reply
 tlon dms delete ~sampel ~author/170.141...               # Delete a DM
 tlon dms accept ~sampel                                  # Accept DM invite
 tlon dms decline ~sampel                                 # Decline DM invite
@@ -436,6 +437,7 @@ tlon posts send chat/~host/slug "Look" --image https://storage.../x.png # Send w
 tlon posts send chat/~host/slug --image https://...      # Image only (no caption)
 tlon posts react chat/~host/slug 170.141... "👍"         # React to a post
 tlon posts unreact chat/~host/slug 170.141...            # Remove reaction
+tlon posts react chat/~host/slug reply-id "👍" --parent root-id  # React to a thread reply
 tlon posts edit chat/~host/slug 170.141... "New text"    # Edit a post's message text
 tlon posts delete chat/~host/slug 170.141...             # Delete a post
 ```

--- a/packages/tlon-skill/bunfig.toml
+++ b/packages/tlon-skill/bunfig.toml
@@ -1,0 +1,9 @@
+# Register the single process-wide '@tloncorp/api' module mock before any
+# test file loads. bun's mock.module cannot be called for the same specifier
+# from two test files: the registrations race (test-file execution order is
+# platform-dependent), the loser's importers fail ESM named-export
+# validation against the winner's shape, and bun's error misleadingly blames
+# packages/api/dist. See scripts/tloncorp-api-mock.ts. Hermetic tests spawn
+# the real CLI in subprocesses, which this mock does not reach.
+[test]
+preload = ["./scripts/tloncorp-api-mock.ts"]

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -854,6 +854,140 @@ export const POSTS_FAMILY_CASES: CliCase[] = [
   ]),
 ];
 
+// `--parent` on the four react/unreact commands (posts + dms families):
+// malformed values are rejected locally (an option-like value or a
+// duplicate flag), and a well-formed value reaches auth — exercising
+// main()'s wiring end to end, not just the exported parser helpers.
+export const REACTION_PARENT_CASES: CliCase[] = [
+  usageErrorCase(
+    'posts react rejects option-like --parent value',
+    [
+      'posts',
+      'react',
+      'chat/~host/channel',
+      '170.141',
+      '👍',
+      '--parent',
+      '--bogus',
+    ],
+    'Usage: tlon posts react'
+  ),
+  usageErrorCase(
+    'posts react rejects duplicate --parent',
+    [
+      'posts',
+      'react',
+      'chat/~host/channel',
+      '170.142',
+      '👍',
+      '--parent',
+      '170.141',
+      '--parent',
+      '170.140',
+    ],
+    'Usage: tlon posts react'
+  ),
+  usageErrorCase(
+    'posts unreact rejects option-like --parent value',
+    [
+      'posts',
+      'unreact',
+      'chat/~host/channel',
+      '170.141',
+      '--parent',
+      '--bogus',
+    ],
+    'Usage: tlon posts unreact'
+  ),
+  usageErrorCase(
+    'posts unreact rejects duplicate --parent',
+    [
+      'posts',
+      'unreact',
+      'chat/~host/channel',
+      '170.142',
+      '--parent',
+      '170.141',
+      '--parent',
+      '170.140',
+    ],
+    'Usage: tlon posts unreact'
+  ),
+  usageErrorCase(
+    'dms react rejects option-like --parent value',
+    ['dms', 'react', '~zod', '~zod/170.141', '👍', '--parent', '--bogus'],
+    'Usage: tlon dms react'
+  ),
+  usageErrorCase(
+    'dms react rejects duplicate --parent',
+    [
+      'dms',
+      'react',
+      '~zod',
+      '~zod/170.142',
+      '👍',
+      '--parent',
+      '~zod/170.141',
+      '--parent',
+      '~zod/170.140',
+    ],
+    'Usage: tlon dms react'
+  ),
+  usageErrorCase(
+    'dms unreact rejects option-like --parent value',
+    ['dms', 'unreact', '~zod', '~zod/170.141', '--parent', '--bogus'],
+    'Usage: tlon dms unreact'
+  ),
+  usageErrorCase(
+    'dms unreact rejects duplicate --parent',
+    [
+      'dms',
+      'unreact',
+      '~zod',
+      '~zod/170.142',
+      '--parent',
+      '~zod/170.141',
+      '--parent',
+      '~zod/170.140',
+    ],
+    'Usage: tlon dms unreact'
+  ),
+  authRequiredCase('posts react with --parent reaches auth', [
+    'posts',
+    'react',
+    'chat/~host/channel',
+    '170.142',
+    '👍',
+    '--parent',
+    '170.141',
+  ]),
+  authRequiredCase('posts unreact with --parent reaches auth', [
+    'posts',
+    'unreact',
+    'chat/~host/channel',
+    '170.142',
+    '--parent',
+    '170.141',
+  ]),
+  authRequiredCase('dms react with --parent reaches auth', [
+    'dms',
+    'react',
+    '~zod',
+    '~zod/170.142',
+    '👍',
+    '--parent',
+    '~zod/170.141',
+  ]),
+  authRequiredCase('dms unreact with --parent reaches auth', [
+    'dms',
+    'unreact',
+    '~zod',
+    '~zod/170.142',
+    '--parent',
+    '~zod/170.141',
+  ]),
+];
+
 // The `notes` family: required-arg matrices (no credential lookup) and
 // valid-looking invocations that reach auth with `Missing Urbit config`.
 export const NOTES_FAMILY_CASES: CliCase[] = [
@@ -1411,6 +1545,7 @@ export const CLI_MATRIX_CASES: CliCase[] = [
   ...NESTED_HELP_CASES,
   ...LITERAL_OPTION_LIKE_VALUE_CASES,
   ...POSTS_FAMILY_CASES,
+  ...REACTION_PARENT_CASES,
   ...NOTES_FAMILY_CASES,
   ...NOTES_CHANNEL_KIND_CASES,
   ...NOTES_CONTENT_UNSUPPORTED_CASES,

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -952,6 +952,16 @@ export const REACTION_PARENT_CASES: CliCase[] = [
     ],
     'Usage: tlon dms unreact'
   ),
+  usageErrorCase(
+    'posts react rejects --parent swallowed into the omitted emoji slot',
+    ['posts', 'react', 'chat/~host/channel', '170.142', '--parent', '170.141'],
+    'Usage: tlon posts react'
+  ),
+  usageErrorCase(
+    'dms react rejects --parent swallowed into the omitted emoji slot',
+    ['dms', 'react', '~zod', '~zod/170.142', '--parent', '~zod/170.141'],
+    'Usage: tlon dms react'
+  ),
   authRequiredCase('posts react with --parent reaches auth', [
     'posts',
     'react',

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -576,6 +576,61 @@ describe('posts react', () => {
       postAuthor: '~nec',
     });
   });
+
+  it('passes --parent through for thread-reply reactions', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      ['react', 'chat/~host/channel', '170142', '🔥', '--parent', '170141'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.addReaction).toEqual([
+      {
+        channelId: 'chat/~host/channel',
+        postId: '170.142',
+        emoji: '🔥',
+        our: '~nec',
+        postAuthor: '~nec',
+        parentId: '170.141',
+      },
+    ]);
+  });
+
+  it('rejects a --parent value that is itself an option token', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      ['react', 'chat/~host/channel', '170141', '🔥', '--parent', '--bogus'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.react}\n`);
+    expectNoAuthOrApi(context);
+  });
+
+  it('rejects a duplicate --parent flag', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      [
+        'react',
+        'chat/~host/channel',
+        '170142',
+        '🔥',
+        '--parent',
+        '170141',
+        '--parent',
+        '170140',
+      ],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.react}\n`);
+    expectNoAuthOrApi(context);
+  });
 });
 
 describe('posts unreact', () => {
@@ -639,6 +694,59 @@ describe('posts unreact', () => {
     expect(exitCode).toBe(1);
     expect(context.stdout()).toBe('');
     expect(context.stderr()).toBe('Error: remove failed\n');
+  });
+
+  it('passes --parent through for thread-reply reaction removal', async () => {
+    const context = makeDeps({ currentUserId: '~bus' });
+    const exitCode = await run(
+      ['unreact', 'chat/~host/channel', '170142', '--parent', '170141'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.removeReaction).toEqual([
+      {
+        channelId: 'chat/~host/channel',
+        postId: '170.142',
+        our: '~bus',
+        postAuthor: '~bus',
+        parentId: '170.141',
+      },
+    ]);
+  });
+
+  it('rejects a --parent value that is itself an option token', async () => {
+    const context = makeDeps({ currentUserId: '~bus' });
+    const exitCode = await run(
+      ['unreact', 'chat/~host/channel', '170141', '--parent', '--bogus'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.unreact}\n`);
+    expectNoAuthOrApi(context);
+  });
+
+  it('rejects a duplicate --parent flag', async () => {
+    const context = makeDeps({ currentUserId: '~bus' });
+    const exitCode = await run(
+      [
+        'unreact',
+        'chat/~host/channel',
+        '170142',
+        '--parent',
+        '170141',
+        '--parent',
+        '170140',
+      ],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.unreact}\n`);
+    expectNoAuthOrApi(context);
   });
 });
 

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -631,6 +631,19 @@ describe('posts react', () => {
     expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.react}\n`);
     expectNoAuthOrApi(context);
   });
+
+  it('rejects an omitted emoji that lets --parent fill the emoji slot', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      ['react', 'chat/~host/chan', '170.142', '--parent', '170.141'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.react}\n`);
+    expectNoAuthOrApi(context);
+  });
 });
 
 describe('posts unreact', () => {
@@ -740,6 +753,19 @@ describe('posts unreact', () => {
         '--parent',
         '170140',
       ],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.unreact}\n`);
+    expectNoAuthOrApi(context);
+  });
+
+  it('rejects an omitted id that lets --parent fill the id slot', async () => {
+    const context = makeDeps({ currentUserId: '~bus' });
+    const exitCode = await run(
+      ['unreact', 'chat/~host/chan', '--parent', '170.141'],
       context.deps
     );
 

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -482,6 +482,15 @@ function parseArgs(args: string[]): ParsedPostsArgs {
       if (!channelId || !postId || !emoji) {
         throw usageError(POSTS_COMMAND_HELP.react);
       }
+      // A positional slot filled by an option token (e.g. `--parent` swallowed
+      // into the emoji slot when the emoji is omitted) is a usage error.
+      if (
+        channelId.startsWith('--') ||
+        postId.startsWith('--') ||
+        emoji.startsWith('--')
+      ) {
+        throw usageError(POSTS_COMMAND_HELP.react);
+      }
       return {
         kind: 'react',
         channelId,
@@ -493,6 +502,9 @@ function parseArgs(args: string[]): ParsedPostsArgs {
     case 'unreact': {
       const [, channelId, postId] = args;
       if (!channelId || !postId) {
+        throw usageError(POSTS_COMMAND_HELP.unreact);
+      }
+      if (channelId.startsWith('--') || postId.startsWith('--')) {
         throw usageError(POSTS_COMMAND_HELP.unreact);
       }
       return {

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -22,8 +22,8 @@ export const POSTS_HELP = `Usage: tlon posts <command>
 Commands:
   send <channel> [message]                 Send a message to a channel [--blob <json>] [--image <url>]
   reply <channel> <post-id> <message>      Reply to a channel post [--author ~ship] [--blob <json>]
-  react <channel> <post-id> <emoji>     React to a post with an emoji
-  unreact <channel> <post-id>           Remove your reaction from a post
+  react <channel> <post-id> <emoji>     React to a post with an emoji [--parent <post-id>]
+  unreact <channel> <post-id>           Remove your reaction from a post [--parent <post-id>]
   edit <channel> <post-id> <message>    Edit a post's message text
   delete <channel> <post-id>            Delete a post
 
@@ -47,8 +47,9 @@ export const POSTS_COMMAND_HELP: Record<string, string> = {
   send: 'Usage: tlon posts send <channel> [message] [--blob <json>] [--image <url>] [--sent-at <ms>] (message optional with --image)',
   reply:
     'Usage: tlon posts reply <channel> <post-id> <message> [--author ~ship] [--blob <json>] [--sent-at <ms>]',
-  react: 'Usage: tlon posts react <channel> <post-id> <emoji>',
-  unreact: 'Usage: tlon posts unreact <channel> <post-id>',
+  react:
+    'Usage: tlon posts react <channel> <post-id> <emoji> [--parent <post-id>]',
+  unreact: 'Usage: tlon posts unreact <channel> <post-id> [--parent <post-id>]',
   edit: 'Usage: tlon posts edit <channel> <post-id> <message>',
   delete: 'Usage: tlon posts delete <channel> <post-id>',
 };
@@ -74,6 +75,7 @@ export interface PostReactionInput {
   emoji: string;
   our: string;
   postAuthor: string;
+  parentId?: string;
 }
 
 export interface PostReactionRemoveInput {
@@ -81,6 +83,7 @@ export interface PostReactionRemoveInput {
   postId: string;
   our: string;
   postAuthor: string;
+  parentId?: string;
 }
 
 export interface PostDeleteInput {
@@ -184,8 +187,14 @@ type ParsedPostsArgs =
       blob?: string;
       sentAt?: number;
     }
-  | { kind: 'react'; channelId: string; postId: string; emoji: string }
-  | { kind: 'unreact'; channelId: string; postId: string }
+  | {
+      kind: 'react';
+      channelId: string;
+      postId: string;
+      emoji: string;
+      parentId?: string;
+    }
+  | { kind: 'unreact'; channelId: string; postId: string; parentId?: string }
   | { kind: 'delete'; channelId: string; postId: string }
   | { kind: 'edit'; channelId: string; postId: string; message: string };
 
@@ -205,6 +214,20 @@ function formatUd(id: string): string {
 
 function formatPostId(postId: string): string {
   return formatUd(extractNumericId(postId));
+}
+
+function optionalReactionParent(
+  args: string[],
+  help: string
+): string | undefined {
+  const idx = args.indexOf('--parent');
+  if (idx === -1) return undefined;
+  // Reject a duplicate `--parent` and a value that is itself an option
+  // token (e.g. `--parent --bogus` reading the next flag as the id).
+  if (args.indexOf('--parent', idx + 1) !== -1) throw usageError(help);
+  const parentId = args[idx + 1];
+  if (!parentId || parentId.startsWith('--')) throw usageError(help);
+  return parentId;
 }
 
 // Optional `--sent-at <unix-ms>`: overrides the send timestamp so a caller
@@ -459,14 +482,25 @@ function parseArgs(args: string[]): ParsedPostsArgs {
       if (!channelId || !postId || !emoji) {
         throw usageError(POSTS_COMMAND_HELP.react);
       }
-      return { kind: 'react', channelId, postId, emoji };
+      return {
+        kind: 'react',
+        channelId,
+        postId,
+        emoji,
+        parentId: optionalReactionParent(args, POSTS_COMMAND_HELP.react),
+      };
     }
     case 'unreact': {
       const [, channelId, postId] = args;
       if (!channelId || !postId) {
         throw usageError(POSTS_COMMAND_HELP.unreact);
       }
-      return { kind: 'unreact', channelId, postId };
+      return {
+        kind: 'unreact',
+        channelId,
+        postId,
+        parentId: optionalReactionParent(args, POSTS_COMMAND_HELP.unreact),
+      };
     }
     case 'delete': {
       const [, channelId, postId] = args;
@@ -497,7 +531,12 @@ function parseArgs(args: string[]): ParsedPostsArgs {
 }
 
 async function reactToPost(
-  parsed: { channelId: string; postId: string; emoji: string },
+  parsed: {
+    channelId: string;
+    postId: string;
+    emoji: string;
+    parentId?: string;
+  },
   deps: PostsDeps
 ): Promise<void> {
   const our = deps.getCurrentUserId();
@@ -507,11 +546,12 @@ async function reactToPost(
     emoji: parsed.emoji,
     our,
     postAuthor: our,
+    ...(parsed.parentId ? { parentId: formatPostId(parsed.parentId) } : {}),
   });
 }
 
 async function unreactToPost(
-  parsed: { channelId: string; postId: string },
+  parsed: { channelId: string; postId: string; parentId?: string },
   deps: PostsDeps
 ): Promise<void> {
   const our = deps.getCurrentUserId();
@@ -520,6 +560,7 @@ async function unreactToPost(
     postId: formatPostId(parsed.postId),
     our,
     postAuthor: our,
+    ...(parsed.parentId ? { parentId: formatPostId(parsed.parentId) } : {}),
   });
 }
 

--- a/packages/tlon-skill/scripts/dms.test.ts
+++ b/packages/tlon-skill/scripts/dms.test.ts
@@ -1,4 +1,31 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, mock } from 'bun:test';
+
+// Mock the api package before importing dms so the test never loads
+// packages/api/dist (which may be stale or absent in CI); every dms function
+// under test takes injected deps, so the real implementations are never used.
+mock.module('@tloncorp/api', () => ({
+  // dms.ts value imports
+  addReaction: async () => undefined,
+  deletePost: async () => undefined,
+  getCurrentUserId: () => '~zod',
+  removeReaction: async () => undefined,
+  respondToDMInvite: async () => undefined,
+  sendPost: async () => undefined,
+  sendReply: async () => undefined,
+  // api-client.ts value imports (transitive via ./api-client)
+  Urbit: class {
+    cookie = '';
+    nodeId = '';
+
+    constructor(readonly url: string) {}
+  },
+  client: { cookie: '' },
+  configureClient: async () => undefined,
+  internalRemoveClient: () => undefined,
+  preSig: (ship: string) => (ship.startsWith('~') ? ship : `~${ship}`),
+  scry: async () => undefined,
+  subscribe: async () => 0,
+}));
 
 function loadDms() {
   return import('./dms');

--- a/packages/tlon-skill/scripts/dms.test.ts
+++ b/packages/tlon-skill/scripts/dms.test.ts
@@ -79,6 +79,33 @@ describe('dms thread reaction parents', () => {
     }
   });
 
+  it('rejects an option token in a positional react/unreact slot before API work', async () => {
+    const dms = await loadDms();
+    const originalExit = process.exit;
+    const originalError = console.error;
+    const cases = [
+      // Emoji omitted: `--parent` would otherwise fill the react slot.
+      ['react', '~mug', '~pen/170.142', '--parent', '~pen/170.141'],
+      // Id omitted: `--parent` would otherwise fill the message-id slot.
+      ['unreact', '~mug', '--parent', '~pen/170.141'],
+    ];
+    for (const args of cases) {
+      const exitCodes: (number | undefined)[] = [];
+      process.exit = ((code?: number) => {
+        exitCodes.push(code);
+        throw new Error('exit');
+      }) as typeof process.exit;
+      console.error = () => {};
+      try {
+        expect(() => dms.validateDmsArgs(args)).toThrow();
+        expect(exitCodes).toEqual([1]);
+      } finally {
+        process.exit = originalExit;
+        console.error = originalError;
+      }
+    }
+  });
+
   it('passes parentId and parentAuthorId for react and unreact', async () => {
     const dms = await loadDms();
     const added: Record<string, unknown>[] = [];

--- a/packages/tlon-skill/scripts/dms.test.ts
+++ b/packages/tlon-skill/scripts/dms.test.ts
@@ -1,31 +1,11 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
-// Mock the api package before importing dms so the test never loads
-// packages/api/dist (which may be stale or absent in CI); every dms function
-// under test takes injected deps, so the real implementations are never used.
-mock.module('@tloncorp/api', () => ({
-  // dms.ts value imports
-  addReaction: async () => undefined,
-  deletePost: async () => undefined,
-  getCurrentUserId: () => '~zod',
-  removeReaction: async () => undefined,
-  respondToDMInvite: async () => undefined,
-  sendPost: async () => undefined,
-  sendReply: async () => undefined,
-  // api-client.ts value imports (transitive via ./api-client)
-  Urbit: class {
-    cookie = '';
-    nodeId = '';
-
-    constructor(readonly url: string) {}
-  },
-  client: { cookie: '' },
-  configureClient: async () => undefined,
-  internalRemoveClient: () => undefined,
-  preSig: (ship: string) => (ship.startsWith('~') ? ship : `~${ship}`),
-  scry: async () => undefined,
-  subscribe: async () => 0,
-}));
+// The process-wide '@tloncorp/api' mock (preloaded via bunfig.toml) is what
+// importing ./dms resolves against; every dms function under test takes
+// injected deps, so the mock's default implementations are never assertion
+// targets. Never register a per-file mock.module for the api — see the
+// module doc for the ordering trap.
+import './tloncorp-api-mock';
 
 function loadDms() {
   return import('./dms');

--- a/packages/tlon-skill/scripts/dms.test.ts
+++ b/packages/tlon-skill/scripts/dms.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'bun:test';
+
+function loadDms() {
+  return import('./dms');
+}
+
+describe('dms thread reaction parents', () => {
+  it('parses an author-prefixed --parent value', async () => {
+    const dms = await loadDms();
+    expect(
+      dms.reactionParent(
+        ['react', '~mug', '~pen/170.142', '👍', '--parent', '~pen/170.141'],
+        'usage'
+      )
+    ).toBe('~pen/170.141');
+  });
+
+  it('rejects a --parent value that is itself an option token', async () => {
+    const dms = await loadDms();
+    const originalExit = process.exit;
+    const originalError = console.error;
+    const exitCodes: (number | undefined)[] = [];
+    process.exit = ((code?: number) => {
+      exitCodes.push(code);
+      throw new Error('exit');
+    }) as typeof process.exit;
+    console.error = () => {};
+    try {
+      expect(() =>
+        dms.reactionParent(
+          ['react', '~mug', '~pen/170.142', '👍', '--parent', '--bogus'],
+          'usage'
+        )
+      ).toThrow();
+      expect(exitCodes).toEqual([1]);
+    } finally {
+      process.exit = originalExit;
+      console.error = originalError;
+    }
+  });
+
+  it('rejects a duplicate --parent flag', async () => {
+    const dms = await loadDms();
+    const originalExit = process.exit;
+    const originalError = console.error;
+    const exitCodes: (number | undefined)[] = [];
+    process.exit = ((code?: number) => {
+      exitCodes.push(code);
+      throw new Error('exit');
+    }) as typeof process.exit;
+    console.error = () => {};
+    try {
+      expect(() =>
+        dms.reactionParent(
+          [
+            'react',
+            '~mug',
+            '~pen/170.142',
+            '👍',
+            '--parent',
+            '~pen/170.141',
+            '--parent',
+            '~pen/170.140',
+          ],
+          'usage'
+        )
+      ).toThrow();
+      expect(exitCodes).toEqual([1]);
+    } finally {
+      process.exit = originalExit;
+      console.error = originalError;
+    }
+  });
+
+  it('passes parentId and parentAuthorId for react and unreact', async () => {
+    const dms = await loadDms();
+    const added: Record<string, unknown>[] = [];
+    const removed: Record<string, unknown>[] = [];
+    const deps = {
+      addReaction: async (input: Record<string, unknown>) => {
+        added.push(input);
+      },
+      removeReaction: async (input: Record<string, unknown>) => {
+        removed.push(input);
+      },
+      getCurrentUserId: () => '~zod',
+      normalizeShip: (ship: string) =>
+        ship.startsWith('~') ? ship : `~${ship}`,
+    };
+
+    expect(
+      await dms.reactToDM(
+        '~mug',
+        '~pen/170.142',
+        '🔥',
+        '~pen/170.141',
+        deps as never
+      )
+    ).toEqual({ success: true });
+    expect(
+      await dms.unreactToDM(
+        '~mug',
+        '~pen/170.142',
+        '~pen/170.141',
+        deps as never
+      )
+    ).toEqual({ success: true });
+
+    const expected = {
+      channelId: '~mug',
+      postId: '170.142',
+      our: '~zod',
+      postAuthor: '~pen',
+      parentId: '170.141',
+      parentAuthorId: '~pen',
+    };
+    expect(added).toEqual([{ ...expected, emoji: '🔥' }]);
+    expect(removed).toEqual([expected]);
+  });
+
+  it('requires an author on a DM thread parent', async () => {
+    const dms = await loadDms();
+    const result = await dms.reactToDM(
+      '~mug',
+      '~pen/170.142',
+      '👍',
+      '170.141',
+      {
+        addReaction: async () => {},
+        removeReaction: async () => {},
+        getCurrentUserId: () => '~zod',
+        normalizeShip: (ship: string) => ship,
+      } as never
+    );
+    expect(result).toEqual({
+      success: false,
+      error: 'Parent ID must include author (e.g., ~ship/123.456)',
+    });
+  });
+});

--- a/packages/tlon-skill/scripts/dms.ts
+++ b/packages/tlon-skill/scripts/dms.ts
@@ -86,7 +86,7 @@ function isDmsMessageHelpLiteral(args: string[]): boolean {
   return false;
 }
 
-function validateDmsArgs(args: string[]): void {
+export function validateDmsArgs(args: string[]): void {
   const command = args[0];
   if (!command || !DMS_COMMAND_HELP[command]) {
     printUsageAndExit(DMS_HELP);
@@ -123,11 +123,17 @@ function validateDmsArgs(args: string[]): void {
     case 'react': {
       if (!args[1] || !args[2] || !args[3])
         printUsageAndExit(DMS_COMMAND_HELP.react);
+      // A positional slot filled by an option token (e.g. `--parent` swallowed
+      // into the emoji slot when the emoji is omitted) is a usage error.
+      if (positionalIsOption(args, 3))
+        printUsageAndExit(DMS_COMMAND_HELP.react);
       reactionParent(args, DMS_COMMAND_HELP.react);
       return;
     }
     case 'unreact':
       if (!args[1] || !args[2]) printUsageAndExit(DMS_COMMAND_HELP.unreact);
+      if (positionalIsOption(args, 2))
+        printUsageAndExit(DMS_COMMAND_HELP.unreact);
       reactionParent(args, DMS_COMMAND_HELP.unreact);
       return;
     case 'delete': {
@@ -158,6 +164,16 @@ export function parsePostId(postId: string): { id: string; authorId?: string } {
     return { id, authorId: normalizeShip(author) };
   }
   return { id: postId };
+}
+
+// True when any positional slot 1..count is an option token (starts with
+// `--`). Guards against a flag being swallowed into a positional slot (e.g.
+// an omitted emoji letting `--parent` land in the react slot).
+function positionalIsOption(args: string[], count: number): boolean {
+  for (let i = 1; i <= count; i += 1) {
+    if (args[i]?.startsWith('--')) return true;
+  }
+  return false;
 }
 
 export function reactionParent(

--- a/packages/tlon-skill/scripts/dms.ts
+++ b/packages/tlon-skill/scripts/dms.ts
@@ -9,8 +9,8 @@
  * Usage:
  *   npx ts-node scripts/dms.ts send <club-id> <message>        (group DMs only)
  *   npx ts-node scripts/dms.ts reply <club-id> <post-id> <msg> (group DMs only)
- *   npx ts-node scripts/dms.ts react <ship> <post-id> <emoji>
- *   npx ts-node scripts/dms.ts unreact <ship> <post-id>
+ *   npx ts-node scripts/dms.ts react <ship> <post-id> <emoji> [--parent <post-id>]
+ *   npx ts-node scripts/dms.ts unreact <ship> <post-id> [--parent <post-id>]
  *   npx ts-node scripts/dms.ts delete <ship> <post-id>
  *   npx ts-node scripts/dms.ts accept <ship>
  *   npx ts-node scripts/dms.ts decline <ship>
@@ -46,8 +46,8 @@ const DMS_HELP = `Usage: tlon dms <command>
 Commands:
   send <club-id> [message]        Send a message to a group DM [--image <url>]
   reply <club-id> <post-id> <msg> Reply in a group DM (post-id must include author)
-  react <ship> <post-id> <emoji>  React to a DM (post-id must include author)
-  unreact <ship> <post-id>        Remove reaction from a DM (post-id must include author)
+  react <ship> <post-id> <emoji>  React to a DM (post-id must include author) [--parent <post-id>]
+  unreact <ship> <post-id>        Remove reaction from a DM (post-id must include author) [--parent <post-id>]
   delete <ship> <post-id>         Delete a DM (post-id may include author)
   accept <ship>                   Accept a DM invite
   decline <ship>                  Decline a DM invite`;
@@ -55,8 +55,8 @@ Commands:
 const DMS_COMMAND_HELP: Record<string, string> = {
   send: 'Usage: tlon dms send <club-id> [message] [--image <url>] (message optional with --image)',
   reply: 'Usage: tlon dms reply <club-id> <post-id> <message>',
-  react: 'Usage: tlon dms react <ship> <post-id> <emoji>',
-  unreact: 'Usage: tlon dms unreact <ship> <post-id>',
+  react: 'Usage: tlon dms react <ship> <post-id> <emoji> [--parent <post-id>]',
+  unreact: 'Usage: tlon dms unreact <ship> <post-id> [--parent <post-id>]',
   delete: 'Usage: tlon dms delete <ship> <post-id>',
   accept: 'Usage: tlon dms accept <ship>',
   decline: 'Usage: tlon dms decline <ship>',
@@ -123,9 +123,13 @@ function validateDmsArgs(args: string[]): void {
     case 'react': {
       if (!args[1] || !args[2] || !args[3])
         printUsageAndExit(DMS_COMMAND_HELP.react);
+      reactionParent(args, DMS_COMMAND_HELP.react);
       return;
     }
     case 'unreact':
+      if (!args[1] || !args[2]) printUsageAndExit(DMS_COMMAND_HELP.unreact);
+      reactionParent(args, DMS_COMMAND_HELP.unreact);
+      return;
     case 'delete': {
       if (!args[1] || !args[2]) printUsageAndExit(DMS_COMMAND_HELP[command]);
       return;
@@ -148,12 +152,30 @@ function isClub(whom: string): boolean {
   return whom.startsWith('0v');
 }
 
-function parsePostId(postId: string): { id: string; authorId?: string } {
+export function parsePostId(postId: string): { id: string; authorId?: string } {
   if (postId.includes('/')) {
     const [author, id] = postId.split('/');
     return { id, authorId: normalizeShip(author) };
   }
   return { id: postId };
+}
+
+export function reactionParent(
+  args: string[],
+  help: string
+): string | undefined {
+  const idx = args.indexOf('--parent');
+  if (idx === -1) return undefined;
+  // Reject a duplicate `--parent` and a value that is itself an option
+  // token (e.g. `--parent --bogus` reading the next flag as the id).
+  if (args.indexOf('--parent', idx + 1) !== -1) {
+    printUsageAndExit(help);
+  }
+  const parentId = args[idx + 1];
+  if (!parentId || parentId.startsWith('--')) {
+    printUsageAndExit(help);
+  }
+  return parentId;
 }
 
 // Send a message to a group DM (club)
@@ -219,13 +241,29 @@ async function replyToClub(
 }
 
 // React to a DM
-async function reactToDM(
+type DmReactionDeps = {
+  addReaction: typeof addReaction;
+  getCurrentUserId: typeof getCurrentUserId;
+  normalizeShip: typeof normalizeShip;
+  removeReaction: typeof removeReaction;
+};
+
+const DEFAULT_REACTION_DEPS: DmReactionDeps = {
+  addReaction,
+  getCurrentUserId,
+  normalizeShip,
+  removeReaction,
+};
+
+export async function reactToDM(
   ship: string,
   postId: string,
-  react: string
+  react: string,
+  parentId?: string,
+  deps: DmReactionDeps = DEFAULT_REACTION_DEPS
 ): Promise<{ success: boolean; error?: string }> {
-  const normalizedShip = normalizeShip(ship);
-  const our = getCurrentUserId();
+  const normalizedShip = deps.normalizeShip(ship);
+  const our = deps.getCurrentUserId();
   const parsed = parsePostId(postId);
 
   if (!parsed.authorId) {
@@ -234,14 +272,24 @@ async function reactToDM(
       error: 'Post ID must include author (e.g., ~ship/123.456)',
     };
   }
+  const parent = parentId ? parsePostId(parentId) : undefined;
+  if (parentId && !parent?.authorId) {
+    return {
+      success: false,
+      error: 'Parent ID must include author (e.g., ~ship/123.456)',
+    };
+  }
 
   try {
-    await addReaction({
+    await deps.addReaction({
       channelId: normalizedShip,
       postId: parsed.id,
       emoji: react,
       our,
       postAuthor: parsed.authorId,
+      ...(parent
+        ? { parentId: parent.id, parentAuthorId: parent.authorId }
+        : {}),
     });
 
     return { success: true };
@@ -251,12 +299,14 @@ async function reactToDM(
 }
 
 // Remove reaction from a DM
-async function unreactToDM(
+export async function unreactToDM(
   ship: string,
-  postId: string
+  postId: string,
+  parentId?: string,
+  deps: DmReactionDeps = DEFAULT_REACTION_DEPS
 ): Promise<{ success: boolean; error?: string }> {
-  const normalizedShip = normalizeShip(ship);
-  const our = getCurrentUserId();
+  const normalizedShip = deps.normalizeShip(ship);
+  const our = deps.getCurrentUserId();
   const parsed = parsePostId(postId);
 
   if (!parsed.authorId) {
@@ -265,13 +315,23 @@ async function unreactToDM(
       error: 'Post ID must include author (e.g., ~ship/123.456)',
     };
   }
+  const parent = parentId ? parsePostId(parentId) : undefined;
+  if (parentId && !parent?.authorId) {
+    return {
+      success: false,
+      error: 'Parent ID must include author (e.g., ~ship/123.456)',
+    };
+  }
 
   try {
-    await removeReaction({
+    await deps.removeReaction({
       channelId: normalizedShip,
       postId: parsed.id,
       our,
       postAuthor: parsed.authorId,
+      ...(parent
+        ? { parentId: parent.id, parentAuthorId: parent.authorId }
+        : {}),
     });
 
     return { success: true };
@@ -340,7 +400,7 @@ async function declineDM(
 }
 
 // CLI
-async function main() {
+export async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
 
@@ -416,7 +476,12 @@ async function main() {
       if (!ship || !postId || !react) {
         printUsageAndExit(DMS_COMMAND_HELP.react);
       }
-      const result = await reactToDM(ship, postId, react);
+      const result = await reactToDM(
+        ship,
+        postId,
+        react,
+        reactionParent(args, DMS_COMMAND_HELP.react)
+      );
       if (result.success) {
         console.log('✓ Reaction added!');
       } else {
@@ -432,7 +497,11 @@ async function main() {
       if (!ship || !postId) {
         printUsageAndExit(DMS_COMMAND_HELP.unreact);
       }
-      const result = await unreactToDM(ship, postId);
+      const result = await unreactToDM(
+        ship,
+        postId,
+        reactionParent(args, DMS_COMMAND_HELP.unreact)
+      );
       if (result.success) {
         console.log('✓ Reaction removed!');
       } else {
@@ -494,4 +563,10 @@ async function main() {
   process.exit(0);
 }
 
-main().catch(printErrorAndExit);
+// The unified CLI dynamically imports this module after setting argv to
+// ['tlon', 'dms', ...], while direct legacy `ts-node scripts/dms.ts` execution
+// retains the source filename in argv[1]. Keep both entry styles working and
+// leave imports side-effect free for the command-level tests.
+if (/(?:^|[\\/])dms\.(?:ts|js)$/.test(process.argv[1] ?? '')) {
+  main().catch(printErrorAndExit);
+}

--- a/packages/tlon-skill/scripts/main.ts
+++ b/packages/tlon-skill/scripts/main.ts
@@ -180,6 +180,7 @@ async function main() {
       case 'dms': {
         process.argv = ['tlon', command, ...scriptArgs];
         const mod = await import('./dms');
+        await mod.main();
         break;
       }
       case 'expose': {

--- a/packages/tlon-skill/scripts/notes-runtime.test.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.test.ts
@@ -1,84 +1,12 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 
 import { CommandError } from './commands/command';
-
-const NOTES_V1_OPS = [
-  'getRequest',
-  'listNotebooks',
-  'getNotebook',
-  'createNotebook',
-  'createGroupNotebook',
-  'listNotes',
-  'getNote',
-  'createNote',
-  'updateNoteBody',
-  'renameNote',
-  'moveNote',
-  'deleteNote',
-  'listNoteHistory',
-  'listFolders',
-  'getFolder',
-  'createFolder',
-  'renameFolder',
-  'moveFolder',
-  'deleteFolder',
-  'listMembers',
-] as const;
-
-type NotesV1Op = (typeof NOTES_V1_OPS)[number];
-type MockedNotesV1 = Record<
-  NotesV1Op,
-  (...args: unknown[]) => Promise<unknown>
->;
-
-class MockNotesV1PendingWriteError extends Error {
-  readonly requestId?: string;
-  readonly status?: string;
-  readonly checks: unknown[];
-
-  constructor({
-    requestId,
-    status,
-    checks = [],
-  }: {
-    requestId?: string;
-    status?: string;
-    checks?: unknown[];
-  } = {}) {
-    super('%notes write request is still pending');
-    this.name = 'NotesV1PendingWriteError';
-    this.requestId = requestId;
-    this.status = status;
-    this.checks = checks;
-  }
-}
-
-const mockedNotesV1 = Object.fromEntries(
-  NOTES_V1_OPS.map((op) => [op, async () => undefined])
-) as MockedNotesV1;
-
-class MockUrbit {
-  cookie = '';
-  nodeId = '';
-
-  constructor(readonly url: string) {}
-}
-
-mock.module('@tloncorp/api', () => ({
-  Urbit: MockUrbit,
-  client: { cookie: '' },
-  configureClient: async () => undefined,
-  internalRemoveClient: () => undefined,
-  preSig: (ship: string) => (ship.startsWith('~') ? ship : `~${ship}`),
-  scry: async () => undefined,
-  subscribe: async () => 0,
-  NotesV1PendingWriteError: MockNotesV1PendingWriteError,
-  notesV1: mockedNotesV1,
-  getGroup: async () => ({ channels: [] }),
-  deleteNotesNotebookStrict: async () => undefined,
-  joinNotesChannel: async () => undefined,
-  leaveNotesChannel: async () => undefined,
-}));
+// Registers the process-wide '@tloncorp/api' mock as an import side effect —
+// see the module doc for why per-file mock.module registrations are unsafe.
+import {
+  MockNotesV1PendingWriteError,
+  mockedNotesV1,
+} from './tloncorp-api-mock';
 
 let runtimeModule: Promise<typeof import('./notes-runtime')> | null = null;
 let channelRuntimeModule: Promise<

--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -1,0 +1,114 @@
+/**
+ * Single shared `mock.module('@tloncorp/api', …)` registration for unit tests.
+ *
+ * `@tloncorp/api` can only be mocked ONCE per `bun test` process: competing
+ * `mock.module` registrations for the same specifier from different test
+ * files are order-dependent — the losing file's importers either see the
+ * winning file's export shape or fail ESM named-export validation against
+ * it (bun's error misleadingly names the real `packages/api/dist` path even
+ * though the shape came from the winning mock). Test-file execution order
+ * is platform-dependent, so a two-registrant suite can pass on macOS and
+ * fail on Linux CI with "Export named 'X' not found".
+ * This module is preloaded for every `bun test` run via bunfig.toml, so the
+ * mock is registered before ANY test file (or the real module) loads —
+ * import ordering inside individual test files cannot break it. Test files
+ * needing the api mocked import the exported objects from here and
+ * configure behavior on them; never call `mock.module('@tloncorp/api', …)`
+ * in a test file.
+ *
+ * The export shape here is the superset of what the mocked import graphs
+ * pull in by value: `api-client.ts` (Urbit, client, configureClient,
+ * internalRemoveClient, preSig, scry, subscribe), `dms.ts` (reactions,
+ * posts, invites), and the notes runtimes (notesV1 et al.).
+ */
+import { mock } from 'bun:test';
+
+export const NOTES_V1_OPS = [
+  'getRequest',
+  'listNotebooks',
+  'getNotebook',
+  'createNotebook',
+  'createGroupNotebook',
+  'listNotes',
+  'getNote',
+  'createNote',
+  'updateNoteBody',
+  'renameNote',
+  'moveNote',
+  'deleteNote',
+  'listNoteHistory',
+  'listFolders',
+  'getFolder',
+  'createFolder',
+  'renameFolder',
+  'moveFolder',
+  'deleteFolder',
+  'listMembers',
+] as const;
+
+export type NotesV1Op = (typeof NOTES_V1_OPS)[number];
+export type MockedNotesV1 = Record<
+  NotesV1Op,
+  (...args: unknown[]) => Promise<unknown>
+>;
+
+export class MockNotesV1PendingWriteError extends Error {
+  readonly requestId?: string;
+  readonly status?: string;
+  readonly checks: unknown[];
+
+  constructor({
+    requestId,
+    status,
+    checks = [],
+  }: {
+    requestId?: string;
+    status?: string;
+    checks?: unknown[];
+  } = {}) {
+    super('%notes write request is still pending');
+    this.name = 'NotesV1PendingWriteError';
+    this.requestId = requestId;
+    this.status = status;
+    this.checks = checks;
+  }
+}
+
+/** Mutable per-test notes surface — reassign ops in a test, restore after. */
+export const mockedNotesV1 = Object.fromEntries(
+  NOTES_V1_OPS.map((op) => [op, async () => undefined])
+) as MockedNotesV1;
+
+export class MockUrbit {
+  cookie = '';
+  nodeId = '';
+
+  constructor(readonly url: string) {}
+}
+
+mock.module('@tloncorp/api', () => ({
+  // api-client.ts value imports
+  Urbit: MockUrbit,
+  client: { cookie: '' },
+  configureClient: async () => undefined,
+  internalRemoveClient: () => undefined,
+  preSig: (ship: string) => (ship.startsWith('~') ? ship : `~${ship}`),
+  scry: async () => undefined,
+  subscribe: async () => 0,
+  // dms.ts value imports (reaction helpers take injected deps in tests, so
+  // these defaults are load-time placeholders, never assertion targets)
+  addReaction: async () => undefined,
+  deletePost: async () => undefined,
+  getCurrentUserId: () => '~zod',
+  removeReaction: async () => undefined,
+  respondToDMInvite: async () => undefined,
+  sendPost: async () => undefined,
+  sendReply: async () => undefined,
+  // notes runtime value imports
+  NotesV1PendingWriteError: MockNotesV1PendingWriteError,
+  notesV1: mockedNotesV1,
+  getGroup: async () => ({ channels: [] }),
+  deleteNotesNotebookStrict: async () => undefined,
+  joinNotesChannel: async () => undefined,
+  leaveNotesChannel: async () => undefined,
+}));

--- a/packages/tlon-skill/tsconfig.json
+++ b/packages/tlon-skill/tsconfig.json
@@ -17,6 +17,7 @@
     "dist",
     "scripts/**/*.test.ts",
     "scripts/**/*.spec.ts",
+    "scripts/tloncorp-api-mock.ts",
     "tests/**/*.ts"
   ]
 }

--- a/packages/tlon-skill/tsconfig.test.json
+++ b/packages/tlon-skill/tsconfig.test.json
@@ -6,6 +6,11 @@
     "declaration": false,
     "types": ["node", "bun-types"]
   },
-  "include": ["scripts/**/*.test.ts", "scripts/**/*.spec.ts", "tests/**/*.ts"],
+  "include": [
+    "scripts/**/*.test.ts",
+    "scripts/**/*.spec.ts",
+    "scripts/tloncorp-api-mock.ts",
+    "tests/**/*.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Fixes TLON-6087

Adds inbound and outbound reaction support to the Hermes Tlon adapter, which previously dropped all reaction events. A reaction on the bot's own post now dispatches as a message (a 👍 on "should I proceed?" reads as a reply), reactions on others' posts become passive notes for the next model turn, and the model can emit reactions back under a configurable gate.

## Changes

**Inbound (`adapter.py`, `history.py`, `tlon_api.py`)**

-   Parse channels/chat reaction events; reactions on the bot's own post dispatch as a message, reactions/removals on others' posts prepend passive notes to the next model dispatch.
-   Own-post detection via SSE-echo cache plus exact on-miss scries; per-post `ReactionState` (full-map diffing, DM tombstones) as the sole dedupe.
-   Club (group-DM) reaction events guarded out; deny-by-default authorization on both branches; sanitized and bounded note encoding.

**Outbound (`adapter.py`, `tlon_tool.py`, `plugin.yaml`)**

-   `TLON_REACTION_LEVEL` (off/ack/minimal/extensive, default `minimal`) gates prompt hints, a message-id envelope for targeting, and tlon-tool access.
-   Non-owner hook carve-out permitting only in-conversation posts/dms react/unreact (family-bound, credential-override-proof).

**CLI (`tlon-skill` posts.ts, dms.ts, main.ts)**

-   `--parent` on posts/dms react/unreact for thread-reply reactions (`parentId`/`parentAuthorId`).
-   Fixes a pre-existing bug: DM thread replies to bot-authored roots now derive the correct parent author in `send()`.

## How did I test?

-   Adapter suite: 549 passing (+27 new over the 522 baseline).
-   tlon-skill suite: 601 passing (+18).
-   Typecheck green.
-   New coverage in `test_adapter_reactions.py`, `dms.test.ts`, plus additions to `test_tlon_api.py`, `test_tlon_tool.py`, `posts.test.ts`, and `cli-test-matrix.ts`.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes

## Rollback plan

Revert

**Note on deliberate non-port:** OpenClaw's legacy 👍/👎/🛑 emoji-approval path was intentionally not ported; A2UI approval cards supersede it.