### PR TITLE
fix(hermes-tlon-adapter): stop the computing presence keepalive from holding a leaked run's lease forever

### DIFF
--- a/packages/hermes-tlon-adapter/adapter.py
+++ b/packages/hermes-tlon-adapter/adapter.py
@@ -3834,6 +3834,14 @@ class TlonAdapter(BasePlatformAdapter):
         )
 
     async def on_processing_complete(self, event: MessageEvent, outcome: Any) -> None:
+        # Release the presence lease first.  The gateway runs this hook through
+        # a wrapper that swallows every exception, so anything that raises
+        # above this call would leave the run registered and the keepalive
+        # would refresh its lease for the life of the process.
+        await self._computing_presence.stop_run(
+            conversation_id=event.source.chat_id,
+            run_id=self._presence_run_id(event),
+        )
         source = getattr(event, "source", None)
         chat_id = str(getattr(source, "chat_id", "") or "")
         message_id = str(
@@ -3843,10 +3851,6 @@ class TlonAdapter(BasePlatformAdapter):
         )
         if chat_id and message_id:
             self._remove_dispatch_state((chat_id, message_id))
-        await self._computing_presence.stop_run(
-            conversation_id=event.source.chat_id,
-            run_id=self._presence_run_id(event),
-        )
         processing_outcome = _processing_outcome_value(outcome)
         self._telemetry.finish_reply(
             event.source.chat_id,

--- a/packages/hermes-tlon-adapter/presence.py
+++ b/packages/hermes-tlon-adapter/presence.py
@@ -25,6 +25,9 @@ DEFAULT_MIN_UPDATE_INTERVAL_MS = 1_000
 ACTIVE_PRESENCE_TIMEOUT = "~m1.s30"
 DEFAULT_MAX_PUBLISH_AGE_MS = 30_000
 DEFAULT_KEEPALIVE_INTERVAL_MS = 20_000
+# A run whose ``stop_run`` never fires would otherwise hold the presence lease
+# open for the life of the process, because the keepalive keeps refreshing it.
+DEFAULT_MAX_RUN_LIFETIME_MS = 30 * 60 * 1_000
 STOPPED_RUN_MEMORY = 8
 
 TOOL_LABELS = {
@@ -190,6 +193,7 @@ class TlonComputingPresenceReporter:
 @dataclass
 class _RunState:
     tool_names: list[str] = field(default_factory=list)
+    started_at_ms: float = field(default_factory=lambda: time.monotonic() * 1000.0)
 
 
 @dataclass(frozen=True)
@@ -206,6 +210,7 @@ class TlonComputingPresenceTracker:
         min_update_interval_ms: int = DEFAULT_MIN_UPDATE_INTERVAL_MS,
         max_publish_age_ms: int = DEFAULT_MAX_PUBLISH_AGE_MS,
         keepalive_interval_ms: int = DEFAULT_KEEPALIVE_INTERVAL_MS,
+        max_run_lifetime_ms: int = DEFAULT_MAX_RUN_LIFETIME_MS,
         on_error: Optional[Callable[[str, BaseException], None]] = None,
     ) -> None:
         self._reporter = reporter
@@ -215,6 +220,7 @@ class TlonComputingPresenceTracker:
             int(max_publish_age_ms),
         )
         self._keepalive_interval_ms = max(0, int(keepalive_interval_ms))
+        self._max_run_lifetime_ms = max(0, int(max_run_lifetime_ms))
         self._on_error = on_error
         self._conversations: dict[str, dict[str, _RunState]] = {}
         self._last_published_state: dict[str, _PublishedState] = {}
@@ -475,9 +481,15 @@ class TlonComputingPresenceTracker:
         try:
             while True:
                 await asyncio.sleep(self._keepalive_interval_ms / 1000.0)
+                expired = await self._drop_expired_runs(conversation_id)
                 async with self._lock:
                     runs = list(self._conversations.get(conversation_id, {}).keys())
                 if not runs:
