### PR TITLE
Fix Edit channel info header clipping under status bar (TLON-6173)

### DIFF
--- a/packages/app/ui/components/ManageChannels/ChannelEditFormLayout.tsx
+++ b/packages/app/ui/components/ManageChannels/ChannelEditFormLayout.tsx
@@ -1,5 +1,5 @@
 import * as db from '@tloncorp/shared/db';
-import { useIsWindowNarrow } from '@tloncorp/ui';
+import { KeyboardAvoidingView, useIsWindowNarrow } from '@tloncorp/ui';
 import { ReactNode } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View } from 'tamagui';
@@ -45,16 +45,23 @@ export function ChannelEditFormLayout({
         useHorizontalTitleLayout={!isWindowNarrow}
         rightControls={rightControls}
       />
-      <ScrollView
-        flex={1}
-        keyboardDismissMode="on-drag"
-        contentContainerStyle={{
-          minHeight: '100%',
-          paddingBottom: insets.bottom,
-        }}
-      >
-        {children}
-      </ScrollView>
+      {/* Keyboard avoidance wraps only the scrollable content, not the
+          ScreenHeader. On Android the shared KeyboardAvoidingView uses
+          behavior="position", which shifts its subtree up when the keyboard
+          opens; including the header there leaves it stranded under the status
+          bar after the keyboard is dismissed (TLON-6173). */}
+      <KeyboardAvoidingView style={{ flex: 1 }}>
+        <ScrollView
+          flex={1}
+          keyboardDismissMode="on-drag"
+          contentContainerStyle={{
+            minHeight: '100%',
+            paddingBottom: insets.bottom,
+          }}
+        >
+          {children}
+        </ScrollView>
+      </KeyboardAvoidingView>
     </View>
   );
 }

--- a/packages/app/ui/components/ManageChannels/EditChannelMetaScreenView.tsx
+++ b/packages/app/ui/components/ManageChannels/EditChannelMetaScreenView.tsx
@@ -1,5 +1,4 @@
 import * as db from '@tloncorp/shared/db';
-import { KeyboardAvoidingView } from '@tloncorp/ui';
 import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -71,59 +70,57 @@ export function EditChannelMetaScreenView({
   );
 
   return (
-    <KeyboardAvoidingView style={{ flex: 1 }}>
-      <ChannelEditFormLayout
-        title="Edit channel info"
-        channel={channel}
-        group={group}
-        onGoBack={onGoBack}
-        isLoading={isLoading}
-        rightControls={
-          <ScreenHeader.TextButton
-            onPress={runSubmit}
-            color="$positiveActionText"
-            disabled={!isValid}
-            testID="ChannelSettingsSaveButton"
-          >
-            Save
-          </ScreenHeader.TextButton>
-        }
-      >
-        <FormFrame paddingBottom="$2xl" flex={1} backgroundType="secondary">
-          <ControlledTextField
-            name="title"
-            label="Name"
-            control={control}
-            inputProps={{
-              placeholder: 'Channel name',
-              testID: 'ChannelTitleInput',
-            }}
-            rules={{
-              maxLength: {
-                value: 30,
-                message: 'Your channel name is limited to 30 characters',
-              },
-            }}
-          />
-          <ControlledTextareaField
-            name="description"
-            label="Description"
-            control={control}
-            inputProps={{
-              placeholder: 'About this channel',
-              numberOfLines: 5,
-              testID: 'ChannelDescriptionInput',
-              multiline: true,
-            }}
-            rules={{
-              maxLength: {
-                value: 300,
-                message: 'Description is limited to 300 characters',
-              },
-            }}
-          />
-        </FormFrame>
-      </ChannelEditFormLayout>
-    </KeyboardAvoidingView>
+    <ChannelEditFormLayout
+      title="Edit channel info"
+      channel={channel}
+      group={group}
+      onGoBack={onGoBack}
+      isLoading={isLoading}
+      rightControls={
+        <ScreenHeader.TextButton
+          onPress={runSubmit}
+          color="$positiveActionText"
+          disabled={!isValid}
+          testID="ChannelSettingsSaveButton"
+        >
+          Save
+        </ScreenHeader.TextButton>
+      }
+    >
+      <FormFrame paddingBottom="$2xl" flex={1} backgroundType="secondary">
+        <ControlledTextField
+          name="title"
+          label="Name"
+          control={control}
+          inputProps={{
+            placeholder: 'Channel name',
+            testID: 'ChannelTitleInput',
+          }}
+          rules={{
+            maxLength: {
+              value: 30,
+              message: 'Your channel name is limited to 30 characters',
+            },
+          }}
+        />
+        <ControlledTextareaField
+          name="description"
+          label="Description"
+          control={control}
+          inputProps={{
+            placeholder: 'About this channel',
+            numberOfLines: 5,
+            testID: 'ChannelDescriptionInput',
+            multiline: true,
+          }}
+          rules={{
+            maxLength: {
+              value: 300,
+              message: 'Description is limited to 300 characters',
+            },
+          }}
+        />
+      </FormFrame>
+    </ChannelEditFormLayout>
   );
 }


