### PR TITLE
openclaw: harden outbound image upload

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/channel.runtime.test.ts
+++ b/packages/openclaw/src/channel.runtime.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the media pipeline, the authenticated-api wrapper, and the send helpers
+// so sendMedia can be exercised without a ship. The account/target resolution
+// (types.js, targets.js) runs for real against a minimal valid config.
+vi.mock('@tloncorp/api', () => ({
+  scry: vi.fn(),
+}));
+vi.mock('./urbit/upload.js', () => ({
+  prepareOutboundMedia: vi.fn(),
+}));
+vi.mock('./urbit/api-client.js', () => ({
+  withAuthenticatedTlonApi: vi.fn(),
+}));
+vi.mock('./urbit/send.js', () => ({
+  buildMediaStory: vi.fn(() => [{ inline: [''] }]),
+  sendDm: vi.fn(),
+  sendDmWithStory: vi.fn(),
+  sendChannelPost: vi.fn(),
+}));
+vi.mock('./monitor/index.js', () => ({
+  monitorTlonProvider: vi.fn(),
+}));
+vi.mock('./setup-surface.js', () => ({
+  tlonSetupWizard: {},
+}));
+
+const cfg = {
+  channels: {
+    tlon: {
+      ship: '~zod',
+      url: 'http://localhost:8080',
+      code: 'lidlut-tabwed-pillex-ridruc',
+    },
+  },
+} as never;
+
+describe('sendMedia', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { withAuthenticatedTlonApi } = await import('./urbit/api-client.js');
+    vi.mocked(withAuthenticatedTlonApi).mockImplementation(
+      async (_params, fn) => fn()
+    );
+    const { sendDmWithStory, sendChannelPost } = await import(
+      './urbit/send.js'
+    );
+    vi.mocked(sendDmWithStory).mockResolvedValue({
+      channel: 'tlon',
+      messageId: '~zod/1',
+      sentAt: 1,
+    });
+    vi.mocked(sendChannelPost).mockResolvedValue({
+      channel: 'tlon',
+      messageId: '~zod/1',
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('forwards mediaAccess/mediaLocalRoots/mediaReadFile to prepareOutboundMedia', async () => {
+    const { prepareOutboundMedia } = await import('./urbit/upload.js');
+    const prepared = {
+      url: 'https://storage.example/u/img.png',
+      isImage: true,
+      width: 10,
+      height: 20,
+      contentType: 'image/png',
+    };
+    vi.mocked(prepareOutboundMedia).mockResolvedValue(prepared);
+
+    const { tlonRuntimeOutbound } = await import('./channel.runtime.js');
+    const mediaAccess = { localRoots: ['/ws'] };
+    const mediaLocalRoots = ['/ws'];
+    const mediaReadFile = async (p: string) => Buffer.from(p);
+
+    await tlonRuntimeOutbound.sendMedia?.({
+      cfg,
+      to: '~nec',
+      text: 'caption',
+      mediaUrl: '/ws/img.png',
+      mediaAccess,
+      mediaLocalRoots,
+      mediaReadFile,
+    } as never);
+
+    expect(prepareOutboundMedia).toHaveBeenCalledWith('/ws/img.png', {
+      mediaAccess,
+      mediaLocalRoots,
+      mediaReadFile,
+    });
+  });
+
+  it('rejects sendMedia when prepareOutboundMedia rejects (no post attempted)', async () => {
+    const { prepareOutboundMedia } = await import('./urbit/upload.js');
+    vi.mocked(prepareOutboundMedia).mockRejectedValue(
+      new Error(
+        'Cannot read media "[local media reference]": Media file not found'
+      )
+    );
+    const { sendDmWithStory, sendChannelPost } = await import(
+      './urbit/send.js'
+    );
+
+    const { tlonRuntimeOutbound } = await import('./channel.runtime.js');
+    await expect(
+      tlonRuntimeOutbound.sendMedia?.({
+        cfg,
+        to: '~nec',
+        text: 'caption',
+        mediaUrl: '/ws/missing.png',
+      } as never)
+    ).rejects.toThrow(/Cannot read media "\[local media reference\]"/);
+
+    expect(sendDmWithStory).not.toHaveBeenCalled();
+    expect(sendChannelPost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openclaw/src/channel.runtime.ts
+++ b/packages/openclaw/src/channel.runtime.ts
@@ -30,7 +30,7 @@ import {
   sendDmWithStory,
 } from './urbit/send.js';
 import { markdownToStory } from './urbit/story.js';
-import { uploadImageFromUrl } from './urbit/upload.js';
+import { prepareOutboundMedia } from './urbit/upload.js';
 
 type ResolvedTlonAccount = ReturnType<typeof resolveTlonAccount>;
 type ConfiguredTlonAccount = ResolvedTlonAccount & {
@@ -257,6 +257,9 @@ export const tlonRuntimeOutbound: Pick<
     to,
     text,
     mediaUrl,
+    mediaAccess,
+    mediaLocalRoots,
+    mediaReadFile,
     accountId,
     replyToId,
     threadId,
@@ -270,11 +273,15 @@ export const tlonRuntimeOutbound: Pick<
         allowPrivateNetwork: account.allowPrivateNetwork ?? undefined,
       },
       async () => {
-        const uploadedUrl = mediaUrl
-          ? await uploadImageFromUrl(mediaUrl)
+        const prepared = mediaUrl
+          ? await prepareOutboundMedia(mediaUrl, {
+              mediaAccess,
+              mediaLocalRoots,
+              mediaReadFile,
+            })
           : undefined;
         const fromShip = normalizeShip(account.ship);
-        const story = buildMediaStory(text, uploadedUrl);
+        const story = buildMediaStory(text, prepared);
         const replyId = resolveReplyId(replyToId, threadId);
         const botProfile = await getBotProfile(fromShip);
         if (parsed.kind === 'dm') {

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -153,7 +153,8 @@ export const tlonPlugin = createChatChannelPlugin({
           '',
           'Tlon gallery channels (heap/~host/name) are for collecting images, links, and media.',
           '- To post to a gallery: use action=send, to=heap/~host/name, message=<text or URL>',
-          '- For image posts, include media=<imageUrl> with an optional message=<caption>',
+          '- media= accepts a public http(s) URL or a file path inside the agent workspace, with an optional message=<caption>. Inline image formats: PNG/JPEG/GIF/WebP. AVIF, HEIC, BMP, ICO, and local SVG must be converted to PNG or JPEG first. A remote SVG URL is posted as a link, not an inline image.',
+          '- Media that cannot be read or uploaded fails the send — do not claim an image was delivered unless the tool call succeeded.',
           '- To react to a gallery comment: use action=react, to=heap/~host/name, messageId=<commentId>, parentId=<postId>, emoji=<emoji>'
         );
 

--- a/packages/openclaw/src/urbit/image-dimensions.test.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.test.ts
@@ -77,6 +77,54 @@ describe('parseRasterHeader', () => {
     });
   });
 
+  function findSof0Offset(bytes: Uint8Array): number {
+    for (let i = 0; i + 1 < bytes.length; i += 1) {
+      if (bytes[i] === 0xff && bytes[i + 1] === 0xc0) {
+        return i;
+      }
+    }
+    throw new Error('SOF0 marker not found');
+  }
+
+  function findEoiOffset(bytes: Uint8Array): number {
+    for (let i = bytes.length - 2; i >= 0; i -= 1) {
+      if (bytes[i] === 0xff && bytes[i + 1] === 0xd9) {
+        return i;
+      }
+    }
+    throw new Error('EOI marker not found');
+  }
+
+  it('parses a zero-SOF-height JPEG with a valid DNL (height recovered from DNL)', () => {
+    const base = realBaselineJpegBytes();
+    const sofOff = findSof0Offset(base);
+    const mutated = new Uint8Array(base.length + 6);
+    mutated.set(base.subarray(0, sofOff + 5), 0);
+    mutated[sofOff + 5] = 0x00;
+    mutated[sofOff + 6] = 0x00;
+    mutated.set(base.subarray(sofOff + 7), sofOff + 7);
+    const eoiOff = findEoiOffset(mutated);
+    const withDnl = new Uint8Array(mutated.length + 6);
+    withDnl.set(mutated.subarray(0, eoiOff), 0);
+    withDnl.set([0xff, 0xdc, 0x00, 0x04, 0x00, 0x03], eoiOff);
+    withDnl.set(mutated.subarray(eoiOff), eoiOff + 6);
+    expect(parseRasterHeader(withDnl)).toEqual({
+      format: 'jpeg',
+      width: 2,
+      height: 3,
+    });
+  });
+
+  it('returns null for a zero-SOF-height JPEG without DNL', () => {
+    const base = realBaselineJpegBytes();
+    const sofOff = findSof0Offset(base);
+    const mutated = new Uint8Array(base.length);
+    mutated.set(base);
+    mutated[sofOff + 5] = 0x00;
+    mutated[sofOff + 6] = 0x00;
+    expect(parseRasterHeader(mutated)).toBeNull();
+  });
+
   it('parses a complete JPEG with post-EOI padding (regression: no false-reject)', () => {
     expect(parseRasterHeader(jpegPostEoiPaddingBytes())).toEqual({
       format: 'jpeg',

--- a/packages/openclaw/src/urbit/image-dimensions.test.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseRasterHeader } from './image-dimensions.js';
+import {
+  gifBytes,
+  jpegBytes,
+  pngHeaderBytes,
+  validPngBytes,
+  webpBytes,
+} from './test-fixtures.js';
+
+describe('parseRasterHeader', () => {
+  it('parses a structurally complete PNG header', () => {
+    expect(parseRasterHeader(pngHeaderBytes(10, 20))).toEqual({
+      format: 'png',
+      width: 10,
+      height: 20,
+    });
+  });
+
+  it('parses a genuine complete PNG (validPngBytes) with real dimensions', () => {
+    expect(parseRasterHeader(validPngBytes())).toEqual({
+      format: 'png',
+      width: 1,
+      height: 1,
+    });
+    expect(parseRasterHeader(validPngBytes(5, 3))).toEqual({
+      format: 'png',
+      width: 5,
+      height: 3,
+    });
+  });
+
+  it('parses GIF87a and GIF89a', () => {
+    expect(parseRasterHeader(gifBytes(10, 20, 'GIF87a'))).toEqual({
+      format: 'gif',
+      width: 10,
+      height: 20,
+    });
+    expect(parseRasterHeader(gifBytes(300, 150, 'GIF89a'))).toEqual({
+      format: 'gif',
+      width: 300,
+      height: 150,
+    });
+  });
+
+  it('parses a structurally complete JPEG SOF segment (SOF walk)', () => {
+    expect(parseRasterHeader(jpegBytes(10, 20))).toEqual({
+      format: 'jpeg',
+      width: 10,
+      height: 20,
+    });
+  });
+
+  it('parses WebP VP8, VP8L, and VP8X', () => {
+    expect(
+      parseRasterHeader(webpBytes({ variant: 'VP8 ', width: 10, height: 20 }))
+    ).toEqual({ format: 'webp', width: 10, height: 20 });
+    expect(
+      parseRasterHeader(webpBytes({ variant: 'VP8L', width: 10, height: 20 }))
+    ).toEqual({ format: 'webp', width: 10, height: 20 });
+    expect(
+      parseRasterHeader(webpBytes({ variant: 'VP8X', width: 10, height: 20 }))
+    ).toEqual({ format: 'webp', width: 10, height: 20 });
+  });
+
+  it('returns null for truncated/incomplete magic', () => {
+    // "GIF8" alone (no 7a/9a, no descriptor).
+    expect(
+      parseRasterHeader(new Uint8Array([0x47, 0x49, 0x46, 0x38]))
+    ).toBeNull();
+    // PNG missing the signature tail (only the first 4 bytes).
+    expect(
+      parseRasterHeader(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))
+    ).toBeNull();
+    // PNG with a corrupted signature tail byte.
+    const badTail = pngHeaderBytes(10, 20);
+    badTail[7] = 0x00;
+    expect(parseRasterHeader(badTail)).toBeNull();
+  });
+
+  it('returns null for a PNG IHDR length != 13', () => {
+    expect(parseRasterHeader(pngHeaderBytes(10, 20, 14))).toBeNull();
+  });
+
+  it('returns null when the declared IHDR/descriptor length exceeds the buffer', () => {
+    // 24-byte PNG: 8 sig + 4 length + 4 'IHDR' + only 8 of the 13 declared IHDR
+    // data bytes and no CRC. The length field still says 13, but the buffer does
+    // not actually contain the full chunk, so it must be rejected.
+    const truncatedPng = pngHeaderBytes(10, 20).slice(0, 24);
+    expect(truncatedPng.length).toBe(24);
+    expect(parseRasterHeader(truncatedPng)).toBeNull();
+    // 10-byte GIF: 6-byte signature + only 4 of the 7 logical-screen-descriptor
+    // bytes. The full 13 bytes must be present before reading width/height.
+    const truncatedGif = gifBytes(10, 20).slice(0, 10);
+    expect(truncatedGif.length).toBe(10);
+    expect(parseRasterHeader(truncatedGif)).toBeNull();
+  });
+
+  it('returns null for malformed WebP length fields', () => {
+    // RIFF size 0.
+    expect(
+      parseRasterHeader(
+        webpBytes({ variant: 'VP8X', width: 10, height: 20, riffSize: 0 })
+      )
+    ).toBeNull();
+    // Oversized RIFF size sentinel.
+    expect(
+      parseRasterHeader(
+        webpBytes({
+          variant: 'VP8X',
+          width: 10,
+          height: 20,
+          riffSize: 0xffffffff,
+        })
+      )
+    ).toBeNull();
+    // VP8X chunk size != 10.
+    expect(
+      parseRasterHeader(
+        webpBytes({ variant: 'VP8X', width: 10, height: 20, chunkSize: 9 })
+      )
+    ).toBeNull();
+    // Variant chunk whose padded end crosses the RIFF boundary.
+    expect(
+      parseRasterHeader(
+        webpBytes({ variant: 'VP8X', width: 10, height: 20, riffSize: 14 })
+      )
+    ).toBeNull();
+  });
+
+  it('returns null for a JPEG SOF with a short length', () => {
+    expect(
+      parseRasterHeader(jpegBytes(10, 20, { components: 3, segLen: 10 }))
+    ).toBeNull();
+  });
+
+  it('returns null for a JPEG SOF with components=0 / length 8', () => {
+    // FF D8 FF C0 00 08 08 00 01 00 01 00 — satisfies length == 8 + 0*3 but is
+    // structurally invalid (a decoder needs >= 1 component).
+    expect(
+      parseRasterHeader(jpegBytes(1, 1, { components: 0, segLen: 8 }))
+    ).toBeNull();
+  });
+
+  it('returns null for unrecognized bytes', () => {
+    expect(
+      parseRasterHeader(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+    ).toBeNull();
+    expect(parseRasterHeader(new Uint8Array([]))).toBeNull();
+  });
+});

--- a/packages/openclaw/src/urbit/image-dimensions.test.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.test.ts
@@ -3,21 +3,33 @@ import { describe, expect, it } from 'vitest';
 import { parseRasterHeader } from './image-dimensions.js';
 import {
   gifBytes,
+  gifEmptyImageDataBytes,
+  gifNoImageDescriptorBytes,
+  gifWithExtensionBytes,
   jpegBytes,
+  jpegEmptyScanBytes,
+  jpegMultiScanBytes,
+  jpegNoScanBytes,
+  jpegPostEoiPaddingBytes,
+  jpegRestartStuffingBytes,
   pngHeaderBytes,
+  realBaselineJpegBytes,
+  realProgressiveJpegBytes,
+  realWebpAnimatedBytes,
+  realWebpLosslessBytes,
+  realWebpLossyBytes,
+  realWebpVp8xStaticBytes,
+  validGifBytes,
   validPngBytes,
   webpBytes,
+  webpVp8xAnimationBytes,
+  webpVp8xAnmfTrailingGarbageBytes,
+  webpVp8xEmptyAnmfBytes,
+  webpVp8xEmptyAnmfThenValidBytes,
+  webpVp8xEmptyVp8Bytes,
 } from './test-fixtures.js';
 
 describe('parseRasterHeader', () => {
-  it('parses a structurally complete PNG header', () => {
-    expect(parseRasterHeader(pngHeaderBytes(10, 20))).toEqual({
-      format: 'png',
-      width: 10,
-      height: 20,
-    });
-  });
-
   it('parses a genuine complete PNG (validPngBytes) with real dimensions', () => {
     expect(parseRasterHeader(validPngBytes())).toEqual({
       format: 'png',
@@ -31,49 +43,169 @@ describe('parseRasterHeader', () => {
     });
   });
 
-  it('parses GIF87a and GIF89a', () => {
-    expect(parseRasterHeader(gifBytes(10, 20, 'GIF87a'))).toEqual({
+  it('parses a genuine complete GIF (validGifBytes) with real dimensions', () => {
+    expect(parseRasterHeader(validGifBytes())).toEqual({
+      format: 'gif',
+      width: 1,
+      height: 1,
+    });
+    expect(parseRasterHeader(validGifBytes(10, 20))).toEqual({
       format: 'gif',
       width: 10,
       height: 20,
     });
-    expect(parseRasterHeader(gifBytes(300, 150, 'GIF89a'))).toEqual({
+  });
+
+  it('parses a GIF with an extension block before the image descriptor', () => {
+    expect(parseRasterHeader(gifWithExtensionBytes(8, 4))).toEqual({
       format: 'gif',
-      width: 300,
-      height: 150,
+      width: 8,
+      height: 4,
     });
   });
 
-  it('parses a structurally complete JPEG SOF segment (SOF walk)', () => {
-    expect(parseRasterHeader(jpegBytes(10, 20))).toEqual({
+  it('parses genuine encoder-produced JPEGs (baseline + progressive) with real dimensions', () => {
+    expect(parseRasterHeader(realBaselineJpegBytes())).toEqual({
+      format: 'jpeg',
+      width: 2,
+      height: 3,
+    });
+    expect(parseRasterHeader(realProgressiveJpegBytes())).toEqual({
+      format: 'jpeg',
+      width: 4,
+      height: 2,
+    });
+  });
+
+  it('parses a complete JPEG with post-EOI padding (regression: no false-reject)', () => {
+    expect(parseRasterHeader(jpegPostEoiPaddingBytes())).toEqual({
+      format: 'jpeg',
+      width: 1,
+      height: 1,
+    });
+    expect(parseRasterHeader(jpegPostEoiPaddingBytes(10, 20))).toEqual({
       format: 'jpeg',
       width: 10,
       height: 20,
     });
   });
 
-  it('parses WebP VP8, VP8L, and VP8X', () => {
-    expect(
-      parseRasterHeader(webpBytes({ variant: 'VP8 ', width: 10, height: 20 }))
-    ).toEqual({ format: 'webp', width: 10, height: 20 });
-    expect(
-      parseRasterHeader(webpBytes({ variant: 'VP8L', width: 10, height: 20 }))
-    ).toEqual({ format: 'webp', width: 10, height: 20 });
+  it('parses a JPEG whose scan contains 0xFF00 stuffing and a restart marker', () => {
+    expect(parseRasterHeader(jpegRestartStuffingBytes(4, 6))).toEqual({
+      format: 'jpeg',
+      width: 4,
+      height: 6,
+    });
+  });
+
+  it('parses a multi-scan JPEG', () => {
+    expect(parseRasterHeader(jpegMultiScanBytes(7, 5))).toEqual({
+      format: 'jpeg',
+      width: 7,
+      height: 5,
+    });
+  });
+
+  it('parses genuine encoder-produced WebPs (VP8, VP8L, VP8X static, animated) with real dimensions', () => {
+    expect(parseRasterHeader(realWebpLossyBytes())).toEqual({
+      format: 'webp',
+      width: 5,
+      height: 4,
+    });
+    expect(parseRasterHeader(realWebpLosslessBytes())).toEqual({
+      format: 'webp',
+      width: 5,
+      height: 4,
+    });
+    expect(parseRasterHeader(realWebpVp8xStaticBytes())).toEqual({
+      format: 'webp',
+      width: 7,
+      height: 3,
+    });
+    expect(parseRasterHeader(realWebpAnimatedBytes())).toEqual({
+      format: 'webp',
+      width: 6,
+      height: 5,
+    });
+  });
+
+  it('returns null for a VP8X-only WebP with no image-data chunk', () => {
     expect(
       parseRasterHeader(webpBytes({ variant: 'VP8X', width: 10, height: 20 }))
-    ).toEqual({ format: 'webp', width: 10, height: 20 });
+    ).toBeNull();
+  });
+
+  it('returns null for a VP8X WebP followed by an empty VP8 chunk', () => {
+    expect(parseRasterHeader(webpVp8xEmptyVp8Bytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for a VP8X WebP followed by an empty ANMF chunk', () => {
+    expect(parseRasterHeader(webpVp8xEmptyAnmfBytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for a VP8X animation with an empty ANMF followed by a valid ANMF', () => {
+    expect(parseRasterHeader(webpVp8xEmptyAnmfThenValidBytes(6, 5))).toBeNull();
+  });
+
+  it('returns null for a VP8X animation whose ANMF has a valid VP8L plus trailing garbage', () => {
+    expect(
+      parseRasterHeader(webpVp8xAnmfTrailingGarbageBytes(6, 5))
+    ).toBeNull();
+  });
+
+  it('returns null for a VP8X WebP with the animation flag set but no ANIM chunk', () => {
+    expect(parseRasterHeader(webpVp8xAnimationBytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for a header-only PNG (no IDAT/IEND)', () => {
+    expect(parseRasterHeader(pngHeaderBytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for a PNG with IDAT but missing IEND', () => {
+    const full = validPngBytes(4, 4);
+    const iendOffset = full.length - 12;
+    const noIend = full.slice(0, iendOffset);
+    expect(parseRasterHeader(noIend)).toBeNull();
+  });
+
+  it('returns null for a header-only GIF (no image descriptor, no trailer)', () => {
+    expect(parseRasterHeader(gifBytes(10, 20, 'GIF87a'))).toBeNull();
+    expect(parseRasterHeader(gifBytes(300, 150, 'GIF89a'))).toBeNull();
+  });
+
+  it('returns null for a GIF with no trailer', () => {
+    const full = validGifBytes(2, 2);
+    const noTrailer = full.slice(0, full.length - 1);
+    expect(parseRasterHeader(noTrailer)).toBeNull();
+  });
+
+  it('returns null for a GIF whose GCT/comment contain 0x2C/0x3B but has no image descriptor', () => {
+    expect(parseRasterHeader(gifNoImageDescriptorBytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for a GIF with an image descriptor but empty image data', () => {
+    expect(parseRasterHeader(gifEmptyImageDataBytes(3, 3))).toBeNull();
+  });
+
+  it('returns null for a JPEG with no SOS/EOI (SOI+SOF only)', () => {
+    expect(parseRasterHeader(jpegBytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for SOI+SOF+FFDA+FFD9 with no SOS header and no scan', () => {
+    expect(parseRasterHeader(jpegNoScanBytes(10, 20))).toBeNull();
+  });
+
+  it('returns null for a complete SOS header with zero entropy-coded scan bytes', () => {
+    expect(parseRasterHeader(jpegEmptyScanBytes(10, 20))).toBeNull();
   });
 
   it('returns null for truncated/incomplete magic', () => {
-    // "GIF8" alone (no 7a/9a, no descriptor).
     expect(
       parseRasterHeader(new Uint8Array([0x47, 0x49, 0x46, 0x38]))
     ).toBeNull();
-    // PNG missing the signature tail (only the first 4 bytes).
     expect(
       parseRasterHeader(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))
     ).toBeNull();
-    // PNG with a corrupted signature tail byte.
     const badTail = pngHeaderBytes(10, 20);
     badTail[7] = 0x00;
     expect(parseRasterHeader(badTail)).toBeNull();
@@ -84,27 +216,20 @@ describe('parseRasterHeader', () => {
   });
 
   it('returns null when the declared IHDR/descriptor length exceeds the buffer', () => {
-    // 24-byte PNG: 8 sig + 4 length + 4 'IHDR' + only 8 of the 13 declared IHDR
-    // data bytes and no CRC. The length field still says 13, but the buffer does
-    // not actually contain the full chunk, so it must be rejected.
     const truncatedPng = pngHeaderBytes(10, 20).slice(0, 24);
     expect(truncatedPng.length).toBe(24);
     expect(parseRasterHeader(truncatedPng)).toBeNull();
-    // 10-byte GIF: 6-byte signature + only 4 of the 7 logical-screen-descriptor
-    // bytes. The full 13 bytes must be present before reading width/height.
     const truncatedGif = gifBytes(10, 20).slice(0, 10);
     expect(truncatedGif.length).toBe(10);
     expect(parseRasterHeader(truncatedGif)).toBeNull();
   });
 
   it('returns null for malformed WebP length fields', () => {
-    // RIFF size 0.
     expect(
       parseRasterHeader(
         webpBytes({ variant: 'VP8X', width: 10, height: 20, riffSize: 0 })
       )
     ).toBeNull();
-    // Oversized RIFF size sentinel.
     expect(
       parseRasterHeader(
         webpBytes({
@@ -115,13 +240,11 @@ describe('parseRasterHeader', () => {
         })
       )
     ).toBeNull();
-    // VP8X chunk size != 10.
     expect(
       parseRasterHeader(
         webpBytes({ variant: 'VP8X', width: 10, height: 20, chunkSize: 9 })
       )
     ).toBeNull();
-    // Variant chunk whose padded end crosses the RIFF boundary.
     expect(
       parseRasterHeader(
         webpBytes({ variant: 'VP8X', width: 10, height: 20, riffSize: 14 })
@@ -136,8 +259,6 @@ describe('parseRasterHeader', () => {
   });
 
   it('returns null for a JPEG SOF with components=0 / length 8', () => {
-    // FF D8 FF C0 00 08 08 00 01 00 01 00 — satisfies length == 8 + 0*3 but is
-    // structurally invalid (a decoder needs >= 1 component).
     expect(
       parseRasterHeader(jpegBytes(1, 1, { components: 0, segLen: 8 }))
     ).toBeNull();

--- a/packages/openclaw/src/urbit/image-dimensions.test.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.test.ts
@@ -95,24 +95,32 @@ describe('parseRasterHeader', () => {
     throw new Error('EOI marker not found');
   }
 
-  it('parses a zero-SOF-height JPEG with a valid DNL (height recovered from DNL)', () => {
+  it('rejects any JPEG carrying a DNL marker (libjpeg-turbo cannot honor it)', () => {
+    // Zero-SOF-height + DNL: rejected — libjpeg-turbo (Android/Chromium)
+    // reports zero-height SOF as "DNL not supported".
     const base = realBaselineJpegBytes();
     const sofOff = findSof0Offset(base);
-    const mutated = new Uint8Array(base.length + 6);
-    mutated.set(base.subarray(0, sofOff + 5), 0);
-    mutated[sofOff + 5] = 0x00;
-    mutated[sofOff + 6] = 0x00;
-    mutated.set(base.subarray(sofOff + 7), sofOff + 7);
-    const eoiOff = findEoiOffset(mutated);
-    const withDnl = new Uint8Array(mutated.length + 6);
-    withDnl.set(mutated.subarray(0, eoiOff), 0);
+    const zeroSof = new Uint8Array(base.length + 6);
+    zeroSof.set(base.subarray(0, sofOff + 5), 0);
+    zeroSof[sofOff + 5] = 0x00;
+    zeroSof[sofOff + 6] = 0x00;
+    zeroSof.set(base.subarray(sofOff + 7), sofOff + 7);
+    const eoiOff = findEoiOffset(zeroSof);
+    const withDnl = new Uint8Array(zeroSof.length + 6);
+    withDnl.set(zeroSof.subarray(0, eoiOff), 0);
     withDnl.set([0xff, 0xdc, 0x00, 0x04, 0x00, 0x03], eoiOff);
-    withDnl.set(mutated.subarray(eoiOff), eoiOff + 6);
-    expect(parseRasterHeader(withDnl)).toEqual({
-      format: 'jpeg',
-      width: 2,
-      height: 3,
-    });
+    withDnl.set(zeroSof.subarray(eoiOff), eoiOff + 6);
+    expect(parseRasterHeader(withDnl)).toBeNull();
+
+    // Nonzero SOF + conflicting small DNL: rejected — libjpeg-turbo ignores the
+    // DNL and decodes at the SOF height, so reporting the DNL height would let
+    // an oversized image pass the pixel bounds.
+    const eoiOff2 = findEoiOffset(base);
+    const conflicting = new Uint8Array(base.length + 6);
+    conflicting.set(base.subarray(0, eoiOff2), 0);
+    conflicting.set([0xff, 0xdc, 0x00, 0x04, 0x00, 0x01], eoiOff2);
+    conflicting.set(base.subarray(eoiOff2), eoiOff2 + 6);
+    expect(parseRasterHeader(conflicting)).toBeNull();
   });
 
   it('returns null for a zero-SOF-height JPEG without DNL', () => {
@@ -233,6 +241,31 @@ describe('parseRasterHeader', () => {
 
   it('returns null for a GIF with an image descriptor but empty image data', () => {
     expect(parseRasterHeader(gifEmptyImageDataBytes(3, 3))).toBeNull();
+  });
+
+  it('rejects GIF frames that exceed or fall outside the logical screen', () => {
+    // validGifBytes layout: 6 sig + 7 LSD + 6 GCT, then 0x2c at 19 and the
+    // descriptor fields at 20 (left), 22 (top), 24 (width), 26 (height).
+    const patch = (edit: (b: Uint8Array) => void): Uint8Array => {
+      const b = new Uint8Array(validGifBytes(4, 4));
+      edit(b);
+      return b;
+    };
+    // Frame wider than the canvas.
+    expect(parseRasterHeader(patch((b) => (b[24] = 5)))).toBeNull();
+    // In-bounds frame size, but the offset pushes it past the canvas edge.
+    expect(parseRasterHeader(patch((b) => (b[20] = 1)))).toBeNull();
+    // Zero-dimension frame is unrenderable.
+    expect(parseRasterHeader(patch((b) => (b[24] = 0)))).toBeNull();
+    // Offset frame that stays inside the canvas still parses.
+    expect(
+      parseRasterHeader(
+        patch((b) => {
+          b[20] = 1;
+          b[24] = 3;
+        })
+      )
+    ).toEqual({ format: 'gif', width: 4, height: 4 });
   });
 
   it('returns null for a JPEG with no SOS/EOI (SOI+SOF only)', () => {

--- a/packages/openclaw/src/urbit/image-dimensions.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.ts
@@ -1,0 +1,229 @@
+/**
+ * Plugin-local raster image header parsing (PNG/JPEG/GIF/WebP).
+ *
+ * Derived from `imageDimensions` in `packages/tlon-skill/scripts/image-attach.ts`
+ * (byte-reader helpers + PNG/JPEG/GIF/WebP header parsing), but returns the
+ * detected format alongside the dimensions and tightens the checks: besides the
+ * canonical magics, the container's structural length fields are validated so a
+ * magic-valid but zero/absurd-length file (e.g. a WebP with a `RIFF` size of `0`
+ * and a `VP8X` chunk size of `0`) is rejected instead of parsing "successfully"
+ * with dimensions that no decoder could honor.
+ *
+ * This is intentionally a private copy rather than a shared export from
+ * `@tloncorp/api`: the plugin and the skill are independently published npm
+ * artifacts, and `@tloncorp/api` (their only shared dependency) resolves from
+ * the npm registry in the plugin's standalone installs
+ * (`packages/openclaw/dev/entrypoint.test.sh:40`), so exporting it there would
+ * gate this fix on a coordinated api release. The plugin variant is stricter by
+ * design.
+ *
+ * Callers, not the parser, judge dimension validity (positive, bounded).
+ */
+
+function u16be(b: Uint8Array, o: number): number {
+  return (b[o] << 8) | b[o + 1];
+}
+
+function u32be(b: Uint8Array, o: number): number {
+  return ((b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3]) >>> 0;
+}
+
+function u16le(b: Uint8Array, o: number): number {
+  return b[o] | (b[o + 1] << 8);
+}
+
+function u24le(b: Uint8Array, o: number): number {
+  return b[o] | (b[o + 1] << 8) | (b[o + 2] << 16);
+}
+
+function u32le(b: Uint8Array, o: number): number {
+  return (b[o] | (b[o + 1] << 8) | (b[o + 2] << 16) | (b[o + 3] << 24)) >>> 0;
+}
+
+function ascii(b: Uint8Array, o: number, len: number): string {
+  return String.fromCharCode(...b.subarray(o, o + len));
+}
+
+export type RasterInfo = {
+  format: 'png' | 'jpeg' | 'gif' | 'webp';
+  width: number;
+  height: number;
+};
+
+/**
+ * Parse raster image dimensions and format from raw bytes.
+ *
+ * Enforces complete canonical magics AND structural length fields. Returns
+ * `null` (never a partial result) when the magic is incomplete, a length field
+ * is implausible, or parsing otherwise fails.
+ */
+export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
+  // PNG: full 8-byte signature; IHDR is always the first chunk and its length
+  // field must be exactly 13.
+  if (bytes.length >= 8 && bytes[0] === 0x89 && ascii(bytes, 1, 3) === 'PNG') {
+    if (
+      bytes[4] !== 0x0d ||
+      bytes[5] !== 0x0a ||
+      bytes[6] !== 0x1a ||
+      bytes[7] !== 0x0a
+    ) {
+      return null;
+    }
+    // Need the chunk header (4-byte length + 4-byte type) before reading the
+    // declared IHDR length and type.
+    if (bytes.length < 16) {
+      return null;
+    }
+    const ihdrLen = u32be(bytes, 8);
+    if (ihdrLen !== 13 || ascii(bytes, 12, 4) !== 'IHDR') {
+      return null;
+    }
+    // The full declared IHDR chunk — length field (4) + type (4) + the declared
+    // data bytes (ihdrLen) + CRC (4) — must actually be present in the buffer,
+    // not merely claimed by the length field. A truncated header that declares
+    // 13 data bytes but stops short of them (or of the CRC) is rejected.
+    if (bytes.length < 8 + 4 + 4 + ihdrLen + 4) {
+      return null;
+    }
+    return { format: 'png', width: u32be(bytes, 16), height: u32be(bytes, 20) };
+  }
+
+  // GIF87a / GIF89a (not just "GIF8"): logical-screen descriptor right after
+  // the six-byte signature.
+  if (bytes.length >= 4 && ascii(bytes, 0, 4) === 'GIF8') {
+    if (bytes.length < 6) {
+      return null;
+    }
+    const sig = ascii(bytes, 0, 6);
+    if (sig !== 'GIF87a' && sig !== 'GIF89a') {
+      return null;
+    }
+    // The full 7-byte logical-screen descriptor (width, height, packed field,
+    // background color index, pixel aspect ratio) must be present in the buffer,
+    // not just the width/height prefix.
+    if (bytes.length < 13) {
+      return null;
+    }
+    return { format: 'gif', width: u16le(bytes, 6), height: u16le(bytes, 8) };
+  }
+
+  // JPEG: SOI + segment walk to a start-of-frame marker. Each scanned segment's
+  // length field must be >= 2 and lie within the buffer; the SOF must carry at
+  // least one component and its length must be exactly 8 + components*3.
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    let i = 2;
+    while (i + 3 < bytes.length) {
+      if (bytes[i] !== 0xff) {
+        return null;
+      }
+      const marker = bytes[i + 1];
+      if (marker === 0xff) {
+        i += 1; // fill byte
+        continue;
+      }
+      if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) {
+        i += 2; // standalone marker, no length
+        continue;
+      }
+      if (marker === 0xd9 || marker === 0xda) {
+        return null; // EOI/SOS before any SOF
+      }
+      const segLen = u16be(bytes, i + 2);
+      if (segLen < 2) {
+        return null;
+      }
+      if (i + 2 + segLen > bytes.length) {
+        return null; // segment crosses the buffer boundary
+      }
+      const isSof =
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc;
+      if (isSof) {
+        if (i + 9 >= bytes.length) {
+          return null;
+        }
+        const components = bytes[i + 9];
+        if (components < 1) {
+          return null;
+        }
+        if (segLen !== 8 + components * 3) {
+          return null;
+        }
+        return {
+          format: 'jpeg',
+          height: u16be(bytes, i + 5),
+          width: u16be(bytes, i + 7),
+        };
+      }
+      i += 2 + segLen;
+    }
+    return null;
+  }
+
+  // WebP: RIFF container; the RIFF size field and the variant chunk size are
+  // bounded against both the RIFF boundary and the buffer before dimension
+  // bytes are read.
+  if (
+    bytes.length >= 12 &&
+    ascii(bytes, 0, 4) === 'RIFF' &&
+    ascii(bytes, 8, 4) === 'WEBP'
+  ) {
+    const riffSize = u32le(bytes, 4);
+    if (riffSize === 0 || riffSize + 8 > bytes.length) {
+      return null; // reject 0 and oversized sentinels (e.g. 0xffffffff)
+    }
+    const riffEnd = 8 + riffSize;
+    if (bytes.length < 20) {
+      return null; // no complete chunk header
+    }
+    const chunk = ascii(bytes, 12, 4);
+    const chunkSize = u32le(bytes, 16);
+    const paddedEnd = 20 + chunkSize + (chunkSize & 1);
+    if (paddedEnd > riffEnd || paddedEnd > bytes.length) {
+      return null; // chunk crosses the RIFF boundary or the buffer
+    }
+    if (chunk === 'VP8 ') {
+      if (chunkSize < 10) {
+        return null;
+      }
+      if (bytes[23] !== 0x9d || bytes[24] !== 0x01 || bytes[25] !== 0x2a) {
+        return null;
+      }
+      return {
+        format: 'webp',
+        width: u16le(bytes, 26) & 0x3fff,
+        height: u16le(bytes, 28) & 0x3fff,
+      };
+    }
+    if (chunk === 'VP8L') {
+      if (chunkSize < 5) {
+        return null;
+      }
+      if (bytes[20] !== 0x2f) {
+        return null;
+      }
+      const bits = u32le(bytes, 21);
+      return {
+        format: 'webp',
+        width: (bits & 0x3fff) + 1,
+        height: ((bits >> 14) & 0x3fff) + 1,
+      };
+    }
+    if (chunk === 'VP8X') {
+      if (chunkSize !== 10) {
+        return null;
+      }
+      return {
+        format: 'webp',
+        width: u24le(bytes, 24) + 1,
+        height: u24le(bytes, 27) + 1,
+      };
+    }
+    return null;
+  }
+
+  return null;
+}

--- a/packages/openclaw/src/urbit/image-dimensions.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.ts
@@ -228,6 +228,23 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
         if (i + 9 > n) {
           return null;
         }
+        // GIF89a §20 requires every frame to fit inside the logical screen.
+        // Decoders diverge on violations (clip, reject, or allocate from the
+        // descriptor), so an oversized descriptor behind a small canvas would
+        // bypass the canvas-based pixel bounds. Reject it, and reject empty
+        // frames, which nothing can render.
+        const frameLeft = u16le(bytes, i);
+        const frameTop = u16le(bytes, i + 2);
+        const frameWidth = u16le(bytes, i + 4);
+        const frameHeight = u16le(bytes, i + 6);
+        if (
+          frameWidth === 0 ||
+          frameHeight === 0 ||
+          frameLeft + frameWidth > u16le(bytes, 6) ||
+          frameTop + frameHeight > u16le(bytes, 8)
+        ) {
+          return null;
+        }
         const imgPacked = bytes[i + 8];
         i += 9;
         if (imgPacked & 0x80) {
@@ -278,8 +295,6 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
     const n = bytes.length;
     let dims: { height: number; width: number } | null = null;
     let sawScan = false;
-    let scanCount = 0;
-    let seenDnl = false;
     let i = 2;
     for (;;) {
       if (i + 1 >= n) {
@@ -364,36 +379,17 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
           return null;
         }
         sawScan = true;
-        scanCount += 1;
         i = k;
         continue;
       }
-      // JPEG permits one DNL after the first scan to supply the nonzero line count.
+      // Reject DNL JPEGs outright. T.81 allows DNL to (re)define the line
+      // count, but the deployed decoder ecosystem does not honor it —
+      // libjpeg-turbo (Android, Chromium) ignores DNL and rejects a zero-height
+      // SOF as "DNL not supported" — so any DNL-dependent height is either
+      // undecodable by clients or diverges from what they decode. Accepting
+      // one would recreate the false-success path this parser exists to close.
       if (marker === 0xdc) {
-        if (scanCount !== 1 || seenDnl) {
-          return null;
-        }
-        if (i + 2 > n) {
-          return null;
-        }
-        const dnlLen = u16be(bytes, i);
-        if (dnlLen !== 4) {
-          return null;
-        }
-        if (i + dnlLen > n) {
-          return null;
-        }
-        if (!dims) {
-          return null;
-        }
-        const nl = u16be(bytes, i + 2);
-        if (nl === 0) {
-          return null;
-        }
-        dims.height = nl;
-        seenDnl = true;
-        i += dnlLen;
-        continue;
+        return null;
       }
       if (i + 2 > n) {
         return null;

--- a/packages/openclaw/src/urbit/image-dimensions.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.ts
@@ -44,6 +44,59 @@ function ascii(b: Uint8Array, o: number, len: number): string {
   return String.fromCharCode(...b.subarray(o, o + len));
 }
 
+// A VP8 /VP8L chunk qualifies as an image bitstream only when its payload is
+// large enough to hold the variant's fixed header AND carries that header's
+// signature (the VP8 0x9d 0x01 0x2a start code at payload offset 3, or the VP8L
+// 0x2f signature byte at offset 0). FourCC presence alone is not enough.
+function webpChunkIsBitstream(
+  b: Uint8Array,
+  fourcc: string,
+  payload: number,
+  size: number
+): boolean {
+  if (fourcc === 'VP8 ') {
+    return (
+      size >= 10 &&
+      b[payload + 3] === 0x9d &&
+      b[payload + 4] === 0x01 &&
+      b[payload + 5] === 0x2a
+    );
+  }
+  if (fourcc === 'VP8L') {
+    return size >= 5 && b[payload] === 0x2f;
+  }
+  return false;
+}
+
+// An ANMF frame payload begins with a 16-byte frame header; the bytes after it
+// are a bounded RIFF chunk list. True when that nested list holds at least one
+// VP8 /VP8L bitstream subchunk passing webpChunkIsBitstream. `start` is the
+// offset of the ANMF payload and `size` its declared length; the walk never
+// reads past [start+16, start+size) or the buffer.
+function webpAnmfHasBitstream(
+  b: Uint8Array,
+  start: number,
+  size: number
+): boolean {
+  if (size < 16) return false;
+  const listEnd = start + size;
+  let off = start + 16;
+  let found = false;
+  while (off < listEnd) {
+    if (off + 8 > listEnd || off + 8 > b.length) return false; // partial header ⇒ malformed
+    const fourcc = ascii(b, off, 4);
+    const subSize = u32le(b, off + 4);
+    const subPayload = off + 8;
+    const subEnd = subPayload + subSize + (subSize & 1);
+    if (subEnd > listEnd || subEnd > b.length) return false; // overrun
+    if (webpChunkIsBitstream(b, fourcc, subPayload, subSize)) found = true;
+    off = subEnd;
+  }
+  // Require exact tiling AND a real bitstream: an empty, header-only, or
+  // trailing-garbage ANMF is a malformed frame.
+  return found && off === listEnd;
+}
+
 export type RasterInfo = {
   format: 'png' | 'jpeg' | 'gif' | 'webp';
   width: number;
@@ -59,7 +112,9 @@ export type RasterInfo = {
  */
 export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
   // PNG: full 8-byte signature; IHDR is always the first chunk and its length
-  // field must be exactly 13.
+  // field must be exactly 13. After reading IHDR, walk the remaining chunk
+  // sequence requiring at least one IDAT (length > 0) followed by an IEND
+  // (length 0). CRC values are NOT verified and IDAT is NOT inflated.
   if (bytes.length >= 8 && bytes[0] === 0x89 && ascii(bytes, 1, 3) === 'PNG') {
     if (
       bytes[4] !== 0x0d ||
@@ -69,8 +124,6 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
     ) {
       return null;
     }
-    // Need the chunk header (4-byte length + 4-byte type) before reading the
-    // declared IHDR length and type.
     if (bytes.length < 16) {
       return null;
     }
@@ -78,18 +131,47 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
     if (ihdrLen !== 13 || ascii(bytes, 12, 4) !== 'IHDR') {
       return null;
     }
-    // The full declared IHDR chunk — length field (4) + type (4) + the declared
-    // data bytes (ihdrLen) + CRC (4) — must actually be present in the buffer,
-    // not merely claimed by the length field. A truncated header that declares
-    // 13 data bytes but stops short of them (or of the CRC) is rejected.
     if (bytes.length < 8 + 4 + 4 + ihdrLen + 4) {
       return null;
     }
-    return { format: 'png', width: u32be(bytes, 16), height: u32be(bytes, 20) };
+    const width = u32be(bytes, 16);
+    const height = u32be(bytes, 20);
+    let offset = 8 + 4 + 4 + ihdrLen + 4;
+    let sawIdat = false;
+    while (offset + 8 <= bytes.length) {
+      const chunkLen = u32be(bytes, offset);
+      const chunkType = ascii(bytes, offset + 4, 4);
+      const chunkEnd = offset + 4 + 4 + chunkLen + 4;
+      if (chunkEnd > bytes.length) {
+        return null;
+      }
+      if (chunkType === 'IDAT' && chunkLen > 0) {
+        sawIdat = true;
+      }
+      if (chunkType === 'IEND') {
+        if (chunkLen !== 0) {
+          return null;
+        }
+        if (!sawIdat) {
+          return null;
+        }
+        return { format: 'png', width, height };
+      }
+      offset = chunkEnd;
+    }
+    return null;
   }
 
-  // GIF87a / GIF89a (not just "GIF8"): logical-screen descriptor right after
-  // the six-byte signature.
+  // GIF87a / GIF89a: six-byte signature + seven-byte logical-screen descriptor,
+  // then a bounded walk of the block grammar rather than a raw scan for 0x2C
+  // (which a 0x2C inside the global color table or an extension payload would
+  // fool). Skip the Global Color Table when its flag is set (3 * 2^(N+1) bytes
+  // per the packed field), then loop over 0x21 extensions (label + data
+  // sub-blocks, each a length byte + that many bytes, terminated by a 0x00
+  // sub-block), 0x2C image descriptors (skip any Local Color Table, then the
+  // LZW-min-code-size byte + image-data sub-blocks), and the 0x3B trailer.
+  // Require at least one real image descriptor carrying NON-EMPTY image data
+  // before the trailer; every step is bounds-checked against the buffer.
   if (bytes.length >= 4 && ascii(bytes, 0, 4) === 'GIF8') {
     if (bytes.length < 6) {
       return null;
@@ -98,42 +180,203 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
     if (sig !== 'GIF87a' && sig !== 'GIF89a') {
       return null;
     }
-    // The full 7-byte logical-screen descriptor (width, height, packed field,
-    // background color index, pixel aspect ratio) must be present in the buffer,
-    // not just the width/height prefix.
     if (bytes.length < 13) {
       return null;
     }
-    return { format: 'gif', width: u16le(bytes, 6), height: u16le(bytes, 8) };
+    const n = bytes.length;
+    let i = 13;
+    const packed = bytes[10];
+    if (packed & 0x80) {
+      i += 3 * (1 << ((packed & 0x07) + 1));
+      if (i > n) {
+        return null;
+      }
+    }
+    let sawImage = false;
+    for (;;) {
+      if (i >= n) {
+        return null;
+      }
+      const block = bytes[i];
+      if (block === 0x3b) {
+        if (!sawImage) {
+          return null;
+        }
+        return {
+          format: 'gif',
+          width: u16le(bytes, 6),
+          height: u16le(bytes, 8),
+        };
+      }
+      if (block === 0x21) {
+        if (i + 2 > n) {
+          return null;
+        }
+        i += 2;
+        for (;;) {
+          if (i >= n) {
+            return null;
+          }
+          const len = bytes[i];
+          i += 1;
+          if (len === 0) {
+            break;
+          }
+          i += len;
+          if (i > n) {
+            return null;
+          }
+        }
+        continue;
+      }
+      if (block === 0x2c) {
+        i += 1;
+        if (i + 9 > n) {
+          return null;
+        }
+        const imgPacked = bytes[i + 8];
+        i += 9;
+        if (imgPacked & 0x80) {
+          i += 3 * (1 << ((imgPacked & 0x07) + 1));
+          if (i > n) {
+            return null;
+          }
+        }
+        if (i >= n) {
+          return null;
+        }
+        i += 1;
+        let dataBytes = 0;
+        for (;;) {
+          if (i >= n) {
+            return null;
+          }
+          const len = bytes[i];
+          i += 1;
+          if (len === 0) {
+            break;
+          }
+          dataBytes += len;
+          i += len;
+          if (i > n) {
+            return null;
+          }
+        }
+        if (dataBytes > 0) {
+          sawImage = true;
+        }
+        continue;
+      }
+      return null;
+    }
   }
 
-  // JPEG: SOI + segment walk to a start-of-frame marker. Each scanned segment's
-  // length field must be >= 2 and lie within the buffer; the SOF must carry at
-  // least one component and its length must be exactly 8 + components*3.
+  // JPEG: SOI + a bounded marker-grammar walk. Record dimensions from a
+  // start-of-frame segment, then require a Start-Of-Scan segment whose header
+  // (length + component selectors) bounds-checks, followed by at least one byte
+  // of entropy-coded scan data, before a syntactic End-Of-Image marker. Within
+  // the scan, byte-stuffing (0xFF00) and restart markers (0xFFD0–0xFFD7) are
+  // part of the scan, not segment terminators, and multiple scans are tolerated.
+  // The EOI need only appear AFTER the scan data — trailing padding after EOI is
+  // permitted, so complete JPEGs with post-EOI bytes still parse. Nothing is
+  // huffman-decoded or dequantized; this is structural presence + bounds only.
   if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    const n = bytes.length;
+    let dims: { height: number; width: number } | null = null;
+    let sawScan = false;
     let i = 2;
-    while (i + 3 < bytes.length) {
+    for (;;) {
+      if (i + 1 >= n) {
+        return null;
+      }
       if (bytes[i] !== 0xff) {
         return null;
       }
-      const marker = bytes[i + 1];
-      if (marker === 0xff) {
-        i += 1; // fill byte
+      while (i < n && bytes[i] === 0xff) {
+        i += 1;
+      }
+      if (i >= n) {
+        return null;
+      }
+      const marker = bytes[i];
+      i += 1;
+      if (
+        marker === 0x01 ||
+        marker === 0xd8 ||
+        (marker >= 0xd0 && marker <= 0xd7)
+      ) {
         continue;
       }
-      if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) {
-        i += 2; // standalone marker, no length
+      if (marker === 0xd9) {
+        if (!dims || !sawScan) {
+          return null;
+        }
+        return { format: 'jpeg', height: dims.height, width: dims.width };
+      }
+      if (marker === 0xda) {
+        if (!dims) {
+          return null;
+        }
+        if (i + 2 > n) {
+          return null;
+        }
+        const sosLen = u16be(bytes, i);
+        if (sosLen < 8) {
+          return null;
+        }
+        if (i + sosLen > n) {
+          return null;
+        }
+        const ns = bytes[i + 2];
+        if (ns < 1 || sosLen !== 6 + ns * 2) {
+          return null;
+        }
+        let k = i + sosLen;
+        let scanData = 0;
+        for (;;) {
+          if (k >= n) {
+            return null;
+          }
+          if (bytes[k] !== 0xff) {
+            k += 1;
+            scanData += 1;
+            continue;
+          }
+          if (k + 1 >= n) {
+            return null;
+          }
+          const next = bytes[k + 1];
+          if (next === 0x00) {
+            k += 2;
+            scanData += 1;
+            continue;
+          }
+          if (next >= 0xd0 && next <= 0xd7) {
+            k += 2;
+            continue;
+          }
+          if (next === 0xff) {
+            k += 1;
+            continue;
+          }
+          break;
+        }
+        if (scanData < 1) {
+          return null;
+        }
+        sawScan = true;
+        i = k;
         continue;
       }
-      if (marker === 0xd9 || marker === 0xda) {
-        return null; // EOI/SOS before any SOF
+      if (i + 2 > n) {
+        return null;
       }
-      const segLen = u16be(bytes, i + 2);
+      const segLen = u16be(bytes, i);
       if (segLen < 2) {
         return null;
       }
-      if (i + 2 + segLen > bytes.length) {
-        return null; // segment crosses the buffer boundary
+      if (i + segLen > n) {
+        return null;
       }
       const isSof =
         marker >= 0xc0 &&
@@ -142,25 +385,23 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
         marker !== 0xc8 &&
         marker !== 0xcc;
       if (isSof) {
-        if (i + 9 >= bytes.length) {
+        if (i + 8 > n) {
           return null;
         }
-        const components = bytes[i + 9];
+        const components = bytes[i + 7];
         if (components < 1) {
           return null;
         }
         if (segLen !== 8 + components * 3) {
           return null;
         }
-        return {
-          format: 'jpeg',
-          height: u16be(bytes, i + 5),
-          width: u16be(bytes, i + 7),
+        dims = {
+          height: u16be(bytes, i + 3),
+          width: u16be(bytes, i + 5),
         };
       }
-      i += 2 + segLen;
+      i += segLen;
     }
-    return null;
   }
 
   // WebP: RIFF container; the RIFF size field and the variant chunk size are
@@ -216,11 +457,55 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
       if (chunkSize !== 10) {
         return null;
       }
-      return {
-        format: 'webp',
-        width: u24le(bytes, 24) + 1,
-        height: u24le(bytes, 27) + 1,
-      };
+      const animFlag = (bytes[20] & 0x02) !== 0;
+      const width = u24le(bytes, 24) + 1;
+      const height = u24le(bytes, 27) + 1;
+      // A VP8X extended header alone carries no pixels. Walk the bounded RIFF
+      // chunk list within the RIFF-size bound and require an actual image
+      // bitstream, not merely a chunk FourCC: a static VP8 /VP8L that passes the
+      // minimum-header checks, or — when the animation flag is set — the
+      // mandatory ANIM chunk plus at least one ANMF frame whose payload carries
+      // a nested VP8 /VP8L bitstream. VP8X-only files, empty/header-only image
+      // chunks, and animation flagged without ANIM/a valid frame are rejected.
+      let off = paddedEnd;
+      let hasImage = false;
+      let hasAnim = false;
+      let hasFrame = false;
+      while (off + 8 <= riffEnd && off + 8 <= bytes.length) {
+        const fourcc = ascii(bytes, off, 4);
+        const cSize = u32le(bytes, off + 4);
+        const payload = off + 8;
+        const cEnd = payload + cSize + (cSize & 1);
+        if (cEnd > riffEnd || cEnd > bytes.length) {
+          return null;
+        }
+        if (fourcc === 'VP8 ' || fourcc === 'VP8L') {
+          if (webpChunkIsBitstream(bytes, fourcc, payload, cSize)) {
+            hasImage = true;
+          }
+        } else if (fourcc === 'ANIM') {
+          if (cSize >= 6) {
+            hasAnim = true;
+          }
+        } else if (fourcc === 'ANMF') {
+          // Every ANMF frame must carry a real bitstream; an empty or malformed
+          // frame — even alongside valid ones — makes the animation invalid
+          // (libwebp rejects such files).
+          if (!webpAnmfHasBitstream(bytes, payload, cSize)) {
+            return null;
+          }
+          hasFrame = true;
+        }
+        off = cEnd;
+      }
+      if (animFlag) {
+        if (!hasAnim || !hasFrame) {
+          return null;
+        }
+      } else if (!hasImage) {
+        return null;
+      }
+      return { format: 'webp', width, height };
     }
     return null;
   }

--- a/packages/openclaw/src/urbit/image-dimensions.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.ts
@@ -284,6 +284,8 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
     const n = bytes.length;
     let dims: { height: number; width: number } | null = null;
     let sawScan = false;
+    let scanCount = 0;
+    let seenDnl = false;
     let i = 2;
     for (;;) {
       if (i + 1 >= n) {
@@ -309,6 +311,9 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
       }
       if (marker === 0xd9) {
         if (!dims || !sawScan) {
+          return null;
+        }
+        if (dims.height === 0) {
           return null;
         }
         return { format: 'jpeg', height: dims.height, width: dims.width };
@@ -365,7 +370,34 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
           return null;
         }
         sawScan = true;
+        scanCount += 1;
         i = k;
+        continue;
+      }
+      if (marker === 0xdc) {
+        if (scanCount !== 1 || seenDnl) {
+          return null;
+        }
+        if (i + 2 > n) {
+          return null;
+        }
+        const dnlLen = u16be(bytes, i);
+        if (dnlLen !== 4) {
+          return null;
+        }
+        if (i + dnlLen > n) {
+          return null;
+        }
+        if (!dims) {
+          return null;
+        }
+        const nl = u16be(bytes, i + 2);
+        if (nl === 0) {
+          return null;
+        }
+        dims.height = nl;
+        seenDnl = true;
+        i += dnlLen;
         continue;
       }
       if (i + 2 > n) {

--- a/packages/openclaw/src/urbit/image-dimensions.ts
+++ b/packages/openclaw/src/urbit/image-dimensions.ts
@@ -1,21 +1,15 @@
 /**
- * Plugin-local raster image header parsing (PNG/JPEG/GIF/WebP).
+ * Plugin-local PNG/JPEG/GIF/WebP header parsing, derived from the Tlon skill
+ * parser (`packages/tlon-skill/scripts/image-attach.ts`) but with stricter
+ * structural validation and format detection: besides the canonical magics, the
+ * container length fields are validated, so a magic-valid but zero/absurd-length
+ * file (e.g. a WebP with RIFF size 0 and a VP8X chunk size of 0) is rejected
+ * instead of parsing "successfully" at dimensions no decoder could honor.
  *
- * Derived from `imageDimensions` in `packages/tlon-skill/scripts/image-attach.ts`
- * (byte-reader helpers + PNG/JPEG/GIF/WebP header parsing), but returns the
- * detected format alongside the dimensions and tightens the checks: besides the
- * canonical magics, the container's structural length fields are validated so a
- * magic-valid but zero/absurd-length file (e.g. a WebP with a `RIFF` size of `0`
- * and a `VP8X` chunk size of `0`) is rejected instead of parsing "successfully"
- * with dimensions that no decoder could honor.
- *
- * This is intentionally a private copy rather than a shared export from
- * `@tloncorp/api`: the plugin and the skill are independently published npm
- * artifacts, and `@tloncorp/api` (their only shared dependency) resolves from
- * the npm registry in the plugin's standalone installs
- * (`packages/openclaw/dev/entrypoint.test.sh:40`), so exporting it there would
- * gate this fix on a coordinated api release. The plugin variant is stricter by
- * design.
+ * Kept a private copy — not a shared `@tloncorp/api` export — because the plugin
+ * and skill publish independently, and their shared dep resolves from the npm
+ * registry in the plugin's standalone installs; exporting there would gate this
+ * fix on a coordinated api release.
  *
  * Callers, not the parser, judge dimension validity (positive, bounded).
  */
@@ -83,12 +77,12 @@ function webpAnmfHasBitstream(
   let off = start + 16;
   let found = false;
   while (off < listEnd) {
-    if (off + 8 > listEnd || off + 8 > b.length) return false; // partial header ⇒ malformed
+    if (off + 8 > listEnd || off + 8 > b.length) return false;
     const fourcc = ascii(b, off, 4);
     const subSize = u32le(b, off + 4);
     const subPayload = off + 8;
     const subEnd = subPayload + subSize + (subSize & 1);
-    if (subEnd > listEnd || subEnd > b.length) return false; // overrun
+    if (subEnd > listEnd || subEnd > b.length) return false;
     if (webpChunkIsBitstream(b, fourcc, subPayload, subSize)) found = true;
     off = subEnd;
   }
@@ -374,6 +368,7 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
         i = k;
         continue;
       }
+      // JPEG permits one DNL after the first scan to supply the nonzero line count.
       if (marker === 0xdc) {
         if (scanCount !== 1 || seenDnl) {
           return null;
@@ -446,17 +441,17 @@ export function parseRasterHeader(bytes: Uint8Array): RasterInfo | null {
   ) {
     const riffSize = u32le(bytes, 4);
     if (riffSize === 0 || riffSize + 8 > bytes.length) {
-      return null; // reject 0 and oversized sentinels (e.g. 0xffffffff)
+      return null;
     }
     const riffEnd = 8 + riffSize;
     if (bytes.length < 20) {
-      return null; // no complete chunk header
+      return null;
     }
     const chunk = ascii(bytes, 12, 4);
     const chunkSize = u32le(bytes, 16);
     const paddedEnd = 20 + chunkSize + (chunkSize & 1);
     if (paddedEnd > riffEnd || paddedEnd > bytes.length) {
-      return null; // chunk crosses the RIFF boundary or the buffer
+      return null;
     }
     if (chunk === 'VP8 ') {
       if (chunkSize < 10) {

--- a/packages/openclaw/src/urbit/send.test.ts
+++ b/packages/openclaw/src/urbit/send.test.ts
@@ -130,3 +130,53 @@ describe('sendDm', () => {
     }
   );
 });
+
+describe('buildMediaStory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('builds an image block with real dims for image media', async () => {
+    const { buildMediaStory } = await import('./send.js');
+    const story = buildMediaStory('caption', {
+      url: 'https://x/img.png',
+      isImage: true,
+      width: 10,
+      height: 20,
+      contentType: 'image/png',
+    });
+    expect(story).toContainEqual({
+      block: {
+        image: { src: 'https://x/img.png', alt: '', height: 20, width: 10 },
+      },
+    });
+  });
+
+  it('builds a link inline for non-image media', async () => {
+    const { buildMediaStory } = await import('./send.js');
+    const story = buildMediaStory(undefined, {
+      url: 'https://x/doc.pdf',
+      isImage: false,
+      width: 0,
+      height: 0,
+    });
+    expect(story).toContainEqual({
+      inline: [
+        { link: { href: 'https://x/doc.pdf', content: 'https://x/doc.pdf' } },
+      ],
+    });
+  });
+
+  it('builds a text-only story when there is no media', async () => {
+    const { buildMediaStory } = await import('./send.js');
+    expect(buildMediaStory('hello', undefined)).toEqual([
+      { inline: ['hello'] },
+    ]);
+  });
+
+  it('returns an empty inline for no text and no media', async () => {
+    const { buildMediaStory } = await import('./send.js');
+    expect(buildMediaStory(undefined, undefined)).toEqual([{ inline: [''] }]);
+  });
+});

--- a/packages/openclaw/src/urbit/send.ts
+++ b/packages/openclaw/src/urbit/send.ts
@@ -7,12 +7,8 @@ import {
 } from '@tloncorp/api';
 import { da, scot } from '@urbit/aura';
 
-import {
-  type Story,
-  createImageBlock,
-  isImageUrl,
-  markdownToStory,
-} from './story.js';
+import { type Story, createImageBlock, markdownToStory } from './story.js';
+import type { PreparedOutboundMedia } from './upload.js';
 
 // --- Helpers ---
 
@@ -211,27 +207,29 @@ export function buildMediaText(
 }
 
 /**
- * Build a story with text and optional media (image)
+ * Build a story with text and optional prepared media (image or link).
  */
 export function buildMediaStory(
   text: string | undefined,
-  mediaUrl: string | undefined
+  media: PreparedOutboundMedia | undefined
 ): Story {
   const story: Story = [];
   const cleanText = text?.trim() ?? '';
-  const cleanUrl = mediaUrl?.trim() ?? '';
 
   // Add text content if present
   if (cleanText) {
     story.push(...markdownToStory(cleanText));
   }
 
-  // Add image block if URL looks like an image
-  if (cleanUrl && isImageUrl(cleanUrl)) {
-    story.push(createImageBlock(cleanUrl, ''));
-  } else if (cleanUrl) {
-    // For non-image URLs, add as a link
-    story.push({ inline: [{ link: { href: cleanUrl, content: cleanUrl } }] });
+  if (media) {
+    if (media.isImage) {
+      // createImageBlock parameter order is (src, alt, height, width).
+      story.push(createImageBlock(media.url, '', media.height, media.width));
+    } else {
+      story.push({
+        inline: [{ link: { href: media.url, content: media.url } }],
+      });
+    }
   }
 
   return story.length > 0 ? story : [{ inline: [''] }];

--- a/packages/openclaw/src/urbit/story.ts
+++ b/packages/openclaw/src/urbit/story.ts
@@ -207,14 +207,6 @@ export function createImageBlock(
 }
 
 /**
- * Check if URL looks like an image
- */
-export function isImageUrl(url: string): boolean {
-  const imageExtensions = /\.(jpg|jpeg|png|gif|webp|svg|bmp|ico)(\?.*)?$/i;
-  return imageExtensions.test(url);
-}
-
-/**
  * Process inlines and extract any image markers into blocks
  */
 function processInlinesForImages(inlines: StoryInline[]): {

--- a/packages/openclaw/src/urbit/test-fixtures.ts
+++ b/packages/openclaw/src/urbit/test-fixtures.ts
@@ -1,0 +1,297 @@
+/**
+ * Shared byte-level image fixtures for the media pipeline unit tests.
+ * Test-only helper; not imported by any runtime source module.
+ */
+import { deflateSync } from 'node:zlib';
+
+/**
+ * A structural PNG header only: 8-byte signature + a complete IHDR chunk whose
+ * trailing CRC is left zero and which carries NO IDAT/IEND. The parser bounds
+ * the chunk against the buffer but never verifies the CRC or requires image
+ * data, so this is enough to exercise parser/classifier BOUNDARY cases — but it
+ * is not a renderable image. Success-path tests that need a genuine image use
+ * `validPngBytes` instead.
+ */
+export function pngHeaderBytes(
+  width: number,
+  height: number,
+  ihdrLen = 13
+): Uint8Array {
+  // A complete IHDR chunk: 8-byte signature + 4-byte length + 4-byte type +
+  // ihdrLen data bytes + 4-byte CRC. The parser bounds the whole chunk against
+  // the buffer, so a structurally complete parser-boundary fixture must carry
+  // the full declared data AND the trailing CRC (a 24-byte header that stops
+  // after width/height is truncated and must be rejected). Note this is a
+  // header only, not a renderable image (no IDAT/IEND; see validPngBytes).
+  const b = new Uint8Array(8 + 4 + 4 + ihdrLen + 4);
+  b.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  b[8] = (ihdrLen >>> 24) & 0xff;
+  b[9] = (ihdrLen >>> 16) & 0xff;
+  b[10] = (ihdrLen >>> 8) & 0xff;
+  b[11] = ihdrLen & 0xff;
+  b.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  b[16] = (width >>> 24) & 0xff;
+  b[17] = (width >>> 16) & 0xff;
+  b[18] = (width >>> 8) & 0xff;
+  b[19] = width & 0xff;
+  b[20] = (height >>> 24) & 0xff;
+  b[21] = (height >>> 16) & 0xff;
+  b[22] = (height >>> 8) & 0xff;
+  b[23] = height & 0xff;
+  // Plausible remaining IHDR data, structurally complete for parser-boundary
+  // tests (CRC intentionally zero; not a renderable image): bit depth 8,
+  // color type 6 (truecolor + alpha), compression/filter/interlace 0. The
+  // parser bounds the chunk but never verifies the CRC value.
+  if (ihdrLen >= 13) {
+    b[24] = 8; // bit depth
+    b[25] = 6; // color type
+    b[26] = 0; // compression method
+    b[27] = 0; // filter method
+    b[28] = 0; // interlace method
+  }
+  return b;
+}
+
+// PNG CRC32 (reflected, polynomial 0xedb88320), computed over chunk type + data.
+const PNG_CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function pngCrc32(bytes: Uint8Array): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i += 1) {
+    c = PNG_CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+/** Serialize a PNG chunk: 4-byte length + 4-byte type + data + 4-byte CRC. */
+function pngChunk(type: string, data: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + 4 + data.length + 4);
+  const len = data.length;
+  out[0] = (len >>> 24) & 0xff;
+  out[1] = (len >>> 16) & 0xff;
+  out[2] = (len >>> 8) & 0xff;
+  out[3] = len & 0xff;
+  const crcInput = new Uint8Array(4 + data.length);
+  for (let i = 0; i < 4; i += 1) {
+    const ch = type.charCodeAt(i);
+    out[4 + i] = ch;
+    crcInput[i] = ch;
+  }
+  out.set(data, 8);
+  crcInput.set(data, 4);
+  const crc = pngCrc32(crcInput);
+  const crcOff = 8 + data.length;
+  out[crcOff] = (crc >>> 24) & 0xff;
+  out[crcOff + 1] = (crc >>> 16) & 0xff;
+  out[crcOff + 2] = (crc >>> 8) & 0xff;
+  out[crcOff + 3] = crc & 0xff;
+  return out;
+}
+
+/**
+ * A genuine, complete, renderable PNG: 8-byte signature + a full IHDR chunk with
+ * a correct CRC + a deflate-compressed IDAT of `height` raw scanlines + an IEND.
+ * Unlike `pngHeaderBytes`, this sniffs as `image/png` AND decodes, so the
+ * real-loader success path proves a genuine image round-trips (not merely that
+ * header-only non-renderable bytes are accepted). Defaults to a 1×1 RGBA image.
+ */
+export function validPngBytes(width = 1, height = 1): Uint8Array {
+  const signature = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
+
+  const ihdr = new Uint8Array(13);
+  ihdr[0] = (width >>> 24) & 0xff;
+  ihdr[1] = (width >>> 16) & 0xff;
+  ihdr[2] = (width >>> 8) & 0xff;
+  ihdr[3] = width & 0xff;
+  ihdr[4] = (height >>> 24) & 0xff;
+  ihdr[5] = (height >>> 16) & 0xff;
+  ihdr[6] = (height >>> 8) & 0xff;
+  ihdr[7] = height & 0xff;
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type: truecolor + alpha (RGBA)
+  // ihdr[10..12] compression/filter/interlace left 0.
+
+  // Raw scanlines: each row is a filter byte (0 = None) followed by `width` RGBA
+  // pixels (4 bytes each), all zero (transparent black). deflate for IDAT.
+  const raw = new Uint8Array(height * (1 + width * 4));
+  const idatData = new Uint8Array(deflateSync(raw));
+
+  const parts = [
+    signature,
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', idatData),
+    pngChunk('IEND', new Uint8Array(0)),
+  ];
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+export function gifBytes(
+  width: number,
+  height: number,
+  sig: 'GIF87a' | 'GIF89a' = 'GIF87a'
+): Uint8Array {
+  // 6-byte signature + the full 7-byte logical-screen descriptor (width, height,
+  // packed field, background color index, pixel aspect ratio). The parser
+  // requires all 13 bytes present, so a 10-byte header carrying only
+  // width/height is truncated and must be rejected.
+  const b = new Uint8Array(13);
+  for (let i = 0; i < sig.length; i += 1) {
+    b[i] = sig.charCodeAt(i);
+  }
+  b[6] = width & 0xff;
+  b[7] = (width >>> 8) & 0xff;
+  b[8] = height & 0xff;
+  b[9] = (height >>> 8) & 0xff;
+  // b[10] packed field, b[11] background color index, b[12] pixel aspect ratio
+  // — left zero.
+  return b;
+}
+
+/**
+ * Minimal ISO-BMFF file: a single `ftyp` box (size + 'ftyp' + major brand +
+ * minor version + one compatible brand). file-type sniffs AVIF/HEIC/HEIF from
+ * the `ftyp` brands, so these bytes carry a real signature rather than relying
+ * on a manually-supplied sniff alone.
+ */
+function ftypBytes(brand: 'avif' | 'heic'): Uint8Array {
+  const b = new Uint8Array(24);
+  b[3] = 24; // box size (big-endian u32, fits in the low byte)
+  b.set([0x66, 0x74, 0x79, 0x70], 4); // "ftyp"
+  for (let i = 0; i < 4; i += 1) {
+    b[8 + i] = brand.charCodeAt(i); // major brand
+  }
+  // minor version (bytes 12-15) left zero.
+  for (let i = 0; i < 4; i += 1) {
+    b[16 + i] = brand.charCodeAt(i); // compatible brand
+  }
+  return b;
+}
+
+export function avifBytes(): Uint8Array {
+  return ftypBytes('avif');
+}
+
+export function heicBytes(): Uint8Array {
+  return ftypBytes('heic');
+}
+
+/**
+ * Minimal BMP: a 14-byte BITMAPFILEHEADER ('BM' + size + reserved + pixel-data
+ * offset) plus the start of a 40-byte BITMAPINFOHEADER — enough for file-type to
+ * sniff `image/bmp`.
+ */
+export function bmpBytes(): Uint8Array {
+  const b = new Uint8Array(30);
+  b[0] = 0x42; // 'B'
+  b[1] = 0x4d; // 'M'
+  b[2] = 30; // file size (low byte)
+  b[10] = 26; // pixel-data offset
+  b[14] = 40; // DIB header size (BITMAPINFOHEADER)
+  return b;
+}
+
+/**
+ * Minimal ICO: an ICONDIR header (reserved=0, type=1 for ICO, count=1). file-type
+ * sniffs `image/x-icon` from this prefix.
+ */
+export function icoBytes(): Uint8Array {
+  const b = new Uint8Array(6);
+  b[2] = 0x01; // type: ICO
+  b[4] = 0x01; // image count: 1
+  return b;
+}
+
+export function jpegBytes(
+  width: number,
+  height: number,
+  opts?: { components?: number; segLen?: number }
+): Uint8Array {
+  const components = opts?.components ?? 3;
+  const segLen = opts?.segLen ?? 8 + components * 3;
+  const b = new Uint8Array(4 + segLen);
+  b[0] = 0xff;
+  b[1] = 0xd8; // SOI
+  b[2] = 0xff;
+  b[3] = 0xc0; // SOF0
+  b[4] = (segLen >>> 8) & 0xff;
+  b[5] = segLen & 0xff;
+  b[6] = 0x08; // precision
+  b[7] = (height >>> 8) & 0xff;
+  b[8] = height & 0xff;
+  b[9] = (width >>> 8) & 0xff;
+  b[10] = width & 0xff;
+  b[11] = components;
+  return b;
+}
+
+export function webpBytes(opts: {
+  variant: 'VP8 ' | 'VP8L' | 'VP8X';
+  width: number;
+  height: number;
+  riffSize?: number;
+  chunkSize?: number;
+}): Uint8Array {
+  const { variant, width, height } = opts;
+  const riffSize = opts.riffSize ?? 22;
+  const chunkSize = opts.chunkSize ?? 10;
+  const b = new Uint8Array(30);
+  b.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  b[4] = riffSize & 0xff;
+  b[5] = (riffSize >>> 8) & 0xff;
+  b[6] = (riffSize >>> 16) & 0xff;
+  b[7] = (riffSize >>> 24) & 0xff;
+  b.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  for (let i = 0; i < 4; i += 1) {
+    b[12 + i] = variant.charCodeAt(i);
+  }
+  b[16] = chunkSize & 0xff;
+  b[17] = (chunkSize >>> 8) & 0xff;
+  b[18] = (chunkSize >>> 16) & 0xff;
+  b[19] = (chunkSize >>> 24) & 0xff;
+  if (variant === 'VP8X') {
+    const w = width - 1;
+    const h = height - 1;
+    b[24] = w & 0xff;
+    b[25] = (w >>> 8) & 0xff;
+    b[26] = (w >>> 16) & 0xff;
+    b[27] = h & 0xff;
+    b[28] = (h >>> 8) & 0xff;
+    b[29] = (h >>> 16) & 0xff;
+  } else if (variant === 'VP8 ') {
+    b[23] = 0x9d;
+    b[24] = 0x01;
+    b[25] = 0x2a;
+    b[26] = width & 0xff;
+    b[27] = (width >>> 8) & 0xff;
+    b[28] = height & 0xff;
+    b[29] = (height >>> 8) & 0xff;
+  } else {
+    // VP8L
+    b[20] = 0x2f;
+    const bits = (width - 1) | ((height - 1) << 14);
+    b[21] = bits & 0xff;
+    b[22] = (bits >>> 8) & 0xff;
+    b[23] = (bits >>> 16) & 0xff;
+    b[24] = (bits >>> 24) & 0xff;
+  }
+  return b;
+}

--- a/packages/openclaw/src/urbit/test-fixtures.ts
+++ b/packages/openclaw/src/urbit/test-fixtures.ts
@@ -4,13 +4,18 @@
  */
 import { deflateSync } from 'node:zlib';
 
+/** Decode a base64 string into raw bytes (test-only fixture helper). */
+function fromB64(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, 'base64'));
+}
+
 /**
  * A structural PNG header only: 8-byte signature + a complete IHDR chunk whose
  * trailing CRC is left zero and which carries NO IDAT/IEND. The parser bounds
  * the chunk against the buffer but never verifies the CRC or requires image
  * data, so this is enough to exercise parser/classifier BOUNDARY cases — but it
- * is not a renderable image. Success-path tests that need a genuine image use
- * `validPngBytes` instead.
+ * is not a renderable image and parseRasterHeader REJECTS it (no IDAT/IEND).
+ * Success-path tests that need a genuine image use `validPngBytes` instead.
  */
 export function pngHeaderBytes(
   width: number,
@@ -99,6 +104,45 @@ function pngChunk(type: string, data: Uint8Array): Uint8Array {
 }
 
 /**
+ * A structurally-complete PNG with arbitrary IHDR dimensions and a minimal
+ * (non-renderable) IDAT + IEND. parseRasterHeader accepts it (IDAT present with
+ * length > 0, IEND present), but the IDAT content is a single zero byte — not
+ * valid deflate data. Useful for testing classifier bounds checks on dimensions
+ * without allocating a real pixel buffer. This is the "accepted residual" case:
+ * a container with data + terminal chunks whose compressed data is corrupt.
+ */
+export function pngCompleteBytes(width: number, height: number): Uint8Array {
+  const signature = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
+  const ihdr = new Uint8Array(13);
+  ihdr[0] = (width >>> 24) & 0xff;
+  ihdr[1] = (width >>> 16) & 0xff;
+  ihdr[2] = (width >>> 8) & 0xff;
+  ihdr[3] = width & 0xff;
+  ihdr[4] = (height >>> 24) & 0xff;
+  ihdr[5] = (height >>> 16) & 0xff;
+  ihdr[6] = (height >>> 8) & 0xff;
+  ihdr[7] = height & 0xff;
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  const parts = [
+    signature,
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', new Uint8Array([0x00])),
+    pngChunk('IEND', new Uint8Array(0)),
+  ];
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+/**
  * A genuine, complete, renderable PNG: 8-byte signature + a full IHDR chunk with
  * a correct CRC + a deflate-compressed IDAT of `height` raw scanlines + an IEND.
  * Unlike `pngHeaderBytes`, this sniffs as `image/png` AND decodes, so the
@@ -152,7 +196,9 @@ export function gifBytes(
   // 6-byte signature + the full 7-byte logical-screen descriptor (width, height,
   // packed field, background color index, pixel aspect ratio). The parser
   // requires all 13 bytes present, so a 10-byte header carrying only
-  // width/height is truncated and must be rejected.
+  // width/height is truncated and must be rejected. This is a header-only
+  // fixture (no image descriptor, no trailer) and represents an INCOMPLETE GIF
+  // that parseRasterHeader must reject. Use validGifBytes for success paths.
   const b = new Uint8Array(13);
   for (let i = 0; i < sig.length; i += 1) {
     b[i] = sig.charCodeAt(i);
@@ -164,6 +210,125 @@ export function gifBytes(
   // b[10] packed field, b[11] background color index, b[12] pixel aspect ratio
   // — left zero.
   return b;
+}
+
+/**
+ * A genuine, structurally-complete minimal GIF: 6-byte signature + 7-byte
+ * logical-screen descriptor + a global color table (2 entries) + an image
+ * descriptor (0x2C) + image data sub-block + trailer (0x3B). Defaults to 1×1.
+ * Unlike `gifBytes`, this has both the image-descriptor separator and the
+ * trailer, so parseRasterHeader accepts it and detectMime sniffs image/gif.
+ */
+export function validGifBytes(
+  width = 1,
+  height = 1,
+  sig: 'GIF87a' | 'GIF89a' = 'GIF87a'
+): Uint8Array {
+  const parts: number[] = [];
+  for (let i = 0; i < sig.length; i += 1) {
+    parts.push(sig.charCodeAt(i));
+  }
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  parts.push(0x80, 0x00, 0x00);
+  parts.push(0x00, 0x00, 0x00, 0xff, 0xff, 0xff);
+  parts.push(0x2c);
+  parts.push(0x00, 0x00, 0x00, 0x00);
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  parts.push(0x00);
+  parts.push(0x02, 0x02, 0x44, 0x01, 0x00);
+  parts.push(0x3b);
+  return new Uint8Array(parts);
+}
+
+/**
+ * A genuine complete GIF89a carrying a Graphic Control Extension (0x21 0xF9)
+ * BEFORE the image descriptor. parseRasterHeader must skip the extension via the
+ * block grammar and still find the real image descriptor + data + trailer.
+ */
+export function gifWithExtensionBytes(width = 1, height = 1): Uint8Array {
+  const parts: number[] = [];
+  for (let i = 0; i < 'GIF89a'.length; i += 1) {
+    parts.push('GIF89a'.charCodeAt(i));
+  }
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  parts.push(0x80, 0x00, 0x00);
+  parts.push(0x00, 0x00, 0x00, 0xff, 0xff, 0xff);
+  // Graphic Control Extension: introducer + label + block size 4 + 4 bytes + 0x00
+  parts.push(0x21, 0xf9, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00);
+  parts.push(0x2c);
+  parts.push(0x00, 0x00, 0x00, 0x00);
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  parts.push(0x00);
+  parts.push(0x02, 0x02, 0x44, 0x01, 0x00);
+  parts.push(0x3b);
+  return new Uint8Array(parts);
+}
+
+/**
+ * A GIF whose Global Color Table AND a comment-extension payload both contain
+ * 0x2C and 0x3B bytes, but which has NO real image descriptor — it goes straight
+ * to the trailer. A naive raw-scan for 0x2C would be fooled into accepting this;
+ * the block-grammar walk must return null.
+ */
+export function gifNoImageDescriptorBytes(width = 1, height = 1): Uint8Array {
+  const parts: number[] = [];
+  for (let i = 0; i < 'GIF89a'.length; i += 1) {
+    parts.push('GIF89a'.charCodeAt(i));
+  }
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  // packed: GCT flag set, size N=1 -> 2^(1+1) = 4 entries (12 bytes)
+  parts.push(0x81, 0x00, 0x00);
+  // GCT (4 entries) laced with 0x2C / 0x3B to fool a naive byte-scan
+  parts.push(
+    0x2c,
+    0x3b,
+    0x2c,
+    0x3b,
+    0x2c,
+    0x3b,
+    0x2c,
+    0x3b,
+    0x2c,
+    0x3b,
+    0x2c,
+    0x3b
+  );
+  // comment extension whose payload also contains 0x2C / 0x3B
+  parts.push(0x21, 0xfe);
+  parts.push(0x04, 0x2c, 0x3b, 0x2c, 0x3b, 0x00);
+  // trailer, no image descriptor
+  parts.push(0x3b);
+  return new Uint8Array(parts);
+}
+
+/**
+ * A GIF with a real image descriptor but EMPTY image data (LZW-min-code-size
+ * byte followed immediately by the 0x00 sub-block terminator). Not renderable;
+ * parseRasterHeader must reject it.
+ */
+export function gifEmptyImageDataBytes(width = 1, height = 1): Uint8Array {
+  const parts: number[] = [];
+  for (let i = 0; i < 'GIF87a'.length; i += 1) {
+    parts.push('GIF87a'.charCodeAt(i));
+  }
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  parts.push(0x80, 0x00, 0x00);
+  parts.push(0x00, 0x00, 0x00, 0xff, 0xff, 0xff);
+  parts.push(0x2c);
+  parts.push(0x00, 0x00, 0x00, 0x00);
+  parts.push(width & 0xff, (width >>> 8) & 0xff);
+  parts.push(height & 0xff, (height >>> 8) & 0xff);
+  parts.push(0x00);
+  // LZW min code size, then an immediate 0x00 terminator (no image data)
+  parts.push(0x02, 0x00);
+  parts.push(0x3b);
+  return new Uint8Array(parts);
 }
 
 /**
@@ -243,6 +408,164 @@ export function jpegBytes(
   return b;
 }
 
+/**
+ * The accepted-residual JPEG: a structurally-complete minimal JPEG (SOI + SOF0
+ * with one component + SOS + a single scan byte + EOI) whose scan byte is a
+ * placeholder, NOT real entropy-coded data — so it is not a renderable image.
+ * parseRasterHeader still accepts it (every required structural block is
+ * present; nothing is decoded) and detectMime sniffs image/jpeg. Unlike
+ * `jpegBytes` (SOI+SOF only, an INCOMPLETE JPEG that parseRasterHeader must
+ * reject). Used for structural acceptance tests; genuine renderable JPEGs use
+ * realBaselineJpegBytes / realProgressiveJpegBytes. Defaults to 1×1.
+ */
+export function validJpegBytes(width = 1, height = 1): Uint8Array {
+  const components = 1;
+  const sofLen = 8 + components * 3;
+  const parts: number[] = [];
+  parts.push(0xff, 0xd8);
+  parts.push(0xff, 0xc0);
+  parts.push((sofLen >>> 8) & 0xff, sofLen & 0xff);
+  parts.push(0x08);
+  parts.push((height >>> 8) & 0xff, height & 0xff);
+  parts.push((width >>> 8) & 0xff, width & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x11, 0x00);
+  parts.push(0xff, 0xda);
+  const sosLen = 6 + components * 2;
+  parts.push((sosLen >>> 8) & 0xff, sosLen & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x00);
+  parts.push(0x00, 0x3f, 0x00);
+  parts.push(0x00);
+  parts.push(0xff, 0xd9);
+  return new Uint8Array(parts);
+}
+
+/**
+ * The accepted-residual JPEG (see validJpegBytes) followed by post-EOI padding.
+ * parseRasterHeader must accept it (the EOI is a syntactic terminator that need
+ * not be the final two bytes); the scan data is still a placeholder, not real
+ * entropy-coded data, so this is not a renderable image.
+ */
+export function jpegPostEoiPaddingBytes(width = 1, height = 1): Uint8Array {
+  const base = validJpegBytes(width, height);
+  const out = new Uint8Array(base.length + 4);
+  out.set(base, 0);
+  // four trailing zero bytes after EOI
+  return out;
+}
+
+/**
+ * SOI + valid SOF + a bare 0xFFDA SOS marker + EOI, with NO SOS segment header
+ * and NO entropy data. Not renderable; parseRasterHeader must reject it.
+ */
+export function jpegNoScanBytes(width = 1, height = 1): Uint8Array {
+  const components = 1;
+  const sofLen = 8 + components * 3;
+  const parts: number[] = [];
+  parts.push(0xff, 0xd8);
+  parts.push(0xff, 0xc0);
+  parts.push((sofLen >>> 8) & 0xff, sofLen & 0xff);
+  parts.push(0x08);
+  parts.push((height >>> 8) & 0xff, height & 0xff);
+  parts.push((width >>> 8) & 0xff, width & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x11, 0x00);
+  parts.push(0xff, 0xda); // bare SOS marker, no header
+  parts.push(0xff, 0xd9); // EOI
+  return new Uint8Array(parts);
+}
+
+/**
+ * SOI + valid SOF + a complete, bounds-valid SOS segment header + EOI, but with
+ * ZERO entropy-coded scan bytes. Not renderable; parseRasterHeader must reject.
+ */
+export function jpegEmptyScanBytes(width = 1, height = 1): Uint8Array {
+  const components = 1;
+  const sofLen = 8 + components * 3;
+  const sosLen = 6 + components * 2;
+  const parts: number[] = [];
+  parts.push(0xff, 0xd8);
+  parts.push(0xff, 0xc0);
+  parts.push((sofLen >>> 8) & 0xff, sofLen & 0xff);
+  parts.push(0x08);
+  parts.push((height >>> 8) & 0xff, height & 0xff);
+  parts.push((width >>> 8) & 0xff, width & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x11, 0x00);
+  parts.push(0xff, 0xda);
+  parts.push((sosLen >>> 8) & 0xff, sosLen & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x00);
+  parts.push(0x00, 0x3f, 0x00);
+  parts.push(0xff, 0xd9); // EOI immediately after the SOS header
+  return new Uint8Array(parts);
+}
+
+/**
+ * A genuine complete JPEG whose single scan contains byte-stuffing (0xFF00) and
+ * a restart marker (0xFFD0). Both are part of the scan, not segment terminators,
+ * so parseRasterHeader must still find the trailing EOI and accept.
+ */
+export function jpegRestartStuffingBytes(width = 1, height = 1): Uint8Array {
+  const components = 1;
+  const sofLen = 8 + components * 3;
+  const sosLen = 6 + components * 2;
+  const parts: number[] = [];
+  parts.push(0xff, 0xd8);
+  parts.push(0xff, 0xc0);
+  parts.push((sofLen >>> 8) & 0xff, sofLen & 0xff);
+  parts.push(0x08);
+  parts.push((height >>> 8) & 0xff, height & 0xff);
+  parts.push((width >>> 8) & 0xff, width & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x11, 0x00);
+  parts.push(0xff, 0xda);
+  parts.push((sosLen >>> 8) & 0xff, sosLen & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x00);
+  parts.push(0x00, 0x3f, 0x00);
+  // scan data interleaving a stuffed 0xFF00 and a restart marker 0xFFD0
+  parts.push(0xab, 0xff, 0x00, 0xcd, 0xff, 0xd0, 0xef);
+  parts.push(0xff, 0xd9);
+  return new Uint8Array(parts);
+}
+
+/**
+ * A genuine progressive-style multi-scan JPEG: SOI + SOF + (SOS + scan) twice +
+ * EOI. parseRasterHeader must tolerate multiple scans and accept.
+ */
+export function jpegMultiScanBytes(width = 1, height = 1): Uint8Array {
+  const components = 1;
+  const sofLen = 8 + components * 3;
+  const sosLen = 6 + components * 2;
+  const parts: number[] = [];
+  parts.push(0xff, 0xd8);
+  parts.push(0xff, 0xc0);
+  parts.push((sofLen >>> 8) & 0xff, sofLen & 0xff);
+  parts.push(0x08);
+  parts.push((height >>> 8) & 0xff, height & 0xff);
+  parts.push((width >>> 8) & 0xff, width & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x11, 0x00);
+  // first scan
+  parts.push(0xff, 0xda);
+  parts.push((sosLen >>> 8) & 0xff, sosLen & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x00);
+  parts.push(0x00, 0x3f, 0x00);
+  parts.push(0x12, 0x34);
+  // second scan
+  parts.push(0xff, 0xda);
+  parts.push((sosLen >>> 8) & 0xff, sosLen & 0xff);
+  parts.push(components);
+  parts.push(0x01, 0x00);
+  parts.push(0x01, 0x3f, 0x00);
+  parts.push(0x56);
+  parts.push(0xff, 0xd9);
+  return new Uint8Array(parts);
+}
+
 export function webpBytes(opts: {
   variant: 'VP8 ' | 'VP8L' | 'VP8X';
   width: number;
@@ -294,4 +617,240 @@ export function webpBytes(opts: {
     b[24] = (bits >>> 24) & 0xff;
   }
   return b;
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((sum, c) => sum + c.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out;
+}
+
+/** Serialize a RIFF chunk: 4-byte FourCC + 4-byte LE size + payload + pad. */
+function riffChunk(fourcc: string, payload: Uint8Array): Uint8Array {
+  const size = payload.length;
+  const out = new Uint8Array(8 + size + (size & 1));
+  for (let i = 0; i < 4; i += 1) {
+    out[i] = fourcc.charCodeAt(i);
+  }
+  out[4] = size & 0xff;
+  out[5] = (size >>> 8) & 0xff;
+  out[6] = (size >>> 16) & 0xff;
+  out[7] = (size >>> 24) & 0xff;
+  out.set(payload, 8);
+  return out;
+}
+
+function riffWebpBytes(body: Uint8Array): Uint8Array {
+  const riffSize = 4 + body.length; // 'WEBP' fourcc + chunks
+  const out = new Uint8Array(8 + riffSize);
+  out.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  out[4] = riffSize & 0xff;
+  out[5] = (riffSize >>> 8) & 0xff;
+  out[6] = (riffSize >>> 16) & 0xff;
+  out[7] = (riffSize >>> 24) & 0xff;
+  out.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  out.set(body, 12);
+  return out;
+}
+
+function vp8xPayload(width: number, height: number, flags = 0): Uint8Array {
+  const p = new Uint8Array(10);
+  p[0] = flags;
+  const w = width - 1;
+  const h = height - 1;
+  p[4] = w & 0xff;
+  p[5] = (w >>> 8) & 0xff;
+  p[6] = (w >>> 16) & 0xff;
+  p[7] = h & 0xff;
+  p[8] = (h >>> 8) & 0xff;
+  p[9] = (h >>> 16) & 0xff;
+  return p;
+}
+
+/** A minimal VP8 (lossy) chunk payload: frame tag + 9D 01 2A sync + dims. */
+function vp8Payload(width: number, height: number): Uint8Array {
+  const p = new Uint8Array(10);
+  p[3] = 0x9d;
+  p[4] = 0x01;
+  p[5] = 0x2a;
+  p[6] = width & 0xff;
+  p[7] = (width >>> 8) & 0xff;
+  p[8] = height & 0xff;
+  p[9] = (height >>> 8) & 0xff;
+  return p;
+}
+
+/**
+ * A VP8X WebP whose animation flag is set but which carries an ANMF frame and
+ * NO mandatory ANIM chunk. Not a valid animation; parseRasterHeader must reject
+ * it (animation flag set without ANIM ⇒ null).
+ */
+export function webpVp8xAnimationBytes(width = 10, height = 20): Uint8Array {
+  const frameHeader = new Uint8Array(16);
+  const w = width - 1;
+  const h = height - 1;
+  frameHeader[6] = w & 0xff;
+  frameHeader[7] = (w >>> 8) & 0xff;
+  frameHeader[8] = (w >>> 16) & 0xff;
+  frameHeader[9] = h & 0xff;
+  frameHeader[10] = (h >>> 8) & 0xff;
+  frameHeader[11] = (h >>> 16) & 0xff;
+  const anmfPayload = concatBytes([
+    frameHeader,
+    riffChunk('VP8 ', vp8Payload(width, height)),
+  ]);
+  const body = concatBytes([
+    riffChunk('VP8X', vp8xPayload(width, height, 0x02)),
+    riffChunk('ANMF', anmfPayload),
+  ]);
+  return riffWebpBytes(body);
+}
+
+/**
+ * A VP8X WebP followed by an EMPTY 'VP8 ' chunk (zero-byte payload). The FourCC
+ * is present but there is no bitstream; parseRasterHeader must reject it.
+ */
+export function webpVp8xEmptyVp8Bytes(width = 10, height = 20): Uint8Array {
+  const body = concatBytes([
+    riffChunk('VP8X', vp8xPayload(width, height)),
+    riffChunk('VP8 ', new Uint8Array(0)),
+  ]);
+  return riffWebpBytes(body);
+}
+
+/**
+ * A VP8X WebP followed by an EMPTY 'ANMF' chunk (zero-byte payload). No frame
+ * header and no nested bitstream; parseRasterHeader must reject it.
+ */
+export function webpVp8xEmptyAnmfBytes(width = 10, height = 20): Uint8Array {
+  const body = concatBytes([
+    riffChunk('VP8X', vp8xPayload(width, height)),
+    riffChunk('ANMF', new Uint8Array(0)),
+  ]);
+  return riffWebpBytes(body);
+}
+
+/** The 16-byte ANMF frame header (frame x/y/w/h-1, duration, flags; zeros). */
+function anmfFrameHeader(width: number, height: number): Uint8Array {
+  const frameHeader = new Uint8Array(16);
+  const w = width - 1;
+  const h = height - 1;
+  frameHeader[6] = w & 0xff;
+  frameHeader[7] = (w >>> 8) & 0xff;
+  frameHeader[8] = (w >>> 16) & 0xff;
+  frameHeader[9] = h & 0xff;
+  frameHeader[10] = (h >>> 8) & 0xff;
+  frameHeader[11] = (h >>> 16) & 0xff;
+  return frameHeader;
+}
+
+/** A minimal VP8L (lossless) chunk payload: 0x2f signature byte + dim bits. */
+function vp8lPayload(width: number, height: number): Uint8Array {
+  const p = new Uint8Array(5);
+  p[0] = 0x2f;
+  const bits = (width - 1) | ((height - 1) << 14);
+  p[1] = bits & 0xff;
+  p[2] = (bits >>> 8) & 0xff;
+  p[3] = (bits >>> 16) & 0xff;
+  p[4] = (bits >>> 24) & 0xff;
+  return p;
+}
+
+/**
+ * A VP8X animation (anim flag set + mandatory ANIM) whose FIRST ANMF frame is
+ * empty (a 16-byte frame header only, no nested bitstream) FOLLOWED BY a valid
+ * ANMF carrying a real VP8L bitstream. libwebp rejects such a file (an empty
+ * frame is malformed even alongside valid ones); parseRasterHeader must reject
+ * it too — a single bad frame invalidates the whole animation.
+ */
+export function webpVp8xEmptyAnmfThenValidBytes(
+  width = 6,
+  height = 5
+): Uint8Array {
+  const emptyAnmf = anmfFrameHeader(width, height); // 16-byte header only
+  const validAnmf = concatBytes([
+    anmfFrameHeader(width, height),
+    riffChunk('VP8L', vp8lPayload(width, height)),
+  ]);
+  const body = concatBytes([
+    riffChunk('VP8X', vp8xPayload(width, height, 0x02)),
+    riffChunk('ANIM', new Uint8Array(6)),
+    riffChunk('ANMF', emptyAnmf),
+    riffChunk('ANMF', validAnmf),
+  ]);
+  return riffWebpBytes(body);
+}
+
+/**
+ * A VP8X animation whose single ANMF frame carries a valid VP8L bitstream
+ * FOLLOWED BY trailing garbage bytes that do not tile the frame payload. The
+ * nested chunk list does not exhaust the frame exactly, so the frame is
+ * malformed and parseRasterHeader must reject the whole animation.
+ */
+export function webpVp8xAnmfTrailingGarbageBytes(
+  width = 6,
+  height = 5
+): Uint8Array {
+  const anmf = concatBytes([
+    anmfFrameHeader(width, height),
+    riffChunk('VP8L', vp8lPayload(width, height)),
+    new Uint8Array([0xde, 0xad, 0xbe]), // trailing garbage, does not tile
+  ]);
+  const body = concatBytes([
+    riffChunk('VP8X', vp8xPayload(width, height, 0x02)),
+    riffChunk('ANIM', new Uint8Array(6)),
+    riffChunk('ANMF', anmf),
+  ]);
+  return riffWebpBytes(body);
+}
+
+// Real encoder-produced fixtures (ffmpeg / cwebp / webpmux output, validated).
+// These ARE genuinely valid, renderable images; the bytes are used verbatim and
+// must not be altered. They back the positive "genuinely valid X parses with
+// real dims AND sniffs via detectMime" tests, unlike the handcrafted structural
+// fixtures above.
+
+/** Genuine baseline (SOF0) JPEG, canvas 2x3. */
+export function realBaselineJpegBytes(): Uint8Array {
+  return fromB64(
+    '/9j/4AAQSkZJRgABAgAAAQABAAD//gAQTGF2YzYyLjI4LjEwMQD/2wBDAAgEBAQEBAUFBQUFBQYGBgYGBgYGBgYGBgYHBwcICAgHBwcGBgcHCAgICAkJCQgICAgJCQoKCgwMCwsODg4RERT/xABMAAEBAAAAAAAAAAAAAAAAAAAABgEBAQAAAAAAAAAAAAAAAAAABgcQAQAAAAAAAAAAAAAAAAAAAAARAQAAAAAAAAAAAAAAAAAAAAD/wAARCAADAAIDASIAAhEAAxEA/9oADAMBAAIRAxEAPwCLAE1/f//Z'
+  );
+}
+
+/** Genuine progressive (SOF2) JPEG, canvas 4x2. */
+export function realProgressiveJpegBytes(): Uint8Array {
+  return fromB64(
+    '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wgARCAACAAQDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAVAQEBAAAAAAAAAAAAAAAAAAAEBv/aAAwDAQACEAMQAAABjRcF/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABBQJ//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwF//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQAGPwJ//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPyF//9oADAMBAAIAAwAAABD3/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPxB//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPxB//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPxB//9k='
+  );
+}
+
+/** Genuine simple lossy WebP (RIFF/WEBP/VP8 ), canvas 5x4. */
+export function realWebpLossyBytes(): Uint8Array {
+  return fromB64(
+    'UklGRkIAAABXRUJQVlA4IDYAAAAwAgCdASoFAAQAAgA0JZgCdEf/7gACMDuTAAD+9DL/dcTvvd9UqPPNOQ8/zfoHnn7P42ogAAA='
+  );
+}
+
+/** Genuine simple lossless WebP (RIFF/WEBP/VP8L), canvas 5x4. */
+export function realWebpLosslessBytes(): Uint8Array {
+  return fromB64('UklGRh4AAABXRUJQVlA4TBEAAAAvBMAAAA8wfxHzH4Y+RPQ/AAA=');
+}
+
+/** Genuine extended static WebP (VP8X+ALPH+VP8 ), canvas 7x3. */
+export function realWebpVp8xStaticBytes(): Uint8Array {
+  return fromB64(
+    'UklGRmAAAABXRUJQVlA4WAoAAAAQAAAABgAAAgAAQUxQSAoAAAABB9C/iAhERP8DVlA4IDAAAADQAQCdASoHAAMAAgA0JaACdLoB+AADsAD+8MQL/yC5YXXI1/8gP+QH/ID/+PIAAAA='
+  );
+}
+
+/** Genuine animated WebP (VP8X+ANIM+ANMF, 2 frames), canvas 6x5. */
+export function realWebpAnimatedBytes(): Uint8Array {
+  return fromB64(
+    'UklGRoQAAABXRUJQVlA4WAoAAAACAAAABQAABAAAQU5JTQYAAAD/////AABBTk1GKAAAAAAAAAAAAAUAAAQAAGQAAAJWUDhMDwAAAC8FAAEABxDlj/4HIqL/AQBBTk1GKAAAAAAAAAAAAAUAAAQAAGQAAABWUDhMDwAAAC8FAAEABxDR/v4HIqL/AQA='
+  );
 }

--- a/packages/openclaw/src/urbit/upload.local.test.ts
+++ b/packages/openclaw/src/urbit/upload.local.test.ts
@@ -13,7 +13,17 @@ import {
 } from 'vitest';
 
 import { parseRasterHeader } from './image-dimensions.js';
-import { pngHeaderBytes, validPngBytes } from './test-fixtures.js';
+import {
+  pngHeaderBytes,
+  realBaselineJpegBytes,
+  realProgressiveJpegBytes,
+  realWebpAnimatedBytes,
+  realWebpLosslessBytes,
+  realWebpLossyBytes,
+  realWebpVp8xStaticBytes,
+  validGifBytes,
+  validPngBytes,
+} from './test-fixtures.js';
 import { prepareOutboundMedia } from './upload.js';
 
 // Local cases use the REAL loadWebMedia + buildOutboundMediaLoadOptions against
@@ -62,6 +72,67 @@ describe('prepareOutboundMedia (local, real loader)', () => {
       format: 'png',
       width: 1,
       height: 1,
+    });
+  });
+
+  it('genuine GIF fixture sniffs as image/gif and parses with real dimensions', async () => {
+    const { detectMime } = await import('openclaw/plugin-sdk/media-mime');
+    const bytes = validGifBytes();
+    expect(await detectMime({ buffer: bytes })).toBe('image/gif');
+    expect(parseRasterHeader(bytes)).toEqual({
+      format: 'gif',
+      width: 1,
+      height: 1,
+    });
+  });
+
+  it('genuine JPEG fixtures sniff as image/jpeg and parse with real dimensions', async () => {
+    const { detectMime } = await import('openclaw/plugin-sdk/media-mime');
+    const baseline = realBaselineJpegBytes();
+    expect(await detectMime({ buffer: baseline })).toBe('image/jpeg');
+    expect(parseRasterHeader(baseline)).toEqual({
+      format: 'jpeg',
+      width: 2,
+      height: 3,
+    });
+    const progressive = realProgressiveJpegBytes();
+    expect(await detectMime({ buffer: progressive })).toBe('image/jpeg');
+    expect(parseRasterHeader(progressive)).toEqual({
+      format: 'jpeg',
+      width: 4,
+      height: 2,
+    });
+  });
+
+  it('genuine WebP fixtures sniff as image/webp and parse with real dimensions', async () => {
+    const { detectMime } = await import('openclaw/plugin-sdk/media-mime');
+    const lossy = realWebpLossyBytes();
+    expect(await detectMime({ buffer: lossy })).toBe('image/webp');
+    expect(parseRasterHeader(lossy)).toEqual({
+      format: 'webp',
+      width: 5,
+      height: 4,
+    });
+    const lossless = realWebpLosslessBytes();
+    expect(await detectMime({ buffer: lossless })).toBe('image/webp');
+    expect(parseRasterHeader(lossless)).toEqual({
+      format: 'webp',
+      width: 5,
+      height: 4,
+    });
+    const vp8xStatic = realWebpVp8xStaticBytes();
+    expect(await detectMime({ buffer: vp8xStatic })).toBe('image/webp');
+    expect(parseRasterHeader(vp8xStatic)).toEqual({
+      format: 'webp',
+      width: 7,
+      height: 3,
+    });
+    const animated = realWebpAnimatedBytes();
+    expect(await detectMime({ buffer: animated })).toBe('image/webp');
+    expect(parseRasterHeader(animated)).toEqual({
+      format: 'webp',
+      width: 6,
+      height: 5,
     });
   });
 

--- a/packages/openclaw/src/urbit/upload.local.test.ts
+++ b/packages/openclaw/src/urbit/upload.local.test.ts
@@ -222,6 +222,26 @@ describe('prepareOutboundMedia (local, real loader)', () => {
     ).rejects.toThrow(/convert it to PNG/);
   });
 
+  it('rejects a local SVG with a >8KiB comment preamble under a non-.svg name (roots only)', async () => {
+    const preamble = '<!--' + 'a'.repeat(70 * 1024) + '-->';
+    const svgPath = writeFixture(
+      'sneaky.xml',
+      preamble + '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    );
+    await expect(
+      prepareOutboundMedia(svgPath, { mediaLocalRoots: [tmpdir] })
+    ).rejects.toThrow(/convert it to PNG/);
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a local file with >64KiB of pure whitespace and no root (roots only)', async () => {
+    const wsPath = writeFixture('blank.xml', ' '.repeat(70 * 1024));
+    await expect(
+      prepareOutboundMedia(wsPath, { mediaLocalRoots: [tmpdir] })
+    ).rejects.toThrow(/convert it to PNG/);
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
   it('strips the MEDIA: prefix for local paths', async () => {
     const pngPath = writeFixture('prefixed.png', validPngBytes());
     mockUploadFile.mockResolvedValue({
@@ -306,7 +326,7 @@ describe('prepareOutboundMedia (local, real loader)', () => {
       });
       expect(result.isImage).toBe(true);
       const fileName = mockUploadFile.mock.calls[0][0].fileName as string;
-      expect(fileName).toMatch(/^upload-\d+\.png$/);
+      expect(fileName).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
       expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
       for (const s of forbidden) {
         expect(fileName).not.toContain(s);

--- a/packages/openclaw/src/urbit/upload.local.test.ts
+++ b/packages/openclaw/src/urbit/upload.local.test.ts
@@ -1,0 +1,255 @@
+import { uploadFile } from '@tloncorp/api';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import { parseRasterHeader } from './image-dimensions.js';
+import { pngHeaderBytes, validPngBytes } from './test-fixtures.js';
+import { prepareOutboundMedia } from './upload.js';
+
+// Local cases use the REAL loadWebMedia + buildOutboundMediaLoadOptions against
+// temp-dir fixtures; only @tloncorp/api's uploadFile is mocked.
+vi.mock('@tloncorp/api', () => ({
+  uploadFile: vi.fn(),
+}));
+
+const mockUploadFile = vi.mocked(uploadFile);
+
+let tmpdir: string;
+let tmpdir2: string;
+
+function writeFixture(name: string, bytes: Uint8Array | string): string {
+  const filePath = path.join(tmpdir, name);
+  fs.writeFileSync(filePath, bytes);
+  return filePath;
+}
+
+const readFileCapability = (p: string) => fs.promises.readFile(p);
+
+beforeAll(() => {
+  tmpdir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-media-'))
+  );
+  tmpdir2 = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-media-other-'))
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpdir, { recursive: true, force: true });
+  fs.rmSync(tmpdir2, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('prepareOutboundMedia (local, real loader)', () => {
+  it('genuine PNG fixture sniffs as image/png and parses with real dimensions', async () => {
+    const { detectMime } = await import('openclaw/plugin-sdk/media-mime');
+    const bytes = validPngBytes();
+    expect(await detectMime({ buffer: bytes })).toBe('image/png');
+    expect(parseRasterHeader(bytes)).toEqual({
+      format: 'png',
+      width: 1,
+      height: 1,
+    });
+  });
+
+  it('uploads a local PNG with roots only', async () => {
+    const pngPath = writeFixture('img.png', validPngBytes());
+    mockUploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/img.png',
+    });
+    const result = await prepareOutboundMedia(pngPath, {
+      mediaLocalRoots: [tmpdir],
+    });
+    expect(result).toEqual({
+      url: 'https://storage.example/u/img.png',
+      isImage: true,
+      width: 1,
+      height: 1,
+      contentType: 'image/png',
+    });
+  });
+
+  it('uploads a local PNG with roots + readFile (host-read admits real images)', async () => {
+    const pngPath = writeFixture('img-host.png', validPngBytes());
+    mockUploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/h.png',
+    });
+    const result = await prepareOutboundMedia(pngPath, {
+      mediaLocalRoots: [tmpdir],
+      mediaReadFile: readFileCapability,
+    });
+    expect(result.isImage).toBe(true);
+    expect(result.width).toBe(1);
+    expect(result.height).toBe(1);
+  });
+
+  it('rejects plaintext named notes.png under roots + readFile (byte verification)', async () => {
+    const notesPath = writeFixture(
+      'notes.png',
+      'this is definitely not an image, just plain text content'
+    );
+    await expect(
+      prepareOutboundMedia(notesPath, {
+        mediaLocalRoots: [tmpdir],
+        mediaReadFile: readFileCapability,
+      })
+    ).rejects.toThrow(
+      /Cannot read media .*Media path or file type is not allowed/
+    );
+  });
+
+  it('rejects a path outside the allowed roots', async () => {
+    const outside = path.join(tmpdir2, 'outside.png');
+    fs.writeFileSync(outside, pngHeaderBytes(10, 20));
+    await expect(
+      prepareOutboundMedia(outside, { mediaLocalRoots: [tmpdir] })
+    ).rejects.toThrow(/Cannot read media/);
+  });
+
+  it('rejects a missing file', async () => {
+    await expect(
+      prepareOutboundMedia(path.join(tmpdir, 'missing.png'), {
+        mediaLocalRoots: [tmpdir],
+      })
+    ).rejects.toThrow(/Cannot read media/);
+  });
+
+  it('rejects a local .svg up front', async () => {
+    await expect(
+      prepareOutboundMedia(path.join(tmpdir, 'does-not-exist.svg'), {
+        mediaLocalRoots: [tmpdir],
+      })
+    ).rejects.toThrow(/convert it to PNG/);
+  });
+
+  it('rejects a percent-encoded file:// .svg up front', async () => {
+    await expect(
+      prepareOutboundMedia(`file://${tmpdir}/nope%2Esvg`, {
+        mediaLocalRoots: [tmpdir],
+      })
+    ).rejects.toThrow(/convert it to PNG/);
+  });
+
+  it('rejects an uppercase .SVG up front', async () => {
+    await expect(
+      prepareOutboundMedia(path.join(tmpdir, 'nope.SVG'), {
+        mediaLocalRoots: [tmpdir],
+      })
+    ).rejects.toThrow(/convert it to PNG/);
+  });
+
+  it('strips the MEDIA: prefix for local paths', async () => {
+    const pngPath = writeFixture('prefixed.png', validPngBytes());
+    mockUploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/p.png',
+    });
+    const result = await prepareOutboundMedia(`MEDIA:${pngPath}`, {
+      mediaLocalRoots: [tmpdir],
+    });
+    expect(result.isImage).toBe(true);
+  });
+
+  it('adds the storage-config hint when upload reports no credentials', async () => {
+    const pngPath = writeFixture('nocreds.png', validPngBytes());
+    mockUploadFile.mockRejectedValue(
+      new Error('No storage credentials configured')
+    );
+    await expect(
+      prepareOutboundMedia(pngPath, { mediaLocalRoots: [tmpdir] })
+    ).rejects.toThrow(/No storage credentials configured/);
+    await expect(
+      prepareOutboundMedia(pngPath, { mediaLocalRoots: [tmpdir] })
+    ).rejects.toThrow(/no storage configured/);
+  });
+
+  it.each([
+    [
+      'a cause bearing a signed S3 query',
+      'PUT https://s3.example.com/key?X-Amz-Signature=secret failed',
+      [
+        'X-Amz-Signature=secret',
+        'secret',
+        'X-Amz-Signature',
+        'PUT',
+        's3.example',
+      ],
+    ],
+    [
+      'a scheme-less cause bearing a signed query',
+      'request failed for /bucket/key?X-Amz-Signature=secretvalue',
+      ['X-Amz-Signature', 'secretvalue', 'request failed', '/bucket/key'],
+    ],
+  ])(
+    'uses a fixed category message for local upload errors with %s (never interpolates raw cause)',
+    async (_label, rawMessage, forbidden) => {
+      const pngPath = writeFixture('upload-err.png', validPngBytes());
+      mockUploadFile.mockRejectedValue(new Error(rawMessage));
+      const promise = prepareOutboundMedia(pngPath, {
+        mediaLocalRoots: [tmpdir],
+      });
+      await expect(promise).rejects.toThrow(/Failed to upload local media/);
+      await expect(promise).rejects.toThrow(/Media upload failed/);
+      await expect(promise).rejects.not.toThrow(/no storage configured/);
+      for (const s of forbidden) {
+        await expect(promise).rejects.not.toThrow(s);
+      }
+    }
+  );
+
+  it.each([
+    ['an ordinary path', 'photo.png', ['photo']],
+    ['a #-fragment name', 'chart#1.png', ['#', 'chart']],
+    [
+      'a percent-encoded name',
+      'file%3Fsig=secretvalue.png',
+      ['secretvalue', 'secret', '3F', 'file'],
+    ],
+    ['an @-bearing name', 'file@2x.png', ['@', 'file']],
+    [
+      'a ?sig= name',
+      'id?sig=secretvalue.png',
+      ['secretvalue', 'secret', 'sig', 'id'],
+    ],
+  ])(
+    'always uses a synthetic upload filename for %s (never derives it from the path)',
+    async (_label, name, forbidden) => {
+      const pngPath = writeFixture(name, validPngBytes());
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example/u/x.png',
+      });
+      const result = await prepareOutboundMedia(pngPath, {
+        mediaLocalRoots: [tmpdir],
+      });
+      expect(result.isImage).toBe(true);
+      const fileName = mockUploadFile.mock.calls[0][0].fileName as string;
+      expect(fileName).toMatch(/^upload-\d+\.png$/);
+      expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
+      for (const s of forbidden) {
+        expect(fileName).not.toContain(s);
+      }
+    }
+  );
+
+  it('rejects with a generic message when the uploaded URL is invalid', async () => {
+    const pngPath = writeFixture('badurl.png', validPngBytes());
+    mockUploadFile.mockResolvedValue({ url: 'http://insecure.example/x.png' });
+    const promise = prepareOutboundMedia(pngPath, {
+      mediaLocalRoots: [tmpdir],
+    });
+    await expect(promise).rejects.toThrow(/Failed to upload local media/);
+    await expect(promise).rejects.not.toThrow(/insecure\.example/);
+  });
+});

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -1,205 +1,929 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock openclaw/plugin-sdk fetchWithSsrFGuard
-vi.mock('openclaw/plugin-sdk/ssrf-runtime', () => ({
-  fetchWithSsrFGuard: vi.fn(),
-}));
+import {
+  avifBytes,
+  bmpBytes,
+  heicBytes,
+  icoBytes,
+  pngHeaderBytes,
+} from './test-fixtures.js';
 
-// Mock @tloncorp/api
+// Mock @tloncorp/api's uploadFile everywhere (test-double contract).
 vi.mock('@tloncorp/api', () => ({
   uploadFile: vi.fn(),
 }));
 
-// Mock context to provide getDefaultSsrFPolicy
-vi.mock('./context.js', () => ({
-  getDefaultSsrFPolicy: vi.fn(() => ({})),
+// Remote cases mock the web-media module — prepareOutboundMedia does not expose
+// fetchImpl, so the module-level mock is the sanctioned seam.
+vi.mock('openclaw/plugin-sdk/web-media', () => ({
+  loadWebMedia: vi.fn(),
 }));
 
-describe('uploadImageFromUrl', () => {
-  beforeEach(() => {
+// Control the byte sniff precisely while keeping the real extensionForMime.
+vi.mock('openclaw/plugin-sdk/media-mime', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('openclaw/plugin-sdk/media-mime')>();
+  return { ...actual, detectMime: vi.fn() };
+});
+
+function utf16le(str: string): Uint8Array {
+  const b = new Uint8Array(str.length * 2);
+  for (let i = 0; i < str.length; i += 1) {
+    const code = str.charCodeAt(i);
+    b[i * 2] = code & 0xff;
+    b[i * 2 + 1] = (code >>> 8) & 0xff;
+  }
+  return b;
+}
+
+function utf16be(str: string): Uint8Array {
+  const b = new Uint8Array(str.length * 2);
+  for (let i = 0; i < str.length; i += 1) {
+    const code = str.charCodeAt(i);
+    b[i * 2] = (code >>> 8) & 0xff;
+    b[i * 2 + 1] = code & 0xff;
+  }
+  return b;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+const SVG_XML =
+  '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>';
+const SVG_DOCTYPE =
+  '<?xml version="1.0"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"></svg>';
+const NON_SVG_XML = '<?xml version="1.0"?><root><item/></root>';
+const GARBAGE = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+
+describe('sanitizeMediaUrl', () => {
+  it('drops userinfo, query, and fragment', async () => {
+    const { sanitizeMediaUrl } = await import('./upload.js');
+    expect(
+      sanitizeMediaUrl(
+        'https://user:pass@host.example/path/img.png?sig=secret#frag'
+      )
+    ).toBe('https://host.example/path/img.png');
+  });
+
+  it('returns a fixed placeholder for a malformed credentialed URL (never echoes raw input)', async () => {
+    const { sanitizeMediaUrl } = await import('./upload.js');
+    const malformed = 'https://user:pass@host:bad/img.png?sig=secret';
+    expect(sanitizeMediaUrl(malformed)).toBe('[unparseable URL]');
+    expect(sanitizeMediaUrl(malformed)).not.toContain('user:pass');
+    expect(sanitizeMediaUrl(malformed)).not.toContain('sig=secret');
+  });
+});
+
+describe('isSvgBytes', () => {
+  it('detects plain, XML-declared, and DOCTYPE-prefixed SVG', async () => {
+    const { isSvgBytes } = await import('./upload.js');
+    expect(isSvgBytes(Buffer.from('<svg xmlns="x"></svg>'))).toBe(true);
+    expect(isSvgBytes(Buffer.from(SVG_XML))).toBe(true);
+    expect(isSvgBytes(Buffer.from(SVG_DOCTYPE))).toBe(true);
+  });
+
+  it('detects UTF-16LE and UTF-16BE BOM-marked SVG', async () => {
+    const { isSvgBytes } = await import('./upload.js');
+    expect(
+      isSvgBytes(
+        concat(new Uint8Array([0xff, 0xfe]), utf16le('<svg xmlns="x"></svg>'))
+      )
+    ).toBe(true);
+    expect(
+      isSvgBytes(
+        concat(new Uint8Array([0xfe, 0xff]), utf16be('<svg xmlns="x"></svg>'))
+      )
+    ).toBe(true);
+  });
+
+  it('does not treat non-SVG XML or raster bytes as SVG', async () => {
+    const { isSvgBytes } = await import('./upload.js');
+    expect(isSvgBytes(Buffer.from(NON_SVG_XML))).toBe(false);
+    expect(isSvgBytes(pngHeaderBytes(10, 20))).toBe(false);
+  });
+
+  it('detects SVG after a DOCTYPE whose quoted literal contains ">"', async () => {
+    const { isSvgBytes } = await import('./upload.js');
+    // A '>' inside the quoted SYSTEM literal must not terminate the DOCTYPE scan.
+    expect(
+      isSvgBytes(
+        Buffer.from('<!DOCTYPE svg SYSTEM "foo>bar"><svg xmlns="x"></svg>')
+      )
+    ).toBe(true);
+    expect(
+      isSvgBytes(
+        Buffer.from("<!DOCTYPE svg SYSTEM 'foo>bar'><svg xmlns='x'></svg>")
+      )
+    ).toBe(true);
+  });
+});
+
+describe('safeUploadFileName', () => {
+  it('replaces unsafe characters and forces the canonical extension', async () => {
+    const { safeUploadFileName } = await import('./upload.js');
+    expect(safeUploadFileName('chart#1.png', 'image/png')).toBe('chart-1.png');
+    expect(safeUploadFileName('a%23b.png', 'image/png')).toBe('a-23b.png');
+    // Mismatched extension is replaced with the canonical one.
+    expect(safeUploadFileName('diagram.xml', 'image/svg+xml')).toBe(
+      'diagram.svg'
+    );
+    expect(safeUploadFileName('blob.bin', 'image/svg+xml')).toBe('blob.svg');
+  });
+
+  it('generates a name when the candidate is empty or fully stripped', async () => {
+    const { safeUploadFileName } = await import('./upload.js');
+    expect(safeUploadFileName('', 'image/png')).toMatch(/^upload-\d+\.png$/);
+    expect(safeUploadFileName('###', 'image/png')).toMatch(/^upload-\d+\.png$/);
+  });
+
+  it('only emits allowlisted characters', async () => {
+    const { safeUploadFileName } = await import('./upload.js');
+    const name = safeUploadFileName('we ird??name##.png', 'image/png');
+    expect(name).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+});
+
+describe('classifyLoadedMedia', () => {
+  it('classifies a structurally complete PNG header as an image with real dims', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(
+      classifyLoadedMedia({
+        buffer: pngHeaderBytes(10, 20),
+        sniffedMime: 'image/png',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toEqual({
+      kind: 'image',
+      width: 10,
+      height: 20,
+      effectiveMime: 'image/png',
+    });
+  });
+
+  it('throws on a zero-dimension PNG (bounds)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: pngHeaderBytes(0, 0),
+        sniffedMime: 'image/png',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/not a valid png image/);
+  });
+
+  it('throws on an excessive-dimension PNG (bounds)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: pngHeaderBytes(100000, 100000),
+        sniffedMime: 'image/png',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/not a valid png image/);
+  });
+
+  it('throws on a parse-success + sniff mismatch', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: pngHeaderBytes(10, 20),
+        sniffedMime: 'image/gif',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/not a valid png image/);
+  });
+
+  it('throws on a parse-success + absent sniff', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: pngHeaderBytes(10, 20),
+        sniffedMime: undefined,
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/not a valid png image/);
+  });
+
+  it.each(['image/png', 'image/jpg', 'image/pjpeg', 'image/x-png'])(
+    'throws on garbage bytes declared as %s (parser-supported never falls through)',
+    async (mime) => {
+      const { classifyLoadedMedia } = await import('./upload.js');
+      expect(() =>
+        classifyLoadedMedia({
+          buffer: GARBAGE,
+          declaredMime: mime,
+          sniffedMime: undefined,
+          isRemote: false,
+          sourceLabel: 'x',
+        })
+      ).toThrow(/not a valid image/);
+    }
+  );
+
+  it.each([
+    ['image/avif', 'avif', avifBytes()],
+    ['image/heic', 'heic', heicBytes()],
+    ['image/bmp', 'bmp', bmpBytes()],
+    ['image/x-icon', 'x-icon', icoBytes()],
+  ])(
+    'throws the convert hint for sniffed %s (not inlined)',
+    async (mime, fmt, buffer) => {
+      const { classifyLoadedMedia } = await import('./upload.js');
+      expect(() =>
+        classifyLoadedMedia({
+          buffer,
+          sniffedMime: mime,
+          isRemote: true,
+          sourceLabel: 'x',
+        })
+      ).toThrow(new RegExp(`${fmt} image that can't be posted inline`));
+    }
+  );
+
+  it('classifies a structurally complete PNG header with a conflicting declared MIME as a PNG image (raster parse is independent of declaredMime)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(
+      classifyLoadedMedia({
+        buffer: pngHeaderBytes(10, 20),
+        declaredMime: 'application/pdf',
+        sniffedMime: 'image/png',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toEqual({
+      kind: 'image',
+      width: 10,
+      height: 20,
+      effectiveMime: 'image/png',
+    });
+  });
+
+  it('routes valid SVG with a conflicting declared image/png to the SVG branch (byte detection precedes parser-supported rejection)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(
+      classifyLoadedMedia({
+        buffer: Buffer.from(SVG_XML),
+        declaredMime: 'image/png',
+        sniffedMime: 'application/xml',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toEqual({ kind: 'link', effectiveMime: 'image/svg+xml' });
+  });
+
+  it('rejects garbage that sniffs as image/png via the parser-supported branch (not the unsupported-image branch)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: GARBAGE,
+        sniffedMime: 'image/png',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/not a valid image/);
+    // Proves the parser-supported rejection fired, not the "can't be posted
+    // inline" unsupported-image branch.
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: GARBAGE,
+        sniffedMime: 'image/png',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).not.toThrow(/can't be posted inline/);
+  });
+
+  it('throws the AVIF convert hint for avif bytes declared as image/jpeg (sniffed-unsupported precedes declared-parseable)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: avifBytes(),
+        declaredMime: 'image/jpeg',
+        sniffedMime: 'image/avif',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/avif image that can't be posted inline/);
+  });
+
+  it('classifies remote SVG (XML-declared, sniff application/xml) as a link', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(
+      classifyLoadedMedia({
+        buffer: Buffer.from(SVG_XML),
+        declaredMime: 'application/xml',
+        sniffedMime: 'application/xml',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toEqual({ kind: 'link', effectiveMime: 'image/svg+xml' });
+  });
+
+  it('classifies remote UTF-16LE/BE BOM and DOCTYPE-prefixed SVG as a link', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    const le = concat(
+      new Uint8Array([0xff, 0xfe]),
+      utf16le('<svg xmlns="x"></svg>')
+    );
+    const be = concat(
+      new Uint8Array([0xfe, 0xff]),
+      utf16be('<svg xmlns="x"></svg>')
+    );
+    for (const buffer of [le, be, Buffer.from(SVG_DOCTYPE)]) {
+      expect(
+        classifyLoadedMedia({
+          buffer,
+          declaredMime: 'application/xml',
+          sniffedMime: 'application/xml',
+          isRemote: true,
+          sourceLabel: 'x',
+        })
+      ).toEqual({ kind: 'link', effectiveMime: 'image/svg+xml' });
+    }
+  });
+
+  it('throws convert-to-PNG for local SVG bytes', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: Buffer.from(SVG_XML),
+        sniffedMime: 'application/xml',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/convert it to PNG/);
+  });
+
+  it('does not treat non-SVG XML as SVG', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(
+      classifyLoadedMedia({
+        buffer: Buffer.from(NON_SVG_XML),
+        declaredMime: 'application/xml',
+        sniffedMime: 'application/xml',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toEqual({ kind: 'link', effectiveMime: 'application/xml' });
+  });
+
+  it('classifies application/pdf as a link', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    expect(
+      classifyLoadedMedia({
+        buffer: Buffer.from('%PDF-1.4 garbage'),
+        declaredMime: 'application/pdf',
+        sniffedMime: 'application/pdf',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toEqual({ kind: 'link', effectiveMime: 'application/pdf' });
+  });
+});
+
+describe('prepareOutboundMedia (remote, mocked loader)', () => {
+  let loadWebMedia: ReturnType<typeof vi.fn>;
+  let uploadFile: ReturnType<typeof vi.fn>;
+  let detectMime: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let savedHosting: string | undefined;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
+    const webMedia = await import('openclaw/plugin-sdk/web-media');
+    const api = await import('@tloncorp/api');
+    const mime = await import('openclaw/plugin-sdk/media-mime');
+    loadWebMedia = vi.mocked(webMedia.loadWebMedia);
+    uploadFile = vi.mocked(api.uploadFile);
+    detectMime = vi.mocked(mime.detectMime);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    savedHosting = process.env.TLON_HOSTING;
+    delete process.env.TLON_HOSTING;
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    logSpy.mockRestore();
+    if (savedHosting === undefined) {
+      delete process.env.TLON_HOSTING;
+    } else {
+      process.env.TLON_HOSTING = savedHosting;
+    }
   });
 
-  it('fetches image and calls uploadFile, returns uploaded URL', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
-
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
-
-    // Mock fetchWithSsrFGuard to return a successful response with a blob
-    const mockBlob = new Blob(['fake-image'], { type: 'image/png' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/image.png',
-      release: vi.fn().mockResolvedValue(undefined),
+  function mockRemoteImage(contentType = 'image/png') {
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from(pngHeaderBytes(10, 20)),
+      contentType,
+      kind: 'image',
     });
+    detectMime.mockResolvedValue('image/png');
+  }
 
-    // Mock uploadFile to return a successful upload
-    mockUploadFile.mockResolvedValue({
-      url: 'https://memex.tlon.network/uploaded.png',
+  it('uploads a remote image and returns the uploaded URL + dims', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({ url: 'https://storage.example/u/img.png' });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const result = await prepareOutboundMedia('https://host/img.png', {});
+    expect(result).toEqual({
+      url: 'https://storage.example/u/img.png',
+      isImage: true,
+      width: 10,
+      height: 20,
+      contentType: 'image/png',
     });
+  });
 
-    const { uploadImageFromUrl } = await import('./upload.js');
-    const result = await uploadImageFromUrl('https://example.com/image.png');
+  it.each([
+    [
+      'a fetch-failed cause bearing a signed query',
+      'Fetch failed https://host/img.png?sig=secret',
+      ['sig=secret', 'secret', '?sig=', 'Fetch failed'],
+    ],
+    [
+      'an uppercase-scheme cause bearing credentials and a signed query',
+      'Fetch failed HTTPS://user:pass@host/img.png?X-Amz-Signature=secretvalue',
+      ['user:pass', 'secretvalue', 'X-Amz-Signature', 'Fetch failed'],
+    ],
+    [
+      'a malformed single-slash cause bearing credentials',
+      'Fetch failed for https:/user:pass@host/img.png?sig=secret: timeout',
+      ['user:pass', 'sig=secret', 'secret', 'Fetch failed', '[url removed]'],
+    ],
+    [
+      'a scheme-less cause bearing a signed query',
+      'request failed for /bucket/key?X-Amz-Signature=secretvalue',
+      ['X-Amz-Signature', 'secretvalue', 'request failed', '/bucket/key'],
+    ],
+  ])(
+    'uses a fixed category message for loader failures with %s (never interpolates raw cause)',
+    async (_label, rawMessage, forbidden) => {
+      loadWebMedia.mockRejectedValue(new Error(rawMessage));
+      const { prepareOutboundMedia } = await import('./upload.js');
+      const promise = prepareOutboundMedia('https://host/img.png', {});
+      await expect(promise).rejects.toThrow(
+        /Cannot read media "https:\/\/host\/img\.png": Failed to read media/
+      );
+      for (const s of forbidden) {
+        await expect(promise).rejects.not.toThrow(s);
+      }
+      for (const call of logSpy.mock.calls) {
+        for (const arg of call) {
+          const str = String(arg);
+          for (const s of forbidden) {
+            expect(str).not.toContain(s);
+          }
+        }
+      }
+    }
+  );
 
-    expect(result).toBe('https://memex.tlon.network/uploaded.png');
-    expect(mockUploadFile).toHaveBeenCalledTimes(1);
-    expect(mockUploadFile).toHaveBeenCalledWith(
+  it.each([
+    ['not-found', 'Media file not found'],
+    ['not-file', 'Media path is not a file'],
+    ['path-not-allowed', 'Media path or file type is not allowed'],
+    ['invalid-file-url', 'Invalid media path'],
+    ['invalid-path', 'Invalid media path'],
+    ['network-path-not-allowed', 'Invalid media path'],
+    ['unsafe-bypass', 'Invalid media path'],
+    ['invalid-root', 'Media access roots are misconfigured'],
+    ['max_bytes', 'Media file is too large'],
+    ['http_error', 'Media URL returned an HTTP error'],
+    ['fetch_failed', 'Failed to fetch media'],
+  ])(
+    'maps the loader discriminator %s to its own fixed actionable phrase',
+    async (code, phrase) => {
+      const err = Object.assign(
+        new Error('raw secret-bearing message ?sig=secretvalue'),
+        { code }
+      );
+      loadWebMedia.mockRejectedValue(err);
+      const { prepareOutboundMedia } = await import('./upload.js');
+      const promise = prepareOutboundMedia('https://host/img.png', {});
+      await expect(promise).rejects.toThrow(
+        `Cannot read media "https://host/img.png": ${phrase}`
+      );
+      // The raw message is never interpolated, even though the discriminator is.
+      await expect(promise).rejects.not.toThrow(/secretvalue/);
+      await expect(promise).rejects.not.toThrow(/raw secret-bearing message/);
+    }
+  );
+
+  it('falls back to the generic phrase for an unknown loader discriminator', async () => {
+    const err = Object.assign(new Error('boom ?sig=secretvalue'), {
+      code: 'some-future-code',
+    });
+    loadWebMedia.mockRejectedValue(err);
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const promise = prepareOutboundMedia('https://host/img.png', {});
+    await expect(promise).rejects.toThrow(/Failed to read media/);
+    await expect(promise).rejects.not.toThrow(/some-future-code/);
+    await expect(promise).rejects.not.toThrow(/secretvalue/);
+  });
+
+  it('posts a remote extensionless SVG as a link with svg content type', async () => {
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from(SVG_XML),
+      contentType: 'application/xml',
+      kind: 'image',
+      fileName: 'blob',
+    });
+    detectMime.mockResolvedValue('application/xml');
+    uploadFile.mockResolvedValue({ url: 'https://storage.example/u/blob.svg' });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const result = await prepareOutboundMedia('https://host/blob', {});
+    expect(uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        blob: mockBlob,
-        contentType: 'image/png',
+        contentType: 'image/svg+xml',
+        fileName: expect.stringMatching(/\.svg$/),
       })
     );
+    expect(result.isImage).toBe(false);
+    expect(result.url).toBe('https://storage.example/u/blob.svg');
+    expect(result.contentType).toBe('image/svg+xml');
   });
 
-  it('returns original URL if fetch fails', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
-
-    // Mock fetchWithSsrFGuard to return a failed response
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: false,
-        status: 404,
-      } as unknown as Response,
-      finalUrl: 'https://example.com/image.png',
-      release: vi.fn().mockResolvedValue(undefined),
+  it('replaces a mismatched extension for SVG bytes (diagram.xml -> .svg)', async () => {
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from(SVG_XML),
+      contentType: 'application/xml',
+      kind: 'image',
     });
-
-    const { uploadImageFromUrl } = await import('./upload.js');
-    const result = await uploadImageFromUrl('https://example.com/image.png');
-
-    expect(result).toBe('https://example.com/image.png');
-  });
-
-  it('returns original URL if upload fails', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
-
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
-
-    // Mock fetchWithSsrFGuard to return a successful response
-    const mockBlob = new Blob(['fake-image'], { type: 'image/png' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/image.png',
-      release: vi.fn().mockResolvedValue(undefined),
+    detectMime.mockResolvedValue('application/xml');
+    uploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/diagram.svg',
     });
-
-    // Mock uploadFile to throw an error
-    mockUploadFile.mockRejectedValue(new Error('Upload failed'));
-
-    const { uploadImageFromUrl } = await import('./upload.js');
-    const result = await uploadImageFromUrl('https://example.com/image.png');
-
-    expect(result).toBe('https://example.com/image.png');
-  });
-
-  it('rejects non-http(s) URLs', async () => {
-    const { uploadImageFromUrl } = await import('./upload.js');
-
-    // file:// URL should be rejected
-    const result = await uploadImageFromUrl('file:///etc/passwd');
-    expect(result).toBe('file:///etc/passwd');
-
-    // ftp:// URL should be rejected
-    const result2 = await uploadImageFromUrl('ftp://example.com/image.png');
-    expect(result2).toBe('ftp://example.com/image.png');
-  });
-
-  it('handles invalid URLs gracefully', async () => {
-    const { uploadImageFromUrl } = await import('./upload.js');
-
-    // Invalid URL should return original
-    const result = await uploadImageFromUrl('not-a-valid-url');
-    expect(result).toBe('not-a-valid-url');
-  });
-
-  it('extracts filename from URL path', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
-
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
-
-    const mockBlob = new Blob(['fake-image'], { type: 'image/jpeg' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/jpeg' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/path/to/my-image.jpg',
-      release: vi.fn().mockResolvedValue(undefined),
-    });
-
-    mockUploadFile.mockResolvedValue({
-      url: 'https://memex.tlon.network/uploaded.jpg',
-    });
-
-    const { uploadImageFromUrl } = await import('./upload.js');
-    await uploadImageFromUrl('https://example.com/path/to/my-image.jpg');
-
-    expect(mockUploadFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fileName: 'my-image.jpg',
-      })
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('https://host/diagram.xml', {});
+    expect(uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'diagram.svg' })
     );
   });
 
-  it('uses default filename when URL has no path', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
+  it('rejects remote URLs with embedded credentials before any fetch', async () => {
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const promise = prepareOutboundMedia(
+      'https://user:pass@host/img.png?sig=secret',
+      {}
     );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
+    await expect(promise).rejects.toThrow(
+      'Media URLs with embedded credentials are not supported'
+    );
+    // The thrown message must not echo the raw credentialed URL, the username,
+    // the password, or the signed query at all.
+    await expect(promise).rejects.not.toThrow(/user:pass@host/);
+    await expect(promise).rejects.not.toThrow(/user/);
+    await expect(promise).rejects.not.toThrow(/pass/);
+    await expect(promise).rejects.not.toThrow(/sig=secret/);
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    // Every argument of every console.log call must be free of the credentials
+    // and signed query (not just a single argument string).
+    for (const call of logSpy.mock.calls) {
+      for (const arg of call) {
+        const s = String(arg);
+        expect(s).not.toContain('user:pass@host');
+        expect(s).not.toContain('sig=secret');
+      }
+    }
+  });
 
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
+  it('throws a generic error for a malformed https-prefixed URL (no raw ERR_INVALID_URL leak)', async () => {
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const malformed = 'https://user:pass@host:bad/img.png?sig=secret';
+    const promise = prepareOutboundMedia(malformed, {});
+    await expect(promise).rejects.toThrow('Invalid media URL');
+    await expect(promise).rejects.not.toThrow(/user/);
+    await expect(promise).rejects.not.toThrow(/pass/);
+    await expect(promise).rejects.not.toThrow(/sig=secret/);
+    await expect(promise).rejects.not.toThrow(/ERR_INVALID_URL/);
+    await expect(promise).rejects.not.toThrow(/bad/);
+    expect(loadWebMedia).not.toHaveBeenCalled();
+  });
 
-    const mockBlob = new Blob(['fake-image'], { type: 'image/png' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/',
-      release: vi.fn().mockResolvedValue(undefined),
+  it('throws a generic error for a malformed file:// URL bearing credentials and a query secret (no raw leak)', async () => {
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const malformed = 'file://user:pass@host:bad/img.png?sig=secret';
+    const promise = prepareOutboundMedia(malformed, {});
+    await expect(promise).rejects.toThrow('Invalid media URL');
+    await expect(promise).rejects.not.toThrow(/user/);
+    await expect(promise).rejects.not.toThrow(/pass/);
+    await expect(promise).rejects.not.toThrow(/sig=secret/);
+    await expect(promise).rejects.not.toThrow(/secret/);
+    await expect(promise).rejects.not.toThrow(/file:\/\//);
+    await expect(promise).rejects.not.toThrow(/ERR_INVALID_URL/);
+    expect(loadWebMedia).not.toHaveBeenCalled();
+  });
+
+  it('treats a noncanonical single-slash https:/ input as a local path (no authority form, no raw leak)', async () => {
+    // A single slash is not the `://` authority form, so the narrowed scheme
+    // guard leaves it for the root-allowlisted loader; the output-side
+    // placeholder label + fixed category phrase keep it from leaking.
+    loadWebMedia.mockRejectedValue(new Error('ENOENT'));
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const malformed = 'https:/user:pass@host/img.png?sig=secret';
+    const promise = prepareOutboundMedia(malformed, {});
+    await expect(promise).rejects.toThrow(/Cannot read media/);
+    await expect(promise).rejects.toThrow(/\[local media reference\]/);
+    await expect(promise).rejects.not.toThrow('Invalid media URL');
+    await expect(promise).rejects.not.toThrow(/user/);
+    await expect(promise).rejects.not.toThrow(/pass/);
+    await expect(promise).rejects.not.toThrow(/sig=secret/);
+    await expect(promise).rejects.not.toThrow(/secret/);
+    await expect(promise).rejects.not.toThrow(/host/);
+    await expect(promise).rejects.not.toThrow(/https:\//);
+    expect(loadWebMedia).toHaveBeenCalled();
+  });
+
+  it('treats a colon-bearing local filename (report:2026.png) as a local path, not a scheme', async () => {
+    // A bare `<word>:<rest>` without `//` is an ordinary workspace-relative
+    // path; the guard must not reject it, leaving the loader to resolve it
+    // against the allowlisted roots.
+    loadWebMedia.mockRejectedValue(new Error('ENOENT'));
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const promise = prepareOutboundMedia('report:2026.png', {});
+    await expect(promise).rejects.toThrow(/Cannot read media/);
+    await expect(promise).rejects.not.toThrow('Invalid media URL');
+    expect(loadWebMedia).toHaveBeenCalledWith(
+      'report:2026.png',
+      expect.anything()
+    );
+  });
+
+  it('rejects an other-scheme (ftp://) credentialed URL before any loader call (no raw leak)', async () => {
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const malformed = 'ftp://user:pass@host/img.png?sig=secret';
+    const promise = prepareOutboundMedia(malformed, {});
+    await expect(promise).rejects.toThrow('Invalid media URL');
+    await expect(promise).rejects.not.toThrow(/user/);
+    await expect(promise).rejects.not.toThrow(/pass/);
+    await expect(promise).rejects.not.toThrow(/sig=secret/);
+    await expect(promise).rejects.not.toThrow(/secret/);
+    await expect(promise).rejects.not.toThrow(/host/);
+    await expect(promise).rejects.not.toThrow(/ftp:\/\//);
+    expect(loadWebMedia).not.toHaveBeenCalled();
+  });
+
+  it('does not reject a legitimate media:// reference (passes it to the loader unchanged)', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({ url: 'https://storage.example/u/img.png' });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const result = await prepareOutboundMedia('media://some-opaque-token', {});
+    expect(loadWebMedia).toHaveBeenCalledWith(
+      'media://some-opaque-token',
+      expect.anything()
+    );
+    expect(result.url).toBe('https://storage.example/u/img.png');
+  });
+
+  it('falls back to the full signed URL on remote https upload failure', async () => {
+    mockRemoteImage();
+    uploadFile.mockRejectedValue(
+      new Error(
+        'Upload failed: https://storage.example.com/bucket/key?X-Amz-Signature=secretvalue'
+      )
+    );
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const result = await prepareOutboundMedia(
+      'https://host/img.png?sig=secret',
+      {}
+    );
+    expect(result.url).toBe('https://host/img.png?sig=secret');
+    expect(result.url).toContain('sig=secret');
+    expect(result.isImage).toBe(true);
+    // The log uses a fixed category phrase — the raw cause is never logged.
+    expect(logSpy).toHaveBeenCalled();
+    for (const call of logSpy.mock.calls) {
+      for (const arg of call) {
+        const s = String(arg);
+        expect(s).not.toContain('secretvalue');
+        expect(s).not.toContain('X-Amz-Signature');
+        expect(s).not.toContain('Upload failed:');
+      }
+    }
+  });
+
+  it('rejects on remote http upload failure (mixed content)', async () => {
+    mockRemoteImage();
+    uploadFile.mockRejectedValue(new Error('upload boom'));
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await expect(
+      prepareOutboundMedia('http://host/img.png', {})
+    ).rejects.toThrow(/Failed to upload media/);
+  });
+
+  it.each([
+    ['http://insecure/x.png'],
+    ['/relative/path.png'],
+    ['https://user:pass@host/x.png'],
+  ])(
+    'treats an invalid uploaded URL %s as an upload failure',
+    async (badUrl) => {
+      mockRemoteImage();
+      uploadFile.mockResolvedValue({ url: badUrl });
+      const { prepareOutboundMedia } = await import('./upload.js');
+      // https source falls back to hotlinking the original.
+      const result = await prepareOutboundMedia('https://host/img.png', {});
+      expect(result.url).toBe('https://host/img.png');
+      // The invalid uploaded URL — especially the credentialed one — must never
+      // be echoed into any log argument.
+      for (const call of logSpy.mock.calls) {
+        for (const arg of call) {
+          const s = String(arg);
+          expect(s).not.toContain('user:pass');
+          expect(s).not.toContain(badUrl);
+        }
+      }
+    }
+  );
+
+  it('treats an uploaded URL with a fragment as invalid', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({ url: 'https://storage.example/key#frag' });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const result = await prepareOutboundMedia('https://host/img.png', {});
+    expect(result.url).toBe('https://host/img.png');
+  });
+
+  it('ignores a secret-bearing loader fileName for remote sources', async () => {
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from(pngHeaderBytes(10, 20)),
+      contentType: 'image/png',
+      kind: 'image',
+      fileName: 'evil<>.png?x=1',
     });
-
-    mockUploadFile.mockResolvedValue({
-      url: 'https://memex.tlon.network/uploaded.png',
+    detectMime.mockResolvedValue('image/png');
+    uploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/photo.png',
     });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('https://host/photo.png', {});
+    expect(uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: 'photo.png' })
+    );
+  });
 
-    const { uploadImageFromUrl } = await import('./upload.js');
-    await uploadImageFromUrl('https://example.com/');
-
-    expect(mockUploadFile).toHaveBeenCalledWith(
+  it('generates a filename when the remote pathname is empty', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/upload.png',
+    });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('https://host/?sig=secret', {});
+    expect(uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
         fileName: expect.stringMatching(/^upload-\d+\.png$/),
       })
     );
+  });
+
+  it('sanitizes a percent-encoded remote pathname filename', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/a-23b.png',
+    });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('https://host/a%23b.png', {});
+    const fileName = uploadFile.mock.calls[0][0].fileName as string;
+    expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
+    expect(fileName).toMatch(/\.png$/);
+  });
+
+  it('strips the MEDIA: prefix for remote URLs', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({ url: 'https://storage.example/u/img.png' });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('MEDIA:https://host/img.png', {});
+    expect(loadWebMedia).toHaveBeenCalledWith(
+      'https://host/img.png',
+      expect.anything()
+    );
+  });
+
+  it('passes hostedDetection when TLON_HOSTING is set, and omits it otherwise', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({ url: 'https://storage.example/u/img.png' });
+    const { prepareOutboundMedia } = await import('./upload.js');
+
+    process.env.TLON_HOSTING = '1';
+    await prepareOutboundMedia('https://host/img.png', {});
+    expect(uploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ hostedDetection: 'assume-hosted' })
+    );
+
+    uploadFile.mockClear();
+    delete process.env.TLON_HOSTING;
+    await prepareOutboundMedia('https://host/img.png', {});
+    expect(uploadFile.mock.calls[0][0]).not.toHaveProperty('hostedDetection');
+  });
+
+  it.each([
+    ['ws://user:pass@host/path?sig=secret'],
+    ['s3://user:pass@host/path?sig=secret'],
+  ])(
+    'rejects a short-scheme (%s) credentialed URL before any loader call',
+    async (url) => {
+      const { prepareOutboundMedia } = await import('./upload.js');
+      const promise = prepareOutboundMedia(url, {});
+      await expect(promise).rejects.toThrow('Invalid media URL');
+      await expect(promise).rejects.not.toThrow(/user:pass/);
+      await expect(promise).rejects.not.toThrow(/sig=secret/);
+      await expect(promise).rejects.not.toThrow(/secret/);
+      expect(loadWebMedia).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([['C:\\Users\\test\\image.png'], ['C:/Users/test/image.png']])(
+    'treats a Windows drive path (%s) as an ordinary local path, not a scheme',
+    async (drivePath) => {
+      loadWebMedia.mockRejectedValue(new Error('ENOENT'));
+      const { prepareOutboundMedia } = await import('./upload.js');
+      const promise = prepareOutboundMedia(drivePath, {});
+      await expect(promise).rejects.toThrow(/Cannot read media/);
+      await expect(promise).rejects.not.toThrow('Invalid media URL');
+      expect(loadWebMedia).toHaveBeenCalled();
+    }
+  );
+
+  it('sanitizes credentials from a malformed media:// reference in the error message', async () => {
+    loadWebMedia.mockRejectedValue(new Error('unresolvable media reference'));
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const promise = prepareOutboundMedia(
+      'media://user:pass@inbound/id?sig=secret',
+      {}
+    );
+    await expect(promise).rejects.toThrow(/Cannot read media/);
+    await expect(promise).rejects.not.toThrow(/user:pass/);
+    await expect(promise).rejects.not.toThrow(/sig=secret/);
+    await expect(promise).rejects.not.toThrow(/secret/);
+  });
+
+  it.each([
+    [
+      'an ordinary local path',
+      '/workspace/images/photo.png',
+      ['photo.png', '/workspace'],
+    ],
+    [
+      'a credential-bearing path',
+      './https://user:pass@host/path?sig=secret',
+      ['user:pass', 'sig=secret', 'host'],
+    ],
+    [
+      'an @-bearing single-char-scheme path',
+      './x://u:p@host/path',
+      ['u:p@host', 'x://', 'host'],
+    ],
+    [
+      'a #-fragment path',
+      './path#X-Amz-Signature=secretvalue',
+      ['X-Amz-Signature', 'secretvalue'],
+    ],
+    [
+      'a percent-encoded path',
+      './file%3Fsig=secretvalue.png',
+      ['secretvalue', 'sig='],
+    ],
+    [
+      'a ?sig= query path',
+      './photo.png?sig=secretvalue',
+      ['sig=secretvalue', 'secretvalue'],
+    ],
+  ])(
+    'uses the fixed [local media reference] placeholder for %s (never echoes the path)',
+    async (_label, input, forbidden) => {
+      loadWebMedia.mockRejectedValue(new Error('ENOENT: no such file'));
+      const { prepareOutboundMedia } = await import('./upload.js');
+      const promise = prepareOutboundMedia(input, {});
+      await expect(promise).rejects.toThrow(/Cannot read media/);
+      await expect(promise).rejects.toThrow(/\[local media reference\]/);
+      for (const s of forbidden) {
+        await expect(promise).rejects.not.toThrow(s);
+      }
+    }
+  );
+
+  it('uses the parsed-pathname basename for remote filenames (allowlist-transformed)', async () => {
+    mockRemoteImage();
+    uploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/file.png',
+    });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('https://host/path/file@name.png', {});
+    const fileName = uploadFile.mock.calls[0][0].fileName as string;
+    expect(fileName).toBe('file-name.png');
+    expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
   });
 });

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -65,47 +65,47 @@ const SVG_DOCTYPE =
 const NON_SVG_XML = '<?xml version="1.0"?><root><item/></root>';
 const GARBAGE = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
 
-describe('isSvgBytes', () => {
+describe('probeSvgBytes (SVG detection)', () => {
   it('detects plain, XML-declared, and DOCTYPE-prefixed SVG', async () => {
-    const { isSvgBytes } = await import('./upload.js');
-    expect(isSvgBytes(Buffer.from('<svg xmlns="x"></svg>'))).toBe(true);
-    expect(isSvgBytes(Buffer.from(SVG_XML))).toBe(true);
-    expect(isSvgBytes(Buffer.from(SVG_DOCTYPE))).toBe(true);
+    const { probeSvgBytes } = await import('./upload.js');
+    expect(probeSvgBytes(Buffer.from('<svg xmlns="x"></svg>'))).toBe('svg');
+    expect(probeSvgBytes(Buffer.from(SVG_XML))).toBe('svg');
+    expect(probeSvgBytes(Buffer.from(SVG_DOCTYPE))).toBe('svg');
   });
 
   it('detects UTF-16LE and UTF-16BE BOM-marked SVG', async () => {
-    const { isSvgBytes } = await import('./upload.js');
+    const { probeSvgBytes } = await import('./upload.js');
     expect(
-      isSvgBytes(
+      probeSvgBytes(
         concat(new Uint8Array([0xff, 0xfe]), utf16le('<svg xmlns="x"></svg>'))
       )
-    ).toBe(true);
+    ).toBe('svg');
     expect(
-      isSvgBytes(
+      probeSvgBytes(
         concat(new Uint8Array([0xfe, 0xff]), utf16be('<svg xmlns="x"></svg>'))
       )
-    ).toBe(true);
+    ).toBe('svg');
   });
 
   it('does not treat non-SVG XML or raster bytes as SVG', async () => {
-    const { isSvgBytes } = await import('./upload.js');
-    expect(isSvgBytes(Buffer.from(NON_SVG_XML))).toBe(false);
-    expect(isSvgBytes(validPngBytes())).toBe(false);
+    const { probeSvgBytes } = await import('./upload.js');
+    expect(probeSvgBytes(Buffer.from(NON_SVG_XML))).not.toBe('svg');
+    expect(probeSvgBytes(validPngBytes())).not.toBe('svg');
   });
 
   it('detects SVG after a DOCTYPE whose quoted literal contains ">"', async () => {
-    const { isSvgBytes } = await import('./upload.js');
+    const { probeSvgBytes } = await import('./upload.js');
     // A '>' inside the quoted SYSTEM literal must not terminate the DOCTYPE scan.
     expect(
-      isSvgBytes(
+      probeSvgBytes(
         Buffer.from('<!DOCTYPE svg SYSTEM "foo>bar"><svg xmlns="x"></svg>')
       )
-    ).toBe(true);
+    ).toBe('svg');
     expect(
-      isSvgBytes(
+      probeSvgBytes(
         Buffer.from("<!DOCTYPE svg SYSTEM 'foo>bar'><svg xmlns='x'></svg>")
       )
-    ).toBe(true);
+    ).toBe('svg');
   });
 });
 
@@ -181,38 +181,20 @@ describe('probeSvgBytes (tri-state)', () => {
   });
 });
 
-describe('safeUploadFileName', () => {
-  it('replaces unsafe characters and forces the canonical extension', async () => {
-    const { safeUploadFileName } = await import('./upload.js');
-    expect(safeUploadFileName('chart#1.png', 'image/png')).toBe('chart-1.png');
-    expect(safeUploadFileName('a%23b.png', 'image/png')).toBe('a-23b.png');
-    // Mismatched extension is replaced with the canonical one.
-    expect(safeUploadFileName('diagram.xml', 'image/svg+xml')).toBe(
-      'diagram.svg'
-    );
-    expect(safeUploadFileName('blob.bin', 'image/svg+xml')).toBe('blob.svg');
-  });
-
-  it('generates a name when the candidate is empty or fully stripped', async () => {
-    const { safeUploadFileName } = await import('./upload.js');
-    expect(safeUploadFileName('', 'image/png')).toMatch(
-      /^upload-\d+-[0-9a-f-]{36}\.png$/
-    );
-    expect(safeUploadFileName('###', 'image/png')).toMatch(
-      /^upload-\d+-[0-9a-f-]{36}\.png$/
-    );
-  });
-
-  it('only emits allowlisted characters', async () => {
-    const { safeUploadFileName } = await import('./upload.js');
-    const name = safeUploadFileName('we ird??name##.png', 'image/png');
+describe('syntheticUploadFileName', () => {
+  it('emits an allowlisted upload-<ts>-<uuid> name with the canonical extension', async () => {
+    const { syntheticUploadFileName } = await import('./upload.js');
+    const name = syntheticUploadFileName('image/png');
+    expect(name).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
     expect(name).toMatch(/^[A-Za-z0-9._-]+$/);
+    // Canonical extension for the mime, regardless of any source name.
+    expect(syntheticUploadFileName('image/svg+xml')).toMatch(/\.svg$/);
   });
 
-  it('generates collision-resistant synthetic names that differ across rapid calls', async () => {
-    const { safeUploadFileName } = await import('./upload.js');
-    const a = safeUploadFileName('', 'image/png');
-    const b = safeUploadFileName('', 'image/png');
+  it('generates collision-resistant names that differ across rapid calls', async () => {
+    const { syntheticUploadFileName } = await import('./upload.js');
+    const a = syntheticUploadFileName('image/png');
+    const b = syntheticUploadFileName('image/png');
     expect(a).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
     expect(b).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
     expect(a).not.toBe(b);

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -109,6 +109,78 @@ describe('isSvgBytes', () => {
   });
 });
 
+describe('probeSvgRoot boundary handling (truncated window)', () => {
+  // When the scan window ends mid-token on a prefix of a preamble opener, the
+  // probe must return 'incomplete' (fail-closed for local sources) rather than
+  // a definitive 'non-svg' that would let a real local SVG slip through.
+  it('treats truncated opener prefixes as incomplete when truncated', async () => {
+    const { probeSvgRoot } = await import('./upload.js');
+    expect(probeSvgRoot('<', true)).toBe('incomplete');
+    expect(probeSvgRoot('<!', true)).toBe('incomplete'); // partial <!-- or <!DOCTYPE
+    expect(probeSvgRoot('<!-', true)).toBe('incomplete'); // partial <!--
+    expect(probeSvgRoot('<!D', true)).toBe('incomplete'); // partial <!DOCTYPE
+    expect(probeSvgRoot('<!doct', true)).toBe('incomplete'); // partial <!DOCTYPE
+    expect(probeSvgRoot('<s', true)).toBe('incomplete'); // partial <svg
+    expect(probeSvgRoot('<svg', true)).toBe('incomplete'); // no delimiter yet
+    expect(probeSvgRoot('   <sv', true)).toBe('incomplete'); // preamble ws + partial
+  });
+
+  it('does not treat ordinary XML/text as incomplete', async () => {
+    const { probeSvgRoot } = await import('./upload.js');
+    expect(probeSvgRoot('<root>', true)).toBe('non-svg');
+    expect(probeSvgRoot('<r', true)).toBe('non-svg'); // not a prefix of any opener
+    expect(probeSvgRoot('<!ENTITY', true)).toBe('non-svg'); // not comment/doctype
+    expect(probeSvgRoot('plain text', true)).toBe('non-svg');
+    expect(probeSvgRoot('<svgx>', true)).toBe('non-svg'); // <svg with a non-delimiter
+  });
+
+  it('stays definitive when the buffer is not truncated', async () => {
+    const { probeSvgRoot } = await import('./upload.js');
+    expect(probeSvgRoot('<svg>', false)).toBe('svg');
+    expect(probeSvgRoot('<svg', false)).toBe('svg'); // whole buffer ends at <svg
+    expect(probeSvgRoot('<!', false)).toBe('non-svg'); // no more bytes coming
+    expect(probeSvgRoot('<root>', false)).toBe('non-svg');
+  });
+});
+
+describe('probeSvgBytes (tri-state)', () => {
+  it('returns svg for a plain SVG root', async () => {
+    const { probeSvgBytes } = await import('./upload.js');
+    expect(probeSvgBytes(Buffer.from('<svg xmlns="x"></svg>'))).toBe('svg');
+    expect(probeSvgBytes(Buffer.from(SVG_XML))).toBe('svg');
+  });
+
+  it('returns non-svg for definitive non-SVG XML', async () => {
+    const { probeSvgBytes } = await import('./upload.js');
+    expect(probeSvgBytes(Buffer.from(NON_SVG_XML))).toBe('non-svg');
+  });
+
+  it('returns svg for SVG with a >8KiB but <64KiB comment preamble', async () => {
+    const { probeSvgBytes } = await import('./upload.js');
+    const preamble = '<!--' + 'a'.repeat(10 * 1024) + '-->';
+    const buf = Buffer.from(preamble + '<svg xmlns="x"></svg>');
+    expect(probeSvgBytes(buf)).toBe('svg');
+  });
+
+  it('returns incomplete for SVG with a >64KiB comment preamble', async () => {
+    const { probeSvgBytes } = await import('./upload.js');
+    const preamble = '<!--' + 'a'.repeat(70 * 1024) + '-->';
+    const buf = Buffer.from(preamble + '<svg xmlns="x"></svg>');
+    expect(probeSvgBytes(buf)).toBe('incomplete');
+  });
+
+  it('returns incomplete for >64KiB of pure whitespace with no root', async () => {
+    const { probeSvgBytes } = await import('./upload.js');
+    const buf = Buffer.from(' '.repeat(70 * 1024) + '<svg xmlns="x"></svg>');
+    expect(probeSvgBytes(buf)).toBe('incomplete');
+  });
+
+  it('returns non-svg for whitespace-only buffer under 64KiB (no more bytes)', async () => {
+    const { probeSvgBytes } = await import('./upload.js');
+    expect(probeSvgBytes(Buffer.from('   '))).toBe('non-svg');
+  });
+});
+
 describe('safeUploadFileName', () => {
   it('replaces unsafe characters and forces the canonical extension', async () => {
     const { safeUploadFileName } = await import('./upload.js');
@@ -123,14 +195,27 @@ describe('safeUploadFileName', () => {
 
   it('generates a name when the candidate is empty or fully stripped', async () => {
     const { safeUploadFileName } = await import('./upload.js');
-    expect(safeUploadFileName('', 'image/png')).toMatch(/^upload-\d+\.png$/);
-    expect(safeUploadFileName('###', 'image/png')).toMatch(/^upload-\d+\.png$/);
+    expect(safeUploadFileName('', 'image/png')).toMatch(
+      /^upload-\d+-[0-9a-f-]{36}\.png$/
+    );
+    expect(safeUploadFileName('###', 'image/png')).toMatch(
+      /^upload-\d+-[0-9a-f-]{36}\.png$/
+    );
   });
 
   it('only emits allowlisted characters', async () => {
     const { safeUploadFileName } = await import('./upload.js');
     const name = safeUploadFileName('we ird??name##.png', 'image/png');
     expect(name).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+
+  it('generates collision-resistant synthetic names that differ across rapid calls', async () => {
+    const { safeUploadFileName } = await import('./upload.js');
+    const a = safeUploadFileName('', 'image/png');
+    const b = safeUploadFileName('', 'image/png');
+    expect(a).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
+    expect(b).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
+    expect(a).not.toBe(b);
   });
 });
 
@@ -363,6 +448,50 @@ describe('classifyLoadedMedia', () => {
     ).toEqual({ kind: 'link', effectiveMime: 'application/xml' });
   });
 
+  it('rejects local SVG with a >8KiB comment preamble (incomplete probe fails closed)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    const preamble = '<!--' + 'a'.repeat(70 * 1024) + '-->';
+    const buf = Buffer.from(preamble + '<svg xmlns="x"></svg>');
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: buf,
+        loaderMime: 'application/xml',
+        sniffedMime: 'application/xml',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/convert it to PNG/);
+  });
+
+  it('rejects local >64KiB whitespace with no root (incomplete probe fails closed)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    const buf = Buffer.from(' '.repeat(70 * 1024));
+    expect(() =>
+      classifyLoadedMedia({
+        buffer: buf,
+        loaderMime: 'application/xml',
+        sniffedMime: 'application/xml',
+        isRemote: false,
+        sourceLabel: 'x',
+      })
+    ).toThrow(/convert it to PNG/);
+  });
+
+  it('classifies remote ambiguous XML with huge preamble as a link (incomplete probe falls through)', async () => {
+    const { classifyLoadedMedia } = await import('./upload.js');
+    const preamble = '<!--' + 'a'.repeat(70 * 1024) + '-->';
+    const buf = Buffer.from(preamble + '<root/>');
+    expect(
+      classifyLoadedMedia({
+        buffer: buf,
+        loaderMime: 'application/xml',
+        sniffedMime: 'application/xml',
+        isRemote: true,
+        sourceLabel: 'x',
+      })
+    ).toEqual({ kind: 'link', effectiveMime: 'application/xml' });
+  });
+
   it('classifies application/pdf as a link', async () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(
@@ -552,7 +681,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     await prepareOutboundMedia('https://host/diagram.xml', {});
     expect(uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        fileName: expect.stringMatching(/^upload-\d+\.svg$/),
+        fileName: expect.stringMatching(/^upload-\d+-[0-9a-f-]{36}\.svg$/),
       })
     );
   });
@@ -756,7 +885,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     await prepareOutboundMedia('https://host/photo.png', {});
     expect(uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        fileName: expect.stringMatching(/^upload-\d+\.png$/),
+        fileName: expect.stringMatching(/^upload-\d+-[0-9a-f-]{36}\.png$/),
       })
     );
   });
@@ -770,7 +899,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     await prepareOutboundMedia('https://host/?sig=secret', {});
     expect(uploadFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        fileName: expect.stringMatching(/^upload-\d+\.png$/),
+        fileName: expect.stringMatching(/^upload-\d+-[0-9a-f-]{36}\.png$/),
       })
     );
   });
@@ -783,7 +912,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://host/a%23b.png', {});
     const fileName = uploadFile.mock.calls[0][0].fileName as string;
-    expect(fileName).toMatch(/^upload-\d+\.png$/);
+    expect(fileName).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
     expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
   });
 
@@ -909,7 +1038,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://host/path/file@name.png', {});
     const fileName = uploadFile.mock.calls[0][0].fileName as string;
-    expect(fileName).toMatch(/^upload-\d+\.png$/);
+    expect(fileName).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
     expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
   });
 
@@ -952,7 +1081,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://cdn.example/tok-SECRETVALUE.png', {});
     const fileName = uploadFile.mock.calls[0][0].fileName as string;
-    expect(fileName).toMatch(/^upload-\d+\.png$/);
+    expect(fileName).toMatch(/^upload-\d+-[0-9a-f-]{36}\.png$/);
     expect(fileName).not.toContain('SECRETVALUE');
     expect(fileName).not.toContain('tok');
     expect(fileName).not.toContain('cdn');

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -5,7 +5,8 @@ import {
   bmpBytes,
   heicBytes,
   icoBytes,
-  pngHeaderBytes,
+  pngCompleteBytes,
+  validPngBytes,
 } from './test-fixtures.js';
 
 // Mock @tloncorp/api's uploadFile everywhere (test-double contract).
@@ -64,25 +65,6 @@ const SVG_DOCTYPE =
 const NON_SVG_XML = '<?xml version="1.0"?><root><item/></root>';
 const GARBAGE = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
 
-describe('sanitizeMediaUrl', () => {
-  it('drops userinfo, query, and fragment', async () => {
-    const { sanitizeMediaUrl } = await import('./upload.js');
-    expect(
-      sanitizeMediaUrl(
-        'https://user:pass@host.example/path/img.png?sig=secret#frag'
-      )
-    ).toBe('https://host.example/path/img.png');
-  });
-
-  it('returns a fixed placeholder for a malformed credentialed URL (never echoes raw input)', async () => {
-    const { sanitizeMediaUrl } = await import('./upload.js');
-    const malformed = 'https://user:pass@host:bad/img.png?sig=secret';
-    expect(sanitizeMediaUrl(malformed)).toBe('[unparseable URL]');
-    expect(sanitizeMediaUrl(malformed)).not.toContain('user:pass');
-    expect(sanitizeMediaUrl(malformed)).not.toContain('sig=secret');
-  });
-});
-
 describe('isSvgBytes', () => {
   it('detects plain, XML-declared, and DOCTYPE-prefixed SVG', async () => {
     const { isSvgBytes } = await import('./upload.js');
@@ -108,7 +90,7 @@ describe('isSvgBytes', () => {
   it('does not treat non-SVG XML or raster bytes as SVG', async () => {
     const { isSvgBytes } = await import('./upload.js');
     expect(isSvgBytes(Buffer.from(NON_SVG_XML))).toBe(false);
-    expect(isSvgBytes(pngHeaderBytes(10, 20))).toBe(false);
+    expect(isSvgBytes(validPngBytes())).toBe(false);
   });
 
   it('detects SVG after a DOCTYPE whose quoted literal contains ">"', async () => {
@@ -153,11 +135,11 @@ describe('safeUploadFileName', () => {
 });
 
 describe('classifyLoadedMedia', () => {
-  it('classifies a structurally complete PNG header as an image with real dims', async () => {
+  it('classifies a genuine complete PNG as an image with real dims', async () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(
       classifyLoadedMedia({
-        buffer: pngHeaderBytes(10, 20),
+        buffer: validPngBytes(10, 20),
         sniffedMime: 'image/png',
         isRemote: false,
         sourceLabel: 'x',
@@ -174,7 +156,7 @@ describe('classifyLoadedMedia', () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(() =>
       classifyLoadedMedia({
-        buffer: pngHeaderBytes(0, 0),
+        buffer: pngCompleteBytes(0, 0),
         sniffedMime: 'image/png',
         isRemote: false,
         sourceLabel: 'x',
@@ -186,7 +168,7 @@ describe('classifyLoadedMedia', () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(() =>
       classifyLoadedMedia({
-        buffer: pngHeaderBytes(100000, 100000),
+        buffer: pngCompleteBytes(100000, 100000),
         sniffedMime: 'image/png',
         isRemote: false,
         sourceLabel: 'x',
@@ -198,7 +180,7 @@ describe('classifyLoadedMedia', () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(() =>
       classifyLoadedMedia({
-        buffer: pngHeaderBytes(10, 20),
+        buffer: validPngBytes(10, 20),
         sniffedMime: 'image/gif',
         isRemote: false,
         sourceLabel: 'x',
@@ -210,7 +192,7 @@ describe('classifyLoadedMedia', () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(() =>
       classifyLoadedMedia({
-        buffer: pngHeaderBytes(10, 20),
+        buffer: validPngBytes(10, 20),
         sniffedMime: undefined,
         isRemote: false,
         sourceLabel: 'x',
@@ -225,7 +207,7 @@ describe('classifyLoadedMedia', () => {
       expect(() =>
         classifyLoadedMedia({
           buffer: GARBAGE,
-          declaredMime: mime,
+          loaderMime: mime,
           sniffedMime: undefined,
           isRemote: false,
           sourceLabel: 'x',
@@ -254,12 +236,12 @@ describe('classifyLoadedMedia', () => {
     }
   );
 
-  it('classifies a structurally complete PNG header with a conflicting declared MIME as a PNG image (raster parse is independent of declaredMime)', async () => {
+  it('classifies a genuine complete PNG with a conflicting loader MIME as a PNG image (raster parse is independent of loaderMime)', async () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(
       classifyLoadedMedia({
-        buffer: pngHeaderBytes(10, 20),
-        declaredMime: 'application/pdf',
+        buffer: validPngBytes(10, 20),
+        loaderMime: 'application/pdf',
         sniffedMime: 'image/png',
         isRemote: true,
         sourceLabel: 'x',
@@ -272,12 +254,12 @@ describe('classifyLoadedMedia', () => {
     });
   });
 
-  it('routes valid SVG with a conflicting declared image/png to the SVG branch (byte detection precedes parser-supported rejection)', async () => {
+  it('routes valid SVG with a conflicting loader image/png to the SVG branch (byte detection precedes parser-supported rejection)', async () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(
       classifyLoadedMedia({
         buffer: Buffer.from(SVG_XML),
-        declaredMime: 'image/png',
+        loaderMime: 'image/png',
         sniffedMime: 'application/xml',
         isRemote: true,
         sourceLabel: 'x',
@@ -307,12 +289,12 @@ describe('classifyLoadedMedia', () => {
     ).not.toThrow(/can't be posted inline/);
   });
 
-  it('throws the AVIF convert hint for avif bytes declared as image/jpeg (sniffed-unsupported precedes declared-parseable)', async () => {
+  it('throws the AVIF convert hint for avif bytes with loader image/jpeg (sniffed-unsupported precedes loader-parseable)', async () => {
     const { classifyLoadedMedia } = await import('./upload.js');
     expect(() =>
       classifyLoadedMedia({
         buffer: avifBytes(),
-        declaredMime: 'image/jpeg',
+        loaderMime: 'image/jpeg',
         sniffedMime: 'image/avif',
         isRemote: true,
         sourceLabel: 'x',
@@ -325,7 +307,7 @@ describe('classifyLoadedMedia', () => {
     expect(
       classifyLoadedMedia({
         buffer: Buffer.from(SVG_XML),
-        declaredMime: 'application/xml',
+        loaderMime: 'application/xml',
         sniffedMime: 'application/xml',
         isRemote: true,
         sourceLabel: 'x',
@@ -347,7 +329,7 @@ describe('classifyLoadedMedia', () => {
       expect(
         classifyLoadedMedia({
           buffer,
-          declaredMime: 'application/xml',
+          loaderMime: 'application/xml',
           sniffedMime: 'application/xml',
           isRemote: true,
           sourceLabel: 'x',
@@ -373,7 +355,7 @@ describe('classifyLoadedMedia', () => {
     expect(
       classifyLoadedMedia({
         buffer: Buffer.from(NON_SVG_XML),
-        declaredMime: 'application/xml',
+        loaderMime: 'application/xml',
         sniffedMime: 'application/xml',
         isRemote: true,
         sourceLabel: 'x',
@@ -386,7 +368,7 @@ describe('classifyLoadedMedia', () => {
     expect(
       classifyLoadedMedia({
         buffer: Buffer.from('%PDF-1.4 garbage'),
-        declaredMime: 'application/pdf',
+        loaderMime: 'application/pdf',
         sniffedMime: 'application/pdf',
         isRemote: true,
         sourceLabel: 'x',
@@ -426,7 +408,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
 
   function mockRemoteImage(contentType = 'image/png') {
     loadWebMedia.mockResolvedValue({
-      buffer: Buffer.from(pngHeaderBytes(10, 20)),
+      buffer: Buffer.from(validPngBytes(10, 20)),
       contentType,
       kind: 'image',
     });
@@ -475,7 +457,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
       const { prepareOutboundMedia } = await import('./upload.js');
       const promise = prepareOutboundMedia('https://host/img.png', {});
       await expect(promise).rejects.toThrow(
-        /Cannot read media "https:\/\/host\/img\.png": Failed to read media/
+        /Cannot read media "\[remote media reference\]": Failed to read media/
       );
       for (const s of forbidden) {
         await expect(promise).rejects.not.toThrow(s);
@@ -514,7 +496,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
       const { prepareOutboundMedia } = await import('./upload.js');
       const promise = prepareOutboundMedia('https://host/img.png', {});
       await expect(promise).rejects.toThrow(
-        `Cannot read media "https://host/img.png": ${phrase}`
+        `Cannot read media "[remote media reference]": ${phrase}`
       );
       // The raw message is never interpolated, even though the discriminator is.
       await expect(promise).rejects.not.toThrow(/secretvalue/);
@@ -556,7 +538,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     expect(result.contentType).toBe('image/svg+xml');
   });
 
-  it('replaces a mismatched extension for SVG bytes (diagram.xml -> .svg)', async () => {
+  it('uses a synthetic filename for remote SVG bytes (never derives from pathname)', async () => {
     loadWebMedia.mockResolvedValue({
       buffer: Buffer.from(SVG_XML),
       contentType: 'application/xml',
@@ -569,7 +551,9 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://host/diagram.xml', {});
     expect(uploadFile).toHaveBeenCalledWith(
-      expect.objectContaining({ fileName: 'diagram.svg' })
+      expect.objectContaining({
+        fileName: expect.stringMatching(/^upload-\d+\.svg$/),
+      })
     );
   });
 
@@ -759,7 +743,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
 
   it('ignores a secret-bearing loader fileName for remote sources', async () => {
     loadWebMedia.mockResolvedValue({
-      buffer: Buffer.from(pngHeaderBytes(10, 20)),
+      buffer: Buffer.from(validPngBytes(10, 20)),
       contentType: 'image/png',
       kind: 'image',
       fileName: 'evil<>.png?x=1',
@@ -771,7 +755,9 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://host/photo.png', {});
     expect(uploadFile).toHaveBeenCalledWith(
-      expect.objectContaining({ fileName: 'photo.png' })
+      expect.objectContaining({
+        fileName: expect.stringMatching(/^upload-\d+\.png$/),
+      })
     );
   });
 
@@ -789,7 +775,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     );
   });
 
-  it('sanitizes a percent-encoded remote pathname filename', async () => {
+  it('uses a synthetic filename for a percent-encoded remote pathname (never derives from URL)', async () => {
     mockRemoteImage();
     uploadFile.mockResolvedValue({
       url: 'https://storage.example/u/a-23b.png',
@@ -797,8 +783,8 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://host/a%23b.png', {});
     const fileName = uploadFile.mock.calls[0][0].fileName as string;
+    expect(fileName).toMatch(/^upload-\d+\.png$/);
     expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
-    expect(fileName).toMatch(/\.png$/);
   });
 
   it('strips the MEDIA: prefix for remote URLs', async () => {
@@ -915,7 +901,7 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     }
   );
 
-  it('uses the parsed-pathname basename for remote filenames (allowlist-transformed)', async () => {
+  it('uses a synthetic filename for remote sources (never derives from URL pathname)', async () => {
     mockRemoteImage();
     uploadFile.mockResolvedValue({
       url: 'https://storage.example/u/file.png',
@@ -923,7 +909,52 @@ describe('prepareOutboundMedia (remote, mocked loader)', () => {
     const { prepareOutboundMedia } = await import('./upload.js');
     await prepareOutboundMedia('https://host/path/file@name.png', {});
     const fileName = uploadFile.mock.calls[0][0].fileName as string;
-    expect(fileName).toBe('file-name.png');
+    expect(fileName).toMatch(/^upload-\d+\.png$/);
     expect(fileName).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+
+  it('never leaks a secret-bearing remote path segment into error text or the uploaded filename', async () => {
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from(validPngBytes(10, 20)),
+      contentType: 'image/png',
+      kind: 'image',
+    });
+    detectMime.mockResolvedValue('image/png');
+    uploadFile.mockRejectedValue(new Error('upload boom'));
+    const { prepareOutboundMedia } = await import('./upload.js');
+    const promise = prepareOutboundMedia(
+      'http://cdn.example/tok-SECRETVALUE.png',
+      {}
+    );
+    await expect(promise).rejects.toThrow(/Failed to upload media/);
+    await expect(promise).rejects.not.toThrow(/SECRETVALUE/);
+    await expect(promise).rejects.not.toThrow(/tok-SECRETVALUE/);
+    await expect(promise).rejects.not.toThrow(/cdn\.example/);
+    for (const call of logSpy.mock.calls) {
+      for (const arg of call) {
+        const s = String(arg);
+        expect(s).not.toContain('SECRETVALUE');
+        expect(s).not.toContain('tok-SECRETVALUE');
+      }
+    }
+  });
+
+  it('uses a synthetic upload filename with no part of the remote path on the upload path', async () => {
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from(validPngBytes(10, 20)),
+      contentType: 'image/png',
+      kind: 'image',
+    });
+    detectMime.mockResolvedValue('image/png');
+    uploadFile.mockResolvedValue({
+      url: 'https://storage.example/u/x.png',
+    });
+    const { prepareOutboundMedia } = await import('./upload.js');
+    await prepareOutboundMedia('https://cdn.example/tok-SECRETVALUE.png', {});
+    const fileName = uploadFile.mock.calls[0][0].fileName as string;
+    expect(fileName).toMatch(/^upload-\d+\.png$/);
+    expect(fileName).not.toContain('SECRETVALUE');
+    expect(fileName).not.toContain('tok');
+    expect(fileName).not.toContain('cdn');
   });
 });

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -316,50 +316,19 @@ export function probeSvgBytes(buffer: Buffer | Uint8Array): SvgProbe {
   return probeSvgRoot(text, truncated);
 }
 
-export function isSvgBytes(buffer: Buffer | Uint8Array): boolean {
-  return probeSvgBytes(buffer) === 'svg';
-}
-
-function cleanFileNameSegment(segment: string): string {
-  return segment
-    .replace(/[^A-Za-z0-9._-]+/g, '-')
-    .replace(/-{2,}/g, '-')
-    .replace(/^[-.]+|[-.]+$/g, '')
-    .slice(0, 100);
-}
-
 /**
- * Sanitize a candidate upload filename to a bounded `[A-Za-z0-9._-]` allowlist
- * and force the canonical extension for `effectiveMime`.
- *
- * `uploadFile` embeds the name verbatim into the storage object key and
- * custom-storage builds the public URL with `new URL(fileKey, publicUrlBase)`,
- * so a name containing `#`, `?`, whitespace, or percent-encoding yields a
- * syntactically valid but wrong URL (the `#…` becomes a fragment) — a fresh
- * false-success path. The canonical extension replaces any mismatched one (an
- * SVG loaded from `diagram.xml` must become `….svg`, not keep `.xml`).
+ * Synthetic upload filename `upload-<timestamp>-<uuid>.<canonical-ext>`. Never
+ * derived from caller/source text: a path or URL segment can carry secrets, and
+ * a `#`/`?`/whitespace in the storage object key would corrupt the public URL
+ * custom-storage builds with `new URL(fileKey, base)`. The extension is canonical
+ * for `effectiveMime`.
  */
-export function safeUploadFileName(
-  name: string,
+export function syntheticUploadFileName(
   effectiveMime: string | undefined
 ): string {
-  const dotIdx = name.lastIndexOf('.');
-  let base = dotIdx > 0 ? name.slice(0, dotIdx) : name;
-  base = cleanFileNameSegment(base);
-  if (!base) {
-    base = `upload-${Date.now()}-${randomUUID()}`;
-  }
+  const base = `upload-${Date.now()}-${randomUUID()}`;
   const canonicalExt = extensionForMime(effectiveMime);
-  if (canonicalExt) {
-    return `${base}.${canonicalExt.replace(/^\./, '')}`;
-  }
-  if (dotIdx > 0) {
-    const ext = cleanFileNameSegment(name.slice(dotIdx + 1));
-    if (ext) {
-      return `${base}.${ext}`;
-    }
-  }
-  return base;
+  return canonicalExt ? `${base}.${canonicalExt.replace(/^\./, '')}` : base;
 }
 
 /**
@@ -619,7 +588,7 @@ export async function prepareOutboundMedia(
   const height = classified.kind === 'image' ? classified.height : 0;
 
   // Synthetic name only: local paths and remote URL components may contain secrets.
-  const fileName = safeUploadFileName('', effectiveMime);
+  const fileName = syntheticUploadFileName(effectiveMime);
 
   let uploadedUrl: string;
   try {

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -1,34 +1,20 @@
 /**
- * Prepare outbound media for a Tlon post.
+ * Load, validate, and upload outbound media for a Tlon post. Only byte-verified
+ * PNG/JPEG/GIF/WebP become inline images; failures that prevent a client-viewable
+ * result throw, so the model sees a failed tool call rather than a false success.
  *
- * Replaces the old `uploadImageFromUrl`, which only understood http(s) URLs and
- * silently returned the input on any failure (so a server-local `/pier/...png`
- * path was posted as an image block clients could never load, while the tool
- * still reported `sent`). This pipeline:
- *
- * - loads remote URLs and workspace-local paths through OpenClaw core's
- *   root-allowlisted, byte-verified loader (`loadWebMedia` +
- *   `buildOutboundMediaLoadOptions`);
- * - classifies the loaded bytes into an inline image (PNG/JPEG/GIF/WebP with
- *   real dimensions and a matching byte sniff) or a link, rejecting malformed,
- *   spoofed, or unrenderable image claims instead of posting them;
- * - uploads to Tlon storage with a sanitized filename and a byte-verified MIME;
- * - throws on any failure that would prevent a client-viewable result, so the
- *   model sees a failed tool call rather than a false success.
- *
- * Security invariants: never log or expose URL credentials or signed-query
- * secrets (`SECURITY.md` — "Never log or expose credentials"); sanitization
- * applies to error text/logs/labels/filenames only, never to the URL that gets
- * posted (stripping `?sig=…` would break signed hotlinks while reporting
- * success).
+ * Security invariant (`SECURITY.md` — "Never log or expose credentials"): never
+ * expose source paths/URLs or raw loader/upload error text in diagnostics (thrown
+ * messages, logs) or in uploaded filenames — a signed query or local path can hide
+ * secrets. The full HTTPS URL is preserved only as data for the hotlink fallback,
+ * never as diagnostic text.
  */
 import { uploadFile } from '@tloncorp/api';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { detectMime, extensionForMime } from 'openclaw/plugin-sdk/media-mime';
-// media-runtime is a deprecated barrel, but it is the ONLY export path for
-// buildOutboundMediaLoadOptions. We use it specifically to preserve core's
-// hostReadCapability byte-verification guard on host reads.
+// Deprecated barrel, but the only export of buildOutboundMediaLoadOptions, which
+// preserves core's host-read byte-verification guard.
 import { buildOutboundMediaLoadOptions } from 'openclaw/plugin-sdk/media-runtime';
 import type { OutboundMediaLoadOptions } from 'openclaw/plugin-sdk/outbound-media';
 import {
@@ -39,17 +25,16 @@ import {
 import { getDefaultSsrFPolicy } from './context.js';
 import { parseRasterHeader } from './image-dimensions.js';
 
-// NOTE: OutboundMediaAccess is NOT exported from the outbound-media subpath at
-// core 2026.5.28 — derive the option types with Pick instead of importing it.
+// OutboundMediaAccess is not exported from this SDK subpath; derive the subset with Pick.
 export type OutboundMediaAccessOpts = Pick<
   OutboundMediaLoadOptions,
   'mediaAccess' | 'mediaLocalRoots' | 'mediaReadFile'
 >;
 
 export type PreparedOutboundMedia = {
-  // Uploaded URL (validated https, no userinfo) — or, on the remote-upload-failure
-  // fallback, the full normalized credential-free ORIGINAL url INCLUDING its query
-  // (signed URLs must remain fetchable; sanitization is for error text/logs only).
+  // Uploaded HTTPS URL, or — on remote-upload-failure fallback — the original
+  // userinfo-free HTTPS URL with its query intact (signed hotlinks must stay
+  // fetchable). Data only: never use it in diagnostics.
   url: string;
   isImage: boolean;
   width: number;
@@ -109,13 +94,10 @@ function normalizeMediaUrl(mediaUrl: string): string {
  * Detect an authority-form URL (`<scheme>://…`) whose scheme is NOT one the
  * pipeline handles (http/https remote, `media://` passthrough, `file://` local).
  *
- * Only the `://` authority form is rejected here. A bare `<word>:<rest>` without
- * `//` — e.g. a workspace-relative filename like `report:2026.png`, or a Windows
- * drive path like `C:\…` / `C:/…` — is an ordinary local path and is left for the
- * root-allowlisted loader to resolve-or-reject against `mediaLocalRoots`. The
- * credential-leak boundary is the output side (fixed category phrases plus the
- * origin+pathname / placeholder source labels), so a non-allowed scheme that
- * lacks the authority form can no longer leak even if it reaches local handling.
+ * Only the `://` authority form is rejected. A bare `<word>:<rest>` without `//`
+ * — a workspace-relative filename like `report:2026.png`, or a Windows drive path
+ * like `C:\…` / `C:/…` — stays a local-path candidate for the root-allowlisted
+ * loader to resolve-or-reject against `mediaLocalRoots`.
  */
 function isDisallowedAuthorityScheme(value: string): boolean {
   const m = /^([A-Za-z][A-Za-z0-9+.-]*):\/\//.exec(value);
@@ -140,9 +122,7 @@ function isDisallowedAuthorityScheme(value: string): boolean {
  * expose) — and compares it against a known allowlist of category tokens. The
  * raw `err.message` is never consulted: it is unbounded free text that may carry
  * credentials or signed-query secrets, so it must never reach an error, log, or
- * filename. This is both actionable (file-not-found vs path-not-allowed vs
- * too-large vs fetch-failed) and airtight (a bounded allowlist of typed
- * discriminator strings mapped to fixed phrases we author).
+ * filename.
  */
 function describeLoadError(err: unknown): string {
   const e = err as { code?: unknown; kind?: unknown; name?: unknown };
@@ -254,6 +234,7 @@ export function probeSvgRoot(text: string, truncated: boolean): SvgProbe {
       let j = i;
       for (; j < n; j += 1) {
         const c = text[j];
+        // A ">" inside a quoted DTD literal does not terminate the DOCTYPE.
         if (c === '"' || c === "'") {
           const quote = c;
           j += 1;
@@ -388,15 +369,16 @@ export function safeUploadFileName(
  *
  * The only formats posted as an inline image block are the four
  * `parseRasterHeader` formats (PNG/JPEG/GIF/WebP — real dimensions + bounded
- * structural header checks + a present, matching byte sniff). Everything else
- * is either rejected with an actionable "convert to PNG/JPEG" error or, for
- * SVG, posted as a link — never as an inline image block.
+ * structural header checks + a present, matching byte sniff). Local SVG and
+ * malformed/unsupported image claims reject with an actionable "convert to
+ * PNG/JPEG" error; remote SVG and non-image media become links.
  */
 export function classifyLoadedMedia(params: {
   buffer: Buffer | Uint8Array;
   loaderMime?: string; // loader-resolved contentType (detectMime byte-sniff precedence already applied by core)
   sniffedMime?: string; // await detectMime({ buffer }) — byte sniff only
   isRemote: boolean;
+  // Fixed diagnostic placeholder only; never source text (see LOCAL/REMOTE_MEDIA_LABEL).
   sourceLabel: string;
 }): ClassifiedMedia {
   const { buffer, loaderMime, sniffedMime, isRemote, sourceLabel } = params;
@@ -436,28 +418,21 @@ export function classifyLoadedMedia(params: {
     }
     return { kind: 'link', effectiveMime: 'image/svg+xml' };
   }
+  // Fail closed for local files: a long valid preamble may still hide an SVG root.
   if (svgProbe === 'incomplete' && !isRemote) {
     throw new Error(
       "SVG files can't be posted as images — convert it to PNG (or upload it and send the URL)"
     );
   }
 
-  // A definitive byte sniff is ground truth about the content, so it is checked
-  // before the loader-resolved content type (which core's detectMime already
-  // gives byte-sniff precedence to, but may still be a generic container type).
-  //
-  // 1. A sniff for a parser-supported format (PNG/JPEG/GIF/WebP) whose header
-  //    did not parse must never fall through — garbage/truncated bytes must not
-  //    post at 0×0.
+  // Byte sniff outranks the loader MIME. A sniffed parser-supported raster whose
+  // header did not parse is malformed — never fall through and post at 0×0.
   if (sniffedCanon && PARSEABLE_MIMES.has(sniffedCanon)) {
     throw new Error(`Media "${sourceLabel}" is not a valid image`);
   }
 
-  // 2. A sniff for any other image format (AVIF/HEIC/HEIF/BMP/ICO …) is a valid
-  //    image we don't inline. This takes precedence over a conflicting
-  //    loader-resolved content type: bytes that definitively sniff as AVIF are
-  //    AVIF even if the loader resolved `image/jpeg`, so the actionable
-  //    convert-hint wins over the generic "not a valid image".
+  // Any other sniffed image format (AVIF/HEIC/BMP/ICO …) is valid but not inlined;
+  // the sniff wins over a conflicting loader MIME so the convert-hint fires.
   if (sniffedCanon?.startsWith('image/')) {
     const fmt = sniffedCanon.slice('image/'.length);
     throw new Error(
@@ -465,9 +440,8 @@ export function classifyLoadedMedia(params: {
     );
   }
 
-  // 3. No definitive sniff: fall back to the loader-resolved content type. A
-  //    loader-resolved parser-supported format whose header did not parse must
-  //    not fall through.
+  // No sniff: fall back to the loader MIME, still rejecting a declared
+  // parser-supported format whose header did not parse.
   if (loaderCanon && PARSEABLE_MIMES.has(loaderCanon)) {
     throw new Error(`Media "${sourceLabel}" is not a valid image`);
   }
@@ -480,23 +454,14 @@ export function classifyLoadedMedia(params: {
 }
 
 /**
- * The local sourceLabel used in error messages is ALWAYS this fixed placeholder
- * — no pattern-matching, no conditional detection. A denylist of suspicious
- * characters can never be airtight (a secret needs no special character to exist
- * inside ordinary-looking path text), so caller/model-controlled local path text
- * never reaches error messages. The decoded local path is still used internally
- * for the SVG check and filesystem reads; this constant only controls what
- * appears in error message text.
+ * Fixed placeholders substituted for the real source in all diagnostics (error
+ * text and logs). The label is ALWAYS one of these constants — never derived
+ * from the path/URL: a denylist can't be airtight (a secret needs no special
+ * character to hide in ordinary-looking path or host text). The real path/URL
+ * stays data-only — used for the SVG check, filesystem reads, fetching, and the
+ * HTTPS hotlink fallback, which does put the original URL in the outbound post.
  */
 const LOCAL_MEDIA_LABEL = '[local media reference]';
-
-/**
- * The remote sourceLabel used in error messages is ALWAYS this fixed placeholder.
- * Hostnames, subdomains, and path segments can themselves carry tokens or secrets,
- * so no part of the URL reaches error text or logs. The full normalized URL is
- * still used internally for fetching and hotlink fallback; this constant only
- * controls what appears in error message text.
- */
 const REMOTE_MEDIA_LABEL = '[remote media reference]';
 
 function isTlonHostingForced(): boolean {
@@ -504,6 +469,7 @@ function isTlonHostingForced(): boolean {
   return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
 }
 
+// Require a directly fetchable HTTPS URL: no userinfo or fragment; queries allowed.
 function isValidUploadedUrl(raw: string): boolean {
   try {
     const u = new URL(raw);
@@ -534,7 +500,8 @@ function bytesToBlobPart(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
  * Apply the upload-failure policy. Remote https sources fall back to hotlinking
  * the full normalized original URL (including its signed query); remote http
  * sources throw (mixed content in the https web client); local sources throw
- * with an actionable message.
+ * with an actionable message. `normalized` may contain signed-query secrets —
+ * return it as fallback data only, never in diagnostic text.
  */
 function handleUploadFailure(params: {
   isRemote: boolean;
@@ -559,23 +526,12 @@ function handleUploadFailure(params: {
 
   if (isRemote) {
     if (/^https:\/\//i.test(normalized)) {
-      // ACCEPTED RESIDUAL (documented, not a bug): if the original https URL
-      // redirects to plain http, the hotlinked https URL may be blocked or
-      // upgraded as mixed content by a secure client. The installed OpenClaw
-      // SDK's WebMediaResult does not expose the final/resolved URL after
-      // redirects (core strips finalUrl before returning), so the plugin cannot
-      // detect the downgrade without an undocumented custom fetchImpl or a
-      // duplicate preflight (TOCTOU) — both disproportionate. The only airtight
-      // fix would be removing remote hotlink fallback entirely, which conflicts
-      // with the deliberately-accepted 'preserve useful web-image sharing'
-      // policy. Revisit if OpenClaw exposes finalUrl or a requireHttps loader
-      // option.
+      // Accepted residual: the loader doesn't expose a redirect's final URL, so
+      // an https source that redirects to http may still fail as a hotlink.
+      // Revisit if WebMediaResult exposes finalUrl or can enforce https.
       //
-      // console.log, not console.warn: warn-level output from this subsystem
-      // does not surface in the harness/CI container logs, which made upload
-      // failures fully silent (source-URL fallback with no visible cause). A
-      // fixed category phrase is logged — the raw upload error is never
-      // interpolated, since it may carry credentials or signed-query secrets.
+      // Use log, not warn: warnings from this subsystem are absent from harness/CI
+      // output. Keep the text fixed — upload errors may contain secrets.
       console.log('[tlon] upload: failed, hotlinking original URL');
       return { url: normalized, isImage, width, height, contentType };
     }
@@ -584,12 +540,8 @@ function handleUploadFailure(params: {
     );
   }
 
-  // The exact-equality check against a known literal thrown by @tloncorp/api's
-  // uploadFile is safe — it compares against a fixed string we author, never
-  // echoing unbounded error text. uploadFile's other failures expose no reliable
-  // bounded discriminator (the HTTP status is interpolated into the free-text
-  // message, with no structured .code/.status field to read), so they keep the
-  // generic 'Media upload failed' phrase rather than a category parsed from text.
+  // Exact-match the one stable uploadFile literal. Its other failures have no
+  // structured discriminator, so never parse or echo their free-text message.
   if (cause === 'No storage credentials configured') {
     throw new Error(
       `Failed to upload local media "${sourceLabel}" to Tlon storage: No storage credentials configured — the ship has no storage configured; configure S3/hosted storage, or pass a public https URL instead.`
@@ -600,23 +552,11 @@ function handleUploadFailure(params: {
   );
 }
 
-/**
- * Load, classify, and upload outbound media, returning a client-viewable result
- * or throwing so the model sees a failed tool call.
- */
 export async function prepareOutboundMedia(
   mediaUrl: string,
   opts: OutboundMediaAccessOpts
 ): Promise<PreparedOutboundMedia> {
   const normalized = normalizeMediaUrl(mediaUrl);
-  // Scheme guard: reject only authority-form URLs (`<scheme>://…`) whose scheme
-  // is not one the pipeline handles (http/https remote, media:// passthrough,
-  // file:// local) — e.g. ftp://, data://, ws://. A bare `<word>:<rest>` without
-  // `//` (a workspace-relative `report:2026.png`, a Windows drive path) is an
-  // ordinary local path and is left for the root-allowlisted loader to
-  // resolve-or-reject; the output-side sanitization is the credential-leak
-  // boundary, so such an input can no longer leak even if it reaches local
-  // handling.
   if (isDisallowedAuthorityScheme(normalized)) {
     throw new Error('Invalid media URL');
   }
@@ -641,11 +581,7 @@ export async function prepareOutboundMedia(
     );
   }
 
-  // sourceLabel is safe by construction: remote sources use the fixed
-  // REMOTE_MEDIA_LABEL placeholder and local sources use the fixed
-  // LOCAL_MEDIA_LABEL placeholder, so caller/model-controlled text never
-  // reaches an error message. The local path is decoded once above for the
-  // SVG check and is not re-decoded here.
+  // Fixed diagnostic placeholder, never caller-controlled source text.
   const sourceLabel = remoteUrl ? REMOTE_MEDIA_LABEL : LOCAL_MEDIA_LABEL;
 
   let media: WebMediaResult;
@@ -660,9 +596,7 @@ export async function prepareOutboundMedia(
       ssrfPolicy: getDefaultSsrFPolicy(),
     });
   } catch (err) {
-    // describeLoadError maps a bounded allowlist of typed discriminator strings
-    // (err.code/kind/name) to fixed phrases — the loader's raw err.message
-    // (unbounded free text, may contain secrets) is never interpolated.
+    // describeLoadError returns a fixed phrase; raw err never interpolated.
     throw new Error(
       `Cannot read media "${sourceLabel}": ${describeLoadError(err)}`
     );
@@ -684,10 +618,7 @@ export async function prepareOutboundMedia(
   const width = classified.kind === 'image' ? classified.width : 0;
   const height = classified.kind === 'image' ? classified.height : 0;
 
-  // Never derive the uploaded filename from caller-controlled text. Both local
-  // and remote sources get a synthetic filename (upload-<timestamp>.<ext>).
-  // Remote URL path segments can carry secrets, so no part of the URL reaches
-  // the storage object key.
+  // Synthetic name only: local paths and remote URL components may contain secrets.
   const fileName = safeUploadFileName('', effectiveMime);
 
   let uploadedUrl: string;
@@ -702,6 +633,7 @@ export async function prepareOutboundMedia(
     });
     uploadedUrl = result.url;
   } catch (err) {
+    // Raw upload text goes only to handleUploadFailure's exact-literal check.
     const cause = err instanceof Error ? err.message : String(err);
     return handleUploadFailure({
       isRemote,

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -105,20 +105,6 @@ function normalizeMediaUrl(mediaUrl: string): string {
 }
 
 /**
- * Source label for remote error messages and logs: `origin + pathname`,
- * dropping userinfo, query, and fragment so signed-query secrets and embedded
- * credentials never reach logs or error text.
- */
-export function sanitizeMediaUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return parsed.origin + parsed.pathname;
-  } catch {
-    return '[unparseable URL]';
-  }
-}
-
-/**
  * Detect an authority-form URL (`<scheme>://…`) whose scheme is NOT one the
  * pipeline handles (http/https remote, `media://` passthrough, `file://` local).
  *
@@ -371,13 +357,13 @@ export function safeUploadFileName(
  */
 export function classifyLoadedMedia(params: {
   buffer: Buffer | Uint8Array;
-  declaredMime?: string; // loader contentType
+  loaderMime?: string; // loader-resolved contentType (detectMime byte-sniff precedence already applied by core)
   sniffedMime?: string; // await detectMime({ buffer }) — byte sniff only
   isRemote: boolean;
   sourceLabel: string;
 }): ClassifiedMedia {
-  const { buffer, declaredMime, sniffedMime, isRemote, sourceLabel } = params;
-  const declaredCanon = canon(declaredMime);
+  const { buffer, loaderMime, sniffedMime, isRemote, sourceLabel } = params;
+  const loaderCanon = canon(loaderMime);
   const sniffedCanon = canon(sniffedMime);
 
   const raster = parseRasterHeader(buffer);
@@ -414,7 +400,8 @@ export function classifyLoadedMedia(params: {
   }
 
   // A definitive byte sniff is ground truth about the content, so it is checked
-  // before the (attacker/server-controllable) declared MIME.
+  // before the loader-resolved content type (which core's detectMime already
+  // gives byte-sniff precedence to, but may still be a generic container type).
   //
   // 1. A sniff for a parser-supported format (PNG/JPEG/GIF/WebP) whose header
   //    did not parse must never fall through — garbage/truncated bytes must not
@@ -424,10 +411,10 @@ export function classifyLoadedMedia(params: {
   }
 
   // 2. A sniff for any other image format (AVIF/HEIC/HEIF/BMP/ICO …) is a valid
-  //    image we don't inline. This takes precedence over a conflicting declared
-  //    MIME: bytes that definitively sniff as AVIF are AVIF even if the response
-  //    header claimed `image/jpeg`, so the actionable convert-hint wins over the
-  //    generic "not a valid image".
+  //    image we don't inline. This takes precedence over a conflicting
+  //    loader-resolved content type: bytes that definitively sniff as AVIF are
+  //    AVIF even if the loader resolved `image/jpeg`, so the actionable
+  //    convert-hint wins over the generic "not a valid image".
   if (sniffedCanon?.startsWith('image/')) {
     const fmt = sniffedCanon.slice('image/'.length);
     throw new Error(
@@ -435,21 +422,18 @@ export function classifyLoadedMedia(params: {
     );
   }
 
-  // 3. No definitive sniff: fall back to the declared MIME. A declared
-  //    parser-supported format whose header did not parse must not fall through.
-  if (declaredCanon && PARSEABLE_MIMES.has(declaredCanon)) {
+  // 3. No definitive sniff: fall back to the loader-resolved content type. A
+  //    loader-resolved parser-supported format whose header did not parse must
+  //    not fall through.
+  if (loaderCanon && PARSEABLE_MIMES.has(loaderCanon)) {
     throw new Error(`Media "${sourceLabel}" is not a valid image`);
   }
 
-  if (declaredCanon?.startsWith('image/')) {
+  if (loaderCanon?.startsWith('image/')) {
     throw new Error(`Media "${sourceLabel}" is not a valid image`);
   }
 
-  return { kind: 'link', effectiveMime: declaredCanon };
-}
-
-function basenameFromRemote(url: URL): string {
-  return url.pathname.split('/').pop() ?? '';
+  return { kind: 'link', effectiveMime: loaderCanon };
 }
 
 /**
@@ -462,6 +446,15 @@ function basenameFromRemote(url: URL): string {
  * appears in error message text.
  */
 const LOCAL_MEDIA_LABEL = '[local media reference]';
+
+/**
+ * The remote sourceLabel used in error messages is ALWAYS this fixed placeholder.
+ * Hostnames, subdomains, and path segments can themselves carry tokens or secrets,
+ * so no part of the URL reaches error text or logs. The full normalized URL is
+ * still used internally for fetching and hotlink fallback; this constant only
+ * controls what appears in error message text.
+ */
+const REMOTE_MEDIA_LABEL = '[remote media reference]';
 
 function isTlonHostingForced(): boolean {
   const raw = (process.env.TLON_HOSTING ?? '').trim().toLowerCase();
@@ -593,14 +586,12 @@ export async function prepareOutboundMedia(
     );
   }
 
-  // sourceLabel is safe by construction: remote sources use the parsed URL's
-  // origin+pathname (userinfo/query/fragment dropped) and local sources use the
-  // fixed LOCAL_MEDIA_LABEL placeholder, so caller/model-controlled path text
-  // never reaches an error message. The local path is decoded once above for the
+  // sourceLabel is safe by construction: remote sources use the fixed
+  // REMOTE_MEDIA_LABEL placeholder and local sources use the fixed
+  // LOCAL_MEDIA_LABEL placeholder, so caller/model-controlled text never
+  // reaches an error message. The local path is decoded once above for the
   // SVG check and is not re-decoded here.
-  const sourceLabel = remoteUrl
-    ? sanitizeMediaUrl(normalized)
-    : LOCAL_MEDIA_LABEL;
+  const sourceLabel = remoteUrl ? REMOTE_MEDIA_LABEL : LOCAL_MEDIA_LABEL;
 
   let media: WebMediaResult;
   try {
@@ -627,7 +618,7 @@ export async function prepareOutboundMedia(
 
   const classified = classifyLoadedMedia({
     buffer,
-    declaredMime: media.contentType,
+    loaderMime: media.contentType,
     sniffedMime,
     isRemote,
     sourceLabel,
@@ -638,14 +629,11 @@ export async function prepareOutboundMedia(
   const width = classified.kind === 'image' ? classified.width : 0;
   const height = classified.kind === 'image' ? classified.height : 0;
 
-  // Never derive the uploaded filename from caller-controlled local path text.
-  // Local and media:// sources always get a synthetic filename
-  // (upload-<timestamp>.<ext>). Remote sources use the basename from the parsed
-  // URL object's .pathname — structurally safe because it's extracted from Node's
-  // URL parser fields, not raw text pattern-matching.
-  const fileName = remoteUrl
-    ? safeUploadFileName(basenameFromRemote(remoteUrl), effectiveMime)
-    : safeUploadFileName('', effectiveMime);
+  // Never derive the uploaded filename from caller-controlled text. Both local
+  // and remote sources get a synthetic filename (upload-<timestamp>.<ext>).
+  // Remote URL path segments can carry secrets, so no part of the URL reaches
+  // the storage object key.
+  const fileName = safeUploadFileName('', effectiveMime);
 
   let uploadedUrl: string;
   try {

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -1,68 +1,695 @@
 /**
- * Upload an image from a URL to Tlon storage.
+ * Prepare outbound media for a Tlon post.
+ *
+ * Replaces the old `uploadImageFromUrl`, which only understood http(s) URLs and
+ * silently returned the input on any failure (so a server-local `/pier/...png`
+ * path was posted as an image block clients could never load, while the tool
+ * still reported `sent`). This pipeline:
+ *
+ * - loads remote URLs and workspace-local paths through OpenClaw core's
+ *   root-allowlisted, byte-verified loader (`loadWebMedia` +
+ *   `buildOutboundMediaLoadOptions`);
+ * - classifies the loaded bytes into an inline image (PNG/JPEG/GIF/WebP with
+ *   real dimensions and a matching byte sniff) or a link, rejecting malformed,
+ *   spoofed, or unrenderable image claims instead of posting them;
+ * - uploads to Tlon storage with a sanitized filename and a byte-verified MIME;
+ * - throws on any failure that would prevent a client-viewable result, so the
+ *   model sees a failed tool call rather than a false success.
+ *
+ * Security invariants: never log or expose URL credentials or signed-query
+ * secrets (`SECURITY.md` — "Never log or expose credentials"); sanitization
+ * applies to error text/logs/labels/filenames only, never to the URL that gets
+ * posted (stripping `?sig=…` would break signed hotlinks while reporting
+ * success).
  */
 import { uploadFile } from '@tloncorp/api';
-import { fetchWithSsrFGuard } from 'openclaw/plugin-sdk/ssrf-runtime';
+import { fileURLToPath } from 'node:url';
+import { detectMime, extensionForMime } from 'openclaw/plugin-sdk/media-mime';
+// media-runtime is a deprecated barrel, but it is the ONLY export path for
+// buildOutboundMediaLoadOptions. We use it specifically to preserve core's
+// hostReadCapability byte-verification guard on host reads.
+import { buildOutboundMediaLoadOptions } from 'openclaw/plugin-sdk/media-runtime';
+import type { OutboundMediaLoadOptions } from 'openclaw/plugin-sdk/outbound-media';
+import {
+  type WebMediaResult,
+  loadWebMedia,
+} from 'openclaw/plugin-sdk/web-media';
 
 import { getDefaultSsrFPolicy } from './context.js';
+import { parseRasterHeader } from './image-dimensions.js';
+
+// NOTE: OutboundMediaAccess is NOT exported from the outbound-media subpath at
+// core 2026.5.28 — derive the option types with Pick instead of importing it.
+export type OutboundMediaAccessOpts = Pick<
+  OutboundMediaLoadOptions,
+  'mediaAccess' | 'mediaLocalRoots' | 'mediaReadFile'
+>;
+
+export type PreparedOutboundMedia = {
+  // Uploaded URL (validated https, no userinfo) — or, on the remote-upload-failure
+  // fallback, the full normalized credential-free ORIGINAL url INCLUDING its query
+  // (signed URLs must remain fetchable; sanitization is for error text/logs only).
+  url: string;
+  isImage: boolean;
+  width: number;
+  height: number;
+  contentType?: string;
+};
+
+type ClassifiedMedia =
+  | { kind: 'image'; width: number; height: number; effectiveMime: string }
+  | { kind: 'link'; effectiveMime?: string };
+
+const PARSEABLE_MIMES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+const MAX_SIDE_PX = 16384;
+const MAX_PIXELS = 50_000_000;
 
 /**
- * Fetch an image from a URL and upload it to Tlon storage.
- * Returns the uploaded URL, or falls back to the original URL on error.
- *
- * Note: configureClient must be called before using this function.
+ * Lowercase a MIME and canonicalize the raster aliases core preserves from
+ * non-canonical response headers (`image/jpg`, `image/pjpeg` → `image/jpeg`;
+ * `image/x-png` → `image/png`).
  */
-export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
-  try {
-    // Validate URL is http/https before fetching
-    const url = new URL(imageUrl);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      console.log(`[tlon] upload: rejected non-http(s) URL: ${imageUrl}`);
-      return imageUrl;
-    }
-
-    // Fetch the image with SSRF protection
-    // Use fetchWithSsrFGuard directly (not urbitFetch) to preserve the full URL path
-    const { response, release } = await fetchWithSsrFGuard({
-      url: imageUrl,
-      init: { method: 'GET' },
-      policy: getDefaultSsrFPolicy(),
-      auditContext: 'tlon-upload-image',
-    });
-
-    try {
-      if (!response.ok) {
-        console.log(
-          `[tlon] upload: failed to fetch image from ${imageUrl}: ${response.status}`
-        );
-        return imageUrl;
-      }
-
-      const contentType = response.headers.get('content-type') || 'image/png';
-      const blob = await response.blob();
-
-      // Extract filename from URL or use a default
-      const urlPath = new URL(imageUrl).pathname;
-      const fileName = urlPath.split('/').pop() || `upload-${Date.now()}.png`;
-
-      // Upload to Tlon storage
-      const result = await uploadFile({
-        blob,
-        fileName,
-        contentType,
-      });
-
-      return result.url;
-    } finally {
-      await release();
-    }
-  } catch (err) {
-    // console.log, not console.warn: warn-level output from this subsystem
-    // does not surface in the harness/CI container logs, which made upload
-    // failures fully silent (source-URL fallback with no visible cause).
-    console.log(
-      `[tlon] upload: failed, using original URL: ${err instanceof Error ? err.stack ?? err.message : String(err)}`
-    );
-    return imageUrl;
+function canon(mime: string | undefined): string | undefined {
+  if (!mime) {
+    return undefined;
   }
+  const m = mime.trim().toLowerCase();
+  if (!m) {
+    return undefined;
+  }
+  if (m === 'image/jpg' || m === 'image/pjpeg') {
+    return 'image/jpeg';
+  }
+  if (m === 'image/x-png') {
+    return 'image/png';
+  }
+  return m;
+}
+
+/**
+ * Strip the agent-tool `MEDIA:` prefix exactly the way core does, then trim.
+ * A `media://` value is a protocol-like reference and is left intact.
+ */
+function normalizeMediaUrl(mediaUrl: string): string {
+  let value = mediaUrl;
+  if (!/^\s*media:\/\//i.test(value)) {
+    value = value.replace(/^\s*MEDIA\s*:\s*/i, '');
+  }
+  return value.trim();
+}
+
+/**
+ * Source label for remote error messages and logs: `origin + pathname`,
+ * dropping userinfo, query, and fragment so signed-query secrets and embedded
+ * credentials never reach logs or error text.
+ */
+export function sanitizeMediaUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin + parsed.pathname;
+  } catch {
+    return '[unparseable URL]';
+  }
+}
+
+/**
+ * Detect an authority-form URL (`<scheme>://…`) whose scheme is NOT one the
+ * pipeline handles (http/https remote, `media://` passthrough, `file://` local).
+ *
+ * Only the `://` authority form is rejected here. A bare `<word>:<rest>` without
+ * `//` — e.g. a workspace-relative filename like `report:2026.png`, or a Windows
+ * drive path like `C:\…` / `C:/…` — is an ordinary local path and is left for the
+ * root-allowlisted loader to resolve-or-reject against `mediaLocalRoots`. The
+ * credential-leak boundary is the output side (fixed category phrases plus the
+ * origin+pathname / placeholder source labels), so a non-allowed scheme that
+ * lacks the authority form can no longer leak even if it reaches local handling.
+ */
+function isDisallowedAuthorityScheme(value: string): boolean {
+  const m = /^([A-Za-z][A-Za-z0-9+.-]*):\/\//.exec(value);
+  if (!m) {
+    return false;
+  }
+  const scheme = m[1].toLowerCase();
+  return (
+    scheme !== 'http' &&
+    scheme !== 'https' &&
+    scheme !== 'media' &&
+    scheme !== 'file'
+  );
+}
+
+/**
+ * Map a loader failure to one of a bounded set of fixed, actionable phrases.
+ *
+ * Reads ONLY a typed discriminator from the caught error — the first non-empty
+ * string among `err.code`, `err.kind`, then `err.name` (the structured fields
+ * OpenClaw core's `LocalMediaAccessError.code` and `MediaFetchError.code`
+ * expose) — and compares it against a known allowlist of category tokens. The
+ * raw `err.message` is never consulted: it is unbounded free text that may carry
+ * credentials or signed-query secrets, so it must never reach an error, log, or
+ * filename. This is both actionable (file-not-found vs path-not-allowed vs
+ * too-large vs fetch-failed) and airtight (a bounded allowlist of typed
+ * discriminator strings mapped to fixed phrases we author).
+ */
+function describeLoadError(err: unknown): string {
+  const e = err as { code?: unknown; kind?: unknown; name?: unknown };
+  let discriminator: string | undefined;
+  for (const candidate of [e?.code, e?.kind, e?.name]) {
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      discriminator = candidate;
+      break;
+    }
+  }
+  switch (discriminator) {
+    case 'not-found':
+      return 'Media file not found';
+    case 'not-file':
+      return 'Media path is not a file';
+    case 'path-not-allowed':
+      // Core emits this both for out-of-root paths and for host-read
+      // byte-type rejections (e.g. plaintext named .png), so the phrase
+      // covers path and file-type disallowance without over-claiming which.
+      return 'Media path or file type is not allowed';
+    case 'invalid-file-url':
+    case 'invalid-path':
+    case 'network-path-not-allowed':
+    case 'unsafe-bypass':
+      return 'Invalid media path';
+    case 'invalid-root':
+      return 'Media access roots are misconfigured';
+    case 'max_bytes':
+      return 'Media file is too large';
+    case 'http_error':
+      return 'Media URL returned an HTTP error';
+    case 'fetch_failed':
+      return 'Failed to fetch media';
+    default:
+      return 'Failed to read media';
+  }
+}
+
+/**
+ * Decode a local reference for path inspection. `file://` URLs are converted
+ * with `fileURLToPath` (which decodes percent-encoding) — core decodes them
+ * before reading, so a raw-string check is bypassed by `file:///ws/image%2Esvg`
+ * otherwise.
+ */
+function decodeLocalPath(normalized: string): string {
+  if (/^file:\/\//i.test(normalized)) {
+    try {
+      return fileURLToPath(normalized);
+    } catch {
+      throw new Error('Invalid media URL');
+    }
+  }
+  return normalized;
+}
+
+function isSvgPath(filePath: string): boolean {
+  return filePath.toLowerCase().endsWith('.svg');
+}
+
+function hasSvgRoot(text: string): boolean {
+  const n = text.length;
+  let i = 0;
+  const skipWs = () => {
+    while (i < n && /\s/.test(text[i])) {
+      i += 1;
+    }
+  };
+  while (i < n) {
+    skipWs();
+    if (i >= n || text[i] !== '<') {
+      return false;
+    }
+    if (text.startsWith('<?', i)) {
+      const end = text.indexOf('?>', i + 2);
+      if (end === -1) {
+        return false;
+      }
+      i = end + 2;
+      continue;
+    }
+    if (text.startsWith('<!--', i)) {
+      const end = text.indexOf('-->', i + 4);
+      if (end === -1) {
+        return false;
+      }
+      i = end + 3;
+      continue;
+    }
+    if (/^<!doctype/i.test(text.slice(i, i + 9))) {
+      let depth = 0;
+      let j = i;
+      for (; j < n; j += 1) {
+        const c = text[j];
+        if (c === '"' || c === "'") {
+          // Skip quoted string content (e.g. a SYSTEM/PUBLIC literal that
+          // contains '>') so a quoted '>' doesn't terminate the DOCTYPE early.
+          const quote = c;
+          j += 1;
+          while (j < n && text[j] !== quote) {
+            j += 1;
+          }
+          // j sits on the closing quote (or n); the loop's j+=1 steps past it.
+        } else if (c === '[') {
+          depth += 1;
+        } else if (c === ']') {
+          depth -= 1;
+        } else if (c === '>' && depth <= 0) {
+          break;
+        }
+      }
+      if (j >= n) {
+        return false;
+      }
+      i = j + 1;
+      continue;
+    }
+    const rest = text.slice(i);
+    if (/^<svg/i.test(rest)) {
+      const after = rest[4];
+      return after === undefined || /[\s/>]/.test(after);
+    }
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Byte-based SVG detection, independent of declared/sniffed MIME. After
+ * stripping a leading UTF-8 / UTF-16LE / UTF-16BE BOM and decoding accordingly
+ * (file-type sniffs BOM-marked UTF-16 XML as `application/xml`), reports
+ * whether the buffer exposes a root `<svg` element within the first few KB
+ * (after an optional XML declaration, comments, PIs, and DOCTYPE). It only
+ * routes SVG to link-vs-reject, so a loose prefix match is sufficient — an SVG
+ * is never inlined, so no well-formedness validation is needed.
+ */
+export function isSvgBytes(buffer: Buffer | Uint8Array): boolean {
+  const bytes = buffer as Uint8Array;
+  let offset = 0;
+  let encoding: 'utf-8' | 'utf-16le' | 'utf-16be' = 'utf-8';
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xef &&
+    bytes[1] === 0xbb &&
+    bytes[2] === 0xbf
+  ) {
+    offset = 3;
+  } else if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    offset = 2;
+    encoding = 'utf-16le';
+  } else if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    offset = 2;
+    encoding = 'utf-16be';
+  }
+  const slice = bytes.subarray(offset, Math.min(bytes.length, offset + 8192));
+  // Node's WHATWG TextDecoder supports the `utf-16be` label directly, so decode
+  // with the detected encoding rather than byte-swapping to LE first.
+  const text = new TextDecoder(encoding).decode(slice);
+  return hasSvgRoot(text);
+}
+
+function cleanFileNameSegment(segment: string): string {
+  return segment
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 100);
+}
+
+/**
+ * Sanitize a candidate upload filename to a bounded `[A-Za-z0-9._-]` allowlist
+ * and force the canonical extension for `effectiveMime`.
+ *
+ * `uploadFile` embeds the name verbatim into the storage object key and
+ * custom-storage builds the public URL with `new URL(fileKey, publicUrlBase)`,
+ * so a name containing `#`, `?`, whitespace, or percent-encoding yields a
+ * syntactically valid but wrong URL (the `#…` becomes a fragment) — a fresh
+ * false-success path. The canonical extension replaces any mismatched one (an
+ * SVG loaded from `diagram.xml` must become `….svg`, not keep `.xml`).
+ */
+export function safeUploadFileName(
+  name: string,
+  effectiveMime: string | undefined
+): string {
+  const dotIdx = name.lastIndexOf('.');
+  let base = dotIdx > 0 ? name.slice(0, dotIdx) : name;
+  base = cleanFileNameSegment(base);
+  if (!base) {
+    base = `upload-${Date.now()}`;
+  }
+  const canonicalExt = extensionForMime(effectiveMime);
+  if (canonicalExt) {
+    return `${base}.${canonicalExt.replace(/^\./, '')}`;
+  }
+  if (dotIdx > 0) {
+    const ext = cleanFileNameSegment(name.slice(dotIdx + 1));
+    if (ext) {
+      return `${base}.${ext}`;
+    }
+  }
+  return base;
+}
+
+/**
+ * Pure classifier deciding whether loaded bytes become an inline image block or
+ * a link, and the authoritative `effectiveMime` to upload/store with. Throws on
+ * malformed, spoofed, or unrenderable image claims and on local SVG.
+ *
+ * The only formats posted as an inline image block are the four
+ * `parseRasterHeader` formats (PNG/JPEG/GIF/WebP — real dimensions + bounded
+ * structural header checks + a present, matching byte sniff). Everything else
+ * is either rejected with an actionable "convert to PNG/JPEG" error or, for
+ * SVG, posted as a link — never as an inline image block.
+ */
+export function classifyLoadedMedia(params: {
+  buffer: Buffer | Uint8Array;
+  declaredMime?: string; // loader contentType
+  sniffedMime?: string; // await detectMime({ buffer }) — byte sniff only
+  isRemote: boolean;
+  sourceLabel: string;
+}): ClassifiedMedia {
+  const { buffer, declaredMime, sniffedMime, isRemote, sourceLabel } = params;
+  const declaredCanon = canon(declaredMime);
+  const sniffedCanon = canon(sniffedMime);
+
+  const raster = parseRasterHeader(buffer);
+  if (raster) {
+    const { format, width, height } = raster;
+    const inBounds =
+      width > 0 &&
+      height > 0 &&
+      width <= MAX_SIDE_PX &&
+      height <= MAX_SIDE_PX &&
+      width * height <= MAX_PIXELS;
+    // A genuine PNG/JPEG/GIF/WebP always sniffs at signature level, so require a
+    // present, matching byte sniff — an absent sniff, a different image type, or
+    // a non-image type rejects crafted magic-only files.
+    const sniffMatches = sniffedCanon === `image/${format}`;
+    if (!inBounds || !sniffMatches) {
+      throw new Error(`Media "${sourceLabel}" is not a valid ${format} image`);
+    }
+    return {
+      kind: 'image',
+      width,
+      height,
+      effectiveMime: `image/${format}`,
+    };
+  }
+
+  if (isSvgBytes(buffer)) {
+    if (!isRemote) {
+      throw new Error(
+        "SVG files can't be posted as images — convert it to PNG (or upload it and send the URL)"
+      );
+    }
+    return { kind: 'link', effectiveMime: 'image/svg+xml' };
+  }
+
+  // A definitive byte sniff is ground truth about the content, so it is checked
+  // before the (attacker/server-controllable) declared MIME.
+  //
+  // 1. A sniff for a parser-supported format (PNG/JPEG/GIF/WebP) whose header
+  //    did not parse must never fall through — garbage/truncated bytes must not
+  //    post at 0×0.
+  if (sniffedCanon && PARSEABLE_MIMES.has(sniffedCanon)) {
+    throw new Error(`Media "${sourceLabel}" is not a valid image`);
+  }
+
+  // 2. A sniff for any other image format (AVIF/HEIC/HEIF/BMP/ICO …) is a valid
+  //    image we don't inline. This takes precedence over a conflicting declared
+  //    MIME: bytes that definitively sniff as AVIF are AVIF even if the response
+  //    header claimed `image/jpeg`, so the actionable convert-hint wins over the
+  //    generic "not a valid image".
+  if (sniffedCanon?.startsWith('image/')) {
+    const fmt = sniffedCanon.slice('image/'.length);
+    throw new Error(
+      `Media "${sourceLabel}" is a ${fmt} image that can't be posted inline — convert it to PNG or JPEG first`
+    );
+  }
+
+  // 3. No definitive sniff: fall back to the declared MIME. A declared
+  //    parser-supported format whose header did not parse must not fall through.
+  if (declaredCanon && PARSEABLE_MIMES.has(declaredCanon)) {
+    throw new Error(`Media "${sourceLabel}" is not a valid image`);
+  }
+
+  if (declaredCanon?.startsWith('image/')) {
+    throw new Error(`Media "${sourceLabel}" is not a valid image`);
+  }
+
+  return { kind: 'link', effectiveMime: declaredCanon };
+}
+
+function basenameFromRemote(url: URL): string {
+  return url.pathname.split('/').pop() ?? '';
+}
+
+/**
+ * The local sourceLabel used in error messages is ALWAYS this fixed placeholder
+ * — no pattern-matching, no conditional detection. A denylist of suspicious
+ * characters can never be airtight (a secret needs no special character to exist
+ * inside ordinary-looking path text), so caller/model-controlled local path text
+ * never reaches error messages. The decoded local path is still used internally
+ * for the SVG check and filesystem reads; this constant only controls what
+ * appears in error message text.
+ */
+const LOCAL_MEDIA_LABEL = '[local media reference]';
+
+function isTlonHostingForced(): boolean {
+  const raw = (process.env.TLON_HOSTING ?? '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function isValidUploadedUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'https:') {
+      return false;
+    }
+    if (u.username || u.password) {
+      return false;
+    }
+    if (u.hash !== '') {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function bytesToBlobPart(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(
+    bytes.buffer as ArrayBuffer,
+    bytes.byteOffset,
+    bytes.byteLength
+  );
+}
+
+/**
+ * Apply the upload-failure policy. Remote https sources fall back to hotlinking
+ * the full normalized original URL (including its signed query); remote http
+ * sources throw (mixed content in the https web client); local sources throw
+ * with an actionable message.
+ */
+function handleUploadFailure(params: {
+  isRemote: boolean;
+  normalized: string;
+  sourceLabel: string;
+  cause: string;
+  isImage: boolean;
+  width: number;
+  height: number;
+  contentType: string | undefined;
+}): PreparedOutboundMedia {
+  const {
+    isRemote,
+    normalized,
+    sourceLabel,
+    cause,
+    isImage,
+    width,
+    height,
+    contentType,
+  } = params;
+
+  if (isRemote) {
+    if (/^https:\/\//i.test(normalized)) {
+      // console.log, not console.warn: warn-level output from this subsystem
+      // does not surface in the harness/CI container logs, which made upload
+      // failures fully silent (source-URL fallback with no visible cause). A
+      // fixed category phrase is logged — the raw upload error is never
+      // interpolated, since it may carry credentials or signed-query secrets.
+      console.log('[tlon] upload: failed, hotlinking original URL');
+      return { url: normalized, isImage, width, height, contentType };
+    }
+    throw new Error(
+      `Failed to upload media "${sourceLabel}": Media upload failed`
+    );
+  }
+
+  // The exact-equality check against a known literal thrown by @tloncorp/api's
+  // uploadFile is safe — it compares against a fixed string we author, never
+  // echoing unbounded error text. uploadFile's other failures expose no reliable
+  // bounded discriminator (the HTTP status is interpolated into the free-text
+  // message, with no structured .code/.status field to read), so they keep the
+  // generic 'Media upload failed' phrase rather than a category parsed from text.
+  if (cause === 'No storage credentials configured') {
+    throw new Error(
+      `Failed to upload local media "${sourceLabel}" to Tlon storage: No storage credentials configured — the ship has no storage configured; configure S3/hosted storage, or pass a public https URL instead.`
+    );
+  }
+  throw new Error(
+    `Failed to upload local media "${sourceLabel}" to Tlon storage: Media upload failed`
+  );
+}
+
+/**
+ * Load, classify, and upload outbound media, returning a client-viewable result
+ * or throwing so the model sees a failed tool call.
+ */
+export async function prepareOutboundMedia(
+  mediaUrl: string,
+  opts: OutboundMediaAccessOpts
+): Promise<PreparedOutboundMedia> {
+  const normalized = normalizeMediaUrl(mediaUrl);
+  // Scheme guard: reject only authority-form URLs (`<scheme>://…`) whose scheme
+  // is not one the pipeline handles (http/https remote, media:// passthrough,
+  // file:// local) — e.g. ftp://, data://, ws://. A bare `<word>:<rest>` without
+  // `//` (a workspace-relative `report:2026.png`, a Windows drive path) is an
+  // ordinary local path and is left for the root-allowlisted loader to
+  // resolve-or-reject; the output-side sanitization is the credential-leak
+  // boundary, so such an input can no longer leak even if it reaches local
+  // handling.
+  if (isDisallowedAuthorityScheme(normalized)) {
+    throw new Error('Invalid media URL');
+  }
+  const isRemoteScheme = /^https?:\/\//i.test(normalized);
+  let remoteUrl: URL | undefined;
+  if (isRemoteScheme) {
+    try {
+      remoteUrl = new URL(normalized);
+    } catch {
+      throw new Error('Invalid media URL');
+    }
+  }
+  const isRemote = remoteUrl !== undefined;
+
+  if (remoteUrl) {
+    if (remoteUrl.username || remoteUrl.password) {
+      throw new Error('Media URLs with embedded credentials are not supported');
+    }
+  } else if (isSvgPath(decodeLocalPath(normalized))) {
+    throw new Error(
+      "SVG files can't be posted as images — convert it to PNG (or upload it and send the URL)"
+    );
+  }
+
+  // sourceLabel is safe by construction: remote sources use the parsed URL's
+  // origin+pathname (userinfo/query/fragment dropped) and local sources use the
+  // fixed LOCAL_MEDIA_LABEL placeholder, so caller/model-controlled path text
+  // never reaches an error message. The local path is decoded once above for the
+  // SVG check and is not re-decoded here.
+  const sourceLabel = remoteUrl
+    ? sanitizeMediaUrl(normalized)
+    : LOCAL_MEDIA_LABEL;
+
+  let media: WebMediaResult;
+  try {
+    media = await loadWebMedia(normalized, {
+      ...buildOutboundMediaLoadOptions({
+        mediaAccess: opts.mediaAccess,
+        mediaLocalRoots: opts.mediaLocalRoots,
+        mediaReadFile: opts.mediaReadFile,
+        optimizeImages: false,
+      }),
+      ssrfPolicy: getDefaultSsrFPolicy(),
+    });
+  } catch (err) {
+    // describeLoadError maps a bounded allowlist of typed discriminator strings
+    // (err.code/kind/name) to fixed phrases — the loader's raw err.message
+    // (unbounded free text, may contain secrets) is never interpolated.
+    throw new Error(
+      `Cannot read media "${sourceLabel}": ${describeLoadError(err)}`
+    );
+  }
+
+  const buffer = media.buffer;
+  const sniffedMime = await detectMime({ buffer });
+
+  const classified = classifyLoadedMedia({
+    buffer,
+    declaredMime: media.contentType,
+    sniffedMime,
+    isRemote,
+    sourceLabel,
+  });
+
+  const isImage = classified.kind === 'image';
+  const effectiveMime = classified.effectiveMime ?? media.contentType;
+  const width = classified.kind === 'image' ? classified.width : 0;
+  const height = classified.kind === 'image' ? classified.height : 0;
+
+  // Never derive the uploaded filename from caller-controlled local path text.
+  // Local and media:// sources always get a synthetic filename
+  // (upload-<timestamp>.<ext>). Remote sources use the basename from the parsed
+  // URL object's .pathname — structurally safe because it's extracted from Node's
+  // URL parser fields, not raw text pattern-matching.
+  const fileName = remoteUrl
+    ? safeUploadFileName(basenameFromRemote(remoteUrl), effectiveMime)
+    : safeUploadFileName('', effectiveMime);
+
+  let uploadedUrl: string;
+  try {
+    const result = await uploadFile({
+      blob: new Blob([bytesToBlobPart(buffer)], { type: effectiveMime }),
+      fileName,
+      contentType: effectiveMime,
+      ...(isTlonHostingForced()
+        ? { hostedDetection: 'assume-hosted' as const }
+        : {}),
+    });
+    uploadedUrl = result.url;
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    return handleUploadFailure({
+      isRemote,
+      normalized,
+      sourceLabel,
+      cause,
+      isImage,
+      width,
+      height,
+      contentType: effectiveMime,
+    });
+  }
+
+  if (!isValidUploadedUrl(uploadedUrl)) {
+    return handleUploadFailure({
+      isRemote,
+      normalized,
+      sourceLabel,
+      cause: 'the storage endpoint returned an unusable URL',
+      isImage,
+      width,
+      height,
+      contentType: effectiveMime,
+    });
+  }
+
+  return {
+    url: uploadedUrl,
+    isImage,
+    width,
+    height,
+    contentType: effectiveMime,
+  };
 }

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -23,6 +23,7 @@
  * success).
  */
 import { uploadFile } from '@tloncorp/api';
+import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { detectMime, extensionForMime } from 'openclaw/plugin-sdk/media-mime';
 // media-runtime is a deprecated barrel, but it is the ONLY export path for
@@ -201,7 +202,22 @@ function isSvgPath(filePath: string): boolean {
   return filePath.toLowerCase().endsWith('.svg');
 }
 
-function hasSvgRoot(text: string): boolean {
+export type SvgProbe = 'svg' | 'non-svg' | 'incomplete';
+
+// Preamble openers valid before an XML root element. When the scan window ends
+// mid-token on a *proper prefix* of one of these, we can't yet decide, so the
+// probe returns 'incomplete' rather than a definitive 'non-svg'. Ordinary
+// XML/text (e.g. "<root") is not a prefix of any opener and stays 'non-svg'.
+const SVG_PREAMBLE_OPENERS = ['<?', '<!--', '<!doctype', '<svg'];
+
+function isTruncatedOpenerPrefix(rest: string): boolean {
+  const r = rest.toLowerCase();
+  return SVG_PREAMBLE_OPENERS.some(
+    (o) => r.length < o.length && o.startsWith(r)
+  );
+}
+
+export function probeSvgRoot(text: string, truncated: boolean): SvgProbe {
   const n = text.length;
   let i = 0;
   const skipWs = () => {
@@ -211,13 +227,16 @@ function hasSvgRoot(text: string): boolean {
   };
   while (i < n) {
     skipWs();
-    if (i >= n || text[i] !== '<') {
-      return false;
+    if (i >= n) {
+      return truncated ? 'incomplete' : 'non-svg';
+    }
+    if (text[i] !== '<') {
+      return 'non-svg';
     }
     if (text.startsWith('<?', i)) {
       const end = text.indexOf('?>', i + 2);
       if (end === -1) {
-        return false;
+        return truncated ? 'incomplete' : 'non-svg';
       }
       i = end + 2;
       continue;
@@ -225,7 +244,7 @@ function hasSvgRoot(text: string): boolean {
     if (text.startsWith('<!--', i)) {
       const end = text.indexOf('-->', i + 4);
       if (end === -1) {
-        return false;
+        return truncated ? 'incomplete' : 'non-svg';
       }
       i = end + 3;
       continue;
@@ -236,14 +255,11 @@ function hasSvgRoot(text: string): boolean {
       for (; j < n; j += 1) {
         const c = text[j];
         if (c === '"' || c === "'") {
-          // Skip quoted string content (e.g. a SYSTEM/PUBLIC literal that
-          // contains '>') so a quoted '>' doesn't terminate the DOCTYPE early.
           const quote = c;
           j += 1;
           while (j < n && text[j] !== quote) {
             j += 1;
           }
-          // j sits on the closing quote (or n); the loop's j+=1 steps past it.
         } else if (c === '[') {
           depth += 1;
         } else if (c === ']') {
@@ -253,7 +269,7 @@ function hasSvgRoot(text: string): boolean {
         }
       }
       if (j >= n) {
-        return false;
+        return truncated ? 'incomplete' : 'non-svg';
       }
       i = j + 1;
       continue;
@@ -261,23 +277,40 @@ function hasSvgRoot(text: string): boolean {
     const rest = text.slice(i);
     if (/^<svg/i.test(rest)) {
       const after = rest[4];
-      return after === undefined || /[\s/>]/.test(after);
+      if (after === undefined) {
+        // Window ended exactly at "<svg" — the name could continue (e.g.
+        // "<svgfoo"), so only treat it as definitive when the whole buffer
+        // ends here; otherwise it is undecided.
+        return truncated ? 'incomplete' : 'svg';
+      }
+      return /[\s/>]/.test(after) ? 'svg' : 'non-svg';
     }
-    return false;
+    if (truncated && isTruncatedOpenerPrefix(rest)) {
+      return 'incomplete';
+    }
+    return 'non-svg';
   }
-  return false;
+  return truncated ? 'incomplete' : 'non-svg';
 }
 
 /**
- * Byte-based SVG detection, independent of declared/sniffed MIME. After
- * stripping a leading UTF-8 / UTF-16LE / UTF-16BE BOM and decoding accordingly
- * (file-type sniffs BOM-marked UTF-16 XML as `application/xml`), reports
- * whether the buffer exposes a root `<svg` element within the first few KB
- * (after an optional XML declaration, comments, PIs, and DOCTYPE). It only
- * routes SVG to link-vs-reject, so a loose prefix match is sufficient — an SVG
- * is never inlined, so no well-formedness validation is needed.
+ * Byte-based SVG probe, independent of declared/sniffed MIME. After stripping a
+ * leading UTF-8 / UTF-16LE / UTF-16BE BOM and decoding accordingly (file-type
+ * sniffs BOM-marked UTF-16 XML as `application/xml`), scans at most 64 KiB of
+ * the buffer for a root `<svg` element (after an optional XML declaration,
+ * comments, PIs, and DOCTYPE). Returns a tri-state:
+ *
+ * - 'svg': a root `<svg` element was found within the window.
+ * - 'non-svg': a definitive non-SVG root element (or non-markup content) was
+ *   reached within the window.
+ * - 'incomplete': the 64 KiB window ended while still consuming otherwise-valid
+ *   preamble (whitespace/comment/PI/DTD) with more buffer bytes remaining — the
+ *   root element was never reached within the scanned window.
+ *
+ * It only routes SVG to link-vs-reject, so a loose prefix match is sufficient —
+ * an SVG is never inlined, so no well-formedness validation is needed.
  */
-export function isSvgBytes(buffer: Buffer | Uint8Array): boolean {
+export function probeSvgBytes(buffer: Buffer | Uint8Array): SvgProbe {
   const bytes = buffer as Uint8Array;
   let offset = 0;
   let encoding: 'utf-8' | 'utf-16le' | 'utf-16be' = 'utf-8';
@@ -295,11 +328,15 @@ export function isSvgBytes(buffer: Buffer | Uint8Array): boolean {
     offset = 2;
     encoding = 'utf-16be';
   }
-  const slice = bytes.subarray(offset, Math.min(bytes.length, offset + 8192));
-  // Node's WHATWG TextDecoder supports the `utf-16be` label directly, so decode
-  // with the detected encoding rather than byte-swapping to LE first.
+  const windowEnd = Math.min(bytes.length, offset + 65536);
+  const truncated = windowEnd < bytes.length;
+  const slice = bytes.subarray(offset, windowEnd);
   const text = new TextDecoder(encoding).decode(slice);
-  return hasSvgRoot(text);
+  return probeSvgRoot(text, truncated);
+}
+
+export function isSvgBytes(buffer: Buffer | Uint8Array): boolean {
+  return probeSvgBytes(buffer) === 'svg';
 }
 
 function cleanFileNameSegment(segment: string): string {
@@ -329,7 +366,7 @@ export function safeUploadFileName(
   let base = dotIdx > 0 ? name.slice(0, dotIdx) : name;
   base = cleanFileNameSegment(base);
   if (!base) {
-    base = `upload-${Date.now()}`;
+    base = `upload-${Date.now()}-${randomUUID()}`;
   }
   const canonicalExt = extensionForMime(effectiveMime);
   if (canonicalExt) {
@@ -390,13 +427,19 @@ export function classifyLoadedMedia(params: {
     };
   }
 
-  if (isSvgBytes(buffer)) {
+  const svgProbe = probeSvgBytes(buffer);
+  if (svgProbe === 'svg') {
     if (!isRemote) {
       throw new Error(
         "SVG files can't be posted as images — convert it to PNG (or upload it and send the URL)"
       );
     }
     return { kind: 'link', effectiveMime: 'image/svg+xml' };
+  }
+  if (svgProbe === 'incomplete' && !isRemote) {
+    throw new Error(
+      "SVG files can't be posted as images — convert it to PNG (or upload it and send the URL)"
+    );
   }
 
   // A definitive byte sniff is ground truth about the content, so it is checked
@@ -516,6 +559,18 @@ function handleUploadFailure(params: {
 
   if (isRemote) {
     if (/^https:\/\//i.test(normalized)) {
+      // ACCEPTED RESIDUAL (documented, not a bug): if the original https URL
+      // redirects to plain http, the hotlinked https URL may be blocked or
+      // upgraded as mixed content by a secure client. The installed OpenClaw
+      // SDK's WebMediaResult does not expose the final/resolved URL after
+      // redirects (core strips finalUrl before returning), so the plugin cannot
+      // detect the downgrade without an undocumented custom fetchImpl or a
+      // duplicate preflight (TOCTOU) — both disproportionate. The only airtight
+      // fix would be removing remote hotlink fallback entirely, which conflicts
+      // with the deliberately-accepted 'preserve useful web-image sharing'
+      // policy. Revisit if OpenClaw exposes finalUrl or a requireHttps loader
+      // option.
+      //
       // console.log, not console.warn: warn-level output from this subsystem
       // does not surface in the harness/CI container logs, which made upload
       // failures fully silent (source-URL fallback with no visible cause). A

--- a/packages/openclaw/test/cases/06-media.test.ts
+++ b/packages/openclaw/test/cases/06-media.test.ts
@@ -211,9 +211,10 @@ describe('media', () => {
 
     console.log(`[TEST] Found image DM with src: ${result.src}`);
 
-    // The image URL must have been rewritten by uploadImageFromUrl.
-    // If upload failed, the function silently returns the original URL,
-    // so equality here means the upload did NOT happen.
+    // The image URL must have been rewritten by prepareOutboundMedia to a fresh
+    // uploaded URL. On remote upload failure it deliberately falls back to
+    // hotlinking the original HTTPS URL, so equality with SOURCE_IMAGE_URL would
+    // mean the upload failed and the hotlink fallback returned the original URL.
     expect(result.src).toBeDefined();
     expect(result.src).not.toBe(SOURCE_IMAGE_URL);
   });


### PR DESCRIPTION
## Summary

Fixes TLON-6199: the OpenClaw Tlon plugin's outbound media handling silently fabricated success. From the field report: a bot generated an image, passed its server-local `/pier/...` path to the message tool, and the adapter logged `Invalid URL` — but still posted the message and reported `deliveryStatus: sent`. The bot then told the user the image was delivered while the user saw a broken block, since the posted image `src` was a path no client can reach.

Root cause: `uploadImageFromUrl` only understood http(s) URLs, and its catch-all returned the _original input string_ on any failure — local path, fetch error, or `No storage credentials configured` alike. `buildMediaStory` then matched the `.png` extension and emitted an image block anyway, and the post itself succeeded, so nothing upstream ever learned the media was broken. The plugin also ignored OpenClaw core's agent media-access machinery, so workspace-local file paths (the natural output of a bot generating an image) couldn't work in the first place, even though they work on other channel plugins.

Now media loads through core's guarded loader and uploads real bytes to Tlon storage; unrecoverable failures surface as a failed send with an actionable error, so the model can recover instead of claiming success (a remote-https upload failure falls back to hotlinking the original URL). Scoped to `packages/openclaw`.

## Why is this diff so large?

A fair question for "fix image upload" — the core fix (load through the guarded loader, fail loudly, classify by bytes) is only a couple hundred lines. The rest breaks down as:

-   **~69% is tests and fixtures.** The parsing and sanitization code here is adversarial-input handling, so it's tested against both real encoder output and deliberately malformed bytes. `test-fixtures.ts` is roughly split between hand-written malformed-container builders (the adversarial cases), a smaller block of base64 from genuine ffmpeg/cwebp-produced files, and comments — data and fixtures to skim, not logic to review.
-   **Error/filename sanitization (~a third of `upload.ts`).** The naive version of this fix leaks secrets: propagating loader errors into thrown messages echoes signed-URL query strings into channel messages, and deriving upload filenames from caller input echoes local paths into storage metadata. Review iterations kept finding new leak paths through raw external text, so the design removes it from all sinks — fixed category messages, fixed labels, synthetic filenames. That costs more lines than pattern-based redaction but is actually closeable.
-   **`image-dimensions.ts` (~540 lines) is a hand-rolled structural validator** for PNG/JPEG/GIF/WebP headers — no decoding, bounded walks only. We deliberately avoided adding an image-parsing dependency in a path that feeds attacker-influenced bytes to storage, and existing header-only libraries (e.g. `image-size`) read the dimension field without requiring the surrounding data/terminators, so they'd re-accept exactly the truncated/malformed bytes this fix rejects. It's a self-contained pure function (`bytes in → dimensions or null`), reviewable in isolation.

The comment layer and some dead generality were trimmed after review (redundant JSDoc, an unused filename sanitizer, a test-only export); the structural validation and the credential-leak boundaries were kept intact.

Suggested review order: `channel.runtime.ts` + `send.ts` (behavior wiring), `upload.ts` (policy), `image-dimensions.ts` (pure parsing), then spot-check tests.

## Changes

-   Replaced `uploadImageFromUrl` with `prepareOutboundMedia` in `src/urbit/upload.ts`: loads media via core's root-allowlisted, SSRF-guarded, byte-verifying `loadWebMedia` (preserving `hostReadCapability`), uploads the bytes, and throws on failure instead of posting a broken image.
-   `sendMedia` (`src/channel.runtime.ts`) now threads core's `mediaAccess` / `mediaLocalRoots` / `mediaReadFile`, so agent-workspace-local file paths work.
-   Added `src/urbit/image-dimensions.ts` (`parseRasterHeader`): structural header validation and real dimensions for PNG/JPEG/GIF/WebP; malformed bytes are rejected rather than posted at 0x0.
-   `classifyLoadedMedia` decides image-vs-link from sniffed bytes (not URL extension): only PNG/JPEG/GIF/WebP post inline; AVIF/HEIC/BMP/ICO and local SVG are rejected with a convert-to-PNG/JPEG error; remote SVG posts as a link; SVG is never inlined.
-   Security: error messages and logs no longer echo URL credentials or signed-query secrets; local source references collapse to a fixed placeholder; uploaded filenames for local sources are synthesized (never derived from caller path text); uploaded URLs are validated as credential-free https with no fragment.
-   `buildMediaStory` (`src/urbit/send.ts`) now takes prepared media and emits real dimensions; removed the extension-based `isImageUrl` from `src/urbit/story.ts`.
-   Updated tool-hint copy in `src/channel.ts` so the model knows the media contract and that failed media now fails the send.

## How did I test?

From `packages/openclaw`: `pnpm test` (1090 passing, 61 files), `pnpm tsc --noEmit` clean, `pnpm lint` 0 errors, `prettier --check` clean on changed files. New unit tests cover `parseRasterHeader`, `classifyLoadedMedia`, `prepareOutboundMedia` (mocked-remote and real-loader local-path via temp-dir fixtures), error-category and credential-safety paths, and `sendMedia` media-access threading. The storage-gated end-to-end image DM case (`test/cases/06-media.test.ts`) exists; the workspace-local variant was left out because there is no harness plumbing to place a file in the gateway agent workspace.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes

Behavior change: sends that previously "succeeded" now fail loudly (unreadable local paths, malformed images, AVIF/HEIC/BMP/ICO, local SVG, non-https/invalid uploaded URLs), and remote SVG now posts as a link instead of an inline image. This is intentional (the point is to stop fabricating success), but operators may see new tool-call failures where bots used to post broken or extension-matched blocks. Loss of AVIF/BMP/ICO inline support is a minor accepted regression.

## Rollback plan

Revert.
