### PR TITLE
fix: tab bar touch targets are much smaller than a native tab bar

### DIFF
--- a/packages/app/ui/components/NavBar/NavBar.tsx
+++ b/packages/app/ui/components/NavBar/NavBar.tsx
@@ -16,7 +16,10 @@ const NavBar = React.memo(function NavBar(props: {
     <View
       width="100%"
       backgroundColor="$background"
-      paddingTop={isAndroid ? '$m' : '$s'}
+      // On native there is no top padding: each icon centers itself within
+      // its min-height touch target, which puts it at the same visual
+      // position the padding used to.
+      paddingTop={Platform.OS === 'web' ? '$s' : undefined}
       paddingBottom={isAndroid ? largeSize + bottom : bottom}
     >
       <XStack justifyContent="space-around" alignItems="flex-start">

--- a/packages/app/ui/components/NavBar/NavIcon.tsx
+++ b/packages/app/ui/components/NavBar/NavIcon.tsx
@@ -3,10 +3,15 @@ import { Icon, IconType } from '@tloncorp/ui';
 import { Pressable } from '@tloncorp/ui';
 import { View } from '@tloncorp/ui';
 import { ComponentProps } from 'react';
+import { Platform } from 'react-native';
 import { Circle, ColorTokens, isWeb } from 'tamagui';
 
 import { getAndroidRoundedBackgroundKey } from '../../utils';
 import { ContactAvatar } from '../Avatar';
+
+// Match platform touch-target guidelines (iOS HIG 44pt, Android Material
+// 48dp); the tab's tappable area spans its full flex share of the bar.
+const NAV_TARGET_MIN_HEIGHT = Platform.OS === 'android' ? 48 : 44;
 
 export function AvatarNavIcon({
   id,
@@ -29,7 +34,9 @@ export function AvatarNavIcon({
       }
     : {
         pressStyle: { backgroundColor: 'unset' },
-        paddingTop: '$s',
+        flex: 1,
+        minHeight: NAV_TARGET_MIN_HEIGHT,
+        justifyContent: 'center',
       };
 
   return (
@@ -80,6 +87,9 @@ export default function NavIcon({
       }
     : {
         pressStyle: { backgroundColor: 'unset' },
+        flex: 1,
+        minHeight: NAV_TARGET_MIN_HEIGHT,
+        justifyContent: 'center',
       };
   return (
     <Pressable
@@ -90,24 +100,28 @@ export default function NavIcon({
       backgroundColor={backgroundColor}
       {...props}
     >
-      <Icon
-        type={resolvedType}
-        color={isActive ? '$primaryText' : '$tertiaryText'}
-      />
-      {shouldShowUnreads ? (
-        <View
-          position="absolute"
-          top="100%"
-          justifyContent="center"
-          alignItems="center"
-        >
-          <Circle
-            key={getAndroidRoundedBackgroundKey(unreadDotBackgroundColor)}
-            size="$s"
-            backgroundColor={unreadDotBackgroundColor}
-          />
-        </View>
-      ) : null}
+      <View>
+        <Icon
+          type={resolvedType}
+          color={isActive ? '$primaryText' : '$tertiaryText'}
+        />
+        {shouldShowUnreads ? (
+          <View
+            position="absolute"
+            top="100%"
+            left={0}
+            right={0}
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Circle
+              key={getAndroidRoundedBackgroundKey(unreadDotBackgroundColor)}
+              size="$s"
+              backgroundColor={unreadDotBackgroundColor}
+            />
+          </View>
+        ) : null}
+      </View>
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary

On mobile, the tab bar icons' tappable area is only as big as the glyph itself — 32×32pt for Home/Activity, and about 20×26pt for the avatar tab. A native tab bar gives each tab a full third of the bar at ≥44pt, so taps that would land fine there do nothing here.

## Changes

- Each tab's pressable gets `flex: 1` and a platform min-height (Apple HIG 44pt / Material 48dp) with centered content, so the touch target spans its full third of the bar.
- Icons stay at the same y-position — the bar's old top padding is absorbed by the taller pressables, so there's no visible shift.
- **The bar gets ~6pt (iOS) / ~8pt (Android) taller** — the old touch band was under the platform minimums, so meeting them costs a little height. This is the one user-visible change.
- The unread dot is re-anchored to the icon glyph instead of the pressable, keeping it just under the icon.
- Web (desktop sidebar and narrow-web bar) keeps its existing styles — the change is native-only.

## How did I test?

Before/after videos below (iOS simulator, coordinate-probed): edge taps that did nothing now navigate. Icon positions verified unchanged via screenshots. `packages/app` tsc + lint pass.

**Before** — three taps inside what would be native tab-bar territory do nothing; only the 4th (dead-center on the bell) navigates:

https://github.com/user-attachments/assets/ad179653-191b-4ac1-abb1-8c2c08069ca9

**After** — the same kind of edge taps all navigate (Activity → Home → Activity → Contacts):

https://github.com/user-attachments/assets/4404cde0-a712-4629-a248-f930047bab9c

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: mobile tab bar layout

Worst case is a visual regression in the tab bar (it sits on every main screen), which would be caught immediately in QA.

## Rollback plan

Revert the commit.

## Screenshots / videos

See test section above for the tap-target videos.

Unread dot on the taller touch target (anchored to the icon, not the pressable, so it keeps its position):

![unread dot under Activity tab icon](https://github.com/user-attachments/assets/21eb156a-aa81-4d78-aff0-4e95bbd4bbe3)

