### PR TITLE
speed up the mobile iteration loop

### DIFF
--- a/.maestro/benchmarks/channel-roundtrip.yaml
+++ b/.maestro/benchmarks/channel-roundtrip.yaml
@@ -1,0 +1,21 @@
+appId: io.tlon.groups
+---
+# Start on a group's channel list. Keeping all rounds in one Maestro process
+# avoids paying driver startup for every navigation sample.
+- assertVisible:
+    id: 'GroupChannelsHeaderTrigger'
+- repeat:
+    times: 3
+    commands:
+      - tapOn:
+          id: 'ChannelListItem-${CHANNEL_TITLE}'
+      - extendedWaitUntil:
+          visible:
+            id: 'MessageInput'
+          timeout: 30000
+      - tapOn:
+          id: 'HeaderBackButton'
+      - extendedWaitUntil:
+          visible:
+            id: 'GroupChannelsHeaderTrigger'
+          timeout: 30000

--- a/.maestro/benchmarks/channel-roundtrip.yaml
+++ b/.maestro/benchmarks/channel-roundtrip.yaml
@@ -1,14 +1,25 @@
 appId: io.tlon.groups
 ---
-# Start on a group's channel list. Keeping all rounds in one Maestro process
-# avoids paying driver startup for every navigation sample.
+# Start on Home or on a group's channel list. Keeping all rounds in one Maestro
+# process avoids paying driver startup for every navigation sample.
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: 'ChatListItem-${GROUP_TITLE}-pinned'
+    timeout: 120000
+- tapOn:
+    id: 'ChatListItem-${GROUP_TITLE}-pinned'
+- extendedWaitUntil:
+    visible:
+      id: 'GroupChannelsHeaderTrigger'
+    timeout: 30000
 - assertVisible:
     id: 'GroupChannelsHeaderTrigger'
 - repeat:
     times: 3
     commands:
       - tapOn:
-          id: 'ChannelListItem-${CHANNEL_TITLE}'
+          id: 'ChannelListItem-.*${CHANNEL_TITLE}.*'
       - extendedWaitUntil:
           visible:
             id: 'MessageInput'

