### PR TITLE
openclaw: prevent failed presence calls from blocking

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/monitor/computing-presence.test.ts
+++ b/packages/openclaw/src/monitor/computing-presence.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  type ComputingPresenceReporter,
   createComputingPresenceReporter,
   createComputingPresenceTracker,
 } from './computing-presence.js';
@@ -32,6 +33,12 @@ vi.mock('@tloncorp/api', () => ({
   serializeComputingStatus,
   setConversationPresence,
 }));
+
+async function flushPresenceQueue() {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
 
 describe('createComputingPresenceTracker', () => {
   beforeEach(() => {
@@ -86,10 +93,11 @@ describe('createComputingPresenceTracker', () => {
 
     const tracker = createComputingPresenceTracker({ reporter });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenCalledWith({
       conversationId: '~nec',
@@ -97,10 +105,11 @@ describe('createComputingPresenceTracker', () => {
       toolNames: [],
     });
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenLastCalledWith({
       conversationId: '~nec',
@@ -119,24 +128,26 @@ describe('createComputingPresenceTracker', () => {
 
       const tracker = createComputingPresenceTracker({ reporter });
 
-      await tracker.refreshRun({
+      tracker.refreshRun({
         conversationId: '~nec',
         runId: 'run-1',
       });
+      await flushPresenceQueue();
 
       expect(reporter.publish).toHaveBeenCalledTimes(1);
 
-      await tracker.addToolCall({
+      tracker.addToolCall({
         conversationId: '~nec',
         runId: 'run-1',
         toolName: 'web_fetch',
       });
 
-      await tracker.addToolCall({
+      tracker.addToolCall({
         conversationId: '~nec',
         runId: 'run-1',
         toolName: 'exec',
       });
+      await flushPresenceQueue();
 
       expect(reporter.publish).toHaveBeenCalledTimes(1);
 
@@ -150,10 +161,11 @@ describe('createComputingPresenceTracker', () => {
         toolNames: ['web_fetch', 'exec'],
       });
 
-      await tracker.clearToolCalls({
+      tracker.clearToolCalls({
         conversationId: '~nec',
         runId: 'run-1',
       });
+      await flushPresenceQueue();
 
       expect(reporter.publish).toHaveBeenCalledTimes(2);
 
@@ -175,15 +187,17 @@ describe('createComputingPresenceTracker', () => {
 
     const tracker = createComputingPresenceTracker({ reporter });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenCalledTimes(1);
   });
@@ -198,26 +212,29 @@ describe('createComputingPresenceTracker', () => {
 
       const tracker = createComputingPresenceTracker({ reporter });
 
-      await tracker.refreshRun({
+      tracker.refreshRun({
         conversationId: '~nec',
         runId: 'run-1',
       });
+      await flushPresenceQueue();
 
       expect(reporter.publish).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(29_999);
-      await tracker.refreshRun({
+      tracker.refreshRun({
         conversationId: '~nec',
         runId: 'run-1',
       });
+      await flushPresenceQueue();
 
       expect(reporter.publish).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(1);
-      await tracker.refreshRun({
+      tracker.refreshRun({
         conversationId: '~nec',
         runId: 'run-1',
       });
+      await flushPresenceQueue();
 
       expect(reporter.publish).toHaveBeenCalledTimes(2);
       expect(reporter.publish).toHaveBeenLastCalledWith({
@@ -240,25 +257,29 @@ describe('createComputingPresenceTracker', () => {
       minUpdateIntervalMs: 0,
     });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: 'chat/~bus/general',
       runId: 'run-1',
     });
-    await tracker.addToolCall({
+    await flushPresenceQueue();
+    tracker.addToolCall({
       conversationId: 'chat/~bus/general',
       runId: 'run-1',
       toolName: 'web_fetch',
     });
+    await flushPresenceQueue();
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: 'chat/~bus/general',
       runId: 'run-2',
     });
-    await tracker.addToolCall({
+    await flushPresenceQueue();
+    tracker.addToolCall({
       conversationId: 'chat/~bus/general',
       runId: 'run-2',
       toolName: 'exec',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenLastCalledWith({
       conversationId: 'chat/~bus/general',
@@ -266,10 +287,11 @@ describe('createComputingPresenceTracker', () => {
       toolNames: ['web_fetch', 'exec'],
     });
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: 'chat/~bus/general',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenLastCalledWith({
       conversationId: 'chat/~bus/general',
@@ -290,15 +312,17 @@ describe('createComputingPresenceTracker', () => {
       minUpdateIntervalMs: 0,
     });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenLastCalledWith({
       conversationId: '~nec',
@@ -306,10 +330,11 @@ describe('createComputingPresenceTracker', () => {
       toolNames: [],
     });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenCalledTimes(2);
   });
@@ -324,21 +349,24 @@ describe('createComputingPresenceTracker', () => {
       minUpdateIntervalMs: 0,
     });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.addToolCall({
+    tracker.addToolCall({
       conversationId: '~nec',
       runId: 'run-1',
       toolName: 'exec',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenLastCalledWith({
       conversationId: '~nec',
@@ -346,15 +374,17 @@ describe('createComputingPresenceTracker', () => {
       toolNames: ['exec'],
     });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenLastCalledWith({
       conversationId: '~nec',
@@ -373,21 +403,87 @@ describe('createComputingPresenceTracker', () => {
       minUpdateIntervalMs: 0,
     });
 
-    await tracker.refreshRun({
+    tracker.refreshRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
-    await tracker.stopRun({
+    tracker.stopRun({
       conversationId: '~nec',
       runId: 'run-1',
     });
+    await flushPresenceQueue();
 
     expect(reporter.publish).toHaveBeenCalledTimes(2);
+  });
+
+  test('lifecycle updates return immediately and coalesce behind a stalled publish', async () => {
+    let resolveFirstPublish: (() => void) | undefined;
+    const firstPublish = new Promise<void>((resolve) => {
+      resolveFirstPublish = resolve;
+    });
+    const reporter = {
+      publish: vi
+        .fn<ComputingPresenceReporter['publish']>()
+        .mockImplementationOnce(() => firstPublish)
+        .mockResolvedValue(undefined),
+    };
+    const tracker = createComputingPresenceTracker({
+      reporter,
+      minUpdateIntervalMs: 0,
+    });
+
+    expect(
+      tracker.refreshRun({ conversationId: '~nec', runId: 'run-1' })
+    ).toBeUndefined();
+    expect(reporter.publish).not.toHaveBeenCalled();
+
+    await flushPresenceQueue();
+    expect(reporter.publish).toHaveBeenCalledTimes(1);
+
+    expect(
+      tracker.addToolCall({
+        conversationId: '~nec',
+        runId: 'run-1',
+        toolName: 'web_fetch',
+      })
+    ).toBeUndefined();
+    expect(
+      tracker.clearToolCalls({ conversationId: '~nec', runId: 'run-1' })
+    ).toBeUndefined();
+    expect(
+      tracker.addToolCall({
+        conversationId: '~nec',
+        runId: 'run-1',
+        toolName: 'exec',
+      })
+    ).toBeUndefined();
+    expect(reporter.publish).toHaveBeenCalledTimes(1);
+
+    resolveFirstPublish?.();
+    await flushPresenceQueue();
+    expect(reporter.publish).toHaveBeenLastCalledWith({
+      conversationId: '~nec',
+      thinking: true,
+      toolNames: ['exec'],
+    });
+    expect(reporter.publish).toHaveBeenCalledTimes(2);
+
+    expect(
+      tracker.stopRun({ conversationId: '~nec', runId: 'run-1' })
+    ).toBeUndefined();
+    await flushPresenceQueue();
+    expect(reporter.publish).toHaveBeenLastCalledWith({
+      conversationId: '~nec',
+      thinking: false,
+      toolNames: [],
+    });
   });
 });

--- a/packages/openclaw/src/monitor/computing-presence.ts
+++ b/packages/openclaw/src/monitor/computing-presence.ts
@@ -93,8 +93,11 @@ export function createComputingPresenceTracker(trackerOpts?: {
   const conversations = new Map<string, Map<string, RunState>>();
   const lastPublishedState = new Map<string, PublishedState>();
   const lastPublishedAt = new Map<string, number>();
-  const pendingState = new Map<string, PublishedState>();
+  const desiredState = new Map<string, PublishedState>();
+  const desiredRevision = new Map<string, number>();
   const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const scheduledConversations = new Set<string>();
+  const publishingConversations = new Set<string>();
   const stoppedRuns = new Map<string, Set<string>>();
 
   const markRunStopped = (conversationId: string, runId: string) => {
@@ -157,96 +160,126 @@ export function createComputingPresenceTracker(trackerOpts?: {
     return true;
   };
 
-  const clearPending = (conversationId: string) => {
+  const clearPendingTimer = (conversationId: string) => {
     const timer = pendingTimers.get(conversationId);
     if (timer) {
       clearTimeout(timer);
       pendingTimers.delete(conversationId);
     }
-
-    pendingState.delete(conversationId);
   };
 
-  const publishNow = async (conversationId: string, state: PublishedState) => {
-    clearPending(conversationId);
-    await reporter.publish({
-      conversationId,
-      ...state,
+  const schedulePublish = (conversationId: string) => {
+    if (
+      publishingConversations.has(conversationId) ||
+      scheduledConversations.has(conversationId) ||
+      pendingTimers.has(conversationId)
+    ) {
+      return;
+    }
+
+    // Lifecycle hooks only enqueue state. Starting the worker in a microtask
+    // keeps ship I/O out of the OpenClaw callback stack entirely.
+    scheduledConversations.add(conversationId);
+    queueMicrotask(() => {
+      scheduledConversations.delete(conversationId);
+      void publishDesiredState(conversationId);
     });
-    if (!state.thinking) {
-      // idle is the terminal state; drop the records so the maps do not grow
-      // unboundedly across the gateway's lifetime
-      lastPublishedState.delete(conversationId);
-      lastPublishedAt.delete(conversationId);
-      return;
-    }
-    lastPublishedState.set(conversationId, clonePublishedState(state));
-    lastPublishedAt.set(conversationId, Date.now());
   };
 
-  const flushPending = async (conversationId: string) => {
-    const nextState = pendingState.get(conversationId);
-    clearPending(conversationId);
-
-    if (!nextState) {
-      return;
-    }
-
-    if (statesEqual(lastPublishedState.get(conversationId), nextState)) {
-      return;
-    }
-
-    await publishNow(conversationId, nextState);
+  const enqueueState = (conversationId: string, state: PublishedState) => {
+    desiredState.set(conversationId, clonePublishedState(state));
+    desiredRevision.set(
+      conversationId,
+      (desiredRevision.get(conversationId) ?? 0) + 1
+    );
+    clearPendingTimer(conversationId);
+    schedulePublish(conversationId);
   };
 
-  const publishThrottled = async (
-    conversationId: string,
-    state: PublishedState
-  ) => {
-    if (statesEqual(lastPublishedState.get(conversationId), state)) {
+  async function publishDesiredState(conversationId: string) {
+    if (publishingConversations.has(conversationId)) {
+      return;
+    }
+
+    const state = desiredState.get(conversationId);
+    const revision = desiredRevision.get(conversationId);
+    if (!state || revision === undefined) {
+      return;
+    }
+
+    const previousState = lastPublishedState.get(conversationId);
+    if (statesEqual(previousState, state)) {
       const publishedAt = lastPublishedAt.get(conversationId) ?? 0;
-      if (Date.now() - publishedAt < maxPublishAgeMs) {
-        clearPending(conversationId);
+      if (!state.thinking || Date.now() - publishedAt < maxPublishAgeMs) {
         return;
       }
-      // fall through: re-publish before the ship-side presence expires
+      // Re-publish before the ship-side active presence expires.
     }
 
-    if (minUpdateIntervalMs === 0) {
-      await publishNow(conversationId, state);
-      return;
+    if (previousState?.thinking && state.thinking && minUpdateIntervalMs > 0) {
+      const nextAllowedAt =
+        (lastPublishedAt.get(conversationId) ?? 0) + minUpdateIntervalMs;
+      const delayMs = nextAllowedAt - Date.now();
+      if (delayMs > 0) {
+        const timer = setTimeout(() => {
+          pendingTimers.delete(conversationId);
+          schedulePublish(conversationId);
+        }, delayMs);
+        pendingTimers.set(conversationId, timer);
+        return;
+      }
     }
 
-    const now = Date.now();
-    const nextAllowedAt =
-      (lastPublishedAt.get(conversationId) ?? 0) + minUpdateIntervalMs;
-    if (now >= nextAllowedAt) {
-      await publishNow(conversationId, state);
-      return;
-    }
-
-    pendingState.set(conversationId, clonePublishedState(state));
-    if (pendingTimers.has(conversationId)) {
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      pendingTimers.delete(conversationId);
-      void safelySync(conversationId, 'flush', async () => {
-        await flushPending(conversationId);
+    publishingConversations.add(conversationId);
+    let published = false;
+    try {
+      await reporter.publish({
+        conversationId,
+        ...state,
       });
-    }, nextAllowedAt - now);
-    pendingTimers.set(conversationId, timer);
-  };
+      published = true;
+    } catch (error) {
+      runtime?.error?.(
+        `[tlon] Failed to publish computing presence for ${conversationId}: ${describeError(error)}`
+      );
+    } finally {
+      publishingConversations.delete(conversationId);
+    }
 
-  const syncConversation = async (conversationId: string) => {
+    if (published) {
+      lastPublishedState.set(conversationId, clonePublishedState(state));
+      lastPublishedAt.set(conversationId, Date.now());
+
+      if (
+        !state.thinking &&
+        statesEqual(desiredState.get(conversationId), state)
+      ) {
+        // Idle is terminal. Drop the records so these maps stay bounded over
+        // the gateway lifetime once the latest desired state is cleared.
+        desiredState.delete(conversationId);
+        desiredRevision.delete(conversationId);
+        lastPublishedState.delete(conversationId);
+        lastPublishedAt.delete(conversationId);
+      }
+    }
+
+    // A single in-flight request owns each conversation. If lifecycle events
+    // superseded it, publish only the newest desired state next.
+    if (desiredRevision.get(conversationId) !== revision) {
+      schedulePublish(conversationId);
+    }
+  }
+
+  const syncConversation = (conversationId: string) => {
     const runs = conversations.get(conversationId);
-    const previousState = lastPublishedState.get(conversationId);
 
     if (!runs || runs.size === 0) {
       conversations.delete(conversationId);
-      if (previousState?.thinking) {
-        await publishNow(conversationId, {
+      const currentState =
+        desiredState.get(conversationId) ??
+        lastPublishedState.get(conversationId);
+      if (currentState?.thinking) {
+        enqueueState(conversationId, {
           thinking: false,
           toolNames: [],
         });
@@ -274,11 +307,7 @@ export function createComputingPresenceTracker(trackerOpts?: {
       toolNames,
     };
 
-    if (!previousState || !previousState.thinking) {
-      await publishNow(conversationId, currentState);
-    } else {
-      await publishThrottled(conversationId, currentState);
-    }
+    enqueueState(conversationId, currentState);
   };
 
   const getRun = (conversationId: string, runId: string) =>
@@ -302,33 +331,17 @@ export function createComputingPresenceTracker(trackerOpts?: {
     return run;
   };
 
-  const safelySync = async (
-    conversationId: string,
-    action: string,
-    fn: () => Promise<void>
-  ) => {
-    try {
-      await fn();
-    } catch (error) {
-      runtime?.error?.(
-        `[tlon] Failed to ${action} computing presence for ${conversationId}: ${describeError(error)}`
-      );
-    }
-  };
-
   return {
-    refreshRun: async (params: { conversationId: string; runId: string }) => {
+    refreshRun: (params: { conversationId: string; runId: string }) => {
       if (isRunStopped(params.conversationId, params.runId)) {
         return;
       }
 
-      await safelySync(params.conversationId, 'refresh', async () => {
-        ensureRun(params.conversationId, params.runId);
-        await syncConversation(params.conversationId);
-      });
+      ensureRun(params.conversationId, params.runId);
+      syncConversation(params.conversationId);
     },
 
-    addToolCall: async (params: {
+    addToolCall: (params: {
       conversationId: string;
       runId: string;
       toolName?: string | null;
@@ -338,53 +351,36 @@ export function createComputingPresenceTracker(trackerOpts?: {
         return;
       }
 
-      await safelySync(params.conversationId, 'update', async () => {
-        // real activity resumes a previously stopped run
-        clearRunStopped(params.conversationId, params.runId);
-        const run = ensureRun(params.conversationId, params.runId);
-        if (!run.toolNames.includes(toolName)) {
-          run.toolNames.push(toolName);
-        }
-        await syncConversation(params.conversationId);
-      });
+      // real activity resumes a previously stopped run
+      clearRunStopped(params.conversationId, params.runId);
+      const run = ensureRun(params.conversationId, params.runId);
+      if (!run.toolNames.includes(toolName)) {
+        run.toolNames.push(toolName);
+      }
+      syncConversation(params.conversationId);
     },
 
-    clearToolCalls: async (params: {
-      conversationId: string;
-      runId: string;
-    }) => {
-      await safelySync(params.conversationId, 'clear tools for', async () => {
-        const run = getRun(params.conversationId, params.runId);
-        if (!run || run.toolNames.length === 0) {
-          return;
-        }
+    clearToolCalls: (params: { conversationId: string; runId: string }) => {
+      const run = getRun(params.conversationId, params.runId);
+      if (!run || run.toolNames.length === 0) {
+        return;
+      }
 
-        run.toolNames = [];
-        await syncConversation(params.conversationId);
-      });
+      run.toolNames = [];
+      syncConversation(params.conversationId);
     },
 
-    stopRun: async (params: { conversationId: string; runId: string }) => {
+    stopRun: (params: { conversationId: string; runId: string }) => {
       markRunStopped(params.conversationId, params.runId);
-      await safelySync(params.conversationId, 'clear', async () => {
-        const runs = conversations.get(params.conversationId);
-        if (!runs) {
-          if (lastPublishedState.get(params.conversationId)?.thinking) {
-            await publishNow(params.conversationId, {
-              thinking: false,
-              toolNames: [],
-            });
-          }
-          return;
-        }
-
+      const runs = conversations.get(params.conversationId);
+      if (runs) {
         runs.delete(params.runId);
         if (runs.size === 0) {
           conversations.delete(params.conversationId);
         }
+      }
 
-        await syncConversation(params.conversationId);
-      });
+      syncConversation(params.conversationId);
     },
   };
 }

--- a/packages/openclaw/src/monitor/index.ts
+++ b/packages/openclaw/src/monitor/index.ts
@@ -3024,28 +3024,30 @@ export async function monitorTlonProvider(
 
       const typingCallbacks = presenceConversationId
         ? createTypingCallbacks({
-            start: async () => {
-              await computingPresence.refreshRun({
+            start: () => {
+              computingPresence.refreshRun({
                 conversationId: presenceConversationId,
                 runId: presenceRunId,
               });
+              return Promise.resolve();
             },
-            stop: async () => {
-              await computingPresence.stopRun({
+            stop: () => {
+              computingPresence.stopRun({
                 conversationId: presenceConversationId,
                 runId: presenceRunId,
               });
+              return Promise.resolve();
             },
             onStartError: (err: unknown) => {
               runtime.error?.(
-                `[tlon] Failed to start computing presence for ${presenceConversationId}: ${
+                `[tlon] Failed to enqueue computing presence for ${presenceConversationId}: ${
                   err instanceof Error ? err.stack ?? err.message : String(err)
                 }`
               );
             },
             onStopError: (err: unknown) => {
               runtime.error?.(
-                `[tlon] Failed to stop computing presence for ${presenceConversationId}: ${
+                `[tlon] Failed to enqueue computing presence stop for ${presenceConversationId}: ${
                   err instanceof Error ? err.stack ?? err.message : String(err)
                 }`
               );
@@ -3055,10 +3057,6 @@ export async function monitorTlonProvider(
             // callbacks, killing the thinking indicator for the rest of long
             // runs. stopRun is already wired to deliver/idle/cleanup.
             maxDurationMs: 0,
-            // The SDK default (2) trips the keepalive permanently after two
-            // transient poke failures, which lets the ship-side presence expire
-            // mid-run. Failures are already logged via onStartError.
-            maxConsecutiveFailures: 5,
           })
         : undefined;
 
@@ -3086,18 +3084,18 @@ export async function monitorTlonProvider(
           });
           logContextLens(lens.lensId, 'model_selected');
         },
-        onAssistantMessageStart: async () => {
+        onAssistantMessageStart: () => {
           if (presenceConversationId) {
-            await computingPresence.clearToolCalls({
+            computingPresence.clearToolCalls({
               conversationId: presenceConversationId,
               runId: presenceRunId,
             });
           }
         },
-        onToolStart: async (payload) => {
+        onToolStart: (payload) => {
           const toolName = payload.name ?? 'unknown';
           if (presenceConversationId) {
-            await computingPresence.addToolCall({
+            computingPresence.addToolCall({
               conversationId: presenceConversationId,
               runId: presenceRunId,
               toolName,
@@ -3316,7 +3314,7 @@ export async function monitorTlonProvider(
                         : 0;
 
                     if (presenceConversationId) {
-                      await computingPresence.stopRun({
+                      computingPresence.stopRun({
                         conversationId: presenceConversationId,
                         runId: presenceRunId,
                       });


### PR DESCRIPTION
## Summary

During tool calls, we update `%presence` status. That update was being awaited and if it timed out, could block the turn for 30s per. Thinking status is intended to be best effort, if for some reason it can't complete that shouldn't prevent the bot from responding.

## Changes

- Makes computing-presence lifecycle callbacks non-blocking: typing, keepalive, assistant start, tool start, and stop now enqueue desired state and return immediately instead of awaiting ship HTTP requests
- Adds a per-conversation single-flight publisher that coalesces superseded updates, preserves throttling/TTL behavior, catches failures, and includes regression coverage for stalled requests


## How did I test?

Locally using the `pnpm dev` Docker setup

## Risks and impact

- Safe to rollback without consulting PR author? Yes
