### PR TITLE
hermes: gallery channel participation

### DIFF
--- a/packages/hermes-tlon-adapter/README.md
+++ b/packages/hermes-tlon-adapter/README.md
@@ -12,7 +12,7 @@ This first pass keeps the integration deliberately small:
 -   group dispatches carry recent channel/thread history as context
 -   DMs dispatch directly, deny-by-default: unknown senders queue for owner approval with rich A2UI approve/deny cards
 
-The model-visible `tlon` tool is not a delivery path. It blocks text `posts send`, `posts reply`, `dms send`, and `dms reply` when they target the current conversation, so normal replies stay inside Hermes' platform delivery path (`TlonAdapter.send()`); proactive sends to other channels/DMs and `--image` sends anywhere remain allowed. It separately blocks `notebook`, since the `%diary` backend is removed — use `tlon notes` for `%notes` notebooks.
+The model-visible `tlon` tool is not a delivery path. It blocks text `posts send`, `posts reply`, `dms send`, and `dms reply` when they target the current conversation, so normal replies stay inside Hermes' platform delivery path (`TlonAdapter.send()`); the exception is `posts send heap/~host/name`, which creates a new top-level item in the current gallery. Proactive sends to other channels/DMs and `--image` sends anywhere remain allowed. It separately blocks `notebook`, since the `%diary` backend is removed — use `tlon notes` for `%notes` notebooks.
 
 When this package can find `@tloncorp/tlon-skill/SKILL.md`, it registers that file as the explicit plugin skill `tlon-platform:tlon`. The model-facing tool and platform hint point at `skill_view("tlon-platform:tlon")`, which works the same way in dev and production because the skill registration travels with the plugin. Set `TLON_SKILL_PATH` when the skill file lives somewhere non-standard.
 
@@ -327,7 +327,7 @@ The `tlon` tool remains owner-only except that non-owner Tlon sessions may use `
 
 ## Reply Placement
 
-Replies post **top-level** in the conversation (Tlon conversations are linear), and messages that arrive inside a thread are answered in that thread, attached to the thread root — this holds for both group channels and DMs (a reply to a DM-thread message lands in that thread, not the main DM). Set `TLON_REPLY_IN_THREAD=true` to instead start a thread on every triggering message.
+Replies post **top-level** in the conversation (Tlon conversations are linear), and messages that arrive inside a thread are answered in that thread, attached to the thread root — this holds for both group channels and DMs (a reply to a DM-thread message lands in that thread, not the main DM). Gallery (`heap/`) conversations always anchor replies to the triggering post as comments. Set `TLON_REPLY_IN_THREAD=true` to instead start a thread on every non-gallery triggering message.
 
 ## Group Message Context
 

--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -1861,6 +1861,8 @@ class TlonAdapter(BasePlatformAdapter):
         if not self._is_owner(message.user_id):
             return False
         reply_parent_id = None if ctx_nest is None else message.reply_to_message_id
+        if ctx_nest and ctx_nest.startswith("heap/") and not reply_parent_id:
+            reply_parent_id = message.message_id
         if is_owner_listen_command(command_text):
             if self._mark_seen(message):
                 self._telemetry.control_command("owner-listen")
@@ -3207,9 +3209,13 @@ class TlonAdapter(BasePlatformAdapter):
         # conversation is already a thread (metadata.thread_id carries the
         # thread ROOT, which is what Tlon replies must attach to). This holds
         # for both group channels and DMs — DM threads thread too.
-        # reply_in_thread=true restores always-thread-on-the-trigger.
+        # reply_in_thread=true restores always-thread-on-the-trigger. Gallery
+        # posts always anchor reactive replies to the trigger: a new heap post
+        # is a separate gallery item, not a conversational reply.
         thread_parent = str(metadata.get("thread_id") or "") or None
-        if thread_parent is None and self.tlon_config.reply_in_thread:
+        if thread_parent is None and (
+            self.tlon_config.reply_in_thread or chat_id.startswith("heap/")
+        ):
             # A top-level own-post reaction's `reply_to` is core's generic
             # trigger anchor, i.e. the synthetic `react/<post>/<reactor>/
             # <emoji>` event id — never a real wire post. Recover the actual
@@ -3712,7 +3718,14 @@ def register(ctx) -> None:
             "group you host or a one-to-one DM), use the tlon tool's posts "
             "send with that target; reserve dms send for group-DM club IDs "
             "starting with 0v. Sending plain text to the current conversation "
-            "that way is blocked. To send an image anywhere — including the "
+            "that way is blocked, except that posts send heap/~host/name creates "
+            "a new top-level gallery item. Galleries use heap/~host/name. Reply "
+            "normally in a gallery to comment on the triggering post; posts send "
+            "heap/~host/name \"text or URL\" creates a new top-level item and is "
+            "allowed even in the current gallery (optional --title \"...\"). React "
+            "to a gallery comment with posts react heap/~host/name <comment-id> "
+            "<emoji> --parent <post-id>; delete with posts delete heap/~host/name "
+            "<post-id>. To send an image anywhere — including the "
             "current conversation — first 'tlon upload <direct-image-url>', then "
             "'tlon posts send <target> [caption] --image <uploaded-url>'. "
             "The platform adapter directly handles owner chat commands for "

--- a/packages/hermes-tlon-adapter/cite.py
+++ b/packages/hermes-tlon-adapter/cite.py
@@ -143,7 +143,7 @@ async def resolve_cites(scry: ScryFn, content: Any, *, max_attempts: int = 3) ->
     for cite, path in attempts:
         try:
             payload = await scry(path)
-            entry = parse_parent_post(payload, cite.post_id or "")
+            entry = parse_parent_post(payload, cite.post_id or "", cite.nest)
             if entry is None:
                 continue
             text = sanitize_context_text(render_history_content(entry))

--- a/packages/hermes-tlon-adapter/history.py
+++ b/packages/hermes-tlon-adapter/history.py
@@ -97,13 +97,20 @@ class MessageCache:
         self._entries.clear()
 
 
-def _entry_from_content(content: Any, seal: Any, fallback_id: Any = None) -> Optional[HistoryEntry]:
+def _entry_from_content(
+    content: Any,
+    seal: Any,
+    fallback_id: Any = None,
+    *,
+    include_title: bool = False,
+) -> Optional[HistoryEntry]:
     if not isinstance(content, dict):
         return None
     text = extract_message_text(content.get("content"))
-    title = extract_message_title(content)
-    if title:
-        text = "\n".join(part for part in (title, text) if part)
+    if include_title:
+        title = extract_message_title(content)
+        if title:
+            text = "\n".join(part for part in (title, text) if part)
     raw_blob = content.get("blob")
     blob = raw_blob if isinstance(raw_blob, str) and raw_blob.strip() else None
     if not text.strip() and not blob:
@@ -126,7 +133,8 @@ def _entry_from_content(content: Any, seal: Any, fallback_id: Any = None) -> Opt
     )
 
 
-def parse_channel_history(payload: Any) -> list[HistoryEntry]:
+def parse_channel_history(payload: Any, nest: Optional[str] = None) -> list[HistoryEntry]:
+    include_title = bool(nest and nest.startswith("heap/"))
     if isinstance(payload, list):
         posts: Sequence[Any] = payload
     elif isinstance(payload, dict):
@@ -142,14 +150,15 @@ def parse_channel_history(payload: Any) -> list[HistoryEntry]:
         post_set = item.get("r-post", {}).get("set") if isinstance(item.get("r-post"), dict) else None
         essay = item.get("essay") or (post_set or {}).get("essay")
         seal = item.get("seal") or (post_set or {}).get("seal")
-        entry = _entry_from_content(essay, seal)
+        entry = _entry_from_content(essay, seal, include_title=include_title)
         if entry is not None:
             entries.append(entry)
     entries.sort(key=lambda entry: entry.timestamp)
     return entries
 
 
-def parse_thread_replies(payload: Any) -> list[HistoryEntry]:
+def parse_thread_replies(payload: Any, nest: Optional[str] = None) -> list[HistoryEntry]:
+    include_title = bool(nest and nest.startswith("heap/"))
     if isinstance(payload, list):
         replies: Sequence[Any] = payload
     elif isinstance(payload, dict):
@@ -170,35 +179,60 @@ def parse_thread_replies(payload: Any) -> list[HistoryEntry]:
         reply_set = item.get("r-reply", {}).get("set") if isinstance(item.get("r-reply"), dict) else None
         memo = item.get("memo") or (reply_set or {}).get("memo")
         seal = item.get("seal") or (reply_set or {}).get("seal")
