### PR TITLE
notes: typed revision conflicts + client recovery for stale expectedRevision

### DIFF
--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -1949,9 +1949,16 @@
     =/  =note:n
       (~(got by notes.notebook-state) nid)
     ?>  (se-can-edit src.bowl)
-    ::  strict optimistic concurrency check (no force-update sentinel)
+    ::  strict optimistic concurrency check (no force-update sentinel).
+    ::  A stale revision finalizes as a typed %conflict rather than
+    ::  crashing: a crash nacks the proxying ship's poke, which it can
+    ::  only report as %unknown — indistinguishable from a transient
+    ::  failure, so clients can't run conflict recovery.
     ?:  !=(revision.note expected-revision)
-      ~|(%revision-mismatch !!)
+      =/  msg=tape
+        %+  weld  "revision-mismatch: expected {<expected-revision>}"
+        ", current {<revision.note>}"
+      (se-finalize-with [%error %conflict ~[leaf+msg]])
     ::  no-op early-out: body unchanged
     ?:  =(body-md.note body)
       se-core

--- a/desk/tests/app/notes.hoon
+++ b/desk/tests/app/notes.hoon
@@ -249,6 +249,19 @@
       ==
     `+.+>+>+.i.caz
   $(caz t.caz)
+::  +find-fact-vase: vase of the first %give %fact card whose cage
+::  carries the given mark, if any. cage layout per +http-status:
+::  mark at -.+>+, vase at +.+>+.
+::
+++  find-fact-vase
+  |=  [caz=(list card) m=mark]
+  ^-  (unit vase)
+  ?~  caz  ~
+  ?:  ?&  ?=([%give %fact * *] i.caz)
+          =(-.+>+.i.caz m)
+      ==
+    `+.+>+.i.caz
+  $(caz t.caz)
 ::
 ::  +init-zod: init agent as ~zod; discard cards
 ::
@@ -377,6 +390,23 @@
   |=  s=state
   ?~  caz
     |+['expected cards but got none']~
+  &+[~ s]
+::  +ex-conflict-response: assert the cards carry a typed
+::  [%error %conflict *] response-update (the stale-revision path), and
+::  no broadcast %notes-response fact (the update must not have applied).
+::
+++  ex-conflict-response
+  |=  caz=(list card)
+  =/  m  (mare ,~)
+  ^-  form:m
+  |=  s=state
+  ?~  van=(find-fact-vase caz %notes-response-update-1)
+    |+['no notes-response-update-1 fact emitted']~
+  =+  !<(ru=response-update:v1:n u.van)
+  ?.  ?=([%error %conflict *] body.ru)
+    |+['response-update body is not %error %conflict']~
+  ?:  (has-fact-mark caz %notes-response)
+    |+['conflicting update was still broadcast to subscribers']~
   &+[~ s]
 ::  +ex-json: assert cage has mark %json
 ::
@@ -810,7 +840,9 @@
   =+  !<(group-channel-del:n u.van)
   &+[~ s2]
 ::  ====  test-update-note-mismatched-revision-rejects  ====
-::  Stale expected-revision crashes; note still readable after.
+::  Stale expected-revision finalizes a typed %conflict response-update
+::  (not a crash, which would nack the proxying ship's poke and surface
+::  as an opaque %unknown); note untouched and still readable after.
 ::
 ++  test-update-note-mismatched-revision-rejects
   %-  eval-mare
@@ -824,12 +856,14 @@
   ;<  *  b  (poke-a [%notebook f [%create-note 2 'Note' 'v1']])
   ;<  *  b  (poke-a [%notebook f [%note 3 [%update 'v2' 0]]])
   ;<  *  b  (poke-a [%notebook f [%note 3 [%update 'v3' 1]]])
-  ::  revision is now 2; expected-revision=1 is stale — must crash
-  ;<  ~  b  (ex-fail (poke-a [%notebook f [%note 3 [%update 'v4' 1]]]))
+  ::  revision is now 2; expected-revision=1 is stale — typed %conflict
+  ;<  caz=(list card)  b  (poke-a [%notebook f [%note 3 [%update 'v4' 1]]])
+  ;<  ~  b  (ex-conflict-response caz)
   ;<  nt=cage  b  (peek-nt f 3)
   (ex-mark nt %notes-note)
 ::  ====  test-update-note-stale-zero-rejects  ====
-::  expected-revision=0 on a note with revision>0 must crash (strict, no force-update).
+::  expected-revision=0 on a note with revision>0 must reject with a
+::  typed %conflict (strict, no force-update sentinel).
 ::
 ++  test-update-note-stale-zero-rejects
   %-  eval-mare
@@ -842,8 +876,9 @@
   =/  f=flag:n  (nb-flag our.bowl 'NB' 1)
   ;<  *  b  (poke-a [%notebook f [%create-note 2 'Note' 'v1']])
   ;<  *  b  (poke-a [%notebook f [%note 3 [%update 'v2' 0]]])
-  ::  revision is now 1; expected-revision=0 is stale — must crash
-  ;<  ~  b  (ex-fail (poke-a [%notebook f [%note 3 [%update 'clobbered' 0]]]))
+  ::  revision is now 1; expected-revision=0 is stale — typed %conflict
+  ;<  caz=(list card)  b  (poke-a [%notebook f [%note 3 [%update 'clobbered' 0]]])
+  ;<  ~  b  (ex-conflict-response caz)
   ;<  nt=cage  b  (peek-nt f 3)
   (ex-mark nt %notes-note)
 ::  ====  test-update-note-at-revision-zero-succeeds  ====

--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   NotesV1PendingWriteError,
+  NotesV1WriteError,
   deleteNotesNotebookBestEffort,
   deleteNotesNotebookStrict,
   formatNotesFlag,
@@ -585,6 +586,53 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
       '/notes/~/v1/notebooks/~zod/blog/notes/12',
       'PUT',
       { body: 'x' }
+    );
+  });
+
+  test('updateNoteBody surfaces a typed conflict error with a tang message', async () => {
+    requestJsonMock.mockResolvedValue({
+      requestId: '0vconflict',
+      body: {
+        type: 'error',
+        errorType: 'conflict',
+        message: ['revision-mismatch: expected 2, current 3'],
+      },
+    });
+
+    const error = await rejectionError(
+      notesV1.updateNoteBody({
+        flag: 'notes/~zod/blog',
+        noteId: 12,
+        body: 'x',
+        expectedRevision: 2,
+      })
+    );
+
+    expect(error).toBeInstanceOf(NotesV1WriteError);
+    const writeError = error as NotesV1WriteError;
+    expect(writeError.errorType).toBe('conflict');
+    expect(writeError.message).toBe(
+      '%notes error: revision-mismatch: expected 2, current 3'
+    );
+  });
+
+  test('error envelopes without errorType still throw with a message', async () => {
+    requestJsonMock.mockResolvedValue({
+      body: { type: 'error', message: 'not-authorized' },
+    });
+
+    const error = await rejectionError(
+      notesV1.updateNoteBody({
+        flag: 'notes/~zod/blog',
+        noteId: 12,
+        body: 'x',
+      })
+    );
+
+    expect(error).toBeInstanceOf(NotesV1WriteError);
+    expect((error as NotesV1WriteError).errorType).toBeUndefined();
+    expect((error as NotesV1WriteError).message).toBe(
+      '%notes error: not-authorized'
     );
   });
 

--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -602,22 +602,33 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
   });
 
   test('note writes extract the applied note from the ok envelope', async () => {
+    // Mirrors the v1 encoder exactly: response %update wraps the
+    // notebook-scoped u-notebook ({type: 'note-update', noteUpdate}) whose
+    // inner u-note carries the applied note (lib/notes/json.hoon).
     const envelope = {
       requestId: '0vok',
       body: {
         type: 'ok',
         response: {
           type: 'update',
+          host: '~zod',
+          flagName: 'blog',
+          time: 1700000000000,
           update: {
-            type: 'note-updated',
-            id: 12,
-            note: {
+            type: 'note-update',
+            host: '~zod',
+            flagName: 'blog',
+            noteUpdate: {
+              type: 'note-updated',
               id: 12,
-              title: 'T',
-              bodyMd: 'x',
-              revision: 4,
-              updatedAt: 1234,
-              updatedBy: '~zod',
+              note: {
+                id: 12,
+                title: 'T',
+                bodyMd: 'x',
+                revision: 4,
+                updatedAt: 1234,
+                updatedBy: '~zod',
+              },
             },
           },
         },
@@ -636,13 +647,39 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
       notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 12, title: 'T' })
     ).resolves.toMatchObject({ id: 12, updatedAt: 1234 });
 
+    // A flat (unwrapped) update payload is not the wire shape — it must
+    // degrade to null rather than be mistaken for the applied note.
+    requestJsonMock.mockResolvedValue({
+      body: {
+        type: 'ok',
+        response: {
+          type: 'update',
+          update: {
+            type: 'note-updated',
+            id: 12,
+            note: { id: 12, title: 'T' },
+          },
+        },
+      },
+    });
+    await expect(
+      notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 12, title: 'T' })
+    ).resolves.toBeNull();
+
     // Malformed payloads degrade to null, never throw past a passing write.
     requestJsonMock.mockResolvedValue({
       body: {
         type: 'ok',
         response: {
           type: 'update',
-          update: { type: 'note-updated', id: 12, note: { title: 'no id' } },
+          update: {
+            type: 'note-update',
+            noteUpdate: {
+              type: 'note-updated',
+              id: 12,
+              note: { title: 'no id' },
+            },
+          },
         },
       },
     });

--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -589,6 +589,18 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     );
   });
 
