### PR TITLE
onboarding: tap bot-group wayfinding tooltip to dismiss

### DIFF
--- a/packages/app/ui/components/Wayfinding/Notices.tsx
+++ b/packages/app/ui/components/Wayfinding/Notices.tsx
@@ -222,11 +222,21 @@ export function ChatInputTooltip() {
 }
 
 export function BotMentionTooltip() {
+  const handleDismiss = useCallback(() => {
+    db.wayfindingProgress.setValue((prev) => ({
+      ...prev,
+      tappedHomeGroupHint: true,
+    }));
+  }, []);
+
   return (
     <View position="absolute" bottom={35} right={50}>
       <YStack gap="$l">
-        <View
-          padding={20}
+        <Pressable
+          onPress={handleDismiss}
+          paddingVertical={20}
+          paddingLeft={20}
+          paddingRight={44}
           width={240}
           backgroundColor="$positiveActionText"
           borderRadius="$l"
@@ -236,7 +246,15 @@ export function BotMentionTooltip() {
             Since you own this group, your Tlonbot will automatically respond to
             your messages. Others can @-mention your bot to interact with it.
           </Text>
-        </View>
+          <View position="absolute" top={8} right={8} padding={4}>
+            <Icon
+              type="Close"
+              size="$s"
+              color="$white"
+              testID="BotMentionWayfindingTooltipDismiss"
+            />
+          </View>
+        </Pressable>
         <XStack width="100%" justifyContent="flex-end">
           <Circle backgroundColor="$positiveActionText" size="$2xl" />
         </XStack>


### PR DESCRIPTION
Fixes [TLON-5963](https://linear.app/tlon/issue/TLON-5963/bot-group-tooltip-not-dismissable)

## Problem

Unlike the home screen tooltip, the bot-group wayfinding tooltip ("Since you own this group, your Tlonbot will automatically respond...") couldn't be dismissed by tapping it. It only went away once the user tapped into the chat input.

## Fix

`BotMentionTooltip` was a plain `View` with no press handler — dismissal only happened via the input's focus handler in `BareChatInput`. This wraps the tooltip bubble in a `Pressable` that sets `wayfindingProgress.tappedHomeGroupHint` on tap and adds a close icon, mirroring the existing `HomeAddTooltip` dismissal pattern. The input-focus dismissal path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)