--- a/apps/tlon-mobile/babel.config.js
+++ b/apps/tlon-mobile/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = function (api) {
+  // The mobile fast loop may skip the expensive whole-app compilers during
+  // iteration. Normal builds and final validation keep both enabled.
   const reactCompilerEnvironment = api.caller((caller) => {
     if (
+      process.env.TLON_REACT_COMPILER_DISABLED === '1' ||
       !caller?.supportsReactCompiler ||
       caller.isNodeModule ||
       caller.isServer ||
@@ -10,6 +13,8 @@ module.exports = function (api) {
     }
     return caller.isDev === false ? 'production' : 'development';
   });
+  const disableTamaguiCompiler =
+    process.env.TLON_TAMAGUI_COMPILER_DISABLED === '1';
 
   return {
     presets: [
@@ -43,7 +48,7 @@ module.exports = function (api) {
           extensions: ['.sql'],
         },
       ],
-      [
+      !disableTamaguiCompiler && [
         '@tamagui/babel-plugin',
         {
           config: './tamagui.config.ts',

--- a/apps/tlon-mobile/ios/Podfile.properties.json
+++ b/apps/tlon-mobile/ios/Podfile.properties.json
@@ -2,5 +2,6 @@
   "expo.jsEngine": "hermes",
   "ios.useFrameworks": "static",
   "ios.forceStaticLinking": "[\"RNFBApp\",\"RNFBCrashlytics\",\"RNFBPerf\"]",
+  "apple.ccacheEnabled": "true",
   "newArchEnabled": "true"
 }

--- a/apps/tlon-mobile/metro.config.js
+++ b/apps/tlon-mobile/metro.config.js
@@ -13,10 +13,9 @@ const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, '../..');
 const baseConfig = getSentryExpoConfig(projectRoot);
 
-// Shared Metro transform cache across worktrees on this machine. Keep values
-// in the transformer config independent of the checkout path: Metro includes
-// that object in its global transform key. Package requests are resolved by the
-// worker at runtime but remain identical across source-identical worktrees.
+// Shared Metro transform cache across worktrees on this machine. Linked
+// dependencies resolve to the prepared worktree, so the opt-in canonical path
+// hook below removes the checkout path from otherwise content-addressed keys.
 // Partition by resolved RN+Expo version so upgrades don't poison the cache.
 //
 // Off by default to avoid affecting normal dev workflows. Opt in with
@@ -33,6 +32,29 @@ const sharedCacheStores =
   process.env.TLON_METRO_SHARED_CACHE_ENABLED === '1'
     ? [new FileStore({ root: sharedCacheRoot })]
     : undefined;
+const getCanonicalCachePath = sharedCacheStores
+  ? (filePath, localPath) => {
+      const normalizedFilePath = filePath.split(path.sep).join('/');
+      const nodeModulesMarker = '/node_modules/';
+      const nodeModulesIndex = normalizedFilePath.indexOf(nodeModulesMarker);
+
+      if (nodeModulesIndex !== -1) {
+        return `node_modules/${normalizedFilePath.slice(
+          nodeModulesIndex + nodeModulesMarker.length
+        )}`;
+      }
+
+      const workspacePath = path.relative(workspaceRoot, filePath);
+      if (
+        !workspacePath.startsWith(`..${path.sep}`) &&
+        workspacePath !== '..'
+      ) {
+        return workspacePath;
+      }
+
+      return localPath;
+    }
+  : undefined;
 
 /**
  * Metro configuration
@@ -43,7 +65,10 @@ const sharedCacheStores =
 const config = {
   ...(sharedCacheStores ? { cacheStores: sharedCacheStores } : {}),
   transformer: {
-    babelTransformerPath: 'react-native-svg-transformer',
+    babelTransformerPath: require.resolve('react-native-svg-transformer'),
+    ...(getCanonicalCachePath
+      ? { unstable_getCanonicalCachePath: getCanonicalCachePath }
+      : {}),
     // Enable inlineRequires (off by default in Expo) to defer module eval until
     // first use, speeding up cold start.
     getTransformOptions: async () => ({

--- a/apps/tlon-mobile/metro.config.js
+++ b/apps/tlon-mobile/metro.config.js
@@ -13,11 +13,11 @@ const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, '../..');
 const baseConfig = getSentryExpoConfig(projectRoot);
 
-// Shared Metro transform cache across worktrees on this machine.
-// metro-transform-worker keys are content-addressed (relative paths only),
-// and Expo's `_expoRelativeProjectRoot` is workspace-relative, so identical
-// sources in different worktrees produce identical keys. Partition by
-// resolved RN+Expo version so upgrades don't poison the cache.
+// Shared Metro transform cache across worktrees on this machine. Keep values
+// in the transformer config independent of the checkout path: Metro includes
+// that object in its global transform key. Package requests are resolved by the
+// worker at runtime but remain identical across source-identical worktrees.
+// Partition by resolved RN+Expo version so upgrades don't poison the cache.
 //
 // Off by default to avoid affecting normal dev workflows. Opt in with
 // TLON_METRO_SHARED_CACHE_ENABLED=1 (e.g., set in the agent-loop harness or by
@@ -43,7 +43,7 @@ const sharedCacheStores =
 const config = {
   ...(sharedCacheStores ? { cacheStores: sharedCacheStores } : {}),
   transformer: {
-    babelTransformerPath: require.resolve('react-native-svg-transformer'),
+    babelTransformerPath: 'react-native-svg-transformer',
     // Enable inlineRequires (off by default in Expo) to defer module eval until
     // first use, speeding up cold start.
     getTransformOptions: async () => ({

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev:ios": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-mobile' dev\" \"pnpm --filter 'tlon-mobile' ios\" \"pnpm --filter '@tloncorp/ui' watch\"",
     "dev:ios:preview": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-mobile' dev\" \"pnpm --filter 'tlon-mobile' ios:preview\" \"pnpm --filter '@tloncorp/ui' watch\"",
     "mobile:fast:bootstrap": "scripts/mobile-fast-bootstrap.sh",
+    "mobile:fast:worktree": "scripts/mobile-fast-worktree.sh",
     "mobile:fast:start": "scripts/mobile-fast-start.sh",
     "dev:desktop": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-desktop' dev\"",
     "dev:web": "pnpm --filter 'tlon-web' dev",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "dev:android": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-mobile' dev\" \"pnpm --filter 'tlon-mobile' android\"",
     "dev:ios": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-mobile' dev\" \"pnpm --filter 'tlon-mobile' ios\" \"pnpm --filter '@tloncorp/ui' watch\"",
     "dev:ios:preview": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-mobile' dev\" \"pnpm --filter 'tlon-mobile' ios:preview\" \"pnpm --filter '@tloncorp/ui' watch\"",
+    "mobile:fast:bootstrap": "scripts/mobile-fast-bootstrap.sh",
+    "mobile:fast:start": "scripts/mobile-fast-start.sh",
     "dev:desktop": "concurrently \"pnpm run dev:shared\" \"pnpm --filter 'tlon-desktop' dev\"",
     "dev:web": "pnpm --filter 'tlon-web' dev",
     "e2e": "pnpm --filter 'tlon-web' e2e",

--- a/packages/app/ui/components/listItems/ChannelListItem.tsx
+++ b/packages/app/ui/components/listItems/ChannelListItem.tsx
@@ -134,7 +134,7 @@ export function ChannelListItem({
     <View ref={containerRef}>
       <Pressable
         testID={isWeb ? undefined : rowTestID}
-        accessibilityLabel={isWeb ? undefined : title}
+        accessibilityLabel={isWeb ? undefined : title ?? undefined}
         accessibilityRole={isWeb ? undefined : 'button'}
         borderRadius="$xl"
         onPress={open ? undefined : handlePress}

--- a/packages/app/ui/components/listItems/ChannelListItem.tsx
+++ b/packages/app/ui/components/listItems/ChannelListItem.tsx
@@ -126,10 +126,16 @@ export function ChannelListItem({
   const groupTitle = utils.useGroupTitle(model.group);
   const isDmType = model.type === 'dm' || model.type === 'groupDm';
   const dmMembers = isDmType ? model.members : [];
+  const rowTestID = isDmType
+    ? `ChannelListItem-${model.id}`
+    : `ChannelListItem-${model.title}`;
 
   return (
     <View ref={containerRef}>
       <Pressable
+        testID={isWeb ? undefined : rowTestID}
+        accessibilityLabel={isWeb ? undefined : title}
+        accessibilityRole={isWeb ? undefined : 'button'}
         borderRadius="$xl"
         onPress={open ? undefined : handlePress}
         onLongPress={isWeb ? undefined : handleLongPress}
@@ -143,11 +149,7 @@ export function ChannelListItem({
         <ListItem
           onLayout={onLayout}
           {...props}
-          testID={
-            model.type === 'dm' || model.type === 'groupDm'
-              ? `ChannelListItem-${model.id}`
-              : `ChannelListItem-${model.title}`
-          }
+          testID={isWeb ? rowTestID : undefined}
         >
           {StartIcon !== undefined ? (
             StartIcon

--- a/patches/README.md
+++ b/patches/README.md
@@ -9,6 +9,29 @@ When adding a patch, document:
 - how to validate it
 - when it can be removed
 
+## metro@0.84.4
+
+Why:
+Metro's transform cache includes each module's path relative to `projectRoot`.
+Our fast worktrees share installed dependencies with a prepared worktree, so
+Metro resolves those dependency symlinks to the prepared worktree's absolute
+path. Identical files then receive different cache keys in different worktrees.
+
+What it does:
+Adds an opt-in `unstable_getCanonicalCachePath` transformer hook used only for
+the cache-key path. The actual path passed to the transform worker is unchanged.
+The mobile shared-cache configuration uses it to express workspace files and
+`node_modules` files relative to stable logical roots.
+
+Validation:
+Populate the shared cache with `mobile:fast:start` in one clean worktree, then
+request the same iOS bundle from a source-identical linked worktree. The second
+bundle should reuse transforms rather than re-running Babel workers.
+
+Removal:
+Drop this patch when Metro exposes an equivalent cache-key path hook upstream,
+or when fast worktrees no longer share dependency trees through symlinks.
+
 ## @gorhom/bottom-sheet@5.2.14
 
 Local patch:

--- a/patches/metro@0.84.4.patch
+++ b/patches/metro@0.84.4.patch
@@ -1,0 +1,29 @@
+diff --git a/src/DeltaBundler/Transformer.js b/src/DeltaBundler/Transformer.js
+index 6dc9cd86b67aa436c045873828422b40e9150d36..30d6966bf2eeb9d2b72862e1ed7804d5ae1cf2e7 100644
+--- a/src/DeltaBundler/Transformer.js
++++ b/src/DeltaBundler/Transformer.js
+@@ -28,8 +28,10 @@ class Transformer {
+       getTransformOptions: _getTransformOptions,
+       transformVariants: _transformVariants,
+       unstable_workerThreads: _workerThreads,
++      unstable_getCanonicalCachePath: getCanonicalCachePath,
+       ...transformerConfig
+     } = this._config.transformer;
++    this._getCanonicalCachePath = getCanonicalCachePath;
+     const transformerOptions = {
+       transformerPath: this._config.transformerPath,
+       transformerConfig,
+@@ -75,10 +77,13 @@ class Transformer {
+       this._config.projectRoot,
+       filePath,
+     );
++    const cachePath = this._getCanonicalCachePath
++      ? this._getCanonicalCachePath(filePath, localPath)
++      : localPath;
+     const partialKey = (0, _metroCache.stableHash)([
+       this._baseHash,
+-      (0, _pathUtils.normalizePathSeparatorsToPosix)(localPath),
++      (0, _pathUtils.normalizePathSeparatorsToPosix)(cachePath),
+       customTransformOptions,
+       dev,
+       experimentalImportSupport,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ patchedDependencies:
   drizzle-orm: 834dc52d077cfbc1aab821e9960422d59032b5e4684b82f56bf452cb0d5db1a7
   expo-background-task: 3daff8d4e5dad45164c728ef157cd94381f3c69e621f0d0af42cde77694fa9d3
   expo-image-manipulator: a0cad1b916a3f3d549acf65332d547d04190f2d46d14756c6ae74c0330f6a7b3
+  metro@0.84.4: 4bc6188fd86196406d897ee6f2929bd4056d81a951297973bdb994404c740f0e
   react-cosmos: 658acdaf59c16d70e54b6b0b9d522593cd973839891ed5446a3dd3045d4e37eb
   react-native-country-codes-picker: 53c90d297e1cc4991af0f2d72d0f33a68e8be46e75bdf3da919a20160791bee5
   react-native-gesture-handler: e6fc0413229a6f38cc4b2432f69ea6cc8692cc4d611e47452f4c65678df5caf4
@@ -16047,7 +16048,7 @@ snapshots:
 
   '@expo/metro@56.0.0':
     dependencies:
-      metro: 0.84.4
+      metro: 0.84.4(patch_hash=4bc6188fd86196406d897ee6f2929bd4056d81a951297973bdb994404c740f0e)
       metro-babel-transformer: 0.84.4
       metro-cache: 0.84.4
       metro-cache-key: 0.84.4
@@ -17561,7 +17562,7 @@ snapshots:
       '@react-native/dev-middleware': 0.86.0
       debug: 4.4.3
       invariant: 2.2.4
-      metro: 0.84.4
+      metro: 0.84.4(patch_hash=4bc6188fd86196406d897ee6f2929bd4056d81a951297973bdb994404c740f0e)
       metro-config: 0.84.4
       metro-core: 0.84.4
       semver: 7.7.3
@@ -25116,7 +25117,7 @@ snapshots:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.84.4
+      metro: 0.84.4(patch_hash=4bc6188fd86196406d897ee6f2929bd4056d81a951297973bdb994404c740f0e)
       metro-cache: 0.84.4
       metro-core: 0.84.4
       metro-runtime: 0.84.4
@@ -25203,7 +25204,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
-      metro: 0.84.4
+      metro: 0.84.4(patch_hash=4bc6188fd86196406d897ee6f2929bd4056d81a951297973bdb994404c740f0e)
       metro-babel-transformer: 0.84.4
       metro-cache: 0.84.4
       metro-cache-key: 0.84.4
@@ -25216,7 +25217,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.84.4:
+  metro@0.84.4(patch_hash=4bc6188fd86196406d897ee6f2929bd4056d81a951297973bdb994404c740f0e):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,7 @@ patchedDependencies:
   expo-image-manipulator: patches/expo-image-manipulator@57.0.1.patch
   expo-background-task: patches/expo-background-task@57.0.1.patch
   '@mattermost/react-native-paste-input@2.0.1': patches/@mattermost__react-native-paste-input@2.0.1.patch
+  metro@0.84.4: patches/metro@0.84.4.patch
 
 allowUnusedPatches: false
 

--- a/scripts/mobile-fast-bootstrap.sh
+++ b/scripts/mobile-fast-bootstrap.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/mobile-fast-bootstrap.sh /absolute/path/to/prepared-worktree
+
+Prepares a fresh worktree for mobile JavaScript work by linking its dependency
+tree to an already-installed worktree, then generating the two required local
+artifacts. The dependency manifests, platform, architecture, Node ABI, and pnpm
+version must match exactly.
+
+Do not run pnpm install in a linked worktree. Remove its node_modules directories
+and perform a normal install when dependencies change.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+target_root="$(git rev-parse --show-toplevel)"
+seed_root="$(cd "$1" && git rev-parse --show-toplevel)"
+
+if [[ "$target_root" == "$seed_root" ]]; then
+  echo "The prepared worktree must be different from the target worktree." >&2
+  exit 1
+fi
+
+if [[ ! -d "$seed_root/node_modules" || ! -e "$seed_root/node_modules/expo" ]]; then
+  echo "The prepared worktree does not have a complete root dependency installation." >&2
+  exit 1
+fi
+
+if [[ -e "$target_root/node_modules" || -L "$target_root/node_modules" ]]; then
+  echo "The target already has node_modules. Refusing to replace it." >&2
+  exit 1
+fi
+
+dependency_signature() {
+  local root="$1"
+
+  (
+    cd "$root"
+    {
+      printf 'platform=%s\n' "$(uname -s)"
+      printf 'architecture=%s\n' "$(uname -m)"
+      printf 'node_abi=%s\n' "$(node -p 'process.versions.modules')"
+      printf 'package_manager=%s\n' "$(node -p "require('./package.json').packageManager || ''")"
+
+      {
+        for file in package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc .nvmrc; do
+          [[ -f "$file" ]] && printf '%s\n' "$file"
+        done
+        find apps packages \
+          -type d -name node_modules -prune -o \
+          -type f -name package.json -print
+        [[ -d patches ]] && find patches -type f -print
+      } | LC_ALL=C sort -u | while IFS= read -r file; do
+        shasum -a 256 "$file"
+      done
+    } | shasum -a 256 | awk '{print $1}'
+  )
+}
+
+echo "Checking that dependency inputs match..."
+target_signature="$(dependency_signature "$target_root")"
+seed_signature="$(dependency_signature "$seed_root")"
+
+if [[ "$target_signature" != "$seed_signature" ]]; then
+  cat >&2 <<EOF
+Dependency inputs do not match the prepared worktree.
+
+Target:   $target_signature
+Prepared: $seed_signature
+
+Use a normal frozen pnpm install for this worktree.
+EOF
+  exit 1
+fi
+
+started_at=$SECONDS
+echo "Linking dependency trees from $seed_root..."
+node - "$seed_root" "$target_root" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const seedRoot = process.argv[2];
+const targetRoot = process.argv[3];
+
+function linkDirectoryEntries(sourceDirectory, targetDirectory) {
+  fs.mkdirSync(targetDirectory, { recursive: true });
+
+  for (const entry of fs.readdirSync(sourceDirectory, { withFileTypes: true })) {
+    const source = path.join(sourceDirectory, entry.name);
+    const target = path.join(targetDirectory, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      fs.symlinkSync(fs.readlinkSync(source), target);
+    } else if (entry.name.startsWith('@') && entry.isDirectory()) {
+      // Scoped directories contain package links. Recreate those links so
+      // workspace dependencies resolve inside the new worktree.
+      linkDirectoryEntries(source, target);
+    } else {
+      fs.symlinkSync(source, target, entry.isDirectory() ? 'dir' : 'file');
+    }
+  }
+}
+
+linkDirectoryEntries(
+  path.join(seedRoot, 'node_modules'),
+  path.join(targetRoot, 'node_modules')
+);
+
+for (const workspaceGroup of ['apps', 'packages']) {
+  const seedGroup = path.join(seedRoot, workspaceGroup);
+  if (!fs.existsSync(seedGroup)) continue;
+
+  for (const workspace of fs.readdirSync(seedGroup, { withFileTypes: true })) {
+    if (!workspace.isDirectory()) continue;
+    const source = path.join(seedGroup, workspace.name, 'node_modules');
+    if (!fs.existsSync(source)) continue;
+    const target = path.join(
+      targetRoot,
+      workspaceGroup,
+      workspace.name,
+      'node_modules'
+    );
+    linkDirectoryEntries(source, target);
+  }
+}
+NODE
+
+cat > "$target_root/node_modules/.tlon-linked-deps" <<EOF
+prepared_worktree=$seed_root
+dependency_signature=$seed_signature
+EOF
+
+linked_at=$SECONDS
+echo "Dependency linking completed in $((linked_at - started_at))s."
+
+echo "Building the editor package..."
+(cd "$target_root" && corepack pnpm --filter @tloncorp/editor build)
+editor_at=$SECONDS
+
+echo "Generating mobile Tailwind artifacts..."
+(cd "$target_root" && corepack pnpm --filter tlon-mobile run generate:tailwind)
+tailwind_at=$SECONDS
+
+echo "Checking the Expo configuration..."
+(cd "$target_root" && corepack pnpm --filter tlon-mobile exec expo config --type public --json >/dev/null)
+finished_at=$SECONDS
+
+cat <<EOF
+
+Mobile worktree ready in $((finished_at - started_at))s:
+  dependencies: $((linked_at - started_at))s
+  editor build: $((editor_at - linked_at))s
+  Tailwind:     $((tailwind_at - editor_at))s
+  Expo check:   $((finished_at - tailwind_at))s
+
+Do not run pnpm install here. If dependencies change, remove node_modules and
+perform a normal frozen install.
+EOF

--- a/scripts/mobile-fast-bootstrap.sh
+++ b/scripts/mobile-fast-bootstrap.sh
@@ -4,12 +4,18 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/mobile-fast-bootstrap.sh /absolute/path/to/prepared-worktree
+Usage:
+  scripts/mobile-fast-bootstrap.sh [--allow-concurrent-native-build] /absolute/path/to/prepared-worktree
+  scripts/mobile-fast-bootstrap.sh --prepare-artifacts
 
 Prepares a fresh worktree for mobile JavaScript work by linking its dependency
-tree to an already-installed worktree, then generating the two required local
-artifacts. The dependency manifests, platform, architecture, Node ABI, and pnpm
-version must match exactly.
+tree to an already-installed worktree. Generated editor and Tailwind artifacts
+are copied when a signed, source-identical set exists; otherwise they are built.
+The dependency manifests, platform, architecture, Node ABI, and pnpm version
+must match exactly.
+
+--prepare-artifacts rebuilds and signs the artifacts in the current worktree so
+it can seed source-identical worktrees.
 
 Do not run pnpm install in a linked worktree. Remove its node_modules directories
 and perform a normal install when dependencies change.
@@ -21,28 +27,97 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   exit 0
 fi
 
-if [[ $# -ne 1 ]]; then
+prepare_artifacts=0
+allow_concurrent_native_build="${TLON_MOBILE_ALLOW_CONCURRENT_NATIVE_BUILD:-0}"
+seed_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prepare-artifacts)
+      prepare_artifacts=1
+      shift
+      ;;
+    --allow-concurrent-native-build)
+      allow_concurrent_native_build=1
+      shift
+      ;;
+    *)
+      if [[ -n "$seed_path" ]]; then
+        usage >&2
+        exit 2
+      fi
+      seed_path="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ "$prepare_artifacts" -eq 1 && -n "$seed_path" ]] \
+  || [[ "$prepare_artifacts" -eq 0 && -z "$seed_path" ]]; then
   usage >&2
   exit 2
 fi
 
 target_root="$(git rev-parse --show-toplevel)"
-seed_root="$(cd "$1" && git rev-parse --show-toplevel)"
 
-if [[ "$target_root" == "$seed_root" ]]; then
-  echo "The prepared worktree must be different from the target worktree." >&2
-  exit 1
+active_native_builds() {
+  ps -axo pid=,command= | awk -v own_pid="$$" '
+    $1 != own_pid && ($0 ~ /[x]codebuild .* (-workspace|-project|-scheme|archive|build)/ || $0 ~ /[e]xpo (run:ios|run:android)/ || $0 ~ /[e]as (build|build:run).*--local/) { print }
+  '
+}
+
+if [[ "$allow_concurrent_native_build" != "1" ]]; then
+  native_builds="$(active_native_builds)"
+  if [[ -n "$native_builds" ]]; then
+    cat >&2 <<EOF
+A native build is already using this machine. Starting bootstrap now is likely
+to make both loops slower:
+$native_builds
+
+Wait for it to finish, or pass --allow-concurrent-native-build to override.
+EOF
+    exit 1
+  fi
 fi
 
-if [[ ! -d "$seed_root/node_modules" || ! -e "$seed_root/node_modules/expo" ]]; then
-  echo "The prepared worktree does not have a complete root dependency installation." >&2
-  exit 1
-fi
+artifact_tree_signature() {
+  local root="$1"
+  shift
 
-if [[ -e "$target_root/node_modules" || -L "$target_root/node_modules" ]]; then
-  echo "The target already has node_modules. Refusing to replace it." >&2
-  exit 1
-fi
+  if [[ -n "$(git -C "$root" status --porcelain --untracked-files=all -- "$@")" ]]; then
+    return 1
+  fi
+
+  (
+    cd "$root"
+    for source_path in "$@"; do
+      printf '%s\0' "$source_path"
+      git rev-parse "HEAD:$source_path"
+    done
+  ) | shasum -a 256 | awk '{print $1}'
+}
+
+editor_signature() {
+  artifact_tree_signature "$1" packages/editor
+}
+
+tailwind_signature() {
+  artifact_tree_signature "$1" \
+    apps/tlon-mobile packages/app packages/ui
+}
+
+write_artifact_manifest() {
+  local root="$1"
+  local dependency="$2"
+  local editor="$3"
+  local tailwind="$4"
+
+  cat > "$root/node_modules/.tlon-generated-artifacts" <<EOF
+dependency_signature=$dependency
+editor_signature=$editor
+tailwind_signature=$tailwind
+EOF
+}
 
 dependency_signature() {
   local root="$1"
@@ -69,6 +144,58 @@ dependency_signature() {
     } | shasum -a 256 | awk '{print $1}'
   )
 }
+
+build_and_sign_artifacts() {
+  local root="$1"
+  local dependency editor tailwind
+
+  dependency="$(dependency_signature "$root")"
+  editor="$(editor_signature "$root" || true)"
+  tailwind="$(tailwind_signature "$root" || true)"
+
+  echo "Building the editor package..."
+  (cd "$root" && corepack pnpm --filter @tloncorp/editor build)
+  editor_at=$SECONDS
+
+  echo "Generating mobile Tailwind artifacts..."
+  (cd "$root" && corepack pnpm --filter tlon-mobile run generate:tailwind)
+  tailwind_at=$SECONDS
+
+  if [[ -n "$editor" && -n "$tailwind" ]]; then
+    write_artifact_manifest "$root" "$dependency" "$editor" "$tailwind"
+  else
+    rm -f "$root/node_modules/.tlon-generated-artifacts"
+    echo "Artifacts were built but not signed because relevant source files are dirty."
+  fi
+}
+
+if [[ "$prepare_artifacts" -eq 1 ]]; then
+  if [[ ! -e "$target_root/node_modules/expo" ]]; then
+    echo "Dependencies are not installed in $target_root." >&2
+    exit 1
+  fi
+  started_at=$SECONDS
+  build_and_sign_artifacts "$target_root"
+  echo "Prepared and signed generated artifacts in $((SECONDS - started_at))s."
+  exit 0
+fi
+
+seed_root="$(cd "$seed_path" && git rev-parse --show-toplevel)"
+
+if [[ "$target_root" == "$seed_root" ]]; then
+  echo "The prepared worktree must be different from the target worktree." >&2
+  exit 1
+fi
+
+if [[ ! -d "$seed_root/node_modules" || ! -e "$seed_root/node_modules/expo" ]]; then
+  echo "The prepared worktree does not have a complete root dependency installation." >&2
+  exit 1
+fi
+
+if [[ -e "$target_root/node_modules" || -L "$target_root/node_modules" ]]; then
+  echo "The target already has node_modules. Refusing to replace it." >&2
+  exit 1
+fi
 
 echo "Checking that dependency inputs match..."
 target_signature="$(dependency_signature "$target_root")"
@@ -146,13 +273,40 @@ EOF
 linked_at=$SECONDS
 echo "Dependency linking completed in $((linked_at - started_at))s."
 
-echo "Building the editor package..."
-(cd "$target_root" && corepack pnpm --filter @tloncorp/editor build)
-editor_at=$SECONDS
+target_editor_signature="$(editor_signature "$target_root" || true)"
+target_tailwind_signature="$(tailwind_signature "$target_root" || true)"
+artifact_manifest="$seed_root/node_modules/.tlon-generated-artifacts"
+reuse_artifacts=0
 
-echo "Generating mobile Tailwind artifacts..."
-(cd "$target_root" && corepack pnpm --filter tlon-mobile run generate:tailwind)
-tailwind_at=$SECONDS
+if [[ -n "$target_editor_signature" && -n "$target_tailwind_signature" \
+  && -f "$artifact_manifest" ]]; then
+  # shellcheck disable=SC1090
+  source "$artifact_manifest"
+  if [[ "${dependency_signature:-}" == "$seed_signature" \
+    && "${editor_signature:-}" == "$target_editor_signature" \
+    && "${tailwind_signature:-}" == "$target_tailwind_signature" \
+    && -f "$seed_root/packages/editor/dist/index.html" \
+    && -f "$seed_root/apps/tlon-mobile/tailwind.css" \
+    && -f "$seed_root/apps/tlon-mobile/tailwind.json" ]]; then
+    reuse_artifacts=1
+  fi
+fi
+
+if [[ "$reuse_artifacts" -eq 1 ]]; then
+  echo "Copying source-identical generated artifacts..."
+  mkdir -p "$target_root/packages/editor/dist"
+  cp -R "$seed_root/packages/editor/dist/." "$target_root/packages/editor/dist/"
+  cp "$seed_root/apps/tlon-mobile/tailwind.css" \
+    "$seed_root/apps/tlon-mobile/tailwind.json" \
+    "$target_root/apps/tlon-mobile/"
+  write_artifact_manifest \
+    "$target_root" "$seed_signature" \
+    "$target_editor_signature" "$target_tailwind_signature"
+  editor_at=$SECONDS
+  tailwind_at=$SECONDS
+else
+  build_and_sign_artifacts "$target_root"
+fi
 
 echo "Checking the Expo configuration..."
 (cd "$target_root" && corepack pnpm --filter tlon-mobile exec expo config --type public --json >/dev/null)
@@ -162,7 +316,7 @@ cat <<EOF
 
 Mobile worktree ready in $((finished_at - started_at))s:
   dependencies: $((linked_at - started_at))s
-  editor build: $((editor_at - linked_at))s
+  editor:       $((editor_at - linked_at))s
   Tailwind:     $((tailwind_at - editor_at))s
   Expo check:   $((finished_at - tailwind_at))s
 

--- a/scripts/mobile-fast-bootstrap.sh
+++ b/scripts/mobile-fast-bootstrap.sh
@@ -62,7 +62,7 @@ target_root="$(git rev-parse --show-toplevel)"
 
 active_native_builds() {
   ps -axo pid=,command= | awk -v own_pid="$$" '
-    $1 != own_pid && ($0 ~ /[x]codebuild .* (-workspace|-project|-scheme|archive|build)/ || $0 ~ /[e]xpo (run:ios|run:android)/ || $0 ~ /[e]as (build|build:run).*--local/) { print }
+    $1 != own_pid && ($0 ~ /[x]codebuild .* (-workspace|-project|-scheme|archive|build)/ || $0 ~ /[Gg]radle.* (assemble|bundle|install|build)/ || $0 ~ /[e]as (build|build:run).*--local/) { print }
   '
 }
 

--- a/scripts/mobile-fast-start.sh
+++ b/scripts/mobile-fast-start.sh
@@ -142,7 +142,7 @@ fi
 
 active_native_builds() {
   ps -axo pid=,command= | awk -v own_pid="$$" '
-    $1 != own_pid && ($0 ~ /[x]codebuild .* (-workspace|-project|-scheme|archive|build)/ || $0 ~ /[e]xpo (run:ios|run:android)/ || $0 ~ /[e]as (build|build:run).*--local/) { print }
+    $1 != own_pid && ($0 ~ /[x]codebuild .* (-workspace|-project|-scheme|archive|build)/ || $0 ~ /[Gg]radle.* (assemble|bundle|install|build)/ || $0 ~ /[e]as (build|build:run).*--local/) { print }
   '
 }
 

--- a/scripts/mobile-fast-start.sh
+++ b/scripts/mobile-fast-start.sh
@@ -16,6 +16,8 @@ Options:
   --scheme SCHEME     App URL scheme (default: io.tlon.groups)
   --build-native      Build and install the development client before Metro
   --skip-eas-cache    Skip the EAS native-cache lookup during --build-native
+  --allow-concurrent-native-build
+                      Start even if another native build is using the machine
   --keep-compilers    Enable the normal React and Tamagui compiler transforms
   --no-launch         Start Metro without opening the app
   -h, --help          Show this help
@@ -33,6 +35,7 @@ keep_compilers=0
 launch_app=1
 build_native=0
 skip_eas_cache=0
+allow_concurrent_native_build="${TLON_MOBILE_ALLOW_CONCURRENT_NATIVE_BUILD:-0}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -58,6 +61,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-eas-cache)
       skip_eas_cache=1
+      shift
+      ;;
+    --allow-concurrent-native-build)
+      allow_concurrent_native_build=1
       shift
       ;;
     --keep-compilers)
@@ -133,16 +140,27 @@ if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
   exit 1
 fi
 
-if pgrep -fal xcodebuild | rg -F "destination id=$device_udid" >/dev/null \
-  || pgrep -fal expo | rg "run:ios.*--device(=| )$device_udid" >/dev/null; then
+active_native_builds() {
+  ps -axo pid=,command= | awk -v own_pid="$$" '
+    $1 != own_pid && ($0 ~ /[x]codebuild .* (-workspace|-project|-scheme|archive|build)/ || $0 ~ /[e]xpo (run:ios|run:android)/ || $0 ~ /[e]as (build|build:run).*--local/) { print }
+  '
+}
+
+native_builds="$(active_native_builds)"
+if [[ -n "$native_builds" && "$allow_concurrent_native_build" != "1" ]]; then
   cat >&2 <<EOF
-Another native build is targeting simulator $device_udid. Wait for it to finish
-or use a different simulator so the installed app is not replaced mid-run.
+Another native build is already using this machine:
+$native_builds
+
+Wait for it to finish so the native build and JavaScript loop do not starve each
+other, or pass --allow-concurrent-native-build to override.
 EOF
   exit 1
 fi
 
 lease_dir="${TMPDIR:-/tmp}/tlon-mobile-simulator-${device_udid}.lease"
+native_lease_dir="${TMPDIR:-/tmp}/tlon-mobile-native-build.lease"
+native_lease_acquired=0
 if ! mkdir "$lease_dir" 2>/dev/null; then
   lease_pid="$(sed -n '1p' "$lease_dir/pid" 2>/dev/null || true)"
   if [[ -n "$lease_pid" ]] && kill -0 "$lease_pid" 2>/dev/null; then
@@ -157,6 +175,28 @@ if ! mkdir "$lease_dir" 2>/dev/null; then
 fi
 printf '%s\n' "$$" > "$lease_dir/pid"
 
+if [[ "$build_native" -eq 1 ]]; then
+  if ! mkdir "$native_lease_dir" 2>/dev/null; then
+    native_lease_pid="$(sed -n '1p' "$native_lease_dir/pid" 2>/dev/null || true)"
+    if [[ -n "$native_lease_pid" ]] && kill -0 "$native_lease_pid" 2>/dev/null; then
+      echo "A mobile native build is already running as process $native_lease_pid." >&2
+      rm -f "$lease_dir/pid"
+      rmdir "$lease_dir" 2>/dev/null || true
+      exit 1
+    fi
+    rm -f "$native_lease_dir/pid"
+    if ! rmdir "$native_lease_dir" 2>/dev/null \
+      || ! mkdir "$native_lease_dir" 2>/dev/null; then
+      echo "Could not recover stale native-build lease $native_lease_dir." >&2
+      rm -f "$lease_dir/pid"
+      rmdir "$lease_dir" 2>/dev/null || true
+      exit 1
+    fi
+  fi
+  printf '%s\n' "$$" > "$native_lease_dir/pid"
+  native_lease_acquired=1
+fi
+
 metro_pid=""
 cleanup() {
   if [[ -n "$metro_pid" ]] && kill -0 "$metro_pid" 2>/dev/null; then
@@ -165,6 +205,10 @@ cleanup() {
   fi
   rm -f "$lease_dir/pid"
   rmdir "$lease_dir" 2>/dev/null || true
+  if [[ "$native_lease_acquired" -eq 1 ]]; then
+    rm -f "$native_lease_dir/pid"
+    rmdir "$native_lease_dir" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT INT TERM
 
@@ -174,7 +218,7 @@ if [[ "$build_native" -eq 1 ]]; then
     native_environment+=("TLON_EAS_CACHE_DISABLED=1")
   fi
 
-  echo "Building and installing the development client while holding the simulator lease..."
+  echo "Building and installing the development client while holding the machine and simulator leases..."
   (
     cd "$repo_root"
     env "${native_environment[@]}" \

--- a/scripts/mobile-fast-start.sh
+++ b/scripts/mobile-fast-start.sh
@@ -253,7 +253,7 @@ metro_environment=(
 )
 if [[ "$keep_compilers" -eq 0 ]]; then
   metro_environment+=(
-    "TLON_METRO_SHARED_CACHE_DIR=$shared_cache_base/fast-compilers-off"
+    "TLON_METRO_SHARED_CACHE_DIR=$shared_cache_base/fast-compilers-off-canonical-v1"
     "TLON_REACT_COMPILER_DISABLED=1"
     "TLON_TAMAGUI_COMPILER_DISABLED=1"
   )

--- a/scripts/mobile-fast-start.sh
+++ b/scripts/mobile-fast-start.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/mobile-fast-start.sh [options]
+
+Starts the shared-cache Metro fast path and opens an installed iOS development
+client. By default it deliberately does not invoke Xcode or rebuild native code.
+
+Options:
+  --device UDID       Use this booted simulator (required if several are booted)
+  --port PORT         Metro port (default: 8081)
+  --app-id ID         Installed bundle identifier (default: io.tlon.groups)
+  --scheme SCHEME     App URL scheme (default: io.tlon.groups)
+  --build-native      Build and install the development client before Metro
+  --skip-eas-cache    Skip the EAS native-cache lookup during --build-native
+  --keep-compilers    Enable the normal React and Tamagui compiler transforms
+  --no-launch         Start Metro without opening the app
+  -h, --help          Show this help
+
+The fast compiler mode is for iteration. Before handing off a change, run once
+with --keep-compilers and complete the normal validation for the changed code.
+EOF
+}
+
+device_udid=""
+port="8081"
+app_id="io.tlon.groups"
+app_scheme="io.tlon.groups"
+keep_compilers=0
+launch_app=1
+build_native=0
+skip_eas_cache=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --device)
+      device_udid="${2:-}"
+      shift 2
+      ;;
+    --port)
+      port="${2:-}"
+      shift 2
+      ;;
+    --app-id)
+      app_id="${2:-}"
+      shift 2
+      ;;
+    --scheme)
+      app_scheme="${2:-}"
+      shift 2
+      ;;
+    --build-native)
+      build_native=1
+      shift
+      ;;
+    --skip-eas-cache)
+      skip_eas_cache=1
+      shift
+      ;;
+    --keep-compilers)
+      keep_compilers=1
+      shift
+      ;;
+    --no-launch)
+      launch_app=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+  echo "Port must be a number between 1 and 65535." >&2
+  exit 2
+fi
+
+if [[ "$skip_eas_cache" -eq 1 && "$build_native" -ne 1 ]]; then
+  echo "--skip-eas-cache is only valid with --build-native." >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+if [[ ! -e "$repo_root/node_modules/expo" ]]; then
+  echo "Dependencies are not installed. Bootstrap or install this worktree first." >&2
+  exit 1
+fi
+
+for generated_file in \
+  "$repo_root/packages/editor/dist/index.html" \
+  "$repo_root/apps/tlon-mobile/tailwind.css" \
+  "$repo_root/apps/tlon-mobile/tailwind.json"; do
+  if [[ ! -f "$generated_file" ]]; then
+    echo "Missing generated file: ${generated_file#"$repo_root"/}" >&2
+    echo "Run the mobile bootstrap or the corresponding generation step first." >&2
+    exit 1
+  fi
+done
+
+if [[ -z "$device_udid" ]]; then
+  device_udid="$(xcrun simctl list devices booted -j | node -e '
+    let input = "";
+    process.stdin.on("data", chunk => input += chunk);
+    process.stdin.on("end", () => {
+      const devices = Object.values(JSON.parse(input).devices).flat();
+      const booted = devices.filter(device => device.state === "Booted");
+      if (booted.length === 1) process.stdout.write(booted[0].udid);
+      else {
+        console.error(`Expected one booted simulator; found ${booted.length}. Pass --device UDID.`);
+        process.exit(1);
+      }
+    });
+  ')"
+fi
+
+if ! xcrun simctl list devices booted | rg -q "$device_udid"; then
+  echo "Simulator $device_udid is not booted." >&2
+  exit 1
+fi
+
+if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "Port $port is already in use." >&2
+  exit 1
+fi
+
+if pgrep -fal xcodebuild | rg -F "destination id=$device_udid" >/dev/null \
+  || pgrep -fal expo | rg "run:ios.*--device(=| )$device_udid" >/dev/null; then
+  cat >&2 <<EOF
+Another native build is targeting simulator $device_udid. Wait for it to finish
+or use a different simulator so the installed app is not replaced mid-run.
+EOF
+  exit 1
+fi
+
+lease_dir="${TMPDIR:-/tmp}/tlon-mobile-simulator-${device_udid}.lease"
+if ! mkdir "$lease_dir" 2>/dev/null; then
+  lease_pid="$(sed -n '1p' "$lease_dir/pid" 2>/dev/null || true)"
+  if [[ -n "$lease_pid" ]] && kill -0 "$lease_pid" 2>/dev/null; then
+    echo "Simulator $device_udid is already owned by mobile loop process $lease_pid." >&2
+    exit 1
+  fi
+  rm -f "$lease_dir/pid"
+  if ! rmdir "$lease_dir" 2>/dev/null || ! mkdir "$lease_dir" 2>/dev/null; then
+    echo "Could not recover stale simulator lease $lease_dir." >&2
+    exit 1
+  fi
+fi
+printf '%s\n' "$$" > "$lease_dir/pid"
+
+metro_pid=""
+cleanup() {
+  if [[ -n "$metro_pid" ]] && kill -0 "$metro_pid" 2>/dev/null; then
+    kill "$metro_pid" 2>/dev/null || true
+    wait "$metro_pid" 2>/dev/null || true
+  fi
+  rm -f "$lease_dir/pid"
+  rmdir "$lease_dir" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if [[ "$build_native" -eq 1 ]]; then
+  native_environment=()
+  if [[ "$skip_eas_cache" -eq 1 ]]; then
+    native_environment+=("TLON_EAS_CACHE_DISABLED=1")
+  fi
+
+  echo "Building and installing the development client while holding the simulator lease..."
+  (
+    cd "$repo_root"
+    env "${native_environment[@]}" \
+      corepack pnpm --filter tlon-mobile exec expo run:ios \
+        --no-bundler --device "$device_udid"
+  )
+fi
+
+app_container="$(xcrun simctl get_app_container "$device_udid" "$app_id" app 2>/dev/null || true)"
+if [[ -z "$app_container" ]]; then
+  echo "$app_id is not installed on simulator $device_udid." >&2
+  echo "Run again with --build-native from a fully prepared worktree." >&2
+  exit 1
+fi
+
+if ! find "$app_container" -maxdepth 5 \
+  \( -iname '*DevLauncher*' -o -iname 'EXDevMenu*' \) -print -quit | rg -q .; then
+  cat >&2 <<EOF
+The installed $app_id app is not an Expo development client.
+
+Build it once from a prepared worktree, then use the default JavaScript-only
+path for subsequent iterations:
+  corepack pnpm mobile:fast:start --build-native --device $device_udid
+EOF
+  exit 1
+fi
+
+shared_cache_base="${TLON_METRO_SHARED_CACHE_DIR:-$HOME/.cache/tlon-metro-shared}"
+metro_environment=(
+  "NODE_OPTIONS=--dns-result-order=ipv4first"
+  "TLON_METRO_SHARED_CACHE_ENABLED=1"
+)
+if [[ "$keep_compilers" -eq 0 ]]; then
+  metro_environment+=(
+    "TLON_METRO_SHARED_CACHE_DIR=$shared_cache_base/fast-compilers-off"
+    "TLON_REACT_COMPILER_DISABLED=1"
+    "TLON_TAMAGUI_COMPILER_DISABLED=1"
+  )
+else
+  metro_environment+=("TLON_METRO_SHARED_CACHE_DIR=$shared_cache_base")
+fi
+
+started_at=$SECONDS
+echo "Starting Metro for simulator $device_udid on port $port..."
+(
+  cd "$repo_root"
+  env "${metro_environment[@]}" \
+    corepack pnpm --filter tlon-mobile exec expo start \
+      --dev-client --host localhost --port "$port"
+) &
+metro_pid=$!
+
+ready=0
+for _ in $(seq 1 120); do
+  if curl -fsS "http://127.0.0.1:$port/status" 2>/dev/null | rg -q 'packager-status:running'; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$metro_pid" 2>/dev/null; then
+    echo "Metro exited before becoming ready." >&2
+    wait "$metro_pid"
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ "$ready" -ne 1 ]]; then
+  echo "Metro did not become ready within 120 seconds." >&2
+  exit 1
+fi
+
+dev_client_url="${app_scheme}://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A${port}"
+echo "Metro ready in $((SECONDS - started_at))s."
+
+if [[ "$launch_app" -eq 1 ]]; then
+  xcrun simctl openurl "$device_udid" "$dev_client_url"
+  echo "Opened the development client. Press Ctrl-C to stop Metro."
+else
+  echo "Development client URL: $dev_client_url"
+  echo "Press Ctrl-C to stop Metro."
+fi
+
+wait "$metro_pid"

--- a/scripts/mobile-fast-worktree.sh
+++ b/scripts/mobile-fast-worktree.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/mobile-fast-worktree.sh [--detach] NAME [START_POINT]
+
+Creates and bootstraps an ephemeral mobile worktree beneath a sibling directory
+whose name ends in .noindex, keeping Spotlight out of the iteration path.
+
+By default the worktree gets branch db/NAME. With --detach, it is detached.
+START_POINT defaults to HEAD. The current worktree is used as the prepared seed.
+EOF
+}
+
+detach=0
+if [[ "${1:-}" == "--detach" ]]; then
+  detach=1
+  shift
+fi
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+name="$1"
+start_point="${2:-HEAD}"
+if ! [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || [[ "$name" == *..* ]]; then
+  echo "NAME may contain letters, numbers, dots, underscores, and hyphens." >&2
+  exit 2
+fi
+
+seed_root="$(git rev-parse --show-toplevel)"
+primary_root="$(git worktree list --porcelain | awk '$1 == "worktree" { print $2; exit }')"
+worktree_parent="$(dirname "$primary_root")/$(basename "$primary_root")-worktrees.noindex"
+target_root="$worktree_parent/$name"
+
+if [[ -e "$target_root" ]]; then
+  echo "Target already exists: $target_root" >&2
+  exit 1
+fi
+
+mkdir -p "$worktree_parent"
+started_at=$SECONDS
+if [[ "$detach" -eq 1 ]]; then
+  git worktree add --detach "$target_root" "$start_point"
+else
+  git worktree add -b "db/$name" "$target_root" "$start_point"
+fi
+created_at=$SECONDS
+
+(cd "$target_root" && scripts/mobile-fast-bootstrap.sh "$seed_root")
+finished_at=$SECONDS
+
+cat <<EOF
+
+Created mobile worktree at $target_root in $((finished_at - started_at))s:
+  worktree: $((created_at - started_at))s
+  bootstrap: $((finished_at - created_at))s
+EOF


### PR DESCRIPTION
## Summary

Shortens the local mobile edit-run-check loop by creating linked worktrees that reuse prepared dependencies and native build outputs, and by sharing Metro transforms across source-identical worktrees.

Adds a repeatable channel navigation benchmark and stable native channel-row selectors so warm interaction timing can be measured consistently.

## Changes

- Add scripts to prepare the mobile environment, create fast linked worktrees, and start the optimized development loop
- Reuse dependency trees, native build products, generated packages, and the Metro transform cache where safe
- Add opt-in fast-loop switches for the React and Tamagui compilers while leaving normal builds unchanged
- Add an opt-in Metro cache-key hook so identical dependencies share transforms across worktree paths
- Ignore idle native build wrappers when deciding whether the app is already being built
- Add a self-contained channel round-trip benchmark and stable native channel-row test IDs and accessibility metadata

## How did I test?

- Rebased onto the latest `origin/develop`; `git range-diff` showed all five original commits preserved exactly
- `pnpm --filter @tloncorp/app tsc`
- `bash -n scripts/mobile-fast-bootstrap.sh scripts/mobile-fast-start.sh scripts/mobile-fast-worktree.sh`
- Ran `--help` for all three new scripts
- Prettier passed on the changed benchmark, mobile configuration, package metadata, and UI component
- `git diff --check`

## Risks and impact

- The fast path is opt-in; normal builds keep the existing compiler and Metro behavior
- The Metro dependency patch is local and can be removed when upstream exposes an equivalent canonical cache-path hook
- Shared Simulator use can still create contention, so concurrent tasks should use separate device IDs

## Rollback plan

Revert the commits.