### PR TITLE
openclaw: fail loudly on unusable outbound media

### DIFF
--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tloncorp/openclaw",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "license": "MIT",
   "repository": {

--- a/packages/openclaw/src/channel.runtime.test.ts
+++ b/packages/openclaw/src/channel.runtime.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./urbit/upload.js', () => ({
+  prepareOutboundMedia: vi.fn(),
+}));
+
+vi.mock('./urbit/send.js', () => ({
+  buildMediaStory: vi.fn(() => [{ inline: ['mock'] }]),
+  sendChannelPost: vi.fn(async () => ({
+    channel: 'tlon',
+    messageId: '~zod/123',
+  })),
+  sendDm: vi.fn(async () => ({
+    channel: 'tlon',
+    messageId: '~zod/123',
+    sentAt: 1000,
+  })),
+  sendDmWithStory: vi.fn(async () => ({
+    channel: 'tlon',
+    messageId: '~zod/123',
+    sentAt: 1000,
+  })),
+}));
+
+vi.mock('./urbit/story.js', () => ({
+  markdownToStory: vi.fn(() => [{ inline: ['text'] }]),
+}));
+
+vi.mock('./urbit/api-client.js', () => ({
+  withAuthenticatedTlonApi: vi.fn(async (_opts, fn) => fn()),
+}));
+
+vi.mock('./urbit/auth.js', () => ({
+  authenticate: vi.fn(),
+}));
+
+vi.mock('./urbit/context.js', () => ({
+  ssrfPolicyFromAllowPrivateNetwork: vi.fn(),
+}));
+
+vi.mock('./urbit/fetch.js', () => ({
+  urbitFetch: vi.fn(),
+}));
+
+vi.mock('./targets.js', () => ({
+  formatTargetHint: vi.fn(() => '~ship or chat/~host/name'),
+  normalizeShip: vi.fn((s: string) => s),
+  parseTlonTarget: vi.fn((t: string) => {
+    if (t.startsWith('~')) {
+      return { kind: 'dm', ship: t };
+    }
+    if (t.includes('/')) {
+      return { kind: 'channel', nest: t };
+    }
+    return null;
+  }),
+}));
+
+vi.mock('./types.js', () => ({
+  resolveTlonAccount: vi.fn(() => ({
+    configured: true,
+    ship: '~zod',
+    url: 'http://localhost:8080',
+    code: 'lit',
+    allowPrivateNetwork: false,
+    contextLens: { enabled: false },
+  })),
+}));
+
+vi.mock('./context-lens.js', () => ({
+  getActiveBackgroundContextLens: vi.fn(() => null),
+  getActiveForegroundContextLensForConversation: vi.fn(() => null),
+  recordBackgroundContextLensOutput: vi.fn(),
+}));
+
+vi.mock('./monitor/index.js', () => ({
+  monitorTlonProvider: vi.fn(),
+}));
+
+vi.mock('./setup-surface.js', () => ({
+  tlonSetupWizard: {},
+}));
+
+vi.mock('./urbit/blob.js', () => ({
+  serializeContextLensReferenceBlob: vi.fn(),
+}));
+
+describe('sendMedia', () => {
+  let tlonRuntimeOutbound: typeof import('./channel.runtime.js').tlonRuntimeOutbound;
+  let prepareOutboundMedia: ReturnType<typeof vi.fn>;
+  let sendDm: ReturnType<typeof vi.fn>;
+  let sendDmWithStory: ReturnType<typeof vi.fn>;
+  let sendChannelPost: ReturnType<typeof vi.fn>;
+
+  const baseCtx = {
+    cfg: {} as never,
+    to: '~nec',
+    text: 'hello',
+    mediaUrl: undefined as string | undefined,
+    accountId: null,
+    replyToId: null,
+    threadId: null,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ tlonRuntimeOutbound } = await import('./channel.runtime.js'));
+    ({ prepareOutboundMedia } = await import('./urbit/upload.js'));
+    ({ sendDm, sendDmWithStory, sendChannelPost } = await import(
+      './urbit/send.js'
+    ));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects on local path and does not post', async () => {
+    prepareOutboundMedia.mockRejectedValue(
+      new Error('Local file paths are not supported on this channel')
+    );
+
+    await expect(
+      tlonRuntimeOutbound.sendMedia({
+        ...baseCtx,
+        mediaUrl: '/pier/secret.png',
+      })
+    ).rejects.toThrow('Local file paths are not supported');
+
+    expect(sendDm).not.toHaveBeenCalled();
+    expect(sendDmWithStory).not.toHaveBeenCalled();
+    expect(sendChannelPost).not.toHaveBeenCalled();
+  });
+
+  it('posts exactly once with valid https URL', async () => {
+    prepareOutboundMedia.mockResolvedValue({
+      url: 'https://example.com/img.png',
+      isImage: true,
+    });
+
+    await tlonRuntimeOutbound.sendMedia({
+      ...baseCtx,
+      mediaUrl: 'https://example.com/img.png',
+    });
+
+    expect(sendDmWithStory).toHaveBeenCalledTimes(1);
+    expect(sendChannelPost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openclaw/src/channel.runtime.ts
+++ b/packages/openclaw/src/channel.runtime.ts
@@ -30,7 +30,7 @@ import {
   sendDmWithStory,
 } from './urbit/send.js';
 import { markdownToStory } from './urbit/story.js';
-import { uploadImageFromUrl } from './urbit/upload.js';
+import { prepareOutboundMedia } from './urbit/upload.js';
 
 type ResolvedTlonAccount = ReturnType<typeof resolveTlonAccount>;
 type ConfiguredTlonAccount = ResolvedTlonAccount & {
@@ -270,11 +270,11 @@ export const tlonRuntimeOutbound: Pick<
         allowPrivateNetwork: account.allowPrivateNetwork ?? undefined,
       },
       async () => {
-        const uploadedUrl = mediaUrl
-          ? await uploadImageFromUrl(mediaUrl)
+        const media = mediaUrl
+          ? await prepareOutboundMedia(mediaUrl)
           : undefined;
         const fromShip = normalizeShip(account.ship);
-        const story = buildMediaStory(text, uploadedUrl);
+        const story = buildMediaStory(text, media);
         const replyId = resolveReplyId(replyToId, threadId);
         const botProfile = await getBotProfile(fromShip);
         if (parsed.kind === 'dm') {

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -154,7 +154,11 @@ export const tlonPlugin = createChatChannelPlugin({
           'Tlon gallery channels (heap/~host/name) are for collecting images, links, and media.',
           '- To post to a gallery: use action=send, to=heap/~host/name, message=<text or URL>',
           '- For image posts, include media=<imageUrl> with an optional message=<caption>',
-          '- To react to a gallery comment: use action=react, to=heap/~host/name, messageId=<commentId>, parentId=<postId>, emoji=<emoji>'
+          '- To react to a gallery comment: use action=react, to=heap/~host/name, messageId=<commentId>, parentId=<postId>, emoji=<emoji>',
+          '',
+          'IMPORTANT: media= accepts a public https URL only (normally the URL returned by `tlon upload`).',
+          'Local file paths are NOT accepted on this channel (unlike other channels) — upload the file first, then pass the returned https URL.',
+          'Media that cannot be fetched will fail the send — never claim an image was delivered unless the tool call succeeded.'
         );
 
         const level = account.reactionLevel ?? 'minimal';

--- a/packages/openclaw/src/urbit/send.test.ts
+++ b/packages/openclaw/src/urbit/send.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { dmReactionReplyParentId } from '../monitor/dm-reactions.js';
 
@@ -129,4 +129,50 @@ describe('sendDm', () => {
       );
     }
   );
+});
+
+describe('buildMediaStory', () => {
+  let buildMediaStory: typeof import('./send.js').buildMediaStory;
+
+  beforeEach(async () => {
+    ({ buildMediaStory } = await import('./send.js'));
+  });
+
+  it('produces an image block for isImage: true', () => {
+    const story = buildMediaStory('caption', {
+      url: 'https://example.com/img.png',
+      isImage: true,
+    });
+    const imageVerse = story.find((v) => 'block' in v && 'image' in v.block);
+    expect(imageVerse).toBeDefined();
+    expect(
+      (imageVerse as { block: { image: { src: string } } }).block.image.src
+    ).toBe('https://example.com/img.png');
+  });
+
+  it('produces a link verse for isImage: false', () => {
+    const story = buildMediaStory('caption', {
+      url: 'https://example.com/doc.pdf',
+      isImage: false,
+    });
+    const linkVerse = story.find(
+      (v) =>
+        'inline' in v &&
+        Array.isArray(v.inline) &&
+        v.inline.some((i) => typeof i === 'object' && 'link' in i)
+    );
+    expect(linkVerse).toBeDefined();
+  });
+
+  it('produces text-only story when media is undefined', () => {
+    const story = buildMediaStory('just text', undefined);
+    expect(story.length).toBeGreaterThan(0);
+    const hasImage = story.some((v) => 'block' in v && 'image' in v.block);
+    expect(hasImage).toBe(false);
+  });
+
+  it('returns empty inline for no text and no media', () => {
+    const story = buildMediaStory(undefined, undefined);
+    expect(story).toEqual([{ inline: [''] }]);
+  });
 });

--- a/packages/openclaw/src/urbit/send.ts
+++ b/packages/openclaw/src/urbit/send.ts
@@ -7,12 +7,7 @@ import {
 } from '@tloncorp/api';
 import { da, scot } from '@urbit/aura';
 
-import {
-  type Story,
-  createImageBlock,
-  isImageUrl,
-  markdownToStory,
-} from './story.js';
+import { type Story, createImageBlock, markdownToStory } from './story.js';
 
 // --- Helpers ---
 
@@ -211,27 +206,27 @@ export function buildMediaText(
 }
 
 /**
- * Build a story with text and optional media (image)
+ * Build a story with text and optional media (image or link)
  */
 export function buildMediaStory(
   text: string | undefined,
-  mediaUrl: string | undefined
+  media: { url: string; isImage: boolean } | undefined
 ): Story {
   const story: Story = [];
   const cleanText = text?.trim() ?? '';
-  const cleanUrl = mediaUrl?.trim() ?? '';
 
-  // Add text content if present
   if (cleanText) {
     story.push(...markdownToStory(cleanText));
   }
 
-  // Add image block if URL looks like an image
-  if (cleanUrl && isImageUrl(cleanUrl)) {
-    story.push(createImageBlock(cleanUrl, ''));
-  } else if (cleanUrl) {
-    // For non-image URLs, add as a link
-    story.push({ inline: [{ link: { href: cleanUrl, content: cleanUrl } }] });
+  if (media) {
+    if (media.isImage) {
+      story.push(createImageBlock(media.url, ''));
+    } else {
+      story.push({
+        inline: [{ link: { href: media.url, content: media.url } }],
+      });
+    }
   }
 
   return story.length > 0 ? story : [{ inline: [''] }];

--- a/packages/openclaw/src/urbit/story.ts
+++ b/packages/openclaw/src/urbit/story.ts
@@ -207,14 +207,6 @@ export function createImageBlock(
 }
 
 /**
- * Check if URL looks like an image
- */
-export function isImageUrl(url: string): boolean {
-  const imageExtensions = /\.(jpg|jpeg|png|gif|webp|svg|bmp|ico)(\?.*)?$/i;
-  return imageExtensions.test(url);
-}
-
-/**
  * Process inlines and extract any image markers into blocks
  */
 function processInlinesForImages(inlines: StoryInline[]): {

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -17,6 +17,7 @@ vi.mock('openclaw/plugin-sdk/media-mime', () => ({
 vi.mock('@tloncorp/api', () => ({
   uploadFile: vi.fn(),
   scry: vi.fn(),
+  getCurrentUserIsHosted: vi.fn(() => false),
 }));
 
 vi.mock('./context.js', () => ({
@@ -131,6 +132,7 @@ describe('prepareOutboundMedia', () => {
   let mockNormalizeMimeType: ReturnType<typeof vi.fn>;
   let mockUploadFile: ReturnType<typeof vi.fn>;
   let mockScry: ReturnType<typeof vi.fn>;
+  let mockIsHosted: ReturnType<typeof vi.fn>;
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
@@ -148,6 +150,8 @@ describe('prepareOutboundMedia', () => {
     mockNormalizeMimeType = vi.mocked(mime.normalizeMimeType);
     mockUploadFile = vi.mocked(api.uploadFile);
     mockScry = vi.mocked(api.scry);
+    mockIsHosted = vi.mocked(api.getCurrentUserIsHosted);
+    mockIsHosted.mockReturnValue(false);
 
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     ({ prepareOutboundMedia } = await import('./upload.js'));
@@ -167,6 +171,41 @@ describe('prepareOutboundMedia', () => {
 
   function mockNoStorage() {
     mockScry.mockRejectedValue(new Error('no storage'));
+  }
+
+  /**
+   * A bot moon as actually deployed: reached over localhost/proxy (so not a
+   * hosted node by URL), no credentials, and `service` at its bunted default of
+   * `presigned-url`. `uploadFile` would throw for this ship, so we must not
+   * call it.
+   */
+  function mockMoonShaped() {
+    mockIsHosted.mockReturnValue(false);
+    mockScry.mockImplementation(async ({ path }: { path: string }) => {
+      if (path === '/credentials') {
+        return { 'storage-update': { credentials: {} } };
+      }
+      return {
+        'storage-update': {
+          configuration: { service: 'presigned-url', currentBucket: '' },
+        },
+      };
+    });
+  }
+
+  /** A genuinely hosted ship with no custom S3: `uploadFile` routes to Memex. */
+  function mockHostedPresigned() {
+    mockIsHosted.mockReturnValue(true);
+    mockScry.mockImplementation(async ({ path }: { path: string }) => {
+      if (path === '/credentials') {
+        return { 'storage-update': { credentials: {} } };
+      }
+      return {
+        'storage-update': {
+          configuration: { service: 'presigned-url', currentBucket: '' },
+        },
+      };
+    });
   }
 
   function mockS3Capable() {
@@ -624,6 +663,65 @@ describe('prepareOutboundMedia', () => {
       );
       expect(mockUploadFile).not.toHaveBeenCalled();
       expect(result.url).toBe('https://example.com/image.png');
+    });
+
+    it('moon-shaped (not hosted, default presigned service, no creds) → hotlink, no uploadFile', async () => {
+      mockImageFetch();
+      mockMoonShaped();
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(result.url).toBe('https://example.com/image.png');
+    });
+  });
+
+  describe('hosted ship without custom S3 (uploadFile routes to Memex)', () => {
+    it('uploads rather than hotlinking', async () => {
+      mockImageFetch();
+      mockHostedPresigned();
+      mockUploadFile.mockResolvedValue({
+        url: 'https://memex.tlon.network/hosted.png',
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).toHaveBeenCalledTimes(1);
+      expect(result.url).toBe('https://memex.tlon.network/hosted.png');
+    });
+
+    it('still uploads when hosted with custom S3 but no current bucket', async () => {
+      mockImageFetch();
+      mockIsHosted.mockReturnValue(true);
+      mockScry.mockImplementation(async ({ path }: { path: string }) => {
+        if (path === '/credentials') {
+          return {
+            'storage-update': {
+              credentials: {
+                accessKeyId: 'ak',
+                endpoint: 'https://s3.example.com',
+                secretAccessKey: 'sk',
+              },
+            },
+          };
+        }
+        return {
+          'storage-update': {
+            configuration: { service: 'presigned-url', currentBucket: '' },
+          },
+        };
+      });
+      mockUploadFile.mockResolvedValue({
+        url: 'https://memex.tlon.network/hosted2.png',
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).toHaveBeenCalledTimes(1);
+      expect(result.url).toBe('https://memex.tlon.network/hosted2.png');
     });
   });
 

--- a/packages/openclaw/src/urbit/upload.test.ts
+++ b/packages/openclaw/src/urbit/upload.test.ts
@@ -1,205 +1,776 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock openclaw/plugin-sdk fetchWithSsrFGuard
 vi.mock('openclaw/plugin-sdk/ssrf-runtime', () => ({
   fetchWithSsrFGuard: vi.fn(),
 }));
 
-// Mock @tloncorp/api
-vi.mock('@tloncorp/api', () => ({
-  uploadFile: vi.fn(),
+vi.mock('openclaw/plugin-sdk/response-limit-runtime', () => ({
+  readResponseWithLimit: vi.fn(),
 }));
 
-// Mock context to provide getDefaultSsrFPolicy
+vi.mock('openclaw/plugin-sdk/media-mime', () => ({
+  detectMime: vi.fn(),
+  extensionForMime: vi.fn(),
+  normalizeMimeType: vi.fn(),
+}));
+
+vi.mock('@tloncorp/api', () => ({
+  uploadFile: vi.fn(),
+  scry: vi.fn(),
+}));
+
 vi.mock('./context.js', () => ({
   getDefaultSsrFPolicy: vi.fn(() => ({})),
 }));
 
-describe('uploadImageFromUrl', () => {
-  beforeEach(() => {
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52,
+]);
+const HTML_BYTES = Buffer.from('<html><body>hi</body></html>');
+
+function mockGuardSuccess(buffer: Buffer, contentType?: string) {
+  return {
+    response: {
+      ok: true,
+      headers: new Headers(contentType ? { 'content-type': contentType } : {}),
+    } as unknown as Response,
+    finalUrl: 'https://example.com/image.png',
+    release: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('classifyInput', () => {
+  let classifyInput: typeof import('./upload.js').classifyInput;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
+    ({ classifyInput } = await import('./upload.js'));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('fetches image and calls uploadFile, returns uploaded URL', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
+  const localForms = [
+    '/pier/foo.png',
+    '///pier/foo.png',
+    './x.png',
+    '../x.png',
+    '.\\x.png',
+    '..\\x.png',
+    '~/x.png',
+    'C:\\x.png',
+    'C:/x.png',
+    'C:foo.png',
+    '\\foo.png',
+    '\\\\srv\\share\\x.png',
+    'file:///pier/foo.png',
+    'x:opaque',
+  ];
 
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
+  it.each(localForms)('classifies %s as local', (input) => {
+    expect(classifyInput(input)).toEqual({ kind: 'local' });
+  });
 
-    // Mock fetchWithSsrFGuard to return a successful response with a blob
-    const mockBlob = new Blob(['fake-image'], { type: 'image/png' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/image.png',
-      release: vi.fn().mockResolvedValue(undefined),
+  it('classifies http:// as http', () => {
+    expect(classifyInput('http://host/x.png')).toEqual({ kind: 'http' });
+  });
+
+  it('classifies userinfo URLs', () => {
+    expect(classifyInput('https://user:pw@host/x')).toEqual({
+      kind: 'userinfo',
     });
+    expect(classifyInput('https://@host/x')).toEqual({ kind: 'userinfo' });
+  });
 
-    // Mock uploadFile to return a successful upload
-    mockUploadFile.mockResolvedValue({
-      url: 'https://memex.tlon.network/uploaded.png',
+  it('does NOT classify backslash-path as userinfo', () => {
+    const result = classifyInput('https://host\\path@name.png');
+    expect(result.kind).toBe('https');
+    if (result.kind === 'https') {
+      expect(result.canonical).toBe('https://host/path@name.png');
+    }
+  });
+
+  const invalidForms = [
+    'ftp://host/x',
+    'data:text/plain,hi',
+    'https:foo',
+    'https:///foo',
+    '//host/path',
+    'image.png',
+    'dir/image.png',
+    'garbage',
+  ];
+
+  it.each(invalidForms)('classifies %s as invalid', (input) => {
+    expect(classifyInput(input)).toEqual({ kind: 'invalid' });
+  });
+
+  it('classifies valid https and returns canonical', () => {
+    const result = classifyInput('HTTPS://host/x.png');
+    expect(result).toEqual({ kind: 'https', canonical: 'https://host/x.png' });
+  });
+
+  it('normalizes MEDIA: prefix', () => {
+    const result = classifyInput('MEDIA: https://host/x.png');
+    expect(result).toEqual({ kind: 'https', canonical: 'https://host/x.png' });
+  });
+
+  it('does not strip media:// prefix', () => {
+    expect(classifyInput('media://host/x.png')).toEqual({ kind: 'invalid' });
+  });
+});
+
+describe('prepareOutboundMedia', () => {
+  let prepareOutboundMedia: typeof import('./upload.js').prepareOutboundMedia;
+  let mockFetchGuard: ReturnType<typeof vi.fn>;
+  let mockReadLimit: ReturnType<typeof vi.fn>;
+  let mockDetectMime: ReturnType<typeof vi.fn>;
+  let mockExtensionForMime: ReturnType<typeof vi.fn>;
+  let mockNormalizeMimeType: ReturnType<typeof vi.fn>;
+  let mockUploadFile: ReturnType<typeof vi.fn>;
+  let mockScry: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const ssrf = await import('openclaw/plugin-sdk/ssrf-runtime');
+    const rlimit = await import('openclaw/plugin-sdk/response-limit-runtime');
+    const mime = await import('openclaw/plugin-sdk/media-mime');
+    const api = await import('@tloncorp/api');
+
+    mockFetchGuard = vi.mocked(ssrf.fetchWithSsrFGuard);
+    mockReadLimit = vi.mocked(rlimit.readResponseWithLimit);
+    mockDetectMime = vi.mocked(mime.detectMime);
+    mockExtensionForMime = vi.mocked(mime.extensionForMime);
+    mockNormalizeMimeType = vi.mocked(mime.normalizeMimeType);
+    mockUploadFile = vi.mocked(api.uploadFile);
+    mockScry = vi.mocked(api.scry);
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    ({ prepareOutboundMedia } = await import('./upload.js'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockImageFetch(buffer = PNG_BYTES, contentType = 'image/png') {
+    mockFetchGuard.mockResolvedValue(mockGuardSuccess(buffer, contentType));
+    mockReadLimit.mockResolvedValue(buffer);
+    mockDetectMime.mockResolvedValue('image/png');
+    mockExtensionForMime.mockReturnValue('.png');
+    mockNormalizeMimeType.mockReturnValue('image/png');
+  }
+
+  function mockNoStorage() {
+    mockScry.mockRejectedValue(new Error('no storage'));
+  }
+
+  function mockS3Capable() {
+    mockScry.mockImplementation(async ({ path }: { path: string }) => {
+      if (path === '/credentials') {
+        return {
+          'storage-update': {
+            credentials: {
+              accessKeyId: 'ak',
+              endpoint: 'https://s3.example.com',
+              secretAccessKey: 'sk',
+            },
+          },
+        };
+      }
+      return {
+        'storage-update': {
+          configuration: { currentBucket: 'my-bucket' },
+        },
+      };
     });
+  }
 
-    const { uploadImageFromUrl } = await import('./upload.js');
-    const result = await uploadImageFromUrl('https://example.com/image.png');
+  describe('local path rejection (no fetch attempted)', () => {
+    const localForms = [
+      '/pier/foo.png',
+      '///pier/foo.png',
+      './x.png',
+      '../x.png',
+      '.\\x.png',
+      '..\\x.png',
+      '~/x.png',
+      'C:\\x.png',
+      'C:/x.png',
+      'C:foo.png',
+      '\\foo.png',
+      '\\\\srv\\share\\x.png',
+      'file:///pier/foo.png',
+      'x:opaque',
+    ];
 
-    expect(result).toBe('https://memex.tlon.network/uploaded.png');
-    expect(mockUploadFile).toHaveBeenCalledTimes(1);
-    expect(mockUploadFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        blob: mockBlob,
-        contentType: 'image/png',
-      })
+    it.each(localForms)(
+      'throws LOCAL_MEDIA_ERROR for %s without fetching',
+      async (input) => {
+        await expect(prepareOutboundMedia(input)).rejects.toThrow(
+          "Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>` using your owner ship's credentials), then resend with the returned https URL."
+        );
+        expect(mockFetchGuard).not.toHaveBeenCalled();
+      }
     );
   });
 
-  it('returns original URL if fetch fails', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
-
-    // Mock fetchWithSsrFGuard to return a failed response
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: false,
-        status: 404,
-      } as unknown as Response,
-      finalUrl: 'https://example.com/image.png',
-      release: vi.fn().mockResolvedValue(undefined),
+  describe('http rejection', () => {
+    it('throws https-only error', async () => {
+      await expect(prepareOutboundMedia('http://host/x.png')).rejects.toThrow(
+        'Only https media URLs are supported.'
+      );
+      expect(mockFetchGuard).not.toHaveBeenCalled();
     });
-
-    const { uploadImageFromUrl } = await import('./upload.js');
-    const result = await uploadImageFromUrl('https://example.com/image.png');
-
-    expect(result).toBe('https://example.com/image.png');
   });
 
-  it('returns original URL if upload fails', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
-
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
-
-    // Mock fetchWithSsrFGuard to return a successful response
-    const mockBlob = new Blob(['fake-image'], { type: 'image/png' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/image.png',
-      release: vi.fn().mockResolvedValue(undefined),
+  describe('userinfo rejection', () => {
+    it('throws for user:pw@host', async () => {
+      await expect(
+        prepareOutboundMedia('https://user:pw@host/x')
+      ).rejects.toThrow(
+        'Media URLs with embedded credentials are not supported.'
+      );
+      expect(mockFetchGuard).not.toHaveBeenCalled();
     });
 
-    // Mock uploadFile to throw an error
-    mockUploadFile.mockRejectedValue(new Error('Upload failed'));
-
-    const { uploadImageFromUrl } = await import('./upload.js');
-    const result = await uploadImageFromUrl('https://example.com/image.png');
-
-    expect(result).toBe('https://example.com/image.png');
+    it('throws for empty userinfo @host', async () => {
+      await expect(prepareOutboundMedia('https://@host/x')).rejects.toThrow(
+        'Media URLs with embedded credentials are not supported.'
+      );
+      expect(mockFetchGuard).not.toHaveBeenCalled();
+    });
   });
 
-  it('rejects non-http(s) URLs', async () => {
-    const { uploadImageFromUrl } = await import('./upload.js');
+  describe('invalid input rejection', () => {
+    const invalidForms = [
+      'ftp://host/x',
+      'data:text/plain,hi',
+      'https:foo',
+      'https:///foo',
+      '//host/path',
+      'image.png',
+      'dir/image.png',
+      'garbage',
+    ];
 
-    // file:// URL should be rejected
-    const result = await uploadImageFromUrl('file:///etc/passwd');
-    expect(result).toBe('file:///etc/passwd');
-
-    // ftp:// URL should be rejected
-    const result2 = await uploadImageFromUrl('ftp://example.com/image.png');
-    expect(result2).toBe('ftp://example.com/image.png');
+    it.each(invalidForms)('throws INVALID for %s', async (input) => {
+      await expect(prepareOutboundMedia(input)).rejects.toThrow(
+        'Invalid media URL — pass a public https URL. If this is a local file, upload it first (e.g. `tlon upload <path>`) and resend with the returned https URL.'
+      );
+      expect(mockFetchGuard).not.toHaveBeenCalled();
+    });
   });
 
-  it('handles invalid URLs gracefully', async () => {
-    const { uploadImageFromUrl } = await import('./upload.js');
+  describe('leak safety', () => {
+    it('thrown messages never contain the input string', async () => {
+      const secret = 'X-Goog-Signature=abc123secret';
+      const input = `/pier/secret-${secret}.png`;
+      try {
+        await prepareOutboundMedia(input);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect((err as Error).message).not.toContain(secret);
+        expect((err as Error).message).not.toContain(input);
+      }
+      const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(logOutput).not.toContain(secret);
+    });
 
-    // Invalid URL should return original
-    const result = await uploadImageFromUrl('not-a-valid-url');
-    expect(result).toBe('not-a-valid-url');
+    it('fetch failure does not leak raw error text', async () => {
+      const secretMsg = 'ECONNREFUSED 10.0.0.1:443 secret-token-xyz';
+      mockFetchGuard.mockRejectedValue(new Error(secretMsg));
+      try {
+        await prepareOutboundMedia('https://host/x.png');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect((err as Error).message).toBe(
+          'Could not fetch media from the provided URL.'
+        );
+        expect((err as Error).message).not.toContain(secretMsg);
+        expect((err as Error).message).not.toContain('secret-token-xyz');
+      }
+      const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(logOutput).not.toContain(secretMsg);
+    });
+
+    it('signed-query URL input not leaked in diagnostics', async () => {
+      const secret = 'X-Goog-Signature=deadbeef';
+      mockFetchGuard.mockRejectedValue(new Error('network failure'));
+      try {
+        await prepareOutboundMedia(`https://host/x.png?${secret}`);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect((err as Error).message).not.toContain(secret);
+      }
+      const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(logOutput).not.toContain(secret);
+    });
+
+    it('signed-query URL not leaked through successful fetch + upload rejection', async () => {
+      const secret = 'SECRETSIG123';
+      const url = `https://host/x.png?X-Goog-Signature=${secret}`;
+      mockImageFetch();
+      mockS3Capable();
+      mockUploadFile.mockRejectedValue(new Error('upload exploded'));
+
+      const result = await prepareOutboundMedia(url);
+      expect(result.url).toBe('https://host/x.png?X-Goog-Signature=' + secret);
+
+      const allLogArgs = logSpy.mock.calls.flat().join(' ');
+      expect(allLogArgs).not.toContain(secret);
+    });
+
+    it('signed-query URL not leaked through successful fetch + non-postable result', async () => {
+      const secret = 'SECRETSIG123';
+      const url = `https://host/x.png?X-Goog-Signature=${secret}`;
+      mockImageFetch();
+      mockS3Capable();
+      mockUploadFile.mockResolvedValue({ url: 'http://bad.example.com/f.png' });
+
+      const result = await prepareOutboundMedia(url);
+      expect(result.url).toBe('https://host/x.png?X-Goog-Signature=' + secret);
+
+      const allLogArgs = logSpy.mock.calls.flat().join(' ');
+      expect(allLogArgs).not.toContain(secret);
+    });
   });
 
-  it('extracts filename from URL path', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
+  describe('guard invocation', () => {
+    it('passes requireHttps: true and the 30s timeout signal', async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+      mockImageFetch();
+      mockNoStorage();
+      await prepareOutboundMedia('https://example.com/image.png');
 
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
+      expect(timeoutSpy).toHaveBeenCalledWith(30000);
+      expect(mockFetchGuard).toHaveBeenCalledWith(
+        expect.objectContaining({ requireHttps: true })
+      );
+      const deadlineSignal = timeoutSpy.mock.results[0]?.value as AbortSignal;
+      const guardArg = mockFetchGuard.mock.calls[0][0] as {
+        signal?: AbortSignal;
+      };
+      expect(guardArg.signal).toBe(deadlineSignal);
+    });
+  });
 
-    const mockBlob = new Blob(['fake-image'], { type: 'image/jpeg' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/jpeg' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/path/to/my-image.jpg',
-      release: vi.fn().mockResolvedValue(undefined),
+  describe('fetch failures', () => {
+    it('non-2xx throws fixed phrase', async () => {
+      mockFetchGuard.mockResolvedValue({
+        response: { ok: false, status: 404, headers: new Headers() },
+        finalUrl: 'https://example.com/x.png',
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+      await expect(
+        prepareOutboundMedia('https://example.com/x.png')
+      ).rejects.toThrow('Could not fetch media from the provided URL.');
     });
 
-    mockUploadFile.mockResolvedValue({
-      url: 'https://memex.tlon.network/uploaded.jpg',
+    it('finalUrl http:// throws fixed phrase', async () => {
+      mockFetchGuard.mockResolvedValue({
+        response: { ok: true, headers: new Headers() },
+        finalUrl: 'http://example.com/x.png',
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+      await expect(
+        prepareOutboundMedia('https://example.com/x.png')
+      ).rejects.toThrow('Could not fetch media from the provided URL.');
     });
 
-    const { uploadImageFromUrl } = await import('./upload.js');
-    await uploadImageFromUrl('https://example.com/path/to/my-image.jpg');
+    it('byte-cap overflow throws fixed phrase', async () => {
+      const guard = mockGuardSuccess(PNG_BYTES);
+      mockFetchGuard.mockResolvedValue(guard);
+      mockReadLimit.mockRejectedValue(new Error('overflow 999 MiB'));
+      await expect(
+        prepareOutboundMedia('https://example.com/x.png')
+      ).rejects.toThrow('Could not fetch media from the provided URL.');
+      expect(mockReadLimit).toHaveBeenCalledWith(
+        guard.response,
+        10 * 1024 * 1024
+      );
+    });
 
-    expect(mockUploadFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fileName: 'my-image.jpg',
-      })
+    it('release() called on every path after guard resolves', async () => {
+      const release = vi.fn().mockResolvedValue(undefined);
+      mockFetchGuard.mockResolvedValue({
+        response: { ok: false, status: 500, headers: new Headers() },
+        finalUrl: 'https://example.com/x.png',
+        release,
+      });
+      await expect(
+        prepareOutboundMedia('https://example.com/x.png')
+      ).rejects.toThrow();
+      expect(release).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejecting release() is remapped to fixed phrase, secret suppressed', async () => {
+      const secret = 'boom-SECRET-cleanup-9821';
+      mockFetchGuard.mockResolvedValue({
+        response: {
+          ok: true,
+          headers: new Headers({ 'content-type': 'image/png' }),
+        },
+        finalUrl: 'https://example.com/x.png',
+        release: vi.fn().mockRejectedValue(new Error(secret)),
+      });
+      mockReadLimit.mockResolvedValue(PNG_BYTES);
+      try {
+        await prepareOutboundMedia('https://example.com/x.png');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect((err as Error).message).toBe(
+          'Could not fetch media from the provided URL.'
+        );
+        expect((err as Error).message).not.toContain(secret);
+      }
+    });
+  });
+
+  describe('uppercase scheme happy path', () => {
+    it('HTTPS:// classifies, fetches, and passes finalUrl check', async () => {
+      mockFetchGuard.mockResolvedValue({
+        response: {
+          ok: true,
+          headers: new Headers({ 'content-type': 'image/png' }),
+        },
+        finalUrl: 'HTTPS://example.com/x.png',
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+      mockReadLimit.mockResolvedValue(PNG_BYTES);
+      mockDetectMime.mockResolvedValue('image/png');
+      mockNormalizeMimeType.mockReturnValue('image/png');
+      mockNoStorage();
+
+      const result = await prepareOutboundMedia('HTTPS://example.com/x.png');
+      expect(result.isImage).toBe(true);
+      expect(result.url).toBe('https://example.com/x.png');
+    });
+  });
+
+  describe('backslash URL canonical posting', () => {
+    it('posts canonical form, not raw backslash spelling', async () => {
+      mockFetchGuard.mockResolvedValue({
+        response: {
+          ok: true,
+          headers: new Headers({ 'content-type': 'image/png' }),
+        },
+        finalUrl: 'https://host/path@name.png',
+        release: vi.fn().mockResolvedValue(undefined),
+      });
+      mockReadLimit.mockResolvedValue(PNG_BYTES);
+      mockDetectMime.mockResolvedValue('image/png');
+      mockNormalizeMimeType.mockReturnValue('image/png');
+      mockNoStorage();
+
+      const result = await prepareOutboundMedia('https://host\\path@name.png');
+      expect(result.url).toBe('https://host/path@name.png');
+    });
+  });
+
+  describe('S3-capable upload', () => {
+    it('uploads and returns uploaded URL with correct filename', async () => {
+      mockImageFetch();
+      mockS3Capable();
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example.com/uploaded.png',
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(result.url).toBe('https://storage.example.com/uploaded.png');
+      expect(result.isImage).toBe(true);
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/^upload-\d+-[0-9a-f-]{36}\.png$/),
+        })
+      );
+
+      const uploadArg = mockUploadFile.mock.calls[0][0];
+      const uploadedBytes = new Uint8Array(await uploadArg.blob.arrayBuffer());
+      expect(uploadedBytes).toEqual(new Uint8Array(PNG_BYTES));
+      expect(uploadArg.blob.type).toBe('image/png');
+      expect(uploadArg.contentType).toBe('image/png');
+    });
+  });
+
+  describe('filename edge cases', () => {
+    it('sniffed PNG gets .png extension', async () => {
+      mockImageFetch();
+      mockS3Capable();
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example.com/f.png',
+      });
+      await prepareOutboundMedia('https://example.com/image.png');
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.png$/),
+        })
+      );
+    });
+
+    it('SVG header fallback with sniff-undefined gets .svg and isImage', async () => {
+      mockFetchGuard.mockResolvedValue(
+        mockGuardSuccess(
+          Buffer.from('<svg></svg>'),
+          'image/svg+xml; charset=utf-8'
+        )
+      );
+      mockReadLimit.mockResolvedValue(Buffer.from('<svg></svg>'));
+      mockDetectMime.mockResolvedValue(undefined);
+      mockNormalizeMimeType.mockReturnValue('image/svg+xml');
+      mockExtensionForMime.mockReturnValue('.svg');
+      mockS3Capable();
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example.com/f.svg',
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.svg'
+      );
+      expect(result.isImage).toBe(true);
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.svg$/),
+        })
+      );
+    });
+
+    it('unknown MIME gets .bin extension', async () => {
+      mockFetchGuard.mockResolvedValue(
+        mockGuardSuccess(Buffer.from('xyz'), 'application/x-custom')
+      );
+      mockReadLimit.mockResolvedValue(Buffer.from('xyz'));
+      mockDetectMime.mockResolvedValue(undefined);
+      mockNormalizeMimeType.mockReturnValue('application/x-custom');
+      mockExtensionForMime.mockReturnValue(undefined);
+      mockS3Capable();
+      mockUploadFile.mockResolvedValue({
+        url: 'https://storage.example.com/f.bin',
+      });
+
+      await prepareOutboundMedia('https://example.com/file.xyz');
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: expect.stringMatching(/\.bin$/),
+        })
+      );
+    });
+  });
+
+  describe('production-shaped (TLON_HOSTING without S3 creds)', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('does not call uploadFile, hotlinks', async () => {
+      vi.stubEnv('TLON_HOSTING', 'true');
+      mockImageFetch();
+      mockScry.mockImplementation(async ({ path }: { path: string }) => {
+        if (path === '/credentials') {
+          return {
+            'storage-update': {
+              credentials: {
+                accessKeyId: '',
+                endpoint: '',
+                secretAccessKey: '',
+              },
+            },
+          };
+        }
+        return {
+          'storage-update': {
+            configuration: { currentBucket: '' },
+          },
+        };
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(result.url).toBe('https://example.com/image.png');
+    });
+  });
+
+  describe('no storage', () => {
+    it('scry empty → hotlink, no uploadFile', async () => {
+      mockImageFetch();
+      mockScry.mockResolvedValue({
+        'storage-update': {
+          credentials: {},
+          configuration: {},
+        },
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(result.url).toBe('https://example.com/image.png');
+    });
+
+    it('scry throws → hotlink, does not fail send', async () => {
+      mockImageFetch();
+      mockScry.mockRejectedValue(new Error('scry failed'));
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(result.url).toBe('https://example.com/image.png');
+    });
+  });
+
+  describe('partial config (creds but no bucket)', () => {
+    it('does not call uploadFile, hotlinks', async () => {
+      mockImageFetch();
+      mockScry.mockImplementation(async ({ path }: { path: string }) => {
+        if (path === '/credentials') {
+          return {
+            'storage-update': {
+              credentials: {
+                accessKeyId: 'ak',
+                endpoint: 'https://s3.example.com',
+                secretAccessKey: 'sk',
+              },
+            },
+          };
+        }
+        return {
+          'storage-update': {
+            configuration: { currentBucket: '' },
+          },
+        };
+      });
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(mockUploadFile).not.toHaveBeenCalled();
+      expect(result.url).toBe('https://example.com/image.png');
+    });
+  });
+
+  describe('upload failure fallback', () => {
+    it('upload throws → hotlink + fixed-phrase log', async () => {
+      mockImageFetch();
+      mockS3Capable();
+      mockUploadFile.mockRejectedValue(
+        new Error('No storage credentials configured')
+      );
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(result.url).toBe('https://example.com/image.png');
+      const logOutput = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(logOutput).toContain('[tlon] media: upload failed');
+      expect(logOutput).not.toContain('No storage credentials configured');
+    });
+  });
+
+  describe('strictPostableUrl fallback cases', () => {
+    const nonPostableReturns = [
+      'http://storage.example.com/f.png',
+      'https://user:pw@storage.example.com/f.png',
+      'https:foo',
+      'https:///foo',
+      'https://@host/f.png',
+      'MEDIA: https://storage.example.com/f.png',
+      ' https://storage.example.com/f.png',
+      'https://storage.example.com/f.png ',
+      '\thttps://storage.example.com/f.png',
+      'https://storage.example.com/f.png\t',
+      '\nhttps://storage.example.com/f.png',
+      'https://storage.example.com/f.png\n',
+    ];
+
+    it.each(nonPostableReturns)(
+      'uploadFile returning %j → hotlink fallback',
+      async (badUrl) => {
+        mockImageFetch();
+        mockS3Capable();
+        mockUploadFile.mockResolvedValue({ url: badUrl });
+
+        const result = await prepareOutboundMedia(
+          'https://example.com/image.png'
+        );
+        expect(result.url).toBe('https://example.com/image.png');
+      }
     );
   });
 
-  it('uses default filename when URL has no path', async () => {
-    const { fetchWithSsrFGuard } = await import(
-      'openclaw/plugin-sdk/ssrf-runtime'
-    );
-    const mockFetch = vi.mocked(fetchWithSsrFGuard);
+  describe('image vs link classification', () => {
+    it('HTML bytes at .png URL → isImage false (link)', async () => {
+      mockFetchGuard.mockResolvedValue(
+        mockGuardSuccess(HTML_BYTES, 'text/html')
+      );
+      mockReadLimit.mockResolvedValue(HTML_BYTES);
+      mockDetectMime.mockResolvedValue('text/html');
+      mockNormalizeMimeType.mockReturnValue('text/html');
+      mockNoStorage();
 
-    const { uploadFile } = await import('@tloncorp/api');
-    const mockUploadFile = vi.mocked(uploadFile);
-
-    const mockBlob = new Blob(['fake-image'], { type: 'image/png' });
-    mockFetch.mockResolvedValue({
-      response: {
-        ok: true,
-        headers: new Headers({ 'content-type': 'image/png' }),
-        blob: () => Promise.resolve(mockBlob),
-      } as unknown as Response,
-      finalUrl: 'https://example.com/',
-      release: vi.fn().mockResolvedValue(undefined),
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(result.isImage).toBe(false);
+      expect(mockDetectMime).toHaveBeenCalledWith({ buffer: HTML_BYTES });
+      expect(mockNormalizeMimeType).toHaveBeenCalledWith('text/html');
     });
 
-    mockUploadFile.mockResolvedValue({
-      url: 'https://memex.tlon.network/uploaded.png',
+    it('HTML bytes with header image/png → link (sniff undefined, header fallback is svg-only)', async () => {
+      mockFetchGuard.mockResolvedValue(
+        mockGuardSuccess(HTML_BYTES, 'image/png')
+      );
+      mockReadLimit.mockResolvedValue(HTML_BYTES);
+      mockDetectMime.mockResolvedValue(undefined);
+      mockNormalizeMimeType.mockReturnValue('image/png');
+      mockNoStorage();
+
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(result.isImage).toBe(false);
+      expect(mockDetectMime).toHaveBeenCalledWith({ buffer: HTML_BYTES });
+      expect(mockNormalizeMimeType).toHaveBeenCalledWith('image/png');
     });
 
-    const { uploadImageFromUrl } = await import('./upload.js');
-    await uploadImageFromUrl('https://example.com/');
+    it('real PNG bytes + wrong header → image (sniff wins)', async () => {
+      mockFetchGuard.mockResolvedValue(
+        mockGuardSuccess(PNG_BYTES, 'text/html')
+      );
+      mockReadLimit.mockResolvedValue(PNG_BYTES);
+      mockDetectMime.mockResolvedValue('image/png');
+      mockNormalizeMimeType.mockReturnValue('text/html');
+      mockNoStorage();
 
-    expect(mockUploadFile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fileName: expect.stringMatching(/^upload-\d+\.png$/),
-      })
-    );
+      const result = await prepareOutboundMedia(
+        'https://example.com/image.png'
+      );
+      expect(result.isImage).toBe(true);
+      expect(mockDetectMime).toHaveBeenCalledWith({ buffer: PNG_BYTES });
+      expect(mockNormalizeMimeType).toHaveBeenCalledWith('text/html');
+    });
+  });
+
+  describe('MEDIA: prefix normalization', () => {
+    it('MEDIA: https://… proceeds normally', async () => {
+      mockImageFetch();
+      mockNoStorage();
+
+      const result = await prepareOutboundMedia(
+        'MEDIA: https://example.com/image.png'
+      );
+      expect(result.url).toBe('https://example.com/image.png');
+      expect(mockFetchGuard).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.com/image.png' })
+      );
+    });
   });
 });

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -1,68 +1,237 @@
-/**
- * Upload an image from a URL to Tlon storage.
- */
-import { uploadFile } from '@tloncorp/api';
+import { scry, uploadFile } from '@tloncorp/api';
+import crypto from 'node:crypto';
+import {
+  detectMime,
+  extensionForMime,
+  normalizeMimeType,
+} from 'openclaw/plugin-sdk/media-mime';
+import { readResponseWithLimit } from 'openclaw/plugin-sdk/response-limit-runtime';
 import { fetchWithSsrFGuard } from 'openclaw/plugin-sdk/ssrf-runtime';
 
 import { getDefaultSsrFPolicy } from './context.js';
 
-/**
- * Fetch an image from a URL and upload it to Tlon storage.
- * Returns the uploaded URL, or falls back to the original URL on error.
- *
- * Note: configureClient must be called before using this function.
- */
-export async function uploadImageFromUrl(imageUrl: string): Promise<string> {
-  try {
-    // Validate URL is http/https before fetching
-    const url = new URL(imageUrl);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      console.log(`[tlon] upload: rejected non-http(s) URL: ${imageUrl}`);
-      return imageUrl;
-    }
+const MAX_MEDIA_BYTES = 10 * 1024 * 1024;
+const FETCH_DEADLINE_MS = 30_000;
 
-    // Fetch the image with SSRF protection
-    // Use fetchWithSsrFGuard directly (not urbitFetch) to preserve the full URL path
-    const { response, release } = await fetchWithSsrFGuard({
-      url: imageUrl,
+const LOCAL_MEDIA_ERROR =
+  "Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>` using your owner ship's credentials), then resend with the returned https URL.";
+const HTTPS_ONLY_ERROR = 'Only https media URLs are supported.';
+const USERINFO_ERROR =
+  'Media URLs with embedded credentials are not supported.';
+const INVALID_MEDIA_ERROR =
+  'Invalid media URL — pass a public https URL. If this is a local file, upload it first (e.g. `tlon upload <path>`) and resend with the returned https URL.';
+const FETCH_FAILED_ERROR = 'Could not fetch media from the provided URL.';
+
+export type ClassifiedInput =
+  | { kind: 'https'; canonical: string }
+  | { kind: 'local' }
+  | { kind: 'http' }
+  | { kind: 'userinfo' }
+  | { kind: 'invalid' };
+
+export function classifyInput(raw: string): ClassifiedInput {
+  const value = normalizeMediaUrl(raw);
+
+  if (
+    /^[A-Za-z]:/.test(value) ||
+    value.startsWith('\\') ||
+    /^\.\.?[\\/]/.test(value) ||
+    value.startsWith('~') ||
+    (/^\//.test(value) && !value.startsWith('//')) ||
+    /^\/{3,}/.test(value)
+  ) {
+    return { kind: 'local' };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return { kind: 'invalid' };
+  }
+
+  if (parsed.protocol === 'file:') {
+    return { kind: 'local' };
+  }
+
+  if (parsed.protocol === 'http:') {
+    return { kind: 'http' };
+  }
+
+  if (parsed.protocol === 'https:') {
+    if (!/^https:\/\/[^/\\]/i.test(value)) {
+      return { kind: 'invalid' };
+    }
+    if (
+      parsed.username ||
+      parsed.password ||
+      /^https:\/\/[^/?#\\]*@/i.test(value)
+    ) {
+      return { kind: 'userinfo' };
+    }
+    return { kind: 'https', canonical: parsed.href };
+  }
+
+  return { kind: 'invalid' };
+}
+
+function normalizeMediaUrl(raw: string): string {
+  let value = raw.trim();
+  if (!/^\s*media:\/\//i.test(value)) {
+    value = value.replace(/^\s*MEDIA\s*:\s*/i, '');
+  }
+  return value;
+}
+
+function strictPostableUrl(u: string): string | null {
+  if (u !== u.trim()) {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(u);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:') {
+    return null;
+  }
+  if (!/^https:\/\/[^/\\]/i.test(u)) {
+    return null;
+  }
+  if (parsed.username || parsed.password || /^https:\/\/[^/?#\\]*@/i.test(u)) {
+    return null;
+  }
+  return parsed.href;
+}
+
+async function shipHasCompleteS3Config(): Promise<boolean> {
+  try {
+    const [rawCreds, rawConfig] = await Promise.all([
+      scry<{
+        'storage-update': {
+          credentials: {
+            accessKeyId?: string;
+            endpoint?: string;
+            secretAccessKey?: string;
+          };
+        };
+      }>({ app: 'storage', path: '/credentials' }),
+      scry<{
+        'storage-update': {
+          configuration: { currentBucket?: string };
+        };
+      }>({ app: 'storage', path: '/configuration' }),
+    ]);
+    const creds = rawCreds['storage-update'].credentials;
+    const config = rawConfig['storage-update'].configuration;
+    return Boolean(
+      creds.accessKeyId &&
+        creds.endpoint &&
+        creds.secretAccessKey &&
+        config.currentBucket
+    );
+  } catch {
+    return false;
+  }
+}
+
+function syntheticUploadFileName(mime: string): string {
+  const ext = extensionForMime(mime) ?? '.bin';
+  return `upload-${Date.now()}-${crypto.randomUUID()}${ext}`;
+}
+
+export async function prepareOutboundMedia(
+  mediaUrl: string
+): Promise<{ url: string; isImage: boolean }> {
+  const classified = classifyInput(mediaUrl);
+
+  switch (classified.kind) {
+    case 'local':
+      throw new Error(LOCAL_MEDIA_ERROR);
+    case 'http':
+      throw new Error(HTTPS_ONLY_ERROR);
+    case 'userinfo':
+      throw new Error(USERINFO_ERROR);
+    case 'invalid':
+      throw new Error(INVALID_MEDIA_ERROR);
+    case 'https':
+      break;
+  }
+
+  const canonical = classified.canonical;
+
+  let response: Response;
+  let finalUrl: string;
+  let release: () => Promise<void>;
+  try {
+    ({ response, finalUrl, release } = await fetchWithSsrFGuard({
+      url: canonical,
       init: { method: 'GET' },
       policy: getDefaultSsrFPolicy(),
-      auditContext: 'tlon-upload-image',
-    });
+      auditContext: 'tlon-media',
+      requireHttps: true,
+      signal: AbortSignal.timeout(FETCH_DEADLINE_MS),
+    }));
+  } catch {
+    throw new Error(FETCH_FAILED_ERROR);
+  }
 
+  let buffer: Buffer;
+  try {
     try {
       if (!response.ok) {
-        console.log(
-          `[tlon] upload: failed to fetch image from ${imageUrl}: ${response.status}`
-        );
-        return imageUrl;
+        throw new Error(FETCH_FAILED_ERROR);
       }
-
-      const contentType = response.headers.get('content-type') || 'image/png';
-      const blob = await response.blob();
-
-      // Extract filename from URL or use a default
-      const urlPath = new URL(imageUrl).pathname;
-      const fileName = urlPath.split('/').pop() || `upload-${Date.now()}.png`;
-
-      // Upload to Tlon storage
-      const result = await uploadFile({
-        blob,
-        fileName,
-        contentType,
-      });
-
-      return result.url;
+      if (new URL(finalUrl).protocol !== 'https:') {
+        throw new Error(FETCH_FAILED_ERROR);
+      }
+      buffer = await readResponseWithLimit(response, MAX_MEDIA_BYTES);
     } finally {
+      // Cleanup runs inside the outer try so a rejecting release() is remapped
+      // to the fixed phrase too, instead of surfacing its own message.
       await release();
     }
-  } catch (err) {
-    // console.log, not console.warn: warn-level output from this subsystem
-    // does not surface in the harness/CI container logs, which made upload
-    // failures fully silent (source-URL fallback with no visible cause).
-    console.log(
-      `[tlon] upload: failed, using original URL: ${err instanceof Error ? err.stack ?? err.message : String(err)}`
-    );
-    return imageUrl;
+  } catch {
+    throw new Error(FETCH_FAILED_ERROR);
+  }
+
+  const sniffedMime = await detectMime({ buffer });
+  const headerMime = normalizeMimeType(response.headers.get('content-type'));
+  const effectiveMime = sniffedMime ?? headerMime ?? 'application/octet-stream';
+
+  let isImage: boolean;
+  if (sniffedMime) {
+    isImage = sniffedMime.startsWith('image/');
+  } else if (headerMime === 'image/svg+xml') {
+    isImage = true;
+  } else {
+    isImage = false;
+  }
+
+  const capable = await shipHasCompleteS3Config();
+  if (!capable) {
+    return { url: canonical, isImage };
+  }
+
+  try {
+    const ab = new ArrayBuffer(buffer.byteLength);
+    new Uint8Array(ab).set(buffer);
+    const blob = new Blob([ab], { type: effectiveMime });
+    const fileName = syntheticUploadFileName(effectiveMime);
+    const result = await uploadFile({
+      blob,
+      fileName,
+      contentType: effectiveMime,
+    });
+    const postable = strictPostableUrl(result.url);
+    if (postable) {
+      return { url: postable, isImage };
+    }
+    console.log('[tlon] media: upload result not postable, using source URL');
+    return { url: canonical, isImage };
+  } catch {
+    console.log('[tlon] media: upload failed, using source URL');
+    return { url: canonical, isImage };
   }
 }

--- a/packages/openclaw/src/urbit/upload.ts
+++ b/packages/openclaw/src/urbit/upload.ts
@@ -1,4 +1,4 @@
-import { scry, uploadFile } from '@tloncorp/api';
+import { getCurrentUserIsHosted, scry, uploadFile } from '@tloncorp/api';
 import crypto from 'node:crypto';
 import {
   detectMime,
@@ -105,7 +105,21 @@ function strictPostableUrl(u: string): string | null {
   return parsed.href;
 }
 
-async function shipHasCompleteS3Config(): Promise<boolean> {
+/**
+ * Whether `uploadFile` could actually store bytes for this ship.
+ *
+ * Mirrors `uploadFile`'s own backend routing (`@tloncorp/api`
+ * `storageApi.ts`) rather than assuming one backend: it picks Memex when the
+ * client is a hosted node and either the service is `presigned-url` or custom
+ * S3 credentials are absent; otherwise it needs custom S3 credentials, plus a
+ * current bucket for the S3 operation itself.
+ *
+ * The point of checking first is bot moons: they are reached over
+ * localhost/proxy (so they are not hosted nodes by URL) and carry no storage
+ * config, so calling `uploadFile` would fail on every single send. Skipping the
+ * call keeps that path quiet. Genuinely hosted ships still reach Memex.
+ */
+async function shipCanStoreUploads(): Promise<boolean> {
   try {
     const [rawCreds, rawConfig] = await Promise.all([
       scry<{
@@ -119,18 +133,35 @@ async function shipHasCompleteS3Config(): Promise<boolean> {
       }>({ app: 'storage', path: '/credentials' }),
       scry<{
         'storage-update': {
-          configuration: { currentBucket?: string };
+          configuration: { currentBucket?: string; service?: string };
         };
       }>({ app: 'storage', path: '/configuration' }),
     ]);
     const creds = rawCreds['storage-update'].credentials;
     const config = rawConfig['storage-update'].configuration;
-    return Boolean(
-      creds.accessKeyId &&
-        creds.endpoint &&
-        creds.secretAccessKey &&
-        config.currentBucket
+
+    const hasCustomS3 = Boolean(
+      creds.accessKeyId && creds.endpoint && creds.secretAccessKey
     );
+
+    // A fresh ship bunts `service` to %presigned-url, so this arm turns on
+    // only for clients whose URL is a hosted node.
+    if (
+      isHostedClient() &&
+      (config.service === 'presigned-url' || !hasCustomS3)
+    ) {
+      return true;
+    }
+
+    return hasCustomS3 && Boolean(config.currentBucket);
+  } catch {
+    return false;
+  }
+}
+
+function isHostedClient(): boolean {
+  try {
+    return getCurrentUserIsHosted();
   } catch {
     return false;
   }
@@ -209,7 +240,7 @@ export async function prepareOutboundMedia(
     isImage = false;
   }
 
-  const capable = await shipHasCompleteS3Config();
+  const capable = await shipCanStoreUploads();
   if (!capable) {
     return { url: canonical, isImage };
   }

--- a/packages/openclaw/test/cases/06-media.test.ts
+++ b/packages/openclaw/test/cases/06-media.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
 import { type TestFixtures, getFixtures, waitFor } from '../lib/index.js';
 import {
+  extractPostText,
   getLatestSequenceForAuthor,
   isPostNewerThanSequence,
 } from '../lib/post-baseline.js';
@@ -9,6 +10,9 @@ import { fakeModel } from '../support/fake-model/client.js';
 
 const SOURCE_IMAGE_URL =
   'https://storage.googleapis.com/tlon-test-ci-shared/test-images/openclaw-image.png';
+
+const LOCAL_MEDIA_ERROR_TEXT =
+  "Local file paths are not supported on this channel — upload the file first (e.g. `tlon upload <path>` using your owner ship's credentials), then resend with the returned https URL.";
 
 // Poke mark verified against fakezod — see plan §1b.
 // JSON keys must be kebab-case (storage-json/hoon), not camelCase.
@@ -211,10 +215,83 @@ describe('media', () => {
 
     console.log(`[TEST] Found image DM with src: ${result.src}`);
 
-    // The image URL must have been rewritten by uploadImageFromUrl.
-    // If upload failed, the function silently returns the original URL,
+    // The image URL must have been rewritten by uploadFile.
+    // If upload failed, the function falls back to the canonical source URL,
     // so equality here means the upload did NOT happen.
     expect(result.src).toBeDefined();
     expect(result.src).not.toBe(SOURCE_IMAGE_URL);
+  });
+
+  test('local path fails loudly and posts nothing (storage-independent)', async () => {
+    const token = `it-localmedia-${Date.now().toString(36)}`;
+    const key = 'media-local-path-reject';
+    const localPath = `/pier/secret-${token}.png`;
+
+    const baselineSequence = await getLatestSequenceForAuthor(
+      fixtures.userState,
+      fixtures.botShip,
+      fixtures.botShip,
+      30
+    );
+
+    await fakeModel.script(
+      key,
+      [
+        {
+          kind: 'tool_call',
+          name: 'message',
+          args: {
+            action: 'send',
+            target: fixtures.userShip,
+            message: token,
+            media: localPath,
+          },
+        },
+        { kind: 'text', content: 'Done.' },
+      ],
+      { allowExtraCalls: 2 }
+    );
+
+    const response = await fixtures.client.prompt(
+      `[tlon-test:${key}] Send an image (media=${localPath}) with text "${token}".`
+    );
+
+    if (!response.success) {
+      throw new Error(response.error ?? 'Prompt failed');
+    }
+
+    // ── Assert (a): follow-up model request carries the failed tool-result ──
+    const calls = await fakeModel.received(key);
+    const followUpWithToolResult = calls.find((call) =>
+      call.messages?.some(
+        (msg) =>
+          msg.role === 'tool' &&
+          msg.content?.text?.includes(LOCAL_MEDIA_ERROR_TEXT)
+      )
+    );
+    expect(followUpWithToolResult).toBeDefined();
+
+    // ── Assert (b): no new bot post carries the token in text OR images ──
+    const posts = await fixtures.userState.channelPosts(fixtures.botShip, 30);
+    const leakedPost = (posts ?? []).find((post) => {
+      const p = post as {
+        authorId?: string;
+        sequenceNum?: number | null;
+        textContent?: string | null;
+        content?: unknown;
+        images?: Array<{ src?: string | null }>;
+      };
+      if (p.authorId !== fixtures.botShip) {
+        return false;
+      }
+      if (!isPostNewerThanSequence(p, baselineSequence)) {
+        return false;
+      }
+      if (extractPostText(p).includes(token)) {
+        return true;
+      }
+      return p.images?.some((img) => img.src?.includes(token)) ?? false;
+    });
+    expect(leakedPost).toBeUndefined();
   });
 });

--- a/packages/openclaw/test/cases/06-media.test.ts
+++ b/packages/openclaw/test/cases/06-media.test.ts
@@ -271,27 +271,48 @@ describe('media', () => {
     );
     expect(followUpWithToolResult).toBeDefined();
 
-    // ── Assert (b): no new bot post carries the token in text OR images ──
+    // ── Assert (b): the media was never delivered, and the plugin posted
+    // nothing of its own.
+    //
+    // OpenClaw core renders a failed tool call back into the conversation
+    // ("⚠️ ✉️ Message: <media> failed" — its `message` display config lists
+    // `media` among the detail keys), so a post mentioning the path is expected
+    // and outside this plugin's control. What must NOT happen is the media
+    // being delivered as an image block, or the plugin posting the caption on
+    // its own before rethrowing.
+    const isCoreFailureNotice = (text: string) =>
+      /^\s*⚠️/.test(text) && /failed/i.test(text);
+
     const posts = await fixtures.userState.channelPosts(fixtures.botShip, 30);
-    const leakedPost = (posts ?? []).find((post) => {
-      const p = post as {
-        authorId?: string;
-        sequenceNum?: number | null;
-        textContent?: string | null;
-        content?: unknown;
-        images?: Array<{ src?: string | null }>;
-      };
-      if (p.authorId !== fixtures.botShip) {
-        return false;
-      }
-      if (!isPostNewerThanSequence(p, baselineSequence)) {
-        return false;
-      }
-      if (extractPostText(p).includes(token)) {
-        return true;
-      }
-      return p.images?.some((img) => img.src?.includes(token)) ?? false;
+    const newBotPosts = (posts ?? [])
+      .map(
+        (post) =>
+          post as {
+            authorId?: string;
+            sequenceNum?: number | null;
+            textContent?: string | null;
+            content?: unknown;
+            images?: Array<{ src?: string | null }>;
+          }
+      )
+      .filter(
+        (p) =>
+          p.authorId === fixtures.botShip &&
+          isPostNewerThanSequence(p, baselineSequence)
+      );
+
+    // No image block anywhere carries the token — the media never landed.
+    const deliveredImage = newBotPosts.find(
+      (p) => p.images?.some((img) => img.src?.includes(token)) ?? false
+    );
+    expect(deliveredImage).toBeUndefined();
+
+    // No post other than core's failure notice mentions the token — the plugin
+    // did not post the caption as a side effect.
+    const pluginPost = newBotPosts.find((p) => {
+      const text = extractPostText(p);
+      return text.includes(token) && !isCoreFailureNotice(text);
     });
-    expect(leakedPost).toBeUndefined();
+    expect(pluginPost).toBeUndefined();
   });
 });

--- a/packages/openclaw/test/support/fake-model/server.mjs
+++ b/packages/openclaw/test/support/fake-model/server.mjs
@@ -16,6 +16,7 @@ console.log(
 );
 
 const TLON_TEST_KEY_RE = /\[tlon-test:([a-zA-Z0-9_.:-]+)\]/g;
+const MAX_SUMMARY_TEXT_LENGTH = 300;
 
 /**
  * Registered scripts: key -> array of steps.
@@ -193,6 +194,7 @@ const server = http.createServer(async (req, res) => {
         stream: body.stream === true,
         messageCount: messages.length,
         userText,
+        messages: summarizeRequestMessages(messages),
         epoch,
         registeredEpoch,
         stale,
@@ -544,4 +546,80 @@ async function readJson(req) {
   }
   const raw = Buffer.concat(chunks).toString('utf8');
   return raw ? JSON.parse(raw) : {};
+}
+
+function summarizeRequestMessages(messages) {
+  return messages.map((message) => {
+    const summary = {
+      role: typeof message?.role === 'string' ? message.role : '<unknown>',
+    };
+    const contentSummary = summarizeContent(message?.content);
+    if (contentSummary) {
+      summary.content = contentSummary;
+    }
+    const toolCalls = summarizeToolCalls(message?.tool_calls);
+    if (toolCalls.length > 0) {
+      summary.tool_calls = toolCalls;
+    }
+    if (typeof message?.tool_call_id === 'string') {
+      summary.tool_call_id = message.tool_call_id;
+    }
+    if (typeof message?.name === 'string') {
+      summary.name = message.name;
+    }
+    return summary;
+  });
+}
+
+function summarizeContent(content) {
+  if (content == null) {
+    return { kind: 'empty' };
+  }
+  if (typeof content === 'string') {
+    return { kind: 'text', text: sanitizePreview(content) };
+  }
+  if (Array.isArray(content)) {
+    return {
+      kind: 'parts',
+      partCount: content.length,
+      text: sanitizePreview(extractText(content)),
+    };
+  }
+  if (typeof content === 'object') {
+    return { kind: 'object', text: sanitizePreview(extractText(content)) };
+  }
+  return { kind: typeof content };
+}
+
+function summarizeToolCalls(toolCalls) {
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+  return toolCalls
+    .filter((toolCall) => toolCall && typeof toolCall === 'object')
+    .map((toolCall) => ({
+      id: typeof toolCall.id === 'string' ? toolCall.id : undefined,
+      type: typeof toolCall.type === 'string' ? toolCall.type : undefined,
+      function: {
+        name:
+          typeof toolCall.function?.name === 'string'
+            ? toolCall.function.name
+            : undefined,
+        arguments:
+          typeof toolCall.function?.arguments === 'string'
+            ? sanitizePreview(toolCall.function.arguments)
+            : undefined,
+      },
+    }));
+}
+
+function sanitizePreview(value) {
+  const normalized = String(value).replace(/\s+/g, ' ').trim();
+  const redacted = normalized.replace(
+    /("(?:api[_-]?key|token|secret|password|credential|code)"\s*:\s*")[^"]+(")/gi,
+    '$1<redacted>$2'
+  );
+  return redacted.length > MAX_SUMMARY_TEXT_LENGTH
+    ? `${redacted.slice(0, MAX_SUMMARY_TEXT_LENGTH)}...`
+    : redacted;
 }


### PR DESCRIPTION
## Summary

Fixes TLON-6199: the OpenClaw plugin accepted a server-local `/pier/...png` path as `media=`, logged `Invalid URL`, posted the message anyway, and reported `deliveryStatus: sent`, so the bot told the user an image was delivered while the user saw a broken block. `media=` now accepts only a credential-free public https URL, and anything the plugin cannot fetch fails the send before anything is posted.

## Changes

-   Replaced `uploadImageFromUrl` with `prepareOutboundMedia` in `packages/openclaw/src/urbit/upload.ts`. Local paths, `file://`, plain http, userinfo URLs, and malformed input are classified and throw before any post is attempted.
-   Removed the blanket catch-all that returned the caller's original input on failure. Fetch failures now throw instead of silently hotlinking unverified input.
-   Accepted URLs are fetched through the SSRF guard with `requireHttps`, a 10 MiB byte cap, and a 30 s deadline, so the plugin confirms the URL resolves before posting.
-   Image-vs-link classification now uses a byte sniff (`detectMime`) instead of the URL extension; deleted the now-unused `isImageUrl` and reshaped `buildMediaStory` to take `{ url, isImage }`.
-   Bytes are mirrored to ship storage only when a scry confirms `uploadFile` could actually store them — mirroring its own backend routing (Memex for a hosted client, otherwise custom S3 credentials plus a current bucket). Otherwise the fetched source URL is hotlinked. Bot moons are reached over localhost and carry no storage config, so they skip a memex upload that would fail on every send; genuinely hosted ships still mirror.
-   Uploaded filenames are synthetic (`upload-<ts>-<uuid>.<ext>`), never derived from caller text. All plugin-emitted errors and logs are fixed literal phrases, so the caller's path or URL never lands in them.
-   Tool-surface docs in `channel.ts` now state that Tlon is an exception to the shared "Media URL/path" schema: upload first with the `tlon` CLI, then pass the returned https URL.
-   Bumped `@tloncorp/openclaw` 0.14.0 → 0.15.0.

## How did I test?

-   `pnpm tsc --noEmit` clean, `pnpm test` 1032 passing across 59 files, `pnpm lint` 0 errors, prettier clean.
-   New/rewritten unit coverage for input classification (local, Windows, UNC, relative, `file://`, http, userinfo, malformed), leak safety (secret-bearing paths and signed-query URLs asserted absent from thrown messages and logs), guard arguments (`requireHttps`, exact 30 s deadline, exact 10 MiB cap), storage gating, uploaded-blob byte integrity, and image-vs-link classification.
-   New `channel.runtime.test.ts` proves a local path rejects with no outbound post attempted.
-   Kept the storage-gated e2e image-send case and added a storage-independent e2e regression case asserting the failed tool result reaches the model and that no post carrying the token exists on the ship. Both e2e cases require the Docker fakezod harness to execute.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes

Intentional behavior changes operators may notice:

-   `http://` URLs, userinfo URLs, and other non-https schemes now fail the send instead of being silently hotlinked; redirects to non-https also fail.
-   Fetch failures now fail the send (previously hotlinked the original URL and reported sent).
-   Classification is by byte sniff, so an extensionless image URL now posts as an image block and a `.png` URL serving non-image bytes now posts as a link.
-   New 10 MiB cap and 30 s deadline on a fetch that was previously unbounded.
-   A genuinely hosted (non-moon) identity without S3 credentials now hotlinks rather than mirroring via memex.
-   Image blocks post 0×0 dimensions; clients coerce 0 to null and recover natural aspect on load.

Accepted residuals:

-   The plugin verifies that _it_ can fetch the URL but cannot prove every client can (expiring or referrer-gated URLs still break later).
-   Hotlinks post the pre-redirect URL, which is what was dereferenced and validated. A one-shot redirect endpoint could therefore fail for recipients — but always posting the resolved URL would more often embed a short-lived signed URL, and the SDK exposes no redirect metadata to tell the two apart.
-   On tool failure, OpenClaw core surfaces the tool's params under its own policy — into logs, and into the conversation via its failure presentation (its `message` display config lists `media` among the detail keys). So a failed send posts a "⚠️ Message: &lt;media&gt; failed" notice containing the media value. The plugin's no-caller-text guarantee is scoped to plugin-emitted diagnostics and uploaded filenames; this is tracked as an upstream follow-up.

## Rollback plan

Revert.
