### PR TITLE
bump desk to 12.0.1 and default invite links to invite.tlon.io

### DIFF
--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -4,7 +4,7 @@
     image+'https://bootstrap.urbit.org/tlon.svg?v=1'
     glob-http+['https://bootstrap.urbit.org/glob-0v7.5f3nm.vtb8h.9piar.i6ol7.77jii.glob' 0v7.5f3nm.vtb8h.9piar.i6ol7.77jii]
     base+'groups'
-    version+[12 0 0]
+    version+[12 0 1]
     website+'https://tlon.io'
     license+'MIT'
 ==

--- a/packages/api/src/client/deeplinks.ts
+++ b/packages/api/src/client/deeplinks.ts
@@ -8,11 +8,9 @@ import { normalizeUrbitColor } from './utils';
 
 const logger = createDevLogger('deeplinks', false);
 
-// the domain new links are written and displayed with. parsing accepts
-// every known host forever. this stays join.tlon.io through the DNS flip
-// so shared links keep opening directly in app versions that only register
-// the old domain; the first release after the flip moves it to invite.tlon.io
-export const CANONICAL_INVITE_HOST = 'join.tlon.io';
+// the domain new links are written and displayed with. parsing continues
+// accepting every known host so existing join.tlon.io links remain valid
+export const CANONICAL_INVITE_HOST = 'invite.tlon.io';
 
 // bare lowercase hostnames; the configured branch domain joins at parse time
 const KNOWN_INVITE_HOSTS = new Set([


### PR DESCRIPTION
## Summary

Prepares the staged 12.0.1 desk/web release and flips the canonical invite-link domain from `join.tlon.io` to `invite.tlon.io`.

Newly synthesized, normalized, cached, and displayed invite links now use `invite.tlon.io`. Parsing continues to accept `join.tlon.io` and the other legacy invite hosts, so existing links remain valid.

## Changes

- Bump `desk/desk.docket-0` from 12.0.0 to 12.0.1
- Set `CANONICAL_INVITE_HOST` to `invite.tlon.io`
- Update the canonical-host comment to reflect the completed cutover

## How did I test?

- `corepack pnpm exec vitest run packages/api/src/client/deeplinks.test.ts` — 17 tests passed
- `corepack pnpm --filter @tloncorp/api tsc --noEmit`
- `git diff --check`

## Risks and impact

- Existing `join.tlon.io` links remain supported
- New and migrated invite links will use `invite.tlon.io`

## Rollback plan

Revert the canonical-host commit and the desk version bump.
