### PR TITLE
notes: fix channel permission saving

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -2,7 +2,7 @@
     info+'Start, host, and cultivate communities. Own your communications, organize your resources, and share documents. Tlon is a decentralized platform that offers a full, communal suite of tools for messaging, writing and sharing media with others.'
     color+0xde.dede
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
-    glob-http+['https://bootstrap.urbit.org/glob-0v5.10fva.2ptat.496ks.a7g7o.9oked.glob' 0v5.10fva.2ptat.496ks.a7g7o.9oked]
+    glob-http+['https://bootstrap.urbit.org/glob-0v7.1bjao.8jc01.t988d.28dru.qgnre.glob' 0v7.1bjao.8jc01.t988d.28dru.qgnre]
     base+'groups'
     version+[12 0 0]
     website+'https://tlon.io'

--- a/packages/app/features/groups/CreateChannelPermissionsScreen.tsx
+++ b/packages/app/features/groups/CreateChannelPermissionsScreen.tsx
@@ -1,7 +1,11 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { createChannel, useGroup } from '@tloncorp/shared';
-import { Button } from '@tloncorp/ui';
+import {
+  NOTES_PERMISSIONS_COMPAT_NOTICE,
+  notesPermissionsCompatActive,
+} from '@tloncorp/shared/logic/notesPermissionsCompat';
+import { Button, Text } from '@tloncorp/ui';
 import { useCallback, useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -9,10 +13,8 @@ import { ScrollView, View, YStack } from 'tamagui';
 
 import { GroupSettingsStackParamList } from '../../navigation/types';
 import { PermissionTable } from '../../ui/components/ManageChannels/ChannelPermissions';
-import {
-  PermissionActionButtons,
-  processFinalPermissions,
-} from '../../ui/components/ManageChannels/ChannelPermissionsContent';
+import { PermissionActionButtons } from '../../ui/components/ManageChannels/ChannelPermissionsContent';
+import { processFinalPermissions } from '../../ui/components/ManageChannels/channelFormUtils';
 import { ScreenHeader } from '../../ui/components/ScreenHeader';
 
 export function CreateChannelPermissionsScreen() {
@@ -31,6 +33,7 @@ export function CreateChannelPermissionsScreen() {
 
   const { groupId, channelTitle, channelType, createdRoleId, selectedRoleIds } =
     route.params;
+  const usesNotesPermissionsCompat = notesPermissionsCompatActive(channelType);
 
   const { data: group } = useGroup({ id: groupId });
 
@@ -40,7 +43,9 @@ export function CreateChannelPermissionsScreen() {
       description: '',
       isPrivate: true,
       readers: selectedRoleIds ?? ['admin'],
-      writers: ['admin'],
+      writers: usesNotesPermissionsCompat
+        ? selectedRoleIds ?? ['admin']
+        : ['admin'],
     },
   });
 
@@ -53,14 +58,20 @@ export function CreateChannelPermissionsScreen() {
         ? currentReaders
         : ['admin', ...currentReaders];
       form.setValue('readers', [...base, createdRoleId]);
+      if (usesNotesPermissionsCompat) {
+        form.setValue('writers', [...base, createdRoleId]);
+      }
     }
-  }, [createdRoleId, form]);
+  }, [createdRoleId, form, usesNotesPermissionsCompat]);
 
   // Handle roles selected from SelectChannelRoles screen
   useEffect(() => {
     if (!selectedRoleIds) return;
     form.setValue('readers', selectedRoleIds);
-  }, [selectedRoleIds, form]);
+    if (usesNotesPermissionsCompat) {
+      form.setValue('writers', selectedRoleIds);
+    }
+  }, [selectedRoleIds, form, usesNotesPermissionsCompat]);
 
   const handleSelectRoles = useCallback(() => {
     const currentReaders = form.getValues('readers');
@@ -85,7 +96,8 @@ export function CreateChannelPermissionsScreen() {
     const { finalReaders, finalWriters } = processFinalPermissions(
       currentReaders,
       currentWriters,
-      currentIsPrivate
+      currentIsPrivate,
+      channelType
     );
 
     createChannel({
@@ -116,7 +128,15 @@ export function CreateChannelPermissionsScreen() {
           contentContainerStyle={{ paddingBottom: insets.bottom }}
         >
           <YStack gap="$2xl" padding="$xl">
-            <PermissionTable groupRoles={group.roles ?? []} />
+            {usesNotesPermissionsCompat && (
+              <Text size="$label/s" color="$tertiaryText">
+                {NOTES_PERMISSIONS_COMPAT_NOTICE}
+              </Text>
+            )}
+            <PermissionTable
+              groupRoles={group.roles ?? []}
+              channelType={channelType}
+            />
             <PermissionActionButtons onSelectRoles={handleSelectRoles} />
             <Button
               preset="primary"

--- a/packages/app/features/groups/EditChannelPrivacyScreen.tsx
+++ b/packages/app/features/groups/EditChannelPrivacyScreen.tsx
@@ -1,4 +1,9 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import {
+  NOTES_PERMISSIONS_COMPAT_NOTICE,
+  notesPermissionsCompatActive,
+} from '@tloncorp/shared/logic/notesPermissionsCompat';
+import { Text } from '@tloncorp/ui';
 import { useCallback, useEffect, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ScrollView, View, YStack } from 'tamagui';
@@ -9,13 +14,11 @@ import {
   PermissionTable,
   PrivateChannelToggle,
 } from '../../ui/components/ManageChannels/ChannelPermissions';
-import {
-  PermissionActionButtons,
-  processFinalPermissions,
-} from '../../ui/components/ManageChannels/ChannelPermissionsContent';
+import { PermissionActionButtons } from '../../ui/components/ManageChannels/ChannelPermissionsContent';
 import {
   MEMBERS_MARKER,
   getChannelPrivacyDefaults,
+  processFinalPermissions,
 } from '../../ui/components/ManageChannels/channelFormUtils';
 import { ScreenHeader } from '../../ui/components/ScreenHeader';
 
@@ -48,6 +51,9 @@ export function EditChannelPrivacyScreen(props: Props) {
   });
 
   const isPrivate = form.watch('isPrivate');
+  const usesNotesPermissionsCompat = notesPermissionsCompatActive(
+    channel?.type
+  );
   const { isDirty } = form.formState;
   const channelIdRef = useRef(channel?.id);
 
@@ -78,21 +84,29 @@ export function EditChannelPrivacyScreen(props: Props) {
         ? currentReaders
         : ['admin', ...currentReaders];
       form.setValue('readers', [...base, createdRoleId]);
+      if (usesNotesPermissionsCompat) {
+        form.setValue('writers', [...base, createdRoleId]);
+      }
       form.setValue('isPrivate', true);
     }
-  }, [createdRoleId, form]);
+  }, [createdRoleId, form, usesNotesPermissionsCompat]);
 
   // Handle roles selected from SelectChannelRoles screen
   useEffect(() => {
     if (!selectedRoleIds) return;
     form.setValue('readers', selectedRoleIds);
+    if (usesNotesPermissionsCompat) {
+      form.setValue('writers', selectedRoleIds);
+      form.setValue('isPrivate', true);
+      return;
+    }
     const currentWriters = form.getValues('writers');
     form.setValue(
       'writers',
       currentWriters.filter((w) => selectedRoleIds.includes(w))
     );
     form.setValue('isPrivate', true);
-  }, [selectedRoleIds, form]);
+  }, [selectedRoleIds, form, usesNotesPermissionsCompat]);
 
   const handleTogglePrivate = useCallback(
     (value: boolean) => {
@@ -141,7 +155,8 @@ export function EditChannelPrivacyScreen(props: Props) {
     const { finalReaders, finalWriters } = processFinalPermissions(
       currentReaders,
       currentWriters,
-      currentIsPrivate
+      currentIsPrivate,
+      channel.type
     );
 
     updateChannel({ ...channel }, finalReaders, finalWriters);
@@ -182,7 +197,15 @@ export function EditChannelPrivacyScreen(props: Props) {
                 onTogglePrivate={handleTogglePrivate}
               />
             </YStack>
-            <PermissionTable groupRoles={group.roles ?? []} />
+            {usesNotesPermissionsCompat && isPrivate && (
+              <Text size="$label/s" color="$tertiaryText">
+                {NOTES_PERMISSIONS_COMPAT_NOTICE}
+              </Text>
+            )}
+            <PermissionTable
+              groupRoles={group.roles ?? []}
+              channelType={channel.type}
+            />
             {isPrivate && (
               <PermissionActionButtons onSelectRoles={handleSelectRoles} />
             )}

--- a/packages/app/ui/components/ManageChannels/ChannelPermissions.tsx
+++ b/packages/app/ui/components/ManageChannels/ChannelPermissions.tsx
@@ -1,4 +1,5 @@
 import * as db from '@tloncorp/shared/db';
+import { notesPermissionsCompatActive } from '@tloncorp/shared/logic/notesPermissionsCompat';
 import { Icon, IconButton, Pressable, Text } from '@tloncorp/ui';
 import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -101,13 +102,16 @@ const actionsColumnWidth = 75;
 
 export function PermissionTable({
   groupRoles,
+  channelType,
 }: {
   groupRoles: db.GroupRole[];
+  channelType?: string;
 }) {
   const { watch, setValue } = useFormContext<ChannelPrivacyFormSchema>();
   const isPrivate = watch('isPrivate');
   const readers = watch('readers');
   const writers = watch('writers');
+  const hasUnifiedPermissions = notesPermissionsCompatActive(channelType);
 
   const displayedRoles = useMemo(() => {
     // Use the union of readers and writers so writer-only roles remain visible
@@ -130,6 +134,25 @@ export function PermissionTable({
       const isCurrentlyWriter = writers.includes(roleId);
       const isCurrentlyReader = readers.includes(roleId);
 
+      if (hasUnifiedPermissions) {
+        const hasAccess = isCurrentlyReader || isCurrentlyWriter;
+        setValue(
+          'readers',
+          hasAccess
+            ? readers.filter((reader) => reader !== roleId)
+            : [...readers, roleId],
+          { shouldDirty: true }
+        );
+        setValue(
+          'writers',
+          hasAccess
+            ? writers.filter((writer) => writer !== roleId)
+            : [...writers, roleId],
+          { shouldDirty: true }
+        );
+        return;
+      }
+
       if (isCurrentlyWriter) {
         // Remove from writers; add to readers if not already there so the role
         // stays visible as read-only instead of vanishing
@@ -149,7 +172,7 @@ export function PermissionTable({
         }
       }
     },
-    [writers, readers, setValue]
+    [writers, readers, setValue, hasUnifiedPermissions]
   );
 
   const handleToggleReader = useCallback(
@@ -168,11 +191,15 @@ export function PermissionTable({
           { shouldDirty: true }
         );
       } else {
-        // Add to readers
+        // Add to readers (and writers when the channel has one shared access
+        // permission, as %notes does).
         setValue('readers', [...readers, roleId], { shouldDirty: true });
+        if (hasUnifiedPermissions && !writers.includes(roleId)) {
+          setValue('writers', [...writers, roleId], { shouldDirty: true });
+        }
       }
     },
-    [readers, writers, setValue]
+    [readers, writers, setValue, hasUnifiedPermissions]
   );
 
   const handleDeleteRole = useCallback(

--- a/packages/app/ui/components/ManageChannels/ChannelPermissionsContent.tsx
+++ b/packages/app/ui/components/ManageChannels/ChannelPermissionsContent.tsx
@@ -1,7 +1,5 @@
 import { Button } from '@tloncorp/ui';
 
-import { MEMBERS_MARKER } from './channelFormUtils';
-
 interface PermissionActionButtonsProps {
   onSelectRoles: () => void;
 }
@@ -14,29 +12,4 @@ export function PermissionActionButtons({
   onSelectRoles,
 }: PermissionActionButtonsProps) {
   return <Button onPress={onSelectRoles} label="Add roles" />;
-}
-
-/**
- * Process readers/writers arrays for submission.
- * If MEMBERS_MARKER is present, returns empty array (everyone has access).
- * Otherwise filters out MEMBERS_MARKER and returns the role IDs.
- */
-export function processFinalPermissions(
-  readers: string[],
-  writers: string[],
-  isPrivate = true
-): { finalReaders: string[]; finalWriters: string[] } {
-  const finalReaders = !isPrivate
-    ? []
-    : readers.includes(MEMBERS_MARKER)
-      ? []
-      : readers.filter((r) => r !== MEMBERS_MARKER);
-
-  const finalWriters = !isPrivate
-    ? []
-    : writers.includes(MEMBERS_MARKER)
-      ? []
-      : writers.filter((w) => w !== MEMBERS_MARKER);
-
-  return { finalReaders, finalWriters };
 }

--- a/packages/app/ui/components/ManageChannels/channelFormUtils.test.ts
+++ b/packages/app/ui/components/ManageChannels/channelFormUtils.test.ts
@@ -6,7 +6,38 @@ import {
   getChannelPrivacyDefaults,
   groupRolesToOptions,
   mapRoleIdsToOptions,
+  processFinalPermissions,
 } from './channelFormUtils';
+
+describe('processFinalPermissions', () => {
+  test('omits writer roles for channels with one shared permission', () => {
+    expect(
+      processFinalPermissions(
+        ['admin', 'viewer'],
+        ['admin', 'viewer'],
+        true,
+        'notes'
+      )
+    ).toEqual({
+      finalReaders: ['admin', 'viewer'],
+      finalWriters: [],
+    });
+  });
+
+  test('makes member-readable unified channels public', () => {
+    expect(
+      processFinalPermissions(
+        ['admin', MEMBERS_MARKER],
+        ['admin', MEMBERS_MARKER],
+        true,
+        'notes'
+      )
+    ).toEqual({
+      finalReaders: [],
+      finalWriters: [],
+    });
+  });
+});
 
 describe('groupRolesToOptions', () => {
   test('converts group roles to options', () => {
@@ -143,5 +174,33 @@ describe('getChannelPrivacyDefaults', () => {
     const result = getChannelPrivacyDefaults(channel);
     expect(result.writers).toContain('admin');
     expect(result.writers[0]).toBe('admin');
+  });
+
+  test('notes channels mirror reader roles and ignore stale writer roles', () => {
+    const channel = {
+      type: 'notes',
+      readerRoles: [{ roleId: 'viewer' }],
+      writerRoles: [{ roleId: 'stale-writer' }],
+    } as any;
+
+    expect(getChannelPrivacyDefaults(channel)).toEqual({
+      isPrivate: true,
+      readers: ['admin', 'viewer'],
+      writers: ['admin', 'viewer'],
+    });
+  });
+
+  test('notes channels with no readers are public despite stale writers', () => {
+    const channel = {
+      type: 'notes',
+      readerRoles: [],
+      writerRoles: [{ roleId: 'stale-writer' }],
+    } as any;
+
+    expect(getChannelPrivacyDefaults(channel)).toEqual({
+      isPrivate: false,
+      readers: [],
+      writers: [],
+    });
   });
 });

--- a/packages/app/ui/components/ManageChannels/channelFormUtils.ts
+++ b/packages/app/ui/components/ManageChannels/channelFormUtils.ts
@@ -1,4 +1,5 @@
 import * as db from '@tloncorp/shared/db';
+import { notesPermissionsCompatActive } from '@tloncorp/shared/logic/notesPermissionsCompat';
 
 /**
  * Form schema for channel privacy settings.
@@ -24,6 +25,34 @@ export const MEMBER_ROLE_OPTION: RoleOption = {
   label: 'Members',
   value: MEMBERS_MARKER,
 };
+
+/**
+ * Process readers/writers arrays for submission.
+ * If MEMBERS_MARKER is present, an empty array grants access to all members.
+ * Channels with unified permissions, such as %notes, do not submit writers.
+ */
+export function processFinalPermissions(
+  readers: string[],
+  writers: string[],
+  isPrivate = true,
+  channelType?: string
+): { finalReaders: string[]; finalWriters: string[] } {
+  const finalReaders = !isPrivate
+    ? []
+    : readers.includes(MEMBERS_MARKER)
+      ? []
+      : readers.filter((reader) => reader !== MEMBERS_MARKER);
+
+  const finalWriters = notesPermissionsCompatActive(channelType)
+    ? []
+    : !isPrivate
+      ? []
+      : writers.includes(MEMBERS_MARKER)
+        ? []
+        : writers.filter((writer) => writer !== MEMBERS_MARKER);
+
+  return { finalReaders, finalWriters };
+}
 
 /**
  * Converts group roles to option format for selectors.
@@ -56,6 +85,25 @@ export const getChannelPrivacyDefaults = (
 ): ChannelPrivacyFormSchema => {
   const readerRoles = channel?.readerRoles?.map((r) => r.roleId) ?? [];
   const writerRoles = channel?.writerRoles?.map((r) => r.roleId) ?? [];
+
+  // %notes has a single access permission: anyone who can read a notebook can
+  // also edit it. Ignore any stale writer roles and mirror the reader roles in
+  // the form so the two controls accurately describe that shared permission.
+  if (notesPermissionsCompatActive(channel?.type)) {
+    const isPrivate = readerRoles.length > 0;
+    const roles = isPrivate
+      ? readerRoles.includes('admin')
+        ? readerRoles
+        : ['admin', ...readerRoles]
+      : [];
+
+    return {
+      readers: roles,
+      writers: roles,
+      isPrivate,
+    };
+  }
+
   const isPrivate = readerRoles.length > 0 || writerRoles.length > 0;
 
   const readers = isPrivate

--- a/packages/shared/src/logic/index.ts
+++ b/packages/shared/src/logic/index.ts
@@ -4,6 +4,7 @@ export * from './embed';
 export * from './semver';
 export * from './reactionSupport';
 export * from './notesPublish';
+export * from './notesPermissionsCompat';
 export * from '@tloncorp/api/lib/types';
 export * from '@tloncorp/api/lib/utils';
 export * as featureFlags from '@tloncorp/api/lib/featureFlags';

--- a/packages/shared/src/logic/notesPermissionsCompat.ts
+++ b/packages/shared/src/logic/notesPermissionsCompat.ts
@@ -1,0 +1,16 @@
+/**
+ * Temporary compatibility boundary for the current %notes permission model.
+ *
+ * %notes does not yet support independent writer roles, so reader roles grant
+ * both read and write access. Keep every client workaround behind this helper:
+ * when %notes gains writer permissions, searching for this symbol identifies
+ * the UI normalization, submission, and backend-poke behavior to remove.
+ */
+export function notesPermissionsCompatActive(
+  channelType: string | null | undefined
+): boolean {
+  return channelType === 'notes';
+}
+
+export const NOTES_PERMISSIONS_COMPAT_NOTICE =
+  'Notebook channels do not support separate read and write permissions. Roles that can read a notebook can also edit it.';

--- a/packages/shared/src/store/channelActions.test.ts
+++ b/packages/shared/src/store/channelActions.test.ts
@@ -11,6 +11,7 @@ import {
   joinGroupChannel,
   leaveGroupChannel,
   markChannelRead,
+  updateChannel,
 } from './channelActions';
 
 setupDatabaseTestSuite();
@@ -318,6 +319,55 @@ test('createChannel does not roll back when the notes listing cannot be verified
   await assertion;
 
   expect(deleteNotesNotebookStrict).not.toHaveBeenCalled();
+});
+
+test('updateChannel saves notes readers without sending writer actions', async () => {
+  const notesChannelId = 'notes/~zod/native-notes';
+  await insertGroupAndChannel({ id: notesChannelId, type: 'notes' });
+  await db.insertChannelPerms([
+    {
+      channelId: notesChannelId,
+      readers: ['admin'],
+      writers: ['stale-writer'],
+    },
+  ]);
+
+  const channel = await db.getChannelWithRelations({ id: notesChannelId });
+  if (!channel) throw new Error('test channel not initialized');
+
+  const updateGroupChannel = vi
+    .spyOn(api, 'updateChannel')
+    .mockResolvedValue(1);
+  const addChannelWriters = vi.spyOn(api, 'addChannelWriters');
+  const removeChannelWriters = vi.spyOn(api, 'removeChannelWriters');
+
+  await updateChannel({
+    groupId,
+    sectionId: 'default',
+    readers: ['admin', 'viewer'],
+    writers: ['admin', 'viewer'],
+    join: true,
+    channel,
+  });
+
+  expect(updateGroupChannel).toHaveBeenCalledWith(
+    expect.objectContaining({
+      groupId,
+      channelId: notesChannelId,
+      channel: expect.objectContaining({ readers: ['admin', 'viewer'] }),
+    })
+  );
+  expect(addChannelWriters).not.toHaveBeenCalled();
+  expect(removeChannelWriters).not.toHaveBeenCalled();
+  await expect(
+    db.getChannelWithRelations({ id: notesChannelId })
+  ).resolves.toMatchObject({
+    readerRoles: expect.arrayContaining([
+      expect.objectContaining({ roleId: 'admin' }),
+      expect.objectContaining({ roleId: 'viewer' }),
+    ]),
+    writerRoles: [],
+  });
 });
 
 test('joinGroupChannel routes notes channels through the notes API', async () => {

--- a/packages/shared/src/store/channelActions.ts
+++ b/packages/shared/src/store/channelActions.ts
@@ -12,6 +12,7 @@ import { createDevLogger } from '../debug';
 import { AnalyticsEvent } from '../domain';
 import * as logic from '../logic';
 import { getRandomId } from '../logic';
+import { notesPermissionsCompatActive } from '../logic/notesPermissionsCompat';
 import { syncNotesNotebook } from './notesActions';
 
 const logger = createDevLogger('ChannelActions', false);
@@ -346,6 +347,7 @@ export async function updateChannel({
   channel: db.Channel;
 }) {
   logger.log('updating channel', channel.id, { readers, writers });
+  const managesWriters = !notesPermissionsCompatActive(channel.type);
   const currentChannel = await db.getChannel({
     id: channel.id,
     includeWriters: true,
@@ -354,12 +356,13 @@ export async function updateChannel({
     (role) => role.roleId
   );
   logger.log('currentChannelWriterIds', currentChannelWriterIds);
-  const writersToAdd = writers.filter(
-    (roleId) => !currentChannelWriterIds?.includes(roleId)
-  );
-  const writersToRemove =
-    currentChannelWriterIds?.filter((roleId) => !writers.includes(roleId)) ??
-    [];
+  const writersToAdd = managesWriters
+    ? writers.filter((roleId) => !currentChannelWriterIds?.includes(roleId))
+    : [];
+  const writersToRemove = managesWriters
+    ? currentChannelWriterIds?.filter((roleId) => !writers.includes(roleId)) ??
+      []
+    : [];
 
   const updatedChannel: db.Channel = {
     ...channel,
@@ -367,7 +370,7 @@ export async function updateChannel({
       channelId: channel.id,
       roleId,
     })),
-    writerRoles: writers.map((roleId) => ({
+    writerRoles: (managesWriters ? writers : []).map((roleId) => ({
       channelId: channel.id,
       roleId,
     })),


### PR DESCRIPTION
## Summary

Fixes TLON-6170 by treating current `%notes` channel access as a single read-and-write permission. Previously, the client allowed asymmetric reader/writer state and sent unsupported writer actions to `%notes`, which could make a save appear successful before reverting or reloading into an odd writer-only state.

## Changes

- Couple the Read and Write controls for Notebook (`%notes`) channels.
- Normalize Notebook permission forms from authoritative reader roles and discard stale writer-only state.
- Save Notebook reader-role changes without sending unsupported writer actions.
- Show a disclaimer explaining that Notebook readers can also edit.
- Isolate the temporary behavior behind `notesPermissionsCompatActive` so all compatibility callsites are easy to find and remove when `%notes` gains independent writer permissions.
- Add regression coverage for form normalization, permission submission, and the shared-store save path.

## How did I test?

- `pnpm --filter @tloncorp/app exec vitest --run ui/components/ManageChannels/channelFormUtils.test.ts`
- `pnpm --filter @tloncorp/shared exec vitest --run src/store/channelActions.test.ts`
- `pnpm --filter @tloncorp/app tsc`
- `pnpm --filter @tloncorp/shared tsc`
- Focused ESLint checks for the changed app and shared files
- `git diff --check`

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [x] Other: Channel permissions

## Rollback plan

Revert commit `7ae06aa29`. This restores the prior generic reader/writer behavior and writer actions for Notebook channels.

## Screenshots / videos

Unchecking "Write" here removes the role from the list, effectively barring the user from creating a role attached to a %notes channel that appears to have read-only permissions in the UI.

<img width="1493" height="1122" alt="Screenshot 2026-07-16 at 2 55 38 PM" src="https://github.com/user-attachments/assets/1e0359c7-6a35-433d-b735-0dc4c61ba9a8" />

