### PR TITLE
OpenClaw: guard against invalid bot generated @mentions

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/urbit/story.test.ts
+++ b/packages/openclaw/src/urbit/story.test.ts
@@ -6,15 +6,38 @@ describe('markdownToStory', () => {
   describe('ship mentions', () => {
     it('converts plain ship mention', () => {
       const story = markdownToStory('~zod is cool');
-      // Should have inline content with ship mention
-      expect(story).toHaveLength(1);
-      expect(story[0]).toHaveProperty('inline');
-      const inlines = (story[0] as { inline: unknown[] }).inline;
-      // Find ship in inlines
-      const hasShip = inlines.some(
-        (i) => typeof i === 'object' && i !== null && 'ship' in i
-      );
-      expect(hasShip).toBe(true);
+      expect(story).toEqual([
+        {
+          inline: [{ ship: '~zod' }, ' is cool'],
+        },
+      ]);
+    });
+
+    it('converts a valid planet name', () => {
+      expect(markdownToStory('Hello ~sampel-palnet')).toEqual([
+        {
+          inline: ['Hello ', { ship: '~sampel-palnet' }],
+        },
+      ]);
+    });
+
+    it.each(['~word', '~thanks', '~foo-bar', '~zod2'])(
+      'keeps invalid ship candidate %s as plain text',
+      (candidate) => {
+        expect(markdownToStory(`Say ${candidate} here`)).toEqual([
+          {
+            inline: [`Say ${candidate} here`],
+          },
+        ]);
+      }
+    );
+
+    it('keeps an invalid ship candidate as plain text inside formatting', () => {
+      expect(markdownToStory('**~word**')).toEqual([
+        {
+          inline: [{ bold: ['~word'] }],
+        },
+      ]);
     });
 
     it('converts ship name wrapped in bold', () => {

--- a/packages/openclaw/src/urbit/story.ts
+++ b/packages/openclaw/src/urbit/story.ts
@@ -1,3 +1,5 @@
+import { valid } from '@urbit/aura';
+
 /**
  * Tlon Story Format - Rich text converter
  *
@@ -57,7 +59,7 @@ function parseInlineMarkdown(text: string): StoryInline[] {
   while (remaining.length > 0) {
     // Ship mentions: ~sampel-palnet
     const shipMatch = remaining.match(/^(~[a-z][-a-z0-9]*)/);
-    if (shipMatch) {
+    if (shipMatch && valid('p', shipMatch[1])) {
       result.push({ ship: shipMatch[1] });
       remaining = remaining.slice(shipMatch[0].length);
       continue;

--- a/packages/tlon-skill/scripts/story.test.ts
+++ b/packages/tlon-skill/scripts/story.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { markdownToStory } from './story';
+import { markdownToStory, textToStory } from './story';
 
 describe('markdownToStory', () => {
   it('treats literal hashtag lines as paragraph text', () => {
@@ -12,6 +12,50 @@ describe('markdownToStory', () => {
       { inline: ['intro'] },
       { block: { header: { tag: 'h1', content: ['Heading'] } } },
       { inline: ['body'] },
+    ]);
+  });
+
+  it('converts a valid ship mention', () => {
+    expect(markdownToStory('Hello ~sampel-palnet')).toEqual([
+      {
+        inline: ['Hello ', { ship: '~sampel-palnet' }],
+      },
+    ]);
+  });
+
+  for (const candidate of ['~word', '~thanks', '~foo-bar', '~zod2']) {
+    it(`keeps invalid ship candidate ${candidate} as plain text`, () => {
+      expect(markdownToStory(`Say ${candidate} here`)).toEqual([
+        {
+          inline: [`Say ${candidate} here`],
+        },
+      ]);
+    });
+  }
+
+  it('keeps an invalid ship candidate as plain text inside formatting', () => {
+    expect(markdownToStory('**~word**')).toEqual([
+      {
+        inline: [{ bold: ['~word'] }],
+      },
+    ]);
+  });
+});
+
+describe('textToStory', () => {
+  it('converts a valid ship mention', () => {
+    expect(textToStory('Hello ~sampel-palnet')).toEqual([
+      {
+        inline: ['Hello ', { ship: '~sampel-palnet' }],
+      },
+    ]);
+  });
+
+  it('keeps an invalid ship candidate as plain text', () => {
+    expect(textToStory('Say ~foo-bar here')).toEqual([
+      {
+        inline: ['Say ', '~foo-bar', ' here'],
+      },
     ]);
   });
 });

--- a/packages/tlon-skill/scripts/story.ts
+++ b/packages/tlon-skill/scripts/story.ts
@@ -1,3 +1,5 @@
+import { valid } from '@urbit/aura';
+
 /**
  * Tlon Story Format - Rich text converter
  *
@@ -47,7 +49,7 @@ function parseInlineMarkdown(text: string): StoryInline[] {
   while (remaining.length > 0) {
     // Ship mentions: ~sampel-palnet
     const shipMatch = remaining.match(/^(~[a-z][-a-z0-9]*)/);
-    if (shipMatch) {
+    if (shipMatch && valid('p', shipMatch[1])) {
       result.push({ ship: shipMatch[1] });
       remaining = remaining.slice(shipMatch[0].length);
       continue;
@@ -268,7 +270,7 @@ export function textToStory(text: string): Story {
   for (const part of parts) {
     if (!part) continue;
 
-    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/)) {
+    if (part.match(/^~[a-z]+-[a-z]+(?:-[a-z]+)*$/) && valid('p', part)) {
       inlines.push({ ship: part });
     } else {
       const lines = part.split('\n');


### PR DESCRIPTION
## Summary

OTT

We saw failing sends due to invalid stories being rejected by the backend. When parsing bot messages, we were not guarding against invalid `@p` mentions.

With this fix they'll just gracefully degrade to raw text.

## Changes
- update story parsers for `OpenClaw` and skill to use `@urbit/aura` based `@p` validation

## How did I test?

Unit tests.

## Risks and impact

- Safe to rollback without consulting PR author? Yes

Fixes TLON-6225