### PR TITLE
boot e2e ships from node:22-bookworm-slim instead of apt-installing at startup

### DIFF
--- a/packages/tlon-bot-e2e/docker/docker-compose.base.yml
+++ b/packages/tlon-bot-e2e/docker/docker-compose.base.yml
@@ -11,16 +11,18 @@ services:
       - "${FAKE_MODEL_PORT:?FAKE_MODEL_PORT is required}:4000"
 
   ships:
-    image: ubuntu:22.04
+    # Node's Debian image supplies a glibc runtime, tar/gzip and an HTTPS client
+    # (node's fetch, with its own CA store) without an apt-get at container
+    # startup. Ship readiness must not depend on Ubuntu's package mirrors: on
+    # 2026-07-22 they degraded to ~500 kB/s and the apt step alone consumed over
+    # half the 180s readiness budget, failing every E2E run for 35+ minutes.
+    # Matches fake-model above, so the stack pulls one base image, not two.
+    image: node:22-bookworm-slim
     command:
       - bash
       - -c
       - |
         set -euo pipefail
-        export DEBIAN_FRONTEND=noninteractive
-        apt-get update
-        apt-get install -y --no-install-recommends ca-certificates curl xz-utils coreutils
-        rm -rf /var/lib/apt/lists/*
 
         cd /data
         mkdir -p /cache
@@ -31,6 +33,46 @@ services:
         echo "    zod code: lidlut-tabwed-pillex-ridrup"
         echo "    ten code: lapseg-nolmel-riswen-hopryc"
         echo "    mug code: ravsut-bolryd-hapsum-pastul"
+
+        download() {
+          node - "$$1" "$$2" <<'NODE'
+        const fs = require('node:fs');
+        const { Readable } = require('node:stream');
+        const { pipeline } = require('node:stream/promises');
+        const [url, output] = process.argv.slice(2);
+
+        (async () => {
+          let lastError;
+          for (let attempt = 1; attempt <= 4; attempt += 1) {
+            try {
+              const response = await fetch(url, {
+                redirect: 'follow',
+                signal: AbortSignal.timeout(300_000),
+              });
+              if (!response.ok || !response.body) {
+                throw new Error(`HTTP $${response.status}`);
+              }
+              await pipeline(
+                Readable.fromWeb(response.body),
+                fs.createWriteStream(output)
+              );
+              return;
+            } catch (error) {
+              lastError = error;
+              fs.rmSync(output, { force: true });
+              console.error(`download attempt $${attempt} failed: $${error}`);
+              if (attempt < 4) {
+                await new Promise((resolve) => setTimeout(resolve, 2_000));
+              }
+            }
+          }
+          throw lastError;
+        })().catch((error) => {
+          console.error(error);
+          process.exit(1);
+        });
+        NODE
+        }
 
         artifact() {
           log() { echo "$@" >&2; }
@@ -49,7 +91,7 @@ services:
           else
             log "    cache: miss ($$path)"
             rm -f "$$tmp"
-            if ! curl -fSL --retry 3 --retry-delay 2 --retry-all-errors "$$url" -o "$$tmp"; then
+            if ! download "$$url" "$$tmp"; then
               log "ERROR: failed to download $$name from $$url"
               exit 1
             fi


### PR DESCRIPTION
## Summary

Boots the shared bot E2E `ships` container from `node:22-bookworm-slim` and downloads pinned artifacts with Node's `fetch`, removing the `apt-get update && apt-get install` that ran at container startup. Ship readiness no longer depends on Ubuntu package mirrors.

## Changes

-   Switched the `ships` service image from `ubuntu:22.04` to `node:22-bookworm-slim` in `packages/tlon-bot-e2e/docker/docker-compose.base.yml`, and deleted the runtime apt block. `coreutils` is Essential in Debian, `xz-utils` was never used (every artifact is gzip, extracted via `tar xzf`), and `ca-certificates` only existed to serve curl.
-   Replaced `curl -fSL --retry 3` with a `download()` helper backed by Node's `fetch`, streaming to disk with a 300s per-attempt timeout. It keeps 4 total attempts (matching `curl --retry 3`), sleeps 2s between attempts only, and removes partial output on failure.
-   Left size/digest verification outside the helper so it still runs on cache hits. All startup diagnostics (`==> artifact <name>`, `cache: hit|miss`, `size:`, `md5:`, `sha256:`) are unchanged.

This follows existing practice in the repo: `packages/openclaw/dev/docker-compose.test.yml` already runs its ships on the same image for the same reason, and `fake-model` in this compose file uses it too, so the stack now pulls one base image instead of two. No new infrastructure is needed, since the repo has no image registry or publishing pipeline.

### Background

The apt install ran unconditionally, before the artifact cache was consulted, and had to finish inside the 180s `waitForShipLogin` budget. On 2026-07-22 the mirrors degraded to ~500 kB/s: the index fetch alone took ~94s (`Fetched 47.2 MB in 1min 34s`), ship boot went from a 47-104s baseline to over 180s, and every Shared E2E run failed for 35+ minutes across multiple branches and two retry cycles. The symptom was an opaque `Timeout waiting for zod fake ship login after 180000ms (last error: fetch failed)` with the container still reported `running`, because vere had never been launched.

## How did I test?

Verified locally:

-   Warm cache (the normal CI path): all three ships answered `/~/login` in 23s, zero apt traffic, all four artifacts `cache: hit` with md5/sha256 still verified.
-   Cold cache (exercises the new downloader): 28s, zero apt, all four downloaded and verified. Both runs are well inside the 180s budget and below the old baseline, which included apt.
-   Corrupted a cached artifact (byte flip, size preserved): container exits 1 with `sha256 mismatch`.
-   Pointed the downloader at a bad URL: `download attempt 1..4 failed`, exit 1, confirming 4 attempts and retry logging.
-   `docker compose config`: exit 0, no interpolation warnings, JS template placeholders intact.
-   Full hermes E2E suite: 21 passed, 1 skipped. tsc, unit tests (94), and prettier all clean.

Artifact pins and digests, `/data` and `/cache` semantics, ports, and the 180s budget are unchanged.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [ ] Onboarding
    -   [ ] State / providers
    -   [ ] Message sync
    -   [ ] Channel display
    -   [ ] Notifications
    -   [x] Other: E2E test infrastructure (`tlon-bot-e2e` docker stack)

The distro moves from Ubuntu 22.04 (glibc 2.35) to Debian bookworm (glibc 2.36). The pinned vere v4.5 binary was executed on it directly and runs with zero unresolved symbols, and a full suite passed. The image tag is floating (`node:22-bookworm-slim`), matching house convention, as the repo pins no images by digest.

## Rollback plan

Revert the PR. It touches one file and involves no state, config, or protocol changes.

## Screenshots / videos

N/A, CI infrastructure change.
