### PR TITLE
context lens: open panel from thread bot run + migrate legacy flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,7 @@ Before finalizing a PR, do a focused pass on your own diff:
 -   **Trim debug fat.** Remove leftover `console.log`s, ad-hoc perf marks, commented-out code, and stale `// TODO` notes that no longer apply. Comments that just describe _what_ the code does belong in the identifiers; keep comments only when they explain _why_ (non-obvious constraints, workarounds, decisions).
 -   **Reuse before adding.** Before introducing a new helper/util/constant, grep for an existing one. Don't ship parallel implementations — if the new one is genuinely better, remove the old in the same PR.
 -   **Audit comments for staleness.** A comment written mid-implementation may describe an earlier approach. If it references deleted code or a previous shape of the function, fix or delete it.
+-   **Always run Prettier before committing.** Run `npx prettier --check` (or `--write`) on your changed files — or `pnpm lint:format` in the affected package — so a formatting-only diff never lands in the commit or trips CI. Editor/tsc/eslint passing does not guarantee Prettier is satisfied.
 
 ## Testing
 

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -104,6 +104,20 @@ export const getSettings = async (): Promise<{
   };
 };
 
+// Backend value of contextLensEnabled without the client cache in between.
+// The local db can't distinguish "never set" from an explicit disable (older
+// builds cached a missing backend value as false), so the legacy-flag
+// migration reads the source of truth directly.
+export const getContextLensEnabledRaw = async (): Promise<
+  boolean | undefined
+> => {
+  const results = await scry<ub.GroupsDeskSettings>({
+    app: 'settings',
+    path: '/desk/groups',
+  });
+  return results.desk.groups?.contextLensEnabled;
+};
+
 type SidebarSortMode = 'alphabetical' | 'arranged' | 'recent';
 
 const toClientSidebarSort = (
@@ -156,9 +170,10 @@ export const toClientSettings = (
     webAppSplashDismissed: settings.desk.groups?.webAppSplashDismissed ?? false,
     mobileAppPromoDismissed:
       settings.desk.groups?.mobileAppPromoDismissed ?? false,
-    // Deliberately not coerced to false: "never set" must survive sync as
-    // null/undefined so migrateLegacyContextLensFlag can distinguish it from
-    // an explicit disable. Readers apply their own ?? false default.
+    // Deliberately not coerced to false: coercion would cache a fabricated
+    // explicit disable over "never set". Readers apply their own ?? false
+    // default; getContextLensEnabledRaw exists for callers that need the
+    // uncached backend value.
     contextLensEnabled: settings.desk.groups?.contextLensEnabled,
   };
 };

--- a/packages/api/src/client/settingsApi.ts
+++ b/packages/api/src/client/settingsApi.ts
@@ -156,7 +156,10 @@ export const toClientSettings = (
     webAppSplashDismissed: settings.desk.groups?.webAppSplashDismissed ?? false,
     mobileAppPromoDismissed:
       settings.desk.groups?.mobileAppPromoDismissed ?? false,
-    contextLensEnabled: settings.desk.groups?.contextLensEnabled ?? false,
+    // Deliberately not coerced to false: "never set" must survive sync as
+    // null/undefined so migrateLegacyContextLensFlag can distinguish it from
+    // an explicit disable. Readers apply their own ?? false default.
+    contextLensEnabled: settings.desk.groups?.contextLensEnabled,
   };
 };
 

