### PR TITLE
Update contacts permission strings to explain purpose per Apple HIG

### DIFF
--- a/apps/tlon-mobile/app.config.ts
+++ b/apps/tlon-mobile/app.config.ts
@@ -122,7 +122,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       'expo-contacts',
       {
-        contactsPermission: 'Allow Tlon Messenger to access your contacts.',
+        contactsPermission:
+          'Tlon Messenger uses your contacts’ names, phone numbers, and email addresses to help you find people you know on the network and invite friends to join. Your contacts are used only for these features and are never shared with other users.',
       },
     ],
     'expo-audio',

--- a/apps/tlon-mobile/ios/Landscape/Info-preview.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info-preview.plist
@@ -59,7 +59,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts&#8217; names, phone numbers, and email addresses to help you find people you know on the network and invite friends to join. Your contacts are used only for these features and are never shared with other users.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/apps/tlon-mobile/ios/Landscape/Info.plist
+++ b/apps/tlon-mobile/ios/Landscape/Info.plist
@@ -57,7 +57,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Tlon needs camera access to take photos for sharing.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>Tlon Messenger wants to access your contacts.</string>
+	<string>Tlon Messenger uses your contacts&#8217; names, phone numbers, and email addresses to help you find people you know on the network and invite friends to join. Your contacts are used only for these features and are never shared with other users.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Tlon needs access to your microphone to allow you to share audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
## Summary

Apple denied our App Store submission over the contacts usage strings. The current strings ("Tlon Messenger wants to access your contacts." / "Allow Tlon Messenger to access your contacts.") only restate the request without explaining why access is needed or how the data is used, which the [HIG privacy guidance](https://developer.apple.com/design/human-interface-guidelines/privacy#Requesting-permission) requires.

## Changes

- Updated `NSContactsUsageDescription` in `apps/tlon-mobile/ios/Landscape/Info.plist` and `Info-preview.plist`
- Updated the `expo-contacts` `contactsPermission` string in `apps/tlon-mobile/app.config.ts`

New string: "Tlon Messenger uses your contacts’ names, phone numbers, and email addresses to help you find people you know on the network and invite friends to join. Your contacts are used only for these features and are never shared with other users."

This matches the actual usage: contact phone numbers are matched via lanyard contact discovery (`syncContactDiscovery`) and contact info powers the invite flow. Wording deliberately avoids claiming contacts never leave the device, since phone numbers are sent to the discovery service for matching.

## How did I test?

String-only change; verified all three occurrences of the old strings were replaced (grep) and no other permission strings were affected.

## Risks and impact

None beyond the permission prompt copy. The new string must be accurate to actual data use — it reflects contact matching and invites only.

## Rollback plan

Revert the commit.

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJgzEz8sCwhm2iBbZDeH8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgzEz8sCwhm2iBbZDeH8r)_