### PR TITLE
fix(hermes-tlon-adapter): correct Context Lens %steward scry probe

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -102,9 +102,53 @@ TLON_SSE_READ_TIMEOUT_SECONDS=60
 TLON_SKILL_PATH=/path/to/tlon-skill/SKILL.md # optional explicit plugin-skill path
 TLON_GATEWAY_STATUS=true
 TLON_GATEWAY_STATUS_OWNER=~friend # optional override; defaults to TLON_OWNER_SHIP
+TLON_CONTEXT_LENS=true # off by default; durable bot-run records via %steward
+TLON_CONTEXT_LENS_OWNER=~friend # optional; defaults to TLON_OWNER_SHIP
 ```
 
 `TLON_OWNER_SHIP` is required: it defines the owner identity for approvals, owner-only tools such as `tlon`/`cronjob`/MCP/file tools, owner-listen, telemetry identity, and home-channel defaults. Without it, Tlon chat-session tool calls fail closed.
+
+## Context Lens
+
+Context Lens records each bot run (context sources, model, tool calls, timings, outputs) on-ship via the `%steward` agent and surfaces them in Tlon Messenger (badge / Bot Run sheet). Hermes uses the same protocol as OpenClaw.
+
+**Harness**
+
+```bash
+TLON_CONTEXT_LENS=true
+# optional; defaults to TLON_OWNER_SHIP
+# TLON_CONTEXT_LENS_OWNER=~friend
+```
+
+Restart the Hermes gateway after changing these.
+
+**Tlon Messenger (owner install)**
+
+- Settings → Experimental Features → **Enable bot context lens panel**
+- Leave **Context lens gateway URL** and **Context lens gateway token** blank. Those are the old direct HTTP stream to a local harness gateway (web-only). They are not required for durable `%steward` records and will not fix a missing steward.
+
+**Ships**
+
+1. `%steward` must be **running** on both the bot ship and the owner ship (`+gall/agents %groups` → `status: running %steward`). It ships with a current `%groups` desk.
+2. On the **owner** ship, explicitly trust the bot once. Moon sponsorship is **not** auto-trust:
+
+```hoon
+:steward &steward-action-1 [%trust-bot ~your-bot-ship]
+```
+
+3. Test with a **new** bot reply. Historical messages do not gain badges retroactively.
+
+**Data path**
+
+1. Hermes probes bot `%steward` with an Eyre scry of `/steward/v1/lens/recent` (care `%x` is applied by Gall/Eyre — do not put `/x/` in the HTTP path).
+2. Healthy log: `[tlon] context-lens sync active (owner=~...)`.
+3. Hermes pokes run milestones to bot `%steward`; the bot fans them to the trusted owner over Ames.
+4. The owner client loads runs from **owner** `%steward` (local DB after sync/scry). Bot-side `{"recent":[]}` is normal when the owner is a different ship — the durable UI store is on the owner.
+5. If the badge appears but the Bot Run sheet says the run is unavailable, owner `%steward` is usually missing trust for the bot (or not installed/running).
+
+**Not the same as gateway status**
+
+`TLON_GATEWAY_STATUS` still pokes the legacy `%gateway-status` agent for online/offline notices. Context Lens uses `%steward`. A ship slog of `steward: gateway lease expired…` means steward is alive and a lease timed out; it does not mean Context Lens is disabled.
 
 The adapter also accepts the older `TLON_SHIP_*`, `TLON_URL/TLON_SHIP/TLON_CODE`, and `URBIT_*` aliases and passes them through to the CLI, so it works with the credential resolver in `@tloncorp/tlon-skill`.
 

--- a/packages/hermes-tlon-adapter/lens.py
+++ b/packages/hermes-tlon-adapter/lens.py
@@ -75,7 +75,13 @@ _CONFIGURE_MARK = "steward-action-1"
 _LENS_MARK = "steward-lens-action-1"
 # Existence probe: a %steward lens scry that any installed agent answers (and
 # our own ship is always allowed to peek). A ship without %steward nacks it.
-_STEWARD_PROBE_PATH = "/x/v1/lens/recent"
+#
+# Eyre HTTP scry URLs are /~/scry/<app><path>.json — care (%x) is applied by
+# Gall/Eyre, not written into the path. Using "/x/v1/..." made the first path
+# segment look like the app name (%x), so the probe always 404'd even when
+# %steward was running. Correct form matches other modern agents
+# (contacts/v1/..., activity/v4/...): app in the path, no care letter.
+_STEWARD_PROBE_PATH = "/steward/v1/lens/recent"
 
 
 def _now_ms() -> int:

--- a/packages/hermes-tlon-adapter/test_lens.py
+++ b/packages/hermes-tlon-adapter/test_lens.py
@@ -253,7 +253,7 @@ class SyncSequencingTests(unittest.TestCase):
 
         run(scenario())
         client = FakeClient.instances[-1]
-        self.assertEqual(client.scries, ["/x/v1/lens/recent"])
+        self.assertEqual(client.scries, ["/steward/v1/lens/recent"])
 
     def test_start_returns_false_when_steward_missing(self):
         cfg = make_config(TLON_CONTEXT_LENS="true", TLON_OWNER_SHIP="~zod")
@@ -275,7 +275,7 @@ class SyncSequencingTests(unittest.TestCase):
 
         run(scenario())
         client = FakeClient.instances[-1]
-        self.assertEqual(client.scries, ["/x/v1/lens/recent"])
+        self.assertEqual(client.scries, ["/steward/v1/lens/recent"])
         self.assertTrue(client.closed)
         self.assertEqual(client.entries(), [])
 


### PR DESCRIPTION
## Summary

Hermes Context Lens refused to activate even when bot-ship `%steward` was running, because the startup existence probe used a broken Eyre scry path.

### Bug

`TlonLensSync` probed with:

```python
_STEWARD_PROBE_PATH = "/x/v1/lens/recent"
```

`TlonSSEClient.scry()` turns that into:

```text
GET {ship}/~/scry/x/v1/lens/recent.json
```

Modern Eyre scry URLs are `/~/scry/<app><path>.json`. Care (`%x`) is applied by Gall/Eyre and must **not** be written into the path. The broken path treated **`%x` as the app name**, so the probe always 404'd and Hermes logged:

```text
[tlon] context-lens skipped: steward agent not reachable
```

…even when Dojo showed `status: running %steward` and `/~/scry/steward/v1/lens/recent.json` returned `200 {"recent":[]}`.

### Fix

```python
_STEWARD_PROBE_PATH = "/steward/v1/lens/recent"
```

→ `/~/scry/steward/v1/lens/recent.json` (same shape as `contacts/v1/...`, `activity/v4/...`).

After the fix, gateway logs:

```text
[tlon] context-lens sync active (owner=~...)
```

Tests updated for the new probe path.

### Docs

README now documents the full Context Lens path so operators don’t chase red herrings:

| Piece | Requirement |
|-------|-------------|
| Hermes | `TLON_CONTEXT_LENS=true` (optional `TLON_CONTEXT_LENS_OWNER`, defaults to `TLON_OWNER_SHIP`); restart gateway |
| Tlon Messenger | Enable **bot context lens panel**; leave **gateway URL/token** blank (legacy web-only HTTP stream, not durable `%steward`) |
| Bot ship | `%steward` running (`+gall/agents %groups`) |
| Owner ship | `%steward` running **and** one-time trust: `:steward &steward-action-1 [%trust-bot ~bot-ship]` |
| Verify | **New** bot reply only (no retroactive badges) |

**Important operator notes (verified on live 408k ships):**

- Badge but “Bot run unavailable” almost always means owner store/trust is missing: bot fans runs to the owner; bot-side `{"recent":[]}` is normal when owner ≠ bot.
- Moon sponsorship is **not** auto-trust.
- `TLON_GATEWAY_STATUS` still pokes legacy `%gateway-status`; Context Lens uses `%steward`. Do not conflate `steward: gateway lease expired…` with “lens disabled.”

## Test plan

- [x] `python -m unittest test_lens.SyncSequencingTests` (includes probe path assertions)
- [x] Live: with `%steward` running, scry `/~/scry/steward/v1/lens/recent.json` → 200
- [x] Live: wrong paths `/~/scry/x/v1/lens/recent.json` and `/~/scry/steward/x/v1/lens/recent.json` → 404
- [x] Live: after fix + gateway restart → `context-lens sync active`
- [x] Live: owner `%trust-bot` for bot moon → Bot Run sheet loads tool-call details for a new DM
- [ ] CI unit tests for hermes-tlon-adapter

## Related

Context Lens emitter/retry: #6033, #6036. Steward protocol: `docs/steward.md`.