### PR TITLE
Update contacts purpose string to satisfy App Store guideline 5.1.1(ii)

### DIFF
--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -122,7 +122,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       'expo-contacts',
       {
-        contactsPermission: 'Allow Tlon Messenger to access your contacts.',
+        contactsPermission:
+          "Tlon Messenger uses your contacts' names, phone numbers, and email addresses to help you find friends who are already on Tlon and invite others to join. For example, if a contact's phone number matches an existing Tlon account, we can suggest connecting with them.",
       },
     ],
     'expo-audio',

--- a/apps/tlon-mobile/ios/Landscape/Info-preview.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info-preview.plist
@@ -59,7 +59,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts&#39; names, phone numbers, and email addresses to help you find friends who are already on Tlon and invite others to join. For example, if a contact&#39;s phone number matches an existing Tlon account, we can suggest connecting with them.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -57,7 +57,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts&#39; names, phone numbers, and email addresses to help you find friends who are already on Tlon and invite others to join. For example, if a contact&#39;s phone number matches an existing Tlon account, we can suggest connecting with them.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary

Apple rejected our submission under Guideline 5.1.1(ii) (Legal – Privacy – Data Collection and Storage) because the contacts purpose string ("Tlon Messenger wants to access your contacts.") did not explain how the app uses the requested data. Per Apple's [Human Interface Guidelines on requesting permission](https://developer.apple.com/design/human-interface-guidelines/privacy#Requesting-permission), purpose strings must clearly describe the use of the data and, in most cases, provide an example.

## Changes

Replaced the contacts purpose string in all three places it is defined:

- `apps/tlon-mobile/app.config.ts` (expo-contacts plugin `contactsPermission`)
- `apps/tlon-mobile/ios/Landscape/Info.plist` (`NSContactsUsageDescription`)
- `apps/tlon-mobile/ios/Landscape/Info-preview.plist` (`NSContactsUsageDescription`)

New string:

> Tlon Messenger uses your contacts' names, phone numbers, and email addresses to help you find friends who are already on Tlon and invite others to join. For example, if a contact's phone number matches an existing Tlon account, we can suggest connecting with them.

This reflects the actual behavior in `packages/shared/src/store/systemContactsApi.native.ts`, which reads names, phone numbers, and emails to match contacts against Tlon accounts and power invites.

## How did I test?

String-only change; verified the new string is consistent across all three definitions and that no other files contain the old string.

## Risks and impact

Low. No behavior change — only the iOS permission prompt copy.

## Rollback plan

Revert this commit.

## Screenshots

N/A (copy change to the system permission dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Anmk7FTEXr71zWe4rCJiXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Anmk7FTEXr71zWe4rCJiXP)_