### PR TITLE
tlon-skill: add %diary-to-%notes migration commands

### DIFF
--- a/packages/tlon-skill/SKILL.md
+++ b/packages/tlon-skill/SKILL.md
@@ -57,10 +57,11 @@ Pass that printed URL as `media=`. On hosted deployments the upload must run
 through the owner ship's config (the bot's own ship has no storage):
 `tlon --config "$TLON_OWNER_CONFIG_PATH" upload <path>`.
 
-> **Removed: diary/notebook channels.** The `%diary` backend has been removed.
-> `tlon notebook`, `--kind diary`, and any `diary/...` nest now fail with an
-> explanatory error pointing at `%notes`. Use the `tlon notes` family for
-> Markdown notebooks instead.
+> **Deprecated: diary channels.** `%diary` is not managed by the CLI:
+> `tlon notebook`, `--kind diary`, and `diary/...` targets fail with guidance
+> toward `%notes`. Use the `tlon notes` family for Markdown notebooks. An owner
+> can preview a legacy diary with `tlon notes migrate-plan <diary-nest>` and
+> migrate it with `tlon notes migrate-apply <diary-nest> --yes`.
 
 ## Installation
 
@@ -469,7 +470,9 @@ Send `--image` takes a **direct** png/jpeg/gif/webp URL — normally the URL ret
 
 `posts edit` edits message text only. The former notebook-only
 `--title`/`--image`/`--content` edit flags are removed (they refuse with an
-explanatory error) along with diary/notebook channels.
+explanatory error). Deprecated diary channels are unmanaged by the CLI except
+through the owner-run `tlon notes migrate-plan <diary-nest>` and
+`tlon notes migrate-apply <diary-nest> --yes` paths.
 
 ### Notes
 
@@ -500,6 +503,9 @@ tlon notes folder-delete notes/~host/name 4 --recursive  # Delete a folder (--re
 tlon notes members notes/~host/name                      # List notebook members
 tlon notes join notes/~host/name                         # Join a notebook
 tlon notes leave notes/~host/name                        # Leave a notebook
+tlon notes migrate-plan diary/~host/name                 # Read-only diary migration plan
+tlon notes migrate-apply diary/~host/name --yes          # Owner-gated migration write
+tlon notes notebook-delete notes/~host/name --yes        # Owner-gated migration recovery
 ```
 
 Note bodies come from exactly one content source. `note-create` accepts

--- a/packages/tlon-skill/references/urbit-api.md
+++ b/packages/tlon-skill/references/urbit-api.md
@@ -100,7 +100,9 @@ Format: `~host/group-name`
 
 ### Nest (Channel ID)
 Format: `{kind}/~host/channel-name`
-Kinds: `chat`, `heap` (the `%diary` notebook kind has been removed; use `%notes`)
+Kinds: `chat`, `heap`; `%diary` is deprecated and unmanaged by the CLI. Owners
+can preview a legacy diary with `tlon notes migrate-plan <diary-nest>` and move
+it to `%notes` with `tlon notes migrate-apply <diary-nest> --yes`.
 
 ## Tips
 

--- a/packages/tlon-skill/scripts/api-client.test.ts
+++ b/packages/tlon-skill/scripts/api-client.test.ts
@@ -68,6 +68,46 @@ afterEach(() => {
 });
 
 describe('ensureClient auth/cache policy', () => {
+  // OpenClaw pipes stderr and relays it verbatim into an owner DM on failure
+  // (migrate-command.ts). Advice about shortening the next shell invocation is
+  // noise there, so the note is for a terminal only.
+  it('does not print the cached-credentials note when stderr is not a TTY', async () => {
+    const resolved = resolution({
+      config: { cookie: 'urbauth-~zod=0v-cookie', code: 'fallback-code' },
+      authKind: 'cookie',
+      fallbackCode: 'fallback-code',
+      mayWriteAuthCache: true,
+    });
+    const { deps, cacheWrites } = makeDeps(resolved, {
+      cookieValid: false,
+      freshCookie: 'urbauth-~zod=0v-fresh',
+    });
+
+    const originalIsTTY = process.stderr.isTTY;
+    const originalError = console.error;
+    const written: string[] = [];
+    console.error = (...args: unknown[]) => {
+      written.push(args.map(String).join(' '));
+    };
+    try {
+      Object.defineProperty(process.stderr, 'isTTY', {
+        value: false,
+        configurable: true,
+      });
+      await ensureClient([], deps);
+    } finally {
+      console.error = originalError;
+      Object.defineProperty(process.stderr, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    }
+
+    // The cookie is still cached; only the advisory is suppressed.
+    expect(cacheWrites).toHaveLength(1);
+    expect(written.join('\n')).not.toContain('Credentials cached');
+  });
+
   it('uses provided cookie first and does not cache it when validation succeeds', async () => {
     const resolved = resolution({
       config: { cookie: 'urbauth-~zod=0v-cookie', code: 'fallback-code' },

--- a/packages/tlon-skill/scripts/api-client.ts
+++ b/packages/tlon-skill/scripts/api-client.ts
@@ -331,9 +331,14 @@ export async function ensureClient(
       const freshCookie = deps.getAuthenticatedCookie();
       if (freshCookie) {
         deps.cacheCookie(cfg.url, cfg.ship, freshCookie);
-        console.error(
-          `Note: Credentials cached for ${preSig(cfg.ship)}. Next time run: tlon --ship ${preSig(cfg.ship)} <command>`
-        );
+        // Only for a human at a terminal. Programmatic callers pipe stderr —
+        // OpenClaw relays it straight into an owner DM on failure — where
+        // advice about shortening the next shell invocation is noise.
+        if (process.stderr.isTTY) {
+          console.error(
+            `Note: Credentials cached for ${preSig(cfg.ship)}. Next time run: tlon --ship ${preSig(cfg.ship)} <command>`
+          );
+        }
       }
     }
 

--- a/packages/tlon-skill/scripts/channels.ts
+++ b/packages/tlon-skill/scripts/channels.ts
@@ -359,7 +359,7 @@ async function createChannelInGroup(
 // listing appeared (see notes-channel.ts).
 async function createNotesChannel(groupId: string, title: string) {
   const nest = await createNotesChannelInGroup(
-    { groupId, title },
+    { groupId, title, readers: [] },
     createNotesChannelDeps()
   );
 

--- a/packages/tlon-skill/scripts/cli-utils.ts
+++ b/packages/tlon-skill/scripts/cli-utils.ts
@@ -140,7 +140,7 @@ export function refuseNotesCitePath(citePath: string | undefined): void {
 // It says *why* — for agents (e.g. OpenClaw) and humans with stale habits — not a
 // generic "unknown command/kind" or backend "channel not found".
 export const DIARY_REMOVED =
-  'diary/notebook channels are no longer supported — they have been replaced by %notes. Use `tlon notes` (see `tlon notes --help`).';
+  'diary/notebook channels are deprecated and unsupported by this CLI — they have been replaced by %notes. Use `tlon notes` (see `tlon notes --help`), or ask the owner to run `tlon notes migrate-plan <diary-nest>` for a read-only preview and `tlon notes migrate-apply <diary-nest> --yes` to migrate.';
 
 // True for a nest addressing a diary channel (e.g. `diary/~host/blog`).
 export function isDiaryNest(nest: string | undefined): boolean {

--- a/packages/tlon-skill/scripts/commands/migrate.test.ts
+++ b/packages/tlon-skill/scripts/commands/migrate.test.ts
@@ -1,0 +1,406 @@
+import type { Story } from '@tloncorp/api';
+import { describe, expect, it } from 'bun:test';
+
+import type { MigrationDeps, MigrationPlan } from '../notes-migrate';
+import {
+  MIGRATE_HELP,
+  formatApplySummaryLines,
+  formatPlanText,
+  parseMigrateArgs,
+  runMigrate,
+  runMigrateApply,
+  runMigratePlan,
+} from './migrate';
+import { run as runNotes } from './notes';
+import type { NotesDeps } from './notes';
+
+const PLAN: MigrationPlan = {
+  sourceNest: 'diary/~zod/blog',
+  group: '~zod/group',
+  sourceTitle: 'Field Notes',
+  targetTitle: 'Field Notes',
+  eligibleCount: 2,
+  tombstoneCount: 1,
+  stubCount: 0,
+  previewTitles: ['First', 'Untitled — 2025-03-14'],
+  writeWidening: true,
+  wideningReasons: [
+    'reader role "members" is not writer-authorizing and would gain write access',
+  ],
+  readerRoles: ['members'],
+  writerRoles: ['writers'],
+  privacy: 'private',
+  archiveTitle: 'Field Notes-ARCHIVE',
+  metrics: {
+    totalComments: 3,
+    totalReactions: 4,
+    citeCount: 5,
+    linkBlockCount: 6,
+    groupMentionCount: 7,
+  },
+};
+
+function migrationDeps(): MigrationDeps {
+  return {
+    getChannelPerm: async () => ({
+      writers: ['writers'],
+      group: '~zod/group',
+    }),
+    getGroup: async () => ({
+      privacy: 'private',
+      admins: [],
+      channels: {
+        'diary/~zod/blog': {
+          added: 1,
+          meta: {
+            title: 'Field Notes',
+            description: '',
+            image: '',
+            cover: '',
+          },
+          section: 'main',
+          readers: ['writers'],
+          join: false,
+        },
+      },
+    }),
+    getChannelPosts: async () => ({
+      posts: [
+        {
+          id: '1',
+          type: 'note',
+          channelId: 'diary/~zod/blog',
+          authorId: '~zod',
+          sentAt: Date.UTC(2025, 0, 1),
+          receivedAt: Date.UTC(2025, 0, 1),
+          sequenceNum: 1,
+          content: [{ inline: ['Hello'] }],
+        },
+      ],
+      older: null,
+      totalPosts: 1,
+    }),
+    createGroupNotebook: async () => {
+      throw new Error('not used');
+    },
+    getNotebookDetail: async () => {
+      throw new Error('not used');
+    },
+    listNotes: async () => {
+      throw new Error('not used');
+    },
+    batchImport: async () => {
+      throw new Error('not used');
+    },
+    getRawGroup: async () => {
+      throw new Error('not used');
+    },
+    updateChannel: async () => {
+      throw new Error('not used');
+    },
+    getActingShip: () => '~zod',
+    assertServerIdentity: async () => {
+      throw new Error('not used');
+    },
+    toUrbitStory: (content) => content as Story,
+    storyToMdastStrict: () => undefined,
+    storyToMarkdown: () => 'Hello',
+    generateRequestId: () => '0v1',
+    recoveryInstruction: () => 'recover',
+    log: () => undefined,
+  };
+}
+
+describe('parseMigrateArgs', () => {
+  it('accepts only the two specified command surfaces', () => {
+    expect(parseMigrateArgs('migrate-plan', ['diary/zod/blog'])).toEqual({
+      sourceNest: 'diary/~zod/blog',
+      allowWriteWidening: false,
+      yes: false,
+    });
+    expect(
+      parseMigrateArgs('migrate-apply', [
+        'diary/~zod/blog',
+        '--yes',
+        '--allow-write-widening',
+      ])
+    ).toEqual({
+      sourceNest: 'diary/~zod/blog',
+      allowWriteWidening: true,
+      yes: true,
+    });
+  });
+
+  for (const removed of [
+    '--into',
+    '--title',
+    '--expect-posts',
+    '--expect-digest',
+    '--self-bind',
+    '--json',
+  ]) {
+    it(`rejects removed flag ${removed}`, () => {
+      expect(() =>
+        parseMigrateArgs('migrate-plan', ['diary/~zod/blog', removed, 'value'])
+      ).toThrow(`${removed} is not permitted`);
+    });
+  }
+
+  it('requires --yes only for apply', () => {
+    expect(() =>
+      parseMigrateArgs('migrate-apply', ['diary/~zod/blog'])
+    ).toThrow('requires --yes');
+    expect(() =>
+      parseMigrateArgs('migrate-plan', ['diary/~zod/blog', '--yes'])
+    ).toThrow('--yes is not permitted');
+  });
+
+  it('rejects duplicate flags and extra positional arguments', () => {
+    expect(() =>
+      parseMigrateArgs('migrate-apply', ['diary/~zod/blog', '--yes', '--yes'])
+    ).toThrow('Duplicate option --yes');
+    expect(() =>
+      parseMigrateArgs('migrate-plan', ['diary/~zod/blog', 'diary/~zod/other'])
+    ).toThrow('Unexpected argument');
+  });
+
+  it('makes bare migrate point at the two supported verbs', () => {
+    expect(() => parseMigrateArgs('migrate', [])).toThrow(
+      'Use either migrate-plan or migrate-apply'
+    );
+  });
+});
+
+describe('plain-text plan rendering', () => {
+  it('states losses, authorship, permission classes, and result', () => {
+    const text = formatPlanText(PLAN);
+    expect(text).toContain('Migration plan — Field Notes');
+    expect(text).toContain('2 posts → 2 notes');
+    expect(text).toContain(
+      '5 post references and 6 link blocks — dropped in conversion'
+    );
+    expect(text).toContain('7 group mentions → converted to plain text');
+    expect(text).toContain('3 comments and 4 post reactions');
+    expect(text).toContain('every note will show ~zod as author');
+    expect(text).toContain('"writers" can post');
+    expect(text).toContain('members with "members" can read');
+    expect(text).toContain('Blocked by default; requires explicit acceptance.');
+    expect(text).toContain('Original renamed "Field Notes-ARCHIVE"');
+  });
+
+  // The read-only terminal report does not accept the widening on the user's
+  // behalf. The flag is named by migrate-apply's refusal instead.
+  it('never names the CLI flag, in either widening state', () => {
+    expect(formatPlanText(PLAN)).not.toContain('--allow-write-widening');
+    expect(
+      formatPlanText({ ...PLAN, writeWidening: false, wideningReasons: [] })
+    ).not.toContain('--allow-write-widening');
+  });
+
+  it('states that an open channel in a public group is readable by anyone', () => {
+    const text = formatPlanText({
+      ...PLAN,
+      readerRoles: [],
+      writerRoles: [],
+      privacy: 'public',
+    });
+    expect(text).toContain('anyone can read');
+    expect(text).toContain('readable by: anyone');
+    expect(text).not.toContain('all group members can read');
+  });
+
+  it('states that an open channel in a private group is readable by group members', () => {
+    const text = formatPlanText({
+      ...PLAN,
+      readerRoles: [],
+      writerRoles: [],
+      privacy: 'private',
+    });
+    expect(text).toContain('all group members can read');
+    expect(text).toContain('readable by: all group members');
+  });
+});
+
+describe('completion summary rendering', () => {
+  it('reports converted group mentions separately from archive-only losses', () => {
+    const lines = formatApplySummaryLines({
+      notesImported: 2,
+      targetNest: 'notes/~zod/field-notes',
+      archiveTitle: 'Field Notes-ARCHIVE',
+      archiveRenamed: true,
+      archiveOnly: PLAN.metrics,
+      warnings: [],
+    });
+    const archiveLine = lines.find((line) => line.includes('Left in archive'));
+    expect(archiveLine).not.toContain('group mention');
+    expect(lines).toContain('  Converted to plain text: 7 group mentions');
+  });
+});
+
+describe('CLI dispatch', () => {
+  it('runs migrate-plan as a complete authenticated read', async () => {
+    const output: string[] = [];
+    let auth = 0;
+    const code = await runMigratePlan(['diary/~zod/blog'], {
+      stdout: (text) => output.push(text),
+      stderr: () => undefined,
+      authenticate: async () => {
+        auth += 1;
+      },
+      migration: migrationDeps(),
+    });
+    expect(code).toBe(0);
+    expect(auth).toBe(1);
+    expect(output.join('')).toContain('Migration plan — Field Notes');
+    expect(output.join('')).not.toStartWith('{');
+  });
+
+  it('validates apply confirmation before authentication', async () => {
+    let auth = 0;
+    await expect(
+      runMigrateApply(['diary/~zod/blog'], {
+        stdout: () => undefined,
+        stderr: () => undefined,
+        authenticate: async () => {
+          auth += 1;
+        },
+        migration: migrationDeps(),
+      })
+    ).rejects.toThrow('requires --yes');
+    expect(auth).toBe(0);
+  });
+
+  it('renders help for the migration command family', async () => {
+    const output: string[] = [];
+    await expect(
+      runMigrate(['--help'], {
+        stdout: (text) => output.push(text),
+        stderr: () => undefined,
+        authenticate: async () => undefined,
+        migration: migrationDeps(),
+      })
+    ).resolves.toBe(0);
+    expect(output.join('')).toContain(MIGRATE_HELP);
+  });
+});
+
+describe('notebook-delete recovery CLI', () => {
+  const markedBody =
+    'Migrated body\n\n<!-- tlon-migrate: diary/~zod/blog 170.141 -->\n';
+
+  function notesDeps(
+    options: {
+      bodies?: Array<string | null>;
+      deletionConfirmed?: boolean;
+    } = {}
+  ) {
+    const stderr: string[] = [];
+    const calls = {
+      auth: 0,
+      deleted: [] as string[],
+      listedNotes: [] as string[],
+      listedNotebooks: 0,
+    };
+    const deps = {
+      stdout: () => undefined,
+      stderr: (text: string) => stderr.push(text),
+      authenticate: async () => {
+        calls.auth += 1;
+      },
+      notesV1: {
+        listNotes: async (nest: string) => {
+          calls.listedNotes.push(nest);
+          return (options.bodies ?? [markedBody]).map((bodyMd, index) => ({
+            id: index + 1,
+            title: `Note ${index + 1}`,
+            bodyMd,
+          }));
+        },
+        listNotebooks: async () => {
+          calls.listedNotebooks += 1;
+          return options.deletionConfirmed === false
+            ? [
+                {
+                  host: '~zod',
+                  flagName: 'book',
+                  notebook: { id: 1, title: 'Book' },
+                },
+              ]
+            : [];
+        },
+      },
+      deleteNotesNotebookStrict: async (nest: string) => {
+        calls.deleted.push(nest);
+      },
+      isPendingWriteError: () => false,
+    } as unknown as NotesDeps;
+    return { calls, deps, stderr: () => stderr.join('') };
+  }
+
+  it('requires --yes before authentication', async () => {
+    const { calls, deps } = notesDeps();
+    expect(await runNotes(['notebook-delete', 'notes/~zod/book'], deps)).toBe(
+      1
+    );
+    expect(calls.auth).toBe(0);
+    expect(calls.deleted).toEqual([]);
+  });
+
+  it('deletes the exact normalized notes nest after authentication', async () => {
+    const { calls, deps } = notesDeps();
+    expect(
+      await runNotes(['notebook-delete', 'notes/zod/book', '--yes'], deps)
+    ).toBe(0);
+    expect(calls.auth).toBe(1);
+    expect(calls.listedNotes).toEqual(['notes/~zod/book']);
+    expect(calls.deleted).toEqual(['notes/~zod/book']);
+    expect(calls.listedNotebooks).toBe(1);
+  });
+
+  it('refuses to delete a notebook containing unmarked notes', async () => {
+    const { calls, deps, stderr } = notesDeps({
+      bodies: [markedBody, 'A member wrote this note.'],
+    });
+
+    expect(
+      await runNotes(['notebook-delete', 'notes/~zod/book', '--yes'], deps)
+    ).toBe(1);
+    expect(stderr()).toContain('found 1 unmarked note(s)');
+    expect(stderr()).toContain('--yes --force');
+    expect(calls.deleted).toEqual([]);
+    expect(calls.listedNotebooks).toBe(0);
+  });
+
+  it('allows intentional deletion of unmarked notes only with --force and --yes', async () => {
+    const forced = notesDeps({ bodies: ['A member wrote this note.'] });
+    expect(
+      await runNotes(
+        ['notebook-delete', 'notes/~zod/book', '--yes', '--force'],
+        forced.deps
+      )
+    ).toBe(0);
+    expect(forced.calls.deleted).toEqual(['notes/~zod/book']);
+
+    const missingYes = notesDeps({ bodies: ['A member wrote this note.'] });
+    expect(
+      await runNotes(
+        ['notebook-delete', 'notes/~zod/book', '--force'],
+        missingYes.deps
+      )
+    ).toBe(1);
+    expect(missingYes.calls.auth).toBe(0);
+    expect(missingYes.calls.deleted).toEqual([]);
+  });
+
+  it('errors instead of reporting deletion when read-back still lists the notebook', async () => {
+    const { calls, deps, stderr } = notesDeps({ deletionConfirmed: false });
+
+    expect(
+      await runNotes(['notebook-delete', 'notes/~zod/book', '--yes'], deps)
+    ).toBe(1);
+    expect(calls.deleted).toEqual(['notes/~zod/book']);
+    expect(calls.listedNotebooks).toBe(1);
+    expect(stderr()).toContain('Notebook deletion was not confirmed');
+    expect(stderr()).toContain('notes/~zod/book is still present');
+  });
+});

--- a/packages/tlon-skill/scripts/commands/migrate.test.ts
+++ b/packages/tlon-skill/scripts/commands/migrate.test.ts
@@ -37,6 +37,7 @@ const PLAN: MigrationPlan = {
     citeCount: 5,
     linkBlockCount: 6,
     groupMentionCount: 7,
+    flattenedInlineCount: 0,
   },
 };
 
@@ -250,7 +251,9 @@ describe('completion summary rendering', () => {
     });
     const archiveLine = lines.find((line) => line.includes('Left in archive'));
     expect(archiveLine).not.toContain('group mention');
-    expect(lines).toContain('  Converted to plain text: 7 group mentions');
+    expect(lines).toContain(
+      '  Converted to plain text: 7 group mentions, 0 tags/inline references'
+    );
   });
 });
 

--- a/packages/tlon-skill/scripts/commands/migrate.test.ts
+++ b/packages/tlon-skill/scripts/commands/migrate.test.ts
@@ -204,7 +204,10 @@ describe('plain-text plan rendering', () => {
       writerRoles: [],
       privacy: 'public',
     });
-    expect(text).toContain('anyone can read');
+    expect(text).toContain(
+      'Now:   all group members can post; anyone can read.'
+    );
+    expect(text).not.toContain('everyone who can read can post');
     expect(text).toContain('readable by: anyone');
     expect(text).not.toContain('all group members can read');
   });
@@ -216,8 +219,22 @@ describe('plain-text plan rendering', () => {
       writerRoles: [],
       privacy: 'private',
     });
-    expect(text).toContain('all group members can read');
+    expect(text).toContain(
+      'Now:   all group members can post; all group members can read.'
+    );
     expect(text).toContain('readable by: all group members');
+  });
+
+  it('states that open writers remain all group members with role-restricted readers', () => {
+    const text = formatPlanText({
+      ...PLAN,
+      readerRoles: ['readers'],
+      writerRoles: [],
+      privacy: 'secret',
+    });
+    expect(text).toContain(
+      'Now:   all group members can post; members with "readers" can read.'
+    );
   });
 });
 
@@ -292,24 +309,37 @@ describe('notebook-delete recovery CLI', () => {
     options: {
       bodies?: Array<string | null>;
       deletionConfirmed?: boolean;
+      groupListings?: Array<{ groupId: string; channelIds: string[] }>;
+      groupSnapshotError?: Error;
+      pollResponses?: Record<string, Array<string[] | Error>>;
     } = {}
   ) {
+    const stdout: string[] = [];
     const stderr: string[] = [];
     const calls = {
       auth: 0,
       deleted: [] as string[],
       listedNotes: [] as string[],
       listedNotebooks: 0,
+      groupSnapshots: 0,
+      groupPolls: [] as string[],
+      sleeps: [] as number[],
+      order: [] as string[],
     };
     const deps = {
-      stdout: () => undefined,
+      stdout: (text: string) => {
+        stdout.push(text);
+        calls.order.push(`stdout:${text.trim()}`);
+      },
       stderr: (text: string) => stderr.push(text),
       authenticate: async () => {
         calls.auth += 1;
+        calls.order.push('authenticate');
       },
       notesV1: {
         listNotes: async (nest: string) => {
           calls.listedNotes.push(nest);
+          calls.order.push('listNotes');
           return (options.bodies ?? [markedBody]).map((bodyMd, index) => ({
             id: index + 1,
             title: `Note ${index + 1}`,
@@ -318,6 +348,7 @@ describe('notebook-delete recovery CLI', () => {
         },
         listNotebooks: async () => {
           calls.listedNotebooks += 1;
+          calls.order.push('listNotebooks');
           return options.deletionConfirmed === false
             ? [
                 {
@@ -331,10 +362,38 @@ describe('notebook-delete recovery CLI', () => {
       },
       deleteNotesNotebookStrict: async (nest: string) => {
         calls.deleted.push(nest);
+        calls.order.push('deleteNotesNotebookStrict');
+      },
+      getGroupChannelListings: async () => {
+        calls.groupSnapshots += 1;
+        calls.order.push('getGroupChannelListings');
+        if (options.groupSnapshotError) throw options.groupSnapshotError;
+        return options.groupListings ?? [];
+      },
+      getGroupChannelIds: async (groupId: string) => {
+        const attempt = calls.groupPolls.filter(
+          (polledGroup) => polledGroup === groupId
+        ).length;
+        calls.groupPolls.push(groupId);
+        calls.order.push(`getGroupChannelIds:${groupId}`);
+        expect(stdout).toEqual([]);
+        const responses = options.pollResponses?.[groupId] ?? [[]];
+        const response = responses[Math.min(attempt, responses.length - 1)];
+        if (response instanceof Error) throw response;
+        return response;
+      },
+      sleep: async (ms: number) => {
+        calls.sleeps.push(ms);
+        calls.order.push(`sleep:${ms}`);
       },
       isPendingWriteError: () => false,
     } as unknown as NotesDeps;
-    return { calls, deps, stderr: () => stderr.join('') };
+    return {
+      calls,
+      deps,
+      stdout: () => stdout.join(''),
+      stderr: () => stderr.join(''),
+    };
   }
 
   it('requires --yes before authentication', async () => {
@@ -347,7 +406,7 @@ describe('notebook-delete recovery CLI', () => {
   });
 
   it('deletes the exact normalized notes nest after authentication', async () => {
-    const { calls, deps } = notesDeps();
+    const { calls, deps, stdout } = notesDeps();
     expect(
       await runNotes(['notebook-delete', 'notes/zod/book', '--yes'], deps)
     ).toBe(0);
@@ -355,6 +414,120 @@ describe('notebook-delete recovery CLI', () => {
     expect(calls.listedNotes).toEqual(['notes/~zod/book']);
     expect(calls.deleted).toEqual(['notes/~zod/book']);
     expect(calls.listedNotebooks).toBe(1);
+    expect(calls.groupSnapshots).toBe(1);
+    expect(calls.groupPolls).toEqual([]);
+    expect(calls.order).toEqual([
+      'authenticate',
+      'listNotes',
+      'getGroupChannelListings',
+      'deleteNotesNotebookStrict',
+      'listNotebooks',
+      'stdout:✓ Notebook deleted: notes/~zod/book',
+    ]);
+    expect(stdout()).toBe('✓ Notebook deleted: notes/~zod/book\n');
+  });
+
+  it('waits for every recorded group listing to clear before reporting success', async () => {
+    const target = 'notes/~zod/book';
+    const { calls, deps, stdout } = notesDeps({
+      groupListings: [
+        { groupId: '~zod/alpha', channelIds: [target, 'chat/~zod/general'] },
+        { groupId: '~zod/beta', channelIds: ['chat/~zod/random'] },
+        { groupId: '~zod/gamma', channelIds: [target] },
+      ],
+      pollResponses: {
+        '~zod/alpha': [[target], []],
+        '~zod/gamma': [[], []],
+      },
+    });
+
+    expect(await runNotes(['notebook-delete', target, '--yes'], deps)).toBe(0);
+    expect(calls.groupPolls).toEqual([
+      '~zod/alpha',
+      '~zod/gamma',
+      '~zod/alpha',
+      '~zod/gamma',
+    ]);
+    expect(calls.groupPolls).not.toContain('~zod/beta');
+    expect(calls.sleeps).toEqual([500]);
+    expect(calls.order.indexOf('getGroupChannelListings')).toBeLessThan(
+      calls.order.indexOf('deleteNotesNotebookStrict')
+    );
+    expect(calls.order.indexOf('listNotebooks')).toBeGreaterThan(
+      calls.order.indexOf('deleteNotesNotebookStrict')
+    );
+    expect(stdout()).toBe(`✓ Notebook deleted: ${target}\n`);
+  });
+
+  it('refuses deletion before mutation when the group snapshot cannot be read', async () => {
+    const target = 'notes/~zod/book';
+    const { calls, deps, stderr, stdout } = notesDeps({
+      groupSnapshotError: new Error('groups unavailable'),
+    });
+
+    expect(await runNotes(['notebook-delete', target, '--yes'], deps)).toBe(1);
+    expect(stderr()).toContain(
+      `Error: Could not inspect group listings before deleting ${target}: groups unavailable`
+    );
+    expect(calls.deleted).toEqual([]);
+    expect(calls.listedNotebooks).toBe(0);
+    expect(calls.groupPolls).toEqual([]);
+    expect(stdout()).toBe('');
+  });
+
+  it('reports deleted but unconfirmed when a recorded listing stays present', async () => {
+    const target = 'notes/~zod/book';
+    const { calls, deps, stderr, stdout } = notesDeps({
+      groupListings: [
+        { groupId: '~zod/alpha', channelIds: [target] },
+        { groupId: '~zod/beta', channelIds: [target] },
+      ],
+      pollResponses: {
+        '~zod/alpha': [[target]],
+        '~zod/beta': [[], [], [], [], new Error('final beta failure')],
+      },
+    });
+
+    expect(await runNotes(['notebook-delete', target, '--yes'], deps)).toBe(1);
+    expect(calls.deleted).toEqual([target]);
+    expect(calls.listedNotebooks).toBe(1);
+    expect(
+      calls.groupPolls.filter((group) => group === '~zod/alpha')
+    ).toHaveLength(5);
+    expect(
+      calls.groupPolls.filter((group) => group === '~zod/beta')
+    ).toHaveLength(5);
+    expect(calls.sleeps).toEqual([500, 500, 500, 500]);
+    expect(stderr()).toBe(
+      `Error: Notebook deleted; group cleanup unconfirmed for ${target}: its old group listing is still present. Wait a few seconds before retrying the migration.\n`
+    );
+    expect(stdout()).not.toContain('✓ Notebook deleted');
+  });
+
+  it('reports deleted but unverifiable when the final group read fails', async () => {
+    const target = 'notes/~zod/book';
+    const { calls, deps, stderr, stdout } = notesDeps({
+      groupListings: [{ groupId: '~zod/alpha', channelIds: [target] }],
+      pollResponses: {
+        '~zod/alpha': [
+          [target],
+          new Error('read 2 failed'),
+          new Error('read 3 failed'),
+          new Error('read 4 failed'),
+          new Error('read 5 failed'),
+        ],
+      },
+    });
+
+    expect(await runNotes(['notebook-delete', target, '--yes'], deps)).toBe(1);
+    expect(calls.deleted).toEqual([target]);
+    expect(calls.listedNotebooks).toBe(1);
+    expect(calls.groupPolls).toHaveLength(5);
+    expect(calls.sleeps).toEqual([500, 500, 500, 500]);
+    expect(stderr()).toBe(
+      `Error: Notebook deleted; group cleanup unconfirmed for ${target}: the group listing could not be checked. Wait a few seconds before retrying the migration.\n`
+    );
+    expect(stdout()).not.toContain('✓ Notebook deleted');
   });
 
   it('refuses to delete a notebook containing unmarked notes', async () => {
@@ -369,6 +542,20 @@ describe('notebook-delete recovery CLI', () => {
     expect(stderr()).toContain('--yes --force');
     expect(calls.deleted).toEqual([]);
     expect(calls.listedNotebooks).toBe(0);
+  });
+
+  it('requires --force when user content follows a valid provenance line', async () => {
+    const { calls, deps, stderr } = notesDeps({
+      bodies: [
+        '<!-- tlon-migrate: diary/~zod/blog 170.141 -->\nUser-added content',
+      ],
+    });
+
+    expect(
+      await runNotes(['notebook-delete', 'notes/~zod/book', '--yes'], deps)
+    ).toBe(1);
+    expect(stderr()).toContain('found 1 unmarked note(s)');
+    expect(calls.deleted).toEqual([]);
   });
 
   it('allows intentional deletion of unmarked notes only with --force and --yes', async () => {

--- a/packages/tlon-skill/scripts/commands/migrate.ts
+++ b/packages/tlon-skill/scripts/commands/migrate.ts
@@ -134,6 +134,7 @@ export function formatPlanText(plan: MigrationPlan): string {
     "WHAT DOESN'T MOVE  (stays readable in the archive)",
     `  ${plan.metrics.citeCount} post references and ${plan.metrics.linkBlockCount} link blocks — dropped in conversion`,
     `  ${plan.metrics.groupMentionCount} group mentions → converted to plain text`,
+    `  ${plan.metrics.flattenedInlineCount} tags and inline references → converted to plain text`,
     `  ${plan.metrics.totalComments} comments and ${plan.metrics.totalReactions} post reactions — remain on the archived channel`,
     `  ${plan.tombstoneCount} tombstones and ${plan.stubCount} sequence stubs — not imported`,
     "  Reactions on comments aren't counted — replies aren't read",
@@ -176,7 +177,7 @@ export function formatApplySummaryLines(summary: ApplySummary): string[] {
       summary.archiveRenamed ? '' : ' (rename in the app)'
     }`,
     `  Left in archive: ${summary.archiveOnly.totalComments} comments, ${summary.archiveOnly.totalReactions} reactions, ${summary.archiveOnly.citeCount} references, ${summary.archiveOnly.linkBlockCount} link blocks`,
