### PR TITLE
ChatList: reset group shortcode field on close

### DIFF
--- a/packages/app/features/top/CreateChatSheet.tsx
+++ b/packages/app/features/top/CreateChatSheet.tsx
@@ -109,12 +109,24 @@ interface CreateChatFormContentProps {
 }
 
 interface JoinGroupByIdPaneProps {
+  open: boolean;
   close: () => void;
 }
 
-const JoinGroupByIdPane = ({ close }: JoinGroupByIdPaneProps) => {
+const JoinGroupByIdPane = ({ open, close }: JoinGroupByIdPaneProps) => {
   const [groupCode, setGroupCode] = useState('');
   const { isCodeValid, state, actions } = useGroupSearch(groupCode);
+
+  const { resetSearch } = actions;
+
+  // the sheet stays mounted after first open, so clear stale search results
+  // when it closes
+  useEffect(() => {
+    if (!open) {
+      setGroupCode('');
+      resetSearch();
+    }
+  }, [open, resetSearch]);
 
   const handleActionComplete = useCallback(
     (action: GroupPreviewAction, group: db.Group) => {
@@ -194,9 +206,11 @@ const JoinGroupByIdPane = ({ close }: JoinGroupByIdPaneProps) => {
 
 const JoinGroupFormContent = ({
   chatType,
+  open,
   close,
 }: {
   chatType: ChatType;
+  open: boolean;
   close: () => void;
 }) => {
   const { title, subtitle } = CHAT_TYPE_CONFIG[chatType];
@@ -206,7 +220,7 @@ const JoinGroupFormContent = ({
     <YStack flex={1} gap="$l" paddingBottom={bottom}>
       <ActionSheet.SimpleHeader title={title} subtitle={subtitle} />
       <ActionSheet.ContentBlock>
-        <JoinGroupByIdPane close={close} />
+        <JoinGroupByIdPane open={open} close={close} />
       </ActionSheet.ContentBlock>
     </YStack>
   );
@@ -425,6 +439,7 @@ export const CreateChatSheet = forwardRef(function CreateChatSheet(
         <View flex={1}>
           <JoinGroupFormContent
             chatType={chatType}
+            open={step === 'createJoinGroup'}
             close={() => setStep('initial')}
           />
         </View>
@@ -620,6 +635,7 @@ export function JoinGroupSheet({
       <YStack flex={1} paddingBottom={bottom}>
         <JoinGroupFormContent
           chatType="joinGroup"
+          open={open}
           close={() => onOpenChange(false)}
         />
       </YStack>


### PR DESCRIPTION
## Summary

Fixes [TLON-6075](https://linear.app/tlon/issue/TLON-6075/group-shortcodes-form-doesnt-reset): after a failed join-by-code attempt (e.g. a secret group's code), reopening the "Join a group with a code (reference)" sheet still showed the stale "Group not found" error instead of a fresh input.

## Root cause

`ActionSheet` intentionally keeps its children mounted after first open (sheets are heavy), so `JoinGroupByIdPane` never unmounts — the entered code and `useGroupSearch`'s `isSearching`/error state survived the sheet closing.

## Fix

Thread the sheet's `open` state down into `JoinGroupByIdPane` and clear the code + search state (via the hook's existing `resetSearch` action) whenever the sheet closes. Covers all dismissal paths (X button, backdrop, escape), on both the desktop dialog and mobile sheet.

## Testing

- `tsc --noEmit` passes in `packages/app`
- Reproduced the issue flow in a live browser against a local ship: entered a code for a nonexistent group → "Group not found" → closed via X → reopened → form shows a fresh empty input

🤖 Generated with [Claude Code](https://claude.com/claude-code)