### PR TITLE
keep join.tlon.io as the canonical link domain for the rollout

### DIFF
--- a/apps/tlon-web/e2e/invite-service.spec.ts
+++ b/apps/tlon-web/e2e/invite-service.spec.ts
@@ -53,7 +53,9 @@ test('should generate an invite link and be able to redeem group/personal invite
   const clipboardText: string = await zodPage.evaluate(
     'navigator.clipboard.readText()'
   );
-  expect(clipboardText).toContain('join.tlon.io');
+  // either canonical host passes so flipping CANONICAL_INVITE_HOST
+  // after the DNS flip doesn't break this spec
+  expect(clipboardText).toMatch(/https:\/\/(join|invite)\.tlon\.io\//);
   const token = clipboardText.split('/').pop();
   expect(token).toBeDefined();
 

--- a/packages/api/src/client/deeplinks.test.ts
+++ b/packages/api/src/client/deeplinks.test.ts
@@ -87,19 +87,19 @@ describe('parseInviteDeepLink', () => {
 describe('inviteUrlFromDeferredPayload', () => {
   test('synthesizes urls from raw tokens', () => {
     expect(inviteUrlFromDeferredPayload('0vabcde')).toBe(
-      'https://invite.tlon.io/0vabcde'
+      'https://join.tlon.io/0vabcde'
     );
     expect(inviteUrlFromDeferredPayload('~zod/team')).toBe(
-      'https://invite.tlon.io/~zod/team'
+      'https://join.tlon.io/~zod/team'
     );
   });
 
   test('extracts token key-value referrer payloads', () => {
     expect(inviteUrlFromDeferredPayload('token=0vabcde')).toBe(
-      'https://invite.tlon.io/0vabcde'
+      'https://join.tlon.io/0vabcde'
     );
     expect(inviteUrlFromDeferredPayload('utm_source=x&token=~zod%2Fteam')).toBe(
-      'https://invite.tlon.io/~zod/team'
+      'https://join.tlon.io/~zod/team'
     );
   });
 
@@ -124,12 +124,12 @@ describe('inviteUrlFromDeferredPayload', () => {
 
 describe('extractNormalizedInviteLink', () => {
   test('normalizes any accepted invite link to the canonical domain', () => {
-    expect(extractNormalizedInviteLink('https://join.tlon.io/0vabcde')).toBe(
-      'https://invite.tlon.io/0vabcde'
+    expect(extractNormalizedInviteLink('https://invite.tlon.io/0vabcde')).toBe(
+      'https://join.tlon.io/0vabcde'
     );
     expect(
       extractNormalizedInviteLink('https://sa96e.app.link/~zod/team')
-    ).toBe('https://invite.tlon.io/~zod/team');
+    ).toBe('https://join.tlon.io/~zod/team');
     expect(extractNormalizedInviteLink('https://example.com/0vabc')).toBeNull();
   });
 });

--- a/packages/api/src/client/deeplinks.test.ts
+++ b/packages/api/src/client/deeplinks.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  CANONICAL_INVITE_HOST,
   extractNormalizedInviteLink,
   getMetadataFromInviteToken,
   inviteUrlFromDeferredPayload,
   parseInviteDeepLink,
 } from './deeplinks';
+
+// expectations track the canonical host so flipping it (the post-flip
+// release lever) needs no test edits; inputs cover both domains
+const canonical = (token: string) =>
+  `https://${CANONICAL_INVITE_HOST}/${token}`;
 
 describe('parseInviteDeepLink', () => {
   test('parses single-segment invite tokens from invite domains', () => {
@@ -86,20 +92,18 @@ describe('parseInviteDeepLink', () => {
 
 describe('inviteUrlFromDeferredPayload', () => {
   test('synthesizes urls from raw tokens', () => {
-    expect(inviteUrlFromDeferredPayload('0vabcde')).toBe(
-      'https://join.tlon.io/0vabcde'
-    );
+    expect(inviteUrlFromDeferredPayload('0vabcde')).toBe(canonical('0vabcde'));
     expect(inviteUrlFromDeferredPayload('~zod/team')).toBe(
-      'https://join.tlon.io/~zod/team'
+      canonical('~zod/team')
     );
   });
 
   test('extracts token key-value referrer payloads', () => {
     expect(inviteUrlFromDeferredPayload('token=0vabcde')).toBe(
-      'https://join.tlon.io/0vabcde'
+      canonical('0vabcde')
     );
     expect(inviteUrlFromDeferredPayload('utm_source=x&token=~zod%2Fteam')).toBe(
-      'https://join.tlon.io/~zod/team'
+      canonical('~zod/team')
     );
   });
 
@@ -124,13 +128,23 @@ describe('inviteUrlFromDeferredPayload', () => {
 
 describe('extractNormalizedInviteLink', () => {
   test('normalizes any accepted invite link to the canonical domain', () => {
+    expect(extractNormalizedInviteLink('https://join.tlon.io/0vabcde')).toBe(
+      canonical('0vabcde')
+    );
     expect(extractNormalizedInviteLink('https://invite.tlon.io/0vabcde')).toBe(
-      'https://join.tlon.io/0vabcde'
+      canonical('0vabcde')
     );
     expect(
       extractNormalizedInviteLink('https://sa96e.app.link/~zod/team')
-    ).toBe('https://join.tlon.io/~zod/team');
+    ).toBe(canonical('~zod/team'));
     expect(extractNormalizedInviteLink('https://example.com/0vabc')).toBeNull();
+  });
+
+  test('canonical links round-trip through the parser', () => {
+    expect(parseInviteDeepLink(canonical('0vabc'))).toEqual({
+      type: 'lure',
+      token: '0vabc',
+    });
   });
 });
 

--- a/packages/api/src/client/deeplinks.ts
+++ b/packages/api/src/client/deeplinks.ts
@@ -9,8 +9,10 @@ import { normalizeUrbitColor } from './utils';
 const logger = createDevLogger('deeplinks', false);
 
 // the domain new links are written and displayed with. parsing accepts
-// every known host forever; join.tlon.io redirects here after the flip
-export const CANONICAL_INVITE_HOST = 'invite.tlon.io';
+// every known host forever. this stays join.tlon.io through the DNS flip
+// so shared links keep opening directly in app versions that only register
+// the old domain; the first release after the flip moves it to invite.tlon.io
+export const CANONICAL_INVITE_HOST = 'join.tlon.io';
 
 // bare lowercase hostnames; the configured branch domain joins at parse time
 const KNOWN_INVITE_HOSTS = new Set([

--- a/packages/shared/src/store/lure.ts
+++ b/packages/shared/src/store/lure.ts
@@ -143,9 +143,9 @@ export const useLureState = create<LureState>((set, get) => ({
         path: flag,
         metadata,
       });
-      // createDeepLink returns the branch-minted url on the old share
-      // domain; every surface that shows a group invite reads this value,
-      // so canonicalize here or join-flavored links reach users
+      // every surface that shows a group invite reads this value, so
+      // normalize here to keep displayed links on the canonical domain
+      // no matter what the minter returned
       deepLinkUrl = mintedUrl
         ? extractNormalizedInviteLink(mintedUrl) ?? mintedUrl
         : mintedUrl;


### PR DESCRIPTION
## Summary

Points the canonical invite-link domain at join.tlon.io instead of invite.tlon.io, so the 9.4.0 rollout changes nothing about how shared links behave. Every app version opens join links directly (they're in everyone's entitlements), and Android invite recovery across a fresh install keeps working through Branch, so the release has no ordering dependency on the DNS flip or on adoption.

All the normalization and cache-migration machinery from #6154 stays exactly as is — this changes only the domain it targets. Mints, displayed links, and cached links all land on join.tlon.io. For everyone on production this makes the migrations a no-op (their caches already say join); only internal testers with invite-flavored links from the RC builds get rewritten back.

After the DNS flip, the first release that flips this one constant to invite.tlon.io moves every surface — mints, display, and cached links — via the same machinery. That's the whole cutover.

Parsing is unchanged: both domains (plus the legacy Branch hosts) are accepted forever, so links of either flavor keep opening the app, including the invite.tlon.io links that join redirects to after the flip.

## Changes

-   `deeplinks.ts` — `CANONICAL_INVITE_HOST` is join.tlon.io for this release; comment documents the flip plan
-   `lure.ts` — comment updated (it described canonicalizing away from join, which is now backwards)
-   `deeplinks.test.ts` — canonical-output expectations are derived from `CANONICAL_INVITE_HOST` and both domains are covered as normalize inputs, plus a round-trip test proving canonical links re-parse. Flipping the constant later touches no tests
-   `invite-service.spec.ts` (e2e) — the clipboard assertion accepts either canonical host instead of pinning join.tlon.io, so the later flip doesn't break the spec

## How did I test?

-   `vitest run src/client/deeplinks.test.ts` — 16/16 pass
-   Prettier clean on all three files
-   Confirmed this is the only test file exercising the normalize/deferred-payload helpers, and the only remaining invite.tlon.io literals in app code are the entitlements/manifests (both domains registered, unchanged) and the known-hosts parse list

## Risks and impact

-   Display-only change; no behavior differences for production users, whose links and caches are already join-flavored
-   The deferred-invite cascade is domain-agnostic on both ends: full URLs pass through verbatim and both hosts parse, so payloads written by the invite page interoperate either way
-   The wayfinding splash and paste-screen placeholder already say join.tlon.io, so displayed links now match the copy again

## Rollback plan

Revert the constant (one line); tests follow it.

## Screenshots

n/a
