### PR TITLE
fix(android): restore notification tap routing under expo-notifications 56

### DIFF
--- a/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
+++ b/apps/tlon-mobile/android/app/src/main/java/io/tlon/landscape/notifications/NotificationManager.kt
@@ -86,6 +86,12 @@ object NotificationMessagesCache {
 
 private const val NOTIFICATION_MANAGER = "NotificationManager"
 
+// FCM stamps this key on notification intents. expo-notifications (SDK 56+)
+// only surfaces a tap to JS when the launch intent carries it
+// (ExpoNotificationLifecycleListener.isFCMIntent); our notifications are
+// posted natively, so we must stamp it on the tap intent ourselves.
+private const val FCM_MESSAGE_ID_KEY = "google.message_id"
+
 private fun getNotificationId(identifier: String): Int {
     return if (identifier.startsWith("0v")) {
         try {
@@ -280,6 +286,10 @@ fun NotificationCompat.Builder.buildMessagingTappable(context: Context, id: Int,
     val tapIntent = Intent(context, MainActivity::class.java)
     tapIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
     tapIntent.replaceExtras(extras)
+    if (!extras.containsKey(FCM_MESSAGE_ID_KEY)) {
+        val messageId = extras.getString("uid") ?: extras.getString("id") ?: id.toString()
+        tapIntent.putExtra(FCM_MESSAGE_ID_KEY, messageId)
+    }
     val tapPendingIntent =  PendingIntent.getActivity(
         context,
         id,


### PR DESCRIPTION
## Summary

Fixes [TLON-6152](https://linear.app/tlon/issue/TLON-6152): since the Expo SDK 54 → 56 upgrade shipped in the Friday Android release, tapping a push notification opened the app on the chat list instead of routing to the tapped channel.

## Changes

expo-notifications 56 added an `isFCMIntent` guard to `ExpoNotificationLifecycleListener` ([source](https://github.com/expo/expo/blob/main/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.kt)): a launch intent is only converted into a notification response for JS if its extras contain `google.message_id` (added upstream to ignore junk OEM intents, e.g. Samsung's `anim_not_finish`). On SDK 54 there was no such guard — any launch intent with extras produced a response.

Our Android notifications are posted natively (`NotificationManager.kt`) with custom tap intents carrying `uid` / `activityEventJsonString` extras but no `google.message_id`, so every tap was silently dropped before reaching `useNotificationListener`.

The fix stamps `google.message_id` (using the notification `uid`) onto the tap intent in `buildMessagingTappable`, which covers all three notification paths (rich, generic, fallback) and both the cold-start (`onCreate`) and backgrounded (`onNewIntent`) tap paths. The key is added only to the tap intent, not to notifications posted at large, so the upstream guard keeps rejecting spurious OEM intents.

## How did I test?

- Traced the regression to the exact upstream guard by diffing expo-notifications 0.32.16 (SDK 54) against 56.0.18 and confirmed the serializer (`toResponseBundleFromExtras`) delivers the intent extras as `request.content.data`, which is exactly what `useNotificationListener` / `pickPlatformPayload` read on Android.
- Not yet exercised on a device/emulator — needs a manual check that tapping a DM / channel / group notification routes correctly on Android from both killed and backgrounded states.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [x] Notifications
  - [ ] Other:

## Rollback plan

Revert the commit; the change is a self-contained 10-line addition to the native notification builder.

## Screenshots / videos

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)