### PR TITLE
logs: modify send-otel thread to use base alloy url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ dump.sqlite3
 clurd
 
 .obsidian
+.pi

--- a/.prettierignore
+++ b/.prettierignore
@@ -39,6 +39,7 @@ dump.sqlite3
 .gitattributes
 clurd
 .obsidian
+.pi
 # From apps/tlon-desktop/.gitignore
 /apps/tlon-desktop/build/
 /apps/tlon-desktop/dist/

--- a/desk/ted/send-otel.hoon
+++ b/desk/ted/send-otel.hoon
@@ -5,6 +5,7 @@
 ::
 =+  retry=3
 =+  retry-delay=~s5
+=+  endpoint='/v1/logs'
 ::
 =>
 |%
@@ -183,7 +184,7 @@
   ==
 =/  =request:http
   :*  %'POST'
-      otel
+      (cat 3 otel endpoint)
       ~['content-type'^'application/json']
       `(as-octs:mimes:html (en:json:html logs))
   ==

--- a/desk/ted/send-otel.hoon
+++ b/desk/ted/send-otel.hoon
@@ -182,9 +182,16 @@
           ==
       ==
   ==
+=/  request-url=@t
+  =/  parsed  (de-purl:html otel)
+  ?.  ?=(^ parsed)
+    otel
+  ?.  ?=(~ q.q.u.parsed)
+    otel
+  (cat 3 otel endpoint)
 =/  =request:http
   :*  %'POST'
-      (cat 3 otel endpoint)
+      request-url
       ~['content-type'^'application/json']
       `(as-octs:mimes:html (en:json:html logs))
   ==

--- a/desk/ted/send-otel.hoon
+++ b/desk/ted/send-otel.hoon
@@ -186,9 +186,14 @@
   =/  parsed  (de-purl:html otel)
   ?.  ?=(^ parsed)
     otel
-  ?.  ?=(~ q.q.u.parsed)
+  =/  purl  u.parsed
+  ::  preserve endpoints whose path list starts with a non-empty segment
+  ?:  ?&  ?=(^ q.q.purl)
+          !=('' i.q.q.purl)
+      ==
     otel
-  (cat 3 otel endpoint)
+  =.  q.purl  (rash endpoint apat:de-purl:html)
+  (crip (en-purl:html purl))
 =/  =request:http
   :*  %'POST'
       request-url


### PR DESCRIPTION
## Summary

In the initial deployment we have used the full alloy url including the endpoint. This has caused some confusion on the hosting side, so we modify `-send-otel` thread to accept base alloy url and append the fixed endpoint by itself.

Note that deploying this will require coordinating with hosting, since all ships will need to be reconfigured. This breaks grafana logging backend until reconfiguration takes place, but it is acceptable given that Posthog remains our default telemetry dashboard for now.

## Changes

1. Assume `otel` url is the bare alloy address.

## How did I test?

Deployed and tested on a hosted moon.

## Risks and impact

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [ ] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert.
