### PR TITLE
fix: pass no args to handleCreateNote from empty notebook pane on web

### DIFF
--- a/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNativeChannel.tsx
@@ -860,7 +860,7 @@ export function NotesNativeChannel({
         <NotesEmptyDetailPane
           canEdit={canEdit}
           isCreating={isCreatingNote}
-          onCreateNote={handleCreateNote}
+          onCreateNote={() => void handleCreateNote()}
         />
       ) : (
         <NotesNoteDetail


### PR DESCRIPTION
## Summary

Fixes issue where clicking Add note failed with this error:

<img width="694" height="601" alt="Screenshot 2026-07-10 at 4 01 18 PM" src="https://github.com/user-attachments/assets/eca57164-2b50-4946-bcbb-e566eb649bff" />

## Changes

- `NotesEmptyDetailPane`'s "New note" button passed `handleCreateNote` bare as `onPress`, so on web the synthetic press event flowed into the optional `folderId?: number` parameter (TS allows assigning `(folderId?: number) => Promise<void>` to the `() => void` prop, so this compiled cleanly). The event object then reached the `%notes` poke body, where `JSON.stringify` threw `Converting circular structure to JSON` on the event target's `__reactFiber$` back-reference.
- Fixed by wrapping the handler: `onCreateNote={() => void handleCreateNote()}`. Audited the other `handleCreateNote` / `openAddFolderDialog` call sites (header action, folder row context menu, `onCreateNoteInFolder`) — all already wrap the handler.

## How did I test?

- Typechecked `packages/app` — no errors in the Notes files (only pre-existing unrelated `react-native-transformer-text-input` resolution errors).
- Verified the failure chain by reading the code path: press event → `folderId` → `getCreateTargetFolderId` (truthy, so folder fallbacks never apply) → `api.notes.createNote({ folder: event })` → poke serialization failure matching the reported error exactly.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit — one-line change with no state or schema impact.

## Screenshots / videos

<!-- Attach any relevant media. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)