+                    # Every run for this conversation is gone.  If the last one
+                    # expired instead of stopping cleanly, release the lease so
+                    # the client stops showing the indicator.
+                    if expired:
+                        await self._release_expired_conversation(conversation_id)
                     return
                 for run_id in runs:
                     await self.refresh_run(
@@ -489,6 +501,57 @@ class TlonComputingPresenceTracker:
         finally:
             if self._keepalive_tasks.get(conversation_id) is asyncio.current_task():
                 self._keepalive_tasks.pop(conversation_id, None)
+
+    async def _drop_expired_runs(self, conversation_id: str) -> bool:
+        """Drop runs past the lifetime cap.  Returns True if any were dropped.
+
+        A run is removed only by ``stop_run``, which the adapter calls from
+        ``on_processing_complete``.  The gateway invokes that hook through a
+        wrapper that swallows every exception, and at least one dispatch path
+        returns before the hook runs at all.  Either case leaks the run, and
+        the keepalive would then refresh its lease forever.
+        """
+        if self._max_run_lifetime_ms <= 0:
+            return False
+
+        now_ms = time.monotonic() * 1000.0
+        async with self._lock:
+            runs = self._conversations.get(conversation_id)
+            if not runs:
+                return False
+            stale = [
+                run_id
+                for run_id, run in runs.items()
+                if now_ms - run.started_at_ms >= self._max_run_lifetime_ms
+            ]
+            for run_id in stale:
+                runs.pop(run_id, None)
+                self._mark_run_stopped_unlocked(conversation_id, run_id)
+            if not runs:
+                self._conversations.pop(conversation_id, None)
+
+        for run_id in stale:
+            logger.warning(
+                "[tlon] Dropping computing presence run %s for %s after %dms; "
+                "stop_run never fired for this turn",
+                run_id,
+                conversation_id,
+                self._max_run_lifetime_ms,
+            )
+        return bool(stale)
+
+    async def _release_expired_conversation(self, conversation_id: str) -> None:
+        previous = self._last_published_state.get(conversation_id)
+        if not previous or not previous.thinking:
+            return
+        await self._safely_sync(
+            conversation_id,
+            "clear",
+            lambda: self._publish_now(
+                conversation_id,
+                _PublishedState(thinking=False, tool_names=()),
+            ),
+        )
 
     def _ensure_run(self, conversation_id: str, run_id: str) -> _RunState:
         runs = self._conversations.setdefault(conversation_id, {})

--- a/packages/hermes-tlon-adapter/test_presence.py
+++ b/packages/hermes-tlon-adapter/test_presence.py
@@ -393,6 +393,79 @@ class PresenceTrackerTests(unittest.TestCase):
         )
         self.assertEqual(last_published_state, {})
 
+    def test_keepalive_stops_republishing_a_run_that_never_stops(self):
+        # A turn whose `stop_run` never fires must not hold the presence lease
+        # open forever.  `on_processing_complete` is the only `stop_run` call
+        # site, the gateway runs it through a hook wrapper that swallows every
+        # exception, and at least one dispatch path returns before the hook.
+        # Any of those leaves the run registered, and the keepalive then
+        # refreshes the lease for the life of the process.
+        reporter = RecordingReporter()
+
+        async def run():
+            tracker = presence.TlonComputingPresenceTracker(
+                reporter=reporter,
+                min_update_interval_ms=0,
+                max_publish_age_ms=0,
+                keepalive_interval_ms=5,
+                max_run_lifetime_ms=40,
+            )
+            # Start a run and never stop it, exactly as a leaked turn does.
+            await tracker.refresh_run(conversation_id="~mug", run_id="run-1")
+
+            deadline = time.monotonic() + 1.0
+            while tracker._conversations.get("~mug") and time.monotonic() < deadline:
+                await asyncio.sleep(0.005)
+
+            leaked = dict(tracker._conversations)
+            published_after_expiry = len(reporter.published)
+            await asyncio.sleep(0.05)
+            still_publishing = len(reporter.published) - published_after_expiry
+
+            await tracker.close()
+            return leaked, still_publishing
+
+        leaked, still_publishing = asyncio.run(run())
+
+        # The expired run is dropped from the tracker.
+        self.assertEqual(leaked, {})
+        # The keepalive stops poking once the run expires.
+        self.assertEqual(still_publishing, 0)
+        # The lease is released, so the client stops showing the indicator.
+        self.assertEqual(
+            reporter.published[-1],
+            {"conversation_id": "~mug", "thinking": False, "tool_names": []},
+        )
+
+    def test_keepalive_republishes_forever_without_a_lifetime_cap(self):
+        # Guards the regression directly: with the cap disabled the keepalive
+        # keeps refreshing a leaked run's lease and never releases it.  This is
+        # the observed production failure, where one turn held the thinking
+        # indicator open for hours until the gateway restarted.
+        reporter = RecordingReporter()
+
+        async def run():
+            tracker = presence.TlonComputingPresenceTracker(
+                reporter=reporter,
+                min_update_interval_ms=0,
+                max_publish_age_ms=0,
+                keepalive_interval_ms=5,
+                max_run_lifetime_ms=0,
+            )
+            await tracker.refresh_run(conversation_id="~mug", run_id="run-1")
+            await asyncio.sleep(0.12)
+            registered = bool(tracker._conversations.get("~mug"))
+            published = list(reporter.published)
+            for task in tracker._keepalive_tasks.values():
+                task.cancel()
+            return registered, published
+
+        registered, published = asyncio.run(run())
+
+        self.assertTrue(registered)
+        self.assertGreaterEqual(len(published), 3)
+        self.assertTrue(all(item["thinking"] is True for item in published))
+
     def test_hook_bridge_updates_active_tracker_from_session_env(self):
         reporter = RecordingReporter()
 