-        entry = _entry_from_content(memo, seal, fallback_id=item.get("id"))
+        entry = _entry_from_content(
+            memo,
+            seal,
+            fallback_id=item.get("id"),
+            include_title=include_title,
+        )
         if entry is not None:
             entries.append(entry)
     entries.sort(key=lambda entry: entry.timestamp)
     return entries
 
 
-def parse_parent_post(payload: Any, parent_id: str) -> Optional[HistoryEntry]:
+def parse_parent_post(
+    payload: Any,
+    parent_id: str,
+    nest: Optional[str] = None,
+) -> Optional[HistoryEntry]:
+    include_title = bool(nest and nest.startswith("heap/"))
     if not isinstance(payload, dict):
         return None
     post = payload.get("post") if isinstance(payload.get("post"), dict) else payload
     post_set = post.get("r-post", {}).get("set") if isinstance(post.get("r-post"), dict) else None
     content = post.get("essay") or post.get("memo") or (post_set or {}).get("essay")
     seal = post.get("seal") or (post_set or {}).get("seal")
-    return _entry_from_content(content, seal, fallback_id=parent_id)
+    return _entry_from_content(
+        content,
+        seal,
+        fallback_id=parent_id,
+        include_title=include_title,
+    )
 
 
-def parse_exact_reply(payload: Any, reply_id: str) -> Optional[HistoryEntry]:
+def parse_exact_reply(
+    payload: Any,
+    reply_id: str,
+    nest: Optional[str] = None,
+) -> Optional[HistoryEntry]:
     """Decode channel-reply-2's memo or reply-essay object, not a reply collection."""
+    include_title = bool(nest and nest.startswith("heap/"))
     if not isinstance(payload, dict):
         return None
     memo = payload.get("memo") or payload.get("reply-essay")
     seal = payload.get("seal")
-    return _entry_from_content(memo, seal, fallback_id=reply_id)
+    return _entry_from_content(
+        memo,
+        seal,
+        fallback_id=reply_id,
+        include_title=include_title,
+    )
 
 
 async def fetch_channel_history(scry: ScryFn, nest: str, count: int) -> list[HistoryEntry]:
     payload = await scry(f"/channels/v4/{nest}/posts/newest/{count}/outline")