--- a/packages/app/lib/featureFlags.ts
+++ b/packages/app/lib/featureFlags.ts
@@ -76,7 +76,9 @@ async function loadInitialState() {
     Object.entries(state).forEach(([name, enabled]) => {
       if (name in featureMeta) {
         useFeatureFlagStore.getState().setEnabled(name as FeatureName, enabled);
-      } else {
+      } else if (name !== 'contextLens') {
+        // `contextLens` is a legacy flag migrated to the synced %settings store
+        // (see migrateLegacyContextLensFlag); it's expected here until stripped.
         console.warn('Unknown feature flag encountered in local storage', name);
       }
     });

--- a/packages/app/ui/components/DetailView.tsx
+++ b/packages/app/ui/components/DetailView.tsx
@@ -23,6 +23,7 @@ export interface DetailViewProps {
   onPressRetry?: (post: db.Post) => Promise<void>;
   onPressDelete: (post: db.Post) => void;
   inspectContextLensPost?: (post: db.Post) => void;
+  onOpenContextLens?: (post: db.Post) => void;
   onGoToBotRun?: (params: { botShip: string; lensId: string }) => void;
   setActiveMessage: (post: db.Post | null) => void;
   activeMessage: db.Post | null;
@@ -45,6 +46,7 @@ export const DetailView = ({
   onPressRetry,
   onPressDelete,
   inspectContextLensPost,
+  onOpenContextLens,
   onGoToBotRun,
   setActiveMessage,
   activeMessage,
@@ -129,6 +131,7 @@ export const DetailView = ({
         onPressRetry={onPressRetry}
         onPressDelete={onPressDelete}
         onPressPost={inspectContextLensPost}
+        onOpenContextLens={onOpenContextLens}
         onGoToBotRun={onGoToBotRun}
         highlightPostId={highlightPostId}
         firstUnreadId={

--- a/packages/app/ui/components/PostScreenView.tsx
+++ b/packages/app/ui/components/PostScreenView.tsx
@@ -216,6 +216,7 @@ export function PostScreenView({
     toggleContextLens,
     clearSelectedContextLensMessage,
     inspectContextLensPost,
+    openContextLensForPost,
   } = useContextLensController({ channel });
 
   const [galleryEditShouldBlur, setGalleryEditShouldBlur] = useState(false);
@@ -433,6 +434,10 @@ export function PostScreenView({
                                 contextLensAvailable && contextLensOpen
                                   ? inspectContextLensPost
                                   : undefined,
+                              openContextLensForPost:
+                                contextLensAvailable && !isWindowNarrow
+                                  ? openContextLensForPost
+                                  : undefined,
                               onGoToBotRun:
                                 contextLensAvailable && isWindowNarrow
                                   ? goToContextLensRun
@@ -584,6 +589,7 @@ function SinglePostView({
   goBack,
   handleGoToImage,
   inspectContextLensPost,
+  openContextLensForPost,
   onGoToBotRun,
   negotiationMatch,
   onPressDelete,
@@ -600,6 +606,7 @@ function SinglePostView({
   group: db.Group | null;
   handleGoToImage?: (post: db.Post, uri?: string) => void;
   inspectContextLensPost?: (post: db.Post) => void;
+  openContextLensForPost?: (post: db.Post) => void;
   onGoToBotRun?: (params: { botShip: string; lensId: string }) => void;
   negotiationMatch: boolean;
   onPressDelete: (post: db.Post) => void;
@@ -869,6 +876,7 @@ function SinglePostView({
             highlightPostId={highlightPostId}
             scrollerRef={scrollerRef}
             inspectContextLensPost={inspectContextLensPost}
+            onOpenContextLens={openContextLensForPost}
             onGoToBotRun={onGoToBotRun}
           />
         ) : null}

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -274,12 +274,24 @@ export async function migrateLegacyContextLensFlag() {
 
   // Only adopt the legacy value when the synced setting has never been set, so
   // we don't resurrect a toggle the user later disabled on another device.
-  const existing = await db.getSettings();
-  if (flags.contextLens === true && existing?.contextLensEnabled == null) {
-    const migrated = await updateContextLensEnabled(true);
-    if (!migrated) {
-      // Keep the legacy key so the next startup can retry the migration.
+  // Check the backend directly: the local cache can't distinguish "never set"
+  // from an explicit disable, since older builds cached a missing backend
+  // value as false.
+  if (flags.contextLens === true) {
+    let raw: boolean | undefined;
+    try {
+      raw = await api.getContextLensEnabledRaw();
+    } catch (e) {
+      // Can't tell whether the setting was ever synced; keep the legacy key
+      // so the next startup retries.
       return;
+    }
+    if (raw == null) {
+      const migrated = await updateContextLensEnabled(true);
+      if (!migrated) {
+        // Keep the legacy key so the next startup can retry the migration.
+        return;
+      }
     }
   }
 

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -242,13 +242,17 @@ export async function updateContextLensEnabled(value: boolean) {
     // optimistic update
     await db.insertSettings({ contextLensEnabled: value });
     await api.setSetting('contextLensEnabled', value);
+    return true;
   } catch (e) {
     logger.trackError('Error updating context lens enabled setting', {
       error: e,
       value,
       severity: AnalyticsSeverity.Medium,
     });
-    await db.insertSettings({ contextLensEnabled: oldValue });
+    // ?? null so the rollback restores "never set" even when no settings row
+    // existed yet (insertSettings skips undefined fields).
+    await db.insertSettings({ contextLensEnabled: oldValue ?? null });
+    return false;
   }
 }
 
@@ -272,7 +276,11 @@ export async function migrateLegacyContextLensFlag() {
   // we don't resurrect a toggle the user later disabled on another device.
   const existing = await db.getSettings();
   if (flags.contextLens === true && existing?.contextLensEnabled == null) {
-    await updateContextLensEnabled(true);
+    const migrated = await updateContextLensEnabled(true);
+    if (!migrated) {
+      // Keep the legacy key so the next startup can retry the migration.
+      return;
+    }
   }
 
   const rest = { ...flags };

--- a/packages/shared/src/store/settingsActions.ts
+++ b/packages/shared/src/store/settingsActions.ts
@@ -252,6 +252,34 @@ export async function updateContextLensEnabled(value: boolean) {
   }
 }
 
+// One-time migration for the context lens toggle, which moved from the
+// client-local feature-flag store (`storage.featureFlags.contextLens`) to the
+// synced %settings store (`contextLensEnabled`). Adopt a user's old local
+// value once, then drop the stale key so this never runs again. Must run after
+// syncSettings so getSettings() reflects the authoritative synced value.
+export async function migrateLegacyContextLensFlag() {
+  let flags: Record<string, unknown> | null = null;
+  try {
+    flags = await db.storage.featureFlags.getValue();
+  } catch (e) {
+    return;
+  }
+  if (!flags || typeof flags !== 'object' || !('contextLens' in flags)) {
+    return;
+  }
+
+  // Only adopt the legacy value when the synced setting has never been set, so
+  // we don't resurrect a toggle the user later disabled on another device.
+  const existing = await db.getSettings();
+  if (flags.contextLens === true && existing?.contextLensEnabled == null) {
+    await updateContextLensEnabled(true);
+  }
+
+  const rest = { ...flags };
+  delete rest.contextLens;
+  await db.storage.featureFlags.setValue(rest);
+}
+
 export async function updatePendingMemberDismissal(
   dismissal: db.PendingMemberDismissal
 ) {

--- a/packages/shared/src/store/sync/sync.ts
+++ b/packages/shared/src/store/sync/sync.ts
@@ -34,6 +34,7 @@ import { useLureState } from '../lure';
 import { verifyPostDelivery } from '../postActions/verifyPostDelivery';
 import { clearPresenceState, handlePresenceEvent } from '../presence';
 import { getSession, setSession, updateSession } from '../session';
+import { migrateLegacyContextLensFlag } from '../settingsActions';
 import { SyncCtx, SyncPriority, syncQueue } from '../syncQueue';
 import { getSystemContacts } from '../systemContactsApi';
 import { clearChannelPostsQueries } from '../useChannelPosts/queries';
@@ -2295,9 +2296,9 @@ export const syncStart = async (alreadySubscribed?: boolean) => {
             retry: true,
           }).then(() => logger.crumb(`finished syncing contacts`))
         : Promise.resolve(),
-      syncSettings({ priority: syncStartPriority.low + 1 }).then(() =>
-        logger.crumb(`finished syncing settings`)
-      ),
+      syncSettings({ priority: syncStartPriority.low + 1 })
+        .then(() => migrateLegacyContextLensFlag())
+        .then(() => logger.crumb(`finished syncing settings`)),
       syncVolumeSettings({ priority: syncStartPriority.low + 1 }).then(() =>
         logger.crumb(`finished syncing volume settings`)
       ),


### PR DESCRIPTION
## Summary

This fixes an issue with the change from #6028 where I didn't hook up the bot run button click to the panel in threads. It also migrates the flag that enables context lens if you never retoggled it. (Although do we just want to turn this on for everyone @jamesacklin?)

## Changes

**Thread bot run button opens the context lens panel (desktop)**
- The desktop panel-open behavior from #6028 was only wired into the main channel / DM collection view (`ListPostCollectionView`), never the thread view. In a thread the `Scroller` never received `onOpenContextLens`, so `onViewBotRun` fell back to the old `ContextLensRunSheet` modal.
- Thread `openContextLensForPost` through `PostScreenView` → `SinglePostView` → `DetailView` → `Scroller`, gated `contextLensAvailable && !isWindowNarrow` to mirror the main-channel path. Narrow/mobile keeps `onGoToBotRun` (the run screen/sheet).

**One-time migration of the legacy `contextLens` flag**
- #6028 moved the context lens toggle from the client-local feature-flag store (`storage.featureFlags.contextLens`) to the synced `%settings` store (`contextLensEnabled`) but did not migrate the old value, so users who had it enabled silently lost the setting.
- Add `migrateLegacyContextLensFlag`, run after `syncSettings` so it reads the authoritative synced value. It only adopts the old value when the setting has never been set (won't resurrect a toggle disabled on another device), then strips the stale local key so it runs once.
- Silence the now-misleading "Unknown feature flag" warning for the legacy `contextLens` key.

## How did I test?

- `tsc --noEmit` clean for `packages/app` and `packages/shared` (aside from a pre-existing, unrelated `@mattermost/react-native-paste-input` native-module resolution warning).
- `eslint` clean on all touched files (remaining `any` warnings are pre-existing and unrelated).
- Not yet exercised in a running app — manual verification of the thread panel-open behavior on desktop and the migration on an account carrying the old local flag is still pending.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [x] State / providers (settings migration + sync ordering)
  - [ ] Message sync
  - [x] Channel display (context lens panel / thread bot run button)
  - [ ] Notifications
  - [x] Other: startup migration runs after `syncSettings`

## Rollback plan

Revert the commit. The thread wiring is pure prop-threading with no persistent effect. The migration is additive and self-limiting (only fires when the synced setting is unset, then strips the legacy key); reverting simply stops it from running and leaves any already-migrated `contextLensEnabled` value in place, which is harmless.

## Screenshots / videos

<!-- Attach any relevant media. -->
