### PR TITLE
render nested blockquote inlines instead of "Unknown content type"

### DIFF
--- a/packages/api/src/__tests__/postContent.blockquote.test.ts
+++ b/packages/api/src/__tests__/postContent.blockquote.test.ts
@@ -1,0 +1,354 @@
+import { expect, test } from 'vitest';
+
+import {
+  PlaintextPreviewConfig,
+  convertContent,
+  plaintextPreviewOf,
+} from '../client/postContent';
+
+test('convertContent renders a nested blockquote as a blockquote inline', () => {
+  const content = convertContent(
+    [
+      {
+        inline: [
+          { blockquote: ['outer quote', { blockquote: ['inner quote'] }] },
+        ],
+      },
+    ],
+    null
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'blockquote',
+      content: [
+        { type: 'text', text: 'outer quote' },
+        {
+          type: 'blockquote',
+          children: [{ type: 'text', text: 'inner quote' }],
+        },
+      ],
+    },
+  ]);
+  expect(JSON.stringify(content)).not.toContain('Unknown content type');
+});
+
+test('convertContent recurses through depth-3 nested blockquotes', () => {
+  const content = convertContent(
+    [
+      {
+        inline: [
+          {
+            blockquote: [
+              'one',
+              { blockquote: ['two', { blockquote: ['three'] }] },
+            ],
+          },
+        ],
+      },
+    ],
+    null
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'blockquote',
+      content: [
+        { type: 'text', text: 'one' },
+        {
+          type: 'blockquote',
+          children: [
+            { type: 'text', text: 'two' },
+            {
+              type: 'blockquote',
+              children: [{ type: 'text', text: 'three' }],
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+});
+
+test('convertContent renders a blockquote nested inside bold', () => {
+  const content = convertContent(
+    [
+      {
+        inline: [{ bold: ['before quote', { blockquote: ['quoted'] }] }],
+      },
+    ],
+    null
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'style',
+          style: 'bold',
+          children: [
+            { type: 'text', text: 'before quote' },
+            {
+              type: 'blockquote',
+              children: [{ type: 'text', text: 'quoted' }],
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+});
+
+test('convertContent renders a nested blockquote after a break (PR #6216 shape)', () => {
+  const content = convertContent(
+    [
+      {
+        inline: [
+          {
+            blockquote: ['outer', { break: null }, { blockquote: ['inner'] }],
+          },
+        ],
+      },
+    ],
+    null
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'blockquote',
+      content: [
+        { type: 'text', text: 'outer' },
+        { type: 'lineBreak' },
+        {
+          type: 'blockquote',
+          children: [{ type: 'text', text: 'inner' }],
+        },
+      ],
+    },
+  ]);
+});
+
+test('convertContent renders nested block code as a code-styled inline (PR #6216 shape)', () => {
+  const content = convertContent(
+    [
+      {
+        inline: [
+          {
+            blockquote: [
+              'before quoted code',
+              { break: null },
+              { code: 'quoted_code()' },
+            ],
+          },
+        ],
+      },
+    ],
+    null
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'blockquote',
+      content: [
+        { type: 'text', text: 'before quoted code' },
+        { type: 'lineBreak' },
+        {
+          type: 'style',
+          style: 'code',
+          children: [{ type: 'text', text: 'quoted_code()' }],
+        },
+      ],
+    },
+  ]);
+});
+
+test('convertContent renders a blockquote nested in a list item (PR #6216 shape)', () => {
+  const content = convertContent(
+    [
+      {
+        block: {
+          listing: {
+            item: ['item ', { break: null }, { blockquote: ['quoted'] }],
+          },
+        },
+      },
+    ],
+    null
+  );
+
+  expect(content).toEqual([
+    {
+      type: 'list',
+      list: {
+        content: [
+          { type: 'text', text: 'item ' },
+          { type: 'lineBreak' },
+          {
+            type: 'blockquote',
+            children: [{ type: 'text', text: 'quoted' }],
+          },
+        ],
+      },
+    },
+  ]);
+});
+
+test('plaintext preview separates a nested quote from preceding text', () => {
+  const story = [
+    {
+      inline: [
+        { blockquote: ['outer quote', { blockquote: ['inner quote'] }] },
+      ],
+    },
+  ];
+  const content = convertContent(story, null);
+
+  expect(plaintextPreviewOf(content)).toBe('> outer quote\n> inner quote');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    '> outer quote > inner quote'
+  );
+});
+
+test('plaintext preview does not stack a separator on an adjacent break', () => {
+  const story = [
+    {
+      inline: [
+        {
+          blockquote: ['outer', { break: null }, { blockquote: ['inner'] }],
+        },
+      ],
+    },
+  ];
+  const content = convertContent(story, null);
+
+  expect(plaintextPreviewOf(content)).toBe('> outer\n> inner');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    '> outer\n> inner'
+  );
+});
+
+test('plaintext preview keeps text after a nested quote separated', () => {
+  const story = [
+    {
+      inline: [
+        {
+          blockquote: [
+            'before',
+            { break: null },
+            { blockquote: ['inner'] },
+            { break: null },
+            'after',
+          ],
+        },
+      ],
+    },
+  ];
+  const content = convertContent(story, null);
+
+  expect(plaintextPreviewOf(content)).toBe('> before\n> inner\nafter');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    '> before\n> inner\nafter'
+  );
+});
+
+test('plaintext preview separates text on both sides of a break-free nested quote', () => {
+  const story = [
+    {
+      inline: [
+        {
+          blockquote: ['before', { blockquote: ['inner'] }, 'after'],
+        },
+      ],
+    },
+  ];
+  const content = convertContent(story, null);
+
+  expect(plaintextPreviewOf(content)).toBe('> before\n> inner\nafter');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    '> before > inner after'
+  );
+});
+
+test('plaintext preview of content without blockquotes is unchanged', () => {
+  const story = [
+    {
+      inline: [
+        'Hello ',
+        { bold: ['bold'] },
+        ' & ',
+        { italics: ['italic'] },
+        { break: null },
+        'See ',
+        { link: { href: 'https://example.com', content: 'example' } },
+        ' ',
+        { ship: '~zod' },
+      ],
+    },
+    {
+      inline: [{ task: { checked: true, content: ['done'] } }],
+    },
+  ];
+  const content = convertContent(story, null);
+
+  expect(plaintextPreviewOf(content)).toBe(
+    'Hello bold & italic\nSee example ~zod\n[x] done'
+  );
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    'Hello bold & italic\nSee example ~zod [x] done'
+  );
+});
+
+// `style` and `task` flatten their children into the surrounding string, so a
+// quote sitting at a wrapper's edge is adjacent in the *output* even though it
+// is not an adjacent sibling in the tree. Boundary detection has to see
+// through the wrapper, or the quote runs into its neighbours.
+
+test('plaintext preview separates a quote at the leading edge of a style wrapper', () => {
+  const content = convertContent(
+    [{ inline: ['before', { bold: [{ blockquote: ['q'] }] }, 'after'] }],
+    null
+  );
+
+  expect(plaintextPreviewOf(content)).toBe('before\n> q\nafter');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    'before > q after'
+  );
+});
+
+test('plaintext preview separates a quote at the trailing edge of a style wrapper', () => {
+  const content = convertContent(
+    [{ inline: [{ bold: ['b', { blockquote: ['q'] }] }, 'after'] }],
+    null
+  );
+
+  expect(plaintextPreviewOf(content)).toBe('b\n> q\nafter');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    'b > q after'
+  );
+});
+
+test('plaintext preview lets a wrapped leading break own the boundary', () => {
+  const content = convertContent(
+    [
+      {
+        inline: [
+          {
+            blockquote: [
+              'a',
+              { blockquote: ['q'] },
+              { bold: [{ break: null }, 'x'] },
+            ],
+          },
+        ],
+      },
+    ],
+    null
+  );
+
+  // The bold opens with a break, which already delimits: no stacked separator.
+  expect(plaintextPreviewOf(content)).toBe('> a\n> q\nx');
+  expect(plaintextPreviewOf(content, PlaintextPreviewConfig.inlineConfig)).toBe(
+    '> a > q\nx'
+  );
+});