-    return parse_channel_history(payload)
+    return parse_channel_history(payload, nest)
 
 
 async def fetch_post(
@@ -212,7 +246,7 @@ async def fetch_post(
     except Exception as exc:
         logger.debug("[tlon] exact post fetch failed for %s: %s", post_id, exc)
         return None
-    return parse_parent_post(payload, post_id)
+    return parse_parent_post(payload, post_id, nest)
 
 
 async def fetch_thread_context(
@@ -230,7 +264,7 @@ async def fetch_thread_context(
         except Exception as exc:
             logger.debug("[tlon] parent post fetch failed for %s: %s", parent_id, exc)
             return None
-        return parse_parent_post(payload, parent_id)
+        return parse_parent_post(payload, parent_id, nest)
 
     async def fetch_replies() -> list[HistoryEntry]:
         try:
@@ -240,7 +274,7 @@ async def fetch_thread_context(
         except Exception as exc:
             logger.debug("[tlon] thread replies fetch failed for %s: %s", parent_id, exc)
             return []
-        return parse_thread_replies(payload)
+        return parse_thread_replies(payload, nest)
 
     parent, replies = await asyncio.gather(fetch_parent(), fetch_replies())
     ordered = ([parent] if parent else []) + replies
@@ -273,7 +307,7 @@ async def fetch_reply(
     except Exception as exc:
         logger.debug("[tlon] exact reply fetch failed for %s: %s", reply_id, exc)
         return None
-    return parse_exact_reply(payload, reply_id)
+    return parse_exact_reply(payload, reply_id, nest)
 
 
 def render_history_content(entry: HistoryEntry) -> str:

--- a/packages/hermes-tlon-adapter/history.py
+++ b/packages/hermes-tlon-adapter/history.py
@@ -177,10 +177,15 @@ def parse_thread_replies(payload: Any, nest: Optional[str] = None) -> list[Histo
         if not isinstance(item, dict):
             continue
         reply_set = item.get("r-reply", {}).get("set") if isinstance(item.get("r-reply"), dict) else None
-        memo = item.get("memo") or (reply_set or {}).get("memo")
+        reply_content = (
+            item.get("reply-essay")
+            or (reply_set or {}).get("reply-essay")
+            or item.get("memo")
+            or (reply_set or {}).get("memo")
+        )
         seal = item.get("seal") or (reply_set or {}).get("seal")
         entry = _entry_from_content(
-            memo,
+            reply_content,
             seal,
             fallback_id=item.get("id"),
             include_title=include_title,

--- a/packages/hermes-tlon-adapter/history.py
+++ b/packages/hermes-tlon-adapter/history.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional, Sequence
 
 from .media import render_content_with_blob
-from .tlon_api import extract_author_ship, extract_message_text
+from .tlon_api import extract_author_ship, extract_message_text, extract_message_title
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +101,9 @@ def _entry_from_content(content: Any, seal: Any, fallback_id: Any = None) -> Opt
     if not isinstance(content, dict):
         return None
     text = extract_message_text(content.get("content"))
+    title = extract_message_title(content)
+    if title:
+        text = "\n".join(part for part in (title, text) if part)
     raw_blob = content.get("blob")
     blob = raw_blob if isinstance(raw_blob, str) and raw_blob.strip() else None
     if not text.strip() and not blob:

--- a/packages/hermes-tlon-adapter/prompts/shared/tlon-groups.md
+++ b/packages/hermes-tlon-adapter/prompts/shared/tlon-groups.md
@@ -17,3 +17,16 @@ tlon groups create-owned "Group Name" --owner {{TLON_OWNER_SHIP}} --description 
 Do not decompose a user-requested new group into plain `tlon groups create`, `tlon groups invite`, and role-management commands. Plain group creation makes a bot-owned group and does not automatically include the requester.
 
 The bot node remains the group host. The owner is the human Tlon user who should be invited and made admin.
+
+## Gallery channels
+
+Galleries use `heap/~host/name` and collect images, links, and other media.
+When replying in a gallery conversation, reply normally: Hermes posts a
+comment on the triggering gallery item. To create a distinct new top-level
+item, use `tlon posts send heap/~host/name "text or URL"` (optionally
+`--title "..."`); upload an image first, then use `--image <uploaded-url>`.
+
+Reaction dispatches for a gallery comment include both its message id and its
+thread root. React to that comment with `tlon posts react heap/~host/name
+<comment-id> <emoji> --parent <post-id>`. Delete a gallery post with `tlon
+posts delete heap/~host/name <post-id>`.

--- a/packages/hermes-tlon-adapter/test_adapter_heap.py
+++ b/packages/hermes-tlon-adapter/test_adapter_heap.py
@@ -1,0 +1,434 @@
+"""Heap/gallery channel parsing, dispatch, history, and reaction coverage."""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from test_adapter_attention import (  # noqa: E402
+    MessageType,
+    PlatformConfig,
+    RecordingCLI,
+    adapter_mod,
+    channel_event,
+    tlon_api,
+)
+
+
+HEAP_NEST = "heap/~zod/gallery"
+history = sys.modules[f"{adapter_mod.__package__}.history"]
+
+
+def heap_event(
+    text="",
+    *,
+    author="~mug",
+    post_id="170.141",
+    content=None,
+    title=None,
+    nest=HEAP_NEST,
+):
+    raw = channel_event(
+        text,
+        author=author,
+        nest=nest,
+        post_id=post_id,
+        content=content,
+    )
+    essay = raw["response"]["post"]["r-post"]["set"]["essay"]
+    essay["kind"] = "/heap"
+    if title is not None:
+        essay["meta"] = title if not isinstance(title, str) else {"title": title}
+    return raw
+
+
+def heap_reply_event(
+    text,
+    *,
+    author="~mug",
+    parent_id="170.140",
+    reply_id="170.141",
+    nest=HEAP_NEST,
+):
+    return {
+        "nest": nest,
+        "response": {
+            "post": {
+                "id": parent_id,
+                "r-post": {
+                    "reply": {
+                        "id": reply_id,
+                        "r-reply": {
+                            "set": {
+                                "seal": {"parent-id": parent_id},
+                                "reply-essay": {
+                                    "author": author,
+                                    "sent": 1000,
+                                    "content": [{"inline": [text]}],
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    }
+
+
+def heap_comment_reacts(*, post_id="170.141", parent_id="170.140", reacts=None):
+    return {
+        "nest": HEAP_NEST,
+        "response": {
+            "post": {
+                "id": parent_id,
+                "r-post": {
+                    "reply": {
+                        "id": post_id,
+                        "r-reply": {"reacts": reacts or {"~mug": "🔥"}},
+                    }
+                },
+            }
+        },
+    }
+
+
+class RecordingScry:
+    def __init__(self, payloads):
+        self.payloads = payloads
+        self.paths = []
+
+    async def scry(self, path):
+        self.paths.append(path)
+        if path not in self.payloads:
+            raise ConnectionError(f"no payload for {path}")
+        return self.payloads[path]
+
+
+class HeapAdapterTests(unittest.TestCase):
+    def make_adapter(self, extra=None):
+        config = {
+            "node_url": "https://pen.tlon.network",
+            "node_id": "~pen",
+            "access_code": "code",
+            "channels": [HEAP_NEST],
+            "owner_ship": "~mug",
+            "allowed_users": ["~mug"],
+            "reaction_level": "minimal",
+        }
+        config.update(extra or {})
+        with patch.dict(os.environ, {}, clear=True):
+            adapter = adapter_mod.TlonAdapter(PlatformConfig(extra=config))
+        adapter._cli = RecordingCLI()
+        return adapter
+
+    async def dispatches(self, adapter, *raw_events):
+        events = []
+
+        async def record(event):
+            events.append(event)
+
+        adapter.handle_message = record
+        for raw in raw_events:
+            await adapter._handle_channel_event(raw)
+        return events
+
+    def test_top_level_gallery_post_parses_caches_and_dispatches(self):
+        adapter = self.make_adapter()
+        raw = heap_event("~pen look at this gallery post")
+
+        parsed = tlon_api.parse_channel_message(raw, self_ship="~pen")
+        events = asyncio.run(self.dispatches(adapter, raw))
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.chat_id, HEAP_NEST)
+        self.assertEqual(parsed.chat_type, "group")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].source.chat_id, HEAP_NEST)
+        self.assertIsNotNone(adapter._message_cache.lookup(HEAP_NEST, "170.141"))
+
+    def test_image_only_gallery_post_dispatches_and_prepares_media(self):
+        adapter = self.make_adapter()
+        content = [
+            {
+                "block": {
+                    "image": {
+                        "src": "https://storage.example.com/gallery.png",
+                        "alt": "~pen gallery image",
+                    }
+                }
+            }
+        ]
+        raw = heap_event(content=content)
+
+        async def fake_prepare(story_content, raw_blob):
+            self.assertEqual(story_content, content)
+            self.assertIsNone(raw_blob)
+            return adapter_mod.PreparedMedia(
+                media_urls=("/cache/gallery.png",),
+                media_types=("image/png",),
+                message_type="photo",
+            )
+
+        with patch.object(adapter_mod, "prepare_inbound_media", fake_prepare):
+            events = asyncio.run(self.dispatches(adapter, raw))
+
+        parsed = tlon_api.parse_channel_message(raw, self_ship="~pen")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.text, "[image: ~pen gallery image]")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].message_type, MessageType.PHOTO)
+        self.assertEqual(events[0].media_urls, ["/cache/gallery.png"])
+        self.assertIsNotNone(adapter._message_cache.lookup(HEAP_NEST, "170.141"))
+
+    def test_block_only_gallery_posts_dispatch_and_cache(self):
+        cases = {
+            "link": [
+                {
+                    "block": {
+                        "link": {
+                            "url": "https://example.com/gallery",
+                            "meta": {"title": "~pen useful link"},
+                        }
+                    }
+                }
+            ],
+            "header": [
+                {
+                    "block": {
+                        "header": {
+                            "tag": "h2",
+                            "content": [{"ship": "~pen"}, " heading"],
+                        }
+                    }
+                }
+            ],
+            "flat listing": [
+                {
+                    "block": {
+                        "listing": {
+                            "list": {
+                                "type": "unordered",
+                                "contents": [],
+                                "items": [{"item": [{"ship": "~pen"}, " first"]}],
+                            }
+                        }
+                    }
+                }
+            ],
+            "nested listing": [
+                {
+                    "block": {
+                        "listing": {
+                            "list": {
+                                "type": "unordered",
+                                "contents": [{"ship": "~pen"}, " parent"],
+                                "items": [
+                                    {
+                                        "list": {
+                                            "type": "unordered",
+                                            "contents": ["nested label"],
+                                            "items": [{"item": ["nested item"]}],
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                }
+            ],
+            "task listing": [
+                {
+                    "block": {
+                        "listing": {
+                            "list": {
+                                "type": "tasklist",
+                                "contents": [],
+                                "items": [
+                                    {
+                                        "item": [
+                                            {
+                                                "task": {
+                                                    "checked": True,
+                                                    "content": [
+                                                        {"ship": "~pen"},
+                                                        " done",
+                                                    ],
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                }
+            ],
+        }
+
+        required_text = {
+            "link": ("https://example.com/gallery",),
+            "header": ("heading",),
+            "flat listing": ("first",),
+            "nested listing": ("parent", "nested label", "nested item"),
+            "task listing": ("done", "[x]"),
+        }
+
+        for name, content in cases.items():
+            with self.subTest(name=name):
+                adapter = self.make_adapter()
+                raw = heap_event(content=content, post_id=f"170.{len(name)}")
+                events = asyncio.run(self.dispatches(adapter, raw))
+                parsed = tlon_api.parse_channel_message(raw, self_ship="~pen")
+
+                self.assertIsNotNone(parsed)
+                for text in required_text[name]:
+                    with self.subTest(required_text=text):
+                        self.assertIn(text, parsed.text)
+                self.assertEqual(len(events), 1)
+                self.assertIsNotNone(
+                    adapter._message_cache.lookup(HEAP_NEST, parsed.message_id)
+                )
+
+    def test_link_only_gallery_post_dispatches_for_owner_listen(self):
+        adapter = self.make_adapter({"owner_listen_enabled_channels": HEAP_NEST})
+        raw = heap_event(
+            content=[
+                {
+                    "block": {
+                        "link": {
+                            "url": "https://example.com/gallery",
+                            "meta": {"title": "Useful link"},
+                        }
+                    }
+                }
+            ]
+        )
+
+        events = asyncio.run(self.dispatches(adapter, raw))
+
+        self.assertEqual(len(events), 1)
+        self.assertIn("Useful link", events[0].text)
+
+    def test_gallery_titles_are_live_heap_only_and_history_safe(self):
+        title_only = heap_event(content=[], title="Gallery ~pen title")
+        title_caption = heap_event(
+            "~pen caption", post_id="170.142", title="Gallery title"
+        )
+        chat_title = heap_event(
+            "caption",
+            nest="chat/~zod/general",
+            post_id="170.143",
+            title="~pen invisible metadata",
+        )
+        malformed_meta = heap_event("caption", post_id="170.144", title=[])
+        absent_meta = heap_event("caption", post_id="170.145")
+
+        parsed_title = tlon_api.parse_channel_message(title_only, self_ship="~pen")
+        parsed_caption = tlon_api.parse_channel_message(title_caption, self_ship="~pen")
+        parsed_chat = tlon_api.parse_channel_message(chat_title, self_ship="~pen")
+
+        self.assertIsNotNone(parsed_title)
+        self.assertIn("Gallery ~pen title", parsed_title.text)
+        self.assertIsNotNone(parsed_caption)
+        self.assertIn("Gallery title", parsed_caption.text)
+        self.assertIn("~pen caption", parsed_caption.text)
+        self.assertIsNotNone(parsed_chat)
+        self.assertEqual(parsed_chat.text, "caption")
+        self.assertIsNotNone(tlon_api.parse_channel_message(malformed_meta, self_ship="~pen"))
+        self.assertIsNotNone(tlon_api.parse_channel_message(absent_meta, self_ship="~pen"))
+
+        adapter = self.make_adapter()
+        events = asyncio.run(self.dispatches(adapter, title_only))
+        self.assertEqual(len(events), 1)
+        self.assertIn("Gallery ~pen title", events[0].text)
+
+    def test_title_only_parent_reaches_thread_history_and_reaction_fetch(self):
+        essay = {
+            "author": "~pen",
+            "sent": 1000,
+            "content": [],
+            "meta": {"title": "Gallery parent title"},
+        }
+        parent_path = f"/channels/v4/{HEAP_NEST}/posts/post/170.141"
+        replies_path = (
+            f"/channels/v4/{HEAP_NEST}/posts/post/id/170.141/replies/newest/5"
+        )
+        scry = RecordingScry(
+            {
+                parent_path: {"post": {"essay": essay, "seal": {"id": "170.141"}}},
+                replies_path: {"replies": []},
+            }
+        )
+
+        entries = asyncio.run(
+            history.fetch_thread_context(scry.scry, HEAP_NEST, "170141", 5)
+        )
+        self.assertEqual([entry.content for entry in entries], ["Gallery parent title"])
+
+        adapter = self.make_adapter()
+        adapter._sse = RecordingScry(
+            {
+                parent_path: {"post": {"essay": essay, "seal": {"id": "170.141"}}},
+            }
+        )
+        raw_reaction = {
+            "nest": HEAP_NEST,
+            "response": {
+                "post": {"id": "170.141", "r-post": {"reacts": {"~mug": "👍"}}}
+            },
+        }
+        events = asyncio.run(self.dispatches(adapter, raw_reaction))
+
+        self.assertEqual(len(events), 1)
+        self.assertIn("Gallery parent title", events[0].text)
+        self.assertEqual(adapter._sse.paths, [parent_path])
+
+    def test_gallery_reply_dispatches_as_a_thread_message(self):
+        adapter = self.make_adapter()
+        raw = heap_reply_event("~pen gallery comment")
+
+        parsed = tlon_api.parse_channel_message(raw, self_ship="~pen")
+        events = asyncio.run(self.dispatches(adapter, raw))
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.message_id, "170.141")
+        self.assertEqual(parsed.reply_to_message_id, "170.140")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].source.thread_id, "170.140")
+
+    def test_auto_discovers_heap_nest_and_dispatches(self):
+        adapter = self.make_adapter(
+            {"channels": ["chat/~pen/general"], "auto_discover": "true"}
+        )
+        raw = heap_event("~pen discover this", post_id="170.146")
+
+        events = asyncio.run(self.dispatches(adapter, raw))
+
+        self.assertIn(HEAP_NEST, adapter._monitored_channels)
+        self.assertEqual(len(events), 1)
+
+    def test_gallery_comment_reaction_dispatches_with_parent_id(self):
+        adapter = self.make_adapter()
+        own_comment = heap_reply_event(
+            "bot comment", author="~pen", parent_id="170.150", reply_id="170.151"
+        )
+        raw_reacts = heap_comment_reacts(post_id="170.151", parent_id="170.150")
+
+        events = asyncio.run(self.dispatches(adapter, own_comment, raw_reacts))
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].reply_to_message_id, "170.150")
+        self.assertEqual(events[0].source.thread_id, "170.150")
+        self.assertIn("[thread root: 170.150]", events[0].text)
+
+    def test_top_level_gallery_control_reply_is_a_comment(self):
+        adapter = self.make_adapter()
+        raw = heap_event("/channel-access status", post_id="170.152")
+
+        events = asyncio.run(self.dispatches(adapter, raw))
+
+        self.assertEqual(events, [])
+        self.assertEqual(len(adapter._cli.thread_replies), 1)
+        self.assertEqual(adapter._cli.thread_replies[0][0], HEAP_NEST)
+        self.assertEqual(adapter._cli.thread_replies[0][1], "170.152")

--- a/packages/hermes-tlon-adapter/test_adapter_send.py
+++ b/packages/hermes-tlon-adapter/test_adapter_send.py
@@ -379,6 +379,60 @@ class RetryableClassificationTests(unittest.TestCase):
         self.assertFalse(result.retryable)
 
 
+class HeapReplyAnchoringTests(unittest.TestCase):
+    def test_gallery_replies_anchor_to_posts_and_recover_reaction_targets(self):
+        class AnchorRecordingCLI(FakeCLI):
+            def __init__(self):
+                super().__init__()
+                self.replies = []
+
+            async def send_reply(
+                self,
+                chat_id,
+                parent,
+                content,
+                *,
+                parent_author=None,
+                blob=None,
+                sent_at=None,
+            ):
+                self.replies.append((chat_id, parent, content, parent_author))
+                return await super().send_reply(
+                    chat_id,
+                    parent,
+                    content,
+                    parent_author=parent_author,
+                    blob=blob,
+                    sent_at=sent_at,
+                )
+
+        adapter = make_adapter()
+        adapter._cli = AnchorRecordingCLI()
+
+        asyncio.run(
+            adapter.send("heap/~zod/gallery", "top-level reply", reply_to="170.141")
+        )
+        asyncio.run(
+            adapter.send(
+                "heap/~zod/gallery",
+                "thread reply",
+                reply_to="170.151",
+                metadata={"thread_id": "170.150"},
+            )
+        )
+        synthetic_id = "react/170.160/~mug/👍"
+        adapter._reaction_reply_targets[synthetic_id] = "170.160"
+        asyncio.run(
+            adapter.send("heap/~zod/gallery", "reaction reply", reply_to=synthetic_id)
+        )
+
+        self.assertEqual(
+            [reply[1] for reply in adapter._cli.replies],
+            ["170.141", "170.150", "170.160"],
+        )
+        self.assertEqual([sent[0] for sent in adapter._cli.sent], ["reply"] * 3)
+
+
 class FatalAuthTests(unittest.TestCase):
     def test_auth_rejection_marks_fatal_and_stops_stream(self):
         adapter = make_adapter()

--- a/packages/hermes-tlon-adapter/test_history.py
+++ b/packages/hermes-tlon-adapter/test_history.py
@@ -27,10 +27,12 @@ load_module("tlon_api")
 history = load_module("history")
 
 
-def essay(author, text, sent, *, blob=None):
+def essay(author, text, sent, *, blob=None, title=None):
     payload = {"author": author, "sent": sent, "content": [{"inline": [text]}]}
     if blob is not None:
         payload["blob"] = blob
+    if title is not None:
+        payload["meta"] = {"title": title}
     return payload
 
 
@@ -148,6 +150,29 @@ class ParseChannelHistoryTests(unittest.TestCase):
 
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].author, "~mug")
+
+    def test_fetch_chat_history_hides_essay_title(self):
+        nest = "chat/~pen/general"
+        path = f"/channels/v4/{nest}/posts/newest/1/outline"
+        payload = {
+            "posts": {
+                "1": {
+                    "essay": essay(
+                        "~mug",
+                        "visible chat text",
+                        1000,
+                        title="hidden chat metadata",
+                    ),
+                    "seal": {"id": "1"},
+                }
+            }
+        }
+
+        entries = asyncio.run(
+            history.fetch_channel_history(make_scry({path: payload}), nest, 1)
+        )
+
+        self.assertEqual([entry.content for entry in entries], ["visible chat text"])
 
     def test_non_dict_payload(self):
         self.assertEqual(history.parse_channel_history(None), [])

--- a/packages/hermes-tlon-adapter/test_history.py
+++ b/packages/hermes-tlon-adapter/test_history.py
@@ -180,17 +180,70 @@ class ParseChannelHistoryTests(unittest.TestCase):
 
 
 class ParseThreadTests(unittest.TestCase):
-    def test_replies_list_with_memo(self):
+    def test_replies_list_with_reply_essay(self):
         payload = {
             "replies": [
-                {"memo": essay("~ten", "second", 2000), "seal": {"id": "2"}},
-                {"memo": essay("~mug", "first", 1000), "seal": {"id": "1"}},
+                {
+                    "reply-essay": essay("~ten", "second", 2000),
+                    "seal": {"id": "2", "parent-id": "0", "reacts": {}},
+                    "revision": "0",
+                },
+                {
+                    "reply-essay": essay("~mug", "first", 1000),
+                    "seal": {"id": "1", "parent-id": "0", "reacts": {}},
+                    "revision": "0",
+                },
             ]
         }
         entries = history.parse_thread_replies(payload)
         self.assertEqual([entry.content for entry in entries], ["first", "second"])
 
-    def test_reply_blob_renders_compactly(self):
+    def test_replies_dict_with_reply_essay(self):
+        payload = {
+            "replies": {
+                "2": {
+                    "reply-essay": essay("~ten", "second", 2000),
+                    "seal": {"id": "2", "parent-id": "0", "reacts": {}},
+                    "revision": "0",
+                },
+                "1": {
+                    "reply-essay": essay("~mug", "first", 1000),
+                    "seal": {"id": "1", "parent-id": "0", "reacts": {}},
+                    "revision": "0",
+                },
+            }
+        }
+
+        entries = history.parse_thread_replies(payload)
+
+        self.assertEqual([entry.content for entry in entries], ["first", "second"])
+        self.assertEqual([entry.post_id for entry in entries], ["1", "2"])
+
+    def test_nested_reply_set_prefers_reply_essay_over_memo(self):
+        payload = {
+            "replies": [
+                {
+                    "id": "2",
+                    "r-reply": {
+                        "set": {
+                            "reply-essay": essay("~ten", "reply essay", 2000),
+                            "memo": essay("~ten", "legacy memo", 2000),
+                            "seal": {
+                                "id": "2",
+                                "parent-id": "0",
+                                "reacts": {},
+                            },
+                        }
+                    },
+                }
+            ]
+        }
+
+        entries = history.parse_thread_replies(payload)
+
+        self.assertEqual([entry.content for entry in entries], ["reply essay"])
+
+    def test_memo_reply_blob_remains_tolerated(self):
         blob = json.dumps(
             [
                 {
@@ -255,6 +308,49 @@ class ParseThreadTests(unittest.TestCase):
             history.fetch_thread_context(make_scry(payloads), nest, "170141", 5)
         )
         self.assertEqual([entry.content for entry in entries], ["root", "reply"])
+
+    def test_fetch_heap_thread_context_includes_reply_essay_comment_title(self):
+        nest = "heap/~pen/gallery"
+        replies_payload = {
+            "replies": [
+                {
+                    "reply-essay": essay(
+                        "~ten",
+                        "gallery comment",
+                        1000,
+                        title="Comment title",
+                    ),
+                    "seal": {
+                        "id": "170142",
+                        "parent-id": "170141",
+                        "reacts": {},
+                    },
+                    "revision": "0",
+                }
+            ]
+        }
+        payloads = {
+            f"/channels/v4/{nest}/posts/post/170.141": {
+                "post": {
+                    "essay": essay("~mug", "gallery parent", 500),
+                    "seal": {"id": "170141"},
+                }
+            },
+            f"/channels/v4/{nest}/posts/post/id/170.141/replies/newest/5": replies_payload,
+        }
+
+        entries = asyncio.run(
+            history.fetch_thread_context(make_scry(payloads), nest, "170141", 5)
+        )
+
+        self.assertEqual(
+            [entry.content for entry in entries],
+            ["gallery parent", "Comment title\ngallery comment"],
+        )
+        chat_entries = history.parse_thread_replies(
+            replies_payload, "chat/~pen/general"
+        )
+        self.assertEqual([entry.content for entry in chat_entries], ["gallery comment"])
 
     def test_fetch_thread_context_survives_partial_failures(self):
         nest = "chat/~pen/general"

--- a/packages/hermes-tlon-adapter/test_tlon_tool.py
+++ b/packages/hermes-tlon-adapter/test_tlon_tool.py
@@ -96,6 +96,7 @@ class TlonToolGuardTests(unittest.TestCase):
             ('posts send ~friend "hi"', "chat/~zod/general"),  # in a channel, DM someone
             ('dms send 0v5.abcde "hi"', "chat/~zod/general"),  # in a channel, group-DM someone
             ('posts reply chat/~bot/general 170.141 "hi"', "~owner"),
+            ('posts send heap/~zod/gallery "new gallery item"', "chat/~zod/general"),
         ]
         for command, chat_id in cases:
             with self.subTest(command=command):
@@ -138,6 +139,84 @@ class TlonToolGuardTests(unittest.TestCase):
         )
         self.assertIsNotNone(blocked)
         self.assertIn("--image", blocked)  # block message teaches the escape
+
+    def test_current_gallery_send_is_allowed_but_gallery_reply_stays_blocked(self):
+        send_args, send_error = tlon_tool.split_tlon_command(
+            'posts send heap/~zod/gallery "new gallery item"'
+        )
+        reply_args, reply_error = tlon_tool.split_tlon_command(
+            'posts reply heap/~zod/gallery 170.141 "gallery comment"'
+        )
+
+        self.assertIsNone(send_error)
+        self.assertIsNone(reply_error)
+        self.assertIsNone(
+            tlon_tool.check_tlon_tool_command(
+                send_args, session_chat_id="heap/~zod/gallery"
+            )
+        )
+        blocked = tlon_tool.check_tlon_tool_command(
+            reply_args, session_chat_id="heap/~zod/gallery"
+        )
+        self.assertIsNotNone(blocked)
+        self.assertIn("current conversation", blocked)
+
+    def test_heap_comment_reactions_and_gallery_delete_are_allowed(self):
+        react_args, react_error = tlon_tool.split_tlon_command(
+            'posts react heap/~zod/gallery 170.142 "🔥" --parent 170.141'
+        )
+        delete_args, delete_error = tlon_tool.split_tlon_command(
+            "posts delete heap/~zod/gallery 170.141"
+        )
+
+        self.assertIsNone(react_error)
+        self.assertIsNone(delete_error)
+        self.assertIsNone(
+            tlon_tool.check_tlon_tool_command(react_args, reaction_level="minimal")
+        )
+        self.assertIsNone(tlon_tool.check_tlon_tool_command(delete_args))
+        blocked = tlon_tool.check_tlon_tool_command(react_args, reaction_level="off")
+        self.assertIsNotNone(blocked)
+        self.assertIn("reactions are disabled", blocked)
+
+    def test_tool_description_includes_gallery_guidance(self):
+        description = tlon_tool.TLON_TOOL_DESCRIPTION
+        command_description = tlon_tool.TLON_TOOL_SCHEMA["parameters"]["properties"][
+            "command"
+        ]["description"]
+
+        self.assertIn("heap/~host/name", description)
+        self.assertIn("--parent <post-id>", description)
+        self.assertIn("posts delete heap/~host/name", description)
+        self.assertIn("heap/~host/name", command_description)
+        self.assertIn("--parent <post-id>", command_description)
+
+        class RecordingContext:
+            def __init__(self):
+                self.platform = None
+
+            def register_hook(self, *_args):
+                pass
+
+            def register_tool(self, **_kwargs):
+                pass
+
+            def register_skill(self, *_args, **_kwargs):
+                pass
+
+            def register_platform(self, **kwargs):
+                self.platform = kwargs
+
+        context = RecordingContext()
+        adapter_mod.register(context)
+        platform_hint = context.platform["platform_hint"]
+
+        self.assertIn("Sending plain text to the current conversation", platform_hint)
+        self.assertIn("except that posts send heap/~host/name", platform_hint)
+        self.assertIn("Reply normally in a gallery to comment on the triggering post", platform_hint)
+        self.assertIn("allowed even in the current gallery", platform_hint)
+        self.assertIn("--parent <post-id>", platform_hint)
+        self.assertIn("posts delete heap/~host/name <post-id>", platform_hint)
 
     def test_blocks_notebook(self):
         args, error = tlon_tool.split_tlon_command('notebook diary/~zod/notes "Title"')

--- a/packages/hermes-tlon-adapter/tlon_api.py
+++ b/packages/hermes-tlon-adapter/tlon_api.py
@@ -1420,6 +1420,17 @@ def extract_message_text(content: Any) -> str:
     return str(content)
 
 
+def extract_message_title(content: Any) -> str:
+    """Return a user-visible essay title when the wire payload has one."""
+    if not isinstance(content, Mapping):
+        return ""
+    meta = content.get("meta")
+    if not isinstance(meta, Mapping):
+        return ""
+    title = meta.get("title")
+    return title.strip() if isinstance(title, str) else ""
+
+
 def _extract_inline_text(inlines: Any) -> str:
     if isinstance(inlines, str):
         return inlines
@@ -1448,11 +1459,32 @@ def _extract_inline_text(inlines: Any) -> str:
                 parts.append(str(item["inline-code"]))
             elif "code" in item:
                 parts.append(str(item["code"]))
+            elif "task" in item and isinstance(item["task"], Mapping):
+                task = item["task"]
+                marker = "[x] " if task.get("checked") else "[ ] "
+                parts.append(marker + _extract_inline_text(task.get("content")))
             elif "break" in item:
                 parts.append("\n")
             elif "tag" in item:
                 parts.append(f"#{item['tag']}")
     return "".join(parts)
+
+
+def _extract_listing_text(listing: Any) -> str:
+    """Extract all text carried by recursive story listing nodes."""
+    if not isinstance(listing, Mapping):
+        return ""
+    item = listing.get("item")
+    if isinstance(item, list):
+        return _extract_inline_text(item)
+    list_node = listing.get("list")
+    if not isinstance(list_node, Mapping):
+        return ""
+    parts = [_extract_inline_text(list_node.get("contents"))]
+    items = list_node.get("items")
+    if isinstance(items, list):
+        parts.extend(_extract_listing_text(child) for child in items)
+    return "\n".join(part for part in parts if part)
 
 
 def _extract_block_text(block: dict[str, Any]) -> str:
@@ -1461,6 +1493,20 @@ def _extract_block_text(block: dict[str, Any]) -> str:
         return f"[image: {image.get('alt') or image.get('src') or ''}]"
     if "cite" in block:
         return "[quoted message]"
+    if "link" in block and isinstance(block["link"], Mapping):
+        link = block["link"]
+        url = str(link.get("url") or "").strip()
+        meta = link.get("meta")
+        title = ""
+        if isinstance(meta, Mapping):
+            title = str(meta.get("title") or meta.get("description") or "").strip()
+        if title and url:
+            return f"[link: {title} — {url}]"
+        return f"[link: {url}]" if url else "[link]"
+    if "header" in block and isinstance(block["header"], Mapping):
+        return _extract_inline_text(block["header"].get("content"))
+    if "listing" in block:
+        return _extract_listing_text(block["listing"])
     if "code" in block and isinstance(block["code"], dict):
         code = block["code"]
         lang = code.get("lang") or ""
@@ -1680,6 +1726,10 @@ def parse_channel_message(
 
     story_content = content.get("content")
     text = extract_message_text(story_content)
+    if nest.startswith("heap/"):
+        title = extract_message_title(content)
+        if title:
+            text = "\n".join(part for part in (title, text) if part)
     raw_blob = content.get("blob")
     blob = raw_blob if isinstance(raw_blob, str) and raw_blob.strip() else None
     if not text.strip() and not blob:

--- a/packages/hermes-tlon-adapter/tlon_tool.py
+++ b/packages/hermes-tlon-adapter/tlon_tool.py
@@ -36,10 +36,11 @@ CREDENTIAL_FLAGS_WITH_VALUE = frozenset(
     {"--config", "--url", "--ship", "--code", "--cookie"}
 )
 
-# Message-send operations. These are blocked only when they target the
+# Message-send operations. These are normally blocked when they target the
 # *current* conversation — those must go through Hermes' streaming reply path
-# (TlonAdapter.send()). Sends to any other channel/DM are proactive and allowed
-# through the tool, since "reply normally" can only reach the current chat.
+# (TlonAdapter.send()). The current-gallery ``posts send`` carveout creates a
+# new top-level gallery item. Sends to any other channel/DM are proactive and
+# allowed through the tool, since "reply normally" can only reach the current chat.
 SEND_OPERATIONS = {
     ("dms", "send"),
     ("dms", "reply"),
@@ -65,11 +66,20 @@ TLON_TOOL_DESCRIPTION = (
     "For user-requested group creation, use groups create-owned with "
     "--owner set to the requesting ship. "
     "To reply to the CURRENT conversation, just write the reply — do not use "
-    "posts/dms send here (that path is blocked so Hermes delivers replies). "
+    "posts/dms send here (that path is blocked so Hermes delivers replies, except "
+    "posts send heap/~host/name creates a new gallery item). "
     "To post to a DIFFERENT channel or one-to-one DM (a proactive send), use "
     "posts send with that target, e.g. posts send chat/~host/channel \"...\" "
     "or posts send ~ship \"...\". Reserve dms send for group-DM club IDs "
     "starting with 0v. "
+    "Gallery channels are heap/~host/name image/link boards. In a gallery, "
+    "replying normally comments on the triggering post; posts send "
+    "heap/~host/name \"text or URL\" creates a new top-level item and is "
+    "allowed even in the current gallery (optional --title \"...\"). Upload "
+    "before image items, then posts send heap/~host/name [caption] --image "
+    "<uploaded-url>. React to a gallery comment with posts react "
+    "heap/~host/name <comment-id> <emoji> --parent <post-id>; delete gallery "
+    "posts with posts delete heap/~host/name <post-id>. "
     "To send an IMAGE anywhere (including the current conversation): first "
     "'upload <direct-image-url>', then 'posts send <target> [caption] --image "
     "<uploaded-url>' (group DMs: dms send <club-id> ... --image <url>)."
@@ -99,10 +109,16 @@ TLON_TOOL_SCHEMA = {
                     "'groups create-owned' so the requester is invited and made admin. "
                     "To post to a different channel or one-to-one DM, use "
                     "'posts send <channel> \"...\"' or 'posts send ~ship \"...\"'. "
+                    "Galleries use heap/~host/name: reply normally to comment on "
+                    "the triggering gallery post, or use 'posts send "
+                    "heap/~host/name \"...\" [--title \"...\"]' for a new item. "
+                    "React to a gallery comment with 'posts react heap/~host/name "
+                    "<comment-id> <emoji> --parent <post-id>'; delete with "
+                    "'posts delete heap/~host/name <post-id>'. "
                     "Use 'dms send <club-id> \"...\"' only for group-DM club IDs "
                     "starting with 0v. Sending to "
                     "the CURRENT conversation is blocked (reply normally "
-                    "instead) EXCEPT image sends: 'posts send <target> "
+                    "instead) EXCEPT new gallery items and image sends: 'posts send <target> "
                     "[caption] --image <uploaded-url>' is allowed anywhere — "
                     "upload first with 'upload <direct-image-url>'. 'notebook' "
                     "is removed; use 'notes' commands for %notes notebooks. "
@@ -306,10 +322,20 @@ def check_tlon_tool_command(
             "Hermes cannot pipe stdin into the tlon CLI process. Write the "
             "Markdown body to a file and use --body <file>."
         )
+    targets_current = _send_targets_current_conversation(
+        args, sub_idx, session_chat_id
+    )
+    target = str(args[sub_idx + 2]).strip() if len(args) > sub_idx + 2 else ""
+    is_current_heap_post_send = (
+        (subcommand, action) == ("posts", "send")
+        and targets_current
+        and target.casefold().startswith("heap/")
+    )
     if (
         (subcommand, action) in SEND_OPERATIONS
         and not _has_image_flag(args)
-        and _send_targets_current_conversation(args, sub_idx, session_chat_id)
+        and targets_current
+        and not is_current_heap_post_send
     ):
         return (
             "Blocked: don't deliver your reply to the current conversation with "

--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -10,8 +10,7 @@ Use the `tlon` command for reading data, managing channels/groups/contacts, and 
 ## Hermes
 
 When running as a Hermes plugin skill, the `tlon` tool is a wrapper around the
-`tlon` CLI for reading data, administration, and management. Do **not** use it
-to send replies or create posts.
+`tlon` CLI for reading data, administration, management, and proactive posts.
 
 For exact command syntax, use the command sections below or run
 `tlon <subcommand> --help` through the tool.
@@ -22,15 +21,21 @@ This invites the requester and makes them an admin. Do not use plain
 `tlon groups create` for user-requested groups; that creates a bot-owned group
 that does not automatically include the requester.
 
-For a normal reply in the current Tlon conversation, respond with final
+For a normal text reply in the current Tlon conversation, respond with final
 assistant text and let Hermes deliver it through `TlonAdapter.send()`. To post
 to a different channel or one-to-one DM (a proactive send), use `posts send`
 with that target (`chat/~host/slug` for channels, `~ship` for one-to-one DMs).
 Reserve `dms send <club-id>` for group DMs, whose club IDs start with `0v`.
 
-Blocked in Hermes' `tlon` tool: plain-text `posts send`/`posts reply`/`dms
-send`/`dms reply` targeting the **current** conversation (reply normally
-instead). Image sends (`--image`) are allowed anywhere,
+Gallery channels use `heap/~host/name`. A normal reply in a gallery becomes a
+comment on the triggering post. Use `posts send heap/~host/name "..."` to
+create a distinct new top-level gallery item, including when that gallery is
+the current conversation; gallery items can use `--title "..."`.
+
+Blocked in Hermes' `tlon` tool: plain-text `posts reply`/`dms send`/`dms reply`
+and `posts send` to a current chat/DM conversation (reply normally instead).
+Current-gallery `posts send` creates a new item and is allowed. Image sends
+(`--image`) are allowed anywhere,
 including the current conversation: `tlon upload <direct-image-url>`, then
 `posts send <target> [caption] --image <uploaded-url>`.
 
@@ -435,11 +440,15 @@ tlon posts send chat/~host/slug "Hello"                  # Send a message
 tlon posts send ~sampel "Hello"                          # Send a 1:1 DM
 tlon posts send chat/~host/slug "Look" --image https://storage.../x.png # Send with an image
 tlon posts send chat/~host/slug --image https://...      # Image only (no caption)
+tlon posts send heap/~host/gallery "A link or caption" --title "Gallery item" # New gallery item
+tlon posts reply heap/~host/gallery 170.141... "Nice work" # Comment on a gallery post
 tlon posts react chat/~host/slug 170.141... "👍"         # React to a post
 tlon posts unreact chat/~host/slug 170.141...            # Remove reaction
 tlon posts react chat/~host/slug reply-id "👍" --parent root-id  # React to a thread reply
+tlon posts react heap/~host/gallery comment-id "🔥" --parent post-id # React to a gallery comment
 tlon posts edit chat/~host/slug 170.141... "New text"    # Edit a post's message text
 tlon posts delete chat/~host/slug 170.141...             # Delete a post
+tlon posts delete heap/~host/gallery 170.141...          # Delete a gallery post
 ```
 
 Send `--image` takes a **direct** png/jpeg/gif/webp URL — normally the URL returned by `tlon upload` — and attaches it as an inline image block (dimensions are read from the image bytes). The message becomes an optional caption.

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -835,11 +835,24 @@ export const POSTS_FAMILY_CASES: CliCase[] = [
     '170.141',
     'Updated message',
   ]),
-  refusalCase(
-    'posts send title on chat nest refuses before auth',
-    ['posts', 'send', 'chat/~host/channel', 'message', '--title', 'Chat title'],
-    '--title is only supported for gallery (heap/) posts'
-  ),
+  {
+    ...usageErrorCase(
+      'posts send title on chat nest refuses before auth',
+      [
+        'posts',
+        'send',
+        'chat/~host/channel',
+        'message',
+        '--title',
+        'Chat title',
+      ],
+      '--title is only supported for gallery (heap/) posts'
+    ),
+    stderrIncludes: [
+      '--title is only supported for gallery (heap/) posts',
+      'Usage: tlon posts send',
+    ],
+  },
   // The minimal help-literal: `--help` in the message slot is treated as edit
   // message content, so this reaches auth instead of printing help.
   authRequiredCase('posts edit minimal help-literal reaches auth', [

--- a/packages/tlon-skill/scripts/cli-test-matrix.ts
+++ b/packages/tlon-skill/scripts/cli-test-matrix.ts
@@ -277,6 +277,24 @@ export const MISSING_REQUIRED_CASES: CliCase[] = [
     ['posts', 'send', 'chat/~host/channel', 'message', '--image'],
     'Usage: tlon posts send'
   ),
+  usageErrorCase(
+    'posts send missing gallery title value',
+    ['posts', 'send', 'heap/~host/gallery', 'message', '--title'],
+    'Usage: tlon posts send'
+  ),
+  usageErrorCase(
+    'posts send rejects an option token as a gallery title value',
+    [
+      'posts',
+      'send',
+      'heap/~zod/gallery',
+      'caption',
+      '--title',
+      '--sent-at',
+      '1234',
+    ],
+    'Usage: tlon posts send'
+  ),
   {
     name: 'posts send rejects non-http image url',
     args: ['posts', 'send', 'chat/~host/channel', '--image', 'ftp://x/y.png'],
@@ -627,6 +645,14 @@ export const LITERAL_OPTION_LIKE_VALUE_CASES: CliCase[] = [
     '--blob',
     '[{"type":"a2ui","version":1,"messages":[]}]',
   ]),
+  authRequiredCase('posts send heap title reaches auth', [
+    'posts',
+    'send',
+    'heap/~host/gallery',
+    'message',
+    '--title',
+    'Gallery item',
+  ]),
   authRequiredCase('posts send image-only reaches auth', [
     'posts',
     'send',
@@ -809,6 +835,11 @@ export const POSTS_FAMILY_CASES: CliCase[] = [
     '170.141',
     'Updated message',
   ]),
+  refusalCase(
+    'posts send title on chat nest refuses before auth',
+    ['posts', 'send', 'chat/~host/channel', 'message', '--title', 'Chat title'],
+    '--title is only supported for gallery (heap/) posts'
+  ),
   // The minimal help-literal: `--help` in the message slot is treated as edit
   // message content, so this reaches auth instead of printing help.
   authRequiredCase('posts edit minimal help-literal reaches auth', [

--- a/packages/tlon-skill/scripts/commands/posts.test.ts
+++ b/packages/tlon-skill/scripts/commands/posts.test.ts
@@ -191,6 +191,12 @@ describe('posts command help and shell', () => {
     expectNoAuthOrApi(context);
   });
 
+  it('documents the gallery-only send title option', () => {
+    expect(POSTS_HELP).toContain('--title <text>');
+    expect(POSTS_COMMAND_HELP.send).toContain('--title <text>');
+    expect(POSTS_HELP).toContain('heap/~host/gallery');
+  });
+
   it('returns a family usage error for bare posts without auth/API work', async () => {
     const context = makeDeps();
     const exitCode = await run([], context.deps);
@@ -344,6 +350,71 @@ describe('posts send', () => {
     expect(context.calls.sendPost[0].blob).toBe('[{"type":"a2ui"}]');
   });
 
+  it('passes a gallery title through as post metadata', async () => {
+    const context = makeDeps({ currentUserId: '~nec', now: 42 });
+    const exitCode = await run(
+      [
+        'send',
+        'heap/~host/gallery',
+        'Gallery caption',
+        '--title',
+        'Gallery title',
+      ],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.sendPost).toEqual([
+      {
+        channelId: 'heap/~host/gallery',
+        authorId: '~nec',
+        sentAt: 42,
+        content: [{ inline: ['Gallery caption'] }],
+        blob: undefined,
+        metadata: { title: 'Gallery title' },
+      },
+    ]);
+  });
+
+  it('rejects --title outside gallery nests before auth', async () => {
+    const context = makeDeps();
+    const exitCode = await run(
+      ['send', 'chat/~host/channel', 'caption', '--title', 'Chat title'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stderr()).toContain(
+      '--title is only supported for gallery (heap/) posts'
+    );
+    expectNoAuthOrApi(context);
+  });
+
+  it('rejects a --title flag with no value before auth', async () => {
+    const context = makeDeps();
+    const exitCode = await run(
+      ['send', 'heap/~host/gallery', 'caption', '--title'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.send}\n`);
+    expectNoAuthOrApi(context);
+  });
+
+  it('rejects a --title value that is itself an option token before auth', async () => {
+    const context = makeDeps();
+    const exitCode = await run(
+      ['send', 'heap/~zod/gallery', 'caption', '--title', '--sent-at', '1234'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(1);
+    expect(context.stdout()).toBe('');
+    expect(context.stderr()).toBe(`${POSTS_COMMAND_HELP.send}\n`);
+    expectNoAuthOrApi(context);
+  });
+
   it('honors --sent-at over the clock', async () => {
     const context = makeDeps({ now: 999 });
     await run(
@@ -433,6 +504,26 @@ describe('posts reply', () => {
         parentId: '170.141.184',
         parentAuthor: '~nec',
         content: [{ inline: ['Thread reply'] }],
+        sentAt: 7,
+        authorId: '~nec',
+      },
+    ]);
+  });
+
+  it('replies to a gallery post with the exact heap target input', async () => {
+    const context = makeDeps({ currentUserId: '~nec', now: 7 });
+    const exitCode = await run(
+      ['reply', 'heap/~host/gallery', '170141184', 'Gallery comment'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.sendReply).toEqual([
+      {
+        channelId: 'heap/~host/gallery',
+        parentId: '170.141.184',
+        parentAuthor: '~nec',
+        content: [{ inline: ['Gallery comment'] }],
         sentAt: 7,
         authorId: '~nec',
       },
@@ -588,6 +679,26 @@ describe('posts react', () => {
     expect(context.calls.addReaction).toEqual([
       {
         channelId: 'chat/~host/channel',
+        postId: '170.142',
+        emoji: '🔥',
+        our: '~nec',
+        postAuthor: '~nec',
+        parentId: '170.141',
+      },
+    ]);
+  });
+
+  it('passes a gallery comment reaction parent through exactly', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      ['react', 'heap/~host/gallery', '170142', '🔥', '--parent', '170141'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.addReaction).toEqual([
+      {
+        channelId: 'heap/~host/gallery',
         postId: '170.142',
         emoji: '🔥',
         our: '~nec',
@@ -819,6 +930,23 @@ describe('posts delete', () => {
         },
       ]);
     }
+  });
+
+  it('deletes a gallery post with the exact heap target input', async () => {
+    const context = makeDeps({ currentUserId: '~nec' });
+    const exitCode = await run(
+      ['delete', 'heap/~host/gallery', '170141184'],
+      context.deps
+    );
+
+    expect(exitCode).toBe(0);
+    expect(context.calls.deletePost).toEqual([
+      {
+        channelId: 'heap/~host/gallery',
+        postId: '170.141.184',
+        authorId: '~nec',
+      },
+    ]);
   });
 
   it('routes facade failures through the shared command-error path', async () => {

--- a/packages/tlon-skill/scripts/commands/posts.ts
+++ b/packages/tlon-skill/scripts/commands/posts.ts
@@ -20,7 +20,7 @@ import {
 export const POSTS_HELP = `Usage: tlon posts <command>
 
 Commands:
-  send <channel> [message]                 Send a message to a channel [--blob <json>] [--image <url>]
+  send <channel> [message]                 Send a message to a channel [--blob <json>] [--image <url>] [--title <text>]
   reply <channel> <post-id> <message>      Reply to a channel post [--author ~ship] [--blob <json>]
   react <channel> <post-id> <emoji>     React to a post with an emoji [--parent <post-id>]
   unreact <channel> <post-id>           Remove your reaction from a post [--parent <post-id>]
@@ -31,12 +31,14 @@ Send options:
   --blob <json>        Attach a post-blob JSON array (e.g. an a2ui entry)
   --image <url>        Attach an image (direct png/jpeg/gif/webp URL, e.g. from
                        'tlon upload'); message becomes an optional caption
+  --title <text>       Set a title on a gallery (heap/) post
   --sent-at <ms>       Override the send timestamp (unix ms); the post id
                        derives from it. Applies to send and reply.
 
 Examples:
   tlon posts send chat/~host/channel "Hello from tlon"
   tlon posts send chat/~host/channel "Look at this" --image https://storage.../tree.png
+  tlon posts send heap/~host/gallery "A link or caption" --title "Gallery item"
   tlon posts reply chat/~host/channel 170.141... "Thread reply"
   tlon posts edit chat/~host/channel 170.141... "Updated message"
 
@@ -44,7 +46,7 @@ Channel format: chat/~host/channel-name, heap/~host/name
 Use 'tlon messages channel <nest> --limit N' to see post IDs.`;
 
 export const POSTS_COMMAND_HELP: Record<string, string> = {
-  send: 'Usage: tlon posts send <channel> [message] [--blob <json>] [--image <url>] [--sent-at <ms>] (message optional with --image)',
+  send: 'Usage: tlon posts send <channel> [message] [--blob <json>] [--image <url>] [--title <text>] [--sent-at <ms>] (message optional with --image)',
   reply:
     'Usage: tlon posts reply <channel> <post-id> <message> [--author ~ship] [--blob <json>] [--sent-at <ms>]',
   react:
@@ -67,7 +69,7 @@ const POSTS_EDIT_REMOVED_FLAGS_MESSAGE =
   'tlon posts edit no longer supports --title/--image/--content (notebook-only affordances). Edit the message text directly; use `tlon notes` for %notes content.';
 
 const POST_REPLY_OPTION_FLAGS = ['author', 'blob', 'sent-at'] as const;
-const POST_SEND_OPTION_FLAGS = ['blob', 'image', 'sent-at'] as const;
+const POST_SEND_OPTION_FLAGS = ['blob', 'image', 'title', 'sent-at'] as const;
 
 export interface PostReactionInput {
   channelId: string;
@@ -114,6 +116,7 @@ export interface PostSendInput {
   sentAt: number;
   content: Story;
   blob?: string;
+  metadata?: { title?: string };
 }
 
 export interface PostReplyInput {
@@ -175,6 +178,7 @@ type ParsedPostsArgs =
       channelId: string;
       message: string;
       imageUrl?: string;
+      title?: string;
       blob?: string;
       sentAt?: number;
     }
@@ -317,6 +321,18 @@ function validatedBlobFlag(
   return blob;
 }
 
+function validatedTitleFlag(args: string[], usage: string): string | undefined {
+  const titleIdx = args.indexOf('--title');
+  if (titleIdx === -1) {
+    return undefined;
+  }
+  const title = args[titleIdx + 1];
+  if (!title || title.startsWith('--')) {
+    throw usageError(usage);
+  }
+  return title;
+}
+
 // Plain `--flag` boundary scan. Edit/reply use this for all their flags — a
 // `--image=url` token is deliberately NOT a flag boundary for edit, matching
 // legacy behavior.
@@ -443,12 +459,20 @@ function parseArgs(args: string[]): ParsedPostsArgs {
         throw usageError(POSTS_COMMAND_HELP.send);
       }
       const blob = validatedBlobFlag(args);
+      const title = validatedTitleFlag(args, POSTS_COMMAND_HELP.send);
+      if (title !== undefined && !args[1].startsWith('heap/')) {
+        throw usageError(
+          '--title is only supported for gallery (heap/) posts',
+          POSTS_COMMAND_HELP.send
+        );
+      }
       const sentAt = validatedSentAt(args, POSTS_COMMAND_HELP.send);
       return {
         kind: 'send',
         channelId: args[1],
         message,
         imageUrl,
+        title,
         blob,
         sentAt,
       };
@@ -603,6 +627,7 @@ async function sendPost(
     channelId: string;
     message: string;
     imageUrl?: string;
+    title?: string;
     blob?: string;
     sentAt?: number;
   },
@@ -624,6 +649,7 @@ async function sendPost(
     sentAt: parsed.sentAt ?? deps.now(),
     content,
     blob: parsed.blob,
+    ...(parsed.title ? { metadata: { title: parsed.title } } : {}),
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes TLON-6095

Adds gallery channel participation to Hermes at parity with the OpenClaw reference: inbound dispatch parsing, gallery posting with titles, react-to-comment, and heap delete. Previously gallery posts with link/header/listing content were silently dropped as empty, and replies in galleries would have published new top-level items instead of comments.

## Changes

-   In `packages/hermes-tlon-adapter/tlon_api.py`, extract text from link, header, and listing story blocks and inline task items, and surface gallery post titles (`meta.title`) in live heap parsing; `history.py` does the same for history, thread-context, and fetch paths
-   In `packages/hermes-tlon-adapter/adapter.py`, replies in heap/ conversations (streaming and owner control-command replies) always anchor to the triggering post as comments, since a top-level "reply" would publish a new gallery item. (OpenClaw's reactive path still has this bug; here we deliberately fix it rather than match it)
-   In `packages/hermes-tlon-adapter/tlon_tool.py`, `posts send` to the current conversation is now allowed for heap/ nests (a new top-level gallery item is a distinct intentional action); chat/DM sends and `posts reply` stay blocked
-   In `packages/tlon-skill`, new `posts send --title` flag for gallery posts (heap-only, validated), wired to `metadata.title`
-   Gallery guidance added to the tlon tool description/schema, the always-on platform hint, `prompts/shared/tlon-groups.md`, and `SKILL.md` (whose Hermes intro previously self-contradicted about proactive sends)

## How did I test?

-   New `test_adapter_heap.py` (12 tests): parsing including block-only posts, titles, auto-discovery, comment reactions, control replies
-   Heap anchoring tests in `test_adapter_send.py`; gating and guidance tests in `test_tlon_tool.py`
-   Full adapter suite green: 695 tests (`python3 -m unittest` via `dev/test.sh`)
-   `packages/tlon-skill` `pnpm check` green: typecheck, 261+ unit tests, compiled-binary smoke matrix including new `--title` cases
-   Prettier clean

## Risks and impact

-   Safe to rollback without consulting PR author? Yes

Heap anchoring touches the shared `send()` delivery path, but is guarded by nest prefix and existing tests pin chat/DM behavior. The tool-guard carveout is heap-only.

## Rollback plan

Revert.