### PR DESCRIPTION
## Summary

A turn whose `stop_run` never fires holds the Tlon computing presence lease open for the life of the gateway process. The client shows the thinking indicator for that conversation until an operator restarts the gateway.

A restart of the client application does NOT clear it. The gateway keeps refreshing a live lease, so the client is rendering correct data. The gateway is the component that reports a turn which ended hours ago.

## Observed behavior

A group chat channel showed the thinking indicator for about 6 hours after the bot finished its work. A DM from the same gateway behaved correctly at the same time.

The presence pokes arrive at a fixed machine cadence, and they name the channel only:

```
10:11:39,149   10:12:30,149   10:13:21,149   10:14:12,149
10:15:03,149   10:15:54,150   10:16:45,150   10:17:36,148
10:18:27,149   10:19:18,149   10:20:09,149   10:21:00,149
```

The interval is 51 seconds. The millisecond field is stable at about `,149`. No user sends messages on that pattern. This is the keepalive loop, not traffic.

## Root cause

`_keepalive_loop` republishes the lease every 20 seconds. It exits on one condition only: the run map for the conversation is empty.

Only `stop_run` empties that map. The adapter calls `stop_run` from `on_processing_complete`. Two paths skip that call:

1. The gateway runs the hook through a wrapper that catches every exception and logs a warning. `on_processing_complete` reads `event.source`, builds ids, and calls `_remove_dispatch_state(...)` before it reaches `stop_run`. Any failure in that earlier work leaks the run, and the only evidence is one warning line.
2. At least one dispatch path returns before the hook runs at all.

A ship-side timeout cannot correct this. The lease is `~m1.s30` and the keepalive refreshes it every 20 seconds, so the status never expires while the process runs.

The leak is per conversation, because the tracker keys runs by conversation id. This explains why the DM stayed correct while the channel did not.

## Reproduction

The leak reproduces against unmodified `develop` with the existing `RecordingReporter` test double. Start a run, never call `stop_run`:

```
run still registered after 350ms: True
keepalive publishes: 35   (all thinking=True)
after another 350ms:   70   <- still climbing
```

70 lease renewals for one turn that already ended.

## Changes

1. Call `stop_run` first in `on_processing_complete`, before the work that can raise. This fixes the swallowed-exception path.
2. Record `started_at_ms` on each run and drop runs past `max_run_lifetime_ms` (default 30 minutes) in `_keepalive_loop`. The loop then publishes `thinking=False` so the client clears the indicator, and logs a warning that names the dropped run. This bounds any missed `stop_run` call, including the early-return path.

Change 1 fixes the known path. Change 2 makes the failure self-correcting. This matters because the hook wrapper swallows errors by design. It will hide the next such bug the same way.

## Tests

Two tests cover the defect. Every existing tracker test calls `stop_run`, so no test covered the case where it never fires.

- `test_keepalive_stops_republishing_a_run_that_never_stops` asserts that an expired run leaves the tracker and releases the lease.
- `test_keepalive_republishes_forever_without_a_lifetime_cap` asserts the unbounded behavior with the cap disabled, which pins the regression.

A revert of the fix must fail the first test on an assertion about the leaked run, not on a missing keyword argument. I verified this by keeping the new signature and neutralizing only the expiry logic:

```
AssertionError: {'~mug': {'run-1': _RunState(tool_names=[], started_at_ms=...)}} != {}
```

`test_presence` passes 15 of 15. The full adapter suite passes 854 of 855. The one failure is `test_adapter_nudge.test_retained_queue_head_waits_for_fully_authenticated_sse`, which fails on `develop` before this branch. Its test double `SlowAuthenticateSSE.subscribe(self, _app, _path)` was never updated when the production `subscribe()` gained `*, optional: bool = False`.

## Open question

The 30-minute default for `max_run_lifetime_ms` is a starting value, not a measured one. It is long enough to leave a slow turn alone and short enough to bound the damage. Raise it if turns can legitimately run longer.

## Note on the gateway restart

The restart that cleared the indicator in production also loaded adapter 0.15.0, which makes that result ambiguous on its own. A diff of the two versions removes the ambiguity:

```console
$ git diff --stat 756541608..8652a4749 -- packages/hermes-tlon-adapter/presence.py
$   # no output: the file did not change
```

The only lifecycle change in `adapter.py` moves the `await self._computing_presence.close()` call later in `disconnect()`. The keepalive logic, the run map, and the `stop_run` call site are unchanged between the two versions. The restart cleared the leaked run because the process died. Version 0.15.0 does not fix this defect.
