### PR TITLE
ops: bump staging mobile version to 9.4.1

### DIFF
--- a/apps/tlon-mobile/android/app/build.gradle
+++ b/apps/tlon-mobile/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         compileSdk rootProject.ext.compileSdkVersion
         versionCode 108
-        versionName "9.4.0"
+        versionName "9.4.1"
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
+++ b/apps/tlon-mobile/ios/Landscape.xcodeproj/project.pbxproj
@@ -1804,7 +1804,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.0;
+				MARKETING_VERSION = 9.4.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1842,7 +1842,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.0;
+				MARKETING_VERSION = 9.4.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2074,7 +2074,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.0;
+				MARKETING_VERSION = 9.4.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2117,7 +2117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.4.0;
+				MARKETING_VERSION = 9.4.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/tlon-mobile/package.json
+++ b/apps/tlon-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tlon-mobile",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "private": true,
   "expo": {
     "autolinking": {


### PR DESCRIPTION
## Summary

Bump the staging mobile app version from 9.4.0 to 9.4.1 for a new production build.

## Changes

- Update the mobile package version
- Update Android versionName
- Update iOS MARKETING_VERSION

## How did I test?

- Verified the diff only changes the three mobile version sources
- Ran git diff --check