--- a/packages/api/src/client/markdown/extractTables.test.ts
+++ b/packages/api/src/client/markdown/extractTables.test.ts
@@ -379,6 +379,41 @@ describe('extractTablesFromContent', () => {
     ]);
   });
 
+  it('degrades a nested blockquote in a cell to "> "-prefixed text', () => {
+    // mdast has no phrasing-level blockquote, so a nested quote inside a
+    // candidate table cell must degrade to text (like `task`), not fall
+    // through to `Unknown content type`.
+    const result = extractTablesFromContent([
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: '| Quote | Author |' },
+          { type: 'lineBreak' },
+          { type: 'text', text: '|---|---|' },
+          { type: 'lineBreak' },
+          { type: 'text', text: '| ' },
+          {
+            type: 'blockquote',
+            children: [{ type: 'text', text: 'quoted' }],
+          },
+          { type: 'text', text: ' | someone |' },
+        ],
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    const table = result[0];
+    if (table.type !== 'table') throw new Error('unreachable');
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows[0].cells[0].content).toEqual([
+      { type: 'text', text: '> quoted' },
+    ]);
+    expect(table.rows[0].cells[1].content).toEqual([
+      { type: 'text', text: 'someone' },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('Unknown content type');
+  });
+
   it('splits paragraph around a table', () => {
     const result = extractTablesFromContent([
       {

--- a/packages/api/src/client/markdown/extractTables.ts
+++ b/packages/api/src/client/markdown/extractTables.ts
@@ -102,6 +102,8 @@ function inlineDataToPhrasing(inline: InlineData): PhrasingContent {
         value: `${inline.checked ? '[x]' : '[ ]'} ${inner}`,
       };
     }
+    case 'blockquote':
+      return { type: 'text', value: inlineDataChildText(inline) };
   }
 }
 
@@ -123,6 +125,8 @@ function inlineDataChildText(inline: InlineData): string {
       return `${inline.checked ? '[x]' : '[ ]'} ${inline.children
         .map(inlineDataChildText)
         .join('')}`;
+    case 'blockquote':
+      return '> ' + inline.children.map(inlineDataChildText).join('');
   }
 }
 

--- a/packages/api/src/client/postContent.ts
+++ b/packages/api/src/client/postContent.ts
@@ -53,6 +53,11 @@ export type TaskInlineData = {
   children: InlineData[];
 };
 
+export type BlockquoteInlineData = {
+  type: 'blockquote';
+  children: InlineData[];
+};
+
 export type InlineData =
   | StyleInlineData
   | TextInlineData
@@ -60,7 +65,8 @@ export type InlineData =
   | GroupMentionInlineData
   | LineBreakInlineData
   | LinkInlineData
-  | TaskInlineData;
+  | TaskInlineData
+  | BlockquoteInlineData;
 
 export type InlineType = InlineData['type'];
 
@@ -356,13 +362,70 @@ function plaintextPreviewOfListData(
   return out.join(config.blockSeparator);
 }
 
+// Whether an inline's serialized text begins/ends at a quote boundary. `style`
+// and `task` flatten their children into the surrounding string, so a quote at
+// a wrapper's edge is adjacent in the *output* even though it is not an
+// adjacent sibling in the tree. `task` emits its `[x] ` marker first, so it can
+// never start with a quote.
+//
+// These walk the literal edge child, not the first child that actually renders
+// anything, so a zero-output sibling (an empty style, an empty text) masks the
+// boundary behind it and the separator is skipped. Reaching that needs an empty
+// wrapper adjacent to a quote inside another wrapper — no Markdown or editor
+// path produces it — so it is left alone rather than pushing edge-walking
+// through empty nodes.
+function opensWithQuote(inline: InlineData): boolean {
+  if (inline.type === 'blockquote') return true;
+  if (inline.type === 'style') {
+    const first = inline.children[0];
+    return first != null && opensWithQuote(first);
+  }
+  return false;
+}
+
+function closesWithQuote(inline: InlineData): boolean {
+  if (inline.type === 'blockquote') return true;
+  if (inline.type === 'style' || inline.type === 'task') {
+    const last = inline.children.at(-1);
+    return last != null && closesWithQuote(last);
+  }
+  return false;
+}
+
+// A leading line break supplies its own delimiter, through wrappers too.
+function opensWithBreak(inline: InlineData): boolean {
+  if (inline.type === 'lineBreak') return true;
+  if (inline.type === 'style') {
+    const first = inline.children[0];
+    return first != null && opensWithBreak(first);
+  }
+  return false;
+}
+
 export function plaintextPreviewOfInlineString(
   inlines: InlineData[],
   config: PlaintextPreviewConfig
 ): string {
-  return inlines
-    .map((inline) => plaintextPreviewOfInline(inline, config))
-    .join('');
+  let out = '';
+  inlines.forEach((inline, i) => {
+    // A quote boundary that is already delimited does not get another
+    // delimiter: skip the separator when the output already ends in a
+    // separator or newline, or when this inline opens with its own break.
+    const previous = i > 0 ? inlines[i - 1] : null;
+    const isQuoteBoundary =
+      opensWithQuote(inline) || (previous != null && closesWithQuote(previous));
+    if (
+      isQuoteBoundary &&
+      !opensWithBreak(inline) &&
+      out.length > 0 &&
+      !out.endsWith(config.blockSeparator) &&
+      !out.endsWith('\n')
+    ) {
+      out += config.blockSeparator;
+    }
+    out += plaintextPreviewOfInline(inline, config);
+  });
+  return out;
 }
 export function plaintextPreviewOfInline(
   inline: InlineData,
@@ -386,6 +449,8 @@ export function plaintextPreviewOfInline(
       out += plaintextPreviewOfInlineString(inline.children, config);
       return out;
     }
+    case 'blockquote':
+      return `> ${plaintextPreviewOfInlineString(inline.children, config)}`;
   }
 }
 

--- a/packages/api/src/client/postContentInlines.ts
+++ b/packages/api/src/client/postContentInlines.ts
@@ -68,6 +68,17 @@ export function convertInlineContent(inlines: ub.Inline[]): InlineData[] {
         checked: inline.task.checked,
         children: convertInlineContent(inline.task.content),
       });
