### PR TITLE
chat: retain link attachment when removing link text

### DIFF
--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -603,11 +603,17 @@ function BareChatInput(
 
             // If the URL was deleted from the text before its metadata
             // arrived, the user never saw a preview - don't surprise them
-            // with one now.
+            // with one now. Un-mark the URL as seen so that if it is typed
+            // again, the next debounce pass re-fetches it (the deletion may
+            // never reach debouncedText, so this pass's marking would
+            // otherwise suppress the re-added URL forever).
             if (!extractPreviewUrls(latestTextRef.current).includes(url)) {
               bareChatInputLogger.log('skipping link preview for removed url', {
                 url,
               });
+              prevUrlsRef.current = prevUrlsRef.current.filter(
+                (u) => u !== url
+              );
               return;
             }
 

--- a/packages/app/ui/components/BareChatInput/index.tsx
+++ b/packages/app/ui/components/BareChatInput/index.tsx
@@ -76,6 +76,21 @@ function normalizePreviewUrl(url: string) {
   }
 }
 
+// Extract normalized, deduplicated URLs eligible for link previews. Strips
+// backtick code spans/blocks (including unclosed ones) first so that URLs
+// inside code fences are not turned into link attachments. Triple-backtick
+// alternation is listed first so that ``` is not accidentally consumed by
+// the single-backtick branch.
+function extractPreviewUrls(text: string): string[] {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  const textOutsideCodeBlocks = text.replace(
+    /```[\s\S]*?(?:```|$)|`[^`]*(?:`|$)/g,
+    ''
+  );
+  const matches = textOutsideCodeBlocks.match(urlRegex) || [];
+  return [...new Set(matches.map(normalizePreviewUrl))];
+}
+
 function useMaxInputHeight(maxInputHeightBasic: number) {
   const keyboardHeight = useKeyboardHeight();
   return keyboardHeight > 0
@@ -252,13 +267,8 @@ function BareChatInput(
     () => height - HEADER_HEIGHT - bottom - top,
     [height, bottom, top]
   );
-  const {
-    attachments,
-    addAttachment,
-    clearAttachments,
-    resetAttachments,
-    removeAttachment,
-  } = useAttachmentContext();
+  const { attachments, addAttachment, clearAttachments, resetAttachments } =
+    useAttachmentContext();
   const [controlledText, setControlledText] = useState('');
   const [inputHeight, setInputHeight] = useState(initialHeight);
   const [sendError, setSendError] = useState(false);
@@ -299,6 +309,8 @@ function BareChatInput(
   const debouncedText = useDebouncedValue(controlledText, 500);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
+  const latestTextRef = useRef(controlledText);
+  latestTextRef.current = controlledText;
   const prevUrlsRef = useRef<string[]>([]);
 
   const processReferences = useCallback(
@@ -554,43 +566,24 @@ function BareChatInput(
     );
   }, [controlledText, attachments]);
 
-  // Sync link attachments with URLs in text
-  // This effect watches for URL changes and updates link previews accordingly
+  // Watch for new URLs in text and add link previews for them. Previews are
+  // intentionally not removed when their URL leaves the text: a common flow is
+  // pasting a link (preview appears), then replacing the link text with a
+  // comment and sending both. Once a preview has appeared, only its explicit
+  // remove button dismisses it.
   useEffect(() => {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    // Strip backtick code spans/blocks (including unclosed ones) before
-    // scanning for URLs so that URLs inside code fences are not turned into
-    // link attachments. Triple-backtick alternation is listed first so that
-    // ``` is not accidentally consumed by the single-backtick branch.
-    const textOutsideCodeBlocks = debouncedText.replace(
-      /```[\s\S]*?(?:```|$)|`[^`]*(?:`|$)/g,
-      ''
-    );
-    const matches = textOutsideCodeBlocks.match(urlRegex) || [];
-
-    // Normalize URLs (remove hash) and deduplicate
-    const currentUrls = [...new Set(matches.map(normalizePreviewUrl))];
+    const currentUrls = extractPreviewUrls(debouncedText);
 
     const prevUrls = prevUrlsRef.current;
-    const linksByUrl = new Map(
+    const existingLinkUrls = new Set(
       attachmentsRef.current
         .filter((a) => a.type === 'link')
-        .map((a) => [normalizePreviewUrl(a.url), a] as const)
+        .map((a) => normalizePreviewUrl(a.url))
     );
 
-    const removedUrls = prevUrls.filter((url) => !currentUrls.includes(url));
     const addedUrls = currentUrls.filter(
-      (url) => !prevUrls.includes(url) && !linksByUrl.has(url)
+      (url) => !prevUrls.includes(url) && !existingLinkUrls.has(url)
     );
-
-    // Remove attachments for URLs no longer in text
-    removedUrls.forEach((url) => {
-      const attachment = linksByUrl.get(url);
-      if (attachment) {
-        bareChatInputLogger.log('removing stale link attachment', { url });
-        removeAttachment(attachment);
-      }
-    });
 
     // Fetch metadata for new URLs
     if (addedUrls.length > 0) {
@@ -603,6 +596,16 @@ function BareChatInput(
             // Check if this request is still valid
             if (currentSession !== inputSessionRef.current) {
               bareChatInputLogger.log('ignoring stale link metadata', {
+                url,
+              });
+              return;
+            }
+
+            // If the URL was deleted from the text before its metadata
+            // arrived, the user never saw a preview - don't surprise them
+            // with one now.
+            if (!extractPreviewUrls(latestTextRef.current).includes(url)) {
+              bareChatInputLogger.log('skipping link preview for removed url', {
                 url,
               });
               return;
@@ -657,7 +660,7 @@ function BareChatInput(
     }
 
     prevUrlsRef.current = currentUrls;
-  }, [debouncedText, store, addAttachment, removeAttachment]);
+  }, [debouncedText, store, addAttachment]);
 
   const adjustInputHeightProgrammatically = useCallback(() => {
     if (!isWeb || !inputRef.current) {


### PR DESCRIPTION
## Summary

Fixes [TLON-6072](https://linear.app/tlon/issue/TLON-6072): pasting a link in Chat shows a preview, but replacing the link text with a comment removed the preview. Once a link preview has appeared it now persists when its URL is edited out of the text, so you can send the link with a comment instead of the raw URL.

## Changes

- `BareChatInput`: the debounced URL-watching effect no longer removes link attachments when their URL leaves the input text (a regression from 9013560, which added URL-sync removal). The preview's remove button is now the only way to dismiss it. This is safe because the attachment carries the URL and is sent as its own `link` block, so the post still contains the clickable link.
- Added a guard so that a URL deleted *before* its metadata arrives doesn't pop in a surprise preview after the fact — checked against the live input text at fetch-resolution time.
- Factored the URL extraction (code-fence stripping, hash normalization, dedupe) into a shared `extractPreviewUrls` helper used by both the effect and the guard.
- The duplicate-preview-on-edit protection from d50ad72 is preserved via the existing-attachment check.

## How did I test?

Drove the real web app (local ~zod ship + vite dev server, `BareChatInput` is shared across web/iOS/Android with no platform branches in the touched code):

- Typed a URL → preview appeared → replaced the whole text with a comment → preview persisted (pre-fix it disappears after the 500ms debounce) → sent → post renders the link preview block plus the comment.
- Clicked the preview's X while the URL was still in the text → removed, and it does not re-add while typing continues.
- Deleted a URL while its metadata fetch was still in flight (local HTTP server with a 6s-delayed response as the link target) → no ghost preview appeared after the fetch resolved.
- `tsc`, eslint, and prettier clean for `packages/app`.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: chat message input / link preview attachments

## Rollback plan

Revert the single commit; no schema, API, or backend changes.

## Screenshots / videos

Verified flow: preview card stays above the input after the URL text is replaced with "check out this cool site", and the sent message shows the link preview block with the comment beneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)