### PR TITLE
feat: claude-tlon-channel — attach local Claude Code sessions to Tlon conversations

### DIFF
--- a/packages/claude-tlon-channel/.claude-plugin/plugin.json
+++ b/packages/claude-tlon-channel/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tlon-channel",
+  "version": "0.1.0",
+  "description": "Attach this Claude Code session to Tlon channels, threads, and DMs. Inbound messages arrive as channel events; reply with the tlon_send tool.",
+  "author": {
+    "name": "Tlon Corporation"
+  }
+}

--- a/packages/claude-tlon-channel/.gitignore
+++ b/packages/claude-tlon-channel/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/claude-tlon-channel/.mcp.json
+++ b/packages/claude-tlon-channel/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "tlon": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/server.js"],
+      "env": {
+        "TLON_URL": "${TLON_URL}",
+        "TLON_SHIP": "${TLON_SHIP}",
+        "TLON_CODE": "${TLON_CODE}",
+        "TLON_CLI": "${TLON_CLI}",
+        "TLON_ATTACH": "${TLON_ATTACH}"
+      }
+    }
+  }
+}

--- a/packages/claude-tlon-channel/README.md
+++ b/packages/claude-tlon-channel/README.md
@@ -1,0 +1,115 @@
+# claude-tlon-channel
+
+A [Claude Code plugin](https://code.claude.com/docs/en/plugins) that attaches
+a **local Claude Code session** to Tlon conversations, logged in as a bot
+ship. Inbound messages from attached channels/threads/DMs are pushed into the
+running session as [MCP channel](https://code.claude.com/docs/en/channels)
+events; the session replies as the bot via the bundled `tlon_send` tool.
+
+Designed to coexist with an [OpenClaw](https://github.com/openclaw/openclaw)
+gateway running as the **same ship** (see `packages/openclaw`): when this
+plugin attaches to a scope it writes an `externalClaims` entry to the ship's
+settings-store, and the OpenClaw Tlon plugin skips messages in claimed scopes
+until the claim expires or is released.
+
+```
+Tlon user ──▶ bot ship (hosting infra)
+                 │  SSE firehose (%chat /v4, %channels /v4)
+                 ▼
+        this MCP server (local) ──▶ notifications/claude/channel ──▶ your session
+                 ▲                                                        │
+                 └───────────── tlon CLI send/reply ◀─────────  tlon_send tool
+```
+
+## Requirements
+
+- Claude Code **v2.1.80+** (MCP channels)
+- Node 22+
+- The `tlon` CLI from [`@tloncorp/tlon-skill`](../tlon-skill) on `PATH`
+  (or point `TLON_CLI` at the binary) — used for outbound sends and reads
+- Bot ship credentials (URL + `+code`)
+
+## Setup
+
+```bash
+pnpm --filter @tloncorp/claude-tlon-channel build
+
+# register the MCP server once (per project you'll run claude from)
+claude mcp add tlon -- node /absolute/path/to/packages/claude-tlon-channel/dist/server.js
+
+export TLON_URL="https://your-bot.tlon.network"
+export TLON_SHIP="~your-bot"
+export TLON_CODE="sampel-ticlyt-migfun-falmel"
+# optional: scopes to attach on startup
+export TLON_ATTACH="chat/~host/dev-chat,~sampel-palnet"
+
+claude --dangerously-load-development-channels server:tlon
+```
+
+Channels are in research preview and custom channels aren't on the approved
+allowlist, so the entry must be passed to
+`--dangerously-load-development-channels` directly — the bypass is
+per-entry, and `--channels server:tlon` alone is rejected. (Even once
+packaged as a marketplace plugin, a non-official channel still needs the dev
+flag: `claude --dangerously-load-development-channels plugin:tlon-channel@<marketplace>`.)
+A dim `Channels (experimental)` notice below the startup banner confirms the
+channel registered; server stderr lands in `~/.claude/debug/<session-id>.txt`.
+
+Ask Claude to "attach to chat/~host/slug" (the `tlon-attach` skill guides
+the workflow), or preset scopes with `TLON_ATTACH`.
+
+## Scopes
+
+| Scope                        | Meaning                          |
+| ---------------------------- | -------------------------------- |
+| `~ship`                      | one-to-one DM                    |
+| `0v...`                      | group DM (club)                  |
+| `chat/~host/slug`            | whole group channel              |
+| `chat/~host/slug/<post-id>`  | a single thread (top-level post) |
+
+## Coexisting with a hosted OpenClaw bot
+
+Both processes log in as the same ship, so without coordination both would
+answer inbound messages. Coordination is a settings-store entry on the ship
+(desk `moltbot`, bucket `tlon`, key `externalClaims`) holding
+`[{ scope, holder, expiresAt }]`:
+
+- **Attach** writes a claim; the OpenClaw monitor drops messages whose scope
+  is claimed and unexpired.
+- Claims have a TTL (default 5 min, `TLON_CLAIM_TTL_MS`) and are refreshed
+  at half TTL while the session is attached — if the local session crashes,
+  the hosted bot resumes within one TTL.
+- **Detach** / clean shutdown releases the claim immediately.
+- Set `TLON_WRITE_CLAIMS=false` to observe without muting the hosted bot
+  (both will respond).
+
+The OpenClaw monitor never reacts to messages authored by the bot ship
+itself, so this session's outbound posts don't re-trigger the hosted bot.
+
+## Environment variables
+
+| Variable             | Required | Default       | Purpose                              |
+| -------------------- | -------- | ------------- | ------------------------------------ |
+| `TLON_URL`           | yes      | —             | Ship HTTP endpoint                    |
+| `TLON_SHIP`          | yes      | —             | Bot ship (`~ship`)                    |
+| `TLON_CODE`          | yes      | —             | `+code` access code                   |
+| `TLON_CLI`           | no       | `tlon`        | Path to the tlon-skill CLI binary     |
+| `TLON_ATTACH`        | no       | —             | Comma-separated startup scopes        |
+| `TLON_CLAIM_HOLDER`  | no       | `claude-code` | Holder id written into claims         |
+| `TLON_CLAIM_TTL_MS`  | no       | `300000`      | Claim lifetime                        |
+| `TLON_WRITE_CLAIMS`  | no       | `true`        | Set `false` to skip claiming          |
+
+(`URBIT_URL` / `URBIT_SHIP` / `URBIT_CODE` are honored as aliases and take
+precedence, matching tlon-skill conventions.)
+
+## Status / known gaps
+
+Scaffold-stage. Not yet covered:
+
+- **Vouched identity**: sends go out as the ship the server logs in as. To
+  appear as a distinct vouched bot identity (moon), the send path needs the
+  vouched-DM route instead of plain `posts send`.
+- `tlon posts reply` / `dms reply` argument order should be verified against
+  the installed tlon-skill version (`tlon posts --help`).
+- DM invites (new conversations) are ignored; attach to an existing DM.
+- Edits, deletes, and reactions are not surfaced as events.

--- a/packages/claude-tlon-channel/package.json
+++ b/packages/claude-tlon-channel/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@tloncorp/claude-tlon-channel",
+  "version": "0.1.0",
+  "description": "Claude Code plugin: attach a local Claude Code session to Tlon channels, threads, and DMs via an MCP channel server",
+  "type": "module",
+  "private": true,
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "start": "node dist/server.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "tsc": "pnpm typecheck",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.9"
+  }
+}

--- a/packages/claude-tlon-channel/skills/tlon-attach/SKILL.md
+++ b/packages/claude-tlon-channel/skills/tlon-attach/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: tlon-attach
+description: Attach this Claude Code session to a Tlon channel, thread, or DM so messages there flow into the session and replies go back out as the bot. Use when the user asks to join, watch, attach to, or talk in a Tlon conversation.
+---
+
+# Attach to a Tlon conversation
+
+This session can participate in Tlon conversations through the `tlon` MCP
+server (from the tlon-channel plugin). The session is logged in **as the bot
+ship** — messages you send appear as the bot.
+
+## Prerequisites
+
+- The session was started with the channel enabled:
+  `claude --dangerously-load-development-channels server:tlon` (custom
+  channels aren't on the research-preview allowlist, so the entry goes on
+  the dev flag — plain `--channels server:tlon` is rejected).
+- Credentials are set: `TLON_URL`, `TLON_SHIP`, `TLON_CODE` (the bot ship
+  and its +code).
+- If the `tlon` MCP server or its tools are missing, tell the user to
+  restart with the flag above and check those env vars.
+
+## Workflow
+
+1. Resolve what the user wants to attach to. Scope formats:
+   - `~ship` — one-to-one DM with that ship
+   - `0v...` — group DM (club id)
+   - `chat/~host/slug` — a whole group channel
+   - `chat/~host/slug/<post-id>` — one thread (top-level post id)
+
+   If the user names a channel loosely ("the dev channel"), use `tlon_read`
+   or ask; don't guess a nest.
+
+2. Call `tlon_attach` with the scope. This also writes a settings-store
+   claim so a hosted OpenClaw bot running as the same ship stops answering
+   there while this session is attached.
+
+3. Pull context with `tlon_read` (recent history, or `postId` for a
+   thread) so you know the conversation before your first reply.
+
+4. New messages arrive as channel events with `meta.target`,
+   `meta.parentId`, and `meta.author`. Reply with `tlon_send` to the same
+   target — and pass `parentId` when the message came from a thread.
+
+5. When the user is done, call `tlon_detach` so the hosted bot resumes
+   responding there. Detach on request or when the user says they're done
+   with the conversation.
+
+## Etiquette
+
+- You are speaking as the bot in front of other people. Be conversational;
+  no tool dumps, stack traces, or file contents unless asked.
+- Don't reply to every message in a busy channel — respond when addressed
+  or when the user asked you to handle something specific.
+- If asked to do local work (code, builds), do it, then post a short
+  summary back to the thread — not the raw output.

--- a/packages/claude-tlon-channel/src/claims.ts
+++ b/packages/claude-tlon-channel/src/claims.ts
@@ -1,0 +1,142 @@
+/**
+ * External-handler claims, written to Urbit's %settings store so a
+ * co-resident OpenClaw gateway (logged in as the same bot ship) knows to
+ * ignore messages in scopes this session has attached to.
+ *
+ * Storage: desk "moltbot", bucket "tlon", entry "externalClaims" — a JSON
+ * string encoding ExternalClaim[]. Claims carry an expiry and are refreshed
+ * at half TTL while held, so a crashed session un-mutes the bot within one
+ * TTL instead of silencing it permanently.
+ */
+import type { EyreClient, EyreLogger } from './eyre.js';
+
+const SETTINGS_DESK = 'moltbot';
+const SETTINGS_BUCKET = 'tlon';
+const CLAIMS_ENTRY_KEY = 'externalClaims';
+
+export type ExternalClaim = {
+  scope: string;
+  holder: string;
+  expiresAt: number;
+};
+
+export function parseClaimsValue(value: unknown): ExternalClaim[] {
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter((item): item is ExternalClaim => {
+    if (!item || typeof item !== 'object') {
+      return false;
+    }
+    const claim = item as Record<string, unknown>;
+    return (
+      typeof claim.scope === 'string' &&
+      typeof claim.holder === 'string' &&
+      typeof claim.expiresAt === 'number'
+    );
+  });
+}
+
+export class ClaimManager {
+  private held = new Set<string>();
+  private refreshTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly eyre: EyreClient,
+    private readonly holder: string,
+    private readonly ttlMs: number,
+    private readonly enabled: boolean,
+    private readonly log: EyreLogger = () => {}
+  ) {}
+
+  async claim(scope: string): Promise<void> {
+    this.held.add(scope);
+    await this.sync();
+    this.ensureRefreshTimer();
+  }
+
+  async release(scope: string): Promise<void> {
+    this.held.delete(scope);
+    await this.sync();
+    if (this.held.size === 0) {
+      this.stopRefreshTimer();
+    }
+  }
+
+  async releaseAll(): Promise<void> {
+    this.held.clear();
+    this.stopRefreshTimer();
+    await this.sync();
+  }
+
+  private ensureRefreshTimer(): void {
+    if (this.refreshTimer || !this.enabled) {
+      return;
+    }
+    this.refreshTimer = setInterval(() => {
+      this.sync().catch((err) =>
+        this.log(`[claims] Refresh failed: ${String(err)}`)
+      );
+    }, Math.max(this.ttlMs / 2, 10_000));
+    this.refreshTimer.unref?.();
+  }
+
+  private stopRefreshTimer(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  /**
+   * Read-modify-write the claims entry: keep other holders' live claims,
+   * replace ours with the current held set.
+   */
+  private async sync(): Promise<void> {
+    if (!this.enabled) {
+      return;
+    }
+    const now = Date.now();
+    let existing: ExternalClaim[] = [];
+    try {
+      const all = await this.eyre.scry<{
+        all?: Record<string, Record<string, Record<string, unknown>>>;
+      }>('settings', '/all.json');
+      existing = parseClaimsValue(
+        all?.all?.[SETTINGS_DESK]?.[SETTINGS_BUCKET]?.[CLAIMS_ENTRY_KEY]
+      );
+    } catch (err) {
+      this.log(`[claims] Settings scry failed (writing fresh): ${String(err)}`);
+    }
+
+    const others = existing.filter(
+      (claim) => claim.holder !== this.holder && claim.expiresAt > now
+    );
+    const ours: ExternalClaim[] = [...this.held].map((scope) => ({
+      scope,
+      holder: this.holder,
+      expiresAt: now + this.ttlMs,
+    }));
+    const next = [...others, ...ours];
+
+    await this.eyre.poke('settings', 'settings-event', {
+      'put-entry': {
+        desk: SETTINGS_DESK,
+        'bucket-key': SETTINGS_BUCKET,
+        'entry-key': CLAIMS_ENTRY_KEY,
+        value: JSON.stringify(next),
+      },
+    });
+    this.log(
+      `[claims] Synced: ${ours.length} held, ${others.length} other-holder`
+    );
+  }
+}

--- a/packages/claude-tlon-channel/src/cli.ts
+++ b/packages/claude-tlon-channel/src/cli.ts
@@ -1,0 +1,76 @@
+/**
+ * Outbound sends and history reads via the `tlon` CLI from
+ * @tloncorp/tlon-skill. The CLI owns the gnarly parts (story format,
+ * threading, target parsing), so this server doesn't reimplement them.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { ServerConfig } from './config.js';
+
+const execFileAsync = promisify(execFile);
+
+export class TlonCli {
+  constructor(private readonly cfg: ServerConfig) {}
+
+  private async run(args: string[]): Promise<string> {
+    try {
+      const { stdout } = await execFileAsync(this.cfg.cliCommand, args, {
+        env: {
+          ...process.env,
+          URBIT_URL: this.cfg.url,
+          URBIT_SHIP: this.cfg.ship,
+          URBIT_CODE: this.cfg.code,
+        },
+        timeout: 60_000,
+        maxBuffer: 4 * 1024 * 1024,
+      });
+      return stdout.trim();
+    } catch (err) {
+      const error = err as { stderr?: string; message?: string };
+      throw new Error(
+        `tlon ${args[0] ?? ''} failed: ${error.stderr?.trim() || error.message}`
+      );
+    }
+  }
+
+  /** target: channel nest (chat/~host/slug), ~ship for 1:1 DM, or 0v club id */
+  async send(target: string, text: string): Promise<string> {
+    if (target.startsWith('0v')) {
+      return this.run(['dms', 'send', target, text]);
+    }
+    return this.run(['posts', 'send', target, text]);
+  }
+
+  async reply(target: string, parentId: string, text: string): Promise<string> {
+    if (target.startsWith('0v')) {
+      return this.run(['dms', 'reply', target, parentId, text]);
+    }
+    return this.run(['posts', 'reply', target, parentId, text]);
+  }
+
+  async readChannel(nest: string, limit: number): Promise<string> {
+    return this.run([
+      'messages',
+      'channel',
+      nest,
+      '--limit',
+      String(Math.min(limit, 50)),
+    ]);
+  }
+
+  async readDm(whom: string, limit: number): Promise<string> {
+    return this.run([
+      'messages',
+      'dm',
+      whom,
+      '--limit',
+      String(Math.min(limit, 50)),
+    ]);
+  }
+
+  /** Fetch a single post with its thread replies. */
+  async readThread(nest: string, postId: string): Promise<string> {
+    return this.run(['messages', 'post', nest, postId]);
+  }
+}