+    } else if (ub.isBlockquote(inline)) {
+      nodes.push({
+        type: 'blockquote',
+        children: convertInlineContent(inline.blockquote),
+      });
+    } else if (ub.isBlockCode(inline)) {
+      nodes.push({
+        type: 'style',
+        style: 'code',
+        children: [{ type: 'text', text: inline.code }],
+      });
     } else {
       console.warn('Unhandled inline type:', { inline });
       nodes.push({

--- a/packages/app/fixtures/NotebookPost.fixture.tsx
+++ b/packages/app/fixtures/NotebookPost.fixture.tsx
@@ -98,4 +98,21 @@ export default {
     );
   },
   DeliveryStates: <PostVariantsFixture post={content.postWithText} />,
+  // TLON-6284: nested quotes and quoted code blocks, which used to render as
+  // "Unknown content type". Checks the Text-in-Text inline path on native.
+  NestedBlockquote: () => {
+    const nested = content.postWithNestedBlockquote;
+    return (
+      <FixtureWrapper fillWidth safeArea>
+        <ScrollView automaticallyAdjustContentInsets>
+          <NotebookContentRenderer
+            marginTop="$-l"
+            marginHorizontal="$-l"
+            paddingHorizontal="$xl"
+            content={convertContent(nested.content, nested.blob)}
+          />
+        </ScrollView>
+      </FixtureWrapper>
+    );
+  },
 };

--- a/packages/app/fixtures/contentHelpers.tsx
+++ b/packages/app/fixtures/contentHelpers.tsx
@@ -241,6 +241,36 @@ export const postWithBlockquote = makePost(
   }
 );
 
