### PR TITLE
onboarding/bot settings: change default model to Luna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ clurd
 
 .obsidian
 .pi
+
+# Local Superpowers planning artifacts
+/docs/superpowers/

--- a/.prettierignore
+++ b/.prettierignore
@@ -40,6 +40,7 @@ dump.sqlite3
 clurd
 .obsidian
 .pi
+/docs/superpowers/
 # From apps/tlon-desktop/.gitignore
 /apps/tlon-desktop/build/
 /apps/tlon-desktop/dist/

--- a/packages/app/features/settings/BotModelSettingsScreen.tsx
+++ b/packages/app/features/settings/BotModelSettingsScreen.tsx
@@ -260,7 +260,7 @@ export function BotModelSettingsScreen(props: Props) {
                     color="$secondaryText"
                     paddingHorizontal="$s"
                   >
-                    Basic uses MiniMax M3.
+                    Basic uses GPT-5.6 Luna.
                   </Text>
                 ) : (
                   <BotSettingsSection title="Model">

--- a/packages/app/features/settings/bot/constants.ts
+++ b/packages/app/features/settings/bot/constants.ts
@@ -3,9 +3,9 @@ import type {
   TlawnProviderModel,
 } from '@tloncorp/api';
 
-export const BASIC_PROVIDER_LABEL = 'Basic (MiniMax M3)';
+export const BASIC_PROVIDER_LABEL = 'Basic (GPT-5.6 Luna)';
 export const BASIC_PROVIDER_ID = 'basic';
-export const BASIC_DEFAULT_MODEL = 'minimax/minimax-m3';
+export const BASIC_DEFAULT_MODEL = 'openai/gpt-5.6-luna';
 export const BASIC_PROVIDER_MODEL: TlawnProviderModel = {
   id: BASIC_DEFAULT_MODEL,
   name: BASIC_PROVIDER_LABEL,

--- a/packages/app/features/settings/bot/helpers.test.ts
+++ b/packages/app/features/settings/bot/helpers.test.ts
@@ -115,12 +115,16 @@ describe('provider config', () => {
       models: [],
       defaultKeys: { basic: { key: 'x' } },
     });
-    // only the shared default MODEL on openrouter maps to Basic
+    // The current shared default model on openrouter maps to Basic.
+    expect(
+      toDisplayProviderId(config, 'openrouter', 'openai/gpt-5.6-luna')
+    ).toBe('basic');
+    // Keep recognizing the previous shared default for stored legacy configs.
     expect(
       toDisplayProviderId(config, 'openrouter', 'minimax/minimax-m3')
     ).toBe('basic');
-    // a custom openrouter model must stay openrouter (else a save would pin it
-    // to minimax and silently rewrite the user's real model)
+    // A custom openrouter model must stay openrouter (otherwise a save would
+    // pin it to the current Basic default and rewrite the user's real model).
     expect(
       toDisplayProviderId(config, 'openrouter', 'anthropic/claude-3.5')
     ).toBe('openrouter');
@@ -414,7 +418,7 @@ describe('channel model overrides', () => {
     expect(entries).toEqual([
       {
         provider: 'basic',
-        model: 'minimax/minimax-m3',
+        model: 'openai/gpt-5.6-luna',
         channels: ['chat/~zod/general'],
       },
     ]);
@@ -432,7 +436,7 @@ describe('channel model overrides', () => {
     expect(entries).toEqual([
       {
         provider: 'basic',
-        model: 'minimax/minimax-m3',
+        model: 'openai/gpt-5.6-luna',
         channels: ['chat/~zod/general'],
       },
     ]);
@@ -455,12 +459,12 @@ describe('toBackendModel', () => {
   it('persists basic as its own provider and pins the model to the default', () => {
     expect(toBackendModel('basic', '')).toEqual({
       provider: 'basic',
-      model: 'minimax/minimax-m3',
+      model: 'openai/gpt-5.6-luna',
     });
     // a stale/leftover model on a Basic pick is ignored
     expect(toBackendModel('basic', 'anthropic/claude-1')).toEqual({
       provider: 'basic',
-      model: 'minimax/minimax-m3',
+      model: 'openai/gpt-5.6-luna',
     });
   });
 

--- a/packages/app/features/settings/bot/helpers.ts
+++ b/packages/app/features/settings/bot/helpers.ts
@@ -9,6 +9,8 @@ import { desig, preSig } from '@tloncorp/api/lib/urbit';
 
 import { BASIC_DEFAULT_MODEL, BASIC_PROVIDER_ID } from './constants';
 
+const LEGACY_BASIC_DEFAULT_MODELS = new Set(['minimax/minimax-m3']);
+
 export type ChannelRuleDraft = {
   mode: 'open' | 'allowlist';
   // Always an explicit list. Solaris can't persist a "follow the defaults" rule
@@ -189,11 +191,11 @@ export const safeKeySummary = (
 // Basic is now persisted as its own backend provider (see toBackendModel), so a
 // stored `basic` entry displays as Basic directly. This heuristic additionally
 // covers legacy configs written before that: an openrouter entry running the
-// shared hosted default model (`BASIC_DEFAULT_MODEL`) with no custom openrouter
-// key is the Basic default key, so show it as Basic. It must be gated on the
-// model — a custom openrouter model (primary, fallback, or channel override)
-// must NOT be relabeled Basic, or a later save (toBackendModel) would pin it to
-// minimax-m3 and silently rewrite the user's real model.
+// current or previous shared hosted default model with no custom openrouter key
+// is the Basic default key, so show it as Basic. It must be gated on the model —
+// a custom openrouter model (primary, fallback, or channel override) must NOT be
+// relabeled Basic, or a later save (toBackendModel) would pin it to the current
+// Basic default and silently rewrite the user's real model.
 export const toDisplayProviderId = (
   config: TlawnProviderConfigInfo | undefined,
   providerId: string,
@@ -201,7 +203,8 @@ export const toDisplayProviderId = (
 ): string => {
   if (
     providerId === 'openrouter' &&
-    model === BASIC_DEFAULT_MODEL &&
+    (model === BASIC_DEFAULT_MODEL ||
+      LEGACY_BASIC_DEFAULT_MODELS.has(model ?? '')) &&
     !config?.keys?.openrouter &&
     config?.defaultKeys?.[BASIC_PROVIDER_ID]
   ) {
@@ -353,8 +356,8 @@ export const toChatFormValues = (
 // to openrouter. It has no model picker, so pin its model to the fixed default
 // (matching the backend's `basicDefaultModel`). Persisting `basic` explicitly
 // keeps it distinct from openrouter even when the user also has their own
-// openrouter key; toDisplayProviderId still reads legacy openrouter/minimax
-// configs as Basic for backward compatibility.
+// openrouter key; toDisplayProviderId still reads the previous OpenRouter-backed
+// Basic model as Basic for backward compatibility.
 export const toBackendModel = (
   provider: string,
   model: string

--- a/packages/app/fixtures/SplashSequence.fixture.tsx
+++ b/packages/app/fixtures/SplashSequence.fixture.tsx
@@ -290,7 +290,7 @@ function BotProviderPaneFixture() {
       <BotProviderPane
         model={model}
         providers={[
-          { label: 'MiniMax', provider: 'basic', requiresKey: false },
+          { label: 'GPT-5.6 Luna', provider: 'basic', requiresKey: false },
           { label: 'Anthropic', provider: 'anthropic', requiresKey: true },
           { label: 'OpenAI', provider: 'openai', requiresKey: true },
           { label: 'OpenRouter', provider: 'openrouter', requiresKey: true },
@@ -352,6 +352,7 @@ function BotModelPaneFixture() {
           { id: 'openai/gpt-4.1-nano' },
           { id: 'openai/o3' },
           { id: 'openai/o4-mini' },
+          { id: 'gpt-5.6-luna' },
           { id: 'google/gemini-1.5-pro' },
           { id: 'google/gemini-1.5-flash' },
           { id: 'google/gemini-2.0-flash' },

--- a/packages/app/ui/components/Wayfinding/SplashSequence.tsx
+++ b/packages/app/ui/components/Wayfinding/SplashSequence.tsx
@@ -87,6 +87,7 @@ import { SystemContactListItem } from '../listItems';
 import { BotChatPreview } from './BotChatPreview';
 import { TlonBotSetupPaneView } from './TlonBotSetupPaneView';
 import { validateProviderKey } from './providerKeyValidation';
+import { resolveInitialProviderModel } from './providerModelDefaults';
 import { useHomeGroupInviteLink } from './useHomeGroupInviteLink';
 import { PrivacyThumbprint } from './visuals/PrivacyThumbprint';
 
@@ -634,9 +635,9 @@ function SplashSequenceComponent(props: {
         return;
       }
       setProviderModels(result.data);
-      // Require an explicit model pick on BotModelPane once real models are
-      // loaded. `handleSaveModelConfig` still keeps a defensive fallback.
-      setBotPrimaryModel('');
+      setBotPrimaryModel((currentModel) =>
+        resolveInitialProviderModel(provider, result.data, currentModel)
+      );
       setCurrentPane(SplashPane.BotModel);
     } catch (e) {
       console.error('Failed to validate provider during onboarding:', e);
@@ -967,7 +968,7 @@ function prejoinTlonbotRevivalWayfindingGroups() {
 }
 
 const PROVIDER_LABELS: Record<string, string> = {
-  basic: 'MiniMax',
+  basic: 'GPT-5.6 Luna',
   anthropic: 'Anthropic',
   openai: 'OpenAI',
   openrouter: 'OpenRouter',

--- a/packages/app/ui/components/Wayfinding/providerModelDefaults.test.ts
+++ b/packages/app/ui/components/Wayfinding/providerModelDefaults.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInitialProviderModel } from './providerModelDefaults';
+
+describe('resolveInitialProviderModel', () => {
+  it('selects GPT-5.6 Luna when a custom OpenAI catalog includes it', () => {
+    expect(
+      resolveInitialProviderModel(
+        'openai',
+        [{ id: 'gpt-5.6-luna' }, { id: 'gpt-5.5' }],
+        ''
+      )
+    ).toBe('gpt-5.6-luna');
+  });
+
+  it('preserves an existing selection that remains available', () => {
+    expect(
+      resolveInitialProviderModel(
+        'openai',
+        [{ id: 'gpt-5.6-luna' }, { id: 'gpt-5.5' }],
+        'gpt-5.5'
+      )
+    ).toBe('gpt-5.5');
+  });
+
+  it('does not default other providers to an OpenAI model', () => {
+    expect(
+      resolveInitialProviderModel('openrouter', [{ id: 'gpt-5.6-luna' }], '')
+    ).toBe('');
+  });
+
+  it('leaves OpenAI unselected when Luna is unavailable', () => {
+    expect(resolveInitialProviderModel('openai', [{ id: 'gpt-5.5' }], '')).toBe(
+      ''
+    );
+  });
+});

--- a/packages/app/ui/components/Wayfinding/providerModelDefaults.ts
+++ b/packages/app/ui/components/Wayfinding/providerModelDefaults.ts
@@ -1,0 +1,20 @@
+import type { TlawnProviderModel } from '@tloncorp/api';
+
+export const OPENAI_ONBOARDING_DEFAULT_MODEL = 'gpt-5.6-luna';
+
+export function resolveInitialProviderModel(
+  provider: string,
+  models: TlawnProviderModel[],
+  currentModel: string
+): string {
+  if (models.some((model) => model.id === currentModel)) {
+    return currentModel;
+  }
+  if (
+    provider === 'openai' &&
+    models.some((model) => model.id === OPENAI_ONBOARDING_DEFAULT_MODEL)
+  ) {
+    return OPENAI_ONBOARDING_DEFAULT_MODEL;
+  }
+  return '';
+}


### PR DESCRIPTION
## Summary

This aligns mobile app with the infrastructure rollout replacing MiniMax M3 with GPT-5.6 Luna as the hosted Basic model. It also streamlines custom OpenAI onboarding by selecting Luna automatically when available.

## Changes

- Updated Basic’s model ID and onboarding/settings copy to GPT-5.6 Luna.
- Added custom OpenAI model resolution that prefers `gpt-5.6-luna`, preserves valid existing selections, and otherwise requires a manual choice.
- Preserved compatibility for legacy MiniMax-backed Basic configurations.
- Added focused tests covering Basic serialization and OpenAI default selection.

## How did I test?

Locally on iOS simulator

## Risks and impact

- Safe to rollback without consulting PR author? Yes
