### PR TITLE
TLON-6174: Make invite links easier to copy and share

### DIFF
--- a/apps/tlon-web/e2e/invite-service.spec.ts
+++ b/apps/tlon-web/e2e/invite-service.spec.ts
@@ -41,11 +41,11 @@ test('should generate an invite link and be able to redeem group/personal invite
   await helpers.openGroupSettings(zodPage);
   await helpers.navigateBack(zodPage);
 
-  await expect(zodPage.getByText('Invite Friends')).toBeVisible({
+  await expect(zodPage.getByText('Copy invite link')).toBeVisible({
     timeout: 15000,
   });
 
-  await zodPage.getByText('Invite Friends').click();
+  await zodPage.getByText('Copy invite link').click();
 
   const clipboardText: string = await zodPage.evaluate(
     'navigator.clipboard.readText()'
@@ -56,7 +56,7 @@ test('should generate an invite link and be able to redeem group/personal invite
 
   // Grab zod's personal invite token
   await zodPage.getByTestId('PersonalInviteNavIcon').click();
-  await zodPage.getByText('Share Invite Link').click();
+  await zodPage.getByText('Copy invite link').click();
   const zodClipboardText: string = await zodPage.evaluate(
     'navigator.clipboard.readText()'
   );

--- a/apps/tlon-web/e2e/invite-service.spec.ts
+++ b/apps/tlon-web/e2e/invite-service.spec.ts
@@ -41,11 +41,14 @@ test('should generate an invite link and be able to redeem group/personal invite
   await helpers.openGroupSettings(zodPage);
   await helpers.navigateBack(zodPage);
 
-  await expect(zodPage.getByText('Copy invite link')).toBeVisible({
+  const groupInviteCopyButton = zodPage.getByRole('button', {
+    name: 'Copy invite link',
+  });
+  await expect(groupInviteCopyButton).toBeVisible({
     timeout: 15000,
   });
 
-  await zodPage.getByText('Copy invite link').click();
+  await groupInviteCopyButton.click();
 
   const clipboardText: string = await zodPage.evaluate(
     'navigator.clipboard.readText()'
@@ -56,7 +59,12 @@ test('should generate an invite link and be able to redeem group/personal invite
 
   // Grab zod's personal invite token
   await zodPage.getByTestId('PersonalInviteNavIcon').click();
-  await zodPage.getByText('Copy invite link').click();
+  const personalInviteSheet = zodPage.getByRole('dialog', {
+    name: 'Invite Friends to Tlon Messenger',
+  });
+  await personalInviteSheet
+    .getByRole('button', { name: 'Copy invite link' })
+    .click();
   const zodClipboardText: string = await zodPage.evaluate(
     'navigator.clipboard.readText()'
   );

--- a/packages/app/fixtures/InviteFriendsToTlonButton.fixture.tsx
+++ b/packages/app/fixtures/InviteFriendsToTlonButton.fixture.tsx
@@ -14,7 +14,8 @@ function InviteFriendsToTlonButtonFixture() {
             With Group
           </Text>
           <Text size="$label/s" color="$tertiaryText">
-            Shows invite button for a group (link generation depends on backend)
+            Shows copy and share actions for a group (link generation depends on
+            backend)
           </Text>
           <InviteFriendsToTlonButton group={group} />
         </YStack>
@@ -34,5 +35,5 @@ function InviteFriendsToTlonButtonFixture() {
 }
 
 export default {
-  'Invite Friends Button': <InviteFriendsToTlonButtonFixture />,
+  'Invite Link Buttons': <InviteFriendsToTlonButtonFixture />,
 };

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -171,7 +171,7 @@ export function InviteFriendsToTlonButton({
       <Button
         {...buttonProps}
         preset={preset}
-        intent="positive"
+        intent={linkHasError ? 'negative' : 'positive'}
         fill="outline"
         size="small"
         label="Share link"

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -119,8 +119,8 @@ export function InviteFriendsToTlonButton({
   const linkIsLoading = status === 'loading' || status === 'stale';
   const linkIsReady = status === 'ready' && typeof shareUrl === 'string';
   const linkIsDisabled = status === 'disabled';
-  const linkFailed =
-    linkIsDisabled || status === 'error' || status === 'unsupported';
+  const linkHasError = status === 'error' || status === 'unsupported';
+  const linkFailed = linkIsDisabled || linkHasError;
 
   const inviteLinkPlaceholder = linkIsDisabled
     ? 'Invite links are disabled'
@@ -136,31 +136,37 @@ export function InviteFriendsToTlonButton({
         <TextInput
           value={linkIsReady ? shareUrl : ''}
           placeholder={inviteLinkPlaceholder}
-          accent="positive"
+          accent={linkHasError ? 'negative' : 'positive'}
           editable={false}
           selectTextOnFocus={linkIsReady}
           frameStyle={{
             flex: 1,
             height: 44,
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0,
-            borderRightWidth: 0,
+            ...(linkHasError
+              ? {}
+              : {
+                  borderTopRightRadius: 0,
+                  borderBottomRightRadius: 0,
+                  borderRightWidth: 0,
+                }),
           }}
         />
-        <Button
-          {...buttonProps}
-          preset={preset}
-          intent="positive"
-          size="small"
-          width={44}
-          borderTopLeftRadius={0}
-          borderBottomLeftRadius={0}
-          icon={didCopy ? 'Checkmark' : 'Copy'}
-          accessibilityLabel={didCopy ? 'Copied' : 'Copy invite link'}
-          loading={linkIsLoading}
-          disabled={!linkIsReady}
-          onPress={handleCopyInviteLink}
-        />
+        {!linkHasError && (
+          <Button
+            {...buttonProps}
+            preset={preset}
+            intent="positive"
+            size="small"
+            width={44}
+            borderTopLeftRadius={0}
+            borderBottomLeftRadius={0}
+            icon={didCopy ? 'Checkmark' : 'Copy'}
+            accessibilityLabel={didCopy ? 'Copied' : 'Copy invite link'}
+            loading={linkIsLoading}
+            disabled={!linkIsReady}
+            onPress={handleCopyInviteLink}
+          />
+        )}
       </XStack>
       <Button
         {...buttonProps}

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -8,10 +8,11 @@ import * as store from '@tloncorp/shared/store';
 import { Button, Text, useCopy } from '@tloncorp/ui';
 import { ComponentProps, useCallback, useEffect } from 'react';
 import { Share } from 'react-native';
-import { XStack, isWeb } from 'tamagui';
+import { XStack, YStack, isWeb } from 'tamagui';
 
 import { useCurrentUserId, useInviteService } from '../contexts/appDataContext';
 import { useIsAdmin } from '../utils';
+import { TextInput } from './Form';
 
 const logger = createDevLogger('InviteButton', false);
 
@@ -24,6 +25,7 @@ export function InviteFriendsToTlonButton({
   | 'icon'
   | 'label'
   | 'leadingIcon'
+  | 'trailingIcon'
   | 'onPress'
   | 'loading'
   | 'disabled'
@@ -120,42 +122,45 @@ export function InviteFriendsToTlonButton({
   const linkFailed =
     linkIsDisabled || status === 'error' || status === 'unsupported';
 
-  const copyButtonLabel = didCopy
-    ? 'Copied'
-    : linkIsReady
-      ? 'Copy invite link'
-      : linkIsDisabled
-        ? 'Invite links are disabled'
-        : linkFailed
-          ? 'Error generating invite link'
-          : linkIsLoading
-            ? 'Generating invite link...'
-            : '';
+  const inviteLinkPlaceholder = linkIsDisabled
+    ? 'Invite links are disabled'
+    : linkFailed
+      ? 'Error generating invite link'
+      : linkIsLoading
+        ? 'Generating invite link...'
+        : '';
 
   return (
-    <XStack width="100%" gap="$m">
+    <YStack width="100%" gap="$m">
+      <XStack width="100%" gap="$m">
+        <TextInput
+          value={linkIsReady ? shareUrl : ''}
+          placeholder={inviteLinkPlaceholder}
+          editable={false}
+          selectTextOnFocus={linkIsReady}
+          frameStyle={{ flex: 1 }}
+        />
+        <Button
+          {...buttonProps}
+          preset={preset}
+          size="medium"
+          icon={didCopy ? 'Checkmark' : 'Copy'}
+          accessibilityLabel={didCopy ? 'Copied' : 'Copy invite link'}
+          loading={linkIsLoading}
+          disabled={!linkIsReady}
+          onPress={handleCopyInviteLink}
+        />
+      </XStack>
       <Button
         {...buttonProps}
-        flex={1}
-        preset={preset}
-        size="small"
-        label={copyButtonLabel}
-        leadingIcon={linkIsLoading ? undefined : 'Link'}
-        loading={linkIsLoading}
-        disabled={!linkIsReady}
-        onPress={handleCopyInviteLink}
-      />
-      <Button
-        {...buttonProps}
-        flex={1}
         preset={preset}
         fill="outline"
-        size="small"
+        size="medium"
         label="Share link"
         leadingIcon="Send"
         disabled={!linkIsReady}
         onPress={handleShareInviteLink}
       />
-    </XStack>
+    </YStack>
   );
 }

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -131,19 +131,29 @@ export function InviteFriendsToTlonButton({
         : '';
 
   return (
-    <YStack width="100%" gap="$m">
-      <XStack width="100%" gap="$m">
+    <YStack width="100%" gap="$s">
+      <XStack width="100%">
         <TextInput
           value={linkIsReady ? shareUrl : ''}
           placeholder={inviteLinkPlaceholder}
           editable={false}
           selectTextOnFocus={linkIsReady}
-          frameStyle={{ flex: 1 }}
+          frameStyle={{
+            flex: 1,
+            height: 44,
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0,
+            borderRightWidth: 0,
+          }}
         />
         <Button
           {...buttonProps}
           preset={preset}
-          size="medium"
+          intent="positive"
+          size="small"
+          width={44}
+          borderTopLeftRadius={0}
+          borderBottomLeftRadius={0}
           icon={didCopy ? 'Checkmark' : 'Copy'}
           accessibilityLabel={didCopy ? 'Copied' : 'Copy invite link'}
           loading={linkIsLoading}
@@ -154,8 +164,9 @@ export function InviteFriendsToTlonButton({
       <Button
         {...buttonProps}
         preset={preset}
+        intent="positive"
         fill="outline"
-        size="medium"
+        size="small"
         label="Share link"
         leadingIcon="Send"
         disabled={!linkIsReady}

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -136,6 +136,7 @@ export function InviteFriendsToTlonButton({
         <TextInput
           value={linkIsReady ? shareUrl : ''}
           placeholder={inviteLinkPlaceholder}
+          accent="positive"
           editable={false}
           selectTextOnFocus={linkIsReady}
           frameStyle={{

--- a/packages/app/ui/components/InviteFriendsToTlonButton.tsx
+++ b/packages/app/ui/components/InviteFriendsToTlonButton.tsx
@@ -8,7 +8,7 @@ import * as store from '@tloncorp/shared/store';
 import { Button, Text, useCopy } from '@tloncorp/ui';
 import { ComponentProps, useCallback, useEffect } from 'react';
 import { Share } from 'react-native';
-import { isWeb } from 'tamagui';
+import { XStack, isWeb } from 'tamagui';
 
 import { useCurrentUserId, useInviteService } from '../contexts/appDataContext';
 import { useIsAdmin } from '../utils';
@@ -20,8 +20,15 @@ export function InviteFriendsToTlonButton({
   ...props
 }: { group?: db.Group } & Omit<
   ComponentProps<typeof Button>,
-  'group' | 'icon' | 'label'
+  | 'group'
+  | 'icon'
+  | 'label'
+  | 'leadingIcon'
+  | 'onPress'
+  | 'loading'
+  | 'disabled'
 >) {
+  const { preset = 'primary', ...buttonProps } = props;
   const userId = useCurrentUserId();
   const isGroupAdmin = useIsAdmin(group?.id ?? '', userId);
   const inviteService = useInviteService();
@@ -36,35 +43,45 @@ export function InviteFriendsToTlonButton({
     logger.trackEvent('Invite Button Shown', { group: group?.id });
   }, [group?.id]);
 
-  const handleInviteButtonPress = useCallback(async () => {
-    if (shareUrl && status === 'ready' && group) {
+  const trackInviteShared = useCallback(() => {
+    if (!shareUrl) return;
+
+    logger.trackEvent(AnalyticsEvent.InviteShared, {
+      inviteId: shareUrl.split('/').pop() ?? null,
+      inviteType: 'group',
+    });
+  }, [shareUrl]);
+
+  const handleCopyInviteLink = useCallback(async () => {
+    if (!shareUrl || status !== 'ready' || !group) return;
+
+    await doCopy();
+    trackInviteShared();
+  }, [doCopy, group, shareUrl, status, trackInviteShared]);
+
+  const handleShareInviteLink = useCallback(async () => {
+    if (!shareUrl || status !== 'ready' || !group) return;
+
+    try {
       if (isWeb) {
-        logger.trackEvent(AnalyticsEvent.InviteShared, {
-          inviteId: shareUrl.split('/').pop() ?? null,
-          inviteType: 'group',
-        });
-
-        doCopy();
-        return;
-      }
-
-      try {
+        if (typeof navigator.share === 'function') {
+          await navigator.share({ url: shareUrl });
+        } else {
+          await doCopy();
+        }
+      } else {
         const result = await Share.share({
           message: shareUrl,
         });
 
-        if (result.action === Share.sharedAction) {
-          logger.trackEvent(AnalyticsEvent.InviteShared, {
-            inviteId: shareUrl.split('/').pop() ?? null,
-            inviteType: 'group',
-          });
-        }
-      } catch (error) {
-        console.error('Error sharing:', error);
+        if (result.action !== Share.sharedAction) return;
       }
-      return;
+
+      trackInviteShared();
+    } catch (error) {
+      console.error('Error sharing:', error);
     }
-  }, [shareUrl, status, group, doCopy]);
+  }, [doCopy, group, shareUrl, status, trackInviteShared]);
 
   useEffect(() => {
     const enableLinks = async () => {
@@ -103,10 +120,10 @@ export function InviteFriendsToTlonButton({
   const linkFailed =
     linkIsDisabled || status === 'error' || status === 'unsupported';
 
-  const buttonLabel = didCopy
+  const copyButtonLabel = didCopy
     ? 'Copied'
     : linkIsReady
-      ? 'Invite Friends'
+      ? 'Copy invite link'
       : linkIsDisabled
         ? 'Invite links are disabled'
         : linkFailed
@@ -116,13 +133,29 @@ export function InviteFriendsToTlonButton({
             : '';
 
   return (
-    <Button
-      preset="secondaryOutline"
-      label={buttonLabel}
-      leadingIcon={linkIsLoading ? undefined : 'AddPerson'}
-      loading={linkIsLoading}
-      onPress={handleInviteButtonPress}
-      {...props}
-    />
+    <XStack width="100%" gap="$m">
+      <Button
+        {...buttonProps}
+        flex={1}
+        preset={preset}
+        size="small"
+        label={copyButtonLabel}
+        leadingIcon={linkIsLoading ? undefined : 'Link'}
+        loading={linkIsLoading}
+        disabled={!linkIsReady}
+        onPress={handleCopyInviteLink}
+      />
+      <Button
+        {...buttonProps}
+        flex={1}
+        preset={preset}
+        fill="outline"
+        size="small"
+        label="Share link"
+        leadingIcon="Send"
+        disabled={!linkIsReady}
+        onPress={handleShareInviteLink}
+      />
+    </XStack>
   );
 }

--- a/packages/app/ui/components/PersonalInviteButton.tsx
+++ b/packages/app/ui/components/PersonalInviteButton.tsx
@@ -3,7 +3,9 @@ import * as db from '@tloncorp/shared/db';
 import { Button, useCopy } from '@tloncorp/ui';
 import { useCallback } from 'react';
 import { Share } from 'react-native';
-import { XStack, isWeb } from 'tamagui';
+import { XStack, YStack, isWeb } from 'tamagui';
+
+import { TextInput } from './Form';
 
 const logger = createDevLogger('PersonalInviteButton', true);
 
@@ -53,32 +55,33 @@ export function PersonalInviteButton() {
   }, [doCopy, inviteLink, isLoading, trackInviteShared]);
 
   return (
-    <XStack width="100%" gap="$m">
+    <YStack width="100%" gap="$m">
+      <XStack width="100%" gap="$m">
+        <TextInput
+          value={inviteLink ?? ''}
+          placeholder="Preparing invite link"
+          editable={false}
+          selectTextOnFocus={!isLoading}
+          frameStyle={{ flex: 1 }}
+        />
+        <Button
+          preset="primary"
+          size="medium"
+          icon={didCopy ? 'Checkmark' : 'Copy'}
+          accessibilityLabel={didCopy ? 'Copied' : 'Copy invite link'}
+          loading={isLoading}
+          disabled={isLoading}
+          onPress={handleCopyInviteLink}
+        />
+      </XStack>
       <Button
-        flex={1}
-        preset="primary"
-        size="small"
-        label={
-          isLoading
-            ? 'Preparing invite link'
-            : didCopy
-              ? 'Copied'
-              : 'Copy invite link'
-        }
-        leadingIcon={isLoading ? undefined : 'Link'}
-        loading={isLoading}
-        disabled={isLoading}
-        onPress={handleCopyInviteLink}
-      />
-      <Button
-        flex={1}
         preset="secondaryOutline"
-        size="small"
+        size="medium"
         label="Share link"
         leadingIcon="Send"
         disabled={isLoading}
         onPress={handleShareInviteLink}
       />
-    </XStack>
+    </YStack>
   );
 }

--- a/packages/app/ui/components/PersonalInviteButton.tsx
+++ b/packages/app/ui/components/PersonalInviteButton.tsx
@@ -55,18 +55,27 @@ export function PersonalInviteButton() {
   }, [doCopy, inviteLink, isLoading, trackInviteShared]);
 
   return (
-    <YStack width="100%" gap="$m">
-      <XStack width="100%" gap="$m">
+    <YStack width="100%" gap="$s">
+      <XStack width="100%">
         <TextInput
           value={inviteLink ?? ''}
           placeholder="Preparing invite link"
           editable={false}
           selectTextOnFocus={!isLoading}
-          frameStyle={{ flex: 1 }}
+          frameStyle={{
+            flex: 1,
+            height: 44,
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0,
+            borderRightWidth: 0,
+          }}
         />
         <Button
-          preset="primary"
-          size="medium"
+          intent="positive"
+          size="small"
+          width={44}
+          borderTopLeftRadius={0}
+          borderBottomLeftRadius={0}
           icon={didCopy ? 'Checkmark' : 'Copy'}
           accessibilityLabel={didCopy ? 'Copied' : 'Copy invite link'}
           loading={isLoading}
@@ -75,8 +84,9 @@ export function PersonalInviteButton() {
         />
       </XStack>
       <Button
-        preset="secondaryOutline"
-        size="medium"
+        intent="positive"
+        fill="outline"
+        size="small"
         label="Share link"
         leadingIcon="Send"
         disabled={isLoading}

--- a/packages/app/ui/components/PersonalInviteButton.tsx
+++ b/packages/app/ui/components/PersonalInviteButton.tsx
@@ -1,16 +1,9 @@
 import { AnalyticsEvent, createDevLogger } from '@tloncorp/shared';
 import * as db from '@tloncorp/shared/db';
-import {
-  LoadingSpinner,
-  Pressable,
-  triggerHaptic,
-  useCopy,
-} from '@tloncorp/ui';
+import { Button, useCopy } from '@tloncorp/ui';
 import { useCallback } from 'react';
 import { Share } from 'react-native';
-import { View, isWeb } from 'tamagui';
-
-import { ListItem } from './ListItem';
+import { XStack, isWeb } from 'tamagui';
 
 const logger = createDevLogger('PersonalInviteButton', true);
 
@@ -19,71 +12,73 @@ export function PersonalInviteButton() {
   const isLoading = !inviteLink;
   const { doCopy, didCopy } = useCopy(inviteLink ?? '');
 
-  const handleInviteButtonPress = useCallback(async () => {
+  const trackInviteShared = useCallback(() => {
+    if (!inviteLink) return;
+
+    logger.trackEvent(AnalyticsEvent.InviteShared, {
+      inviteId: inviteLink.split('/').pop() ?? null,
+      inviteType: 'user',
+    });
+  }, [inviteLink]);
+
+  const handleCopyInviteLink = useCallback(async () => {
     if (isLoading || !inviteLink) return;
 
-    if (isWeb) {
-      doCopy();
-      return;
-    }
+    await doCopy();
+    trackInviteShared();
+  }, [doCopy, inviteLink, isLoading, trackInviteShared]);
+
+  const handleShareInviteLink = useCallback(async () => {
+    if (isLoading || !inviteLink) return;
 
     try {
-      triggerHaptic('baseButtonClick');
-      const result = await Share.share({
-        message: inviteLink,
-      });
-
-      if (result.action === Share.sharedAction) {
-        logger.trackEvent(AnalyticsEvent.InviteShared, {
-          inviteId: inviteLink.split('/').pop() ?? null,
-          inviteType: 'user',
+      if (isWeb) {
+        if (typeof navigator.share === 'function') {
+          await navigator.share({ url: inviteLink });
+        } else {
+          await doCopy();
+        }
+      } else {
+        const result = await Share.share({
+          message: inviteLink,
         });
+
+        if (result.action !== Share.sharedAction) return;
       }
+
+      trackInviteShared();
     } catch (error) {
       console.error('Error sharing:', error);
     }
-    return;
-  }, [doCopy, inviteLink, isLoading]);
+  }, [doCopy, inviteLink, isLoading, trackInviteShared]);
 
   return (
-    <Pressable onPress={handleInviteButtonPress} disabled={isLoading}>
-      <ListItem backgroundColor="$primaryText" opacity={isLoading ? 0.6 : 1}>
-        {isLoading ? (
-          <View
-            width="$4xl"
-            height="$4xl"
-            borderRadius="$s"
-            justifyContent="center"
-            alignItems="center"
-            flexShrink={0}
-            alignSelf="center"
-          >
-            <LoadingSpinner size="small" color="$background" />
-          </View>
-        ) : (
-          <ListItem.SystemIcon
-            icon="Send"
-            color="$background"
-            backgroundColor="unset"
-          />
-        )}
-        <ListItem.MainContent>
-          <ListItem.Title color="$background">
-            {isLoading
-              ? 'Preparing invite link'
-              : didCopy
-                ? 'Copied'
-                : 'Share Invite Link'}
-          </ListItem.Title>
-        </ListItem.MainContent>
-        <ListItem.EndContent>
-          <ListItem.SystemIcon
-            icon="ChevronRight"
-            color="$background"
-            backgroundColor="unset"
-          />
-        </ListItem.EndContent>
-      </ListItem>
-    </Pressable>
+    <XStack width="100%" gap="$m">
+      <Button
+        flex={1}
+        preset="primary"
+        size="small"
+        label={
+          isLoading
+            ? 'Preparing invite link'
+            : didCopy
+              ? 'Copied'
+              : 'Copy invite link'
+        }
+        leadingIcon={isLoading ? undefined : 'Link'}
+        loading={isLoading}
+        disabled={isLoading}
+        onPress={handleCopyInviteLink}
+      />
+      <Button
+        flex={1}
+        preset="secondaryOutline"
+        size="small"
+        label="Share link"
+        leadingIcon="Send"
+        disabled={isLoading}
+        onPress={handleShareInviteLink}
+      />
+    </XStack>
   );
 }

--- a/packages/app/ui/components/PersonalInviteButton.tsx
+++ b/packages/app/ui/components/PersonalInviteButton.tsx
@@ -60,6 +60,7 @@ export function PersonalInviteButton() {
         <TextInput
           value={inviteLink ?? ''}
           placeholder="Preparing invite link"
+          accent="positive"
           editable={false}
           selectTextOnFocus={!isLoading}
           frameStyle={{

--- a/packages/app/ui/components/PersonalInviteSheet.tsx
+++ b/packages/app/ui/components/PersonalInviteSheet.tsx
@@ -9,6 +9,8 @@ import { ActionSheet } from './ActionSheet';
 import { ListItem } from './ListItem';
 import { PersonalInviteButton } from './PersonalInviteButton';
 
+const PERSONAL_INVITE_TITLE = 'Invite Friends to Tlon Messenger';
+
 export function PersonalInviteSheet({
   open,
   onOpenChange,
@@ -27,10 +29,11 @@ export function PersonalInviteSheet({
     <ActionSheet
       open={open}
       onOpenChange={onOpenChange}
+      title={PERSONAL_INVITE_TITLE}
       snapPointsMode="fit"
       modal
     >
-      <ActionSheet.SimpleHeader title="Invite Friends to Tlon Messenger" />
+      <ActionSheet.SimpleHeader title={PERSONAL_INVITE_TITLE} />
       <ActionSheet.Content flex={1} paddingBottom={0}>
         <ActionSheet.ScrollableContent flex={1}>
           {hasOpenedRef.current && (

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2013,8 +2013,8 @@ export function GroupsPane(props: {
       </YStack>
       <YStack paddingHorizontal="$xl" gap="$l" marginTop="$xl">
         {props.hostingBotEnabled ? (
-          <YStack width="100%" gap="$m">
-            <XStack width="100%" gap="$m">
+          <YStack width="100%" gap="$s">
+            <XStack width="100%">
               <TextInput
                 value={groupInviteIsReady ? homeGroupInviteUrl ?? '' : ''}
                 placeholder={
@@ -2024,7 +2024,13 @@ export function GroupsPane(props: {
                 }
                 editable={false}
                 selectTextOnFocus={groupInviteIsReady}
-                frameStyle={{ flex: 1 }}
+                frameStyle={{
+                  flex: 1,
+                  height: 44,
+                  borderTopRightRadius: 0,
+                  borderBottomRightRadius: 0,
+                  borderRightWidth: 0,
+                }}
               />
               <Button
                 onPress={groupInviteIsReady ? copyHomeGroupInvite : undefined}
@@ -2032,8 +2038,11 @@ export function GroupsPane(props: {
                 accessibilityLabel={
                   didCopyHomeGroupInvite ? 'Copied' : 'Copy invite link'
                 }
-                intent={groupInviteIsReady ? 'positive' : undefined}
-                size="medium"
+                intent="positive"
+                size="small"
+                width={44}
+                borderTopLeftRadius={0}
+                borderBottomLeftRadius={0}
                 loading={groupInviteIsLoading}
                 disabled={!groupInviteIsReady}
                 glow={groupInviteIsReady}
@@ -2042,9 +2051,9 @@ export function GroupsPane(props: {
             <Button
               onPress={groupInviteIsReady ? shareHomeGroupInvite : undefined}
               label="Share link"
-              intent={groupInviteIsReady ? 'positive' : undefined}
+              intent="positive"
               fill="outline"
-              size="medium"
+              size="small"
               leadingIcon="Send"
               disabled={!groupInviteIsReady}
             />

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -27,6 +27,7 @@ import {
   Pressable,
   Text,
   ZStack,
+  useCopy,
   useToast,
 } from '@tloncorp/ui';
 import * as Clipboard from 'expo-clipboard';
@@ -49,6 +50,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
+  XStack,
   YStack,
   getTokenValue,
   isWeb,
@@ -962,22 +964,6 @@ function prejoinTlonbotRevivalWayfindingGroups() {
       });
     });
   });
-}
-
-async function shareTlonbotGroupInvite(homeGroupInviteLink: string) {
-  if (isWeb) {
-    try {
-      await navigator.clipboard.writeText(homeGroupInviteLink);
-    } catch (e) {
-      console.error('Failed to copy invite link:', e);
-    }
-    return;
-  }
-  try {
-    await Share.share({ message: homeGroupInviteLink });
-  } catch (e) {
-    console.error('Failed to share invite link:', e);
-  }
 }
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -1897,6 +1883,25 @@ export function GroupsPane(props: {
     });
   const groupInviteIsLoading = homeGroupInviteState === 'loading';
   const groupInviteIsReady = homeGroupInviteState === 'ready';
+  const { doCopy: copyHomeGroupInvite, didCopy: didCopyHomeGroupInvite } =
+    useCopy(homeGroupInviteUrl ?? '');
+  const shareHomeGroupInvite = useCallback(async () => {
+    if (!homeGroupInviteUrl) return;
+
+    try {
+      if (isWeb) {
+        if (typeof navigator.share === 'function') {
+          await navigator.share({ url: homeGroupInviteUrl });
+        } else {
+          await copyHomeGroupInvite();
+        }
+      } else {
+        await Share.share({ message: homeGroupInviteUrl });
+      }
+    } catch (e) {
+      console.error('Failed to share invite link:', e);
+    }
+  }, [copyHomeGroupInvite, homeGroupInviteUrl]);
   const [resolvedBotShipId, setResolvedBotShipId] = useState(
     props.botShipId ?? null
   );
@@ -2008,26 +2013,37 @@ export function GroupsPane(props: {
       </YStack>
       <YStack paddingHorizontal="$xl" gap="$l" marginTop="$xl">
         {props.hostingBotEnabled ? (
-          <Button
-            onPress={
-              groupInviteIsReady && homeGroupInviteUrl
-                ? () => shareTlonbotGroupInvite(homeGroupInviteUrl)
-                : undefined
-            }
-            label={
-              groupInviteIsReady
-                ? 'Share invite link'
-                : groupInviteIsLoading
-                  ? 'Preparing invite link'
-                  : 'Invite link unavailable'
-            }
-            intent={groupInviteIsReady ? 'positive' : undefined}
-            size="large"
-            leadingIcon={groupInviteIsLoading ? undefined : 'Link'}
-            loading={groupInviteIsLoading}
-            disabled={!groupInviteIsReady}
-            glow={groupInviteIsReady}
-          />
+          <XStack width="100%" gap="$m">
+            <Button
+              flex={1}
+              onPress={groupInviteIsReady ? copyHomeGroupInvite : undefined}
+              label={
+                groupInviteIsReady
+                  ? didCopyHomeGroupInvite
+                    ? 'Copied'
+                    : 'Copy invite link'
+                  : groupInviteIsLoading
+                    ? 'Preparing invite link'
+                    : 'Invite link unavailable'
+              }
+              intent={groupInviteIsReady ? 'positive' : undefined}
+              size="small"
+              leadingIcon={groupInviteIsLoading ? undefined : 'Link'}
+              loading={groupInviteIsLoading}
+              disabled={!groupInviteIsReady}
+              glow={groupInviteIsReady}
+            />
+            <Button
+              flex={1}
+              onPress={groupInviteIsReady ? shareHomeGroupInvite : undefined}
+              label="Share link"
+              intent={groupInviteIsReady ? 'positive' : undefined}
+              fill="outline"
+              size="small"
+              leadingIcon="Send"
+              disabled={!groupInviteIsReady}
+            />
+          </XStack>
         ) : null}
         <Button
           data-testid="got-it"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2059,7 +2059,7 @@ export function GroupsPane(props: {
             <Button
               onPress={groupInviteIsReady ? shareHomeGroupInvite : undefined}
               label="Share link"
-              intent="positive"
+              intent={groupInviteHasError ? 'negative' : 'positive'}
               fill="outline"
               size="small"
               leadingIcon="Send"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2013,37 +2013,42 @@ export function GroupsPane(props: {
       </YStack>
       <YStack paddingHorizontal="$xl" gap="$l" marginTop="$xl">
         {props.hostingBotEnabled ? (
-          <XStack width="100%" gap="$m">
-            <Button
-              flex={1}
-              onPress={groupInviteIsReady ? copyHomeGroupInvite : undefined}
-              label={
-                groupInviteIsReady
-                  ? didCopyHomeGroupInvite
-                    ? 'Copied'
-                    : 'Copy invite link'
-                  : groupInviteIsLoading
+          <YStack width="100%" gap="$m">
+            <XStack width="100%" gap="$m">
+              <TextInput
+                value={groupInviteIsReady ? homeGroupInviteUrl ?? '' : ''}
+                placeholder={
+                  groupInviteIsLoading
                     ? 'Preparing invite link'
                     : 'Invite link unavailable'
-              }
-              intent={groupInviteIsReady ? 'positive' : undefined}
-              size="small"
-              leadingIcon={groupInviteIsLoading ? undefined : 'Link'}
-              loading={groupInviteIsLoading}
-              disabled={!groupInviteIsReady}
-              glow={groupInviteIsReady}
-            />
+                }
+                editable={false}
+                selectTextOnFocus={groupInviteIsReady}
+                frameStyle={{ flex: 1 }}
+              />
+              <Button
+                onPress={groupInviteIsReady ? copyHomeGroupInvite : undefined}
+                icon={didCopyHomeGroupInvite ? 'Checkmark' : 'Copy'}
+                accessibilityLabel={
+                  didCopyHomeGroupInvite ? 'Copied' : 'Copy invite link'
+                }
+                intent={groupInviteIsReady ? 'positive' : undefined}
+                size="medium"
+                loading={groupInviteIsLoading}
+                disabled={!groupInviteIsReady}
+                glow={groupInviteIsReady}
+              />
+            </XStack>
             <Button
-              flex={1}
               onPress={groupInviteIsReady ? shareHomeGroupInvite : undefined}
               label="Share link"
               intent={groupInviteIsReady ? 'positive' : undefined}
               fill="outline"
-              size="small"
+              size="medium"
               leadingIcon="Send"
               disabled={!groupInviteIsReady}
             />
-          </XStack>
+          </YStack>
         ) : null}
         <Button
           data-testid="got-it"

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2022,6 +2022,7 @@ export function GroupsPane(props: {
                     ? 'Preparing invite link'
                     : 'Invite link unavailable'
                 }
+                accent="positive"
                 editable={false}
                 selectTextOnFocus={groupInviteIsReady}
                 frameStyle={{

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -1883,6 +1883,7 @@ export function GroupsPane(props: {
     });
   const groupInviteIsLoading = homeGroupInviteState === 'loading';
   const groupInviteIsReady = homeGroupInviteState === 'ready';
+  const groupInviteHasError = homeGroupInviteState === 'unavailable';
   const { doCopy: copyHomeGroupInvite, didCopy: didCopyHomeGroupInvite } =
     useCopy(homeGroupInviteUrl ?? '');
   const shareHomeGroupInvite = useCallback(async () => {
@@ -2022,32 +2023,38 @@ export function GroupsPane(props: {
                     ? 'Preparing invite link'
                     : 'Invite link unavailable'
                 }
-                accent="positive"
+                accent={groupInviteHasError ? 'negative' : 'positive'}
                 editable={false}
                 selectTextOnFocus={groupInviteIsReady}
                 frameStyle={{
                   flex: 1,
                   height: 44,
-                  borderTopRightRadius: 0,
-                  borderBottomRightRadius: 0,
-                  borderRightWidth: 0,
+                  ...(groupInviteHasError
+                    ? {}
+                    : {
+                        borderTopRightRadius: 0,
+                        borderBottomRightRadius: 0,
+                        borderRightWidth: 0,
+                      }),
                 }}
               />
-              <Button
-                onPress={groupInviteIsReady ? copyHomeGroupInvite : undefined}
-                icon={didCopyHomeGroupInvite ? 'Checkmark' : 'Copy'}
-                accessibilityLabel={
-                  didCopyHomeGroupInvite ? 'Copied' : 'Copy invite link'
-                }
-                intent="positive"
-                size="small"
-                width={44}
-                borderTopLeftRadius={0}
-                borderBottomLeftRadius={0}
-                loading={groupInviteIsLoading}
-                disabled={!groupInviteIsReady}
-                glow={groupInviteIsReady}
-              />
+              {!groupInviteHasError && (
+                <Button
+                  onPress={groupInviteIsReady ? copyHomeGroupInvite : undefined}
+                  icon={didCopyHomeGroupInvite ? 'Checkmark' : 'Copy'}
+                  accessibilityLabel={
+                    didCopyHomeGroupInvite ? 'Copied' : 'Copy invite link'
+                  }
+                  intent="positive"
+                  size="small"
+                  width={44}
+                  borderTopLeftRadius={0}
+                  borderBottomLeftRadius={0}
+                  loading={groupInviteIsLoading}
+                  disabled={!groupInviteIsReady}
+                  glow={groupInviteIsReady}
+                />
+              )}
             </XStack>
             <Button
               onPress={groupInviteIsReady ? shareHomeGroupInvite : undefined}


### PR DESCRIPTION
## Summary

Surfaces invite URLs in a compact read-only field with an attached copy action, followed by a full-width share button. The layout is applied consistently across group invites, personal invites, and onboarding.

## Changes

- Display the generated invite URL in a selectable, non-editable text field.
- Visually join the copy button to the field with shared edges and corners.
- Apply the positive-action treatment to the URL field, copy action, and share control.
- Show invite-link failures as a full-width negative field without a copy action.
- Apply the negative outline treatment to Share when invite-link generation fails.
- Reduce control height and spacing for a more compact presentation.
- Keep checkmark feedback after copying.
- Use native web sharing when available, with clipboard fallback.
- Preserve native share sheets on mobile and keep invite analytics tracking.
- Locate icon-only copy actions by accessible name in the invite-service E2E test.
- Scope the personal invite copy action to its dialog to avoid strict-mode duplicate matches.
- Give the personal invite dialog an accessible title matching its visible header.
- Update the Cosmos fixture and invite-service E2E selectors.

## How did I test?

- `pnpm --filter @tloncorp/app tsc`
- `pnpm --filter tlon-web tsc`
- `pnpm --filter @tloncorp/app test` — 269 passed, 3 skipped
- `pnpm --dir apps/tlon-web exec playwright test e2e/invite-service.spec.ts --list`
- ESLint on all changed TypeScript files
- Rendered generating, ready, and error states together in the web fixture browser

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [x] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: Invite flows

## Rollback plan

Revert commits `c988aa66f`, `21109ab0e`, `6333ad526`, `a7738f2a4`, `731a6ab93`, `fb28c3554`, `a4a3d9a7b`, and `82b77c8ff`.

## Screenshots / videos

### After: generating, ready, and error states

<img width="1280" height="720" alt="Invite link generating, ready, and error states after TLON-6174" src="https://github.com/user-attachments/assets/adaf175a-5f53-4208-9c74-c7c968e90093" />