### PR TITLE
ChatList: reset member selection between group creation flows

### DIFF
--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -341,6 +341,9 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
       const didCreate = await createChat(params);
       if (didCreate) {
         setStep('initial');
+        setSelectedTemplateId(undefined);
+        setGroupTitle(undefined);
+        setSelectedContactIds([]);
       }
     },
     [createChat, isCreatingChat]
@@ -395,7 +398,7 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
       {triggerWithOnPress}
       <ActionSheet
         open={step === 'selectType'}
-        onOpenChange={() => setStep('initial')}
+        onOpenChange={handleOpenChange}
         mode="dialog"
         closeButton
         dialogContentProps={{ width: 380 }}
@@ -407,17 +410,17 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
       </ActionSheet>
       <GroupTypeSelectionSheet
         open={step === 'selectGroupType'}
-        onOpenChange={() => setStep('initial')}
+        onOpenChange={handleOpenChange}
         onSelectGroupType={handleGroupTypeSelected}
       />
       <GroupTitleInputSheet
         open={step === 'setGroupTitle'}
-        onOpenChange={() => setStep('initial')}
+        onOpenChange={handleOpenChange}
         onSubmitTitle={handleTitleSubmitted}
       />
       <ActionSheet
         open={step === 'createJoinGroup'}
-        onOpenChange={() => setStep('initial')}
+        onOpenChange={handleOpenChange}
         mode="dialog"
         closeButton
         dialogContentProps={{ width: 600 }}
@@ -431,7 +434,7 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
       </ActionSheet>
       <ActionSheet
         open={step === 'createDm' || step === 'createGroup'}
-        onOpenChange={() => setStep('initial')}
+        onOpenChange={handleOpenChange}
         mode="dialog"
         closeButton
         dialogContentProps={{ height: 'auto', maxHeight: 1200, width: 600 }}
@@ -559,6 +562,17 @@ export function CreateChatInviteSheet({
 }) {
   const [screenScrolling, setScreenScrolling] = useState(false);
   const [selectedContactIds, setSelectedContactIds] = useState<string[]>([]);
+  const [contentKey, setContentKey] = useState(0);
+
+  // The sheet stays mounted across opens, so ContactBook's internal selection
+  // and search state would otherwise leak into the next creation flow. Clear
+  // our selection and remount the form whenever the sheet closes.
+  useEffect(() => {
+    if (!open) {
+      setSelectedContactIds([]);
+      setContentKey((key) => key + 1);
+    }
+  }, [open]);
 
   const handleSelectDmContact = useCallback(
     (contactId: string) => {
@@ -574,7 +588,6 @@ export function CreateChatInviteSheet({
       templateId,
       title,
     });
-    setSelectedContactIds([]);
   }, [onSubmit, selectedContactIds, templateId, title]);
 
   // hack: ensure the nested ContactBook will scroll properly within the sheet
@@ -595,6 +608,7 @@ export function CreateChatInviteSheet({
       hasScrollableContent
     >
       <CreateChatFormContent
+        key={contentKey}
         chatType={chatType}
         isCreating={isCreating}
         onSelectDmContact={handleSelectDmContact}


### PR DESCRIPTION
## Problem

When creating two groups in a row on mobile, the second creation flow opened with the previous flow's member search and selection still visible ([TLON-5770](https://linear.app/tlon/issue/TLON-5770)). Worse, the persisted checkmarks were purely visual — the sheet's own `selectedContactIds` had already been cleared after the first submit, so continuing produced a memberless group (per Mark's comment on the issue).

## Root cause

`CreateChatInviteSheet` (the narrow/mobile path) stays mounted across opens. `ContactBook` keeps its selection and `SearchBar` its query in internal state, so they survive into the next flow, while `handlePressCreateGroup` cleared the sheet's parallel `selectedContactIds` copy immediately on submit — desyncing the visual state from the real state.

The wide/desktop path had the inverse latent bug: the tamagui Dialog unmounts `ContactBook` on close (fresh checkmarks), but the parent `CreateChatSheet`'s `selectedContactIds` / `groupTitle` / `selectedTemplateId` were never reset after a successful create or on dialog close, so a subsequent group could silently inherit the previous flow's members or title.

## Fix

- `CreateChatInviteSheet`: clear `selectedContactIds` and remount the form content (bumped `key`) whenever the sheet closes, so every open starts with a clean search and no checkmarks.
- Stop clearing the selection on submit — on a failed create the sheet stays open with selection intact, so retrying works and the checkmarks always reflect what will be submitted.
- `CreateChatSheet`: reset `selectedTemplateId` / `groupTitle` / `selectedContactIds` after a successful create, and wire the desktop dialogs' `onOpenChange` to `handleOpenChange` so abandoning the flow also resets them.

## Testing

- `tsc` and eslint clean.
- `create-group.spec.ts` e2e (desktop web path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)