--- a/packages/claude-tlon-channel/src/config.ts
+++ b/packages/claude-tlon-channel/src/config.ts
@@ -1,0 +1,73 @@
+/**
+ * Server configuration, resolved from environment variables.
+ *
+ * Credential env vars follow the same conventions as @tloncorp/tlon-skill:
+ * URBIT_* aliases take precedence over TLON_* for the same field.
+ */
+
+export type ServerConfig = {
+  /** Ship HTTP endpoint, e.g. https://your-bot.tlon.network */
+  url: string;
+  /** Bot ship the server logs in as, e.g. ~sampel-palnet */
+  ship: string;
+  /** +code access code */
+  code: string;
+  /** Path to the tlon CLI binary from @tloncorp/tlon-skill (outbound sends/reads) */
+  cliCommand: string;
+  /** Scopes to attach on startup (comma-separated in TLON_ATTACH) */
+  initialScopes: string[];
+  /** Holder id written into settings-store claims */
+  claimHolder: string;
+  /** Claim lifetime; refreshed at half this interval while attached */
+  claimTtlMs: number;
+  /** Write claims to settings-store so a co-resident OpenClaw gateway ignores attached scopes */
+  writeClaims: boolean;
+};
+
+export function normalizeShip(ship: string): string {
+  const trimmed = ship.trim().toLowerCase();
+  return trimmed.startsWith('~') ? trimmed : `~${trimmed}`;
+}
+
+function env(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value && value.trim() !== '') {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+export function loadConfig(): ServerConfig {
+  const url = env('URBIT_URL', 'TLON_URL');
+  const ship = env('URBIT_SHIP', 'TLON_SHIP');
+  const code = env('URBIT_CODE', 'TLON_CODE');
+
+  const missing = [
+    !url && 'TLON_URL',
+    !ship && 'TLON_SHIP',
+    !code && 'TLON_CODE',
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`
+    );
+  }
+
+  const claimTtlMs = Number(env('TLON_CLAIM_TTL_MS') ?? '') || 5 * 60 * 1000;
+
+  return {
+    url: url!.replace(/\/+$/, ''),
+    ship: normalizeShip(ship!),
+    code: code!,
+    cliCommand: env('TLON_CLI') ?? 'tlon',
+    initialScopes: (env('TLON_ATTACH') ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+    claimHolder: env('TLON_CLAIM_HOLDER') ?? 'claude-code',
+    claimTtlMs,
+    writeClaims: env('TLON_WRITE_CLAIMS') !== 'false',
+  };
+}

--- a/packages/claude-tlon-channel/src/eyre.ts
+++ b/packages/claude-tlon-channel/src/eyre.ts
@@ -1,0 +1,306 @@
+/**
+ * Minimal Eyre (Urbit HTTP API) client: +code login, channel pokes and
+ * subscriptions, SSE event stream with acking and reconnect, scries.
+ *
+ * Intentionally small and dependency-free. The heavier lifting (message
+ * sends, history reads) goes through the tlon CLI instead — see cli.ts.
+ */
+import { randomUUID } from 'node:crypto';
+
+export type EyreLogger = (message: string) => void;
+
+type Subscription = {
+  actionId: number;
+  app: string;
+  path: string;
+  onEvent: (data: unknown) => void;
+};
+
+export class EyreClient {
+  private cookie: string | null = null;
+  private channelId: string;
+  private nextActionId = 1;
+  private lastEventId = 0;
+  private unackedEvents = 0;
+  private subscriptions: Subscription[] = [];
+  private closed = false;
+  private streamAbort: AbortController | null = null;
+  private readonly debug = process.env.TLON_DEBUG === '1';
+
+  constructor(
+    private readonly url: string,
+    private readonly ship: string,
+    private readonly code: string,
+    private readonly log: EyreLogger = () => {}
+  ) {
+    this.channelId = `claude-tlon-${Date.now()}-${randomUUID().slice(0, 8)}`;
+  }
+
+  get shipName(): string {
+    return this.ship;
+  }
+
+  async login(): Promise<void> {
+    const response = await fetch(`${this.url}/~/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: `password=${encodeURIComponent(this.code)}`,
+      redirect: 'manual',
+    });
+    const setCookie = response.headers.get('set-cookie');
+    if (!setCookie || !/urbauth/.test(setCookie)) {
+      throw new Error(
+        `Login to ${this.url} failed (status ${response.status})`
+      );
+    }
+    this.cookie = setCookie.split(';')[0];
+    this.log(`[eyre] Authenticated to ${this.url} as ${this.ship}`);
+  }
+
+  private async putActions(actions: Record<string, unknown>[]): Promise<void> {
+    if (!this.cookie) {
+      await this.login();
+    }
+    const put = () =>
+      fetch(`${this.url}/~/channel/${this.channelId}`, {
+        method: 'PUT',
+        headers: {
+          'content-type': 'application/json',
+          cookie: this.cookie!,
+        },
+        body: JSON.stringify(actions),
+      });
+    let response = await put();
+    if (response.status === 401 || response.status === 403) {
+      await this.login();
+      response = await put();
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Channel PUT failed: ${response.status} ${await response
+          .text()
+          .catch(() => '')}`
+      );
+    }
+  }
+
+  async poke(app: string, mark: string, json: unknown): Promise<void> {
+    const id = this.nextActionId++;
+    await this.putActions([
+      {
+        id,
+        action: 'poke',
+        ship: this.ship.replace(/^~/, ''),
+        app,
+        mark,
+        json,
+      },
+    ]);
+  }
+
+  async subscribe(
+    app: string,
+    path: string,
+    onEvent: (data: unknown) => void
+  ): Promise<void> {
+    const id = this.nextActionId++;
+    this.subscriptions.push({ actionId: id, app, path, onEvent });
+    await this.putActions([
+      {
+        id,
+        action: 'subscribe',
+        ship: this.ship.replace(/^~/, ''),
+        app,
+        path,
+      },
+    ]);
+    this.log(`[eyre] Subscribed to ${app}${path}`);
+  }
+
+  async scry<T = unknown>(app: string, path: string): Promise<T> {
+    if (!this.cookie) {
+      await this.login();
+    }
+    const response = await fetch(`${this.url}/~/scry/${app}${path}`, {
+      headers: { cookie: this.cookie! },
+    });
+    if (!response.ok) {
+      throw new Error(`Scry ${app}${path} failed: ${response.status}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  /**
+   * Open the SSE stream and dispatch events to subscriptions until closed.
+   * Reconnects with backoff; on channel loss, re-creates the channel and
+   * replays all subscriptions.
+   */
+  async runEventStream(): Promise<void> {
+    let backoffMs = 1000;
+    while (!this.closed) {
+      try {
+        await this.streamOnce();
+        backoffMs = 1000;
+      } catch (err) {
+        if (this.closed) {
+          return;
+        }
+        this.log(`[eyre] Stream error: ${String(err)}`);
+      }
+      if (this.closed) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      backoffMs = Math.min(backoffMs * 2, 30_000);
+      // Assume the channel died; start fresh and resubscribe everything.
+      await this.reset().catch((err) =>
+        this.log(`[eyre] Reset failed: ${String(err)}`)
+      );
+    }
+  }
+
+  private async reset(): Promise<void> {
+    this.channelId = `claude-tlon-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    this.lastEventId = 0;
+    this.unackedEvents = 0;
+    const existing = this.subscriptions;
+    this.subscriptions = [];
+    for (const sub of existing) {
+      await this.subscribe(sub.app, sub.path, sub.onEvent);
+    }
+  }
+
+  private async streamOnce(): Promise<void> {
+    if (!this.cookie) {
+      await this.login();
+    }
+    this.streamAbort = new AbortController();
+    const response = await fetch(`${this.url}/~/channel/${this.channelId}`, {
+      headers: {
+        accept: 'text/event-stream',
+        cookie: this.cookie!,
+        'last-event-id': String(this.lastEventId),
+      },
+      signal: this.streamAbort.signal,
+    });
+    if (!response.ok || !response.body) {
+      throw new Error(`SSE connect failed: ${response.status}`);
+    }
+    this.log('[eyre] Event stream connected');
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let eventId: number | null = null;
+    let dataLines: string[] = [];
+
+    const flush = async () => {
+      if (dataLines.length === 0) {
+        return;
+      }
+      const payload = dataLines.join('\n');
+      dataLines = [];
+      if (eventId !== null) {
+        this.lastEventId = eventId;
+        eventId = null;
+        this.unackedEvents++;
+        if (this.unackedEvents >= 30) {
+          this.unackedEvents = 0;
+          this.putActions([
+            { id: this.nextActionId++, action: 'ack', 'event-id': this.lastEventId },
+          ]).catch((err) => this.log(`[eyre] Ack failed: ${String(err)}`));
+        }
+      }
+      try {
+        this.dispatch(JSON.parse(payload));
+      } catch (err) {
+        this.log(`[eyre] Bad event payload: ${String(err)}`);
+      }
+    };
+
+    for await (const chunk of response.body) {
+      buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line === '') {
+          await flush();
+        } else if (line.startsWith('id:')) {
+          eventId = Number(line.slice(3).trim());
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trimStart());
+        }
+      }
+    }
+    throw new Error('SSE stream ended');
+  }
+
+  private dispatch(event: unknown): void {
+    if (!event || typeof event !== 'object') {
+      return;
+    }
+    const evt = event as {
+      id?: number;
+      response?: string;
+      json?: unknown;
+      err?: unknown;
+      ok?: unknown;
+    };
+    if (evt.response === 'diff') {
+      const sub = this.subscriptions.find((s) => s.actionId === evt.id);
+      if (sub) {
+        try {
+          sub.onEvent(evt.json);
+        } catch (err) {
+          this.log(`[eyre] Event handler error: ${String(err)}`);
+        }
+      } else if (this.debug) {
+        this.log(`[eyre] Diff for unknown subscription id ${evt.id}`);
+      }
+      return;
+    }
+    if (evt.response === 'quit') {
+      const sub = this.subscriptions.find((s) => s.actionId === evt.id);
+      if (sub) {
+        this.log(`[eyre] Subscription quit: ${sub.app}${sub.path}; resubscribing`);
+        this.subscribe(sub.app, sub.path, sub.onEvent).catch((err) =>
+          this.log(`[eyre] Resubscribe failed: ${String(err)}`)
+        );
+        this.subscriptions = this.subscriptions.filter((s) => s !== sub);
+      }
+      return;
+    }
+    if (evt.response === 'poke' && evt.err) {
+      this.log(`[eyre] Poke nack: ${JSON.stringify(evt.err)}`);
+      return;
+    }
+    if (evt.response === 'subscribe') {
+      const sub = this.subscriptions.find((s) => s.actionId === evt.id);
+      const label = sub ? `${sub.app}${sub.path}` : `action ${evt.id}`;
+      if (evt.err) {
+        this.log(
+          `[eyre] Subscribe FAILED for ${label}: ${JSON.stringify(evt.err)}`
+        );
+      } else {
+        this.log(`[eyre] Subscribe acked for ${label}`);
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.streamAbort?.abort();
+    if (this.cookie) {
+      await fetch(`${this.url}/~/channel/${this.channelId}`, {
+        method: 'PUT',
+        headers: {
+          'content-type': 'application/json',
+          cookie: this.cookie,
+        },
+        body: JSON.stringify([
+          { id: this.nextActionId++, action: 'delete' },
+        ]),
+      }).catch(() => {});
+    }
+  }
+}

--- a/packages/claude-tlon-channel/src/inbound.ts
+++ b/packages/claude-tlon-channel/src/inbound.ts
@@ -1,0 +1,157 @@
+/**
+ * Parse %channels and %chat firehose events (/v4 subscriptions) into a
+ * simple inbound-message shape. Event structures mirror the local types in
+ * the OpenClaw Tlon plugin's monitor (packages/openclaw/src/monitor/index.ts).
+ *
+ * Only new posts and replies are surfaced; reactions, edits, and deletes are
+ * ignored — the attached session cares about conversation turns.
+ */
+import { extractStoryText } from './story-text.js';
+
+export type InboundMessage = {
+  kind: 'dm' | 'club' | 'channel';
+  /** DM counterparty or club id (chat firehose only) */
+  whom?: string;
+  /** Channel nest (channels firehose only) */
+  nest?: string;
+  /** Message id (post id, or writ id for DMs) */
+  id: string;
+  /** Top-level post id when this is a thread reply */
+  parentId?: string;
+  author: string;
+  text: string;
+  sent: number;
+};
+
+type Author = string | { ship?: string };
+
+function authorShip(author: Author | undefined): string | undefined {
+  if (typeof author === 'string') {
+    return author;
+  }
+  return author?.ship;
+}
+
+type Essay = { content?: unknown; author?: Author; sent?: number };
+
+/** channels /v4 — { nest, response: { post: ... } } */
+export function parseChannelsEvent(event: unknown): InboundMessage | null {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+  const evt = event as {
+    nest?: string;
+    response?: {
+      post?: {
+        id?: string;
+        'r-post'?: {
+          set?: { essay?: Essay } | null;
+          reply?: {
+            id?: string;
+            'r-reply'?: { set?: { 'reply-essay'?: Essay } | null };
+          };
+        };
+      };
+    };
+  };
+  const nest = evt.nest;
+  const post = evt.response?.post;
+  if (!nest || !post) {
+    return null;
+  }
+
+  const rPost = post['r-post'];
+  const topEssay = rPost?.set?.essay;
+  if (topEssay) {
+    const author = authorShip(topEssay.author);
+    if (!author || !post.id) {
+      return null;
+    }
+    return {
+      kind: 'channel',
+      nest,
+      id: post.id,
+      author,
+      text: extractStoryText(topEssay.content),
+      sent: topEssay.sent ?? Date.now(),
+    };
+  }
+
+  const reply = rPost?.reply;
+  const replyEssay = reply?.['r-reply']?.set?.['reply-essay'];
+  if (replyEssay && post.id) {
+    const author = authorShip(replyEssay.author);
+    if (!author) {
+      return null;
+    }
+    return {
+      kind: 'channel',
+      nest,
+      id: reply?.id ?? '',
+      parentId: post.id,
+      author,
+      text: extractStoryText(replyEssay.content),
+      sent: replyEssay.sent ?? Date.now(),
+    };
+  }
+
+  return null;
+}
+
+/** chat /v4 — { whom, id, response: delta } (DM invites arrive as arrays; ignored) */
+export function parseChatEvent(event: unknown): InboundMessage | null {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    return null;
+  }
+  const evt = event as {
+    whom?: string;
+    id?: string;
+    response?: {
+      add?: { essay?: Essay };
+      reply?: {
+        id?: string;
+        delta?: { add?: { 'reply-essay'?: Essay; id?: string } };
+      };
+    };
+  };
+  const whom = evt.whom;
+  if (!whom) {
+    return null;
+  }
+  const kind: InboundMessage['kind'] = whom.startsWith('0v') ? 'club' : 'dm';
+
+  const essay = evt.response?.add?.essay;
+  if (essay) {
+    const author = authorShip(essay.author);
+    if (!author) {
+      return null;
+    }
+    return {
+      kind,
+      whom,
+      id: evt.id ?? '',
+      author,
+      text: extractStoryText(essay.content),
+      sent: essay.sent ?? Date.now(),
+    };
+  }
+
+  const replyEssay = evt.response?.reply?.delta?.add?.['reply-essay'];
+  if (replyEssay) {
+    const author = authorShip(replyEssay.author);
+    if (!author) {
+      return null;
+    }
+    return {
+      kind,
+      whom,
+      id: evt.response?.reply?.delta?.add?.id ?? '',
+      parentId: evt.id,
+      author,
+      text: extractStoryText(replyEssay.content),
+      sent: replyEssay.sent ?? Date.now(),
+    };
+  }
+
+  return null;
+}

--- a/packages/claude-tlon-channel/src/scopes.test.ts
+++ b/packages/claude-tlon-channel/src/scopes.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchScope, parseScope, scopeKey } from './scopes.js';
+
+describe('parseScope', () => {
+  it('parses each scope kind', () => {
+    expect(parseScope('~sampel-palnet')).toEqual({
+      kind: 'dm',
+      ship: '~sampel-palnet',
+    });
+    expect(parseScope('0v5.abcde')).toEqual({ kind: 'club', id: '0v5.abcde' });
+    expect(parseScope('chat/~zod/general')).toEqual({
+      kind: 'channel',
+      nest: 'chat/~zod/general',
+    });
+    expect(parseScope('chat/~zod/general/170.141.184')).toEqual({
+      kind: 'thread',
+      nest: 'chat/~zod/general',
+      parentId: '170141184',
+    });
+  });
+
+  it('normalizes ship case and missing sig', () => {
+    expect(parseScope('SAMPEL')).toBeNull(); // no sig, not a nest
+    expect(parseScope('~SAMPEL')).toEqual({ kind: 'dm', ship: '~sampel' });
+    expect(parseScope('chat/~ZOD/general')?.kind).toBe('channel');
+  });
+
+  it('rejects garbage', () => {
+    expect(parseScope('')).toBeNull();
+    expect(parseScope('chat/general')).toBeNull();
+    expect(parseScope('chat/~zod/general/x/y')).toBeNull();
+  });
+});
+
+describe('matchScope', () => {
+  const scopes = [
+    parseScope('~ten')!,
+    parseScope('chat/~zod/general')!,
+    parseScope('chat/~zod/dev/170.141.184')!,
+  ];
+
+  it('matches DMs by counterparty', () => {
+    expect(matchScope(scopes, { whom: '~ten' })?.kind).toBe('dm');
+    expect(matchScope(scopes, { whom: '~bus' })).toBeUndefined();
+  });
+
+  it('matches channel scopes for posts and their threads', () => {
+    expect(
+      matchScope(scopes, { nest: 'chat/~zod/general' })?.kind
+    ).toBe('channel');
+    expect(
+      matchScope(scopes, {
+        nest: 'chat/~zod/general',
+        parentId: '1.234',
+      })?.kind
+    ).toBe('channel');
+  });
+
+  it('matches thread scopes only under the claimed post', () => {
+    expect(
+      matchScope(scopes, {
+        nest: 'chat/~zod/dev',
+        parentId: '170141184',
+      })?.kind
+    ).toBe('thread');
+    expect(
+      matchScope(scopes, { nest: 'chat/~zod/dev', parentId: '999' })
+    ).toBeUndefined();
+    expect(matchScope(scopes, { nest: 'chat/~zod/dev' })).toBeUndefined();
+  });
+
+  it('scopeKey round-trips through parseScope', () => {
+    for (const scope of scopes) {
+      expect(scopeKey(parseScope(scopeKey(scope))!)).toBe(scopeKey(scope));
+    }
+  });
+});

--- a/packages/claude-tlon-channel/src/scopes.ts
+++ b/packages/claude-tlon-channel/src/scopes.ts
@@ -1,0 +1,116 @@
+/**
+ * Attachment scopes — the grammar shared with the OpenClaw plugin's
+ * `externalClaims` settings entry. A scope names a slice of the bot's
+ * conversation surface that this local session takes over:
+ *
+ *   ~sampel-palnet                 one-to-one DM with a ship
+ *   0v5.abcde...                   group DM (club id)
+ *   chat/~host/slug                a whole group channel
+ *   chat/~host/slug/170.141...     a single thread (top-level post id)
+ */
+import { normalizeShip } from './config.js';
+
+export type Scope =
+  | { kind: 'dm'; ship: string }
+  | { kind: 'club'; id: string }
+  | { kind: 'channel'; nest: string }
+  | { kind: 'thread'; nest: string; parentId: string };
+
+/** Strip @ud dot-grouping so post ids compare regardless of formatting. */
+export function normalizePostId(id: string): string {
+  return id.replace(/\./g, '');
+}
+
+export function parseScope(raw: string): Scope | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  if (trimmed.startsWith('~')) {
+    return { kind: 'dm', ship: normalizeShip(trimmed) };
+  }
+  if (trimmed.startsWith('0v')) {
+    return { kind: 'club', id: trimmed };
+  }
+  const parts = trimmed.split('/');
+  if (parts.length === 3 && parts[1].startsWith('~')) {
+    return {
+      kind: 'channel',
+      nest: `${parts[0]}/${parts[1].toLowerCase()}/${parts[2]}`,
+    };
+  }
+  if (parts.length === 4 && parts[1].startsWith('~')) {
+    return {
+      kind: 'thread',
+      nest: `${parts[0]}/${parts[1].toLowerCase()}/${parts[2]}`,
+      parentId: normalizePostId(parts[3]),
+    };
+  }
+  return null;
+}
+
+export function scopeKey(scope: Scope): string {
+  switch (scope.kind) {
+    case 'dm':
+      return scope.ship;
+    case 'club':
+      return scope.id;
+    case 'channel':
+      return scope.nest;
+    case 'thread':
+      return `${scope.nest}/${scope.parentId}`;
+  }
+}
+
+/** Inbound-message coordinates used for scope matching. */
+export type MessageLocus = {
+  /** DM counterparty (`~ship`) or club id (`0v...`); unset for group channels */
+  whom?: string;
+  /** Channel nest for group-channel messages */
+  nest?: string;
+  /** Top-level post id when the message is a thread reply */
+  parentId?: string | null;
+};
+
+/**
+ * Return the attached scope covering this locus, or undefined. A channel
+ * scope covers the whole channel including threads; a thread scope covers
+ * only replies under that top-level post.
+ */
+export function matchScope(
+  scopes: Iterable<Scope>,
+  locus: MessageLocus
+): Scope | undefined {
+  const normalizedParent = locus.parentId
+    ? normalizePostId(locus.parentId)
+    : undefined;
+  for (const scope of scopes) {
+    switch (scope.kind) {
+      case 'dm':
+        if (locus.whom && normalizeShip(locus.whom) === scope.ship) {
+          return scope;
+        }
+        break;
+      case 'club':
+        if (locus.whom === scope.id) {
+          return scope;
+        }
+        break;
+      case 'channel':
+        if (locus.nest === scope.nest) {
+          return scope;
+        }
+        break;
+      case 'thread':
+        if (
+          locus.nest === scope.nest &&
+          normalizedParent !== undefined &&
+          normalizedParent === scope.parentId
+        ) {
+          return scope;
+        }
+        break;
+    }
+  }
+  return undefined;
+}

--- a/packages/claude-tlon-channel/src/server.ts
+++ b/packages/claude-tlon-channel/src/server.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+/**
+ * MCP channel server: attaches a local Claude Code session to Tlon
+ * channels, threads, and DMs, logged in as the bot ship.
+ *
+ * - Inbound: subscribes to the ship's %channels and %chat firehoses over
+ *   SSE; messages inside attached scopes are pushed into the session as
+ *   `notifications/claude/channel` events (Claude Code v2.1.80+,
+ *   started with `claude --channels ...`).
+ * - Outbound: `tlon_send` shells out to the tlon CLI (@tloncorp/tlon-skill).
+ * - Coexistence: attached scopes are claimed in the ship's settings-store
+ *   (`externalClaims`) so an OpenClaw gateway running as the same ship
+ *   ignores them — see packages/openclaw.
+ *
+ * All logging goes to stderr; stdout is the MCP stdio transport.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { ClaimManager } from './claims.js';
+import { TlonCli } from './cli.js';
+import { loadConfig, normalizeShip } from './config.js';
+import { EyreClient } from './eyre.js';
+import { type InboundMessage, parseChannelsEvent, parseChatEvent } from './inbound.js';
+import { type Scope, matchScope, parseScope, scopeKey } from './scopes.js';
+
+const log = (message: string) => console.error(message);
+
+const INSTRUCTIONS = `You are attached to Tlon (Urbit messenger) as the bot ship. Inbound
+messages from attached scopes arrive as channel events with meta fields:
+scope, kind (dm | club | channel), target, messageId, parentId (set when the
+message is a thread reply), author, and sent.
+
+To reply, call tlon_send. Reply in the same place the message came from:
+- DM / group DM: target = the meta.target value
+- channel message: target = the nest; pass parentId to reply in a thread.
+  If meta.parentId is set, the conversation is a thread — pass that parentId
+  so your reply lands in the same thread.
+
+Use tlon_read to pull recent history for context before replying when you
+have not seen the conversation yet. Manage which conversations you follow
+with tlon_attach / tlon_detach; scopes:
+  ~ship                        one-to-one DM
+  0v...                        group DM (club)
+  chat/~host/slug              whole channel
+  chat/~host/slug/<post-id>    single thread
+
+You are speaking as the bot's identity. Keep replies conversational and
+channel-appropriate; do not paste large tool output or file contents into
+chat unless asked.`;
+
+type Attachment = { scope: Scope; raw: string };
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const eyre = new EyreClient(cfg.url, cfg.ship, cfg.code, log);
+  const cli = new TlonCli(cfg);
+  const claims = new ClaimManager(
+    eyre,
+    cfg.claimHolder,
+    cfg.claimTtlMs,
+    cfg.writeClaims,
+    log
+  );
+
+  const attachments = new Map<string, Attachment>();
+  const seenMessageIds = new Set<string>();
+
+  const server = new Server(
+    { name: 'tlon', version: '0.1.0' },
+    {
+      capabilities: {
+        experimental: { 'claude/channel': {} },
+        tools: {},
+      },
+      instructions: INSTRUCTIONS,
+    }
+  );
+
+  const notifyInbound = (message: InboundMessage, scope: Scope) => {
+    // Dedupe across SSE reconnect replays.
+    const dedupeKey = `${message.whom ?? message.nest}/${message.id}`;
+    if (seenMessageIds.has(dedupeKey)) {
+      return;
+    }
+    seenMessageIds.add(dedupeKey);
+    if (seenMessageIds.size > 2000) {
+      for (const key of seenMessageIds) {
+        seenMessageIds.delete(key);
+        if (seenMessageIds.size <= 1000) {
+          break;
+        }
+      }
+    }
+
+    const target = message.whom ?? message.nest ?? '';
+    server
+      .notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: `${message.author}: ${message.text}`,
+          // meta values must all be strings (Record<string, string>);
+          // non-identifier keys and non-string values are dropped by the host.
+          meta: {
+            scope: scopeKey(scope),
+            kind: message.kind,
+            target,
+            messageId: message.id,
+            ...(message.parentId ? { parentId: message.parentId } : {}),
+            author: message.author,
+            sent: new Date(message.sent).toISOString(),
+          },
+        },
+      })
+      .catch((err) => log(`[tlon] Notification failed: ${String(err)}`));
+  };
+
+  const debug = process.env.TLON_DEBUG === '1';
+
+  const handleInbound = (message: InboundMessage | null) => {
+    if (!message || !message.text) {
+      return;
+    }
+    if (normalizeShip(message.author) === cfg.ship) {
+      if (debug) {
+        log(`[tlon] Ignoring own message in ${message.whom ?? message.nest}`);
+      }
+      return; // our own sends (including this session's)
+    }
+    const scope = matchScope(
+      [...attachments.values()].map((a) => a.scope),
+      {
+        whom: message.whom,
+        nest: message.nest,
+        parentId: message.parentId,
+      }
+    );
+    if (scope) {
+      log(
+        `[tlon] Inbound from ${message.author} in ${scopeKey(scope)} → channel event`
+      );
+      notifyInbound(message, scope);
+    } else if (debug) {
+      log(
+        `[tlon] Inbound from ${message.author} matched no attached scope ` +
+          `(whom=${message.whom ?? '-'} nest=${message.nest ?? '-'} parent=${message.parentId ?? '-'}); ` +
+          `attached: ${[...attachments.keys()].join(', ') || '(none)'}`
+      );
+    }
+  };
+
+  const attach = async (raw: string): Promise<string> => {
+    const scope = parseScope(raw);
+    if (!scope) {
+      throw new Error(
+        `Invalid scope: "${raw}". Expected ~ship, 0v club id, chat/~host/slug, or chat/~host/slug/<post-id>.`
+      );
+    }
+    const key = scopeKey(scope);
+    if (attachments.has(key)) {
+      return `Already attached to ${key}.`;
+    }
+    attachments.set(key, { scope, raw });
+    try {
+      await claims.claim(key);
+    } catch (err) {
+      log(`[tlon] Claim write failed for ${key}: ${String(err)}`);
+      return `Attached to ${key}, but failed to write the settings-store claim (a co-resident OpenClaw bot may also respond): ${String(err)}`;
+    }
+    return `Attached to ${key}. New messages there will arrive as channel events.`;
+  };
+
+  const detach = async (raw: string): Promise<string> => {
+    const scope = parseScope(raw);
+    const key = scope ? scopeKey(scope) : raw.trim();
+    if (!attachments.delete(key)) {
+      return `Not attached to ${key}.`;
+    }
+    await claims
+      .release(key)
+      .catch((err) => log(`[tlon] Claim release failed: ${String(err)}`));
+    return `Detached from ${key}.`;
+  };
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'tlon_attach',
+        description:
+          'Attach to a Tlon scope so its new messages arrive as channel events. Scopes: ~ship (DM), 0v... (group DM), chat/~host/slug (channel), chat/~host/slug/<post-id> (thread).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scope: { type: 'string', description: 'Scope to attach to' },
+          },
+          required: ['scope'],
+        },
+      },
+      {
+        name: 'tlon_detach',
+        description: 'Detach from a previously attached Tlon scope.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scope: { type: 'string', description: 'Scope to detach from' },
+          },
+          required: ['scope'],
+        },
+      },
+      {
+        name: 'tlon_attachments',
+        description: 'List currently attached Tlon scopes.',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        name: 'tlon_send',
+        description:
+          'Send a message to Tlon as the bot. target: channel nest, ~ship DM, or 0v group DM. Pass parentId to reply in a thread.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            target: {
+              type: 'string',
+              description: 'chat/~host/slug, ~ship, or 0v club id',
+            },
+            text: { type: 'string', description: 'Message text (markdown)' },
+            parentId: {
+              type: 'string',
+              description: 'Top-level post id to reply under (thread reply)',
+            },
+          },
+          required: ['target', 'text'],
+        },
+      },
+      {
+        name: 'tlon_read',
+        description:
+          'Read recent Tlon history for context. target: channel nest or ~ship/0v DM. Pass postId to fetch one post with its thread replies.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            target: { type: 'string' },
+            limit: { type: 'number', description: 'Max messages (default 20)' },
+            postId: {
+              type: 'string',
+              description: 'Fetch this post and its replies instead of history',
+            },
+          },
+          required: ['target'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const text = async (): Promise<string> => {
+      switch (request.params.name) {
+        case 'tlon_attach':
+          return attach(String(args.scope ?? ''));
+        case 'tlon_detach':
+          return detach(String(args.scope ?? ''));
+        case 'tlon_attachments': {
+          const keys = [...attachments.keys()];
+          return keys.length === 0
+            ? 'No attached scopes.'
+            : `Attached scopes:\n${keys.map((k) => `- ${k}`).join('\n')}`;
+        }
+        case 'tlon_send': {
+          const target = String(args.target ?? '');
+          const body = String(args.text ?? '');
+          const parentId = args.parentId ? String(args.parentId) : undefined;
+          const result = parentId
+            ? await cli.reply(target, parentId, body)
+            : await cli.send(target, body);
+          return result || 'Sent.';
+        }
+        case 'tlon_read': {
+          const target = String(args.target ?? '');
+          const limit = Number(args.limit ?? 20) || 20;
+          if (args.postId) {
+            return cli.readThread(target, String(args.postId));
+          }
+          if (target.startsWith('~') || target.startsWith('0v')) {
+            return cli.readDm(target, limit);
+          }
+          return cli.readChannel(target, limit);
+        }
+        default:
+          throw new Error(`Unknown tool: ${request.params.name}`);
+      }
+    };
+    try {
+      return { content: [{ type: 'text', text: await text() }] };
+    } catch (err) {
+      return {
+        content: [{ type: 'text', text: String(err) }],
+        isError: true,
+      };
+    }
+  });
+
+  // --- Startup ---
+  await eyre.login();
+  await eyre.subscribe('channels', '/v4', (data) =>
+    handleInbound(parseChannelsEvent(data))
+  );
+  await eyre.subscribe('chat', '/v4', (data) =>
+    handleInbound(parseChatEvent(data))
+  );
+  void eyre.runEventStream();
+
+  for (const raw of cfg.initialScopes) {
+    await attach(raw).then(log, (err) => log(String(err)));
+  }
+
+  const shutdown = async () => {
+    log('[tlon] Shutting down; releasing claims');
+    await claims.releaseAll().catch(() => {});
+    await eyre.close().catch(() => {});
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  log(`[tlon] MCP channel server ready as ${cfg.ship} (${cfg.url})`);
+}
+
+main().catch((err) => {
+  console.error(`[tlon] Fatal: ${String(err)}`);
+  process.exit(1);
+});

--- a/packages/claude-tlon-channel/src/story-text.ts
+++ b/packages/claude-tlon-channel/src/story-text.ts
@@ -1,0 +1,83 @@
+/**
+ * Flatten a Tlon story (list of verses) to plain-ish markdown text.
+ * Adapted from the OpenClaw Tlon plugin's extractMessageText.
+ */
+
+function extractInlineText(inlines: unknown[]): string {
+  return inlines
+    .map((item) => {
+      if (typeof item === 'string') {
+        return item;
+      }
+      if (!item || typeof item !== 'object') {
+        return '';
+      }
+      const inline = item as Record<string, unknown>;
+      if (typeof inline.ship === 'string') {
+        return inline.ship;
+      }
+      if ('sect' in inline) {
+        return `@${inline.sect || 'all'}`;
+      }
+      if (inline.break !== undefined) {
+        return '\n';
+      }
+      const link = inline.link as { href?: string } | undefined;
+      if (link?.href) {
+        return link.href;
+      }
+      if (typeof inline['inline-code'] === 'string') {
+        return `\`${inline['inline-code']}\``;
+      }
+      if (typeof inline.code === 'string') {
+        return `\`${inline.code}\``;
+      }
+      if (Array.isArray(inline.bold)) {
+        return `**${extractInlineText(inline.bold)}**`;
+      }
+      if (Array.isArray(inline.italics)) {
+        return `*${extractInlineText(inline.italics)}*`;
+      }
+      if (Array.isArray(inline.strike)) {
+        return `~~${extractInlineText(inline.strike)}~~`;
+      }
+      if (Array.isArray(inline.blockquote)) {
+        return `> ${extractInlineText(inline.blockquote)}`;
+      }
+      return '';
+    })
+    .join('');
+}
+
+export function extractStoryText(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  return content
+    .map((verse) => {
+      if (!verse || typeof verse !== 'object') {
+        return '';
+      }
+      const v = verse as Record<string, unknown>;
+      if (Array.isArray(v.inline)) {
+        return extractInlineText(v.inline);
+      }
+      if (v.block && typeof v.block === 'object') {
+        const block = v.block as Record<string, unknown>;
+        const image = block.image as { src?: string; alt?: string } | undefined;
+        if (image?.src) {
+          return `[image: ${image.alt || image.src}]`;
+        }
+        const code = block.code as { code?: string } | undefined;
+        if (code?.code) {
+          return `\`\`\`\n${code.code}\n\`\`\``;
+        }
+        if (block.cite) {
+          return '[quoted message]';
+        }
+      }
+      return '';
+    })
+    .filter((line) => line !== '')
+    .join('\n');
+}

