### PR TITLE
Update contacts permission strings to satisfy Apple review guidelines

### DIFF
--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -122,7 +122,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       'expo-contacts',
       {
-        contactsPermission: 'Allow Tlon Messenger to access your contacts.',
+        contactsPermission:
+          'Tlon Messenger uses your contacts to help you find people you know who are already on Tlon and to invite others to join. For example, contact phone numbers are matched against Tlon profiles to show you which of your contacts you can message.',
       },
     ],
     'expo-audio',

--- a/apps/tlon-mobile/ios/Landscape/Info-preview.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info-preview.plist
@@ -59,7 +59,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts to help you find people you know who are already on Tlon and to invite others to join. For example, contact phone numbers are matched against Tlon profiles to show you which of your contacts you can message.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -57,7 +57,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts to help you find people you know who are already on Tlon and to invite others to join. For example, contact phone numbers are matched against Tlon profiles to show you which of your contacts you can message.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary

Apple denied our App Store submission because the contacts usage description only stated that the app wants access to contacts, without explaining why. This PR rewrites the purpose string per Apple's [Human Interface Guidelines on requesting permission](https://developer.apple.com/design/human-interface-guidelines/privacy#Requesting-permission), which call for explaining why the app needs access and providing an example of how the data is used.

## Changes

- `apps/tlon-mobile/app.config.ts` — updated the `expo-contacts` plugin `contactsPermission` string (source of truth for generated builds)
- `apps/tlon-mobile/ios/Landscape/Info.plist` and `Info-preview.plist` — updated `NSContactsUsageDescription` to match

New string:

> Tlon Messenger uses your contacts to help you find people you know who are already on Tlon and to invite others to join. For example, contact phone numbers are matched against Tlon profiles to show you which of your contacts you can message.

This accurately reflects how contacts are used in the app (lanyard contact discovery/matching and contact-book invites).

## How did I test?

String-only change; verified all `NSContactsUsageDescription` occurrences in the repo were updated consistently.

## Risks and impact

- Safe to rollback without consulting PR author? (Yes)
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [x] Other: iOS permission prompt copy only

## Rollback plan

Revert the commit; no state or migration implications.

## Screenshots / videos

N/A — copy change to the system permission dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmkaZZnujNxu5kAnRZfVTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmkaZZnujNxu5kAnRZfVTi)_