### PR TITLE
onboarding: refresh invite explanation copy

### DIFF
--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2181,7 +2181,7 @@ export function PrivacyPane(props: { onActionPress: () => void }) {
 const logger = createDevLogger('SplashSequence', true);
 
 const INVITE_EXPLANATION_TEXT =
-  "Anyone you invite will skip the waitlist. You'll receive a DM when they join.";
+  "You'll receive a DM when they join.";
 
 export function InviteContactsContent(props: {
   onComplete: () => void;

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2180,8 +2180,7 @@ export function PrivacyPane(props: { onActionPress: () => void }) {
 
 const logger = createDevLogger('SplashSequence', true);
 
-const INVITE_EXPLANATION_TEXT =
-  "You'll receive a DM when they join.";
+const INVITE_EXPLANATION_TEXT = "You'll receive a DM when they join.";
 
 export function InviteContactsContent(props: {
   onComplete: () => void;


### PR DESCRIPTION
## Summary
- Remove the dated waitlist reference from the invite explanation text
- Keep the message focused on the DM notification users receive when someone joins

## Testing
- Not run (not requested)