### PR TITLE
ci: put openclaw and tlon-bot-e2e unit coverage behind the merge gate (TLON-6154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,15 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=6144
 
-  # Checks for the bot/plugin packages that historically rode along in
-  # test-build and run nowhere else. Only needed when test-build is skipped
-  # (bot-only PRs); on mixed PRs test-build's repo-wide prettier/lint/tsc/
-  # test:ci already covers all of this. Deliberately NOT re-running what the
-  # path-triggered plugin workflows (hermes-ci/openclaw-ci) already run on the
-  # same PR: openclaw unit/security tests and tlon-bot-e2e tsc + unit tests.
+  # Unit-level checks for the bot/plugin packages, mirroring what test-build's
+  # repo-wide prettier/lint/tsc/test:ci ran for them before gating. Only
+  # needed when test-build is skipped (bot-only PRs); on mixed PRs test-build
+  # covers all of this. The openclaw and tlon-bot-e2e unit steps duplicate
+  # jobs in the path-triggered hermes-ci/openclaw-ci workflows, on purpose:
+  # those workflows can't be required status checks (a paths-filtered workflow
+  # never reports on unrelated PRs, wedging a required context), so this job
+  # is what puts that coverage behind the CI OK merge gate. Their heavyweight
+  # shared-E2E suites stay in the plugin workflows only, non-blocking.
   bot-checks:
     needs: changes
     if: needs.changes.outputs.app == 'false' && needs.changes.outputs.bots == 'true'
@@ -148,6 +151,14 @@ jobs:
 
       - name: Lint OpenClaw
         run: pnpm --filter '@tloncorp/openclaw' lint
+
+      - name: Run OpenClaw unit and security tests
+        run: pnpm --filter '@tloncorp/openclaw' test
+
+      - name: tlon-bot-e2e typecheck and unit tests
+        run: |
+          pnpm --filter '@tloncorp/tlon-bot-e2e' tsc
+          pnpm --filter '@tloncorp/tlon-bot-e2e' test:unit
 
       - name: tlon-skill typecheck, tests, and build smoke
         run: pnpm --filter '@tloncorp/tlon-skill' check


### PR DESCRIPTION
## Summary

Follow-up to #6128, addressing a Codex finding that landed after merge: put the openclaw and tlon-bot-e2e unit-level test coverage behind the `CI OK` merge gate, restoring exactly what the required `test-build` covered for those packages before gating.

## Changes

- `bot-checks` now also runs `pnpm --filter '@tloncorp/openclaw' test` (vitest over `src/`, includes the security tests) and tlon-bot-e2e `tsc` + unit tests.
- This deliberately duplicates the unit jobs in the path-triggered `hermes-ci`/`openclaw-ci` workflows: those workflows can never be required status checks (a paths-filtered workflow doesn't report on unrelated PRs, which would wedge a required context), so `bot-checks` is the only way to put that coverage behind the gate. Their heavyweight shared-E2E suites stay in the plugin workflows only, non-blocking — as they've always been.
- Updated the `bot-checks` header comment to explain the duplication rationale.

## How did I test?

- Ran the added steps locally: openclaw vitest (823 tests passed), tlon-bot-e2e `tsc` (clean) and unit tests (passed).
- This PR touches only `ci.yml` → `app=true`, so the full suite runs here; the new steps execute on the next bot-only PR.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [x] Other: CI workflow only — adds ~2–3 min to bot-only PR runs

## Rollback plan

Revert the commit; no state or deployed artifacts involved.

## Screenshots / videos

N/A

TLON-6154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
