### PR TITLE
stabilize group invite end-to-end setup

### DIFF
--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -358,12 +358,34 @@ export async function acceptGroupInvite(page: Page, groupName?: string) {
   await expect(acceptButton).toBeVisible({ timeout: 10000 });
   await acceptButton.click();
 
-  // Wait for joining to complete and "Go to group" button to appear
-  await expect(page.getByText('Go to group')).toBeVisible({ timeout: 45000 });
+  // A completed join closes the preview and returns to Home. "Go to group"
+  // can appear during that transition, but clicking it races the sheet closing.
+  // Wait for every non-terminal preview state to disappear instead.
+  await expect(async () => {
+    await expect(acceptButton).not.toBeVisible();
+    await expect(
+      page.getByText('Joining, please wait...', { exact: true })
+    ).not.toBeVisible();
+    await expect(
+      page.getByText('Go to group', { exact: true })
+    ).not.toBeVisible();
+    await expect(
+      page.getByText('Joining failed', { exact: true })
+    ).not.toBeVisible();
+  }).toPass({
+    timeout: 45000,
+    intervals: [500, 1000],
+  });
 
-  // Click "Go to group"
-  await page.getByText('Go to group').click();
-  await page.waitForTimeout(1000);
+  // Enter the joined group through its stable Home row. Besides proving that
+  // the join is usable, this clears the transient NEW state that otherwise
+  // masks unread counts in subsequent assertions.
+  const joinedGroupRow = namedInviteRow?.first() ?? untitledInviteRow.first();
+  await expect(joinedGroupRow).toBeVisible({ timeout: 15000 });
+  await joinedGroupRow.click();
+  await expect(page.getByTestId('ChannelListItem-General')).toBeVisible({
+    timeout: 15000,
+  });
 }
 
 export async function rejectGroupInvite(page: Page) {

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -342,15 +342,15 @@ export async function acceptGroupInvite(page: Page, groupName?: string) {
     'GroupListItem-Untitled group-unpinned'
   );
 
+  let inviteRow = untitledInviteRow.first();
   if (
     namedInviteRow &&
     (await namedInviteRow.first().isVisible({ timeout: 30000 }))
   ) {
-    await namedInviteRow.first().click();
-  } else {
-    await expect(untitledInviteRow).toBeVisible({ timeout: 30000 });
-    await untitledInviteRow.click();
+    inviteRow = namedInviteRow.first();
   }
+  await expect(inviteRow).toBeVisible({ timeout: 30000 });
+  await inviteRow.click();
   await page.waitForTimeout(500);
 
   // Click accept
@@ -380,9 +380,8 @@ export async function acceptGroupInvite(page: Page, groupName?: string) {
   // Enter the joined group through its stable Home row. Besides proving that
   // the join is usable, this clears the transient NEW state that otherwise
   // masks unread counts in subsequent assertions.
-  const joinedGroupRow = namedInviteRow?.first() ?? untitledInviteRow.first();
-  await expect(joinedGroupRow).toBeVisible({ timeout: 15000 });
-  await joinedGroupRow.click();
+  await expect(inviteRow).toBeVisible({ timeout: 15000 });
+  await inviteRow.click();
   await expect(page.getByTestId('ChannelListItem-General')).toBeVisible({
     timeout: 15000,
   });

--- a/apps/tlon-web/e2e/helpers.ts
+++ b/apps/tlon-web/e2e/helpers.ts
@@ -350,6 +350,10 @@ export async function acceptGroupInvite(page: Page, groupName?: string) {
     inviteRow = namedInviteRow.first();
   }
   await expect(inviteRow).toBeVisible({ timeout: 30000 });
+  const inviteGroupId = await inviteRow.getAttribute('data-group-id');
+  if (!inviteGroupId) {
+    throw new Error('Group invite row is missing its stable group ID');
+  }
   await inviteRow.click();
   await page.waitForTimeout(500);
 
@@ -380,8 +384,11 @@ export async function acceptGroupInvite(page: Page, groupName?: string) {
   // Enter the joined group through its stable Home row. Besides proving that
   // the join is usable, this clears the transient NEW state that otherwise
   // masks unread counts in subsequent assertions.
-  await expect(inviteRow).toBeVisible({ timeout: 15000 });
-  await inviteRow.click();
+  const joinedGroupRow = page.locator(
+    `[data-group-id=${JSON.stringify(inviteGroupId)}]`
+  );
+  await expect(joinedGroupRow).toBeVisible({ timeout: 15000 });
+  await joinedGroupRow.click();
   await expect(page.getByTestId('ChannelListItem-General')).toBeVisible({
     timeout: 15000,
   });

--- a/packages/app/ui/components/listItems/GroupListItem.tsx
+++ b/packages/app/ui/components/listItems/GroupListItem.tsx
@@ -120,6 +120,7 @@ export const GroupListItem = ({
   return (
     <View ref={containerRef}>
       <Pressable
+        data-group-id={model.id}
         borderRadius="$xl"
         onPress={open ? undefined : handlePress}
         onLongPress={isWeb ? undefined : handleLongPress}


### PR DESCRIPTION
## Summary

Stabilizes group-invite end-to-end setup by following the app's completed-join behavior: let the preview close, then re-select the exact joined group by its stable model ID.

This is a test-only change. It exposes the existing group ID to Playwright without changing runtime behavior.

## Changes

- Replace the race-prone `Go to group` wait and click with a completed-transition wait
- Preserve the exact named-or-untitled invite row selected before accepting
- Capture the selected group's stable ID and use it after pending/unpinned list reordering
- Verify the joined group's General channel and clear its transient `NEW` state before later assertions

## How did I test?

- Prettier passed for the changed helper and group-list item
- `pnpm --filter tlon-web tsc --noEmit`
- `git diff --check`
- [Current-head CI passed](https://github.com/tloncorp/tlon-apps/actions/runs/30096431255), including E2E in 20m45s
- Before the review follow-ups, [six consecutive E2E reruns passed](https://github.com/tloncorp/tlon-apps/actions/runs/30042902657): 83 tests, 0 failures, and 0 errors in every run
- Those six E2E jobs averaged 22m32s versus the 24m11s baseline