### PR TITLE
openclaw: prevent false bot-offline reports in 6.11+

### DIFF
--- a/packages/openclaw/dev/Dockerfile.test
+++ b/packages/openclaw/dev/Dockerfile.test
@@ -3,8 +3,16 @@ FROM node:22-bookworm-slim
 RUN apt-get update && apt-get install -y git curl jq && rm -rf /var/lib/apt/lists/*
 RUN npm install -g pnpm@11.9.0
 
-# Install OpenClaw globally (pinned to avoid dependency bugs in latest)
-RUN npm install -g openclaw@2026.5.28
+# Install OpenClaw globally. The default remains the package's development pin,
+# while the focused gateway-status lane selects affected cores by build arg.
+# Keep this default in lockstep with DEFAULT_CORE_VERSION in
+# test/cases/08-gateway-status.test.ts (08 asserts installed == requested).
+# Bumping both to 2026.6.11/2026.7.1 promotes 08 from a smoke test to the full
+# prewarm regression guard on the existing shared E2E lane — no matrix lane needed.
+ARG OPENCLAW_CORE_VERSION=2026.5.28
+RUN npm install -g "openclaw@${OPENCLAW_CORE_VERSION}"
+ENV OPENCLAW_CORE_VERSION=${OPENCLAW_CORE_VERSION}
+RUN echo "[tlon-e2e-build] openclaw-core-version=${OPENCLAW_CORE_VERSION}"
 
 # Install the Brave web-search plugin at build time. openclaw@2026.5.28
 # rejects tools.web.search.provider "brave" (set by entrypoint.test.sh when

--- a/packages/openclaw/dev/docker-compose.test.yml
+++ b/packages/openclaw/dev/docker-compose.test.yml
@@ -12,14 +12,79 @@ services:
 
   # Both fakezod ships in one container (they need shared fake ames)
   ships:
-    image: ubuntu:22.04
+    # Node's Debian image supplies a glibc runtime, tar/gzip, and an HTTPS
+    # client without an apt-get at container startup. Avoiding Ubuntu's HTTP
+    # package mirror keeps ship boot independent of ports.ubuntu.com.
+    image: node:22-bookworm-slim
     command:
       - bash
       - -c
       - |
         set -e
-        apt-get update && apt-get install -y curl xz-utils
         cd /data
+
+        download() {
+          node - "$$1" "$$2" "$$3" "$$4" "$$5" <<'NODE'
+        const crypto = require('node:crypto');
+        const fs = require('node:fs');
+        const { Readable } = require('node:stream');
+        const { pipeline } = require('node:stream/promises');
+        const [url, output, digestKind, expectedDigest, expectedSize] =
+          process.argv.slice(2);
+
+        async function verify() {
+          const stat = await fs.promises.stat(output);
+          if (stat.size !== Number(expectedSize)) {
+            throw new Error(
+              `size mismatch: expected $${expectedSize}, got $${stat.size}`
+            );
+          }
+          const hash = crypto.createHash(digestKind);
+          for await (const chunk of fs.createReadStream(output)) {
+            hash.update(chunk);
+          }
+          const actualDigest = hash.digest('hex');
+          if (actualDigest !== expectedDigest) {
+            throw new Error(
+              `$${digestKind} mismatch: expected $${expectedDigest}, got $${actualDigest}`
+            );
+          }
+          console.error(
+            `verified $${output}: $${stat.size} bytes, $${digestKind}=$${actualDigest}`
+          );
+        }
+
+        (async () => {
+          let lastError;
+          for (let attempt = 1; attempt <= 3; attempt += 1) {
+            try {
+              const response = await fetch(url, {
+                redirect: 'follow',
+                signal: AbortSignal.timeout(300_000),
+              });
+              if (!response.ok || !response.body) {
+                throw new Error(`HTTP $${response.status}`);
+              }
+              await pipeline(
+                Readable.fromWeb(response.body),
+                fs.createWriteStream(output)
+              );
+              await verify();
+              return;
+            } catch (error) {
+              lastError = error;
+              fs.rmSync(output, { force: true });
+              console.error(`download attempt $${attempt} failed: $${error}`);
+              await new Promise((resolve) => setTimeout(resolve, 2_000));
+            }
+          }
+          throw lastError;
+        })().catch((error) => {
+          console.error(error);
+          process.exit(1);
+        });
+        NODE
+        }
 
         # Pin both halves of the runtime/snapshot pair so the version skew that
         # crashed serf replay (stale snapshot -> downgrade runtime to replay ->
@@ -29,25 +94,26 @@ services:
         echo "==> vere pin: vere-v4.5  pier gen: 27"
 
         echo "==> Downloading zod..."
-        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-zod27.tgz -o rube-zod27.tgz || { echo "Failed to download zod"; exit 1; }
+        download https://bootstrap.urbit.org/rube-zod27.tgz rube-zod27.tgz md5 6e3f322f441fcd942590470b10b7cea5 283602626 || { echo "Failed to download zod"; exit 1; }
         ls -la rube-zod27.tgz
         echo "==> Extracting zod..."
         tar xzf rube-zod27.tgz || { echo "Failed to extract zod"; exit 1; }
 
         echo "==> Downloading ten..."
-        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-ten27.tgz -o rube-ten27.tgz || { echo "Failed to download ten"; exit 1; }
+        download https://bootstrap.urbit.org/rube-ten27.tgz rube-ten27.tgz md5 b3ec907c2a851cff05a4676806836ded 283381725 || { echo "Failed to download ten"; exit 1; }
         ls -la rube-ten27.tgz
         echo "==> Extracting ten..."
         tar xzf rube-ten27.tgz || { echo "Failed to extract ten"; exit 1; }
 
         echo "==> Downloading mug..."
-        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://bootstrap.urbit.org/rube-mug27.tgz -o rube-mug27.tgz || { echo "Failed to download mug"; exit 1; }
+        download https://bootstrap.urbit.org/rube-mug27.tgz rube-mug27.tgz md5 b378f62ec7a95a243d5d88976193ad1a 284181858 || { echo "Failed to download mug"; exit 1; }
         ls -la rube-mug27.tgz
         echo "==> Extracting mug..."
         tar xzf rube-mug27.tgz || { echo "Failed to extract mug"; exit 1; }
 
         echo "==> Downloading vere..."
-        curl -fSL --retry 3 --retry-delay 2 --retry-all-errors https://github.com/urbit/vere/releases/download/vere-v4.5/linux-x86_64.tgz | tar xz || { echo "Failed to download vere"; exit 1; }
+        download https://github.com/urbit/vere/releases/download/vere-v4.5/linux-x86_64.tgz vere.tgz sha256 bf7a30aad0a820bf217f3f81239b1029d16f11ba5274d45067d811489f817eed 9728849 || { echo "Failed to download vere"; exit 1; }
+        tar xzf vere.tgz || { echo "Failed to extract vere"; exit 1; }
         VERE=$$(ls -1 vere-*-linux-x86_64 | head -1)
         chmod +x $$VERE
         echo "==> Using vere: $$VERE"
@@ -68,7 +134,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.test
+      args:
+        OPENCLAW_CORE_VERSION: ${OPENCLAW_CORE_VERSION:-2026.5.28}
     environment:
+      - OPENCLAW_CORE_VERSION=${OPENCLAW_CORE_VERSION:-2026.5.28}
       - TLON_URL=${TLON_URL:-http://ships:8080}
       - TLON_SHIP=${TLON_SHIP:-~zod}
       - TLON_CODE=${TLON_CODE:-lidlut-tabwed-pillex-ridrup}

--- a/packages/openclaw/dev/entrypoint.test.sh
+++ b/packages/openclaw/dev/entrypoint.test.sh
@@ -16,6 +16,14 @@ echo "==> OPENCLAW_STATE_DIR=$OPENCLAW_STATE_DIR"
 echo "==> User: $(whoami)"
 echo "==> Working directory: $(pwd)"
 
+requested_core_version="${OPENCLAW_CORE_VERSION:-2026.5.28}"
+installed_core_version="$(node -e 'const fs=require("node:fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version)' "$(npm root -g)/openclaw/package.json")"
+if [ "$installed_core_version" != "$requested_core_version" ]; then
+  echo "FATAL: requested OpenClaw core $requested_core_version but installed $installed_core_version"
+  exit 1
+fi
+echo "[tlon-e2e] openclaw-core-version=$installed_core_version requested=$requested_core_version"
+
 # The mounted package declares workspace:^ deps that only resolve inside the
 # tlon-apps pnpm workspace. Copy it to a container-local dir (also the
 # id-shaped path OpenClaw's path hint expects) and rewrite those deps to

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -31,11 +31,7 @@ import {
   installTlonDiagnosticSubscriptions,
   shouldInstallTlonDiagnosticSubscriptions,
 } from './src/diagnostic-subscriptions.js';
-import { sendGatewayStop } from './src/gateway-status.js';
-import {
-  createGatewayStatusManager,
-  setGatewayStatusManager,
-} from './src/gateway-status.js';
+import { registerGatewayStatusHooks } from './src/gateway-status-registration.js';
 import { resolveBridgeForCommand } from './src/monitor/command-auth.js';
 import { isRouteDebugEnabled } from './src/monitor/session-routing.js';
 import { handleOwnerListenCommand } from './src/owner-listen-command.js';
@@ -51,7 +47,6 @@ import {
   reportHarnessDebug,
   reportHarnessError,
   reportOutboundRoute,
-  reportPluginError,
   reportSessionDiagnostic,
   reportSessionLifecycle,
   reportSessionTurnCreated,
@@ -73,7 +68,7 @@ import {
   liveToolTraceContentsEnabled,
   shouldLogAfterToolTrace,
 } from './src/tool-trace.js';
-import { listTlonAccountIds, resolveTlonAccount } from './src/types.js';
+import { resolveTlonAccount } from './src/types.js';
 import {
   formatTlonVersionIdentity,
   resolveTlonSkillVersion,
@@ -942,87 +937,28 @@ export default defineChannelPluginEntry({
   registerFull(api) {
     // ── Gateway-status liveness integration ───────────────────
     //
-    // v1 requires exactly one Tlon account. With multiple accounts, multiple
-    // monitors call configureTlonApiWithPoke() and the last one wins the
-    // global @tloncorp/api singleton — making it unsafe to route heartbeats or
-    // stop pokes to a specific ship. Disable entirely rather than route to the
-    // wrong ship.
+    // registerFull is NOT a once-per-process call: OpenClaw invokes it once
+    // per load pass — tool discovery, full channel activation, and (on
+    // 6.11+) a ~10s post-startup runtime-plugin prewarm that re-runs it
+    // into a SEPARATE plugin registry. `gateway_start`/`gateway_stop` are
+    // fire-once, non-latched hooks bound against whichever registry is
+    // active when they fire, so nulling-and-recreating the coordinator here
+    // on every pass (the old behavior) could orphan an already-resolved
+    // coordinator behind a never-resolved replacement.
     //
-    // We count ALL configured account entries (not just currently-runnable
-    // ones) on purpose. The manager is a process-lifetime singleton created
-    // here in registerFull, which does NOT re-run on config reload. If we
-    // counted only runnable accounts, a config of one complete account plus a
-    // disabled/unconfigured stub would enable the singleton, and later
-    // completing the stub would start a second monitor that races the shared
-    // API slot — without registerFull re-evaluating the gate. Counting every
-    // entry keeps the feature off whenever a second account exists at all.
-    const gsAccountIds = listTlonAccountIds(api.config);
-    setGatewayStatusManager(null);
-
-    if (gsAccountIds.length > 1) {
-      api.logger.warn(
-        `[gateway-status] disabled: ${gsAccountIds.length} Tlon accounts configured, ` +
-          `but v1 only supports one (global @tloncorp/api client cannot target multiple ships)`
-      );
-    } else if (gsAccountIds.length === 1) {
-      const gsManager = createGatewayStatusManager({
-        logger: {
-          log: (m) => api.logger.info(m),
-          error: (m) => {
-            reportPluginError({
-              pluginErrorSource: 'gateway_status_heartbeat',
-              errorKind: 'heartbeat',
-              errorText: m,
-            });
-            api.logger.warn(m);
-          },
-        },
-      });
-      setGatewayStatusManager(gsManager);
-
-      api.on('gateway_start', () => {
-        gsManager.signalGatewayStarted();
-        api.logger.info('[gateway-status] gateway_start received');
-      });
-
-      api.on('gateway_stop', async (event) => {
-        if (gsManager.stopped) {
-          return;
-        }
-        // Latch stopped FIRST, unconditionally. An activation task may be
-        // in flight (between the %gateway-start poke and markActivated());
-        // latching here makes its post-poke recheck bail so it can't start a
-        // heartbeat after we've already passed the shutdown hook.
-        const startPokeInFlightOrDone =
-          gsManager.activated || gsManager.starting;
-        gsManager.stopHeartbeat();
-        gsManager.markStopped();
-        // Only send %gateway-stop if a %gateway-start has been or is being
-        // sent. If activation never reached the start poke, there is nothing
-        // for the ship to stop.
-        if (!startPokeInFlightOrDone) {
-          return;
-        }
-        try {
-          const sent = await sendGatewayStop({
-            bootId: gsManager.bootId,
-            reason: event.reason ?? 'shutdown',
-          });
-          if (sent) {
-            api.logger.info(
-              `[gateway-status] stopped (reason=${event.reason ?? 'shutdown'})`
-            );
-          } else {
-            api.logger.warn(
-              '[gateway-status] stop skipped: api-client params not published'
-            );
-          }
-        } catch (err) {
-          api.logger.warn(`[gateway-status] stop poke failed: ${String(err)}`);
-        }
-      });
-    }
-    // else: zero accounts configured — nothing to do
+    // registerGatewayStatusHooks() is idempotent across passes: it
+    // get-or-creates a single process-lifetime coordinator (independent of
+    // Tlon account count — see gateway-status.ts) and (re)binds the hooks
+    // onto the CURRENT pass's `api` every time. Per-monitor eligibility
+    // (exactly one Tlon account) is evaluated in the monitor itself, from
+    // its own config snapshot, so an account added/removed via a
+    // channels.tlon hot-reload takes effect without a second registerFull.
+    registerGatewayStatusHooks(api, {
+      logger: {
+        log: (m) => api.logger.info(m),
+        error: (m) => api.logger.warn(m),
+      },
+    });
 
     // Resolve the tlon tool binary once. The tool itself and version
     // diagnostics share this path so telemetry reports what OpenClaw will

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.4.0",
+    "@urbit/nockjs": "^1.6.0",
     "dotenv": "^17.2.4",
     "openclaw": "2026.5.28",
     "typescript": "^5.7.0",

--- a/packages/openclaw/src/channel.runtime.ts
+++ b/packages/openclaw/src/channel.runtime.ts
@@ -379,6 +379,7 @@ export async function startTlonGatewayAccount(
     runtime: ctx.runtime,
     abortSignal: ctx.abortSignal,
     accountId: account.accountId,
+    cfg: ctx.cfg,
   });
 }
 

--- a/packages/openclaw/src/gateway-status-registration.test.ts
+++ b/packages/openclaw/src/gateway-status-registration.test.ts
@@ -1,0 +1,237 @@
+import {
+  configureGatewayStatus,
+  gatewayHeartbeat,
+  gatewayStart,
+  gatewayStop,
+} from '@tloncorp/api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerGatewayStatusHooks } from './gateway-status-registration.js';
+import {
+  API_CLIENT_PARAMS_SLOT,
+  type SharedApiClientParams,
+  getGatewayStatusCoordinator,
+  setGatewayStatusCoordinator,
+} from './gateway-status.js';
+import { sharedSlot } from './shared-state.js';
+
+vi.mock('@tloncorp/api', () => ({
+  configureGatewayStatus: vi.fn().mockResolvedValue(undefined),
+  gatewayStart: vi.fn().mockResolvedValue(undefined),
+  gatewayHeartbeat: vi.fn().mockResolvedValue(undefined),
+  gatewayStop: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./urbit/api-client.js', () => ({
+  configureTlonApiWithPoke: vi.fn(),
+}));
+
+const stubApiClientParams: SharedApiClientParams = {
+  poke: vi.fn().mockResolvedValue(undefined),
+  shipName: 'test-bot',
+  shipUrl: 'http://localhost:8080',
+};
+
+/** A promise the test can settle on its own schedule. */
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** Flush a bounded number of microtasks so a would-be-pending promise proves itself pending. */
+async function flushMicrotasks(times = 20): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+/**
+ * A minimal fake plugin `api` — just enough of `OpenClawPluginApi` for
+ * `registerGatewayStatusHooks` (only `.on(...)`). Each instance models one
+ * `registerFull` pass's own hook registry: handlers registered on it are
+ * separate from handlers registered on any other instance, mirroring how
+ * OpenClaw builds a fresh `api`/registry per load pass.
+ */
+function createFakeHookApi() {
+  // A structural stand-in for the real generic `<K>(hookName: K, handler:
+  // PluginHookHandlerMap[K]) => void` signature can't be typed precisely
+  // without reproducing that whole generic map; `any` is the pragmatic
+  // escape hatch OpenClaw's own SDK types force here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handlers = new Map<string, ((...args: any[]) => unknown)[]>();
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    }),
+    fire: async (event: string, payload: unknown = {}) => {
+      const list = handlers.get(event) ?? [];
+      for (const handler of list) {
+        await handler(payload);
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  // These resolve with the poke response id (a number); the value itself is
+  // never asserted on, only that the call happened.
+  vi.mocked(configureGatewayStatus).mockClear().mockResolvedValue(1);
+  vi.mocked(gatewayStart).mockClear().mockResolvedValue(1);
+  vi.mocked(gatewayHeartbeat).mockClear().mockResolvedValue(1);
+  vi.mocked(gatewayStop).mockClear().mockResolvedValue(1);
+  sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(
+    stubApiClientParams
+  );
+  setGatewayStatusCoordinator(null);
+});
+
+afterEach(() => {
+  sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
+  setGatewayStatusCoordinator(null);
+});
+
+describe('registerGatewayStatusHooks', () => {
+  it('creates the coordinator on the first call and reuses it on later calls', () => {
+    const api1 = createFakeHookApi();
+    const c1 = registerGatewayStatusHooks(api1, {
+      logger: {},
+    });
+    expect(getGatewayStatusCoordinator()).toBe(c1);
+
+    const api2 = createFakeHookApi();
+    const c2 = registerGatewayStatusHooks(api2, {
+      logger: {},
+    });
+    expect(c2).toBe(c1);
+    expect(getGatewayStatusCoordinator()).toBe(c1);
+  });
+
+  it('rebinds gateway_start/gateway_stop on every pass', () => {
+    const api1 = createFakeHookApi();
+    registerGatewayStatusHooks(api1, { logger: {} });
+    const api2 = createFakeHookApi();
+    registerGatewayStatusHooks(api2, { logger: {} });
+
+    expect(api1.on).toHaveBeenCalledWith('gateway_start', expect.any(Function));
+    expect(api1.on).toHaveBeenCalledWith('gateway_stop', expect.any(Function));
+    expect(api2.on).toHaveBeenCalledWith('gateway_start', expect.any(Function));
+    expect(api2.on).toHaveBeenCalledWith('gateway_stop', expect.any(Function));
+  });
+
+  it('three-registry prewarm regression: discovery creates the coordinator, full reuses it and its gateway_start resolves it, prewarm reuses it without re-firing start, and its gateway_stop closes over the SAME coordinator', async () => {
+    // Pass 1: tool discovery — registerFull(api) with no channel load.
+    const discoveryApi = createFakeHookApi();
+    const discoveryCoordinator = registerGatewayStatusHooks(discoveryApi, {
+      logger: {},
+    });
+
+    // Pass 2: full channel activation — a DIFFERENT api/registry.
+    const fullApi = createFakeHookApi();
+    const fullCoordinator = registerGatewayStatusHooks(fullApi, {
+      logger: {},
+    });
+    expect(fullCoordinator).toBe(discoveryCoordinator);
+
+    // Only the full pass's registry actually receives the gateway_start
+    // emit in real OpenClaw (the runtime registry). Firing it here resolves
+    // the SAME coordinator instance.
+    await fullApi.fire('gateway_start', { port: 80 });
+    expect(fullCoordinator.currentGeneration).toBe(1);
+    const lc = await fullCoordinator.waitForStartedLifecycle();
+    expect(lc.generation).toBe(1);
+
+    // Pass 3: the 6.11/7.1 post-startup runtime-plugin prewarm — ANOTHER
+    // separate api/registry, ~10s later. It must reuse the coordinator
+    // rather than orphaning it behind a fresh, never-resolved one.
+    const prewarmApi = createFakeHookApi();
+    const prewarmCoordinator = registerGatewayStatusHooks(prewarmApi, {
+      logger: {},
+    });
+    expect(prewarmCoordinator).toBe(discoveryCoordinator);
+    // The prewarm pass's registry never receives its own gateway_start
+    // (core only emits it once, against the runtime registry) — generation
+    // stays at 1, already resolved.
+    expect(prewarmCoordinator.currentGeneration).toBe(1);
+
+    // The prewarm pass's gateway_stop hook — bound against prewarmApi's
+    // registry — must still latch and stop the SAME coordinator/generation
+    // that the full pass's gateway_start resolved (not a phantom, still-
+    // pending manager B, which is the pre-fix deadlock).
+    await prewarmApi.fire('gateway_stop', { reason: 'shutdown' });
+    expect(prewarmCoordinator.stopped).toBe(true);
+    expect(discoveryCoordinator.stopped).toBe(true);
+    expect(discoveryCoordinator.currentGeneration).toBe(1);
+    // No %gateway-stop poke, though: activation never reached the start
+    // poke in this test (only the gateway_start hook fired), so there is
+    // nothing for the ship to stop.
+    expect(gatewayStop).not.toHaveBeenCalled();
+  });
+
+  it('duplicate gateway_start across two passes does not create an extra generation', async () => {
+    const api1 = createFakeHookApi();
+    const coordinator = registerGatewayStatusHooks(api1, { logger: {} });
+    await api1.fire('gateway_start', { port: 80 });
+    expect(coordinator.currentGeneration).toBe(1);
+
+    const api2 = createFakeHookApi();
+    registerGatewayStatusHooks(api2, { logger: {} });
+    // A duplicate emit (e.g. a stray re-fire against a later pass) must not
+    // mint generation 2 while generation 1 is still started.
+    await api2.fire('gateway_start', { port: 80 });
+    expect(coordinator.currentGeneration).toBe(1);
+  });
+
+  it('gateway_stop latches the coordinator stopped and sends %gateway-stop when a start was activated', async () => {
+    const api1 = createFakeHookApi();
+    const coordinator = registerGatewayStatusHooks(api1, { logger: {} });
+    await api1.fire('gateway_start', { port: 80 });
+    coordinator.markActivated(coordinator.currentGeneration);
+
+    await api1.fire('gateway_stop', { reason: 'shutdown' });
+    expect(coordinator.stopped).toBe(true);
+    expect(gatewayStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('gateway_stop handler stays pending until the %gateway-stop poke settles, and forwards the reason', async () => {
+    // OpenClaw awaits promises returned from gateway_stop handlers before
+    // tearing down channels; the handler must not resolve until the poke
+    // settles (else shutdown races the poke, leaving steward %up until lease
+    // expiry). The fake api's fire() awaits the handler, so a pending poke
+    // keeps fire() pending too.
+    const pokeSettled = deferred<number>();
+    vi.mocked(gatewayStop).mockReturnValueOnce(pokeSettled.promise);
+
+    const api1 = createFakeHookApi();
+    const coordinator = registerGatewayStatusHooks(api1, { logger: {} });
+    await api1.fire('gateway_start', { port: 80 });
+    coordinator.markActivated(coordinator.currentGeneration);
+
+    let handlerResolved = false;
+    const firePromise = api1
+      .fire('gateway_stop', { reason: 'restart' })
+      .then(() => {
+        handlerResolved = true;
+      });
+
+    await flushMicrotasks();
+    // Poke is in flight → the handler (and thus fire) must still be pending.
+    expect(handlerResolved).toBe(false);
+    expect(gatewayStop).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(gatewayStop).mock.calls[0][0]).toMatchObject({
+      reason: 'restart',
+    });
+
+    pokeSettled.resolve(1);
+    await firePromise;
+    expect(handlerResolved).toBe(true);
+  });
+});

--- a/packages/openclaw/src/gateway-status-registration.ts
+++ b/packages/openclaw/src/gateway-status-registration.ts
@@ -1,0 +1,67 @@
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk/core';
+
+import {
+  type GatewayStatusCoordinator,
+  type GatewayStatusCoordinatorLogger,
+  createGatewayStatusCoordinator,
+  getGatewayStatusCoordinator,
+  setGatewayStatusCoordinator,
+} from './gateway-status.js';
+
+// registerFull is NOT a once-per-process call: OpenClaw invokes it once per
+// load pass (tool discovery, full channel activation, and — on 6.11+ —
+// a ~10s post-startup runtime-plugin prewarm that re-runs it into a
+// separate plugin registry). `gateway_start`/`gateway_stop` are fire-once,
+// non-latched hooks bound against whichever registry is active when they
+// fire, so a listener registered into a stale or replaced registry is
+// simply never invoked.
+//
+// This helper is therefore built to be called on EVERY registerFull pass:
+// it gets-or-creates the process-lifetime coordinator (via the shared-state
+// slot in gateway-status.ts, which survives plugin module isolation) and
+// (re)binds the hooks onto the CURRENT pass's `api`. Reusing the same
+// coordinator instance across passes — instead of nulling and recreating it
+// — is what lets a gateway_start that fires against a later pass's registry
+// still resolve the same lifecycle a monitor is waiting on.
+
+export interface RegisterGatewayStatusHooksOptions {
+  logger: GatewayStatusCoordinatorLogger;
+}
+
+/**
+ * Idempotently wires up the process-lifetime gateway-status coordinator
+ * against `api`. Safe to call on every `registerFull` pass — see module
+ * doc comment above.
+ */
+export function registerGatewayStatusHooks(
+  api: Pick<OpenClawPluginApi, 'on'>,
+  regOpts: RegisterGatewayStatusHooksOptions
+): GatewayStatusCoordinator {
+  const coordinator =
+    getGatewayStatusCoordinator() ??
+    (() => {
+      const created = createGatewayStatusCoordinator({
+        logger: regOpts.logger,
+      });
+      setGatewayStatusCoordinator(created);
+      return created;
+    })();
+
+  api.on('gateway_start', () => {
+    const lc = coordinator.beginGeneration();
+    regOpts.logger.log?.(
+      `[gateway-status] gateway_start received (generation=${lc.generation})`
+    );
+  });
+
+  // Return the promise (do NOT `void` it): OpenClaw awaits promises returned
+  // from gateway_stop handlers before tearing down channel monitors, so the
+  // handler must stay pending until the %gateway-stop poke settles.
+  // Discarding it lets shutdown race ahead of the poke, leaving steward %up
+  // until the lease expires (and can drop the restart-notice behavior).
+  api.on('gateway_stop', (event) =>
+    coordinator.markStopped(coordinator.currentGeneration, event.reason)
+  );
+
+  return coordinator;
+}

--- a/packages/openclaw/src/gateway-status.test.ts
+++ b/packages/openclaw/src/gateway-status.test.ts
@@ -1,27 +1,40 @@
-import { gatewayHeartbeat, gatewayStop } from '@tloncorp/api';
+import {
+  configureGatewayStatus,
+  gatewayHeartbeat,
+  gatewayStart,
+  gatewayStop,
+} from '@tloncorp/api';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   API_CLIENT_PARAMS_SLOT,
-  type GatewayStatusManager,
+  GATEWAY_STATUS_START_WATCHDOG_MS,
+  type GatewayStatusCoordinator,
   type SharedApiClientParams,
   computeLeaseUntil,
-  createGatewayStatusManager,
-  getGatewayStatusManager,
+  createGatewayStatusCoordinator,
+  gateGatewayStatusActivation,
+  getGatewayStatusCoordinator,
+  isGatewayStatusEligible,
+  runGatewayStatusActivation,
   sendGatewayStop,
-  setGatewayStatusManager,
+  setGatewayStatusCoordinator,
+  startGatewayHeartbeatLoop,
 } from './gateway-status.js';
 import { sharedSlot } from './shared-state.js';
 import { configureTlonApiWithPoke } from './urbit/api-client.js';
 
 vi.mock('@tloncorp/api', () => ({
+  configureGatewayStatus: vi.fn().mockResolvedValue(undefined),
+  gatewayStart: vi.fn().mockResolvedValue(undefined),
   gatewayHeartbeat: vi.fn().mockResolvedValue(undefined),
   gatewayStop: vi.fn().mockResolvedValue(undefined),
 }));
 
-// The heartbeat now calls configureTlonApiWithPoke each tick to defeat
-// OpenClaw plugin module isolation; in tests we stub it to a no-op so the
-// fake @tloncorp/api singleton stays as the vitest mock above.
+// The heartbeat and sendGatewayStop paths call configureTlonApiWithPoke each
+// time to defeat OpenClaw plugin module isolation; in tests we stub it to a
+// no-op so the fake @tloncorp/api singleton stays as the vitest mock above.
 vi.mock('./urbit/api-client.js', () => ({
   configureTlonApiWithPoke: vi.fn(),
 }));
@@ -32,241 +45,755 @@ const stubApiClientParams: SharedApiClientParams = {
   shipUrl: 'http://localhost:8080',
 };
 
-describe('gateway-status: createGatewayStatusManager', () => {
-  let manager: GatewayStatusManager;
+/** A promise the test can resolve/reject on its own schedule. */
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Await `promise`, but fail fast (in ~ms) if it does not settle. The
+ * dangerous-schedule cases below resolve purely from synchronous coordinator
+ * state transitions the test drives — no real time — so a bounded number of
+ * microtask flushes is enough. Without this, a coordinator regression that
+ * fails to resolve a waiter would hang the test until the 180s suite timeout
+ * instead of failing in milliseconds.
+ */
+async function expectSettled<T>(
+  promise: Promise<T>,
+  label: string,
+  maxMicrotaskFlushes = 200
+): Promise<T> {
+  let settled = false;
+  // Attach a handler so a rejection is observed here too (no unhandled
+  // rejection); the caller still awaits `promise` and sees the outcome.
+  promise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+  for (let i = 0; i < maxMicrotaskFlushes && !settled; i += 1) {
+    await Promise.resolve();
+  }
+  if (!settled) {
+    throw new Error(
+      `${label} did not settle within ${maxMicrotaskFlushes} microtask flushes — likely a coordinator regression`
+    );
+  }
+  return promise;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // These resolve with the poke response id (a number); the value itself is
+  // never asserted on, only that the call happened.
+  vi.mocked(configureGatewayStatus).mockClear().mockResolvedValue(1);
+  vi.mocked(gatewayStart).mockClear().mockResolvedValue(1);
+  vi.mocked(gatewayHeartbeat).mockClear().mockResolvedValue(1);
+  vi.mocked(gatewayStop).mockClear().mockResolvedValue(1);
+  vi.mocked(configureTlonApiWithPoke).mockClear();
+  sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(
+    stubApiClientParams
+  );
+  setGatewayStatusCoordinator(null);
+});
+
+afterEach(() => {
+  sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
+  setGatewayStatusCoordinator(null);
+  vi.useRealTimers();
+});
+
+describe('gateway-status: createGatewayStatusCoordinator — generations', () => {
+  let coordinator: GatewayStatusCoordinator;
 
   beforeEach(() => {
-    vi.useFakeTimers();
-    vi.mocked(gatewayHeartbeat).mockClear();
-    // Publish stub api-client params so the heartbeat's per-tick
-    // configure-then-poke can find data in the shared slot and proceed.
-    sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(
-      stubApiClientParams
-    );
-    manager = createGatewayStatusManager({ logger: undefined });
+    coordinator = createGatewayStatusCoordinator({ logger: undefined });
   });
 
-  afterEach(() => {
-    manager.stopHeartbeat();
-    sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
-    vi.useRealTimers();
+  it('starts idle: generation 0, empty bootId, not stopped', () => {
+    expect(coordinator.currentGeneration).toBe(0);
+    expect(coordinator.bootId).toBe('');
+    expect(coordinator.stopped).toBe(false);
   });
 
-  it('bootId is a valid UUID', () => {
-    expect(manager.bootId).toMatch(
+  it('beginGeneration mints generation 1 with a valid UUID bootId', () => {
+    const lc = coordinator.beginGeneration();
+    expect(lc.generation).toBe(1);
+    expect(lc.bootId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     );
+    expect(coordinator.currentGeneration).toBe(1);
+    expect(coordinator.bootId).toBe(lc.bootId);
   });
 
-  it('each manager gets a unique bootId', () => {
-    const other = createGatewayStatusManager({ logger: undefined });
-    expect(manager.bootId).not.toBe(other.bootId);
+  it('duplicate gateway_start (beginGeneration while already started) is a no-op: no extra generation', () => {
+    const lc1 = coordinator.beginGeneration();
+    const lc2 = coordinator.beginGeneration();
+    expect(lc2).toEqual(lc1);
+    expect(coordinator.currentGeneration).toBe(1);
   });
 
-  describe('gateway_start coordination', () => {
-    it('signalGatewayStarted resolves waitForGatewayStart', async () => {
-      let resolved = false;
-      const p = manager.waitForGatewayStart().then(() => {
-        resolved = true;
-      });
-      expect(resolved).toBe(false);
+  it('beginGeneration after markStopped bumps the generation and mints a fresh bootId', async () => {
+    const lc1 = coordinator.beginGeneration();
+    await coordinator.markStopped(lc1.generation);
+    expect(coordinator.stopped).toBe(true);
 
-      manager.signalGatewayStarted();
-      await p;
-      expect(resolved).toBe(true);
-    });
-
-    it('waitForGatewayStart resolves immediately if already signaled', async () => {
-      manager.signalGatewayStarted();
-
-      let resolved = false;
-      await manager.waitForGatewayStart().then(() => {
-        resolved = true;
-      });
-      expect(resolved).toBe(true);
-    });
+    const lc2 = coordinator.beginGeneration();
+    expect(lc2.generation).toBe(2);
+    expect(lc2.bootId).not.toBe(lc1.bootId);
+    expect(coordinator.stopped).toBe(false);
   });
 
-  describe('heartbeat', () => {
-    it('startHeartbeat is no-op when not activated', () => {
-      manager.startHeartbeat();
-      vi.advanceTimersByTime(60_000);
-      expect(gatewayHeartbeat).not.toHaveBeenCalled();
-    });
+  it('markStarting/markActivated are no-ops for a stale (non-current) generation', () => {
+    const lc1 = coordinator.beginGeneration();
+    coordinator.markStarting(lc1.generation + 1); // a generation that doesn't exist yet
+    coordinator.markActivated(lc1.generation + 1);
+    // No observable state change from the stale calls; confirm via the
+    // markStopped behavior, which only sends %gateway-stop if
+    // starting/activated is true for the CURRENT generation.
+    void coordinator.markStopped(lc1.generation);
+    expect(gatewayStop).not.toHaveBeenCalled();
+  });
 
-    it('startHeartbeat is no-op when stopped', () => {
-      manager.markActivated();
-      manager.markStopped();
-      manager.startHeartbeat();
-      vi.advanceTimersByTime(60_000);
-      expect(gatewayHeartbeat).not.toHaveBeenCalled();
-    });
+  it('markStopped is a no-op (including no poke) if starting/activated was never set', async () => {
+    const lc1 = coordinator.beginGeneration();
+    await coordinator.markStopped(lc1.generation);
+    expect(gatewayStop).not.toHaveBeenCalled();
+  });
 
-    it('sends periodic heartbeats when activated', () => {
-      manager.markActivated();
-      manager.startHeartbeat();
-
-      expect(gatewayHeartbeat).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
-
-      const call = vi.mocked(gatewayHeartbeat).mock.calls[0][0];
-      expect(call.bootId).toBe(manager.bootId);
-      expect(call.leaseUntil).toBeGreaterThan(Date.now());
-
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
-    });
-
-    it('stopHeartbeat clears interval', () => {
-      manager.markActivated();
-      manager.startHeartbeat();
-
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
-
-      manager.stopHeartbeat();
-      vi.advanceTimersByTime(60_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
-    });
-
-    it('stopHeartbeat is idempotent', () => {
-      manager.markActivated();
-      manager.startHeartbeat();
-      manager.stopHeartbeat();
-      manager.stopHeartbeat(); // should not throw
-    });
-
-    it('heartbeat error does not crash', () => {
-      vi.mocked(gatewayHeartbeat).mockRejectedValueOnce(
-        new Error('poke failed')
-      );
-      manager.markActivated();
-      manager.startHeartbeat();
-
-      // First heartbeat fails
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
-
-      // Second heartbeat still fires
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
-    });
-
-    it('startHeartbeat does not create duplicate intervals', () => {
-      manager.markActivated();
-      manager.startHeartbeat();
-      manager.startHeartbeat(); // second call should be no-op
-
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(1); // not 2
-    });
-
-    it('does not renew a late activation that finishes after gateway_stop', () => {
-      // Simulate the bounded stale-online race: a %gateway-start poke was in
-      // flight, gateway_stop latched the manager stopped, then the activation
-      // continuation resumed late. Even if it marks activated and asks for a
-      // heartbeat, stopped must win so any ship-side online state expires at
-      // the original lease instead of being renewed forever.
-      manager.markStarting();
-      manager.stopHeartbeat();
-      manager.markStopped();
-
-      manager.markActivated();
-      manager.startHeartbeat();
-
-      vi.advanceTimersByTime(120_000);
-      expect(gatewayHeartbeat).not.toHaveBeenCalled();
-      expect(manager.stopped).toBe(true);
-      expect(manager.activated).toBe(true);
-    });
-
-    it('skips the heartbeat poke when api-client params are not published', () => {
-      // Clear the params the suite beforeEach published. The per-tick body
-      // must bail before configuring/pokeing when the shared slot is empty.
-      sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
-      manager.markActivated();
-      manager.startHeartbeat();
-
-      vi.advanceTimersByTime(60_000);
-      expect(gatewayHeartbeat).not.toHaveBeenCalled();
-    });
-
-    it('re-activates after stopHeartbeat without markStopped (config-reload survival)', () => {
-      // First monitor incarnation: activate + heartbeat.
-      manager.markActivated();
-      manager.startHeartbeat();
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
-
-      // Monitor teardown stops the heartbeat but must NOT latch the shared
-      // manager stopped — that's the gateway_stop hook's job. A replacement
-      // monitor (config reload) reuses this same process-lifetime manager.
-      manager.stopHeartbeat();
-      expect(manager.stopped).toBe(false);
-
-      // Replacement monitor re-activates; the heartbeat resumes instead of
-      // staying dead until a full gateway restart.
-      manager.startHeartbeat();
-      vi.advanceTimersByTime(30_000);
-      expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
+  it('markStopped sends %gateway-stop when a start was in flight (starting=true)', async () => {
+    const lc1 = coordinator.beginGeneration();
+    coordinator.markStarting(lc1.generation);
+    await coordinator.markStopped(lc1.generation, 'shutdown');
+    expect(gatewayStop).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(gatewayStop).mock.calls[0][0]).toMatchObject({
+      bootId: lc1.bootId,
+      reason: 'shutdown',
     });
   });
 
-  describe('lifecycle flags', () => {
-    it('starting starts false', () => {
-      expect(manager.starting).toBe(false);
-    });
+  it('markStopped sends %gateway-stop when activated=true', async () => {
+    const lc1 = coordinator.beginGeneration();
+    coordinator.markActivated(lc1.generation);
+    await coordinator.markStopped(lc1.generation);
+    expect(gatewayStop).toHaveBeenCalledTimes(1);
+  });
 
-    it('markStarting sets starting', () => {
-      manager.markStarting();
-      expect(manager.starting).toBe(true);
-    });
+  it('markStopped is idempotent: a second call for the same generation does not re-poke', async () => {
+    const lc1 = coordinator.beginGeneration();
+    coordinator.markActivated(lc1.generation);
+    await coordinator.markStopped(lc1.generation);
+    await coordinator.markStopped(lc1.generation);
+    expect(gatewayStop).toHaveBeenCalledTimes(1);
+  });
 
-    it('activated starts false', () => {
-      expect(manager.activated).toBe(false);
-    });
+  it('markStopped for a stale generation number is a no-op', async () => {
+    const lc1 = coordinator.beginGeneration();
+    coordinator.markActivated(lc1.generation);
+    await coordinator.markStopped(lc1.generation);
+    const lc2 = coordinator.beginGeneration();
+    coordinator.markActivated(lc2.generation);
+    vi.mocked(gatewayStop).mockClear();
 
-    it('markActivated sets activated', () => {
-      manager.markActivated();
-      expect(manager.activated).toBe(true);
-    });
-
-    it('stopped starts false', () => {
-      expect(manager.stopped).toBe(false);
-    });
-
-    it('markStopped sets stopped', () => {
-      manager.markStopped();
-      expect(manager.stopped).toBe(true);
-    });
-
-    it('starting is set independently of activated (in-flight start window)', () => {
-      // The gateway_stop hook relies on `starting` to know a %gateway-start
-      // poke is in flight even before markActivated() runs, so it can still
-      // send a matching %gateway-stop during a shutdown that races activation.
-      manager.markStarting();
-      expect(manager.starting).toBe(true);
-      expect(manager.activated).toBe(false);
-    });
+    // A stale/duplicate stop hook firing for the OLD generation must not
+    // touch the new one.
+    await coordinator.markStopped(lc1.generation);
+    expect(gatewayStop).not.toHaveBeenCalled();
+    expect(coordinator.stopped).toBe(false);
   });
 });
 
-describe('gateway-status: module-level accessor', () => {
+describe('gateway-status: waitForStartedLifecycle', () => {
+  let coordinator: GatewayStatusCoordinator;
+
   beforeEach(() => {
-    setGatewayStatusManager(null);
+    coordinator = createGatewayStatusCoordinator({ logger: undefined });
   });
 
+  it('resolves immediately if the current lifecycle is already started and not stopped', async () => {
+    const lc1 = coordinator.beginGeneration();
+    const resolved = await coordinator.waitForStartedLifecycle();
+    expect(resolved).toEqual(lc1);
+  });
+
+  it('wait-before-first-start: resolves only when the first generation starts', async () => {
+    let resolved: { generation: number; bootId: string } | null = null;
+    const p = coordinator.waitForStartedLifecycle().then((lc) => {
+      resolved = lc;
+    });
+    await Promise.resolve();
+    expect(resolved).toBeNull();
+
+    const lc1 = coordinator.beginGeneration();
+    await expectSettled(p, 'wait-before-first-start');
+    expect(resolved).toEqual(lc1);
+  });
+
+  it('replacement after stop(N), before start(N+1): resolves on N+1, not the stale stopped generation', async () => {
+    const lc1 = coordinator.beginGeneration();
+    await coordinator.markStopped(lc1.generation);
+
+    let resolved: { generation: number; bootId: string } | null = null;
+    const p = coordinator.waitForStartedLifecycle().then((lc) => {
+      resolved = lc;
+    });
+    await Promise.resolve();
+    expect(resolved).toBeNull();
+
+    const lc2 = coordinator.beginGeneration();
+    await expectSettled(p, 'replacement-after-stop');
+    expect(resolved).toEqual(lc2);
+    expect((resolved as unknown as { generation: number }).generation).toBe(2);
+  });
+
+  it('rejects when the signal aborts while waiting', async () => {
+    const controller = new AbortController();
+    const p = coordinator.waitForStartedLifecycle(controller.signal);
+    controller.abort();
+    await expect(p).rejects.toThrow();
+  });
+
+  it('rejects immediately if the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      coordinator.waitForStartedLifecycle(controller.signal)
+    ).rejects.toThrow();
+  });
+});
+
+describe('gateway-status: isGatewayStatusEligible', () => {
+  it('is false with zero configured accounts', () => {
+    expect(isGatewayStatusEligible({ channels: {} } as OpenClawConfig)).toBe(
+      false
+    );
+  });
+
+  it('is true with exactly one configured account', () => {
+    expect(
+      isGatewayStatusEligible({
+        channels: { tlon: { ship: '~zod' } },
+      } as OpenClawConfig)
+    ).toBe(true);
+  });
+
+  it('is false with more than one configured account', () => {
+    expect(
+      isGatewayStatusEligible({
+        channels: {
+          tlon: {
+            ship: '~zod',
+            accounts: { second: { ship: '~bus' } },
+          },
+        },
+      } as OpenClawConfig)
+    ).toBe(false);
+  });
+});
+
+describe('gateway-status: startGatewayHeartbeatLoop', () => {
+  it('sends periodic heartbeats while isValid() is true', async () => {
+    const stop = startGatewayHeartbeatLoop({
+      bootId: 'boot-1',
+      isValid: () => true,
+    });
+    expect(gatewayHeartbeat).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(gatewayHeartbeat).mock.calls[0][0].bootId).toBe('boot-1');
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
+    stop();
+  });
+
+  it('clears itself the tick after isValid() turns false', async () => {
+    let valid = true;
+    startGatewayHeartbeatLoop({ bootId: 'boot-1', isValid: () => valid });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+
+    valid = false;
+    await vi.advanceTimersByTimeAsync(30_000);
+    // The tick fires, sees isValid() === false, clears itself without poking.
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() clears the interval immediately, before any self-check tick', async () => {
+    const stop = startGatewayHeartbeatLoop({
+      bootId: 'boot-1',
+      isValid: () => true,
+    });
+    stop();
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(gatewayHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it('two independent loops do not affect each other (monitor-local isolation)', async () => {
+    const stopA = startGatewayHeartbeatLoop({
+      bootId: 'boot-A',
+      isValid: () => true,
+    });
+    startGatewayHeartbeatLoop({ bootId: 'boot-B', isValid: () => true });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
+
+    // Stopping A's loop (as a stale monitor's cleanup would) must not
+    // affect B's independent interval.
+    stopA();
+    await vi.advanceTimersByTimeAsync(30_000);
+    const bootIds = vi
+      .mocked(gatewayHeartbeat)
+      .mock.calls.map((call) => call[0].bootId);
+    expect(bootIds.filter((id) => id === 'boot-A')).toHaveLength(1);
+    expect(bootIds.filter((id) => id === 'boot-B')).toHaveLength(2);
+  });
+
+  it('skips the poke when api-client params are not published', async () => {
+    sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
+    startGatewayHeartbeatLoop({ bootId: 'boot-1', isValid: () => true });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it('calls onError and does not crash when the poke rejects', async () => {
+    vi.mocked(gatewayHeartbeat).mockRejectedValueOnce(new Error('boom'));
+    const onError = vi.fn();
+    startGatewayHeartbeatLoop({
+      bootId: 'boot-1',
+      isValid: () => true,
+      onError,
+    });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('gateway-status: runGatewayStatusActivation', () => {
+  let coordinator: GatewayStatusCoordinator;
+
+  beforeEach(() => {
+    coordinator = createGatewayStatusCoordinator({ logger: undefined });
+  });
+
+  it('waits for the lifecycle, sends %configure + %gateway-start, then starts the heartbeat', async () => {
+    const registerHeartbeatStop = vi.fn();
+    const lc = coordinator.beginGeneration();
+    await runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop,
+    });
+
+    expect(configureGatewayStatus).toHaveBeenCalledTimes(1);
+    expect(gatewayStart).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(gatewayStart).mock.calls[0][0]).toMatchObject({
+      bootId: lc.bootId,
+    });
+    expect(registerHeartbeatStop).toHaveBeenCalledTimes(1);
+
+    // configure must precede gateway-start
+    const configureOrder = vi.mocked(configureGatewayStatus).mock
+      .invocationCallOrder[0];
+    const startOrder = vi.mocked(gatewayStart).mock.invocationCallOrder[0];
+    expect(configureOrder).toBeLessThan(startOrder);
+  });
+
+  it('in-process start→stop→start (no second registerFull): generation 2 gets a fresh bootId and activates', async () => {
+    const lc1 = coordinator.beginGeneration();
+    await runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+    });
+    expect(gatewayStart).toHaveBeenCalledTimes(1);
+
+    await coordinator.markStopped(lc1.generation);
+    const lc2 = coordinator.beginGeneration();
+    expect(lc2.generation).toBe(2);
+    expect(lc2.bootId).not.toBe(lc1.bootId);
+
+    await runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+    });
+    expect(gatewayStart).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(gatewayStart).mock.calls[1][0]).toMatchObject({
+      bootId: lc2.bootId,
+    });
+  });
+
+  it('stopping the returned heartbeat handle (as cleanup does when eligibility flips false) halts further heartbeats', async () => {
+    let stopHandle: (() => void) | undefined;
+    coordinator.beginGeneration();
+    await runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: (stop) => {
+        stopHandle = stop;
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+
+    stopHandle?.();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop during %configure: no %gateway-start, no heartbeat, no stop handle', async () => {
+    const configureCalled = deferred<void>();
+    const configureResult = deferred<void>();
+    vi.mocked(configureGatewayStatus).mockImplementationOnce(() => {
+      configureCalled.resolve();
+      return configureResult.promise as unknown as ReturnType<
+        typeof configureGatewayStatus
+      >;
+    });
+    const registerHeartbeatStop = vi.fn();
+
+    const lc = coordinator.beginGeneration();
+    const activation = runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop,
+    });
+
+    await expectSettled(
+      configureCalled.promise,
+      'stop-during-configure:called'
+    );
+    await coordinator.markStopped(lc.generation);
+    configureResult.resolve();
+    await expectSettled(activation, 'stop-during-configure:activation');
+
+    expect(gatewayStart).not.toHaveBeenCalled();
+    // No heartbeat loop was ever created (the stop handle callback is only
+    // invoked after markActivated + startGatewayHeartbeatLoop).
+    expect(registerHeartbeatStop).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(gatewayHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it('stop during %gateway-start: no heartbeat afterward', async () => {
+    const startCalled = deferred<void>();
+    const startResult = deferred<void>();
+    vi.mocked(gatewayStart).mockImplementationOnce(() => {
+      startCalled.resolve();
+      return startResult.promise as unknown as ReturnType<typeof gatewayStart>;
+    });
+    const registerHeartbeatStop = vi.fn();
+
+    const lc = coordinator.beginGeneration();
+    const activation = runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop,
+    });
+
+    await expectSettled(startCalled.promise, 'stop-during-start:called');
+    await coordinator.markStopped(lc.generation);
+    startResult.resolve();
+    await expectSettled(activation, 'stop-during-start:activation');
+
+    expect(registerHeartbeatStop).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(gatewayHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it('bails without activating when isTornDown() is already true', async () => {
+    coordinator.beginGeneration();
+    await runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => true,
+      registerHeartbeatStop: vi.fn(),
+    });
+    expect(configureGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns silently (no telemetry) when aborted while waiting for the lifecycle to start', async () => {
+    const controller = new AbortController();
+    const onActivationError = vi.fn();
+    const activation = runGatewayStatusActivation({
+      coordinator, // never started
+      owner: '~zod',
+      signal: controller.signal,
+      isTornDown: () => false,
+      onActivationError,
+      registerHeartbeatStop: vi.fn(),
+    });
+    controller.abort();
+    await activation;
+    expect(configureGatewayStatus).not.toHaveBeenCalled();
+    expect(onActivationError).not.toHaveBeenCalled();
+  });
+
+  it('aborting the signal mid-wait (as monitor teardown does) cancels the wait AND clears the watchdog', async () => {
+    // Mirrors the monitor-local activation abort composed into the signal:
+    // teardown before the gateway ever starts must cancel the pending wait
+    // and prevent the watchdog from emitting telemetry after teardown.
+    const controller = new AbortController();
+    const onWatchdogTimeout = vi.fn();
+    const activation = runGatewayStatusActivation({
+      coordinator, // never started: the wait would otherwise hang
+      owner: '~zod',
+      signal: controller.signal,
+      isTornDown: () => false,
+      onWatchdogTimeout,
+      registerHeartbeatStop: vi.fn(),
+    });
+
+    controller.abort();
+    await expectSettled(activation, 'abort-mid-wait');
+
+    // Watchdog timer was cleared on abort — advancing well past it fires nothing.
+    await vi.advanceTimersByTimeAsync(GATEWAY_STATUS_START_WATCHDOG_MS * 2);
+    expect(onWatchdogTimeout).not.toHaveBeenCalled();
+    expect(configureGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it('watchdog: fires once (log/telemetry-only), never activates, and clears on abort', async () => {
+    const onWatchdogTimeout = vi.fn();
+    const controller = new AbortController();
+    const activation = runGatewayStatusActivation({
+      coordinator, // never started: waitForStartedLifecycle never resolves
+      owner: '~zod',
+      signal: controller.signal,
+      isTornDown: () => false,
+      onWatchdogTimeout,
+      registerHeartbeatStop: vi.fn(),
+    });
+
+    await vi.advanceTimersByTimeAsync(GATEWAY_STATUS_START_WATCHDOG_MS);
+    expect(onWatchdogTimeout).toHaveBeenCalledTimes(1);
+    expect(configureGatewayStatus).not.toHaveBeenCalled();
+
+    // One-shot: it does not fire again on further elapsed time.
+    await vi.advanceTimersByTimeAsync(GATEWAY_STATUS_START_WATCHDOG_MS * 2);
+    expect(onWatchdogTimeout).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+    await activation;
+    expect(configureGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it('watchdog timer is cleared once the lifecycle starts (no timeout fires after)', async () => {
+    const onWatchdogTimeout = vi.fn();
+    const activation = runGatewayStatusActivation({
+      coordinator,
+      owner: '~zod',
+      isTornDown: () => false,
+      onWatchdogTimeout,
+      registerHeartbeatStop: vi.fn(),
+    });
+    // Resolve the wait almost immediately.
+    coordinator.beginGeneration();
+    await activation;
+
+    await vi.advanceTimersByTimeAsync(GATEWAY_STATUS_START_WATCHDOG_MS * 2);
+    expect(onWatchdogTimeout).not.toHaveBeenCalled();
+  });
+
+  it("watchdog timer is unref()'d so it never keeps the process alive", async () => {
+    // Wrap the (already-faked) setTimeout so we can spy on the timer object's
+    // unref(). The only setTimeout the activation calls before the wait
+    // resolves is the watchdog, so any unref() we observe here is its.
+    const fakeSetTimeout = globalThis.setTimeout;
+    const unrefed: unknown[] = [];
+    const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+      ...args: Parameters<typeof setTimeout>
+    ) => {
+      const timer = fakeSetTimeout(...args) as ReturnType<typeof setTimeout> & {
+        unref?: () => unknown;
+      };
+      if (typeof timer.unref === 'function') {
+        const originalUnref = timer.unref.bind(timer);
+        timer.unref = () => {
+          unrefed.push(timer);
+          return originalUnref();
+        };
+      }
+      return timer;
+    }) as typeof setTimeout);
+
+    const activation = runGatewayStatusActivation({
+      coordinator, // never started yet
+      owner: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+    });
+    // The watchdog setTimeout runs synchronously before the first await, so
+    // its unref() has already fired by now.
+    expect(unrefed.length).toBeGreaterThan(0);
+
+    spy.mockRestore();
+    // Let the activation resolve and clean up its watchdog timer.
+    coordinator.beginGeneration();
+    await activation;
+  });
+});
+
+// Cases 6 & 7 of the plan, exercised through the SAME gate the monitor runs
+// (gateGatewayStatusActivation) rather than the raw isGatewayStatusEligible
+// predicate — so these would fail if the monitor's eligibility gate were
+// removed or reverted to a stale registration-time value. Each cfg here
+// stands in for the channel-start `ctx.cfg` snapshot the monitor threads in;
+// the coordinator is reused across "monitors" with no re-registration.
+describe('gateway-status: gateGatewayStatusActivation (per-monitor gate)', () => {
+  let coordinator: GatewayStatusCoordinator;
+
+  const oneAccount = {
+    channels: { tlon: { ship: '~zod' } },
+  } as OpenClawConfig;
+  const twoAccounts = {
+    channels: {
+      tlon: { ship: '~zod', accounts: { second: { ship: '~bus' } } },
+    },
+  } as OpenClawConfig;
+  const zeroAccounts = { channels: {} } as OpenClawConfig;
+
+  beforeEach(() => {
+    coordinator = createGatewayStatusCoordinator({ logger: undefined });
+    // The gate activates against a started lifecycle.
+    coordinator.beginGeneration();
+  });
+
+  it('activates with a 1-account snapshot (0/>1 → 1 hot reload)', async () => {
+    const result = gateGatewayStatusActivation({
+      cfg: oneAccount,
+      coordinator,
+      effectiveOwnerShip: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+    });
+    expect(result).not.toBeNull();
+    await expectSettled(result as Promise<void>, 'gate:one-account');
+    expect(gatewayStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT activate with a >1-account snapshot; reports the skip', () => {
+    const onMultiAccountSkip = vi.fn();
+    const result = gateGatewayStatusActivation({
+      cfg: twoAccounts,
+      coordinator,
+      effectiveOwnerShip: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+      onMultiAccountSkip,
+    });
+    expect(result).toBeNull();
+    expect(gatewayStart).not.toHaveBeenCalled();
+    expect(onMultiAccountSkip).toHaveBeenCalledWith(2);
+  });
+
+  it('does NOT activate with a 0-account snapshot and does not report a multi-account skip', () => {
+    const onMultiAccountSkip = vi.fn();
+    const result = gateGatewayStatusActivation({
+      cfg: zeroAccounts,
+      coordinator,
+      effectiveOwnerShip: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+      onMultiAccountSkip,
+    });
+    expect(result).toBeNull();
+    expect(gatewayStart).not.toHaveBeenCalled();
+    expect(onMultiAccountSkip).not.toHaveBeenCalled();
+  });
+
+  it('does NOT activate without an owner even with a 1-account snapshot', () => {
+    const result = gateGatewayStatusActivation({
+      cfg: oneAccount,
+      coordinator,
+      effectiveOwnerShip: null,
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+    });
+    expect(result).toBeNull();
+    expect(gatewayStart).not.toHaveBeenCalled();
+  });
+
+  it('1 → >1 hot reload without re-registration: old monitor heartbeat stops, replacement does NOT activate', async () => {
+    // Monitor A: 1 account → activates + heartbeat, capturing its stop
+    // handle exactly as the monitor's registerHeartbeatStop callback does.
+    let tornDownA = false;
+    let stopHeartbeatA: (() => void) | null = null;
+    const activationA = gateGatewayStatusActivation({
+      cfg: oneAccount,
+      coordinator,
+      effectiveOwnerShip: '~zod',
+      isTornDown: () => tornDownA,
+      registerHeartbeatStop: (stop) => {
+        stopHeartbeatA = stop;
+      },
+    });
+    expect(activationA).not.toBeNull();
+    await expectSettled(activationA as Promise<void>, 'gate:hot-reload-A');
+    expect(gatewayStart).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+
+    // Config reload: monitor A is torn down (its cleanup stops its own local
+    // heartbeat), then monitor B starts with a >1-account snapshot — same
+    // coordinator, NO registerFull re-run.
+    tornDownA = true;
+    stopHeartbeatA?.();
+
+    const onMultiAccountSkip = vi.fn();
+    const activationB = gateGatewayStatusActivation({
+      cfg: twoAccounts,
+      coordinator,
+      effectiveOwnerShip: '~zod',
+      isTornDown: () => false,
+      registerHeartbeatStop: vi.fn(),
+      onMultiAccountSkip,
+    });
+    expect(activationB).toBeNull();
+    expect(onMultiAccountSkip).toHaveBeenCalledWith(2);
+
+    // No replacement activation, and monitor A's heartbeat is dead.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(gatewayStart).toHaveBeenCalledTimes(1);
+    expect(gatewayHeartbeat).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('gateway-status: coordinator shared-state accessor', () => {
   it('returns null when not set', () => {
-    // Reset by setting to null via internal trick — in real code, null is the initial state
-    expect(getGatewayStatusManager()).toBeNull();
+    expect(getGatewayStatusCoordinator()).toBeNull();
   });
 
-  it('stores and retrieves manager', () => {
-    const manager = createGatewayStatusManager({ logger: undefined });
-    setGatewayStatusManager(manager);
-    expect(getGatewayStatusManager()).toBe(manager);
+  it('stores and retrieves the coordinator', () => {
+    const coordinator = createGatewayStatusCoordinator({ logger: undefined });
+    setGatewayStatusCoordinator(coordinator);
+    expect(getGatewayStatusCoordinator()).toBe(coordinator);
   });
 });
 
@@ -283,12 +810,6 @@ describe('gateway-status: computeLeaseUntil', () => {
 
 describe('gateway-status: sendGatewayStop', () => {
   beforeEach(() => {
-    vi.mocked(gatewayStop).mockClear();
-    vi.mocked(configureTlonApiWithPoke).mockClear();
-    sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
-  });
-
-  afterEach(() => {
     sharedSlot<SharedApiClientParams>(API_CLIENT_PARAMS_SLOT).set(null);
   });
 

--- a/packages/openclaw/src/gateway-status.ts
+++ b/packages/openclaw/src/gateway-status.ts
@@ -1,7 +1,14 @@
-import { gatewayHeartbeat, gatewayStop } from '@tloncorp/api';
+import {
+  configureGatewayStatus,
+  gatewayHeartbeat,
+  gatewayStart,
+  gatewayStop,
+} from '@tloncorp/api';
 import { randomUUID } from 'node:crypto';
+import type { OpenClawConfig } from 'openclaw/plugin-sdk/core';
 
 import { sharedSlot } from './shared-state.js';
+import { listTlonAccountIds } from './types.js';
 import { configureTlonApiWithPoke } from './urbit/api-client.js';
 
 // Shared-state slot for the @tloncorp/api client params. The monitor
@@ -27,163 +34,254 @@ const apiClientParamsSlot = sharedSlot<SharedApiClientParams>(
 );
 
 // ── Constants (matching design doc recommendations) ─────────
-const HEARTBEAT_INTERVAL_MS = 30_000; // 30s
+export const HEARTBEAT_INTERVAL_MS = 30_000; // 30s
 const LEASE_DURATION_MS = 90_000; // 90s
 export const ACTIVE_WINDOW_SECS = 300; // 5 min
 export const OFFLINE_REPLY_COOLDOWN_SECS = 300; // 5 min
+
+// A poke that hangs (observed racing an SSE reconnect) must not be allowed
+// to wedge activation forever; bound it and retry instead.
+export const GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS = 15_000;
+export const GATEWAY_STATUS_ACTIVATION_RETRY_MS = 30_000;
+
+// Log/telemetry-only: SSE only goes live at api.connect(), well after this
+// activation task launches, so a timer firing here can never tell us
+// anything is actually wrong — it can only tell us to go look. It NEVER
+// triggers activation itself.
+export const GATEWAY_STATUS_START_WATCHDOG_MS = 60_000;
 
 export function computeLeaseUntil(): number {
   return Date.now() + LEASE_DURATION_MS;
 }
 
-// ── Manager interface ───────────────────────────────────────
-export interface GatewayStatusManager {
-  readonly bootId: string;
-
-  /** Resolve the "gateway started" Promise. Called by gateway_start hook. */
-  signalGatewayStarted(): void;
-
-  /** Returns a Promise that resolves when gateway_start has fired. */
-  waitForGatewayStart(): Promise<void>;
-
-  /**
-   * True once the activation task is about to send the %gateway-start poke
-   * (set immediately before the gatewayStart call). Distinguishes "a start
-   * poke is/was in flight" from "activation fully completed", so the
-   * gateway_stop hook can send a matching %gateway-stop even if shutdown
-   * lands before markActivated().
-   */
-  readonly starting: boolean;
-  markStarting(): void;
-
-  /** True after monitor has successfully sent %configure + %gateway-start. */
-  readonly activated: boolean;
-  markActivated(): void;
-
-  /** True after gateway_stop hook has sent %gateway-stop. */
-  readonly stopped: boolean;
-  markStopped(): void;
-
-  /** Start heartbeat interval. No-op if not activated or already stopped. */
-  startHeartbeat(): void;
-
-  /** Stop heartbeat interval. Idempotent. */
-  stopHeartbeat(): void;
+/** True iff exactly one Tlon account is configured. v1 requires exactly one
+ * because the global @tloncorp/api client can't target multiple ships;
+ * with >1 account, every eligible monitor would race the same client. */
+export function isGatewayStatusEligible(cfg: OpenClawConfig): boolean {
+  return listTlonAccountIds(cfg).length === 1;
 }
 
-// ── Factory ─────────────────────────────────────────────────
-export function createGatewayStatusManager(opts: {
-  logger?: { log?: (msg: string) => void; error?: (msg: string) => void };
-}): GatewayStatusManager {
-  const bootId = randomUUID();
-  let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+// ── Generation-aware coordinator ─────────────────────────────
+//
+// Models one "lifecycle" per gateway boot: a `gateway_start` hook call
+// begins a generation, a `gateway_stop` hook call latches it stopped. The
+// coordinator itself is process-lifetime and created exactly once (see
+// gateway-status-registration.ts) — but unlike the old one-shot manager it
+// survives BOTH an in-process stop→start restart (SIGUSR1, no fresh
+// `globalThis`) AND a repeated `registerFull` pass (OpenClaw
+// 6.11+'s post-startup runtime-plugin prewarm), because generations reset
+// its internal latches instead of the whole object being replaced.
+export interface GatewayLifecycle {
+  readonly generation: number;
+  readonly bootId: string;
+}
+
+export interface GatewayStatusCoordinatorLogger {
+  log?: (msg: string) => void;
+  error?: (msg: string) => void;
+}
+
+export interface GatewayStatusCoordinator {
+  /** Generation of the current (possibly stopped) lifecycle. 0 = no lifecycle has ever started. */
+  readonly currentGeneration: number;
+  /** bootId of the current lifecycle. Empty string before the first generation. */
+  readonly bootId: string;
+  /** True once `markStopped` has latched the CURRENT generation stopped. */
+  readonly stopped: boolean;
+
+  /**
+   * Idle/stopped → started transition ONLY. From idle (generation 0) or a
+   * stopped generation, bumps the generation, mints a fresh bootId, and
+   * resets the starting/activated/stopped latches. Called while the current
+   * generation is already started (not stopped) it is a no-op that returns
+   * the CURRENT generation unchanged — so re-binding this hook on every
+   * `registerFull` pass, or a duplicate `gateway_start` emit, never mints an
+   * extra generation.
+   */
+  beginGeneration(): GatewayLifecycle;
+
+  /**
+   * Atomic wait — no capture-then-wait race. Resolves immediately iff the
+   * current lifecycle is started AND not stopped; otherwise resolves with
+   * the NEXT lifecycle produced by `beginGeneration()`. This is what makes
+   * "monitor starts before gateway_start fires" (the common in-process
+   * restart ordering) and "monitor starts after stop(N), before start(N+1)"
+   * both resolve on the correct (next) generation instead of a stale one.
+   */
+  waitForStartedLifecycle(signal?: AbortSignal): Promise<GatewayLifecycle>;
+
+  /** Mark that a %gateway-start poke is in flight for `generation`. No-op if `generation` is stale. */
+  markStarting(generation: number): void;
+
+  /** Mark `generation` fully activated (the %gateway-start poke succeeded). No-op if `generation` is stale. */
+  markActivated(generation: number): void;
+
+  /**
+   * Latch `generation` stopped and, if a start was in flight or done for
+   * it, send the matching %gateway-stop poke. No-op (including no poke) if
+   * `generation` is stale or already stopped. Latching happens
+   * synchronously before the poke so a concurrent activation's
+   * post-poke recheck can observe `stopped` immediately.
+   */
+  markStopped(generation: number, reason?: string): Promise<void>;
+}
+
+export function createGatewayStatusCoordinator(opts?: {
+  logger?: GatewayStatusCoordinatorLogger;
+}): GatewayStatusCoordinator {
+  let generation = 0;
+  let bootId = '';
   let starting = false;
   let activated = false;
   let stopped = false;
+  type Waiter = (lc: GatewayLifecycle) => void;
+  let waiters: Waiter[] = [];
 
-  let resolveStarted: () => void;
-  const startedPromise = new Promise<void>((r) => {
-    resolveStarted = r;
-  });
+  const isStarted = () => generation > 0 && !stopped;
+
+  const flushWaiters = (lc: GatewayLifecycle): void => {
+    const toResolve = waiters;
+    waiters = [];
+    for (const resolve of toResolve) {
+      resolve(lc);
+    }
+  };
+
+  const beginGeneration = (): GatewayLifecycle => {
+    if (isStarted()) {
+      return { generation, bootId };
+    }
+    generation += 1;
+    bootId = randomUUID();
+    starting = false;
+    activated = false;
+    stopped = false;
+    const lc: GatewayLifecycle = { generation, bootId };
+    flushWaiters(lc);
+    return lc;
+  };
+
+  const waitForStartedLifecycle = (
+    signal?: AbortSignal
+  ): Promise<GatewayLifecycle> => {
+    if (isStarted()) {
+      return Promise.resolve({ generation, bootId });
+    }
+    if (signal?.aborted) {
+      return Promise.reject(
+        new Error('Aborted while waiting for gateway lifecycle start')
+      );
+    }
+    return new Promise<GatewayLifecycle>((resolve, reject) => {
+      const onResolve: Waiter = (lc) => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve(lc);
+      };
+      const onAbort = () => {
+        waiters = waiters.filter((w) => w !== onResolve);
+        reject(new Error('Aborted while waiting for gateway lifecycle start'));
+      };
+      waiters.push(onResolve);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  };
+
+  const markStarting = (gen: number): void => {
+    if (gen !== generation) {
+      return;
+    }
+    starting = true;
+  };
+
+  const markActivated = (gen: number): void => {
+    if (gen !== generation) {
+      return;
+    }
+    activated = true;
+  };
+
+  const markStopped = async (gen: number, reason?: string): Promise<void> => {
+    if (gen !== generation || stopped) {
+      return;
+    }
+    // Latch stopped FIRST, unconditionally, before the async %gateway-stop
+    // poke below. An activation may be in flight (between the
+    // %gateway-start poke and markActivated()); latching synchronously
+    // makes its post-poke recheck bail so it can't start a heartbeat after
+    // we've already decided this generation is done.
+    const startPokeInFlightOrDone = starting || activated;
+    const stoppedBootId = bootId;
+    stopped = true;
+    // Only send %gateway-stop if a %gateway-start has been or is being
+    // sent. If activation never reached the start poke, there is nothing
+    // for the ship to stop.
+    if (!startPokeInFlightOrDone) {
+      return;
+    }
+    try {
+      const sent = await sendGatewayStop({
+        bootId: stoppedBootId,
+        reason: reason ?? 'shutdown',
+      });
+      if (sent) {
+        opts?.logger?.log?.(
+          `[gateway-status] stopped (reason=${reason ?? 'shutdown'})`
+        );
+      } else {
+        opts?.logger?.error?.(
+          '[gateway-status] stop skipped: api-client params not published'
+        );
+      }
+    } catch (err) {
+      opts?.logger?.error?.(
+        `[gateway-status] stop poke failed: ${String(err)}`
+      );
+    }
+  };
 
   return {
-    bootId,
-
-    signalGatewayStarted() {
-      resolveStarted();
+    get currentGeneration() {
+      return generation;
     },
-    waitForGatewayStart() {
-      return startedPromise;
+    get bootId() {
+      return bootId;
     },
-
-    get starting() {
-      return starting;
-    },
-    markStarting() {
-      starting = true;
-    },
-
-    get activated() {
-      return activated;
-    },
-    markActivated() {
-      activated = true;
-    },
-
     get stopped() {
       return stopped;
     },
-    markStopped() {
-      stopped = true;
-    },
-
-    startHeartbeat() {
-      if (stopped || !activated || heartbeatInterval) {
-        return;
-      }
-      heartbeatInterval = setInterval(async () => {
-        try {
-          // Configure THIS module's @tloncorp/api instance against the
-          // monitor-published params every tick. Under OpenClaw plugin
-          // module isolation this code path can hold a separate
-          // @tloncorp/api instance from the monitor; outbound DMs via
-          // `withAuthenticatedTlonApi` can also rotate the global
-          // client between heartbeats. Reapplying here keeps the
-          // heartbeat poke pointed at the SSE-bound client.
-          const params = apiClientParamsSlot.get();
-          if (!params) {
-            opts.logger?.error?.(
-              '[gateway-status] heartbeat skipped: api-client params not published'
-            );
-            return;
-          }
-          configureTlonApiWithPoke(
-            params.poke,
-            params.shipName,
-            params.shipUrl
-          );
-          await gatewayHeartbeat({ bootId, leaseUntil: computeLeaseUntil() });
-        } catch (err) {
-          opts.logger?.error?.(
-            `[gateway-status] heartbeat failed: ${String(err)}`
-          );
-        }
-      }, HEARTBEAT_INTERVAL_MS);
-      opts.logger?.log?.(
-        `[gateway-status] heartbeat started (interval=${HEARTBEAT_INTERVAL_MS}ms)`
-      );
-    },
-
-    stopHeartbeat() {
-      if (heartbeatInterval) {
-        clearInterval(heartbeatInterval);
-        heartbeatInterval = null;
-        opts.logger?.log?.('[gateway-status] heartbeat stopped');
-      }
-    },
+    beginGeneration,
+    waitForStartedLifecycle,
+    markStarting,
+    markActivated,
+    markStopped,
   };
 }
 
 // Routed through shared-state so the slot survives plugin module isolation —
 // the extension sets, the monitor reads, and they live in separate contexts.
-const managerSlot = sharedSlot<GatewayStatusManager>('gateway-status.manager');
+const coordinatorSlot = sharedSlot<GatewayStatusCoordinator>(
+  'gateway-status.coordinator'
+);
 
-export function setGatewayStatusManager(m: GatewayStatusManager | null): void {
-  managerSlot.set(m);
+export function setGatewayStatusCoordinator(
+  c: GatewayStatusCoordinator | null
+): void {
+  coordinatorSlot.set(c);
 }
 
-export function getGatewayStatusManager(): GatewayStatusManager | null {
-  return managerSlot.get();
+export function getGatewayStatusCoordinator(): GatewayStatusCoordinator | null {
+  return coordinatorSlot.get();
 }
 
 // Configure THIS module's @tloncorp/api singleton against the
 // monitor-published params, then send the gateway-stop poke. Callers
-// (notably the gateway_stop hook in index.ts) must go through this helper
-// instead of importing `gatewayStop` directly, because under OpenClaw
-// >=2026.4.27 plugin module isolation the entry module's @tloncorp/api
-// instance is never configured — only the monitor's is. Routing through
-// gateway-status.ts reuses the same configured instance the heartbeat uses.
-// Returns true if the poke was sent, false if the params slot was empty.
+// (notably GatewayStatusCoordinator.markStopped) must go through this
+// helper instead of importing `gatewayStop` directly, because under
+// OpenClaw >=2026.4.27 plugin module isolation the entry module's
+// @tloncorp/api instance is never configured — only the monitor's is.
+// Routing through gateway-status.ts reuses the same configured instance
+// the heartbeat uses. Returns true if the poke was sent, false if the
+// params slot was empty.
 export async function sendGatewayStop(params: {
   bootId: string;
   reason: string;
@@ -199,4 +297,310 @@ export async function sendGatewayStop(params: {
   );
   await gatewayStop({ bootId: params.bootId, reason: params.reason });
   return true;
+}
+
+// ── Monitor-local heartbeat ──────────────────────────────────
+//
+// Fix C: the heartbeat interval lives with the CALLER (the monitor), not on
+// the coordinator — each activation owns its own `setInterval`, so a stale
+// monitor's cleanup can never kill a replacement monitor's heartbeat by
+// construction (no shared interval, no ownership token needed). Each tick
+// still self-checks `isValid()` and clears itself, as a safety net on top
+// of the caller's own direct `stop()` on cleanup.
+export interface StartGatewayHeartbeatLoopOptions {
+  bootId: string;
+  /** Re-checked every tick; when false the interval clears itself. */
+  isValid: () => boolean;
+  logger?: GatewayStatusCoordinatorLogger;
+  onError?: (err: unknown) => void;
+  intervalMs?: number;
+}
+
+/** Starts a monitor-local heartbeat loop; returns a `stop()` the caller should invoke on teardown. */
+export function startGatewayHeartbeatLoop(
+  heartbeatOpts: StartGatewayHeartbeatLoopOptions
+): () => void {
+  const intervalMs = heartbeatOpts.intervalMs ?? HEARTBEAT_INTERVAL_MS;
+  const interval = setInterval(async () => {
+    if (!heartbeatOpts.isValid()) {
+      clearInterval(interval);
+      return;
+    }
+    try {
+      // Configure THIS module's @tloncorp/api instance against the
+      // monitor-published params every tick. Under OpenClaw plugin
+      // module isolation this code path can hold a separate
+      // @tloncorp/api instance from the monitor; outbound DMs via
+      // `withAuthenticatedTlonApi` can also rotate the global client
+      // between heartbeats. Reapplying here keeps the heartbeat poke
+      // pointed at the SSE-bound client.
+      const params = apiClientParamsSlot.get();
+      if (!params) {
+        heartbeatOpts.logger?.error?.(
+          '[gateway-status] heartbeat skipped: api-client params not published'
+        );
+        return;
+      }
+      configureTlonApiWithPoke(params.poke, params.shipName, params.shipUrl);
+      await gatewayHeartbeat({
+        bootId: heartbeatOpts.bootId,
+        leaseUntil: computeLeaseUntil(),
+      });
+    } catch (err) {
+      heartbeatOpts.onError?.(err);
+      heartbeatOpts.logger?.error?.(
+        `[gateway-status] heartbeat failed: ${String(err)}`
+      );
+    }
+  }, intervalMs);
+  heartbeatOpts.logger?.log?.(
+    `[gateway-status] heartbeat started (interval=${intervalMs}ms)`
+  );
+  return () => clearInterval(interval);
+}
+
+// ── Activation orchestration ─────────────────────────────────
+//
+// Extracted so it's independently unit-testable without pulling in the
+// (very large) monitor module: wait for a started lifecycle, send
+// %configure + %gateway-start for THAT lifecycle, then hand off to the
+// monitor-local heartbeat. Re-checks the lifecycle-validity predicate
+// (same generation, not stopped, not aborted, not torn down) after every
+// await, and bails silently the instant it fails — this is the
+// generation-aware form of the manager's old `stopped` rechecks.
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+// Bound an activation poke so a silently-hung promise surfaces as a
+// retryable error instead of leaving gateway-status dead for the
+// lifecycle's lifetime. The underlying poke may still settle after the
+// timeout; the trailing no-op catch keeps a late rejection from becoming
+// an unhandled rejection, and a late duplicate poke is harmless (same
+// bootId/values).
+function withActivationTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs: number
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      promise.catch(() => {});
+      reject(new Error(`${label} poke timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
+export interface RunGatewayStatusActivationOptions {
+  coordinator: GatewayStatusCoordinator;
+  owner: string;
+  signal?: AbortSignal;
+  /** True once the monitor's own teardown has run. */
+  isTornDown: () => boolean;
+  logger?: GatewayStatusCoordinatorLogger;
+  onActivationError?: (err: unknown, attempt: number) => void;
+  onHeartbeatError?: (err: unknown) => void;
+  onWatchdogTimeout?: () => void;
+  /** Invoked once with a stop() handle as soon as the heartbeat starts, so the caller can clear it directly on teardown. */
+  registerHeartbeatStop: (stop: () => void) => void;
+  activationTimeoutMs?: number;
+  activationRetryMs?: number;
+  watchdogMs?: number;
+}
+
+export async function runGatewayStatusActivation(
+  activationOpts: RunGatewayStatusActivationOptions
+): Promise<void> {
+  const {
+    coordinator,
+    owner,
+    signal,
+    isTornDown,
+    logger,
+    onActivationError,
+    onHeartbeatError,
+    onWatchdogTimeout,
+    registerHeartbeatStop,
+  } = activationOpts;
+  const activationTimeoutMs =
+    activationOpts.activationTimeoutMs ?? GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS;
+  const activationRetryMs =
+    activationOpts.activationRetryMs ?? GATEWAY_STATUS_ACTIVATION_RETRY_MS;
+  const watchdogMs =
+    activationOpts.watchdogMs ?? GATEWAY_STATUS_START_WATCHDOG_MS;
+
+  let lc: GatewayLifecycle;
+  let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    watchdogTimer = setTimeout(() => {
+      logger?.error?.(
+        `[gateway-status] waitForStartedLifecycle has not resolved after ${watchdogMs}ms — log/telemetry only, does not activate`
+      );
+      onWatchdogTimeout?.();
+    }, watchdogMs);
+    watchdogTimer.unref?.();
+    lc = await coordinator.waitForStartedLifecycle(signal);
+  } catch {
+    // Aborted while waiting for a lifecycle to start (monitor torn down
+    // before the gateway did). Nothing to activate.
+    return;
+  } finally {
+    if (watchdogTimer) {
+      clearTimeout(watchdogTimer);
+    }
+  }
+
+  const isValid = (): boolean =>
+    coordinator.currentGeneration === lc.generation &&
+    !coordinator.stopped &&
+    !signal?.aborted &&
+    !isTornDown();
+
+  if (!isValid()) {
+    return;
+  }
+
+  // One-shot activation proved fragile: a single silently-hung poke
+  // (observed when activation raced an SSE reconnect) left gateway-status
+  // dead for the whole lifecycle, so the ship marked the gateway %down and
+  // auto-replied "bot is offline" to owner DMs. Retry with a per-attempt
+  // timeout until activation sticks or this lifecycle is superseded/torn
+  // down.
+  for (let attempt = 1; ; attempt += 1) {
+    if (!isValid()) {
+      return;
+    }
+    try {
+      await withActivationTimeout(
+        configureGatewayStatus({
+          owner,
+          activeWindowSecs: ACTIVE_WINDOW_SECS,
+          offlineReplyCooldownSecs: OFFLINE_REPLY_COOLDOWN_SECS,
+        }),
+        '%configure',
+        activationTimeoutMs
+      );
+      if (!isValid()) {
+        return;
+      }
+      // Mark starting before the %gateway-start poke so a concurrent
+      // gateway_stop hook knows a start poke is in flight and sends a
+      // matching %gateway-stop even if shutdown lands before markActivated().
+      coordinator.markStarting(lc.generation);
+      await withActivationTimeout(
+        gatewayStart({ bootId: lc.bootId, leaseUntil: computeLeaseUntil() }),
+        '%gateway-start',
+        activationTimeoutMs
+      );
+      if (!isValid()) {
+        return;
+      }
+      coordinator.markActivated(lc.generation);
+      const stopHeartbeat = startGatewayHeartbeatLoop({
+        bootId: lc.bootId,
+        isValid,
+        logger,
+        onError: onHeartbeatError,
+      });
+      registerHeartbeatStop(stopHeartbeat);
+      logger?.log?.(
+        `[gateway-status] activated (bootId=${lc.bootId}, owner=${owner}, generation=${lc.generation}, attempt=${attempt})`
+      );
+      return;
+    } catch (err) {
+      onActivationError?.(err, attempt);
+      logger?.error?.(
+        `[gateway-status] activation attempt ${attempt} failed: ${String(err)} — retrying in ${activationRetryMs / 1000}s`
+      );
+    }
+    await abortableDelay(activationRetryMs, signal);
+  }
+}
+
+// ── Per-monitor activation gate (Fix B) ──────────────────────
+//
+// The single production decision point for whether THIS monitor should
+// drive gateway-status for its boot. Derives eligibility from the monitor's
+// own config snapshot (`cfg` = the channel-start `ctx.cfg`, threaded via
+// MonitorTlonOpts), so an account added/removed through a `channels.tlon`
+// hot-reload — which restarts monitors WITHOUT re-running `registerFull` —
+// re-evaluates the gate on the fresh snapshot. Kept as one exported
+// function so tests exercise the exact gate the monitor runs (not a re-typed
+// copy that could drift from, or silently revert past, the production path).
+export interface GateGatewayStatusActivationOptions {
+  cfg: OpenClawConfig;
+  coordinator: GatewayStatusCoordinator | null;
+  effectiveOwnerShip: string | null;
+  signal?: AbortSignal;
+  isTornDown: () => boolean;
+  logger?: GatewayStatusCoordinatorLogger;
+  onActivationError?: (err: unknown, attempt: number) => void;
+  onHeartbeatError?: (err: unknown) => void;
+  onWatchdogTimeout?: () => void;
+  /** Called (with the account count) when activation is skipped because >1 Tlon account is configured. */
+  onMultiAccountSkip?: (accountCount: number) => void;
+  registerHeartbeatStop: (stop: () => void) => void;
+  activationTimeoutMs?: number;
+  activationRetryMs?: number;
+  watchdogMs?: number;
+}
+
+/**
+ * Decide-and-launch. Returns the in-flight activation promise when this
+ * monitor is eligible (coordinator present, owner known, exactly one Tlon
+ * account), else `null`. The monitor fire-and-forgets it; tests await it.
+ */
+export function gateGatewayStatusActivation(
+  gateOpts: GateGatewayStatusActivationOptions
+): Promise<void> | null {
+  const { cfg, coordinator, effectiveOwnerShip } = gateOpts;
+  if (!coordinator || !effectiveOwnerShip) {
+    return null;
+  }
+  if (isGatewayStatusEligible(cfg)) {
+    return runGatewayStatusActivation({
+      coordinator,
+      owner: effectiveOwnerShip,
+      signal: gateOpts.signal,
+      isTornDown: gateOpts.isTornDown,
+      logger: gateOpts.logger,
+      onActivationError: gateOpts.onActivationError,
+      onHeartbeatError: gateOpts.onHeartbeatError,
+      onWatchdogTimeout: gateOpts.onWatchdogTimeout,
+      registerHeartbeatStop: gateOpts.registerHeartbeatStop,
+      activationTimeoutMs: gateOpts.activationTimeoutMs,
+      activationRetryMs: gateOpts.activationRetryMs,
+      watchdogMs: gateOpts.watchdogMs,
+    });
+  }
+  const accountCount = listTlonAccountIds(cfg).length;
+  if (accountCount > 1) {
+    gateOpts.onMultiAccountSkip?.(accountCount);
+  }
+  return null;
 }

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -1,5 +1,4 @@
 import type { Story } from '@tloncorp/api';
-import { configureGatewayStatus, gatewayStart } from '@tloncorp/api';
 import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import { createTypingCallbacks } from 'openclaw/plugin-sdk/channel-runtime';
@@ -29,14 +28,10 @@ import {
   setEffectiveOwnerShip,
 } from '../effective-owner.js';
 import {
-  ACTIVE_WINDOW_SECS,
-  OFFLINE_REPLY_COOLDOWN_SECS,
-  computeLeaseUntil,
-  getGatewayStatusManager,
-} from '../gateway-status.js';
-import {
   API_CLIENT_PARAMS_SLOT,
   type SharedApiClientParams,
+  gateGatewayStatusActivation,
+  getGatewayStatusCoordinator,
 } from '../gateway-status.js';
 import { handleOwnerListenCommand } from '../owner-listen-command.js';
 import {
@@ -239,6 +234,15 @@ export type MonitorTlonOpts = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string | null;
+  /**
+   * Channel-start config snapshot (the gateway adapter's `ctx.cfg`), used
+   * instead of an independent `core.config.loadConfig()` call so
+   * gateway-status eligibility (Fix B) reads the SAME config OpenClaw used
+   * to enumerate/start accounts, avoiding a transient mismatch if a second
+   * config write races. Falls back to `loadConfig()` when absent (e.g. a
+   * caller that doesn't thread a snapshot through).
+   */
+  cfg?: OpenClawConfig;
 };
 
 type ChannelAuthorization = {
@@ -265,63 +269,11 @@ type ChatFirehoseEvent = DmInvite[] | WritResponse;
 /** Refresh stale settings subscription state periodically as a fallback for silently-dead SSE subscriptions. */
 const SETTINGS_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
-const GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS = 15_000;
-const GATEWAY_STATUS_ACTIVATION_RETRY_MS = 30_000;
-
 function classifyPluginError(error: unknown): string {
   if (error instanceof Error) {
     return error.name || 'Error';
   }
   return typeof error;
-}
-
-// Bound an activation poke so a silently-hung promise surfaces as a
-// retryable error instead of leaving gateway-status dead for the process
-// lifetime. The underlying poke may still settle after the timeout; the
-// trailing no-op catch keeps a late rejection from becoming an unhandled
-// rejection, and a late duplicate poke is harmless (same bootId/values).
-function withActivationTimeout<T>(
-  promise: Promise<T>,
-  label: string
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      promise.catch(() => {});
-      reject(
-        new Error(
-          `${label} poke timed out after ${GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS}ms`
-        )
-      );
-    }, GATEWAY_STATUS_ACTIVATION_TIMEOUT_MS);
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (err) => {
-        clearTimeout(timer);
-        reject(err);
-      }
-    );
-  });
-}
-
-function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-    const onAbort = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
 }
 
 /**
@@ -370,7 +322,9 @@ export async function monitorTlonProvider(
   opts: MonitorTlonOpts = {}
 ): Promise<void> {
   const core = getTlonRuntime();
-  const cfg = core.config.loadConfig();
+  // Prefer the channel-start config snapshot (Fix B) over an independent
+  // load: see the MonitorTlonOpts.cfg doc comment.
+  const cfg = opts.cfg ?? core.config.loadConfig();
   if (cfg.channels?.tlon?.enabled === false) {
     return;
   }
@@ -616,13 +570,31 @@ export async function monitorTlonProvider(
   };
   apiClientParamsSlot.set(myApiClientParams);
 
-  // gsManager is hoisted here (from its prior location at the
+  // gsCoordinator is hoisted here (from its prior location at the
   // gateway-status activation block below) so cleanupGatewayStatus can
-  // close over it. getGatewayStatusManager() returns the manager
-  // singleton index.ts published during plugin registration; it is
-  // null when multi-account or zero-account configs disable the
-  // feature (see index.ts registration gate).
-  const gsManager = getGatewayStatusManager();
+  // close over it. getGatewayStatusCoordinator() returns the
+  // process-lifetime coordinator index.ts's registerFull publishes on
+  // every load pass (tool discovery, full activation, and the 6.11+
+  // prewarm) — it is created unconditionally, independent of Tlon account
+  // count; see gateway-status.ts. Per-monitor eligibility (exactly one
+  // account) is checked below, from THIS monitor's config snapshot.
+  const gsCoordinator = getGatewayStatusCoordinator();
+
+  // Monitor-local heartbeat handle (Fix C): each activation owns its own
+  // interval, so a stale monitor's cleanup can never kill a replacement
+  // monitor's heartbeat by construction. Populated once activation
+  // actually starts the heartbeat; cleared/cleared-out on teardown.
+  let stopGatewayHeartbeat: (() => void) | null = null;
+
+  // Monitor-local abort for the gateway-status ACTIVATION ORCHESTRATION
+  // only (the waitForStartedLifecycle() wait, the start watchdog, and the
+  // retry backoff) — NOT the in-flight pokes (that abort is the deferred
+  // Fix D). Aborting this from cleanupGatewayStatus() lets teardown cancel
+  // a pending wait even when the host abortSignal never fires (e.g.
+  // bootstrap throws because api.connect() failed), so the coordinator does
+  // not retain the waiter + monitor closure and the watchdog can't emit
+  // telemetry after teardown.
+  const gatewayStatusActivationAbort = new AbortController();
 
   // Idempotent gateway-status teardown. Called from every path that
   // can leave this monitor: (a) synchronous abort already raised at
@@ -638,16 +610,21 @@ export async function monitorTlonProvider(
       return;
     }
     gatewayStatusCleanupRan = true;
-    gsManager?.stopHeartbeat();
-    // Deliberately do NOT call gsManager.markStopped() here. The manager is
-    // a process-lifetime singleton (set once in index.ts's registerFull,
-    // which does not re-run on config reload) reused across monitor
-    // restarts. markStopped() is a one-way latch the gateway_stop hook owns;
-    // if monitor teardown set it, a config-reload's replacement monitor
-    // would reuse the latched manager, its activation would see stopped and
-    // bail, and gateway-status would stay dead until a full gateway restart.
-    // Zombie-heartbeat prevention is monitor-local via gatewayStatusCleanupRan
-    // (checked in the activation task before startHeartbeat).
+    stopGatewayHeartbeat?.();
+    stopGatewayHeartbeat = null;
+    // Cancel any pending activation wait/watchdog/backoff (orchestration
+    // only — never the in-flight poke requests).
+    gatewayStatusActivationAbort.abort();
+    // Deliberately do NOT call gsCoordinator.markStopped() here. The
+    // coordinator is process-lifetime (created once, reused across BOTH
+    // registerFull passes and in-process monitor restarts). markStopped()
+    // latches a specific GENERATION stopped and is the gateway_stop hook's
+    // job; if monitor teardown called it, a config-reload's replacement
+    // monitor would find its generation already stopped and bail, leaving
+    // gateway-status dead until the next real %gateway-start. Zombie-
+    // heartbeat prevention is monitor-local via gatewayStatusCleanupRan
+    // (checked by the activation task, and by every heartbeat tick's own
+    // validity predicate).
     if (apiClientParamsSlot.get() === myApiClientParams) {
       apiClientParamsSlot.set(null);
     }
@@ -1296,127 +1273,62 @@ export async function monitorTlonProvider(
     }
 
     // ── Gateway-status: non-blocking background activation ──────
-    // (gsManager was hoisted to the slot-publish region above so that
-    // cleanupGatewayStatus can close over it; we reuse the same captured
-    // reference here.)
-
-    if (gsManager && effectiveOwnerShip) {
-      const capturedOwnerShip = effectiveOwnerShip;
-      const signal = opts.abortSignal;
-
-      // Fire-and-forget: wait for gateway_start signal, then activate.
-      // Does NOT block monitor startup — discovery, subscriptions, etc. proceed immediately.
-      void (async () => {
-        // Named abort handler so it can be removed once the race settles. When
-        // the "started" branch wins (every config-reload restart, since
-        // waitForGatewayStart() is already resolved on the process-lifetime
-        // manager), a bare addEventListener would linger on the host's signal
-        // forever — `{ once: true }` only removes it after it fires — retaining
-        // this activation closure and the SSE-bound monitor state. Same
-        // retention class the outer-finally removeEventListener avoids.
-        let onRaceAbort: (() => void) | undefined;
-        try {
-          const abortRace =
-            signal &&
-            new Promise<'aborted'>((r) => {
-              if (signal.aborted) {
-                r('aborted');
-                return;
-              }
-              onRaceAbort = () => r('aborted');
-              signal.addEventListener('abort', onRaceAbort, { once: true });
-            });
-          const raced = await Promise.race([
-            gsManager.waitForGatewayStart().then(() => 'started' as const),
-            ...(abortRace ? [abortRace] : []),
-          ]);
-          if (signal && onRaceAbort) {
-            signal.removeEventListener('abort', onRaceAbort);
-          }
-          if (
-            raced !== 'started' ||
-            gatewayStatusCleanupRan ||
-            gsManager.stopped
-          ) {
-            return;
-          }
-
-          // One-shot activation proved fragile: a single silently-hung poke
-          // (observed when activation raced an SSE reconnect) left
-          // gateway-status dead for the whole process lifetime, so the ship
-          // marked the gateway %down and auto-replied "bot is offline" to
-          // owner DMs. Retry with a per-attempt timeout until activation
-          // sticks or this monitor is torn down.
-          for (let attempt = 1; ; attempt += 1) {
-            if (
-              signal?.aborted ||
-              gatewayStatusCleanupRan ||
-              gsManager.stopped
-            ) {
-              return;
-            }
-            try {
-              await withActivationTimeout(
-                configureGatewayStatus({
-                  owner: capturedOwnerShip,
-                  activeWindowSecs: ACTIVE_WINDOW_SECS,
-                  offlineReplyCooldownSecs: OFFLINE_REPLY_COOLDOWN_SECS,
-                }),
-                '%configure'
-              );
-              // Recheck after each await: this monitor can be torn down
-              // (gatewayStatusCleanupRan), the signal can abort, or the gateway can
-              // stop (gsManager.stopped) while these pokes are in flight. Without
-              // the recheck we would leave a zombie heartbeat interval running.
-              // The cleanup flag is monitor-local on purpose — see
-              // cleanupGatewayStatus for why we don't latch the shared manager.
-              if (
-                signal?.aborted ||
-                gatewayStatusCleanupRan ||
-                gsManager.stopped
-              ) {
-                return;
-              }
-              // Mark starting before the %gateway-start poke so a concurrent
-              // gateway_stop hook knows a start poke is in flight and sends a
-              // matching %gateway-stop even if shutdown lands before markActivated().
-              gsManager.markStarting();
-              await withActivationTimeout(
-                gatewayStart({
-                  bootId: gsManager.bootId,
-                  leaseUntil: computeLeaseUntil(),
-                }),
-                '%gateway-start'
-              );
-              if (
-                signal?.aborted ||
-                gatewayStatusCleanupRan ||
-                gsManager.stopped
-              ) {
-                return;
-              }
-              gsManager.markActivated();
-              gsManager.startHeartbeat();
-              runtime.log?.(
-                `[gateway-status] activated (bootId=${gsManager.bootId}, owner=${capturedOwnerShip}, attempt=${attempt})`
-              );
-              return;
-            } catch (err) {
-              capturePluginError('gateway_status_activation', err, {
-                attempt,
-              });
-              runtime.error?.(
-                `[gateway-status] activation attempt ${attempt} failed: ${String(err)} — retrying in ${GATEWAY_STATUS_ACTIVATION_RETRY_MS / 1000}s`
-              );
-            }
-            await abortableDelay(GATEWAY_STATUS_ACTIVATION_RETRY_MS, signal);
-          }
-        } catch (err) {
-          capturePluginError('gateway_status_activation', err);
-          runtime.error?.(`[gateway-status] start failed: ${String(err)}`);
+    // (gsCoordinator was hoisted to the slot-publish region above so that
+    // cleanupGatewayStatus can close over its heartbeat handle; we reuse
+    // the same captured reference here.)
+    //
+    // Fix B: eligibility (exactly one Tlon account) is derived from THIS
+    // monitor's own config snapshot (`cfg`, the channel-start `ctx.cfg`),
+    // not from anything registerFull decided — an account added/removed via
+    // a channels.tlon hot-reload restarts monitors without a second
+    // registerFull, so a value cached at registration time would go stale.
+    // gsCoordinator itself is created unconditionally in index.ts
+    // (independent of account count). The decision lives in the shared
+    // gateGatewayStatusActivation() so tests exercise the exact gate.
+    //
+    // Compose the host abort (config-reload/shutdown restart) with the
+    // monitor-local activation abort (bootstrap-failure teardown) so the
+    // orchestration's wait/watchdog/backoff honor either.
+    const gatewayStatusSignal = opts.abortSignal
+      ? AbortSignal.any([opts.abortSignal, gatewayStatusActivationAbort.signal])
+      : gatewayStatusActivationAbort.signal;
+    void gateGatewayStatusActivation({
+      cfg,
+      coordinator: gsCoordinator,
+      effectiveOwnerShip,
+      signal: gatewayStatusSignal,
+      isTornDown: () => gatewayStatusCleanupRan,
+      logger: {
+        log: (m) => runtime.log?.(m),
+        error: (m) => runtime.error?.(m),
+      },
+      onActivationError: (err, attempt) =>
+        capturePluginError('gateway_status_activation', err, { attempt }),
+      onHeartbeatError: (err) =>
+        capturePluginError('gateway_status_heartbeat', err),
+      onWatchdogTimeout: () =>
+        capturePluginError(
+          'gateway_status_activation',
+          new Error('gateway-status start watchdog timeout'),
+          { errorKind: 'start_watchdog_timeout' }
+        ),
+      onMultiAccountSkip: (count) =>
+        runtime.log?.(
+          `[gateway-status] skipped: ${count} Tlon accounts configured, ` +
+            `but v1 only supports one (global @tloncorp/api client cannot target multiple ships)`
+        ),
+      registerHeartbeatStop: (stop) => {
+        // A concurrent teardown may have already run cleanupGatewayStatus
+        // (which clears/nulls this handle) between the heartbeat starting
+        // and this callback running; stop it immediately instead of
+        // leaving a zombie interval that only self-clears on its next tick.
+        if (gatewayStatusCleanupRan) {
+          stop();
+          return;
         }
-      })();
-    }
+        stopGatewayHeartbeat = stop;
+      },
+    });
 
     // Fetch group metadata AFTER settings are loaded so approval cards can display
     // friendly group names for both auto-discovered and manually configured channels.

--- a/packages/openclaw/test/cases/08-gateway-status.test.ts
+++ b/packages/openclaw/test/cases/08-gateway-status.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Live gateway-status regression coverage (TLON-6132).
+ *
+ * Test 1 is the sensitivity guard: on prewarming cores, a forced Tlon monitor
+ * restart must establish a new lease and then renew it from the replacement
+ * monitor. Test 2 is omitted because rube-27's archived activity feed does not
+ * advance the old agent's owner-activity; a regenerated steward pier can cover
+ * it later.
+ */
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import {
+  type BoundedNounClient,
+  type GatewayStatusScry,
+  assertOpenClawContainerRunning,
+  createBoundedNounClient,
+  decodeGatewayStatus,
+  getContainerLogsSince,
+  getTestConfig,
+  setGatewayStatusRestartConfig,
+} from '../lib/index.js';
+
+const ARCHIVE = 'pinned rube-zod27';
+// Must match dev/Dockerfile.test's ARG OPENCLAW_CORE_VERSION default: the test
+// asserts the container's installed core equals this requested version. Bumping
+// both together to 2026.6.11/2026.7.1 (already in the known-prewarm map below)
+// promotes this case from a 5.28 smoke test to the full prewarm regression guard.
+const DEFAULT_CORE_VERSION = '2026.5.28';
+const HARD_TEST_TIMEOUT_MS = 180_000;
+const INTERNAL_TEST_TIMEOUT_MS = 165_000;
+const DIAGNOSTIC_RESERVE_MS = 12_000;
+const MIN_POLL_OPERATION_BUDGET_MS = 2_000;
+const STATUS_SCRY = {
+  app: 'gateway-status',
+  path: '/status',
+  archive: ARCHIVE,
+} as const;
+const GATEWAY_START = '[gateway-status] gateway_start received (generation=1)';
+const ACTIVATED = '[gateway-status] activated (';
+const REGISTERING_TOOL = '[tlon] Registering tlon tool, binary:';
+const PREWARM_RE = /agent runtime plugins pre-warmed in \d+ms/;
+const RESTARTING_CHANNEL = 'restarting tlon channel';
+const STARTING_MONITOR = '[tlon] Starting monitor for ~zod';
+const CORE_VERSION_RE =
+  /\[tlon-e2e\] openclaw-core-version=([^\s]+) requested=([^\s]+)/g;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function evidence(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index >= 0) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function nthIndex(
+  haystack: string,
+  needle: string,
+  occurrence: number
+): number {
+  let offset = 0;
+  for (let current = 1; current <= occurrence; current += 1) {
+    const index = haystack.indexOf(needle, offset);
+    if (index < 0) {
+      return -1;
+    }
+    if (current === occurrence) {
+      return index;
+    }
+    offset = index + needle.length;
+  }
+  return -1;
+}
+
+function regexIndexAfter(logs: string, regex: RegExp, after: number): number {
+  const sliced = logs.slice(after);
+  const match = sliced.match(regex);
+  return match?.index == null ? -1 : after + match.index;
+}
+
+function lineAt(logs: string, index: number): string {
+  if (index < 0) {
+    return '<missing>';
+  }
+  const start = logs.lastIndexOf('\n', index) + 1;
+  const end = logs.indexOf('\n', index);
+  return logs.slice(start, end < 0 ? undefined : end).trim();
+}
+
+function lastLogLines(logs: string, count = 100): string {
+  return logs.trim().split(/\r?\n/).slice(-count).join('\n');
+}
+
+function statusSummary(status: GatewayStatusScry | null): string {
+  if (!status) {
+    return '<none>';
+  }
+  return `${status.status} lease=${status.leaseUntil ?? 'null'} raw=${status.raw}`;
+}
+
+function markerSummary(logs: string): string {
+  return [
+    `${GATEWAY_START} count=${countOccurrences(logs, GATEWAY_START)}`,
+    `${ACTIVATED} count=${countOccurrences(logs, ACTIVATED)}`,
+    `${REGISTERING_TOOL} count=${countOccurrences(logs, REGISTERING_TOOL)}`,
+    `${RESTARTING_CHANNEL} count=${countOccurrences(logs, RESTARTING_CHANNEL)}`,
+    `${STARTING_MONITOR} count=${countOccurrences(logs, STARTING_MONITOR)}`,
+  ].join('; ');
+}
+
+function readPrewarmExpectation(coreVersion: string): boolean {
+  const raw = process.env.TEST_EXPECT_OPENCLAW_PREWARM;
+  if (raw != null && raw !== '0' && raw !== '1') {
+    throw new Error(
+      `TEST_EXPECT_OPENCLAW_PREWARM must be 0 or 1 for core ${coreVersion}`
+    );
+  }
+  const known: Record<string, boolean> = {
+    '2026.5.28': false,
+    '2026.6.11': true,
+    '2026.7.1': true,
+  };
+  if (raw == null) {
+    if (!(coreVersion in known)) {
+      throw new Error(
+        `TEST_EXPECT_OPENCLAW_PREWARM must be explicit for unknown core ${coreVersion}`
+      );
+    }
+    return known[coreVersion];
+  }
+  const explicit = raw === '1';
+  if (coreVersion in known) {
+    expect(
+      explicit,
+      `wrong prewarm expectation for known OpenClaw core ${coreVersion}`
+    ).toBe(known[coreVersion]);
+  }
+  return explicit;
+}
+
+function remainingTimeout(
+  deadline: number,
+  maximumMs: number,
+  operation: string
+): number {
+  const remainingMs = Math.floor(deadline - Date.now());
+  if (remainingMs <= 0) {
+    throw new Error(
+      `Internal ${INTERNAL_TEST_TIMEOUT_MS}ms deadline exhausted before ${operation}`
+    );
+  }
+  return Math.min(maximumMs, remainingMs);
+}
+
+function phaseDeadline(overallDeadline: number, windowMs: number): number {
+  return Math.min(
+    Date.now() + windowMs,
+    overallDeadline - DIAGNOSTIC_RESERVE_MS
+  );
+}
+
+function canStartPoll(deadline: number): boolean {
+  return Date.now() + MIN_POLL_OPERATION_BUDGET_MS < deadline;
+}
+
+async function sleepWithin(deadline: number, maximumMs: number): Promise<void> {
+  await sleep(remainingTimeout(deadline, maximumMs, 'poll sleep'));
+}
+
+function startupIndices(
+  logs: string,
+  expectPrewarm: boolean
+): {
+  gatewayStart: number;
+  activated: number;
+  registering: number;
+  prewarm: number;
+} {
+  const gatewayStart = logs.indexOf(GATEWAY_START);
+  const activated = logs.indexOf(
+    ACTIVATED,
+    gatewayStart + GATEWAY_START.length
+  );
+  const registering = expectPrewarm
+    ? logs.indexOf(REGISTERING_TOOL, gatewayStart + GATEWAY_START.length)
+    : -1;
+  const prewarm = expectPrewarm
+    ? regexIndexAfter(logs, PREWARM_RE, registering + REGISTERING_TOOL.length)
+    : -1;
+  return { gatewayStart, activated, registering, prewarm };
+}
+
+function startupReady(logs: string, expectPrewarm: boolean): boolean {
+  const indices = startupIndices(logs, expectPrewarm);
+  if (indices.gatewayStart < 0 || indices.activated <= indices.gatewayStart) {
+    return false;
+  }
+  return (
+    !expectPrewarm ||
+    (indices.registering > indices.gatewayStart &&
+      indices.prewarm > indices.registering)
+  );
+}
+
+describe('gateway-status lifecycle', () => {
+  let nounClient: BoundedNounClient;
+  let composeFile: string;
+
+  const readLogs = (deadline: number): string => {
+    assertOpenClawContainerRunning(
+      composeFile,
+      remainingTimeout(deadline, 10_000, 'container liveness check')
+    );
+    return getContainerLogsSince(
+      composeFile,
+      new Date(0).toISOString(),
+      remainingTimeout(deadline, 10_000, 'container log read')
+    );
+  };
+
+  const readStatus = async (deadline: number): Promise<GatewayStatusScry> => {
+    assertOpenClawContainerRunning(
+      composeFile,
+      remainingTimeout(deadline, 10_000, 'status container liveness check')
+    );
+    const remainingMs = remainingTimeout(
+      deadline,
+      30_000,
+      'gateway status noun scry'
+    );
+    // noun-scry bounds each possible auth/fetch/retry phase separately. Give
+    // each phase a fraction of the remaining operation budget so the complete
+    // request cannot consume the test's internal overall deadline.
+    const timeoutMs = Math.max(1, Math.floor(remainingMs / 6));
+    return decodeGatewayStatus(
+      await nounClient.scry({ ...STATUS_SCRY, timeoutMs })
+    );
+  };
+
+  const waitForLogs = async (
+    description: string,
+    timeoutMs: number,
+    overallDeadline: number,
+    predicate: (logs: string) => boolean
+  ): Promise<string> => {
+    const deadline = phaseDeadline(overallDeadline, timeoutMs);
+    let logs = '';
+    while (canStartPoll(deadline)) {
+      logs = readLogs(deadline);
+      if (predicate(logs)) {
+        return logs;
+      }
+      await sleepWithin(deadline, 1_000);
+    }
+    throw new Error(
+      `Timed out waiting for ${description}. ${markerSummary(logs)}\n` +
+        `Last 100 OpenClaw log lines:\n${lastLogLines(logs)}`
+    );
+  };
+
+  beforeAll(() => {
+    const config = getTestConfig();
+    nounClient = createBoundedNounClient(config.bot);
+    composeFile = process.env.TEST_COMPOSE_FILE ?? '';
+    if (!composeFile) {
+      throw new Error('TEST_COMPOSE_FILE is required');
+    }
+    if (!process.env.TEST_COMPOSE_PROJECT_NAME) {
+      throw new Error('TEST_COMPOSE_PROJECT_NAME is required for isolation');
+    }
+  });
+
+  test(
+    'survives prewarm, forced monitor restart, and two-stage lease renewal',
+    async () => {
+      const overallDeadline = Date.now() + INTERNAL_TEST_TIMEOUT_MS;
+      const requestedVersion =
+        process.env.TEST_OPENCLAW_CORE_VERSION ?? DEFAULT_CORE_VERSION;
+      const expectPrewarm = readPrewarmExpectation(requestedVersion);
+
+      const startupLogs = await waitForLogs(
+        'ordered gateway startup/prewarm evidence',
+        25_000,
+        overallDeadline,
+        (logs) => startupReady(logs, expectPrewarm)
+      );
+      const versionMarkers = [...startupLogs.matchAll(CORE_VERSION_RE)];
+      const lastVersionMarker = versionMarkers.at(-1);
+      expect(
+        lastVersionMarker,
+        'installed core version marker is missing'
+      ).toBeDefined();
+      expect(lastVersionMarker?.[1], 'installed core version').toBe(
+        requestedVersion
+      );
+      expect(lastVersionMarker?.[2], 'requested core version marker').toBe(
+        requestedVersion
+      );
+
+      const startup = startupIndices(startupLogs, expectPrewarm);
+      evidence(`[gateway-status-e2e] core=${requestedVersion}`);
+      evidence(
+        `[gateway-status-e2e] ${lineAt(startupLogs, startup.gatewayStart)}`
+      );
+      evidence(
+        `[gateway-status-e2e] ${lineAt(startupLogs, startup.activated)}`
+      );
+      if (expectPrewarm) {
+        evidence(
+          `[gateway-status-e2e] ${lineAt(startupLogs, startup.registering)}`
+        );
+        evidence(
+          `[gateway-status-e2e] ${lineAt(startupLogs, startup.prewarm)}`
+        );
+      } else {
+        evidence('[gateway-status-e2e] prewarm assertion skipped (5.28 smoke)');
+      }
+
+      // Observe a real heartbeat lease advance before taking L0. Mutating just
+      // after this leaves nearly a full 30-second interval before any stale
+      // monitor callback could run, making the post-restart stages unambiguous.
+      const seed = await readStatus(overallDeadline);
+      if (
+        seed.status !== 'up' ||
+        seed.leaseUntil == null ||
+        seed.leaseUntil <= Date.now()
+      ) {
+        throw new Error(
+          `Initial gateway ship liveness failed: ${statusSummary(seed)}`
+        );
+      }
+      const heartbeatDeadline = phaseDeadline(overallDeadline, 36_000);
+      let baseline: GatewayStatusScry | null = null;
+      let lastStatus: GatewayStatusScry | null = seed;
+      while (canStartPoll(heartbeatDeadline)) {
+        const current = await readStatus(heartbeatDeadline);
+        lastStatus = current;
+        if (
+          current.status === 'up' &&
+          current.leaseUntil != null &&
+          current.leaseUntil > seed.leaseUntil
+        ) {
+          baseline = current;
+          break;
+        }
+        await sleepWithin(heartbeatDeadline, 500);
+      }
+      if (!baseline?.leaseUntil) {
+        const logs = readLogs(overallDeadline);
+        throw new Error(
+          `Initial gateway heartbeat did not advance the ship lease; ` +
+            `seed=${seed.leaseUntil}, L0=absent, last=${statusSummary(lastStatus)}. ` +
+            `${markerSummary(logs)}\nLast 100 OpenClaw log lines:\n${lastLogLines(logs)}`
+        );
+      }
+      const l0 = baseline.leaseUntil;
+      evidence(
+        `[gateway-status-e2e] L0=${l0} observed immediately after pre-restart heartbeat`
+      );
+
+      await sleepWithin(overallDeadline, 1_500);
+      const preMutationLogs = readLogs(overallDeadline);
+      const mutationBoundary = preMutationLogs.length;
+      const restartCountBefore = countOccurrences(
+        preMutationLogs,
+        RESTARTING_CHANNEL
+      );
+      const monitorCountBefore = countOccurrences(
+        preMutationLogs,
+        STARTING_MONITOR
+      );
+      const configDeadline = phaseDeadline(overallDeadline, 20_000);
+      const configResult = setGatewayStatusRestartConfig(
+        composeFile,
+        remainingTimeout(configDeadline, 20_000, 'config mutation')
+      );
+      evidence(
+        `[gateway-status-e2e] config exit=${configResult.exitCode} ` +
+          `${configResult.stdout.trim()} ${configResult.stderr.trim()}`.trim()
+      );
+      expect(configResult.exitCode, 'config mutation must exit 0').toBe(0);
+      assertOpenClawContainerRunning(
+        composeFile,
+        remainingTimeout(overallDeadline, 10_000, 'post-config liveness check')
+      );
+
+      const restartLogs = await waitForLogs(
+        'forced Tlon channel restart and replacement monitor',
+        20_000,
+        overallDeadline,
+        (logs) => {
+          const restartIndex = nthIndex(
+            logs,
+            RESTARTING_CHANNEL,
+            restartCountBefore + 1
+          );
+          const monitorIndex = nthIndex(
+            logs,
+            STARTING_MONITOR,
+            monitorCountBefore + 1
+          );
+          return (
+            restartIndex >= mutationBoundary &&
+            monitorIndex >= mutationBoundary &&
+            (!expectPrewarm || monitorIndex > startup.prewarm)
+          );
+        }
+      );
+      const restartIndex = nthIndex(
+        restartLogs,
+        RESTARTING_CHANNEL,
+        restartCountBefore + 1
+      );
+      const monitorIndex = nthIndex(
+        restartLogs,
+        STARTING_MONITOR,
+        monitorCountBefore + 1
+      );
+      evidence(`[gateway-status-e2e] ${lineAt(restartLogs, restartIndex)}`);
+      evidence(`[gateway-status-e2e] ${lineAt(restartLogs, monitorIndex)}`);
+
+      // Stage 1 is one liveness assertion: the post-restart activation marker
+      // gates acceptance of a ship lease advance, but a missing marker is
+      // reported as failure to establish L1 rather than as a standalone log
+      // assertion. This keeps deliberate broken-code REDs ship-state based.
+      const stage1Deadline = phaseDeadline(overallDeadline, 20_000);
+      let l1: number | null = null;
+      lastStatus = null;
+      let postRestartActivated = false;
+      while (canStartPoll(stage1Deadline)) {
+        const logs = readLogs(stage1Deadline);
+        const activatedIndex = logs.indexOf(
+          ACTIVATED,
+          monitorIndex + STARTING_MONITOR.length
+        );
+        postRestartActivated = activatedIndex > monitorIndex;
+        const current = await readStatus(stage1Deadline);
+        lastStatus = current;
+        if (
+          postRestartActivated &&
+          current.status === 'up' &&
+          current.leaseUntil != null &&
+          current.leaseUntil > l0 &&
+          current.leaseUntil > Date.now()
+        ) {
+          l1 = current.leaseUntil;
+          break;
+        }
+        await sleepWithin(stage1Deadline, 500);
+      }
+      if (l1 == null) {
+        const logs = readLogs(overallDeadline);
+        throw new Error(
+          `Gateway liveness Stage 1 failed: replacement monitor did not establish ` +
+            `a new live ship lease. L0=${l0}, L1=absent, ` +
+            `postRestartActivated=${postRestartActivated}, last=${statusSummary(lastStatus)}. ` +
+            `${markerSummary(logs)}\nLast 100 OpenClaw log lines:\n${lastLogLines(logs)}`
+        );
+      }
+      evidence(`[gateway-status-e2e] L1=${l1} (> L0=${l0})`);
+
+      // Stage 2's 45-second budget starts only after L1 is accepted. Requiring
+      // both a second advance and >=45s remaining proves a replacement-monitor
+      // heartbeat, not one stale callback from the torn-down monitor.
+      const stage2Deadline = phaseDeadline(overallDeadline, 45_000);
+      let l2: number | null = null;
+      lastStatus = null;
+      while (canStartPoll(stage2Deadline)) {
+        const current = await readStatus(stage2Deadline);
+        lastStatus = current;
+        if (
+          current.status === 'up' &&
+          current.leaseUntil != null &&
+          current.leaseUntil > l1 &&
+          current.leaseUntil >= Date.now() + 45_000
+        ) {
+          l2 = current.leaseUntil;
+          break;
+        }
+        await sleepWithin(stage2Deadline, 1_000);
+      }
+      if (l2 == null) {
+        const logs = readLogs(overallDeadline);
+        throw new Error(
+          `Gateway liveness Stage 2 failed: replacement monitor did not renew ` +
+            `its ship lease. L0=${l0}, L1=${l1}, L2=absent, ` +
+            `last=${statusSummary(lastStatus)}. ${markerSummary(logs)}\n` +
+            `Last 100 OpenClaw log lines:\n${lastLogLines(logs)}`
+        );
+      }
+      evidence(`[gateway-status-e2e] L2=${l2} (> L1=${l1})`);
+    },
+    HARD_TEST_TIMEOUT_MS
+  );
+});

--- a/packages/openclaw/test/lib/docker-logs.ts
+++ b/packages/openclaw/test/lib/docker-logs.ts
@@ -4,7 +4,7 @@
  * Captures OpenClaw container logs for asserting tool invocations
  * in integration tests run under docker compose (pnpm test:integration).
  */
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 
 type LiveToolTraceOptions = {
   composeFile: string;
@@ -32,7 +32,8 @@ const TOOL_TRACE_LINE_RE =
  */
 export function getContainerLogsSince(
   composeFile: string,
-  sinceIso: string
+  sinceIso: string,
+  timeoutMs = 10_000
 ): string {
   const composeFiles = resolveComposeFiles(composeFile);
   const output = execFileSync(
@@ -48,12 +49,87 @@ export function getContainerLogsSince(
     ],
     {
       encoding: 'utf-8',
-      timeout: 10_000,
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
       cwd: process.cwd(),
       env: composeEnv(),
     }
   );
   return output;
+}
+
+/** Fail immediately when the integration gateway container is not running. */
+export function assertOpenClawContainerRunning(
+  composeFile: string,
+  timeoutMs = 10_000
+): void {
+  const composeFiles = resolveComposeFiles(composeFile);
+  const output = execFileSync(
+    'docker',
+    [
+      'compose',
+      ...composeFileArgs(composeFiles),
+      'ps',
+      '--status',
+      'running',
+      '--quiet',
+      'openclaw',
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: timeoutMs,
+      cwd: process.cwd(),
+      env: composeEnv(),
+    }
+  );
+  if (!output.trim()) {
+    throw new Error('OpenClaw container exited or is not running');
+  }
+}
+
+export interface ConfigSetResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run the exact liveness-neutral config mutation used by the regression test. */
+export function setGatewayStatusRestartConfig(
+  composeFile: string,
+  timeoutMs = 20_000
+): ConfigSetResult {
+  const composeFiles = resolveComposeFiles(composeFile);
+  const result = spawnSync(
+    'docker',
+    [
+      'compose',
+      ...composeFileArgs(composeFiles),
+      'exec',
+      '-T',
+      'openclaw',
+      'openclaw',
+      'config',
+      'set',
+      'channels.tlon.showModelSignature',
+      'true',
+      '--strict-json',
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: timeoutMs,
+      maxBuffer: 2 * 1024 * 1024,
+      cwd: process.cwd(),
+      env: composeEnv(),
+    }
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  return {
+    exitCode: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
 }
 
 function escapeRegex(s: string): string {
@@ -310,5 +386,13 @@ function composeEnv(projectName?: string): NodeJS.ProcessEnv {
     projectName ??
     process.env.TEST_COMPOSE_PROJECT_NAME ??
     process.env.COMPOSE_PROJECT_NAME;
-  return name ? { ...process.env, COMPOSE_PROJECT_NAME: name } : process.env;
+  const env = {
+    ...process.env,
+    // Optional compose values. Empty defaults keep every test-side logs/ps
+    // poll from emitting interpolation warnings when secrets are absent.
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY ?? '',
+    BRAVE_API_KEY: process.env.BRAVE_API_KEY ?? '',
+    TLONBOT_TOKEN: process.env.TLONBOT_TOKEN ?? '',
+  };
+  return name ? { ...env, COMPOSE_PROJECT_NAME: name } : env;
 }

--- a/packages/openclaw/test/lib/index.ts
+++ b/packages/openclaw/test/lib/index.ts
@@ -8,7 +8,18 @@ export {
   createStateClient,
   type StateClient,
   type StateClientConfig,
+  withStateClientLock,
 } from './state.js';
+
+export {
+  createBoundedNounClient,
+  decodeDa,
+  decodeGatewayStatus,
+  type BoundedNounClient,
+  type BoundedNounScryOptions,
+  type GatewayStatusScry,
+  type GatewayStatusValue,
+} from './noun-scry.js';
 
 export {
   createTlonClient,
@@ -34,8 +45,11 @@ export {
 } from './fixtures.js';
 
 export {
+  assertOpenClawContainerRunning,
   getContainerLogsSince,
+  setGatewayStatusRestartConfig,
   startLiveToolTrace,
   toolWasInvoked,
+  type ConfigSetResult,
   type LiveToolTraceHandle,
 } from './docker-logs.js';

--- a/packages/openclaw/test/lib/noun-scry.ts
+++ b/packages/openclaw/test/lib/noun-scry.ts
@@ -1,0 +1,237 @@
+import { da } from '@urbit/aura';
+import { Atom, Cell, type Noun, cue, enjs } from '@urbit/nockjs';
+
+import { type StateClientConfig, withStateClientLock } from './state.js';
+
+export type GatewayStatusValue = 'unknown' | 'up' | 'down';
+
+export interface GatewayStatusScry {
+  status: GatewayStatusValue;
+  leaseUntil: number | null;
+  raw: string;
+}
+
+export interface BoundedNounScryOptions {
+  app: string;
+  path: string;
+  archive: string;
+  timeoutMs?: number;
+}
+
+export interface BoundedNounClient {
+  scry(options: BoundedNounScryOptions): Promise<Noun>;
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+
+async function withAbortDeadline<T>(
+  label: string,
+  timeoutMs: number,
+  request: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(new Error(`${label} exceeded ${timeoutMs}ms`));
+  }, timeoutMs);
+
+  try {
+    return await request(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`${label} timed out after ${timeoutMs}ms`, {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function unpackJamBytes(buffer: ArrayBuffer): Noun {
+  const hex = [...new Uint8Array(buffer)]
+    .reverse()
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  if (!hex) {
+    throw new Error('noun response body was empty');
+  }
+  return cue(Atom.fromString(hex, 16));
+}
+
+/**
+ * Create a raw authenticated noun client whose login and noun body read each
+ * have a real AbortSignal deadline. Calls share StateClient's serialization
+ * lock and always release it in that lock's `finally` block.
+ */
+export function createBoundedNounClient(
+  config: StateClientConfig
+): BoundedNounClient {
+  const shipUrl = config.shipUrl.replace(/\/$/, '');
+  let cookie: string | null = null;
+
+  const authenticate = async (timeoutMs: number): Promise<void> => {
+    const response = await withAbortDeadline(
+      `Urbit authentication for ${config.shipName}`,
+      timeoutMs,
+      (signal) =>
+        fetch(`${shipUrl}/~/login`, {
+          method: 'POST',
+          body: `password=${encodeURIComponent(config.code)}`,
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          signal,
+        })
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Urbit authentication for ${config.shipName} failed with HTTP ${response.status}`
+      );
+    }
+    cookie = response.headers.get('set-cookie')?.split(';')[0]?.trim() ?? null;
+    if (!cookie) {
+      throw new Error(
+        `Urbit authentication for ${config.shipName} returned no session cookie`
+      );
+    }
+  };
+
+  const fetchNoun = async (
+    url: string,
+    timeoutMs: number
+  ): Promise<{ response: Response; body: ArrayBuffer | null }> => {
+    return withAbortDeadline(`noun scry ${url}`, timeoutMs, async (signal) => {
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Cookie: cookie ?? '',
+          Connection: 'close',
+          'X-Channel-Format': 'application/x-urb-jam',
+        },
+        signal,
+      });
+      const body = response.ok ? await response.arrayBuffer() : null;
+      return { response, body };
+    });
+  };
+
+  const fetchNounWithNetworkRetry = async (
+    url: string,
+    timeoutMs: number
+  ): Promise<{ response: Response; body: ArrayBuffer | null }> => {
+    try {
+      return await fetchNoun(url, timeoutMs);
+    } catch (error) {
+      // An AbortController deadline is a real bounded failure. A fake ship's
+      // HTTP server can, however, close an idle keep-alive socket during the
+      // monitor restart; retry that transport failure once, under a fresh
+      // AbortController/deadline, without weakening 404 semantics below.
+      if (error instanceof Error && error.message.includes('timed out')) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return fetchNoun(url, timeoutMs);
+    }
+  };
+
+  return {
+    async scry(options) {
+      return withStateClientLock(async () => {
+        const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+        const path = options.path.startsWith('/')
+          ? options.path
+          : `/${options.path}`;
+        const url = `${shipUrl}/~/scry/${options.app}${path}.noun`;
+
+        if (!cookie) {
+          await authenticate(timeoutMs);
+        }
+
+        let result = await fetchNounWithNetworkRetry(url, timeoutMs);
+        if (result.response.status === 403) {
+          cookie = null;
+          await authenticate(timeoutMs);
+          result = await fetchNounWithNetworkRetry(url, timeoutMs);
+        }
+
+        if (result.response.status === 404) {
+          throw new Error(
+            `Terminal noun scry 404: app=%${options.app}, path=${options.path}, archive=${options.archive}`
+          );
+        }
+        if (!result.response.ok || !result.body) {
+          throw new Error(
+            `Noun scry failed with HTTP ${result.response.status}: app=%${options.app}, path=${options.path}, archive=${options.archive}`
+          );
+        }
+
+        return unpackJamBytes(result.body);
+      });
+    },
+  };
+}
+
+function malformedGatewayStatus(noun: Noun, reason: string): never {
+  throw new Error(
+    `Malformed gateway-status noun (${reason}); raw=${noun.toString()}`
+  );
+}
+
+/** Decode the old standalone agent's `[status (unit @da)]` noun. */
+export function decodeGatewayStatus(noun: Noun): GatewayStatusScry {
+  const raw = noun.toString();
+  if (!(noun instanceof Cell)) {
+    return malformedGatewayStatus(noun, 'outer noun is not a cell');
+  }
+  if (!(noun.head instanceof Atom)) {
+    return malformedGatewayStatus(noun, 'status head is not an atom');
+  }
+
+  const status = enjs.cord(noun.head);
+  if (status !== 'unknown' && status !== 'up' && status !== 'down') {
+    return malformedGatewayStatus(noun, `invalid status %${status}`);
+  }
+
+  let leaseUntil: number | null;
+  if (noun.tail instanceof Atom) {
+    if (noun.tail.number !== 0n) {
+      return malformedGatewayStatus(noun, 'empty lease unit is not atom 0');
+    }
+    leaseUntil = null;
+  } else {
+    if (!(noun.tail instanceof Cell)) {
+      return malformedGatewayStatus(
+        noun,
+        'lease unit is neither atom nor cell'
+      );
+    }
+    if (!(noun.tail.head instanceof Atom) || noun.tail.head.number !== 0n) {
+      return malformedGatewayStatus(noun, 'lease some head is not atom 0');
+    }
+    if (!(noun.tail.tail instanceof Atom)) {
+      return malformedGatewayStatus(noun, 'lease @da tail is not an atom');
+    }
+    leaseUntil = da.toUnix(noun.tail.tail.number);
+    if (!Number.isFinite(leaseUntil)) {
+      return malformedGatewayStatus(noun, 'lease @da did not decode finitely');
+    }
+  }
+
+  return { status, leaseUntil, raw };
+}
+
+/** Decode a bare @da noun, used by the standalone owner-activity scry. */
+export function decodeDa(noun: Noun): number {
+  if (!(noun instanceof Atom)) {
+    throw new Error(
+      `Malformed @da noun (expected atom); raw=${noun.toString()}`
+    );
+  }
+  const unix = da.toUnix(noun.number);
+  if (!Number.isFinite(unix)) {
+    throw new Error(`Malformed @da noun (non-finite); raw=${noun.toString()}`);
+  }
+  return unix;
+}

--- a/packages/openclaw/test/lib/state.ts
+++ b/packages/openclaw/test/lib/state.ts
@@ -94,15 +94,28 @@ export interface StateClient {
   }): Promise<void>;
 }
 
-let apiQueue: Promise<unknown> = Promise.resolve();
+let apiQueue: Promise<void> = Promise.resolve();
 
-function runExclusive<T>(fn: () => Promise<T>): Promise<T> {
-  const next = apiQueue.then(fn, fn);
-  apiQueue = next.then(
-    () => undefined,
-    () => undefined
-  );
-  return next;
+/**
+ * Serialize access to the process-global @tloncorp/api client.
+ *
+ * The explicit release in `finally` is important for bounded raw requests:
+ * an aborted login or scry must never leave every later StateClient call
+ * waiting behind a lock that cannot settle.
+ */
+export async function withStateClientLock<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = apiQueue;
+  let release!: () => void;
+  apiQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
 }
 
 /**
@@ -116,7 +129,7 @@ export function createStateClient(config: StateClientConfig): StateClient {
   let connected = false;
 
   const withClient = async <T>(fn: () => Promise<T>) => {
-    return runExclusive(async () => {
+    return withStateClientLock(async () => {
       if (!connected) {
         await urbit.connect();
         connected = true;

--- a/packages/openclaw/test/run.sh
+++ b/packages/openclaw/test/run.sh
@@ -35,6 +35,35 @@ if [ -f .env ]; then
   done < .env
 fi
 
+# Every package-local run owns a distinct Compose project. Respect an explicit
+# caller-provided name for reproducibility, otherwise generate a safe default
+# before the first docker compose command can run.
+requested_project_name="${TEST_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME:-tlon-openclaw-e2e-${UID:-0}-$$}}"
+COMPOSE_PROJECT_NAME="$(printf '%s' "$requested_project_name" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-')"
+TEST_COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME"
+export COMPOSE_PROJECT_NAME TEST_COMPOSE_PROJECT_NAME
+
+# The image defaults to 5.28. Affected/future versions must carry an explicit
+# prewarm expectation so a missing core marker never silently becomes smoke.
+OPENCLAW_CORE_VERSION="${OPENCLAW_CORE_VERSION:-2026.5.28}"
+case "$OPENCLAW_CORE_VERSION" in
+  2026.5.28) derived_expect_prewarm=0 ;;
+  2026.6.11|2026.7.1) derived_expect_prewarm=1 ;;
+  *)
+    if [ -z "${TEST_EXPECT_OPENCLAW_PREWARM:-}" ]; then
+      echo "Error: TEST_EXPECT_OPENCLAW_PREWARM must be explicit for OpenClaw $OPENCLAW_CORE_VERSION"
+      exit 1
+    fi
+    derived_expect_prewarm="$TEST_EXPECT_OPENCLAW_PREWARM"
+    ;;
+esac
+TEST_EXPECT_OPENCLAW_PREWARM="${TEST_EXPECT_OPENCLAW_PREWARM:-$derived_expect_prewarm}"
+TEST_OPENCLAW_CORE_VERSION="$OPENCLAW_CORE_VERSION"
+export OPENCLAW_CORE_VERSION TEST_OPENCLAW_CORE_VERSION TEST_EXPECT_OPENCLAW_PREWARM
+
+echo "==> Compose project: $COMPOSE_PROJECT_NAME"
+echo "==> OpenClaw core: $OPENCLAW_CORE_VERSION (expect prewarm=$TEST_EXPECT_OPENCLAW_PREWARM)"
+
 # Force the integration suite onto the scripted fake-model. The .env load
 # above intentionally exposes dev creds (OPENROUTER_API_KEY, MODEL=...) so
 # `pnpm dev` works locally; without these overrides those would leak into
@@ -97,11 +126,16 @@ export ZOD_PORT TEN_PORT MUG_PORT FAKE_MODEL_PORT
 TLONBOT_DIR="${TLONBOT_DIR:-$(pwd)/../../../tlonbot}"
 export TLONBOT_DIR
 COMPOSE_FILES="-f dev/docker-compose.test.yml"
+COMPOSE_FILE_PATHS=("$PWD/dev/docker-compose.test.yml")
 if [ -f "dev/docker-compose.local.yml" ] && [ -d "$TLONBOT_DIR" ]; then
   COMPOSE_FILES="$COMPOSE_FILES -f dev/docker-compose.local.yml"
+  COMPOSE_FILE_PATHS+=("$PWD/dev/docker-compose.local.yml")
   export TEST_TLONBOT_MOUNTED=1
   echo "==> Using local tlonbot volume mount ($TLONBOT_DIR)"
 fi
+export TEST_COMPOSE_FILE="${COMPOSE_FILE_PATHS[0]}"
+TEST_COMPOSE_FILES="$(node -e 'console.log(JSON.stringify(process.argv.slice(1)))' "${COMPOSE_FILE_PATHS[@]}")"
+export TEST_COMPOSE_FILES
 
 # Cleanup function - called on exit (normal, error, or signal-initiated)
 cleanup() {
@@ -249,7 +283,6 @@ export TEST_THIRD_PARTY_SHIP="~mug"
 export TEST_THIRD_PARTY_CODE="$MUG_CODE"
 export TEST_MODE="tlon"
 export TEST_GATEWAY_URL="http://localhost:$GATEWAY_PORT"
-export TEST_COMPOSE_FILE="dev/docker-compose.test.yml"
 export FAKE_MODEL_BASE_URL="http://localhost:$FAKE_MODEL_PORT"
 
 # Debug: show env vars
@@ -257,6 +290,8 @@ echo "Env vars:"
 echo "  TLON_URL=$TLON_URL"
 echo "  TLON_SHIP=$TLON_SHIP"
 echo "  TEST_USER_SHIP=$TEST_USER_SHIP"
+echo "  TEST_OPENCLAW_CORE_VERSION=$TEST_OPENCLAW_CORE_VERSION"
+echo "  TEST_COMPOSE_PROJECT_NAME=$TEST_COMPOSE_PROJECT_NAME"
 echo ""
 
 # Run test cases sequentially to avoid overlapping DM prompts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1121,6 +1121,9 @@ importers:
       '@types/node':
         specifier: ^25.4.0
         version: 25.9.3
+      '@urbit/nockjs':
+        specifier: ^1.6.0
+        version: 1.6.0
       dotenv:
         specifier: ^17.2.4
         version: 17.4.2


### PR DESCRIPTION
## Summary

Fixes TLON-6132.

Fixes Tlon bots falsely DMing their owner "your bot is offline" while the bot is live. The `%steward` ship agent sends that auto-reply when it never receives a `%gateway-start` poke for the current boot; OpenClaw core 2026.6.11/7.1 added a ~10s post-startup runtime-plugin prewarm that re-ran `registerFull`, and the old code discarded the already-resolved `GatewayStatusManager` for a fresh, never-resolved one, so the ship never learned the gateway was up. Plugin-only fix in `packages/openclaw`, no Hoon/protocol/mark changes. Also adds an end-to-end regression test that reproduces the failure on a real affected core.

## Changes

-   Replaced the once-per-process manager with a generation-aware gateway-status coordinator, created once and reused across every `registerFull` pass (tool-discovery, full-activation, prewarm). `gateway_start` begins a new generation (fresh bootId, reset latches) so it survives in-process SIGUSR1 restarts. `waitForStartedLifecycle()` resolves atomically for the current or next generation, removing the capture-then-wait race.
-   Monitor activation now gates on a lifecycle-validity predicate (generation unchanged, not stopped, not aborted/cleaned) rechecked after each await, so a stop mid-activation cannot send `%gateway-start` post-shutdown.
-   Per-monitor eligibility derived from the channel-start `ctx.cfg` snapshot (exactly one Tlon account), so `channels.tlon` hot-reloads are tracked without a stale shared flag.
-   Monitor-local heartbeat (no shared interval), removing a stale-cleanup-kills-replacement race.
-   Log/telemetry-only start watchdog (never fabricates liveness); monitor cleanup aborts a pending activation wait/watchdog (orchestration cancellation only).
-   Adds an integration regression test (`test/cases/08-gateway-status.test.ts`): forces a post-prewarm `channels.tlon` monitor restart to reproduce the deadlock, then asserts ship-side liveness with a two-stage lease oracle (a real heartbeat must renew the lease, not just a stale `%up`). Supporting harness changes: an `OPENCLAW_CORE_VERSION` build arg so the case can run against affected cores, a bounded (abortable) `%noun` scry helper, and container-version/restart verification.
-   Two rarer restart-window issues (late `%gateway-start` reorder on rapid restart; transient reply overlap while stopping) are deferred to follow-up tickets, not this PR.

## How did I test?

-   `pnpm tsc --noEmit` clean; `pnpm test` passing (853/853), adding 11 unit regression cases: the three-registry prewarm reproduction, in-process stop then start, stop-during-activation, hot-reload eligibility, and heartbeat isolation.
-   The new e2e is **proven to discriminate on a real OpenClaw 2026.6.11 gateway↔ship round-trip**: RED on the pre-fix code (the ship never renews its lease → `%down`) and GREEN on the fix (the replacement monitor re-activates and the heartbeat renews the lease). On the default `2026.5.28` core it runs as a liveness smoke test and passes — verified through the shared E2E runner (the exact path CI uses).

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Plugin-only change; no Hoon/`%steward`/protocol/mark changes and no persistent state.
-   Empirically reproduced and fixed on real core 2026.6.11 (and confirmed 2026.7.1 is affected via source), so the earlier "6.11/7.1 canary required" gap is substantially closed; a live hosted-bot canary is still prudent before broad rollout. Rollout also needs the upstream `extensions/tlon` sync, since the plugin is copied into OpenClaw core.
-   CI impact: the new case is auto-discovered by the Shared E2E job and adds ~1 min there. On the default `2026.5.28` core it runs as a **smoke** test — it does not yet guard the regression, because that core has no prewarm. It becomes the full regression guard automatically once the default core is bumped to `2026.6.11`/`2026.7.1` (both already recognized by the case): move `dev/Dockerfile.test`'s `OPENCLAW_CORE_VERSION` default and `08`'s `DEFAULT_CORE_VERSION` in lockstep, then re-run the shared E2E suite. No separate CI matrix lane is required — this rides the planned core upgrade.

## Rollback plan

Revert