-    `  Converted to plain text: ${summary.archiveOnly.groupMentionCount} group mentions`,
+    `  Converted to plain text: ${summary.archiveOnly.groupMentionCount} group mentions, ${summary.archiveOnly.flattenedInlineCount} tags/inline references`,
     ...summary.warnings.map((warning) => `  Warning: ${warning}`),
   ];
 }

--- a/packages/tlon-skill/scripts/commands/migrate.ts
+++ b/packages/tlon-skill/scripts/commands/migrate.ts
@@ -1,0 +1,225 @@
+import type {
+  MigrationDeps,
+  MigrationOptions,
+  MigrationPlan,
+} from '../notes-migrate';
+import { canonicalizeNest, parseNest } from '../notes-migrate';
+import { type ApplySummary, executeApply } from '../notes-migrate-apply';
+import { executePlan } from '../notes-migrate-plan';
+import {
+  type CommandDeps,
+  commandError,
+  isHelpArg,
+  usageError,
+  writeHelp,
+  writeLine,
+} from './command';
+
+export const MIGRATE_HELP = `Usage: tlon notes migrate-plan <diary-nest>
+       tlon notes migrate-apply <diary-nest> --yes [--allow-write-widening]
+
+Migrate a diary channel to a fresh %notes notebook.
+
+Commands:
+  migrate-plan   Complete read-only conversion plan
+  migrate-apply  Create, import, verify, and archive (requires --yes)
+
+Options:
+  --allow-write-widening  Accept the reported editor-access widening
+  --yes                   Confirm migrate-apply
+`;
+
+export interface MigrateCommandDeps extends CommandDeps {
+  authenticate: () => Promise<void>;
+  migration: MigrationDeps;
+}
+
+export function parseMigrateArgs(
+  subcommand: string,
+  args: string[]
+): MigrationOptions {
+  if (subcommand !== 'migrate-plan' && subcommand !== 'migrate-apply') {
+    throw usageError(
+      subcommand === 'migrate'
+        ? 'Use either migrate-plan or migrate-apply'
+        : `Unknown migrate subcommand: ${subcommand}`,
+      MIGRATE_HELP
+    );
+  }
+
+  const allowed = new Set(
+    subcommand === 'migrate-plan'
+      ? ['allow-write-widening']
+      : ['allow-write-widening', 'yes']
+  );
+  const seenFlags = new Set<string>();
+  let sourceNest: string | undefined;
+
+  for (const arg of args) {
+    if (arg.startsWith('--')) {
+      const flag = arg.slice(2);
+      if (!allowed.has(flag)) {
+        throw usageError(
+          `Option --${flag} is not permitted for ${subcommand}`,
+          MIGRATE_HELP
+        );
+      }
+      if (seenFlags.has(flag)) {
+        throw usageError(`Duplicate option --${flag}`, MIGRATE_HELP);
+      }
+      seenFlags.add(flag);
+      continue;
+    }
+    if (sourceNest) {
+      throw usageError(`Unexpected argument: ${arg}`, MIGRATE_HELP);
+    }
+    sourceNest = arg;
+  }
+
+  if (!sourceNest) {
+    throw usageError('Missing required <diary-nest> argument', MIGRATE_HELP);
+  }
+  const canonical = canonicalizeNest(sourceNest);
+  if (parseNest(canonical).kind !== 'diary') {
+    throw commandError(`Expected a diary/... nest, got: ${sourceNest}`);
+  }
+  const yes = seenFlags.has('yes');
+  if (subcommand === 'migrate-apply' && !yes) {
+    throw commandError('migrate-apply requires --yes to confirm execution');
+  }
+  return {
+    sourceNest: canonical,
+    allowWriteWidening: seenFlags.has('allow-write-widening'),
+    yes,
+  };
+}
+
+function quoteRoles(roles: string[]): string {
+  return roles.map((role) => `"${role}"`).join(', ');
+}
+
+function readerClass(
+  access: Pick<MigrationPlan, 'readerRoles' | 'privacy'>
+): string {
+  if (access.readerRoles.length > 0) {
+    return `members with ${quoteRoles(access.readerRoles)}`;
+  }
+  return access.privacy === 'public' ? 'anyone' : 'all group members';
+}
+
+function writerClass(plan: MigrationPlan): string {
+  if (plan.writerRoles.length === 0) {
+    return 'everyone who can read can post';
+  }
+  return `${quoteRoles(plan.writerRoles)} can post`;
+}
+
+export function formatPlanText(plan: MigrationPlan): string {
+  const lines = [
+    `Migration plan — ${plan.sourceTitle}`,
+    `${plan.sourceNest}  →  new notebook in ${plan.group}`,
+    '',
+    'WHAT MOVES',
+    `  ${plan.eligibleCount} posts → ${plan.eligibleCount} notes`,
+  ];
+  if (plan.previewTitles.length > 0) {
+    lines.push(
+      `  First few: ${plan.previewTitles
+        .map((title) => `"${title}"`)
+        .join(' · ')}`
+    );
+  }
+  lines.push(
+    '',
+    "WHAT DOESN'T MOVE  (stays readable in the archive)",
+    `  ${plan.metrics.citeCount} post references and ${plan.metrics.linkBlockCount} link blocks — dropped in conversion`,
+    `  ${plan.metrics.groupMentionCount} group mentions → converted to plain text`,
+    `  ${plan.metrics.totalComments} comments and ${plan.metrics.totalReactions} post reactions — remain on the archived channel`,
+    `  ${plan.tombstoneCount} tombstones and ${plan.stubCount} sequence stubs — not imported`,
+    "  Reactions on comments aren't counted — replies aren't read",
+    '  Post descriptions, covers and attachments: archive-only',
+    '  Note order follows the import, not the original post dates',
+    '',
+    `AUTHORSHIP — every note will show ${parseNest(plan.sourceNest).host} as author, dated today.`,
+    '  The notebook format cannot carry the original author or date.',
+    '  Each note keeps a line naming its original author and date;',
+    '  the true values remain on the archived channel.',
+    '',
+    `PERMISSIONS${plan.writeWidening ? ' — this widens write access' : ''}`,
+    `  Now:   ${writerClass(plan)}; ${readerClass(plan)} can read.`,
+    `  After: every member who can read the notebook can EDIT every note.`
+  );
+  if (plan.writeWidening) {
+    for (const reason of plan.wideningReasons) {
+      lines.push(`  - ${reason}`);
+    }
+    lines.push('  Blocked by default; requires explicit acceptance.');
+  } else {
+    lines.push('  No write-access widening detected.');
+  }
+  lines.push(
+    '',
+    'RESULT',
+    `  New notebook "${plan.targetTitle}", readable by: ${readerClass(plan)}`,
+    `  Original renamed "${plan.archiveTitle}" — nothing is deleted.`,
+    '  The original stays WRITABLE; renaming does not close it.'
+  );
+  return lines.join('\n');
+}
+
+export function formatApplySummaryLines(summary: ApplySummary): string[] {
+  return [
+    'Migration complete.',
+    `  Notes imported: ${summary.notesImported}`,
+    `  Target: ${summary.targetNest}`,
+    `  Archive title: ${summary.archiveTitle}${
+      summary.archiveRenamed ? '' : ' (rename in the app)'
+    }`,
+    `  Left in archive: ${summary.archiveOnly.totalComments} comments, ${summary.archiveOnly.totalReactions} reactions, ${summary.archiveOnly.citeCount} references, ${summary.archiveOnly.linkBlockCount} link blocks`,
+    `  Converted to plain text: ${summary.archiveOnly.groupMentionCount} group mentions`,
+    ...summary.warnings.map((warning) => `  Warning: ${warning}`),
+  ];
+}
+
+export async function runMigratePlan(
+  args: string[],
+  deps: MigrateCommandDeps
+): Promise<number> {
+  if (isHelpArg(args[0])) return writeHelp(deps, MIGRATE_HELP);
+  const options = parseMigrateArgs('migrate-plan', args);
+  await deps.authenticate();
+  const { plan } = await executePlan(options, deps.migration);
+  writeLine(deps.stdout, formatPlanText(plan));
+  return 0;
+}
+
+export async function runMigrateApply(
+  args: string[],
+  deps: MigrateCommandDeps
+): Promise<number> {
+  if (isHelpArg(args[0])) return writeHelp(deps, MIGRATE_HELP);
+  const options = parseMigrateArgs('migrate-apply', args);
+  await deps.authenticate();
+  const { summary } = await executeApply(options, deps.migration);
+
+  for (const line of formatApplySummaryLines(summary)) {
+    writeLine(deps.stdout, line);
+  }
+  return 0;
+}
+
+export async function runMigrate(
+  args: string[],
+  deps: MigrateCommandDeps
+): Promise<number> {
+  const subcommand = args[0];
+  if (!subcommand) {
+    throw usageError('Use either migrate-plan or migrate-apply', MIGRATE_HELP);
+  }
+  if (isHelpArg(subcommand)) return writeHelp(deps, MIGRATE_HELP);
+  const rest = args.slice(1);
+  if (subcommand === 'migrate-plan') return runMigratePlan(rest, deps);
+  if (subcommand === 'migrate-apply') return runMigrateApply(rest, deps);
+  parseMigrateArgs(subcommand, rest);
+  throw new Error('unreachable');
+}

