### PR TITLE
fix: copying message text loses line breaks

### DIFF
--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -379,15 +379,12 @@ export async function handleAction({
       await Clipboard.setStringAsync(logic.getPostReferencePath(post));
       break;
     case 'copyText': {
-      // post.textContent is a single-line preview (line breaks collapsed to
-      // spaces), so re-derive plaintext from the full content to keep them.
       let text: string;
       try {
         text = logic.plaintextPreviewOf(
           logic.convertContent(post.content, post.blob),
           {
             ...logic.PlaintextPreviewConfig.defaultConfig,
-            // Keep clipboard text free of synthetic "(Ref)" markers.
             includeRefTag: false,
           }
         );

--- a/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
+++ b/packages/app/ui/components/ChatMessage/ChatMessageActions/MessageActions.tsx
@@ -378,9 +378,27 @@ export async function handleAction({
     case 'copyRef':
       await Clipboard.setStringAsync(logic.getPostReferencePath(post));
       break;
-    case 'copyText':
-      await Clipboard.setStringAsync(post.textContent ?? '');
+    case 'copyText': {
+      // post.textContent is a single-line preview (line breaks collapsed to
+      // spaces), so re-derive plaintext from the full content to keep them.
+      let text: string;
+      try {
+        text = logic.plaintextPreviewOf(
+          logic.convertContent(post.content, post.blob),
+          {
+            ...logic.PlaintextPreviewConfig.defaultConfig,
+            // Keep clipboard text free of synthetic "(Ref)" markers.
+            includeRefTag: false,
+          }
+        );
+      } catch (e) {
+        // convertContent throws on unrecognized block types (e.g. content
+        // written by a newer client); fall back to the stored preview.
+        text = post.textContent ?? '';
+      }
+      await Clipboard.setStringAsync(text);
       break;
+    }
     case 'delete':
       store.deletePost({ post });
       break;


### PR DESCRIPTION
## Summary

"Copy message text" copies `post.textContent`, which is stored using the inline preview config — the one chat-list previews use, where line breaks are collapsed into spaces. Copying a multi-line message therefore pastes as a single flat line.

## Changes

`copyText` now derives the clipboard string from the full post content (`plaintextPreviewOf(convertContent(...))` with the line-break-preserving config, ref tags off so reference posts don't copy a synthetic `(Ref)` marker) instead of the stored single-line preview. If content conversion throws (unrecognized block types from a newer client), it falls back to the stored preview — same guard the content renderers use.

**Known remaining gap:** the quote-reply path also uses `post.textContent` and still flattens multi-line messages; left untouched here since prefixing `> ` per line is a separate behavior decision.

## How did I test?

On the iOS simulator with a 3-line message: verified the clipboard contains 3 lines after Copy message text, and pasted into the composer.

**Before** — pasting the copied text produces one flat line:

https://github.com/user-attachments/assets/1beb64d1-ca91-4025-92ce-bcd09cbc2d24

**After** — the paste keeps all three lines:

https://github.com/user-attachments/assets/0073ed57-aec5-4744-a67b-7716cfe6d50a

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: message actions (copy to clipboard)

Scope is the copy action only; worst case is malformed clipboard text.

## Rollback plan

Revert the commit.

## Screenshots / videos

See test section above.