+// TLON-6284: a quote nested inside another quote, plus a code block nested in a
+// quote. Both are legal wire inlines that used to render "Unknown content
+// type". The `break` between siblings matches what markdown conversion emits.
+export const postWithNestedBlockquote = makePost(
+  exampleContacts.met,
+  [
+    verse.inline(
+      inline.blockquote(
+        'Outer quote, which contains another quote:',
+        inline.break(),
+        inline.blockquote('Inner quote, nested one level deeper.'),
+        inline.break(),
+        'Back to the outer quote.'
+      )
+    ),
+    verse.inline(
+      inline.blockquote(
+        'A quote containing a code block:',
+        inline.break(),
+        inline.code('nested_code_block()')
+      )
+    ),
+    verse.inline('Trailing paragraph, for spacing reference.'),
+  ],
+  {
+    replyCount: 0,
+    isEdited: false,
+  }
+);
+
 export const postWithCode = makePost(
   exampleContacts.hooncell,
   [
@@ -691,6 +721,7 @@ export const postsByType = {
   text: postWithText,
   mention: postWithMention,
   blockquote: postWithBlockquote,
+  nestedBlockquote: postWithNestedBlockquote,
   code: postWithCode,
   list: postWithList,
   link: postWithLink,

--- a/packages/app/ui/components/PostContent/InlineRenderer.tsx
+++ b/packages/app/ui/components/PostContent/InlineRenderer.tsx
@@ -1,5 +1,6 @@
 import { AnalyticsEvent, trackEvent } from '@tloncorp/shared';
 import {
+  BlockquoteInlineData,
   GroupMentionInlineData,
   InlineData,
   InlineFromType,
@@ -215,6 +216,17 @@ export function InlineTask({ inline: node }: { inline: TaskInlineData }) {
   );
 }
 
+export function InlineBlockquote({ inline }: { inline: BlockquoteInlineData }) {
+  return (
+    <Text color="$tertiaryText">
+      {' > '}
+      {inline.children.map((child, i) => (
+        <InlineRenderer inline={child} key={i} />
+      ))}{' '}
+    </Text>
+  );
+}
+
 export type InlineRenderer<T extends InlineData> = React.ComponentType<{
   inline: T;
   color?: ColorTokens;
@@ -232,6 +244,7 @@ export const defaultInlineRenderers: InlineRendererConfig = {
   lineBreak: InlineLineBreak,
   link: InlineLink,
   task: InlineTask,
+  blockquote: InlineBlockquote,
 };
 
 const InlineRendererContext = React.createContext<

--- a/packages/shared/src/logic/notesPublish.ts
+++ b/packages/shared/src/logic/notesPublish.ts
@@ -31,6 +31,7 @@ code{padding:2px 5px;border-radius:4px}
 pre{padding:16px;border:1px solid var(--border);border-radius:8px;overflow:auto}
 pre code{padding:0;background:transparent}
 blockquote{border-left:3px solid var(--action-text);padding-left:16px;color:var(--tertiary-text)}
+.tlon-inline-quote{border-left:3px solid var(--action-text);padding-left:8px;color:var(--tertiary-text)}
 hr{border:0;border-top:1px solid var(--border);margin:2em 0}
 img,video{max-width:100%;border-radius:8px}
 .tlon-table-scroll{max-width:100%;overflow-x:auto}
@@ -160,6 +161,8 @@ function renderInlineToHtml(inline: InlineData): string {
       const tag = inlineStyleTags[inline.style];
       return `<${tag}>${children}</${tag}>`;
     }
+    case 'blockquote':
+      return `<span class="tlon-inline-quote">${renderInlinesToHtml(inline.children)}</span>`;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes [TLON-6284](https://linear.app/tlon/issue/TLON-6284): a blockquote nested inside another inline rendered as the literal text `Unknown content type`. `convertInlineContent` had no `isBlockquote` arm, so nested quotes fell through to the unhandled-inline fallback (top-level quotes were fine, they get hoisted to block level first). Nested `BlockCode` hit the same fallback and is fixed here too.

Independent of #6216, which makes this bug reachable from ordinary markdown by converting nested quotes/code into these wire inlines instead of dropping them. No shared files.

## Changes

- `packages/api/src/client/postContentInlines.ts`: added `isBlockquote` (recursive, any depth) and `isBlockCode` arms. Also fixes quotes in list items, since `convertListing` shares this function.
- `packages/api/src/client/postContent.ts`: added `BlockquoteInlineData` to the `InlineData` union and a `blockquote` arm to `plaintextPreviewOfInline`. `plaintextPreviewOfInlineString` is now boundary-aware so a quote's `> ` prefix doesn't glue to its siblings, and doesn't stack a delimiter where an adjacent line break already provides one. The wrapper-transparent predicates (`opensWithQuote`/`closesWithQuote`/`opensWithBreak`) exist because `style`/`task` flatten children into the surrounding string.
- `packages/api/src/client/markdown/extractTables.ts`: arms in `inlineDataToPhrasing` and `inlineDataChildText`. Degrades to text, as `task` already does, since mdast has no phrasing-level blockquote.
- `packages/shared/src/logic/notesPublish.ts`: `renderInlineToHtml` emits `<span class="tlon-inline-quote">` plus one CSS rule. Not `<blockquote>`, which is invalid inside `<p>`/`<li>`/`<td>`.
- `packages/app/ui/components/PostContent/InlineRenderer.tsx`: `InlineBlockquote`, registered in `defaultInlineRenderers`. Text-only and space-delimited on both edges, because nested inlines render inside a `Text` flow where only `Text` may nest on native.
- Tests and fixtures: new `packages/api/src/__tests__/postContent.blockquote.test.ts` (14 tests), one added test in `extractTables.test.ts`, `postWithNestedBlockquote` in `contentHelpers.tsx`, and a `NestedBlockquote` specimen in `NotebookPost.fixture.tsx`.

Most of the non-converter arms are forced: adding a member to `InlineData` breaks its exhaustive consumers until each has an arm.

## How did I test?

- `packages/api` 329/329 pass; relevant `packages/shared` suites (notesPublish, roundTrip, tiptap) 65/65.
- Mutation tested: reverting the production change fails 13 of the 14 new tests (the survivor is an intentional no-op regression guard that must pass both ways). Targeted mutations confirmed each boundary predicate is independently covered.
- `pnpm -r tsc` clean for api/shared/app; prettier clean.
- Ran on an iPhone 16 simulator via the cosmos `NestedBlockquote` fixture: quote renders indented and `> `-prefixed, text resumes after it, quoted code renders monospace, no placeholder and no layout error. Worth doing separately because the `Text`-in-`Text` constraint driving the renderer design is a React Native behavior neither vitest nor the web build exercises.

## Risks and impact

Low. The converter and renderer changes only alter output for content that previously rendered `Unknown content type`, so any behavior change is on already-broken content. The exception is `plaintextPreviewOfInlineString`, which is on the hot path for every post preview; it only inserts a separator adjacent to a `blockquote` inline, and a regression test pins byte-identical output for content with no blockquotes.

Known limitation: already-ingested posts keep their stale persisted `textContent` preview (containing `Unknown content type`) until they're next re-ingested. There is no backfill. Post bodies convert at render time and fix immediately on open.

- Safe to rollback without consulting PR author? Yes
- Affects important code area:
  - [ ] Onboarding
  - [ ] State / providers
  - [ ] Message sync
  - [x] Channel display
  - [ ] Notifications
  - [ ] Other:

## Rollback plan

Revert

## Screenshots / videos

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-08-06 at 13 03 35" src="https://github.com/user-attachments/assets/619994f9-c7ef-4ab2-a4bd-c569a039f089" />