--- a/packages/tlon-skill/scripts/commands/migrate.ts
+++ b/packages/tlon-skill/scripts/commands/migrate.ts
@@ -109,7 +109,7 @@ function readerClass(
 
 function writerClass(plan: MigrationPlan): string {
   if (plan.writerRoles.length === 0) {
-    return 'everyone who can read can post';
+    return 'all group members can post';
   }
   return `${quoteRoles(plan.writerRoles)} can post`;
 }

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -34,6 +34,7 @@ const NOTES_V1_OPS = [
   'moveFolder',
   'deleteFolder',
   'listMembers',
+  'batchImport',
 ] as const;
 
 type NotesV1Op = (typeof NOTES_V1_OPS)[number];

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -122,6 +122,9 @@ function makeDeps(options: MakeDepsOptions = {}) {
       await options.leaveNotesNotebook?.(nest);
     },
     deleteNotesNotebookStrict: async () => undefined,
+    getGroupChannelListings: async () => [],
+    getGroupChannelIds: async () => [],
+    sleep: async () => undefined,
     readFile: (path) => {
       calls.readFile.push(path);
       calls.order.push('readFile');

--- a/packages/tlon-skill/scripts/commands/notes.test.ts
+++ b/packages/tlon-skill/scripts/commands/notes.test.ts
@@ -120,6 +120,7 @@ function makeDeps(options: MakeDepsOptions = {}) {
       calls.order.push('leaveNotesNotebook');
       await options.leaveNotesNotebook?.(nest);
     },
+    deleteNotesNotebookStrict: async () => undefined,
     readFile: (path) => {
       calls.readFile.push(path);
       calls.order.push('readFile');
@@ -458,13 +459,13 @@ describe('notes request status', () => {
       notesV1: {
         getRequest: async () => ({
           requestId: '0verr',
-          body: { type: 'error', message: 'target unavailable' },
+          body: { type: 'error', errorType: 'not-found', message: '' },
         }),
       },
     });
     expect(await run(['request', '0verr'], failed.deps)).toBe(1);
     expect(failed.stdout()).toContain('Status: error');
-    expect(failed.stdout()).toContain('Message: target unavailable');
+    expect(failed.stdout()).toContain('Message: not-found');
   });
 
   it('prints notebook request results', async () => {

--- a/packages/tlon-skill/scripts/commands/notes.ts
+++ b/packages/tlon-skill/scripts/commands/notes.ts
@@ -8,6 +8,7 @@ import type {
   NotesV1RequestStatus,
 } from '@tloncorp/api';
 
+import type { MigrationDeps } from '../notes-migrate';
 import {
   type NotesPendingWriteErrorLike,
   formatPendingWriteError,
@@ -22,6 +23,7 @@ import {
   writeHelp,
   writeLine,
 } from './command';
+import { type MigrateCommandDeps, runMigrate } from './migrate';
 
 export const NOTES_HELP = `Usage: tlon notes <command>
 
@@ -54,9 +56,12 @@ Commands:
   folder-rename <nest> <id> <name>        Rename a folder
   folder-move <nest> <id> <parent-id>     Move a folder under a parent
   folder-delete <nest> <id> [--recursive] Delete a folder (--recursive for non-empty)
+  notebook-delete <nest> --yes [--force]   Delete a notebook for migration recovery
   members <nest>                          List notebook members
   join <nest>                             Join a notes notebook
   leave <nest>                            Leave a notes notebook
+  migrate-plan <diary-nest>               Plan a diary migration (read-only)
+  migrate-apply <diary-nest> --yes         Apply a diary migration
 
 Content sources (Markdown):
   --body <file>       Read the note body from a Markdown file
@@ -105,11 +110,19 @@ export const NOTES_COMMAND_HELP: Record<string, string> = {
     'Usage: tlon notes folder-move <nest> <id> <parent-id>\nExample: tlon notes folder-move notes/~zod/blog 4 3',
   'folder-delete':
     'Usage: tlon notes folder-delete <nest> <id> [--recursive]\nExample: tlon notes folder-delete notes/~zod/blog 4 --recursive',
+  'notebook-delete':
+    'Usage: tlon notes notebook-delete <notes-nest> --yes [--force]\nDelete a notebook after a failed migration. Refuses notebooks containing unmarked notes unless --force is passed; --yes is always required.',
   members:
     'Usage: tlon notes members <nest>\nExample: tlon notes members notes/~zod/blog',
   join: 'Usage: tlon notes join <nest>\nExample: tlon notes join notes/~zod/blog',
   leave:
     'Usage: tlon notes leave <nest>\nExample: tlon notes leave notes/~zod/blog',
+  migrate:
+    'Usage: tlon notes migrate-plan <diary-nest> [--allow-write-widening]\n       tlon notes migrate-apply <diary-nest> --yes [--allow-write-widening]',
+  'migrate-plan':
+    'Usage: tlon notes migrate-plan <diary-nest> [--allow-write-widening]\nComplete read-only migration plan',
+  'migrate-apply':
+    'Usage: tlon notes migrate-apply <diary-nest> --yes [--allow-write-widening]\nExecute migration (requires --yes)',
 };
 
 // The %notes v1 protocol (path construction, request payloads, canonical
@@ -124,8 +137,10 @@ export interface NotesDeps extends CommandDeps {
   isPendingWriteError: (error: unknown) => error is NotesPendingWriteErrorLike;
   joinNotesNotebook: (nest: string) => Promise<void>;
   leaveNotesNotebook: (nest: string) => Promise<void>;
+  deleteNotesNotebookStrict: (nest: string) => Promise<void>;
   readFile: (path: string) => string;
   readStdin: () => Promise<string>;
+  migration?: MigrationDeps;
 }
 
 type ContentSource = { kind: 'file'; path: string } | { kind: 'stdin' };
@@ -165,9 +180,11 @@ type ParsedNotesArgs =
   | { kind: 'folder-rename'; target: Nest; id: string; folderName: string }
   | { kind: 'folder-move'; target: Nest; id: string; parent: number }
   | { kind: 'folder-delete'; target: Nest; id: string; recursive: boolean }
+  | { kind: 'notebook-delete'; target: Nest; force: boolean }
   | { kind: 'members'; target: Nest }
   | { kind: 'join'; target: Nest }
-  | { kind: 'leave'; target: Nest };
+  | { kind: 'leave'; target: Nest }
+  | { kind: 'migrate'; subcommand: string; rest: string[] };
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -546,6 +563,28 @@ function parseArgs(args: string[]): ParsedNotesArgs {
         recursive: args.includes('--recursive'),
       };
     }
+    case 'notebook-delete': {
+      const nest = args[1];
+      const flags = args.slice(2);
+      const yesCount = flags.filter((flag) => flag === '--yes').length;
+      const forceCount = flags.filter((flag) => flag === '--force').length;
+      if (
+        !nest ||
+        yesCount !== 1 ||
+        forceCount > 1 ||
+        flags.some((flag) => flag !== '--yes' && flag !== '--force')
+      ) {
+        throw usageError(
+          'notebook-delete requires a notes nest and --yes, with optional --force',
+          help
+        );
+      }
+      return {
+        kind: 'notebook-delete',
+        target: parseNotesNest(nest, help),
+        force: forceCount === 1,
+      };
+    }
     case 'members': {
       if (!args[1]) {
         throw usageError(help);
@@ -563,6 +602,11 @@ function parseArgs(args: string[]): ParsedNotesArgs {
         throw usageError(help);
       }
       return { kind: 'leave', target: parseNotesNest(args[1], help) };
+    }
+    case 'migrate':
+    case 'migrate-plan':
+    case 'migrate-apply': {
+      return { kind: 'migrate', subcommand: command, rest: args.slice(1) };
     }
   }
 
@@ -649,12 +693,22 @@ function formatRequestStatus(status: NotesV1RequestStatus): string[] {
       lines.push(`Title: ${status.body.notebook.notebook.title}`);
       lines.push(`ID: ${status.body.notebook.notebook.id}`);
       break;
-    case 'error':
+    case 'error': {
+      // The workspace source type requires errorType, while a stale generated
+      // root declaration may still omit it until @tloncorp/api is rebuilt.
+      const errorBody = status.body as typeof status.body & {
+        errorType: string;
+      };
       lines.push('Status: error');
       lines.push(
-        `Message: ${status.body.message?.trim() || 'backend returned an error without details'}`
+        `Message: ${
+          errorBody.message?.trim() ||
+          errorBody.errorType ||
+          'no diagnostic provided'
+        }`
       );
       break;
+    }
     case 'pending':
       lines.push(
         `Status: pending${status.body.status ? ` (${status.body.status})` : ''}`
@@ -970,12 +1024,58 @@ async function runLeave(target: Nest, deps: NotesDeps): Promise<number> {
   return 0;
 }
 
+async function runNotebookDelete(
+  target: Nest,
+  force: boolean,
+  deps: NotesDeps
+): Promise<number> {
+  const notes = await deps.notesV1.listNotes(target.nest);
+  const unmarkedCount = notes.filter(
+    (note) =>
+      typeof note.bodyMd !== 'string' ||
+      !/(?:^|\n)<!-- tlon-migrate: diary\/~?[^/\s]+\/[^\s]+ [^\s]+ -->\s*$/.test(
+        note.bodyMd
+      )
+  ).length;
+  if (unmarkedCount > 0 && !force) {
+    throw commandError(
+      `Refusing to delete ${target.nest}: found ${unmarkedCount} unmarked note(s) without a tlon-migrate provenance footer. ` +
+        `Re-run with --yes --force only if deleting those notes is intentional.`
+    );
+  }
+
+  await deps.deleteNotesNotebookStrict(target.nest);
+  const notebooks = await deps.notesV1.listNotebooks();
+  if (notebooks.some((notebook) => notebookNest(notebook) === target.nest)) {
+    throw commandError(
+      `Notebook deletion was not confirmed: ${target.nest} is still present`
+    );
+  }
+  writeLine(deps.stdout, `✓ Notebook deleted: ${target.nest}`);
+  return 0;
+}
+
 export async function run(args: string[], deps: NotesDeps): Promise<number> {
   try {
     const parsed = parseArgs(args);
 
     if (parsed.kind === 'help') {
       return writeHelp(deps, parsed.help);
+    }
+
+    if (parsed.kind === 'migrate') {
+      if (!deps.migration) {
+        throw commandError(
+          'Migration dependencies not available in this runtime'
+        );
+      }
+      const migrateDeps: MigrateCommandDeps = {
+        stdout: deps.stdout,
+        stderr: deps.stderr,
+        authenticate: deps.authenticate,
+        migration: deps.migration,
+      };
+      return await runMigrate([parsed.subcommand, ...parsed.rest], migrateDeps);
     }
 
     await deps.authenticate();
@@ -1039,6 +1139,8 @@ export async function run(args: string[], deps: NotesDeps): Promise<number> {
           parsed.recursive,
           deps
         );
+      case 'notebook-delete':
+        return await runNotebookDelete(parsed.target, parsed.force, deps);
       case 'members':
         return await runMembers(parsed.target, deps);
       case 'join':

--- a/packages/tlon-skill/scripts/commands/notes.ts
+++ b/packages/tlon-skill/scripts/commands/notes.ts
@@ -8,6 +8,7 @@ import type {
   NotesV1RequestStatus,
 } from '@tloncorp/api';
 
+import { pollGroupListings } from '../notes-channel';
 import type { MigrationDeps } from '../notes-migrate';
 import {
   type NotesPendingWriteErrorLike,
@@ -138,6 +139,11 @@ export interface NotesDeps extends CommandDeps {
   joinNotesNotebook: (nest: string) => Promise<void>;
   leaveNotesNotebook: (nest: string) => Promise<void>;
   deleteNotesNotebookStrict: (nest: string) => Promise<void>;
+  getGroupChannelListings: () => Promise<
+    Array<{ groupId: string; channelIds: string[] }>
+  >;
+  getGroupChannelIds: (groupId: string) => Promise<string[]>;
+  sleep: (ms: number) => Promise<void>;
   readFile: (path: string) => string;
   readStdin: () => Promise<string>;
   migration?: MigrationDeps;
@@ -1044,6 +1050,39 @@ async function runNotebookDelete(
     );
   }
 
+  const recordedGroupIds = new Set<string>();
+  try {
+    const listings: unknown = await deps.getGroupChannelListings();
+    if (!Array.isArray(listings)) {
+      throw new Error('expected an array of group listings');
+    }
+    for (const listing of listings) {
+      if (!listing || typeof listing !== 'object') {
+        throw new Error('encountered a malformed group listing');
+      }
+      const { groupId, channelIds } = listing as {
+        groupId?: unknown;
+        channelIds?: unknown;
+      };
+      if (
+        typeof groupId !== 'string' ||
+        !Array.isArray(channelIds) ||
+        channelIds.some((channelId) => typeof channelId !== 'string')
+      ) {
+        throw new Error('encountered a malformed group listing');
+      }
+      if (channelIds.includes(target.nest)) {
+        recordedGroupIds.add(groupId);
+      }
+    }
+  } catch (error) {
+    throw commandError(
+      `Could not inspect group listings before deleting ${target.nest}: ${errorMessage(
+        error
+      )}`
+    );
+  }
+
   await deps.deleteNotesNotebookStrict(target.nest);
   const notebooks = await deps.notesV1.listNotebooks();
   if (notebooks.some((notebook) => notebookNest(notebook) === target.nest)) {
@@ -1051,6 +1090,26 @@ async function runNotebookDelete(
       `Notebook deletion was not confirmed: ${target.nest} is still present`
     );
   }
+
+  if (recordedGroupIds.size > 0) {
+    const verdict = await pollGroupListings(
+      [...recordedGroupIds],
+      target.nest,
+      'absent-from-all',
+      deps
+    );
+    if (verdict === 'not-confirmed') {
+      throw commandError(
+        `Notebook deleted; group cleanup unconfirmed for ${target.nest}: its old group listing is still present. Wait a few seconds before retrying the migration.`
+      );
+    }
+    if (verdict === 'unverifiable') {
+      throw commandError(
+        `Notebook deleted; group cleanup unconfirmed for ${target.nest}: the group listing could not be checked. Wait a few seconds before retrying the migration.`
+      );
+    }
+  }
+
   writeLine(deps.stdout, `✓ Notebook deleted: ${target.nest}`);
   return 0;
 }

--- a/packages/tlon-skill/scripts/groups.ts
+++ b/packages/tlon-skill/scripts/groups.ts
@@ -1355,7 +1355,7 @@ async function addChannel(
 // appeared (see notes-channel.ts).
 async function addNotesChannel(groupId: string, title: string) {
   const nest = await createNotesChannelInGroup(
-    { groupId, title },
+    { groupId, title, readers: [] },
     createNotesChannelDeps()
   );
 

--- a/packages/tlon-skill/scripts/migrate-helpers.ts
+++ b/packages/tlon-skill/scripts/migrate-helpers.ts
@@ -1,0 +1,80 @@
+import { commandError } from './commands/command';
+import type { GroupChannelV7, MigrationDeps } from './notes-migrate';
+import { normalizeShip } from './notes-migrate';
+
+function requireRawChannel(
+  raw: Record<string, unknown>,
+  groupId: string,
+  nest: string
+): Record<string, unknown> {
+  const channels = raw.channels;
+  if (!channels || typeof channels !== 'object' || Array.isArray(channels)) {
+    throw commandError(
+      `Group ${groupId}: raw v7 channels are missing or malformed`
+    );
+  }
+  const channel = (channels as Record<string, unknown>)[nest];
+  if (!channel || typeof channel !== 'object' || Array.isArray(channel)) {
+    throw commandError(
+      `Channel ${nest} not found in group ${groupId} — cannot rename`
+    );
+  }
+  return channel as Record<string, unknown>;
+}
+
+function requireRawMeta(
+  channel: Record<string, unknown>,
+  nest: string
+): Record<string, unknown> {
+  const meta = channel.meta;
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    throw commandError(
+      `Channel ${nest}: raw metadata is missing or malformed — cannot rename losslessly`
+    );
+  }
+  return meta as Record<string, unknown>;
+}
+
+export async function archiveRename(
+  deps: Pick<MigrationDeps, 'getRawGroup' | 'updateChannel'>,
+  groupId: string,
+  nest: string,
+  newTitle: string
+): Promise<void> {
+  const raw = await deps.getRawGroup(groupId);
+  const original = requireRawChannel(raw, groupId, nest);
+  requireRawMeta(original, nest);
+
+  const channel = JSON.parse(JSON.stringify(original)) as GroupChannelV7;
+  channel.meta = { ...channel.meta, title: newTitle };
+  await deps.updateChannel({
+    groupId,
+    channelId: nest,
+    channel,
+  });
+
+  const confirmedRaw = await deps.getRawGroup(groupId);
+  const confirmedChannel = requireRawChannel(confirmedRaw, groupId, nest);
+  const confirmedMeta = requireRawMeta(confirmedChannel, nest);
+  if (confirmedMeta.title !== newTitle) {
+    throw commandError(
+      `Source rename was not confirmed: ${nest} still has title ${JSON.stringify(
+        confirmedMeta.title
+      )}, expected ${JSON.stringify(newTitle)}`
+    );
+  }
+}
+
+export function assertActingShipIsHost(
+  actingShip: string,
+  host: string,
+  context: string
+): void {
+  const normalizedActing = normalizeShip(actingShip);
+  const normalizedHost = normalizeShip(host);
+  if (normalizedActing !== normalizedHost) {
+    throw commandError(
+      `${context}: acting ship ${normalizedActing} is not the host ${normalizedHost}. Migration must run from the ship that hosts it.`
+    );
+  }
+}

--- a/packages/tlon-skill/scripts/notes-channel-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-channel-runtime.ts
@@ -1,13 +1,34 @@
-import {
-  NotesV1PendingWriteError,
-  deleteNotesNotebookStrict,
-  getGroup,
-  notesV1,
-} from '@tloncorp/api';
+import { NotesV1PendingWriteError, getGroup, notesV1 } from '@tloncorp/api';
 
 import { commandError, errorMessage } from './commands/command';
 import type { NotesChannelDeps } from './notes-channel';
 import { pendingWriteCommandErrorMessage } from './notes-pending-write';
+
+export function mapChannelReaders(
+  channel: { readerRoles?: Array<{ roleId: string }> | null } | undefined,
+  nest: string,
+  groupId: string
+): string[] | null {
+  if (!channel) return null;
+  if (!Array.isArray(channel.readerRoles)) {
+    throw new Error(
+      `Channel ${nest} in group ${groupId}: readerRoles field is missing or malformed — refusing to assume open`
+    );
+  }
+  if (
+    channel.readerRoles.some(
+      (reader) =>
+        !reader ||
+        typeof reader !== 'object' ||
+        typeof reader.roleId !== 'string'
+    )
+  ) {
+    throw new Error(
+      `Channel ${nest} in group ${groupId}: readerRoles entries are malformed — refusing to assume open`
+    );
+  }
+  return channel.readerRoles.map((r) => r.roleId);
+}
 
 export function createNotesChannelDeps(): NotesChannelDeps {
   return {
@@ -25,10 +46,10 @@ export function createNotesChannelDeps(): NotesChannelDeps {
       const group = await getGroup(groupId);
       return (group.channels ?? []).map((channel) => channel.id);
     },
-    // Strict: propagate failures so the create flow can report whether the
-    // rollback actually removed the stray notebook.
-    deleteNotesNotebookStrict: async (nest: string) => {
-      await deleteNotesNotebookStrict(nest);
+    getChannelReaders: async (groupId: string, nest: string) => {
+      const group = await getGroup(groupId);
+      const channel = (group.channels ?? []).find((c) => c.id === nest);
+      return mapChannelReaders(channel, nest, groupId);
     },
     sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
     log: (message: string) => console.log(message),

--- a/packages/tlon-skill/scripts/notes-channel-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-channel-runtime.ts
@@ -4,6 +4,27 @@ import { commandError, errorMessage } from './commands/command';
 import type { NotesChannelDeps } from './notes-channel';
 import { pendingWriteCommandErrorMessage } from './notes-pending-write';
 
+export function mapGroupChannelIds(group: unknown, groupId: string): string[] {
+  if (!group || typeof group !== 'object') {
+    throw new Error(`Group ${groupId}: group response is malformed`);
+  }
+  const channels = (group as { channels?: unknown }).channels;
+  if (!Array.isArray(channels)) {
+    throw new Error(`Group ${groupId}: channels array is missing or malformed`);
+  }
+  if (
+    channels.some(
+      (channel) =>
+        !channel ||
+        typeof channel !== 'object' ||
+        typeof (channel as { id?: unknown }).id !== 'string'
+    )
+  ) {
+    throw new Error(`Group ${groupId}: channel id is missing or malformed`);
+  }
+  return channels.map((channel) => (channel as { id: string }).id);
+}
+
 export function mapChannelReaders(
   channel: { readerRoles?: Array<{ roleId: string }> | null } | undefined,
   nest: string,
@@ -44,7 +65,7 @@ export function createNotesChannelDeps(): NotesChannelDeps {
     },
     getGroupChannelIds: async (groupId: string) => {
       const group = await getGroup(groupId);
-      return (group.channels ?? []).map((channel) => channel.id);
+      return mapGroupChannelIds(group, groupId);
     },
     getChannelReaders: async (groupId: string, nest: string) => {
       const group = await getGroup(groupId);

--- a/packages/tlon-skill/scripts/notes-channel.test.ts
+++ b/packages/tlon-skill/scripts/notes-channel.test.ts
@@ -6,201 +6,222 @@ import {
   createNotesChannelInGroup,
 } from './notes-channel';
 
-// A successful PR-7 group-mode create summary.
 const SUMMARY: NotesV1NotebookSummary = {
   host: '~zod',
   flagName: 'newbook',
   notebook: { id: 5, title: 'New' },
 };
 const NEW_NEST = 'notes/~zod/newbook';
+const READERS = ['members'];
 
 interface MakeDepsOptions {
-  createGroupNotesNotebook?: (input: {
-    title: string;
-    group: { host: string; flagName: string };
-    readers: string[];
-  }) => Promise<NotesV1NotebookSummary>;
-  getGroupChannelIds?: (groupId: string) => Promise<string[]>;
-  deleteNotesNotebookStrict?: (nest: string) => Promise<void>;
+  create?: NotesChannelDeps['createGroupNotesNotebook'];
+  channelIds?: NotesChannelDeps['getGroupChannelIds'];
+  readers?: NotesChannelDeps['getChannelReaders'];
 }
 
 function makeDeps(options: MakeDepsOptions = {}) {
   const calls = {
-    createGroupNotesNotebook: [] as unknown[],
-    getGroupChannelIds: [] as string[],
-    deleteNotesNotebookStrict: [] as string[],
+    create: [] as Array<
+      Parameters<NotesChannelDeps['createGroupNotesNotebook']>[0]
+    >,
+    channelIds: [] as string[],
+    readers: [] as [string, string][],
     sleep: [] as number[],
-    log: [] as string[],
   };
-
   const deps: NotesChannelDeps = {
     createGroupNotesNotebook: async (input) => {
-      calls.createGroupNotesNotebook.push(input);
-      return options.createGroupNotesNotebook
-        ? await options.createGroupNotesNotebook(input)
-        : SUMMARY;
+      calls.create.push(input);
+      return options.create ? options.create(input) : SUMMARY;
     },
     getGroupChannelIds: async (groupId) => {
-      calls.getGroupChannelIds.push(groupId);
-      return options.getGroupChannelIds
-        ? await options.getGroupChannelIds(groupId)
-        : [];
+      calls.channelIds.push(groupId);
+      return options.channelIds ? options.channelIds(groupId) : [NEW_NEST];
     },
-    deleteNotesNotebookStrict: async (nest) => {
-      calls.deleteNotesNotebookStrict.push(nest);
-      if (options.deleteNotesNotebookStrict) {
-        await options.deleteNotesNotebookStrict(nest);
-      }
+    getChannelReaders: async (groupId, nest) => {
+      calls.readers.push([groupId, nest]);
+      return options.readers ? options.readers(groupId, nest) : READERS;
     },
     sleep: async (ms) => {
       calls.sleep.push(ms);
     },
-    log: (message) => {
-      calls.log.push(message);
-    },
+    log: () => undefined,
   };
-
-  return { deps, calls };
+  return { calls, deps };
 }
 
 describe('createNotesChannelInGroup', () => {
-  it('creates the group-bound notebook via the API helper and returns the nest', async () => {
-    const { deps, calls } = makeDeps({
-      getGroupChannelIds: async () => [NEW_NEST],
-    });
-
-    const nest = await createNotesChannelInGroup(
-      { groupId: '~zod/group', title: 'New' },
+  it('threads and verifies the exact reader roles', async () => {
+    const { calls, deps } = makeDeps();
+    const target = await createNotesChannelInGroup(
+      { groupId: '~zod/group', title: 'New', readers: READERS },
       deps
     );
 
-    expect(nest).toBe(NEW_NEST);
-    // Routes through the notesV1 API helper — never builds paths or pokes
-    // %channels itself.
-    expect(calls.createGroupNotesNotebook).toEqual([
+    expect(target).toBe(NEW_NEST);
+    expect(calls.create).toEqual([
       {
         title: 'New',
         group: { host: '~zod', flagName: 'group' },
-        readers: [],
+        readers: READERS,
       },
     ]);
-    expect(calls.deleteNotesNotebookStrict).toEqual([]);
+    expect(calls.readers).toEqual([['~zod/group', NEW_NEST]]);
   });
 
-  it('retries the listing check and succeeds once the channel appears', async () => {
-    let attempts = 0;
-    const { deps, calls } = makeDeps({
-      getGroupChannelIds: async () => {
-        attempts += 1;
-        return attempts >= 3 ? [NEW_NEST] : [];
-      },
-    });
-
-    const nest = await createNotesChannelInGroup(
-      { groupId: '~zod/group', title: 'New' },
-      deps
-    );
-
-    expect(nest).toBe(NEW_NEST);
-    expect(calls.getGroupChannelIds).toHaveLength(3);
-    expect(calls.sleep).toHaveLength(2);
-    expect(calls.deleteNotesNotebookStrict).toEqual([]);
-  });
-
-  it('strict-deletes and reports removal when the listing never registers', async () => {
-    const { deps, calls } = makeDeps({ getGroupChannelIds: async () => [] });
-
+  it('accepts an explicitly open reader set after verifying it', async () => {
+    const { deps } = makeDeps({ readers: async () => [] });
     await expect(
-      createNotesChannelInGroup({ groupId: '~zod/group', title: 'New' }, deps)
-    ).rejects.toThrow('Removed the stray notebook');
-
-    expect(calls.deleteNotesNotebookStrict).toEqual([NEW_NEST]);
-    expect(calls.getGroupChannelIds).toHaveLength(5);
-    expect(calls.sleep).toHaveLength(4);
+      createNotesChannelInGroup(
+        { groupId: '~zod/group', title: 'New', readers: [] },
+        deps
+      )
+    ).resolves.toBe(NEW_NEST);
   });
 
-  it('reports manual-cleanup guidance when strict rollback delete rejects', async () => {
-    const { deps, calls } = makeDeps({
-      getGroupChannelIds: async () => [],
-      deleteNotesNotebookStrict: async () => {
-        throw new Error('delete failed');
+  it('compares reader roles as sets rather than by response order', async () => {
+    const { deps } = makeDeps({ readers: async () => ['b', 'a'] });
+    await expect(
+      createNotesChannelInGroup(
+        { groupId: '~zod/group', title: 'New', readers: ['a', 'b'] },
+        deps
+      )
+    ).resolves.toBe(NEW_NEST);
+  });
+
+  it('calls onCreated before post-create verification', async () => {
+    const created: string[] = [];
+    const { deps } = makeDeps({ readers: async () => ['wrong'] });
+    await expect(
+      createNotesChannelInGroup(
+        {
+          groupId: '~zod/group',
+          title: 'New',
+          readers: READERS,
+          onCreated: (nest) => created.push(nest),
+        },
+        deps
+      )
+    ).rejects.toThrow('do not match the approved set');
+    expect(created).toEqual([NEW_NEST]);
+  });
+
+  it('fails closed when the created channel readers cannot be found', async () => {
+    const { deps } = makeDeps({ readers: async () => null });
+    await expect(
+      createNotesChannelInGroup(
+        { groupId: '~zod/group', title: 'New', readers: READERS },
+        deps
+      )
+    ).rejects.toThrow('could not be read for reader verification');
+  });
+
+  it('preserves the created nest and cleanup command when the reader scry fails', async () => {
+    const { deps } = makeDeps({
+      readers: async () => {
+        throw new Error('transient group scry failure');
       },
     });
 
-    let error: Error | undefined;
+    let caught: unknown;
     try {
       await createNotesChannelInGroup(
-        { groupId: '~zod/group', title: 'New' },
+        { groupId: '~zod/group', title: 'New', readers: READERS },
         deps
       );
-    } catch (e) {
-      error = e as Error;
+    } catch (error) {
+      caught = error;
     }
+    expect(caught).toBeInstanceOf(Error);
+    const message = caught instanceof Error ? caught.message : String(caught);
 
-    expect(calls.deleteNotesNotebookStrict).toEqual([NEW_NEST]);
-    expect(error?.message).toContain(NEW_NEST);
-    expect(error?.message).toContain('Manual cleanup');
-    // Must NOT claim the stray notebook was removed.
-    expect(error?.message).not.toContain('Removed the stray notebook');
+    expect(message).toContain(`%notes created ${NEW_NEST}`);
+    expect(message).toContain('transient group scry failure');
+    expect(message).toContain(`tlon notes notebook-delete ${NEW_NEST} --yes`);
   });
 
-  it('does NOT roll back when the listing can not be verified (all reads fail)', async () => {
-    const { deps, calls } = makeDeps({
-      getGroupChannelIds: async () => {
-        throw new Error('group scry failed');
+  it('retries asynchronous listing registration', async () => {
+    let attempt = 0;
+    const { calls, deps } = makeDeps({
+      channelIds: async () => {
+        attempt += 1;
+        return attempt === 3 ? [NEW_NEST] : [];
       },
     });
-
     await expect(
-      createNotesChannelInGroup({ groupId: '~zod/group', title: 'New' }, deps)
+      createNotesChannelInGroup(
+        { groupId: '~zod/group', title: 'New', readers: READERS },
+        deps
+      )
+    ).resolves.toBe(NEW_NEST);
+    expect(calls.channelIds).toHaveLength(3);
+    expect(calls.sleep).toEqual([500, 500]);
+  });
+
+  it('leaves an unverified notebook in place when listing stays absent', async () => {
+    const created: string[] = [];
+    const { calls, deps } = makeDeps({ channelIds: async () => [] });
+    try {
+      await createNotesChannelInGroup(
+        {
+          groupId: '~zod/group',
+          title: 'New',
+          readers: READERS,
+          onCreated: (nest) => created.push(nest),
+        },
+        deps
+      );
+      throw new Error('Expected listing verification to fail');
+    } catch (error) {
+      expect(String(error)).toContain('host may not support group-mode notes');
+      expect(String(error)).not.toContain('PR 7');
+      expect(String(error)).toContain('Left the notebook in place');
+    }
+    expect(created).toEqual([NEW_NEST]);
+    expect(calls.channelIds).toHaveLength(5);
+  });
+
+  it('fails as unverifiable when the final group read fails', async () => {
+    const { deps } = makeDeps({
+      channelIds: async () => {
+        throw new Error('scry failed');
+      },
+    });
+    await expect(
+      createNotesChannelInGroup(
+        { groupId: '~zod/group', title: 'New', readers: READERS },
+        deps
+      )
     ).rejects.toThrow('could not be verified');
-
-    expect(calls.deleteNotesNotebookStrict).toEqual([]);
-    expect(calls.getGroupChannelIds).toHaveLength(5);
   });
 
-  it('treats a trailing read failure as unverifiable, not absent', async () => {
-    let reads = 0;
-    const { deps, calls } = makeDeps({
-      getGroupChannelIds: async () => {
-        reads += 1;
-        if (reads === 1) {
-          return [];
-        }
-        throw new Error('group scry failed');
+  it('propagates create failures without polling', async () => {
+    const { calls, deps } = makeDeps({
+      create: async () => {
+        throw new Error('denied');
       },
     });
-
     await expect(
-      createNotesChannelInGroup({ groupId: '~zod/group', title: 'New' }, deps)
-    ).rejects.toThrow('could not be verified');
-
-    expect(calls.deleteNotesNotebookStrict).toEqual([]);
+      createNotesChannelInGroup(
+        { groupId: '~zod/group', title: 'New', readers: READERS },
+        deps
+      )
+    ).rejects.toThrow('denied');
+    expect(calls.channelIds).toEqual([]);
   });
 
-  it('propagates a create failure from the API helper', async () => {
-    const { deps, calls } = makeDeps({
-      createGroupNotesNotebook: async () => {
-        throw new Error('%notes error: denied');
-      },
-    });
-
+  it('rejects a malformed group before creating', async () => {
+    const { calls, deps } = makeDeps();
     await expect(
-      createNotesChannelInGroup({ groupId: '~zod/group', title: 'New' }, deps)
-    ).rejects.toThrow('%notes error: denied');
-
-    // Never reached the listing verification or any cleanup.
-    expect(calls.getGroupChannelIds).toEqual([]);
-    expect(calls.deleteNotesNotebookStrict).toEqual([]);
-  });
-
-  it('rejects a malformed group id before any request', async () => {
-    const { deps, calls } = makeDeps();
-
-    await expect(
-      createNotesChannelInGroup({ groupId: 'badgroup', title: 'New' }, deps)
+      createNotesChannelInGroup(
+        {
+          groupId: 'bad',
+          title: 'New',
+          readers: READERS,
+        },
+        deps
+      )
     ).rejects.toThrow('Invalid group id');
-
-    expect(calls.createGroupNotesNotebook).toEqual([]);
+    expect(calls.create).toEqual([]);
   });
 });

--- a/packages/tlon-skill/scripts/notes-channel.ts
+++ b/packages/tlon-skill/scripts/notes-channel.ts
@@ -1,13 +1,12 @@
 import type { NotesV1NotebookSummary } from '@tloncorp/api';
 
-import { commandError } from './commands/command';
+import { commandError, errorMessage } from './commands/command';
 
 // Shared, dependency-injected logic for creating a `%notes` group channel.
 //
-// Phase D assumes `arthyn/notes` PR 7 (group-channel mode): a notebook bound to
-// a group is registered as a `%groups` channel by `%notes` itself. The skill
-// only calls the `notesV1.createGroupNotebook` API helper and verifies the
-// listing — it never pokes `%channels` and never adds the group listing itself.
+// A notebook bound to a group is registered as a `%groups` channel by `%notes`
+// itself. The skill only calls the `notesV1.createGroupNotebook` API helper and
+// verifies the listing — it never pokes `%channels` or adds the group listing.
 
 const VERIFY_ATTEMPTS = 5;
 const VERIFY_DELAY_MS = 500;
@@ -23,8 +22,12 @@ export interface NotesChannelDeps {
   // Channel ids currently listed in the target group (used to confirm `%notes`
   // registered the group listing).
   getGroupChannelIds: (groupId: string) => Promise<string[]>;
-  // Strict notebook removal (propagates failures) for the failed-create rollback.
-  deleteNotesNotebookStrict: (nest: string) => Promise<void>;
+  // Read the reader roles for a channel in a group (used for post-create
+  // reader verification). Returns null if the channel is not found.
+  getChannelReaders: (
+    groupId: string,
+    nest: string
+  ) => Promise<string[] | null>;
   sleep: (ms: number) => Promise<void>;
   log: (message: string) => void;
 }
@@ -32,6 +35,8 @@ export interface NotesChannelDeps {
 export interface NotesChannelInput {
   groupId: string;
   title: string;
+  readers: string[];
+  onCreated?: (nest: string) => void;
 }
 
 // 'registered': a successful group read saw the listing.
@@ -45,7 +50,7 @@ type ListingVerdict = 'registered' | 'absent' | 'unverifiable';
 // "absent" is only concluded from the final poll: registration is async, so an
 // early successful poll can legitimately show the listing missing, and if the
 // later polls then fail we must not treat that stale early read as proof of
-// absence — that would roll back a possibly-valid create.
+// absence.
 async function verifyListing(
   groupId: string,
   nest: string,
@@ -75,56 +80,70 @@ export async function createNotesChannelInGroup(
   input: NotesChannelInput,
   deps: NotesChannelDeps
 ): Promise<string> {
-  const slash = input.groupId.indexOf('/');
-  if (slash === -1) {
+  const groupParts = input.groupId.split('/');
+  if (
+    groupParts.length !== 2 ||
+    !groupParts[0] ||
+    !groupParts[1] ||
+    !Array.isArray(input.readers) ||
+    input.readers.some((reader) => typeof reader !== 'string')
+  ) {
     throw commandError(
-      `Invalid group id: ${input.groupId}. Expected ~host/name.`
+      `Invalid group id or readers for ${input.groupId}. Expected ~host/name and an explicit reader-role array.`
     );
   }
-  const groupHost = input.groupId.slice(0, slash);
-  const groupName = input.groupId.slice(slash + 1);
+  const [groupHost, groupName] = groupParts;
+  const readers = input.readers;
 
   deps.log(`Creating %notes channel "${input.title}" in ${input.groupId}...`);
 
-  // The `{group, readers}` payload is the PR-7 group-mode contract — empty
-  // readers means group-wide readable; `%notes` registers the %groups listing.
   const summary = await deps.createGroupNotesNotebook({
     title: input.title,
     group: { host: groupHost, flagName: groupName },
-    readers: [],
+    readers,
   });
   const nest = `notes/${summary.host}/${summary.flagName}`;
 
-  // Pre-PR-7 degradation guard. A create against an un-upgraded %notes silently
-  // makes a *solo* notebook, and the response can't tell the difference — the
-  // notebook-summary JSON is identical for a solo and a group create. So verify
-  // the listing actually registered. Never treat the bare create (or its
-  // response) as the capability check.
+  if (input.onCreated) {
+    input.onCreated(nest);
+  }
+
   const verdict = await verifyListing(input.groupId, nest, deps);
   if (verdict === 'registered') {
+    let actualReaders: string[] | null;
+    try {
+      actualReaders = await deps.getChannelReaders(input.groupId, nest);
+    } catch (error) {
+      throw commandError(
+        `%notes created ${nest}, but its readers could not be verified: ${errorMessage(
+          error
+        )}. ` +
+          `The notebook was left in place; to remove it, run \`tlon notes notebook-delete ${nest} --yes\`.`
+      );
+    }
+    if (actualReaders === null) {
+      throw commandError(
+        `%notes created ${nest} but its channel record in ${input.groupId} could not be read for reader verification. ` +
+          `Left the notebook in place — verify its readers manually.`
+      );
+    }
+    const expectedSorted = readers.slice().sort();
+    const actualSorted = actualReaders.slice().sort();
+    if (JSON.stringify(expectedSorted) !== JSON.stringify(actualSorted)) {
+      throw commandError(
+        `%notes created ${nest} but its readers [${actualSorted.join(', ')}] do not match the approved set [${expectedSorted.join(', ')}]. ` +
+          `Left the notebook in place — restrict its readers manually before use.`
+      );
+    }
     return nest;
   }
   if (verdict === 'absent') {
-    // A successful read confirmed the listing is missing: the host didn't
-    // register it (likely pre-PR-7). Roll back the stray solo notebook with the
-    // strict delete so we can report whether cleanup actually succeeded.
-    try {
-      await deps.deleteNotesNotebookStrict(nest);
-    } catch {
-      throw commandError(
-        `%notes created ${nest} but it did not register as a channel in ${input.groupId} — ` +
-          `the host may not support group-mode notes (PR 7), and removing the stray notebook also failed. ` +
-          `Manual cleanup of ${nest} may be required.`
-      );
-    }
     throw commandError(
       `%notes created ${nest} but it did not register as a channel in ${input.groupId} — ` +
-        `the host may not support group-mode notes (PR 7). Removed the stray notebook.`
+        `the host may not support group-mode notes, or the listing poke has not arrived. ` +
+        `Left the notebook in place — verify it manually and remove it if it is a stray solo notebook.`
     );
   }
-  // unverifiable: every group read failed, so we can't tell whether the listing
-  // registered. Don't roll back a possibly-valid create — leave it for the
-  // operator rather than risk deleting a good notebook.
   throw commandError(
     `%notes created ${nest} but its channel listing in ${input.groupId} could not be verified ` +
       `(the group read failed). Left the notebook in place — verify it manually and remove it if it is a stray solo notebook.`

--- a/packages/tlon-skill/scripts/notes-channel.ts
+++ b/packages/tlon-skill/scripts/notes-channel.ts
@@ -11,7 +11,12 @@ import { commandError, errorMessage } from './commands/command';
 const VERIFY_ATTEMPTS = 5;
 const VERIFY_DELAY_MS = 500;
 
-export interface NotesChannelDeps {
+export interface GroupListingPollDeps {
+  getGroupChannelIds: (groupId: string) => Promise<string[]>;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export interface NotesChannelDeps extends GroupListingPollDeps {
   // POST the group-bound notebook via `@tloncorp/api` notesV1 and return its
   // summary (the API unwraps the envelope / rejects errors).
   createGroupNotesNotebook: (input: {
@@ -19,16 +24,12 @@ export interface NotesChannelDeps {
     group: { host: string; flagName: string };
     readers: string[];
   }) => Promise<NotesV1NotebookSummary>;
-  // Channel ids currently listed in the target group (used to confirm `%notes`
-  // registered the group listing).
-  getGroupChannelIds: (groupId: string) => Promise<string[]>;
   // Read the reader roles for a channel in a group (used for post-create
   // reader verification). Returns null if the channel is not found.
   getChannelReaders: (
     groupId: string,
     nest: string
   ) => Promise<string[] | null>;
-  sleep: (ms: number) => Promise<void>;
   log: (message: string) => void;
 }
 
@@ -39,41 +40,60 @@ export interface NotesChannelInput {
   onCreated?: (nest: string) => void;
 }
 
-// 'registered': a successful group read saw the listing.
-// 'absent': the *final* poll succeeded and still did not see the listing.
-// 'unverifiable': the final poll failed, so we can't be sure the listing didn't
-// register after our last successful read.
-type ListingVerdict = 'registered' | 'absent' | 'unverifiable';
+export type GroupListingGoal = 'present-in-all' | 'absent-from-all';
+export type GroupListingVerdict =
+  | 'confirmed'
+  | 'not-confirmed'
+  | 'unverifiable';
 
-// Poll the target group until the new `notes/...` listing appears (it registers
-// asynchronously, like the other post-mutation verifications in groups.ts).
-// "absent" is only concluded from the final poll: registration is async, so an
-// early successful poll can legitimately show the listing missing, and if the
-// later polls then fail we must not treat that stale early read as proof of
-// absence.
-async function verifyListing(
-  groupId: string,
+// Group channel listings update asynchronously after a `%notes` mutation.
+// Read every relevant group concurrently on each attempt so confirmation is
+// based on one coherent polling round, not on independently exhausted loops.
+export async function pollGroupListings(
+  groupIds: string[],
   nest: string,
-  deps: NotesChannelDeps
-): Promise<ListingVerdict> {
-  let lastReadSucceeded = false;
+  goal: GroupListingGoal,
+  deps: GroupListingPollDeps
+): Promise<GroupListingVerdict> {
   for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt += 1) {
-    try {
-      const channelIds = await deps.getGroupChannelIds(groupId);
-      if (channelIds.includes(nest)) {
-        return 'registered';
+    const reads = await Promise.all(
+      groupIds.map(async (groupId) => {
+        try {
+          const channelIds = await deps.getGroupChannelIds(groupId);
+          return {
+            succeeded: true as const,
+            containsNest: channelIds.includes(nest),
+          };
+        } catch {
+          return { succeeded: false as const, containsNest: false };
+        }
+      })
+    );
+    const confirmed = reads.every(
+      (read) =>
+        read.succeeded &&
+        (goal === 'present-in-all' ? read.containsNest : !read.containsNest)
+    );
+    if (confirmed) return 'confirmed';
+
+    if (attempt === VERIFY_ATTEMPTS) {
+      const hasSuccessfulOpposingRead = reads.some(
+        (read) =>
+          read.succeeded &&
+          (goal === 'present-in-all' ? !read.containsNest : read.containsNest)
+      );
+      if (hasSuccessfulOpposingRead) {
+        return 'not-confirmed';
       }
-      lastReadSucceeded = true;
-    } catch {
-      // Transient read failure; retry. Leaves lastReadSucceeded false so a
-      // trailing failure is reported as unverifiable rather than absent.
-      lastReadSucceeded = false;
+      return reads.some((read) => !read.succeeded)
+        ? 'unverifiable'
+        : 'not-confirmed';
     }
-    if (attempt < VERIFY_ATTEMPTS) {
-      await deps.sleep(VERIFY_DELAY_MS);
-    }
+
+    await deps.sleep(VERIFY_DELAY_MS);
   }
-  return lastReadSucceeded ? 'absent' : 'unverifiable';
+
+  return 'unverifiable';
 }
 
 export async function createNotesChannelInGroup(
@@ -108,8 +128,13 @@ export async function createNotesChannelInGroup(
     input.onCreated(nest);
   }
 
-  const verdict = await verifyListing(input.groupId, nest, deps);
-  if (verdict === 'registered') {
+  const verdict = await pollGroupListings(
+    [input.groupId],
+    nest,
+    'present-in-all',
+    deps
+  );
+  if (verdict === 'confirmed') {
     let actualReaders: string[] | null;
     try {
       actualReaders = await deps.getChannelReaders(input.groupId, nest);
@@ -137,7 +162,7 @@ export async function createNotesChannelInGroup(
     }
     return nest;
   }
-  if (verdict === 'absent') {
+  if (verdict === 'not-confirmed') {
     throw commandError(
       `%notes created ${nest} but it did not register as a channel in ${input.groupId} — ` +
         `the host may not support group-mode notes, or the listing poke has not arrived. ` +

--- a/packages/tlon-skill/scripts/notes-migrate-apply.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-apply.test.ts
@@ -267,6 +267,31 @@ describe('verifyTargetContents', () => {
 });
 
 describe('executeApply', () => {
+  it('refuses an archived source without writes and leaves ordinary sources unaffected', async () => {
+    const ordinary = makeHarness();
+    await expect(
+      executeApply(applyOptions(), ordinary.deps)
+    ).resolves.toMatchObject({ status: 'success' });
+    expect(ordinary.calls.create).toBe(1);
+
+    const archivedGroup = sourceGroup();
+    archivedGroup.channels[SOURCE].meta.title = 'Field Notes-ARCHIVE';
+    const archived = makeHarness({ group: archivedGroup });
+    await expect(executeApply(applyOptions(), archived.deps)).rejects.toThrow(
+      `Refusing to migrate ${SOURCE}: its title appears to have been migrated already. ` +
+        `If that is incorrect, rename the source channel to remove the archive marker, then re-run the migration.`
+    );
+    expect(archived.calls.identity).toBe(0);
+    expect(archived.calls.create).toBe(0);
+    expect(archived.calls.detail).toBe(0);
+    expect(archived.calls.batch).toEqual([]);
+    expect(archived.calls.listNotes).toBe(0);
+    expect(archived.calls.getRawGroup).toBe(0);
+    expect(archived.calls.updateChannel).toEqual([]);
+    expect(archived.imported).toEqual([]);
+    expect(archived.order).toEqual([]);
+  });
+
   it('requires explicit confirmation before any reads', async () => {
     const context = makeHarness();
     await expect(

--- a/packages/tlon-skill/scripts/notes-migrate-apply.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-apply.test.ts
@@ -318,6 +318,7 @@ describe('executeApply', () => {
           citeCount: 0,
           linkBlockCount: 0,
           groupMentionCount: 0,
+          flattenedInlineCount: 0,
         },
         warnings: [],
       },

--- a/packages/tlon-skill/scripts/notes-migrate-apply.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-apply.test.ts
@@ -1,0 +1,646 @@
+import type { Post, Story } from '@tloncorp/api';
+import { describe, expect, it } from 'bun:test';
+
+import type {
+  GroupChannelV7,
+  GroupInfo,
+  MigrationDeps,
+  MigrationOptions,
+} from './notes-migrate';
+import { executeApply, verifyTargetContents } from './notes-migrate-apply';
+
+const SOURCE = 'diary/~zod/blog';
+const GROUP = '~zod/group';
+const TARGET = 'notes/~zod/newbook';
+const TARGET_FLAG = '~zod/newbook';
+const DAY = Date.UTC(2025, 0, 2);
+
+function post(text = 'Hello'): Post {
+  return {
+    id: '170.141',
+    type: 'note',
+    channelId: SOURCE,
+    authorId: '~zod',
+    sentAt: DAY,
+    receivedAt: DAY,
+    sequenceNum: 1,
+    content: [{ inline: [text] }],
+    reactions: [],
+    replyCount: 0,
+  };
+}
+
+function channel(
+  title: string,
+  readers: string[] = ['writers']
+): GroupChannelV7 {
+  return {
+    added: DAY,
+    meta: {
+      title,
+      description: 'preserve description',
+      image: 'preserve image',
+      cover: 'preserve cover',
+    },
+    section: 'main',
+    readers,
+    join: false,
+  };
+}
+
+function sourceGroup(
+  readers: string[] = ['writers'],
+  privacy: GroupInfo['privacy'] = 'private'
+): GroupInfo {
+  return {
+    privacy,
+    admins: ['admins'],
+    channels: { [SOURCE]: channel('Field Notes', readers) },
+  };
+}
+
+interface HarnessOptions {
+  group?: GroupInfo;
+  writers?: string[];
+  sourcePost?: Post;
+  identity?: () => Promise<void>;
+  create?: MigrationDeps['createGroupNotebook'];
+  detail?: Awaited<ReturnType<MigrationDeps['getNotebookDetail']>>;
+  batch?: MigrationDeps['batchImport'];
+  listNotes?: MigrationDeps['listNotes'];
+  getRawGroup?: MigrationDeps['getRawGroup'];
+  updateChannel?: MigrationDeps['updateChannel'];
+  renameConfirmed?: boolean;
+  requestId?: string;
+  recoveryInstruction?: MigrationDeps['recoveryInstruction'];
+  // Group returned on every getGroup call after the first, so a test can
+  // simulate the source's permissions drifting mid-migration.
+  groupAfterFirstRead?: GroupInfo;
+  // Same idea for channel writers, which are the other input to the widening gate.
+  writersAfterFirstRead?: string[];
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const baseGroup = options.group ?? sourceGroup();
+  let currentSourceTitle = 'Field Notes';
+  const imported: { title: string; body: string }[] = [];
+  const order: string[] = [];
+  const logs: string[] = [];
+  const calls = {
+    identity: 0,
+    create: 0,
+    detail: 0,
+    batch: [] as Parameters<MigrationDeps['batchImport']>[0][],
+    listNotes: 0,
+    getRawGroup: 0,
+    updateChannel: [] as Parameters<MigrationDeps['updateChannel']>[0][],
+    getGroup: 0,
+    perm: 0,
+  };
+
+  const deps: MigrationDeps = {
+    getChannelPerm: async () => {
+      calls.perm += 1;
+      const drifted = calls.perm > 1 && options.writersAfterFirstRead;
+      return {
+        writers: drifted
+          ? (options.writersAfterFirstRead as string[])
+          : options.writers ?? ['writers'],
+        group: GROUP,
+      };
+    },
+    getGroup: async () => {
+      calls.getGroup += 1;
+      return calls.getGroup > 1 && options.groupAfterFirstRead
+        ? options.groupAfterFirstRead
+        : baseGroup;
+    },
+    getChannelPosts: async () => ({
+      posts: [options.sourcePost ?? post()],
+      older: null,
+      totalPosts: 1,
+    }),
+    createGroupNotebook: async (input) => {
+      calls.create += 1;
+      order.push('create');
+      const trackedInput = {
+        ...input,
+        onCreated: (nest: string) => {
+          input.onCreated(nest);
+        },
+      };
+      if (options.create) return options.create(trackedInput);
+      trackedInput.onCreated(TARGET);
+      return TARGET;
+    },
+    getNotebookDetail: async () => {
+      calls.detail += 1;
+      order.push('detail');
+      return (
+        options.detail ?? {
+          rootFolderId: 42,
+          host: '~zod',
+          flagName: 'newbook',
+        }
+      );
+    },
+    listNotes: async (target) => {
+      calls.listNotes += 1;
+      order.push('read-back');
+      if (options.listNotes) return options.listNotes(target);
+      return imported.map((item) => ({
+        title: item.title,
+        bodyMd: item.body,
+      }));
+    },
+    batchImport: async (input) => {
+      calls.batch.push(input);
+      order.push('import');
+      if (options.batch) return options.batch(input);
+      imported.push(...input.notes);
+      return input.requestId;
+    },
+    getRawGroup: async (groupId) => {
+      calls.getRawGroup += 1;
+      order.push('raw-group');
+      if (options.getRawGroup) return options.getRawGroup(groupId);
+      return {
+        admissions: { privacy: 'private' },
+        admins: ['admins'],
+        seats: {},
+        roles: {},
+        channels: { [SOURCE]: channel(currentSourceTitle) },
+      };
+    },
+    updateChannel: async (input) => {
+      calls.updateChannel.push(input);
+      order.push('rename');
+      await options.updateChannel?.(input);
+      if (options.renameConfirmed !== false) {
+        currentSourceTitle = input.channel.meta.title;
+      }
+    },
+    getActingShip: () => '~zod',
+    assertServerIdentity: async () => {
+      calls.identity += 1;
+      order.push('identity');
+      await options.identity?.();
+    },
+    toUrbitStory: (content) => content as Story,
+    storyToMdastStrict: () => undefined,
+    storyToMarkdown: (story) =>
+      story
+        .flatMap((verse) =>
+          'inline' in verse
+            ? verse.inline.filter((value) => typeof value === 'string')
+            : []
+        )
+        .join(''),
+    generateRequestId: () => options.requestId ?? '0v12345',
+    recoveryInstruction:
+      options.recoveryInstruction ??
+      ((targetNest) =>
+        `delete the notebook \`${targetNest}\` in the Notes app and run \`tlon notes migrate-apply <diary-nest> --yes\` again.`),
+    log: (message) => logs.push(message),
+  };
+  return { calls, deps, imported, logs, order };
+}
+
+function applyOptions(
+  overrides: Partial<MigrationOptions> = {}
+): MigrationOptions {
+  return {
+    sourceNest: SOURCE,
+    allowWriteWidening: false,
+    yes: true,
+    ...overrides,
+  };
+}
+
+async function captureError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return error as Error;
+  }
+  throw new Error('Expected operation to reject');
+}
+
+describe('verifyTargetContents', () => {
+  it('compares a multiset rather than note ordering', () => {
+    expect(() =>
+      verifyTargetContents(
+        [
+          { postId: '1', sequenceNum: 1, title: 'same', body: 'body\n' },
+          { postId: '2', sequenceNum: 2, title: 'same', body: 'body\n' },
+          { postId: '3', sequenceNum: 3, title: 'other', body: 'x\n' },
+        ],
+        [
+          { title: 'other', bodyMd: 'x\n' },
+          { title: 'same', bodyMd: 'body\n' },
+          { title: 'same', bodyMd: 'body\n' },
+        ]
+      )
+    ).not.toThrow();
+  });
+
+  it('detects duplicate-count differences', () => {
+    expect(() =>
+      verifyTargetContents(
+        [
+          { postId: '1', sequenceNum: 1, title: 'same', body: 'body\n' },
+          { postId: '2', sequenceNum: 2, title: 'same', body: 'body\n' },
+        ],
+        [{ title: 'same', bodyMd: 'body\n' }]
+      )
+    ).toThrow(/1 expected note/);
+  });
+
+  it('fails closed when the list response omits a body', () => {
+    expect(() =>
+      verifyTargetContents(
+        [{ postId: '1', sequenceNum: 1, title: 'a', body: 'b' }],
+        [{ title: 'a', bodyMd: null }]
+      )
+    ).toThrow('missing an exact title or Markdown body');
+  });
+});
+
+describe('executeApply', () => {
+  it('requires explicit confirmation before any reads', async () => {
+    const context = makeHarness();
+    await expect(
+      executeApply(applyOptions({ yes: false }), context.deps)
+    ).rejects.toThrow('requires explicit confirmation');
+    expect(context.calls.getGroup).toBe(0);
+    expect(context.calls.create).toBe(0);
+  });
+
+  it('runs the fresh-target flow and archives by raw title-only round trip', async () => {
+    const context = makeHarness();
+    const result = await executeApply(applyOptions(), context.deps);
+
+    expect(result).toEqual({
+      status: 'success',
+      summary: {
+        notesImported: 1,
+        targetNest: TARGET,
+        archiveTitle: 'Field Notes-ARCHIVE',
+        archiveRenamed: true,
+        archiveOnly: {
+          totalComments: 0,
+          totalReactions: 0,
+          citeCount: 0,
+          linkBlockCount: 0,
+          groupMentionCount: 0,
+        },
+        warnings: [],
+      },
+    });
+    expect(context.order).toEqual([
+      'identity',
+      'create',
+      'detail',
+      'import',
+      'read-back',
+      'raw-group',
+      'rename',
+      'raw-group',
+    ]);
+    expect(context.logs[0]).toBe(`Target notebook created: ${TARGET}`);
+    expect(context.calls.batch[0]).toMatchObject({
+      flag: TARGET_FLAG,
+      folder: 42,
+      requestId: '0v12345',
+    });
+
+    const renamed = context.calls.updateChannel[0].channel;
+    expect(renamed.meta.title).toBe('Field Notes-ARCHIVE');
+    expect(renamed.meta.description).toBe('preserve description');
+    expect(renamed.meta.image).toBe('preserve image');
+    expect(renamed.meta.cover).toBe('preserve cover');
+    expect(renamed.readers).toEqual(['writers']);
+    expect(context.calls.getRawGroup).toBe(2);
+  });
+
+  it('passes the exact source reader roles into creation', async () => {
+    let createInput:
+      | Parameters<MigrationDeps['createGroupNotebook']>[0]
+      | undefined;
+    const context = makeHarness({
+      group: sourceGroup(['members']),
+      writers: [],
+      create: async (input) => {
+        createInput = input;
+        input.onCreated(TARGET);
+        return TARGET;
+      },
+    });
+    await executeApply(applyOptions(), context.deps);
+    expect(createInput?.readers).toEqual(['members']);
+  });
+
+  it('refuses widening before identity or creation', async () => {
+    const context = makeHarness({
+      group: sourceGroup(['members']),
+      writers: ['writers'],
+    });
+    await expect(executeApply(applyOptions(), context.deps)).rejects.toThrow(
+      'would widen write access'
+    );
+    expect(context.calls.identity).toBe(0);
+    expect(context.calls.create).toBe(0);
+  });
+
+  it('permits widening only with explicit acceptance', async () => {
+    const context = makeHarness({
+      group: sourceGroup(['members']),
+      writers: ['writers'],
+    });
+    await expect(
+      executeApply(applyOptions({ allowWriteWidening: true }), context.deps)
+    ).resolves.toMatchObject({ status: 'success' });
+  });
+
+  it('checks server identity after all reads but before the first write', async () => {
+    const context = makeHarness({
+      identity: async () => {
+        throw new Error('identity mismatch');
+      },
+    });
+    await expect(executeApply(applyOptions(), context.deps)).rejects.toThrow(
+      'identity mismatch'
+    );
+    expect(context.calls.create).toBe(0);
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('uses conservative title-based recovery when creation fails', async () => {
+    const context = makeHarness({
+      create: async () => {
+        throw new Error('create denied');
+      },
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('create denied');
+    expect(error.message).toContain(
+      'Notebook creation may or may not have landed'
+    );
+    expect(error.message).toContain(
+      'Look for a notebook with the requested title in the Notes app and remove it before retrying'
+    );
+    expect(context.calls.batch).toEqual([]);
+    expect(context.calls.updateChannel).toEqual([]);
+  });
+
+  it('adds recovery guidance when post-create reader verification fails', async () => {
+    const context = makeHarness({
+      create: async (input) => {
+        input.onCreated(TARGET);
+        throw new Error('reader verification failed');
+      },
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('reader verification failed');
+    expect(error.message).toContain(
+      `delete the notebook \`${TARGET}\` in the Notes app`
+    );
+    expect(context.calls.batch).toEqual([]);
+    expect(context.calls.updateChannel).toEqual([]);
+  });
+
+  it('uses the runtime-injected recovery instruction', async () => {
+    const context = makeHarness({
+      create: async (input) => {
+        input.onCreated(TARGET);
+        throw new Error('reader verification failed');
+      },
+      recoveryInstruction: (targetNest) =>
+        `ask the owner to run \`tlon notes notebook-delete ${targetNest} --yes\`, then \`tlon notes migrate-apply <diary-nest> --yes\`.`,
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain(
+      `ask the owner to run \`tlon notes notebook-delete ${TARGET} --yes\`, then \`tlon notes migrate-apply <diary-nest> --yes\`.`
+    );
+    expect(error.message).not.toContain('Notes app');
+  });
+
+  it('uses the real non-zero root folder id', async () => {
+    const context = makeHarness({
+      detail: { rootFolderId: 987, host: '~zod', flagName: 'newbook' },
+    });
+    await executeApply(applyOptions(), context.deps);
+    expect(context.calls.batch[0].folder).toBe(987);
+  });
+
+  it('rejects a zero root folder id, which %notes cannot produce', async () => {
+    const context = makeHarness({
+      detail: { rootFolderId: 0, host: '~zod', flagName: 'newbook' },
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('rootFolderId');
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('refuses when writers tighten mid-read so the run would now widen access', async () => {
+    // The widening gate is decided from the pre-read snapshot. If writers go
+    // from open to restricted during the read, an open-readers channel now
+    // widens write access, and the operator was never asked.
+    const context = makeHarness({
+      writers: [],
+      writersAfterFirstRead: ['writers'],
+      group: sourceGroup([]),
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('writer roles changed');
+    expect(error.message).toContain('widen write access');
+    expect(context.calls.create).toBe(0);
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('allows a mid-read writer change when widening is explicitly accepted', async () => {
+    const context = makeHarness({
+      writers: [],
+      writersAfterFirstRead: ['writers'],
+      group: sourceGroup([]),
+    });
+    await executeApply(
+      applyOptions({ allowWriteWidening: true }),
+      context.deps
+    );
+    expect(context.calls.create).toBe(1);
+  });
+
+  it('refuses when only admins drift and the live permissions now widen access', async () => {
+    const initialGroup = sourceGroup(['admins']);
+    const driftedGroup = sourceGroup(['admins']);
+    driftedGroup.admins = [];
+    const context = makeHarness({
+      group: initialGroup,
+      groupAfterFirstRead: driftedGroup,
+      writers: ['writers'],
+    });
+
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+
+    expect(error.message).toContain('admin or privacy settings changed');
+    expect(error.message).toContain('widen write access');
+    expect(error.message).toContain(
+      'reader role "admins" is not writer-authorizing'
+    );
+    expect(context.calls.create).toBe(0);
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('refuses when the source is restricted while posts are being read', async () => {
+    // The plan snapshots readers before the source read; if the source is
+    // locked down during it, creating from the stale snapshot would republish
+    // the whole diary at the old, wider visibility.
+    const context = makeHarness({
+      // Writers open too, so the plan itself reports no widening and the run
+      // reaches the pre-create check rather than stopping at the widening gate.
+      writers: [],
+      group: sourceGroup([]),
+      groupAfterFirstRead: sourceGroup(['members']),
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('reader roles changed');
+    expect(error.message).toContain('members');
+    expect(context.calls.create).toBe(0);
+    expect(context.calls.batch).toEqual([]);
+    expect(context.calls.updateChannel).toEqual([]);
+  });
+
+  it('refuses when notebook detail reports a different flagName', async () => {
+    // Importing uses detail.flagName while read-back uses targetNest; if they
+    // disagree the notes land somewhere we never verify and never clean up.
+    const context = makeHarness({
+      detail: {
+        rootFolderId: 42,
+        host: '~zod',
+        flagName: 'someone-elses-book',
+      },
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('someone-elses-book');
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('rejects malformed root folder data after creation', async () => {
+    const context = makeHarness({
+      detail: { rootFolderId: Number.NaN, host: '~zod', flagName: 'newbook' },
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('rootFolderId');
+    expect(error.message).toContain('delete the notebook');
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('rejects a zero request id before calling batch import', async () => {
+    const context = makeHarness({ requestId: '0v0' });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('invalid zero value');
+    expect(error.message).toContain('delete the notebook');
+    expect(context.calls.batch).toEqual([]);
+  });
+
+  it('names the failed chunk and known-target recovery', async () => {
+    const context = makeHarness({
+      batch: async () => {
+        throw new Error('socket reset');
+      },
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('Chunk 1/1 failed');
+    expect(error.message).toContain('may or may not have landed');
+    expect(error.message).toContain('delete the notebook');
+    expect(context.calls.listNotes).toBe(0);
+    expect(context.calls.updateChannel).toEqual([]);
+  });
+
+  it('rejects a mismatched echoed request id', async () => {
+    const context = makeHarness({ batch: async () => '0vwrong' });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('echoed request id 0vwrong');
+    expect(error.message).toContain('may or may not have landed');
+    expect(context.calls.updateChannel).toEqual([]);
+  });
+
+  it('blocks archive rename when exact read-back verification fails', async () => {
+    const context = makeHarness({
+      listNotes: async () => [{ title: 'different', bodyMd: 'different' }],
+    });
+    const error = await captureError(
+      executeApply(applyOptions(), context.deps)
+    );
+    expect(error.message).toContain('Read-back verification failed');
+    expect(error.message).toContain('delete the notebook');
+    expect(context.calls.updateChannel).toEqual([]);
+  });
+
+  it('treats archive rename failure as non-fatal', async () => {
+    const context = makeHarness({
+      getRawGroup: async () => {
+        throw new Error('groups unavailable');
+      },
+    });
+    const result = await executeApply(applyOptions(), context.deps);
+    expect(result.summary.archiveRenamed).toBe(false);
+    expect(result.summary.warnings[0]).toContain(
+      'Rename the channel in the app'
+    );
+    expect(result.summary.targetNest).toBe(TARGET);
+  });
+
+  it('warns and reports archiveRenamed false when rename read-back is unconfirmed', async () => {
+    const context = makeHarness({ renameConfirmed: false });
+
+    const result = await executeApply(applyOptions(), context.deps);
+
+    expect(context.calls.updateChannel).toHaveLength(1);
+    expect(context.calls.getRawGroup).toBe(2);
+    expect(result.summary.archiveRenamed).toBe(false);
+    expect(result.summary.warnings[0]).toContain(
+      'Source rename was not confirmed'
+    );
+    expect(result.summary.warnings[0]).toContain(
+      'Rename the channel in the app'
+    );
+    expect(result.summary.notesImported).toBe(1);
+  });
+
+  it('preflights an oversized note before identity and creation', async () => {
+    const context = makeHarness({
+      sourcePost: post('x'.repeat(600 * 1024)),
+    });
+    await expect(executeApply(applyOptions(), context.deps)).rejects.toThrow(
+      'exceeds byte cap'
+    );
+    expect(context.calls.identity).toBe(0);
+    expect(context.calls.create).toBe(0);
+  });
+});

--- a/packages/tlon-skill/scripts/notes-migrate-apply.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-apply.ts
@@ -1,0 +1,338 @@
+import { commandError, errorMessage } from './commands/command';
+import { archiveRename } from './migrate-helpers';
+import {
+  type ConvertedNote,
+  MIGRATION_LIMITS,
+  type MigrationDeps,
+  type MigrationOptions,
+  type MigrationPlan,
+  chunkNotes,
+  computeWriteWidening,
+  measureEnvelopeBytes,
+  normalizeShip,
+  parseNest,
+} from './notes-migrate';
+import {
+  PREFLIGHT_ENVELOPE_CONTEXT,
+  prepareMigration,
+} from './notes-migrate-plan';
+
+export interface ApplySummary {
+  notesImported: number;
+  targetNest: string;
+  archiveTitle: string;
+  archiveRenamed: boolean;
+  archiveOnly: MigrationPlan['metrics'];
+  warnings: string[];
+}
+
+export interface ApplyResult {
+  status: 'success';
+  summary: ApplySummary;
+}
+
+function exactPairKey(title: string, body: string): string {
+  return JSON.stringify([title, body]);
+}
+
+function increment(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+export function verifyTargetContents(
+  expected: ConvertedNote[],
+  actual: { title: string; bodyMd?: string | null }[]
+): void {
+  const expectedPairs = new Map<string, number>();
+  const actualPairs = new Map<string, number>();
+  for (const note of expected) {
+    increment(expectedPairs, exactPairKey(note.title, note.body));
+  }
+  for (const [index, note] of actual.entries()) {
+    if (typeof note.title !== 'string' || typeof note.bodyMd !== 'string') {
+      throw commandError(
+        `Read-back note ${index + 1} is missing an exact title or Markdown body`
+      );
+    }
+    increment(actualPairs, exactPairKey(note.title, note.bodyMd));
+  }
+
+  const missing = [...expectedPairs].reduce(
+    (count, [key, expectedCount]) =>
+      count + Math.max(0, expectedCount - (actualPairs.get(key) ?? 0)),
+    0
+  );
+  const unexpected = [...actualPairs].reduce(
+    (count, [key, actualCount]) =>
+      count + Math.max(0, actualCount - (expectedPairs.get(key) ?? 0)),
+    0
+  );
+  if (missing > 0 || unexpected > 0) {
+    throw commandError(
+      `Read-back verification failed: ${missing} expected note(s) missing and ${unexpected} unexpected note(s) present`
+    );
+  }
+}
+
+function validateNotebookDetail(
+  detail: { rootFolderId: number; host: string; flagName: string },
+  actingShip: string,
+  targetNest: string
+): void {
+  // %notes derives rootFolderId as notebookId + 1 (desk/lib/notes/json.hoon:16-17),
+  // so a real notebook never has root folder 0.
+  if (!Number.isSafeInteger(detail.rootFolderId) || detail.rootFolderId < 1) {
+    throw commandError(
+      `Target ${targetNest}: rootFolderId is missing or malformed`
+    );
+  }
+  if (!detail.flagName) {
+    throw commandError(`Target ${targetNest}: flagName is missing`);
+  }
+  // The import addresses the notebook by the flag this response carries, while
+  // read-back addresses `targetNest`. If they disagree the notes land in a
+  // different notebook than the one we verify and name in recovery, so refuse.
+  if (detail.flagName !== parseNest(targetNest).name) {
+    throw commandError(
+      `Target ${targetNest}: notebook detail reports flagName "${detail.flagName}", not "${
+        parseNest(targetNest).name
+      }"`
+    );
+  }
+  if (normalizeShip(detail.host) !== normalizeShip(actingShip)) {
+    throw commandError(
+      `Target ${targetNest} is hosted by ${normalizeShip(
+        detail.host
+      )}, not acting ship ${normalizeShip(actingShip)}`
+    );
+  }
+}
+
+async function importChunks(
+  notes: ConvertedNote[],
+  targetFlag: string,
+  rootFolderId: number,
+  deps: MigrationDeps
+): Promise<void> {
+  const chunks = chunkNotes(notes, MIGRATION_LIMITS.HTTP_BATCH_ENVELOPE_BYTES, {
+    ...PREFLIGHT_ENVELOPE_CONTEXT,
+    flag: targetFlag,
+    folder: rootFolderId,
+  });
+
+  for (const [index, chunk] of chunks.entries()) {
+    const requestId = deps.generateRequestId();
+    if (!requestId || requestId === '0v0') {
+      throw commandError(
+        `Request-id generator returned an invalid zero value for chunk ${
+          index + 1
+        }`
+      );
+    }
+    const actualBytes = measureEnvelopeBytes(chunk, {
+      flag: targetFlag,
+      folder: rootFolderId,
+      requestId,
+    });
+    if (actualBytes > MIGRATION_LIMITS.HTTP_BATCH_ENVELOPE_BYTES) {
+      throw commandError(
+        `Chunk ${index + 1}/${chunks.length} exceeds the byte cap after target resolution (${actualBytes} bytes)`
+      );
+    }
+
+    let echoedId: string;
+    try {
+      echoedId = await deps.batchImport({
+        flag: targetFlag,
+        folder: rootFolderId,
+        notes: chunk.map(({ title, body }) => ({ title, body })),
+        requestId,
+      });
+    } catch (error) {
+      throw commandError(
+        `Chunk ${index + 1}/${chunks.length} failed: ${errorMessage(
+          error
+        )}. The import may or may not have landed.`
+      );
+    }
+    if (echoedId !== requestId) {
+      throw commandError(
+        `Chunk ${index + 1}/${chunks.length} echoed request id ${echoedId}, expected ${requestId}. The import may or may not have landed.`
+      );
+    }
+  }
+}
+
+function sameRoleSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = [...a].sort();
+  const right = [...b].sort();
+  return left.every((role, index) => role === right[index]);
+}
+
+/**
+ * Both inputs to the consent decision — who can read the source, and who can
+ * write it — are captured in `plan` before the source read, which is the
+ * longest step in a migration (up to 50 paged round trips). Either can drift in
+ * that window, and each drift is harmful in its own way:
+ *
+ *   - readers tighten: creating from the stale snapshot republishes the whole
+ *     diary at the old, wider visibility while the original looks locked down.
+ *   - writers tighten: the run was gated on a widening verdict computed from
+ *     open writers, so a migration that now *does* widen write access proceeds
+ *     without the operator ever being asked.
+ *
+ * Re-read both immediately before the create and recompute the gate on live
+ * values. Nothing has been written at this point, so drift is a clean refusal
+ * with no cleanup to perform.
+ */
+async function assertPermissionsUnchanged(
+  plan: MigrationPlan,
+  options: MigrationOptions,
+  deps: MigrationDeps
+): Promise<void> {
+  const group = await deps.getGroup(plan.group);
+  const sourceChannel = group.channels[plan.sourceNest];
+  if (!sourceChannel || !Array.isArray(sourceChannel.readers)) {
+    throw commandError(
+      `Source ${plan.sourceNest}: reader roles could not be re-read before creating the target — refusing to proceed`
+    );
+  }
+
+  const perm = await deps.getChannelPerm(plan.sourceNest);
+  if (!Array.isArray(perm.writers)) {
+    throw commandError(
+      `Source ${plan.sourceNest}: writers could not be re-read before creating the target — refusing to proceed`
+    );
+  }
+
+  const writerRolesChanged = !sameRoleSet(plan.writerRoles, perm.writers);
+  const liveWidening = computeWriteWidening({
+    readerRoles: sourceChannel.readers,
+    writerRoles: perm.writers,
+    admins: group.admins,
+    privacy: group.privacy,
+  });
+
+  const approved = [...plan.readerRoles].sort();
+  const live = [...sourceChannel.readers].sort();
+  const changed =
+    approved.length !== live.length ||
+    approved.some((role, index) => role !== live[index]);
+  if (changed) {
+    throw commandError(
+      `Source ${plan.sourceNest}: reader roles changed during the migration ` +
+        `(planned for [${approved.join(', ')}], now [${live.join(', ')}]). ` +
+        `Nothing was created — re-run to migrate at the current permissions.`
+    );
+  }
+
+  if (liveWidening.widening && !options.allowWriteWidening) {
+    const changedInput = writerRolesChanged
+      ? 'writer roles changed'
+      : 'group admin or privacy settings changed';
+    throw commandError(
+      `Source ${plan.sourceNest}: ${changedInput} during the migration and it would now widen write access: ` +
+        `${liveWidening.reasons.join('; ')}. Nothing was created — re-run to review the current permissions.`
+    );
+  }
+}
+
+export async function executeApply(
+  options: MigrationOptions,
+  deps: MigrationDeps
+): Promise<ApplyResult> {
+  if (!options.yes) {
+    throw commandError('Migration apply requires explicit confirmation');
+  }
+  const prepared = await prepareMigration(options, deps);
+  if (prepared.plan.writeWidening && !options.allowWriteWidening) {
+    throw commandError(
+      `Migration would widen write access: ${prepared.plan.wideningReasons.join(
+        '; '
+      )}. Refusing without explicit acceptance — pass --allow-write-widening to accept.`
+    );
+  }
+
+  await deps.assertServerIdentity();
+  await assertPermissionsUnchanged(prepared.plan, options, deps);
+
+  let targetNest: string | null = null;
+  try {
+    targetNest = await deps.createGroupNotebook({
+      title: prepared.plan.targetTitle,
+      groupId: prepared.plan.group,
+      readers: [...prepared.plan.readerRoles],
+      onCreated: (nest) => {
+        targetNest = nest;
+        deps.log(`Target notebook created: ${nest}`);
+      },
+    });
+  } catch (error) {
+    if (!targetNest) {
+      throw commandError(
+        `${errorMessage(
+          error
+        )}\nNotebook creation may or may not have landed. Look for a notebook with the requested title in the Notes app and remove it before retrying.`
+      );
+    }
+    throw commandError(
+      `${errorMessage(
+        error
+      )}\nThe target notebook exists. ${deps.recoveryInstruction(targetNest)}`
+    );
+  }
+
+  try {
+    const actingShip = normalizeShip(deps.getActingShip());
+    const detail = await deps.getNotebookDetail(targetNest);
+    validateNotebookDetail(detail, actingShip, targetNest);
+    const targetFlag = `${normalizeShip(detail.host)}/${detail.flagName}`;
+
+    await importChunks(
+      prepared.convertedNotes,
+      targetFlag,
+      detail.rootFolderId,
+      deps
+    );
+
+    const targetNotes = await deps.listNotes(targetNest);
+    verifyTargetContents(prepared.convertedNotes, targetNotes);
+
+    const warnings: string[] = [];
+    let archiveRenamed = false;
+    try {
+      await archiveRename(
+        deps,
+        prepared.plan.group,
+        prepared.plan.sourceNest,
+        prepared.plan.archiveTitle
+      );
+      archiveRenamed = true;
+    } catch (error) {
+      const warning = `Migration succeeded, but the source rename failed: ${errorMessage(
+        error
+      )}. Rename the channel in the app.`;
+      warnings.push(warning);
+      deps.log(warning);
+    }
+
+    return {
+      status: 'success',
+      summary: {
+        notesImported: prepared.convertedNotes.length,
+        targetNest,
+        archiveTitle: prepared.plan.archiveTitle,
+        archiveRenamed,
+        archiveOnly: prepared.plan.metrics,
+        warnings,
+      },
+    };
+  } catch (error) {
+    throw commandError(
+      `${errorMessage(
+        error
+      )}\nThe target notebook exists. ${deps.recoveryInstruction(targetNest)}`
+    );
+  }
+}

--- a/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
@@ -55,6 +55,30 @@ function groupWithTitle(title: string): GroupInfo {
   return sourceGroup;
 }
 
+function groupWithNotebooks(
+  ...notebooks: Array<{ host: string; name: string; title: string }>
+): GroupInfo {
+  const sourceGroup = group();
+  return {
+    ...sourceGroup,
+    channels: {
+      ...sourceGroup.channels,
+      ...Object.fromEntries(
+        notebooks.map(({ host, name, title }) => [
+          `notes/${host}/${name}`,
+          {
+            ...sourceGroup.channels[SOURCE],
+            meta: {
+              ...sourceGroup.channels[SOURCE].meta,
+              title,
+            },
+          },
+        ])
+      ),
+    },
+  };
+}
+
 type Page = Awaited<ReturnType<MigrationDeps['getChannelPosts']>>;
 
 function makeDeps(
@@ -63,6 +87,7 @@ function makeDeps(
     actingShip?: string;
     group?: GroupInfo;
     perm?: { writers: string[]; group: string };
+    listNotes?: MigrationDeps['listNotes'];
   } = {}
 ) {
   const pages = options.pages ?? [
@@ -75,6 +100,7 @@ function makeDeps(
       mode: 'newest' | 'older';
       count: number;
     }>,
+    listNotes: [] as string[],
     mutate: 0,
     identity: 0,
   };
@@ -96,7 +122,11 @@ function makeDeps(
     },
     createGroupNotebook: mutation,
     getNotebookDetail: mutation,
-    listNotes: mutation,
+    listNotes: async (target) => {
+      calls.listNotes.push(target);
+      if (options.listNotes) return options.listNotes(target);
+      return [];
+    },
     batchImport: mutation,
     getRawGroup: mutation,
     updateChannel: mutation,
@@ -347,7 +377,167 @@ describe('executePlan', () => {
       `Refusing to migrate ${SOURCE}: its title appears to have been migrated already. ` +
         `If that is incorrect, rename the source channel to remove the archive marker, then re-run the migration.`
     );
+    expect(archived.calls.listNotes).toEqual([]);
     expect(archived.calls.posts).toEqual([]);
+  });
+
+  it('refuses a same-title notes target containing provenance for this source', async () => {
+    const target = 'notes/~zod/field-notes';
+    const { calls, deps } = makeDeps({
+      group: groupWithNotebooks({
+        host: '~zod',
+        name: 'field-notes',
+        title: 'Field Notes',
+      }),
+      listNotes: async () => [
+        {
+          title: 'Migrated note',
+          bodyMd: `Body\n\n<!-- tlon-migrate: ${SOURCE} 170.141 -->`,
+        },
+      ],
+    });
+
+    const result = executePlan(options(), deps);
+    await expect(result).rejects.toThrow(SOURCE);
+    await expect(result).rejects.toThrow(target);
+    await expect(result).rejects.toThrow('rename');
+    await expect(result).rejects.toThrow(
+      `tlon notes notebook-delete ${target} --yes`
+    );
+    expect(calls.listNotes).toEqual([target]);
+    expect(calls.posts).toEqual([]);
+  });
+
+  it('scries only same-title notes candidates and allows unrelated provenance', async () => {
+    const candidate = 'notes/~zod/field-notes';
+    const sourceGroup = groupWithNotebooks(
+      {
+        host: '~zod',
+        name: 'different-title',
+        title: 'Different title',
+      },
+      {
+        host: '~zod',
+        name: 'field-notes',
+        title: 'Field Notes',
+      }
+    );
+    sourceGroup.channels['chat/~zod/field-notes'] = {
+      ...sourceGroup.channels[SOURCE],
+      meta: {
+        ...sourceGroup.channels[SOURCE].meta,
+        title: 'Field Notes',
+      },
+    };
+    const { calls, deps } = makeDeps({
+      group: sourceGroup,
+      listNotes: async () => [
+        {
+          title: 'Unrelated note',
+          bodyMd: 'Body\n\n<!-- tlon-migrate: diary/~zod/blog-copy 170.141 -->',
+        },
+      ],
+    });
+
+    await expect(executePlan(options(), deps)).resolves.toMatchObject({
+      plan: { targetTitle: 'Field Notes' },
+    });
+    expect(calls.listNotes).toEqual([candidate]);
+  });
+
+  it('checks every same-title candidate before allowing a retry', async () => {
+    const firstTarget = 'notes/~zod/field-notes-old';
+    const secondTarget = 'notes/~zod/field-notes';
+    const { calls, deps } = makeDeps({
+      group: groupWithNotebooks(
+        {
+          host: '~zod',
+          name: 'field-notes-old',
+          title: 'Field Notes',
+        },
+        {
+          host: '~zod',
+          name: 'field-notes',
+          title: 'Field Notes',
+        }
+      ),
+      listNotes: async (target) => [
+        target === firstTarget
+          ? {
+              title: 'Unrelated note',
+              bodyMd:
+                'Body\n\n<!-- tlon-migrate: diary/~zod/blog-copy 170.141 -->',
+            }
+          : {
+              title: 'Migrated note',
+              bodyMd: `Body\n\n<!-- tlon-migrate: ${SOURCE} 170.141 -->`,
+            },
+      ],
+    });
+
+    await expect(executePlan(options(), deps)).rejects.toThrow(secondTarget);
+    expect(calls.listNotes).toEqual([firstTarget, secondTarget]);
+    expect(calls.posts).toEqual([]);
+  });
+
+  // Scoped to a thrown read. A successful response carrying a malformed
+  // `bodyMd` is treated as absent provenance and fails open by design; see the
+  // note on `hasSourceProvenanceFooter`.
+  it('fails closed when reading a colliding target throws', async () => {
+    const target = 'notes/~zod/field-notes';
+    const readError = new Error('target notes unavailable');
+    const { calls, deps } = makeDeps({
+      group: groupWithNotebooks({
+        host: '~zod',
+        name: 'field-notes',
+        title: 'Field Notes',
+      }),
+      listNotes: async () => {
+        throw readError;
+      },
+    });
+
+    await expect(executePlan(options(), deps)).rejects.toBe(readError);
+    expect(calls.listNotes).toEqual([target]);
+    expect(calls.posts).toEqual([]);
+    expect(calls.mutate).toBe(0);
+  });
+
+  it('never scries a same-title notebook hosted by another ship', async () => {
+    const foreignTarget = 'notes/~sampel-palnet/field-notes';
+    const localTarget = 'notes/~zod/field-notes-copy';
+    const { calls, deps } = makeDeps({
+      group: groupWithNotebooks(
+        {
+          host: '~sampel-palnet',
+          name: 'field-notes',
+          title: 'Field Notes',
+        },
+        {
+          host: '~zod',
+          name: 'field-notes-copy',
+          title: 'Field Notes',
+        }
+      ),
+      listNotes: async (target) => {
+        if (target === foreignTarget) {
+          throw new Error('foreign notebook must not be scried');
+        }
+        return [
+          {
+            title: 'Unrelated note',
+            bodyMd:
+              'Body\n\n<!-- tlon-migrate: diary/~zod/blog-copy 170.141 -->',
+          },
+        ];
+      },
+    });
+
+    await expect(executePlan(options(), deps)).resolves.toMatchObject({
+      plan: { targetTitle: 'Field Notes' },
+    });
+    expect(calls.listNotes).toEqual([localTarget]);
+    expect(calls.listNotes).not.toContain(foreignTarget);
   });
 
   it('performs complete read and conversion without invoking any mutation', async () => {

--- a/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
@@ -1,0 +1,384 @@
+import type { Post, Story } from '@tloncorp/api';
+import { describe, expect, it } from 'bun:test';
+
+import type {
+  GroupInfo,
+  MigrationDeps,
+  MigrationOptions,
+} from './notes-migrate';
+import { executePlan, readSourceComplete } from './notes-migrate-plan';
+
+const SOURCE = 'diary/~zod/blog';
+const GROUP = '~zod/group';
+const DAY = Date.UTC(2025, 0, 2);
+
+function post(id: string, sequenceNum: number, text = id): Post {
+  return {
+    id,
+    type: 'note',
+    channelId: SOURCE,
+    authorId: '~zod',
+    sentAt: DAY + sequenceNum,
+    receivedAt: DAY + sequenceNum,
+    sequenceNum,
+    content: [{ inline: [text] }],
+    replyCount: 0,
+    reactions: [],
+  };
+}
+
+function group(overrides: Partial<GroupInfo> = {}): GroupInfo {
+  return {
+    privacy: 'private',
+    admins: ['admins'],
+    channels: {
+      [SOURCE]: {
+        added: DAY,
+        meta: {
+          title: 'Field Notes',
+          description: '',
+          image: '',
+          cover: '',
+        },
+        section: 'main',
+        readers: ['writers'],
+        join: false,
+      },
+    },
+    ...overrides,
+  };
+}
+
+type Page = Awaited<ReturnType<MigrationDeps['getChannelPosts']>>;
+
+function makeDeps(
+  options: {
+    pages?: Page[];
+    actingShip?: string;
+    group?: GroupInfo;
+    perm?: { writers: string[]; group: string };
+  } = {}
+) {
+  const pages = options.pages ?? [
+    { posts: [post('1', 1)], older: null, totalPosts: 1 },
+  ];
+  const calls = {
+    posts: [] as Array<{
+      nest: string;
+      cursor: string | undefined;
+      mode: 'newest' | 'older';
+      count: number;
+    }>,
+    mutate: 0,
+    identity: 0,
+  };
+  let pageIndex = 0;
+  const mutation = async () => {
+    calls.mutate += 1;
+    throw new Error('plan attempted a mutation');
+  };
+  const deps: MigrationDeps = {
+    getChannelPerm: async () =>
+      options.perm ?? { writers: ['writers'], group: GROUP },
+    getGroup: async () => options.group ?? group(),
+    getChannelPosts: async (nest, cursor, mode, count) => {
+      calls.posts.push({ nest, cursor, mode, count });
+      const page = pages[pageIndex];
+      pageIndex += 1;
+      if (!page) throw new Error('unexpected page read');
+      return page;
+    },
+    createGroupNotebook: mutation,
+    getNotebookDetail: mutation,
+    listNotes: mutation,
+    batchImport: mutation,
+    getRawGroup: mutation,
+    updateChannel: mutation,
+    getActingShip: () => options.actingShip ?? '~zod',
+    assertServerIdentity: async () => {
+      calls.identity += 1;
+    },
+    toUrbitStory: (content) => content as Story,
+    storyToMdastStrict: () => undefined,
+    storyToMarkdown: (story) =>
+      story
+        .flatMap((verse) =>
+          'inline' in verse
+            ? verse.inline.filter((value) => typeof value === 'string')
+            : []
+        )
+        .join(''),
+    generateRequestId: () => '0v1',
+    recoveryInstruction: () => 'recover',
+    log: () => undefined,
+  };
+  return { calls, deps };
+}
+
+function options(overrides: Partial<MigrationOptions> = {}): MigrationOptions {
+  return {
+    sourceNest: SOURCE,
+    allowWriteWidening: false,
+    yes: false,
+    ...overrides,
+  };
+}
+
+describe('readSourceComplete', () => {
+  it('starts at newest, follows older cursors, and sorts globally by sequence', async () => {
+    const { calls, deps } = makeDeps({
+      pages: [
+        {
+          posts: [post('3', 3), post('2', 2)],
+          older: 'cursor-1',
+          totalPosts: 3,
+        },
+        { posts: [post('1', 1)], older: null, totalPosts: 3 },
+      ],
+    });
+    const result = await readSourceComplete(SOURCE, deps);
+    expect(result.map((row) => row.id)).toEqual(['1', '2', '3']);
+    expect(calls.posts).toEqual([
+      {
+        nest: SOURCE,
+        cursor: undefined,
+        mode: 'newest',
+        count: 100,
+      },
+      {
+        nest: SOURCE,
+        cursor: 'cursor-1',
+        mode: 'older',
+        count: 100,
+      },
+    ]);
+  });
+
+  it('rejects a non-adjacent cursor cycle', async () => {
+    const { deps } = makeDeps({
+      pages: [
+        { posts: [post('3', 3)], older: 'a', totalPosts: 3 },
+        { posts: [post('2', 2)], older: 'b', totalPosts: 3 },
+        { posts: [post('1', 1)], older: 'a', totalPosts: 3 },
+      ],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+      'repeated cursor'
+    );
+  });
+
+  it('rejects duplicate post ids across pages', async () => {
+    const { deps } = makeDeps({
+      pages: [
+        { posts: [post('same', 2)], older: 'a', totalPosts: 2 },
+        { posts: [post('same', 1)], older: null, totalPosts: 2 },
+      ],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+      'duplicate post id same'
+    );
+  });
+
+  it('rejects totalPosts drift', async () => {
+    const { deps } = makeDeps({
+      pages: [
+        { posts: [post('2', 2)], older: 'a', totalPosts: 2 },
+        { posts: [post('1', 1)], older: null, totalPosts: 3 },
+      ],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+      'totalPosts changed'
+    );
+  });
+
+  it('rejects a non-null cursor yielding no rows', async () => {
+    const { deps } = makeDeps({
+      pages: [
+        { posts: [post('1', 1)], older: 'a', totalPosts: 1 },
+        { posts: [], older: null, totalPosts: 1 },
+      ],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+      'yielded no new rows'
+    );
+  });
+
+  it('checks terminal non-stub rows against totalPosts', async () => {
+    const { deps } = makeDeps({
+      pages: [{ posts: [post('1', 1)], older: null, totalPosts: 2 }],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+      'completeness invariant failed'
+    );
+  });
+
+  it('does not count a synthetic stub toward totalPosts', async () => {
+    const stub = {
+      ...post('stub', 2),
+      isSequenceStub: true,
+    };
+    const { deps } = makeDeps({
+      pages: [
+        {
+          posts: [post('1', 1), stub],
+          older: null,
+          totalPosts: 1,
+        },
+      ],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).resolves.toHaveLength(2);
+  });
+
+  it('uses the raw seal reaction count when UI normalization filtered entries', async () => {
+    const sourcePost = {
+      ...post('1', 1),
+      reactions: [],
+      rawReactionCount: 3,
+    };
+    const { deps } = makeDeps({
+      pages: [{ posts: [sourcePost], older: null, totalPosts: 1 }],
+    });
+
+    const result = await readSourceComplete(SOURCE, deps);
+
+    expect(result[0].reactionCount).toBe(3);
+  });
+
+  it('rejects a source above the 5,000-post ceiling immediately', async () => {
+    const { deps } = makeDeps({
+      pages: [{ posts: [post('1', 1)], older: null, totalPosts: 5001 }],
+    });
+    await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+      'exceeds the migration ceiling'
+    );
+  });
+
+  it('rejects missing or malformed sequence numbers on eligible posts', async () => {
+    for (const sequenceNum of [undefined, null, '1', 1.5, -1]) {
+      const malformed = {
+        ...post('1', 1),
+        sequenceNum,
+      } as unknown as Post;
+      const { deps } = makeDeps({
+        pages: [{ posts: [malformed], older: null, totalPosts: 1 }],
+      });
+      await expect(readSourceComplete(SOURCE, deps)).rejects.toThrow(
+        'sequenceNum'
+      );
+    }
+  });
+
+  it('counts but does not import a sequence-less tombstone without perturbing eligible order', async () => {
+    const tombstone = {
+      ...post('gone', 0),
+      sequenceNum: null,
+      isDeleted: true,
+    } as Post;
+    const { deps } = makeDeps({
+      pages: [
+        {
+          posts: [post('third', 3), tombstone, post('first', 1)],
+          older: null,
+          totalPosts: 3,
+        },
+      ],
+    });
+
+    const result = await executePlan(options(), deps);
+
+    expect(result.plan).toMatchObject({
+      eligibleCount: 2,
+      tombstoneCount: 1,
+      stubCount: 0,
+      previewTitles: ['first', 'third'],
+    });
+    expect(result.convertedNotes.map((note) => note.postId)).toEqual([
+      'first',
+      'third',
+    ]);
+    expect(result.convertedNotes.map((note) => note.sequenceNum)).toEqual([
+      1, 3,
+    ]);
+    expect(result.convertedNotes.some((note) => note.postId === 'gone')).toBe(
+      false
+    );
+  });
+});
+
+describe('executePlan', () => {
+  it('performs complete read and conversion without invoking any mutation', async () => {
+    const tombstone = { ...post('gone', 2), isDeleted: true };
+    const { calls, deps } = makeDeps({
+      pages: [
+        {
+          posts: [post('live', 3, 'Converted title'), tombstone],
+          older: null,
+          totalPosts: 2,
+        },
+      ],
+    });
+    const result = await executePlan(options(), deps);
+    expect(result.plan).toMatchObject({
+      sourceNest: SOURCE,
+      group: GROUP,
+      sourceTitle: 'Field Notes',
+      targetTitle: 'Field Notes',
+      eligibleCount: 1,
+      tombstoneCount: 1,
+      stubCount: 0,
+      previewTitles: ['Converted title'],
+      writeWidening: false,
+      archiveTitle: 'Field Notes-ARCHIVE',
+    });
+    expect(result.convertedNotes[0].body).toContain(
+      '<!-- tlon-migrate: diary/~zod/blog live -->'
+    );
+    expect(calls.mutate).toBe(0);
+    expect(calls.identity).toBe(0);
+  });
+
+  it('refuses a source hosted by another ship before reading posts', async () => {
+    const { calls, deps } = makeDeps({ actingShip: '~nec' });
+    await expect(executePlan(options(), deps)).rejects.toThrow(
+      'acting ship ~nec is not the host ~zod'
+    );
+    expect(calls.posts).toEqual([]);
+  });
+
+  it('refuses a group hosted by another ship', async () => {
+    const { calls, deps } = makeDeps({
+      perm: { writers: [], group: '~nec/group' },
+    });
+    await expect(executePlan(options(), deps)).rejects.toThrow(
+      'source group: acting ship ~zod is not the host ~nec'
+    );
+    expect(calls.posts).toEqual([]);
+  });
+
+  it('fails closed when the source channel is missing from the group', async () => {
+    const { deps } = makeDeps({ group: group({ channels: {} }) });
+    await expect(executePlan(options(), deps)).rejects.toThrow(
+      'refusing to assume open readers'
+    );
+  });
+
+  it('refuses an empty eligible source set', async () => {
+    const deleted = { ...post('gone', 1), isDeleted: true };
+    const { deps } = makeDeps({
+      pages: [{ posts: [deleted], older: null, totalPosts: 1 }],
+    });
+    await expect(executePlan(options(), deps)).rejects.toThrow(
+      'has no eligible posts'
+    );
+  });
+
+  it('reports widening without enumerating group seats', async () => {
+    const sourceGroup = group();
+    sourceGroup.channels[SOURCE].readers = ['members'];
+    const { deps } = makeDeps({ group: sourceGroup });
+    const { plan } = await executePlan(options(), deps);
+    expect(plan.writeWidening).toBe(true);
+    expect(plan.wideningReasons.join(' ')).toContain('reader role "members"');
+    expect(JSON.stringify(plan)).not.toContain('~sampel-palnet');
+  });
+});

--- a/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
@@ -49,6 +49,12 @@ function group(overrides: Partial<GroupInfo> = {}): GroupInfo {
   };
 }
 
+function groupWithTitle(title: string): GroupInfo {
+  const sourceGroup = group();
+  sourceGroup.channels[SOURCE].meta.title = title;
+  return sourceGroup;
+}
+
 type Page = Awaited<ReturnType<MigrationDeps['getChannelPosts']>>;
 
 function makeDeps(
@@ -306,6 +312,44 @@ describe('readSourceComplete', () => {
 });
 
 describe('executePlan', () => {
+  it('refuses an archived source while preserving exact suffix semantics', async () => {
+    const ordinary = makeDeps({ group: groupWithTitle('Field Notes') });
+    await expect(executePlan(options(), ordinary.deps)).resolves.toMatchObject({
+      plan: { sourceTitle: 'Field Notes' },
+    });
+
+    const differentCase = makeDeps({
+      group: groupWithTitle('Field Notes-archive'),
+    });
+    await expect(
+      executePlan(options(), differentCase.deps)
+    ).resolves.toMatchObject({
+      plan: {
+        sourceTitle: 'Field Notes-archive',
+        archiveTitle: 'Field Notes-archive-ARCHIVE',
+      },
+    });
+
+    const emptyTitle = makeDeps({ group: groupWithTitle('  ') });
+    await expect(
+      executePlan(options(), emptyTitle.deps)
+    ).resolves.toMatchObject({
+      plan: {
+        targetTitle: 'blog',
+        archiveTitle: 'blog-ARCHIVE',
+      },
+    });
+
+    const archived = makeDeps({
+      group: groupWithTitle('  Field Notes-ARCHIVE  '),
+    });
+    await expect(executePlan(options(), archived.deps)).rejects.toThrow(
+      `Refusing to migrate ${SOURCE}: its title appears to have been migrated already. ` +
+        `If that is incorrect, rename the source channel to remove the archive marker, then re-run the migration.`
+    );
+    expect(archived.calls.posts).toEqual([]);
+  });
+
   it('performs complete read and conversion without invoking any mutation', async () => {
     const tombstone = { ...post('gone', 2), isDeleted: true };
     const { calls, deps } = makeDeps({

--- a/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.test.ts
@@ -408,6 +408,55 @@ describe('executePlan', () => {
     expect(calls.posts).toEqual([]);
   });
 
+  it('refuses provenance on an earlier line when content is appended', async () => {
+    const target = 'notes/~zod/field-notes';
+    const { calls, deps } = makeDeps({
+      group: groupWithNotebooks({
+        host: '~zod',
+        name: 'field-notes',
+        title: 'Field Notes',
+      }),
+      listNotes: async () => [
+        {
+          title: 'Migrated note with later edits',
+          bodyMd: `<!-- tlon-migrate: ${SOURCE} 170.141 -->\nUser-added content`,
+        },
+      ],
+    });
+
+    const result = executePlan(options(), deps);
+    await expect(result).rejects.toThrow(SOURCE);
+    await expect(result).rejects.toThrow(target);
+    expect(calls.listNotes).toEqual([target]);
+    expect(calls.posts).toEqual([]);
+  });
+
+  it('refuses provenance on an earlier complete CRLF line after content is appended', async () => {
+    const target = 'notes/~zod/field-notes';
+    const { calls, deps } = makeDeps({
+      group: groupWithNotebooks({
+        host: '~zod',
+        name: 'field-notes',
+        title: 'Field Notes',
+      }),
+      listNotes: async () => [
+        {
+          title: 'Migrated note with later edits',
+          bodyMd: `<!-- tlon-migrate: ${SOURCE} 170.141 -->\r\nUser-added content`,
+        },
+      ],
+    });
+
+    const result = executePlan(options(), deps);
+    await expect(result).rejects.toThrow(SOURCE);
+    await expect(result).rejects.toThrow(target);
+    await expect(result).rejects.toThrow(
+      `tlon notes notebook-delete ${target} --yes`
+    );
+    expect(calls.listNotes).toEqual([target]);
+    expect(calls.posts).toEqual([]);
+  });
+
   it('scries only same-title notes candidates and allows unrelated provenance', async () => {
     const candidate = 'notes/~zod/field-notes';
     const sourceGroup = groupWithNotebooks(
@@ -433,8 +482,17 @@ describe('executePlan', () => {
       group: sourceGroup,
       listNotes: async () => [
         {
-          title: 'Unrelated note',
-          bodyMd: 'Body\n\n<!-- tlon-migrate: diary/~zod/blog-copy 170.141 -->',
+          title: 'Unrelated source marker',
+          bodyMd:
+            'Body\n<!-- tlon-migrate: diary/~zod/blog-copy 170.141 -->\nAppended content',
+        },
+        {
+          title: 'Leading whitespace marker',
+          bodyMd: `Body\n <!-- tlon-migrate: ${SOURCE} 170.141 -->\nAppended content`,
+        },
+        {
+          title: 'Trailing whitespace marker',
+          bodyMd: `Body\n<!-- tlon-migrate: ${SOURCE} 170.141 --> \nAppended content`,
         },
       ],
     });

--- a/packages/tlon-skill/scripts/notes-migrate-plan.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.ts
@@ -1,0 +1,286 @@
+import type { Post } from '@tloncorp/api';
+
+import { commandError } from './commands/command';
+import { assertActingShipIsHost } from './migrate-helpers';
+import {
+  type ConvertedNote,
+  MIGRATION_LIMITS,
+  type MigrationDeps,
+  type MigrationOptions,
+  type MigrationPlan,
+  type SourcePost,
+  archiveTitle,
+  canonicalizeNest,
+  chunkNotes,
+  computeWriteWidening,
+  convertPost,
+  countArchiveOnlyMetrics,
+  deriveTargetTitle,
+  filterEligiblePosts,
+  normalizeShip,
+  parseNest,
+  sortPostsBySequence,
+} from './notes-migrate';
+
+export const PREFLIGHT_ENVELOPE_CONTEXT = {
+  flag: `~${'z'.repeat(64)}/${'z'.repeat(128)}`,
+  folder: Number.MAX_SAFE_INTEGER,
+  requestId: `0v${'v'.repeat(64)}`,
+} as const;
+
+export interface PreparedMigration {
+  plan: MigrationPlan;
+  convertedNotes: ConvertedNote[];
+}
+
+function requireSequenceNum(post: Post): number {
+  if (
+    post.isDeleted === true &&
+    (post.sequenceNum === null || post.sequenceNum === undefined)
+  ) {
+    // The channels API normalizes a backend @ud 0 to null. Old tombstones can
+    // legitimately carry that value, and they are counted for completeness
+    // but never imported. Keep them sortable without relaxing validation for
+    // any eligible post.
+    return 0;
+  }
+  if (
+    typeof post.sequenceNum !== 'number' ||
+    !Number.isInteger(post.sequenceNum) ||
+    post.sequenceNum < 0
+  ) {
+    throw commandError(
+      `Source post ${post.id}: missing or malformed sequenceNum`
+    );
+  }
+  return post.sequenceNum;
+}
+
+function getPostReactionCount(post: Post): number {
+  const rawReactionCount = (post as Post & { rawReactionCount?: unknown })
+    .rawReactionCount;
+  if (
+    typeof rawReactionCount === 'number' &&
+    Number.isInteger(rawReactionCount) &&
+    rawReactionCount >= 0
+  ) {
+    return rawReactionCount;
+  }
+  return Array.isArray(post.reactions) ? post.reactions.length : 0;
+}
+
+export function postToSourcePost(post: Post): SourcePost {
+  if (!post.id || typeof post.id !== 'string') {
+    throw commandError('Source returned a post with no id');
+  }
+  if (!post.authorId || typeof post.authorId !== 'string') {
+    throw commandError(`Source post ${post.id}: missing authorId`);
+  }
+  if (typeof post.sentAt !== 'number' || !Number.isFinite(post.sentAt)) {
+    throw commandError(`Source post ${post.id}: missing or malformed sentAt`);
+  }
+  return {
+    id: post.id,
+    sequenceNum: requireSequenceNum(post),
+    title: typeof post.title === 'string' ? post.title : '',
+    image: typeof post.image === 'string' ? post.image : '',
+    sentAt: post.sentAt,
+    authorId: post.authorId,
+    content: post.content ?? null,
+    isDeleted: post.isDeleted === true,
+    isSequenceStub: post.isSequenceStub === true,
+    replyCount:
+      typeof post.replyCount === 'number' && post.replyCount >= 0
+        ? post.replyCount
+        : 0,
+    reactionCount: getPostReactionCount(post),
+  };
+}
+
+function assertTotalPosts(totalPosts: number, sourceNest: string): void {
+  if (
+    !Number.isInteger(totalPosts) ||
+    totalPosts < 0 ||
+    totalPosts > MIGRATION_LIMITS.MAX_SOURCE_POSTS
+  ) {
+    if (totalPosts > MIGRATION_LIMITS.MAX_SOURCE_POSTS) {
+      throw commandError(
+        `Source ${sourceNest}: ${totalPosts} posts exceeds the migration ceiling of ${MIGRATION_LIMITS.MAX_SOURCE_POSTS}`
+      );
+    }
+    throw commandError(
+      `Source ${sourceNest}: totalPosts is missing or malformed`
+    );
+  }
+}
+
+export async function readSourceComplete(
+  sourceNest: string,
+  deps: Pick<MigrationDeps, 'getChannelPosts'>
+): Promise<SourcePost[]> {
+  const posts: SourcePost[] = [];
+  const postIds = new Set<string>();
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  let mode: 'newest' | 'older' = 'newest';
+  let expectedTotal: number | undefined;
+
+  while (true) {
+    const page = await deps.getChannelPosts(
+      sourceNest,
+      cursor,
+      mode,
+      MIGRATION_LIMITS.SOURCE_PAGE_SIZE
+    );
+    assertTotalPosts(page.totalPosts, sourceNest);
+    if (expectedTotal === undefined) expectedTotal = page.totalPosts;
+    else if (page.totalPosts !== expectedTotal) {
+      throw commandError(
+        `Source ${sourceNest}: totalPosts changed across pages (${expectedTotal} → ${page.totalPosts})`
+      );
+    }
+
+    const pagePosts = page.posts.map(postToSourcePost);
+    if (mode === 'older' && pagePosts.length === 0) {
+      throw commandError(
+        `Source ${sourceNest}: non-null cursor yielded no new rows`
+      );
+    }
+    for (const post of pagePosts) {
+      if (postIds.has(post.id)) {
+        throw commandError(
+          `Source ${sourceNest}: duplicate post id ${post.id}`
+        );
+      }
+      postIds.add(post.id);
+      posts.push(post);
+    }
+    if (posts.length > MIGRATION_LIMITS.MAX_SOURCE_POSTS) {
+      throw commandError(
+        `Source ${sourceNest}: more than ${MIGRATION_LIMITS.MAX_SOURCE_POSTS} rows were returned`
+      );
+    }
+
+    if (page.older === null) break;
+    if (typeof page.older !== 'string' || page.older.length === 0) {
+      throw commandError(`Source ${sourceNest}: malformed older cursor`);
+    }
+    if (seenCursors.has(page.older)) {
+      throw commandError(
+        `Source ${sourceNest}: repeated cursor "${page.older}"`
+      );
+    }
+    seenCursors.add(page.older);
+    cursor = page.older;
+    mode = 'older';
+  }
+
+  const nonStubCount = posts.filter((post) => !post.isSequenceStub).length;
+  if (nonStubCount !== expectedTotal) {
+    throw commandError(
+      `Source ${sourceNest}: completeness invariant failed — accumulated ${nonStubCount} non-stub rows but totalPosts is ${expectedTotal}`
+    );
+  }
+  return sortPostsBySequence(posts);
+}
+
+function parseGroupHost(groupId: string): string {
+  const parts = groupId.split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw commandError(
+      `Source permission returned malformed group flag: ${groupId}`
+    );
+  }
+  return normalizeShip(parts[0]);
+}
+
+export async function prepareMigration(
+  options: MigrationOptions,
+  deps: MigrationDeps
+): Promise<PreparedMigration> {
+  const sourceNest = canonicalizeNest(options.sourceNest);
+  const source = parseNest(sourceNest);
+  if (source.kind !== 'diary') {
+    throw commandError(`Expected a diary/... nest, got: ${sourceNest}`);
+  }
+
+  const actingShip = normalizeShip(deps.getActingShip());
+  assertActingShipIsHost(actingShip, source.host, 'source channel');
+
+  const perm = await deps.getChannelPerm(sourceNest);
+  if (!Array.isArray(perm.writers)) {
+    throw commandError(
+      `Source ${sourceNest}: writers are missing or malformed — refusing to assume open`
+    );
+  }
+  const groupHost = parseGroupHost(perm.group);
+  assertActingShipIsHost(actingShip, groupHost, 'source group');
+
+  const group = await deps.getGroup(perm.group);
+  const sourceChannel = group.channels[sourceNest];
+  if (!sourceChannel) {
+    throw commandError(
+      `Source channel ${sourceNest} not found in group ${perm.group} — refusing to assume open readers`
+    );
+  }
+  if (!Array.isArray(sourceChannel.readers)) {
+    throw commandError(
+      `Source channel ${sourceNest}: readers are missing or malformed — refusing to assume open`
+    );
+  }
+
+  const sortedPosts = await readSourceComplete(sourceNest, deps);
+  const { eligible, tombstones, stubs } = filterEligiblePosts(sortedPosts);
+  if (eligible.length === 0) {
+    throw commandError(`Source ${sourceNest} has no eligible posts to migrate`);
+  }
+
+  const convertedNotes = eligible.map((post) =>
+    convertPost(post, sourceNest, deps)
+  );
+  chunkNotes(
+    convertedNotes,
+    MIGRATION_LIMITS.HTTP_BATCH_ENVELOPE_BYTES,
+    PREFLIGHT_ENVELOPE_CONTEXT
+  );
+
+  const widening = computeWriteWidening({
+    readerRoles: sourceChannel.readers,
+    writerRoles: perm.writers,
+    admins: group.admins,
+    privacy: group.privacy,
+  });
+  const sourceTitle = sourceChannel.meta.title || source.name;
+  const targetTitle = deriveTargetTitle(sourceTitle, source.name);
+  const metrics = countArchiveOnlyMetrics(sortedPosts);
+
+  return {
+    plan: {
+      sourceNest,
+      group: perm.group,
+      sourceTitle,
+      targetTitle,
+      eligibleCount: eligible.length,
+      tombstoneCount: tombstones.length,
+      stubCount: stubs.length,
+      previewTitles: convertedNotes
+        .slice(0, MIGRATION_LIMITS.PREVIEW_TITLES)
+        .map((note) => note.title),
+      writeWidening: widening.widening,
+      wideningReasons: widening.reasons,
+      readerRoles: [...sourceChannel.readers],
+      writerRoles: [...perm.writers],
+      privacy: group.privacy,
+      archiveTitle: archiveTitle(sourceTitle, source.name),
+      metrics,
+    },
+    convertedNotes,
+  };
+}
+
+export async function executePlan(
+  options: MigrationOptions,
+  deps: MigrationDeps
+): Promise<PreparedMigration> {
+  return prepareMigration(options, deps);
+}

--- a/packages/tlon-skill/scripts/notes-migrate-plan.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.ts
@@ -200,21 +200,19 @@ function parseGroupHost(groupId: string): string {
 // throwing here would block a legitimate migration on any deployment that does
 // not, which is worse than allowing a duplicate the owner can delete. A read
 // that throws still fails closed.
-function hasSourceProvenanceFooter(
+function hasSourceProvenanceLine(
   note: { bodyMd?: string | null },
   sourceNest: string
 ): boolean {
   if (typeof note.bodyMd !== 'string') return false;
 
-  const lastLine = note.bodyMd.trimEnd().split('\n').at(-1);
-  if (!lastLine) return false;
-
   const prefix = `<!-- tlon-migrate: ${sourceNest} `;
   const suffix = ' -->';
-  if (!lastLine.startsWith(prefix) || !lastLine.endsWith(suffix)) return false;
-
-  const postId = lastLine.slice(prefix.length, -suffix.length);
-  return postId.length > 0 && !/\s/.test(postId);
+  return note.bodyMd.split(/\r?\n/).some((line) => {
+    if (!line.startsWith(prefix) || !line.endsWith(suffix)) return false;
+    const postId = line.slice(prefix.length, -suffix.length);
+    return postId.length > 0 && !/\s/.test(postId);
+  });
 }
 
 export async function prepareMigration(
@@ -279,7 +277,7 @@ export async function prepareMigration(
 
     const targetNotes = await deps.listNotes(targetNest);
     if (
-      !targetNotes.some((note) => hasSourceProvenanceFooter(note, sourceNest))
+      !targetNotes.some((note) => hasSourceProvenanceLine(note, sourceNest))
     ) {
       continue;
     }

--- a/packages/tlon-skill/scripts/notes-migrate-plan.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.ts
@@ -229,6 +229,20 @@ export async function prepareMigration(
     );
   }
 
+  const rawSourceTitle = sourceChannel.meta.title;
+  const trimmedSourceTitle = rawSourceTitle.trim();
+  // An empty title falls back to the nest name in archiveTitle, but that does
+  // not mean the source's actual title carries the migration marker.
+  if (
+    trimmedSourceTitle.length > 0 &&
+    archiveTitle(rawSourceTitle, source.name) === trimmedSourceTitle
+  ) {
+    throw commandError(
+      `Refusing to migrate ${sourceNest}: its title appears to have been migrated already. ` +
+        `If that is incorrect, rename the source channel to remove the archive marker, then re-run the migration.`
+    );
+  }
+
   const sortedPosts = await readSourceComplete(sourceNest, deps);
   const { eligible, tombstones, stubs } = filterEligiblePosts(sortedPosts);
   if (eligible.length === 0) {
@@ -250,7 +264,7 @@ export async function prepareMigration(
     admins: group.admins,
     privacy: group.privacy,
   });
-  const sourceTitle = sourceChannel.meta.title || source.name;
+  const sourceTitle = rawSourceTitle || source.name;
   const targetTitle = deriveTargetTitle(sourceTitle, source.name);
   const metrics = countArchiveOnlyMetrics(sortedPosts);
 

--- a/packages/tlon-skill/scripts/notes-migrate-plan.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-plan.ts
@@ -194,6 +194,29 @@ function parseGroupHost(groupId: string): string {
   return normalizeShip(parts[0]);
 }
 
+// Absent or non-string `bodyMd` counts as "no provenance" rather than as an
+// inspection failure, so such a note fails open and permits a re-migration.
+// That is deliberate: the current backend always encodes a string body, and
+// throwing here would block a legitimate migration on any deployment that does
+// not, which is worse than allowing a duplicate the owner can delete. A read
+// that throws still fails closed.
+function hasSourceProvenanceFooter(
+  note: { bodyMd?: string | null },
+  sourceNest: string
+): boolean {
+  if (typeof note.bodyMd !== 'string') return false;
+
+  const lastLine = note.bodyMd.trimEnd().split('\n').at(-1);
+  if (!lastLine) return false;
+
+  const prefix = `<!-- tlon-migrate: ${sourceNest} `;
+  const suffix = ' -->';
+  if (!lastLine.startsWith(prefix) || !lastLine.endsWith(suffix)) return false;
+
+  const postId = lastLine.slice(prefix.length, -suffix.length);
+  return postId.length > 0 && !/\s/.test(postId);
+}
+
 export async function prepareMigration(
   options: MigrationOptions,
   deps: MigrationDeps
@@ -243,6 +266,31 @@ export async function prepareMigration(
     );
   }
 
+  const sourceTitle = rawSourceTitle || source.name;
+  const targetTitle = deriveTargetTitle(sourceTitle, source.name);
+  const actingShipNotebookPrefix = `notes/${actingShip}/`;
+  for (const [targetNest, channel] of Object.entries(group.channels)) {
+    if (
+      !targetNest.startsWith(actingShipNotebookPrefix) ||
+      channel.meta.title !== targetTitle
+    ) {
+      continue;
+    }
+
+    const targetNotes = await deps.listNotes(targetNest);
+    if (
+      !targetNotes.some((note) => hasSourceProvenanceFooter(note, sourceNest))
+    ) {
+      continue;
+    }
+
+    throw commandError(
+      `Refusing to migrate ${sourceNest}: it appears to have already been migrated to ${targetNest}, which contains notes imported from this source. ` +
+        `If that notebook should be kept, rename it or rename the source, then re-run the migration. ` +
+        `To discard it instead, run \`tlon notes notebook-delete ${targetNest} --yes\`, then retry with \`tlon notes migrate-apply ${sourceNest} --yes\`.`
+    );
+  }
+
   const sortedPosts = await readSourceComplete(sourceNest, deps);
   const { eligible, tombstones, stubs } = filterEligiblePosts(sortedPosts);
   if (eligible.length === 0) {
@@ -264,8 +312,6 @@ export async function prepareMigration(
     admins: group.admins,
     privacy: group.privacy,
   });
-  const sourceTitle = rawSourceTitle || source.name;
-  const targetTitle = deriveTargetTitle(sourceTitle, source.name);
   const metrics = countArchiveOnlyMetrics(sortedPosts);
 
   return {

--- a/packages/tlon-skill/scripts/notes-migrate-runtime.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-runtime.test.ts
@@ -1,0 +1,280 @@
+import { tryParse, valid } from '@urbit/aura';
+import { describe, expect, it } from 'bun:test';
+
+import { mapChannelReaders } from './notes-channel-runtime';
+import {
+  assertServerIdentity,
+  createMigrationDeps,
+  generateRequestId,
+  parseGroupV7,
+} from './notes-migrate-runtime';
+import { mockedGetChannelPosts, mockedScry } from './tloncorp-api-mock';
+
+function rawGroup(overrides: Record<string, unknown> = {}) {
+  return {
+    admins: ['admins'],
+    admissions: { privacy: 'private' },
+    channels: {
+      'diary/~zod/blog': {
+        added: 123,
+        meta: {
+          title: 'Blog',
+          description: 'Description',
+          image: '',
+          cover: '',
+        },
+        section: 'main',
+        readers: ['members'],
+        join: false,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('generateRequestId', () => {
+  it('emits a canonical valid non-zero @uv', () => {
+    const id = generateRequestId(() =>
+      Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+    );
+    expect(valid('uv', id)).toBe(true);
+    expect(tryParse('uv', id)).not.toBe(0n);
+    expect(id).not.toBe('0v0');
+  });
+
+  it('draws again when the entropy source returns all zeroes', () => {
+    let draws = 0;
+    const id = generateRequestId(() => {
+      draws += 1;
+      const bytes = new Uint8Array(16);
+      if (draws === 2) bytes[15] = 1;
+      return bytes;
+    });
+    expect(draws).toBe(2);
+    expect(id).toBe('0v1');
+    expect(tryParse('uv', id)).toBe(1n);
+  });
+
+  it('asserts the entropy source byte count', () => {
+    expect(() => generateRequestId(() => new Uint8Array(15))).toThrow(
+      'wrong byte count'
+    );
+  });
+});
+
+describe('parseGroupV7', () => {
+  it('parses only migration-required group fields and exact reader arrays', () => {
+    expect(parseGroupV7(rawGroup(), '~zod/group')).toEqual({
+      privacy: 'private',
+      admins: ['admins'],
+      channels: {
+        'diary/~zod/blog': {
+          added: 123,
+          meta: {
+            title: 'Blog',
+            description: 'Description',
+            image: '',
+            cover: '',
+          },
+          section: 'main',
+          readers: ['members'],
+          join: false,
+        },
+      },
+    });
+  });
+
+  const malformedCases: Array<[string, Record<string, unknown>]> = [
+    ['admins', { admins: undefined }],
+    ['admissions', { admissions: undefined }],
+    ['privacy', { admissions: { privacy: 'open' } }],
+    ['channels', { channels: undefined }],
+    [
+      'readers',
+      {
+        channels: {
+          'diary/~zod/blog': {
+            added: 1,
+            meta: {
+              title: 'Blog',
+              description: '',
+              image: '',
+              cover: '',
+            },
+            section: 'main',
+            join: false,
+          },
+        },
+      },
+    ],
+  ];
+  for (const [field, override] of malformedCases) {
+    it(`fails closed on malformed ${field}`, () => {
+      expect(() => parseGroupV7(rawGroup(override), '~zod/group')).toThrow();
+    });
+  }
+
+  it('does not reinterpret a v6 fleet/bloc/cabals/cordon group', () => {
+    expect(() =>
+      parseGroupV7(
+        {
+          fleet: {},
+          bloc: {},
+          cabals: {},
+          cordon: { open: null },
+          channels: {},
+        },
+        '~zod/group'
+      )
+    ).toThrow(/admins/);
+  });
+});
+
+describe('assertServerIdentity', () => {
+  it('makes one authenticated GET and accepts an exact ship match', async () => {
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    await assertServerIdentity({
+      configuredShip: 'zod',
+      url: 'http://ship.test',
+      cookie: 'urbauth=token',
+      fetchFn: async (url, init) => {
+        calls.push([String(url), init]);
+        return new Response('~zod', { status: 200 });
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('http://ship.test/~/name');
+    expect(calls[0][1]).toMatchObject({
+      method: 'GET',
+      credentials: 'include',
+      headers: { Cookie: 'urbauth=token' },
+    });
+  });
+
+  it('fails closed on a configured/authenticated mismatch', async () => {
+    await expect(
+      assertServerIdentity({
+        configuredShip: '~zod',
+        url: 'http://ship.test',
+        fetchFn: async () => new Response('~nec', { status: 200 }),
+      })
+    ).rejects.toThrow('configured ~zod, authenticated as ~nec');
+  });
+
+  it('fails closed on empty identity or an HTTP error without retrying', async () => {
+    let calls = 0;
+    await expect(
+      assertServerIdentity({
+        configuredShip: '~zod',
+        url: 'http://ship.test',
+        fetchFn: async () => {
+          calls += 1;
+          return new Response('', { status: 401 });
+        },
+      })
+    ).rejects.toThrow('HTTP 401');
+    expect(calls).toBe(1);
+
+    await expect(
+      assertServerIdentity({
+        configuredShip: '~zod',
+        url: 'http://ship.test',
+        fetchFn: async () => new Response('', { status: 200 }),
+      })
+    ).rejects.toThrow('empty response');
+  });
+});
+
+describe('runtime adapters fail closed', () => {
+  it('uses the exact routed channel-perm scry path', async () => {
+    const original = mockedScry.impl;
+    const calls: unknown[] = [];
+    mockedScry.impl = async (input: unknown) => {
+      calls.push(input);
+      return { writers: ['writers'], group: '~zod/group' };
+    };
+    try {
+      const deps = createMigrationDeps();
+      await expect(deps.getChannelPerm('diary/~zod/blog')).resolves.toEqual({
+        writers: ['writers'],
+        group: '~zod/group',
+      });
+      expect(calls).toEqual([
+        {
+          app: 'channels',
+          path: '/diary/~zod/blog/perm',
+        },
+      ]);
+    } finally {
+      mockedScry.impl = original;
+    }
+  });
+
+  it('passes newest/older options through with skipGapFill enabled', async () => {
+    const original = mockedGetChannelPosts.impl;
+    const calls: unknown[] = [];
+    mockedGetChannelPosts.impl = async (input: unknown) => {
+      calls.push(input);
+      return { posts: [], older: null, totalPosts: 0 };
+    };
+    try {
+      const deps = createMigrationDeps();
+      await deps.getChannelPosts('diary/~zod/blog', undefined, 'newest', 100);
+      expect(calls[0]).toMatchObject({
+        channelId: 'diary/~zod/blog',
+        mode: 'newest',
+        count: 100,
+        includeReplies: false,
+        skipGapFill: true,
+      });
+    } finally {
+      mockedGetChannelPosts.impl = original;
+    }
+  });
+
+  it('refuses a posts response that omits totalPosts', async () => {
+    const original = mockedGetChannelPosts.impl;
+    mockedGetChannelPosts.impl = async () => ({
+      posts: [],
+      older: null,
+      totalPosts: undefined as unknown as number,
+    });
+    try {
+      const deps = createMigrationDeps();
+      await expect(
+        deps.getChannelPosts('diary/~zod/blog', undefined, 'newest', 100)
+      ).rejects.toThrow('omitted totalPosts');
+    } finally {
+      mockedGetChannelPosts.impl = original;
+    }
+  });
+
+  it('maps exact reader roles and never defaults a malformed field to open', () => {
+    expect(
+      mapChannelReaders(
+        { readerRoles: [{ roleId: 'members' }] },
+        'notes/~zod/book',
+        '~zod/group'
+      )
+    ).toEqual(['members']);
+    expect(
+      mapChannelReaders(undefined, 'notes/~zod/book', '~zod/group')
+    ).toBeNull();
+    expect(() =>
+      mapChannelReaders({ readerRoles: null }, 'notes/~zod/book', '~zod/group')
+    ).toThrow('refusing to assume open');
+  });
+});
+
+describe('recoveryInstruction', () => {
+  it('gives CLI commands, not the bot slash command', () => {
+    const instruction =
+      createMigrationDeps().recoveryInstruction('notes/~zod/newbook');
+    expect(instruction).toContain(
+      'tlon notes notebook-delete notes/~zod/newbook --yes'
+    );
+    expect(instruction).toContain('tlon notes migrate-apply');
+    expect(instruction).not.toContain('/migrate');
+    expect(instruction).not.toContain('Notes app');
+  });
+});

--- a/packages/tlon-skill/scripts/notes-migrate-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-migrate-runtime.ts
@@ -1,0 +1,301 @@
+import {
+  type Story,
+  batchImportNotesV1,
+  client,
+  getChannelPosts,
+  getCurrentUserId,
+  notesV1,
+  scry,
+  toUrbitStory,
+  updateChannel,
+} from '@tloncorp/api';
+// @ts-expect-error -- subpath export not resolvable under moduleResolution:Node
+import { storyToMarkdown, storyToMdast } from '@tloncorp/api/client/markdown';
+import { randomBytes } from 'crypto';
+
+import { getConfig } from './api-client';
+import { createNotesChannelInGroup } from './notes-channel';
+import { createNotesChannelDeps } from './notes-channel-runtime';
+import {
+  type ChannelPerm,
+  type GroupChannelV7,
+  type GroupInfo,
+  type MigrationDeps,
+  normalizeShip,
+} from './notes-migrate';
+
+const UV_ALPHABET = '0123456789abcdefghijklmnopqrstuv';
+
+function renderUv(bytes: Uint8Array): string {
+  let bits = '';
+  for (const byte of bytes) bits += byte.toString(2).padStart(8, '0');
+  bits = bits.replace(/^0+/, '') || '0';
+  const padded = bits.padStart(Math.ceil(bits.length / 5) * 5, '0');
+  let digits = '';
+  for (let i = 0; i < padded.length; i += 5) {
+    digits += UV_ALPHABET[Number.parseInt(padded.slice(i, i + 5), 2)];
+  }
+  const grouped: string[] = [];
+  for (let i = digits.length; i > 0; i -= 5) {
+    grouped.unshift(digits.slice(Math.max(0, i - 5), i));
+  }
+  return `0v${grouped.join('.')}`;
+}
+
+export function generateRequestId(
+  draw: (size: number) => Uint8Array = randomBytes
+): string {
+  let bytes: Uint8Array;
+  do {
+    bytes = draw(16);
+    if (bytes.length !== 16) {
+      throw new Error(
+        'Request-id entropy source returned the wrong byte count'
+      );
+    }
+  } while (!bytes.some((byte) => byte !== 0));
+
+  const requestId = renderUv(bytes);
+  if (requestId === '0v0') {
+    throw new Error('Request-id generator produced the forbidden zero atom');
+  }
+  return requestId;
+}
+
+function requireStringArray(value: unknown, context: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== 'string')
+  ) {
+    throw new Error(`${context}: expected an array of strings`);
+  }
+  return [...value];
+}
+
+function requireRecord(
+  value: unknown,
+  context: string
+): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${context}: expected an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireMeta(value: unknown, context: string): GroupChannelV7['meta'] {
+  const meta = requireRecord(value, context);
+  for (const field of ['title', 'description', 'image', 'cover'] as const) {
+    if (typeof meta[field] !== 'string') {
+      throw new Error(`${context}.${field}: expected a string`);
+    }
+  }
+  return {
+    title: meta.title as string,
+    description: meta.description as string,
+    image: meta.image as string,
+    cover: meta.cover as string,
+  };
+}
+
+export function parseGroupV7(
+  raw: Record<string, unknown>,
+  flag: string
+): GroupInfo {
+  const group = requireRecord(raw, `Group ${flag}`);
+  const admins = requireStringArray(group.admins, `Group ${flag}.admins`);
+  const admissions = requireRecord(
+    group.admissions,
+    `Group ${flag}.admissions`
+  );
+  const privacy = admissions.privacy;
+  if (privacy !== 'public' && privacy !== 'private' && privacy !== 'secret') {
+    throw new Error(
+      `Group ${flag}.admissions.privacy: unrecognized value ${String(privacy)}`
+    );
+  }
+
+  const channelsRecord = requireRecord(
+    group.channels,
+    `Group ${flag}.channels`
+  );
+  const channels: Record<string, GroupChannelV7> = {};
+  for (const [nest, rawChannel] of Object.entries(channelsRecord)) {
+    const channel = requireRecord(rawChannel, `Group ${flag}.channels.${nest}`);
+    if (typeof channel.added !== 'number') {
+      throw new Error(
+        `Group ${flag}.channels.${nest}.added: expected a number`
+      );
+    }
+    if (typeof channel.section !== 'string') {
+      throw new Error(
+        `Group ${flag}.channels.${nest}.section: expected a string`
+      );
+    }
+    if (typeof channel.join !== 'boolean') {
+      throw new Error(
+        `Group ${flag}.channels.${nest}.join: expected a boolean`
+      );
+    }
+    channels[nest] = {
+      added: channel.added,
+      meta: requireMeta(channel.meta, `Group ${flag}.channels.${nest}.meta`),
+      section: channel.section,
+      readers: requireStringArray(
+        channel.readers,
+        `Group ${flag}.channels.${nest}.readers`
+      ),
+      join: channel.join,
+    };
+  }
+
+  return {
+    privacy,
+    admins,
+    channels,
+  };
+}
+
+export interface ServerIdentityInput {
+  configuredShip: string;
+  url: string;
+  cookie?: string;
+  fetchFn: (
+    input: string | URL | Request,
+    init?: RequestInit
+  ) => Promise<Response>;
+}
+
+export async function assertServerIdentity(
+  input: ServerIdentityInput
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (input.cookie) headers.Cookie = input.cookie;
+  const response = await input.fetchFn(`${input.url}/~/name`, {
+    method: 'GET',
+    credentials: 'include',
+    headers,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Server identity check failed with HTTP ${response.status}`
+    );
+  }
+  const actual = (await response.text()).trim();
+  const expected = normalizeShip(input.configuredShip);
+  if (!actual || normalizeShip(actual) !== expected) {
+    throw new Error(
+      `Server identity mismatch: configured ${expected}, authenticated as ${
+        actual ? normalizeShip(actual) : '(empty response)'
+      }`
+    );
+  }
+}
+
+export function createMigrationDeps(): MigrationDeps {
+  return {
+    getChannelPerm: async (nest: string): Promise<ChannelPerm> => {
+      const perm = await scry<unknown>({
+        app: 'channels',
+        path: `/${nest}/perm`,
+      });
+      const record = requireRecord(perm, `Channel ${nest}.perm`);
+      const writers = requireStringArray(
+        record.writers,
+        `Channel ${nest}.perm.writers`
+      );
+      if (typeof record.group !== 'string' || !record.group) {
+        throw new Error(`Channel ${nest}.perm.group: expected a group flag`);
+      }
+      return { writers, group: record.group };
+    },
+
+    getGroup: async (flag: string) => {
+      const raw = await scry<Record<string, unknown>>({
+        app: 'groups',
+        path: `/v2/ui/groups/${flag}`,
+      });
+      return parseGroupV7(raw, flag);
+    },
+
+    getChannelPosts: async (nest, cursor, mode, count) => {
+      const result = await getChannelPosts({
+        channelId: nest,
+        cursor,
+        mode,
+        count,
+        includeReplies: false,
+        skipGapFill: true,
+      });
+      if (typeof result.totalPosts !== 'number') {
+        throw new Error(`Channel ${nest}: response omitted totalPosts`);
+      }
+      const older = result.older;
+      if (older !== null && older !== undefined && typeof older !== 'string') {
+        throw new Error(`Channel ${nest}: response returned malformed cursor`);
+      }
+      return {
+        posts: result.posts ?? [],
+        older: older ?? null,
+        totalPosts: result.totalPosts,
+      };
+    },
+
+    createGroupNotebook: ({ title, groupId, readers, onCreated }) =>
+      createNotesChannelInGroup(
+        { title, groupId, readers, onCreated },
+        createNotesChannelDeps()
+      ),
+
+    getNotebookDetail: async (target) => {
+      const detail = await notesV1.getNotebook(target);
+      return {
+        rootFolderId: detail.notebook.rootFolderId,
+        host: detail.host,
+        flagName: detail.flagName,
+      };
+    },
+
+    listNotes: (target) => notesV1.listNotes(target),
+
+    batchImport: (input) => batchImportNotesV1(input),
+
+    getRawGroup: (groupId) =>
+      scry<Record<string, unknown>>({
+        app: 'groups',
+        path: `/v2/ui/groups/${groupId}`,
+      }),
+
+    updateChannel: async (input) => {
+      await updateChannel(input);
+    },
+
+    getActingShip: () => getCurrentUserId(),
+
+    assertServerIdentity: async () => {
+      const config = getConfig();
+      await assertServerIdentity({
+        configuredShip: config.ship,
+        url: config.url,
+        cookie: client.cookie,
+        fetchFn: client.fetchFn,
+      });
+    },
+
+    storyToMarkdown: (story: Story) => storyToMarkdown(story),
+
+    storyToMdastStrict: (story: Story) => {
+      storyToMdast(story, { strict: true });
+    },
+
+    toUrbitStory: (content: unknown) => toUrbitStory(content as never),
+
+    generateRequestId,
+
+    // CLI-native wording. Bot adapters inject their own slash-command phrasing
+    // through this dep rather than reusing this string.
+    recoveryInstruction: (targetNest) =>
+      `run \`tlon notes notebook-delete ${targetNest} --yes\`, then retry with \`tlon notes migrate-apply <diary-nest> --yes\`.`,
+
+    log: (message) => console.log(message),
+  };
+}

--- a/packages/tlon-skill/scripts/notes-migrate.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate.test.ts
@@ -1,0 +1,493 @@
+import { toUrbitStory } from '@tloncorp/api';
+// @ts-expect-error -- subpath export not resolvable under moduleResolution:Node
+import { storyToMarkdown, storyToMdast } from '@tloncorp/api/client/markdown';
+import { describe, expect, it } from 'bun:test';
+
+import {
+  type ConvertedNote,
+  type MigrationDeps,
+  type SourcePost,
+  archiveTitle,
+  assembleNoteBody,
+  buildAttributionLine,
+  buildProvenanceFooter,
+  canonicalizeNest,
+  chunkNotes,
+  computeWriteWidening,
+  convertPost,
+  countArchiveOnlyMetrics,
+  deriveNoteTitle,
+  deriveTargetTitle,
+  filterEligiblePosts,
+  measureEnvelopeBytes,
+  normalizeTitle,
+  parseNest,
+  sortPostsBySequence,
+  truncateTitle,
+  validateImageUrl,
+} from './notes-migrate';
+
+const DAY = Date.UTC(2025, 2, 14, 12);
+const CTX = { flag: '~zod/book', folder: 17, requestId: '0v12345' };
+
+function source(overrides: Partial<SourcePost> = {}): SourcePost {
+  return {
+    id: '170.141',
+    sequenceNum: 1,
+    title: 'A title',
+    image: '',
+    sentAt: DAY,
+    authorId: '~sampel-palnet',
+    content: [{ inline: ['Hello'] }],
+    isDeleted: false,
+    isSequenceStub: false,
+    replyCount: 0,
+    reactionCount: 0,
+    ...overrides,
+  };
+}
+
+const conversionDeps: Pick<
+  MigrationDeps,
+  'storyToMarkdown' | 'storyToMdastStrict' | 'toUrbitStory'
+> = {
+  toUrbitStory: (content) => toUrbitStory(content as never),
+  storyToMdastStrict: (story) => {
+    storyToMdast(story, { strict: true });
+  },
+  storyToMarkdown,
+};
+
+function note(id: string, title: string, body: string): ConvertedNote {
+  return { postId: id, sequenceNum: Number(id), title, body };
+}
+
+describe('migration nest and title helpers', () => {
+  it('canonicalizes a missing ship sigil', () => {
+    expect(canonicalizeNest('diary/zod/blog')).toBe('diary/~zod/blog');
+    expect(parseNest('diary/~zod/blog')).toEqual({
+      kind: 'diary',
+      host: '~zod',
+      name: 'blog',
+    });
+  });
+
+  for (const invalid of [
+    'diary/~zod',
+    'diary//blog',
+    '/~zod/blog',
+    'diary/~zod/',
+    'diary/~zod/blog/extra',
+    'diary/~zod/my blog',
+  ]) {
+    it(`rejects malformed nest ${JSON.stringify(invalid)}`, () => {
+      expect(() => parseNest(invalid)).toThrow('Invalid nest format');
+    });
+  }
+
+  it('NFC-normalizes and collapses target-title whitespace', () => {
+    expect(normalizeTitle('  Cafe\u0301 \n Notes  ')).toBe('Café Notes');
+    expect(deriveTargetTitle(' \n ', 'field-notes')).toBe('field-notes');
+  });
+
+  it('truncates by code point to 80 including the ellipsis', () => {
+    const result = truncateTitle('😀'.repeat(81));
+    expect([...result]).toHaveLength(80);
+    expect(result).toEndWith('…');
+  });
+
+  it('uses explicit title, first Markdown line, then dated fallback', () => {
+    expect(deriveNoteTitle(source({ title: ' Named ' }), 'ignored')).toBe(
+      'Named'
+    );
+    expect(
+      deriveNoteTitle(source({ title: '' }), '\n  First line \nnext')
+    ).toBe('First line');
+    expect(deriveNoteTitle(source({ title: '' }), '')).toBe(
+      'Untitled — 2025-03-14'
+    );
+  });
+
+  it('appends the archive suffix at most once with nest fallback', () => {
+    expect(archiveTitle('Field Notes', 'field-notes')).toBe(
+      'Field Notes-ARCHIVE'
+    );
+    expect(archiveTitle('Field Notes-ARCHIVE', 'field-notes')).toBe(
+      'Field Notes-ARCHIVE'
+    );
+    expect(archiveTitle(' ', 'field-notes')).toBe('field-notes-ARCHIVE');
+  });
+});
+
+describe('body assembly and conversion', () => {
+  it('writes attribution, image, Markdown, and provenance in order', () => {
+    const body = assembleNoteBody({
+      attributionLine: buildAttributionLine('sampel-palnet', DAY),
+      headerImageUrl: 'https://example.test/header.png',
+      convertedMarkdown: 'Hello',
+      provenanceFooter: buildProvenanceFooter(
+        'diary/~sampel-palnet/blog',
+        '170.141'
+      ),
+    });
+    expect(body).toBe(
+      '*Originally posted by ~sampel-palnet on 2025-03-14 12:00:00 UTC.*\n\n' +
+        '![](<https://example.test/header.png>)\n\n' +
+        'Hello\n\n' +
+        '<!-- tlon-migrate: diary/~sampel-palnet/blog 170.141 -->\n'
+    );
+    expect(body.endsWith('\n\n')).toBe(false);
+  });
+
+  const imageCases = [
+    ['https://example.test/a.png', true],
+    ['https://example.test/a b.png', false],
+    ['https://example.test/<a>.png', false],
+    ['https://example.test/a\\b.png', false],
+    ['https://example.test/a\u0007b.png', false],
+    ['https://example.test/a\u0080b.png', false],
+  ] as const;
+  for (const [url, valid] of imageCases) {
+    it(`${valid ? 'accepts' : 'rejects'} image URL ${JSON.stringify(url)}`, () => {
+      expect(validateImageUrl(url)).toBe(valid);
+    });
+  }
+
+  it('rejects a bad image before returning a note', () => {
+    expect(() =>
+      convertPost(
+        source({ image: 'https://example.test/bad image.png' }),
+        'diary/~zod/blog',
+        conversionDeps
+      )
+    ).toThrow(/header image URL/);
+  });
+
+  it('parses serialized null-or-array content', () => {
+    const converted = convertPost(
+      source({ content: JSON.stringify([{ inline: ['Serialized'] }]) }),
+      'diary/~zod/blog',
+      conversionDeps
+    );
+    expect(converted.body).toContain('Serialized');
+    expect(() =>
+      convertPost(
+        source({ content: '{"not":"an array"}' }),
+        'diary/~zod/blog',
+        conversionDeps
+      )
+    ).toThrow('content must be null or array');
+  });
+
+  it('preserves Sect, Tag, and BlockReference as plain text', () => {
+    const converted = convertPost(
+      source({
+        content: [
+          {
+            inline: [
+              { sect: 'writers' },
+              ' ',
+              { tag: '#field-notes' },
+              ' ',
+              { block: { index: 2, text: 'quoted block' } },
+            ],
+          },
+        ],
+      }),
+      'diary/~zod/blog',
+      conversionDeps
+    );
+    expect(converted.body).toContain('@writers #field-notes quoted block');
+  });
+
+  it('renders a backend-shaped ship mention with exactly one sigil', () => {
+    const converted = convertPost(
+      source({
+        content: [{ inline: ['Hello ', { ship: '~zod' }, '!'] }],
+      }),
+      'diary/~zod/blog',
+      conversionDeps
+    );
+    expect(converted.body).toContain('Hello ~zod!');
+    expect(converted.body).not.toContain('~~zod');
+  });
+
+  it('strictly rejects an unknown inline recursively inside Bold', () => {
+    expect(() =>
+      convertPost(
+        source({
+          content: [{ inline: [{ bold: [{ futureVariant: 'unsafe' }] }] }],
+        }),
+        'diary/~zod/blog',
+        conversionDeps
+      )
+    ).toThrow(/conversion failed/i);
+  });
+
+  it('wraps malformed JSON with the post id', () => {
+    expect(() =>
+      convertPost(
+        source({ id: 'bad-post', content: '[' }),
+        'diary/~zod/blog',
+        conversionDeps
+      )
+    ).toThrow(/^Post bad-post:/);
+  });
+});
+
+describe('eligibility, metrics, and ordering', () => {
+  it('separates live posts, tombstones, and synthetic stubs', () => {
+    const live = source({ id: 'live' });
+    const deleted = source({ id: 'deleted', isDeleted: true });
+    const stub = source({ id: 'stub', isSequenceStub: true });
+    expect(filterEligiblePosts([live, deleted, stub])).toEqual({
+      eligible: [live],
+      tombstones: [deleted],
+      stubs: [stub],
+    });
+  });
+
+  it('sorts globally by ascending sequence number', () => {
+    expect(
+      sortPostsBySequence([
+        source({ id: '3', sequenceNum: 3 }),
+        source({ id: '1', sequenceNum: 1 }),
+        source({ id: '2', sequenceNum: 2 }),
+      ]).map((post) => post.id)
+    ).toEqual(['1', '2', '3']);
+  });
+
+  it('counts normalized cites, link blocks, and recursive group mentions', () => {
+    const metrics = countArchiveOnlyMetrics([
+      source({
+        replyCount: 4,
+        reactionCount: 3,
+        content: [
+          {
+            type: 'reference',
+            referenceType: 'channel',
+            channelId: 'diary/~zod/other',
+            postId: '1',
+          },
+          { block: { link: { url: 'https://example.test' } } },
+          {
+            inline: [
+              { sect: 'all' },
+              { bold: [{ sect: 'writers' }] },
+              { task: { checked: false, content: [{ sect: null }] } },
+            ],
+          },
+        ],
+      }),
+    ]);
+    expect(metrics).toEqual({
+      totalComments: 4,
+      totalReactions: 3,
+      citeCount: 1,
+      linkBlockCount: 1,
+      groupMentionCount: 3,
+    });
+  });
+
+  it('counts a group mention in a header', () => {
+    const metrics = countArchiveOnlyMetrics([
+      source({
+        content: [
+          {
+            block: {
+              header: {
+                tag: 'h2',
+                content: [{ sect: 'members' }],
+              },
+            },
+          },
+        ],
+      }),
+    ]);
+    expect(metrics.groupMentionCount).toBe(1);
+  });
+
+  it('counts a group mention inside an arbitrarily nested list item', () => {
+    const metrics = countArchiveOnlyMetrics([
+      source({
+        content: [
+          {
+            block: {
+              listing: {
+                list: {
+                  type: 'unordered',
+                  contents: [],
+                  items: [
+                    {
+                      list: {
+                        type: 'ordered',
+                        contents: [],
+                        items: [
+                          {
+                            item: [
+                              {
+                                bold: [{ sect: 'members' }],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      }),
+    ]);
+    expect(metrics.groupMentionCount).toBe(1);
+  });
+
+  it('counts a group mention in a list’s own contents', () => {
+    const metrics = countArchiveOnlyMetrics([
+      source({
+        content: [
+          {
+            block: {
+              listing: {
+                list: {
+                  type: 'unordered',
+                  contents: [{ sect: 'members' }],
+                  items: [],
+                },
+              },
+            },
+          },
+        ],
+      }),
+    ]);
+    expect(metrics.groupMentionCount).toBe(1);
+  });
+
+  it('counts a raw pre-normalization cite block', () => {
+    expect(
+      countArchiveOnlyMetrics([
+        source({ content: [{ block: { cite: { group: '~zod/g' } } }] }),
+      ]).citeCount
+    ).toBe(1);
+  });
+});
+
+describe('write-widening predicate', () => {
+  const cases: Array<{
+    name: string;
+    input: Parameters<typeof computeWriteWidening>[0];
+    widening: boolean;
+  }> = [
+    {
+      name: 'restricted readers authorized by writers',
+      input: {
+        readerRoles: ['writers'],
+        writerRoles: ['writers'],
+        admins: [],
+        privacy: 'private',
+      },
+      widening: false,
+    },
+    {
+      name: 'empty writers means all readers already write',
+      input: {
+        readerRoles: ['members'],
+        writerRoles: [],
+        admins: [],
+        privacy: 'private',
+      },
+      widening: false,
+    },
+    {
+      name: 'admin reader role authorizes writing',
+      input: {
+        readerRoles: ['moderators'],
+        writerRoles: ['writers'],
+        admins: ['moderators'],
+        privacy: 'secret',
+      },
+      widening: false,
+    },
+    {
+      name: 'open readers with restricted writers',
+      input: {
+        readerRoles: [],
+        writerRoles: ['writers'],
+        admins: [],
+        privacy: 'private',
+      },
+      widening: true,
+    },
+    {
+      name: 'reader-only role',
+      input: {
+        readerRoles: ['members'],
+        writerRoles: ['writers'],
+        admins: ['admins'],
+        privacy: 'private',
+      },
+      widening: true,
+    },
+    {
+      name: 'public and open',
+      input: {
+        readerRoles: [],
+        writerRoles: [],
+        admins: [],
+        privacy: 'public',
+      },
+      widening: true,
+    },
+  ];
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      const result = computeWriteWidening(testCase.input);
+      expect(result.widening).toBe(testCase.widening);
+      expect(result.reasons.length > 0).toBe(testCase.widening);
+    });
+  }
+});
+
+describe('escaped envelope measurement and chunking', () => {
+  it('measures the exact escaped UTF-8 JSON envelope', () => {
+    const notes = [{ title: '"😀"', body: 'line\nsecond\\line' }];
+    const expected = Buffer.byteLength(
+      JSON.stringify({
+        requestId: CTX.requestId,
+        action: {
+          type: 'notebook',
+          flag: CTX.flag,
+          action: {
+            type: 'batch-import',
+            folder: CTX.folder,
+            notes,
+          },
+        },
+      }),
+      'utf8'
+    );
+    expect(measureEnvelopeBytes(notes, CTX)).toBe(expected);
+  });
+
+  it('keeps an exact-boundary chunk together', () => {
+    const notes = [note('1', 'one', 'a'), note('2', 'two', 'b')];
+    const cap = measureEnvelopeBytes(notes, CTX);
+    expect(chunkNotes(notes, cap, CTX)).toEqual([notes]);
+  });
+
+  it('splits before crossing the escaped-byte boundary', () => {
+    const notes = [note('1', 'one', 'a'), note('2', 'two', 'b')];
+    const cap = measureEnvelopeBytes(notes, CTX) - 1;
+    expect(chunkNotes(notes, cap, CTX)).toEqual([[notes[0]], [notes[1]]]);
+  });
+
+  it('rejects an oversized single note', () => {
+    const oversized = note('9', 'large', 'x'.repeat(200));
+    const cap = measureEnvelopeBytes([oversized], CTX) - 1;
+    expect(() => chunkNotes([oversized], cap, CTX)).toThrow(
+      /Note 9 exceeds byte cap/
+    );
+  });
+});

--- a/packages/tlon-skill/scripts/notes-migrate.test.ts
+++ b/packages/tlon-skill/scripts/notes-migrate.test.ts
@@ -286,7 +286,47 @@ describe('eligibility, metrics, and ordering', () => {
       citeCount: 1,
       linkBlockCount: 1,
       groupMentionCount: 3,
+      flattenedInlineCount: 0,
     });
+  });
+
+  it('counts tags and inline block references as flattened, not dropped', () => {
+    // Both survive migration as their visible text but lose what they were.
+    // Before this was counted, the plan reported nothing at all for either,
+    // so an owner was told the post migrated intact. Wire shapes are taken
+    // from hand-authored-wire-exact-story-variants.json.
+    const metrics = countArchiveOnlyMetrics([
+      source({
+        content: [
+          { inline: ['tag ', { tag: 'wire-exact-tag' }] },
+          {
+            inline: [
+              'reference ',
+              { block: { index: 0, text: 'wire-exact-block-reference' } },
+            ],
+          },
+        ],
+      }),
+    ]);
+    expect(metrics.flattenedInlineCount).toBe(2);
+    // They are not cites or link blocks; those counts stay untouched.
+    expect(metrics.citeCount).toBe(0);
+    expect(metrics.linkBlockCount).toBe(0);
+  });
+
+  it('counts a tag nested inside a header', () => {
+    const metrics = countArchiveOnlyMetrics([
+      source({
+        content: [
+          {
+            block: {
+              header: { tag: 'h2', content: [{ tag: 'nested-tag' }] },
+            },
+          },
+        ],
+      }),
+    ]);
+    expect(metrics.flattenedInlineCount).toBe(1);
   });
 
   it('counts a group mention in a header', () => {

--- a/packages/tlon-skill/scripts/notes-migrate.ts
+++ b/packages/tlon-skill/scripts/notes-migrate.ts
@@ -1,0 +1,569 @@
+import type { Post, Story } from '@tloncorp/api';
+
+// Kept local because @tloncorp/api/urbit subpaths do not resolve under moduleResolution: Node.
+export interface GroupChannelV7 {
+  added: number;
+  meta: {
+    title: string;
+    description: string;
+    image: string;
+    cover: string;
+  };
+  section: string;
+  readers: string[];
+  join: boolean;
+}
+
+export const MIGRATION_LIMITS = {
+  HTTP_BATCH_ENVELOPE_BYTES: 512 * 1024,
+  SOURCE_PAGE_SIZE: 100,
+  MAX_SOURCE_POSTS: 5000,
+  PREVIEW_TITLES: 4,
+  NOTE_TITLE_MAX_CODE_POINTS: 80,
+} as const;
+
+export interface MigrationOptions {
+  sourceNest: string;
+  allowWriteWidening: boolean;
+  yes: boolean;
+}
+
+export interface ChannelPerm {
+  writers: string[];
+  group: string;
+}
+
+export interface GroupInfo {
+  privacy: 'public' | 'secret' | 'private';
+  admins: string[];
+  channels: Record<string, GroupChannelV7>;
+}
+
+export interface SourcePost {
+  id: string;
+  sequenceNum: number;
+  title: string;
+  image: string;
+  sentAt: number;
+  authorId: string;
+  content: unknown;
+  isDeleted: boolean;
+  isSequenceStub: boolean;
+  replyCount: number;
+  reactionCount: number;
+}
+
+export interface ConvertedNote {
+  postId: string;
+  sequenceNum: number;
+  title: string;
+  body: string;
+}
+
+export interface ArchiveOnlyMetrics {
+  totalComments: number;
+  totalReactions: number;
+  citeCount: number;
+  linkBlockCount: number;
+  groupMentionCount: number;
+}
+
+export interface MigrationPlan {
+  sourceNest: string;
+  group: string;
+  sourceTitle: string;
+  targetTitle: string;
+  eligibleCount: number;
+  tombstoneCount: number;
+  stubCount: number;
+  previewTitles: string[];
+  writeWidening: boolean;
+  wideningReasons: string[];
+  readerRoles: string[];
+  writerRoles: string[];
+  privacy: GroupInfo['privacy'];
+  archiveTitle: string;
+  metrics: ArchiveOnlyMetrics;
+}
+
+export interface MigrationDeps {
+  getChannelPerm: (nest: string) => Promise<ChannelPerm>;
+  getGroup: (flag: string) => Promise<GroupInfo>;
+  getChannelPosts: (
+    nest: string,
+    cursor: string | undefined,
+    mode: 'newest' | 'older',
+    count: number
+  ) => Promise<{
+    posts: Post[];
+    older: string | null;
+    totalPosts: number;
+  }>;
+  createGroupNotebook: (input: {
+    title: string;
+    groupId: string;
+    readers: string[];
+    onCreated: (nest: string) => void;
+  }) => Promise<string>;
+  getNotebookDetail: (
+    target: string
+  ) => Promise<{ rootFolderId: number; host: string; flagName: string }>;
+  listNotes: (
+    target: string
+  ) => Promise<{ title: string; bodyMd?: string | null }[]>;
+  batchImport: (input: {
+    flag: string;
+    folder: number;
+    notes: { title: string; body: string }[];
+    requestId: string;
+  }) => Promise<string>;
+  getRawGroup: (groupId: string) => Promise<Record<string, unknown>>;
+  updateChannel: (input: {
+    groupId: string;
+    channelId: string;
+    channel: GroupChannelV7;
+  }) => Promise<void>;
+  getActingShip: () => string;
+  assertServerIdentity: () => Promise<void>;
+  storyToMarkdown: (story: Story) => string;
+  storyToMdastStrict: (story: Story) => void;
+  toUrbitStory: (content: unknown) => Story;
+  generateRequestId: () => string;
+  recoveryInstruction: (targetNest: string) => string;
+  log: (message: string) => void;
+}
+
+export function canonicalizeNest(nest: string): string {
+  const { kind, host, name } = parseNest(nest);
+  return `${kind}/${host}/${name}`;
+}
+
+export function parseNest(nest: string): {
+  kind: string;
+  host: string;
+  name: string;
+} {
+  const parts = nest.split('/');
+  if (
+    parts.length !== 3 ||
+    parts.some((part) => part.length === 0) ||
+    /\s/.test(nest)
+  ) {
+    throw new Error(`Invalid nest format: ${nest}. Expected: kind/~host/name`);
+  }
+  return {
+    kind: parts[0],
+    host: parts[1].startsWith('~') ? parts[1] : `~${parts[1]}`,
+    name: parts[2],
+  };
+}
+
+export function normalizeShip(ship: string): string {
+  return ship.startsWith('~') ? ship : `~${ship}`;
+}
+
+export function normalizeTitle(title: string): string {
+  return truncateTitle(title.normalize('NFC').replace(/\s+/g, ' ').trim());
+}
+
+export function truncateTitle(title: string): string {
+  const max = MIGRATION_LIMITS.NOTE_TITLE_MAX_CODE_POINTS;
+  const codePoints = [...title];
+  if (codePoints.length <= max) return title;
+  return `${codePoints
+    .slice(0, max - 1)
+    .join('')
+    .trimEnd()}\u2026`;
+}
+
+function formatUtcDay(timestamp: number): string {
+  const date = new Date(timestamp);
+  if (!Number.isFinite(timestamp) || Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid post timestamp: ${timestamp}`);
+  }
+  const yyyy = date.getUTCFullYear();
+  const mm = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(date.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * `%batch-import` cannot carry a post's original time, so the attribution line
+ * in the body is the only surviving record of it once the source is archived.
+ * Keep full precision there — a day is not recoverable back into a timestamp.
+ * The title fallback deliberately stays day-granular; a clock time reads as
+ * noise in a note title.
+ */
+function formatUtcTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  if (!Number.isFinite(timestamp) || Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid post timestamp: ${timestamp}`);
+  }
+  const hh = String(date.getUTCHours()).padStart(2, '0');
+  const mi = String(date.getUTCMinutes()).padStart(2, '0');
+  const ss = String(date.getUTCSeconds()).padStart(2, '0');
+  return `${formatUtcDay(timestamp)} ${hh}:${mi}:${ss} UTC`;
+}
+
+export function deriveNoteTitle(
+  post: SourcePost,
+  convertedMarkdown?: string
+): string {
+  if (post.title.trim()) {
+    return truncateTitle(post.title.trim());
+  }
+  if (convertedMarkdown) {
+    const firstLine = convertedMarkdown
+      .split('\n')
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (firstLine) return truncateTitle(firstLine);
+  }
+  return `Untitled \u2014 ${formatUtcDay(post.sentAt)}`;
+}
+
+export function deriveTargetTitle(
+  sourceTitle: string | null | undefined,
+  nestName: string
+): string {
+  return normalizeTitle(sourceTitle?.trim() ? sourceTitle : nestName);
+}
+
+export function buildAttributionLine(authorId: string, sentAt: number): string {
+  return `*Originally posted by ${normalizeShip(authorId)} on ${formatUtcTimestamp(
+    sentAt
+  )}.*`;
+}
+
+export function buildProvenanceFooter(
+  sourceNest: string,
+  postId: string
+): string {
+  return `<!-- tlon-migrate: ${sourceNest} ${postId} -->`;
+}
+
+export function validateImageUrl(url: string): boolean {
+  if (/[<>\\\s]/.test(url)) return false;
+  for (let i = 0; i < url.length; i += 1) {
+    const code = url.charCodeAt(i);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return false;
+  }
+  return true;
+}
+
+export function assembleNoteBody(input: {
+  attributionLine: string;
+  headerImageUrl: string | null;
+  convertedMarkdown: string;
+  provenanceFooter: string;
+}): string {
+  const blocks = [input.attributionLine];
+  if (input.headerImageUrl) {
+    blocks.push(`![](<${input.headerImageUrl}>)`);
+  }
+  if (input.convertedMarkdown) {
+    blocks.push(input.convertedMarkdown);
+  }
+  blocks.push(input.provenanceFooter);
+  return `${blocks.join('\n\n')}\n`;
+}
+
+export interface WriteWideningResult {
+  widening: boolean;
+  reasons: string[];
+}
+
+export function computeWriteWidening(input: {
+  readerRoles: string[];
+  writerRoles: string[];
+  admins: string[];
+  privacy: GroupInfo['privacy'];
+}): WriteWideningResult {
+  const reasons: string[] = [];
+  const { readerRoles, writerRoles, admins, privacy } = input;
+  const openReaders = readerRoles.length === 0;
+
+  if (openReaders && writerRoles.length > 0) {
+    reasons.push(
+      'readers are open while writers are restricted, so all readers would gain write access'
+    );
+  }
+  if (openReaders && privacy === 'public') {
+    reasons.push(
+      'the channel is public and open, so non-members who join would become editors'
+    );
+  }
+  for (const role of readerRoles) {
+    const writerAuthorizing =
+      writerRoles.length === 0 ||
+      writerRoles.includes(role) ||
+      admins.includes(role);
+    if (!writerAuthorizing) {
+      reasons.push(
+        `reader role "${role}" is not writer-authorizing and would gain write access`
+      );
+    }
+  }
+  return { widening: reasons.length > 0, reasons };
+}
+
+export interface ChunkEnvelopeContext {
+  flag: string;
+  folder: number;
+  requestId: string;
+}
+
+export function measureEnvelopeBytes(
+  notes: { title: string; body: string }[],
+  ctx: ChunkEnvelopeContext
+): number {
+  return Buffer.byteLength(
+    JSON.stringify({
+      requestId: ctx.requestId,
+      action: {
+        type: 'notebook',
+        flag: ctx.flag,
+        action: {
+          type: 'batch-import',
+          folder: ctx.folder,
+          notes: notes.map(({ title, body }) => ({ title, body })),
+        },
+      },
+    }),
+    'utf8'
+  );
+}
+
+export function chunkNotes(
+  notes: ConvertedNote[],
+  byteCap: number,
+  ctx: ChunkEnvelopeContext
+): ConvertedNote[][] {
+  const chunks: ConvertedNote[][] = [];
+  let current: ConvertedNote[] = [];
+
+  for (const note of notes) {
+    const singleBytes = measureEnvelopeBytes([note], ctx);
+    if (singleBytes > byteCap) {
+      throw new Error(
+        `Note ${note.postId} exceeds byte cap ${byteCap} as a single-note chunk (${singleBytes} bytes)`
+      );
+    }
+    if (
+      current.length > 0 &&
+      measureEnvelopeBytes([...current, note], ctx) > byteCap
+    ) {
+      chunks.push(current);
+      current = [];
+    }
+    current.push(note);
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+export function archiveTitle(sourceTitle: string, nestName: string): string {
+  const base = sourceTitle.trim() || nestName;
+  return base.endsWith('-ARCHIVE') ? base : `${base}-ARCHIVE`;
+}
+
+export function convertPost(
+  post: SourcePost,
+  sourceNest: string,
+  deps: Pick<
+    MigrationDeps,
+    'storyToMarkdown' | 'storyToMdastStrict' | 'toUrbitStory'
+  >
+): ConvertedNote {
+  let content = post.content;
+  if (typeof content === 'string') {
+    try {
+      content = JSON.parse(content);
+    } catch (error) {
+      throw new Error(
+        `Post ${post.id}: content is not valid JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+  if (content !== null && !Array.isArray(content)) {
+    throw new Error(
+      `Post ${post.id}: content must be null or array, got ${typeof content}`
+    );
+  }
+
+  let markdown: string;
+  try {
+    const story = deps.toUrbitStory(content);
+    deps.storyToMdastStrict(story);
+    markdown = deps.storyToMarkdown(story);
+  } catch (error) {
+    throw new Error(
+      `Post ${post.id}: conversion failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  let headerImageUrl: string | null = null;
+  if (post.image.trim()) {
+    if (!validateImageUrl(post.image)) {
+      throw new Error(
+        `Post ${post.id}: header image URL contains invalid characters`
+      );
+    }
+    headerImageUrl = post.image;
+  }
+
+  return {
+    postId: post.id,
+    sequenceNum: post.sequenceNum,
+    title: deriveNoteTitle(post, markdown),
+    body: assembleNoteBody({
+      attributionLine: buildAttributionLine(post.authorId, post.sentAt),
+      headerImageUrl,
+      convertedMarkdown: markdown,
+      provenanceFooter: buildProvenanceFooter(sourceNest, post.id),
+    }),
+  };
+}
+
+export function filterEligiblePosts(posts: SourcePost[]): {
+  eligible: SourcePost[];
+  tombstones: SourcePost[];
+  stubs: SourcePost[];
+} {
+  const eligible: SourcePost[] = [];
+  const tombstones: SourcePost[] = [];
+  const stubs: SourcePost[] = [];
+  for (const post of posts) {
+    if (post.isSequenceStub) stubs.push(post);
+    else if (post.isDeleted) tombstones.push(post);
+    else eligible.push(post);
+  }
+  return { eligible, tombstones, stubs };
+}
+
+function visitInlines(
+  inlines: unknown[],
+  visitor: (inline: Record<string, unknown>) => void
+): void {
+  for (const inline of inlines) {
+    if (!inline || typeof inline !== 'object') continue;
+    const value = inline as Record<string, unknown>;
+    visitor(value);
+    for (const key of ['bold', 'italics', 'strike', 'blockquote']) {
+      if (Array.isArray(value[key])) {
+        visitInlines(value[key] as unknown[], visitor);
+      }
+    }
+    const task = value.task;
+    if (task && typeof task === 'object') {
+      const taskContent = (task as Record<string, unknown>).content;
+      if (Array.isArray(taskContent)) {
+        visitInlines(taskContent, visitor);
+      }
+    }
+  }
+}
+
+function visitListing(
+  listing: unknown,
+  visitor: (inline: Record<string, unknown>) => void
+): void {
+  if (!listing || typeof listing !== 'object') return;
+  const value = listing as Record<string, unknown>;
+  if (Array.isArray(value.item)) {
+    visitInlines(value.item, visitor);
+  }
+  if (!value.list || typeof value.list !== 'object') return;
+  const list = value.list as Record<string, unknown>;
+  if (Array.isArray(list.contents)) {
+    visitInlines(list.contents, visitor);
+  }
+  if (Array.isArray(list.items)) {
+    for (const item of list.items) {
+      visitListing(item, visitor);
+    }
+  }
+}
+
+function visitStoryInlines(
+  story: Story,
+  visitor: (inline: Record<string, unknown>) => void
+): void {
+  for (const verse of story) {
+    if (!verse || typeof verse !== 'object') continue;
+    const value = verse as unknown as Record<string, unknown>;
+    if (Array.isArray(value.inline)) {
+      visitInlines(value.inline, visitor);
+    }
+    if (!value.block || typeof value.block !== 'object') continue;
+    const block = value.block as Record<string, unknown>;
+    if (block.header && typeof block.header === 'object') {
+      const content = (block.header as Record<string, unknown>).content;
+      if (Array.isArray(content)) {
+        visitInlines(content, visitor);
+      }
+    }
+    if ('listing' in block) {
+      visitListing(block.listing, visitor);
+    }
+  }
+}
+
+function countGroupMentions(story: Story): number {
+  let count = 0;
+  visitStoryInlines(story, (inline) => {
+    if ('sect' in inline) count += 1;
+  });
+  return count;
+}
+
+export function countArchiveOnlyMetrics(
+  posts: SourcePost[]
+): ArchiveOnlyMetrics {
+  const result: ArchiveOnlyMetrics = {
+    totalComments: 0,
+    totalReactions: 0,
+    citeCount: 0,
+    linkBlockCount: 0,
+    groupMentionCount: 0,
+  };
+  for (const post of posts) {
+    result.totalComments += post.replyCount;
+    result.totalReactions += post.reactionCount;
+    let content = post.content;
+    if (typeof content === 'string') {
+      try {
+        content = JSON.parse(content);
+      } catch {
+        continue;
+      }
+    }
+    if (!Array.isArray(content)) continue;
+    const story = content as Story;
+    for (const verse of story) {
+      if (!verse || typeof verse !== 'object') continue;
+      const value = verse as unknown as Record<string, unknown>;
+      if (
+        value.type === 'reference' &&
+        typeof value.referenceType === 'string'
+      ) {
+        result.citeCount += 1;
+      }
+      if (value.block && typeof value.block === 'object') {
+        const block = value.block as Record<string, unknown>;
+        if ('cite' in block) result.citeCount += 1;
+        if ('link' in block) result.linkBlockCount += 1;
+      }
+    }
+    result.groupMentionCount += countGroupMentions(story);
+  }
+  return result;
+}
+
+export function sortPostsBySequence(posts: SourcePost[]): SourcePost[] {
+  return posts.slice().sort((a, b) => a.sequenceNum - b.sequenceNum);
+}

--- a/packages/tlon-skill/scripts/notes-migrate.ts
+++ b/packages/tlon-skill/scripts/notes-migrate.ts
@@ -66,6 +66,8 @@ export interface ArchiveOnlyMetrics {
   citeCount: number;
   linkBlockCount: number;
   groupMentionCount: number;
+  /** Inline tags and block references. Flattened to their text, not dropped. */
+  flattenedInlineCount: number;
 }
 
 export interface MigrationPlan {
@@ -521,6 +523,17 @@ function countGroupMentions(story: Story): number {
   return count;
 }
 
+// Tags and inline block references survive as their visible text but lose what
+// they were. That is the same class of change the plan already discloses for
+// group mentions, so it is reported the same way rather than left silent.
+function countFlattenedInlines(story: Story): number {
+  let count = 0;
+  visitStoryInlines(story, (inline) => {
+    if ('tag' in inline || 'block' in inline) count += 1;
+  });
+  return count;
+}
+
 export function countArchiveOnlyMetrics(
   posts: SourcePost[]
 ): ArchiveOnlyMetrics {
@@ -530,6 +543,7 @@ export function countArchiveOnlyMetrics(
     citeCount: 0,
     linkBlockCount: 0,
     groupMentionCount: 0,
+    flattenedInlineCount: 0,
   };
   for (const post of posts) {
     result.totalComments += post.replyCount;
@@ -560,6 +574,7 @@ export function countArchiveOnlyMetrics(
       }
     }
     result.groupMentionCount += countGroupMentions(story);
+    result.flattenedInlineCount += countFlattenedInlines(story);
   }
   return result;
 }

--- a/packages/tlon-skill/scripts/notes-runtime.test.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.test.ts
@@ -5,6 +5,8 @@ import { CommandError } from './commands/command';
 // see the module doc for why per-file mock.module registrations are unsafe.
 import {
   MockNotesV1PendingWriteError,
+  mockedGetGroup,
+  mockedGetGroups,
   mockedNotesV1,
 } from './tloncorp-api-mock';
 
@@ -33,6 +35,58 @@ async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
 }
 
 describe('notes runtime wrapper', () => {
+  it('wires validated group listings for notebook cleanup', async () => {
+    const originalGetGroups = mockedGetGroups.impl;
+    const originalGetGroup = mockedGetGroup.impl;
+    mockedGetGroups.impl = async () => [
+      {
+        id: '~zod/alpha',
+        channels: [{ id: 'notes/~zod/book' }, { id: 'chat/~zod/general' }],
+      },
+      {
+        id: '~zod/beta',
+        channels: [{ id: 'diary/~zod/blog' }],
+      },
+    ];
+    mockedGetGroup.impl = async (groupId: unknown) => ({
+      id: groupId,
+      channels: [{ id: 'notes/~zod/book' }, { id: 'chat/~zod/general' }],
+    });
+
+    try {
+      const { createNotesDeps } = await loadRuntime();
+      const deps = createNotesDeps();
+
+      await expect(deps.getGroupChannelListings()).resolves.toEqual([
+        {
+          groupId: '~zod/alpha',
+          channelIds: ['notes/~zod/book', 'chat/~zod/general'],
+        },
+        {
+          groupId: '~zod/beta',
+          channelIds: ['diary/~zod/blog'],
+        },
+      ]);
+      await expect(deps.getGroupChannelIds('~zod/alpha')).resolves.toEqual([
+        'notes/~zod/book',
+        'chat/~zod/general',
+      ]);
+
+      mockedGetGroup.impl = async () => ({ channels: [{ id: 7 }] });
+      await expect(deps.getGroupChannelIds('~zod/alpha')).rejects.toThrow(
+        'channel id'
+      );
+
+      mockedGetGroups.impl = async () => [{ id: '~zod/alpha' }];
+      await expect(deps.getGroupChannelListings()).rejects.toThrow(
+        'channels array'
+      );
+    } finally {
+      mockedGetGroups.impl = originalGetGroups;
+      mockedGetGroup.impl = originalGetGroup;
+    }
+  });
+
   it('rethrows pending-write errors unchanged from production deps', async () => {
     const pending = new MockNotesV1PendingWriteError({
       requestId: '0vabc',

--- a/packages/tlon-skill/scripts/notes-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.ts
@@ -1,6 +1,7 @@
 import {
   type NotesV1Api,
   NotesV1PendingWriteError,
+  deleteNotesNotebookStrict,
   joinNotesChannel,
   leaveNotesChannel,
   notesV1,
@@ -73,16 +74,17 @@ function wrapNotesV1(): NotesV1Api {
 }
 
 export function createNotesDeps(): NotesDeps {
+  let _migration: import('./notes-migrate').MigrationDeps | undefined;
   return {
     ...createProcessCommandDeps(),
     // No subscriptions: %notes CRUD is request/response over the v1 HTTP API.
+    // Membership uses the %notes action wrappers (not the v0 app-sync helpers).
     authenticate: async () => {
       await ensureClient();
     },
     notesV1: wrapNotesV1(),
     isPendingWriteError: (error): error is NotesPendingWriteErrorLike =>
       error instanceof NotesV1PendingWriteError,
-    // Membership uses the %notes action wrappers (not the v0 app-sync helpers).
     joinNotesNotebook: async (nest: string) => {
       try {
         await joinNotesChannel(nest);
@@ -97,7 +99,21 @@ export function createNotesDeps(): NotesDeps {
         throw commandError(notesRuntimeErrorMessage(error));
       }
     },
+    deleteNotesNotebookStrict: async (nest: string) => {
+      try {
+        await deleteNotesNotebookStrict(nest);
+      } catch (error) {
+        throw commandError(notesRuntimeErrorMessage(error));
+      }
+    },
     readFile: (path: string) => fs.readFileSync(path, 'utf-8'),
     readStdin,
+    get migration() {
+      if (!_migration) {
+        const { createMigrationDeps } = require('./notes-migrate-runtime');
+        _migration = createMigrationDeps();
+      }
+      return _migration;
+    },
   };
 }

--- a/packages/tlon-skill/scripts/notes-runtime.ts
+++ b/packages/tlon-skill/scripts/notes-runtime.ts
@@ -2,6 +2,8 @@ import {
   type NotesV1Api,
   NotesV1PendingWriteError,
   deleteNotesNotebookStrict,
+  getGroup,
+  getGroups,
   joinNotesChannel,
   leaveNotesChannel,
   notesV1,
@@ -11,6 +13,7 @@ import * as fs from 'fs';
 import { ensureClient } from './api-client';
 import { commandError, errorMessage } from './commands/command';
 import type { NotesDeps } from './commands/notes';
+import { mapGroupChannelIds } from './notes-channel-runtime';
 import type { NotesPendingWriteErrorLike } from './notes-pending-write';
 
 const STDIN_TIMEOUT_MS = 30_000;
@@ -106,6 +109,30 @@ export function createNotesDeps(): NotesDeps {
         throw commandError(notesRuntimeErrorMessage(error));
       }
     },
+    getGroupChannelListings: async () => {
+      const groups: unknown = await getGroups();
+      if (!Array.isArray(groups)) {
+        throw new Error('Groups response is malformed: expected an array');
+      }
+      return groups.map((group, index) => {
+        if (!group || typeof group !== 'object') {
+          throw new Error(`Group listing ${index}: group is malformed`);
+        }
+        const groupId = (group as { id?: unknown }).id;
+        if (typeof groupId !== 'string') {
+          throw new Error(`Group listing ${index}: group id is malformed`);
+        }
+        return {
+          groupId,
+          channelIds: mapGroupChannelIds(group, groupId),
+        };
+      });
+    },
+    getGroupChannelIds: async (groupId: string) => {
+      const group = await getGroup(groupId);
+      return mapGroupChannelIds(group, groupId);
+    },
+    sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
     readFile: (path: string) => fs.readFileSync(path, 'utf-8'),
     readStdin,
     get migration() {

--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -79,6 +79,18 @@ export const mockedNotesV1 = Object.fromEntries(
   NOTES_V1_OPS.map((op) => [op, async () => undefined])
 ) as MockedNotesV1;
 
+export const mockedGetChannelPosts = {
+  impl: async (..._args: unknown[]) => ({
+    posts: [],
+    older: null,
+    totalPosts: 0,
+  }),
+};
+
+export const mockedScry = {
+  impl: async (..._args: unknown[]): Promise<unknown> => undefined,
+};
+
 export class MockUrbit {
   cookie = '';
   nodeId = '';
@@ -89,11 +101,11 @@ export class MockUrbit {
 mock.module('@tloncorp/api', () => ({
   // api-client.ts value imports
   Urbit: MockUrbit,
-  client: { cookie: '' },
+  client: { cookie: '', url: 'http://localhost', fetchFn: fetch },
   configureClient: async () => undefined,
   internalRemoveClient: () => undefined,
   preSig: (ship: string) => (ship.startsWith('~') ? ship : `~${ship}`),
-  scry: async () => undefined,
+  scry: (...args: unknown[]) => mockedScry.impl(...args),
   subscribe: async () => 0,
   // dms.ts value imports (reaction helpers take injected deps in tests, so
   // these defaults are load-time placeholders, never assertion targets)
@@ -104,6 +116,10 @@ mock.module('@tloncorp/api', () => ({
   respondToDMInvite: async () => undefined,
   sendPost: async () => undefined,
   sendReply: async () => undefined,
+  batchImportNotesV1: async (input: { requestId: string }) => input.requestId,
+  getChannelPosts: (...args: unknown[]) => mockedGetChannelPosts.impl(...args),
+  toUrbitStory: (content: unknown) => content ?? [],
+  updateChannel: async () => undefined,
   // notes runtime value imports
   NotesV1PendingWriteError: MockNotesV1PendingWriteError,
   notesV1: mockedNotesV1,

--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -104,6 +104,14 @@ export const mockedScry = {
   impl: async (..._args: unknown[]): Promise<unknown> => undefined,
 };
 
+export const mockedGetGroups = {
+  impl: async (..._args: unknown[]): Promise<unknown> => [],
+};
+
+export const mockedGetGroup = {
+  impl: async (..._args: unknown[]): Promise<unknown> => ({ channels: [] }),
+};
+
 export class MockUrbit {
   cookie = '';
   nodeId = '';
@@ -136,7 +144,8 @@ mock.module('@tloncorp/api', () => ({
   // notes runtime value imports
   NotesV1PendingWriteError: MockNotesV1PendingWriteError,
   notesV1: mockedNotesV1,
-  getGroup: async () => ({ channels: [] }),
+  getGroups: (...args: unknown[]) => mockedGetGroups.impl(...args),
+  getGroup: (...args: unknown[]) => mockedGetGroup.impl(...args),
   deleteNotesNotebookStrict: async () => undefined,
   joinNotesChannel: async () => undefined,
   leaveNotesChannel: async () => undefined,

--- a/packages/tlon-skill/scripts/tloncorp-api-mock.ts
+++ b/packages/tlon-skill/scripts/tloncorp-api-mock.ts
@@ -21,6 +21,7 @@
  * internalRemoveClient, preSig, scry, subscribe), `dms.ts` (reactions,
  * posts, invites), and the notes runtimes (notesV1 et al.).
  */
+import type { NotesV1Api } from '@tloncorp/api';
 import { mock } from 'bun:test';
 
 export const NOTES_V1_OPS = [
@@ -44,6 +45,7 @@ export const NOTES_V1_OPS = [
   'moveFolder',
   'deleteFolder',
   'listMembers',
+  'batchImport',
 ] as const;
 
 export type NotesV1Op = (typeof NOTES_V1_OPS)[number];
@@ -51,6 +53,17 @@ export type MockedNotesV1 = Record<
   NotesV1Op,
   (...args: unknown[]) => Promise<unknown>
 >;
+
+// `NOTES_V1_OPS` is hand-maintained and `mockedNotesV1` is built with a cast,
+// so an operation added to `NotesV1Api` upstream would silently go missing from
+// every test double. A *runtime* comparison against `notesV1` cannot catch that:
+// this module mocks `@tloncorp/api` process-wide, so the `notesV1` any test sees
+// is generated from this very list and the check would compare the list to
+// itself. Types are not mocked, so these resolve against the real package and
+// fail `tsc` in both directions if the list and the interface diverge.
+type AssertNever<T extends never> = T;
+type _NoOpsMissing = AssertNever<Exclude<keyof NotesV1Api, NotesV1Op>>;
+type _NoExtraOps = AssertNever<Exclude<NotesV1Op, keyof NotesV1Api>>;
 
 export class MockNotesV1PendingWriteError extends Error {
   readonly requestId?: string;


### PR DESCRIPTION
> **Base branch is `patrick/tlon-6248-api-content-loss-and-notes-support` (PR #6216), not `develop`.** This PR is stacked. Every `@tloncorp/api` symbol it imports (`batchImportNotesV1`, `deleteNotesNotebookStrict`, `storyToMarkdown`, `storyToMdast`, `toUrbitStory`, `NotesV1RequestStatus.errorType`) lands in the parent, not here. Review this diff against that branch, or the imports will read as unresolved.
>
> PR 2 of 4 for TLON-6248. (A) `packages/api` = #6216, the parent. (B) this one, the CLI. (C) `packages/openclaw` and (D) `packages/hermes-tlon-adapter` both target B and merge together.

## Summary

Adds `tlon notes migrate-plan` and `tlon notes migrate-apply` to the tlon-skill CLI: a client-side migration that reads a legacy `%diary` channel, converts each post to Markdown, creates a fresh `%notes` notebook in the same group with the source channel's reader roles, imports the notes, verifies them by exact read-back, and renames the original as an archive. Adds `tlon notes notebook-delete <nest> --yes` as the recovery path when an apply fails partway.

The migration is client-side because there is no backend affordance for any part of it. The `%notes` action surface (`desk/sur/notes.hoon:132-167`) has no arm that accepts a `%channels` nest; `%channels` exposes no export or hand-off; and `desk/app/diary.hoon` is a tombstone whose `on-poke` and `on-watch` crash with `%deprecated` (`desk/app/diary.hoon:36`, `:41`). Reading posts out over the existing channel API and writing them in over `%batch-import` is the only path available.

## Changes

**New: migration core (pure, dependency-injected)**

-   `scripts/notes-migrate.ts` holds every decision that can be made without I/O: nest parsing and canonicalization, title normalization and 80-code-point truncation, note-body assembly, post conversion, eligibility filtering, archive-only metric counting, the write-widening predicate, and byte-cap chunking. `MIGRATION_LIMITS` (`:17-23`) fixes the operating envelope: a 512 KiB HTTP batch envelope, 100-post source pages, and a hard ceiling of 5,000 source posts.
-   `scripts/notes-migrate-plan.ts` does the reads. `readSourceComplete` (`:107-175`) pages newest-then-older and refuses to proceed on any of: `totalPosts` drift across pages, a repeated cursor, a duplicate post id, a non-null cursor that yields zero rows, or a terminal non-stub count that disagrees with `totalPosts`. `prepareMigration` (`:187-269`) additionally requires that the acting ship hosts both the source channel and its group (`:197-207`), and refuses to infer permissions from missing data: absent `perm.writers` (`:201`), a source channel missing from the group (`:210`), or a non-array `readers` (`:216`) all abort rather than default to open.
-   `scripts/notes-migrate-apply.ts` does the writes, in a fixed order: refuse without `--yes`, prepare (all reads), gate on write widening, `assertServerIdentity`, create, read notebook detail, import chunks, exact read-back verify, rename source. `verifyTargetContents` (`:40-73`) compares exact `(title, body)` multisets, so a duplicated or dropped note fails the run. Every failure after creation carries an injected recovery instruction naming the target nest.
-   `scripts/notes-migrate-runtime.ts` binds the above to real APIs. `generateRequestId` (`:45-63`) renders 16 bytes of `crypto.randomBytes` as a dotted `@uv` and rejects the zero atom. `parseGroupV7` (`:100-156`) validates the `/v2/ui/groups/{flag}` scry field by field. `assertServerIdentity` (`:168-192`) fetches `/~/name` and compares it against the configured ship before any write.
-   `scripts/migrate-helpers.ts` holds `archiveRename` (a raw-JSON title-only round trip through `updateChannel`, so description/image/cover/readers/section survive untouched) and `assertActingShipIsHost`.
-   `scripts/commands/migrate.ts` is arg parsing plus plain-text rendering. `parseMigrateArgs` (`:37-95`) rejects unknown and duplicate flags per subcommand, requires exactly one positional nest, and requires that nest be `diary/...`. `formatPlanText` (`:117-168`) renders the plan as labeled prose sections, not JSON.

**New: recovery command**

-   `tlon notes notebook-delete <notes-nest> --yes [--force]` deletes a notebook via the strict delete, then confirms by read-back that it is actually gone — the underlying poke returns once sent, so reporting success on the send alone would claim a cleanup that may never have landed. Before deleting it lists the notebook's notes and **refuses** if any body lacks the `tlon-migrate` provenance footer that every migrated note carries, naming how many unmarked notes it found; `--force` overrides. That keeps recovery from destroying a note someone _created_ in the target while the import was still running. It does not detect an _edit_ to an already-imported note: such a note still carries its footer and is treated as migration content. Closing that would need a content manifest rather than a marker, and it requires a second person writing into a seconds-old notebook mid-run — deliberately out of scope. Argument validation runs before `authenticate()`, so a missing `--yes` costs no network
    call.

**Reader roles threaded through notes-channel creation**

-   `createNotesChannelInGroup` now takes an explicit `readers: string[]` and an optional `onCreated` callback (`scripts/notes-channel.ts:35-40`). `readers` is no longer hardcoded to `[]`; callers that want a group-wide notebook pass `[]` explicitly (`scripts/channels.ts:362`, `scripts/groups.ts:1358`). This matters because an empty reader set is not "closed" but "open". `%notes` says so in its own action type, "empty = open" (`desk/sur/notes.hoon:134-137`), and `+go-can-read` enforces it: `=(~ readers.channel)` is readable by every member, and by anyone at all when the group is public (`desk/app/groups.hoon:4709-4729`). Silently defaulting to `[]` while migrating a role-restricted diary would have published it.
-   After the group listing registers, the create path now re-reads the channel's `readerRoles` and compares them as a set against the approved list (`scripts/notes-channel.ts:112-128`). A mismatch, or a channel record that cannot be read back, aborts and leaves the notebook in place with instructions rather than proceeding.
-   **Behavior change to an existing path: a failed listing check no longer deletes the notebook.** Creating a `%notes` channel in a group is two steps — `%notes` creates the notebook, then the group registers it as a channel listing — and the second is asynchronous, so `verifyListing` (`scripts/notes-channel.ts:54`) polls for it. It returns `absent` only when the **final** poll _succeeded_ and still did not see the listing (positive evidence of absence); a trailing read failure returns `unverifiable` instead, so a stale early read is never mistaken for proof.

    Previously `absent` triggered a strict delete, rolling the notebook back. The reasoning was that a host too old to support group-mode notebooks would create a _standalone_ notebook that the group never lists, leaving an orphan the operator never asked for — so the CLI cleaned it up and reported whether cleanup succeeded.

    That rollback is now unsafe, because this same path creates the **migration target**. A group-registration hiccup would destroy a notebook that may already hold imported notes, and auto-deleting something that might contain data is worse than leaving debris. `absent` and `unverifiable` therefore behave alike now: report, leave the notebook in place, and tell the operator to check it (`:140-150`). `tlon notes notebook-delete` is the explicit manual escape hatch that replaces the automatic rollback.

    The trade-off: a stray solo notebook from a pre-group-mode host used to disappear on its own and now accumulates until someone removes it by hand. This affects `tlon channels create --kind notes` and `tlon groups add-channel`, not just migration. The triggering case is narrow — `%notes` is kiln-reined on from `%groups` (`desk/app/channels.hoon:799-816`), so any host with current `%groups` already has current `%notes`; you would need a host mid-upgrade or on an older `%groups`.

-   `mapChannelReaders` (`scripts/notes-channel-runtime.ts:7-31`) throws on a missing or malformed `readerRoles` rather than mapping it to `[]`.

**Wiring and docs**

-   `scripts/commands/notes.ts` routes `migrate` / `migrate-plan` / `migrate-apply` to `runMigrate` before `authenticate()`, so a malformed invocation never opens a session (`:1031-1044`).
-   `scripts/notes-runtime.ts:109-115` exposes `migration` as a lazy getter, so the plain `tlon notes` commands do not pay for loading the migration runtime.
-   `formatRequestStatus` now falls back to `errorType` when a `%notes` error body has no message (`scripts/commands/notes.ts:687-696`), matching the parent PR's type change.
-   `DIARY_REMOVED` (`scripts/cli-utils.ts:142`), `SKILL.md`, and `references/urbit-api.md` change from "diary has been removed" to "diary is deprecated and unmanaged by the CLI", and point at `/migrate <diary-nest>` for owners.
-   `scripts/tloncorp-api-mock.ts` gains swappable `scry` / `getChannelPosts` mocks plus `batchImportNotesV1`, `toUrbitStory`, and `updateChannel` stubs.

**Known protocol limitations, surfaced in the plan output rather than papered over**

-   `%batch-import` cannot carry authorship or timestamps. Its type is `[%batch-import folder=@ud notes=(list [title=@t body=@t])]` (`desk/sur/notes.hoon:165`), and the HTTP handlers force `=. src.bowl our.bowl` immediately after authenticating (`desk/app/notes.hoon:338`, `:593`), so every imported note is authored by the notebook host at import time. Original author and post time are unrecoverable. The migration compensates by prepending an italic attribution line to each body carrying the original author and the original post time to the second in UTC (`notes-migrate.ts:216-220`) — that line is the only surviving record of the real timestamp once the source is archived, so it keeps full precision rather than a date and appending an HTML-comment provenance marker naming the source nest and post id (`:222-227`), and `formatPlanText` states the loss in plain language before anything is written (`commands/migrate.ts:143-146`).
-   The request id is not a deduplication key. `handle-v1-post` resolves it, overwrites `requests` at that key, and dispatches (`desk/app/notes.hoon:353-368`), so replaying an id re-runs the action. The apply path therefore treats a failed or mismatched chunk as "may or may not have landed" and does not retry (`notes-migrate-apply.ts:138-149`).
-   A 401 is conclusive. `%notes` authenticates before dispatch (`desk/app/notes.hoon:333-334`, `:590-591`), so an unauthorized request never ran the action.

## How did I test?

-   `pnpm typecheck` across both `tsconfig.json` and `tsconfig.test.json`: clean.
-   `pnpm test:unit`: 400 pass, 0 fail, 2,172 assertions across 22 files.
-   `pnpm test:integration` (hermetic CLI suite): 356 pass, 0 fail, 8,127 assertions. This suite contains no migration cases; it is a regression check that the rest of the CLI surface still behaves, which matters here because `notes-channel.ts` is shared with the channel-create path.
-   New unit coverage, by module:
    -   `notes-migrate.test.ts` covers nest/title helpers, body assembly and conversion, eligibility and metrics, the write-widening predicate, and envelope measurement plus chunking.
    -   `notes-migrate-plan.test.ts:127-265` drives `readSourceComplete` through each refusal: cursor cycle, duplicate ids, `totalPosts` drift, an empty page behind a non-null cursor, the terminal completeness check, the 5,000-post ceiling, and a missing `sequenceNum`. It also asserts a synthetic sequence stub is excluded from the `totalPosts` reconciliation.
    -   `notes-migrate-apply.test.ts:250-506` asserts the exact call order (`identity → create → detail → import → read-back → raw-group → rename`), that widening is refused before identity or creation, that an oversized note is caught in preflight before any write, that read-back failure blocks the archive rename, that a rename failure is non-fatal and downgrades to a warning, and that the archive rename preserves description/image/cover/readers.
    -   `notes-migrate-runtime.test.ts` covers `@uv` request-id rendering, `parseGroupV7` field validation, the `/~/name` identity check, the exact channel-perm scry path, and that the posts adapter refuses a response missing `totalPosts`.
    -   `commands/migrate.test.ts` covers arg parsing, plan and summary rendering, dispatch, and the `notebook-delete` recovery command (including that `--yes` is validated pre-auth).
    -   `notes-channel.test.ts` was rewritten for the readers contract: exact reader threading, order-insensitive set comparison, `onCreated` firing before verification, fail-closed on an unreadable channel record, and the new leave-in-place behavior on `absent`.
-   **Exercised end to end against a live fake ship** (`~zod`, group `~zod/v136bbet`), not only against injected fakes. A `%diary` channel was seeded with posts, `migrate-plan` reviewed, and `migrate-apply` run twice; the target notebooks were then read back and compared against the source.
    -   Both structural directions were checked, since a diary post carries Story that the CLI turns into Markdown and the app turns back into Story to render it. Unordered, ordered and task lists, nested blockquotes, inline code, bold, and ship mentions all survived: a nested quote emitted `> outer` / `>` / `> > inner`, and a task list emitted `- [x]` / `- [ ]`.
    -   The untitled post exercised `deriveNoteTitle`'s first-line fallback, and the source was renamed and left writable as the plan states.
    -   One caveat found while doing this, worth repeating for anyone reproducing it: seeding a diary through the CLI's own `markdownToStory` (`scripts/story.ts`) produces no `%listing` blocks at all — a Markdown list becomes literal text with a hard break. Seeded that way the migration looks like it mangles lists, when in fact it is faithfully round-tripping literal text. Structural coverage requires seeding Story directly. That converter is unrelated to the migration path, which uses `@tloncorp/api`; it is a separate pre-existing CLI gap.
-   Prettier: all changed `.ts` files pass. `SKILL.md` and `references/urbit-api.md` report style issues, but both already fail at `develop`. They are left unformatted deliberately so this diff carries no unrelated churn.

## Risks and impact

-   Safe to rollback without consulting PR author? Yes, with the caveat that this is stacked on #6216 and must be reverted before (or together with) the parent.
-   Affects important code area:
    -   [ ] Onboarding
    -   [ ] State / providers
    -   [ ] Message sync
    -   [ ] Channel display
    -   [ ] Notifications
    -   [x] Other: `packages/tlon-skill` only. No app, `packages/shared`, or Hoon code is touched. Within the CLI, the one shared blast radius is `createNotesChannelInGroup`, which also backs `tlon channels create --kind notes` and `tlon groups add-channel`: those callers now pass `readers: []` explicitly and inherit the post-create reader verification and the removal of delete-on-absent rollback.

The design deliberately declines several mitigations. Each is a considered tradeoff, not an oversight:

-   **No resume path.** A partial apply is recovered by deleting the new notebook (`tlon notes notebook-delete <nest> --yes`) and running again. Resume would need a durable cursor keyed to a backend that offers no idempotency, so the failure mode is instead made cheap and obvious. Every post-creation error message names the target nest and the recovery step.
-   **No consent digest or permission fingerprint.** The plan is rendered for a human to read and accept out of band. Hashing it would imply a binding the backend cannot honor, since the plan is a snapshot of state that can change the instant it is printed.
-   **Single-shot apply.** No confirmation round-trip, no pending state, no expiry, no nonce. `--yes` on the command line is the whole gate, plus `--allow-write-widening` when the source's reader/writer split means the copy would grant edit rights to readers who cannot currently post.
-   **No single-flight lock.** Two concurrent applies produce a duplicate notebook, which reduces to the delete-and-re-run case above.
-   **Sequence-less tombstones no longer block a migration.** `@tloncorp/api` normalizes a backend sequence of zero to `null` (`packages/api/src/client/postsApi.ts:1286`), and old tombstones legitimately carry zero — `desk/app/channels.hoon:960` has a `%bad-tombstone-for` debug print for exactly that state. Requiring a sequence before filtering tombstones therefore made any diary containing an old deleted post unmigratable, over a value belonging to a post that is never imported. Deleted posts with an absent sequence are now accepted and sorted as zero; eligible posts are still strictly validated, and tombstone counting, stub counting and eligible ordering are unchanged.
-   **The archive rename is confirmed by read-back.** The rename bottoms out in a poke that returns once sent, so `archiveRenamed: true` previously meant "sent", not "applied". The group is re-read and the title compared; an unconfirmed rename reports `archiveRenamed: false` with the existing warning rather than throwing, because by that point every note is imported and verified — the migration genuinely succeeded, and throwing would invite a retry that duplicates the notebook.
-   **[TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) between plan and apply is unmitigated.** Permissions or posts can change between the two commands. `migrate-apply` re-runs the full read and re-derives the plan, so it acts on fresh state, but it does not diff against whatever the operator saw earlier.
-   **Drift _within_ an apply is mitigated at the one point where it discloses.** The reader snapshot is taken before the source read, which is the longest step in the run — up to 50 paged round trips. If the source were restricted during it, creating the target from that snapshot would republish the whole diary at the old, wider visibility while the original looked correctly locked down, and nobody would be told. `assertPermissionsUnchanged` re-reads the source's permissions immediately before `createGroupNotebook`. A reader change aborts outright. Independently, the widening verdict is always recomputed from all four live inputs — readers, writers, admins and group privacy — and aborts if it now widens without `--allow-write-widening`, since the gate the operator passed was decided from the pre-read snapshot. Recomputing unconditionally matters because a reader role losing admin authority, or a private group becoming public, changes the verdict while readers and writers both look
    unchanged. Nothing has been written at that point, so drift is a clean refusal with no cleanup to perform. This is deliberately narrow: it does not fingerprint writers, privacy or admin roles, and does not re-check after creation.
-   **The archived source stays writable.** The migration renames it (appending `-ARCHIVE`, `notes-migrate.ts:349-352`) and deletes nothing. Renaming does not close a channel, and the plan output says so explicitly. Comments, reactions, post references, link blocks, covers, and attachments all remain readable there, which is the point: the archive is the lossless copy.

## Rollback plan

Revert
