### PR TITLE
notes: implement basic bounded search

### DIFF
--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -270,14 +270,11 @@
   ?:  ?=([%notes %~.~ %v1 *] site)
     =/  pax=(list @t)  t.t.t.site
     ::  other /notes/~/v1/* — GET reads, POST/PATCH/DELETE first-class writes
-    ?:  =(%'GET' method)  (handle-v1-read eyre-id pax inbound-request)
+    ?:  =(%'GET' method)  (handle-v1-read eyre-id pax args inbound-request)
     ::  vere's runtime HTTP server rejects PATCH (400 before reaching the
     ::  agent), so note-body updates use PUT.
     ?:  ?=(?(%'POST' %'PUT' %'DELETE') method)
-      =/  recursive=?
-        %+  lien  args
-        |=  [key=@t value=@t]
-        &(=(key 'recursive') =(value 'true'))
+      =/  recursive=?  =((query-cord args 'recursive') `'true')
       (handle-v1-write eyre-id method pax recursive inbound-request)
     (http-error eyre-id 405 'method not allowed')
   ::  PWA-related static assets: manifest, service worker, icons.
@@ -429,11 +426,15 @@
 ::    /notes/~/v1/notebooks/{host}/{name}/notes/{id}
 ::    /notes/~/v1/notebooks/{host}/{name}/notes/{id}/history
 ::    /notes/~/v1/notebooks/{host}/{name}/members
-::    /notes/~/v1/notebooks/{host}/{name}/search/bounded/text/{from}/{tries}/{needle}
+::    /notes/~/v1/notebooks/{host}/{name}/search/bounded/text?needle&from&tries
 ::    /notes/~/v1/invites
 ::
 ++  handle-v1-read
-  |=  [eyre-id=@ta pax=(list @t) =inbound-request:eyre]
+  |=  $:  eyre-id=@ta
+          pax=(list @t)
+          args=(list [key=@t value=@t])
+          =inbound-request:eyre
+      ==
   ^+  cor
   ?.  (request-authorized inbound-request)
     (http-error eyre-id 401 'unauthorized')
@@ -452,10 +453,30 @@
     =/  =flag:n  [(slav %p i.t.path) `@tas`i.t.t.path]
     ?~  (~(get by books) flag)
       (http-error eyre-id 404 'notebook not found')
-    ?~  jon=(no-read-json:(no-abed:no-core flag) t.t.t.path)
+    ?~  jon=(no-read-json:(no-abed:no-core flag) t.t.t.path args)
       (http-error eyre-id 404 'not found')
     (give-json-response eyre-id u.jon)
   ==
+::  +query-cord / +query-ud: read one key out of the URL's query args.
+::  de-purl already percent-decoded the values, so a query param can carry
+::  arbitrary text — unlike a path segment, which apat splits a trailing
+::  dot-group off of as a file extension.
+::
+++  query-cord
+  |=  [args=(list [key=@t value=@t]) key=@t]
+  ^-  (unit @t)
+  ?~  args  ~
+  ?:  =(key key.i.args)  `value.i.args
+  $(args t.args)
+::
+++  query-ud
+  |=  [args=(list [key=@t value=@t]) key=@t]
+  ^-  (unit @ud)
+  ?~  val=(query-cord args key)  ~
+  ::  accept a plain decimal ("1234") as well as the dot-grouped hoon @ud
+  ::  literal ("1.234"), so a client can echo an id straight back at us.
+  ?^  plain=(rush u.val dum:ag)  plain
+  (slaw %ud u.val)
 ::  +field-cord / +field-ud: lenient reads of one key from a json object
 ::  for the write endpoints. Return ~ on a missing key or wrong json shape,
 ::  so a cheap model sending a slightly-off body gets a 400, not a 500.
@@ -2715,11 +2736,11 @@
     notes-response+!>(`response:n`[%snapshot flag visibility.notebook-state notebook-state])
   ::  +no-read-json: per-notebook read surface for the v1 GET API. Same
   ::  data as +no-peek but JSON-encoded for HTTP. `rest` is the path
-  ::  remainder after /notes/~/v1/notebooks/{host}/{name}. Membership-
-  ::  gated like no-peek.
+  ::  remainder after /notes/~/v1/notebooks/{host}/{name}, `args` the
+  ::  URL's query args. Membership-gated like no-peek.
   ::
   ++  no-read-json
-    |=  rest=path
+    |=  [rest=path args=(list [key=@t value=@t])]
     ^-  (unit json)
     ::  our.bowl, not src.bowl — see read-notebooks-json. The HTTP auth
     ::  gate already ran; identity is the ship.
@@ -2760,16 +2781,25 @@
         [who r]
       `(member-records:enjs:notes-json mrecords)
     ::
-        [%search %bounded %text from=@ tries=@ nedl=@ ~]
-      =*  vars  t.t.t.rest
+        [%search %bounded %text ~]
+      ::  search params ride in the query string, not the path: the needle is
+      ::  free text, and as a path segment its trailing dot-group would be
+      ::  eaten as a file extension (see the /request/{id} branch of
+      ::  +serve-http). `needle` is required, `from` defaults to the newest
+      ::  note and `tries` to a budget that keeps one call cheap.
+      ?~  nedl=(query-cord args 'needle')  ~
       :-  ~
       %-  scam:enjs:notes-json
       %^    no-search
-          ?:  =(%$ from.i.vars)  ~
-          `(slav %ud from.i.vars)
-        (slav %ud tries.i.t.vars)
-      (slav %t nedl.i.t.t.vars)
+          (query-ud args 'from')
+        (fall (query-ud args 'tries') default-search-tries)
+      u.nedl
     ==
+  ::
+  ::  +default-search-tries: budget for a v1 search that didn't ask for one.
+  ::  Small enough that a single unbounded-looking request stays cheap.
+  ::
+  ++  default-search-tries  100
   ::
   ::  +no-search: backwards bounded search
   ::

--- a/desk/app/notes.hoon
+++ b/desk/app/notes.hoon
@@ -429,6 +429,7 @@
 ::    /notes/~/v1/notebooks/{host}/{name}/notes/{id}
 ::    /notes/~/v1/notebooks/{host}/{name}/notes/{id}/history
 ::    /notes/~/v1/notebooks/{host}/{name}/members
+::    /notes/~/v1/notebooks/{host}/{name}/search/bounded/text/{from}/{tries}/{needle}
 ::    /notes/~/v1/invites
 ::
 ++  handle-v1-read
@@ -2692,6 +2693,16 @@
         |=  [who=ship r=role:n]
         [who r]
       ``notes-members+!>(mrecords)
+    ::
+        %search
+      ?.  ?=([%bounded %text from=@ tries=@ nedl=@ ~] rest)
+        ~
+      :^  ~  ~  %notes-scam  !>
+      %^    no-search
+          ?:  =(%$ from.rest)  ~
+          `(slav %ud from.rest)
+        (slav %ud tries.rest)
+      (slav %t nedl.rest)
     ==
   ::  +no-watch: handle local UI stream subscription for this notebook
   ::
@@ -2748,6 +2759,79 @@
         |=  [who=ship r=role:n]
         [who r]
       `(member-records:enjs:notes-json mrecords)
+    ::
+        [%search %bounded %text from=@ tries=@ nedl=@ ~]
+      =*  vars  t.t.t.rest
+      :-  ~
+      %-  scam:enjs:notes-json
+      %^    no-search
+          ?:  =(%$ from.i.vars)  ~
+          `(slav %ud from.i.vars)
+        (slav %ud tries.i.t.vars)
+      (slav %t nedl.i.t.t.vars)
     ==
+  ::
+  ::  +no-search: backwards bounded search
+  ::
+  ++  no-search
+    |=  [from=(unit @ud) tries=@ud nedl=@t]
+    ^-  scam:n
+    =/  notes=(list [nid=@ud =note:n])
+      ::NOTE  filtering for u.from prior to sort actually slightly slower
+      ::      (in tested cases)
+      %+  sort  ~(tap by notes.notebook-state)
+      |=([[a=@ud *] [b=@ud *]] (gth a b))
+    =/  from=@ud
+      (fall from ?~(notes 0 +(nid.i.notes)))
+    =|  found=(list note:n)
+    =*  done  [from (flop found)]
+    ?:  =(0 from)       done
+    |^  ?~  notes       =.(from 0 done)
+        ?:  =(0 tries)  done  ::  compute out of bounds
+        ?:  (gte nid.i.notes from)
+          $(notes t.notes)    ::  move into range
+        =.  from   nid.i.notes
+        =.  tries  (dec tries)
+        ?.  ?|  (find nedl title.note.i.notes)
+                (find nedl body-md.note.i.notes)  ::NOTE  treats *markdown* opaquely
+            ==
+          $(notes t.notes)
+        $(notes t.notes, found [note.i.notes found])
+    ::
+    ::NOTE  +find and co from /app/channels, never case-sensitive
+    ++  find
+      |=  [nedl=@t hay=@t]
+      ~>  %spin.['find']
+      ^-  ?
+      =/  nlen  (met 3 nedl)
+      =/  hlen  (met 3 hay)
+      ?:  (lth hlen nlen)
+        |
+      =.  nedl  (cass nedl)
+      =.  hay   (cass hay)
+      =/  pos   0
+      =/  lim   (sub hlen nlen)
+      |-
+      ?:  (gth pos lim)
+        |
+      ?:  =(nedl (cut 3 [pos nlen] hay))
+        &
+      $(pos +(pos))
+    ::
+    ::NOTE  :(cork trip ^cass crip) may be _very slightly_ faster,
+    ::      but not enough to matter
+    ++  cass
+      |=  text=@t
+      ~>  %spin.['cass']
+      ^-  @t
+      %^    run
+          3
+        text
+      |=  dat=@
+      ^-  @
+      ?.  &((gth dat 64) (lth dat 91))
+        dat
+      (add dat 32)
+    --
   --
 --

--- a/desk/app/notes/openapi.json
+++ b/desk/app/notes/openapi.json
@@ -941,7 +941,7 @@
         }
       }
     },
-    "/notes/~/v1/notebooks/{host}/{name}/search/bounded/text/{from}/{tries}/{needle}": {
+    "/notes/~/v1/notebooks/{host}/{name}/search/bounded/text": {
       "get": {
         "summary": "Search notes by text (bounded, resumable)",
         "description": "Case-insensitive substring search over each note's title and\nmarkdown body, walking the notebook newest-first (descending note\nid). The walk is bounded by `tries` rather than by a result count,\nso one call examines at most `tries` notes and may return fewer\nhits than that — or none. Page through by feeding the returned\n`last` back in as `from` until `last` is 0.\n",
@@ -964,35 +964,35 @@
             }
           },
           {
-            "in": "path",
-            "name": "from",
-            "required": true,
-            "description": "Exclusive cursor: only notes with an id strictly below this are\nexamined. Pass the `last` from the previous page. Empty starts at\nthe newest note; any id above the notebook's highest does the same.\nWritten as a Hoon `@ud` literal, which is dot-grouped in threes\nabove 999 — a `last` of 1234 must be sent as `1.234`, not `1234`.\n",
-            "schema": {
-              "type": "string",
-              "pattern": "^$|^[0-9]{1,3}(\\.[0-9]{3})*$"
-            },
-            "example": "1.234"
-          },
-          {
-            "in": "path",
-            "name": "tries",
-            "required": true,
-            "description": "Budget of notes to examine in this call, not hits to collect.\n",
-            "schema": {
-              "type": "integer"
-            },
-            "example": 50
-          },
-          {
-            "in": "path",
+            "in": "query",
             "name": "needle",
             "required": true,
-            "description": "Search text as a Hoon `@t` literal — a `~~` prefix with\nnon-knot characters escaped (`~~hello` for `hello`). Unescaped\ntext is rejected. NOTE: a needle whose escaped form contains a\n`.` is currently truncated at the last dot group, since the URL\nparser reads it as a file extension; single-word lowercase\nneedles are unaffected.\n",
+            "description": "Search text, URL-encoded. Plain text — no Hoon `@t` escaping, and\ndots, spaces and punctuation are all fine.\n",
             "schema": {
               "type": "string"
             },
-            "example": "~~hello"
+            "example": "notes.hoon"
+          },
+          {
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "description": "Exclusive cursor: only notes with an id strictly below this are\nexamined. Pass the `last` from the previous page, verbatim. Omit\nto start at the newest note; any id above the notebook's highest\ndoes the same.\n",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 1234
+          },
+          {
+            "in": "query",
+            "name": "tries",
+            "required": false,
+            "description": "Budget of notes to examine in this call, not hits to collect.\nDefaults to 100.\n",
+            "schema": {
+              "type": "integer",
+              "default": 100
+            },
+            "example": 50
           }
         ],
         "responses": {

--- a/desk/app/notes/openapi.json
+++ b/desk/app/notes/openapi.json
@@ -941,6 +941,80 @@
         }
       }
     },
+    "/notes/~/v1/notebooks/{host}/{name}/search/bounded/text/{from}/{tries}/{needle}": {
+      "get": {
+        "summary": "Search notes by text (bounded, resumable)",
+        "description": "Case-insensitive substring search over each note's title and\nmarkdown body, walking the notebook newest-first (descending note\nid). The walk is bounded by `tries` rather than by a result count,\nso one call examines at most `tries` notes and may return fewer\nhits than that — or none. Page through by feeding the returned\n`last` back in as `from` until `last` is 0.\n",
+        "operationId": "searchNotes",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "from",
+            "required": true,
+            "description": "Exclusive cursor: only notes with an id strictly below this are\nexamined. Pass the `last` from the previous page. Empty starts at\nthe newest note; any id above the notebook's highest does the same.\nWritten as a Hoon `@ud` literal, which is dot-grouped in threes\nabove 999 — a `last` of 1234 must be sent as `1.234`, not `1234`.\n",
+            "schema": {
+              "type": "string",
+              "pattern": "^$|^[0-9]{1,3}(\\.[0-9]{3})*$"
+            },
+            "example": "1.234"
+          },
+          {
+            "in": "path",
+            "name": "tries",
+            "required": true,
+            "description": "Budget of notes to examine in this call, not hits to collect.\n",
+            "schema": {
+              "type": "integer"
+            },
+            "example": 50
+          },
+          {
+            "in": "path",
+            "name": "needle",
+            "required": true,
+            "description": "Search text as a Hoon `@t` literal — a `~~` prefix with\nnon-knot characters escaped (`~~hello` for `hello`). Unescaped\ntext is rejected. NOTE: a needle whose escaped form contains a\n`.` is currently truncated at the last dot group, since the URL\nparser reads it as a file extension; single-word lowercase\nneedles are unaffected.\n",
+            "schema": {
+              "type": "string"
+            },
+            "example": "~~hello"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One page of search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Scam"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
     "/notes/~/v1/invites": {
       "get": {
         "summary": "Pending invites we've received",
@@ -2269,6 +2343,27 @@
           },
           "revision": {
             "type": "integer"
+          }
+        }
+      },
+      "Scam": {
+        "type": "object",
+        "description": "One page of bounded search results.",
+        "required": [
+          "last",
+          "notes"
+        ],
+        "properties": {
+          "last": {
+            "type": "integer",
+            "description": "Resume cursor: the id of the last note examined, to be passed\nback as `from` for the next page. 0 means the walk reached the\noldest note — stop paging. Hits found on that final page are\nstill included alongside the 0.\n"
+          },
+          "notes": {
+            "type": "array",
+            "description": "Matching notes, newest first.",
+            "items": {
+              "$ref": "#/components/schemas/Note"
+            }
           }
         }
       },

--- a/desk/lib/notes/json.hoon
+++ b/desk/lib/notes/json.hoon
@@ -367,6 +367,12 @@
     |=  ts=tang
     ^-  json
     [%a ~]
+  ::  +scam: search results
+  ::
+  ++  scam
+    |=  =scam:n
+    ^-  json
+    (pairs 'last'^(numb last.scam) 'notes'^(notes scan.scam) ~)
   ::  v1: request-id-wrapped response shapes
   ::  encoded for delivery over /notes/~/v1 HTTP and /v1 SSE paths.
   ::

--- a/desk/mar/notes/scam.hoon
+++ b/desk/mar/notes/scam.hoon
@@ -1,0 +1,14 @@
+/-  n=notes
+/+  notes-json
+|_  sc=scam:n
+++  grad  %noun
+++  grab
+  |%
+  ++  noun  scam:n
+  --
+++  grow
+  |%
+  ++  noun  sc
+  ++  json  (scam:enjs:notes-json sc)
+  --
+--

--- a/desk/sur/notes.hoon
+++ b/desk/sur/notes.hoon
@@ -324,6 +324,12 @@
 ::  $said: single-shot /v0/said response
 ::
 +$  said  [=flag =note-preview]
+::  $scam: bounded search results
+::
++$  scam
+  $:  last=@ud          ::  last note-id that was searched, 0 for end
+      scan=(list note)  ::  search results
+  ==
 ::  Type aliases
 ::
 +$  action    a-notes

--- a/desk/tests/app/notes.hoon
+++ b/desk/tests/app/notes.hoon
@@ -176,6 +176,20 @@
     $(caz t.caz)
   =/  rh=response-header:http  !<(response-header:http +.+>+.i.caz)
   `status-code.rh
+::  +http-body: extract the response body from an %http-response-data fact
+::  card, if any. Axis lark as in +http-status.
+::
+++  http-body
+  |=  caz=(list card)
+  ^-  (unit @t)
+  |-  ^-  (unit @t)
+  ?~  caz  ~
+  ?.  ?=([%give %fact * *] i.caz)  $(caz t.caz)
+  ?.  =(`mark`-.+>+.i.caz %http-response-data)
+    $(caz t.caz)
+  =/  dat=(unit octs)  !<((unit octs) +.+>+.i.caz)
+  ?~  dat  ~
+  `q.u.dat
 ::  Card introspection helpers. Hoon's `?=` narrowing on a $% card type
 ::  doesn't propagate inner `=face` shorthand through the union, so we
 ::  reach into the card by axis lark and compare raw nouns. (`;;` casts
@@ -2763,10 +2777,61 @@
   ;<  *  b  (mk-note f 'gone' 'find-me')
   ;<  *  b  (poke-a [%notebook f [%note 4 [%delete ~]]])
   (ex-search f [~ 5 'find-me'] [0 ~[3]])
+::  +search-url: construct a v1 HTTP search url from args. Search params
+::  are query args, so the needle goes over the wire as (url-encoded)
+::  plain text and .from/.tries are optional.
+::
+++  search-url
+  |=  [=flag:n from=(unit @ud) tries=(unit @ud) nedl=tape]
+  ^-  @t
+  %-  crip
+  ;:  weld
+    "/notes/~/v1/notebooks/{<`@p`ship.flag>}/{(trip name.flag)}"
+    "/search/bounded/text?needle={nedl}"
+    ?~(from "" "&from={(trip (scot %ud u.from))}")
+    ?~(tries "" "&tries={(trip (scot %ud u.tries))}")
+  ==
+::  +api-key-header: x-api-key header for the freshly-initialized ship
+::
+++  api-key-header
+  =/  m  (mare ,(list [@t @t]))
+  ^-  form:m
+  ;<  sv=vase  bind:m  get-save
+  =/  s=state-15:n  !<(state-15:n sv)
+  (pure:m ~[['x-api-key' ?~(api-key.s '' u.api-key.s)]])
+::  +ex-get-search: GET a v1 search url and assert 200 plus the `last`
+::  cursor and note ids in the JSON response body.
+::
+++  ex-get-search
+  |=  $:  hdrs=(list [@t @t])
+          url=@t
+          want=[last=@ud ids=(list @ud)]
+      ==
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  caz=(list card)  bind:m  (http-get-v1 hdrs url)
+  |=  s=state
+  ?.  =((http-status caz) `200)
+    |+~[(crip "GET {(trip url)} expected 200, got {<(http-status caz)>}")]
+  ?~  body=(http-body caz)
+    |+~[(crip "GET {(trip url)}: no response body")]
+  ?~  jon=(de:json:html u.body)
+    |+~[(crip "GET {(trip url)}: body not json: {(trip u.body)}")]
+  =/  got=[last=@ud ids=(list @ud)]
+    %.  u.jon
+    %-  ot:dejs:format
+    :~  ['last' ni:dejs:format]
+        ['notes' (ar:dejs:format (ot:dejs:format ~[['id' ni:dejs:format]]))]
+    ==
+  ?.  =(ids.got ids.want)
+    |+~[(crip "GET {(trip url)}: expected ids {<ids.want>}, got {<ids.got>}")]
+  ?.  =(last.got last.want)
+    |+~[(crip "GET {(trip url)}: expected last {<last.want>}, got {<last.got>}")]
+  &+[~ s]
 ::  +test-search-v1-http-initial
 ::
-::  should behave identically to scry search, and take empty path segment
-::  in the "from" position as "start with latest".
+::  should behave identically to scry search, and resume from the returned
+::  .last when it's fed back in as .from.
 ::
 ++  test-search-v1-http-initial
   %-  eval-mare
@@ -2775,17 +2840,51 @@
   ^-  form:m
   ;<  f=flag:n  b  (init-nb 'HttpSearch')
   ;<  *  b  (mk-note f 'needle' 'plain')
-  ;<  sv=vase  b  get-save
-  =/  s0=state-15:n  !<(state-15:n sv)
-  =/  key=@t  ?~(api-key.s0 '' u.api-key.s0)
-  =/  hdr=(list [@t @t])  ~[['x-api-key' key]]
+  ;<  *  b  (mk-note f 'plain' 'needle')
+  ;<  hdr=(list [@t @t])  b  api-key-header
+  ;<  ~  b  (ex-get-search hdr (search-url f ~ `1 "needle") [4 ~[4]])
+  ;<  ~  b  (ex-get-search hdr (search-url f `4 `5 "needle") [0 ~[3]])
+  ::  no .tries: the default budget covers this notebook whole
+  (ex-get-search hdr (search-url f ~ ~ "needle") [0 ~[4 3]])
+::  +test-search-v1-http-needle-is-plain-text
+::
+::  the needle is a query arg, so it survives dots (which the URL parser
+::  would otherwise take for a file extension) and url-encoded spaces.
+::
+++  test-search-v1-http-needle-is-plain-text
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'DottedNeedle')
+  ;<  *  b  (mk-note f 'shipped v1.0 today' 'plain')
+  ;<  *  b  (mk-note f 'plain' 'say hello world to it')
+  ;<  *  b  (mk-note f 'plain' 'nothing to see')
+  ;<  hdr=(list [@t @t])  b  api-key-header
+  ;<  ~  b  (ex-get-search hdr (search-url f ~ ~ "v1.0") [0 ~[3]])
+  ::  a dotted needle must not match on its truncated prefix
+  ;<  ~  b  (ex-get-search hdr (search-url f ~ ~ "v1.9") [0 ~])
+  (ex-get-search hdr (search-url f ~ ~ "hello%20world") [0 ~[4]])
+::  +test-search-v1-http-needle-required
+::
+::  a search without a needle is not a search
+::
+++  test-search-v1-http-needle-required
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'NoNeedle')
+  ;<  *  b  (mk-note f 'whatever' 'plain')
+  ;<  hdr=(list [@t @t])  b  api-key-header
   =/  base=tape
     "/notes/~/v1/notebooks/{<`@p`ship.f>}/{(trip name.f)}"
-  =/  tries=tape  (trip (scot %ud 5))
-  =/  nedl=tape   (trip (scot %t 'needle'))
-  =/  url=@t
-    (crip "{base}/search/bounded/text//{tries}/{nedl}")
-  (ex-get-200 hdr url)
+  ;<  caz=(list card)  b
+    (http-get-v1 hdr (crip "{base}/search/bounded/text"))
+  |=  s=state
+  ?.  =((http-status caz) `404)
+    |+~[(crip "expected 404 from needle-less search, got {<(http-status caz)>}")]
+  &+[~ s]
 ::  +test-search-scans-many-large-bodies
 ::
 ::  search should perform reasonably on large content bodies.

--- a/desk/tests/app/notes.hoon
+++ b/desk/tests/app/notes.hoon
@@ -2553,4 +2553,260 @@
   :~  (ex-fact ~ %notes-denied !>(~))
       (ex-card [%give %kick ~ ~])
   ==
+::
+::  search tests
+::
+::  primarily use search through scry.
+::  setup convention: notebook w/ id 1, root folder w/ id 2,
+::  notes are ids 3, 4, 5, ... in creation order.
+::
+::  +init-nb: init as ~zod and create a notebook, yielding its flag
+::
+++  init-nb
+  |=  title=@t
+  =/  m  (mare ,flag:n)
+  ^-  form:m
+  ;<  ~  bind:m  init-zod
+  ;<  =bowl:gall  bind:m  get-bowl
+  ;<  *  bind:m  (poke-a [%create-notebook title])
+  (pure:m (nb-flag our.bowl title 1))
+::  +mk-note: create a note in the root folder
+::
+++  mk-note
+  |=  [=flag:n title=@t body=@t]
+  (poke-a [%notebook flag [%create-note 2 title body]])
+::  +mk-n-notes: create .n identical notes in the root folder
+::
+++  mk-n-notes
+  |=  [=flag:n n=@ud title=@t body=@t]
+  =/  m  (mare ,~)
+  |-  ^-  form:m
+  ?:  =(0 n)  (pure:m ~)
+  =/  rest=form:m  $(n (dec n))
+  ;<  *  bind:m  (mk-note flag title body)
+  rest
+::  +search-path: construct search scry path from args
+::
+++  search-path
+  |=  [=flag:n from=(unit @ud) tries=@ud nedl=@t]
+  ^-  path
+  :~  %x  %v0  %search  (scot %p ship.flag)  name.flag
+      %bounded  %text
+      ?~(from %$ (scot %ud u.from))
+      (scot %ud tries)
+      (scot %t nedl)
+  ==
+::  +peek-search: scam from search scry
+::
+++  peek-search
+  |=  [=flag:n q=[from=(unit @ud) tries=@ud nedl=@t]]
+  =/  m  (mare ,scam:n)
+  ^-  form:m
+  |=  s=state
+  =/  pax=path  (search-path flag from.q tries.q nedl.q)
+  =/  peek=(unit (unit cage))  (~(on-peek agent.s bowl.s) pax)
+  ?~  peek  |+~['search scry path invalid' (spat pax)]
+  ?~  u.peek  |+~['search scry unexpectedly empty' (spat pax)]
+  ?.  =(p.u.u.peek %notes-scam)
+    |+~['expected notes-scam mark from search scry']
+  &+[!<(scam:n q.u.u.peek) s]
+::  +ex-search: expect post ids in search result
+::
+++  ex-search
+  |=  $:  =flag:n
+          q=[from=(unit @ud) tries=@ud nedl=@t]
+          want=[last=@ud ids=(list @ud)]
+      ==
+  =/  m  (mare ,~)
+  ^-  form:m
+  ;<  =scam:n  bind:m  (peek-search flag q)
+  |=  s=state
+  =/  got=(list @ud)  (turn scan.scam |=(nt=note:n id.nt))
+  ?.  =(got ids.want)
+    |+~[(crip "search {<nedl.q>}: expected ids {<ids.want>}, got {<got>}")]
+  ?.  =(last.scam last.want)
+    |+~[(crip "search {<nedl.q>}: last {<last.want>}, got {<last.scam>}")]
+  &+[~ s]
+::  +test-search-matches-title-and-body
+::
+::  needle must be searched for in both title and body
+::
+++  test-search-matches-title-and-body
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Matching')
+  ;<  *  b  (mk-note f 'needle in title' 'plain body')
+  ;<  *  b  (mk-note f 'plain title' 'has a needle inside')
+  ;<  *  b  (mk-note f 'plain title' 'plain body')
+  (ex-search f [~ 3 'needle'] [0 ~[4 3]])
+::  +test-search-includes-newest-note
+::
+::  search without .from argument must include latest note
+::
+++  test-search-includes-newest-note
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Newest')
+  ;<  *  b  (mk-note f 'first' 'plain')
+  ;<  *  b  (mk-note f 'second' 'plain')
+  ;<  *  b  (mk-note f 'newest' 'plain')
+  (ex-search f [~ 3 'newest'] [0 ~[5]])
+::  +test-search-cursor-resume-covers-every-note-once
+::
+::  .last in search results must paginate correctly when passed in continuation
+::
+++  test-search-cursor-resume-covers-every-note-once
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Paging')
+  ;<  *  b  (mk-note f 'n1' 'hay')
+  ;<  *  b  (mk-note f 'n2' 'hay')
+  ;<  *  b  (mk-note f 'n3' 'hay')
+  ;<  *  b  (mk-note f 'n4' 'hay')
+  ;<  *  b  (mk-note f 'n5' 'hay')
+  ;<  ~  b  (ex-search f [~ 2 'hay'] [6 ~[7 6]])
+  ;<  ~  b  (ex-search f [`6 2 'hay'] [4 ~[5 4]])
+  (ex-search f [`4 2 'hay'] [0 ~[3]])
+::  +test-search-tries-one-advances
+::
+::  even when trying only one result, .last must advance correctly
+::
+++  test-search-tries-one-advances
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'OneAtATime')
+  ;<  *  b  (mk-note f 'a' 'hay')
+  ;<  *  b  (mk-note f 'b' 'hay')
+  ;<  *  b  (mk-note f 'c' 'hay')
+  ;<  ~  b  (ex-search f [~ 1 'hay'] [5 ~[5]])
+  ;<  ~  b  (ex-search f [`5 1 'hay'] [4 ~[4]])
+  (ex-search f [`4 1 'hay'] [0 ~[3]])
+::  +test-search-tries-bounds-notes-examined-not-hits
+::
+::  search should be bounded by tries, not hits
+::
+++  test-search-tries-bounds-notes-examined-not-hits
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Budget')
+  ;<  *  b  (mk-note f 'needle' 'plain')
+  ;<  *  b  (mk-note f 'plain' 'plain')
+  ;<  *  b  (mk-note f 'plain' 'plain')
+  ;<  ~  b  (ex-search f [~ 1 'needle'] [5 ~])
+  ;<  ~  b  (ex-search f [`5 1 'needle'] [4 ~])
+  (ex-search f [`4 1 'needle'] [0 ~[3]])
+::  +test-search-exhaustion-returns-zero-with-final-hits
+::
+::  last page of search results must produce last=0
+::
+++  test-search-exhaustion-returns-zero-with-final-hits
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'TheEnd')
+  ;<  *  b  (mk-note f 'oldest' 'needle here')
+  ;<  *  b  (mk-note f 'newer' 'plain')
+  (ex-search f [~ 10 'needle'] [0 ~[3]])
+::  +test-search-empty-notebook
+::
+++  test-search-empty-notebook
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Empty')
+  (ex-search f [~ 5 'anything'] [0 ~])
+::  +test-search-cursor-at-oldest-id-excludes-it
+::
+++  test-search-cursor-at-oldest-id-excludes-it
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Boundary')
+  ;<  *  b  (mk-note f 'a' 'hay')
+  ;<  *  b  (mk-note f 'b' 'hay')
+  ;<  *  b  (mk-note f 'c' 'hay')
+  (ex-search f [`3 5 'hay'] [0 ~])
+::  +test-search-case-insensitive
+::
+++  test-search-case-insensitive
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Casing')
+  ;<  *  b  (mk-note f 'UPPER' 'x')
+  ;<  *  b  (mk-note f 'y' 'lower')
+  ;<  ~  b  (ex-search f [~ 2 'upper'] [0 ~[3]])
+  (ex-search f [~ 2 'LOWER'] [0 ~[4]])
+::  +test-search-skips-deleted-note
+::
+++  test-search-skips-deleted-note
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'Deleting')
+  ;<  *  b  (mk-note f 'keep' 'find-me')
+  ;<  *  b  (mk-note f 'gone' 'find-me')
+  ;<  *  b  (poke-a [%notebook f [%note 4 [%delete ~]]])
+  (ex-search f [~ 5 'find-me'] [0 ~[3]])
+::  +test-search-v1-http-initial
+::
+::  should behave identically to scry search, and take empty path segment
+::  in the "from" position as "start with latest".
+::
+++  test-search-v1-http-initial
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  ;<  f=flag:n  b  (init-nb 'HttpSearch')
+  ;<  *  b  (mk-note f 'needle' 'plain')
+  ;<  sv=vase  b  get-save
+  =/  s0=state-15:n  !<(state-15:n sv)
+  =/  key=@t  ?~(api-key.s0 '' u.api-key.s0)
+  =/  hdr=(list [@t @t])  ~[['x-api-key' key]]
+  =/  base=tape
+    "/notes/~/v1/notebooks/{<`@p`ship.f>}/{(trip name.f)}"
+  =/  tries=tape  (trip (scot %ud 5))
+  =/  nedl=tape   (trip (scot %t 'needle'))
+  =/  url=@t
+    (crip "{base}/search/bounded/text//{tries}/{nedl}")
+  (ex-get-200 hdr url)
+::  +test-search-scans-many-large-bodies
+::
+::  search should perform reasonably on large content bodies.
+::  keep an eye on timings in test output!
+::
+++  test-search-scans-many-large-bodies
+  %-  eval-mare
+  =/  m  (mare ,~)
+  =*  b  bind:m
+  ^-  form:m
+  =/  body-size=@ud   10.000
+  =/  filler-count=@ud  9
+  =/  filler=@t  (fil 3 body-size 'x')
+  ::  needle-bearing body: filler first, needle last (+cat puts `b` low, and
+  ::  cords run low-byte-first), so the scan can't short-circuit early
+  =/  hay=@t  (cat 3 filler 'zzfindmezz')
+  ;<  f=flag:n  b  (init-nb 'BigBodies')
+  ::  oldest note, id 3 — the only one that matches
+  ;<  *  b  (mk-note f 'big' hay)
+  ::  ids 4 .. 12, same filler body, no match
+  ;<  ~  b  (mk-n-notes f filler-count 'big' filler)
+  ::  tries covers all 10 notes, so the walk exhausts and reports the end
+  (ex-search f [~ +(filler-count) 'zzfindmezz'] [0 ~[3]])
 --


### PR DESCRIPTION
## Summary

Similar to the search in channels agent introduced in #3293, we add a search endpoint to notes which bounds its results by posts _searched_ rather than posts _returned_. Adds this both as a scry endpoint and an HTTP one.  
Closes TLON-6237.

## Changes

Nothing crazy different from what already exists in channels: optional `from` to specify a location to start the backwards search, `tries` to bound the search and encoded `nedl` for the search string.

We tweak `+find` to do the `+cass` on the _entire_ `.hay` ahead of time, which is more performant in the "search through big content string" scenarios we hit in notebooks.

I stuck with local convention best I could, but couple of things to note about that for explicit review/discussion @arthyn:
- Something's deranged about URL parsing/handling in `+serve-http`: for `/notes/~/v1/request/0vabc.defgh` we take the `.defgh` out of `ext` and put it back onto the request path. We don't do this for any other endpoints. (And so I don't do it here, even though the `@t` encoding needs it.) Is there a reason we don't require `.json` extension everywhere? Or (sorta) require absence of `ext`?  (Except the file serving places obviously, but presence/absence of `/~` infix helps differentiate.)
- Local convention is to emit note IDs as json numbers, but to parse them as `@ud`s in endpoint paths. As a result, you can't just chuck `last` into the next search page URL, you need to put the dots in by hand. LLM will complain about this, but it matches existing behavior.

## How did I test?

Wrote and ran tests for normal cases and all edge cases encountered during development. No client integration yet.

## Risks and impact

- Yes, safe to rollback without consulting PR author.

## Rollback plan

Revert.