### PR TITLE
ButtonV2: fix labels wrapping on Android

### DIFF
--- a/packages/ui/src/components/ButtonV2.tsx
+++ b/packages/ui/src/components/ButtonV2.tsx
@@ -320,6 +320,7 @@ const ButtonText = styled(Text, {
   context: ButtonContext,
   userSelect: 'none',
   color: '$secondaryText',
+  numberOfLines: 1,
   trimmed: false,
   style: {
     WebkitFontSmoothing: 'antialiased',


### PR DESCRIPTION
## Summary

Prevent button labels from wrapping onto a clipped second line on Android. Fixes TLON-6033 and fixes TLON-6032

## Changes

- Set `numberOfLines: 1` on the shared `ButtonText` component.
- Apply the constraint to both standard `Button` labels and custom `Button.Frame` / `Button.Text` compositions, including the channel permissions and profile actions.

## How did I test?

- `pnpm --filter '@tloncorp/ui' tsc`
- `pnpm --filter '@tloncorp/ui' exec eslint src/components/ButtonV2.tsx`
- `pnpm --filter '@tloncorp/app' tsc`
- `pnpm --filter '@tloncorp/app' test --run` — 269 passed, 3 skipped
- `pnpm --filter '@tloncorp/ui' test --run` — package has no test files

No Android device was connected for visual verification.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: shared button label rendering

The shared constraint intentionally keeps button labels to one line. Labels that exceed their available width will use the native single-line overflow behavior instead of increasing button height.

## Rollback plan

Revert commit `ffdec4a31`.

## Screenshots / videos

See the Android screenshots attached to TLON-6033 and TLON-6032.