### PR TITLE
Add version-controlled agent skills (tools/agent-skills)

### DIFF
--- a/tools/agent-skills/README.md
+++ b/tools/agent-skills/README.md
@@ -1,0 +1,54 @@
+# Agent skills
+
+Version-controlled, **agent-agnostic** skills for working on this repo with a
+coding agent (Claude Code, Cursor, or anything that loads
+[Agent Skills](https://www.anthropic.com/news/skills)-style `SKILL.md` folders).
+
+Each skill is a plain folder: a `SKILL.md` (YAML frontmatter + Markdown
+instructions) plus optional `scripts/` and `references/`. Nothing here needs a
+specific agent runtime to read — the instructions call out the *capabilities*
+they assume (a shell, filesystem, vision, a Linear integration, GitHub, a
+browser-automation tool) and use each agent's own tools for those.
+
+These were distilled from real sessions, so they lead with the traps that
+actually cost time rather than generic advice.
+
+## Skills
+
+| Skill | What it does |
+|-------|--------------|
+| [`mobile-qa/`](mobile-qa/SKILL.md) | Run a mobile QA checklist on a physical **Android** device over `adb`, then triage failures → file Linear issues (with screenshots) → fix → rebuild and verify on-device. |
+| [`verify/`](verify/SKILL.md) | Verify web UI changes end-to-end with a single local ship + one vite dev server (lighter than the full `start-playwright-dev.sh` rig). |
+
+Each `SKILL.md` opens with a **"Capabilities this skill assumes"** section — read
+that first to know what your agent needs.
+
+## Installing
+
+A skill is just a folder, so installation is "put the folder where your agent
+looks for skills":
+
+- **Claude Code** — copy (or symlink) the folder into `~/.claude/skills/`
+  (personal) or a repo's `.claude/skills/` (project). Note this repo's
+  `.claude/skills/` is git-ignored, which is why the tracked source lives here.
+- **Claude.ai / Claude Code "Save skill"** — package it as a `.skill` file (below)
+  and use the Save-skill flow.
+- **Any other agent** — point it at the folder, or hand it the `SKILL.md`.
+
+### Packaging a `.skill` file
+
+A `.skill` is a zip of the skill folder (folder at the archive root):
+
+```bash
+cd tools/agent-skills
+zip -r -D -X mobile-qa.skill mobile-qa -x '*.DS_Store'
+zip -r -D -X verify.skill    verify    -x '*.DS_Store'
+```
+
+## Contributing
+
+Keep these portable: prefer concrete, copy-pasteable shell commands, and when a
+step needs an agent capability (viewing an image, calling Linear, driving a
+browser), describe the *capability* rather than hard-coding one agent's tool
+name. Explain the *why* behind a gotcha so the next reader (human or agent) can
+generalize it.

--- a/tools/agent-skills/mobile-qa/SKILL.md
+++ b/tools/agent-skills/mobile-qa/SKILL.md
@@ -145,15 +145,22 @@ exact PR-body shape are in **`references/fix-and-verify.md`**.
 
 ## Phase 5 — Verify on-device
 
-The preview build **embeds its JS bundle and boots straight into the app**, so
-Metro hot-reload does not pick up a code change — the only way to get a fix onto
-the device is a native rebuild that bundles the current source. The full recipe
-(JDK/SDK env, `local.properties`, `gradlew :app:installPreviewDebug`, the
-non-destructive "never uninstall" rule that preserves the user's login, and the
-screen-sleep/unlock handling for the long build) is in
-**`references/fix-and-verify.md`**.
+**Know your variant** — this is easy to get wrong. `previewDebug` is a
+`debuggableVariant` in `apps/tlon-mobile/android/app/build.gradle`, so its JS
+bundle is **not** embedded; that build loads JS from **Metro**. So:
 
-After it installs: reproduce the original failing steps, screenshot the
+- **JS/TS-only fix (common case): verify via Metro, no rebuild.** Start Metro on
+  the fixed source (`APP_VARIANT=preview npx expo start --dev-client`), point the
+  device at it, and confirm Metro logs an `Android Bundling` line when the app
+  loads — otherwise you're looking at stale/cached JS and the check is a lie.
+- **Native change, or a standalone APK that embeds the fix:** build the bundling
+  variant `previewRelease` (with `APP_VARIANT=preview`) — **not**
+  `installPreviewDebug`, which won't contain your source.
+
+The full recipe (both paths, JDK/SDK env, the non-destructive "never uninstall"
+rule, screen-sleep/unlock handling) is in **`references/fix-and-verify.md`**.
+
+Once the fix is live: reproduce the original failing steps, screenshot the
 now-correct behavior, and view the shot to confirm. Proof is the before
 (filed screenshot) and after (post-fix screenshot) of the same repro.
 

--- a/tools/agent-skills/mobile-qa/SKILL.md
+++ b/tools/agent-skills/mobile-qa/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: mobile-qa
+description: >-
+  Run a mobile QA checklist on a physical Android device over adb for tlon-apps,
+  then triage what fails into fixes. Use this whenever the user hands over a list
+  of QA tasks / test cases / a "QA pass" to run on-device, asks to drive the
+  Android app (io.tlon.groups[.preview]) via adb, wants failures filed as Linear
+  issues (with screenshots), or wants a found bug fixed, PR'd, and verified on the
+  device. Covers the full loop: drive the UI → record pass/fail → file Linear
+  issues → fix the code → rebuild and verify on-device. Reach for it even when the
+  user only asks for one phase ("run these QA tasks on my phone", "file that as a
+  Linear bug with a screenshot", "now fix it and verify on device").
+---
+
+# Mobile QA (Android, on-device) → triage → fix → verify
+
+This skill drives the tlon-apps Android app on a **physical device over adb**,
+runs a QA checklist, and turns failures into filed-and-fixed work. It exists
+because the useful signal from mobile QA is spread across five phases that each
+have their own traps; doing them from memory reliably loses time to the same
+snags (adb not on PATH, RN swipes that snap back, taps that miss because
+screenshot coordinates were guessed, a preview build that won't hot-reload).
+
+The phases are independent — the user may ask for any subset. Read the phase you
+need; each points to a reference file for the fiddly details.
+
+1. **Setup & device control** — locate adb, drive taps/swipes/text, screenshot loop
+2. **Run the QA pass** — work the checklist, record pass/fail with evidence
+3. **File Linear issues** — one per real failure, screenshot attached
+4. **Fix** — find the screen, mirror a working sibling, PR it
+5. **Verify on-device** — rebuild with the fix, reproduce, capture proof shots
+
+## Capabilities this skill assumes
+
+This is a workflow recipe, not tied to any one agent. It works in any coding
+agent that has:
+
+- **A shell** to run `adb`, `git`, `gh`, `curl`, `pnpm`/`npx`, and Gradle.
+- **Filesystem read/write** for the repo and a scratch directory.
+- **Image input (vision)** — you drive the UI by taking screenshots and *looking*
+  at them, so an agent that can't see images can't run Phase 2.
+- **A Linear integration** for Phase 3 — either a Linear MCP server or the Linear
+  REST/GraphQL API called directly with a token. `references/linear-filing.md` is
+  written against MCP tool names, but each maps 1:1 to an API call.
+- **GitHub access** for Phase 4 — the `gh` CLI (used here) or the GitHub API.
+
+Where this skill says "view"/"look at" a screenshot, use your agent's
+image-viewing capability. Paths like `scripts/adbx.sh` are relative to this
+skill's install directory — resolve them there (shown as `$SKILL` below).
+
+## Before you start: this is usually a real account
+
+The app on the device is almost always the user's **real, logged-in account**
+with real colleagues and groups — not a throwaway ship. That constraint shapes
+the whole pass. Read `references/safety.md` first and keep it in mind: never send
+messages to real people, route destructive/admin tests (kick/ban/leave/delete)
+through a throwaway group you create and later delete, and confirm outward-facing
+actions. When the plan involves genuinely destructive or person-affecting steps,
+surface them and get a yes before doing them — a blanket "run the QA tasks" is not
+consent to nuke a shared group.
+
+Single device also means you can verify the *initiating* side of an action but
+not "all members see the change" cross-ship effects, and you can't do
+mismatched-agent-version tests. Mark those `NOT TESTABLE (single device)` rather
+than guessing.
+
+## Phase 1 — Setup & device control
+
+`adb` is typically **not on PATH**. The helper script `scripts/adbx.sh` locates
+it and wraps the common gestures; use it instead of re-deriving adb invocations.
+
+```bash
+# point screenshots at a scratch dir (default ./.qa-screens), then sanity-check
+export QA_SHOT_DIR=/path/to/scratch
+SKILL=/path/to/this/skill        # wherever your agent installed it
+A="$SKILL/scripts/adbx.sh"
+"$A" adb devices -l          # confirm a device is attached
+"$A" focus                   # what app/activity is focused
+"$A" shot s001               # capture; prints the PNG path
+```
+
+Then **view the PNG** (image input required) to see the screen. Screenshots are
+the device's native resolution (e.g. 1080×2400). `input tap`/`swipe` take
+**device-native coordinates**, so tap the raw pixel coordinates from the
+screenshot — do not apply the viewer's display-scale factor to them.
+
+The full gesture/quirk catalogue (slow-drag for RN rows, long-press, reading
+element bounds when a tap misses, the `input text` space bug, keyboard-dismiss
+traps, screen sleep/lock) lives in **`references/adb-driving.md`**. Skim it before
+driving — several of these will bite on the first attempt otherwise.
+
+## Phase 2 — Run the QA pass
+
+Work the checklist top to bottom. For each row: perform the action, screenshot,
+view the shot, and judge the result against the "Expected" column.
+
+Keep a running results table in a scratch markdown file (one row per checklist
+item) so nothing is lost and the final report is a copy-paste. Use these verdicts:
+
+- **PASS** / **FAIL** — behaved / didn't behave as the Expected column says
+- **PASS\*** — works but with a wording/path discrepancy worth noting (e.g. a
+  button labeled "Edit group" where the checklist says "Customize"); record what
+  actually appeared
+- **NOT RUN** — skipped to avoid disruption (outward-facing/destructive on a real
+  account, or a gesture that can't be driven via synthetic input); say why
+- **NOT TESTABLE** — needs a second ship / mismatched version / cross-ship confirmation
+- **N/A** — precondition doesn't hold (e.g. "if new account" on an existing one)
+
+Be honest and specific in the notes — a FAIL should name the observed behavior,
+and a PASS\* should quote the actual label/URL/path. When a failure looks real,
+capture a clean screenshot of the broken state; you'll reuse it when filing.
+
+Report failures first, then discrepancies, then not-run/not-testable, then "all
+else passed". The user asked which ones fail — lead with that.
+
+## Phase 3 — File Linear issues
+
+One issue per genuine failure. The mechanics — team lookup, `save_issue` with the
+`Bug` label, and the three-step screenshot attachment (prepare upload → `curl` PUT
+with the signed headers → finalize) — are in **`references/linear-filing.md`**.
+
+Before filing, confirm with the user which failures to file if there are several;
+don't mass-create issues unprompted. Write issues someone can act on without this
+conversation: summary, numbered repro steps, expected vs actual, environment
+(device, `io.tlon.groups.preview`, build version from `dumpsys`), and any
+measured detail that makes the bug concrete (e.g. an element's bounds). If the
+user already has the broken state on their device, take a fresh screenshot rather
+than reusing an older one.
+
+## Phase 4 — Fix
+
+Locate the screen from a string in the UI (`grep -rn "Edit channel info"
+packages/`), then look for a **working sibling** — a near-identical screen that
+doesn't have the bug — and mirror its structure. Most mobile-UI bugs here are a
+component wired slightly differently than an equivalent that works; the diff
+against the working version is the fix and the explanation.
+
+Then the standard hygiene: `pnpm -r tsc` (or `npx tsc --noEmit` in the package),
+Prettier on changed files, branch off `develop`, commit with the
+`Co-Authored-By: Claude ...` trailer, push, and `gh pr create` using the repo PR
+template (`.github/pull_request_template.md` — Summary / Changes / How did I
+test? / Risks and impact / Rollback plan / Screenshots). Naming the branch
+`<user>/tlon-<NNNN>-...` auto-links the PR to the Linear issue. Details and the
+exact PR-body shape are in **`references/fix-and-verify.md`**.
+
+## Phase 5 — Verify on-device
+
+The preview build **embeds its JS bundle and boots straight into the app**, so
+Metro hot-reload does not pick up a code change — the only way to get a fix onto
+the device is a native rebuild that bundles the current source. The full recipe
+(JDK/SDK env, `local.properties`, `gradlew :app:installPreviewDebug`, the
+non-destructive "never uninstall" rule that preserves the user's login, and the
+screen-sleep/unlock handling for the long build) is in
+**`references/fix-and-verify.md`**.
+
+After it installs: reproduce the original failing steps, screenshot the
+now-correct behavior, and view the shot to confirm. Proof is the before
+(filed screenshot) and after (post-fix screenshot) of the same repro.
+
+## A note on pacing
+
+Phases 4–5 involve a long Gradle build and a physical device that sleeps/locks.
+Run the build in the background and watch for its terminal state; set
+`adbx.sh stayon` so the screen doesn't sleep mid-pass; and if the device is on a
+secure lockscreen, ask the user to unlock it — never attempt to bypass a PIN.

--- a/tools/agent-skills/mobile-qa/SKILL.md
+++ b/tools/agent-skills/mobile-qa/SKILL.md
@@ -70,7 +70,8 @@ than guessing.
 it and wraps the common gestures; use it instead of re-deriving adb invocations.
 
 ```bash
-# point screenshots at a scratch dir (default ./.qa-screens), then sanity-check
+# point screenshots at a scratch dir (default: a temp dir OUTSIDE the repo, so
+# real-account captures never land in the worktree), then sanity-check
 export QA_SHOT_DIR=/path/to/scratch
 SKILL=/path/to/this/skill        # wherever your agent installed it
 A="$SKILL/scripts/adbx.sh"

--- a/tools/agent-skills/mobile-qa/references/adb-driving.md
+++ b/tools/agent-skills/mobile-qa/references/adb-driving.md
@@ -1,0 +1,102 @@
+# Driving the Android app over adb
+
+Everything here is wrapped by `scripts/adbx.sh`; this file explains the traps so
+the wrapper's behavior makes sense and you know which command to reach for.
+
+## Locating adb
+
+adb is frequently not on PATH. Common real locations on macOS:
+
+- `/opt/homebrew/share/android-commandlinetools/platform-tools/adb` (Homebrew `android-commandlinetools`)
+- `~/Library/Android/sdk/platform-tools/adb` (Android Studio)
+
+`adbx.sh` searches these; if it can't find adb, install/point at one before continuing.
+
+## Screenshots and the coordinate model
+
+- Capture with `adbx.sh shot <name>` (`adb exec-out screencap -p > file.png`), then
+  **view the PNG** (image input required) to see the screen.
+- The screenshot is the device's **native resolution** (e.g. 1080×2400). Your
+  image viewer may *display* it scaled and mention a multiply factor — that factor
+  is for reading the displayed image, **not** for input.
+- `input tap`/`input swipe` use **device-native coordinates**. So tap the raw
+  pixel coordinate as it appears in the native-resolution screenshot; do **not**
+  multiply by the viewer's display-scale factor. Getting this wrong makes every
+  tap land slightly off.
+
+## When a tap keeps missing: read the real bounds
+
+Guessing a control's center from a screenshot is the #1 cause of wrong taps
+(e.g. tapping "New channel" but hitting "New section" because the rows were
+closer together than they looked). Instead of re-guessing, dump the accessibility
+tree and use exact bounds:
+
+```bash
+adbx.sh bounds "New channel"     # prints bounds="[x1,y1][x2,y2]" for matches
+# tap the center: ((x1+x2)/2, (y1+y2)/2)
+```
+
+`adbx.sh ui` dumps the whole tree if you need to find nearby elements or a
+resource-id/testID. Element `testID`s render as `content-desc` (or resource-id)
+in the dump — searching by the testID you set in code is often the fastest anchor.
+
+## Gestures that have sharp edges
+
+### RN swipeable rows / reorderable lists: use `drag`, not `swipe`
+
+React Native's pan-gesture rows (swipe-to-mark-read, drag-to-reorder channels)
+treat a fast `adb input swipe` as a **fling** and snap back — nothing is revealed
+or moved. Use `adbx.sh drag x1 y1 x2 y2`, which issues discrete `motionevent
+DOWN/MOVE.../UP` with small holds so the pan responder engages.
+
+- **Swipe-to-reveal an action** (e.g. mark-read check on a home-list row): drag a
+  short distance right and stop; the action button appears, then `tap` it.
+  Note the action only appears when it's applicable — the mark-read check only
+  shows on rows that actually have unreads.
+- **Drag-to-reorder / drag-into-section**: even a controlled `drag` may not
+  reliably trigger RN reorderable lists via synthetic events. If it won't take
+  after a couple of honest attempts, record the test as `NOT RUN — drag-and-drop
+  not reliably triggerable via adb` rather than reporting a false FAIL. It's an
+  automation limit, not necessarily an app defect.
+
+### Long-press
+
+`adbx.sh longpress x y` (a zero-distance swipe held ~800ms) opens context sheets
+(long-press a group/channel/message).
+
+### Typing: spaces truncate `input text`
+
+`adb shell input text "two words"` sends the space as a word-break and drops
+everything after it — you get "two". Options: type one word at a time, or accept
+that only the first token lands (often fine for QA where any non-empty value
+works). Don't assume a multi-word string went in; screenshot and check.
+
+To clear a field: focus it, `key 123` (move-end), then repeat `key 67` (DEL) once
+per character, then type the new value.
+
+### Dismissing the keyboard without dismissing the sheet
+
+Inside a bottom sheet, `key 4` (Back) dismisses the **whole sheet**, not just the
+keyboard — and one Back too many exits the app to the launcher. To drop just the
+keyboard, tap the keyboard's hide-chevron (bottom-left of the IME) or tap a
+neutral area of the sheet. After a keyboard show→hide, re-screenshot before
+tapping header buttons; some screens re-layout and controls move.
+
+## The device sleeps and locks during long steps
+
+A physical device sleeps on its own timeout — screenshots taken after that come
+back **all black**, and it may be sitting on the lockscreen (`dumpsys window`
+shows `mDreamingLockscreen=true`, focus `NotificationShade`).
+
+- `adbx.sh stayon` (`svc power stayon true`) keeps the screen on **while charging** —
+  set it at the start of any pass that includes a long build.
+- `adbx.sh wake` sends a wake key.
+- A **secure lockscreen** (PIN/pattern) must be unlocked by the user. Never try to
+  enter or bypass a PIN. Ask the user to unlock and leave the device on, then continue.
+
+## Relaunching / navigating
+
+- `adbx.sh launch io.tlon.groups.preview` cold-launches the app.
+- `adbx.sh stop io.tlon.groups.preview` force-stops it.
+- `adbx.sh focus` shows the focused activity — useful to confirm you're actually
+  in the app and not on the launcher/lockscreen.

--- a/tools/agent-skills/mobile-qa/references/fix-and-verify.md
+++ b/tools/agent-skills/mobile-qa/references/fix-and-verify.md
@@ -1,0 +1,111 @@
+# Fixing the bug and verifying it on-device
+
+## Fixing
+
+1. **Find the screen** from a visible string:
+   `grep -rn "Edit channel info" packages/` → the view component.
+
+2. **Find a working sibling.** These mobile bugs are usually a component wired
+   slightly differently than an equivalent screen that behaves correctly. Example
+   from TLON-6173: `EditChannelMetaScreenView` wrapped its whole layout (header
+   included) in `KeyboardAvoidingView`, while the working `MetaEditorScreenView`
+   ("Edit group info") kept the `ScreenHeader` outside the KAV and wrapped only
+   the `ScrollView`. The fix was to mirror the working structure. Diffing against
+   the sibling gives you both the fix and the root-cause explanation for the PR.
+
+3. **Hygiene before committing:**
+   - Typecheck: `cd packages/<pkg> && npx tsc --noEmit` (or `pnpm -r tsc`).
+   - Prettier: `npx prettier --write <changed files>`.
+   - Branch off `develop`: `git checkout -b <user>/tlon-<NNNN>-<slug>`
+     (the `tlon-<NNNN>` segment auto-links the PR to the Linear issue).
+   - Commit. If your agent uses a co-author trailer, add it (e.g.
+     `Co-Authored-By: <agent> <email>`).
+   - Push, then `gh pr create --base develop` with a body following the repo
+     template (`.github/pull_request_template.md`): **Summary / Changes / How did
+     I test? / Risks and impact / Rollback plan / Screenshots**. `gh` does not
+     apply the template automatically — fill it in.
+   - **Embed the before/after screenshots** — see *Embedding screenshots in the
+     PR* below (it's easy to get this wrong and ship a PR with broken images).
+
+## Embedding screenshots in the PR
+
+GitHub only renders an image whose URL it can fetch **anonymously**. That rules
+out Linear `assetUrl`s (they need a Linear login → broken image) and, for private
+repos, `raw.githubusercontent.com` (needs a token). Prefer, in order:
+
+1. **GitHub user-attachments — best; permanent, works for public *and* private
+   repos, stays off the PR diff.** In the PR (or comment) composer on github.com,
+   drag-drop or paste the image file. GitHub uploads it to its own CDN and inserts
+   a `https://github.com/user-attachments/assets/<uuid>` URL. These URLs are
+   signed-but-public, so they render for every viewer regardless of repo
+   visibility. **There is no `gh` CLI or REST endpoint for this upload** — it only
+   happens through the web composer. So the reliable flow is: create the PR with
+   `gh`, then open it in the browser and drag the images into the description. If
+   you (as an agent) can't drive a browser, hand the image files to the user and
+   ask them to drop them in — or use the fallback below.
+2. **Fallback for public repos — raw URL on a throwaway branch.** Push the PNGs to
+   a small branch (not the PR head, to keep them off the diff) and reference
+   `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>`. Verify it
+   returns `200 image/png` before relying on it. Caveat: the branch must live as
+   long as the PR should show the images — delete it and they 404 — so this is
+   less durable than user-attachments.
+
+**Never** embed an `uploads.linear.app` URL in a PR; it needs auth and renders
+broken. (Linear attachments are fine *on the Linear issue itself* — just not in
+GitHub.)
+
+## Verifying on-device — why a rebuild is required
+
+The installed preview app (`io.tlon.groups.preview`) is **debuggable but embeds
+its JS bundle** and boots straight into the app (no dev-launcher screen). Because
+of that:
+
+- Starting Metro and reloading does **not** apply your change — the app never
+  requests a bundle from Metro (confirmed by no bundling line in the Metro log),
+  and the `expo-development-client` deep link is ignored when it's already running
+  the embedded bundle.
+- The only way to get the fix onto the device is a **native rebuild** that bundles
+  the current source (which now includes your fix).
+
+## The rebuild (non-destructive)
+
+Prereqs present on a typical tlon-apps macOS dev box:
+
+- JDK 17: `/opt/homebrew/opt/openjdk@17`
+- Android SDK: `/opt/homebrew/share/android-commandlinetools` (platforms + build-tools)
+
+Steps:
+
+```bash
+# 1. Point Gradle at the SDK (android/local.properties, git-ignored)
+echo "sdk.dir=/opt/homebrew/share/android-commandlinetools" \
+  > apps/tlon-mobile/android/local.properties
+
+# 2. Build + install the preview debug variant (matches io.tlon.groups.preview).
+#    Run in the BACKGROUND — a cold build is ~10-20 min.
+cd apps/tlon-mobile/android
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17
+export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
+export PATH="$JAVA_HOME/bin:$ANDROID_HOME/platform-tools:$PATH"
+./gradlew :app:installPreviewDebug -x lint
+```
+
+Watch for `BUILD SUCCESSFUL` / `Installed on` (success) or `BUILD FAILED` /
+`FAILURE:` (with an `adbx.sh stayon` set so the device screen stays awake).
+
+### Data-safety rule: never uninstall
+
+Reinstalling over the existing app is safe **as long as you do not uninstall it**.
+If the debug signature matches the installed one, `adb install -r` preserves app
+data and the user's login. If signatures differ, the install simply **fails**
+(no data loss) — it does not silently wipe. So: never run `adb uninstall`. Worst
+case is "couldn't install, report that", never "logged the user out of their real
+account". If it fails on signature mismatch, tell the user rather than forcing it.
+
+## Capture the proof
+
+After it installs, reproduce the exact failing steps from the Linear repro,
+screenshot the corrected behavior, and view the shot to confirm. The deliverable
+is a before (the filed broken-state shot) and after (post-fix shot) of the same
+repro. For TLON-6173 that's: Group → Channels → ⋮ → Channel info → edit pencil →
+focus Name → dismiss keyboard → header back/**Save** stay on-screen and tappable.

--- a/tools/agent-skills/mobile-qa/references/fix-and-verify.md
+++ b/tools/agent-skills/mobile-qa/references/fix-and-verify.md
@@ -16,8 +16,11 @@
 3. **Hygiene before committing:**
    - Typecheck: `cd packages/<pkg> && npx tsc --noEmit` (or `pnpm -r tsc`).
    - Prettier: `npx prettier --write <changed files>`.
-   - Branch off `develop`: `git checkout -b <user>/tlon-<NNNN>-<slug>`
-     (the `tlon-<NNNN>` segment auto-links the PR to the Linear issue).
+   - Branch off `develop` **explicitly** — don't rely on current HEAD:
+     `git fetch origin && git switch -c <user>/tlon-<NNNN>-<slug> origin/develop`.
+     (`git checkout -b <name>` with no start point branches from wherever you
+     happen to be; on a stale feature branch that drags unrelated commits into the
+     PR.) The `tlon-<NNNN>` segment auto-links the PR to the Linear issue.
    - Commit. If your agent uses a co-author trailer, add it (e.g.
      `Co-Authored-By: <agent> <email>`).
    - Push, then `gh pr create --base develop` with a body following the repo
@@ -54,57 +57,77 @@ repos, `raw.githubusercontent.com` (needs a token). Prefer, in order:
 broken. (Linear attachments are fine *on the Linear issue itself* — just not in
 GitHub.)
 
-## Verifying on-device — why a rebuild is required
+## Verifying on-device — know your variant first
 
-The installed preview app (`io.tlon.groups.preview`) is **debuggable but embeds
-its JS bundle** and boots straight into the app (no dev-launcher screen). Because
-of that:
+Whether you need a rebuild depends entirely on the build variant, and this is
+easy to get wrong. In `apps/tlon-mobile/android/app/build.gradle`,
+`previewDebug` (and the other `*Debug*` variants) are listed in
+**`debuggableVariants`**, which — per the Expo config comment right above it —
+**skips bundling the JS bundle and assets**. So:
 
-- Starting Metro and reloading does **not** apply your change — the app never
-  requests a bundle from Metro (confirmed by no bundling line in the Metro log),
-  and the `expo-development-client` deep link is ignored when it's already running
-  the embedded bundle.
-- The only way to get the fix onto the device is a **native rebuild** that bundles
-  the current source (which now includes your fix).
+- **`previewDebug` does NOT embed your JS.** It loads the bundle from **Metro** at
+  runtime. `./gradlew :app:installPreviewDebug` therefore does *not* put your
+  current source on the device by itself — without Metro it runs stale/last-cached
+  JS, and Phase 5 can falsely pass or fail against the wrong code.
+- Only a **bundling (release-style) variant** embeds the current JS into a
+  standalone APK: **`previewRelease`** (`pnpm --filter tlon-mobile
+  android:release:preview`).
 
-## The rebuild (non-destructive)
+### For a JS/TS-only fix (the common case) → use Metro, no rebuild needed
 
-Prereqs present on a typical tlon-apps macOS dev box:
-
-- JDK 17: `/opt/homebrew/opt/openjdk@17`
-- Android SDK: `/opt/homebrew/share/android-commandlinetools` (platforms + build-tools)
-
-Steps:
+If a `previewDebug` build is already installed (the usual dev/preview state), you
+don't need Gradle at all:
 
 ```bash
-# 1. Point Gradle at the SDK (android/local.properties, git-ignored)
+# 1. Start Metro on the FIXED source (background; keep it running):
+cd apps/tlon-mobile && APP_VARIANT=preview npx expo start --dev-client --port 8081
+# 2. Make the device reach it, then load it:
+adb reverse tcp:8081 tcp:8081
+adb shell am start -a android.intent.action.VIEW \
+  -d "io.tlon.groups.preview://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+# (or force-stop + relaunch and pick "localhost:8081" from the dev-launcher's
+#  Recently Opened list)
+```
+
+**Confirm you're actually on your Metro bundle**, or you may verify stale code:
+watch the Metro log for an `Android Bundling …` line when the app loads. If no
+bundling request arrives, the app is running an embedded/cached bundle — your fix
+is NOT live. (This is the trap that makes Phase 5 lie.)
+
+### For a native change, or a standalone APK that embeds the fix → build a bundling variant
+
+Prereqs on a typical macOS dev box: JDK 17 (`/opt/homebrew/opt/openjdk@17`) and
+the Android SDK (`/opt/homebrew/share/android-commandlinetools`).
+
+```bash
 echo "sdk.dir=/opt/homebrew/share/android-commandlinetools" \
   > apps/tlon-mobile/android/local.properties
-
-# 2. Build + install the preview debug variant (matches io.tlon.groups.preview).
-#    Run in the BACKGROUND — a cold build is ~10-20 min.
 cd apps/tlon-mobile/android
 export JAVA_HOME=/opt/homebrew/opt/openjdk@17
 export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
 export PATH="$JAVA_HOME/bin:$ANDROID_HOME/platform-tools:$PATH"
-./gradlew :app:installPreviewDebug -x lint
+# previewRelease EMBEDS the JS (bundling variant). Cold build ~10-20 min; run in bg.
+./gradlew :app:installPreviewRelease -x lint
 ```
 
-Watch for `BUILD SUCCESSFUL` / `Installed on` (success) or `BUILD FAILED` /
-`FAILURE:` (with an `adbx.sh stayon` set so the device screen stays awake).
+Watch for `BUILD SUCCESSFUL` / `Installed on` vs `BUILD FAILED` / `FAILURE:`, and
+set `adbx.sh stayon` so the screen stays awake during the long build.
 
 ### Data-safety rule: never uninstall
 
 Reinstalling over the existing app is safe **as long as you do not uninstall it**.
-If the debug signature matches the installed one, `adb install -r` preserves app
-data and the user's login. If signatures differ, the install simply **fails**
-(no data loss) — it does not silently wipe. So: never run `adb uninstall`. Worst
-case is "couldn't install, report that", never "logged the user out of their real
-account". If it fails on signature mismatch, tell the user rather than forcing it.
+If signatures match, `adb install -r` preserves app data and the user's login. If
+signatures differ (e.g. a release-signed `previewRelease` over a debug-signed
+`previewDebug`), the install simply **fails** — it does not silently wipe. So:
+never run `adb uninstall`. Worst case is "couldn't install, report that", never
+"logged the user out of their real account". If it fails on signature mismatch,
+tell the user rather than forcing it — the Metro flow above avoids the mismatch
+entirely for JS fixes.
 
 ## Capture the proof
 
-After it installs, reproduce the exact failing steps from the Linear repro,
+Once the fix is live on the device (Metro-loaded for a JS fix, or installed for a
+bundling build), reproduce the exact failing steps from the Linear repro,
 screenshot the corrected behavior, and view the shot to confirm. The deliverable
 is a before (the filed broken-state shot) and after (post-fix shot) of the same
 repro. For TLON-6173 that's: Group → Channels → ⋮ → Channel info → edit pencil →

--- a/tools/agent-skills/mobile-qa/references/fix-and-verify.md
+++ b/tools/agent-skills/mobile-qa/references/fix-and-verify.md
@@ -99,6 +99,19 @@ is NOT live. (This is the trap that makes Phase 5 lie.)
 Prereqs on a typical macOS dev box: JDK 17 (`/opt/homebrew/opt/openjdk@17`) and
 the Android SDK (`/opt/homebrew/share/android-commandlinetools`).
 
+Simplest: use the package script, which sets the variant env for you:
+
+```bash
+# EMBEDS the JS as the preview variant. Cold build ~10-20 min; run in bg.
+pnpm --filter tlon-mobile android:release:preview
+```
+
+If you invoke Gradle directly instead, you **must** set `APP_VARIANT=preview` —
+`app.config.ts` derives the Expo scheme and `extra.appVariant` from it and
+defaults to *production* when it's unset, so a bare `installPreviewRelease` embeds
+production JS constants (Branch keys, deep-link scheme, etc.) under the preview
+applicationId, making preview-only behavior unverifiable:
+
 ```bash
 echo "sdk.dir=/opt/homebrew/share/android-commandlinetools" \
   > apps/tlon-mobile/android/local.properties
@@ -106,8 +119,7 @@ cd apps/tlon-mobile/android
 export JAVA_HOME=/opt/homebrew/opt/openjdk@17
 export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
 export PATH="$JAVA_HOME/bin:$ANDROID_HOME/platform-tools:$PATH"
-# previewRelease EMBEDS the JS (bundling variant). Cold build ~10-20 min; run in bg.
-./gradlew :app:installPreviewRelease -x lint
+APP_VARIANT=preview ./gradlew :app:installPreviewRelease -x lint
 ```
 
 Watch for `BUILD SUCCESSFUL` / `Installed on` vs `BUILD FAILED` / `FAILURE:`, and

--- a/tools/agent-skills/mobile-qa/references/fix-and-verify.md
+++ b/tools/agent-skills/mobile-qa/references/fix-and-verify.md
@@ -78,12 +78,17 @@ easy to get wrong. In `apps/tlon-mobile/android/app/build.gradle`,
 If a `previewDebug` build is already installed (the usual dev/preview state), you
 don't need Gradle at all:
 
+Use the `adbx.sh` wrapper (`A="$SKILL/scripts/adbx.sh"`) for the adb calls —
+`adb` is usually not on PATH (Phase 1), and the wrapper's `adb` passthrough
+resolves it.
+
 ```bash
-# 1. Start Metro on the FIXED source (background; keep it running):
-cd apps/tlon-mobile && APP_VARIANT=preview npx expo start --dev-client --port 8081
-# 2. Make the device reach it, then load it:
-adb reverse tcp:8081 tcp:8081
-adb shell am start -a android.intent.action.VIEW \
+# 1. Start Metro on the FIXED source. It runs in the FOREGROUND and blocks, so
+#    background it (append & / separate session) and keep it running:
+( cd apps/tlon-mobile && APP_VARIANT=preview npx expo start --dev-client --port 8081 ) &
+# 2. Make the device reach it, then load it (via the wrapper, not bare adb):
+"$A" adb reverse tcp:8081 tcp:8081
+"$A" adb shell am start -a android.intent.action.VIEW \
   -d "io.tlon.groups.preview://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
 # (or force-stop + relaunch and pick "localhost:8081" from the dev-launcher's
 #  Recently Opened list)
@@ -113,8 +118,11 @@ production JS constants (Branch keys, deep-link scheme, etc.) under the preview
 applicationId, making preview-only behavior unverifiable:
 
 ```bash
-echo "sdk.dir=/opt/homebrew/share/android-commandlinetools" \
-  > apps/tlon-mobile/android/local.properties
+# Append sdk.dir only if absent — don't clobber an existing local.properties
+# (it may hold machine-specific SDK/NDK paths from prior Android builds):
+lp=apps/tlon-mobile/android/local.properties
+grep -qs '^sdk.dir=' "$lp" || \
+  echo "sdk.dir=/opt/homebrew/share/android-commandlinetools" >> "$lp"
 cd apps/tlon-mobile/android
 export JAVA_HOME=/opt/homebrew/opt/openjdk@17
 export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools

--- a/tools/agent-skills/mobile-qa/references/linear-filing.md
+++ b/tools/agent-skills/mobile-qa/references/linear-filing.md
@@ -55,8 +55,12 @@ what you have.
    b. PUT the raw bytes to `uploadRequest.url`, sending **every** header in
       `uploadRequest.headers` verbatim (casing included) or you get HTTP 403:
 
+      Use `--fail-with-body` so curl **exits non-zero** on a 4xx/5xx (an expired
+      signed URL or a wrong/missing header returns 403 while plain `curl` still
+      exits 0):
+
       ```bash
-      curl -sS -X PUT --data-binary @file.png \
+      curl -sS --fail-with-body -X PUT --data-binary @file.png \
         -H "content-type: image/png" \
         -H "cache-control: public, max-age=31536000" \
         -H "x-goog-content-length-range: <size>,<size>" \
@@ -66,8 +70,11 @@ what you have.
       (This is a plain outbound PUT; it needs real network, so if your shell runs
       in a network sandbox, run this step with the sandbox disabled.)
 
-   c. `create_attachment_from_upload` with the `issue` and the `assetUrl` from
-      step (a) to link it.
+   c. **Only if the PUT succeeded (2xx / curl exit 0)**, call
+      `create_attachment_from_upload` with the `issue` and the `assetUrl` from
+      step (a). If the PUT failed, re-run `prepare_attachment_upload` (the URL
+      expires in ~60s) and retry — don't finalize, or the issue gets a broken /
+      missing screenshot.
 
 6. **Report** the issue id + URL back to the user.
 

--- a/tools/agent-skills/mobile-qa/references/linear-filing.md
+++ b/tools/agent-skills/mobile-qa/references/linear-filing.md
@@ -1,0 +1,77 @@
+# Filing failures as Linear issues (with screenshots)
+
+You need a Linear integration. Two ways, pick whichever your agent has:
+
+- **Linear MCP server** — use its tools (`list_teams`, `save_issue`,
+  `prepare_attachment_upload`, `create_attachment_from_upload`,
+  `list_issue_labels`). In Claude Code these may be *deferred* and need loading
+  first, e.g. `ToolSearch: select:mcp__<linear-server>__list_teams,...` (the
+  `<linear-server>` id is the UUID prefix on the Linear tools).
+- **Linear GraphQL API directly** — with a personal API token
+  (`Authorization: <token>`, `POST https://api.linear.app/graphql`). The steps
+  below map 1:1: `list_teams` → `teams` query, `save_issue` → `issueCreate`,
+  `list_issue_labels` → `issueLabels`, and the attachment flow →
+  `fileUpload` mutation (returns a signed `uploadUrl` + headers) then
+  `attachmentCreate` with the returned asset URL.
+
+The recipe below uses the MCP tool names; substitute the API calls if that's
+what you have.
+
+## Steps
+
+1. **Pick the team.** `list_teams` → for tlon-apps the target is **`Tlon`**
+   (icon "Terminal"). Prefer passing the team by name (`"Tlon"`).
+
+2. **Confirm scope with the user** if there are several failures — don't
+   mass-create issues unprompted. File the ones they want.
+
+3. **Find the label.** `list_issue_labels --team Tlon --name bug` → use the `Bug`
+   label (pass `labels: ["Bug"]` to `save_issue`).
+
+4. **Create the issue** with `save_issue` (no `id` = create). Give the description
+   as real Markdown (literal newlines, not `\n`). Structure it so someone can act
+   without this conversation:
+
+   - **Summary** — what's wrong, one paragraph, with any concrete measurement
+     (e.g. "Save button bounds `[912,0][1038,53]`, i.e. under the status bar").
+   - **Steps to reproduce** — numbered, from a cold start.
+   - **Expected** vs **Actual**.
+   - **Notes** — when it does/doesn't happen; likely-area hunch if you have one.
+   - **Environment** — platform, device model + Android version, app id
+     (`io.tlon.groups.preview`), and build version from
+     `adbx.sh adb shell dumpsys package io.tlon.groups.preview | grep versionName`.
+
+   `save_issue` returns the issue identifier (e.g. `TLON-6173`) and `url`. Keep both.
+
+5. **Attach the screenshot** of the broken state (three steps — order matters, and
+   the signed URL expires in ~60s so do them back-to-back):
+
+   a. `prepare_attachment_upload` with `issue`, `filename`, `contentType:
+      "image/png"`, and the exact byte `size` (`stat -f%z file.png`). It returns
+      `uploadRequest` (url + signed headers) and an `assetUrl`.
+
+   b. PUT the raw bytes to `uploadRequest.url`, sending **every** header in
+      `uploadRequest.headers` verbatim (casing included) or you get HTTP 403:
+
+      ```bash
+      curl -sS -X PUT --data-binary @file.png \
+        -H "content-type: image/png" \
+        -H "cache-control: public, max-age=31536000" \
+        -H "x-goog-content-length-range: <size>,<size>" \
+        -H 'Content-Disposition: attachment; filename="file.png"' \
+        -w "HTTP %{http_code}\n" "<uploadRequest.url>"
+      ```
+      (This is a plain outbound PUT; it needs real network, so if your shell runs
+      in a network sandbox, run this step with the sandbox disabled.)
+
+   c. `create_attachment_from_upload` with the `issue` and the `assetUrl` from
+      step (a) to link it.
+
+6. **Report** the issue id + URL back to the user.
+
+## Tips
+
+- If the user says they have the broken state on the device right now, take a
+  **fresh** `adbx.sh shot` for the attachment rather than reusing an older image.
+- The branch name you'll use for the fix (`<user>/tlon-<NNNN>-...`) auto-links the
+  PR to the issue, so no manual linking is needed later.

--- a/tools/agent-skills/mobile-qa/references/linear-filing.md
+++ b/tools/agent-skills/mobile-qa/references/linear-filing.md
@@ -47,8 +47,10 @@ what you have.
    the signed URL expires in ~60s so do them back-to-back):
 
    a. `prepare_attachment_upload` with `issue`, `filename`, `contentType:
-      "image/png"`, and the exact byte `size` (`stat -f%z file.png`). It returns
-      `uploadRequest` (url + signed headers) and an `assetUrl`.
+      "image/png"`, and the exact byte `size`. Get the size portably with
+      `wc -c < file.png` (works on macOS **and** Linux; `stat -f%z` is
+      BSD/macOS-only and errors out on GNU/Linux). It returns `uploadRequest`
+      (url + signed headers) and an `assetUrl`.
 
    b. PUT the raw bytes to `uploadRequest.url`, sending **every** header in
       `uploadRequest.headers` verbatim (casing included) or you get HTTP 403:

--- a/tools/agent-skills/mobile-qa/references/safety.md
+++ b/tools/agent-skills/mobile-qa/references/safety.md
@@ -1,0 +1,51 @@
+# Safety on a real account
+
+The device almost always has the user's **real, logged-in account** — real
+colleagues, real groups, real DMs (you can tell from the conversation content).
+Treat it that way. A blanket "run the QA tasks" authorizes reading and driving the
+UI; it is **not** consent to do things that reach real people or destroy shared
+state.
+
+## Do freely (inward-facing, reversible)
+
+Navigation, opening sheets/screens, filtering, tab switching, pin/unpin,
+mark-as-read, viewing member lists and settings, changing a setting you then
+restore. Screenshot as evidence.
+
+## Do NOT do on the real account
+
+- **Send messages** to real people (DMs, group posts, replies).
+- **Invite / kick / ban / revoke** against real ships.
+- **Leave / delete** a real shared group or channel the user is in.
+- **Forward** content into a real conversation with people in it.
+- **Join** an arbitrary group by a real code.
+
+For the destructive/admin *tests* that the checklist genuinely needs, route them
+through a **throwaway group you create yourself** (create → run kick/ban/leave/
+delete/permissions against it → delete it as cleanup). That exercises the same UI
+without touching shared state. A bot DM (e.g. `openjames`) or a placeholder ship
+(`~sampel-palnet`) is a safe target for "route to a DM" style tests since nothing
+is delivered to a real person.
+
+## When a step is unavoidably outward-facing
+
+Surface it and get an explicit yes before doing it. If the user has broadly
+authorized destructive actions, still apply judgment: run them against your
+throwaway constructs, not the company's primary 80-member group. Confirming a
+`Leave`/`Delete` dialog and then **cancelling** is a valid way to verify the
+confirm-dialog test without the irreversible step — record it as such.
+
+## Single-device limits — mark, don't guess
+
+- "All members see the change" / cross-ship propagation → verify only the
+  initiating side; mark the propagation `needs 2nd ship`.
+- Mismatched-agent-version warnings, private-group ask-to-join accept/reject →
+  `NOT TESTABLE (single device)`.
+
+## Housekeeping
+
+- If you create a throwaway group, **delete it** at the end (host → Delete group).
+- If you set `svc power stayon true`, that's fine to leave; it only affects
+  behavior while charging.
+- If you toggled a real setting to test it (notification level, privacy), restore
+  it unless the object is a throwaway you're about to delete.

--- a/tools/agent-skills/mobile-qa/scripts/adbx.sh
+++ b/tools/agent-skills/mobile-qa/scripts/adbx.sh
@@ -6,7 +6,8 @@
 # motionevent drag for React Native rows that ignore `input swipe`) and `bounds`
 # (read an element's real coordinates when a tap keeps missing).
 #
-# Screenshots go to $QA_SHOT_DIR (default ./.qa-screens).
+# Screenshots go to $QA_SHOT_DIR (default: a temp dir outside the repo, so
+# real-account captures never land in the worktree / get committed).
 #
 # Usage:
 #   A=.claude/skills/mobile-qa/scripts/adbx.sh
@@ -34,7 +35,10 @@ find_adb() {
 }
 
 ADB="$(find_adb)"
-SS="${QA_SHOT_DIR:-./.qa-screens}"
+# Default to a temp dir OUTSIDE the repo — screenshots can contain real-account
+# content (private chats, member lists), and Phase 4 commits from the worktree,
+# so a repo-relative default risks accidentally committing them.
+SS="${QA_SHOT_DIR:-${TMPDIR:-/tmp}/tlon-qa-screens}"
 mkdir -p "$SS"
 
 cmd="${1:-}"; shift || true

--- a/tools/agent-skills/mobile-qa/scripts/adbx.sh
+++ b/tools/agent-skills/mobile-qa/scripts/adbx.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# adbx.sh — thin wrapper for driving an Android device during a QA pass.
+#
+# Locates adb (it is usually not on PATH), and wraps the gestures that come up
+# constantly plus the two that have sharp edges: `drag` (a slow, controlled
+# motionevent drag for React Native rows that ignore `input swipe`) and `bounds`
+# (read an element's real coordinates when a tap keeps missing).
+#
+# Screenshots go to $QA_SHOT_DIR (default ./.qa-screens).
+#
+# Usage:
+#   A=.claude/skills/mobile-qa/scripts/adbx.sh
+#   "$A" shot home            # capture -> $QA_SHOT_DIR/home.png (path printed)
+#   "$A" tap 540 750          # device-native coords (same as the screenshot)
+#   "$A" swipe 540 1900 540 600 400
+#   "$A" longpress 540 750    # long-press (opens context sheets)
+#   "$A" drag 540 452 540 760 # slow drag for RN reorder / swipe-to-reveal rows
+#   "$A" text hello           # NOTE: spaces break `input text` (see below)
+#   "$A" bounds "Save"        # print bounds of elements matching text/desc
+#   "$A" launch io.tlon.groups.preview
+set -uo pipefail
+
+find_adb() {
+  if command -v adb >/dev/null 2>&1; then command -v adb; return; fi
+  for p in \
+    "$HOME/Library/Android/sdk/platform-tools/adb" \
+    "/opt/homebrew/share/android-commandlinetools/platform-tools/adb" \
+    "/usr/local/share/android-commandlinetools/platform-tools/adb" \
+    "/usr/local/bin/adb"; do
+    [ -x "$p" ] && { echo "$p"; return; }
+  done
+  echo "adb not found on PATH or in common SDK locations" >&2
+  exit 127
+}
+
+ADB="$(find_adb)"
+SS="${QA_SHOT_DIR:-./.qa-screens}"
+mkdir -p "$SS"
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  tap)       "$ADB" shell input tap "$1" "$2" ;;
+  swipe)     "$ADB" shell input swipe "$1" "$2" "$3" "$4" "${5:-300}" ;;
+  # long-press = zero-distance swipe held for N ms (default 800)
+  longpress) "$ADB" shell input swipe "$1" "$2" "$1" "$2" "${3:-800}" ;;
+  # drag x1 y1 x2 y2 — controlled motionevent drag with per-step holds.
+  # Use this for RN reorderable lists and swipe-action rows: a plain
+  # `input swipe` is treated as a fling and snaps back without revealing/moving.
+  drag)
+    x1="$1"; y1="$2"; x2="$3"; y2="$4"
+    seq="input motionevent DOWN $x1 $y1;"
+    for i in 1 2 3 4 5 6 7 8; do
+      mx=$(( x1 + (x2 - x1) * i / 8 ))
+      my=$(( y1 + (y2 - y1) * i / 8 ))
+      seq="$seq input motionevent MOVE $mx $my; sleep 0.06;"
+    done
+    seq="$seq sleep 0.4; input motionevent UP $x2 $y2"
+    "$ADB" shell "$seq" ;;
+  # `input text` sends a space as a word break and TRUNCATES the rest. For text
+  # with spaces, call once per word or substitute %s. This wrapper passes through
+  # a single token; keep tokens space-free.
+  text)      "$ADB" shell input text "$1" ;;
+  key)       "$ADB" shell input keyevent "$1" ;;
+  back)      "$ADB" shell input keyevent 4 ;;
+  home)      "$ADB" shell input keyevent 3 ;;
+  wake)      "$ADB" shell input keyevent 224 ;;
+  stayon)    "$ADB" shell svc power stayon true ;;   # don't sleep while charging
+  shot)      "$ADB" exec-out screencap -p > "$SS/${1:-shot}.png"; echo "$SS/${1:-shot}.png" ;;
+  ui)        "$ADB" shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1; "$ADB" shell cat /sdcard/ui.xml ;;
+  # bounds "<needle>" — fresh ui dump, print bounds= of nodes whose line matches
+  # the needle (text or content-desc). Center = midpoint of [x1,y1][x2,y2].
+  bounds)
+    "$ADB" shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1
+    "$ADB" shell cat /sdcard/ui.xml | tr '>' '\n' | grep -i -- "$1" \
+      | grep -oE '(text|content-desc)="[^"]*"|bounds="[^"]+"' | paste - - - 2>/dev/null \
+      || "$ADB" shell cat /sdcard/ui.xml | tr '>' '\n' | grep -i -- "$1" ;;
+  focus)     "$ADB" shell dumpsys window | grep -iE 'mCurrentFocus' | head -1 ;;
+  launch)    "$ADB" shell monkey -p "$1" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 ;;
+  stop)      "$ADB" shell am force-stop "$1" ;;
+  adb)       "$ADB" "$@" ;;
+  *)
+    echo "usage: adbx.sh {tap|swipe|longpress|drag|text|key|back|home|wake|stayon|shot|ui|bounds|focus|launch|stop|adb} ..." >&2
+    exit 2 ;;
+esac

--- a/tools/agent-skills/mobile-qa/scripts/adbx.sh
+++ b/tools/agent-skills/mobile-qa/scripts/adbx.sh
@@ -65,7 +65,18 @@ case "$cmd" in
   home)      "$ADB" shell input keyevent 3 ;;
   wake)      "$ADB" shell input keyevent 224 ;;
   stayon)    "$ADB" shell svc power stayon true ;;   # don't sleep while charging
-  shot)      "$ADB" exec-out screencap -p > "$SS/${1:-shot}.png"; echo "$SS/${1:-shot}.png" ;;
+  shot)
+    # Only advertise the path if capture actually succeeded — a disconnected /
+    # unauthorized / ambiguous (multiple) device makes screencap fail and would
+    # otherwise leave an empty PNG that looks like valid evidence.
+    out="$SS/${1:-shot}.png"
+    if "$ADB" exec-out screencap -p > "$out" && [ -s "$out" ]; then
+      echo "$out"
+    else
+      echo "screencap failed (no authorized device? disconnected? multiple devices?)" >&2
+      rm -f "$out"
+      exit 1
+    fi ;;
   ui)        "$ADB" shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1; "$ADB" shell cat /sdcard/ui.xml ;;
   # bounds "<needle>" — fresh ui dump, print bounds= of nodes whose line matches
   # the needle (text or content-desc). Center = midpoint of [x1,y1][x2,y2].

--- a/tools/agent-skills/verify/SKILL.md
+++ b/tools/agent-skills/verify/SKILL.md
@@ -33,11 +33,19 @@ screenshot. Where noted, use your tool's own verbs for those actions.
 1. Piers + urbit binary live in `apps/tlon-web/rube/dist/` after any rube
    run (zod/, ten/, urbit_extracted/urbit). If missing, let
    `./start-playwright-dev.sh` run once to download/extract, then kill it.
-2. Boot one ship (zod, http port 35453 per `apps/tlon-web/e2e/shipManifest.json`):
+2. Boot one ship (zod, http port 35453 per `apps/tlon-web/e2e/shipManifest.json`).
+   **First make sure no ship is already using this pier/port** — deleting a live
+   `.vere.lock` and booting a second Vere on the same pier corrupts/wedges it.
+   Only remove the lock once you've confirmed nothing is running:
    ```
    cd apps/tlon-web
-   rm -f rube/dist/zod/zod/.vere.lock
-   ./rube/dist/urbit_extracted/urbit rube/dist/zod/zod -d --http-port 35453
+   # Bail if a ship is already serving this port (reuse it instead of double-booting):
+   if lsof -ti :35453 >/dev/null 2>&1 || pgrep -f 'rube/dist/urbit_extracted/urbit' >/dev/null; then
+     echo "A ship/port is already live — reuse it; do NOT delete the lock or boot again."
+   else
+     rm -f rube/dist/zod/zod/.vere.lock
+     ./rube/dist/urbit_extracted/urbit rube/dist/zod/zod -d --http-port 35453
+   fi
    ```
 3. Start web server (background):
    ```

--- a/tools/agent-skills/verify/SKILL.md
+++ b/tools/agent-skills/verify/SKILL.md
@@ -36,21 +36,23 @@ screenshot. Where noted, use your tool's own verbs for those actions.
 2. Boot the **zod** ship (http port 35453 per `apps/tlon-web/e2e/shipManifest.json`).
    **First make sure zod's own port/pier isn't already live** — deleting a live
    `.vere.lock` and booting a second Vere on the same pier corrupts/wedges it.
-   Gate specifically on **zod's port `:35453`** (not "any urbit" — another rube
-   ship like `~ten` on `:38473` is irrelevant here and must not make you skip
-   booting zod, or Vite below points at a dead port). The `-d` flag runs Vere as a
-   detached daemon, so this returns and you can proceed:
+   Gate on **zod specifically** — its port `:35453` **or** a live process on the
+   `zod/zod` pier. Check both, because a zod daemon that is still booting has
+   created `.vere.lock` but hasn't bound `:35453` yet; a port-only check would then
+   delete a live lock and start a second Vere on the same pier (the exact
+   corruption this guards against). The pier-path match keeps it zod-specific, so
+   another rube ship like `~ten` (`ten/ten`, `:38473`) is correctly ignored and
+   doesn't make you skip booting zod. The `-d` flag runs Vere as a detached
+   daemon, so the boot returns and you can proceed:
    ```
    cd apps/tlon-web
-   if lsof -ti :35453 >/dev/null 2>&1; then
-     echo "zod already serving :35453 — reuse it; do NOT delete the lock or boot again."
+   if lsof -ti :35453 >/dev/null 2>&1 || pgrep -f 'rube/dist/zod/zod' >/dev/null; then
+     echo "zod already live (port :35453 or zod/zod pier process) — reuse it; do NOT delete the lock or boot again."
    else
      rm -f rube/dist/zod/zod/.vere.lock
      ./rube/dist/urbit_extracted/urbit rube/dist/zod/zod -d --http-port 35453   # -d = daemon (detached)
    fi
    ```
-   (If a stale zod process holds the pier but isn't listening on `:35453`, the
-   `-d` boot after removing the lock recovers it.)
 3. Start the web server. It runs in the **foreground and blocks**, so launch it as
    a long-lived background/detached process (your agent's background-run
    mechanism, a separate terminal/session, or append `&`) — otherwise the recipe

--- a/tools/agent-skills/verify/SKILL.md
+++ b/tools/agent-skills/verify/SKILL.md
@@ -33,24 +33,31 @@ screenshot. Where noted, use your tool's own verbs for those actions.
 1. Piers + urbit binary live in `apps/tlon-web/rube/dist/` after any rube
    run (zod/, ten/, urbit_extracted/urbit). If missing, let
    `./start-playwright-dev.sh` run once to download/extract, then kill it.
-2. Boot one ship (zod, http port 35453 per `apps/tlon-web/e2e/shipManifest.json`).
-   **First make sure no ship is already using this pier/port** — deleting a live
+2. Boot the **zod** ship (http port 35453 per `apps/tlon-web/e2e/shipManifest.json`).
+   **First make sure zod's own port/pier isn't already live** — deleting a live
    `.vere.lock` and booting a second Vere on the same pier corrupts/wedges it.
-   Only remove the lock once you've confirmed nothing is running:
+   Gate specifically on **zod's port `:35453`** (not "any urbit" — another rube
+   ship like `~ten` on `:38473` is irrelevant here and must not make you skip
+   booting zod, or Vite below points at a dead port). The `-d` flag runs Vere as a
+   detached daemon, so this returns and you can proceed:
    ```
    cd apps/tlon-web
-   # Bail if a ship is already serving this port (reuse it instead of double-booting):
-   if lsof -ti :35453 >/dev/null 2>&1 || pgrep -f 'rube/dist/urbit_extracted/urbit' >/dev/null; then
-     echo "A ship/port is already live — reuse it; do NOT delete the lock or boot again."
+   if lsof -ti :35453 >/dev/null 2>&1; then
+     echo "zod already serving :35453 — reuse it; do NOT delete the lock or boot again."
    else
      rm -f rube/dist/zod/zod/.vere.lock
-     ./rube/dist/urbit_extracted/urbit rube/dist/zod/zod -d --http-port 35453
+     ./rube/dist/urbit_extracted/urbit rube/dist/zod/zod -d --http-port 35453   # -d = daemon (detached)
    fi
    ```
-3. Start web server (background):
+   (If a stale zod process holds the pier but isn't listening on `:35453`, the
+   `-d` boot after removing the lock recovers it.)
+3. Start the web server. It runs in the **foreground and blocks**, so launch it as
+   a long-lived background/detached process (your agent's background-run
+   mechanism, a separate terminal/session, or append `&`) — otherwise the recipe
+   hangs here and never reaches the browser step:
    ```
    cd apps/tlon-web
-   SHIP_URL=http://localhost:35453 VITE_DISABLE_SPLASH_MODAL=true pnpm dev-no-ssl --port 3000
+   SHIP_URL=http://localhost:35453 VITE_DISABLE_SPLASH_MODAL=true pnpm dev-no-ssl --port 3000 &
    ```
 4. Browse `http://localhost:3000/apps/groups/`, log in with zod code
    `lidlut-tabwed-pillex-ridrup`. Rube nukes ship state, so create a quick

--- a/tools/agent-skills/verify/SKILL.md
+++ b/tools/agent-skills/verify/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify
+description: Verify tlon-apps web UI changes end-to-end with a single local ship + vite dev server (lighter than the full playwright-dev rig)
+---
+
+# Verify tlon-apps UI changes (single-ship recipe)
+
+The full `./start-playwright-dev.sh` rig boots 2+ ships (2GB loom each) and
+can get OOM-killed on low-memory machines mid desk-commit ("Ships process
+exited unexpectedly with code null"). For UI verification a single ship +
+one vite server is enough and much lighter.
+
+**Capabilities assumed** (this is a recipe, not tied to one agent — any agent
+with these can follow it): a **shell** (urbit binary, `pnpm`, `curl`, `lsof`),
+**filesystem** access to the repo, and a **browser-automation tool** that can
+navigate, type/fill inputs, click by selector, evaluate JS in the page, and
+screenshot. Where noted, use your tool's own verbs for those actions.
+
+## Gotchas (hit these before, save the debugging)
+
+- **asdf**: repo `.tool-versions` pins nodejs 20.11.0 which may not be
+  installed. Prefix commands with `ASDF_NODEJS_VERSION=25.9.0` (or whatever
+  `asdf list nodejs` shows) or the pnpm shim fails with "No version is set
+  for command pnpm".
+- **peru**: rube's desk assembly needs `peru` on PATH (`brew install pipx &&
+  pipx install peru`). Without it rube dies at "Vendoring desk dependencies".
+- **Process sandbox**: launch the ship and web server as real, long-lived
+  detached processes. Some agent execution sandboxes kill detached/background
+  processes — if yours does, run these steps with the sandbox disabled.
+
+## Recipe
+
+1. Piers + urbit binary live in `apps/tlon-web/rube/dist/` after any rube
+   run (zod/, ten/, urbit_extracted/urbit). If missing, let
+   `./start-playwright-dev.sh` run once to download/extract, then kill it.
+2. Boot one ship (zod, http port 35453 per `apps/tlon-web/e2e/shipManifest.json`):
+   ```
+   cd apps/tlon-web
+   rm -f rube/dist/zod/zod/.vere.lock
+   ./rube/dist/urbit_extracted/urbit rube/dist/zod/zod -d --http-port 35453
+   ```
+3. Start web server (background):
+   ```
+   cd apps/tlon-web
+   SHIP_URL=http://localhost:35453 VITE_DISABLE_SPLASH_MODAL=true pnpm dev-no-ssl --port 3000
+   ```
+4. Browse `http://localhost:3000/apps/groups/`, log in with zod code
+   `lidlut-tabwed-pillex-ridrup`. Rube nukes ship state, so create a quick
+   group via the + button to get a chat channel.
+5. Vite serves `packages/app` etc. from source (workspace `main: index.ts`),
+   so edits hot-reload; confirm served code with
+   `curl -s "http://localhost:3000/apps/groups/@fs/<abs-path-to-file>" | grep <new-identifier>`.
+
+## Browser-driving notes
+
+- Synthesized `key` events (cmd+a, Backspace, Return) do NOT reach the RN-web
+  textarea. Use your browser tool's **type**/**fill** action instead. To
+  "select-all + type over", set the value in one fill/input action (same as a
+  real replace) rather than key-by-key. To send, click
+  `[data-testid="MessageInputSendButton"]`.
+- The TanStack devtools floating toggle overlaps the send button bottom-right;
+  hide it first: `document.querySelector('button[aria-label="Open Tanstack
+  query devtools"]').style.display='none'`.
+- Screenshot coords are viewport × (screenshot_width / viewport_width) —
+  get element rects via JS and scale.
+- Link-preview metadata fetches go browser → ship metagrab → target URL, so a
+  local `node` HTTP server with a `setTimeout` response works as a slow/
+  controllable metadata target (ship can reach localhost).
+
+## Teardown
+
+`lsof -ti:3000 | xargs kill -9; lsof -ti:35453 | xargs kill -9;
+pkill -f "rube/dist/urbit_extracted"`

--- a/tools/agent-skills/verify/SKILL.md
+++ b/tools/agent-skills/verify/SKILL.md
@@ -46,7 +46,11 @@ screenshot. Where noted, use your tool's own verbs for those actions.
    daemon, so the boot returns and you can proceed:
    ```
    cd apps/tlon-web
-   if lsof -ti :35453 >/dev/null 2>&1 || pgrep -f 'rube/dist/zod/zod' >/dev/null; then
+   # Note the [r] trick: `pgrep -f 'rube/...'` would otherwise match the wrapper
+   # shell running this very block (its command line contains the pattern) and
+   # always report "live". `[r]ube` matches the ship process but not the literal
+   # `[r]ube` in this shell's argv.
+   if lsof -ti :35453 >/dev/null 2>&1 || pgrep -f '[r]ube/dist/zod/zod' >/dev/null; then
      echo "zod already live (port :35453 or zod/zod pier process) — reuse it; do NOT delete the lock or boot again."
    else
      rm -f rube/dist/zod/zod/.vere.lock
@@ -59,7 +63,10 @@ screenshot. Where noted, use your tool's own verbs for those actions.
    hangs here and never reaches the browser step:
    ```
    cd apps/tlon-web
-   SHIP_URL=http://localhost:35453 VITE_DISABLE_SPLASH_MODAL=true pnpm dev-no-ssl --port 3000 &
+   # --strictPort: fail loudly if :3000 is taken instead of silently falling
+   # through to the next free port (which would leave you verifying stale UI at
+   # localhost:3000). If it fails, kill/reuse the existing :3000 server first.
+   SHIP_URL=http://localhost:35453 VITE_DISABLE_SPLASH_MODAL=true pnpm dev-no-ssl --port 3000 --strictPort &
    ```
 4. Browse `http://localhost:3000/apps/groups/`, log in with zod code
    `lidlut-tabwed-pillex-ridrup`. Rube nukes ship state, so create a quick


### PR DESCRIPTION
## Summary

Adds `tools/agent-skills/` — a tracked home for reusable, **agent-agnostic** skills for working on this repo with a coding agent (Claude Code, Cursor, or anything that loads `SKILL.md`-style skill folders). `.claude/skills/` is git-ignored, so these portable copies are the shareable source of truth teammates can install.

## Changes

- `tools/agent-skills/README.md` — what these are, capabilities model, install-per-agent, and how to package a `.skill`.
- `tools/agent-skills/mobile-qa/` — on-device **Android** QA over `adb` → triage → file Linear issues (with screenshots) → fix → rebuild & verify on-device. Bundles `scripts/adbx.sh` (device-driving helper) and `references/` for the fiddly bits (adb gestures, Linear filing, fix+verify build recipe, real-account safety).
- `tools/agent-skills/verify/` — single local ship + one vite server recipe for web UI verification (lighter than `start-playwright-dev.sh`).

Both are written to be portable: each opens with a "Capabilities this skill assumes" section and uses each agent's own tools (shell / filesystem / vision / Linear / GitHub / browser automation) rather than Claude-specific mechanics.

## How did I test?

- Content distilled from real sessions on this repo (the `mobile-qa` loop was dogfooded end-to-end: drove the Android app, filed [TLON-6173](https://linear.app/tlon/issue/TLON-6173), fixed it in #6148, and verified on-device).
- `adbx.sh` passes `bash -n` and its usage/dispatch was exercised live.
- Docs-only + a shell helper; no app code touched.

## Risks and impact

- Safe to rollback without consulting PR author? **Yes**
- Affects important code area:
  - [ ] (none — new `tools/` docs + helper script, no app/build code)

## Rollback plan

Delete `tools/agent-skills/`. Nothing else references it.

## Screenshots / videos

n/a (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)