### PR TITLE
tlon-skill: document the media= upload contract for OpenClaw

### DIFF
--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -43,6 +43,20 @@ including the current conversation: `tlon upload <direct-image-url>`, then
 
 When running as an OpenClaw skill, use the built-in `message` tool for sending outbound messages (DMs and channel posts). The `tlon` command is for reading data, administration, and management — not for sending messages. The `message` tool routes through the proper delivery infrastructure (threading, bot profile, rate limiting).
 
+**Images are the exception: upload them first.** The `message` tool's `media=`
+parameter takes only an uploaded https URL — never a local file path, unlike
+other OpenClaw channels. `tlon upload` accepts a URL, a local file path, or
+stdin, and prints the uploaded URL:
+
+```bash
+tlon upload ./generated-chart.png      # local file — prints the uploaded URL
+tlon upload https://example.com/x.png  # remote URL
+```
+
+Pass that printed URL as `media=`. On hosted deployments the upload must run
+through the owner ship's config (the bot's own ship has no storage):
+`tlon --config "$TLON_OWNER_CONFIG_PATH" upload <path>`.
+
 > **Removed: diary/notebook channels.** The `%diary` backend has been removed.
 > `tlon notebook`, `--kind diary`, and any `diary/...` nest now fail with an
 > explanatory error pointing at `%notes`. Use the `tlon notes` family for


### PR DESCRIPTION
## Summary

Documents the `media=` contract for OpenClaw in the skill's OpenClaw section: `media=` takes only an uploaded https URL, and `tlon upload` accepts a local file path (or URL, or stdin) and prints the URL to pass.

Context: a bot generated an image locally and passed its `/pier/...png` path straight to `media=`. The plugin-side fix is #6195; this closes the documentation half. `tlon upload` already supported local paths — that capability was just buried ~470 lines into the command reference, while the primary image flow only ever showed a URL.

## Changes

-   Added a short "Images are the exception" block under `## OpenClaw` in `SKILL.md` covering the `media=` contract, `tlon upload` accepting local paths, and the owner-config requirement on hosted deployments.

## How did I test?

Docs only — no code changes. Content verified against `scripts/commands/upload.ts` (accepts URL, local path, or stdin; prints the uploaded URL) and against the plugin behavior landing in #6195.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes
-   Affects important code area:
    -   [x] Other: tlon-skill documentation

No runtime effect. Note this does not reach deployed bots until `@tloncorp/tlon-skill` is version-bumped and republished — production resolves the skill from the registry (currently `0.4.4`), so this rides the next skill release rather than requiring one.

## Rollback plan

Revert