### PR TITLE
prevent missing PostHog keys from crashing the app

### DIFF
--- a/packages/app/utils/posthogSingleton.test.ts
+++ b/packages/app/utils/posthogSingleton.test.ts
@@ -1,0 +1,32 @@
+import { expect, test, vi } from 'vitest';
+
+import { posthogEnabled } from './posthogSingleton';
+
+const { postHogConstructor } = vi.hoisted(() => ({
+  postHogConstructor: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  process.env.NODE_ENV = 'production';
+});
+
+vi.mock('posthog-react-native', () => ({
+  default: class PostHog {
+    constructor(...args: unknown[]) {
+      postHogConstructor(...args);
+    }
+  },
+}));
+
+vi.mock('../constants', () => ({
+  POST_HOG_API_KEY: '',
+  POST_HOG_IN_DEV: false,
+}));
+
+test('disables PostHog instead of throwing when a production key is missing', () => {
+  expect(posthogEnabled).toBe(false);
+  expect(postHogConstructor).toHaveBeenCalledWith('dummy-key', {
+    host: 'https://data-bridge-v1.vercel.app/ingest',
+    disabled: true,
+  });
+});

--- a/packages/app/utils/posthogSingleton.test.ts
+++ b/packages/app/utils/posthogSingleton.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 
 import { posthogEnabled } from './posthogSingleton';
 
@@ -7,9 +7,12 @@ const { postHogConstructor } = vi.hoisted(() => ({
 }));
 
 vi.hoisted(() => {
-  process.env.NODE_ENV = 'production';
+  vi.stubEnv('NODE_ENV', 'production');
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 vi.mock('posthog-react-native', () => ({
   default: class PostHog {
     constructor(...args: unknown[]) {

--- a/packages/app/utils/posthogSingleton.ts
+++ b/packages/app/utils/posthogSingleton.ts
@@ -3,6 +3,7 @@ import PostHog from 'posthog-react-native';
 import { POST_HOG_API_KEY, POST_HOG_IN_DEV } from '../constants';
 
 export const posthogEnabled = (() => {
+  if (POST_HOG_API_KEY === '') return false;
   if (process.env.NODE_ENV === 'test') return false;
   if (process.env.NODE_ENV === 'development') {
     return POST_HOG_IN_DEV;
@@ -11,14 +12,9 @@ export const posthogEnabled = (() => {
 })();
 
 export const posthog: PostHog = new PostHog(
-  // PostHog complains on passing an empty string. Allow omitting PostHog key
-  // when PostHog is disabled by passing a dummy key and then disabling the client.
-  // (If PostHog is enabled, pass the empty string to get a nice error message.)
-  POST_HOG_API_KEY !== ''
-    ? POST_HOG_API_KEY
-    : posthogEnabled
-      ? ''
-      : 'dummy-key',
+  // PostHog rejects an empty key even when disabled, so use an inert placeholder
+  // when telemetry is unavailable.
+  POST_HOG_API_KEY || 'dummy-key',
   {
     host: 'https://data-bridge-v1.vercel.app/ingest',
     disabled: !posthogEnabled,


### PR DESCRIPTION
## Summary

Prevent a missing PostHog API key from crashing the app during startup.

In local development, the crash occurs when `POST_HOG_IN_DEV=true` but the matching API key is missing. Normal development with PostHog disabled does not hit this path. Release builds previously hit it whenever their key was missing.

## Changes

- disable PostHog when no API key is configured
- use an inert placeholder key for the disabled client because the SDK rejects empty keys
- add a regression test for a production build with no key

## How did I test?

- reproduced the crash on an iPhone release build and confirmed the PostHog missing-key exception in the device console
- verified the fixed keyless release build succeeds and installs on device
- ran the focused regression test
- ran TypeScript, ESLint, Prettier, and diff checks
