### PR TITLE
Clarify contacts permission strings per Apple privacy guidelines

### DIFF
--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -122,7 +122,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       'expo-contacts',
       {
-        contactsPermission: 'Allow Tlon Messenger to access your contacts.',
+        contactsPermission:
+          'Tlon Messenger uses your contacts to help you find people you know who are already on the network and to invite others via SMS or email.',
       },
     ],
     'expo-audio',

--- a/apps/tlon-mobile/ios/Landscape/Info-preview.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info-preview.plist
@@ -59,7 +59,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts to help you find people you know who are already on the network and to invite others via SMS or email.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -57,7 +57,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts to help you find people you know who are already on the network and to invite others via SMS or email.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary

Apple rejected our submission over the contacts usage description. The existing strings ("Tlon Messenger wants to access your contacts." / "Allow Tlon Messenger to access your contacts.") stated no purpose, which violates Apple's [privacy HIG](https://developer.apple.com/design/human-interface-guidelines/privacy#Requesting-permission) requirement that permission requests explain why the app needs access and how the data will be used.

## Changes

Updated the contacts usage string in all three places it's defined to describe the actual in-app uses (contact matching to find people you know on the network, and inviting contacts via SMS/email):

- `apps/tlon-mobile/app.config.ts` (`expo-contacts` plugin `contactsPermission`)
- `apps/tlon-mobile/ios/Landscape/Info.plist` (`NSContactsUsageDescription`)
- `apps/tlon-mobile/ios/Landscape/Info-preview.plist` (`NSContactsUsageDescription`)

New string: "Tlon Messenger uses your contacts to help you find people you know who are already on the network and to invite others via SMS or email."

Deliberately avoided claims like "never stored on our servers" since contact-book phone numbers are sent through the lanyard verifier flow for matching — the string sticks to purpose, which is what Apple requires.

## How did I test?

String-only change; verified all three occurrences updated via grep.

## Risks and impact

None beyond the permission prompt copy; no code paths changed.

## Rollback plan

Revert the commit.

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCmT55oc9QAigxg1HY5udt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCmT55oc9QAigxg1HY5udt)_