### PR TITLE
notes-json: don't +scot %tas

### DIFF
--- a/desk/lib/notes/json.hoon
+++ b/desk/lib/notes/json.hoon
@@ -154,7 +154,7 @@
           'host'^s+(scot %p ship.flag)
           'flagName'^s+name.flag
           'notebook'^(notebook notebook.upd)
-          'visibility'^s+(scot %tas visibility.upd)
+          'visibility'^s+visibility.upd
       ==
         %updated
       :~  'type'^s+'notebook-updated'
@@ -171,14 +171,14 @@
       :~  'type'^s+'notebook-visibility-changed'
           'host'^s+(scot %p ship.flag)
           'flagName'^s+name.flag
-          'visibility'^s+(scot %tas visibility.upd)
+          'visibility'^s+visibility.upd
       ==
         %member-joined
       :~  'type'^s+'member-joined'
           'host'^s+(scot %p ship.flag)
           'flagName'^s+name.flag
           'who'^s+(scot %p who.upd)
-          'role'^s+(scot %tas role.upd)
+          'role'^s+role.upd
       ==
         %member-left
       :~  'type'^s+'member-left'
@@ -220,7 +220,7 @@
     :~  'host'^s+(scot %p ship.flag.ns)
         'flagName'^s+name.flag.ns
         'notebook'^(notebook notebook.ns)
-        'visibility'^s+(scot %tas visibility.ns)
+        'visibility'^s+visibility.ns
     ==
   ::  +notebook-summaries: encode (list notebook-summary)
   ::
@@ -237,7 +237,7 @@
     :~  'host'^s+(scot %p ship.flag.nd)
         'flagName'^s+name.flag.nd
         'notebook'^(notebook notebook.nd)
-        'visibility'^s+(scot %tas visibility.nd)
+        'visibility'^s+visibility.nd
     ==
   ::  +member-record: encode one /v0/members item
   ::
@@ -246,7 +246,7 @@
     ^-  json
     %-  pairs
     :~  'ship'^s+(scot %p ship.mr)
-        'role'^s+(scot %tas role.mr)
+        'role'^s+role.mr
     ==
   ::  +member-records: encode (list member-record)
   ::
@@ -355,7 +355,7 @@
       :~  'type'^s+'snapshot'
           'host'^s+(scot %p ship.flag.res)
           'flagName'^s+name.flag.res
-          'visibility'^s+(scot %tas visibility.res)
+          'visibility'^s+visibility.res
       ==
     ==
   ::  +tang-json: render a tang as a JSON array.
@@ -375,12 +375,12 @@
     ++  action-error
       |=  e=action-error:v1:n
       ^-  json
-      s+(scot %tas e)
+      s+e
     ::
     ++  poke-status
       |=  s=poke-status:v1:n
       ^-  json
-      s+(scot %tas s)
+      s+s
     ::  +response: subscriber → client. Encoded as {requestId, body}.
     ::
     ++  response
@@ -476,7 +476,7 @@
           %created
         :~  'type'^s+'notebook-created'
             'notebook'^(notebook notebook.upd)
-            'visibility'^s+(scot %tas visibility.upd)
+            'visibility'^s+visibility.upd
         ==
           %updated
         :~  'type'^s+'notebook-updated'
@@ -486,12 +486,12 @@
         ~[['type' s+'notebook-deleted']]
           %visibility
         :~  'type'^s+'notebook-visibility-changed'
-            'visibility'^s+(scot %tas visibility.upd)
+            'visibility'^s+visibility.upd
         ==
           %member-joined
         :~  'type'^s+'member-joined'
             'who'^s+(scot %p who.upd)
-            'role'^s+(scot %tas role.upd)
+            'role'^s+role.upd
         ==
           %member-left
         :~  'type'^s+'member-left'


### PR DESCRIPTION
## Summary

Don't needlessly `+scot` things we know to be ascii strings. The underlying logic here is essentially an expensive no-op for all our cases.

## How did I test?

The proof is in the pudding.

## Risks and impact

- Yes, safe to rollback without consulting PR author.
- Affects important code area:
  - [x] Channel display

## Rollback plan

Revert.

## Screenshots / videos

<img width="589" height="70" alt="image" src="https://github.com/user-attachments/assets/4a0ac3e3-513e-4d19-a654-e5de4c2a3814" />
