### PR TITLE
ci: skip app test-build for bot-plugin-only changes (TLON-6154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,15 @@ jobs:
   # for ANY change except ones confined to the isolated bot/plugin packages
   # (openclaw/hermes/tlon-bot-e2e/tlon-skill — not consumed by the app, covered
   # by their own workflows) or docs. New packages therefore default to running
-  # the app suite, so we never silently skip needed tests.
+  # the app suite, so we never silently skip needed tests. `bots` mirrors that
+  # package list positively; it gates the bot-checks job that keeps the checks
+  # only test-build used to provide (see below) running on bot-only PRs.
   changes:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       app: ${{ steps.filter.outputs.app }}
       backend: ${{ steps.filter.outputs.backend }}
+      bots: ${{ steps.filter.outputs.bots }}
     steps:
       - name: Filter changed paths
         uses: dorny/paths-filter@v3
@@ -32,8 +35,18 @@ jobs:
             backend:
               - 'desk/**'
               - 'backend/**'
+            bots:
+              - 'packages/openclaw/**'
+              - 'packages/hermes-tlon-adapter/**'
+              - 'packages/tlon-bot-e2e/**'
+              - 'packages/tlon-skill/**'
 
+  # The app-wide suite. Skipped when a PR only touches the bot/plugin packages
+  # or docs; a skipped run still satisfies the `test-build` required status
+  # check (GitHub treats jobs skipped via `if:` as passing).
   test-build:
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout
@@ -84,6 +97,50 @@ jobs:
         run: pnpm build:all
         env:
           NODE_OPTIONS: --max-old-space-size=6144
+
+  # Checks for the bot/plugin packages that historically rode along in
+  # test-build and run nowhere else. Only needed when test-build is skipped
+  # (bot-only PRs); on mixed PRs test-build's repo-wide prettier/lint/tsc/
+  # test:ci already covers all of this. Deliberately NOT re-running what the
+  # path-triggered plugin workflows (hermes-ci/openclaw-ci) already run on the
+  # same PR: openclaw unit/security tests and tlon-bot-e2e tsc + unit tests.
+  bot-checks:
+    needs: changes
+    if: needs.changes.outputs.app == 'false' && needs.changes.outputs.bots == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    name: Bot Package Checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+        with:
+          run_install: |
+            - recursive: true
+              args: [--frozen-lockfile]
+
+      - name: Check Prettier (bot packages)
+        run: pnpm prettier --check 'packages/{openclaw,tlon-skill,tlon-bot-e2e}/**/*.{ts,tsx}'
+
+      - name: Lint OpenClaw
+        run: pnpm --filter '@tloncorp/openclaw' lint
+
+      - name: tlon-skill typecheck, tests, and build smoke
+        run: pnpm --filter '@tloncorp/tlon-skill' check
+
+      - name: Run Hermes adapter unit tests
+        run: ./packages/hermes-tlon-adapter/dev/test.sh
 
   # Production-build smoke test. The parallel e2e suite runs against the Vite
   # *dev* server; this boots the minified `vite build` output to catch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,10 @@ jobs:
               - 'packages/tlon-bot-e2e/**'
               - 'packages/tlon-skill/**'
 
-  # The app-wide suite and the repo's required status check. Skipped only when
-  # the filter positively reported app == 'false' (bot-/docs-only PRs); a
-  # skipped run still satisfies the required check. Written `!= 'false'`
-  # rather than `== 'true'` to fail closed: if the changes job errors, its
-  # outputs are empty and a plain `== 'true'` gate would skip this job —
-  # letting the PR merge with no tests run.
+  # The app-wide suite. Skipped only when the filter positively reported
+  # app == 'false' (bot-/docs-only PRs). Written `!= 'false'` rather than
+  # `== 'true'` to fail closed: if the changes job errors, its outputs are
+  # empty and a plain `== 'true'` gate would skip the suite entirely.
   test-build:
     needs: changes
     if: ${{ !cancelled() && needs.changes.outputs.app != 'false' }}
@@ -156,6 +154,30 @@ jobs:
 
       - name: Run Hermes adapter unit tests
         run: ./packages/hermes-tlon-adapter/dev/test.sh
+
+  # Merge gate: the single required status check for this repo ("CI OK" in
+  # branch protection). It aggregates the conditionally-skipped jobs above
+  # into one context that always reports: a skipped need is fine (the filter
+  # said that suite wasn't relevant to the diff), but any failure or
+  # cancellation — including the changes job itself erroring — fails the
+  # gate. `always()` (not `!cancelled()`) so a cancelled run reports a
+  # failure instead of a skip, which would satisfy the required check.
+  # When adding a new filter-gated job, append it to `needs` here.
+  ci-ok:
+    name: CI OK
+    needs: [changes, test-build, bot-checks]
+    if: ${{ always() }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Verify gated jobs succeeded or were skipped
+        run: |
+          for result in ${{ join(needs.*.result, ' ') }}; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::A gated job reported '$result'"
+              exit 1
+            fi
+          done
+          echo "All gated jobs succeeded or were skipped."
 
   # Production-build smoke test. The parallel e2e suite runs against the Vite
   # *dev* server; this boots the minified `vite build` output to catch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,21 @@ jobs:
   changes:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
-      app: ${{ steps.filter.outputs.app }}
+      app: ${{ steps.filter-app.outputs.app }}
       backend: ${{ steps.filter.outputs.backend }}
       bots: ${{ steps.filter.outputs.bots }}
     steps:
-      - name: Filter changed paths
+      # An ignore-list filter only works with predicate-quantifier `every`:
+      # a file counts only if it matches every pattern — `**` AND each `!`
+      # exclusion. Under the default `some`, `**` matches everything and the
+      # exclusions are dead letters (the pre-#6128 gating had this bug).
+      # The quantifier is step-wide and `every` would break the positive
+      # OR-lists below, so `app` gets its own step.
+      - name: Filter changed paths (app ignore-list)
         uses: dorny/paths-filter@v3
-        id: filter
+        id: filter-app
         with:
+          predicate-quantifier: 'every'
           filters: |
             app:
               - '**'
@@ -32,6 +39,11 @@ jobs:
               - '!packages/tlon-skill/**'
               - '!docs/**'
               - '!**/*.md'
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
             backend:
               - 'desk/**'
               - 'backend/**'
@@ -41,12 +53,15 @@ jobs:
               - 'packages/tlon-bot-e2e/**'
               - 'packages/tlon-skill/**'
 
-  # The app-wide suite. Skipped when a PR only touches the bot/plugin packages
-  # or docs; a skipped run still satisfies the `test-build` required status
-  # check (GitHub treats jobs skipped via `if:` as passing).
+  # The app-wide suite and the repo's required status check. Skipped only when
+  # the filter positively reported app == 'false' (bot-/docs-only PRs); a
+  # skipped run still satisfies the required check. Written `!= 'false'`
+  # rather than `== 'true'` to fail closed: if the changes job errors, its
+  # outputs are empty and a plain `== 'true'` gate would skip this job —
+  # letting the PR merge with no tests run.
   test-build:
     needs: changes
-    if: needs.changes.outputs.app == 'true'
+    if: ${{ !cancelled() && needs.changes.outputs.app != 'false' }}
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,13 @@ When writing or modifying bash scripts, ensure compatibility with both macOS and
 -   Test scripts on both macOS and Linux when possible
 -   Use portable command options (e.g., `grep -E` instead of `egrep`)
 
+## Pull Requests
+
+When creating a PR, structure the body with the repo's PR template
+(`.github/pull_request_template.md`): Summary / Changes / How did I test? /
+Risks and impact / Rollback plan / Screenshots. `gh pr create` does not apply
+the template automatically — fill it in explicitly.
+
 ## Pre-PR Cleanup
 
 Before finalizing a PR, do a focused pass on your own diff:


### PR DESCRIPTION
## Summary

PRs confined to the isolated bot/plugin packages (`packages/openclaw`, `packages/hermes-tlon-adapter`, `packages/tlon-bot-e2e`, `packages/tlon-skill`) still ran the full app `test-build` job — ~20+ min of repo-wide prettier/lint/`pnpm -r tsc`/`test:ci`/`build:all`. This gates `test-build` on the existing `changes.app` filter and adds a lightweight `bot-checks` job so no coverage is lost.

## Changes

- **Fix the pre-existing `app` filter, which never actually evaluated false** (caught by Codex review): `dorny/paths-filter` defaults `predicate-quantifier` to `some`, so the leading `'**'` matched every file and the `!` exclusions were dead letters — bot-only PRs were already running `smoke-test`/`e2e-parallel` despite the gating (confirmed on #6026's run). The `app` ignore-list now lives in its own filter step with `predicate-quantifier: every`; the positive OR-lists (`backend`, `bots`) stay in a second step with the default quantifier, which `every` would break.
- Gate `test-build` on the `changes.app` output, **fail-closed**: the condition is `!cancelled() && app != 'false'`, so if the `changes` job itself errors (empty outputs), the suite runs instead of skipping the repo's only required check (also caught by Codex). A run skipped via `if:` still reports and satisfies the required status check (unlike a workflow-level `paths:` filter, which would leave it pending forever).
- Add a `bot-checks` job (new `bots` filter; runs only when `test-build` is skipped) covering the checks that previously ran **nowhere but** `test-build`:
  - hermes adapter python unit tests (585 tests — these only ran via root `test:ci` → `pnpm run -r test`)
  - tlon-skill typecheck + tests + build smoke (`pnpm --filter '@tloncorp/tlon-skill' check`)
  - openclaw eslint
  - prettier over the bot TS packages
- Deliberately **not** re-running what the path-triggered `hermes-ci`/`openclaw-ci` workflows already run on the same PR: openclaw unit/security tests, tlon-bot-e2e tsc + unit tests.
- Add a **`ci-ok` merge-gate job** ("CI OK", also from Codex review): always reports, passes when every gated job (`changes`, `test-build`, `bot-checks`) succeeded or was filter-skipped, fails on any failure or cancellation. This becomes the repo's single required status check, so a red `bot-checks` actually blocks bot-only PRs; future filter-gated jobs just get appended to its `needs`.
- Add a "Pull Requests" section to `CLAUDE.md` instructing Claude Code to follow `.github/pull_request_template.md` when creating PRs.

### What runs when (PR CI after this change)

✓ = runs, — = skipped. The tiny `changes` filter job and the `CI OK` merge gate (~10s each) always run; `CI OK` is the (to-be-)required check and fails if any gated job failed.

| PR touches only… | test-build (required) | bot-checks | smoke-test | e2e-parallel | backend-test | hermes-ci | openclaw-ci |
|---|---|---|---|---|---|---|---|
| App code (apps/, packages/shared, ui, app, editor, …) | ✓ | — | ✓ | ✓ | — | — | — |
| `packages/api` or `pnpm-lock.yaml` | ✓ | — | ✓ | ✓ | — | ✓ | ✓ |
| `desk/` or `backend/` (Hoon) | ✓ | — | ✓ | ✓ | ✓ | — | — |
| `packages/hermes-tlon-adapter` | — | ✓ | — | — | — | ✓ | — |
| `packages/openclaw` | — | ✓ | — | — | — | — | ✓ |
| `packages/tlon-skill` | — | ✓ | — | — | — | ✓ | ✓ |
| `packages/tlon-bot-e2e` | — | ✓ | — | — | — | ✓ | ✓ |
| `docs/` or `**/*.md` | — | — | — | — | — | — | — |

Mixed PRs compose: any app-side file flips `test-build`/`smoke-test`/`e2e-parallel` back on and turns `bot-checks` off (test-build's repo-wide `-r` scripts cover the bot packages in that case).

## How did I test?

- **Live end-to-end verification** via throwaway draft PR #6129 (hermes-only change, based against this branch so it ran the fixed workflow): `test-build`/`smoke-test`/`e2e-parallel`/`backend-test` all skipped, `Bot Package Checks` ran and passed — [run](https://github.com/tloncorp/tlon-apps/actions/runs/29287695586). This PR's own run shows the other direction: it touches `ci.yml` (not ignore-listed) → `app=true` → full suite runs, `bot-checks` skipped.
- Simulated the `predicate-quantifier: every` semantics locally with picomatch across representative paths (bot files → `app=false`, app/desk/workflow files → `app=true`)
- Ran the new `bot-checks` steps locally: `./packages/hermes-tlon-adapter/dev/test.sh` (585 tests OK), `pnpm --filter '@tloncorp/openclaw' lint` (0 errors), scoped prettier check (clean)
- `js-yaml` parse of the workflow passes

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [x] Other: CI workflows only — no app/runtime code touched
- **Branch-protection follow-up (must happen right after merge)**: swap the required status check on `develop` from `test-build` to `CI OK`. Doing it before merge would block every open PR on a context that doesn't exist on develop yet; until it's done, a bot-only PR satisfies the skipped `test-build` and a red `bot-checks` can't block merge.

## Rollback plan

Revert the commit. No state, migrations, or deployed artifacts involved; branch protection is unchanged by this PR.

## Screenshots / videos

N/A

TLON-6154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