--- a/packages/claude-tlon-channel/tsconfig.json
+++ b/packages/claude-tlon-channel/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": false,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/packages/openclaw/src/monitor/external-claims.test.ts
+++ b/packages/openclaw/src/monitor/external-claims.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseExternalClaims } from '../settings.js';
+import { findExternalClaim } from './utils.js';
+
+const NOW = 1_700_000_000_000;
+
+const claim = (scope: string, expiresAt = NOW + 60_000) => ({
+  scope,
+  holder: 'claude-code',
+  expiresAt,
+});
+
+describe('parseExternalClaims', () => {
+  it('parses a JSON string of claims (settings-store format)', () => {
+    const value = JSON.stringify([claim('chat/~zod/general')]);
+    expect(parseExternalClaims(value)).toEqual([claim('chat/~zod/general')]);
+  });
+
+  it('parses a plain array', () => {
+    expect(parseExternalClaims([claim('~ten')])).toEqual([claim('~ten')]);
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    const value = [
+      claim('~ten'),
+      { scope: 'chat/~zod/general' }, // missing holder/expiresAt
+      'not-an-object',
+      null,
+    ];
+    expect(parseExternalClaims(value)).toEqual([claim('~ten')]);
+  });
+
+  it('returns undefined for garbage', () => {
+    expect(parseExternalClaims('not json')).toBeUndefined();
+    expect(parseExternalClaims(42)).toBeUndefined();
+    expect(parseExternalClaims(undefined)).toBeUndefined();
+  });
+});
+
+describe('findExternalClaim', () => {
+  it('matches a DM claim by sender ship', () => {
+    const claims = [claim('~ten')];
+    expect(
+      findExternalClaim(
+        claims,
+        { isGroup: false, senderShip: '~ten' },
+        NOW
+      )
+    ).toEqual(claims[0]);
+    expect(
+      findExternalClaim(
+        claims,
+        { isGroup: false, senderShip: 'ten' },
+        NOW
+      )
+    ).toEqual(claims[0]);
+  });
+
+  it('matches a channel claim for any message in the channel', () => {
+    const claims = [claim('chat/~zod/general')];
+    expect(
+      findExternalClaim(
+        claims,
+        {
+          isGroup: true,
+          channelNest: 'chat/~zod/general',
+          senderShip: '~ten',
+        },
+        NOW
+      )
+    ).toEqual(claims[0]);
+    expect(
+      findExternalClaim(
+        claims,
+        {
+          isGroup: true,
+          channelNest: 'chat/~zod/general',
+          parentId: '170.141.184',
+          senderShip: '~ten',
+        },
+        NOW
+      )
+    ).toEqual(claims[0]);
+  });
+
+  it('matches a thread claim only for replies under that post', () => {
+    const claims = [claim('chat/~zod/general/170.141.184')];
+    expect(
+      findExternalClaim(
+        claims,
+        {
+          isGroup: true,
+          channelNest: 'chat/~zod/general',
+          parentId: '170141184', // undotted form still matches
+          senderShip: '~ten',
+        },
+        NOW
+      )
+    ).toEqual(claims[0]);
+    expect(
+      findExternalClaim(
+        claims,
+        {
+          isGroup: true,
+          channelNest: 'chat/~zod/general',
+          parentId: '999.999.999',
+          senderShip: '~ten',
+        },
+        NOW
+      )
+    ).toBeUndefined();
+    // Top-level channel messages are not covered by a thread claim.
+    expect(
+      findExternalClaim(
+        claims,
+        {
+          isGroup: true,
+          channelNest: 'chat/~zod/general',
+          senderShip: '~ten',
+        },
+        NOW
+      )
+    ).toBeUndefined();
+  });
+
+  it('ignores expired claims', () => {
+    const claims = [claim('~ten', NOW - 1)];
+    expect(
+      findExternalClaim(
+        claims,
+        { isGroup: false, senderShip: '~ten' },
+        NOW
+      )
+    ).toBeUndefined();
+  });
+
+  it('does not cross-match DMs against channel scopes', () => {
+    const claims = [claim('chat/~zod/general')];
+    expect(
+      findExternalClaim(
+        claims,
+        { isGroup: false, senderShip: '~ten' },
+        NOW
+      )
+    ).toBeUndefined();
+  });
+});

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -152,6 +152,7 @@ import {
   type ParsedCite,
   extractCites,
   extractMessageText,
+  findExternalClaim,
   formatModelName,
   isBotMentioned,
   isChannelRestricted,
@@ -2281,6 +2282,21 @@ export async function monitorTlonProvider(
       // Used for reactions: agent sees no thread context (so it responds), but
       // the reply is still delivered as a thread reply.
       const deliverParentId = params.replyParentId ?? parentId;
+
+      // An external handler (e.g. a local Claude Code session attached via
+      // the claude-tlon-channel plugin) may have claimed this scope in the
+      // settings store; while the claim is live, it responds instead of us.
+      const externalClaim = findExternalClaim(
+        settingsManager.current.externalClaims,
+        { isGroup, channelNest, parentId, senderShip },
+        Date.now()
+      );
+      if (externalClaim) {
+        runtime.log?.(
+          `[tlon] Skipping message ${messageId}: scope ${externalClaim.scope} claimed by external handler "${externalClaim.holder}"`
+        );
+        return;
+      }
       const groupChannel = channelNest; // For compatibility
       let messageText = sanitizeMessageText(params.messageText);
       const rawMessageText = messageText; // Preserve original before any modifications

--- a/packages/openclaw/src/monitor/utils.ts
+++ b/packages/openclaw/src/monitor/utils.ts
@@ -466,3 +466,56 @@ export function sanitizeMessageText(text: string): string {
 
   return sanitized;
 }
+
+/**
+ * Find an unexpired external-handler claim covering an inbound message.
+ * Claims are written to the settings store by local sessions (e.g. the
+ * claude-tlon-channel Claude Code plugin) that attach to a conversation as
+ * this ship; while one is live the monitor should not respond there.
+ *
+ * Scope grammar (must stay in sync with packages/claude-tlon-channel):
+ *   ~ship                        one-to-one DM with that ship
+ *   chat/~host/slug              whole group channel
+ *   chat/~host/slug/<post-id>    single thread (top-level post id)
+ *
+ * Group-DM (club) scopes are not yet matchable here because processMessage
+ * does not carry the club id.
+ */
+export function findExternalClaim(
+  claims:
+    | { scope: string; holder: string; expiresAt: number }[]
+    | undefined,
+  locus: {
+    isGroup: boolean;
+    channelNest?: string;
+    parentId?: string | null;
+    senderShip: string;
+  },
+  now: number
+): { scope: string; holder: string; expiresAt: number } | undefined {
+  if (!claims || claims.length === 0) {
+    return undefined;
+  }
+  const stripDots = (id: string) => id.replace(/\./g, '');
+  const candidates = new Set<string>();
+  if (locus.isGroup && locus.channelNest) {
+    candidates.add(locus.channelNest);
+    if (locus.parentId) {
+      candidates.add(`${locus.channelNest}/${stripDots(locus.parentId)}`);
+    }
+  } else if (!locus.isGroup) {
+    candidates.add(normalizeShip(locus.senderShip));
+  }
+  return claims.find((claim) => {
+    if (claim.expiresAt <= now) {
+      return false;
+    }
+    // Normalize thread scopes so dotted and undotted post ids match.
+    const parts = claim.scope.split('/');
+    const normalized =
+      parts.length === 4
+        ? `${parts[0]}/${parts[1]}/${parts[2]}/${stripDots(parts[3])}`
+        : claim.scope;
+    return candidates.has(normalized);
+  });
+}

--- a/packages/openclaw/src/settings.ts
+++ b/packages/openclaw/src/settings.ts
@@ -37,6 +37,22 @@ export type PendingApproval = {
   notificationMessageId?: string;
 };
 
+/**
+ * A scope claimed by an external handler (e.g. a local Claude Code session
+ * attached via the claude-tlon-channel plugin). While a claim is unexpired,
+ * the monitor skips inbound messages in that scope so the external handler
+ * can respond instead. Scope grammar:
+ *   ~ship                        one-to-one DM
+ *   chat/~host/slug              whole group channel
+ *   chat/~host/slug/<post-id>    single thread (top-level post id)
+ */
+export type ExternalClaim = {
+  scope: string;
+  holder: string;
+  /** Epoch ms; claims past this are ignored (crash-safety TTL) */
+  expiresAt: number;
+};
+
 export type TlonSettingsStore = {
   groupChannels?: string[];
   dmAllowlist?: string[];
@@ -77,6 +93,8 @@ export type TlonSettingsStore = {
   ownerListenEnabled?: boolean;
   /** Channels opted out of owner-listen even when the global toggle is on. */
   ownerListenDisabledChannels?: string[];
+  /** Scopes temporarily claimed by external handlers (see ExternalClaim). */
+  externalClaims?: ExternalClaim[];
 };
 
 export type TlonSettingsState = {
@@ -408,7 +426,47 @@ export function parseSettingsResponse(raw: unknown): TlonSettingsStore {
           (x): x is string => typeof x === 'string'
         )
       : undefined,
+    externalClaims: parseExternalClaims(settings.externalClaims),
   };
+}
+
+/**
+ * Parse externalClaims — handles both JSON string and array formats
+ * (settings-store stores complex objects as JSON strings). Expiry is checked
+ * at message time, not parse time, since the parsed value can live in memory
+ * long past a claim's TTL.
+ */
+export function parseExternalClaims(
+  value: unknown
+): ExternalClaim[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  return parsed.filter((item): item is ExternalClaim => {
+    if (!item || typeof item !== 'object') {
+      return false;
+    }
+    const claim = item as Record<string, unknown>;
+    return (
+      typeof claim.scope === 'string' &&
+      typeof claim.holder === 'string' &&
+      typeof claim.expiresAt === 'number'
+    );
+  });
 }
 
 function isChannelRulesObject(
@@ -604,6 +662,9 @@ export function applySettingsUpdate(
       next.ownerListenDisabledChannels = Array.isArray(value)
         ? value.filter((x): x is string => typeof x === 'string')
         : undefined;
+      break;
+    case 'externalClaims':
+      next.externalClaims = parseExternalClaims(value);
       break;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,6 +1055,22 @@ importers:
         specifier: 0.73.0
         version: 0.73.0(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3)(@types/react@19.2.17)(react@19.2.3)
 
+  packages/claude-tlon-channel:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.29.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.19.31
+      typescript:
+        specifier: ~5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.31)(jsdom@23.2.0)(lightningcss@1.32.0)(terser@5.46.0)
+
   packages/editor:
     dependencies:
       '@tiptap/core':
@@ -3419,7 +3435,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -6305,8 +6320,22 @@ packages:
   '@vitest/expect@1.5.0':
     resolution: {integrity: sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.8':
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
@@ -6319,6 +6348,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@4.1.8':
     resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
@@ -6327,6 +6359,9 @@ packages:
 
   '@vitest/runner@1.5.0':
     resolution: {integrity: sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@4.1.8':
     resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
@@ -6337,6 +6372,9 @@ packages:
   '@vitest/snapshot@1.5.0':
     resolution: {integrity: sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@4.1.8':
     resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
@@ -6346,6 +6384,9 @@ packages:
   '@vitest/spy@1.5.0':
     resolution: {integrity: sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@4.1.8':
     resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
@@ -6354,6 +6395,9 @@ packages:
 
   '@vitest/utils@1.5.0':
     resolution: {integrity: sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
@@ -6930,6 +6974,10 @@ packages:
     resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
     engines: {node: '>=4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -6988,6 +7036,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -7460,6 +7512,10 @@ packages:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-equal@2.2.2:
     resolution: {integrity: sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==}
 
@@ -7834,6 +7890,9 @@ packages:
   es-iterator-helpers@1.0.18:
     resolution: {integrity: sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -9942,6 +10001,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -10849,6 +10911,10 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
@@ -12614,6 +12680,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -12630,12 +12699,24 @@ packages:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
@@ -13081,6 +13162,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-plugin-pwa@0.17.5:
     resolution: {integrity: sha512-UxRNPiJBzh4tqU/vc8G2TxmrUTzT6BqvSzhszLk62uKsf+npXdvLxGDz9C675f4BJi6MbD2tPnJhi5txlMzxbQ==}
     engines: {node: '>=16.0.0'}
@@ -13211,6 +13297,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 1.5.0
       '@vitest/ui': 1.5.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -16395,14 +16506,14 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3)(@types/react@19.2.17)(react@19.2.3)
 
-  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0)':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.21.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16441,7 +16552,7 @@ snapshots:
   '@grpc/grpc-js@1.9.15':
     dependencies:
       '@grpc/proto-loader': 0.7.15
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
@@ -16509,7 +16620,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -16522,14 +16633,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.3)
+      jest-config: 29.7.0(@types/node@20.19.31)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -16558,7 +16669,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -16576,7 +16687,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -16598,7 +16709,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -16668,7 +16779,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -16752,7 +16863,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
@@ -19704,7 +19815,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.9':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/bun@1.3.14':
     dependencies:
@@ -19714,7 +19825,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       '@types/responselike': 1.0.3
 
   '@types/chai-subset@1.3.5':
@@ -19753,11 +19864,11 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/hammerjs@2.0.45': {}
 
@@ -19769,7 +19880,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -19792,7 +19903,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -19800,11 +19911,11 @@ snapshots:
 
   '@types/jsonfile@6.1.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/lodash@4.14.183': {}
 
@@ -19837,7 +19948,7 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       xmlbuilder: 15.1.1
     optional: true
 
@@ -19892,11 +20003,11 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/retry@0.12.0': {}
 
@@ -19906,7 +20017,7 @@ snapshots:
 
   '@types/set-cookie-parser@2.4.2':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/stack-utils@2.0.1': {}
 
@@ -19917,7 +20028,7 @@ snapshots:
 
   '@types/tar-stream@2.2.2':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   '@types/testing-library__jest-dom@5.14.5(patch_hash=cf4e4e793d22cd793da0c584ea39f50bf28a9b3e80d42a7169122bc40c8b02a9)':
     dependencies:
@@ -19958,7 +20069,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
     optional: true
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)':
@@ -20256,6 +20367,13 @@ snapshots:
       '@vitest/utils': 1.5.0
       chai: 4.4.1
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -20265,6 +20383,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@2.1.9(vite@5.1.6(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.1.6(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0)
+
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
@@ -20272,6 +20398,10 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -20287,6 +20417,11 @@ snapshots:
     dependencies:
       '@vitest/utils': 1.5.0
       p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
       pathe: 1.1.2
 
   '@vitest/runner@4.1.8':
@@ -20306,6 +20441,12 @@ snapshots:
       pathe: 1.1.2
       pretty-format: 29.7.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/snapshot@4.1.8':
     dependencies:
       '@vitest/pretty-format': 4.1.8
@@ -20321,6 +20462,10 @@ snapshots:
     dependencies:
       tinyspy: 2.2.1
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@4.1.8': {}
 
   '@vitest/utils@0.34.6':
@@ -20335,6 +20480,12 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -20997,7 +21148,7 @@ snapshots:
 
   bun-types@1.3.14:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
 
   bundle-name@4.1.0:
     dependencies:
@@ -21098,6 +21249,14 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.0.8
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -21155,6 +21314,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  check-error@2.1.3: {}
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -21179,7 +21340,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -21188,7 +21349,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -21629,6 +21790,8 @@ snapshots:
     dependencies:
       type-detect: 4.0.8
 
+  deep-eql@5.0.2: {}
+
   deep-equal@2.2.2:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -22050,6 +22213,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.2
       safe-array-concat: 1.1.3
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -23888,7 +24053,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -23926,6 +24091,36 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.31):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.31
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@25.9.3):
     dependencies:
@@ -23982,7 +24177,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -23996,7 +24191,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -24040,7 +24235,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -24079,7 +24274,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -24114,7 +24309,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -24142,7 +24337,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -24188,7 +24383,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -24224,7 +24419,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -24233,13 +24428,13 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -24625,6 +24820,8 @@ snapshots:
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
+
+  loupe@3.2.1: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -25649,13 +25846,13 @@ snapshots:
       '@clack/core': 1.3.1
       '@clack/prompts': 1.4.0
       '@earendil-works/pi-tui': 0.76.0
-      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0)
       '@grammyjs/runner': 2.0.3(grammy@1.43.0(encoding@0.1.13))
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0(encoding@0.1.13))
       '@homebridge/ciao': 1.3.9
       '@lydell/node-pty': 1.2.0-beta.12
       '@mistralai/mistralai': 2.2.5
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0
       '@mozilla/readability': 0.6.0
       '@openclaw/fs-safe': 0.3.0
       '@openclaw/proxyline': 0.3.3(undici@8.3.0)
@@ -25895,6 +26092,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
+
+  pathval@2.0.1: {}
 
   pe-library@0.4.1: {}
 
@@ -26276,7 +26475,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.9.3
+      '@types/node': 20.19.31
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -27975,6 +28174,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -27986,9 +28187,15 @@ snapshots:
 
   tinypool@0.8.4: {}
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@3.1.0: {}
 
   tinyspy@2.2.1: {}
+
+  tinyspy@3.0.2: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -28453,6 +28660,23 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.1.6(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-pwa@0.17.5(@types/babel__core@7.20.5)(vite@5.1.6(@types/node@25.9.3)(lightningcss@1.32.0)(terser@5.46.0))(workbox-window@7.0.0):
     dependencies:
       debug: 4.4.3
@@ -28481,6 +28705,17 @@ snapshots:
       - rollup
       - supports-color
       - typescript
+
+  vite@5.1.6(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      esbuild: 0.27.3
+      postcss: 8.5.15
+      rollup: 4.13.0
+    optionalDependencies:
+      '@types/node': 20.19.31
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.46.0
 
   vite@5.1.6(@types/node@25.9.3)(lightningcss@1.32.0)(terser@5.46.0):
     dependencies:
@@ -28575,6 +28810,41 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@20.19.31)(jsdom@23.2.0)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.1.6(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.1.6(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@20.19.31)(lightningcss@1.32.0)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.31
+      jsdom: 23.2.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
       - sass
       - stylus
       - sugarss


### PR DESCRIPTION
## Summary

Adds `packages/claude-tlon-channel`, a Claude Code plugin whose MCP channel server logs into a bot ship and bridges Tlon conversations into a locally running Claude Code session: inbound messages from attached channels/threads/DMs arrive as channel events, and the session replies as the ship via the bundled `tlon_send` tool. Also adds an `externalClaims` coexistence gate to the OpenClaw Tlon plugin so a hosted bot running as the same ship backs off scopes a local session has attached to.

## Changes

- **New package `packages/claude-tlon-channel`** (plugin manifest, MCP config, `tlon-attach` skill):
  - Minimal dependency-free Eyre client (+code login, SSE with ack/reconnect/resubscribe) subscribing to the `%chat /v4` and `%channels /v4` firehoses
  - Firehose parsing for posts, thread replies, and DMs; scope grammar `~ship` / `0v…` / `chat/~host/slug` / `chat/~host/slug/<post-id>`
  - MCP channel server (Claude Code v2.1.80+ research preview): pushes matched messages as `notifications/claude/channel` events; tools `tlon_attach`/`tlon_detach`/`tlon_attachments`/`tlon_send`/`tlon_read` (outbound via the `tlon` CLI from @tloncorp/tlon-skill)
  - Settings-store claims (`externalClaims`, desk `moltbot` bucket `tlon`) with 5-min TTL refreshed at half-life; released on detach/shutdown
- **OpenClaw plugin**: `parseExternalClaims` in settings.ts, `findExternalClaim` matcher in monitor utils, and an early gate in `processMessage` that skips messages in claimed, unexpired scopes (channel claims cover threads; thread claims cover only that thread; DM claims match the counterparty)

## How did I test?

- Unit tests: 7 new tests for scope parsing/matching in the new package; 13 new tests for claim parsing/matching in openclaw; full openclaw suite passes (835)
- Manual end-to-end on a live ship: standalone server run confirmed subscribe acks, thread-scoped event matching, and notification emission; full loop verified inside a `claude --dangerously-load-development-channels server:tlon` session (inbound thread message → channel event → reply posted back via `tlon_send`)

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: OpenClaw gateway inbound dispatch (new early-return gate; no-op unless an `externalClaims` settings entry exists)

## Rollback plan

Revert both commits. The new package is self-contained; the openclaw gate is a single early-return in `processMessage` plus additive settings parsing — with no `externalClaims` entry in the settings store, behavior is unchanged. Stale claims self-expire via TTL, so no ship-side state cleanup is needed.

## Screenshots / videos

n/a (terminal feature)

## Known gaps

- Group-DM (club) scopes aren't matchable in the openclaw gate yet (`processMessage` doesn't carry the club id)
- Sends go out as the ship identity; vouched/moon identity sends are future work
- Custom channels are research-preview: launch requires `claude --dangerously-load-development-channels server:tlon` (per-entry bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)