+  test('updateNoteBody distinguishes applied writes from no-change', async () => {
+    requestJsonMock.mockResolvedValue({ body: { type: 'ok' } });
+    await expect(
+      notesV1.updateNoteBody({ flag: 'notes/~zod/blog', noteId: 12, body: 'x' })
+    ).resolves.toBe('ok');
+
+    requestJsonMock.mockResolvedValue({ body: { type: 'no-change' } });
+    await expect(
+      notesV1.updateNoteBody({ flag: 'notes/~zod/blog', noteId: 12, body: 'x' })
+    ).resolves.toBe('no-change');
+  });
+
   test('updateNoteBody surfaces a typed conflict error with a tang message', async () => {
     requestJsonMock.mockResolvedValue({
       requestId: '0vconflict',

--- a/packages/api/src/client/notesApi.test.ts
+++ b/packages/api/src/client/notesApi.test.ts
@@ -593,12 +593,62 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     requestJsonMock.mockResolvedValue({ body: { type: 'ok' } });
     await expect(
       notesV1.updateNoteBody({ flag: 'notes/~zod/blog', noteId: 12, body: 'x' })
-    ).resolves.toBe('ok');
+    ).resolves.toMatchObject({ status: 'ok', note: null });
 
     requestJsonMock.mockResolvedValue({ body: { type: 'no-change' } });
     await expect(
       notesV1.updateNoteBody({ flag: 'notes/~zod/blog', noteId: 12, body: 'x' })
-    ).resolves.toBe('no-change');
+    ).resolves.toMatchObject({ status: 'no-change', note: null });
+  });
+
+  test('note writes extract the applied note from the ok envelope', async () => {
+    const envelope = {
+      requestId: '0vok',
+      body: {
+        type: 'ok',
+        response: {
+          type: 'update',
+          update: {
+            type: 'note-updated',
+            id: 12,
+            note: {
+              id: 12,
+              title: 'T',
+              bodyMd: 'x',
+              revision: 4,
+              updatedAt: 1234,
+              updatedBy: '~zod',
+            },
+          },
+        },
+      },
+    };
+
+    requestJsonMock.mockResolvedValue(envelope);
+    await expect(
+      notesV1.updateNoteBody({ flag: 'notes/~zod/blog', noteId: 12, body: 'x' })
+    ).resolves.toMatchObject({
+      status: 'ok',
+      note: { id: 12, revision: 4, updatedAt: 1234, updatedBy: '~zod' },
+    });
+
+    await expect(
+      notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 12, title: 'T' })
+    ).resolves.toMatchObject({ id: 12, updatedAt: 1234 });
+
+    // Malformed payloads degrade to null, never throw past a passing write.
+    requestJsonMock.mockResolvedValue({
+      body: {
+        type: 'ok',
+        response: {
+          type: 'update',
+          update: { type: 'note-updated', id: 12, note: { title: 'no id' } },
+        },
+      },
+    });
+    await expect(
+      notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 12, title: 'T' })
+    ).resolves.toBeNull();
   });
 
   test('updateNoteBody surfaces a typed conflict error with a tang message', async () => {
@@ -730,11 +780,11 @@ describe('notesV1 writes send pinned v1 HTTP bodies', () => {
     await expect(
       notesV1.deleteNote({ flag: 'notes/~zod/blog', noteId: 1 })
     ).resolves.toBeUndefined();
-    // explicit ok envelope
+    // explicit ok envelope without an update payload → null applied note
     requestJsonMock.mockResolvedValue({ body: { type: 'ok' } });
     await expect(
       notesV1.renameNote({ flag: 'notes/~zod/blog', noteId: 1, title: 'x' })
-    ).resolves.toBeUndefined();
+    ).resolves.toBeNull();
     // error / pending / unexpected envelopes reject
     for (const body of [
       { type: 'error', message: 'nope' },

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -868,9 +868,31 @@ async function createNoteV1({
   assertWriteOk(res, noteCreateChecks(notesChannelId(normalized)));
 }
 
-// Returns whether the host applied the write: 'no-change' means the body
-// already matched and the note's revision was NOT bumped — callers tracking
-// revisions must not advance theirs.
+// The ok envelope of a note write carries the applied update
+// ({type: 'note-updated', note: {...}}) with the host's authoritative
+// revision and server-stamped updatedAt/updatedBy. Extract it when present;
+// null for no-change (no update emitted), bare bodies, or unexpected shapes.
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+function noteFromWriteEnvelope(res: any): NotesV1Note | null {
+  const update = res?.body?.response?.update;
+  if (!update || update.type !== 'note-updated' || !update.note) {
+    return null;
+  }
+  try {
+    return normalizeNoteV1(update.note);
+  } catch {
+    return null;
+  }
+}
+
+export interface NotesV1NoteWriteResult {
+  // 'no-change' means the body already matched and the note's revision was
+  // NOT bumped — callers tracking revisions must not advance theirs.
+  status: 'ok' | 'no-change';
+  // The applied note from the response payload, when the host emitted one.
+  note: NotesV1Note | null;
+}
+
 async function updateNoteBodyV1({
   flag,
   noteId,
@@ -881,7 +903,7 @@ async function updateNoteBodyV1({
   noteId: number;
   body: string;
   expectedRevision?: number;
-}): Promise<'ok' | 'no-change'> {
+}): Promise<NotesV1NoteWriteResult> {
   const normalized = normalizeNotesTarget(flag);
   const payload: { body: string; expectedRevision?: number } = { body };
   if (expectedRevision !== undefined) {
@@ -889,7 +911,10 @@ async function updateNoteBodyV1({
   }
   const res = await requestJson(noteV1Path(normalized, noteId), 'PUT', payload);
   assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
-  return res?.body?.type === 'no-change' ? 'no-change' : 'ok';
+  return {
+    status: res?.body?.type === 'no-change' ? 'no-change' : 'ok',
+    note: noteFromWriteEnvelope(res),
+  };
 }
 
 async function renameNoteV1({
@@ -900,12 +925,13 @@ async function renameNoteV1({
   flag: NotesTarget;
   noteId: number;
   title: string;
-}): Promise<void> {
+}): Promise<NotesV1Note | null> {
   const normalized = normalizeNotesTarget(flag);
   const res = await requestJson(noteV1Path(normalized, noteId), 'PUT', {
     title,
   });
   assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
+  return noteFromWriteEnvelope(res);
 }
 
 async function moveNoteV1({

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -868,6 +868,9 @@ async function createNoteV1({
   assertWriteOk(res, noteCreateChecks(notesChannelId(normalized)));
 }
 
+// Returns whether the host applied the write: 'no-change' means the body
+// already matched and the note's revision was NOT bumped — callers tracking
+// revisions must not advance theirs.
 async function updateNoteBodyV1({
   flag,
   noteId,
@@ -878,7 +881,7 @@ async function updateNoteBodyV1({
   noteId: number;
   body: string;
   expectedRevision?: number;
-}): Promise<void> {
+}): Promise<'ok' | 'no-change'> {
   const normalized = normalizeNotesTarget(flag);
   const payload: { body: string; expectedRevision?: number } = { body };
   if (expectedRevision !== undefined) {
@@ -886,6 +889,7 @@ async function updateNoteBodyV1({
   }
   const res = await requestJson(noteV1Path(normalized, noteId), 'PUT', payload);
   assertWriteOk(res, noteChecks(notesChannelId(normalized), noteId));
+  return res?.body?.type === 'no-change' ? 'no-change' : 'ok';
 }
 
 async function renameNoteV1({

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -868,18 +868,22 @@ async function createNoteV1({
   assertWriteOk(res, noteCreateChecks(notesChannelId(normalized)));
 }
 
-// The ok envelope of a note write carries the applied update
-// ({type: 'note-updated', note: {...}}) with the host's authoritative
-// revision and server-stamped updatedAt/updatedBy. Extract it when present;
-// null for no-change (no update emitted), bare bodies, or unexpected shapes.
+// The ok envelope of a note write carries the applied update, nested per
+// the u-notebook encoder: body.response.update is the notebook-scoped
+// wrapper ({type: 'note-update', noteUpdate: {...}}) and the inner
+// noteUpdate ({type: 'note-updated', note: {...}}) holds the note with the
+// host's authoritative revision and server-stamped updatedAt/updatedBy.
+// Extract it when present; null for no-change (no update emitted), bare
+// bodies, or unexpected shapes.
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 function noteFromWriteEnvelope(res: any): NotesV1Note | null {
   const update = res?.body?.response?.update;
-  if (!update || update.type !== 'note-updated' || !update.note) {
+  const noteUpdate = update?.type === 'note-update' ? update.noteUpdate : null;
+  if (!noteUpdate || noteUpdate.type !== 'note-updated' || !noteUpdate.note) {
     return null;
   }
   try {
-    return normalizeNoteV1(update.note);
+    return normalizeNoteV1(noteUpdate.note);
   } catch {
     return null;
   }

--- a/packages/api/src/client/notesApi.ts
+++ b/packages/api/src/client/notesApi.ts
@@ -288,7 +288,7 @@ export type NotesV1RequestBody =
   | { type: 'ok' }
   | { type: 'no-change' }
   | { type: 'notebook'; notebook: NotesV1NotebookSummary }
-  | { type: 'error'; message?: string }
+  | { type: 'error'; message?: string; errorType?: string }
   | { type: 'pending'; status?: string }
   | { type: 'api-key' };
 
@@ -309,6 +309,27 @@ export interface NotesV1PendingWriteErrorOptions {
   requestId?: string;
   status?: string;
   checks?: NotesV1PendingWriteCheck[];
+}
+
+// Typed failure from the %notes action-error union ('conflict',
+// 'not-authorized', 'not-found', ...). `errorType` mirrors the wire's
+// `errorType` field; 'conflict' on a note update means the expectedRevision
+// was stale (optimistic-concurrency check failed on the host).
+export class NotesV1WriteError extends Error {
+  readonly errorType?: string;
+
+  constructor(message: string, errorType?: string) {
+    super(message);
+    this.name = 'NotesV1WriteError';
+    this.errorType = errorType;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function isNotesV1ConflictError(
+  error: unknown
+): error is NotesV1WriteError {
+  return error instanceof NotesV1WriteError && error.errorType === 'conflict';
 }
 
 export class NotesV1PendingWriteError extends Error {
@@ -607,8 +628,13 @@ function normalizeRequestBodyV1(raw: any): NotesV1RequestBody {
       const message =
         body.message === undefined || body.message === null
           ? undefined
-          : String(body.message);
-      return { type: 'error', message };
+          : errorMessageText(body.message);
+      return {
+        type: 'error',
+        message,
+        errorType:
+          typeof body.errorType === 'string' ? body.errorType : undefined,
+      };
     }
     case 'pending':
       return {
@@ -632,15 +658,28 @@ function normalizeRequestStatusV1(raw: unknown): NotesV1RequestStatus {
 
 // --- envelope handling -----------------------------------------------------
 
+// The wire's `message` is a rendered tang: an array of lines. Older
+// responses may carry a plain string.
+function errorMessageText(raw: any): string {
+  if (typeof raw === 'string') {
+    return raw.trim();
+  }
+  if (Array.isArray(raw)) {
+    return raw.map(String).join('\n').trim();
+  }
+  return raw === undefined || raw === null ? '' : String(raw).trim();
+}
+
 function notesEnvelopeErrorMessage(body: any): string {
-  const raw = body?.message;
-  const detail =
-    typeof raw === 'string'
-      ? raw.trim()
-      : raw === undefined || raw === null
-        ? ''
-        : String(raw).trim();
+  const detail = errorMessageText(body?.message);
   return `%notes error: ${detail || 'backend returned an error without details'}`;
+}
+
+function notesEnvelopeError(body: any): NotesV1WriteError {
+  return new NotesV1WriteError(
+    notesEnvelopeErrorMessage(body),
+    typeof body?.errorType === 'string' ? body.errorType : undefined
+  );
 }
 
 function envelopeRequestId(res: any): string | undefined {
@@ -710,7 +749,7 @@ function unwrapNotebookEnvelope(
     case 'notebook':
       return normalizeNotebookSummaryV1(requireObject(body.notebook));
     case 'error':
-      throw new Error(notesEnvelopeErrorMessage(body));
+      throw notesEnvelopeError(body);
     case 'pending':
       throw pendingWriteError(res, checks);
     default:
@@ -733,7 +772,7 @@ function assertWriteOk(res: any, checks: NotesV1PendingWriteCheck[]): void {
     case 'notebook':
       return;
     case 'error':
-      throw new Error(notesEnvelopeErrorMessage(body));
+      throw notesEnvelopeError(body);
     case 'pending':
       throw pendingWriteError(res, checks);
     default:

--- a/packages/app/ui/components/NotesChannel/NotesFeedback.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesFeedback.tsx
@@ -55,9 +55,11 @@ export function confirmNotesDestructiveAction({
 export function NotesBanner({
   message,
   tone = 'neutral',
+  actions,
 }: {
   message: string;
   tone?: 'neutral' | 'negative';
+  actions?: { label: string; onPress: () => void }[];
 }) {
   const isNegative = tone === 'negative';
   const [showDetails, setShowDetails] = useState(false);
@@ -92,6 +94,17 @@ export function NotesBanner({
         >
           {displayMessage.message}
         </Text>
+        {actions?.map((action) => (
+          <Pressable key={action.label} onPress={action.onPress}>
+            <Text
+              size="$label/s"
+              fontWeight="600"
+              color={isNegative ? '$negativeActionText' : '$secondaryText'}
+            >
+              {action.label}
+            </Text>
+          </Pressable>
+        ))}
         {displayMessage.details ? (
           <Pressable onPress={() => setShowDetails((showing) => !showing)}>
             <Text

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -771,6 +771,17 @@ export function NotesNoteDetail({
         // reportConflict drops it if the selection has since moved on.
         if (e instanceof NotesNoteConflictError) {
           reportConflict(flag, e);
+          return;
+        }
+        // Non-conflict failures (e.g. an unclassifiable conflict from a
+        // lagging replica) must not fail silently either: while this note
+        // is still in the editor, show the error so autosave/user retries.
+        // After unmount the durable stash carries the edits, and the
+        // stash-restore pass surfaces a conflict if the note moved on.
+        const ctx = flushCtxRef.current;
+        if (ctx?.flag === flag && ctx.base?.noteId === base.noteId) {
+          setSaveState('error');
+          setError(errorMessage(e, 'Failed to save note'));
         }
       });
   }, [clearConflict, preserveScrollOffset, reportConflict, runSave]);
@@ -809,6 +820,12 @@ export function NotesNoteDetail({
   // clean too, but its restore pass hasn't run yet, so its stash survives.
   useEffect(() => {
     if (!notebookFlag || !draftBase) return;
+    // While a conflict is pending, leave the stash alone. A restored
+    // conflict pairs old drafts with the row's newer base — re-stashing
+    // would stamp them with the new baseRevision, and a restart would then
+    // restore them as ordinary drafts whose autosave silently overwrites
+    // the remote work the conflict was protecting.
+    if (conflictNote) return;
     if (!isDirty) {
       if (stashRestoreCheckedRef.current === stashRestoreKey) {
         clearDraftStash(notebookFlag, draftBase.noteId);
@@ -826,6 +843,7 @@ export function NotesNoteDetail({
     }));
   }, [
     bodyDraft,
+    conflictNote,
     draftBase,
     isDirty,
     notebookFlag,
@@ -835,8 +853,7 @@ export function NotesNoteDetail({
 
   // Restore a stashed draft after a crash/kill. Only restore while the
   // editor is clean and the row is still at the stash's base revision —
-  // then pushing the restored draft can't clobber anyone's newer work. A
-  // stash from an older revision is superseded; drop it.
+  // then pushing the restored draft can't clobber anyone's newer work.
   useEffect(() => {
     if (!notebookFlag || !draftBase || isDirty || !stashRestoreKey) return;
     if (stashRestoreCheckedRef.current === stashRestoreKey) return;
@@ -846,7 +863,29 @@ export function NotesNoteDetail({
       const stash = stashes[draftStashKey(notebookFlag, draftBase.noteId)];
       if (cancelled || !stash) return;
       if (stash.baseRevision !== draftBase.revision) {
-        clearDraftStash(notebookFlag, draftBase.noteId);
+        if (
+          stash.title === draftBase.title &&
+          stash.body === draftBase.bodyMd
+        ) {
+          // The stashed content is exactly what the row now holds — the
+          // save landed (e.g. a late flush succeeded). Nothing to recover.
+          clearDraftStash(notebookFlag, draftBase.noteId);
+          return;
+        }
+        // The stashed edits never landed and the note moved on (a flush
+        // hit a conflict and the session ended before recovery could run).
+        // Restoring them as plain drafts would be worse than dropping
+        // them: their base revision is now current, so the next autosave
+        // would silently overwrite the newer remote work. Surface it as
+        // the standing conflict it is — row as "theirs", stash as "mine" —
+        // which also suspends autosave until the user picks a side.
+        setTitleDraft(stash.title);
+        setBodyDraft(stash.body);
+        setConflictNote(draftBase);
+        setError(
+          'This note was changed elsewhere. Your unsaved changes are kept.'
+        );
+        setSaveState('error');
         return;
       }
       if (stash.title !== draftBase.title || stash.body !== draftBase.bodyMd) {

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -648,11 +648,20 @@ export function NotesNoteDetail({
   const resolveConflictUseTheirs = useCallback(() => {
     if (!conflictNote || !draftBase || !notebookFlag) return;
     const adopted = rebaseDraftOnConflict(draftBase, conflictNote);
+    const discardedBody = bodyDraftRef.current;
     setConflictNote(null);
     setError(null);
     setDraftBase(adopted);
     setTitleDraft(adopted.title);
     setBodyDraft(adopted.bodyMd);
+    // Sync the out-of-band flush inputs in the same tick. The draft refs
+    // and flush context normally catch up in post-commit effects; a
+    // background/unmount flush firing inside that gap would pair the
+    // discarded drafts with the pre-adoption base and queue a save of the
+    // very content the user just chose to throw away.
+    titleDraftRef.current = adopted.title;
+    bodyDraftRef.current = adopted.bodyMd;
+    flushCtxRef.current = { flag: notebookFlag, base: adopted, canEdit };
     // Persist the host's copy locally so the reactive row catches up with
     // the adoption instead of reloading the stale pre-conflict content
     // over it. (The draft-loading effect also skips rows that trail the
@@ -662,16 +671,17 @@ export function NotesNoteDetail({
     // restore effect would resurrect them against the adopted revision.
     clearDraftStash(notebookFlag, draftBase.noteId, {
       title: titleDraft,
-      body: bodyDraftRef.current,
+      body: discardedBody,
     });
     clearMatchingNotesNoteDraftSnapshot({
       notebookFlag,
       noteId: draftBase.noteId,
       title: titleDraft,
-      body: bodyDraftRef.current,
+      body: discardedBody,
     });
     setSaveState('idle');
   }, [
+    canEdit,
     conflictNote,
     draftBase,
     notebookFlag,

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -1,4 +1,5 @@
 import {
+  NotesNoteConflictError,
   convertContent,
   markdownToStory,
   normalizeNotebookNoteTitle,
@@ -241,6 +242,13 @@ export function NotesNoteDetail({
   const [bodyInputWidth, setBodyInputWidth] = useState(0);
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [error, setError] = useState<string | null>(null);
+  // The host's copy of the note after a save hit a genuine revision
+  // conflict. While set, autosave is suspended and the banner offers the
+  // user the resolution (keep mine / use theirs) — a blind retry can never
+  // succeed since the editor's base revision is stale by definition.
+  const [conflictNote, setConflictNote] = useState<
+    NotesNoteConflictError['remoteNote'] | null
+  >(null);
   const [isPreviewing, setPreviewMode] = useNotePreviewMode(
     notebookFlag,
     noteId,
@@ -432,6 +440,7 @@ export function NotesNoteDetail({
     if (!sameNote) {
       setSaveState('idle');
       setError(null);
+      setConflictNote(null);
     }
   }, [draftBase, isDirty, preserveScrollOffset, selectedNote]);
 
@@ -484,68 +493,132 @@ export function NotesNoteDetail({
     []
   );
 
-  const saveSelectedNote = useCallback(async () => {
-    if (!notebookFlag || !draftBase || !canEdit) return false;
-    const bodyToSave = bodyDraftRef.current;
-    const dirty =
-      normalizeNotebookNoteTitle(titleDraft) !== draftBase.title ||
-      bodyToSave !== draftBase.bodyMd;
-    if (!dirty) return true;
-    preserveScrollOffset();
-    setSaveState('saving');
+  const saveSelectedNote = useCallback(
+    async (baseOverride?: db.NotesNote) => {
+      const base = baseOverride ?? draftBase;
+      if (!notebookFlag || !base || !canEdit) return false;
+      const bodyToSave = bodyDraftRef.current;
+      const dirty =
+        normalizeNotebookNoteTitle(titleDraft) !== base.title ||
+        bodyToSave !== base.bodyMd;
+      if (!dirty) return true;
+      preserveScrollOffset();
+      setSaveState('saving');
+      setError(null);
+      rememberNotesNoteDraftSnapshot({
+        notebookFlag,
+        noteId: base.noteId,
+        title: titleDraft,
+        body: bodyToSave,
+        isDirty: true,
+        updatedAt: Date.now(),
+      });
+      try {
+        const updated = await runSave(
+          notebookFlag,
+          base,
+          titleDraft,
+          bodyToSave
+        );
+        // Rebase onto the saved revision; keystrokes typed during the save
+        // leave the drafts dirty against it, so the next cycle saves them.
+        if (updated) {
+          setDraftBase(updated);
+        }
+        clearDraftStash(notebookFlag, base.noteId, {
+          title: titleDraft,
+          body: bodyToSave,
+        });
+        clearMatchingNotesNoteDraftSnapshot({
+          notebookFlag,
+          noteId: base.noteId,
+          title: titleDraft,
+          body: bodyToSave,
+        });
+        setSaveState('saved');
+        return true;
+      } catch (e) {
+        setSaveState('error');
+        const message = errorMessage(e, 'Failed to save note');
+        trackNotesActionError('save note', e, message, {
+          noteId: base.noteId,
+        });
+        setError(message);
+        if (e instanceof NotesNoteConflictError) {
+          setConflictNote(e.remoteNote);
+        }
+        return false;
+      }
+    },
+    [
+      canEdit,
+      draftBase,
+      notebookFlag,
+      preserveScrollOffset,
+      runSave,
+      titleDraft,
+    ]
+  );
+
+  // Genuine conflict resolution, mirroring the ship-served notes app: the
+  // user picks a side. "Keep mine" rebases the editor's base onto the
+  // host's copy (so the next save asserts the host revision) and saves the
+  // drafts over it; "Use theirs" adopts the host's copy and discards the
+  // local drafts.
+  const rebaseDraftOnConflict = useCallback(
+    (base: db.NotesNote, remote: NotesNoteConflictError['remoteNote']) => ({
+      ...base,
+      title: remote.title ?? base.title,
+      bodyMd: remote.bodyMd ?? base.bodyMd,
+      revision: remote.revision ?? base.revision,
+      updatedAt: remote.updatedAt ?? base.updatedAt,
+      updatedBy: remote.updatedBy ?? base.updatedBy,
+    }),
+    []
+  );
+
+  const resolveConflictKeepMine = useCallback(() => {
+    if (!conflictNote || !draftBase) return;
+    const rebased = rebaseDraftOnConflict(draftBase, conflictNote);
+    setConflictNote(null);
     setError(null);
-    rememberNotesNoteDraftSnapshot({
+    setDraftBase(rebased);
+    void saveSelectedNote(rebased);
+  }, [conflictNote, draftBase, rebaseDraftOnConflict, saveSelectedNote]);
+
+  const resolveConflictUseTheirs = useCallback(() => {
+    if (!conflictNote || !draftBase || !notebookFlag) return;
+    const adopted = rebaseDraftOnConflict(draftBase, conflictNote);
+    setConflictNote(null);
+    setError(null);
+    setDraftBase(adopted);
+    setTitleDraft(adopted.title);
+    setBodyDraft(adopted.bodyMd);
+    // Drop the crash-insurance stashes for the discarded drafts, or the
+    // restore effect would resurrect them against the adopted revision.
+    clearDraftStash(notebookFlag, draftBase.noteId, {
+      title: titleDraft,
+      body: bodyDraftRef.current,
+    });
+    clearMatchingNotesNoteDraftSnapshot({
       notebookFlag,
       noteId: draftBase.noteId,
       title: titleDraft,
-      body: bodyToSave,
-      isDirty: true,
-      updatedAt: Date.now(),
+      body: bodyDraftRef.current,
     });
-    try {
-      const updated = await runSave(
-        notebookFlag,
-        draftBase,
-        titleDraft,
-        bodyToSave
-      );
-      // Rebase onto the saved revision; keystrokes typed during the save
-      // leave the drafts dirty against it, so the next cycle saves them.
-      if (updated) {
-        setDraftBase(updated);
-      }
-      clearDraftStash(notebookFlag, draftBase.noteId, {
-        title: titleDraft,
-        body: bodyToSave,
-      });
-      clearMatchingNotesNoteDraftSnapshot({
-        notebookFlag,
-        noteId: draftBase.noteId,
-        title: titleDraft,
-        body: bodyToSave,
-      });
-      setSaveState('saved');
-      return true;
-    } catch (e) {
-      setSaveState('error');
-      const message = errorMessage(e, 'Failed to save note');
-      trackNotesActionError('save note', e, message, {
-        noteId: draftBase.noteId,
-      });
-      setError(message);
-      return false;
-    }
+    setSaveState('idle');
   }, [
-    canEdit,
+    conflictNote,
     draftBase,
     notebookFlag,
-    preserveScrollOffset,
-    runSave,
+    rebaseDraftOnConflict,
     titleDraft,
   ]);
 
   useEffect(() => {
-    if (!canEdit || saveState === 'saving') return;
+    // A pending conflict suspends autosave: retrying against a stale base
+    // can never succeed, and the user hasn't picked a side yet.
+    if (!canEdit || saveState === 'saving' || conflictNote) return;
     if (!isDirty) {
       // Edits were reverted back to the saved content; there's nothing to
       // save, so don't leave a stale "Not synced" showing.
@@ -559,7 +632,7 @@ export function NotesNoteDetail({
       saveSelectedNote();
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(timeout);
-  }, [canEdit, isDirty, saveSelectedNote, saveState]);
+  }, [canEdit, conflictNote, isDirty, saveSelectedNote, saveState]);
 
   // Save target for flushes that run outside the React data flow (unmount
   // cleanup, AppState changes). Synced in an effect so a selection-change
@@ -616,7 +689,15 @@ export function NotesNoteDetail({
         }
         setSaveState('saved');
       })
-      .catch(() => {});
+      .catch((e) => {
+        // No-ops after unmount; while mounted, surface a conflict so the
+        // resolution banner appears instead of a silently-failed flush.
+        if (e instanceof NotesNoteConflictError) {
+          setConflictNote(e.remoteNote);
+          setError(e.message);
+          setSaveState('error');
+        }
+      });
   }, [preserveScrollOffset, runSave]);
 
   // Flush unsaved work when switching notes or unmounting — the poke
@@ -818,7 +899,20 @@ export function NotesNoteDetail({
 
   return (
     <YStack flex={1} backgroundColor="$background">
-      {error ? <NotesBanner message={error} tone="negative" /> : null}
+      {error ? (
+        <NotesBanner
+          message={error}
+          tone="negative"
+          actions={
+            conflictNote
+              ? [
+                  { label: 'Keep mine', onPress: resolveConflictKeepMine },
+                  { label: 'Use theirs', onPress: resolveConflictUseTheirs },
+                ]
+              : undefined
+          }
+        />
+      ) : null}
       <ScrollView
         ref={scrollViewRef}
         flex={1}

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -629,6 +629,7 @@ export function NotesNoteDetail({
       ...base,
       title: remote.title ?? base.title,
       bodyMd: remote.bodyMd ?? base.bodyMd,
+      folderId: remote.folderId ?? base.folderId,
       revision: remote.revision ?? base.revision,
       updatedAt: remote.updatedAt ?? base.updatedAt,
       updatedBy: remote.updatedBy ?? base.updatedBy,

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -543,6 +543,21 @@ export function NotesNoteDetail({
     []
   );
 
+  // Counterpart to reportConflict: a save that SUCCEEDS for the current
+  // note supersedes any conflict still showing. The save chain is FIFO, so
+  // a stale queued save (e.g. a background flush from before a "Keep mine"
+  // resolution) can reject and re-arm the banner after the resolution
+  // cleared it; without this, the banner sticks and autosave stays
+  // suspended even though the rebased save landed.
+  const clearConflict = useCallback((flag: string, noteId: number) => {
+    const ctx = flushCtxRef.current;
+    if (!ctx || ctx.flag !== flag || ctx.base?.noteId !== noteId) {
+      return;
+    }
+    setConflictNote(null);
+    setError(null);
+  }, []);
+
   const saveSelectedNote = useCallback(
     async (baseOverride?: db.NotesNote) => {
       const base = baseOverride ?? draftBase;
@@ -586,6 +601,7 @@ export function NotesNoteDetail({
           body: bodyToSave,
         });
         setSaveState('saved');
+        clearConflict(notebookFlag, base.noteId);
         return true;
       } catch (e) {
         const message = errorMessage(e, 'Failed to save note');
@@ -610,6 +626,7 @@ export function NotesNoteDetail({
     },
     [
       canEdit,
+      clearConflict,
       draftBase,
       notebookFlag,
       preserveScrollOffset,
@@ -746,6 +763,7 @@ export function NotesNoteDetail({
           setDraftBase(updated);
         }
         setSaveState('saved');
+        clearConflict(flag, base.noteId);
       })
       .catch((e) => {
         // No-ops after unmount; while mounted, surface a conflict so the
@@ -755,7 +773,7 @@ export function NotesNoteDetail({
           reportConflict(flag, e);
         }
       });
-  }, [preserveScrollOffset, reportConflict, runSave]);
+  }, [clearConflict, preserveScrollOffset, reportConflict, runSave]);
 
   // Flush unsaved work when switching notes or unmounting — the poke
   // outlives the component.

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -666,7 +666,6 @@ export function NotesNoteDetail({
   const resolveConflictUseTheirs = useCallback(() => {
     if (!conflictNote || !draftBase || !notebookFlag) return;
     const adopted = rebaseDraftOnConflict(draftBase, conflictNote);
-    const discardedBody = bodyDraftRef.current;
     setConflictNote(null);
     setError(null);
     setDraftBase(adopted);
@@ -685,27 +684,16 @@ export function NotesNoteDetail({
     // over it. (The draft-loading effect also skips rows that trail the
     // base revision, covering the render gap until this write lands.)
     void adoptNotebookNoteRemote({ notebookFlag, remote: conflictNote });
-    // Drop the crash-insurance stashes for the discarded drafts, or the
-    // restore effect would resurrect them against the adopted revision.
-    clearDraftStash(notebookFlag, draftBase.noteId, {
-      title: titleDraft,
-      body: discardedBody,
-    });
-    clearMatchingNotesNoteDraftSnapshot({
-      notebookFlag,
-      noteId: draftBase.noteId,
-      title: titleDraft,
-      body: discardedBody,
-    });
+    // Drop this note's crash-insurance stashes unconditionally: the user
+    // just discarded the local side. A content-matched clear would miss a
+    // stash frozen at the PRE-conflict draft (the stash writer pauses
+    // while the banner is up, so typing during it leaves the stash stale),
+    // and the restore effect would resurrect that discarded text as a
+    // fresh conflict.
+    clearDraftStash(notebookFlag, draftBase.noteId);
+    clearNotesNoteDraftSnapshot(notebookFlag, draftBase.noteId);
     setSaveState('idle');
-  }, [
-    canEdit,
-    conflictNote,
-    draftBase,
-    notebookFlag,
-    rebaseDraftOnConflict,
-    titleDraft,
-  ]);
+  }, [canEdit, conflictNote, draftBase, notebookFlag, rebaseDraftOnConflict]);
 
   useEffect(() => {
     // A pending conflict suspends autosave: retrying against a stale base

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -588,14 +588,22 @@ export function NotesNoteDetail({
         setSaveState('saved');
         return true;
       } catch (e) {
-        setSaveState('error');
         const message = errorMessage(e, 'Failed to save note');
         trackNotesActionError('save note', e, message, {
           noteId: base.noteId,
         });
-        setError(message);
         if (e instanceof NotesNoteConflictError) {
           reportConflict(notebookFlag, e);
+          return false;
+        }
+        // Only surface the failure while its note is still in the editor —
+        // an autosave that rejects after the user switched notes must not
+        // mark the newly-selected note as failed. (reportConflict applies
+        // the same guard for conflicts.)
+        const ctx = flushCtxRef.current;
+        if (ctx?.flag === notebookFlag && ctx.base?.noteId === base.noteId) {
+          setSaveState('error');
+          setError(message);
         }
         return false;
       }

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -1,5 +1,6 @@
 import {
   NotesNoteConflictError,
+  adoptNotebookNoteRemote,
   convertContent,
   markdownToStory,
   normalizeNotebookNoteTitle,
@@ -430,7 +431,18 @@ export function NotesNoteDetail({
   // overwriting the remote work.
   useEffect(() => {
     const sameNote = (selectedNote?.id ?? null) === (draftBase?.id ?? null);
-    if (sameNote && (isDirty || selectedNote === draftBase)) return;
+    // Never adopt a row that trails the base's revision: right after a save
+    // or a conflict resolution the reactive row lags the persisted write by
+    // a render or two, and reloading it would regress the editor onto stale
+    // content and a stale revision.
+    const rowTrailsBase =
+      sameNote &&
+      selectedNote != null &&
+      draftBase != null &&
+      selectedNote.revision < draftBase.revision;
+    if (sameNote && (isDirty || selectedNote === draftBase || rowTrailsBase)) {
+      return;
+    }
     if (sameNote) {
       preserveScrollOffset();
     }
@@ -493,6 +505,44 @@ export function NotesNoteDetail({
     []
   );
 
+  // Save target for flushes that run outside the React data flow (unmount
+  // cleanup, AppState changes). Synced in an effect so a selection-change
+  // cleanup still sees the previous note as its base rather than the new
+  // render's; the draft refs lag in step, keeping base and drafts paired.
+  const flushCtxRef = useRef<{
+    flag: string | null | undefined;
+    base: db.NotesNote | null;
+    canEdit: boolean;
+  } | null>(null);
+  useEffect(() => {
+    flushCtxRef.current = {
+      flag: notebookFlag,
+      base: draftBase,
+      canEdit,
+    };
+  });
+
+  // A conflict from an async save is only actionable while its note is
+  // still the one in the editor. A note-switch flush can reject after the
+  // selection moved on; resolving that stale conflict would rebase the
+  // newly-selected note with the old note's content, so drop it instead.
+  const reportConflict = useCallback(
+    (flag: string, conflict: NotesNoteConflictError) => {
+      const ctx = flushCtxRef.current;
+      if (
+        !ctx ||
+        ctx.flag !== flag ||
+        ctx.base?.noteId !== conflict.remoteNote.noteId
+      ) {
+        return;
+      }
+      setConflictNote(conflict.remoteNote);
+      setError(conflict.message);
+      setSaveState('error');
+    },
+    []
+  );
+
   const saveSelectedNote = useCallback(
     async (baseOverride?: db.NotesNote) => {
       const base = baseOverride ?? draftBase;
@@ -545,7 +595,7 @@ export function NotesNoteDetail({
         });
         setError(message);
         if (e instanceof NotesNoteConflictError) {
-          setConflictNote(e.remoteNote);
+          reportConflict(notebookFlag, e);
         }
         return false;
       }
@@ -555,6 +605,7 @@ export function NotesNoteDetail({
       draftBase,
       notebookFlag,
       preserveScrollOffset,
+      reportConflict,
       runSave,
       titleDraft,
     ]
@@ -594,6 +645,11 @@ export function NotesNoteDetail({
     setDraftBase(adopted);
     setTitleDraft(adopted.title);
     setBodyDraft(adopted.bodyMd);
+    // Persist the host's copy locally so the reactive row catches up with
+    // the adoption instead of reloading the stale pre-conflict content
+    // over it. (The draft-loading effect also skips rows that trail the
+    // base revision, covering the render gap until this write lands.)
+    void adoptNotebookNoteRemote({ notebookFlag, remote: conflictNote });
     // Drop the crash-insurance stashes for the discarded drafts, or the
     // restore effect would resurrect them against the adopted revision.
     clearDraftStash(notebookFlag, draftBase.noteId, {
@@ -633,23 +689,6 @@ export function NotesNoteDetail({
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(timeout);
   }, [canEdit, conflictNote, isDirty, saveSelectedNote, saveState]);
-
-  // Save target for flushes that run outside the React data flow (unmount
-  // cleanup, AppState changes). Synced in an effect so a selection-change
-  // cleanup still sees the previous note as its base rather than the new
-  // render's; the draft refs lag in step, keeping base and drafts paired.
-  const flushCtxRef = useRef<{
-    flag: string | null | undefined;
-    base: db.NotesNote | null;
-    canEdit: boolean;
-  } | null>(null);
-  useEffect(() => {
-    flushCtxRef.current = {
-      flag: notebookFlag,
-      base: draftBase,
-      canEdit,
-    };
-  });
 
   const flushPendingSave = useCallback(() => {
     const bodyToSave = bodyDraftRef.current;
@@ -692,13 +731,12 @@ export function NotesNoteDetail({
       .catch((e) => {
         // No-ops after unmount; while mounted, surface a conflict so the
         // resolution banner appears instead of a silently-failed flush.
+        // reportConflict drops it if the selection has since moved on.
         if (e instanceof NotesNoteConflictError) {
-          setConflictNote(e.remoteNote);
-          setError(e.message);
-          setSaveState('error');
+          reportConflict(flag, e);
         }
       });
-  }, [preserveScrollOffset, runSave]);
+  }, [preserveScrollOffset, reportConflict, runSave]);
 
   // Flush unsaved work when switching notes or unmounting — the poke
   // outlives the component.

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -589,6 +589,22 @@ export function NotesNoteDetail({
         // leave the drafts dirty against it, so the next cycle saves them.
         if (updated) {
           setDraftBase(updated);
+          // A save we did NOT rename in can come back with a different
+          // title: another client renamed, and the response payload's
+          // authoritative note carried it into `updated`. The untouched
+          // title draft still holds the old title — left alone it reads as
+          // a local edit and the next autosave would rename the host note
+          // BACK, silently undoing the other client's rename. Rebase it,
+          // but only when the user had no rename in flight (title matched
+          // the base going in) and didn't touch it during the save.
+          if (
+            normalizeNotebookNoteTitle(titleDraft) === base.title &&
+            titleDraftRef.current === titleDraft &&
+            updated.title !== titleDraft
+          ) {
+            setTitleDraft(updated.title);
+            titleDraftRef.current = updated.title;
+          }
         }
         clearDraftStash(notebookFlag, base.noteId, {
           title: titleDraft,
@@ -769,6 +785,17 @@ export function NotesNoteDetail({
         // the next cycle doesn't re-send a stale revision.
         if (updated) {
           setDraftBase(updated);
+          // Same untouched-title rebase as the foreground save path: a
+          // remote rename carried back by the payload must not leave the
+          // stale title draft looking like a local edit.
+          if (
+            normalizeNotebookNoteTitle(titleToSave) === base.title &&
+            titleDraftRef.current === titleToSave &&
+            updated.title !== titleToSave
+          ) {
+            setTitleDraft(updated.title);
+            titleDraftRef.current = updated.title;
+          }
         }
         setSaveState('saved');
         clearConflict(flag, base.noteId);

--- a/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
+++ b/packages/app/ui/components/NotesChannel/NotesNoteDetail.tsx
@@ -655,13 +655,33 @@ export function NotesNoteDetail({
   );
 
   const resolveConflictKeepMine = useCallback(() => {
-    if (!conflictNote || !draftBase) return;
+    if (!conflictNote || !draftBase || !notebookFlag) return;
     const rebased = rebaseDraftOnConflict(draftBase, conflictNote);
     setConflictNote(null);
     setError(null);
     setDraftBase(rebased);
+    // Re-stamp the durable stash against the rebased base in the same tick.
+    // The stash writer pauses while a banner is up, so the stash may still
+    // hold the pre-conflict draft; if it survived the save's content-matched
+    // clear, the restore pass would resurrect that obsolete draft as a
+    // ghost conflict.
+    void db.notesNoteDrafts.setValue((stashes) => ({
+      ...stashes,
+      [draftStashKey(notebookFlag, rebased.noteId)]: {
+        title: titleDraftRef.current,
+        body: bodyDraftRef.current,
+        baseRevision: rebased.revision,
+        stashedAt: Date.now(),
+      },
+    }));
     void saveSelectedNote(rebased);
-  }, [conflictNote, draftBase, rebaseDraftOnConflict, saveSelectedNote]);
+  }, [
+    conflictNote,
+    draftBase,
+    notebookFlag,
+    rebaseDraftOnConflict,
+    saveSelectedNote,
+  ]);
 
   const resolveConflictUseTheirs = useCallback(() => {
     if (!conflictNote || !draftBase || !notebookFlag) return;

--- a/packages/app/ui/components/SystemNotices.tsx
+++ b/packages/app/ui/components/SystemNotices.tsx
@@ -178,8 +178,8 @@ export function ContactBookPrompt(props: {
         <YStack gap="$xl">
           <NoticeTitle>Find Friends</NoticeTitle>
           <NoticeBody>
-            Sync your contact book to easily find people you know on Tlon.
-            Your contacts are never uploaded — we only send anonymous, hashed
+            Sync your contact book to easily find people you know on Tlon. Your
+            contacts are never uploaded — we only send anonymous, hashed
             identifiers to our server to match you with people you know.
           </NoticeBody>
         </YStack>

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -2417,9 +2417,8 @@ function ConnectContactBookContent(props: {
           </SplashParagraph>
           {shouldShowConnectOption && (
             <SplashParagraph fontWeight="600" color="$primaryText">
-              Your contacts are never uploaded — we only send anonymous,
-              hashed identifiers to our server to match you with people you
-              know.
+              Your contacts are never uploaded — we only send anonymous, hashed
+              identifiers to our server to match you with people you know.
             </SplashParagraph>
           )}
         </ScrollView>

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -555,6 +555,37 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
   ['notesNotebooks', 'notesFolders', 'notesNotes', 'notesMembers']
 );
 
+export const updateNotesNote = createWriteQuery(
+  'updateNotesNote',
+  async (
+    {
+      notebookFlag,
+      noteId,
+      ...update
+    }: {
+      notebookFlag: string;
+      noteId: number;
+    } & Partial<
+      Pick<
+        NotesNote,
+        'bodyMd' | 'revision' | 'title' | 'updatedAt' | 'updatedBy'
+      >
+    >,
+    ctx: QueryCtx
+  ) => {
+    return ctx.db
+      .update($notesNotes)
+      .set(update)
+      .where(
+        and(
+          eq($notesNotes.notebookFlag, notebookFlag),
+          eq($notesNotes.noteId, noteId)
+        )
+      );
+  },
+  ['notesNotes']
+);
+
 export const deleteNotesNote = createWriteQuery(
   'deleteNotesNote',
   async (

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -530,27 +530,24 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
       );
 
       // Snapshots race the save path's immediate write-through (which
-      // persists body + revision the moment a note PUT succeeds): a sync
-      // that fetched before the save but lands after it would silently
-      // regress the row. Revisions are monotonic per note, so an incoming
-      // revision below the stored one proves the snapshot is stale for
-      // that note — keep the locally persisted fields. Read inside the
-      // transaction so the comparison can't itself race the write-through.
-      const currentNotes = await txCtx.db
-        .select({
-          noteId: $notesNotes.noteId,
-          bodyMd: $notesNotes.bodyMd,
-          revision: $notesNotes.revision,
-        })
-        .from($notesNotes)
-        .where(eq($notesNotes.notebookFlag, notebook.id));
+      // persists a note the moment a PUT succeeds): a sync that fetched
+      // before the save but lands after it would silently regress the row.
+      // Revisions are monotonic per note, so an incoming revision below the
+      // stored one proves the snapshot is stale for that note — keep the
+      // stored row wholesale. Splicing only some newer fields onto the
+      // stale copy would fabricate a row that never existed on the host
+      // (e.g. new revision + old title). Read inside the transaction so
+      // the comparison can't itself race the write-through.
+      const currentNotes = await txCtx.db.query.notesNotes.findMany({
+        where: eq($notesNotes.notebookFlag, notebook.id),
+      });
       const currentByNoteId = new Map(
         currentNotes.map((note) => [note.noteId, note])
       );
       const mergedNotes = notes.map((incoming) => {
         const current = currentByNoteId.get(incoming.noteId);
         return current && current.revision > incoming.revision
-          ? { ...incoming, bodyMd: current.bodyMd, revision: current.revision }
+          ? { ...current, syncedAt: incoming.syncedAt }
           : incoming;
       });
 

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -529,11 +529,36 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
         NOTES_SNAPSHOT_BATCH_SIZE
       );
 
+      // Snapshots race the save path's immediate write-through (which
+      // persists body + revision the moment a note PUT succeeds): a sync
+      // that fetched before the save but lands after it would silently
+      // regress the row. Revisions are monotonic per note, so an incoming
+      // revision below the stored one proves the snapshot is stale for
+      // that note — keep the locally persisted fields. Read inside the
+      // transaction so the comparison can't itself race the write-through.
+      const currentNotes = await txCtx.db
+        .select({
+          noteId: $notesNotes.noteId,
+          bodyMd: $notesNotes.bodyMd,
+          revision: $notesNotes.revision,
+        })
+        .from($notesNotes)
+        .where(eq($notesNotes.notebookFlag, notebook.id));
+      const currentByNoteId = new Map(
+        currentNotes.map((note) => [note.noteId, note])
+      );
+      const mergedNotes = notes.map((incoming) => {
+        const current = currentByNoteId.get(incoming.noteId);
+        return current && current.revision > incoming.revision
+          ? { ...incoming, bodyMd: current.bodyMd, revision: current.revision }
+          : incoming;
+      });
+
       await txCtx.db
         .delete($notesNotes)
         .where(eq($notesNotes.notebookFlag, notebook.id));
       await batchAction(
-        notes,
+        mergedNotes,
         async (batch) => {
           await txCtx.db.insert($notesNotes).values(batch);
         },

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -597,7 +597,7 @@ export const updateNotesNote = createWriteQuery(
     } & Partial<
       Pick<
         NotesNote,
-        'bodyMd' | 'revision' | 'title' | 'updatedAt' | 'updatedBy'
+        'bodyMd' | 'folderId' | 'revision' | 'title' | 'updatedAt' | 'updatedBy'
       >
     >,
     ctx: QueryCtx

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -544,9 +544,16 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
       const currentByNoteId = new Map(
         currentNotes.map((note) => [note.noteId, note])
       );
+      // Renames and moves don't bump the revision, so equal revisions are
+      // ordered by updatedAt (both stamped by the host clock).
       const mergedNotes = notes.map((incoming) => {
         const current = currentByNoteId.get(incoming.noteId);
-        return current && current.revision > incoming.revision
+        const currentIsNewer =
+          current &&
+          (current.revision > incoming.revision ||
+            (current.revision === incoming.revision &&
+              (current.updatedAt ?? 0) > (incoming.updatedAt ?? 0)));
+        return currentIsNewer
           ? { ...current, syncedAt: incoming.syncedAt }
           : incoming;
       });

--- a/packages/shared/src/db/queries.ts
+++ b/packages/shared/src/db/queries.ts
@@ -584,6 +584,14 @@ export const saveNotesNotebookSnapshot = createWriteQuery(
   ['notesNotebooks', 'notesFolders', 'notesNotes', 'notesMembers']
 );
 
+// Revision-monotonic note write. When the update carries a `revision`, the
+// row is only written if it hasn't already advanced past it (equal revisions
+// break ties on `updatedAt` when the update carries one, mirroring the
+// snapshot merge — renames/moves don't bump the revision). The guard lives
+// in the UPDATE's WHERE clause so the comparison and the write are one
+// atomic statement: a check-then-write across separate queries would race
+// concurrent sync writes. Updates without a `revision` (metadata-only
+// fallbacks) apply unconditionally.
 export const updateNotesNote = createWriteQuery(
   'updateNotesNote',
   async (
@@ -602,15 +610,29 @@ export const updateNotesNote = createWriteQuery(
     >,
     ctx: QueryCtx
   ) => {
+    const conditions = [
+      eq($notesNotes.notebookFlag, notebookFlag),
+      eq($notesNotes.noteId, noteId),
+    ];
+    if (update.revision != null) {
+      const equalRevision =
+        update.updatedAt != null
+          ? and(
+              eq($notesNotes.revision, update.revision),
+              or(
+                isNull($notesNotes.updatedAt),
+                lte($notesNotes.updatedAt, update.updatedAt)
+              )
+            )
+          : eq($notesNotes.revision, update.revision);
+      conditions.push(
+        or(lt($notesNotes.revision, update.revision), equalRevision)!
+      );
+    }
     return ctx.db
       .update($notesNotes)
       .set(update)
-      .where(
-        and(
-          eq($notesNotes.notebookFlag, notebookFlag),
-          eq($notesNotes.noteId, noteId)
-        )
-      );
+      .where(and(...conditions));
   },
   ['notesNotes']
 );

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -814,10 +814,12 @@ test('saveNotesNotebookSnapshot does not regress a locally persisted newer revis
   };
   await db.saveNotesNotebookSnapshot(snapshot);
 
-  // The save path's write-through lands a newer body + revision...
+  // A conflict resolved with "use theirs" adopts the host copy — body,
+  // revision, AND title — via the same local write path.
   await db.updateNotesNote({
     notebookFlag,
     noteId: note.noteId,
+    title: 'Adopted title',
     bodyMd: 'freshly saved body',
     revision: note.revision + 1,
   });
@@ -825,11 +827,64 @@ test('saveNotesNotebookSnapshot does not regress a locally persisted newer revis
   // ...then a sync that fetched before the save lands with the old copy.
   await db.saveNotesNotebookSnapshot(snapshot);
 
+  // The stored row must survive wholesale: splicing only body/revision
+  // onto the stale copy would fabricate a new-revision row with the old
+  // title, which the editor would then adopt.
   await expect(
     db.getNotesNote({ notebookFlag, noteId: note.noteId })
   ).resolves.toMatchObject({
+    title: 'Adopted title',
     bodyMd: 'freshly saved body',
     revision: note.revision + 1,
+  });
+});
+
+test('saveNotebookNote ignores replica reads trailing below the rejected revision', async () => {
+  // Local state is ahead of the replica: the write-through landed rev 2
+  // locally, the replica still serves rev 1, and the host rejected rev 2
+  // because it moved on to rev 3.
+  const base = makeNote('Trailing replica note');
+  const localNote = { ...base, bodyMd: 'our saved body', revision: 2 };
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [localNote],
+    members: [],
+  });
+
+  const trailingReplica = { ...base, bodyMd: 'ancient body', revision: 1 };
+  const advancedRemote = { ...base, bodyMd: 'newest host body', revision: 3 };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(advancedRemote),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'getNote')
+    .mockResolvedValueOnce(makeApiNotesNote(trailingReplica))
+    .mockResolvedValue(makeApiNotesNote(advancedRemote));
+  vi.spyOn(api.notes, 'updateNoteBody').mockRejectedValue(
+    new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+  );
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note: localNote,
+    title: localNote.title,
+    body: 'my draft',
+  });
+
+  // The rev-1 read is older than the user's own base — offering it as
+  // "theirs" would let a resolution regress the note. Only the advanced
+  // copy may be classified.
+  await expect(attempt).rejects.toBeInstanceOf(NotesNoteConflictError);
+  await expect(attempt).rejects.toMatchObject({
+    remoteNote: expect.objectContaining({
+      bodyMd: advancedRemote.bodyMd,
+      revision: advancedRemote.revision,
+    }),
   });
 });
 

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -13,6 +13,7 @@ import {
   testNotebookFlag as notebookFlag,
 } from '../test/notesFixtures';
 import {
+  NotesNoteConflictError,
   createNotebookNote,
   deleteNotebookNote,
   noteIsPublished,
@@ -348,6 +349,201 @@ test('saveNotebookNote hydrates saved note details when list notes omit them', a
     bodyMd: savedNote.bodyMd,
     revision: savedNote.revision,
   });
+});
+
+test('saveNotebookNote persists the bumped revision when read-back stays stale', async () => {
+  const note = makeNote('Slow replica');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  // The replica never reflects the write within the poll budget: every
+  // snapshot (and hydration) still carries the pre-save body and revision.
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([makeApiNotesNote(note)]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(note));
+  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue(undefined);
+
+  const saved = await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: 'freshly typed body',
+  });
+
+  // A successful update deterministically lands on expectedRevision + 1;
+  // the stale read-back must not leave the old revision behind (it would
+  // wedge every later save on a revision conflict).
+  expect(saved).toMatchObject({
+    bodyMd: 'freshly typed body',
+    revision: note.revision + 1,
+  });
+}, 15_000);
+
+test('saveNotebookNote treats a conflict as applied when the host already has our content', async () => {
+  const note = makeNote('Flushed note');
+  const body = 'flushed body';
+  const hostNote = { ...note, bodyMd: body, revision: note.revision + 1 };
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(hostNote),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(hostNote));
+  const updateNoteBody = vi
+    .spyOn(api.notes, 'updateNoteBody')
+    .mockRejectedValue(
+      new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+    );
+
+  const saved = await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body,
+  });
+
+  expect(updateNoteBody).toHaveBeenCalledTimes(1);
+  expect(saved).toMatchObject({ bodyMd: body, revision: hostNote.revision });
+});
+
+test('saveNotebookNote rebases onto its own previous save and retries once', async () => {
+  const note = makeNote('Evolving note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const firstBody = 'first draft';
+  const firstSaved = {
+    ...note,
+    bodyMd: firstBody,
+    revision: note.revision + 1,
+  };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  const listNotes = vi
+    .spyOn(api.notes, 'listNotes')
+    .mockResolvedValue([makeApiNotesNote(firstSaved)]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  const getNote = vi
+    .spyOn(api.notes, 'getNote')
+    .mockResolvedValue(makeApiNotesNote(firstSaved));
+  const updateNoteBody = vi
+    .spyOn(api.notes, 'updateNoteBody')
+    .mockResolvedValue(undefined);
+
+  // Save 1 lands `firstBody` at revision + 1 on the host.
+  await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: firstBody,
+  });
+
+  // Save 2 is issued from a stale base (the editor never learned save 1's
+  // revision). The host rejects it as a conflict; the recovery recognizes
+  // the host content as our own previous save and retries rebased.
+  const secondBody = 'first draft plus more typing';
+  const secondSaved = {
+    ...note,
+    bodyMd: secondBody,
+    revision: firstSaved.revision + 1,
+  };
+  updateNoteBody
+    .mockRejectedValueOnce(
+      new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+    )
+    .mockResolvedValueOnce(undefined);
+  listNotes.mockResolvedValue([makeApiNotesNote(secondSaved)]);
+  getNote.mockResolvedValue(makeApiNotesNote(firstSaved));
+
+  const saved = await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: secondBody,
+  });
+
+  expect(updateNoteBody).toHaveBeenLastCalledWith({
+    flag: notebookFlag,
+    noteId: note.noteId,
+    body: secondBody,
+    expectedRevision: firstSaved.revision,
+  });
+  expect(saved).toMatchObject({
+    bodyMd: secondBody,
+    revision: secondSaved.revision,
+  });
+});
+
+test('saveNotebookNote surfaces a typed conflict when the host content diverged', async () => {
+  const note = makeNote('Contested note');
+  const remoteNote = {
+    ...note,
+    bodyMd: 'someone else rewrote this',
+    revision: note.revision + 1,
+  };
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(remoteNote),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'getNote').mockResolvedValue(
+    makeApiNotesNote(remoteNote)
+  );
+  const updateNoteBody = vi
+    .spyOn(api.notes, 'updateNoteBody')
+    .mockRejectedValue(
+      new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+    );
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: 'my competing edit',
+  });
+
+  await expect(attempt).rejects.toBeInstanceOf(NotesNoteConflictError);
+  await expect(attempt).rejects.toMatchObject({
+    remoteNote: expect.objectContaining({
+      bodyMd: remoteNote.bodyMd,
+      revision: remoteNote.revision,
+    }),
+  });
+  expect(updateNoteBody).toHaveBeenCalledTimes(1);
 });
 
 test('deleteNotebookNote waits for the deleted note to disappear from sync', async () => {

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../test/notesFixtures';
 import {
   NotesNoteConflictError,
+  adoptNotebookNoteRemote,
   createNotebookNote,
   deleteNotebookNote,
   noteIsPublished,
@@ -544,6 +545,39 @@ test('saveNotebookNote surfaces a typed conflict when the host content diverged'
     }),
   });
   expect(updateNoteBody).toHaveBeenCalledTimes(1);
+});
+
+test('adoptNotebookNoteRemote persists the host copy locally', async () => {
+  const note = makeNote('Local note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const remote = makeApiNotesNote({
+    ...note,
+    title: 'Remote title',
+    bodyMd: 'remote body',
+    revision: note.revision + 2,
+    updatedAt: 500,
+  });
+
+  const adopted = await adoptNotebookNoteRemote({ notebookFlag, remote });
+
+  expect(adopted).toMatchObject({
+    title: 'Remote title',
+    bodyMd: 'remote body',
+    revision: note.revision + 2,
+  });
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({
+    title: 'Remote title',
+    bodyMd: 'remote body',
+    revision: note.revision + 2,
+  });
 });
 
 test('deleteNotebookNote waits for the deleted note to disappear from sync', async () => {

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -718,6 +718,121 @@ test('saveNotebookNote surfaces a typed conflict when the host content diverged'
   expect(updateNoteBody).toHaveBeenCalledTimes(1);
 });
 
+test('saveNotebookNote waits out a stale replica before classifying a conflict', async () => {
+  const note = makeNote('Laggy replica note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  // The host rejected our revision, but the subscriber replica still
+  // serves the pre-conflict copy on the first read; the remote edit's
+  // broadcast lands between polls.
+  const staleReplica = makeApiNotesNote(note);
+  const advancedRemote = {
+    ...note,
+    bodyMd: 'remote edit that caused the conflict',
+    revision: note.revision + 1,
+  };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(advancedRemote),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  const getNote = vi
+    .spyOn(api.notes, 'getNote')
+    .mockResolvedValueOnce(staleReplica)
+    .mockResolvedValueOnce(staleReplica)
+    .mockResolvedValue(makeApiNotesNote(advancedRemote));
+  vi.spyOn(api.notes, 'updateNoteBody').mockRejectedValue(
+    new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+  );
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: 'my draft',
+  });
+
+  // The stale reads must not be classified: "theirs" is the advanced copy,
+  // never the replica echo of our own base.
+  await expect(attempt).rejects.toBeInstanceOf(NotesNoteConflictError);
+  await expect(attempt).rejects.toMatchObject({
+    remoteNote: expect.objectContaining({
+      bodyMd: advancedRemote.bodyMd,
+      revision: advancedRemote.revision,
+    }),
+  });
+  expect(getNote.mock.calls.length).toBeGreaterThanOrEqual(3);
+});
+
+test('saveNotebookNote rethrows the raw conflict when the replica never advances', async () => {
+  const note = makeNote('Stuck replica note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([makeApiNotesNote(note)]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(note));
+  vi.spyOn(api.notes, 'updateNoteBody').mockRejectedValue(
+    new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+  );
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: 'my draft',
+  });
+
+  // Unclassifiable — must NOT become a NotesNoteConflictError built from
+  // the stale echo; the raw typed error lets the next autosave retry.
+  await expect(attempt).rejects.toBeInstanceOf(api.NotesV1WriteError);
+}, 15_000);
+
+test('saveNotesNotebookSnapshot does not regress a locally persisted newer revision', async () => {
+  const note = makeNote('Write-through note');
+  const snapshot = {
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  };
+  await db.saveNotesNotebookSnapshot(snapshot);
+
+  // The save path's write-through lands a newer body + revision...
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: note.noteId,
+    bodyMd: 'freshly saved body',
+    revision: note.revision + 1,
+  });
+
+  // ...then a sync that fetched before the save lands with the old copy.
+  await db.saveNotesNotebookSnapshot(snapshot);
+
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({
+    bodyMd: 'freshly saved body',
+    revision: note.revision + 1,
+  });
+});
+
 test('adoptNotebookNoteRemote persists the host copy locally', async () => {
   const note = makeNote('Local note');
   await db.saveNotesNotebookSnapshot({

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -1010,6 +1010,35 @@ test('adoptNotebookNoteRemote refuses to downgrade a row that advanced past the 
   });
 });
 
+test('adoptNotebookNoteRemote keeps newer same-revision metadata', async () => {
+  // Renames/moves don't bump the revision: a rename synced after the
+  // conflict copy was captured leaves the row at the same revision with
+  // newer metadata.
+  const note = makeNote('Renamed while deciding');
+  const renamedRow = {
+    ...note,
+    title: 'Newer synced title',
+    updatedAt: (note.updatedAt ?? 0) + 1_000,
+  };
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [renamedRow],
+    members: [],
+  });
+
+  const staleConflictCopy = makeApiNotesNote(note);
+  const adopted = await adoptNotebookNoteRemote({
+    notebookFlag,
+    remote: staleConflictCopy,
+  });
+
+  expect(adopted).toMatchObject({ title: 'Newer synced title' });
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({ title: 'Newer synced title' });
+});
+
 test('adoptNotebookNoteRemote persists the host copy locally', async () => {
   const note = makeNote('Local note');
   await db.saveNotesNotebookSnapshot({

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -971,6 +971,45 @@ test('saveNotebookNote rethrows the raw error when the retry races and the repli
   await expect(attempt).rejects.toBeInstanceOf(api.NotesV1WriteError);
 }, 15_000);
 
+test('adoptNotebookNoteRemote refuses to downgrade a row that advanced past the copy', async () => {
+  const note = makeNote('Advanced note');
+  const advancedRow = {
+    ...note,
+    bodyMd: 'newer synced body',
+    revision: note.revision + 4,
+  };
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [advancedRow],
+    members: [],
+  });
+
+  // The conflict banner's captured copy is older than what the row has
+  // since synced to.
+  const staleConflictCopy = makeApiNotesNote({
+    ...note,
+    bodyMd: 'older conflict copy',
+    revision: note.revision + 1,
+  });
+
+  const adopted = await adoptNotebookNoteRemote({
+    notebookFlag,
+    remote: staleConflictCopy,
+  });
+
+  expect(adopted).toMatchObject({
+    bodyMd: 'newer synced body',
+    revision: advancedRow.revision,
+  });
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({
+    bodyMd: 'newer synced body',
+    revision: advancedRow.revision,
+  });
+});
+
 test('adoptNotebookNoteRemote persists the host copy locally', async () => {
   const note = makeNote('Local note');
   await db.saveNotesNotebookSnapshot({

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -72,13 +72,6 @@ test('saveNotebookNote preserves an empty title', async () => {
     members: [],
   });
 
-  const renamedNote = makeApiNotesNote(makeNote(''));
-  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
-  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
-    makeApiNotesFolder(rootFolder),
-  ]);
-  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([renamedNote]);
-  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
   const renameNote = vi
     .spyOn(api.notes, 'renameNote')
     .mockResolvedValue(undefined);
@@ -347,42 +340,6 @@ test('saveNotebookNote persists sent content from the response contract, no read
   });
 });
 
-test('saveNotebookNote persists the bumped revision when read-back stays stale', async () => {
-  const note = makeNote('Slow replica');
-  await db.saveNotesNotebookSnapshot({
-    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
-    folders: [rootFolder],
-    notes: [note],
-    members: [],
-  });
-
-  // The replica never reflects the write within the poll budget: every
-  // snapshot (and hydration) still carries the pre-save body and revision.
-  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
-  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
-    makeApiNotesFolder(rootFolder),
-  ]);
-  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([makeApiNotesNote(note)]);
-  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
-  vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(note));
-  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue('ok');
-
-  const saved = await saveNotebookNote({
-    notebookFlag,
-    note,
-    title: note.title,
-    body: 'freshly typed body',
-  });
-
-  // A successful update deterministically lands on expectedRevision + 1;
-  // the stale read-back must not leave the old revision behind (it would
-  // wedge every later save on a revision conflict).
-  expect(saved).toMatchObject({
-    bodyMd: 'freshly typed body',
-    revision: note.revision + 1,
-  });
-}, 15_000);
-
 test('saveNotebookNote treats a conflict as applied when the host already has our content', async () => {
   const note = makeNote('Flushed note');
   const body = 'flushed body';
@@ -504,16 +461,6 @@ test('saveNotebookNote keeps the local revision when the host reports no-change'
     members: [],
   });
 
-  const hostNote = { ...note, bodyMd: body };
-  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
-  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
-    makeApiNotesFolder(rootFolder),
-  ]);
-  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
-    makeApiNotesNote(hostNote),
-  ]);
-  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
-  vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(hostNote));
   // The host body already matched, so the revision was NOT bumped.
   vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue('no-change');
 

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -72,9 +72,7 @@ test('saveNotebookNote preserves an empty title', async () => {
     members: [],
   });
 
-  const renameNote = vi
-    .spyOn(api.notes, 'renameNote')
-    .mockResolvedValue(undefined);
+  const renameNote = vi.spyOn(api.notes, 'renameNote').mockResolvedValue(null);
 
   const saved = await saveNotebookNote({
     notebookFlag,
@@ -306,10 +304,8 @@ test('saveNotebookNote persists sent content from the response contract, no read
   const listNotes = vi.spyOn(api.notes, 'listNotes');
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue('ok');
-  const renameNote = vi
-    .spyOn(api.notes, 'renameNote')
-    .mockResolvedValue(undefined);
+    .mockResolvedValue({ status: 'ok', note: null });
+  const renameNote = vi.spyOn(api.notes, 'renameNote').mockResolvedValue(null);
 
   const saved = await saveNotebookNote({
     notebookFlag,
@@ -337,6 +333,58 @@ test('saveNotebookNote persists sent content from the response contract, no read
     title: 'New title',
     bodyMd: 'updated body',
     revision: note.revision + 1,
+  });
+});
+
+test('saveNotebookNote persists host stamps from write-response payloads', async () => {
+  const note = makeNote('Stamped note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const hostStamp = (note.updatedAt ?? 0) + 5_000;
+  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue({
+    status: 'ok',
+    note: {
+      id: note.noteId,
+      title: 'Renamed by host payload',
+      bodyMd: 'updated body',
+      revision: note.revision + 1,
+      updatedAt: hostStamp,
+      updatedBy: '~zod',
+    },
+  });
+  vi.spyOn(api.notes, 'renameNote').mockResolvedValue({
+    id: note.noteId,
+    title: 'Renamed by host payload',
+    bodyMd: 'updated body',
+    revision: note.revision + 1,
+    updatedAt: hostStamp + 1,
+    updatedBy: '~zod',
+  });
+
+  await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: 'Renamed by host payload',
+    body: 'updated body',
+  });
+
+  // The row carries the host's stamps, so the snapshot merge's
+  // equal-revision tiebreak defends this write against a stale snapshot
+  // already in flight (which is exactly how a rename-only save would
+  // otherwise get reverted).
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({
+    title: 'Renamed by host payload',
+    bodyMd: 'updated body',
+    revision: note.revision + 1,
+    updatedAt: hostStamp + 1,
+    updatedBy: '~zod',
   });
 });
 
@@ -405,7 +453,7 @@ test('saveNotebookNote rebases onto its own previous save and retries once', asy
     .mockResolvedValue(makeApiNotesNote(firstSaved));
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue('ok');
+    .mockResolvedValue({ status: 'ok', note: null });
 
   // Save 1 lands `firstBody` at revision + 1 on the host.
   await saveNotebookNote({
@@ -428,7 +476,7 @@ test('saveNotebookNote rebases onto its own previous save and retries once', asy
     .mockRejectedValueOnce(
       new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
     )
-    .mockResolvedValueOnce('ok');
+    .mockResolvedValueOnce({ status: 'ok', note: null });
   listNotes.mockResolvedValue([makeApiNotesNote(secondSaved)]);
   getNote.mockResolvedValue(makeApiNotesNote(firstSaved));
 
@@ -462,7 +510,10 @@ test('saveNotebookNote keeps the local revision when the host reports no-change'
   });
 
   // The host body already matched, so the revision was NOT bumped.
-  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue('no-change');
+  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue({
+    status: 'no-change',
+    note: null,
+  });
 
   const saved = await saveNotebookNote({
     notebookFlag,
@@ -504,7 +555,7 @@ test('saveNotebookNote does not auto-rebase over a remote revert to our old cont
     .mockResolvedValue(makeApiNotesNote(firstSaved));
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue('ok');
+    .mockResolvedValue({ status: 'ok', note: null });
 
   // Save 1 seeds the last-saved cache with firstBody at revision + 1.
   await saveNotebookNote({
@@ -568,7 +619,7 @@ test('saveNotebookNote surfaces a conflict when the rebased retry races another 
     .mockResolvedValue(makeApiNotesNote(firstSaved));
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue('ok');
+    .mockResolvedValue({ status: 'ok', note: null });
 
   // Save 1 seeds the last-saved cache.
   await saveNotebookNote({
@@ -888,7 +939,7 @@ test('saveNotebookNote rethrows the raw error when the retry races and the repli
   );
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue('ok');
+    .mockResolvedValue({ status: 'ok', note: null });
 
   await saveNotebookNote({
     notebookFlag,

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -300,13 +300,8 @@ test('createNotebookNote hydrates created note details when list notes omit them
   });
 });
 
-test('saveNotebookNote hydrates saved note details when list notes omit them', async () => {
+test('saveNotebookNote persists sent content from the response contract, no read-back', async () => {
   const note = makeNote('Draft note');
-  const savedNote = {
-    ...note,
-    bodyMd: 'updated body',
-    revision: note.revision + 1,
-  };
   await db.saveNotesNotebookSnapshot({
     notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
     folders: [rootFolder],
@@ -314,41 +309,41 @@ test('saveNotebookNote hydrates saved note details when list notes omit them', a
     members: [],
   });
 
-  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
-  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
-    makeApiNotesFolder(rootFolder),
-  ]);
-  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
-    makeApiNoteSummary(savedNote),
-  ]);
-  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
-  const getNote = vi
-    .spyOn(api.notes, 'getNote')
-    .mockResolvedValue(makeApiNotesNote(savedNote));
+  const getNote = vi.spyOn(api.notes, 'getNote');
+  const listNotes = vi.spyOn(api.notes, 'listNotes');
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
     .mockResolvedValue('ok');
+  const renameNote = vi
+    .spyOn(api.notes, 'renameNote')
+    .mockResolvedValue(undefined);
 
   const saved = await saveNotebookNote({
     notebookFlag,
     note,
-    title: note.title,
-    body: savedNote.bodyMd,
+    title: 'New title',
+    body: 'updated body',
   });
 
   expect(updateNoteBody).toHaveBeenCalledWith({
     flag: notebookFlag,
     noteId: note.noteId,
-    body: savedNote.bodyMd,
+    body: 'updated body',
     expectedRevision: note.revision,
   });
-  expect(getNote).toHaveBeenCalledWith({
-    flag: { host: '~zod', name: 'native-notes' },
+  expect(renameNote).toHaveBeenCalledWith({
+    flag: notebookFlag,
     noteId: note.noteId,
+    title: 'New title',
   });
+  // Successful writes fully determine the result — the save path must not
+  // fetch anything to learn what it just wrote.
+  expect(getNote).not.toHaveBeenCalled();
+  expect(listNotes).not.toHaveBeenCalled();
   expect(saved).toMatchObject({
-    bodyMd: savedNote.bodyMd,
-    revision: savedNote.revision,
+    title: 'New title',
+    bodyMd: 'updated body',
+    revision: note.revision + 1,
   });
 });
 

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -327,7 +327,7 @@ test('saveNotebookNote hydrates saved note details when list notes omit them', a
     .mockResolvedValue(makeApiNotesNote(savedNote));
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue(undefined);
+    .mockResolvedValue('ok');
 
   const saved = await saveNotebookNote({
     notebookFlag,
@@ -370,7 +370,7 @@ test('saveNotebookNote persists the bumped revision when read-back stays stale',
   vi.spyOn(api.notes, 'listNotes').mockResolvedValue([makeApiNotesNote(note)]);
   vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
   vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(note));
-  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue(undefined);
+  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue('ok');
 
   const saved = await saveNotebookNote({
     notebookFlag,
@@ -453,7 +453,7 @@ test('saveNotebookNote rebases onto its own previous save and retries once', asy
     .mockResolvedValue(makeApiNotesNote(firstSaved));
   const updateNoteBody = vi
     .spyOn(api.notes, 'updateNoteBody')
-    .mockResolvedValue(undefined);
+    .mockResolvedValue('ok');
 
   // Save 1 lands `firstBody` at revision + 1 on the host.
   await saveNotebookNote({
@@ -476,7 +476,7 @@ test('saveNotebookNote rebases onto its own previous save and retries once', asy
     .mockRejectedValueOnce(
       new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
     )
-    .mockResolvedValueOnce(undefined);
+    .mockResolvedValueOnce('ok');
   listNotes.mockResolvedValue([makeApiNotesNote(secondSaved)]);
   getNote.mockResolvedValue(makeApiNotesNote(firstSaved));
 
@@ -496,6 +496,177 @@ test('saveNotebookNote rebases onto its own previous save and retries once', asy
   expect(saved).toMatchObject({
     bodyMd: secondBody,
     revision: secondSaved.revision,
+  });
+});
+
+test('saveNotebookNote keeps the local revision when the host reports no-change', async () => {
+  const note = makeNote('Converging note');
+  const body = 'body already on host';
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const hostNote = { ...note, bodyMd: body };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(hostNote),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  vi.spyOn(api.notes, 'getNote').mockResolvedValue(makeApiNotesNote(hostNote));
+  // The host body already matched, so the revision was NOT bumped.
+  vi.spyOn(api.notes, 'updateNoteBody').mockResolvedValue('no-change');
+
+  const saved = await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body,
+  });
+
+  // Persisting expected + 1 here would leave the local DB one revision
+  // ahead of the host and wedge the next save on a phantom conflict.
+  expect(saved).toMatchObject({ bodyMd: body, revision: note.revision });
+});
+
+test('saveNotebookNote does not auto-rebase over a remote revert to our old content', async () => {
+  const note = makeNote('Reverted note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const firstBody = 'our earlier save';
+  const firstSaved = {
+    ...note,
+    bodyMd: firstBody,
+    revision: note.revision + 1,
+  };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(firstSaved),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  const getNote = vi
+    .spyOn(api.notes, 'getNote')
+    .mockResolvedValue(makeApiNotesNote(firstSaved));
+  const updateNoteBody = vi
+    .spyOn(api.notes, 'updateNoteBody')
+    .mockResolvedValue('ok');
+
+  // Save 1 seeds the last-saved cache with firstBody at revision + 1.
+  await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: firstBody,
+  });
+
+  // Meanwhile other edits landed and someone restored our old content via
+  // note history: same bytes as our cached save, but at a later revision.
+  // That is a genuine conflict — auto-rebasing would silently overwrite
+  // the restore.
+  const revertedRemote = {
+    ...note,
+    bodyMd: firstBody,
+    revision: firstSaved.revision + 3,
+  };
+  updateNoteBody.mockRejectedValue(
+    new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+  );
+  getNote.mockResolvedValue(makeApiNotesNote(revertedRemote));
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note: firstSaved,
+    title: note.title,
+    body: 'draft typed after our save',
+  });
+
+  await expect(attempt).rejects.toBeInstanceOf(NotesNoteConflictError);
+  // Only the failed initial PUT from save 2 — no rebased retry.
+  expect(updateNoteBody).toHaveBeenCalledTimes(2);
+});
+
+test('saveNotebookNote surfaces a conflict when the rebased retry races another edit', async () => {
+  const note = makeNote('Racing note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const firstBody = 'first draft';
+  const firstSaved = {
+    ...note,
+    bodyMd: firstBody,
+    revision: note.revision + 1,
+  };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(firstSaved),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  const getNote = vi
+    .spyOn(api.notes, 'getNote')
+    .mockResolvedValue(makeApiNotesNote(firstSaved));
+  const updateNoteBody = vi
+    .spyOn(api.notes, 'updateNoteBody')
+    .mockResolvedValue('ok');
+
+  // Save 1 seeds the last-saved cache.
+  await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: firstBody,
+  });
+
+  // Save 2 conflicts; the recovery fetch matches our own save, but another
+  // edit lands between that fetch and the rebased retry, so the retry
+  // conflicts too. It must surface the latest remote copy as a typed
+  // conflict, not escape as a generic error.
+  const racedRemote = {
+    ...note,
+    bodyMd: 'racing writer content',
+    revision: firstSaved.revision + 1,
+  };
+  const conflict = new api.NotesV1WriteError(
+    '%notes error: revision-mismatch',
+    'conflict'
+  );
+  updateNoteBody.mockRejectedValue(conflict);
+  getNote
+    .mockResolvedValueOnce(makeApiNotesNote(firstSaved))
+    .mockResolvedValueOnce(makeApiNotesNote(racedRemote));
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: 'first draft plus more typing',
+  });
+
+  await expect(attempt).rejects.toBeInstanceOf(NotesNoteConflictError);
+  await expect(attempt).rejects.toMatchObject({
+    remoteNote: expect.objectContaining({
+      bodyMd: racedRemote.bodyMd,
+      revision: racedRemote.revision,
+    }),
   });
 });
 

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -984,6 +984,7 @@ test('adoptNotebookNoteRemote persists the host copy locally', async () => {
     ...note,
     title: 'Remote title',
     bodyMd: 'remote body',
+    folderId: rootFolder.folderId + 5,
     revision: note.revision + 2,
     updatedAt: 500,
   });
@@ -993,6 +994,7 @@ test('adoptNotebookNoteRemote persists the host copy locally', async () => {
   expect(adopted).toMatchObject({
     title: 'Remote title',
     bodyMd: 'remote body',
+    folderId: rootFolder.folderId + 5,
     revision: note.revision + 2,
   });
   await expect(

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -352,6 +352,9 @@ test('saveNotebookNote persists host stamps from write-response payloads', async
       id: note.noteId,
       title: 'Renamed by host payload',
       bodyMd: 'updated body',
+      // Another client's same-revision move rode along on the host row —
+      // the payload's folder is authoritative.
+      folderId: rootFolder.folderId + 7,
       revision: note.revision + 1,
       updatedAt: hostStamp,
       updatedBy: '~zod',
@@ -382,6 +385,7 @@ test('saveNotebookNote persists host stamps from write-response payloads', async
   ).resolves.toMatchObject({
     title: 'Renamed by host payload',
     bodyMd: 'updated body',
+    folderId: rootFolder.folderId + 7,
     revision: note.revision + 1,
     updatedAt: hostStamp + 1,
     updatedBy: '~zod',

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -888,6 +888,89 @@ test('saveNotebookNote ignores replica reads trailing below the rejected revisio
   });
 });
 
+test('saveNotesNotebookSnapshot keeps newer metadata at an equal revision', async () => {
+  // Renames/moves don't bump the revision, so a stale snapshot can carry
+  // the same revision with older metadata.
+  const note = makeNote('Renamed note');
+  const staleSnapshot = {
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  };
+  await db.saveNotesNotebookSnapshot(staleSnapshot);
+
+  // An adoption writes a newer title at the SAME revision (host rename).
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: note.noteId,
+    title: 'Adopted rename',
+    updatedAt: (note.updatedAt ?? 0) + 1_000,
+  });
+
+  await db.saveNotesNotebookSnapshot(staleSnapshot);
+
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({ title: 'Adopted rename' });
+});
+
+test('saveNotebookNote rethrows the raw error when the retry races and the replica lags', async () => {
+  const note = makeNote('Retry-lag note');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  const firstBody = 'first draft';
+  const firstSaved = {
+    ...note,
+    bodyMd: firstBody,
+    revision: note.revision + 1,
+  };
+  vi.spyOn(api.notes, 'getNotebook').mockResolvedValue(notebookSummary);
+  vi.spyOn(api.notes, 'listFolders').mockResolvedValue([
+    makeApiNotesFolder(rootFolder),
+  ]);
+  vi.spyOn(api.notes, 'listNotes').mockResolvedValue([
+    makeApiNotesNote(firstSaved),
+  ]);
+  vi.spyOn(api.notes, 'listMembers').mockResolvedValue([]);
+  // The replica serves our own previous save forever: good enough to
+  // classify the first conflict as own-echo, but it never advances past
+  // the rebased retry's rejected revision.
+  vi.spyOn(api.notes, 'getNote').mockResolvedValue(
+    makeApiNotesNote(firstSaved)
+  );
+  const updateNoteBody = vi
+    .spyOn(api.notes, 'updateNoteBody')
+    .mockResolvedValue('ok');
+
+  await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: firstBody,
+  });
+
+  updateNoteBody.mockRejectedValue(
+    new api.NotesV1WriteError('%notes error: revision-mismatch', 'conflict')
+  );
+
+  const attempt = saveNotebookNote({
+    notebookFlag,
+    note,
+    title: note.title,
+    body: 'first draft plus more typing',
+  });
+
+  // Building a conflict from our own previous save would offer the user's
+  // discarded past as "theirs" — the raw error must escape instead.
+  await expect(attempt).rejects.toBeInstanceOf(api.NotesV1WriteError);
+}, 15_000);
+
 test('adoptNotebookNoteRemote persists the host copy locally', async () => {
   const note = makeNote('Local note');
   await db.saveNotesNotebookSnapshot({

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -1007,6 +1007,63 @@ test('adoptNotebookNoteRemote refuses to downgrade a row that advanced past the 
   });
 });
 
+test('updateNotesNote is revision-monotonic in a single atomic write', async () => {
+  const note = makeNote('Guarded note');
+  const row = { ...note, revision: 5, updatedAt: 1_000 };
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [row],
+    members: [],
+  });
+
+  // Older revision: skipped.
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: note.noteId,
+    bodyMd: 'stale write',
+    revision: 4,
+  });
+  // Equal revision with an older stamp: skipped.
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: note.noteId,
+    title: 'stale rename',
+    revision: 5,
+    updatedAt: 500,
+  });
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({
+    bodyMd: row.bodyMd,
+    title: row.title,
+    revision: 5,
+  });
+
+  // Equal revision with a newer stamp: applies (rename/move semantics).
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: note.noteId,
+    title: 'fresh rename',
+    revision: 5,
+    updatedAt: 2_000,
+  });
+  // Newer revision: applies.
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: note.noteId,
+    bodyMd: 'fresh body',
+    revision: 6,
+  });
+  await expect(
+    db.getNotesNote({ notebookFlag, noteId: note.noteId })
+  ).resolves.toMatchObject({
+    title: 'fresh rename',
+    bodyMd: 'fresh body',
+    revision: 6,
+  });
+});
+
 test('adoptNotebookNoteRemote keeps newer same-revision metadata', async () => {
   // Renames/moves don't bump the revision: a rename synced after the
   // conflict copy was captured leaves the row at the same revision with

--- a/packages/shared/src/store/notesActions.test.ts
+++ b/packages/shared/src/store/notesActions.test.ts
@@ -1007,6 +1007,44 @@ test('adoptNotebookNoteRemote refuses to downgrade a row that advanced past the 
   });
 });
 
+test('rename-only save adopts a raced remote body from the payload', async () => {
+  const note = makeNote('Raced rename');
+  await db.saveNotesNotebookSnapshot({
+    notebook: makeNotesNotebook({ rootFolderId: rootFolder.folderId }),
+    folders: [rootFolder],
+    notes: [note],
+    members: [],
+  });
+
+  // Another client's body edit landed first; the host applied our rename on
+  // top and the payload carries the complete newer note.
+  const remoteBody = 'body edited by someone else';
+  vi.spyOn(api.notes, 'renameNote').mockResolvedValue({
+    id: note.noteId,
+    title: 'Renamed locally',
+    bodyMd: remoteBody,
+    revision: note.revision + 1,
+    updatedAt: (note.updatedAt ?? 0) + 100,
+    updatedBy: '~zod',
+  });
+
+  const saved = await saveNotebookNote({
+    notebookFlag,
+    note,
+    title: 'Renamed locally',
+    body: note.bodyMd, // body untouched locally
+  });
+
+  // Persisting the payload's revision WITHOUT its body would fabricate a
+  // row whose next body edit passes optimistic concurrency and silently
+  // overwrites the remote edit.
+  expect(saved).toMatchObject({
+    title: 'Renamed locally',
+    bodyMd: remoteBody,
+    revision: note.revision + 1,
+  });
+});
+
 test('updateNotesNote is revision-monotonic in a single atomic write', async () => {
   const note = makeNote('Guarded note');
   const row = { ...note, revision: 5, updatedAt: 1_000 };

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -635,12 +635,20 @@ export async function adoptNotebookNoteRemote({
   // The conflict copy was captured when the banner appeared; the local row
   // can have advanced past it (another remote edit synced while the user
   // decided). Adopting would downgrade the row — keep it and let the
-  // editor converge on the fresher copy instead.
+  // editor converge on the fresher copy instead. Renames/moves don't bump
+  // the revision, so equal revisions break ties on updatedAt, mirroring
+  // the snapshot merge.
   const current = await db.getNotesNote({
     notebookFlag,
     noteId: remote.noteId,
   });
-  if (current && (remote.revision ?? 0) < current.revision) {
+  const remoteRevision = remote.revision ?? 0;
+  if (
+    current &&
+    (remoteRevision < current.revision ||
+      (remoteRevision === current.revision &&
+        (remote.updatedAt ?? 0) < (current.updatedAt ?? 0)))
+  ) {
     return current;
   }
   await db.updateNotesNote({

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -632,6 +632,17 @@ export async function adoptNotebookNoteRemote({
   notebookFlag: string;
   remote: api.NotesNote;
 }) {
+  // The conflict copy was captured when the banner appeared; the local row
+  // can have advanced past it (another remote edit synced while the user
+  // decided). Adopting would downgrade the row — keep it and let the
+  // editor converge on the fresher copy instead.
+  const current = await db.getNotesNote({
+    notebookFlag,
+    noteId: remote.noteId,
+  });
+  if (current && (remote.revision ?? 0) < current.revision) {
+    return current;
+  }
   await db.updateNotesNote({
     notebookFlag,
     noteId: remote.noteId,

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -473,10 +473,13 @@ const lastSavedNoteState = new Map<
   { body: string; revision: number }
 >();
 
-// Poll the note read until it reports a revision other than `staleRevision`,
-// or null if it never does within the retry budget. Used by conflict
-// recovery: a conflict proves the host is not at `staleRevision`, so a read
-// still reporting it is a replica that hasn't caught up yet, not an answer.
+// Poll the note read until it reports a revision GREATER than
+// `staleRevision`, or null if it never does within the retry budget. Used by
+// conflict recovery: a conflict proves the host has moved past
+// `staleRevision`, so any read at or below it (the rejected copy itself, or
+// an even older one — the replica can trail our local write-through) is a
+// replica that hasn't caught up yet, not an answer. Classifying against it
+// would offer content older than the user's own base as "theirs".
 async function fetchNotePastRevision(
   notebookFlag: string,
   noteId: number,
@@ -486,7 +489,7 @@ async function fetchNotePastRevision(
   try {
     await withRetry(async () => {
       latest = await api.notes.getNote({ flag: notebookFlag, noteId });
-      if ((latest.revision ?? 0) === staleRevision) {
+      if ((latest.revision ?? 0) <= staleRevision) {
         throw notYetSynced;
       }
     }, notesRetryOptions);

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -541,6 +541,29 @@ async function persistNoteWrite(
   await db.updateNotesNote({ notebookFlag, noteId, bodyMd, revision });
 }
 
+// Persist the host's copy of a note locally — used when the user resolves
+// a revision conflict with "use theirs". Without this the editor's reactive
+// row still holds the stale pre-conflict content and would immediately
+// reload it over the adoption.
+export async function adoptNotebookNoteRemote({
+  notebookFlag,
+  remote,
+}: {
+  notebookFlag: string;
+  remote: api.NotesNote;
+}) {
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId: remote.noteId,
+    title: remote.title,
+    bodyMd: remote.bodyMd ?? '',
+    revision: remote.revision ?? 0,
+    updatedAt: remote.updatedAt ?? null,
+    updatedBy: remote.updatedBy ?? null,
+  });
+  return db.getNotesNote({ notebookFlag, noteId: remote.noteId });
+}
+
 export async function publishNotebookNote({
   notebookFlag,
   noteId,

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -462,11 +462,16 @@ export class NotesNoteConflictError extends Error {
   }
 }
 
-// Body content this client last successfully sent per note. Used to recognize
-// a revision conflict caused by our *own* already-applied write — e.g. the
-// read-back after an earlier save never landed locally — which is safe to
-// rebase over, unlike a genuinely divergent remote edit.
-const lastSavedNoteBody = new Map<string, string>();
+// The exact state (content + resulting revision) this client last
+// successfully wrote per note. Used to recognize a revision conflict caused
+// by our *own* already-applied write — e.g. the read-back after an earlier
+// save never landed locally — which is safe to rebase over. Both fields must
+// match: content alone would also match a *remote* edit that restored our
+// old text (e.g. via note history), which is a genuine conflict.
+const lastSavedNoteState = new Map<
+  string,
+  { body: string; revision: number }
+>();
 
 async function updateNotebookNoteBody({
   notebookFlag,
@@ -479,8 +484,9 @@ async function updateNotebookNoteBody({
 }) {
   const noteKey = `${notebookFlag}/${note.noteId}`;
   const expectedRevision = note.revision;
+  let result: Awaited<ReturnType<typeof api.notes.updateNoteBody>>;
   try {
-    await api.notes.updateNoteBody({
+    result = await api.notes.updateNoteBody({
       flag: notebookFlag,
       noteId: note.noteId,
       body,
@@ -498,21 +504,40 @@ async function updateNotebookNoteBody({
     if (remote.bodyMd === body) {
       // Our exact content is already on the host (an unload flush or an
       // earlier retry landed) — nothing left to send.
-      lastSavedNoteBody.set(noteKey, body);
+      lastSavedNoteState.set(noteKey, { body, revision: remoteRevision });
       await persistNoteWrite(notebookFlag, note.noteId, body, remoteRevision);
       return;
     }
-    if (remote.bodyMd === lastSavedNoteBody.get(noteKey)) {
-      // The "conflicting" revision is our own previous save whose read-back
-      // never landed locally. The draft evolved from that content, so
-      // rebasing onto the host's revision loses nothing.
-      await api.notes.updateNoteBody({
-        flag: notebookFlag,
-        noteId: note.noteId,
+    const lastSaved = lastSavedNoteState.get(noteKey);
+    if (
+      lastSaved &&
+      remote.bodyMd === lastSaved.body &&
+      remoteRevision === lastSaved.revision
+    ) {
+      // The "conflicting" revision is exactly the state our own previous
+      // save produced, so its read-back just never landed locally. The
+      // draft evolved from that content; rebasing onto the host's revision
+      // loses nothing. The retry itself can race another writer — surface
+      // that as a fresh conflict rather than a generic failure.
+      try {
+        await api.notes.updateNoteBody({
+          flag: notebookFlag,
+          noteId: note.noteId,
+          body,
+          expectedRevision: remoteRevision,
+        });
+      } catch (retryError) {
+        if (!api.isNotesV1ConflictError(retryError)) {
+          throw retryError;
+        }
+        throw new NotesNoteConflictError(
+          await api.notes.getNote({ flag: notebookFlag, noteId: note.noteId })
+        );
+      }
+      lastSavedNoteState.set(noteKey, {
         body,
-        expectedRevision: remoteRevision,
+        revision: remoteRevision + 1,
       });
-      lastSavedNoteBody.set(noteKey, body);
       await persistNoteWrite(
         notebookFlag,
         note.noteId,
@@ -523,8 +548,13 @@ async function updateNotebookNoteBody({
     }
     throw new NotesNoteConflictError(remote);
   }
-  lastSavedNoteBody.set(noteKey, body);
-  await persistNoteWrite(notebookFlag, note.noteId, body, expectedRevision + 1);
+  // %no-change means the host body already matched and the revision was NOT
+  // bumped — persisting expected + 1 would put the local DB one revision
+  // ahead of the host and re-wedge the next save.
+  const nextRevision =
+    result === 'no-change' ? expectedRevision : expectedRevision + 1;
+  lastSavedNoteState.set(noteKey, { body, revision: nextRevision });
+  await persistNoteWrite(notebookFlag, note.noteId, body, nextRevision);
 }
 
 // A successful body update moves the note to exactly expectedRevision + 1

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -617,9 +617,14 @@ async function updateNotebookNoteBody({
 // Persist a write's outcome to the local row. The revision comes from the
 // response payload when present, else the response contract (a successful
 // body update lands on exactly expectedRevision + 1) — no read-back either
-// way. The payload also carries the host's authoritative updatedAt /
-// updatedBy stamps; persisting them lets the snapshot merge's equal-revision
-// tiebreak defend this write against stale snapshots already in flight.
+// way. The payload is the host's authoritative post-write note, so every
+// field it carries is persisted (explicit write fields win): a body PUT
+// applied on top of another client's same-revision rename/move returns
+// their title/folder, and persisting only our own fields would fabricate a
+// row that the snapshot merge then defends against the very snapshot
+// carrying the remote metadata. The host stamps also let the merge's
+// equal-revision tiebreak defend this write against stale snapshots
+// already in flight.
 async function persistNoteWrite(
   notebookFlag: string,
   noteId: number,
@@ -628,6 +633,8 @@ async function persistNoteWrite(
     title?: string;
     revision?: number;
     applied?: {
+      title?: string | null;
+      folderId?: number | null;
       updatedAt?: number | null;
       updatedBy?: string | null;
     } | null;
@@ -637,9 +644,11 @@ async function persistNoteWrite(
   await db.updateNotesNote({
     notebookFlag,
     noteId,
-    ...fields,
+    ...(applied?.title != null ? { title: applied.title } : {}),
+    ...(applied?.folderId != null ? { folderId: applied.folderId } : {}),
     ...(applied?.updatedAt != null ? { updatedAt: applied.updatedAt } : {}),
     ...(applied?.updatedBy != null ? { updatedBy: applied.updatedBy } : {}),
+    ...fields,
   });
 }
 

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -463,8 +463,9 @@ export class NotesNoteConflictError extends Error {
 
 // The exact state (content + resulting revision) this client last
 // successfully wrote per note. Used to recognize a revision conflict caused
-// by our *own* already-applied write — e.g. the read-back after an earlier
-// save never landed locally — which is safe to rebase over. Both fields must
+// by our *own* already-applied write — e.g. an earlier save applied on the
+// host but its local persist never landed (the process died in between) —
+// which is safe to rebase over. Both fields must
 // match: content alone would also match a *remote* edit that restored our
 // old text (e.g. via note history), which is a genuine conflict.
 const lastSavedNoteState = new Map<
@@ -554,7 +555,7 @@ async function updateNotebookNoteBody({
       remoteRevision === lastSaved.revision
     ) {
       // The "conflicting" revision is exactly the state our own previous
-      // save produced, so its read-back just never landed locally. The
+      // save produced, so only its local persist never landed. The
       // draft evolved from that content; rebasing onto the host's revision
       // loses nothing. The retry itself can race another writer — surface
       // that as a fresh conflict rather than a generic failure.
@@ -607,10 +608,10 @@ async function updateNotebookNoteBody({
 }
 
 // A successful body update moves the note to exactly expectedRevision + 1
-// (the host bumps by one). Persist that immediately instead of relying on
-// the snapshot read-back: the post-save poll gives up silently when replica
-// propagation is slow, and a save that reports success while leaving the
-// stale revision in the local DB wedges every later save on a conflict.
+// (the host bumps by one), so the local row can be written from the response
+// contract alone — no read-back. A save that reported success while leaving
+// a stale revision in the local DB would wedge every later save on a
+// conflict.
 async function persistNoteWrite(
   notebookFlag: string,
   noteId: number,

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -428,22 +428,21 @@ export async function saveNotebookNote({
       noteId: note.noteId,
       title: nextTitle,
     });
+    // A successful rename means the host's title is exactly the string we
+    // sent (renames don't bump the revision). Persist it directly — no
+    // read-back needed, same contract-based reasoning as the body/revision
+    // write-through above.
+    await db.updateNotesNote({
+      notebookFlag,
+      noteId: note.noteId,
+      title: nextTitle,
+    });
   }
 
-  await syncNotesNotebookUntil(
-    notebookFlag,
-    (snapshot) => {
-      const updated = findSnapshotNote(snapshot, note.noteId);
-      return Boolean(
-        updated &&
-          (!shouldRename || updated.title === nextTitle) &&
-          (!shouldUpdateBody || updated.bodyMd === body)
-      );
-    },
-    shouldUpdateBody
-      ? { hydrateNoteIds: [note.noteId], requireHydratedNotes: true }
-      : undefined
-  );
+  // Everything we sent is persisted; server-stamped metadata (updatedAt /
+  // updatedBy) arrives via the subscription-triggered sync moments later.
+  // No read-back wait: the old poll-until-visible loop here is what
+  // silently returned stale revisions when the replica lagged.
   return db.getNotesNote({ notebookFlag, noteId: note.noteId });
 }
 

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -473,6 +473,32 @@ const lastSavedNoteState = new Map<
   { body: string; revision: number }
 >();
 
+// Poll the note read until it reports a revision other than `staleRevision`,
+// or null if it never does within the retry budget. Used by conflict
+// recovery: a conflict proves the host is not at `staleRevision`, so a read
+// still reporting it is a replica that hasn't caught up yet, not an answer.
+async function fetchNotePastRevision(
+  notebookFlag: string,
+  noteId: number,
+  staleRevision: number
+): Promise<api.NotesNote | null> {
+  let latest: api.NotesNote | null = null;
+  try {
+    await withRetry(async () => {
+      latest = await api.notes.getNote({ flag: notebookFlag, noteId });
+      if ((latest.revision ?? 0) === staleRevision) {
+        throw notYetSynced;
+      }
+    }, notesRetryOptions);
+  } catch (e) {
+    if (e !== notYetSynced) {
+      throw e;
+    }
+    return null;
+  }
+  return latest;
+}
+
 async function updateNotebookNoteBody({
   notebookFlag,
   note,
@@ -496,10 +522,21 @@ async function updateNotebookNoteBody({
     if (!api.isNotesV1ConflictError(e)) {
       throw e;
     }
-    const remote = await api.notes.getNote({
-      flag: notebookFlag,
-      noteId: note.noteId,
-    });
+    // On subscribed notebooks the v1 GET serves our ship's replica, which
+    // can still hold the very copy the host just rejected (its broadcast
+    // may not have arrived). Classifying against that stale copy builds a
+    // nonsense conflict — "theirs" identical to our base, and a resolution
+    // that retries the same rejected revision. Wait for the replica to move
+    // past the rejected revision; if it doesn't, we can't classify yet, so
+    // rethrow and let the next autosave cycle try again.
+    const remote = await fetchNotePastRevision(
+      notebookFlag,
+      note.noteId,
+      expectedRevision
+    );
+    if (!remote) {
+      throw e;
+    }
     const remoteRevision = remote.revision ?? 0;
     if (remote.bodyMd === body) {
       // Our exact content is already on the host (an unload flush or an
@@ -530,8 +567,15 @@ async function updateNotebookNoteBody({
         if (!api.isNotesV1ConflictError(retryError)) {
           throw retryError;
         }
+        // Best effort: surface the raced writer's copy if the replica has
+        // it; fall back to what we already fetched (it is at least past
+        // the originally rejected revision).
         throw new NotesNoteConflictError(
-          await api.notes.getNote({ flag: notebookFlag, noteId: note.noteId })
+          (await fetchNotePastRevision(
+            notebookFlag,
+            note.noteId,
+            remoteRevision
+          )) ?? remote
         );
       }
       lastSavedNoteState.set(noteKey, {

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -419,12 +419,7 @@ export async function saveNotebookNote({
   // The body update must land before the rename: it asserts expectedRevision,
   // which any other mutation would invalidate. Don't parallelize these.
   if (shouldUpdateBody) {
-    await api.notes.updateNoteBody({
-      flag: notebookFlag,
-      noteId: note.noteId,
-      body,
-      expectedRevision: note.revision,
-    });
+    await updateNotebookNoteBody({ notebookFlag, note, body });
   }
 
   if (shouldRename) {
@@ -450,6 +445,100 @@ export async function saveNotebookNote({
       : undefined
   );
   return db.getNotesNote({ notebookFlag, noteId: note.noteId });
+}
+
+// A revision conflict that isn't ours to auto-resolve: the note on the host
+// diverged from the editor's base. Carries the host's copy so the UI can
+// offer a real resolution instead of a blind retry (which can never succeed —
+// the editor's base revision stays stale while it holds unsaved changes).
+export class NotesNoteConflictError extends Error {
+  readonly remoteNote: api.NotesNote;
+
+  constructor(remoteNote: api.NotesNote) {
+    super('This note was changed elsewhere. Your unsaved changes are kept.');
+    this.name = 'NotesNoteConflictError';
+    this.remoteNote = remoteNote;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// Body content this client last successfully sent per note. Used to recognize
+// a revision conflict caused by our *own* already-applied write — e.g. the
+// read-back after an earlier save never landed locally — which is safe to
+// rebase over, unlike a genuinely divergent remote edit.
+const lastSavedNoteBody = new Map<string, string>();
+
+async function updateNotebookNoteBody({
+  notebookFlag,
+  note,
+  body,
+}: {
+  notebookFlag: string;
+  note: db.NotesNote;
+  body: string;
+}) {
+  const noteKey = `${notebookFlag}/${note.noteId}`;
+  const expectedRevision = note.revision;
+  try {
+    await api.notes.updateNoteBody({
+      flag: notebookFlag,
+      noteId: note.noteId,
+      body,
+      expectedRevision,
+    });
+  } catch (e) {
+    if (!api.isNotesV1ConflictError(e)) {
+      throw e;
+    }
+    const remote = await api.notes.getNote({
+      flag: notebookFlag,
+      noteId: note.noteId,
+    });
+    const remoteRevision = remote.revision ?? 0;
+    if (remote.bodyMd === body) {
+      // Our exact content is already on the host (an unload flush or an
+      // earlier retry landed) — nothing left to send.
+      lastSavedNoteBody.set(noteKey, body);
+      await persistNoteWrite(notebookFlag, note.noteId, body, remoteRevision);
+      return;
+    }
+    if (remote.bodyMd === lastSavedNoteBody.get(noteKey)) {
+      // The "conflicting" revision is our own previous save whose read-back
+      // never landed locally. The draft evolved from that content, so
+      // rebasing onto the host's revision loses nothing.
+      await api.notes.updateNoteBody({
+        flag: notebookFlag,
+        noteId: note.noteId,
+        body,
+        expectedRevision: remoteRevision,
+      });
+      lastSavedNoteBody.set(noteKey, body);
+      await persistNoteWrite(
+        notebookFlag,
+        note.noteId,
+        body,
+        remoteRevision + 1
+      );
+      return;
+    }
+    throw new NotesNoteConflictError(remote);
+  }
+  lastSavedNoteBody.set(noteKey, body);
+  await persistNoteWrite(notebookFlag, note.noteId, body, expectedRevision + 1);
+}
+
+// A successful body update moves the note to exactly expectedRevision + 1
+// (the host bumps by one). Persist that immediately instead of relying on
+// the snapshot read-back: the post-save poll gives up silently when replica
+// propagation is slow, and a save that reports success while leaving the
+// stale revision in the local DB wedges every later save on a conflict.
+async function persistNoteWrite(
+  notebookFlag: string,
+  noteId: number,
+  bodyMd: string,
+  revision: number
+) {
+  await db.updateNotesNote({ notebookFlag, noteId, bodyMd, revision });
 }
 
 export async function publishNotebookNote({

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -570,16 +570,19 @@ async function updateNotebookNoteBody({
         if (!api.isNotesV1ConflictError(retryError)) {
           throw retryError;
         }
-        // Best effort: surface the raced writer's copy if the replica has
-        // it; fall back to what we already fetched (it is at least past
-        // the originally rejected revision).
-        throw new NotesNoteConflictError(
-          (await fetchNotePastRevision(
-            notebookFlag,
-            note.noteId,
-            remoteRevision
-          )) ?? remote
+        // Surface the raced writer's copy once the replica has it. If it
+        // hasn't advanced yet, rethrow the raw error instead of building a
+        // conflict from `remote` — that copy is our OWN previous save, and
+        // offering it as "theirs" would let a resolution regress the note.
+        const raced = await fetchNotePastRevision(
+          notebookFlag,
+          note.noteId,
+          remoteRevision
         );
+        if (!raced) {
+          throw retryError;
+        }
+        throw new NotesNoteConflictError(raced);
       }
       lastSavedNoteState.set(noteKey, {
         body,

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -423,24 +423,23 @@ export async function saveNotebookNote({
   }
 
   if (shouldRename) {
-    await api.notes.renameNote({
+    const applied = await api.notes.renameNote({
       flag: notebookFlag,
       noteId: note.noteId,
       title: nextTitle,
     });
     // A successful rename means the host's title is exactly the string we
-    // sent (renames don't bump the revision). Persist it directly — no
-    // read-back needed, same contract-based reasoning as the body/revision
-    // write-through above.
-    await db.updateNotesNote({
-      notebookFlag,
-      noteId: note.noteId,
-      title: nextTitle,
+    // sent (renames don't bump the revision). Persist it with the response
+    // payload's host-stamped updatedAt/updatedBy, so a stale snapshot
+    // already in flight can't win the equal-revision tiebreak and reload
+    // the old title over this write.
+    await persistNoteWrite(notebookFlag, note.noteId, {
+      title: applied?.title ?? nextTitle,
+      applied,
     });
   }
 
-  // Everything we sent is persisted; server-stamped metadata (updatedAt /
-  // updatedBy) arrives via the subscription-triggered sync moments later.
+  // Everything the writes determined is persisted from their responses.
   // No read-back wait: the old poll-until-visible loop here is what
   // silently returned stale revisions when the replica lagged.
   return db.getNotesNote({ notebookFlag, noteId: note.noteId });
@@ -545,7 +544,11 @@ async function updateNotebookNoteBody({
       // Our exact content is already on the host (an unload flush or an
       // earlier retry landed) — nothing left to send.
       lastSavedNoteState.set(noteKey, { body, revision: remoteRevision });
-      await persistNoteWrite(notebookFlag, note.noteId, body, remoteRevision);
+      await persistNoteWrite(notebookFlag, note.noteId, {
+        bodyMd: body,
+        revision: remoteRevision,
+        applied: remote,
+      });
       return;
     }
     const lastSaved = lastSavedNoteState.get(noteKey);
@@ -559,8 +562,9 @@ async function updateNotebookNoteBody({
       // draft evolved from that content; rebasing onto the host's revision
       // loses nothing. The retry itself can race another writer — surface
       // that as a fresh conflict rather than a generic failure.
+      let retryResult: api.NotesV1NoteWriteResult;
       try {
-        await api.notes.updateNoteBody({
+        retryResult = await api.notes.updateNoteBody({
           flag: notebookFlag,
           noteId: note.noteId,
           body,
@@ -584,41 +588,59 @@ async function updateNotebookNoteBody({
         }
         throw new NotesNoteConflictError(raced);
       }
-      lastSavedNoteState.set(noteKey, {
-        body,
-        revision: remoteRevision + 1,
+      const retryRevision = retryResult.note?.revision ?? remoteRevision + 1;
+      lastSavedNoteState.set(noteKey, { body, revision: retryRevision });
+      await persistNoteWrite(notebookFlag, note.noteId, {
+        bodyMd: body,
+        revision: retryRevision,
+        applied: retryResult.note,
       });
-      await persistNoteWrite(
-        notebookFlag,
-        note.noteId,
-        body,
-        remoteRevision + 1
-      );
       return;
     }
     throw new NotesNoteConflictError(remote);
   }
   // %no-change means the host body already matched and the revision was NOT
   // bumped — persisting expected + 1 would put the local DB one revision
-  // ahead of the host and re-wedge the next save.
+  // ahead of the host and re-wedge the next save. When the ok envelope
+  // carries the applied note, its revision is authoritative.
   const nextRevision =
-    result === 'no-change' ? expectedRevision : expectedRevision + 1;
+    result.note?.revision ??
+    (result.status === 'no-change' ? expectedRevision : expectedRevision + 1);
   lastSavedNoteState.set(noteKey, { body, revision: nextRevision });
-  await persistNoteWrite(notebookFlag, note.noteId, body, nextRevision);
+  await persistNoteWrite(notebookFlag, note.noteId, {
+    bodyMd: body,
+    revision: nextRevision,
+    applied: result.note,
+  });
 }
 
-// A successful body update moves the note to exactly expectedRevision + 1
-// (the host bumps by one), so the local row can be written from the response
-// contract alone — no read-back. A save that reported success while leaving
-// a stale revision in the local DB would wedge every later save on a
-// conflict.
+// Persist a write's outcome to the local row. The revision comes from the
+// response payload when present, else the response contract (a successful
+// body update lands on exactly expectedRevision + 1) — no read-back either
+// way. The payload also carries the host's authoritative updatedAt /
+// updatedBy stamps; persisting them lets the snapshot merge's equal-revision
+// tiebreak defend this write against stale snapshots already in flight.
 async function persistNoteWrite(
   notebookFlag: string,
   noteId: number,
-  bodyMd: string,
-  revision: number
+  write: {
+    bodyMd?: string;
+    title?: string;
+    revision?: number;
+    applied?: {
+      updatedAt?: number | null;
+      updatedBy?: string | null;
+    } | null;
+  }
 ) {
-  await db.updateNotesNote({ notebookFlag, noteId, bodyMd, revision });
+  const { applied, ...fields } = write;
+  await db.updateNotesNote({
+    notebookFlag,
+    noteId,
+    ...fields,
+    ...(applied?.updatedAt != null ? { updatedAt: applied.updatedAt } : {}),
+    ...(applied?.updatedBy != null ? { updatedBy: applied.updatedBy } : {}),
+  });
 }
 
 // Persist the host's copy of a note locally — used when the user resolves

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -637,6 +637,9 @@ export async function adoptNotebookNoteRemote({
     noteId: remote.noteId,
     title: remote.title,
     bodyMd: remote.bodyMd ?? '',
+    // The conflicting edit can ride along with a move; leave the folder
+    // untouched when the read omits it.
+    ...(remote.folderId != null ? { folderId: remote.folderId } : {}),
     revision: remote.revision ?? 0,
     updatedAt: remote.updatedAt ?? null,
     updatedBy: remote.updatedBy ?? null,

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -635,17 +635,22 @@ async function persistNoteWrite(
     applied?: {
       title?: string | null;
       folderId?: number | null;
+      revision?: number | null;
       updatedAt?: number | null;
       updatedBy?: string | null;
     } | null;
   }
 ) {
   const { applied, ...fields } = write;
+  // db.updateNotesNote is revision-monotonic: carrying the revision (from
+  // the explicit write or the payload) arms its atomic guard, so a newer
+  // row synced between our response and this persist is never downgraded.
   await db.updateNotesNote({
     notebookFlag,
     noteId,
     ...(applied?.title != null ? { title: applied.title } : {}),
     ...(applied?.folderId != null ? { folderId: applied.folderId } : {}),
+    ...(applied?.revision != null ? { revision: applied.revision } : {}),
     ...(applied?.updatedAt != null ? { updatedAt: applied.updatedAt } : {}),
     ...(applied?.updatedBy != null ? { updatedBy: applied.updatedBy } : {}),
     ...fields,
@@ -665,23 +670,10 @@ export async function adoptNotebookNoteRemote({
 }) {
   // The conflict copy was captured when the banner appeared; the local row
   // can have advanced past it (another remote edit synced while the user
-  // decided). Adopting would downgrade the row — keep it and let the
-  // editor converge on the fresher copy instead. Renames/moves don't bump
-  // the revision, so equal revisions break ties on updatedAt, mirroring
-  // the snapshot merge.
-  const current = await db.getNotesNote({
-    notebookFlag,
-    noteId: remote.noteId,
-  });
-  const remoteRevision = remote.revision ?? 0;
-  if (
-    current &&
-    (remoteRevision < current.revision ||
-      (remoteRevision === current.revision &&
-        (remote.updatedAt ?? 0) < (current.updatedAt ?? 0)))
-  ) {
-    return current;
-  }
+  // decided), and adopting would downgrade it. db.updateNotesNote's atomic
+  // revision guard (equal revisions tie-broken on updatedAt) skips the
+  // write in that case, and the read below returns whichever copy won —
+  // the editor converges on it either way.
   await db.updateNotesNote({
     notebookFlag,
     noteId: remote.noteId,
@@ -691,8 +683,8 @@ export async function adoptNotebookNoteRemote({
     // untouched when the read omits it.
     ...(remote.folderId != null ? { folderId: remote.folderId } : {}),
     revision: remote.revision ?? 0,
-    updatedAt: remote.updatedAt ?? null,
-    updatedBy: remote.updatedBy ?? null,
+    ...(remote.updatedAt != null ? { updatedAt: remote.updatedAt } : {}),
+    ...(remote.updatedBy != null ? { updatedBy: remote.updatedBy } : {}),
   });
   return db.getNotesNote({ notebookFlag, noteId: remote.noteId });
 }

--- a/packages/shared/src/store/notesActions.ts
+++ b/packages/shared/src/store/notesActions.ts
@@ -634,6 +634,7 @@ async function persistNoteWrite(
     revision?: number;
     applied?: {
       title?: string | null;
+      bodyMd?: string | null;
       folderId?: number | null;
       revision?: number | null;
       updatedAt?: number | null;
@@ -645,10 +646,16 @@ async function persistNoteWrite(
   // db.updateNotesNote is revision-monotonic: carrying the revision (from
   // the explicit write or the payload) arms its atomic guard, so a newer
   // row synced between our response and this persist is never downgraded.
+  // The payload's fields are persisted as a unit — body INCLUDED: a
+  // rename-only save racing a remote body edit returns the host's newer
+  // body and revision together, and persisting the revision without the
+  // body would fabricate a row that lets the next body edit pass the
+  // optimistic-concurrency check and silently overwrite the remote edit.
   await db.updateNotesNote({
     notebookFlag,
     noteId,
     ...(applied?.title != null ? { title: applied.title } : {}),
+    ...(applied?.bodyMd != null ? { bodyMd: applied.bodyMd } : {}),
     ...(applied?.folderId != null ? { folderId: applied.folderId } : {}),
     ...(applied?.revision != null ? { revision: applied.revision } : {}),
     ...(applied?.updatedAt != null ? { updatedAt: applied.updatedAt } : {}),


### PR DESCRIPTION
## Summary

Note body saves could wedge permanently: the editor sent a stale `expectedRevision`, the host crashed on the mismatch (surfacing as an opaque `%notes error: unknown`), and the client retried the same stale revision forever — even while fresh queries were visibly returning the updated note. This PR types the error on the backend and makes the client both avoid the staleness and recover from genuine conflicts.

Fixes TLON-6229

## Changes

**Backend (`desk/app/notes.hoon`)**
- `se-update-note` no longer crashes on a stale `expectedRevision` (`~|(%revision-mismatch !!)` → nack → `%unknown`). It finalizes a typed `[%error %conflict "revision-mismatch: expected N, current M"]` via the existing `se-finalize-with` arm. `%conflict` was already in the `action-error` union, so **no mark or wire changes** — old ships/clients stay compatible.

**API (`packages/api`)**
- Error envelopes surface `errorType` as a typed `NotesV1WriteError` (+ `isNotesV1ConflictError` guard); tang-array messages render as joined lines instead of `String(array)`.

**Store (`packages/shared`)**
- A successful body PUT deterministically lands on `expected + 1`, so `saveNotebookNote` persists that revision (and body) to the local DB immediately (new `db.updateNotesNote`) instead of relying solely on the snapshot read-back — which silently gives up after ~2.4s and previously left the stale revision behind, wedging every later save.
- On a conflict it fetches the host copy and recovers: content already on the host → treated as applied; host content is our own previous save (tracked per note) → rebase and retry once; genuine divergence → typed `NotesNoteConflictError` carrying the remote note.

**UI (`packages/app` NotesChannel)**
- A genuine conflict suspends autosave (a blind retry can never succeed) and shows a banner with **Keep mine** / **Use theirs** resolution, mirroring the ship-served `ui.html` notes app's conflict flow. The background/unmount flush surfaces conflicts instead of swallowing them.

## How did I test?

- Desk agent tests on a kelvin-408 dev ship: **76/76 pass**, including `test-update-note-mismatched-revision-rejects` / `test-update-note-stale-zero-rejects` rewritten to assert the typed `%error %conflict` response-update fact and that the rejected update is not broadcast to subscribers.
- `packages/shared` vitest: 19/19, with four new tests — stale read-back still persists the bumped revision; conflict with already-applied content treated as success; rebase-and-retry over our own previous save; typed conflict on divergent content.
- `packages/api` vitest: 45/45, with new coverage for the typed conflict envelope and tang messages.
- `tsc` clean on shared/api/app; prettier + eslint clean on changed files.

## Risks and impact

- Backend behavior change: a stale-revision update now returns a typed error instead of crashing the poke. The strict no-force-update semantics are unchanged; the no-op early-out and archive behavior are untouched. `%conflict` is an existing union member, so cross-ship compat is preserved.
- The client's optimistic revision persist assumes the host bumps by exactly one per successful update, which `se-update-note` guarantees; a later successful snapshot sync always supersedes it with replica truth.
- The auto-rebase path only fires when the host's content byte-matches what this client previously sent, so cross-user (and cross-device) divergence always surfaces as an explicit user choice, never a silent overwrite. Overwritten revisions remain recoverable via note history.

## Rollback plan

Revert the PR. No migrations, no mark changes, no state changes; old and new desks/clients interoperate in any combination.

## Screenshots

N/A (banner reuses the existing NotesBanner styling with added action buttons).