### PR TITLE
fix native mention insertion duplicating input text

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -410,9 +410,12 @@ function BareChatInput(
       inputRef.current?.focus();
 
       if (!isWeb) {
+        // Only set the selection here — the input's text on native is driven
+        // by the TextWithMentions children. Setting `text` via setNativeProps
+        // would be *prepended* to the child text by RCTBaseTextInputShadowView,
+        // duplicating the message.
         requestAnimationFrame(() => {
           inputRef.current?.setNativeProps({
-            text: selectionResult.text,
             selection: {
               start: selectionResult.cursorPosition,
               end: selectionResult.cursorPosition,


### PR DESCRIPTION
## Summary

Fixes message duplication in the native chat input after selecting a mention, introduced by #6089. Selecting a mention duplicated the drafted message in the input, and every subsequent keystroke duplicated the entire contents again.

## Changes

- In `BareChatInput`'s `onMentionSelect`, the post-selection `setNativeProps` call now sets only `selection`, not `text`. On iOS the input's text is driven by the `TextWithMentions` children, and `RCTBaseTextInputShadowView` *prepends* the `text` prop to the child-derived attributed string rather than replacing it — so setting both rendered the message twice, and compounded once `onChangeText` echoed the doubled text back into state.
- The `requestAnimationFrame` cursor positioning from #6089 (the actual iOS mention-spacing fix) is preserved.

## How did I test?

Ran the dev client on the iOS simulator against Metro and drove the flow with Maestro in a DM:

- Typed `hello @pinser`, selected a contact from the mention popup → `hello @openjames ` inserted exactly once, mention highlighted, cursor placed after the trailing space.
- Typed 30 more characters → no duplication (previously the first keystroke here doubled the whole message).
- Added a second mention mid-message and kept typing → both mentions intact, no compounding.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: chat input (native mention insertion)

## Rollback plan

Revert this commit. Note that reverting restores the #6089 duplication bug; reverting both this and the `setNativeProps` block from #6089 restores the older (cursor-misplacement) behavior instead.

## Screenshots / videos

Verified on iPhone 17 Pro simulator (iOS 26.5): after mention selection the input reads `hello @openjames testing mentions after the fix and a second one @@gork done` with both mentions highlighted and no duplicated text. (The doubled `@` on `@gork` is pre-existing: that contact's nickname literally starts with `@`, and `useMentions` prepends `@` unconditionally — unrelated to this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)