### PR TITLE
web: add browser notifications

### DIFF
--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -151,10 +151,10 @@ const extractNestedRouteDesktop = (state: any) => {
   return null;
 };
 
-// Needs to render inside the NavigationContainer so notification clicks can
-// navigate. AppRoutes only mounts once the client is ready (post-splash on
-// web, post-clientReady in Electron), and the hook itself no-ops in Electron.
-function BrowserNotifications() {
+// Mobile notifications can mount directly under the NavigationContainer.
+// Desktop mounts the hook from TopLevelDrawer, below GlobalSearchProvider, so
+// notification clicks retain the user's last Home/Messages tab.
+function MobileBrowserNotifications() {
   useBrowserNotifications();
   return null;
 }
@@ -365,7 +365,7 @@ function AppRoutes() {
           navigationInChildEnabled
         >
           <ForwardPostSheetProvider>
-            <BrowserNotifications />
+            <MobileBrowserNotifications />
             <BasePathNavigator isMobile={true} />
           </ForwardPostSheetProvider>
         </NavigationContainer>
@@ -387,7 +387,6 @@ function AppRoutes() {
           navigationInChildEnabled
         >
           <ForwardPostSheetProvider>
-            <BrowserNotifications />
             <BasePathNavigator isMobile={false} />
           </ForwardPostSheetProvider>
         </NavigationContainer>

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -151,6 +151,14 @@ const extractNestedRouteDesktop = (state: any) => {
   return null;
 };
 
+// Needs to render inside the NavigationContainer so notification clicks can
+// navigate. AppRoutes only mounts once the client is ready (post-splash on
+// web, post-clientReady in Electron), and the hook itself no-ops in Electron.
+function BrowserNotifications() {
+  useBrowserNotifications();
+  return null;
+}
+
 function AppRoutes() {
   useFindSuggestedContacts();
   const contactsQuery = store.useContacts();
@@ -357,6 +365,7 @@ function AppRoutes() {
           navigationInChildEnabled
         >
           <ForwardPostSheetProvider>
+            <BrowserNotifications />
             <BasePathNavigator isMobile={true} />
           </ForwardPostSheetProvider>
         </NavigationContainer>
@@ -378,6 +387,7 @@ function AppRoutes() {
           navigationInChildEnabled
         >
           <ForwardPostSheetProvider>
+            <BrowserNotifications />
             <BasePathNavigator isMobile={false} />
           </ForwardPostSheetProvider>
         </NavigationContainer>
@@ -470,7 +480,6 @@ function ConnectedWebApp() {
   const session = store.useCurrentSession();
   const hasSyncedRef = React.useRef(false);
   const telemetry = useTelemetry();
-  useBrowserNotifications(dbIsLoaded);
 
   const isNewSignup = useMemo(() => {
     return logic.detectWebSignup();

--- a/apps/tlon-web/src/app.tsx
+++ b/apps/tlon-web/src/app.tsx
@@ -10,6 +10,7 @@ import {
   useNavigationContainerRef,
 } from '@react-navigation/native';
 import { ENABLED_LOGGERS } from '@tloncorp/app/constants';
+import useBrowserNotifications from '@tloncorp/app/hooks/useBrowserNotifications';
 import { useConfigureUrbitClient } from '@tloncorp/app/hooks/useConfigureUrbitClient';
 import { useCurrentUserId } from '@tloncorp/app/hooks/useCurrentUser';
 import useDesktopNotifications from '@tloncorp/app/hooks/useDesktopNotifications';
@@ -469,6 +470,7 @@ function ConnectedWebApp() {
   const session = store.useCurrentSession();
   const hasSyncedRef = React.useRef(false);
   const telemetry = useTelemetry();
+  useBrowserNotifications(dbIsLoaded);
 
   const isNewSignup = useMemo(() => {
     return logic.detectWebSignup();

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,6 +39,7 @@
     "lint": "eslint src/",
     "lint:format": "prettier ./ --write",
     "prepare": "pnpm build",
+    "test": "vitest",
     "watch": "tsup --watch",
     "tsc": "tsc --noEmit"
   },

--- a/packages/api/src/client/activityApi.test.ts
+++ b/packages/api/src/client/activityApi.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type * as ub from '../urbit';
+import { subscribeToActivity } from './activityApi';
+import { subscribe } from './urbit';
+
+vi.mock('./urbit', async () => {
+  const actual = await vi.importActual<typeof import('./urbit')>('./urbit');
+
+  return {
+    ...actual,
+    subscribe: vi.fn(),
+  };
+});
+
+const EVENT_TIME = '170.141.184.506.853.155.647.879.036.981.225.717.760';
+
+function mockActivityAdd({
+  event,
+  source,
+  sourceKey,
+}: {
+  event: ub.ActivityEvent;
+  source: ub.Source;
+  sourceKey: string;
+}) {
+  vi.mocked(subscribe).mockImplementationOnce(async (_endpoint, onUpdate) => {
+    await (onUpdate as (update: ub.ActivityUpdate) => void | Promise<void>)({
+      add: {
+        event,
+        source,
+        time: EVENT_TIME,
+        'source-key': sourceKey,
+      },
+    });
+    return 7;
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(subscribe).mockReset();
+});
+
+describe('subscribeToActivity invite conversion', () => {
+  test('converts DM invites for opt-in subscribers', async () => {
+    mockActivityAdd({
+      event: { notified: true, 'dm-invite': { ship: '~bus' } },
+      source: { dm: { ship: '~bus' } },
+      sourceKey: 'ship/~bus',
+    });
+    const handler = vi.fn();
+
+    await subscribeToActivity(handler, { includeInvites: true });
+
+    expect(handler).toHaveBeenCalledWith({
+      type: 'addActivityEvent',
+      events: [
+        expect.objectContaining({
+          id: EVENT_TIME,
+          sourceId: 'ship/~bus',
+          bucketId: 'all',
+          shouldNotify: true,
+          type: 'dm-invite',
+          channelId: '~bus',
+          authorId: '~bus',
+        }),
+      ],
+    });
+  });
+
+  test('converts group invites for opt-in subscribers', async () => {
+    mockActivityAdd({
+      event: {
+        notified: true,
+        'group-invite': { ship: '~bus', group: '~zod/tlon' },
+      },
+      source: { group: '~zod/tlon' },
+      sourceKey: 'group/~zod/tlon',
+    });
+    const handler = vi.fn();
+
+    await subscribeToActivity(handler, { includeInvites: true });
+
+    expect(handler).toHaveBeenCalledWith({
+      type: 'addActivityEvent',
+      events: [
+        expect.objectContaining({
+          sourceId: 'group/~zod/tlon',
+          type: 'group-invite',
+          groupId: '~zod/tlon',
+          groupEventUserId: '~bus',
+        }),
+      ],
+    });
+  });
+
+  test('keeps invite events out of the default activity-feed stream', async () => {
+    mockActivityAdd({
+      event: {
+        notified: true,
+        'group-invite': { ship: '~bus', group: '~zod/tlon' },
+      },
+      source: { group: '~zod/tlon' },
+      sourceKey: 'group/~zod/tlon',
+    });
+    const handler = vi.fn();
+
+    await subscribeToActivity(handler);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/client/activityApi.ts
+++ b/packages/api/src/client/activityApi.ts
@@ -171,11 +171,16 @@ function toActivityEvent({
   sourceId,
   bucketId,
   event,
+  includeInvites = false,
 }: {
   id: string | number;
   sourceId: string;
   event: ub.ActivityEvent;
   bucketId: db.ActivityBucket;
+  // Invite events have no activity-feed rendering, so they're only converted
+  // for subscribers that opt in (e.g. notification hooks). The sync path that
+  // inserts feed events must leave this off.
+  includeInvites?: boolean;
 }): db.ActivityEvent | null {
   const timestamp = typeof id === 'number' ? id : udToDate(id);
   const shouldNotify = event.notified;
@@ -335,6 +340,27 @@ function toActivityEvent({
     };
   }
 
+  if (includeInvites && 'dm-invite' in event) {
+    const whom = event['dm-invite'];
+    return {
+      ...baseFields,
+      type: 'dm-invite',
+      channelId: 'ship' in whom ? whom.ship : whom.club,
+      // for a ship DM the counterparty is the inviter; club invites don't
+      // carry the inviting ship
+      authorId: 'ship' in whom ? whom.ship : null,
+    };
+  }
+
+  if (includeInvites && 'group-invite' in event) {
+    return {
+      ...baseFields,
+      type: 'group-invite',
+      groupId: event['group-invite'].group,
+      groupEventUserId: event['group-invite'].ship,
+    };
+  }
+
   if ('contact' in event) {
     const contactEvent = event.contact;
     const update = parseContactUpdateEvent(baseFields.id, event);
@@ -452,7 +478,8 @@ export type ActivityEvent =
   | { type: 'addActivityEvent'; events: db.ActivityEvent[] };
 
 export function subscribeToActivity(
-  handler: (event: ActivityEvent) => void
+  handler: (event: ActivityEvent) => void,
+  options?: { includeInvites?: boolean }
 ): Promise<number> {
   return subscribe<ub.ActivityUpdate>(
     // v5 is the v9-native update stream (carries reacts); v4 down-converts to
@@ -615,6 +642,7 @@ export function subscribeToActivity(
           sourceId,
           bucketId: 'all',
           event: rawEvent,
+          includeInvites: options?.includeInvites,
         });
 
         const events = [];

--- a/packages/app/features/settings/PushNotificationSettingsScreen.tsx
+++ b/packages/app/features/settings/PushNotificationSettingsScreen.tsx
@@ -2,10 +2,12 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as ub from '@tloncorp/api/urbit';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
+import { Button } from '@tloncorp/ui';
 import { ComponentProps, useCallback, useMemo } from 'react';
 import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useBrowserNotificationPermission } from '../../hooks/useBrowserNotificationPermission';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { RootStackParamList } from '../../navigation/types';
 import {
@@ -28,11 +30,25 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
   const baseVolumeSetting = store.useBaseVolumeLevel();
   const { data: exceptions } = store.useVolumeExceptions();
   const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
+  const browserNotifications = useBrowserNotificationPermission();
 
   const numExceptions = useMemo(
     () => (exceptions?.channels.length ?? 0) + (exceptions?.groups.length ?? 0),
     [exceptions]
   );
+
+  const browserPermissionLabel = useMemo(() => {
+    switch (browserNotifications.permission) {
+      case 'granted':
+        return 'Enabled';
+      case 'denied':
+        return 'Blocked in browser';
+      case 'default':
+        return 'Not enabled';
+      default:
+        return 'Unsupported';
+    }
+  }, [browserNotifications.permission]);
 
   const setLevel = useCallback(
     async (level: ub.NotificationLevel) => {
@@ -82,6 +98,24 @@ export function PushNotificationSettingsScreen({ navigation }: Props) {
             value={baseVolumeSetting}
             onChange={setLevel}
           />
+
+          {browserNotifications.isSupported ? (
+            <YStack marginTop="$xl" gap="$m">
+              <TlonText.Text size="$label/2xl">
+                Browser notifications
+              </TlonText.Text>
+              <TlonText.Text size="$label/m" color="$secondaryText">
+                {browserPermissionLabel}
+              </TlonText.Text>
+              {browserNotifications.canRequestPermission ? (
+                <Button
+                  preset="primary"
+                  label="Enable"
+                  onPress={browserNotifications.requestPermission}
+                />
+              ) : null}
+            </YStack>
+          ) : null}
           {numExceptions > 0 ? (
             <ExceptionsDisplay
               channels={exceptions?.channels ?? []}

--- a/packages/app/hooks/useBrowserNotificationPermission.ts
+++ b/packages/app/hooks/useBrowserNotificationPermission.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type BrowserNotificationPermission = NotificationPermission | 'unsupported';
+
+function getBrowserNotificationPermission(): BrowserNotificationPermission {
+  if (
+    typeof window === 'undefined' ||
+    !window.isSecureContext ||
+    !('Notification' in window)
+  ) {
+    return 'unsupported';
+  }
+
+  return window.Notification.permission;
+}
+
+export function useBrowserNotificationPermission() {
+  const [permission, setPermission] = useState<BrowserNotificationPermission>(
+    getBrowserNotificationPermission
+  );
+
+  useEffect(() => {
+    setPermission(getBrowserNotificationPermission());
+  }, []);
+
+  const requestPermission = useCallback(async () => {
+    if (
+      typeof window === 'undefined' ||
+      !window.isSecureContext ||
+      !('Notification' in window)
+    ) {
+      setPermission('unsupported');
+      return 'unsupported';
+    }
+
+    const nextPermission = await window.Notification.requestPermission();
+    setPermission(nextPermission);
+    return nextPermission;
+  }, []);
+
+  return useMemo(
+    () => ({
+      isSupported: permission !== 'unsupported',
+      permission,
+      hasPermission: permission === 'granted',
+      canRequestPermission: permission === 'default',
+      requestPermission,
+    }),
+    [permission, requestPermission]
+  );
+}

--- a/packages/app/hooks/useBrowserNotificationPermission.ts
+++ b/packages/app/hooks/useBrowserNotificationPermission.ts
@@ -1,13 +1,22 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { isElectron } from './useIsElectron';
+
 type BrowserNotificationPermission = NotificationPermission | 'unsupported';
 
+function browserNotificationsSupported() {
+  // Electron uses native desktop notifications (useDesktopNotifications), so
+  // browser notifications are not offered there.
+  return (
+    typeof window !== 'undefined' &&
+    window.isSecureContext &&
+    'Notification' in window &&
+    !isElectron()
+  );
+}
+
 function getBrowserNotificationPermission(): BrowserNotificationPermission {
-  if (
-    typeof window === 'undefined' ||
-    !window.isSecureContext ||
-    !('Notification' in window)
-  ) {
+  if (!browserNotificationsSupported()) {
     return 'unsupported';
   }
 
@@ -24,11 +33,7 @@ export function useBrowserNotificationPermission() {
   }, []);
 
   const requestPermission = useCallback(async () => {
-    if (
-      typeof window === 'undefined' ||
-      !window.isSecureContext ||
-      !('Notification' in window)
-    ) {
+    if (!browserNotificationsSupported()) {
       setPermission('unsupported');
       return 'unsupported';
     }

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -3,8 +3,101 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   getBrowserNotificationContactName,
   getBrowserNotificationCopy,
+  getBrowserNotificationTargetWithRetry,
+  isOtherBrowserNotificationTabForegrounded,
   navigateToBrowserNotificationTarget,
 } from './useBrowserNotifications.helpers';
+
+describe('isOtherBrowserNotificationTabForegrounded', () => {
+  const now = 20_000;
+
+  it('detects a recent foreground lease owned by another tab', () => {
+    expect(
+      isOtherBrowserNotificationTabForegrounded({
+        serializedTab: JSON.stringify({
+          tabId: 'other-tab',
+          updatedAt: now - 1_000,
+        }),
+        currentTabId: 'current-tab',
+        now,
+        ttlMs: 15_000,
+      })
+    ).toBe(true);
+  });
+
+  it('ignores the current tab and expired or malformed leases', () => {
+    const baseInput = {
+      currentTabId: 'current-tab',
+      now,
+      ttlMs: 15_000,
+    };
+
+    expect(
+      isOtherBrowserNotificationTabForegrounded({
+        ...baseInput,
+        serializedTab: JSON.stringify({
+          tabId: 'current-tab',
+          updatedAt: now - 1_000,
+        }),
+      })
+    ).toBe(false);
+    expect(
+      isOtherBrowserNotificationTabForegrounded({
+        ...baseInput,
+        serializedTab: JSON.stringify({
+          tabId: 'other-tab',
+          updatedAt: now - 15_000,
+        }),
+      })
+    ).toBe(false);
+    expect(
+      isOtherBrowserNotificationTabForegrounded({
+        ...baseInput,
+        serializedTab: 'not-json',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('getBrowserNotificationTargetWithRetry', () => {
+  it('retries a missing target and returns it once synchronization catches up', async () => {
+    const target = { id: 'chat/~zod/general' };
+    const getTarget = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(target);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      getBrowserNotificationTargetWithRetry(getTarget, [250], wait)
+    ).resolves.toBe(target);
+    expect(getTarget).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(250);
+  });
+
+  it('does not wait when the target is already synchronized', async () => {
+    const target = { id: 'chat/~zod/general' };
+    const getTarget = vi.fn().mockResolvedValue(target);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      getBrowserNotificationTargetWithRetry(getTarget, [250, 500], wait)
+    ).resolves.toBe(target);
+    expect(getTarget).toHaveBeenCalledOnce();
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it('stops after the bounded retry schedule when the target stays missing', async () => {
+    const getTarget = vi.fn().mockResolvedValue(null);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      getBrowserNotificationTargetWithRetry(getTarget, [250, 500], wait)
+    ).resolves.toBeNull();
+    expect(getTarget).toHaveBeenCalledTimes(3);
+    expect(wait.mock.calls).toEqual([[250], [500]]);
+  });
+});
 
 describe('getBrowserNotificationContactName', () => {
   const contact = {

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -3,10 +3,28 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   getBrowserNotificationContactName,
   getBrowserNotificationCopy,
+  getBrowserNotificationGroupTitle,
   getBrowserNotificationTargetWithRetry,
   isOtherBrowserNotificationTabForegrounded,
   navigateToBrowserNotificationTarget,
 } from './useBrowserNotifications.helpers';
+
+describe('getBrowserNotificationGroupTitle', () => {
+  it.each([undefined, null, ''])(
+    'uses the fallback for an empty group title (%s)',
+    (groupTitle) => {
+      expect(
+        getBrowserNotificationGroupTitle(groupTitle, 'Group invitation')
+      ).toBe('Group invitation');
+    }
+  );
+
+  it('preserves an explicit group title', () => {
+    expect(getBrowserNotificationGroupTitle('Tlon', 'Group invitation')).toBe(
+      'Tlon'
+    );
+  });
+});
 
 describe('isOtherBrowserNotificationTabForegrounded', () => {
   const now = 20_000;

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getBrowserNotificationCopy,
+  navigateToBrowserNotificationTarget,
+} from './useBrowserNotifications.helpers';
+
+describe('getBrowserNotificationCopy', () => {
+  it('falls back to the contact name when a DM title is empty', () => {
+    expect(
+      getBrowserNotificationCopy({
+        activityType: 'post',
+        channelTitle: '',
+        contactName: 'Alice',
+        contentText: 'Hello',
+        reactValue: '',
+      })
+    ).toEqual({
+      title: 'Alice',
+      body: 'Hello',
+    });
+  });
+
+  it.each([
+    ['flag-post', 'post'],
+    ['flag-reply', 'reply'],
+  ])('uses flag-specific copy for %s activity', (activityType, kind) => {
+    const copy = getBrowserNotificationCopy({
+      activityType,
+      channelTitle: 'General',
+      contactName: 'Alice',
+      contentText: '',
+      groupTitle: 'Tlon',
+      reactValue: '',
+    });
+
+    expect(copy).toEqual({
+      title: `Flagged ${kind} in Tlon`,
+      body: `Alice flagged a ${kind} in your group`,
+    });
+    expect(copy.body).not.toBe('New message');
+  });
+});
+
+describe('navigateToBrowserNotificationTarget', () => {
+  it('resets parented activity, including replies and reactions, to its thread', () => {
+    const resetToChannel = vi.fn();
+    const resetToPost = vi.fn();
+
+    navigateToBrowserNotificationTarget(
+      {
+        channelId: 'chat/~zod/general',
+        groupId: '~zod/tlon',
+        parentAuthorId: '~zod',
+        parentId: '~zod/1',
+        postId: '~bus/2',
+      },
+      { resetToChannel, resetToPost }
+    );
+
+    expect(resetToPost).toHaveBeenCalledWith({
+      postId: '~zod/1',
+      authorId: '~zod',
+      channelId: 'chat/~zod/general',
+      groupId: '~zod/tlon',
+      selectedPostId: '~bus/2',
+    });
+    expect(resetToChannel).not.toHaveBeenCalled();
+  });
+
+  it('keeps parentless activity routed to its channel', () => {
+    const resetToChannel = vi.fn();
+    const resetToPost = vi.fn();
+
+    navigateToBrowserNotificationTarget(
+      {
+        channelId: 'chat/~zod/general',
+        groupId: '~zod/tlon',
+        postId: '~bus/2',
+      },
+      { resetToChannel, resetToPost }
+    );
+
+    expect(resetToChannel).toHaveBeenCalledWith('chat/~zod/general', {
+      groupId: '~zod/tlon',
+    });
+    expect(resetToPost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -166,6 +166,21 @@ describe('getBrowserNotificationCopy', () => {
     });
     expect(copy.body).not.toBe('New message');
   });
+
+  it('uses invite copy for dm-invite activity instead of the message fallback', () => {
+    expect(
+      getBrowserNotificationCopy({
+        activityType: 'dm-invite',
+        channelTitle: '',
+        contactName: 'Alice',
+        contentText: '',
+        reactValue: '',
+      })
+    ).toEqual({
+      title: 'Alice',
+      body: 'Invited you to chat',
+    });
+  });
 });
 
 describe('navigateToBrowserNotificationTarget', () => {

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -180,8 +180,9 @@ describe('getBrowserNotificationCopy', () => {
 
     expect(copy).toEqual({
       title: `Flagged ${kind} in Tlon`,
-      body: `Alice flagged a ${kind} in your group`,
+      body: `A ${kind} by Alice was flagged in your group`,
     });
+    expect(copy.body).not.toContain('Alice flagged');
     expect(copy.body).not.toBe('New message');
   });
 

--- a/packages/app/hooks/useBrowserNotifications.helpers.test.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.test.ts
@@ -1,9 +1,42 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  getBrowserNotificationContactName,
   getBrowserNotificationCopy,
   navigateToBrowserNotificationTarget,
 } from './useBrowserNotifications.helpers';
+
+describe('getBrowserNotificationContactName', () => {
+  const contact = {
+    id: '~ravmel-ropdyl',
+    nickname: 'galen',
+    bio: null,
+    color: null,
+    avatarImage: null,
+    status: null,
+    coverImage: null,
+  };
+
+  it('uses a contact nickname when Calm nickname suppression is disabled', () => {
+    expect(
+      getBrowserNotificationContactName({
+        contact,
+        contactId: contact.id,
+        disableNicknames: false,
+      })
+    ).toBe('galen');
+  });
+
+  it('uses the contact ID when Calm nickname suppression is enabled', () => {
+    expect(
+      getBrowserNotificationContactName({
+        contact,
+        contactId: contact.id,
+        disableNicknames: true,
+      })
+    ).toBe('~ravmel-ropdyl');
+  });
+});
 
 describe('getBrowserNotificationCopy', () => {
   it('falls back to the contact name when a DM title is empty', () => {
@@ -68,7 +101,7 @@ describe('navigateToBrowserNotificationTarget', () => {
     expect(resetToChannel).not.toHaveBeenCalled();
   });
 
-  it('keeps parentless activity routed to its channel', () => {
+  it('routes parentless activity to its channel and focuses the target post', () => {
     const resetToChannel = vi.fn();
     const resetToPost = vi.fn();
 
@@ -83,6 +116,7 @@ describe('navigateToBrowserNotificationTarget', () => {
 
     expect(resetToChannel).toHaveBeenCalledWith('chat/~zod/general', {
       groupId: '~zod/tlon',
+      selectedPostId: '~bus/2',
     });
     expect(resetToPost).not.toHaveBeenCalled();
   });

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -1,0 +1,114 @@
+type BrowserNotificationCopyInput = {
+  activityType: string;
+  channelTitle?: string | null;
+  contactName: string;
+  contentText: string;
+  groupTitle?: string | null;
+  reactValue: string;
+};
+
+export function getBrowserNotificationCopy({
+  activityType,
+  channelTitle,
+  contactName,
+  contentText,
+  groupTitle,
+  reactValue,
+}: BrowserNotificationCopyInput) {
+  const flaggedKind =
+    activityType === 'flag-post'
+      ? 'post'
+      : activityType === 'flag-reply'
+        ? 'reply'
+        : null;
+  const isReact = activityType === 'react';
+
+  let title = flaggedKind
+    ? `Flagged ${flaggedKind}`
+    : channelTitle || contactName || 'New message';
+  let body = flaggedKind
+    ? `${contactName} flagged a ${flaggedKind} in your group`
+    : isReact
+      ? `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your post`
+      : contentText || 'New message';
+
+  if (groupTitle) {
+    title = `${title} in ${groupTitle}`;
+    if (!isReact && !flaggedKind) {
+      body = contentText
+        ? `${contactName || 'Someone'}: ${contentText}`
+        : `New message in ${groupTitle}`;
+    }
+  }
+
+  return { title, body };
+}
+
+type BrowserNotificationTargetInput = {
+  parentAuthorId?: string | null;
+  parentId?: string | null;
+  postId?: string | null;
+};
+
+type BrowserNotificationNavigationTarget =
+  | { type: 'channel' }
+  | {
+      type: 'thread';
+      parentAuthorId: string;
+      parentId: string;
+      selectedPostId?: string;
+    };
+
+function getBrowserNotificationNavigationTarget({
+  parentAuthorId,
+  parentId,
+  postId,
+}: BrowserNotificationTargetInput): BrowserNotificationNavigationTarget {
+  if (!parentId) {
+    return { type: 'channel' };
+  }
+
+  return {
+    type: 'thread',
+    parentAuthorId: parentAuthorId ?? '',
+    parentId,
+    selectedPostId: postId ?? undefined,
+  };
+}
+
+type BrowserNotificationNavigationInput = BrowserNotificationTargetInput & {
+  channelId: string;
+  groupId?: string | null;
+};
+
+type BrowserNotificationNavigationActions = {
+  resetToChannel: (channelId: string, options: { groupId?: string }) => void;
+  resetToPost: (post: {
+    postId: string;
+    authorId: string;
+    channelId: string;
+    groupId?: string;
+    selectedPostId?: string;
+  }) => void;
+};
+
+export function navigateToBrowserNotificationTarget(
+  input: BrowserNotificationNavigationInput,
+  actions: BrowserNotificationNavigationActions
+) {
+  const target = getBrowserNotificationNavigationTarget(input);
+  const groupId = input.groupId ?? undefined;
+
+  if (target.type === 'thread') {
+    actions.resetToPost({
+      postId: target.parentId,
+      authorId: target.parentAuthorId,
+      channelId: input.channelId,
+      groupId,
+      selectedPostId: target.selectedPostId,
+    });
+    return;
+  }
+
+  actions.resetToChannel(input.channelId, { groupId });
+}

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -97,6 +97,13 @@ export function getBrowserNotificationContactName({
   );
 }
 
+export function getBrowserNotificationGroupTitle(
+  groupTitle: string | null | undefined,
+  fallbackTitle: string
+) {
+  return groupTitle || fallbackTitle;
+}
+
 type BrowserNotificationCopyInput = {
   activityType: string;
   channelTitle?: string | null;

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -134,7 +134,7 @@ export function getBrowserNotificationCopy({
     ? `Flagged ${flaggedKind}`
     : channelTitle || contactName || 'New message';
   let body = flaggedKind
-    ? `${contactName} flagged a ${flaggedKind} in your group`
+    ? `A ${flaggedKind} by ${contactName} was flagged in your group`
     : isReact
       ? `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your post`
       : isDmInvite

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -121,6 +121,7 @@ export function getBrowserNotificationCopy({
         ? 'reply'
         : null;
   const isReact = activityType === 'react';
+  const isDmInvite = activityType === 'dm-invite';
 
   let title = flaggedKind
     ? `Flagged ${flaggedKind}`
@@ -129,7 +130,10 @@ export function getBrowserNotificationCopy({
     ? `${contactName} flagged a ${flaggedKind} in your group`
     : isReact
       ? `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your post`
-      : contentText || 'New message';
+      : isDmInvite
+        ? // the title already names the inviter (DM titles are the counterparty)
+          'Invited you to chat'
+        : contentText || 'New message';
 
   if (groupTitle) {
     title = `${title} in ${groupTitle}`;

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -2,6 +2,77 @@ import type * as db from '@tloncorp/shared/db';
 
 import { resolveContactNameProps } from '../ui/components/contactNameResolver';
 
+export type BrowserNotificationForegroundTab = {
+  tabId: string;
+  updatedAt: number;
+};
+
+export function parseBrowserNotificationForegroundTab(
+  serializedTab: string | null
+): BrowserNotificationForegroundTab | null {
+  if (!serializedTab) {
+    return null;
+  }
+
+  try {
+    const tab: unknown = JSON.parse(serializedTab);
+    if (
+      typeof tab === 'object' &&
+      tab !== null &&
+      'tabId' in tab &&
+      typeof tab.tabId === 'string' &&
+      'updatedAt' in tab &&
+      typeof tab.updatedAt === 'number'
+    ) {
+      return { tabId: tab.tabId, updatedAt: tab.updatedAt };
+    }
+  } catch {
+    // Ignore malformed/stale values from previous app versions.
+  }
+
+  return null;
+}
+
+export function isOtherBrowserNotificationTabForegrounded({
+  serializedTab,
+  currentTabId,
+  now,
+  ttlMs,
+}: {
+  serializedTab: string | null;
+  currentTabId: string;
+  now: number;
+  ttlMs: number;
+}) {
+  const foregroundTab = parseBrowserNotificationForegroundTab(serializedTab);
+  if (!foregroundTab || foregroundTab.tabId === currentTabId) {
+    return false;
+  }
+
+  const ageMs = now - foregroundTab.updatedAt;
+  return ageMs >= 0 && ageMs < ttlMs;
+}
+
+export async function getBrowserNotificationTargetWithRetry<T>(
+  getTarget: () => Promise<T | null | undefined>,
+  retryDelaysMs: readonly number[],
+  wait: (delayMs: number) => Promise<void> = (delayMs) =>
+    new Promise((resolve) => setTimeout(resolve, delayMs))
+): Promise<T | null> {
+  let target = await getTarget();
+
+  for (const delayMs of retryDelaysMs) {
+    if (target != null) {
+      return target;
+    }
+
+    await wait(delayMs);
+    target = await getTarget();
+  }
+
+  return target ?? null;
+}
+
 type BrowserNotificationContactNameInput = {
   contact: db.Contact | null;
   contactId?: string | null;

--- a/packages/app/hooks/useBrowserNotifications.helpers.ts
+++ b/packages/app/hooks/useBrowserNotifications.helpers.ts
@@ -1,3 +1,31 @@
+import type * as db from '@tloncorp/shared/db';
+
+import { resolveContactNameProps } from '../ui/components/contactNameResolver';
+
+type BrowserNotificationContactNameInput = {
+  contact: db.Contact | null;
+  contactId?: string | null;
+  disableNicknames: boolean;
+};
+
+export function getBrowserNotificationContactName({
+  contact,
+  contactId,
+  disableNicknames,
+}: BrowserNotificationContactNameInput) {
+  if (!contactId) {
+    return 'Unknown';
+  }
+
+  return (
+    resolveContactNameProps({
+      contact,
+      contactId,
+      calmDisableNicknames: disableNicknames,
+    }).children || contactId
+  );
+}
+
 type BrowserNotificationCopyInput = {
   activityType: string;
   channelTitle?: string | null;
@@ -51,7 +79,7 @@ type BrowserNotificationTargetInput = {
 };
 
 type BrowserNotificationNavigationTarget =
-  | { type: 'channel' }
+  | { type: 'channel'; selectedPostId?: string }
   | {
       type: 'thread';
       parentAuthorId: string;
@@ -65,7 +93,7 @@ function getBrowserNotificationNavigationTarget({
   postId,
 }: BrowserNotificationTargetInput): BrowserNotificationNavigationTarget {
   if (!parentId) {
-    return { type: 'channel' };
+    return { type: 'channel', selectedPostId: postId ?? undefined };
   }
 
   return {
@@ -82,7 +110,10 @@ type BrowserNotificationNavigationInput = BrowserNotificationTargetInput & {
 };
 
 type BrowserNotificationNavigationActions = {
-  resetToChannel: (channelId: string, options: { groupId?: string }) => void;
+  resetToChannel: (
+    channelId: string,
+    options: { groupId?: string; selectedPostId?: string }
+  ) => void;
   resetToPost: (post: {
     postId: string;
     authorId: string;
@@ -110,5 +141,8 @@ export function navigateToBrowserNotificationTarget(
     return;
   }
 
-  actions.resetToChannel(input.channelId, { groupId });
+  actions.resetToChannel(input.channelId, {
+    groupId,
+    selectedPostId: target.selectedPostId,
+  });
 }

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -1,0 +1,144 @@
+import * as api from '@tloncorp/api';
+import { createDevLogger } from '@tloncorp/shared';
+import * as db from '@tloncorp/shared/db';
+import { getTextContent } from '@tloncorp/shared/logic';
+import { useCallback, useEffect, useRef } from 'react';
+
+const logger = createDevLogger('useBrowserNotifications', false);
+
+interface NotificationData {
+  type: string;
+  channelId?: string;
+  groupId?: string;
+}
+
+function canUseBrowserNotifications() {
+  return (
+    typeof window !== 'undefined' &&
+    window.isSecureContext &&
+    'Notification' in window
+  );
+}
+
+function hasNotificationPermission() {
+  return (
+    canUseBrowserNotifications() && window.Notification.permission === 'granted'
+  );
+}
+
+export default function useBrowserNotifications(isClientReady: boolean) {
+  const processedNotifications = useRef<Set<string>>(new Set());
+  const subscribedRef = useRef(false);
+
+  const showActivityNotification = useCallback(
+    async (activityEvent: db.ActivityEvent) => {
+      if (!canUseBrowserNotifications()) {
+        return;
+      }
+
+      const notificationKey = activityEvent.id;
+      if (processedNotifications.current.has(notificationKey)) {
+        return;
+      }
+
+      processedNotifications.current.add(notificationKey);
+      if (processedNotifications.current.size > 100) {
+        processedNotifications.current = new Set(
+          Array.from(processedNotifications.current).slice(-50)
+        );
+      }
+
+      if (!hasNotificationPermission()) {
+        return;
+      }
+
+      if (!activityEvent.channelId) {
+        logger.error('No channel ID in activity event:', activityEvent);
+        return;
+      }
+
+      try {
+        const channel = await db.getChannelWithRelations({
+          id: activityEvent.channelId,
+        });
+        if (!channel) {
+          return;
+        }
+
+        const contactId = activityEvent.authorId;
+        const contact = contactId
+          ? await db.getContact({ id: contactId })
+          : null;
+        const contactName = contact?.nickname ?? contactId ?? 'Unknown';
+        const contentText = activityEvent.content
+          ? getTextContent(activityEvent.content as api.PostContent)
+          : '';
+
+        let title = channel.title ?? contactName ?? 'New message';
+        let body = contentText || 'New message';
+
+        if (activityEvent.groupId) {
+          const group = await db.getGroup({ id: activityEvent.groupId });
+          if (group) {
+            title = `${title} in ${group.title}`;
+            body = contentText
+              ? `${contactName ?? 'Someone'}: ${contentText}`
+              : `New message in ${group.title}`;
+          }
+        }
+
+        const notification = new window.Notification(title, {
+          body,
+          tag: notificationKey,
+          data: {
+            type: 'channel',
+            channelId: activityEvent.channelId,
+            groupId: channel.groupId ?? undefined,
+          } satisfies NotificationData,
+        });
+
+        notification.onclick = () => {
+          window.focus();
+        };
+      } catch (error) {
+        logger.error(
+          'Error processing channel activity for browser notifications',
+          error
+        );
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (
+      !isClientReady ||
+      subscribedRef.current ||
+      !canUseBrowserNotifications()
+    ) {
+      return;
+    }
+
+    subscribedRef.current = true;
+
+    const handleActivityEvent = (event: api.ActivityEvent) => {
+      if (event.type !== 'addActivityEvent') {
+        return;
+      }
+
+      const activityEvent =
+        event.events.find((e) => e.bucketId === 'all') ?? event.events[0];
+
+      if (activityEvent?.shouldNotify) {
+        showActivityNotification(activityEvent);
+      }
+    };
+
+    try {
+      api.subscribeToActivity(handleActivityEvent);
+    } catch (error) {
+      subscribedRef.current = false;
+      logger.error('Error subscribing to browser notification activity', error);
+    }
+  }, [isClientReady, showActivityNotification]);
+}

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -5,6 +5,7 @@ import { getTextContent, useMutableRef } from '@tloncorp/shared/logic';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { useRootNavigation } from '../navigation/utils';
+import { reactDisplayValue } from '../ui/components/Activity/ActivitySummaryMessage';
 import { useIsElectron } from './useIsElectron';
 
 const logger = createDevLogger('useBrowserNotifications', false);
@@ -31,6 +32,42 @@ function isAppForegrounded() {
   );
 }
 
+async function getContactName(contactId: string | null | undefined) {
+  const contact = contactId ? await db.getContact({ id: contactId }) : null;
+  return contact?.nickname ?? contactId ?? 'Unknown';
+}
+
+// Group join requests have a groupId but no channelId; clicking routes to the
+// group instead of a channel.
+async function showGroupAskNotification(
+  activityEvent: db.ActivityEvent,
+  notificationKey: string,
+  resetToGroupRef: { current: (groupId: string) => Promise<void> }
+) {
+  const groupId = activityEvent.groupId;
+  if (!groupId) {
+    logger.error('No group ID in group-ask activity event:', activityEvent);
+    return;
+  }
+
+  const group = await db.getGroup({ id: groupId });
+  const contactName = await getContactName(activityEvent.groupEventUserId);
+
+  const notification = new window.Notification(
+    group?.title ?? 'Group join request',
+    {
+      body: `${contactName} is requesting to join`,
+      tag: notificationKey,
+    }
+  );
+
+  notification.onclick = () => {
+    window.focus();
+    resetToGroupRef.current(groupId);
+    notification.close();
+  };
+}
+
 /**
  * Shows browser notifications for incoming activity. Electron gets native
  * notifications via useDesktopNotifications instead, so this bails there.
@@ -42,8 +79,9 @@ function isAppForegrounded() {
 export default function useBrowserNotifications() {
   const processedNotifications = useRef<Set<string>>(new Set());
   const isElectron = useIsElectron();
-  const { resetToChannel } = useRootNavigation();
+  const { resetToChannel, resetToGroup } = useRootNavigation();
   const resetToChannelRef = useMutableRef(resetToChannel);
+  const resetToGroupRef = useMutableRef(resetToGroup);
 
   const showActivityNotification = useCallback(
     async (activityEvent: db.ActivityEvent) => {
@@ -68,37 +106,51 @@ export default function useBrowserNotifications() {
         );
       }
 
-      const channelId = activityEvent.channelId;
-      if (!channelId) {
-        logger.error('No channel ID in activity event:', activityEvent);
-        return;
-      }
-
       try {
+        if (activityEvent.type === 'group-ask') {
+          await showGroupAskNotification(
+            activityEvent,
+            notificationKey,
+            resetToGroupRef
+          );
+          return;
+        }
+
+        const channelId = activityEvent.channelId;
+        if (!channelId) {
+          logger.error('No channel ID in activity event:', activityEvent);
+          return;
+        }
+
         const channel = await db.getChannelWithRelations({ id: channelId });
         if (!channel) {
           return;
         }
 
-        const contactId = activityEvent.authorId;
-        const contact = contactId
-          ? await db.getContact({ id: contactId })
-          : null;
-        const contactName = contact?.nickname ?? contactId ?? 'Unknown';
-        const contentText = activityEvent.content
-          ? getTextContent(activityEvent.content as api.PostContent)
+        const contactName = await getContactName(activityEvent.authorId);
+        const isReact = activityEvent.type === 'react';
+        const reactValue = isReact
+          ? reactDisplayValue(activityEvent.content)
           : '';
+        const contentText =
+          !isReact && activityEvent.content
+            ? getTextContent(activityEvent.content as api.PostContent)
+            : '';
 
         let title = channel.title ?? contactName ?? 'New message';
-        let body = contentText || 'New message';
+        let body = isReact
+          ? `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your post`
+          : contentText || 'New message';
 
         if (activityEvent.groupId) {
           const group = await db.getGroup({ id: activityEvent.groupId });
           if (group) {
             title = `${title} in ${group.title}`;
-            body = contentText
-              ? `${contactName ?? 'Someone'}: ${contentText}`
-              : `New message in ${group.title}`;
+            if (!isReact) {
+              body = contentText
+                ? `${contactName ?? 'Someone'}: ${contentText}`
+                : `New message in ${group.title}`;
+            }
           }
         }
 
@@ -116,12 +168,12 @@ export default function useBrowserNotifications() {
         };
       } catch (error) {
         logger.error(
-          'Error processing channel activity for browser notifications',
+          'Error processing activity for browser notifications',
           error
         );
       }
     },
-    [resetToChannelRef]
+    [resetToChannelRef, resetToGroupRef]
   );
 
   useEffect(() => {

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -6,6 +6,10 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { useRootNavigation } from '../navigation/utils';
 import { reactDisplayValue } from '../ui/components/Activity/ActivitySummaryMessage';
+import {
+  getBrowserNotificationCopy,
+  navigateToBrowserNotificationTarget,
+} from './useBrowserNotifications.helpers';
 import { useIsElectron } from './useIsElectron';
 
 const logger = createDevLogger('useBrowserNotifications', false);
@@ -79,9 +83,10 @@ async function showGroupAskNotification(
 export default function useBrowserNotifications() {
   const processedNotifications = useRef<Set<string>>(new Set());
   const isElectron = useIsElectron();
-  const { resetToChannel, resetToGroup } = useRootNavigation();
+  const { resetToChannel, resetToGroup, resetToPost } = useRootNavigation();
   const resetToChannelRef = useMutableRef(resetToChannel);
   const resetToGroupRef = useMutableRef(resetToGroup);
+  const resetToPostRef = useMutableRef(resetToPost);
 
   const showActivityNotification = useCallback(
     async (activityEvent: db.ActivityEvent) => {
@@ -134,25 +139,19 @@ export default function useBrowserNotifications() {
           : '';
         const contentText =
           !isReact && activityEvent.content
-            ? getTextContent(activityEvent.content as api.PostContent)
+            ? getTextContent(activityEvent.content as api.PostContent) ?? ''
             : '';
-
-        let title = channel.title ?? contactName ?? 'New message';
-        let body = isReact
-          ? `${contactName} reacted${reactValue ? ` ${reactValue}` : ''} to your post`
-          : contentText || 'New message';
-
-        if (activityEvent.groupId) {
-          const group = await db.getGroup({ id: activityEvent.groupId });
-          if (group) {
-            title = `${title} in ${group.title}`;
-            if (!isReact) {
-              body = contentText
-                ? `${contactName ?? 'Someone'}: ${contentText}`
-                : `New message in ${group.title}`;
-            }
-          }
-        }
+        const group = activityEvent.groupId
+          ? await db.getGroup({ id: activityEvent.groupId })
+          : null;
+        const { title, body } = getBrowserNotificationCopy({
+          activityType: activityEvent.type,
+          channelTitle: channel.title,
+          contactName,
+          contentText,
+          groupTitle: group?.title,
+          reactValue,
+        });
 
         const notification = new window.Notification(title, {
           body,
@@ -161,9 +160,19 @@ export default function useBrowserNotifications() {
 
         notification.onclick = () => {
           window.focus();
-          resetToChannelRef.current(channelId, {
-            groupId: channel.groupId ?? undefined,
-          });
+          navigateToBrowserNotificationTarget(
+            {
+              channelId,
+              groupId: channel.groupId ?? activityEvent.groupId ?? undefined,
+              parentAuthorId: activityEvent.parentAuthorId,
+              parentId: activityEvent.parentId,
+              postId: activityEvent.postId,
+            },
+            {
+              resetToChannel: resetToChannelRef.current,
+              resetToPost: resetToPostRef.current,
+            }
+          );
           notification.close();
         };
       } catch (error) {
@@ -173,7 +182,7 @@ export default function useBrowserNotifications() {
         );
       }
     },
-    [resetToChannelRef, resetToGroupRef]
+    [resetToChannelRef, resetToGroupRef, resetToPostRef]
   );
 
   useEffect(() => {

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -191,19 +191,30 @@ async function getContactName(
   });
 }
 
-// Group join requests have a groupId but no channelId; clicking routes to the
-// group instead of a channel.
-async function showGroupAskNotification(
-  activityEvent: db.ActivityEvent,
-  notificationKey: string,
-  disableNicknames: boolean,
-  shouldSuppressNotification: () => boolean,
-  resetToGroupRef: { current: (groupId: string) => Promise<void> }
-) {
+// Group join requests and group invites have a groupId but no channelId;
+// clicking routes to the group (join requests) or the chat list where the
+// invite is surfaced (invites).
+async function showGroupNotification({
+  activityEvent,
+  notificationKey,
+  disableNicknames,
+  shouldSuppressNotification,
+  fallbackTitle,
+  getBody,
+  navigateOnClick,
+}: {
+  activityEvent: db.ActivityEvent;
+  notificationKey: string;
+  disableNicknames: boolean;
+  shouldSuppressNotification: () => boolean;
+  fallbackTitle: string;
+  getBody: (contactName: string) => string;
+  navigateOnClick: (groupId: string) => void;
+}) {
   const groupId = activityEvent.groupId;
   if (!groupId) {
-    logger.error('No group ID in group-ask activity event:', activityEvent);
-    return;
+    logger.error('No group ID in group activity event:', activityEvent);
+    return false;
   }
 
   const group = await db.getGroup({ id: groupId });
@@ -216,17 +227,14 @@ async function showGroupAskNotification(
     return false;
   }
 
-  const notification = new window.Notification(
-    group?.title ?? 'Group join request',
-    {
-      body: `${contactName} is requesting to join`,
-      tag: notificationKey,
-    }
-  );
+  const notification = new window.Notification(group?.title ?? fallbackTitle, {
+    body: getBody(contactName),
+    tag: notificationKey,
+  });
 
   notification.onclick = () => {
     window.focus();
-    resetToGroupRef.current(groupId);
+    navigateOnClick(groupId);
     notification.close();
   };
 
@@ -247,9 +255,11 @@ export default function useBrowserNotifications() {
   const isElectron = useIsElectron();
   const isAppForegrounded = useIsAppForegroundedAcrossTabs(!isElectron);
   const { disableNicknames } = useCalm();
-  const { resetToChannel, resetToGroup, resetToPost } = useRootNavigation();
+  const { resetToChannel, resetToGroup, resetToGroupInvite, resetToPost } =
+    useRootNavigation();
   const resetToChannelRef = useMutableRef(resetToChannel);
   const resetToGroupRef = useMutableRef(resetToGroup);
+  const resetToGroupInviteRef = useMutableRef(resetToGroupInvite);
   const resetToPostRef = useMutableRef(resetToPost);
 
   const showActivityNotification = useCallback(
@@ -274,14 +284,26 @@ export default function useBrowserNotifications() {
       inFlightNotifications.current.add(notificationKey);
 
       try {
-        if (activityEvent.type === 'group-ask') {
-          const didNotify = await showGroupAskNotification(
+        if (
+          activityEvent.type === 'group-ask' ||
+          activityEvent.type === 'group-invite'
+        ) {
+          const isAsk = activityEvent.type === 'group-ask';
+          const didNotify = await showGroupNotification({
             activityEvent,
             notificationKey,
             disableNicknames,
-            isAppForegrounded,
-            resetToGroupRef
-          );
+            shouldSuppressNotification: isAppForegrounded,
+            fallbackTitle: isAsk ? 'Group join request' : 'Group invitation',
+            getBody: (contactName) =>
+              isAsk
+                ? `${contactName} is requesting to join`
+                : `${contactName} invited you to join`,
+            navigateOnClick: (groupId) =>
+              isAsk
+                ? resetToGroupRef.current(groupId)
+                : resetToGroupInviteRef.current(groupId),
+          });
           if (didNotify) {
             rememberProcessedNotification(
               processedNotifications,
@@ -374,6 +396,7 @@ export default function useBrowserNotifications() {
       isAppForegrounded,
       resetToChannelRef,
       resetToGroupRef,
+      resetToGroupInviteRef,
       resetToPostRef,
     ]
   );
@@ -387,18 +410,23 @@ export default function useBrowserNotifications() {
     let subscriptionId: number | null = null;
 
     api
-      .subscribeToActivity((event: api.ActivityEvent) => {
-        if (event.type !== 'addActivityEvent') {
-          return;
-        }
+      .subscribeToActivity(
+        (event: api.ActivityEvent) => {
+          if (event.type !== 'addActivityEvent') {
+            return;
+          }
 
-        const activityEvent =
-          event.events.find((e) => e.bucketId === 'all') ?? event.events[0];
+          const activityEvent =
+            event.events.find((e) => e.bucketId === 'all') ?? event.events[0];
 
-        if (activityEvent?.shouldNotify) {
-          showActivityNotification(activityEvent);
-        }
-      })
+          if (activityEvent?.shouldNotify) {
+            showActivityNotification(activityEvent);
+          }
+        },
+        // dm-invite/group-invite events notify by default but aren't part of
+        // the converted feed stream; opt in here (see toActivityEvent)
+        { includeInvites: true }
+      )
       .then((id) => {
         if (cancelled) {
           // effect already cleaned up before the subscription landed

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -6,15 +6,22 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { useRootNavigation } from '../navigation/utils';
 import { reactDisplayValue } from '../ui/components/Activity/ActivitySummaryMessage';
-import { useCalm } from '../ui/contexts/appDataContext';
+import { useCalm, useCurrentUserId } from '../ui/contexts/appDataContext';
 import {
   getBrowserNotificationContactName,
   getBrowserNotificationCopy,
+  getBrowserNotificationTargetWithRetry,
+  isOtherBrowserNotificationTabForegrounded,
   navigateToBrowserNotificationTarget,
+  parseBrowserNotificationForegroundTab,
 } from './useBrowserNotifications.helpers';
 import { useIsElectron } from './useIsElectron';
 
 const logger = createDevLogger('useBrowserNotifications', false);
+const CHANNEL_LOOKUP_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
+const FOREGROUND_TAB_HEARTBEAT_MS = 5_000;
+const FOREGROUND_TAB_TTL_MS = 15_000;
+const FOREGROUND_TAB_STORAGE_PREFIX = 'tlon.browserNotifications.foregroundTab';
 
 function canUseBrowserNotifications() {
   return (
@@ -30,12 +37,146 @@ function hasNotificationPermission() {
   );
 }
 
-function isAppForegrounded() {
+function isCurrentDocumentForegrounded() {
   return (
     typeof document !== 'undefined' &&
     document.visibilityState === 'visible' &&
     document.hasFocus()
   );
+}
+
+function getBrowserNotificationStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function createBrowserNotificationTabId() {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function clearOwnedForegroundTab(
+  storage: Storage,
+  storageKey: string,
+  tabId: string
+) {
+  try {
+    const foregroundTab = parseBrowserNotificationForegroundTab(
+      storage.getItem(storageKey)
+    );
+    if (foregroundTab?.tabId === tabId) {
+      storage.removeItem(storageKey);
+    }
+  } catch {
+    // Storage can be disabled even when the localStorage property is present.
+  }
+}
+
+function useIsAppForegroundedAcrossTabs(enabled: boolean) {
+  const currentUserId = useCurrentUserId();
+  const tabIdRef = useRef<string | null>(null);
+  const tabId = tabIdRef.current ?? createBrowserNotificationTabId();
+  tabIdRef.current = tabId;
+  const storageKey = `${FOREGROUND_TAB_STORAGE_PREFIX}:${currentUserId || 'unknown'}`;
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      typeof window === 'undefined' ||
+      typeof document === 'undefined'
+    ) {
+      return;
+    }
+
+    const syncForegroundState = () => {
+      const storage = getBrowserNotificationStorage();
+      if (!storage) {
+        return;
+      }
+
+      try {
+        if (isCurrentDocumentForegrounded()) {
+          storage.setItem(
+            storageKey,
+            JSON.stringify({ tabId, updatedAt: Date.now() })
+          );
+        } else {
+          clearOwnedForegroundTab(storage, storageKey, tabId);
+        }
+      } catch {
+        // Fall back to this document's foreground state when storage is blocked.
+      }
+    };
+    const clearForegroundState = () => {
+      const storage = getBrowserNotificationStorage();
+      if (storage) {
+        clearOwnedForegroundTab(storage, storageKey, tabId);
+      }
+    };
+
+    syncForegroundState();
+    window.addEventListener('focus', syncForegroundState);
+    window.addEventListener('blur', clearForegroundState);
+    window.addEventListener('pagehide', clearForegroundState);
+    document.addEventListener('visibilitychange', syncForegroundState);
+    const heartbeatId = window.setInterval(
+      syncForegroundState,
+      FOREGROUND_TAB_HEARTBEAT_MS
+    );
+
+    return () => {
+      window.removeEventListener('focus', syncForegroundState);
+      window.removeEventListener('blur', clearForegroundState);
+      window.removeEventListener('pagehide', clearForegroundState);
+      document.removeEventListener('visibilitychange', syncForegroundState);
+      window.clearInterval(heartbeatId);
+      clearForegroundState();
+    };
+  }, [enabled, storageKey, tabId]);
+
+  return useCallback(() => {
+    if (isCurrentDocumentForegrounded()) {
+      return true;
+    }
+
+    const storage = getBrowserNotificationStorage();
+    if (!storage) {
+      return false;
+    }
+
+    try {
+      return isOtherBrowserNotificationTabForegrounded({
+        serializedTab: storage.getItem(storageKey),
+        currentTabId: tabId,
+        now: Date.now(),
+        ttlMs: FOREGROUND_TAB_TTL_MS,
+      });
+    } catch {
+      return false;
+    }
+  }, [storageKey, tabId]);
+}
+
+function rememberProcessedNotification(
+  processedNotifications: { current: Set<string> },
+  notificationKey: string
+) {
+  processedNotifications.current.add(notificationKey);
+  if (processedNotifications.current.size > 100) {
+    processedNotifications.current = new Set(
+      Array.from(processedNotifications.current).slice(-50)
+    );
+  }
 }
 
 async function getContactName(
@@ -56,6 +197,7 @@ async function showGroupAskNotification(
   activityEvent: db.ActivityEvent,
   notificationKey: string,
   disableNicknames: boolean,
+  shouldSuppressNotification: () => boolean,
   resetToGroupRef: { current: (groupId: string) => Promise<void> }
 ) {
   const groupId = activityEvent.groupId;
@@ -70,6 +212,10 @@ async function showGroupAskNotification(
     disableNicknames
   );
 
+  if (!hasNotificationPermission() || shouldSuppressNotification()) {
+    return false;
+  }
+
   const notification = new window.Notification(
     group?.title ?? 'Group join request',
     {
@@ -83,6 +229,8 @@ async function showGroupAskNotification(
     resetToGroupRef.current(groupId);
     notification.close();
   };
+
+  return true;
 }
 
 /**
@@ -95,7 +243,9 @@ async function showGroupAskNotification(
  */
 export default function useBrowserNotifications() {
   const processedNotifications = useRef<Set<string>>(new Set());
+  const inFlightNotifications = useRef<Set<string>>(new Set());
   const isElectron = useIsElectron();
+  const isAppForegrounded = useIsAppForegroundedAcrossTabs(!isElectron);
   const { disableNicknames } = useCalm();
   const { resetToChannel, resetToGroup, resetToPost } = useRootNavigation();
   const resetToChannelRef = useMutableRef(resetToChannel);
@@ -114,25 +264,30 @@ export default function useBrowserNotifications() {
       }
 
       const notificationKey = activityEvent.id;
-      if (processedNotifications.current.has(notificationKey)) {
+      if (
+        processedNotifications.current.has(notificationKey) ||
+        inFlightNotifications.current.has(notificationKey)
+      ) {
         return;
       }
 
-      processedNotifications.current.add(notificationKey);
-      if (processedNotifications.current.size > 100) {
-        processedNotifications.current = new Set(
-          Array.from(processedNotifications.current).slice(-50)
-        );
-      }
+      inFlightNotifications.current.add(notificationKey);
 
       try {
         if (activityEvent.type === 'group-ask') {
-          await showGroupAskNotification(
+          const didNotify = await showGroupAskNotification(
             activityEvent,
             notificationKey,
             disableNicknames,
+            isAppForegrounded,
             resetToGroupRef
           );
+          if (didNotify) {
+            rememberProcessedNotification(
+              processedNotifications,
+              notificationKey
+            );
+          }
           return;
         }
 
@@ -142,8 +297,15 @@ export default function useBrowserNotifications() {
           return;
         }
 
-        const channel = await db.getChannelWithRelations({ id: channelId });
+        const channel = await getBrowserNotificationTargetWithRetry(
+          () => db.getChannelWithRelations({ id: channelId }),
+          CHANNEL_LOOKUP_RETRY_DELAYS_MS
+        );
         if (!channel) {
+          logger.warn(
+            'Channel unavailable after retrying browser notification target:',
+            channelId
+          );
           return;
         }
 
@@ -171,6 +333,10 @@ export default function useBrowserNotifications() {
           reactValue,
         });
 
+        if (!hasNotificationPermission() || isAppForegrounded()) {
+          return;
+        }
+
         const notification = new window.Notification(title, {
           body,
           tag: notificationKey,
@@ -193,14 +359,23 @@ export default function useBrowserNotifications() {
           );
           notification.close();
         };
+        rememberProcessedNotification(processedNotifications, notificationKey);
       } catch (error) {
         logger.error(
           'Error processing activity for browser notifications',
           error
         );
+      } finally {
+        inFlightNotifications.current.delete(notificationKey);
       }
     },
-    [disableNicknames, resetToChannelRef, resetToGroupRef, resetToPostRef]
+    [
+      disableNicknames,
+      isAppForegrounded,
+      resetToChannelRef,
+      resetToGroupRef,
+      resetToPostRef,
+    ]
   );
 
   useEffect(() => {

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -10,6 +10,7 @@ import { useCalm, useCurrentUserId } from '../ui/contexts/appDataContext';
 import {
   getBrowserNotificationContactName,
   getBrowserNotificationCopy,
+  getBrowserNotificationGroupTitle,
   getBrowserNotificationTargetWithRetry,
   isOtherBrowserNotificationTabForegrounded,
   navigateToBrowserNotificationTarget,
@@ -227,10 +228,13 @@ async function showGroupNotification({
     return false;
   }
 
-  const notification = new window.Notification(group?.title ?? fallbackTitle, {
-    body: getBody(contactName),
-    tag: notificationKey,
-  });
+  const notification = new window.Notification(
+    getBrowserNotificationGroupTitle(group?.title, fallbackTitle),
+    {
+      body: getBody(contactName),
+      tag: notificationKey,
+    }
+  );
 
   notification.onclick = () => {
     window.focus();

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -1,16 +1,13 @@
 import * as api from '@tloncorp/api';
 import { createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import { getTextContent } from '@tloncorp/shared/logic';
+import { getTextContent, useMutableRef } from '@tloncorp/shared/logic';
 import { useCallback, useEffect, useRef } from 'react';
 
-const logger = createDevLogger('useBrowserNotifications', false);
+import { useRootNavigation } from '../navigation/utils';
+import { useIsElectron } from './useIsElectron';
 
-interface NotificationData {
-  type: string;
-  channelId?: string;
-  groupId?: string;
-}
+const logger = createDevLogger('useBrowserNotifications', false);
 
 function canUseBrowserNotifications() {
   return (
@@ -26,13 +23,36 @@ function hasNotificationPermission() {
   );
 }
 
-export default function useBrowserNotifications(isClientReady: boolean) {
+function isAppForegrounded() {
+  return (
+    typeof document !== 'undefined' &&
+    document.visibilityState === 'visible' &&
+    document.hasFocus()
+  );
+}
+
+/**
+ * Shows browser notifications for incoming activity. Electron gets native
+ * notifications via useDesktopNotifications instead, so this bails there.
+ *
+ * Must be mounted inside the NavigationContainer (clicking a notification
+ * navigates to the source channel), and only once the client is configured
+ * and syncing.
+ */
+export default function useBrowserNotifications() {
   const processedNotifications = useRef<Set<string>>(new Set());
-  const subscribedRef = useRef(false);
+  const isElectron = useIsElectron();
+  const { resetToChannel } = useRootNavigation();
+  const resetToChannelRef = useMutableRef(resetToChannel);
 
   const showActivityNotification = useCallback(
     async (activityEvent: db.ActivityEvent) => {
-      if (!canUseBrowserNotifications()) {
+      if (!hasNotificationPermission()) {
+        return;
+      }
+
+      if (isAppForegrounded()) {
+        // the user is already looking at the app
         return;
       }
 
@@ -48,19 +68,14 @@ export default function useBrowserNotifications(isClientReady: boolean) {
         );
       }
 
-      if (!hasNotificationPermission()) {
-        return;
-      }
-
-      if (!activityEvent.channelId) {
+      const channelId = activityEvent.channelId;
+      if (!channelId) {
         logger.error('No channel ID in activity event:', activityEvent);
         return;
       }
 
       try {
-        const channel = await db.getChannelWithRelations({
-          id: activityEvent.channelId,
-        });
+        const channel = await db.getChannelWithRelations({ id: channelId });
         if (!channel) {
           return;
         }
@@ -90,15 +105,14 @@ export default function useBrowserNotifications(isClientReady: boolean) {
         const notification = new window.Notification(title, {
           body,
           tag: notificationKey,
-          data: {
-            type: 'channel',
-            channelId: activityEvent.channelId,
-            groupId: channel.groupId ?? undefined,
-          } satisfies NotificationData,
         });
 
         notification.onclick = () => {
           window.focus();
+          resetToChannelRef.current(channelId, {
+            groupId: channel.groupId ?? undefined,
+          });
+          notification.close();
         };
       } catch (error) {
         logger.error(
@@ -107,38 +121,47 @@ export default function useBrowserNotifications(isClientReady: boolean) {
         );
       }
     },
-    []
+    [resetToChannelRef]
   );
 
   useEffect(() => {
-    if (
-      !isClientReady ||
-      subscribedRef.current ||
-      !canUseBrowserNotifications()
-    ) {
+    if (isElectron || !canUseBrowserNotifications()) {
       return;
     }
 
-    subscribedRef.current = true;
+    let cancelled = false;
+    let subscriptionId: number | null = null;
 
-    const handleActivityEvent = (event: api.ActivityEvent) => {
-      if (event.type !== 'addActivityEvent') {
-        return;
-      }
+    api
+      .subscribeToActivity((event: api.ActivityEvent) => {
+        if (event.type !== 'addActivityEvent') {
+          return;
+        }
 
-      const activityEvent =
-        event.events.find((e) => e.bucketId === 'all') ?? event.events[0];
+        const activityEvent =
+          event.events.find((e) => e.bucketId === 'all') ?? event.events[0];
 
-      if (activityEvent?.shouldNotify) {
-        showActivityNotification(activityEvent);
+        if (activityEvent?.shouldNotify) {
+          showActivityNotification(activityEvent);
+        }
+      })
+      .then((id) => {
+        if (cancelled) {
+          // effect already cleaned up before the subscription landed
+          api.unsubscribe(id);
+        } else {
+          subscriptionId = id;
+        }
+      })
+      .catch((e) => {
+        logger.error('Error subscribing to browser notification activity', e);
+      });
+
+    return () => {
+      cancelled = true;
+      if (subscriptionId != null) {
+        api.unsubscribe(subscriptionId);
       }
     };
-
-    try {
-      api.subscribeToActivity(handleActivityEvent);
-    } catch (error) {
-      subscribedRef.current = false;
-      logger.error('Error subscribing to browser notification activity', error);
-    }
-  }, [isClientReady, showActivityNotification]);
+  }, [isElectron, showActivityNotification]);
 }

--- a/packages/app/hooks/useBrowserNotifications.ts
+++ b/packages/app/hooks/useBrowserNotifications.ts
@@ -6,7 +6,9 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { useRootNavigation } from '../navigation/utils';
 import { reactDisplayValue } from '../ui/components/Activity/ActivitySummaryMessage';
+import { useCalm } from '../ui/contexts/appDataContext';
 import {
+  getBrowserNotificationContactName,
   getBrowserNotificationCopy,
   navigateToBrowserNotificationTarget,
 } from './useBrowserNotifications.helpers';
@@ -36,9 +38,16 @@ function isAppForegrounded() {
   );
 }
 
-async function getContactName(contactId: string | null | undefined) {
+async function getContactName(
+  contactId: string | null | undefined,
+  disableNicknames: boolean
+) {
   const contact = contactId ? await db.getContact({ id: contactId }) : null;
-  return contact?.nickname ?? contactId ?? 'Unknown';
+  return getBrowserNotificationContactName({
+    contact,
+    contactId,
+    disableNicknames,
+  });
 }
 
 // Group join requests have a groupId but no channelId; clicking routes to the
@@ -46,6 +55,7 @@ async function getContactName(contactId: string | null | undefined) {
 async function showGroupAskNotification(
   activityEvent: db.ActivityEvent,
   notificationKey: string,
+  disableNicknames: boolean,
   resetToGroupRef: { current: (groupId: string) => Promise<void> }
 ) {
   const groupId = activityEvent.groupId;
@@ -55,7 +65,10 @@ async function showGroupAskNotification(
   }
 
   const group = await db.getGroup({ id: groupId });
-  const contactName = await getContactName(activityEvent.groupEventUserId);
+  const contactName = await getContactName(
+    activityEvent.groupEventUserId,
+    disableNicknames
+  );
 
   const notification = new window.Notification(
     group?.title ?? 'Group join request',
@@ -83,6 +96,7 @@ async function showGroupAskNotification(
 export default function useBrowserNotifications() {
   const processedNotifications = useRef<Set<string>>(new Set());
   const isElectron = useIsElectron();
+  const { disableNicknames } = useCalm();
   const { resetToChannel, resetToGroup, resetToPost } = useRootNavigation();
   const resetToChannelRef = useMutableRef(resetToChannel);
   const resetToGroupRef = useMutableRef(resetToGroup);
@@ -116,6 +130,7 @@ export default function useBrowserNotifications() {
           await showGroupAskNotification(
             activityEvent,
             notificationKey,
+            disableNicknames,
             resetToGroupRef
           );
           return;
@@ -132,7 +147,10 @@ export default function useBrowserNotifications() {
           return;
         }
 
-        const contactName = await getContactName(activityEvent.authorId);
+        const contactName = await getContactName(
+          activityEvent.authorId,
+          disableNicknames
+        );
         const isReact = activityEvent.type === 'react';
         const reactValue = isReact
           ? reactDisplayValue(activityEvent.content)
@@ -182,7 +200,7 @@ export default function useBrowserNotifications() {
         );
       }
     },
-    [resetToChannelRef, resetToGroupRef, resetToPostRef]
+    [disableNicknames, resetToChannelRef, resetToGroupRef, resetToPostRef]
   );
 
   useEffect(() => {

--- a/packages/app/navigation/desktop/HomeNavigator.tsx
+++ b/packages/app/navigation/desktop/HomeNavigator.tsx
@@ -26,6 +26,7 @@ import { UserProfileScreen } from '../../features/top/UserProfileScreen';
 import { GroupSettingsStack } from '../../navigation/GroupSettingsStack';
 import { DESKTOP_SIDEBAR_WIDTH, useGlobalSearch } from '../../ui';
 import { NotebookSidebarProvider } from '../../ui/contexts/notebookSidebar';
+import { getDesktopGroupInvitePreviewProps } from '../routeHelpers';
 import { HomeDrawerParamList } from '../types';
 import { mediaViewerScreenOptions } from '../utils';
 import { HomeSidebar } from './HomeSidebar';
@@ -75,6 +76,8 @@ const DrawerContent = memo((props: DrawerContentComponentProps) => {
   const state = props.state as NavigationState<HomeDrawerParamList>;
   const focusedRoute = state.routes[props.state.index];
   const focusedRouteParams = focusedRoute.params;
+  const groupInvitePreviewProps =
+    getDesktopGroupInvitePreviewProps(focusedRouteParams);
   // @ts-expect-error - nested params is not in the type
   const nestedFocusedRouteParams = focusedRouteParams?.params;
   if (
@@ -131,8 +134,8 @@ const DrawerContent = memo((props: DrawerContentComponentProps) => {
     }
   } else if (focusedRoute.params && 'channelId' in focusedRoute.params) {
     return <HomeSidebar focusedChannelId={focusedRoute.params.channelId} />;
-  } else if (focusedRoute.params && 'previewGroupId' in focusedRoute.params) {
-    return <HomeSidebar previewGroupId={focusedRoute.params.previewGroupId} />;
+  } else if (groupInvitePreviewProps) {
+    return <HomeSidebar {...groupInvitePreviewProps} />;
   } else {
     return <HomeSidebar />;
   }

--- a/packages/app/navigation/desktop/HomeSidebar.tsx
+++ b/packages/app/navigation/desktop/HomeSidebar.tsx
@@ -1,6 +1,6 @@
 import { useIsFocused } from '@react-navigation/native';
 import { markInvitesRead } from '@tloncorp/api';
-import { createDevLogger } from '@tloncorp/shared';
+import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
 import * as store from '@tloncorp/shared/store';
 import { Text } from '@tloncorp/ui';
@@ -12,6 +12,10 @@ import {
   CreateChatSheet,
   CreateChatSheetMethods,
 } from '../../features/top/CreateChatSheet';
+import {
+  getGroupInviteSheetState,
+  isGroupInviteReady,
+} from '../../features/top/groupInvitePreview';
 import { useChatSettingsNavigation } from '../../hooks/useChatSettingsNavigation';
 import { useFilteredChats } from '../../hooks/useFilteredChats';
 import { useGroupActions } from '../../hooks/useGroupActions';
@@ -40,16 +44,27 @@ const logger = createDevLogger('HomeSidebar', false);
 
 interface Props {
   previewGroupId?: string;
+  previewGroupFromInviteNotification?: boolean;
   focusedChannelId?: string;
 }
 
 export const HomeSidebar = memo(
-  ({ previewGroupId, focusedChannelId }: Props) => {
+  ({
+    previewGroupId,
+    previewGroupFromInviteNotification,
+    focusedChannelId,
+  }: Props) => {
     const [inviteSheetGroup, setInviteSheetGroup] = useState<string | null>();
 
     const [selectedGroupId, setSelectedGroupId] = useState<string | null>(
       previewGroupId ?? null
     );
+    const [inviteNotificationGroupId, setInviteNotificationGroupId] = useState<
+      string | null
+    >(previewGroupFromInviteNotification ? previewGroupId ?? null : null);
+    const [waitElapsedForGroupId, setWaitElapsedForGroupId] = useState<
+      string | null
+    >(null);
     const { data: selectedGroup } = store.useGroup({
       id: selectedGroupId ?? '',
     });
@@ -60,6 +75,52 @@ export const HomeSidebar = memo(
     const { performGroupAction } = useGroupActions();
 
     const connStatus = store.useConnectionStatus();
+    const session = store.useCurrentSession();
+
+    const initSyncSettled =
+      session?.phase === 'low' || session?.phase === 'ready';
+    const syncReadyForInvite = connStatus === 'Connected' && initSyncSettled;
+    const awaitingInviteGroupId =
+      syncReadyForInvite &&
+      selectedGroupId != null &&
+      selectedGroupId === inviteNotificationGroupId &&
+      !isGroupInviteReady(selectedGroup)
+        ? selectedGroupId
+        : null;
+
+    useEffect(() => {
+      if (awaitingInviteGroupId == null) {
+        return;
+      }
+      const groupId = awaitingInviteGroupId;
+      const timeout = setTimeout(
+        () => setWaitElapsedForGroupId(groupId),
+        15_000
+      );
+      return () => clearTimeout(timeout);
+    }, [awaitingInviteGroupId]);
+
+    const {
+      sheetOpen: groupPreviewSheetOpen,
+      sheetGroup: groupPreviewSheetGroup,
+      shouldCloseUnresolved: groupInviteUnresolved,
+    } = getGroupInviteSheetState({
+      selectedGroupId,
+      selectedGroup,
+      inviteNotificationGroupId,
+      waitElapsedForGroupId,
+    });
+
+    useEffect(() => {
+      if (groupInviteUnresolved) {
+        logger.trackEvent(AnalyticsEvent.ErrorPushNotifNavigate, {
+          context: 'group invite preview never resolved',
+        });
+        setSelectedGroupId(null);
+        setInviteNotificationGroupId(null);
+        setWaitElapsedForGroupId(null);
+      }
+    }, [groupInviteUnresolved]);
 
     const noChats = useMemo(
       () =>
@@ -113,6 +174,8 @@ export const HomeSidebar = memo(
         if (item.type === 'group') {
           if (item.isPending) {
             setSelectedGroupId(item.id);
+            setInviteNotificationGroupId(null);
+            setWaitElapsedForGroupId(null);
           } else {
             navigateToGroup(item.group.id);
           }
@@ -141,12 +204,17 @@ export const HomeSidebar = memo(
     useEffect(() => {
       if (previewGroupId) {
         setSelectedGroupId(previewGroupId);
+        setInviteNotificationGroupId(
+          previewGroupFromInviteNotification ? previewGroupId : null
+        );
       }
-    }, [previewGroupId]);
+    }, [previewGroupId, previewGroupFromInviteNotification]);
 
     const handleGroupPreviewSheetOpenChange = useCallback((open: boolean) => {
       if (!open) {
         setSelectedGroupId(null);
+        setInviteNotificationGroupId(null);
+        setWaitElapsedForGroupId(null);
       }
     }, []);
 
@@ -182,6 +250,8 @@ export const HomeSidebar = memo(
       (action: GroupPreviewAction, group: db.Group) => {
         performGroupAction(action, group);
         setSelectedGroupId(null);
+        setInviteNotificationGroupId(null);
+        setWaitElapsedForGroupId(null);
       },
       [performGroupAction]
     );
@@ -271,9 +341,9 @@ export const HomeSidebar = memo(
               </View>
               <MobileAppPromoBanner />
               <GroupPreviewSheet
-                open={!!selectedGroup}
+                open={groupPreviewSheetOpen}
                 onOpenChange={handleGroupPreviewSheetOpenChange}
-                group={selectedGroup ?? undefined}
+                group={groupPreviewSheetGroup}
                 onActionComplete={handleGroupAction}
               />
               <InviteUsersSheet

--- a/packages/app/navigation/desktop/TopLevelDrawer.tsx
+++ b/packages/app/navigation/desktop/TopLevelDrawer.tsx
@@ -9,6 +9,7 @@ import { useCallback, useRef, useState } from 'react';
 import { getVariableValue, useTheme } from 'tamagui';
 
 import { GlobalSearch } from '../../features/chat-list/GlobalSearch';
+import useBrowserNotifications from '../../hooks/useBrowserNotifications';
 import { useCurrentUserId } from '../../hooks/useCurrentUser';
 import {
   AvatarNavIcon,
@@ -184,6 +185,9 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
 };
 
 const TopLevelDrawerInner = () => {
+  // This must stay below GlobalSearchProvider so notification navigation uses
+  // the user's actual last-open desktop tab instead of the context default.
+  useBrowserNotifications();
   const { navigateToGroup, navigateToChannel } = useRootNavigation();
 
   return (

--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   NavigationChainNode,
   getActiveTopLevelDrawerRouteName,
+  getDesktopGroupInvitePreviewProps,
   getDesktopGroupInviteRoute,
   getDesktopPostRoute,
 } from './routeHelpers';
@@ -218,5 +219,31 @@ describe('getDesktopGroupInviteRoute', () => {
         },
       },
     });
+  });
+});
+
+describe('getDesktopGroupInvitePreviewProps', () => {
+  test('preserves the notification marker for the desktop Home sidebar', () => {
+    expect(
+      getDesktopGroupInvitePreviewProps({
+        previewGroupId: '~zod/test-group',
+        previewGroupFromInviteNotification: true,
+      })
+    ).toEqual({
+      previewGroupId: '~zod/test-group',
+      previewGroupFromInviteNotification: true,
+    });
+  });
+
+  test('treats an ordinary group preview as a non-notification selection', () => {
+    expect(
+      getDesktopGroupInvitePreviewProps({
+        previewGroupId: '~zod/test-group',
+      })
+    ).toEqual({
+      previewGroupId: '~zod/test-group',
+      previewGroupFromInviteNotification: false,
+    });
+    expect(getDesktopGroupInvitePreviewProps(undefined)).toBeNull();
   });
 });

--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -173,6 +173,16 @@ describe('getDesktopPostRoute', () => {
     expect(route.params.screen).toBe('GroupDM');
   });
 
+  test('notes channel -> Home even when the last open tab is Messages', () => {
+    const route = getDesktopPostRoute('Messages', {
+      ...base,
+      channelId: 'notes/~zod/blog',
+      groupId: '~zod/tlon',
+    });
+    expect(route.name).toBe('Home');
+    expect(route.params.screen).toBe('Channel');
+  });
+
   test('selectedPostId is threaded onto both wrapper and nested Post params', () => {
     const route = getDesktopPostRoute('Home', {
       ...base,

--- a/packages/app/navigation/routeHelpers.test.ts
+++ b/packages/app/navigation/routeHelpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   NavigationChainNode,
   getActiveTopLevelDrawerRouteName,
+  getDesktopGroupInviteRoute,
   getDesktopPostRoute,
 } from './routeHelpers';
 
@@ -202,5 +203,20 @@ describe('getDesktopPostRoute', () => {
     });
     expect(route.params.params.selectedPostId).toBeUndefined();
     expect(route.params.params.params.selectedPostId).toBeUndefined();
+  });
+});
+
+describe('getDesktopGroupInviteRoute', () => {
+  test('opens the clicked invite in the nested desktop ChatList', () => {
+    expect(getDesktopGroupInviteRoute('~zod/test-group')).toEqual({
+      name: 'Home',
+      params: {
+        screen: 'ChatList',
+        params: {
+          previewGroupId: '~zod/test-group',
+          previewGroupFromInviteNotification: true,
+        },
+      },
+    });
   });
 });

--- a/packages/app/navigation/routeHelpers.ts
+++ b/packages/app/navigation/routeHelpers.ts
@@ -122,3 +122,21 @@ export function getDesktopPostRoute(
     },
   } as const;
 }
+
+/**
+ * Build the nested desktop route used when a group-invite notification is
+ * opened. The ChatList params identify the invite that was clicked and keep
+ * the invite preview open while its group data is loading.
+ */
+export function getDesktopGroupInviteRoute(groupId: string) {
+  return {
+    name: 'Home',
+    params: {
+      screen: 'ChatList',
+      params: {
+        previewGroupId: groupId,
+        previewGroupFromInviteNotification: true,
+      },
+    },
+  } as const;
+}

--- a/packages/app/navigation/routeHelpers.ts
+++ b/packages/app/navigation/routeHelpers.ts
@@ -140,3 +140,26 @@ export function getDesktopGroupInviteRoute(groupId: string) {
     },
   } as const;
 }
+
+/**
+ * Extract the group-invite preview state that the desktop drawer content must
+ * pass to HomeSidebar. Keeping this as a pure helper makes it harder for the
+ * notification marker to drift out of sync with the nested route shape.
+ */
+export function getDesktopGroupInvitePreviewProps(routeParams: unknown) {
+  if (
+    typeof routeParams !== 'object' ||
+    routeParams === null ||
+    !('previewGroupId' in routeParams) ||
+    typeof routeParams.previewGroupId !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    previewGroupId: routeParams.previewGroupId,
+    previewGroupFromInviteNotification:
+      'previewGroupFromInviteNotification' in routeParams &&
+      routeParams.previewGroupFromInviteNotification === true,
+  };
+}

--- a/packages/app/navigation/routeHelpers.ts
+++ b/packages/app/navigation/routeHelpers.ts
@@ -1,4 +1,8 @@
-import { isDmChannelId, isGroupDmChannelId } from '@tloncorp/api/client';
+import {
+  isDmChannelId,
+  isGroupDmChannelId,
+  parseNotesChannelId,
+} from '@tloncorp/api/client';
 
 // Pure, side-effect-light navigation route helpers.
 //
@@ -96,8 +100,11 @@ export function getDesktopPostRoute(
   }
 ) {
   const screen = screenNameFromChannelId(postParams.channelId);
+  // Notes channels always open under Home, where the notebook sidebar and
+  // channel takeover providers are mounted.
+  const resolvedTab = parseNotesChannelId(postParams.channelId) ? 'Home' : tab;
   return {
-    name: tab,
+    name: resolvedTab,
     params: {
       screen,
       pop: true,

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -114,6 +114,37 @@ function useResetToChannel() {
   );
 }
 
+function useResetToPost() {
+  const navigation = useNavigation();
+  const navigationRef = logic.useMutableRef(navigation);
+  const reset = useTypedReset();
+  const isWindowNarrow = useIsWindowNarrow();
+  const { lastOpenTab } = useGlobalSearch();
+
+  return useCallback(
+    function resetToPost(postParams: RootStackParamList['Post']) {
+      if (isWindowNarrow) {
+        const screenName = screenNameFromChannelId(postParams.channelId);
+        reset([
+          { name: 'ChatList' },
+          {
+            name: screenName,
+            params: {
+              channelId: postParams.channelId,
+              groupId: postParams.groupId,
+            },
+          },
+          { name: 'Post', params: postParams },
+        ]);
+      } else {
+        const tab = getTab(navigationRef.current, lastOpenTab);
+        reset([getDesktopPostRoute(tab, postParams)]);
+      }
+    },
+    [isWindowNarrow, lastOpenTab, navigationRef, reset]
+  );
+}
+
 function useResetToDm() {
   const resetToChannel = useResetToChannel();
 
@@ -447,6 +478,7 @@ export function useRootNavigation() {
   const navigateToPost = useNavigateToPost();
   const resetToGroup = useResetToGroup();
   const resetToDm = useResetToDm();
+  const resetToPost = useResetToPost();
 
   return useMemo(
     () => ({
@@ -460,6 +492,7 @@ export function useRootNavigation() {
       resetToGroup,
       resetToChannel,
       resetToDm,
+      resetToPost,
       navigateBack,
       navigateToBotSettings,
     }),
@@ -476,6 +509,7 @@ export function useRootNavigation() {
       resetToGroup,
       resetToChannel,
       resetToDm,
+      resetToPost,
     ]
   );
 }

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -20,6 +20,7 @@ import type {
 import {
   TOP_LEVEL_DRAWER_ROUTES,
   getActiveTopLevelDrawerRouteName,
+  getDesktopGroupInviteRoute,
   getDesktopPostRoute,
   screenNameFromChannelId,
 } from './routeHelpers';
@@ -201,9 +202,7 @@ function useResetToGroupInvite() {
         },
       ]);
     } else {
-      // desktop has no group-preview route; land on the chat list where the
-      // invite is surfaced
-      reset([{ name: 'Home', params: { screen: 'ChatList' } }]);
+      reset([getDesktopGroupInviteRoute(groupId)]);
     }
   };
 }

--- a/packages/app/navigation/utils.ts
+++ b/packages/app/navigation/utils.ts
@@ -183,6 +183,31 @@ function useResetToGroup() {
   };
 }
 
+function useResetToGroupInvite() {
+  const reset = useTypedReset();
+  const isWindowNarrow = useIsWindowNarrow();
+
+  return async function resetToGroupInvite(groupId: string) {
+    if (isWindowNarrow) {
+      // matches the mobile push-notification tap: chat list with the invited
+      // group's preview sheet open (see groupInvitePreviewRouteStack)
+      reset([
+        {
+          name: 'ChatList',
+          params: {
+            previewGroupId: groupId,
+            previewGroupFromInviteNotification: true,
+          },
+        },
+      ]);
+    } else {
+      // desktop has no group-preview route; land on the chat list where the
+      // invite is surfaced
+      reset([{ name: 'Home', params: { screen: 'ChatList' } }]);
+    }
+  };
+}
+
 function useNavigateToChannel() {
   const isWindowNarrow = useIsWindowNarrow();
   const navigation = useNavigation();
@@ -477,6 +502,7 @@ export function useRootNavigation() {
   const navigateBackFromPost = useNavigateBackFromPost();
   const navigateToPost = useNavigateToPost();
   const resetToGroup = useResetToGroup();
+  const resetToGroupInvite = useResetToGroupInvite();
   const resetToDm = useResetToDm();
   const resetToPost = useResetToPost();
 
@@ -490,6 +516,7 @@ export function useRootNavigation() {
       navigateToChatDetails,
       navigateToChatVolume,
       resetToGroup,
+      resetToGroupInvite,
       resetToChannel,
       resetToDm,
       resetToPost,
@@ -507,6 +534,7 @@ export function useRootNavigation() {
       navigateToGroup,
       navigateToPost,
       resetToGroup,
+      resetToGroupInvite,
       resetToChannel,
       resetToDm,
       resetToPost,

--- a/packages/app/ui/components/Activity/ActivitySummaryMessage.tsx
+++ b/packages/app/ui/components/Activity/ActivitySummaryMessage.tsx
@@ -174,7 +174,7 @@ function postVerb(channelType: string) {
 
 // Reactions reuse the activity event `content` column to carry the raw react
 // value: a native emoji string, or a custom `{ any }` value.
-function reactDisplayValue(content: unknown): string {
+export function reactDisplayValue(content: unknown): string {
   if (typeof content === 'string') {
     return content;
   }


### PR DESCRIPTION
Picks up #5846 (thanks @wca4a) rebased onto `develop`, and addresses the review feedback in https://github.com/tloncorp/tlon-apps/pull/5846#issuecomment-4491681857:

1. **Notifications are suppressed while the app is foregrounded** — checked at show time via `document.visibilityState === 'visible' && document.hasFocus()`, so a visible-but-unfocused window still notifies.
2. **Subscription lifecycle cleanup** — `useBrowserNotifications` now mirrors `useDesktopNotifications`: it keeps the subscription id from `api.subscribeToActivity` and calls `api.unsubscribe` on effect cleanup (including the race where cleanup runs before the subscribe promise lands), replacing the one-shot `subscribedRef`.
3. **Clicking a notification routes to the conversation** — the click handler focuses the window and calls `resetToChannel(channelId, { groupId })`. To make navigation available, the hook moved from `ConnectedWebApp` (outside the `NavigationContainer`) into a `BrowserNotifications` component mounted inside both containers — the same pattern mobile uses for `useNotificationListener`. By that mount point the client is always ready (web splash gates on the database task; Electron gates on `clientReady`), so the `isClientReady` param is gone.

Also: Electron is treated as unsupported for browser notifications — it already gets native notifications via `useDesktopNotifications`, so the hook bails there and the settings section is hidden (Electron auto-grants `Notification.permission`, which would otherwise show a misleading "Enabled").

## Verification

- `tsc` clean in `packages/app` and `apps/tlon-web`; eslint clean on touched files.
- Booted a local ship + vite: app loads with the hook mounted inside the `NavigationContainer` (no crash from `useNavigation` at container level, in both narrow and desktop layouts), and the settings screen shows "Browser notifications / Not enabled" with a working Enable button in Chrome while correctly hiding the section in an Electron-UA browser.
- Not verified live: an actual end-to-end notification click (requires a second ship + granted browser permission); the navigation call reuses `resetToChannel` and the container-level dispatch pattern mobile already uses in production for push-notification taps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)