### PR DESCRIPTION
## Summary

On Android, the **Edit channel info** screen's header (back button, title, and **Save**) would render behind the status bar and become untappable after the keyboard was shown and then dismissed — leaving no way to save the rename or navigate back via the header. This wraps only the scrollable content in the `KeyboardAvoidingView` so the header stays put.

Fixes [TLON-6173](https://linear.app/tlon/issue/TLON-6173).

## Changes

- `ChannelEditFormLayout` now wraps only its `ScrollView` in `KeyboardAvoidingView`, keeping the `ScreenHeader` outside it. This mirrors the already-correct `MetaEditorScreenView` ("Edit group info") layout.
- Removed the now-redundant outer `KeyboardAvoidingView` (and its import) from `EditChannelMetaScreenView`, which previously wrapped the entire layout — header included.

### Root cause

The shared `KeyboardAvoidingView` uses `behavior="position"` on Android, which translates its whole subtree up when the keyboard opens and does not fully restore the offset on dismiss. Because the header was inside that subtree, the show→hide sequence left it stranded under the status bar. The header rendered correctly on first load and while the keyboard was up — only the dismiss triggered the collapse.

## How did I test?

- `tsc --noEmit` passes clean for `packages/app` (0 errors); Prettier clean.
- **Verified on-device** (Pixel 7a, Android, built + installed `previewDebug` with this change). Reproduced the exact failing sequence — Group → Channels → ⋮ → Channel info → Rename → focus Name (keyboard up) → dismiss keyboard — and confirmed the header (back / **Save**) stays below the status bar and tappable.
  - Objective check via `uiautomator` bounds of the Save button after keyboard dismiss:
    - **Before (bug):** `[912,0][1038,53]` — top edge at y=0, under the status bar, taps swallowed by the OS.
    - **After (fix):** `[912,108][1038,234]` — clear of the status bar, tappable.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [x] Channel display (channel settings UI only)
  - [ ] Other:

Low risk: purely a layout wrapper reorganization on the channel-edit screen; no logic, data, or API changes.

## Rollback plan

Revert this commit. No migrations or state changes involved.

## Screenshots / videos

Same repro both times (Edit channel info → focus Name → dismiss keyboard).

**Before** (old build) — title + Save clipped under the status bar:

![before clipped header](https://raw.githubusercontent.com/tloncorp/tlon-apps/tlon-6173-pr-screens/pr-screenshots/before-clipped-header.png)

**After** (this fix, on-device) — header + Save intact below the status bar:

![after fixed header](https://raw.githubusercontent.com/tloncorp/tlon-apps/tlon-6173-pr-screens/pr-screenshots/after-fixed-header.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)