### PR TITLE
canonicalize group invite links and run the cache migration for updaters

### DIFF
--- a/packages/app/provider/AppDataProvider.tsx
+++ b/packages/app/provider/AppDataProvider.tsx
@@ -43,10 +43,10 @@ export function AppDataProvider({
       if (!normalized || normalized === cached) {
         return;
       }
-      // re-read before writing: a logout wipe queued during the reads
-      // must win — writing the old account's link back after the wipe
-      // would hand it to the next account
-      const current = await db.personalInviteLink.getValue();
+      // re-read before writing, waiting on the storage lock so any
+      // queued logout wipe completes first — writing the old account's
+      // link back after the wipe would hand it to the next account
+      const current = await db.personalInviteLink.getValue(true);
       if (cancelled || current !== cached) {
         return;
       }

--- a/packages/app/provider/AppDataProvider.tsx
+++ b/packages/app/provider/AppDataProvider.tsx
@@ -34,15 +34,27 @@ export function AppDataProvider({
   // onboarding boot sequence never runs for signed-in updaters, so the
   // migration lives here, where every session mounts
   useEffect(() => {
-    void db.personalInviteLink.getValue().then((cached) => {
-      if (!cached) {
+    let cancelled = false;
+    void db.personalInviteLink.getValue().then(async (cached) => {
+      if (cancelled || !cached) {
         return;
       }
       const normalized = extractNormalizedInviteLink(cached);
-      if (normalized && normalized !== cached) {
-        void db.personalInviteLink.setValue(normalized);
+      if (!normalized || normalized === cached) {
+        return;
       }
+      // re-read before writing: a logout wipe queued during the reads
+      // must win — writing the old account's link back after the wipe
+      // would hand it to the next account
+      const current = await db.personalInviteLink.getValue();
+      if (cancelled || current !== cached) {
+        return;
+      }
+      void db.personalInviteLink.setValue(normalized);
     });
+    return () => {
+      cancelled = true;
+    };
   }, []);
   return (
     <AppDataContextProvider

--- a/packages/app/provider/AppDataProvider.tsx
+++ b/packages/app/provider/AppDataProvider.tsx
@@ -1,6 +1,8 @@
+import * as db from '@tloncorp/shared/db';
 import * as domain from '@tloncorp/shared/domain';
+import { extractNormalizedInviteLink } from '@tloncorp/shared/logic';
 import * as store from '@tloncorp/shared/store';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 
 import {
   BRANCH_DOMAIN,
@@ -27,6 +29,21 @@ export function AppDataProvider({
   const session = store.useCurrentSession();
   const contactsQuery = store.useContacts();
   const calmSettingsQuery = store.useCalmSettings();
+
+  // links cached by older versions carry the old share domain. the
+  // onboarding boot sequence never runs for signed-in updaters, so the
+  // migration lives here, where every session mounts
+  useEffect(() => {
+    void db.personalInviteLink.getValue().then((cached) => {
+      if (!cached) {
+        return;
+      }
+      const normalized = extractNormalizedInviteLink(cached);
+      if (normalized && normalized !== cached) {
+        void db.personalInviteLink.setValue(normalized);
+      }
+    });
+  }, []);
   return (
     <AppDataContextProvider
       currentUserId={currentUserId}

--- a/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
+++ b/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
@@ -46,7 +46,7 @@ export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
       return;
     }
     let cancelled = false;
-    void db.homeGroupInviteLink.getValue().then((current) => {
+    void db.homeGroupInviteLink.getValue(true).then((current) => {
       if (cancelled || current !== cachedInviteLink) {
         return;
       }

--- a/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
+++ b/packages/app/ui/components/Wayfinding/useHomeGroupInviteLink.ts
@@ -35,15 +35,26 @@ export function useHomeGroupInviteLink({ enabled }: { enabled: boolean }) {
   });
 
   // links cached by older versions carry the old share domain — normalize
-  // in place so updaters share canonical links (mirrors verifyUserInviteLink)
+  // in place so updaters share canonical links. same logout guard as the
+  // personal-link migration: never write back after a session wipe
   useEffect(() => {
     if (!cachedInviteLink) {
       return;
     }
     const normalized = extractNormalizedInviteLink(cachedInviteLink);
-    if (normalized && normalized !== cachedInviteLink) {
-      db.homeGroupInviteLink.setValue(normalized);
+    if (!normalized || normalized === cachedInviteLink) {
+      return;
     }
+    let cancelled = false;
+    void db.homeGroupInviteLink.getValue().then((current) => {
+      if (cancelled || current !== cachedInviteLink) {
+        return;
+      }
+      void db.homeGroupInviteLink.setValue(normalized);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [cachedInviteLink]);
 
   const shouldRecoverFromLure = enabled && !cachedInviteLink && !!homeGroup?.id;

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -9,6 +9,7 @@ import create from 'zustand';
 import * as db from '../db';
 import { createDevLogger } from '../debug';
 import { AnalyticsEvent } from '../domain';
+import { extractNormalizedInviteLink } from '../logic';
 import { createGroupInviteLink } from './inviteActions';
 
 interface LureMetadata {
@@ -136,12 +137,18 @@ export const useLureState = create<LureState>((set, get) => ({
         invitedGroupiconImageColor: group?.iconImageColor ?? undefined,
       };
 
-      deepLinkUrl = await createDeepLink({
+      const mintedUrl = await createDeepLink({
         fallbackUrl: url,
         type: 'lure',
         path: flag,
         metadata,
       });
+      // createDeepLink returns the branch-minted url on the old share
+      // domain; every surface that shows a group invite reads this value,
+      // so canonicalize here or join-flavored links reach users
+      deepLinkUrl = mintedUrl
+        ? extractNormalizedInviteLink(mintedUrl) ?? mintedUrl
+        : mintedUrl;
       lureLogger.crumb('deepLinkUrl created', deepLinkUrl);
     }
 


### PR DESCRIPTION
## Summary

Build 439 still showed old-domain links. Two root causes, both now closed:

- **Group shares never touched the normalizer.** `lure.ts` stores and displays the Branch-minted URL verbatim (`createDeepLink`'s return), freshly re-minted every session — not a stale cache. Normalizing at that single choke point covers every group share surface, including home-group recovery.
- **The personal-link migration was unreachable for its audience.** `verifyUserInviteLink` runs only in the onboarding boot sequence (`signupContext`), which signed-in updaters never execute. The cached-value migration now runs from `AppDataProvider`, which every session mounts.

## How did I test?

Typecheck across shared/app. Verification on device: share a group invite and the personal invite on this build — both should read invite.tlon.io.

## Risks and impact

Share-surface strings only; parsing accepts both domains forever.

## Rollback plan

Revert.