### PR TITLE
backend: %grouper enable from group Lure Pioneer thread 

### DIFF
--- a/desk/ted/pioneer/create-group-lure-invite.hoon
+++ b/desk/ted/pioneer/create-group-lure-invite.hoon
@@ -42,6 +42,8 @@
 =/  =metadata:v1:reel  [%groups-0 fields]
 =/  =wire  /group-lure-invite/(scot %da now.bowl)
 ;<  ~  bind:m
+  (poke:io [our.bowl %grouper] grouper-enable+!>(q.flag))
+;<  ~  bind:m
   ::NOTE  deranged path construction because reel does the same...
   (watch:io wire [our.bowl %reel] (stab (cat 3 '/v1/id-link/' flag-str)))
 ;<  ~  bind:m


### PR DESCRIPTION
## Summary

OTT

Ensure new Lures we create always get grouper enabled from the Pioneer desk thread. For use with provisioning accounts from Hosting.